### PR TITLE
feat(agent_orchestrator): co-locate Playground "Insert sample" with the agent definition

### DIFF
--- a/apps/mercato/src/modules/agent_examples/agents/deals_health_check/SAMPLE.json
+++ b/apps/mercato/src/modules/agent_examples/agents/deals_health_check/SAMPLE.json
@@ -1,0 +1,11 @@
+{
+  "deal": {
+    "id": "demo-deal-1",
+    "name": "Acme Corp — Enterprise plan",
+    "stage": "Proposal",
+    "value": 48000,
+    "probability": 0.65,
+    "daysInStage": 12,
+    "recentActivity": "Sent revised pricing; awaiting procurement sign-off."
+  }
+}

--- a/apps/mercato/src/modules/agent_examples/agents/deals_health_check/sub-agents/activity_scan/SAMPLE.json
+++ b/apps/mercato/src/modules/agent_examples/agents/deals_health_check/sub-agents/activity_scan/SAMPLE.json
@@ -1,0 +1,15 @@
+{
+  "deal": {
+    "id": "demo-deal-1",
+    "name": "Acme Corp — Enterprise plan",
+    "stage": "Proposal",
+    "value": 48000,
+    "probability": 0.65,
+    "daysInStage": 12,
+    "activities": [
+      { "type": "email", "at": "2026-06-18", "summary": "Sent revised pricing proposal." },
+      { "type": "call", "at": "2026-06-20", "summary": "Procurement asked about volume discounts." },
+      { "type": "meeting", "at": "2026-06-23", "summary": "Demo with the security team." }
+    ]
+  }
+}

--- a/apps/mercato/src/modules/agent_examples/agents/support_resolution_advisor/SAMPLE.json
+++ b/apps/mercato/src/modules/agent_examples/agents/support_resolution_advisor/SAMPLE.json
@@ -1,0 +1,5 @@
+{
+  "subject": "Still can't process payouts",
+  "body": "Third day our payouts are stuck and support hasn't replied. This is blocking our whole finance team.",
+  "customerEmail": "vip@acme.test"
+}

--- a/apps/mercato/src/modules/agent_examples/ai-agents.ts
+++ b/apps/mercato/src/modules/agent_examples/ai-agents.ts
@@ -31,6 +31,10 @@ export const aiAgents: AiAgentDefinition[] = [
       'Every field is REQUIRED. Never invent details that are not in the ticket.',
     ].join(' '),
     result: { kind: 'informative', schema: ticketTriageResult },
+    sampleInput: {
+      subject: 'Charged twice this month',
+      body: 'Hi, I was billed for two subscriptions this month but I only have one account. Please refund the duplicate charge.',
+    },
   }),
 
   // `support.triage_batch` is a MANAGER agent that demonstrates the
@@ -56,6 +60,22 @@ export const aiAgents: AiAgentDefinition[] = [
     ].join(' '),
     subAgents: ['support.ticket_triage'],
     result: { kind: 'informative', schema: triageBatchResult },
+    sampleInput: {
+      tickets: [
+        {
+          subject: 'Charged twice this month',
+          body: 'I was billed for two subscriptions this month but I only have one account. Please refund the duplicate charge.',
+        },
+        {
+          subject: 'How do I export my data?',
+          body: 'I would like to download a CSV of my orders for last quarter. Where can I find that?',
+        },
+        {
+          subject: 'Site is completely down',
+          body: 'Our whole team is getting 500 errors on every page since this morning. This is blocking all of us.',
+        },
+      ],
+    },
   }),
 ]
 

--- a/packages/cli/src/lib/generators/__tests__/agent-files-extension.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/agent-files-extension.test.ts
@@ -103,6 +103,39 @@ describe('createAgentFilesExtension', () => {
     expect(dockerContent).toContain('write: deny')
   })
 
+  it('emits an agent SAMPLE.json into the manifest as sampleInput', () => {
+    const fixture = makeRepoFixture()
+    repoRoot = fixture.repoRoot
+    const agentDir = path.join(fixture.appBase, 'agents', 'deals_health_check')
+    fs.writeFileSync(
+      path.join(agentDir, 'SAMPLE.json'),
+      JSON.stringify({ deal: { id: 'demo-deal-1', stage: 'Proposal' } }),
+      'utf8',
+    )
+
+    const extension = createAgentFilesExtension()
+    extension.scanModule(createScanContext('agent_examples', fixture.appBase, fixture.pkgBase))
+    extension.generateOutput()
+
+    const manifest = fs.readFileSync(
+      path.join(repoRoot, 'packages/enterprise/src/modules/agent_orchestrator/generated/file-agents.generated.ts'),
+      'utf8',
+    )
+    expect(manifest).toContain('sampleInput: {"deal":{"id":"demo-deal-1","stage":"Proposal"}}')
+  })
+
+  it('fails generation on a malformed SAMPLE.json', () => {
+    const fixture = makeRepoFixture()
+    repoRoot = fixture.repoRoot
+    const agentDir = path.join(fixture.appBase, 'agents', 'deals_health_check')
+    fs.writeFileSync(path.join(agentDir, 'SAMPLE.json'), '{ not valid json', 'utf8')
+
+    const extension = createAgentFilesExtension()
+    expect(() =>
+      extension.scanModule(createScanContext('agent_examples', fixture.appBase, fixture.pkgBase)),
+    ).toThrow(/malformed SAMPLE\.json/)
+  })
+
   it('fails generation on a malformed agent dir (missing OUTCOME.md)', () => {
     const fixture = makeRepoFixture()
     repoRoot = fixture.repoRoot

--- a/packages/cli/src/lib/generators/extensions/agent-files.ts
+++ b/packages/cli/src/lib/generators/extensions/agent-files.ts
@@ -80,6 +80,8 @@ type DiscoveredAgent = {
   maxSteps?: number
   provider?: string
   model?: string
+  /** Optional `SAMPLE.json` example input for the Playground "Insert sample" button. */
+  sampleInput?: unknown
 }
 
 const FRONTMATTER_RE = /^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/
@@ -239,6 +241,24 @@ function assertOutcomeSchemaSupported(node: unknown, where: string, path = '$'):
 
 function sanitizeAgentName(id: string): string {
   return id.replace(/[^a-z0-9_-]/gi, '_')
+}
+
+/**
+ * Read the optional `agents/<id>/SAMPLE.json` example input emitted into the
+ * manifest for the Playground "Insert sample" button. Pure JSON (no markdown),
+ * so a missing file is fine; a malformed one fails generation LOUDLY (naming the
+ * dir) rather than being silently dropped. Must stay in sync with
+ * `lib/sdk/defineFileAgent.ts` `loadSampleInput`.
+ */
+function discoverSampleInput(dir: string): unknown {
+  const samplePath = path.join(dir, 'SAMPLE.json')
+  if (!fs.existsSync(samplePath)) return undefined
+  try {
+    return JSON.parse(fs.readFileSync(samplePath, 'utf8'))
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`[internal] malformed SAMPLE.json at ${dir}: ${detail}`)
+  }
 }
 
 /**
@@ -525,6 +545,7 @@ function discoverSubAgents(agentDir: string): DiscoveredAgent[] {
       maxSteps: agent.maxSteps,
       provider: agent.provider,
       model: agent.model,
+      sampleInput: discoverSampleInput(dir),
     })
   }
   return subAgents
@@ -674,6 +695,9 @@ function renderDescriptor(agent: DiscoveredAgent, indent: string): string {
   if (agent.maxSteps != null) optional.push(`${indent}  maxSteps: ${agent.maxSteps},`)
   if (agent.provider != null) optional.push(`${indent}  provider: ${JSON.stringify(agent.provider)},`)
   if (agent.model != null) optional.push(`${indent}  model: ${JSON.stringify(agent.model)},`)
+  if (agent.sampleInput !== undefined) {
+    optional.push(`${indent}  sampleInput: ${JSON.stringify(agent.sampleInput)},`)
+  }
   const skillsContent = agent.skillsContent.map((skill) => ({
     id: skill.id,
     instructions: skill.instructions,
@@ -758,6 +782,11 @@ export type FileAgentDescriptor = {
   maxSteps?: number
   provider?: string
   model?: string
+  /**
+   * Optional example \`input\` for the Playground "Insert sample" button, read
+   * from \`agents/<id>/SAMPLE.json\`. Any JSON value the agent accepts as input.
+   */
+  sampleInput?: unknown
 }
 
 export const fileAgentDescriptors: FileAgentDescriptor[] = [${
@@ -855,6 +884,7 @@ export function createAgentFilesExtension(): GeneratorExtension {
         maxSteps: agent.maxSteps,
         provider: agent.provider,
         model: agent.model,
+        sampleInput: discoverSampleInput(dir),
       })
     }
   }

--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/defineFileAgent.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/defineFileAgent.test.ts
@@ -109,6 +109,32 @@ describe('loadFileAgentDir', () => {
     expect(loaded!.openCodeAgentFile).toContain('submit_outcome')
   })
 
+  it('reads an optional SAMPLE.json into entry.sampleInput (and ignores a malformed one)', () => {
+    const good = makeAgentDir({ agentMd: VALID_AGENT_MD, outcome: VALID_OUTCOME })
+    fs.writeFileSync(
+      path.join(good, 'SAMPLE.json'),
+      JSON.stringify({ deal: { id: 'demo-deal-1', stage: 'Proposal' } }),
+      'utf8',
+    )
+    created.push(good)
+    expect(loadFileAgentDir(good)!.entry.sampleInput).toEqual({
+      deal: { id: 'demo-deal-1', stage: 'Proposal' },
+    })
+
+    // No SAMPLE.json → undefined.
+    const none = makeAgentDir({ agentMd: VALID_AGENT_MD, outcome: VALID_OUTCOME })
+    created.push(none)
+    expect(loadFileAgentDir(none)!.entry.sampleInput).toBeUndefined()
+
+    // Malformed SAMPLE.json never blocks loading — the sample is just dropped.
+    const bad = makeAgentDir({ agentMd: VALID_AGENT_MD, outcome: VALID_OUTCOME })
+    fs.writeFileSync(path.join(bad, 'SAMPLE.json'), '{ not valid', 'utf8')
+    created.push(bad)
+    const loadedBad = loadFileAgentDir(bad)
+    expect(loadedBad).not.toBeNull()
+    expect(loadedBad!.entry.sampleInput).toBeUndefined()
+  })
+
   it('returns null when AGENT.md or OUTCOME.md is missing', () => {
     const onlyAgentMd = makeAgentDir({ agentMd: VALID_AGENT_MD })
     const onlyOutcome = makeAgentDir({ outcome: VALID_OUTCOME })

--- a/packages/enterprise/src/modules/agent_orchestrator/ai-agents.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/ai-agents.ts
@@ -52,6 +52,18 @@ export const aiAgents: AiAgentDefinition[] = [
     // contributes its read-only `customers.analyze_deals` tool to this agent.
     skills: ['deals.stage_playbook'],
     result: { kind: 'actionable', schema: dealHealthCheckResult },
+    // Inline `deal` so the Playground runs deterministically (no DB lookup).
+    sampleInput: {
+      deal: {
+        id: 'demo-deal-1',
+        name: 'Acme Corp — Enterprise plan',
+        stage: 'Proposal',
+        value: 48000,
+        probability: 0.65,
+        daysInStage: 12,
+        recentActivity: 'Sent revised pricing; awaiting procurement sign-off.',
+      },
+    },
   }),
 ]
 

--- a/packages/enterprise/src/modules/agent_orchestrator/api/agents/route.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/api/agents/route.ts
@@ -16,6 +16,8 @@ const agentItemSchema = z.object({
   skills: z.array(z.string()),
   label: z.string(),
   description: z.string(),
+  // Optional per-agent example input for the Playground "Insert sample" button.
+  sampleInput: z.unknown().optional(),
 })
 
 const agentListResponseSchema = z.object({
@@ -36,6 +38,7 @@ export async function GET(req: Request) {
     skills: entry.skills,
     label: entry.label,
     description: entry.description,
+    sampleInput: entry.sampleInput,
   }))
   return NextResponse.json({ items })
 }

--- a/packages/enterprise/src/modules/agent_orchestrator/backend/playground/page.tsx
+++ b/packages/enterprise/src/modules/agent_orchestrator/backend/playground/page.tsx
@@ -28,25 +28,6 @@ type AgentResult =
   | { kind: 'informative'; data: unknown }
   | { kind: 'actionable'; proposal: { actions: unknown[]; confidence?: number; rationale?: string } }
 
-/**
- * Per-agent example inputs surfaced via the "Insert sample" button. Keyed by the
- * stable agent id; the demo `deals.health_check` agent accepts an inline `deal`
- * (no DB lookup, deterministic in the playground) or a `dealId`.
- */
-const SAMPLE_INPUTS: Record<string, unknown> = {
-  'deals.health_check': {
-    deal: {
-      id: 'demo-deal-1',
-      name: 'Acme Corp — Enterprise plan',
-      stage: 'Proposal',
-      value: 48000,
-      probability: 0.65,
-      daysInStage: 12,
-      recentActivity: 'Sent revised pricing; awaiting procurement sign-off.',
-    },
-  },
-}
-
 export default function AgentPlaygroundPage() {
   const t = useT()
   const searchParams = useSearchParams()
@@ -87,10 +68,11 @@ export default function AgentPlaygroundPage() {
     [agents, agentId],
   )
 
-  const sampleInput = React.useMemo(
-    () => (agentId && agentId in SAMPLE_INPUTS ? SAMPLE_INPUTS[agentId] : undefined),
-    [agentId],
-  )
+  // Per-agent example input ships with the agent definition (code agents via
+  // `defineAgent({ sampleInput })`, file agents via `agents/<id>/SAMPLE.json`)
+  // and arrives on the agent list payload — the Playground no longer hardcodes
+  // samples. The button hides when an agent declares none.
+  const sampleInput = selectedAgent?.sampleInput
 
   const run = React.useCallback(async () => {
     if (!agentId) {
@@ -168,7 +150,7 @@ export default function AgentPlaygroundPage() {
             <label className="text-sm font-medium" htmlFor="ao-pg-input">
               {t('agent_orchestrator.playground.inputLabel')}
             </label>
-            {sampleInput ? (
+            {sampleInput !== undefined ? (
               <Button
                 type="button"
                 variant="outline"

--- a/packages/enterprise/src/modules/agent_orchestrator/components/types.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/components/types.ts
@@ -90,6 +90,8 @@ export type AgentView = {
   runtime: AgentRuntime
   tools: string[]
   skills: string[]
+  /** Optional example input for the Playground "Insert sample" button. */
+  sampleInput?: unknown
 }
 
 export type SkillDetailView = {
@@ -243,6 +245,7 @@ export function mapAgent(item: Record<string, unknown>): AgentView | null {
     runtime,
     tools: Array.isArray(item.tools) ? item.tools.filter((tool): tool is string => typeof tool === 'string') : [],
     skills: Array.isArray(item.skills) ? item.skills.filter((skill): skill is string => typeof skill === 'string') : [],
+    sampleInput: item.sampleInput,
   }
 }
 

--- a/packages/enterprise/src/modules/agent_orchestrator/generated/file-agents.generated.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/generated/file-agents.generated.ts
@@ -52,6 +52,11 @@ export type FileAgentDescriptor = {
   maxSteps?: number
   provider?: string
   model?: string
+  /**
+   * Optional example `input` for the Playground "Insert sample" button, read
+   * from `agents/<id>/SAMPLE.json`. Any JSON value the agent accepts as input.
+   */
+  sampleInput?: unknown
 }
 
 export const fileAgentDescriptors: FileAgentDescriptor[] = [
@@ -85,11 +90,13 @@ export const fileAgentDescriptors: FileAgentDescriptor[] = [
       maxSteps: 6,
       provider: "anthropic",
       model: "claude-sonnet-4-5",
+      sampleInput: {"deal":{"id":"demo-deal-1","name":"Acme Corp — Enterprise plan","stage":"Proposal","value":48000,"probability":0.65,"daysInStage":12,"activities":[{"type":"email","at":"2026-06-18","summary":"Sent revised pricing proposal."},{"type":"call","at":"2026-06-20","summary":"Procurement asked about volume discounts."},{"type":"meeting","at":"2026-06-23","summary":"Demo with the security team."}]}},
     },
     ],
     maxSteps: 12,
     provider: "anthropic",
     model: "claude-sonnet-4-5",
+    sampleInput: {"deal":{"id":"demo-deal-1","name":"Acme Corp — Enterprise plan","stage":"Proposal","value":48000,"probability":0.65,"daysInStage":12,"recentActivity":"Sent revised pricing; awaiting procurement sign-off."}},
   },
   {
     id: "support.resolution_advisor",
@@ -107,5 +114,6 @@ export const fileAgentDescriptors: FileAgentDescriptor[] = [
     maxSteps: 12,
     provider: "anthropic",
     model: "claude-sonnet-4-5",
+    sampleInput: {"subject":"Still can't process payouts","body":"Third day our payouts are stuck and support hasn't replied. This is blocking our whole finance team.","customerEmail":"vip@acme.test"},
   },
 ]

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/sdk/defineAgent.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/sdk/defineAgent.ts
@@ -67,6 +67,14 @@ export interface DefineAgentInput {
   runtime?: AgentRuntime
   /** Zod from data/validators.ts; IS the output.schema (single source). */
   result: { kind: AgentResultKind; schema: ZodTypeAny }
+  /**
+   * Optional example `input` surfaced by the Playground's "Insert sample"
+   * button. Co-located with the agent so each agent ships its own runnable
+   * example instead of the Playground hardcoding per-agent samples. Any JSON
+   * value the agent accepts as input. Additive/BC-safe: agents without it just
+   * hide the button.
+   */
+  sampleInput?: unknown
 }
 
 export interface AgentRegistryEntry {
@@ -87,6 +95,8 @@ export interface AgentRegistryEntry {
   loop?: { maxSteps?: number }
   /** Runtime the agent executes on. Always set (default `'in-process'`). */
   runtime: AgentRuntime
+  /** Optional Playground "Insert sample" input (see DefineAgentInput). */
+  sampleInput?: unknown
 }
 
 const registry = new Map<string, AgentRegistryEntry>()
@@ -131,6 +141,7 @@ export function defineAgent(input: DefineAgentInput): AiAgentDefinition {
     defaultModel: input.defaultModel,
     loop: input.loop,
     runtime: 'in-process',
+    sampleInput: input.sampleInput,
   })
   const skillSections = resolvedSkills.map(
     (skill) => `## Skill: ${skill.label}\n${skill.instructions}`,
@@ -331,6 +342,7 @@ async function loadFileAgents(): Promise<void> {
         defaultModel: descriptor.model,
         loop: descriptor.maxSteps != null ? { maxSteps: descriptor.maxSteps } : undefined,
         runtime: 'opencode',
+        sampleInput: descriptor.sampleInput,
       })
       // Phase 3: register the agent's resolved skill content into the runtime
       // lookup so `load_skill` can return it without fs access. Optional + BC: a

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/sdk/defineFileAgent.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/sdk/defineFileAgent.ts
@@ -145,6 +145,24 @@ function sanitizeAgentName(id: string): string {
   return id.replace(/[^a-z0-9_-]/gi, '_')
 }
 
+/**
+ * Read the optional `agents/<id>/SAMPLE.json` example input, surfaced by the
+ * Playground's "Insert sample" button. Pure JSON (no markdown/frontmatter) so it
+ * needs no custom parser. Returns undefined when the file is absent or invalid
+ * (a malformed sample must never block agent loading — the button just hides).
+ * Must stay in sync with the generator's `discoverSampleInput`.
+ */
+function loadSampleInput(dir: string): unknown {
+  const samplePath = path.join(dir, 'SAMPLE.json')
+  if (!fs.existsSync(samplePath)) return undefined
+  try {
+    return JSON.parse(fs.readFileSync(samplePath, 'utf8'))
+  } catch {
+    console.warn(`[internal] malformed SAMPLE.json at ${dir}; ignoring.`)
+    return undefined
+  }
+}
+
 function renderToolPermissionLine(toolName: string): string {
   return `  ${JSON.stringify(toolName)}: true`
 }
@@ -480,6 +498,7 @@ function loadSubAgentDir(dir: string): LoadedFileAgent {
     defaultModel: agent.model,
     loop: agent.maxSteps != null ? { maxSteps: agent.maxSteps } : undefined,
     runtime: 'opencode',
+    sampleInput: loadSampleInput(dir),
   }
 
   const openCodeAgentFile = renderOpenCodeAgentFile({
@@ -598,6 +617,7 @@ export function loadFileAgentDir(dir: string): LoadedFileAgent | null {
     defaultModel: agent.model,
     loop: agent.maxSteps != null ? { maxSteps: agent.maxSteps } : undefined,
     runtime: 'opencode',
+    sampleInput: loadSampleInput(dir),
   }
 
   const openCodeAgentFile = renderOpenCodeAgentFile({


### PR DESCRIPTION
## Summary

The Playground hardcoded a per-agent `SAMPLE_INPUTS` map keyed by agent id, so the enterprise page had to know about agents from other modules (e.g. `agent_examples`), and a newly-added agent could not ship its own example. This makes the sample **an optional value on the agent definition** and threads it through to the Playground's "Insert sample" button.

## The new authoring contract

- **Code agents** (`defineAgent`): optional `sampleInput?: unknown`.
  ```ts
  defineAgent({ id: 'deals.health_check', /* … */ sampleInput: { deal: { /* … */ } } })
  ```
- **File-defined agents** (`agents/<id>/`): optional `SAMPLE.json` next to `AGENT.md`/`OUTCOME.md` (pure JSON, mirrors the existing optional-file convention).

## Flow

`defineAgent({ sampleInput })` / `SAMPLE.json` → `AgentRegistryEntry.sampleInput` → generated manifest (`FileAgentDescriptor.sampleInput`) → `/api/agent_orchestrator/agents` item → `mapAgent` → `AgentView.sampleInput` → Playground reads `selectedAgent.sampleInput`. The button shows for any agent that declares a sample; the page no longer hardcodes anything. All additive / BC-safe.

## Changes

- **SDK**: `lib/sdk/defineAgent.ts` (input + registry field), `lib/sdk/defineFileAgent.ts` (`loadSampleInput` reads `SAMPLE.json` for primary + sub-agents)
- **Generator**: `packages/cli/.../agent-files.ts` (discovers `SAMPLE.json`, emits into the manifest type + descriptors; malformed JSON fails generation loudly) — both parsers updated in sync
- **API/UI**: `api/agents/route.ts`, `components/types.ts` (`AgentView` + `mapAgent`), `backend/playground/page.tsx` (removed the hardcoded map)
- **Samples authored**: `deals.health_check`, `support.ticket_triage`, `support.triage_batch` via `sampleInput`; `SAMPLE.json` for `deals_health_check`, its `activity_scan` sub-agent, and `support_resolution_advisor` (uses the canned `vip@acme.test` so the demo history lookup returns rich data)

## Verification

- `yarn generate` regenerated the manifest — diff is exactly the 3 samples + type field, **no `docker/opencode` churn** (samples don't enter agent prompts)
- `yarn build:packages` ✅, `yarn typecheck` ✅
- Tests: agent_orchestrator suite **241 passed**, CLI generator **8 passed**, ESLint clean
- New tests: generator (SAMPLE.json → manifest; malformed fails) + loader (`entry.sampleInput`; absent → undefined; malformed → ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A27RfM1VrHTk8szze4eQzY