### PR TITLE
fix(ui): actions dropdown clips long localized labels (#3580)

### DIFF
--- a/packages/ui/src/backend/__tests__/ActionsDropdown.test.tsx
+++ b/packages/ui/src/backend/__tests__/ActionsDropdown.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { screen, fireEvent } from '@testing-library/react'
+import { ActionsDropdown, type ActionItem } from '../forms/ActionsDropdown'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+// Regression coverage for issue #3580: in the Polish locale the long
+// "Oznacz wszystko jako nieprzeczytane" label overflowed the conversation
+// actions dropdown because the menu used a fixed `w-52` width and the items
+// inherited `whitespace-nowrap` from the Button primitive, clipping the label.
+const LONG_POLISH_LABEL = 'Oznacz wszystko jako nieprzeczytane'
+const TRIGGER_LABEL = 'Conversation actions'
+
+function renderDropdown(items: ActionItem[]) {
+  return renderWithProviders(
+    <ActionsDropdown items={items} triggerMode="icon" ariaLabel={TRIGGER_LABEL} />,
+    { dict: {} },
+  )
+}
+
+function openMenu() {
+  fireEvent.click(screen.getByRole('button', { name: TRIGGER_LABEL }))
+}
+
+describe('ActionsDropdown', () => {
+  it('grows to fit long labels instead of clipping them with a fixed width (issue #3580)', () => {
+    renderDropdown([{ id: 'mark-all-unread', label: LONG_POLISH_LABEL, onSelect: jest.fn() }])
+
+    openMenu()
+
+    const menu = screen.getByRole('menu')
+    expect(menu.className).toContain('w-max')
+    expect(menu.className).toContain('max-w-xs')
+    expect(menu.className).toContain('min-w-52')
+    // The original bug was a hard `w-52` cap that truncated longer localized labels.
+    expect(menu.className).not.toMatch(/(^|\s)w-52(\s|$)/)
+
+    expect(screen.getByText(LONG_POLISH_LABEL)).toBeInTheDocument()
+  })
+
+  it('lets long menu-item labels wrap to a second line instead of staying on one clipped line', () => {
+    renderDropdown([{ id: 'mark-all-unread', label: LONG_POLISH_LABEL, onSelect: jest.fn() }])
+
+    openMenu()
+
+    const item = screen.getByRole('menuitem', { name: LONG_POLISH_LABEL })
+    expect(item.className).toContain('whitespace-normal')
+    expect(item.className).toContain('h-auto')
+    expect(item.className).not.toMatch(/(^|\s)whitespace-nowrap(\s|$)/)
+  })
+
+  it('still invokes the action handler when a menu item is clicked', () => {
+    const onSelect = jest.fn()
+    renderDropdown([{ id: 'mark-all-unread', label: LONG_POLISH_LABEL, onSelect }])
+
+    openMenu()
+    fireEvent.click(screen.getByRole('menuitem', { name: LONG_POLISH_LABEL }))
+
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/ui/src/backend/forms/ActionsDropdown.tsx
+++ b/packages/ui/src/backend/forms/ActionsDropdown.tsx
@@ -159,7 +159,7 @@ export function ActionsDropdown({
         <div
           ref={menuRef}
           role="menu"
-          className="fixed w-52 rounded-md border bg-background p-1 shadow-md focus-visible:outline-none z-dropdown"
+          className="fixed min-w-52 w-max max-w-xs rounded-md border bg-background p-1 shadow-md focus-visible:outline-none z-dropdown"
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
           style={{
@@ -176,7 +176,7 @@ export function ActionsDropdown({
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="w-full justify-start"
+                className="w-full justify-start h-auto min-h-8 py-1.5 whitespace-normal text-left leading-snug"
                 role="menuitem"
                 disabled={item.disabled}
                 onClick={() => {


### PR DESCRIPTION
Fixes #3580

## Problem
In the Polish locale, the Messages conversation actions menu (`...` button on `/backend/messages/{id}`) clipped the long label "Oznacz wszystko jako nieprzeczytane" — it rendered as "Oznacz wszystko jako nieprzec…" and was unreadable.

## Root Cause
The shared `ActionsDropdown` (used by `FormHeader`'s `menuActions`, so this affected every detail-page actions menu, not just Messages) rendered its menu container with a **fixed** `w-52` (208px) width, while each menu item is a `Button` that inherits `whitespace-nowrap` from the button primitive. Any label wider than 208px (common once translated — the Polish string is ~2× the English "Mark all unread") was forced onto one line and clipped at the container edge.

## What Changed
`packages/ui/src/backend/forms/ActionsDropdown.tsx`:
- Menu container: `w-52` → `min-w-52 w-max max-w-xs`. The dropdown now grows to fit its widest item (keeping the previous 208px as a *minimum* so short menus are unchanged) and is capped at `max-w-xs` so an extreme label can't blow out the layout.
- Menu items: added `h-auto min-h-8 py-1.5 whitespace-normal text-left leading-snug` so a label that exceeds the cap wraps to a second line instead of clipping, with the row growing to fit.

This satisfies both halves of the issue's expected result: the menu is wide enough for the longest Polish label, and wraps as a fallback. Right-edge anchoring is unchanged, so the menu still opens flush under the trigger.

DS-compliant: only DS-scale width/spacing utilities, no arbitrary values, no hardcoded colors.

## Tests
- New `packages/ui/src/backend/__tests__/ActionsDropdown.test.tsx` (3 cases): the menu grows instead of using a fixed `w-52`, long labels are allowed to wrap (`whitespace-normal`/`h-auto`, no `whitespace-nowrap`), and the action handler still fires on click. Verified the width/wrap cases fail on the pre-fix code and pass after.
- `FormHeader` + `ActionsDropdown` suites: 5 passed.
- UI `tsc --noEmit`: no new errors (only the unrelated pre-existing `#generated/*` shim resolution in a fresh worktree).
- ESLint on changed files: clean.

## Backward Compatibility
No contract surface changes — only internal Tailwind className strings in a shared component. No prop, type, export, or signature changes.