### PR TITLE
docs(contributing): warn that enterprise-module contributions are not accepted

### DIFF
--- a/.ai/runs/2026-06-25-contributing-enterprise-warning.md
+++ b/.ai/runs/2026-06-25-contributing-enterprise-warning.md
@@ -52,4 +52,4 @@ None (`--skill-url` not used).
 
 ### Phase 1: Add the warning section
 
-- [ ] 1.1 Add "Enterprise Module Contributions" warning section to CONTRIBUTING.md
+- [x] 1.1 Add "Enterprise Module Contributions" warning section to CONTRIBUTING.md — 2c7aff04e

--- a/.ai/runs/2026-06-25-contributing-enterprise-warning.md
+++ b/.ai/runs/2026-06-25-contributing-enterprise-warning.md
@@ -1,0 +1,55 @@
+# Execution Plan — Add enterprise-module contribution warning to CONTRIBUTING.md
+
+## Overview
+
+Add a clear warning to `CONTRIBUTING.md` explaining that we cannot accept external
+contributions to the commercial enterprise module (`@open-mercato/enterprise`,
+`packages/enterprise/`) because of licensing and intellectual-property / IP-transfer
+constraints. The enterprise package is proprietary, commercial software governed by a
+separate license; merging outside contributions into it would create copyright /
+IP-ownership complications that the project's open-source CLA cannot resolve.
+
+This is a **docs-only** change.
+
+### Goal
+
+Make it unambiguous to would-be contributors that PRs touching `packages/enterprise/`
+will not be accepted, and point them at the appropriate channel (partnership program /
+commercial licensing) instead.
+
+### Affected files
+
+- `CONTRIBUTING.md` (single edit — new section)
+
+### Non-goals
+
+- No changes to the enterprise license text, the CLA, or any code.
+- No changes to PR automation, labels, or CI.
+- No new policy beyond restating the existing commercial-license reality.
+
+### External References
+
+None (`--skill-url` not used).
+
+### Risks
+
+- Low. Docs-only. Worst case is wording that under- or over-states the policy; mitigated
+  by grounding the language in the existing `packages/enterprise/LICENSE.md` and
+  `apps/docs/cla.md`.
+
+## Implementation Plan
+
+### Phase 1: Add the warning section
+
+- Insert a dedicated "Enterprise Module Contributions" section into `CONTRIBUTING.md`
+  near the Pull Requests guidance, stating that contributions to
+  `packages/enterprise/` cannot be accepted due to licensing / IP-transfer constraints,
+  and linking to the enterprise license and partnership program.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Add the warning section
+
+- [ ] 1.1 Add "Enterprise Module Contributions" warning section to CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,35 @@ This ensures design decisions are documented and the codebase remains well-under
 - Reference related issues or discussions; add screenshots or recordings for UI tweaks.
 - Tag maintainers early if you need design or architectural guidance.
 
+### Enterprise Module Contributions
+
+> [!IMPORTANT]
+> **We cannot accept external contributions to the enterprise module.**
+
+The `@open-mercato/enterprise` package (`packages/enterprise/`) is commercial,
+proprietary software governed by its own [license](packages/enterprise/LICENSE.md) — not
+the open-source terms that cover the rest of this repository. Because of the licensing and
+intellectual-property / IP-transfer constraints around that package, **we are unable to
+review, accept, or merge pull requests that modify anything under `packages/enterprise/`**,
+even when they are otherwise high quality.
+
+What this means in practice:
+
+- Do not open PRs that add to, modify, refactor, or reverse-engineer files under
+  `packages/enterprise/`. They will be closed without merge.
+- The Contributor License Agreement (see [`apps/docs/cla.md`](apps/docs/cla.md)) governs
+  contributions to the open-source projects only; it does not grant rights to the
+  commercial enterprise codebase, so it cannot be used to upstream enterprise changes.
+- If you have found a bug in an enterprise module, please report it through your
+  commercial support channel or open an issue describing the problem (without proposing a
+  code change to the package).
+- If you want to build or extend enterprise functionality, reach out about the
+  [Open Mercato Partnership Program](packages/enterprise/README.md) and commercial
+  licensing instead.
+
+Contributions to every other package and app in this repository are welcome — only the
+`packages/enterprise/` tree is off-limits.
+
 ### Package Previews
 
 PRs do not publish npm canary packages automatically. Maintainers can add `publish-pkg-preview` to publish pkg.pr.new package previews for the current PR commit. If a fresh preview is needed after more commits, remove and re-add the label.


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-06-25-contributing-enterprise-warning.md
Status: complete

## Goal
- Warn contributors in `CONTRIBUTING.md` that we cannot accept external contributions to the commercial enterprise module due to licensing and IP-transfer constraints.

## What Changed
- Added an **Enterprise Module Contributions** subsection under *Pull Requests* in `CONTRIBUTING.md`.
- States that PRs modifying anything under `packages/enterprise/` cannot be reviewed/accepted/merged, explains why (proprietary commercial license + IP-transfer constraints), and clarifies the open-source CLA does not cover that tree.
- Points contributors to the enterprise license, the bug-reporting channel, and the Partnership Program / commercial licensing for enterprise work.

## Tests
- Docs-only change; no code paths affected.
- Manual re-read of the diff.
- Verified all three relative link targets resolve: `packages/enterprise/LICENSE.md`, `packages/enterprise/README.md`, `apps/docs/cla.md`.

## Backward Compatibility
- No contract surface changes. Documentation only.

## Progress
See [Progress section in the plan](.ai/runs/2026-06-25-contributing-enterprise-warning.md#progress).
