### PR TITLE
feat(data_sync): add delete methods to ExternalIdMappingService (#3516)

### DIFF
--- a/packages/core/src/modules/data_sync/lib/__tests__/id-mapping.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/id-mapping.test.ts
@@ -1,8 +1,9 @@
-import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { createExternalIdMappingService } from '../id-mapping'
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
 }))
 
 describe('createExternalIdMappingService', () => {
@@ -103,5 +104,114 @@ describe('createExternalIdMappingService', () => {
     expect(existingByLocalId.deletedAt).toBeInstanceOf(Date)
     expect(em.flush).toHaveBeenCalledTimes(1)
     expect(persist).not.toHaveBeenCalled()
+  })
+
+  describe('deleteExternalIdMapping', () => {
+    it('soft-deletes the matching mapping and returns true', async () => {
+      const existing = {
+        id: 'mapping-1',
+        integrationId: 'sync_magento',
+        internalEntityType: 'sales_order',
+        internalEntityId: 'order-1',
+        externalId: 'magento-1',
+        deletedAt: null as Date | null,
+      }
+      ;(findOneWithDecryption as jest.Mock).mockResolvedValueOnce(existing)
+
+      const em = { flush: jest.fn().mockResolvedValue(undefined) }
+      const service = createExternalIdMappingService(em as never)
+      const result = await service.deleteExternalIdMapping(
+        'sync_magento',
+        'sales_order',
+        'order-1',
+        { organizationId: 'org-1', tenantId: 'tenant-1' },
+      )
+
+      expect(result).toBe(true)
+      expect(existing.deletedAt).toBeInstanceOf(Date)
+      expect(em.flush).toHaveBeenCalledTimes(1)
+      const where = (findOneWithDecryption as jest.Mock).mock.calls[0][2]
+      expect(where).toMatchObject({
+        integrationId: 'sync_magento',
+        internalEntityType: 'sales_order',
+        internalEntityId: 'order-1',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        deletedAt: null,
+      })
+    })
+
+    it('returns false and does not flush when no mapping exists', async () => {
+      ;(findOneWithDecryption as jest.Mock).mockResolvedValueOnce(null)
+
+      const em = { flush: jest.fn().mockResolvedValue(undefined) }
+      const service = createExternalIdMappingService(em as never)
+      const result = await service.deleteExternalIdMapping(
+        'sync_magento',
+        'sales_order',
+        'order-missing',
+        { organizationId: 'org-1', tenantId: 'tenant-1' },
+      )
+
+      expect(result).toBe(false)
+      expect(em.flush).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteExternalIdMappings', () => {
+    it('soft-deletes every matching mapping and returns the count', async () => {
+      const rows = [
+        { id: 'mapping-1', internalEntityId: 'order-1', deletedAt: null as Date | null },
+        { id: 'mapping-2', internalEntityId: 'order-2', deletedAt: null as Date | null },
+      ]
+      ;(findWithDecryption as jest.Mock).mockResolvedValueOnce(rows)
+
+      const em = { flush: jest.fn().mockResolvedValue(undefined) }
+      const service = createExternalIdMappingService(em as never)
+      const result = await service.deleteExternalIdMappings(
+        'sync_magento',
+        'sales_order',
+        ['order-1', 'order-2', 'order-1'],
+        { organizationId: 'org-1', tenantId: 'tenant-1' },
+      )
+
+      expect(result).toBe(2)
+      expect(rows[0].deletedAt).toBeInstanceOf(Date)
+      expect(rows[1].deletedAt).toBeInstanceOf(Date)
+      expect(em.flush).toHaveBeenCalledTimes(1)
+      const where = (findWithDecryption as jest.Mock).mock.calls[0][2]
+      expect(where.internalEntityId).toEqual({ $in: ['order-1', 'order-2'] })
+    })
+
+    it('returns 0 without querying or flushing for an empty id list', async () => {
+      const em = { flush: jest.fn().mockResolvedValue(undefined) }
+      const service = createExternalIdMappingService(em as never)
+      const result = await service.deleteExternalIdMappings(
+        'sync_magento',
+        'sales_order',
+        [],
+        { organizationId: 'org-1', tenantId: 'tenant-1' },
+      )
+
+      expect(result).toBe(0)
+      expect(findWithDecryption as jest.Mock).not.toHaveBeenCalled()
+      expect(em.flush).not.toHaveBeenCalled()
+    })
+
+    it('returns 0 and does not flush when nothing matches', async () => {
+      ;(findWithDecryption as jest.Mock).mockResolvedValueOnce([])
+
+      const em = { flush: jest.fn().mockResolvedValue(undefined) }
+      const service = createExternalIdMappingService(em as never)
+      const result = await service.deleteExternalIdMappings(
+        'sync_magento',
+        'sales_order',
+        ['order-x'],
+        { organizationId: 'org-1', tenantId: 'tenant-1' },
+      )
+
+      expect(result).toBe(0)
+      expect(em.flush).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/core/src/modules/data_sync/lib/id-mapping.ts
+++ b/packages/core/src/modules/data_sync/lib/id-mapping.ts
@@ -1,5 +1,5 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SyncExternalIdMapping } from '../../integrations/data/entities'
 
 type MappingScope = {
@@ -118,6 +118,63 @@ export function createExternalIdMappingService(em: EntityManager) {
 
       await em.persist(created).flush()
       return created
+    },
+
+    async deleteExternalIdMapping(
+      integrationId: string,
+      entityType: string,
+      localId: string,
+      scope: MappingScope,
+    ): Promise<boolean> {
+      const row = await findOneWithDecryption(
+        em,
+        SyncExternalIdMapping,
+        {
+        integrationId,
+        internalEntityType: entityType,
+        internalEntityId: localId,
+        organizationId: scope.organizationId,
+        tenantId: scope.tenantId,
+        deletedAt: null,
+        },
+        undefined,
+        scope,
+      )
+      if (!row) return false
+      row.deletedAt = new Date()
+      await em.flush()
+      return true
+    },
+
+    async deleteExternalIdMappings(
+      integrationId: string,
+      entityType: string,
+      localIds: string[],
+      scope: MappingScope,
+    ): Promise<number> {
+      const uniqueLocalIds = Array.from(new Set(localIds))
+      if (uniqueLocalIds.length === 0) return 0
+      const rows = await findWithDecryption(
+        em,
+        SyncExternalIdMapping,
+        {
+        integrationId,
+        internalEntityType: entityType,
+        internalEntityId: { $in: uniqueLocalIds },
+        organizationId: scope.organizationId,
+        tenantId: scope.tenantId,
+        deletedAt: null,
+        },
+        undefined,
+        scope,
+      )
+      if (rows.length === 0) return 0
+      const now = new Date()
+      for (const row of rows) {
+        row.deletedAt = now
+      }
+      await em.flush()
+      return rows.length
     },
   }
 }


### PR DESCRIPTION
Fixes #3516

## Problem
`ExternalIdMappingService` (via `createExternalIdMappingService` in `data_sync/lib/id-mapping.ts`) exposed `lookupLocalId`, `lookupExternalId`, and `storeExternalIdMapping` but had **no delete method**. The Magento 2 sync adapter's deletion and reconciliation paths (blocking #606 / #2603) needed to soft-delete mappings without falling back to raw `em.nativeDelete(SyncExternalIdMapping, …)`, which would break module isolation.

## Root Cause
Missing seam — the service simply never offered a delete operation.

## What Changed
- Added `deleteExternalIdMapping(integrationId, entityType, localId, scope): Promise<boolean>` — finds the matching active mapping via `findOneWithDecryption`, soft-deletes it (`deletedAt = new Date()`), flushes, and returns `true`; returns `false` (no flush) when nothing matches.
- Added `deleteExternalIdMappings(integrationId, entityType, localIds, scope): Promise<number>` — dedups ids, short-circuits to `0` on an empty list, finds matching active rows via `findWithDecryption` (`{ $in }`), soft-deletes each, flushes, and returns the soft-deleted count.
- Both methods stay `organizationId`/`tenantId`-scoped and use the decryption helpers (no raw `em.find`/`em.findOne`), consistent with the rest of the service. The query→mutate→flush ordering matches `storeExternalIdMapping`, so no `withAtomicFlush` is required.
- The `SyncExternalIdMapping` entity already has a `deleted_at` column, so no migration is needed.

## Tests
- Extended `data_sync/lib/__tests__/id-mapping.test.ts` (now 7 passing):
  - single delete soft-deletes a found row → `true`, with the scoped/`deletedAt: null` filter asserted
  - single delete returns `false` and does not flush when no row exists
  - bulk delete soft-deletes every match, dedups ids (`{ $in }`), and returns the count
  - bulk delete returns `0` without querying or flushing for an empty id list
  - bulk delete returns `0` and does not flush when nothing matches
- Verified: `yarn workspace @open-mercato/core test data_sync` (10 suites / 37 tests pass), `turbo typecheck --filter=@open-mercato/core`, `yarn build:packages`, `yarn generate`, lint on changed files — all green.

## Backward Compatibility
Purely additive — two new methods on the service return object; no existing method signature, return shape, DI key (`externalIdMappingService`), event ID, or DB schema changed. `ExternalIdMappingService` (a `ReturnType` type) gains the methods automatically.