### PR TITLE
feat(sales): SalesOrderService.findByExternalReference() (#3518)

### DIFF
--- a/packages/core/src/modules/sales/di.ts
+++ b/packages/core/src/modules/sales/di.ts
@@ -7,6 +7,7 @@ import { registerOptimisticLockReaders } from '@open-mercato/shared/lib/crud/opt
 import { DefaultSalesCalculationService } from './services/salesCalculationService'
 import { DefaultTaxCalculationService } from './services/taxCalculationService'
 import { SalesDocumentNumberGenerator } from './services/salesDocumentNumberGenerator'
+import { DefaultSalesOrderService } from './services/salesOrderService'
 import {
   SalesOrder,
   SalesOrderLine,
@@ -82,6 +83,11 @@ export function register(container: AppContainer) {
       .proxy(),
     salesDocumentNumberGenerator: asFunction(({ em }: AppCradle) => {
       return new SalesDocumentNumberGenerator(em)
+    })
+      .singleton()
+      .proxy(),
+    salesOrderService: asFunction(({ em }: AppCradle) => {
+      return new DefaultSalesOrderService(em)
     })
       .singleton()
       .proxy(),

--- a/packages/core/src/modules/sales/services/__tests__/salesOrderService.test.ts
+++ b/packages/core/src/modules/sales/services/__tests__/salesOrderService.test.ts
@@ -1,0 +1,62 @@
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { DefaultSalesOrderService } from '../salesOrderService'
+import { SalesOrder } from '../../data/entities'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+}))
+
+const findOneWithDecryptionMock = findOneWithDecryption as jest.MockedFunction<
+  typeof findOneWithDecryption
+>
+
+describe('DefaultSalesOrderService.findByExternalReference', () => {
+  const scope = { organizationId: 'org-1', tenantId: 'tenant-1' }
+
+  beforeEach(() => {
+    findOneWithDecryptionMock.mockReset()
+  })
+
+  it('looks up a non-deleted order by external reference within the tenant scope, decrypting fields', async () => {
+    const order = { id: 'order-1', externalReference: 'MAGENTO-100000123' } as SalesOrder
+    findOneWithDecryptionMock.mockResolvedValue(order)
+    const em = {} as any
+    const service = new DefaultSalesOrderService(em)
+
+    const result = await service.findByExternalReference('MAGENTO-100000123', scope)
+
+    expect(result).toBe(order)
+    expect(findOneWithDecryptionMock).toHaveBeenCalledTimes(1)
+    expect(findOneWithDecryptionMock).toHaveBeenCalledWith(
+      em,
+      SalesOrder,
+      {
+        externalReference: 'MAGENTO-100000123',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        deletedAt: null,
+      },
+      undefined,
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+  })
+
+  it('returns null when no matching order exists', async () => {
+    findOneWithDecryptionMock.mockResolvedValue(null)
+    const service = new DefaultSalesOrderService({} as any)
+
+    const result = await service.findByExternalReference('MAGENTO-404', scope)
+
+    expect(result).toBeNull()
+    expect(findOneWithDecryptionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('short-circuits to null without querying for a blank reference', async () => {
+    const service = new DefaultSalesOrderService({} as any)
+
+    const result = await service.findByExternalReference('', scope)
+
+    expect(result).toBeNull()
+    expect(findOneWithDecryptionMock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/sales/services/salesOrderService.ts
+++ b/packages/core/src/modules/sales/services/salesOrderService.ts
@@ -1,0 +1,38 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { SalesOrder } from '../data/entities'
+
+export type SalesOrderLookupScope = {
+  organizationId: string
+  tenantId: string
+}
+
+export interface SalesOrderService {
+  findByExternalReference(
+    externalReference: string,
+    scope: SalesOrderLookupScope,
+  ): Promise<SalesOrder | null>
+}
+
+export class DefaultSalesOrderService implements SalesOrderService {
+  constructor(private readonly em: EntityManager) {}
+
+  async findByExternalReference(
+    externalReference: string,
+    scope: SalesOrderLookupScope,
+  ): Promise<SalesOrder | null> {
+    if (!externalReference) return null
+    return findOneWithDecryption(
+      this.em,
+      SalesOrder,
+      {
+        externalReference,
+        organizationId: scope.organizationId,
+        tenantId: scope.tenantId,
+        deletedAt: null,
+      },
+      undefined,
+      { tenantId: scope.tenantId, organizationId: scope.organizationId },
+    )
+  }
+}


### PR DESCRIPTION
Fixes #3518

## Problem
The Magento 2 integration spec (#606 / #2603) needs an idempotent
order-create pre-check that detects whether a `SalesOrder` with a given
Magento reference already exists, before attempting a duplicate insert.
`SalesOrder` carries an `externalReference` column but the sales module
exposed no service seam to look an order up by it. Without this seam the
integration package would have to call `em.findOne(SalesOrder, …)`
cross-module, breaking module isolation.

## Root Cause
Missing capability — no service method existed for external-reference
lookups on sales orders.

## What Changed
- Added `packages/core/src/modules/sales/services/salesOrderService.ts`
  exporting the `SalesOrderService` interface and `DefaultSalesOrderService`:
  - `findByExternalReference(externalReference, { organizationId, tenantId })`
    returns `Promise<SalesOrder | null>`.
  - Uses `findOneWithDecryption` (passing the tenant/org decryption scope)
    so field-level encryption on `SalesOrder` is respected on the returned
    record.
  - Filters by `organizationId`, `tenantId`, and `deletedAt: null` (tenant
    isolation + soft-delete safety).
  - Short-circuits to `null` for a blank reference so an empty Magento
    reference can never match an unrelated order.
- Registered the service in the sales DI container under the
  `salesOrderService` key (`asFunction(...).singleton().proxy()`),
  mirroring `taxCalculationService` / `salesDocumentNumberGenerator`, so
  integration packages resolve it via DI without importing sales internals.

## Tests
- `services/__tests__/salesOrderService.test.ts` (new):
  - asserts the lookup queries by `externalReference` + org/tenant +
    `deletedAt: null` through `findOneWithDecryption` with the correct
    decryption scope;
  - returns `null` when no order matches;
  - short-circuits to `null` without querying for a blank reference.
- Validation run: `yarn build:packages`, `yarn generate`,
  `yarn build:packages`, `yarn typecheck` (all packages green),
  `yarn workspace @open-mercato/core test` for `modules/sales` +
  `module-decoupling` (50 suites / 350 tests pass).

## Backward Compatibility
- Additive only: a new service file and a new `salesOrderService` DI key.
  No existing types, signatures, import paths, event IDs, API routes, DB
  schema, or DI names were changed or removed.