### PR TITLE
feat(catalog): public seam to resolve a CatalogProduct by SKU or externalId (#3517)

### DIFF
--- a/packages/core/src/modules/catalog/lib/__tests__/productResolution.test.ts
+++ b/packages/core/src/modules/catalog/lib/__tests__/productResolution.test.ts
@@ -1,0 +1,136 @@
+import { resolveProductBySkuOrExternalId } from '../productResolution'
+
+function createMockEm() {
+  const em = {
+    findOne: jest.fn().mockResolvedValue(null),
+    find: jest.fn().mockResolvedValue([]),
+    fork: jest.fn(),
+  }
+  em.fork.mockReturnValue(em)
+  return em
+}
+
+const ORG_ID = '22222222-2222-4222-8222-222222222222'
+const TENANT_ID = '33333333-3333-4333-8333-333333333333'
+const PRODUCT_ID = '44444444-4444-4444-8444-444444444444'
+const SCOPE = { organizationId: ORG_ID, tenantId: TENANT_ID }
+
+describe('resolveProductBySkuOrExternalId', () => {
+  it('returns null without querying when no identifiers are provided', async () => {
+    const em = createMockEm()
+    const result = await resolveProductBySkuOrExternalId(em as never, {}, SCOPE)
+    expect(result).toBeNull()
+    expect(em.findOne).not.toHaveBeenCalled()
+  })
+
+  it('resolves by sku scoped to org/tenant and excludes soft-deleted rows', async () => {
+    const em = createMockEm()
+    const product = { id: PRODUCT_ID, sku: 'ABC-1', organizationId: ORG_ID, tenantId: TENANT_ID }
+    em.findOne.mockResolvedValueOnce(product)
+
+    const result = await resolveProductBySkuOrExternalId(em as never, { sku: 'ABC-1' }, SCOPE)
+
+    expect(result).toBe(product)
+    expect(em.findOne).toHaveBeenCalledTimes(1)
+    const filter = em.findOne.mock.calls[0][1] as Record<string, unknown>
+    expect(filter.sku).toBe('ABC-1')
+    expect(filter.organizationId).toBe(ORG_ID)
+    expect(filter.tenantId).toBe(TENANT_ID)
+    expect(filter.deletedAt).toBeNull()
+  })
+
+  it('returns null when the sku lookup finds nothing', async () => {
+    const em = createMockEm()
+    const result = await resolveProductBySkuOrExternalId(em as never, { sku: 'missing' }, SCOPE)
+    expect(result).toBeNull()
+    expect(em.findOne).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves by externalId (OM product id) when it is a valid UUID without a sku query', async () => {
+    const em = createMockEm()
+    const product = { id: PRODUCT_ID, organizationId: ORG_ID, tenantId: TENANT_ID }
+    em.findOne.mockResolvedValueOnce(product)
+
+    const result = await resolveProductBySkuOrExternalId(
+      em as never,
+      { externalId: PRODUCT_ID, sku: 'ABC-1' },
+      SCOPE,
+    )
+
+    expect(result).toBe(product)
+    expect(em.findOne).toHaveBeenCalledTimes(1)
+    const filter = em.findOne.mock.calls[0][1] as Record<string, unknown>
+    expect(filter.id).toBe(PRODUCT_ID)
+    expect(filter.organizationId).toBe(ORG_ID)
+    expect(filter.tenantId).toBe(TENANT_ID)
+    expect(filter.deletedAt).toBeNull()
+    expect(filter.sku).toBeUndefined()
+  })
+
+  it('falls back to the sku lookup when the externalId match is not found', async () => {
+    const em = createMockEm()
+    const product = { id: PRODUCT_ID, sku: 'ABC-1', organizationId: ORG_ID, tenantId: TENANT_ID }
+    em.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(product)
+
+    const result = await resolveProductBySkuOrExternalId(
+      em as never,
+      { externalId: PRODUCT_ID, sku: 'ABC-1' },
+      SCOPE,
+    )
+
+    expect(result).toBe(product)
+    expect(em.findOne).toHaveBeenCalledTimes(2)
+    expect((em.findOne.mock.calls[0][1] as Record<string, unknown>).id).toBe(PRODUCT_ID)
+    expect((em.findOne.mock.calls[1][1] as Record<string, unknown>).sku).toBe('ABC-1')
+  })
+
+  it('skips the id query for a non-UUID externalId and uses the sku fallback', async () => {
+    const em = createMockEm()
+    const product = { id: PRODUCT_ID, sku: 'MAGENTO-SKU', organizationId: ORG_ID, tenantId: TENANT_ID }
+    em.findOne.mockResolvedValueOnce(product)
+
+    const result = await resolveProductBySkuOrExternalId(
+      em as never,
+      { externalId: 'not-a-uuid', sku: 'MAGENTO-SKU' },
+      SCOPE,
+    )
+
+    expect(result).toBe(product)
+    expect(em.findOne).toHaveBeenCalledTimes(1)
+    const filter = em.findOne.mock.calls[0][1] as Record<string, unknown>
+    expect(filter.sku).toBe('MAGENTO-SKU')
+    expect(filter.id).toBeUndefined()
+  })
+
+  it('returns null without querying when only a non-UUID externalId is provided', async () => {
+    const em = createMockEm()
+    const result = await resolveProductBySkuOrExternalId(em as never, { externalId: 'not-a-uuid' }, SCOPE)
+    expect(result).toBeNull()
+    expect(em.findOne).not.toHaveBeenCalled()
+  })
+
+  it('trims surrounding whitespace from identifiers before querying', async () => {
+    const em = createMockEm()
+    em.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(null)
+
+    await resolveProductBySkuOrExternalId(
+      em as never,
+      { externalId: `  ${PRODUCT_ID}  `, sku: '  ABC-1  ' },
+      SCOPE,
+    )
+
+    expect((em.findOne.mock.calls[0][1] as Record<string, unknown>).id).toBe(PRODUCT_ID)
+    expect((em.findOne.mock.calls[1][1] as Record<string, unknown>).sku).toBe('ABC-1')
+  })
+
+  it('ignores empty-string identifiers', async () => {
+    const em = createMockEm()
+    const result = await resolveProductBySkuOrExternalId(
+      em as never,
+      { externalId: '   ', sku: '' },
+      SCOPE,
+    )
+    expect(result).toBeNull()
+    expect(em.findOne).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/catalog/lib/productResolution.ts
+++ b/packages/core/src/modules/catalog/lib/productResolution.ts
@@ -1,0 +1,75 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { CatalogProduct } from '../data/entities'
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export type ResolveCatalogProductLookup = {
+  sku?: string | null
+  externalId?: string | null
+}
+
+export type ResolveCatalogProductScope = {
+  organizationId: string
+  tenantId: string
+}
+
+function normalizeLookupValue(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+/**
+ * Public seam for cross-module callers (e.g. the `sync_magento` order mapper) to look up a
+ * {@link CatalogProduct} without reaching into the catalog ORM directly. Uses
+ * `findOneWithDecryption` so encrypted product fields are respected, and always scopes the query by
+ * `organizationId` + `tenantId` plus `deletedAt: null`.
+ *
+ * Catalog does not store a foreign external id on the product — those mappings live per-integration
+ * in `SyncExternalIdMapping` (data_sync) and resolve to the local OM product id. `externalId` here is
+ * therefore matched against the OM product `id` (the value an external→local mapping yields) and only
+ * when it is a valid UUID, so a stray non-UUID value falls through to the SKU lookup instead of
+ * raising a Postgres uuid-cast error. When both identifiers are supplied the `externalId` match takes
+ * precedence, mirroring the mapping-first/SKU-fallback order used by the existing sync importers.
+ */
+export async function resolveProductBySkuOrExternalId(
+  em: EntityManager,
+  lookup: ResolveCatalogProductLookup,
+  scope: ResolveCatalogProductScope,
+): Promise<CatalogProduct | null> {
+  const externalId = normalizeLookupValue(lookup.externalId)
+  const sku = normalizeLookupValue(lookup.sku)
+  if (!externalId && !sku) return null
+
+  if (externalId && UUID_REGEX.test(externalId)) {
+    const byExternalId = await findOneWithDecryption(
+      em,
+      CatalogProduct,
+      {
+        id: externalId,
+        organizationId: scope.organizationId,
+        tenantId: scope.tenantId,
+        deletedAt: null,
+      },
+      undefined,
+      scope,
+    )
+    if (byExternalId) return byExternalId
+  }
+
+  if (sku) {
+    return findOneWithDecryption(
+      em,
+      CatalogProduct,
+      {
+        sku,
+        organizationId: scope.organizationId,
+        tenantId: scope.tenantId,
+        deletedAt: null,
+      },
+      undefined,
+      scope,
+    )
+  }
+
+  return null
+}


### PR DESCRIPTION
Fixes #3517

## Problem
The catalog module exposed no public seam to look up a `CatalogProduct` by SKU. Cross-module callers — notably the upcoming `sync_magento` order mapper (spec `.ai/specs/2026-05-29-magento-2-integration.md`, blocking #606 / #2603) — would otherwise have to call `em.findOne(CatalogProduct, …)` directly, breaking module isolation and bypassing tenant-data encryption.

## Root Cause
Catalog only had internal, unexported product resolvers (`resolveProductUnitDefaults`, `resolveProductId`, `resolveProductUniqueConstraint`). There was no encryption-aware, tenant-scoped, public function for another module to resolve a product without an ORM dependency on catalog internals.

## What Changed
- Added `resolveProductBySkuOrExternalId(em, lookup, scope)` in `packages/core/src/modules/catalog/lib/productResolution.ts`, exported on the catalog public surface (deep import `@open-mercato/core/modules/catalog/lib/productResolution`, matching the existing `lib/pricing` seam).
- Resolves a `CatalogProduct` via `findOneWithDecryption` (never raw `em.findOne`), always scoped by `organizationId` + `tenantId` and `deletedAt: null`.
- `sku` matches `CatalogProduct.sku`. Catalog stores **no** foreign external id on the product — those mappings live per-integration in `SyncExternalIdMapping` (data_sync) and resolve to the local OM product id. `externalId` is therefore matched against the OM product `id` (the value an external→local mapping yields), and only when it is a valid UUID, so a stray non-UUID value falls through to the SKU lookup instead of raising a Postgres uuid-cast error. When both are supplied, `externalId` takes precedence — mirroring the mapping-first / SKU-fallback order the existing sync importers use.
- Catalog is the upstream module here (data_sync/`sync_*` import catalog, not vice versa), so the seam intentionally does **not** resolve data_sync's `externalIdMappingService`; the consumer keeps doing the external→local id mapping and passes the resolved local id in.

## Tests
- New unit suite `packages/core/src/modules/catalog/lib/__tests__/productResolution.test.ts` (9 cases): resolves by SKU (scoped, soft-delete-aware); resolves by externalId/UUID without a SKU query; externalId precedence + SKU fallback when the id match misses; non-UUID externalId is skipped (no DB error) and falls back to SKU; returns null with no query when no identifiers / only a non-UUID / empty-string identifiers are given; trims whitespace before querying.
- Verified no raw `em.find` / `em.findOne` in the new production file.
- `tsc --noEmit` over `@open-mercato/core` reports zero errors attributable to the new files.

## Backward Compatibility
- Purely additive: one new public function on a new module file. No existing types, signatures, import paths, event IDs, DI names, ACL features, API routes, or DB schema changed. No migration.
