### PR TITLE
fix(messages): redirect to inbox after marking unread from detail (#3576)

### DIFF
--- a/.ai/qa/scenarios/TC-MSG-002-inbox-open-mark-read-and-mark-unread.md
+++ b/.ai/qa/scenarios/TC-MSG-002-inbox-open-mark-read-and-mark-unread.md
@@ -24,13 +24,14 @@ Validates recipient inbox behavior when opening an unread message and toggling i
 |------|--------|-----------------|
 | 1 | Open `/backend/messages` with `Inbox` selected | Unread message appears in list |
 | 2 | Open the unread message from the table | Message detail page loads |
-| 3 | Verify actions section header controls | `Mark unread` button is visible for currently read detail |
-| 4 | Click `Mark unread` | Button changes to `Mark read` and state updates without full page reload |
-| 5 | Click `Back to messages`, filter by `Status = Unread` | Same message appears in filtered results |
+| 3 | Verify actions section header controls | `Mark unread` action is visible for currently read detail |
+| 4 | Click `Mark unread` | App returns to the inbox list automatically (Gmail-style) so auto-mark-read cannot re-mark the message |
+| 5 | Filter the inbox by `Status = Unread` | The same message appears in filtered results and is still unread |
 
 ## Expected Results
 - Opening detail changes recipient state to read
-- Manual toggle to unread works from detail page
+- Marking unread from the detail page redirects back to the inbox (#3576)
+- The message stays unread after returning to the inbox — the page-level auto-mark-read does not silently undo the action
 - List filters reflect updated message state
 
 ## Edge Cases / Error Scenarios

--- a/packages/core/src/modules/messages/__integration__/TC-MSG-002.spec.ts
+++ b/packages/core/src/modules/messages/__integration__/TC-MSG-002.spec.ts
@@ -1,15 +1,21 @@
 import { expect, test } from '@playwright/test';
 import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { apiRequest } from '@open-mercato/core/modules/core/__integration__/helpers/api';
 import { composeInternalMessage, deleteMessageIfExists, messageRowBySubject, searchMessages } from './helpers';
 
 /**
  * TC-MSG-002: Inbox Open Mark Read And Mark Unread
  * Source: .ai/qa/scenarios/TC-MSG-002-inbox-open-mark-read-and-mark-unread.md
+ *
+ * Regression for #3576: "Mark unread" triggered from the message detail page must
+ * navigate back to the inbox (Gmail-style) so the page-level auto-mark-read cannot
+ * silently re-mark the message as read while the user stays on the detail view.
  */
 test.describe('TC-MSG-002: Inbox Open Mark Read And Mark Unread', () => {
-  test('should mark unread message as read on open and allow marking unread again', async ({ page, request }) => {
+  test('should mark unread message as read on open and stay unread after marking unread again', async ({ page, request }) => {
     let messageId: string | null = null;
     let adminToken: string | null = null;
+    let recipientToken: string | null = null;
 
     try {
       const fixture = await composeInternalMessage(request, {
@@ -17,6 +23,7 @@ test.describe('TC-MSG-002: Inbox Open Mark Read And Mark Unread', () => {
       });
       messageId = fixture.messageId;
       adminToken = fixture.senderToken;
+      recipientToken = fixture.recipientToken;
 
       await login(page, 'employee');
       await page.goto('/backend/messages');
@@ -36,7 +43,21 @@ test.describe('TC-MSG-002: Inbox Open Mark Read And Mark Unread', () => {
       }).first();
       await expect(markUnreadItem).toBeVisible();
       await markUnreadItem.click();
-      await expect(page).toHaveURL(new RegExp(`/backend/messages/${messageId}$`, 'i'));
+
+      // #3576: after marking unread the app returns to the inbox list rather than
+      // lingering on the detail page (where auto-mark-read would undo the action).
+      await expect(page).toHaveURL(/\/backend\/messages\/?$/i);
+
+      // The message must stay unread for the recipient after returning to the inbox.
+      const detailResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/messages/${messageId}?skipMarkRead=1`,
+        { token: recipientToken },
+      );
+      expect(detailResponse.ok()).toBeTruthy();
+      const detailBody = (await detailResponse.json()) as { isRead?: boolean };
+      expect(detailBody.isRead).toBe(false);
     } finally {
       await deleteMessageIfExists(request, adminToken, messageId);
     }

--- a/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetails.test.tsx
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetails.test.tsx
@@ -42,6 +42,7 @@ jest.mock('../useMessageDetailsQueries', () => ({
     attachmentsQuery: { isLoading: false },
     attachments: [],
     refreshDetailWithoutAutoMarkRead: jest.fn(),
+    suppressAutoMarkRead: jest.fn(),
     listItemComponentKey: null,
     contentComponentKey: null,
     actionsComponentKey: null,

--- a/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx
@@ -43,6 +43,7 @@ function setup(detailOverrides: Partial<MessageDetail> = {}) {
   const refreshDetailWithoutAutoMarkRead = jest.fn().mockResolvedValue(null)
   const onDeleted = jest.fn()
   const onMarkedUnread = jest.fn()
+  const suppressAutoMarkRead = jest.fn()
   const detailQuery = { refetch } as unknown as UseQueryResult<MessageDetail | null, Error>
   const detail = {
     id: 'message-1',
@@ -61,9 +62,10 @@ function setup(detailOverrides: Partial<MessageDetail> = {}) {
     onDeleted,
     onMarkedUnread,
     refreshDetailWithoutAutoMarkRead,
+    suppressAutoMarkRead,
   }))
 
-  return { ...view, refetch, refreshDetailWithoutAutoMarkRead, onDeleted, onMarkedUnread }
+  return { ...view, refetch, refreshDetailWithoutAutoMarkRead, onDeleted, onMarkedUnread, suppressAutoMarkRead }
 }
 
 describe('useMessageDetailsActions guarded writes (#3258)', () => {
@@ -211,7 +213,7 @@ describe('useMessageDetailsActions mark-unread redirect (#3576)', () => {
   })
 
   it('navigates back to the inbox after marking a read message unread', async () => {
-    const { result, onMarkedUnread, refreshDetailWithoutAutoMarkRead, refetch } = setup({ isRead: true })
+    const { result, onMarkedUnread, refreshDetailWithoutAutoMarkRead, refetch, suppressAutoMarkRead } = setup({ isRead: true })
 
     await act(async () => {
       await result.current.toggleRead()
@@ -221,10 +223,12 @@ describe('useMessageDetailsActions mark-unread redirect (#3576)', () => {
     expect(refreshDetailWithoutAutoMarkRead).toHaveBeenCalledTimes(1)
     expect(refetch).not.toHaveBeenCalled()
     expect(onMarkedUnread).toHaveBeenCalledTimes(1)
+    // Suppress auto-mark-read so a late SSE-driven detail refetch cannot silently re-mark it read.
+    expect(suppressAutoMarkRead).toHaveBeenCalledTimes(1)
   })
 
   it('does not navigate when marking an unread message read', async () => {
-    const { result, onMarkedUnread, refetch } = setup({ isRead: false })
+    const { result, onMarkedUnread, refetch, suppressAutoMarkRead } = setup({ isRead: false })
 
     await act(async () => {
       await result.current.toggleRead()
@@ -233,10 +237,11 @@ describe('useMessageDetailsActions mark-unread redirect (#3576)', () => {
     expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1/read', { method: 'PUT' })
     expect(refetch).toHaveBeenCalledTimes(1)
     expect(onMarkedUnread).not.toHaveBeenCalled()
+    expect(suppressAutoMarkRead).not.toHaveBeenCalled()
   })
 
   it('navigates back to the inbox after marking a conversation unread', async () => {
-    const { result, onMarkedUnread, refreshDetailWithoutAutoMarkRead, refetch } = setup()
+    const { result, onMarkedUnread, refreshDetailWithoutAutoMarkRead, refetch, suppressAutoMarkRead } = setup()
 
     await act(async () => {
       await result.current.markConversationUnread()
@@ -248,6 +253,8 @@ describe('useMessageDetailsActions mark-unread redirect (#3576)', () => {
     // Navigation supersedes the in-place refresh, so the detail is never re-fetched.
     expect(refreshDetailWithoutAutoMarkRead).not.toHaveBeenCalled()
     expect(refetch).not.toHaveBeenCalled()
+    // Suppress auto-mark-read so a late SSE-driven detail refetch cannot silently re-mark it read.
+    expect(suppressAutoMarkRead).toHaveBeenCalledTimes(1)
   })
 
   it('does not navigate when the mark-unread request fails', async () => {

--- a/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx
@@ -42,6 +42,7 @@ function setup(detailOverrides: Partial<MessageDetail> = {}) {
   const refetch = jest.fn().mockResolvedValue(null)
   const refreshDetailWithoutAutoMarkRead = jest.fn().mockResolvedValue(null)
   const onDeleted = jest.fn()
+  const onMarkedUnread = jest.fn()
   const detailQuery = { refetch } as unknown as UseQueryResult<MessageDetail | null, Error>
   const detail = {
     id: 'message-1',
@@ -58,10 +59,11 @@ function setup(detailOverrides: Partial<MessageDetail> = {}) {
     attachments: [],
     isArchived: false,
     onDeleted,
+    onMarkedUnread,
     refreshDetailWithoutAutoMarkRead,
   }))
 
-  return { ...view, refetch, refreshDetailWithoutAutoMarkRead, onDeleted }
+  return { ...view, refetch, refreshDetailWithoutAutoMarkRead, onDeleted, onMarkedUnread }
 }
 
 describe('useMessageDetailsActions guarded writes (#3258)', () => {
@@ -193,6 +195,76 @@ describe('useMessageDetailsActions guarded writes (#3258)', () => {
     // surfacing), and the failure is reported via flash rather than navigation.
     expect(mockRunMutation).toHaveBeenCalledTimes(1)
     expect(onDeleted).not.toHaveBeenCalled()
+    expect(mockFlash).toHaveBeenCalledWith(expect.any(String), 'error')
+  })
+})
+
+describe('useMessageDetailsActions mark-unread redirect (#3576)', () => {
+  beforeEach(() => {
+    mockApiCall.mockReset()
+    mockFlash.mockReset()
+    mockRunMutation.mockReset()
+    mockRetryLastMutation.mockReset()
+    mockUseGuardedMutation.mockClear()
+    mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    mockApiCall.mockResolvedValue(okResult({ ok: true }))
+  })
+
+  it('navigates back to the inbox after marking a read message unread', async () => {
+    const { result, onMarkedUnread, refreshDetailWithoutAutoMarkRead, refetch } = setup({ isRead: true })
+
+    await act(async () => {
+      await result.current.toggleRead()
+    })
+
+    expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1/read', { method: 'DELETE' })
+    expect(refreshDetailWithoutAutoMarkRead).toHaveBeenCalledTimes(1)
+    expect(refetch).not.toHaveBeenCalled()
+    expect(onMarkedUnread).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not navigate when marking an unread message read', async () => {
+    const { result, onMarkedUnread, refetch } = setup({ isRead: false })
+
+    await act(async () => {
+      await result.current.toggleRead()
+    })
+
+    expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1/read', { method: 'PUT' })
+    expect(refetch).toHaveBeenCalledTimes(1)
+    expect(onMarkedUnread).not.toHaveBeenCalled()
+  })
+
+  it('navigates back to the inbox after marking a conversation unread', async () => {
+    const { result, onMarkedUnread, refreshDetailWithoutAutoMarkRead, refetch } = setup()
+
+    await act(async () => {
+      await result.current.markConversationUnread()
+    })
+
+    expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1/conversation/read', { method: 'DELETE' })
+    expect(mockFlash).toHaveBeenCalledWith('Conversation marked unread.', 'success')
+    expect(onMarkedUnread).toHaveBeenCalledTimes(1)
+    // Navigation supersedes the in-place refresh, so the detail is never re-fetched.
+    expect(refreshDetailWithoutAutoMarkRead).not.toHaveBeenCalled()
+    expect(refetch).not.toHaveBeenCalled()
+  })
+
+  it('does not navigate when the mark-unread request fails', async () => {
+    mockApiCall.mockResolvedValue({
+      ok: false,
+      status: 500,
+      result: { error: 'boom' },
+      response: {} as Response,
+      cacheStatus: null,
+    })
+    const { result, onMarkedUnread } = setup({ isRead: true })
+
+    await act(async () => {
+      await result.current.toggleRead()
+    })
+
+    expect(onMarkedUnread).not.toHaveBeenCalled()
     expect(mockFlash).toHaveBeenCalledWith(expect.any(String), 'error')
   })
 })

--- a/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsQueries.test.tsx
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsQueries.test.tsx
@@ -145,6 +145,32 @@ describe('useMessageDetailsQueries.refreshDetailWithoutAutoMarkRead', () => {
   })
 })
 
+describe('useMessageDetailsQueries.suppressAutoMarkRead (#3576)', () => {
+  it('auto-marks read on the initial detail fetch', async () => {
+    apiCallMock.mockResolvedValue({ ok: true, status: 200, result: { id: 'msg-1' } })
+
+    const queryClient = { setQueryData: jest.fn(), getQueryData: jest.fn() }
+    setupHook(queryClient)
+    expect(lastDetailQueryFn).toBeTruthy()
+
+    await lastDetailQueryFn!()
+    expect(apiCallMock).toHaveBeenCalledWith('/api/messages/msg-1')
+  })
+
+  it('skips auto-mark-read on subsequent refetches once suppressed', async () => {
+    apiCallMock.mockResolvedValue({ ok: true, status: 200, result: { id: 'msg-1' } })
+
+    const queryClient = { setQueryData: jest.fn(), getQueryData: jest.fn() }
+    const { result } = setupHook(queryClient)
+    expect(lastDetailQueryFn).toBeTruthy()
+
+    result.current.suppressAutoMarkRead()
+    await lastDetailQueryFn!()
+
+    expect(apiCallMock).toHaveBeenCalledWith('/api/messages/msg-1?skipMarkRead=1')
+  })
+})
+
 describe('useMessageDetailsQueries derived state', () => {
   it('surfaces a deleted-message error when detail data is null and the query succeeded', () => {
     apiCallMock.mockResolvedValue({ ok: false, status: 404, result: null })

--- a/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetails.ts
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetails.ts
@@ -63,6 +63,7 @@ export function useMessageDetails(id: string) {
     onDeleted: () => router.push('/backend/messages'),
     onMarkedUnread: () => router.push('/backend/messages'),
     refreshDetailWithoutAutoMarkRead: queryState.refreshDetailWithoutAutoMarkRead,
+    suppressAutoMarkRead: queryState.suppressAutoMarkRead,
   })
 
   const conversationState = useMessageDetailsConversation({

--- a/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetails.ts
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetails.ts
@@ -61,6 +61,7 @@ export function useMessageDetails(id: string) {
     attachments: queryState.attachments,
     isArchived,
     onDeleted: () => router.push('/backend/messages'),
+    onMarkedUnread: () => router.push('/backend/messages'),
     refreshDetailWithoutAutoMarkRead: queryState.refreshDetailWithoutAutoMarkRead,
   })
 

--- a/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
@@ -18,6 +18,7 @@ import { isSafeNavigationHref, parseObjectActionId, toErrorMessage } from '../ut
 
 type RequestAndRefreshOptions = {
   skipDetailAutoMarkRead?: boolean
+  onSuccess?: () => void
 }
 
 type ConversationActionKind = 'archiveConversation' | 'deleteConversation' | 'markAllUnread'
@@ -37,6 +38,7 @@ type UseMessageDetailsActionsInput = {
   attachments: MessageAttachment[] | undefined
   isArchived: boolean
   onDeleted: () => void
+  onMarkedUnread: () => void
   refreshDetailWithoutAutoMarkRead: () => Promise<MessageDetail | null>
 }
 
@@ -48,6 +50,7 @@ export function useMessageDetailsActions({
   attachments,
   isArchived,
   onDeleted,
+  onMarkedUnread,
   refreshDetailWithoutAutoMarkRead,
 }: UseMessageDetailsActionsInput) {
   const [replyOpen, setReplyOpen] = React.useState(false)
@@ -88,6 +91,7 @@ export function useMessageDetailsActions({
         context: { resourceKind: 'message', messageId: id, action: 'state-change', retryLastMutation },
         mutationPayload: { messageId: id, action: 'state-change', url, method },
       })
+      options?.onSuccess?.()
     } catch (err) {
       flash(
         err instanceof Error
@@ -194,9 +198,9 @@ export function useMessageDetailsActions({
       url: `/api/messages/${encodeURIComponent(targetMessageId)}/conversation/read`,
       method: 'DELETE',
       successMessage: t('messages.flash.conversationMarkedUnread', 'Conversation marked unread.'),
-      skipDetailAutoMarkRead: true,
+      onSuccess: onMarkedUnread,
     })
-  }, [id, runConversationAction, t])
+  }, [id, onMarkedUnread, runConversationAction, t])
 
   const deleteConversation = React.useCallback(async (messageId?: string) => {
     const targetMessageId = messageId ?? id
@@ -365,9 +369,9 @@ export function useMessageDetailsActions({
     await requestAndRefresh(
       `/api/messages/${encodeURIComponent(id)}/read`,
       detail?.isRead ? 'DELETE' : 'PUT',
-      detail?.isRead ? { skipDetailAutoMarkRead: true } : undefined,
+      detail?.isRead ? { skipDetailAutoMarkRead: true, onSuccess: onMarkedUnread } : undefined,
     )
-  }, [detail?.isRead, id, requestAndRefresh])
+  }, [detail?.isRead, id, onMarkedUnread, requestAndRefresh])
 
   const toggleArchive = React.useCallback(async () => {
     await requestAndRefresh(

--- a/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
@@ -40,6 +40,7 @@ type UseMessageDetailsActionsInput = {
   onDeleted: () => void
   onMarkedUnread: () => void
   refreshDetailWithoutAutoMarkRead: () => Promise<MessageDetail | null>
+  suppressAutoMarkRead: () => void
 }
 
 export function useMessageDetailsActions({
@@ -52,6 +53,7 @@ export function useMessageDetailsActions({
   onDeleted,
   onMarkedUnread,
   refreshDetailWithoutAutoMarkRead,
+  suppressAutoMarkRead,
 }: UseMessageDetailsActionsInput) {
   const [replyOpen, setReplyOpen] = React.useState(false)
   const [forwardOpen, setForwardOpen] = React.useState(false)
@@ -193,6 +195,7 @@ export function useMessageDetailsActions({
   }, [id, runConversationAction, t])
 
   const markConversationUnread = React.useCallback(async (messageId?: string) => {
+    suppressAutoMarkRead()
     const targetMessageId = messageId ?? id
     await runConversationAction('markAllUnread', {
       url: `/api/messages/${encodeURIComponent(targetMessageId)}/conversation/read`,
@@ -200,7 +203,7 @@ export function useMessageDetailsActions({
       successMessage: t('messages.flash.conversationMarkedUnread', 'Conversation marked unread.'),
       onSuccess: onMarkedUnread,
     })
-  }, [id, onMarkedUnread, runConversationAction, t])
+  }, [id, onMarkedUnread, runConversationAction, suppressAutoMarkRead, t])
 
   const deleteConversation = React.useCallback(async (messageId?: string) => {
     const targetMessageId = messageId ?? id
@@ -366,12 +369,15 @@ export function useMessageDetailsActions({
   }, [detail?.actionData?.actions])
 
   const toggleRead = React.useCallback(async () => {
+    if (detail?.isRead) {
+      suppressAutoMarkRead()
+    }
     await requestAndRefresh(
       `/api/messages/${encodeURIComponent(id)}/read`,
       detail?.isRead ? 'DELETE' : 'PUT',
       detail?.isRead ? { skipDetailAutoMarkRead: true, onSuccess: onMarkedUnread } : undefined,
     )
-  }, [detail?.isRead, id, onMarkedUnread, requestAndRefresh])
+  }, [detail?.isRead, id, onMarkedUnread, requestAndRefresh, suppressAutoMarkRead])
 
   const toggleArchive = React.useCallback(async () => {
     await requestAndRefresh(

--- a/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsQueries.ts
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsQueries.ts
@@ -26,10 +26,19 @@ export function useMessageDetailsQueries({
     [id, scopeVersion],
   )
 
+  const suppressAutoMarkReadRef = React.useRef(false)
+
+  React.useEffect(() => {
+    suppressAutoMarkReadRef.current = false
+  }, [id])
+
   const detailQuery = useQuery<MessageDetail | null>({
     queryKey: detailQueryKey,
     queryFn: async () => {
-      const call = await apiCall<MessageDetail>(`/api/messages/${encodeURIComponent(id)}`)
+      const detailUrl = suppressAutoMarkReadRef.current
+        ? `/api/messages/${encodeURIComponent(id)}?skipMarkRead=1`
+        : `/api/messages/${encodeURIComponent(id)}`
+      const call = await apiCall<MessageDetail>(detailUrl)
       if (call.status === 404) {
         return null
       }
@@ -97,6 +106,10 @@ export function useMessageDetailsQueries({
     return call.result
   }, [detailQueryKey, id, queryClient, t])
 
+  const suppressAutoMarkRead = React.useCallback(() => {
+    suppressAutoMarkReadRef.current = true
+  }, [])
+
   const listItemComponentKey = detail?.typeDefinition.ui?.listItemComponent ?? null
   const contentComponentKey = detail?.typeDefinition.ui?.contentComponent ?? null
   const actionsComponentKey = detail?.typeDefinition.ui?.actionsComponent ?? null
@@ -111,6 +124,7 @@ export function useMessageDetailsQueries({
     attachmentsQuery,
     attachments,
     refreshDetailWithoutAutoMarkRead,
+    suppressAutoMarkRead,
     listItemComponentKey,
     contentComponentKey,
     actionsComponentKey,


### PR DESCRIPTION
Fixes #3576

## Problem
"Oznacz jako nieprzeczytane" / "Oznacz wszystko jako nieprzeczytane" (Mark as unread / Mark all unread) triggered from the message **detail page** (`/backend/messages/{id}`) looked successful (flash/toast shown) but was silently undone. If the user stayed on the detail page, the page-level auto-mark-read re-marked the message as read, so it appeared **read** again when they returned to the inbox. The action was effectively a no-op for anyone who didn't immediately navigate away.

## Root Cause
The message detail view auto-marks the message read on open via `GET /api/messages/{id}` (without `skipMarkRead`). After "Mark as unread" the detail stays mounted, so any refetch of the detail query (e.g. the SSE-driven `messages.message.*` invalidation, or a re-render) re-runs that auto-mark-read GET and overwrites the unread state. `skipDetailAutoMarkRead` only protects the explicit post-action refresh, not the page-level auto-mark-read that keeps firing while the user remains on the page.

## What Changed
- After a successful **Mark as unread** the app now navigates back to the inbox (`/backend/messages`), matching standard mail-client behaviour (e.g. Gmail).
  - Single message: `toggleRead` redirects only when going read → unread (marking *read* still stays in place).
  - Conversation: `markConversationUnread` redirects after success.
- Implemented via a small internal `onMarkedUnread` callback on `useMessageDetailsActions` (wired to `router.push('/backend/messages')` in `useMessageDetails`) and an `onSuccess` hook on the existing `requestAndRefresh` path. Failures still surface via flash and do **not** navigate.

## Follow-up fix — closing the SSE re-mark-read race (commit `bb9a2277d`)
The redirect alone did not close the race in CI (`TC-MSG-002` failed: the message came back **read**). Marking unread emits `messages.message.marked_unread` (`clientBroadcast`); its SSE delivery invalidates the **still-mounted** detail query, which refetches `GET /api/messages/{id}` **without** `skipMarkRead` and re-marks the message read *before* the redirect unmounts the page. Navigation timing cannot reliably win that race.

Fix: once an explicit mark-unread (single message or conversation) is initiated, **suppress auto-mark-read on the detail query** via a ref read at fetch time, so any subsequent refetch (SSE-driven or in-flight) uses `?skipMarkRead=1` and cannot silently re-mark read. The ref resets on message-id change. The Gmail-style redirect is kept as UX; the suppression makes it correct regardless of navigation/SSE timing.
- `useMessageDetailsQueries.ts` — `suppressAutoMarkReadRef` + `skipMarkRead=1` suffix at fetch time + exposed `suppressAutoMarkRead()`.
- `useMessageDetailsActions.ts` — call `suppressAutoMarkRead()` at the start of `markConversationUnread` and the read→unread branch of `toggleRead`.
- `useMessageDetails.ts` — wire `suppressAutoMarkRead` from the queries hook into the actions hook.

## Tests
- Unit tests in `useMessageDetailsActions.test.tsx`: navigates on mark-unread (single + conversation), does **not** navigate when marking read, does **not** navigate on request failure; asserts `suppressAutoMarkRead` fires on the unread paths and not on mark-read.
- Unit tests in `useMessageDetailsQueries.test.tsx`: detail fetch auto-marks read by default, and uses `?skipMarkRead=1` once suppressed.
- Updated `TC-MSG-002` integration spec to assert the redirect to the inbox and that the message stays unread for the recipient (via `GET ...?skipMarkRead=1`); updated the matching QA scenario doc.
- Full gate green: `yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn i18n:check-sync`, `eslint`, messages module unit tests (257 passing), and `yarn build:app`.

## Backward Compatibility
No contract surface changes. The new `onMarkedUnread` / `suppressAutoMarkRead` params are on internal-only hooks (`useMessageDetailsActions` / `useMessageDetailsQueries`, not exported from the package); the sole consumer is updated. No API routes, event IDs, DI names, or ACL features changed.

## Security impact
None — change is limited to client-side navigation and a client-side fetch flag after an existing, already-guarded mutation. No auth, authorization, secrets, encryption, logging, or audit-trail behaviour is affected.
