### PR TITLE
refactor: audit encrypted-sort safety for sync-akeneo discovery and messages GET (#3386 P3)

### DIFF
--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -507,6 +507,13 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
     const personScope = { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null }
     const shouldLoadCanonicalInteractions = includeInteractions || includeActivities || includeTodos
 
+    // Audited for #3386 rollout (P3): every findWithDecryption call in this
+    // block and in the activities/todoLinks fetches below sorts only on
+    // non-encrypted system columns (isPrimary, createdAt, occurredAt,
+    // scheduledAt). Each fetch is bounded by entity scope (one person) plus
+    // an explicit limit, so neither the paginated-list hazard (#3278) nor the
+    // two-phase encrypted-sort migration apply here.
+    //
     // These reads only depend on the resolved person + scope + email visibility
     // filter, so dispatch them together to avoid a server-side request waterfall
     // before the detail surface can render (issue #3203).

--- a/packages/core/src/modules/messages/api/__tests__/list.test.ts
+++ b/packages/core/src/modules/messages/api/__tests__/list.test.ts
@@ -1,0 +1,183 @@
+/** @jest-environment node */
+
+// P3 audit coverage for #3386: proves that the messages GET handler uses the
+// correct two-phase shape — Kysely SQL ORDER BY m.sent_at + LIMIT/OFFSET
+// (non-encrypted field) produces a bounded page of IDs, then findWithDecryption
+// is called only for those IDs, never for the full result set.
+
+import {
+  Kysely,
+  PostgresAdapter,
+  PostgresQueryCompiler,
+  PostgresIntrospector,
+  DummyDriver,
+  type CompiledQuery,
+} from 'kysely'
+import { Message, MessageObject } from '../../data/entities'
+import { User } from '../../../auth/data/entities'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+
+const resolveMessageContextMock = jest.fn()
+
+jest.mock('@open-mercato/core/modules/messages/lib/routeHelpers', () => ({
+  resolveMessageContext: (...args: unknown[]) => resolveMessageContextMock(...args),
+  canUseMessageEmailFeature: jest.fn(async () => true),
+}))
+
+jest.mock('@open-mercato/core/modules/messages/lib/searchLookup', () => ({
+  findMessageIdsBySearchTokens: jest.fn(async () => []),
+}))
+
+jest.mock('@open-mercato/core/modules/messages/lib/message-types-registry', () => ({
+  getMessageType: jest.fn(() => null),
+}))
+
+const findWithDecryptionMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => findWithDecryptionMock(...args),
+}))
+
+const recordedQueries: CompiledQuery[] = []
+
+function isScopeQuery(q: CompiledQuery): boolean {
+  const s = q.sql.toLowerCase()
+  // The scope query selects message rows and is the only one with ORDER BY
+  return s.includes('messages') && s.includes('order by')
+}
+
+function createRecordingKysely(): Kysely<any> {
+  const db = new Kysely<any>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+      createIntrospector: (instance: Kysely<any>) => new PostgresIntrospector(instance),
+    },
+  })
+
+  ;(db.getExecutor() as any).executeQuery = async (q: CompiledQuery) => {
+    recordedQueries.push(q)
+
+    const s = q.sql.toLowerCase()
+
+    if (s.includes('count(*)')) {
+      return { rows: [{ count: '3' }] }
+    }
+
+    if (isScopeQuery(q)) {
+      return {
+        rows: [
+          { id: 'msg-a', sender_user_id: userId, is_draft: false, recipient_status: null, read_at: null },
+          { id: 'msg-b', sender_user_id: userId, is_draft: false, recipient_status: null, read_at: null },
+        ],
+      }
+    }
+
+    return { rows: [] }
+  }
+
+  return db
+}
+
+function makeMessage(id: string): Partial<Message> {
+  return {
+    id,
+    type: 'default',
+    visibility: null,
+    sourceEntityType: null,
+    sourceEntityId: null,
+    externalEmail: null,
+    externalName: null,
+    subject: `Subject ${id}`,
+    body: `Body ${id}`,
+    senderUserId: userId,
+    priority: null,
+    actionData: null,
+    actionTaken: null,
+    sentAt: new Date('2026-01-01T00:00:00Z'),
+    threadId: null,
+  } as unknown as Partial<Message>
+}
+
+import { GET } from '../route'
+
+function buildMockEm() {
+  return {
+    getKysely: () => createRecordingKysely(),
+    find: jest.fn(async (entity: unknown) => {
+      if (entity === MessageObject) return []
+      return []
+    }),
+  }
+}
+
+beforeEach(() => {
+  recordedQueries.length = 0
+  findWithDecryptionMock.mockReset()
+
+  findWithDecryptionMock.mockImplementation(
+    async (_em: unknown, entity: unknown, where: Record<string, unknown>) => {
+      if (entity === Message) {
+        const ids = (where as any)?.id?.$in as string[] | undefined
+        return (ids ?? []).map(makeMessage)
+      }
+      if (entity === User) return []
+      return []
+    },
+  )
+
+  resolveMessageContextMock.mockResolvedValue({
+    ctx: {
+      container: { resolve: (name: string) => (name === 'em' ? buildMockEm() : null) },
+    },
+    scope: { tenantId, organizationId: orgId, userId },
+  })
+})
+
+describe('messages GET — encrypted-sort audit (#3386 P3)', () => {
+  it('sorts at SQL level on m.sent_at (non-encrypted column), not in-memory after decrypt', async () => {
+    const res = await GET(new Request(`http://localhost/api/messages?pageSize=2`))
+    expect(res.status).toBe(200)
+
+    const scopeQuery = recordedQueries.find(isScopeQuery)
+    expect(scopeQuery).toBeDefined()
+    expect(scopeQuery!.sql.toLowerCase()).toMatch(/order by\s+"m"\."sent_at"\s+desc/)
+  })
+
+  it('passes LIMIT and OFFSET so pagination is DB-side, not in-memory', async () => {
+    const res = await GET(new Request(`http://localhost/api/messages?page=2&pageSize=2`))
+    expect(res.status).toBe(200)
+
+    const scopeQuery = recordedQueries.find(isScopeQuery)
+    expect(scopeQuery).toBeDefined()
+    expect(scopeQuery!.sql.toLowerCase()).toMatch(/limit/)
+    expect(scopeQuery!.sql.toLowerCase()).toMatch(/offset/)
+  })
+
+  it('calls findWithDecryption for Message only with the bounded page IDs, never the full set', async () => {
+    const res = await GET(new Request(`http://localhost/api/messages?pageSize=2`))
+    expect(res.status).toBe(200)
+
+    const messageCalls = findWithDecryptionMock.mock.calls.filter(
+      ([, entity]) => entity === Message,
+    )
+    expect(messageCalls).toHaveLength(1)
+
+    const [, , where] = messageCalls[0] as [unknown, unknown, Record<string, unknown>]
+    const ids = (where as any)?.id?.$in as string[]
+    // Must be exactly the two IDs the SQL scope query returned — bounded to the page
+    expect(ids).toEqual(['msg-a', 'msg-b'])
+  })
+
+  it('returns the decrypted message fields, confirming the two phases connect end-to-end', async () => {
+    const res = await GET(new Request(`http://localhost/api/messages?pageSize=2`))
+    const body = await res.json() as { items: { id: string; subject: string }[] }
+    expect(body.items).toHaveLength(2)
+    expect(body.items[0]!.subject).toBe('Subject msg-a')
+    expect(body.items[1]!.subject).toBe('Subject msg-b')
+  })
+})

--- a/packages/core/src/modules/messages/api/route.ts
+++ b/packages/core/src/modules/messages/api/route.ts
@@ -189,6 +189,14 @@ export async function GET(req: Request) {
     return q
   }
 
+  // Audited for #3386 rollout (P3): sort is on m.sent_at (a plain timestamp —
+  // not in the messages:message encryption map whose encrypted fields are:
+  // subject, body, external_email, external_name, action_data, action_result).
+  // The handler already uses the correct two-phase shape: Kysely SQL
+  // ORDER BY + LIMIT/OFFSET produces a bounded page of IDs, then
+  // findWithDecryption is called only for those IDs — never for the full
+  // result set. The #3278 unbounded-decrypt hazard does not apply here.
+  // Covered by __tests__/list.test.ts.
   const countResult = await buildBaseQuery()
     .select(sql<number>`count(*)`.as('count'))
     .executeTakeFirst() as { count: string | number } | undefined

--- a/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/discovery-route.test.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/discovery-route.test.ts
@@ -1,0 +1,78 @@
+/** @jest-environment node */
+
+// P3 audit coverage for #3386: confirms that both findWithDecryption calls in
+// the discovery route sort on non-encrypted columns (SalesChannel.name,
+// CatalogPriceKind.title), so the #3278 two-phase encrypted-sort path is not
+// needed here.
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+
+type FindWithDecryptionArgs = [unknown, unknown, unknown, Record<string, unknown>, unknown]
+const findWithDecryptionMock = jest.fn<Promise<unknown[]>, FindWithDecryptionArgs>(async () => [])
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => findWithDecryptionMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: async () => ({ tenantId, orgId, sub: null }),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (token: string) => {
+      if (token === 'em') return {}
+      if (token === 'integrationCredentialsService') {
+        return {
+          resolve: async () => null,
+        }
+      }
+      return undefined
+    },
+  }),
+}))
+
+import { GET } from '../api/discovery/route'
+import { SalesChannel } from '@open-mercato/core/modules/sales/data/entities'
+import { CatalogPriceKind } from '@open-mercato/core/modules/catalog/data/entities'
+
+beforeEach(() => {
+  findWithDecryptionMock.mockClear()
+  findWithDecryptionMock.mockResolvedValue([])
+})
+
+describe('discovery route — encrypted-sort audit (#3386 P3)', () => {
+  it('fetches SalesChannel with orderBy name, which is not an encrypted field', async () => {
+    const res = await GET(new Request('http://localhost/api/data-sync/akeneo/discovery'))
+    expect(res.status).toBe(200)
+
+    const salesChannelCall = findWithDecryptionMock.mock.calls.find(
+      ([, entity]) => entity === SalesChannel,
+    )
+    expect(salesChannelCall).toBeDefined()
+    // arg[3] is the ORM find options (fields + orderBy); arg[2] is the where clause
+    expect(salesChannelCall![3]).toMatchObject({ orderBy: { name: 'asc' } })
+  })
+
+  it('fetches CatalogPriceKind with orderBy title, which is not an encrypted field', async () => {
+    const res = await GET(new Request('http://localhost/api/data-sync/akeneo/discovery'))
+    expect(res.status).toBe(200)
+
+    const priceKindCall = findWithDecryptionMock.mock.calls.find(
+      ([, entity]) => entity === CatalogPriceKind,
+    )
+    expect(priceKindCall).toBeDefined()
+    // arg[3] is the ORM find options (fields + orderBy); arg[2] is the where clause
+    expect(priceKindCall![3]).toMatchObject({ orderBy: { title: 'asc' } })
+  })
+
+  it('returns ok:false with empty discovery data when credentials are absent', async () => {
+    const res = await GET(new Request('http://localhost/api/data-sync/akeneo/discovery'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(false)
+    expect(body.locales).toEqual([])
+    expect(body.channels).toEqual([])
+  })
+})

--- a/packages/sync-akeneo/src/modules/sync_akeneo/api/discovery/route.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/api/discovery/route.ts
@@ -34,6 +34,12 @@ export async function GET(req: Request) {
   const container = await createRequestContainer()
   const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
   const em = container.resolve('em') as EntityManager
+  // Audited for #3386 rollout (P3): both orderBy fields are non-encrypted.
+  // SalesChannel.name is absent from the sales:sales_channel encryption map
+  // (only address/contact fields are encrypted). CatalogPriceKind has no
+  // encryption map at all. This is a discovery endpoint with no pagination,
+  // so the #3278 two-phase encrypted-sort does not apply. Covered by
+  // __tests__/discovery-route.test.ts.
   const [localChannels, priceKinds] = await Promise.all([
     findWithDecryption(em, SalesChannel, {
       organizationId: auth.orgId,


### PR DESCRIPTION
## Summary

Follow-up to #3386 (P1: labels, P2: activities). This PR covers the **P3 audit** of two remaining candidate endpoints identified in #3386.

### Endpoints audited

**`packages/sync-akeneo/src/modules/sync_akeneo/api/discovery/route.ts`**
- `SalesChannel` — sorted by `name` (asc). `name` is absent from the `sales:sales_channel` encryption map (only address/contact fields are encrypted). Safe.
- `CatalogPriceKind` — sorted by `title` (asc). The catalog module has no encryption map at all. Safe.
- Discovery endpoint — no pagination, so the #3278 two-phase encrypted-sort migration does not apply.

**`packages/core/src/modules/messages/api/route.ts`**
- Sorts via Kysely SQL on `m.sent_at` (not in the `messages:message` encryption map). Already uses proper two-phase: SQL order+paginate → page IDs → `findWithDecryption` bounded to page. Safe.

### Candidate list confirmation

No new custom list handlers with the `findWithDecryption` + in-memory-sort-after-decrypt pattern were found outside the shared engines (see commit 3).

## Changes per commit

1. `refactor(sync-akeneo)` — audit comment + unit tests for discovery route
2. `refactor(messages)` — audit comment + unit tests for messages GET route
3. `refactor` — candidate list grep result documented

## Test plan

- [ ] `cd packages/sync-akeneo && npx jest --testPathPatterns="discovery-route" --no-coverage`
- [ ] `cd packages/core && npx jest --testPathPatterns="messages/api/__tests__/list" --no-coverage`
- [ ] No behavior changes — audit + documentation only