### PR TITLE
fix(customers): defer optimistic-lock floor to authorized record-lock keep-mine (#3601)

### DIFF
--- a/packages/core/src/modules/customers/data/__tests__/optimisticLockGuard.test.ts
+++ b/packages/core/src/modules/customers/data/__tests__/optimisticLockGuard.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Regression coverage for issue #3601: the universal optimistic-lock floor
+ * (`customers.optimistic-lock`, registered with `targetEntity: '*'`) must defer
+ * to an authorized enterprise record-lock "Keep mine" override instead of
+ * rejecting it on the now-stale `updated_at`.
+ */
+import {
+  clearOptimisticLockReadersForTests,
+  registerOptimisticLockReaders,
+} from '@open-mercato/shared/lib/crud/optimistic-lock-store'
+import {
+  OPTIMISTIC_LOCK_CONFLICT_CODE,
+  OPTIMISTIC_LOCK_HEADER_NAME,
+} from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+const resolveMock = jest.fn(() => ({}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({ resolve: resolveMock })),
+}))
+
+import { guards, isAuthorizedRecordLockOverride } from '../guards'
+import type { MutationGuardInput } from '@open-mercato/shared/lib/crud/mutation-guard-registry'
+
+const RESOURCE_KIND = 'customers.deal'
+const CURRENT_UPDATED_AT = '2026-06-25T18:58:35.000Z'
+const STALE_UPDATED_AT = '2026-06-25T18:38:06.000Z'
+
+const optimisticLockGuard = guards.find((guard) => guard.id === 'customers.optimistic-lock')!
+
+function buildInput(headers: Record<string, string>): MutationGuardInput {
+  return {
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    userId: 'user-1',
+    resourceKind: RESOURCE_KIND,
+    resourceId: '11111111-1111-4111-8111-111111111111',
+    operation: 'update',
+    requestMethod: 'PUT',
+    requestHeaders: new Headers(headers),
+    mutationPayload: null,
+  }
+}
+
+describe('isAuthorizedRecordLockOverride', () => {
+  it('is true for keep-mine resolutions (case/whitespace tolerant)', () => {
+    expect(isAuthorizedRecordLockOverride(new Headers({ 'x-om-record-lock-resolution': 'accept_mine' }))).toBe(true)
+    expect(isAuthorizedRecordLockOverride(new Headers({ 'x-om-record-lock-resolution': 'merged' }))).toBe(true)
+    expect(isAuthorizedRecordLockOverride(new Headers({ 'x-om-record-lock-resolution': '  ACCEPT_MINE ' }))).toBe(true)
+  })
+
+  it('is false for accept-incoming, absent, or unknown resolutions', () => {
+    expect(isAuthorizedRecordLockOverride(new Headers({ 'x-om-record-lock-resolution': 'accept_incoming' }))).toBe(false)
+    expect(isAuthorizedRecordLockOverride(new Headers({ 'x-om-record-lock-resolution': 'normal' }))).toBe(false)
+    expect(isAuthorizedRecordLockOverride(new Headers({}))).toBe(false)
+  })
+})
+
+describe('customers.optimistic-lock guard — record-lock keep-mine deferral (#3601)', () => {
+  const previousEnv = process.env.OM_OPTIMISTIC_LOCK
+
+  beforeEach(() => {
+    clearOptimisticLockReadersForTests()
+    resolveMock.mockClear()
+    resolveMock.mockReturnValue({})
+    process.env.OM_OPTIMISTIC_LOCK = 'all'
+    registerOptimisticLockReaders({
+      [RESOURCE_KIND]: async () => CURRENT_UPDATED_AT,
+    })
+  })
+
+  afterAll(() => {
+    clearOptimisticLockReadersForTests()
+    if (previousEnv === undefined) delete process.env.OM_OPTIMISTIC_LOCK
+    else process.env.OM_OPTIMISTIC_LOCK = previousEnv
+  })
+
+  it('rejects a stale update with 409 when no resolution header is present (control)', async () => {
+    const result = await optimisticLockGuard.validate(
+      buildInput({ [OPTIMISTIC_LOCK_HEADER_NAME]: STALE_UPDATED_AT }),
+    )
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(409)
+    expect(result.body?.code).toBe(OPTIMISTIC_LOCK_CONFLICT_CODE)
+  })
+
+  it('defers (passes) when the request carries an authorized accept_mine override', async () => {
+    const result = await optimisticLockGuard.validate(
+      buildInput({
+        [OPTIMISTIC_LOCK_HEADER_NAME]: STALE_UPDATED_AT,
+        'x-om-record-lock-resolution': 'accept_mine',
+      }),
+    )
+    expect(result.ok).toBe(true)
+    // Deferral short-circuits before any DB read.
+    expect(resolveMock).not.toHaveBeenCalled()
+  })
+
+  it('defers (passes) for a merged override too', async () => {
+    const result = await optimisticLockGuard.validate(
+      buildInput({
+        [OPTIMISTIC_LOCK_HEADER_NAME]: STALE_UPDATED_AT,
+        'x-om-record-lock-resolution': 'merged',
+      }),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  it('still enforces the floor for accept_incoming (which reloads with a fresh timestamp)', async () => {
+    const result = await optimisticLockGuard.validate(
+      buildInput({
+        [OPTIMISTIC_LOCK_HEADER_NAME]: STALE_UPDATED_AT,
+        'x-om-record-lock-resolution': 'accept_incoming',
+      }),
+    )
+    expect(result.ok).toBe(false)
+    expect(result.status).toBe(409)
+  })
+})

--- a/packages/core/src/modules/customers/data/guards.ts
+++ b/packages/core/src/modules/customers/data/guards.ts
@@ -16,6 +16,32 @@ function normalizeIsoToken(raw: string): string | null {
   return new Date(ms).toISOString()
 }
 
+/**
+ * HTTP header carrying the enterprise `record_locks` conflict resolution the
+ * client chose in the merge dialog. This guard only reads the header value off
+ * the request (no enterprise import) — it is the integration contract between
+ * the record-lock layer and this universal optimistic-lock floor.
+ */
+const RECORD_LOCK_RESOLUTION_HEADER_NAME = 'x-om-record-lock-resolution'
+
+/**
+ * Resolutions that express an explicit, privileged intent to OVERWRITE the
+ * incoming concurrent write ("Keep mine" / merged). When the request asserts
+ * one of these, the record-lock guard (which runs first, at priority 0) has
+ * already authorized the override against `canOverrideIncoming`, so the
+ * stale-`updated_at` floor MUST defer to it — otherwise it rejects exactly the
+ * overwrite the user just authorized, looping the merge dialog on a fresh 409
+ * (issue #3601). `accept_incoming` is intentionally NOT here: that path reloads
+ * with a fresh `updated_at` and must still pass through the floor normally.
+ */
+const RECORD_LOCK_OVERRIDE_RESOLUTIONS: ReadonlySet<string> = new Set(['accept_mine', 'merged'])
+
+export function isAuthorizedRecordLockOverride(headers: Headers): boolean {
+  const raw = headers.get(RECORD_LOCK_RESOLUTION_HEADER_NAME)
+  if (typeof raw !== 'string') return false
+  return RECORD_LOCK_OVERRIDE_RESOLUTIONS.has(raw.trim().toLowerCase())
+}
+
 const optimisticLockGuard: MutationGuard = {
   id: 'customers.optimistic-lock',
   targetEntity: '*',
@@ -24,6 +50,9 @@ const optimisticLockGuard: MutationGuard = {
   async validate(input) {
     const config = parseOptimisticLockEnv(process.env[OPTIMISTIC_LOCK_ENV_VAR])
     if (config.mode === 'off') return { ok: true }
+    // A privileged record-lock "Keep mine" override deliberately overwrites the
+    // concurrent write; the floor must not block it on the now-stale timestamp.
+    if (isAuthorizedRecordLockOverride(input.requestHeaders)) return { ok: true }
     const enabled = config.mode === 'all' || config.entities.has(input.resourceKind.toLowerCase())
     if (!enabled) return { ok: true }
     const readers = getAllOptimisticLockReaders()


### PR DESCRIPTION
Fixes #3601

## Problem
With enterprise `record_locks` enabled, a privileged user's **"Keep mine" / "Zachowaj moje zmiany"** action on a genuine merge conflict never succeeds: the retry `PUT` is rejected by the always-on OSS optimistic-lock floor with `409 optimistic_lock_conflict`, the overwrite is not persisted, repeated clicks loop on a fresh 409, and the OSS conflict bar renders **on top of the still-open merge dialog** (two conflict surfaces at once). The only escape discards the user's edits. No data loss — the incoming write is preserved — but the privileged user can never keep their own version.

## Root Cause
The universal optimistic-lock floor is the `customers.optimistic-lock` mutation guard (`targetEntity: '*'`, priority 100) in `customers/data/guards.ts`. It runs **independently of, and after,** the enterprise record-lock guard (priority 0).

On a "Keep mine" resubmit the record-lock guard authorizes the override (`record_locks/validate → 200`, `resolution: accept_mine`, gated by `canOverrideIncoming`), but the same `PUT` still carries the **stale** `x-om-ext-optimistic-lock-expected-updated-at` the form originally loaded with. The floor compares that stale value to the now-bumped `updated_at` and rejects — independently of the `accept_mine` resolution the request also signals. `accept_incoming` avoids this only because it `window.location.reload()`s, sending a fresh `updated_at`; `accept_mine` resubmits the same form. That asymmetry is the bug.

## What Changed
- `packages/core/src/modules/customers/data/guards.ts`: the floor now **defers** (passes) when the request carries an authorized record-lock override header `x-om-record-lock-resolution: accept_mine | merged`. By the time the floor runs, the record-lock guard (priority 0) has already validated that the privileged user may overwrite incoming changes, so the floor must not block the very overwrite they authorized. Extracted as a tiny exported, testable helper `isAuthorizedRecordLockOverride(headers)`; the guard reads only the HTTP header value (no enterprise import).
- `accept_incoming` is deliberately **not** deferred — it reloads with a fresh `updated_at` and must keep passing the floor normally.

This mirrors and completes the `accept_incoming` floor-deferral fix that already landed in #3505 / #3551.

## Tests
- New `packages/core/src/modules/customers/data/__tests__/optimisticLockGuard.test.ts` (6 cases):
  - `isAuthorizedRecordLockOverride` recognizes `accept_mine` / `merged` (case/whitespace tolerant) and rejects `accept_incoming` / unknown / absent.
  - Guard **rejects** a stale update with `409` when no resolution header is present (control).
  - Guard **defers** (passes, no DB read) for `accept_mine` and for `merged`.
  - Guard **still enforces** the floor for `accept_incoming`.
- Full `modules/customers/data/__tests__` suite green (39 tests).
- Note: repo-wide `yarn typecheck` currently fails in this environment on a pre-existing TS 6.0.3 / `--ignoreDeprecations` `tsconfig` error unrelated to this change; Jest transpiled and ran the changed `guards.ts` successfully.

## Backward Compatibility
- No contract surface changes. Additive guard logic on an existing discovered file; no new routes/entities/events/DI keys. The floor stays additive and opt-in (clients that send no expected-`updated_at` header still pass), so behavior is unchanged for every path except the previously-broken keep-mine override.
