### PR TITLE
fix(agent_orchestrator): attribute playground runs to resolved org, fail closed under "All organizations" (#3629)

### DIFF
--- a/.ai/runs/2026-06-26-agent-orchestrator-bugfixes/PLAN.md
+++ b/.ai/runs/2026-06-26-agent-orchestrator-bugfixes/PLAN.md
@@ -92,7 +92,7 @@
 
 ## Progress
 
-- [ ] PR-A (#3629) — org-scope fix + fail-closed + test
-- [ ] PR-A — audit `invokeAgentForWorkflow.ts` org derivation
+- [x] PR-A (#3629) — org-scope fix + fail-closed + test (branch `fix/3629-agent-run-org-scope`; `run/route.ts` now resolves `resolveOrganizationScopeForRequest` and fails closed when no single org is selected; regression test `agent-run-org-scope.test.ts`, 3 cases; enterprise typecheck + 244 unit tests green)
+- [x] PR-A — audit `invokeAgentForWorkflow.ts` org derivation — **safe, no change**: it takes `organizationId` from the workflow instance ctx (a persisted concrete org), not from live request header scope
 - [ ] PR-B (#3632) — executor transaction/rollback fix + durable FAILED + message + template + tests
 - [ ] PR-C (#3628) — OpenCode trace capture + ingest + tests (confirm in-process parity decision)

--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/agent-run-org-scope.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/agent-run-org-scope.test.ts
@@ -1,0 +1,107 @@
+/** @jest-environment node */
+import { POST } from '../api/agents/[id]/run/route'
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: jest.fn(async () => undefined),
+  runCrudMutationGuardAfterSuccess: jest.fn(async () => undefined),
+}))
+
+const TENANT_A = '11111111-1111-4111-8111-111111111111'
+const ORG_REAL = '22222222-2222-4222-8222-222222222222'
+const ORG_STALE = '284107f1-87d9-4d06-87eb-67bff80bd21b'
+const USER = '44444444-4444-4444-8444-444444444444'
+const AGENT_ID = 'deals.health_check'
+
+function makeRequest(body: unknown = { input: { deal: { id: 'deal-1' } } }) {
+  return new Request(`http://localhost/api/agent_orchestrator/agents/${AGENT_ID}/run`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const params = Promise.resolve({ id: AGENT_ID })
+
+async function setupContainer() {
+  const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+  const run = jest.fn(async () => ({ kind: 'informative', data: { ok: true } }))
+  ;(createRequestContainer as jest.Mock).mockResolvedValue({
+    resolve: (token: string) => {
+      if (token === 'agentRuntime') return { run }
+      return null
+    },
+  })
+  return { run }
+}
+
+describe('POST /api/agent_orchestrator/agents/:id/run — organization scope (#3629)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('attributes the run to the resolved selected org, not the raw (stale) auth.orgId', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { resolveOrganizationScopeForRequest } = await import(
+      '@open-mercato/core/modules/directory/utils/organizationScope'
+    )
+    // auth.orgId carries a stale/phantom "home" org; the canonical resolver
+    // returns the real concretely-selected org.
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ sub: USER, tenantId: TENANT_A, orgId: ORG_STALE })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: ORG_REAL,
+      filterIds: [ORG_REAL],
+      allowedIds: [ORG_REAL],
+      tenantId: TENANT_A,
+    })
+    const { run } = await setupContainer()
+
+    const res = await POST(makeRequest(), { params })
+    expect(res.status).toBe(200)
+    expect(run).toHaveBeenCalledTimes(1)
+    const ctxArg = run.mock.calls[0][2] as { organizationId: string }
+    expect(ctxArg.organizationId).toBe(ORG_REAL)
+    expect(ctxArg.organizationId).not.toBe(ORG_STALE)
+  })
+
+  it('fails closed (400) and never runs the agent when no single org is selected ("All organizations")', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { resolveOrganizationScopeForRequest } = await import(
+      '@open-mercato/core/modules/directory/utils/organizationScope'
+    )
+    // "All organizations" scope: the resolver widens and yields no concrete selection.
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ sub: USER, tenantId: TENANT_A, orgId: null, isSuperAdmin: true })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: TENANT_A,
+    })
+    const { run } = await setupContainer()
+
+    const res = await POST(makeRequest(), { params })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(String(body.error)).toMatch(/organization/i)
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue(null)
+
+    const res = await POST(makeRequest(), { params })
+    expect(res.status).toBe(401)
+  })
+})

--- a/packages/enterprise/src/modules/agent_orchestrator/api/agents/[id]/run/route.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/api/agents/[id]/run/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { validateCrudMutationGuard, runCrudMutationGuardAfterSuccess } from '@open-mercato/shared/lib/crud/mutation-guard'
 import { agentRunRequestSchema, baseAgentResultSchema } from '../../../../data/validators'
@@ -24,7 +25,7 @@ type RouteContext = { params: Promise<{ id: string }> }
 export async function POST(req: Request, ctx: RouteContext) {
   const auth = await getAuthFromRequest(req)
   if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  if (!auth.tenantId || !auth.orgId || !auth.sub) {
+  if (!auth.tenantId || !auth.sub) {
     return NextResponse.json({ error: 'Tenant context required' }, { status: 400 })
   }
 
@@ -40,9 +41,27 @@ export async function POST(req: Request, ctx: RouteContext) {
 
   const container = await createRequestContainer()
 
+  // Attribute the run to the concretely selected organization, resolved through
+  // the canonical scope resolver (the same one the caseload reads with). Raw
+  // `auth.orgId` is not trustworthy here: under the "All organizations" scope it
+  // is either null (superadmin) or a stale account/home org, which would stamp an
+  // AgentRun/AgentProposal under an org the caseload never queries — silently
+  // orphaning the proposal from human disposition (#3629). Fail closed instead.
+  const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
+  const organizationId = scope?.selectedId ?? null
+  if (!organizationId) {
+    return NextResponse.json(
+      {
+        error:
+          'Select a single organization before running an agent. Agent runs must be attributed to one organization so the resulting proposal is reviewable in the caseload.',
+      },
+      { status: 400 },
+    )
+  }
+
   const guardResult = await validateCrudMutationGuard(container, {
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub,
     resourceKind: 'agent_orchestrator.agent_run',
     resourceId: id,
@@ -56,7 +75,7 @@ export async function POST(req: Request, ctx: RouteContext) {
 
   const runCtx: AgentRunCtx = {
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub,
   }
 
@@ -77,7 +96,7 @@ export async function POST(req: Request, ctx: RouteContext) {
   if (guardResult?.shouldRunAfterSuccess) {
     await runCrudMutationGuardAfterSuccess(container, {
       tenantId: auth.tenantId,
-      organizationId: auth.orgId,
+      organizationId,
       userId: auth.sub,
       resourceKind: 'agent_orchestrator.agent_run',
       resourceId: id,
@@ -108,7 +127,7 @@ export const openApi: OpenApiRouteDoc = {
         { status: 200, description: 'Typed AgentResult', schema: baseAgentResultSchema },
       ],
       errors: [
-        { status: 400, description: 'Tenant context missing', schema: errorSchema },
+        { status: 400, description: 'Tenant context missing, or no single organization is selected (run under "All organizations" is rejected)', schema: errorSchema },
         { status: 401, description: 'Unauthorized', schema: errorSchema },
         { status: 403, description: 'Missing agent_orchestrator.agents.run', schema: errorSchema },
         { status: 404, description: 'Unknown agent id', schema: errorSchema },


### PR DESCRIPTION
## What & why

The Playground agent run route (`POST /api/agent_orchestrator/agents/[id]/run`) stamped `agent_runs.organization_id` and `agent_proposals.organization_id` from **raw `auth.orgId`**. Under the **"All organizations"** header scope that value is either `null` (superadmin) or a **stale account/home org id** — so the actionable proposal persisted under an org the caseload never queries and was **silently orphaned** from human disposition.

Fixes #3629.

## Change

- Resolve the concretely-selected org via `resolveOrganizationScopeForRequest` — the **same** canonical resolver the caseload (`api/proposals`, `makeCrudRoute`) reads with — and use `scope.selectedId` for the run context, the mutation guard, and the after-success guard.
- **Fail closed** with a clear message when no single org is selected (the "All organizations" case), instead of persisting an unreachable proposal. This matches the established precedent (`resolveCustomersRequestContext`, and the Deals-Map fail-closed-under-all-orgs behavior).
- The `INVOKE_AGENT` **workflow** path is unaffected — audited and confirmed it derives org from the workflow instance context (a persisted concrete org), not from live request header scope.

## Tests

`__tests__/agent-run-org-scope.test.ts` (3 cases):
- run is attributed to the **resolved** org, not the stale `auth.orgId`;
- **400 + agent never runs** under "All organizations";
- 401 unauthenticated.

Enterprise `typecheck` clean; full `agent_orchestrator` unit suite green (244 tests).

## Notes

- Behavior-preserving for the normal case: a concrete selection (or a regular user's single accessible org) resolves exactly as before; only the genuinely-ambiguous all-orgs case changes — from silent orphaning to an explicit, actionable error.
- No schema/migration change.
- Part of the 3-bug remediation plan (`.ai/runs/2026-06-26-agent-orchestrator-bugfixes/PLAN.md`); siblings #3632 and #3628 are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
