### PR TITLE
fix(dev-runtime): guard nullable externalSignal deref in warmup fetch (#3617)

### DIFF
--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -720,14 +720,14 @@ async function resolveWarmupTenantIdFromDatabase(email) {
 
 async function fetchWithTimeout(url, init = {}, timeoutMs = 45000, externalSignal = null) {
   if (externalSignal?.aborted) {
-    throw externalSignal.reason ?? new Error('warmup request aborted')
+    throw externalSignal?.reason ?? new Error('warmup request aborted')
   }
 
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   timer.unref?.()
   const abortFromExternalSignal = () => {
-    controller.abort(externalSignal.reason ?? new Error('warmup request aborted'))
+    controller.abort(externalSignal?.reason ?? new Error('warmup request aborted'))
   }
   externalSignal?.addEventListener?.('abort', abortFromExternalSignal, { once: true })
 

--- a/packages/create-app/template/scripts/dev-runtime.mjs
+++ b/packages/create-app/template/scripts/dev-runtime.mjs
@@ -695,14 +695,14 @@ async function resolveWarmupTenantIdFromDatabase(email) {
 
 async function fetchWithTimeout(url, init = {}, timeoutMs = 45000, externalSignal = null) {
   if (externalSignal?.aborted) {
-    throw externalSignal.reason ?? new Error('warmup request aborted')
+    throw externalSignal?.reason ?? new Error('warmup request aborted')
   }
 
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), timeoutMs)
   timer.unref?.()
   const abortFromExternalSignal = () => {
-    controller.abort(externalSignal.reason ?? new Error('warmup request aborted'))
+    controller.abort(externalSignal?.reason ?? new Error('warmup request aborted'))
   }
   externalSignal?.addEventListener?.('abort', abortFromExternalSignal, { once: true })
 

--- a/scripts/__tests__/dev-runtime-external-signal-guard.test.mjs
+++ b/scripts/__tests__/dev-runtime-external-signal-guard.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+const RUNTIME_FILES = [
+  'apps/mercato/scripts/dev.mjs',
+  'packages/create-app/template/scripts/dev-runtime.mjs',
+]
+
+const BARE_DEREF = /externalSignal\.[A-Za-z_$]/g
+const GUARDED_REASON = /externalSignal\?\.reason\s*\?\?\s*new Error\('warmup request aborted'\)/g
+
+function readRuntimeFile(relPath) {
+  return fs.readFileSync(path.resolve(ROOT, relPath), 'utf8')
+}
+
+for (const relPath of RUNTIME_FILES) {
+  test(`${relPath} never dereferences the nullable externalSignal without optional chaining`, () => {
+    const content = readRuntimeFile(relPath)
+    const bareReads = content.match(BARE_DEREF) ?? []
+    assert.deepEqual(
+      bareReads,
+      [],
+      `Found bare externalSignal member access in ${relPath}: ${bareReads.join(', ')}. ` +
+        `externalSignal defaults to null, so every read must use optional chaining (externalSignal?.x) to avoid a TypeError.`,
+    )
+  })
+
+  test(`${relPath} keeps the abort-reason fallback null-safe`, () => {
+    const content = readRuntimeFile(relPath)
+    const guarded = content.match(GUARDED_REASON) ?? []
+    assert.equal(
+      guarded.length,
+      2,
+      `Expected both abort paths in ${relPath} to read externalSignal?.reason with the error fallback, found ${guarded.length}.`,
+    )
+  })
+}
+
+test('app dev runtime and create-app template mirror share identical externalSignal abort handling', () => {
+  const [appContent, templateContent] = RUNTIME_FILES.map(readRuntimeFile)
+  const extractBlock = (content) => {
+    const start = content.indexOf('async function fetchWithTimeout(')
+    assert.notEqual(start, -1, 'fetchWithTimeout not found')
+    const end = content.indexOf('\n}', start)
+    assert.notEqual(end, -1, 'fetchWithTimeout end not found')
+    return content.slice(start, end)
+  }
+  assert.equal(
+    extractBlock(appContent),
+    extractBlock(templateContent),
+    'fetchWithTimeout must stay byte-identical between dev.mjs and the create-app template mirror (template-sync no-op).',
+  )
+})


### PR DESCRIPTION
Fixes #3617

## Problem
`fetchWithTimeout(url, init, timeoutMs, externalSignal = null)` in the dev warmup helper treats `externalSignal` as nullable and guards every access with optional chaining (`externalSignal?.aborted`, `externalSignal?.addEventListener?.`, `externalSignal?.removeEventListener?.`) — except two abort paths that read `externalSignal.reason` bare.

## Root Cause
The two bare reads are only latent today because the preceding optional-chaining guards short-circuit when the signal is null (the early `throw` is gated by `externalSignal?.aborted`, and `abortFromExternalSignal` is only attached via `externalSignal?.addEventListener?.`). They become a real `TypeError: Cannot read properties of null (reading 'reason')` — crashing the dev runtime — the moment the listener is invoked or wired differently during a refactor. They are also a readability trap: the inconsistent style suggests they are intentional when they are not.

## What Changed
- `apps/mercato/scripts/dev.mjs` — both abort paths now read `externalSignal?.reason ?? new Error('warmup request aborted')`.
- `packages/create-app/template/scripts/dev-runtime.mjs` — identical edit applied to the create-app template mirror, so `scripts/template-sync.ts` stays unaffected (the `fetchWithTimeout` block remains byte-identical between the two files; verified the relative drift is unchanged).
- Added `scripts/__tests__/dev-runtime-external-signal-guard.test.mjs` — a source-level regression guard (same pattern as `scripts/__tests__/prod-compose-node-options.test.mjs`) asserting that both runtime files never dereference the nullable `externalSignal` without optional chaining, keep both abort-reason fallbacks null-safe, and share identical abort handling.

Behavior is unchanged for every current caller (null and non-null signals alike); this only hardens two bare derefs to the `?.` convention already used throughout the function.

## Tests
- New regression test fails against the pre-fix code (`externalSignal.reason` bare → assertion failure) and passes after the fix (5/5).
- `yarn test:scripts`: 271/273 pass. The 2 failures are in `watch-packages.test.mjs` (`runConsolidatedWatch` real-`fs.watch` timing tests) — pre-existing/environmental and untouched by this change.
- `yarn template:sync`: the `scripts/dev.mjs` + `scripts/dev-runtime.mjs` entries are **pre-existing drift on `develop`** (confirmed by reverting this change); this PR does not alter that relative state.
- `eslint` clean on all changed files.

## Backward Compatibility
- No contract surface changes. `fetchWithTimeout` is an internal, non-exported dev-tooling helper. No API routes, response fields, event IDs, widget spot IDs, ACL IDs, DI names, or import paths affected. Dev-tooling only — no runtime/product code, no API or schema surface.