### PR TITLE
refactor(sync_akeneo): remove dead always-true comparison in getSystemProbe (#3621)

### DIFF
--- a/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
@@ -127,6 +127,50 @@ describe('akeneo client security', () => {
     }))
   })
 
+  it('falls back to the attributes reachability probe and reports an unknown version (issue #3621)', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'token-123', expires_in: 3600 }))
+      .mockResolvedValueOnce(new Response('system information unavailable', { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({
+        _embedded: { items: [{ code: 'sku' }] },
+        _links: {},
+        items_count: 1,
+      }))
+
+    const client = createAkeneoClient(validCredentials)
+    await expect(client.getSystemProbe()).resolves.toEqual({ version: null })
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(String(fetchMock.mock.calls[2][0])).toContain('/api/rest/v1/attributes')
+  })
+
+  it('reports an unknown version even when the attributes probe returns no items (issue #3621)', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'token-123', expires_in: 3600 }))
+      .mockResolvedValueOnce(new Response('system information unavailable', { status: 404 }))
+      .mockResolvedValueOnce(jsonResponse({
+        _embedded: { items: [] },
+        _links: {},
+        items_count: 0,
+      }))
+
+    const client = createAkeneoClient(validCredentials)
+    await expect(client.getSystemProbe()).resolves.toEqual({ version: null })
+  })
+
+  it('propagates when the attributes reachability probe also fails (issue #3621)', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ access_token: 'token-123', expires_in: 3600 }))
+      .mockResolvedValueOnce(new Response('system information unavailable', { status: 404 }))
+      .mockResolvedValueOnce(new Response('unreachable', { status: 500 }))
+
+    const client = createAkeneoClient(validCredentials)
+    await expect(client.getSystemProbe()).rejects.toThrow('Akeneo request failed (500)')
+  })
+
   it('rejects cross-origin next urls before any authenticated request is sent', async () => {
     const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
     const client = createAkeneoClient(validCredentials)

--- a/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
@@ -479,11 +479,11 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
         version: typeof result.pim_version === 'string' ? result.pim_version : null,
       }
     } catch {
-      const attrs = await readList<AkeneoAttribute>('/api/rest/v1/attributes', {
+      await readList<AkeneoAttribute>('/api/rest/v1/attributes', {
         limit: 1,
         pagination_type: 'page',
       })
-      return { version: attrs.items.length >= 0 ? null : null }
+      return { version: null }
     }
   }
 


### PR DESCRIPTION
Fixes #3621

## Problem
- In the Akeneo client's `getSystemProbe` fallback (`packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts`), the catch branch returned `{ version: attrs.items.length >= 0 ? null : null }`. An array length is never negative, so the condition is always `true`, and both ternary branches return `null` — doubly dead code that made the reachability probe read as if it once meant to distinguish "got attributes back" from "did not."

## Root Cause
- The `readList<AkeneoAttribute>(...)` call is the real reachability probe for an older/locked-down PIM that doesn't expose `/system-information`, but its result was bound to `attrs` only to feed a tautological no-op. The fallback's actual contract is "the API still responds, so report a reachable PIM with an unknown version (`version: null`)."

## What Changed
- Dropped the tautological `attrs.items.length >= 0 ? null : null` ternary and the now-unused `attrs` binding; the fallback returns `{ version: null }` directly.
- Kept `await readList<AkeneoAttribute>('/api/rest/v1/attributes', …)` as the genuine reachability probe — if `/attributes` also fails it throws and propagates out of `getSystemProbe`, which is the correct behavior for an unreachable PIM.

## Tests
- Added three regression tests to `client.test.ts` locking in the fallback contract:
  - system-information unavailable + attributes reachable → `{ version: null }` (asserts the `/api/rest/v1/attributes` probe is actually hit).
  - system-information unavailable + attributes returns **no items** → still `{ version: null }` (directly covers the removed `items.length >= 0` branch).
  - system-information unavailable + attributes also fails → error propagates.
- `yarn build:packages` → `yarn generate` → `yarn build:packages` (fresh worktree), `yarn typecheck` (21/21), full `sync-akeneo` suite (9 suites / 56 tests) and `yarn test` all green. The single failing test in the run is the pre-existing machine-locale issue in `@open-mercato/ui` `format.test.ts` (Polish locale renders `1234,50 USD`), unrelated to this change.

## Backward Compatibility
- No contract surface changes. `getSystemProbe`'s signature and return shape (`{ version: string | null }`) are unchanged, and behavior on this path is identical (it already returned `{ version: null }` in every case). Internal helper only — no API responses, event IDs, ACL/DI names, routes, or schema touched.