### PR TITLE
refactor(shared): drop dead/misleading loop-counter reassignments in matchRoutePattern (#3622)

### DIFF
--- a/packages/core/src/modules/workflows/lib/event-trigger-service.ts
+++ b/packages/core/src/modules/workflows/lib/event-trigger-service.ts
@@ -123,6 +123,9 @@ function isSafeWorkflowRegexPattern(pattern: string): boolean {
   let lastClosedGroup: RegexGroupFrame | null = null
   let lastAtomWasQuantified = false
 
+  // Hand-written single-pass lexer: `index` is intentionally advanced inside the
+  // loop body (escape pairs, `(?:` prefixes, multi-char quantifiers, lazy `?`) on
+  // top of the `index += 1` update clause. Do not "simplify" these in-body writes.
   for (let index = 0; index < pattern.length; index += 1) {
     const char = pattern[index]
 

--- a/packages/shared/src/modules/__tests__/registry.test.ts
+++ b/packages/shared/src/modules/__tests__/registry.test.ts
@@ -251,6 +251,26 @@ describe('CLI Modules Registry', () => {
     it('returns undefined when static segments do not match even case-insensitively', () => {
       expect(matchRoutePattern('/login', '/sign-in')).toBeUndefined()
     })
+
+    it('captures all trailing segments after a static prefix for catch-all (issue #3622)', () => {
+      expect(matchRoutePattern('/files/[...path]', '/files/a/b/c')).toEqual({ path: ['a', 'b', 'c'] })
+    })
+
+    it('captures a single trailing segment for catch-all (issue #3622)', () => {
+      expect(matchRoutePattern('/files/[...path]', '/files/a')).toEqual({ path: ['a'] })
+    })
+
+    it('returns undefined when a catch-all has no segment to consume (issue #3622)', () => {
+      expect(matchRoutePattern('/files/[...path]', '/files')).toBeUndefined()
+    })
+
+    it('captures trailing segments for optional catch-all (issue #3622)', () => {
+      expect(matchRoutePattern('/docs/[[...slug]]', '/docs/a/b')).toEqual({ slug: ['a', 'b'] })
+    })
+
+    it('returns an empty array for optional catch-all with no trailing segments (issue #3622)', () => {
+      expect(matchRoutePattern('/docs/[[...slug]]', '/docs')).toEqual({ slug: [] })
+    })
   })
 
   describe('findBackendMatch', () => {

--- a/packages/shared/src/modules/registry.ts
+++ b/packages/shared/src/modules/registry.ts
@@ -313,12 +313,10 @@ export function matchRoutePattern(pattern: string, pathname: string): RouteMatch
       const key = mCatchAll[1]
       if (i >= uSegs.length) return undefined
       params[key] = uSegs.slice(i)
-      i = uSegs.length
-      return i === uSegs.length ? params : undefined
+      return params
     } else if (mOptCatch) {
       const key = mOptCatch[1]
       params[key] = i < uSegs.length ? uSegs.slice(i) : []
-      i = uSegs.length
       return params
     } else if (mDyn) {
       if (i >= uSegs.length) return undefined


### PR DESCRIPTION
Fixes #3622

## Problem
Two `for` loops reassigned their counter variable inside the loop body. As the issue documents, neither is a correctness bug, but they read as the classic "counter repositioned mid-loop" smell, and one is dead code.

## Root Cause
In `matchRoutePattern` (`packages/shared/src/modules/registry.ts`):
- **catch-all branch** — set `i = uSegs.length` and then returned `i === uSegs.length ? params : undefined`. After that assignment the comparison is always `true`, so the branch always returned `params`. The empty-input case is already handled by the `if (i >= uSegs.length) return undefined` guard immediately above. The reassignment + tautological ternary only existed to make the next comparison true.
- **optional-catch-all branch** — set `i = uSegs.length` immediately before `return params`, which never reads `i`. Pure dead code.

Both branches `return` inside the loop, so neither `i` write was ever observed by the post-loop `if (i !== uSegs.length)` check.

## What Changed
- `registry.ts`: collapsed both branches to a plain `return params`, removing the misleading and dead counter writes. Route-matching behavior and return values are unchanged.
- `event-trigger-service.ts`: added a clarifying comment above the regex-safety scanner loop noting it is a hand-written single-pass lexer that **intentionally** advances `index` inside the body (escape pairs, `(?:` prefixes, multi-char quantifiers, lazy `?`). No functional change — this is the "leave it, but document the intent" half of the issue.

### Note on the issue's proposed expression
The issue suggested `return i >= uSegs.length ? params : undefined` for the catch-all branch. That would **invert** the result: after the `i >= uSegs.length` guard returns `undefined`, control only reaches the return when `i < uSegs.length`, so that expression would return `undefined` for every matching catch-all. Since the issue explicitly states "No behavior change," this PR implements the behavior-preserving `return params` instead, which matches the stated intent.

## Tests
- Added 5 characterization tests to `registry.test.ts` locking `matchRoutePattern`'s catch-all and optional-catch-all behavior on exactly the touched branches (multi-segment capture, single-segment capture, empty-catch-all → `undefined`, optional-catch-all capture, optional-catch-all-empty → `{ slug: [] }`). These would fail under the inverted interpretation above.
- Full `@open-mercato/shared` suite: 1303 tests pass.
- Workflows regex-scanner suites (`event-trigger-redos`, `event-trigger-cache`): pass.
- `yarn build:packages`, `yarn generate`, full `yarn typecheck` (21/21): green.

## Backward Compatibility
No contract surface changes. `matchRoutePattern`'s signature and return values are unchanged; this is a pure internal cleanup plus a comment and tests.