### PR TITLE
fix(search): fall back to default Ollama URL when OLLAMA_BASE_URL is empty (#3511)

### DIFF
--- a/packages/search/src/modules/search/lib/__tests__/provider-probe.ollama-fallback.test.ts
+++ b/packages/search/src/modules/search/lib/__tests__/provider-probe.ollama-fallback.test.ts
@@ -1,0 +1,60 @@
+jest.mock('../../../../vector', () => ({
+  EMBEDDING_PROVIDERS: {},
+}))
+
+import { createEmbeddingProviderProbe } from '../provider-probe'
+import type { AppContainer } from '@open-mercato/shared/lib/di/container'
+
+const ORIGINAL_ENV = { ...process.env }
+const ORIGINAL_FETCH = global.fetch
+
+function makeProbeContainer(): AppContainer {
+  return {
+    resolve: () => {
+      throw new Error('no cache in test')
+    },
+  } as unknown as AppContainer
+}
+
+describe('provider-probe — Ollama base URL fallback (issue #3511)', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('ECONNREFUSED')) as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+    global.fetch = ORIGINAL_FETCH
+  })
+
+  it('falls back to the documented default URL when OLLAMA_BASE_URL is an empty string', async () => {
+    process.env.OLLAMA_BASE_URL = ''
+    const probe = createEmbeddingProviderProbe(makeProbeContainer())
+    const result = await probe.checkAvailability('ollama', { force: true })
+    expect(result.available).toBe(false)
+    expect(result.reason).toBe('Ollama not reachable at http://localhost:11434')
+  })
+
+  it('falls back to the default URL when OLLAMA_BASE_URL is whitespace only', async () => {
+    process.env.OLLAMA_BASE_URL = '   '
+    const probe = createEmbeddingProviderProbe(makeProbeContainer())
+    const result = await probe.checkAvailability('ollama', { force: true })
+    expect(result.reason).toBe('Ollama not reachable at http://localhost:11434')
+  })
+
+  it('falls back to the default URL when OLLAMA_BASE_URL is unset', async () => {
+    delete process.env.OLLAMA_BASE_URL
+    const probe = createEmbeddingProviderProbe(makeProbeContainer())
+    const result = await probe.checkAvailability('ollama', { force: true })
+    expect(result.reason).toBe('Ollama not reachable at http://localhost:11434')
+  })
+
+  it('uses a configured OLLAMA_BASE_URL verbatim (trimmed)', async () => {
+    process.env.OLLAMA_BASE_URL = '  http://ollama.example.com:11434  '
+    const probe = createEmbeddingProviderProbe(makeProbeContainer())
+    const result = await probe.checkAvailability('ollama', { force: true })
+    expect(result.reason).toBe('Ollama not reachable at http://ollama.example.com:11434')
+  })
+})

--- a/packages/search/src/modules/search/lib/provider-probe.ts
+++ b/packages/search/src/modules/search/lib/provider-probe.ts
@@ -45,7 +45,7 @@ const resolveCache = (container: AppContainer): CacheStrategy | null => {
   }
 }
 
-const ollamaBaseUrl = () => process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434'
+const ollamaBaseUrl = () => process.env.OLLAMA_BASE_URL?.trim() || 'http://localhost:11434'
 
 const keyPresence = (providerId: EmbeddingProviderId): ProviderAvailability => {
   const info = EMBEDDING_PROVIDERS[providerId]


### PR DESCRIPTION
Fixes #3511

## Problem
When `OLLAMA_BASE_URL=` is set to an empty string in `.env` (the default state of the shipped `.env` template), the Ollama provider probe reported its unavailability reason as `"Ollama not reachable at "` — with no endpoint — instead of `"Ollama not reachable at http://localhost:11434"`. The empty URL also leaked into the Vector Search card / button text on `/backend/config/search` and into the `GET /api/search/embeddings` `providerAvailability` response, making it impossible for users to see which endpoint was tried.

## Root Cause
`packages/search/src/modules/search/lib/provider-probe.ts:48` resolved the base URL with `??`:

```ts
process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434'
```

`??` only substitutes `null`/`undefined`, so an empty-string env value (`''`) was passed through verbatim and used as the probe base URL.

## What Changed
- `provider-probe.ts`: resolve the base URL with `?.trim() ||` so any falsy/blank value (empty **or** whitespace-only) falls back to the documented default `http://localhost:11434`. This matches the `?.trim()` convention already used for every key-based provider in the same file, and also normalizes a whitespace-padded URL.

```ts
process.env.OLLAMA_BASE_URL?.trim() || 'http://localhost:11434'
```

## Tests
- New `provider-probe.ollama-fallback.test.ts` regression suite exercising the fix through the public `createEmbeddingProviderProbe(...).checkAvailability('ollama')` path (the resolver is private). Covers empty-string, whitespace-only, unset, and explicitly-configured `OLLAMA_BASE_URL` values. Verified the 3 new fallback cases fail on the old `??` code and pass after the fix.
- Full `@open-mercato/search` suite green: **23 suites / 230 tests**.
- `tsc --noEmit` for the search package: clean.
- ESLint on the changed files: clean.

No i18n strings, generated files, entities, or routes changed, so those checks were not applicable.

## Backward Compatibility
- No contract surface changes. `ollamaBaseUrl` is a private (non-exported) helper; all exported symbols and signatures are unchanged. The `reason` field shape is unchanged — only its content is corrected.