### PR TITLE
refactor(customers): extract shared customers ai-tools helpers (#3627)

### DIFF
--- a/packages/core/src/modules/customers/__tests__/ai-tools/_shared.test.ts
+++ b/packages/core/src/modules/customers/__tests__/ai-tools/_shared.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Regression coverage for the customers AI-tools shared helpers (#3627).
+ *
+ * Two guarantees:
+ *  1. The `_shared.ts` helpers (`toIso`, `toCustomerListSummary`,
+ *     `buildRelatedRecords`) behave as the per-pack copies did before the DRY
+ *     extraction.
+ *  2. The DRY invariant: `companies-pack` and `people-pack` route their
+ *     related-records output through the single shared builder, so the shared
+ *     collections (addresses / activities / notes / tasks / interactions /
+ *     tags / deals) cannot drift apart again.
+ */
+const findWithDecryptionMock = jest.fn()
+const findOneWithDecryptionMock = jest.fn()
+const runMock = jest.fn()
+const createRunnerMock = jest.fn(() => ({ run: runMock }))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => findWithDecryptionMock(...args),
+  findOneWithDecryption: (...args: unknown[]) => findOneWithDecryptionMock(...args),
+}))
+
+jest.mock(
+  '@open-mercato/ai-assistant/modules/ai_assistant/lib/ai-api-operation-runner',
+  () => {
+    const actual = jest.requireActual(
+      '@open-mercato/ai-assistant/modules/ai_assistant/lib/ai-api-operation-runner',
+    )
+    return {
+      ...actual,
+      createAiApiOperationRunner: (...args: unknown[]) => createRunnerMock(...args),
+    }
+  },
+)
+
+import companiesAiTools from '../../ai-tools/companies-pack'
+import peopleAiTools from '../../ai-tools/people-pack'
+import { buildRelatedRecords, toCustomerListSummary, toIso } from '../../ai-tools/_shared'
+import type { CustomersAiToolDefinition } from '../../ai-tools/types'
+import { makeCtx } from './shared'
+
+function findTool(tools: CustomersAiToolDefinition[], name: string) {
+  const tool = tools.find((entry) => entry.name === name)
+  if (!tool) throw new Error(`tool ${name} missing`)
+  return tool
+}
+
+describe('customers ai-tools _shared helpers', () => {
+  describe('toIso', () => {
+    it('returns null for empty values', () => {
+      expect(toIso(null)).toBeNull()
+      expect(toIso(undefined)).toBeNull()
+      expect(toIso('')).toBeNull()
+    })
+
+    it('returns null for unparseable values', () => {
+      expect(toIso('not-a-date')).toBeNull()
+    })
+
+    it('normalizes Date instances and date strings to ISO', () => {
+      expect(toIso(new Date('2024-01-01T00:00:00.000Z'))).toBe('2024-01-01T00:00:00.000Z')
+      expect(toIso('2024-01-01T00:00:00.000Z')).toBe('2024-01-01T00:00:00.000Z')
+    })
+  })
+
+  describe('toCustomerListSummary', () => {
+    it('reads snake_case fields and normalizes createdAt to ISO', () => {
+      const summary = toCustomerListSummary({
+        id: 'c1',
+        display_name: 'Acme',
+        primary_email: 'hello@acme.example',
+        owner_user_id: 'u1',
+        organization_id: 'org-1',
+        tenant_id: 'tenant-1',
+        created_at: '2024-01-01T00:00:00.000Z',
+      })
+      expect(summary).toEqual({
+        id: 'c1',
+        displayName: 'Acme',
+        primaryEmail: 'hello@acme.example',
+        primaryPhone: null,
+        status: null,
+        lifecycleStage: null,
+        source: null,
+        ownerUserId: 'u1',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        createdAt: '2024-01-01T00:00:00.000Z',
+      })
+    })
+
+    it('falls back to camelCase fields when snake_case is absent', () => {
+      const summary = toCustomerListSummary({ displayName: 'Beta', primaryPhone: '123' })
+      expect(summary.displayName).toBe('Beta')
+      expect(summary.primaryPhone).toBe('123')
+      expect(summary.createdAt).toBeNull()
+    })
+  })
+
+  describe('buildRelatedRecords', () => {
+    const data = {
+      addresses: [{ id: 'addr-1', name: 'HQ', addressLine1: '1 Main St', isPrimary: true }],
+      activities: [{ id: 'act-1', activityType: 'email', occurredAt: '2024-01-03T00:00:00.000Z' }],
+      comments: [{ id: 'note-1', body: 'note', createdAt: '2024-01-03T00:00:00.000Z' }],
+      todos: [{ id: 't-1', todoSource: 'example' }],
+      interactions: [{ id: 'i-1', interactionType: 'task', status: 'planned' }],
+      tags: [{ id: 'tag-1', label: 'VIP' }],
+      deals: [{ id: 'd-1', title: 'Big', status: 'open', valueAmount: '1000', valueCurrency: 'USD' }],
+      people: [{ id: 'p-1', displayName: 'Alice' }],
+    }
+
+    it('omits the people collection by default and preserves key order', () => {
+      const related = buildRelatedRecords(data)
+      expect(Object.keys(related)).toEqual([
+        'addresses',
+        'activities',
+        'notes',
+        'tasks',
+        'interactions',
+        'tags',
+        'deals',
+      ])
+      expect((related as Record<string, unknown>).people).toBeUndefined()
+    })
+
+    it('appends the people collection when includePeople is set', () => {
+      const related = buildRelatedRecords(data, { includePeople: true })
+      expect(Object.keys(related)).toEqual([
+        'addresses',
+        'activities',
+        'notes',
+        'tasks',
+        'interactions',
+        'tags',
+        'deals',
+        'people',
+      ])
+      expect(related.people).toEqual([
+        {
+          id: 'p-1',
+          displayName: 'Alice',
+          primaryEmail: null,
+          primaryPhone: null,
+          jobTitle: null,
+          department: null,
+        },
+      ])
+    })
+
+    it('coerces missing collections to empty arrays', () => {
+      const related = buildRelatedRecords({})
+      expect(related.addresses).toEqual([])
+      expect(related.activities).toEqual([])
+      expect(related.notes).toEqual([])
+      expect(related.tasks).toEqual([])
+      expect(related.interactions).toEqual([])
+      expect(related.tags).toEqual([])
+      expect(related.deals).toEqual([])
+    })
+  })
+})
+
+describe('customers ai-tools DRY invariant (#3627)', () => {
+  beforeEach(() => {
+    runMock.mockReset()
+    createRunnerMock.mockClear()
+  })
+
+  const sharedRelatedPayload = {
+    addresses: [
+      {
+        id: 'addr-1',
+        name: 'HQ',
+        purpose: 'billing',
+        addressLine1: '1 Main St',
+        addressLine2: 'Suite 2',
+        city: 'Metropolis',
+        region: 'NY',
+        postalCode: '00001',
+        country: 'US',
+        isPrimary: true,
+      },
+    ],
+    activities: [
+      {
+        id: 'act-1',
+        activityType: 'call',
+        subject: 'Intro',
+        body: 'hi',
+        occurredAt: '2024-01-03T00:00:00.000Z',
+        createdAt: '2024-01-03T00:00:00.000Z',
+      },
+    ],
+    comments: [
+      { id: 'note-1', body: 'Hello', authorUserId: 'user-1', createdAt: '2024-01-03T00:00:00.000Z' },
+    ],
+    todos: [
+      { id: 'task-1', todoId: 'task-1', todoSource: 'example', createdAt: '2024-01-03T00:00:00.000Z' },
+    ],
+    interactions: [
+      {
+        id: 'int-1',
+        interactionType: 'task',
+        title: 'Follow up',
+        status: 'planned',
+        scheduledAt: '2024-01-04T00:00:00.000Z',
+        occurredAt: null,
+      },
+    ],
+    tags: [{ id: 'tag-1', label: 'VIP', slug: 'vip', color: '#ff0000' }],
+    deals: [
+      {
+        id: 'deal-1',
+        title: 'Big deal',
+        status: 'open',
+        pipelineStageId: 'stage-1',
+        valueAmount: '1000',
+        valueCurrency: 'USD',
+      },
+    ],
+  }
+
+  const companyId = 'a1bd846b-5f8f-43bb-8c79-c6933afa09fe'
+  const personId = 'ba9d7593-367c-4a93-9918-c998ff3e5a1d'
+  const sharedKeys = ['addresses', 'activities', 'notes', 'tasks', 'interactions', 'tags', 'deals']
+
+  it('produces byte-identical shared related collections from both packs', async () => {
+    const getCompany = findTool(companiesAiTools, 'customers.get_company')
+    const getPerson = findTool(peopleAiTools, 'customers.get_person')
+
+    runMock.mockResolvedValueOnce({
+      success: true,
+      statusCode: 200,
+      data: {
+        company: { id: companyId, displayName: 'Acme', tenantId: 'tenant-1' },
+        profile: null,
+        customFields: {},
+        ...sharedRelatedPayload,
+      },
+    })
+    const companyResult = (await getCompany.handler(
+      { companyId, includeRelated: true },
+      makeCtx() as any,
+    )) as Record<string, unknown>
+
+    runMock.mockResolvedValueOnce({
+      success: true,
+      statusCode: 200,
+      data: {
+        person: { id: personId, displayName: 'Alice', tenantId: 'tenant-1' },
+        profile: null,
+        customFields: {},
+        ...sharedRelatedPayload,
+      },
+    })
+    const personResult = (await getPerson.handler(
+      { personId, includeRelated: true },
+      makeCtx() as any,
+    )) as Record<string, unknown>
+
+    const companyRelated = companyResult.related as Record<string, unknown>
+    const personRelated = personResult.related as Record<string, unknown>
+
+    for (const key of sharedKeys) {
+      expect(personRelated[key]).toEqual(companyRelated[key])
+    }
+
+    expect((companyRelated.people as unknown[]).length).toBe(0)
+    expect(personRelated.people).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/customers/ai-tools/_shared.ts
+++ b/packages/core/src/modules/customers/ai-tools/_shared.ts
@@ -1,0 +1,270 @@
+/**
+ * Shared helpers for customers AI tool packs.
+ *
+ * Mirrors the catalog precedent (`packages/core/src/modules/catalog/ai-tools/_shared.ts`):
+ * the company and people packs previously carried byte-for-byte-identical copies
+ * of the date-to-ISO helper, the `resolveEm` / `buildScope` accessors, the
+ * list-row → summary mapper, and the related-records builder
+ * (addresses / activities / notes / tasks / interactions / tags / deals, plus a
+ * companies-only `people` mapper). Centralizing them here gives both packs one
+ * source of truth so a change to the related-records output shape no longer has
+ * to be applied — and kept in sync — in two places.
+ *
+ * This is a pure internal refactor: tool names, input schemas, `requiredFeatures`,
+ * and emitted output shapes stay identical.
+ */
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { AiToolExecutionContext } from '@open-mercato/ai-assistant/modules/ai_assistant/lib/ai-api-operation-runner'
+import type { CustomersToolContext } from './types'
+
+export function toIso(value: unknown): string | null {
+  if (!value) return null
+  const dt = value instanceof Date ? value : new Date(String(value))
+  if (Number.isNaN(dt.getTime())) return null
+  return dt.toISOString()
+}
+
+export function resolveEm(ctx: CustomersToolContext | AiToolExecutionContext): EntityManager {
+  return ctx.container.resolve<EntityManager>('em')
+}
+
+export function buildScope(ctx: CustomersToolContext | AiToolExecutionContext, tenantId: string) {
+  return {
+    tenantId,
+    organizationId: ctx.organizationId,
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/*  List-row summary mapper                                                    */
+/* -------------------------------------------------------------------------- */
+
+export type CustomerListApiItemBase = {
+  id?: string
+  display_name?: string | null
+  displayName?: string | null
+  primary_email?: string | null
+  primaryEmail?: string | null
+  primary_phone?: string | null
+  primaryPhone?: string | null
+  status?: string | null
+  lifecycle_stage?: string | null
+  lifecycleStage?: string | null
+  source?: string | null
+  owner_user_id?: string | null
+  ownerUserId?: string | null
+  organization_id?: string | null
+  organizationId?: string | null
+  tenant_id?: string | null
+  tenantId?: string | null
+  created_at?: string | null
+  createdAt?: string | null
+}
+
+export type CustomerListSummary = {
+  id: string | undefined
+  displayName: string | null
+  primaryEmail: string | null
+  primaryPhone: string | null
+  status: string | null
+  lifecycleStage: string | null
+  source: string | null
+  ownerUserId: string | null
+  organizationId: string | null
+  tenantId: string | null
+  createdAt: string | null
+}
+
+export function toCustomerListSummary(row: CustomerListApiItemBase): CustomerListSummary {
+  const createdAtRaw = row.created_at ?? row.createdAt ?? null
+  const createdAt = createdAtRaw ? new Date(String(createdAtRaw)).toISOString() : null
+  return {
+    id: row.id,
+    displayName: row.display_name ?? row.displayName ?? null,
+    primaryEmail: row.primary_email ?? row.primaryEmail ?? null,
+    primaryPhone: row.primary_phone ?? row.primaryPhone ?? null,
+    status: row.status ?? null,
+    lifecycleStage: row.lifecycle_stage ?? row.lifecycleStage ?? null,
+    source: row.source ?? null,
+    ownerUserId: row.owner_user_id ?? row.ownerUserId ?? null,
+    organizationId: row.organization_id ?? row.organizationId ?? null,
+    tenantId: row.tenant_id ?? row.tenantId ?? null,
+    createdAt,
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Related-records mappers                                                    */
+/* -------------------------------------------------------------------------- */
+
+function asRows(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? (value as Array<Record<string, unknown>>) : []
+}
+
+export function mapAddresses(rows: Array<Record<string, unknown>>) {
+  return rows.map((address) => ({
+    id: address.id,
+    name: address.name ?? null,
+    purpose: address.purpose ?? null,
+    addressLine1: address.addressLine1 ?? null,
+    addressLine2: address.addressLine2 ?? null,
+    city: address.city ?? null,
+    region: address.region ?? null,
+    postalCode: address.postalCode ?? null,
+    country: address.country ?? null,
+    isPrimary: !!address.isPrimary,
+  }))
+}
+
+export function mapActivities(rows: Array<Record<string, unknown>>) {
+  return rows.map((activity) => ({
+    id: activity.id,
+    activityType: activity.activityType,
+    subject: activity.subject ?? null,
+    body: activity.body ?? null,
+    occurredAt: toIso(activity.occurredAt),
+    createdAt: toIso(activity.createdAt),
+  }))
+}
+
+export function mapNotes(rows: Array<Record<string, unknown>>) {
+  return rows.map((comment) => ({
+    id: comment.id,
+    body: comment.body,
+    authorUserId: comment.authorUserId ?? null,
+    createdAt: toIso(comment.createdAt),
+  }))
+}
+
+export function mapTasks(rows: Array<Record<string, unknown>>) {
+  return rows.map((task) => ({
+    id: task.id,
+    todoId: task.todoId ?? task.id,
+    todoSource: task.todoSource ?? null,
+    createdAt: toIso(task.createdAt),
+  }))
+}
+
+export function mapInteractions(rows: Array<Record<string, unknown>>) {
+  return rows.map((interaction) => ({
+    id: interaction.id,
+    interactionType: interaction.interactionType,
+    title: interaction.title ?? null,
+    status: interaction.status,
+    scheduledAt: toIso(interaction.scheduledAt),
+    occurredAt: toIso(interaction.occurredAt),
+  }))
+}
+
+export type RelatedTag = { id: string; slug: string; label: string; color: string | null }
+
+export function mapTags(rows: Array<Record<string, unknown>>): RelatedTag[] {
+  return rows
+    .map((tag) => {
+      if (!tag || typeof tag !== 'object') return null
+      const id = typeof tag.id === 'string' ? tag.id : null
+      const label = typeof tag.label === 'string' ? tag.label : null
+      if (!id || !label) return null
+      const slug = typeof tag.slug === 'string' ? tag.slug : label
+      const color = typeof tag.color === 'string' ? tag.color : null
+      return { id, slug, label, color }
+    })
+    .filter((entry): entry is RelatedTag => entry !== null)
+}
+
+export type RelatedDeal = {
+  id: string
+  title: string
+  status: string | null
+  pipelineStageId: string | null
+  valueAmount: string | null
+  valueCurrency: string | null
+}
+
+export function mapDeals(rows: Array<Record<string, unknown>>): RelatedDeal[] {
+  return rows
+    .map((deal) => {
+      if (!deal || typeof deal !== 'object') return null
+      const id = typeof deal.id === 'string' ? deal.id : null
+      if (!id) return null
+      return {
+        id,
+        title: typeof deal.title === 'string' ? deal.title : '',
+        status: typeof deal.status === 'string' ? deal.status : null,
+        pipelineStageId: typeof deal.pipelineStageId === 'string' ? deal.pipelineStageId : null,
+        valueAmount:
+          typeof deal.valueAmount === 'string'
+            ? deal.valueAmount
+            : deal.valueAmount === null || deal.valueAmount === undefined
+              ? null
+              : String(deal.valueAmount),
+        valueCurrency: typeof deal.valueCurrency === 'string' ? deal.valueCurrency : null,
+      }
+    })
+    .filter((value): value is RelatedDeal => value !== null)
+}
+
+export type RelatedPerson = {
+  id: string
+  displayName: string
+  primaryEmail: string | null
+  primaryPhone: string | null
+  jobTitle: string | null
+  department: string | null
+}
+
+export function mapPeople(rows: Array<Record<string, unknown>>): RelatedPerson[] {
+  return rows
+    .map((person) => {
+      if (!person || typeof person !== 'object') return null
+      const id = typeof person.id === 'string' ? person.id : null
+      const displayName = typeof person.displayName === 'string' ? person.displayName : null
+      if (!id || !displayName) return null
+      return {
+        id,
+        displayName,
+        primaryEmail: typeof person.primaryEmail === 'string' ? person.primaryEmail : null,
+        primaryPhone: typeof person.primaryPhone === 'string' ? person.primaryPhone : null,
+        jobTitle: typeof person.jobTitle === 'string' ? person.jobTitle : null,
+        department: typeof person.department === 'string' ? person.department : null,
+      }
+    })
+    .filter((value): value is RelatedPerson => value !== null)
+}
+
+export type CustomerRelatedRecords = {
+  addresses: ReturnType<typeof mapAddresses>
+  activities: ReturnType<typeof mapActivities>
+  notes: ReturnType<typeof mapNotes>
+  tasks: ReturnType<typeof mapTasks>
+  interactions: ReturnType<typeof mapInteractions>
+  tags: RelatedTag[]
+  deals: RelatedDeal[]
+  people?: RelatedPerson[]
+}
+
+/**
+ * Builds the related-records block from a customers detail API payload
+ * (`addresses`, `activities`, `comments`, `todos`, `interactions`, `tags`,
+ * `deals`, and — for companies — `people`). The key order matches the
+ * pre-refactor literals so the emitted shape is unchanged. Pass
+ * `includePeople: true` to add the companies-only `people` collection.
+ */
+export function buildRelatedRecords(
+  data: Record<string, unknown>,
+  options: { includePeople?: boolean } = {},
+): CustomerRelatedRecords {
+  const related: CustomerRelatedRecords = {
+    addresses: mapAddresses(asRows(data.addresses)),
+    activities: mapActivities(asRows(data.activities)),
+    notes: mapNotes(asRows(data.comments)),
+    tasks: mapTasks(asRows(data.todos)),
+    interactions: mapInteractions(asRows(data.interactions)),
+    tags: mapTags(asRows(data.tags)),
+    deals: mapDeals(asRows(data.deals)),
+  }
+  if (options.includePeople) {
+    related.people = mapPeople(asRows(data.people))
+  }
+  return related
+}

--- a/packages/core/src/modules/customers/ai-tools/companies-pack.ts
+++ b/packages/core/src/modules/customers/ai-tools/companies-pack.ts
@@ -19,6 +19,12 @@ import {
   type AiToolExecutionContext,
 } from '@open-mercato/ai-assistant/modules/ai_assistant/lib/ai-api-operation-runner'
 import { assertTenantScope, type CustomersAiToolDefinition, type CustomersToolContext } from './types'
+import {
+  buildRelatedRecords,
+  toCustomerListSummary,
+  toIso,
+  type CustomerRelatedRecords,
+} from './_shared'
 
 const listCompaniesInput = z
   .object({
@@ -108,27 +114,13 @@ const listCompaniesTool = defineApiBackedAiTool<
     const data = (response.data ?? {}) as ListCompaniesApiResponse
     const rawItems: ListCompaniesApiItem[] = Array.isArray(data.items) ? data.items : []
     return {
-      items: rawItems.map((row) => {
-        const createdAtRaw = row.created_at ?? row.createdAt ?? null
-        const createdAt = createdAtRaw ? new Date(String(createdAtRaw)).toISOString() : null
-        return {
-          id: row.id,
-          displayName: row.display_name ?? row.displayName ?? null,
-          primaryEmail: row.primary_email ?? row.primaryEmail ?? null,
-          primaryPhone: row.primary_phone ?? row.primaryPhone ?? null,
-          status: row.status ?? null,
-          lifecycleStage: row.lifecycle_stage ?? row.lifecycleStage ?? null,
-          source: row.source ?? null,
-          ownerUserId: row.owner_user_id ?? row.ownerUserId ?? null,
-          organizationId: row.organization_id ?? row.organizationId ?? null,
-          tenantId: row.tenant_id ?? row.tenantId ?? null,
-          domain: row.domain ?? null,
-          websiteUrl: row.website_url ?? row.websiteUrl ?? null,
-          industry: row.industry ?? null,
-          sizeBucket: row.size_bucket ?? row.sizeBucket ?? null,
-          createdAt,
-        }
-      }),
+      items: rawItems.map((row) => ({
+        ...toCustomerListSummary(row),
+        domain: row.domain ?? null,
+        websiteUrl: row.website_url ?? row.websiteUrl ?? null,
+        industry: row.industry ?? null,
+        sizeBucket: row.size_bucket ?? row.sizeBucket ?? null,
+      })),
       total: typeof data.total === 'number' ? data.total : 0,
       limit,
       offset,
@@ -145,13 +137,6 @@ const getCompanyInput = z.object({
 })
 
 type GetCompanyInput = z.infer<typeof getCompanyInput>
-
-function toIsoCompany(value: unknown): string | null {
-  if (!value) return null
-  const dt = value instanceof Date ? value : new Date(String(value))
-  if (Number.isNaN(dt.getTime())) return null
-  return dt.toISOString()
-}
 
 const getCompanyTool: CustomersAiToolDefinition = {
   name: 'customers.get_company',
@@ -193,134 +178,9 @@ const getCompanyTool: CustomersAiToolDefinition = {
     const profileRow = (data.profile ?? null) as Record<string, unknown> | null
     const customFields = (data.customFields ?? {}) as Record<string, unknown>
 
-    let related: Record<string, unknown> | null = null
+    let related: CustomerRelatedRecords | null = null
     if (includeRelated) {
-      const addresses = Array.isArray(data.addresses) ? (data.addresses as Array<Record<string, unknown>>) : []
-      const activities = Array.isArray(data.activities) ? (data.activities as Array<Record<string, unknown>>) : []
-      const notes = Array.isArray(data.comments) ? (data.comments as Array<Record<string, unknown>>) : []
-      const todos = Array.isArray(data.todos) ? (data.todos as Array<Record<string, unknown>>) : []
-      const interactions = Array.isArray(data.interactions) ? (data.interactions as Array<Record<string, unknown>>) : []
-      const tagsRows = Array.isArray(data.tags) ? (data.tags as Array<Record<string, unknown>>) : []
-      const dealsRows = Array.isArray(data.deals) ? (data.deals as Array<Record<string, unknown>>) : []
-      const peopleRows = Array.isArray(data.people) ? (data.people as Array<Record<string, unknown>>) : []
-      related = {
-        addresses: addresses.map((address) => ({
-          id: address.id,
-          name: address.name ?? null,
-          purpose: address.purpose ?? null,
-          addressLine1: address.addressLine1 ?? null,
-          addressLine2: address.addressLine2 ?? null,
-          city: address.city ?? null,
-          region: address.region ?? null,
-          postalCode: address.postalCode ?? null,
-          country: address.country ?? null,
-          isPrimary: !!address.isPrimary,
-        })),
-        activities: activities.map((activity) => ({
-          id: activity.id,
-          activityType: activity.activityType,
-          subject: activity.subject ?? null,
-          body: activity.body ?? null,
-          occurredAt: toIsoCompany(activity.occurredAt),
-          createdAt: toIsoCompany(activity.createdAt),
-        })),
-        notes: notes.map((comment) => ({
-          id: comment.id,
-          body: comment.body,
-          authorUserId: comment.authorUserId ?? null,
-          createdAt: toIsoCompany(comment.createdAt),
-        })),
-        tasks: todos.map((task) => ({
-          id: task.id,
-          todoId: task.todoId ?? task.id,
-          todoSource: task.todoSource ?? null,
-          createdAt: toIsoCompany(task.createdAt),
-        })),
-        interactions: interactions.map((interaction) => ({
-          id: interaction.id,
-          interactionType: interaction.interactionType,
-          title: interaction.title ?? null,
-          status: interaction.status,
-          scheduledAt: toIsoCompany(interaction.scheduledAt),
-          occurredAt: toIsoCompany(interaction.occurredAt),
-        })),
-        tags: tagsRows
-          .map((tag) => {
-            if (!tag || typeof tag !== 'object') return null
-            const id = typeof tag.id === 'string' ? tag.id : null
-            const label = typeof tag.label === 'string' ? tag.label : null
-            if (!id || !label) return null
-            const slug = typeof tag.slug === 'string' ? tag.slug : label
-            const color = typeof tag.color === 'string' ? tag.color : null
-            return { id, slug, label, color }
-          })
-          .filter(
-            (entry): entry is { id: string; slug: string; label: string; color: string | null } =>
-              entry !== null,
-          ),
-        deals: dealsRows
-          .map((deal) => {
-            if (!deal || typeof deal !== 'object') return null
-            const id = typeof deal.id === 'string' ? deal.id : null
-            if (!id) return null
-            return {
-              id,
-              title: typeof deal.title === 'string' ? deal.title : '',
-              status: typeof deal.status === 'string' ? deal.status : null,
-              pipelineStageId:
-                typeof deal.pipelineStageId === 'string' ? deal.pipelineStageId : null,
-              valueAmount:
-                typeof deal.valueAmount === 'string'
-                  ? deal.valueAmount
-                  : deal.valueAmount === null || deal.valueAmount === undefined
-                    ? null
-                    : String(deal.valueAmount),
-              valueCurrency:
-                typeof deal.valueCurrency === 'string' ? deal.valueCurrency : null,
-            }
-          })
-          .filter(
-            (
-              value,
-            ): value is {
-              id: string
-              title: string
-              status: string | null
-              pipelineStageId: string | null
-              valueAmount: string | null
-              valueCurrency: string | null
-            } => value !== null,
-          ),
-        people: peopleRows
-          .map((person) => {
-            if (!person || typeof person !== 'object') return null
-            const id = typeof person.id === 'string' ? person.id : null
-            const displayName = typeof person.displayName === 'string' ? person.displayName : null
-            if (!id || !displayName) return null
-            return {
-              id,
-              displayName,
-              primaryEmail:
-                typeof person.primaryEmail === 'string' ? person.primaryEmail : null,
-              primaryPhone:
-                typeof person.primaryPhone === 'string' ? person.primaryPhone : null,
-              jobTitle: typeof person.jobTitle === 'string' ? person.jobTitle : null,
-              department: typeof person.department === 'string' ? person.department : null,
-            }
-          })
-          .filter(
-            (
-              value,
-            ): value is {
-              id: string
-              displayName: string
-              primaryEmail: string | null
-              primaryPhone: string | null
-              jobTitle: string | null
-              department: string | null
-            } => value !== null,
-          ),
-      }
+      related = buildRelatedRecords(data, { includePeople: true })
     }
     return {
       found: true as const,
@@ -336,8 +196,8 @@ const getCompanyTool: CustomersAiToolDefinition = {
         ownerUserId: companyRow.ownerUserId ?? null,
         organizationId: companyRow.organizationId ?? null,
         tenantId: companyRow.tenantId ?? null,
-        createdAt: toIsoCompany(companyRow.createdAt),
-        updatedAt: toIsoCompany(companyRow.updatedAt),
+        createdAt: toIso(companyRow.createdAt),
+        updatedAt: toIso(companyRow.updatedAt),
       },
       profile: profileRow
         ? {

--- a/packages/core/src/modules/customers/ai-tools/people-pack.ts
+++ b/packages/core/src/modules/customers/ai-tools/people-pack.ts
@@ -17,7 +17,6 @@
  * documented aggregate detail route). Tool name, schema, requiredFeatures,
  * and output shape are unchanged.
  */
-import type { EntityManager } from '@mikro-orm/postgresql'
 import { z } from 'zod'
 import { defineApiBackedAiTool } from '@open-mercato/ai-assistant/modules/ai_assistant/lib/api-backed-tool'
 import {
@@ -30,19 +29,16 @@ import {
   CustomerPersonProfile,
 } from '../data/entities'
 import { assertTenantScope, type CustomersAiToolDefinition, type CustomersToolContext } from './types'
+import {
+  buildRelatedRecords,
+  buildScope,
+  resolveEm,
+  toCustomerListSummary,
+  toIso,
+  type CustomerRelatedRecords,
+} from './_shared'
 
 const NIL_UUID = '00000000-0000-0000-0000-000000000000'
-
-function resolveEm(ctx: CustomersToolContext | AiToolExecutionContext): EntityManager {
-  return ctx.container.resolve<EntityManager>('em')
-}
-
-function buildScope(ctx: CustomersToolContext | AiToolExecutionContext, tenantId: string) {
-  return {
-    tenantId,
-    organizationId: ctx.organizationId,
-  }
-}
 
 const listPeopleInput = z
   .object({
@@ -146,23 +142,7 @@ const listPeopleTool = defineApiBackedAiTool<ListPeopleInput, ListPeopleApiRespo
     const data = (response.data ?? {}) as ListPeopleApiResponse
     const rawItems: ListPeopleApiItem[] = Array.isArray(data.items) ? data.items : []
     return {
-      items: rawItems.map((row) => {
-        const createdAtRaw = row.created_at ?? row.createdAt ?? null
-        const createdAt = createdAtRaw ? new Date(String(createdAtRaw)).toISOString() : null
-        return {
-          id: row.id,
-          displayName: row.display_name ?? row.displayName ?? null,
-          primaryEmail: row.primary_email ?? row.primaryEmail ?? null,
-          primaryPhone: row.primary_phone ?? row.primaryPhone ?? null,
-          status: row.status ?? null,
-          lifecycleStage: row.lifecycle_stage ?? row.lifecycleStage ?? null,
-          source: row.source ?? null,
-          ownerUserId: row.owner_user_id ?? row.ownerUserId ?? null,
-          organizationId: row.organization_id ?? row.organizationId ?? null,
-          tenantId: row.tenant_id ?? row.tenantId ?? null,
-          createdAt,
-        }
-      }),
+      items: rawItems.map((row) => toCustomerListSummary(row)),
       total: typeof data.total === 'number' ? data.total : 0,
       limit,
       offset,
@@ -181,13 +161,6 @@ const getPersonInput = z.object({
 type GetPersonInput = z.infer<typeof getPersonInput>
 
 type ApiPersonDetailRow = Record<string, unknown> | null | undefined
-
-function toIso(value: unknown): string | null {
-  if (!value) return null
-  const dt = value instanceof Date ? value : new Date(String(value))
-  if (Number.isNaN(dt.getTime())) return null
-  return dt.toISOString()
-}
 
 const getPersonTool: CustomersAiToolDefinition = {
   name: 'customers.get_person',
@@ -226,104 +199,9 @@ const getPersonTool: CustomersAiToolDefinition = {
     const profileRow = (data.profile ?? null) as ApiPersonDetailRow
     const customFields = (data.customFields ?? {}) as Record<string, unknown>
 
-    let related: Record<string, unknown> | null = null
+    let related: CustomerRelatedRecords | null = null
     if (includeRelated) {
-      const addresses = Array.isArray(data.addresses) ? (data.addresses as Array<Record<string, unknown>>) : []
-      const activities = Array.isArray(data.activities) ? (data.activities as Array<Record<string, unknown>>) : []
-      const notes = Array.isArray(data.comments) ? (data.comments as Array<Record<string, unknown>>) : []
-      const todos = Array.isArray(data.todos) ? (data.todos as Array<Record<string, unknown>>) : []
-      const interactions = Array.isArray(data.interactions) ? (data.interactions as Array<Record<string, unknown>>) : []
-      const tagsRows = Array.isArray(data.tags) ? (data.tags as Array<Record<string, unknown>>) : []
-      const dealsRows = Array.isArray(data.deals) ? (data.deals as Array<Record<string, unknown>>) : []
-      related = {
-        addresses: addresses.map((address) => ({
-          id: address.id,
-          name: address.name ?? null,
-          purpose: address.purpose ?? null,
-          addressLine1: address.addressLine1 ?? null,
-          addressLine2: address.addressLine2 ?? null,
-          city: address.city ?? null,
-          region: address.region ?? null,
-          postalCode: address.postalCode ?? null,
-          country: address.country ?? null,
-          isPrimary: !!address.isPrimary,
-        })),
-        activities: activities.map((activity) => ({
-          id: activity.id,
-          activityType: activity.activityType,
-          subject: activity.subject ?? null,
-          body: activity.body ?? null,
-          occurredAt: toIso(activity.occurredAt),
-          createdAt: toIso(activity.createdAt),
-        })),
-        notes: notes.map((comment) => ({
-          id: comment.id,
-          body: comment.body,
-          authorUserId: comment.authorUserId ?? null,
-          createdAt: toIso(comment.createdAt),
-        })),
-        tasks: todos.map((task) => ({
-          id: task.id,
-          todoId: task.todoId ?? task.id,
-          todoSource: task.todoSource ?? null,
-          createdAt: toIso(task.createdAt),
-        })),
-        interactions: interactions.map((interaction) => ({
-          id: interaction.id,
-          interactionType: interaction.interactionType,
-          title: interaction.title ?? null,
-          status: interaction.status,
-          scheduledAt: toIso(interaction.scheduledAt),
-          occurredAt: toIso(interaction.occurredAt),
-        })),
-        tags: tagsRows
-          .map((tag) => {
-            if (!tag || typeof tag !== 'object') return null
-            const id = typeof tag.id === 'string' ? tag.id : null
-            const label = typeof tag.label === 'string' ? tag.label : null
-            if (!id || !label) return null
-            const slug = typeof tag.slug === 'string' ? tag.slug : label
-            const color = typeof tag.color === 'string' ? tag.color : null
-            return { id, slug, label, color }
-          })
-          .filter(
-            (entry): entry is { id: string; slug: string; label: string; color: string | null } =>
-              entry !== null,
-          ),
-        deals: dealsRows
-          .map((deal) => {
-            if (!deal || typeof deal !== 'object') return null
-            const id = typeof deal.id === 'string' ? deal.id : null
-            if (!id) return null
-            return {
-              id,
-              title: typeof deal.title === 'string' ? deal.title : '',
-              status: typeof deal.status === 'string' ? deal.status : null,
-              pipelineStageId:
-                typeof deal.pipelineStageId === 'string' ? deal.pipelineStageId : null,
-              valueAmount:
-                typeof deal.valueAmount === 'string'
-                  ? deal.valueAmount
-                  : deal.valueAmount === null || deal.valueAmount === undefined
-                    ? null
-                    : String(deal.valueAmount),
-              valueCurrency:
-                typeof deal.valueCurrency === 'string' ? deal.valueCurrency : null,
-            }
-          })
-          .filter(
-            (
-              value,
-            ): value is {
-              id: string
-              title: string
-              status: string | null
-              pipelineStageId: string | null
-              valueAmount: string | null
-              valueCurrency: string | null
-            } => value !== null,
-          ),
-      }
+      related = buildRelatedRecords(data)
     }
 
     return {


### PR DESCRIPTION
Fixes #3627

## Problem
The customers AI-tools `companies-pack.ts` and `people-pack.ts` carried large blocks of copy-pasted code:
- an identical date-to-ISO helper under two names (`toIsoCompany` vs `toIso`),
- the same list-row → camelCase summary mapper,
- `resolveEm` / `buildScope` (only in people-pack),
- a byte-for-byte-identical related-records block (addresses / activities / notes / tasks / interactions / tags / deals).

The sibling `catalog/ai-tools/_shared.ts` already solved exactly this; customers had no equivalent, so the two packs had drifted into parallel maintenance — any change to the related-records output shape had to be applied in two places.

## Root Cause
No shared helper module for the customers AI-tools packs, so each pack maintained its own copy of identical logic.

## What Changed
- Added `packages/core/src/modules/customers/ai-tools/_shared.ts`, mirroring the catalog precedent. It exports:
  - `toIso(value)` — the single date-to-ISO helper (replaces `toIsoCompany` / local `toIso`).
  - `resolveEm` / `buildScope` — moved out of people-pack.
  - `toCustomerListSummary(row)` — the shared list-row summary mapper.
  - per-collection mappers (`mapAddresses` / `mapActivities` / `mapNotes` / `mapTasks` / `mapInteractions` / `mapTags` / `mapDeals` / `mapPeople`) plus `buildRelatedRecords(data, { includePeople })`, with exported result types.
- `companies-pack.ts` now spreads `toCustomerListSummary` and calls `buildRelatedRecords(data, { includePeople: true })`.
- `people-pack.ts` now uses the shared helpers and calls `buildRelatedRecords(data)` (no `people` collection).
- Net: ~290 lines of duplicated code removed.

## Tests
- Existing `companies-pack` / `people-pack` unit tests pass unchanged (28 tests) — proving tool names, schemas, `requiredFeatures`, and output shapes are identical.
- New `__tests__/ai-tools/_shared.test.ts`:
  - direct unit coverage of `toIso`, `toCustomerListSummary`, and `buildRelatedRecords` (incl. key-order and `includePeople` behavior);
  - a **DRY-invariant** test that runs `customers.get_company` and `customers.get_person` against the same payload and asserts the seven shared related collections are byte-identical — locking the invariant so the packs cannot drift again.
- Full customers ai-tools suite: 252 tests pass.
- `yarn workspace @open-mercato/core typecheck` → 0 errors (after `build:packages` + `generate`).
- ESLint clean on touched files.

## Backward Compatibility
No contract surface changes. Tool names, input schemas, `requiredFeatures`, and emitted output shapes are unchanged; `_shared.ts` is an internal helper (not auto-discovered, not a tool-pack export), so the generated `ai-tools.generated.ts` registry is unaffected.