### PR TITLE
test(communication_channels): make thread-token HMAC-tamper test deterministic

### DIFF
--- a/packages/core/src/modules/communication_channels/lib/__tests__/thread-token.test.ts
+++ b/packages/core/src/modules/communication_channels/lib/__tests__/thread-token.test.ts
@@ -54,7 +54,14 @@ describe('thread-token', () => {
 
     it('verifyToken rejects a token tampered in the HMAC portion', () => {
       const token = generateToken()
-      const tampered = `${token.slice(0, -2)}AA`
+      // Flip the first character of the 11-char HMAC portion. Its 6 bits are
+      // all significant (they map to the top of HMAC byte 0), so any different
+      // base64url char changes the decoded HMAC. Swapping the trailing char(s)
+      // is unreliable: the last char of an 8-byte value carries 2 padding bits
+      // the decoder discards, so e.g. `…AA` can decode to the original HMAC.
+      const hmacStart = token.length - 11
+      const replacement = token[hmacStart] === 'A' ? 'B' : 'A'
+      const tampered = `${token.slice(0, hmacStart)}${replacement}${token.slice(hmacStart + 1)}`
       expect(verifyToken(tampered)).toBe(false)
     })
 


### PR DESCRIPTION
## Problem
The CI `test` job intermittently fails on:

```
● thread-token › verifyToken rejects a token tampered in the HMAC portion
    expect(verifyToken(tampered)).toBe(false)
    Expected: false
    Received: true
```

This surfaced as a red `test` check on unrelated PRs (e.g. #3641), with no code change in that area — a classic flaky test.

## Root Cause
The test tampered with the HMAC by replacing the **last two** chars of the 11-char base64url HMAC portion with `AA`:

```ts
const tampered = `${token.slice(0, -2)}AA`
```

The HMAC is 8 bytes = 64 bits. base64url packs 6 bits/char, so the **final** char of an 8-byte value carries 2 trailing **padding bits that the decoder discards**. For ~0.1% of random tokens, the original HMAC already ends in chars that decode to the same bytes as the `…AA` replacement, so the "tampered" token decodes to the **identical HMAC** and `verifyToken` correctly returns `true` — failing the assertion.

Measured locally: **98 false-accepts per 100,000 tokens** (≈0.098%), which matches the observed CI flake rate.

## Fix
Flip the **first** char of the HMAC portion instead. Its 6 bits are all significant (they map to the top of HMAC byte 0), so any different base64url char is guaranteed to change the decoded HMAC — mirroring the existing "random portion" tamper test directly above it.

Measured locally: **0 false-accepts per 100,000 tokens.**

## Tests
- `thread-token.test.ts` suite: 31/31 pass.
- Stress harness (throwaway, not committed): old approach 98/100k false-accepts; new approach 0/100k.

## Backward Compatibility
Test-only change. No production code, signatures, or contract surfaces touched.

## Risk
- **Blast radius:** none — a single test assertion.
- **Rollback:** revert this commit.
