### PR TITLE
fix(ui): obey Rules of Hooks in DataTable, MFA page, feature_toggles (#3616)

### DIFF
--- a/packages/core/src/modules/feature_toggles/components/__tests__/booleanOverrideSelectValue.test.ts
+++ b/packages/core/src/modules/feature_toggles/components/__tests__/booleanOverrideSelectValue.test.ts
@@ -3,8 +3,8 @@
 import { booleanOverrideSelectValue } from '../overrideFormConfig'
 
 // Guards BOTH boolean <Select> call sites: the per-tenant override card
-// (overrideFormConfig.renderOverrideValueComponent) and the GLOBAL toggle
-// default-value form (formConfig.renderDefaultValueCreateComponent). The
+// (overrideFormConfig.OverrideValueField) and the GLOBAL toggle
+// default-value form (formConfig.DefaultValueField). The
 // latter previously bound `props.value as string || 'false'`, which leaked a
 // real boolean `true` straight into <Select value>, matched no <SelectItem>,
 // and rendered blank (QA round-6 follow-up to #2410).

--- a/packages/core/src/modules/feature_toggles/components/__tests__/formConfigHoistedFields.test.tsx
+++ b/packages/core/src/modules/feature_toggles/components/__tests__/formConfigHoistedFields.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for #3616: the feature_toggles default-value and
+ * override-value renderers used to be plain render helpers that called useT() on
+ * their first line. CrudForm invokes a custom field's `component` as a bare
+ * function call (`field.component({...})`), so useT() ran inside the *caller's*
+ * render frame and only for the field that was actually mounted — a conditional
+ * hook. The renderers are now real hoisted components (DefaultValueField /
+ * OverrideValueField) referenced via `component: (props) => <Comp {...props} />`,
+ * so the hook runs inside the component's own boundary. Mirrors #3173.
+ */
+import * as React from 'react'
+import * as fs from 'fs'
+import * as path from 'path'
+import { render } from '@testing-library/react'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { createFieldDefinitions } from '@open-mercato/core/modules/feature_toggles/components/formConfig'
+import { createOverrideFieldDefinitions } from '@open-mercato/core/modules/feature_toggles/components/overrideFormConfig'
+
+const t = (key: string) => key
+
+type CustomComponent = (props: Record<string, unknown>) => React.ReactNode
+
+function getCustomComponent(fields: Array<{ id: string; component?: CustomComponent }>, id: string): CustomComponent {
+  const field = fields.find((f) => f.id === id)
+  if (!field?.component) throw new Error(`missing custom component for ${id}`)
+  return field.component
+}
+
+// Mimics how CrudForm hosts a custom field: the host owns hooks and then invokes
+// `field.component({...})` as a bare function call. If that call runs a hook
+// (the bug), toggling whether the field is shown changes the host's hook count
+// and React throws. When the component returns JSX that mounts a real component,
+// the host's hook count is stable.
+function Host({ show, component, fieldProps }: { show: boolean; component: CustomComponent; fieldProps: Record<string, unknown> }) {
+  const [marker] = React.useState('marker')
+  return (
+    <div data-marker={marker}>{show ? component(fieldProps) : null}</div>
+  )
+}
+
+const defaultFieldProps = {
+  id: 'defaultValue',
+  value: true,
+  setValue: () => {},
+  setFormValue: () => {},
+  values: { type: 'boolean' },
+}
+
+const overrideFieldProps = {
+  id: 'overrideValue',
+  value: true,
+  setValue: () => {},
+  setFormValue: () => {},
+  values: { toggleType: 'boolean', isOverride: true },
+}
+
+describe('feature_toggles hoisted custom field components (#3616)', () => {
+  it('keeps host hook count stable when the default-value field mounts/unmounts', () => {
+    const component = getCustomComponent(createFieldDefinitions(t) as any, 'defaultValue')
+    const { rerender } = render(
+      <I18nProvider locale="en" dict={{}}>
+        <Host show={false} component={component} fieldProps={defaultFieldProps} />
+      </I18nProvider>,
+    )
+    expect(() => {
+      rerender(
+        <I18nProvider locale="en" dict={{}}>
+          <Host show component={component} fieldProps={defaultFieldProps} />
+        </I18nProvider>,
+      )
+    }).not.toThrow()
+  })
+
+  it('keeps host hook count stable when the override-value field mounts/unmounts', () => {
+    const component = getCustomComponent(createOverrideFieldDefinitions(t) as any, 'overrideValue')
+    const { rerender } = render(
+      <I18nProvider locale="en" dict={{}}>
+        <Host show={false} component={component} fieldProps={overrideFieldProps} />
+      </I18nProvider>,
+    )
+    expect(() => {
+      rerender(
+        <I18nProvider locale="en" dict={{}}>
+          <Host show component={component} fieldProps={overrideFieldProps} />
+        </I18nProvider>,
+      )
+    }).not.toThrow()
+  })
+
+  it('renders the default-value boolean selector', () => {
+    const component = getCustomComponent(createFieldDefinitions(t) as any, 'defaultValue')
+    const { container } = render(
+      <I18nProvider locale="en" dict={{}}>
+        <div>{component(defaultFieldProps)}</div>
+      </I18nProvider>,
+    )
+    expect(container.textContent).toContain('Default Value (Boolean)')
+  })
+})
+
+describe('feature_toggles hoisted custom field components — structural (#3616)', () => {
+  const formSource = fs.readFileSync(path.join(__dirname, '..', 'formConfig.tsx'), 'utf8')
+  const overrideSource = fs.readFileSync(path.join(__dirname, '..', 'overrideFormConfig.tsx'), 'utf8')
+
+  it('declares DefaultValueField at module scope and wires it as a component element', () => {
+    expect(formSource).toMatch(/^export function DefaultValueField\b/m)
+    expect(formSource).toMatch(/<DefaultValueField\b/)
+    expect(formSource).not.toMatch(/renderDefaultValueCreateComponent/)
+  })
+
+  it('declares OverrideValueField at module scope and wires it as a component element', () => {
+    expect(overrideSource).toMatch(/^export function OverrideValueField\b/m)
+    expect(overrideSource).toMatch(/<OverrideValueField\b/)
+    expect(overrideSource).not.toMatch(/renderOverrideValueComponent/)
+  })
+})

--- a/packages/core/src/modules/feature_toggles/components/formConfig.tsx
+++ b/packages/core/src/modules/feature_toggles/components/formConfig.tsx
@@ -13,7 +13,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { booleanOverrideSelectValue } from "./overrideFormConfig";
 
 
-export function renderDefaultValueCreateComponent(props: CrudCustomFieldRenderProps) {
+export function DefaultValueField(props: CrudCustomFieldRenderProps) {
     const t = useT()
     const selectedType = props.values?.type as string;
 
@@ -132,7 +132,7 @@ export function createFieldDefinitions(
             id: 'defaultValue',
             label: '',
             type: 'custom',
-            component: renderDefaultValueCreateComponent,
+            component: (props) => <DefaultValueField {...props} />,
             description: t('feature_toggles.form.fields.defaultValue.description'),
         },
     ]

--- a/packages/core/src/modules/feature_toggles/components/overrideFormConfig.tsx
+++ b/packages/core/src/modules/feature_toggles/components/overrideFormConfig.tsx
@@ -20,7 +20,7 @@ export function booleanOverrideSelectValue(value: unknown): 'true' | 'false' {
   return value === true || value === 'true' ? 'true' : 'false'
 }
 
-export function renderOverrideValueComponent(props: CrudCustomFieldRenderProps) {
+export function OverrideValueField(props: CrudCustomFieldRenderProps) {
     const t = useT()
     const toggleType = props.values?.toggleType as string;
     const isOverride = props.values?.isOverride as boolean;
@@ -119,7 +119,7 @@ export function createOverrideFieldDefinitions(
             id: 'overrideValue',
             label: '',
             type: 'custom',
-            component: renderOverrideValueComponent,
+            component: (props) => <OverrideValueField {...props} />,
             description: t('feature_toggles.override.fields.overrideValue.description'),
         },
     ]

--- a/packages/enterprise/src/modules/security/backend/profile/security/mfa/__tests__/page.hooks.test.tsx
+++ b/packages/enterprise/src/modules/security/backend/profile/security/mfa/__tests__/page.hooks.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for #3616: the MFA settings page's provider cell must not
+ * call useProviderListComponent conditionally. Previously ProviderListCell
+ * returned early for recovery_codes / missing-provider rows and only then called
+ * the hook, so the same cell fiber switching row kind between renders changed the
+ * hook count and React threw "Rendered more/fewer hooks than during the previous
+ * render". The hook now lives in a dedicated ProviderRowItem that always receives
+ * a provider; ProviderListCell itself calls no hooks.
+ */
+import * as React from 'react'
+import * as fs from 'fs'
+import * as path from 'path'
+import { render } from '@testing-library/react'
+import type { MfaProvider } from '@open-mercato/enterprise/modules/security/types'
+
+// useProviderListComponent is the conditional hook at the heart of the bug. Mock
+// it with a real React hook (useMemo) so that, in the unfixed code, the early
+// returns in ProviderListCell would change the hook count between renders.
+jest.mock('@open-mercato/enterprise/modules/security/components/mfa-ui-registry', () => ({
+  useProviderListComponent: (provider: MfaProvider) => {
+    React.useMemo(() => provider.type, [provider.type])
+    return function ListComponent({ provider: p }: { provider: MfaProvider }) {
+      return <div data-testid="provider-list-item">{p.label}</div>
+    }
+  },
+}))
+
+jest.mock(
+  '@open-mercato/enterprise/modules/security/components/mfa-provider-list-items/RecoveryCodesListItem',
+  () => ({
+    __esModule: true,
+    default: () => <div data-testid="recovery-codes-item">Recovery codes</div>,
+  }),
+)
+
+// Mock the heavy/unrelated imports the page module pulls in at import time so the
+// test stays focused on the cell components and does not boot a full DataTable.
+jest.mock('next/navigation.js', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  PageBody: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}))
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({ DataTable: () => <div /> }))
+jest.mock('@open-mercato/ui/backend/EmptyState', () => ({ EmptyState: () => <div /> }))
+jest.mock('@open-mercato/ui/backend/detail', () => ({ LoadingMessage: () => <div /> }))
+jest.mock('@open-mercato/ui/backend/forms/FormHeader', () => ({ FormHeader: () => <div /> }))
+jest.mock('@open-mercato/enterprise/modules/security/components/MfaEnrollmentNotice', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+jest.mock('@open-mercato/enterprise/modules/security/components/hooks/useMfaStatus', () => ({
+  useMfaStatus: () => ({ loading: false, methods: [], providers: [] }),
+}))
+jest.mock('@open-mercato/enterprise/modules/security/lib/mfa-enrollment-notice', () => ({
+  removeMfaEnrollmentNoticeQueryFromHref: () => null,
+  resolveMfaEnrollmentNotice: () => ({ visible: false, overdue: false }),
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pageModule = require('../page')
+const ProviderListCell = pageModule.ProviderListCell as React.ComponentType<{
+  row: { kind: 'provider' | 'recovery_codes'; provider?: MfaProvider; configuredCount?: number }
+  onOpenProvider: (providerType: string) => void
+}>
+
+const provider: MfaProvider = {
+  type: 'totp',
+  label: 'Authenticator app',
+  icon: 'shield',
+  allowMultiple: false,
+}
+
+const providerRow = { kind: 'provider' as const, provider, configuredCount: 1 }
+const recoveryRow = { kind: 'recovery_codes' as const }
+
+describe('SecurityMfaPage ProviderListCell hook stability (#3616)', () => {
+  it('does not change hook count when a cell switches provider → recovery_codes', () => {
+    const { rerender } = render(
+      <ProviderListCell row={providerRow} onOpenProvider={() => {}} />,
+    )
+    expect(() => {
+      rerender(<ProviderListCell row={recoveryRow} onOpenProvider={() => {}} />)
+    }).not.toThrow()
+  })
+
+  it('does not change hook count when a cell switches recovery_codes → provider', () => {
+    const { rerender } = render(
+      <ProviderListCell row={recoveryRow} onOpenProvider={() => {}} />,
+    )
+    expect(() => {
+      rerender(<ProviderListCell row={providerRow} onOpenProvider={() => {}} />)
+    }).not.toThrow()
+  })
+
+  it('renders the provider list item for a provider row', () => {
+    const { getByTestId } = render(
+      <ProviderListCell row={providerRow} onOpenProvider={() => {}} />,
+    )
+    expect(getByTestId('provider-list-item').textContent).toBe('Authenticator app')
+  })
+})
+
+describe('SecurityMfaPage ProviderListCell — structural (#3616)', () => {
+  const source = fs.readFileSync(path.join(__dirname, '..', 'page.tsx'), 'utf8')
+
+  it('declares ProviderRowItem that calls the hook unconditionally', () => {
+    expect(source).toMatch(/function ProviderRowItem\b/)
+  })
+
+  it('does not call useProviderListComponent inside ProviderListCell after an early return', () => {
+    const cellBody = source.slice(source.indexOf('function ProviderListCell'))
+    expect(cellBody).not.toMatch(/useProviderListComponent/)
+  })
+})

--- a/packages/enterprise/src/modules/security/backend/profile/security/mfa/page.tsx
+++ b/packages/enterprise/src/modules/security/backend/profile/security/mfa/page.tsx
@@ -31,20 +31,40 @@ type ProviderListCellProps = {
   onOpenProvider: (providerType: string) => void
 }
 
-function ProviderListCell({ row, onOpenProvider }: ProviderListCellProps) {
+type ProviderRowItemProps = {
+  provider: MfaProvider
+  configuredCount: number
+  onOpenProvider: (providerType: string) => void
+}
+
+// Always receives a provider so useProviderListComponent runs unconditionally,
+// keeping the hook count stable. The recovery_codes / missing-provider branches
+// live in the parent (ProviderListCell), which now calls no hooks at all.
+export function ProviderRowItem({ provider, configuredCount, onOpenProvider }: ProviderRowItemProps) {
+  const ListComponent = useProviderListComponent(provider)
+
+  return (
+    <ListComponent
+      provider={provider}
+      configuredCount={configuredCount}
+      onClick={() => onOpenProvider(provider.type)}
+    />
+  )
+}
+
+export function ProviderListCell({ row, onOpenProvider }: ProviderListCellProps) {
   if (row.kind === 'recovery_codes') {
     return <RecoveryCodesListItem onClick={() => onOpenProvider('recovery_codes')} />
   }
 
   const provider = row.provider
   if (!provider) return null
-  const ListComponent = useProviderListComponent(provider)
 
   return (
-    <ListComponent
+    <ProviderRowItem
       provider={provider}
       configuredCount={row.configuredCount ?? 0}
-      onClick={() => onOpenProvider(provider.type)}
+      onOpenProvider={onOpenProvider}
     />
   )
 }

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -2690,14 +2690,18 @@ export function DataTable<T>({
     return () => observer.disconnect()
   }, [tableScrollEl])
   const allRows = table.getRowModel().rows
-  const rowVirtualizer = virtualized
-    ? useVirtualizer({
-        count: allRows.length,
-        getScrollElement: () => virtualScrollRef.current,
-        estimateSize: () => 48,
-        overscan: virtualizedOverscan,
-      })
-    : null
+  // Hooks must run on every render regardless of props (Rules of Hooks). Call
+  // useVirtualizer unconditionally and keep it inert when virtualization is off
+  // (count 0, no scroll element → no observers, no measurement work), then
+  // derive the nullable handle from the prop. Mirrors the unconditional-hooks-
+  // first pattern in RowActions.
+  const rowVirtualizerInstance = useVirtualizer({
+    count: virtualized ? allRows.length : 0,
+    getScrollElement: () => (virtualized ? virtualScrollRef.current : null),
+    estimateSize: () => 48,
+    overscan: virtualizedOverscan,
+  })
+  const rowVirtualizer = virtualized ? rowVirtualizerInstance : null
   const virtualMaxHeightStyle: React.CSSProperties | undefined = virtualized
     ? {
         maxHeight: typeof virtualizedMaxHeight === 'number'

--- a/packages/ui/src/backend/__tests__/DataTable.virtualizedHooks.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.virtualizedHooks.test.tsx
@@ -1,0 +1,89 @@
+/** @jest-environment jsdom */
+/**
+ * Regression coverage for #3616: DataTable's useVirtualizer must run on every
+ * render regardless of the `virtualized` prop (Rules of Hooks). Previously the
+ * hook was called inside a ternary gated on `virtualized`, so toggling the prop
+ * on a mounted table changed the hook count between renders and React threw
+ * "Rendered more/fewer hooks than during the previous render", blanking the
+ * entire table.
+ */
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { DataTable } from '../DataTable'
+import type { ColumnDef } from '@tanstack/react-table'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+}))
+
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false }),
+}))
+
+type Row = { id: string; name: string }
+
+const columns: ColumnDef<Row>[] = [{ accessorKey: 'name', header: 'Name' }]
+const data: Row[] = [
+  { id: '1', name: 'Ada' },
+  { id: '2', name: 'Zed' },
+]
+
+function renderTable(virtualized: boolean, queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <I18nProvider locale="en" dict={{}}>
+        <DataTable columns={columns} data={data} virtualized={virtualized} />
+      </I18nProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('DataTable virtualized hook stability (#3616)', () => {
+  it('does not change hook count when toggling virtualized off → on', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    try {
+      const { rerender } = renderTable(false, queryClient)
+      expect(() => {
+        rerender(
+          <QueryClientProvider client={queryClient}>
+            <I18nProvider locale="en" dict={{}}>
+              <DataTable columns={columns} data={data} virtualized />
+            </I18nProvider>
+          </QueryClientProvider>,
+        )
+      }).not.toThrow()
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('does not change hook count when toggling virtualized on → off', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    try {
+      const { rerender } = renderTable(true, queryClient)
+      expect(() => {
+        rerender(
+          <QueryClientProvider client={queryClient}>
+            <I18nProvider locale="en" dict={{}}>
+              <DataTable columns={columns} data={data} virtualized={false} />
+            </I18nProvider>
+          </QueryClientProvider>,
+        )
+      }).not.toThrow()
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('still renders rows in the default non-virtualized mode', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    try {
+      const { container } = renderTable(false, queryClient)
+      expect(container.textContent).toContain('Ada')
+    } finally {
+      queryClient.clear()
+    }
+  })
+})


### PR DESCRIPTION
Fixes #3616

## Problem
Four spots called React Hooks conditionally or outside a real component boundary, violating the Rules of Hooks. The highest-impact one is in `DataTable`, which renders on nearly every backend list page: a hook ran only when the `virtualized` prop was truthy, so if that prop ever flips between renders React throws "rendered more/fewer hooks than during the previous render" and the whole table blanks out.

## Root Cause
- `packages/ui/src/backend/DataTable.tsx` — `useVirtualizer` was called inside a ternary gated on `virtualized`, so the hook count changed with the prop.
- `packages/enterprise/.../mfa/page.tsx` — `ProviderListCell` returned early for `recovery_codes` / missing-provider rows and only then called `useProviderListComponent` (a conditional hook after early returns; the same cell fiber is reused across rows).
- `packages/core/.../feature_toggles/components/formConfig.tsx` & `overrideFormConfig.tsx` — `renderDefaultValueCreateComponent` / `renderOverrideValueComponent` were plain render helpers that called `useT()` on their first line. `CrudForm` invokes a custom field's `component` as a bare function call (`field.component({...})`), so `useT()` ran inside the *caller's* render frame and only for the field actually mounted (conditional).

## What Changed
- **DataTable**: call `useVirtualizer` unconditionally and keep it inert when virtualization is off (`count` 0, no scroll element → no observers / no measurement), then derive `rowVirtualizer = virtualized ? instance : null`. Behavior for non-virtualized tables is byte-for-byte unchanged.
- **MFA page**: split out a dedicated `ProviderRowItem` that always receives a `provider` and calls `useProviderListComponent` unconditionally; `ProviderListCell` keeps the `recovery_codes` / missing-provider early returns but now calls no hooks at all.
- **feature_toggles**: convert the two render helpers into hoisted components (`DefaultValueField` / `OverrideValueField`) referenced via `component: (props) => <Comp {...props} />`, so `useT()` runs inside a valid component boundary. Same hoist-to-module-scope refactor applied in #3173.

## Tests
Added regression tests for each spot (verified red→green by reverting the fix):
- `DataTable.virtualizedHooks.test.tsx` — toggling `virtualized` off↔on on a mounted table no longer throws; non-virtualized rows still render.
- `mfa/__tests__/page.hooks.test.tsx` — a cell switching between a provider row and a recovery-codes row on the same fiber no longer throws; plus structural assertions.
- `feature_toggles/.../formConfigHoistedFields.test.tsx` — mounting/unmounting the custom fields inside a host does not change the host hook count; plus structural assertions.

Other checks run: `yarn build:packages`, `yarn generate`, `yarn typecheck` (ui/core/enterprise), targeted suites (DataTable 28, feature_toggles 83, security 254, all green), `yarn build:app`.

## Backward Compatibility
No public contract surface changes — same props, same rendered output, same field/component wiring. `DataTable` / `CrudForm` props are unchanged. The two renamed feature_toggles helpers were internal-only (self-referenced, not in any documented import table or AGENTS.md, no external consumers); renaming them to real components matches the #3173 precedent. The MFA page gains additive named exports (`ProviderListCell`, `ProviderRowItem`) for testability.