### PR TITLE
fix(customers): gate calendar event peek Edit button by manage permission (#3649)

### DIFF
--- a/packages/core/src/modules/customers/components/calendar/CalendarScreen.tsx
+++ b/packages/core/src/modules/customers/components/calendar/CalendarScreen.tsx
@@ -499,6 +499,7 @@ export function CalendarScreen() {
         showWeekends={preferences.showWeekends}
         showConflicts={preferences.conflictWarnings}
         aiSummaries={preferences.aiSummaries}
+        canManage={canManage}
         highlightItemId={highlightItemId}
         onItemClick={openEditEditor}
         onJoin={handleJoin}

--- a/packages/core/src/modules/customers/components/calendar/EventPeekPopover.tsx
+++ b/packages/core/src/modules/customers/components/calendar/EventPeekPopover.tsx
@@ -5,6 +5,7 @@ import { Sparkles } from 'lucide-react'
 import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@open-mercato/ui/primitives/popover'
+import { SimpleTooltip } from '@open-mercato/ui/primitives/tooltip'
 import { formatTimeRange } from './EventBlock'
 import type { CalendarItem, CalendarPlatform } from './types'
 
@@ -20,6 +21,7 @@ export type EventPeekPopoverProps = {
   open: boolean
   joinUrl: string | null
   aiSummaries: boolean
+  canManage?: boolean
   onOpenChange(open: boolean): void
   onJoin(item: CalendarItem): void
   onEdit(item: CalendarItem): void
@@ -31,6 +33,7 @@ export function EventPeekPopover({
   open,
   joinUrl,
   aiSummaries,
+  canManage = true,
   onOpenChange,
   onJoin,
   onEdit,
@@ -81,17 +84,32 @@ export function EventPeekPopover({
                 {t('customers.calendar.peek.join', 'Join')}
               </Button>
             ) : null}
-            <Button
-              type="button"
-              size="sm"
-              variant="secondary"
-              onClick={() => {
-                onOpenChange(false)
-                onEdit(item)
-              }}
-            >
-              {t('customers.calendar.peek.edit', 'Edit')}
-            </Button>
+            {canManage ? (
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  onOpenChange(false)
+                  onEdit(item)
+                }}
+              >
+                {t('customers.calendar.peek.edit', 'Edit')}
+              </Button>
+            ) : (
+              <SimpleTooltip
+                content={t(
+                  'customers.calendar.peek.editForbidden',
+                  "You don't have permission to edit events",
+                )}
+              >
+                <span className="inline-flex">
+                  <Button type="button" size="sm" variant="secondary" disabled className="pointer-events-none">
+                    {t('customers.calendar.peek.edit', 'Edit')}
+                  </Button>
+                </span>
+              </SimpleTooltip>
+            )}
           </div>
         </div>
       </PopoverContent>

--- a/packages/core/src/modules/customers/components/calendar/TimeGrid.tsx
+++ b/packages/core/src/modules/customers/components/calendar/TimeGrid.tsx
@@ -160,6 +160,7 @@ export function TimeGrid({
   showWeekends,
   showConflicts,
   aiSummaries,
+  canManage = true,
   highlightItemId,
   onItemClick,
   onJoin,
@@ -351,6 +352,7 @@ export function TimeGrid({
                       open={selectedId === item.id}
                       joinUrl={resolveJoinUrl(item.location)}
                       aiSummaries={aiSummaries}
+                      canManage={canManage}
                       onOpenChange={(open) => setSelectedId(open ? item.id : null)}
                       onJoin={onJoin}
                       onEdit={onItemClick}
@@ -462,6 +464,7 @@ export function TimeGrid({
                       open={selectedId === block.item.id}
                       joinUrl={resolveJoinUrl(block.item.location)}
                       aiSummaries={aiSummaries}
+                      canManage={canManage}
                       onOpenChange={(open) => setSelectedId(open ? block.item.id : null)}
                       onJoin={onJoin}
                       onEdit={onItemClick}

--- a/packages/core/src/modules/customers/components/calendar/__tests__/EventPeekPopover.test.tsx
+++ b/packages/core/src/modules/customers/components/calendar/__tests__/EventPeekPopover.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { EventPeekPopover } from '../EventPeekPopover'
+import type { CalendarItem } from '../types'
+
+const dict = {
+  'customers.calendar.peek.edit': 'Edit',
+  'customers.calendar.peek.editForbidden': "You don't have permission to edit events",
+  'customers.calendar.peek.join': 'Join',
+  'customers.calendar.grid.untitled': 'Untitled',
+}
+
+function buildItem(): CalendarItem {
+  const start = new Date('2026-06-26T10:00:00.000Z')
+  const end = new Date('2026-06-26T11:00:00.000Z')
+  return {
+    id: 'item-1',
+    title: 'Quarterly review',
+    interactionType: 'meeting',
+    category: 'meeting',
+    status: 'planned',
+    start,
+    end,
+    allDay: false,
+    location: null,
+    platform: null,
+    locationKind: null,
+    participants: [],
+    ownerUserId: null,
+    entityId: null,
+    dealId: null,
+    color: null,
+    isRecurringOccurrence: false,
+    updatedAt: null,
+    raw: { id: 'item-1', interactionType: 'meeting', status: 'planned' },
+  }
+}
+
+function renderPopover(canManage: boolean, onEdit: jest.Mock, onOpenChange: jest.Mock) {
+  return renderWithProviders(
+    <EventPeekPopover
+      item={buildItem()}
+      open
+      joinUrl={null}
+      aiSummaries={false}
+      canManage={canManage}
+      onOpenChange={onOpenChange}
+      onJoin={jest.fn()}
+      onEdit={onEdit}
+    >
+      <button type="button">trigger</button>
+    </EventPeekPopover>,
+    { dict },
+  )
+}
+
+describe('EventPeekPopover — edit permission gating (#3649)', () => {
+  it('opens the editor when the user can manage interactions', () => {
+    const onEdit = jest.fn()
+    const onOpenChange = jest.fn()
+    renderPopover(true, onEdit, onOpenChange)
+
+    const editButton = screen.getByRole('button', { name: 'Edit' })
+    expect(editButton).not.toBeDisabled()
+
+    fireEvent.click(editButton)
+    expect(onEdit).toHaveBeenCalledTimes(1)
+    expect(onEdit).toHaveBeenCalledWith(expect.objectContaining({ id: 'item-1' }))
+  })
+
+  it('disables the Edit button and never calls onEdit when the user cannot manage interactions', () => {
+    const onEdit = jest.fn()
+    const onOpenChange = jest.fn()
+    renderPopover(false, onEdit, onOpenChange)
+
+    const editButton = screen.getByRole('button', { name: 'Edit' })
+    expect(editButton).toBeDisabled()
+
+    fireEvent.click(editButton)
+    expect(onEdit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/components/calendar/types.ts
+++ b/packages/core/src/modules/customers/components/calendar/types.ts
@@ -87,6 +87,7 @@ export interface TimeGridProps {
   showWeekends: boolean
   showConflicts: boolean
   aiSummaries: boolean
+  canManage?: boolean
   highlightItemId?: string | null
   onItemClick(item: CalendarItem): void
   onJoin(item: CalendarItem): void

--- a/packages/core/src/modules/customers/i18n/de.json
+++ b/packages/core/src/modules/customers/i18n/de.json
@@ -312,6 +312,7 @@
   "customers.calendar.peek.attendee": "1 Teilnehmer",
   "customers.calendar.peek.attendees": "{count} Teilnehmer",
   "customers.calendar.peek.edit": "Bearbeiten",
+  "customers.calendar.peek.editForbidden": "Sie haben keine Berechtigung, Termine zu bearbeiten",
   "customers.calendar.peek.join": "Beitreten",
   "customers.calendar.platform.meet": "Meet",
   "customers.calendar.platform.slack": "Slack",

--- a/packages/core/src/modules/customers/i18n/en.json
+++ b/packages/core/src/modules/customers/i18n/en.json
@@ -312,6 +312,7 @@
   "customers.calendar.peek.attendee": "1 attendee",
   "customers.calendar.peek.attendees": "{count} attendees",
   "customers.calendar.peek.edit": "Edit",
+  "customers.calendar.peek.editForbidden": "You don't have permission to edit events",
   "customers.calendar.peek.join": "Join",
   "customers.calendar.platform.meet": "Meet",
   "customers.calendar.platform.slack": "Slack",

--- a/packages/core/src/modules/customers/i18n/es.json
+++ b/packages/core/src/modules/customers/i18n/es.json
@@ -312,6 +312,7 @@
   "customers.calendar.peek.attendee": "1 asistente",
   "customers.calendar.peek.attendees": "{count} asistentes",
   "customers.calendar.peek.edit": "Editar",
+  "customers.calendar.peek.editForbidden": "No tienes permiso para editar eventos",
   "customers.calendar.peek.join": "Unirse",
   "customers.calendar.platform.meet": "Meet",
   "customers.calendar.platform.slack": "Slack",

--- a/packages/core/src/modules/customers/i18n/pl.json
+++ b/packages/core/src/modules/customers/i18n/pl.json
@@ -312,6 +312,7 @@
   "customers.calendar.peek.attendee": "1 uczestnik",
   "customers.calendar.peek.attendees": "{count} uczestników",
   "customers.calendar.peek.edit": "Edytuj",
+  "customers.calendar.peek.editForbidden": "Nie masz uprawnień do edycji wydarzeń",
   "customers.calendar.peek.join": "Dołącz",
   "customers.calendar.platform.meet": "Meet",
   "customers.calendar.platform.slack": "Slack",


### PR DESCRIPTION
Fixes #3649

## Problem
For a user with the **employee** role, clicking **Edit** in a calendar event's peek popover did nothing — no editor, no error, no network request. The employee role intentionally lacks `customers.interactions.manage`, so blocking the edit is correct; the bug was the **silent no-op** (a clickable button that gives no feedback).

## Root Cause
`EventPeekPopover` rendered the Edit button unconditionally and relied solely on `CalendarScreen.openEditEditor`'s silent `if (!canManage) return` as the guard. That guard produces no user-visible feedback, so the button looked actionable but did nothing. Elsewhere in the calendar (`UpcomingCards`) the same action is already gated on `canManage`; the peek popover was missing the guard.

## What Changed
- Thread the existing `canManage` flag from `CalendarScreen` → `TimeGrid` → `EventPeekPopover` (new optional `canManage` prop on `TimeGridProps` and `EventPeekPopoverProps`, defaulting to `true` so existing callers are unaffected).
- In `EventPeekPopover`, when the user cannot manage interactions the Edit button now renders **disabled with a permission tooltip** (mirroring the `DecisionMakersFooter` disabled-Button-in-Tooltip pattern) instead of an enabled button that silently no-ops.
- Added the `customers.calendar.peek.editForbidden` permission message to all four locales (en, pl, de, es).
- The server-side `if (!canManage) return` guard in `openEditEditor` is retained as defense-in-depth.

## Tests
- New `EventPeekPopover.test.tsx` regression test (`@open-mercato/core`):
  - `canManage = true` → Edit button is enabled and clicking it calls `onEdit`.
  - `canManage = false` → Edit button is disabled and `onEdit` is never called.
- `yarn workspace @open-mercato/core typecheck` → clean (after `build:packages` + `generate`).
- `yarn i18n:check-sync` → all four locales in sync.
- eslint on the changed files → clean.

## Backward Compatibility
- No contract-surface changes. The new `canManage` props are optional and default to `true`, preserving prior behavior for any external caller. No API, event ID, DI, ACL, or import-path changes.

## Security impact
- This change strengthens an access-control affordance (it does not relax one): a manage-only action that previously rendered as an apparently-clickable control is now clearly disabled for users without `customers.interactions.manage`. Authorization itself is unchanged and still enforced server-side; the UI now communicates the restriction instead of silently ignoring the click.
