### PR TITLE
refactor(crud): run custom-route writes through the full mutation-guard registry (#3619)

### DIFF
--- a/packages/core/src/modules/communication_channels/lib/__tests__/route-mutation-guard.test.ts
+++ b/packages/core/src/modules/communication_channels/lib/__tests__/route-mutation-guard.test.ts
@@ -1,0 +1,95 @@
+import type { AwilixContainer } from 'awilix'
+import { registerMutationGuards } from '@open-mercato/shared/lib/crud/mutation-guard-store'
+import type { MutationGuard } from '@open-mercato/shared/lib/crud/mutation-guard-registry'
+import { validateRouteMutationGuard } from '../route-mutation-guard'
+
+function makeContainer(registrations: Record<string, unknown> = {}): AwilixContainer {
+  return {
+    resolve: (name: string) => {
+      if (Object.prototype.hasOwnProperty.call(registrations, name)) return registrations[name]
+      throw new Error(`[test] no registration for ${name}`)
+    },
+  } as unknown as AwilixContainer
+}
+
+function makeRequest(method = 'POST'): Request {
+  return new Request('https://example.test/api/communication_channels/channels/chan-1/set-primary', { method })
+}
+
+const auth = { sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' }
+
+afterEach(() => {
+  registerMutationGuards([])
+  jest.restoreAllMocks()
+})
+
+describe('communication_channels validateRouteMutationGuard', () => {
+  it('routes a custom write through the full registry and blocks when a channel guard rejects', async () => {
+    const guard: MutationGuard = {
+      id: 'channel-guard',
+      targetEntity: 'communication_channels.channel',
+      operations: ['update', 'delete'],
+      validate: jest.fn().mockResolvedValue({ ok: false, status: 422, body: { error: 'channel blocked' } }),
+    }
+    registerMutationGuards([{ moduleId: 'communication_channels', guards: [guard] }])
+
+    const result = await validateRouteMutationGuard({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth,
+      input: { resourceKind: 'communication_channels.channel', resourceId: 'chan-1', operation: 'custom' },
+    })
+
+    expect('response' in result).toBe(true)
+    if (!('response' in result)) throw new Error('expected blocked response')
+    expect(result.response.status).toBe(422)
+    // proves the 'custom' operation was mapped to 'update' so the guard matched
+    expect(guard.validate).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns an afterSuccess runner that fires registry afterSuccess on success', async () => {
+    const afterSuccess = jest.fn().mockResolvedValue(undefined)
+    const guard: MutationGuard = {
+      id: 'channel-after-guard',
+      targetEntity: 'communication_channels.channel',
+      operations: ['update'],
+      validate: jest.fn().mockResolvedValue({ ok: true, shouldRunAfterSuccess: true }),
+      afterSuccess,
+    }
+    registerMutationGuards([{ moduleId: 'communication_channels', guards: [guard] }])
+
+    const result = await validateRouteMutationGuard({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth,
+      input: { resourceKind: 'communication_channels.channel', resourceId: 'chan-1', operation: 'custom' },
+    })
+
+    expect('response' in result).toBe(false)
+    if ('response' in result) throw new Error('expected passed result')
+    await result.afterSuccess()
+    expect(afterSuccess).toHaveBeenCalledTimes(1)
+  })
+
+  it('short-circuits to a no-op when auth is incomplete', async () => {
+    const guard: MutationGuard = {
+      id: 'never-runs',
+      targetEntity: 'communication_channels.channel',
+      operations: ['update'],
+      validate: jest.fn().mockResolvedValue({ ok: false }),
+    }
+    registerMutationGuards([{ moduleId: 'communication_channels', guards: [guard] }])
+
+    const result = await validateRouteMutationGuard({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth: { sub: null, tenantId: null },
+      input: { resourceKind: 'communication_channels.channel', resourceId: 'chan-1', operation: 'custom' },
+    })
+
+    expect('response' in result).toBe(false)
+    if ('response' in result) throw new Error('expected no-op result')
+    await expect(result.afterSuccess()).resolves.toBeUndefined()
+    expect(guard.validate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/communication_channels/lib/route-mutation-guard.ts
+++ b/packages/core/src/modules/communication_channels/lib/route-mutation-guard.ts
@@ -1,9 +1,5 @@
 import type { AwilixContainer } from 'awilix'
-import {
-  runCrudMutationGuardAfterSuccess,
-  validateCrudMutationGuard,
-  type CrudMutationGuardValidationResult,
-} from '@open-mercato/shared/lib/crud/mutation-guard'
+import { runRouteMutationGuards } from '@open-mercato/shared/lib/crud/route-mutation-guard'
 
 type RouteAuth = {
   sub?: string | null
@@ -19,10 +15,21 @@ type RouteMutationGuardInput = {
 }
 
 export type RouteMutationGuardContext = {
-  result: CrudMutationGuardValidationResult | null
+  /**
+   * Marker kept for source compatibility with callers; the registry result is
+   * fully handled inside the wrapper, so callers only need `afterSuccess`.
+   */
+  result: { ok: true } | null
   afterSuccess: () => Promise<void>
 }
 
+/**
+ * Run a communication-channels custom write route through the full mutation
+ * guard registry (`runRouteMutationGuards`) instead of only the legacy DI
+ * service. Returns `{ response }` when a guard blocks the mutation, or
+ * `{ result, afterSuccess }` to run after a successful write — preserving the
+ * shape the dependent routes already consume.
+ */
 export async function validateRouteMutationGuard(params: {
   container: AwilixContainer
   req: Request
@@ -34,35 +41,28 @@ export async function validateRouteMutationGuard(params: {
     return { result: null, afterSuccess: async () => undefined }
   }
 
-  const base = {
-    tenantId: auth.tenantId,
-    organizationId: auth.orgId ?? null,
-    userId: auth.sub,
-    resourceKind: input.resourceKind,
-    resourceId: input.resourceId,
-    operation: input.operation ?? 'custom',
-    requestMethod: req.method,
-    requestHeaders: req.headers,
-  } as const
-
-  const result = await validateCrudMutationGuard(container, {
-    ...base,
-    mutationPayload: input.mutationPayload ?? null,
+  const guarded = await runRouteMutationGuards({
+    container,
+    req,
+    auth: {
+      userId: auth.sub,
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId ?? null,
+    },
+    input: {
+      resourceKind: input.resourceKind,
+      resourceId: input.resourceId,
+      operation: input.operation ?? 'custom',
+      mutationPayload: input.mutationPayload ?? null,
+    },
   })
-  if (result && !result.ok) {
-    return {
-      response: Response.json(result.body, { status: result.status }),
-    }
+
+  if (!guarded.ok) {
+    return { response: guarded.response }
   }
 
   return {
-    result,
-    afterSuccess: async () => {
-      if (!result?.ok || !result.shouldRunAfterSuccess) return
-      await runCrudMutationGuardAfterSuccess(container, {
-        ...base,
-        metadata: result.metadata ?? null,
-      })
-    },
+    result: { ok: true },
+    afterSuccess: guarded.runAfterSuccess,
   }
 }

--- a/packages/core/src/modules/notifications/__tests__/mutation-guard.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/mutation-guard.test.ts
@@ -12,8 +12,8 @@ const ctx = {
   selectedOrganizationId: organizationId,
 }
 
-const validateCrudMutationGuardMock = jest.fn()
-const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const runRouteMutationGuardsMock = jest.fn()
+const runAfterSuccessMock = jest.fn()
 
 const serviceMock = {
   create: jest.fn(),
@@ -27,9 +27,8 @@ const serviceMock = {
   markAllAsRead: jest.fn(),
 }
 
-jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
-  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
-  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+jest.mock('@open-mercato/shared/lib/crud/route-mutation-guard', () => ({
+  runRouteMutationGuards: (...args: unknown[]) => runRouteMutationGuardsMock(...args),
 }))
 
 jest.mock('@open-mercato/shared/lib/api/context', () => ({
@@ -79,20 +78,18 @@ const jsonRequest = (url: string, method: string, body?: unknown) =>
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   })
 
-const guardArgs = (overrides: Record<string, unknown>) =>
+const guardCall = (input: Record<string, unknown>) =>
   expect.objectContaining({
-    tenantId,
-    organizationId,
-    userId,
-    requestMethod: expect.any(String),
-    ...overrides,
+    container,
+    auth: expect.objectContaining({ tenantId, organizationId, userId }),
+    input: expect.objectContaining(input),
   })
 
-describe('notification write routes run the mutation guard lifecycle', () => {
+describe('notification write routes run the mutation guard registry', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
-    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+    runAfterSuccessMock.mockResolvedValue(undefined)
+    runRouteMutationGuardsMock.mockResolvedValue({ ok: true, runAfterSuccess: runAfterSuccessMock })
     serviceMock.create.mockResolvedValue({ id: notificationId })
     serviceMock.createBatch.mockResolvedValue([{ id: notificationId }])
     serviceMock.markAsRead.mockResolvedValue(undefined)
@@ -113,14 +110,10 @@ describe('notification write routes run the mutation guard lifecycle', () => {
 
     expect(response.status).toBe(201)
     expect(serviceMock.create).toHaveBeenCalled()
-    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
-      container,
-      guardArgs({ resourceKind: 'notifications.notification', resourceId: '', operation: 'create' }),
+    expect(runRouteMutationGuardsMock).toHaveBeenCalledWith(
+      guardCall({ resourceKind: 'notifications.notification', operation: 'create' }),
     )
-    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalledWith(
-      container,
-      guardArgs({ resourceKind: 'notifications.notification', operation: 'create' }),
-    )
+    expect(runAfterSuccessMock).toHaveBeenCalled()
   })
 
   it('guards bulk create (POST /api/notifications/batch)', async () => {
@@ -134,11 +127,10 @@ describe('notification write routes run the mutation guard lifecycle', () => {
 
     expect(response.status).toBe(201)
     expect(serviceMock.createBatch).toHaveBeenCalled()
-    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
-      container,
-      guardArgs({ resourceKind: 'notifications.notification', operation: 'create' }),
+    expect(runRouteMutationGuardsMock).toHaveBeenCalledWith(
+      guardCall({ resourceKind: 'notifications.notification', operation: 'create' }),
     )
-    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    expect(runAfterSuccessMock).toHaveBeenCalled()
   })
 
   it('guards single-action update (PUT /api/notifications/[id]/read)', async () => {
@@ -149,11 +141,10 @@ describe('notification write routes run the mutation guard lifecycle', () => {
 
     expect(response.status).toBe(200)
     expect(serviceMock.markAsRead).toHaveBeenCalledWith(notificationId, expect.anything())
-    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
-      container,
-      guardArgs({ resourceKind: 'notifications.notification', resourceId: notificationId, operation: 'update' }),
+    expect(runRouteMutationGuardsMock).toHaveBeenCalledWith(
+      guardCall({ resourceKind: 'notifications.notification', resourceId: notificationId, operation: 'update' }),
     )
-    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    expect(runAfterSuccessMock).toHaveBeenCalled()
   })
 
   it('guards restore (PUT /api/notifications/[id]/restore)', async () => {
@@ -164,11 +155,10 @@ describe('notification write routes run the mutation guard lifecycle', () => {
 
     expect(response.status).toBe(200)
     expect(serviceMock.restoreDismissed).toHaveBeenCalled()
-    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
-      container,
-      guardArgs({ resourceKind: 'notifications.notification', resourceId: notificationId, operation: 'update' }),
+    expect(runRouteMutationGuardsMock).toHaveBeenCalledWith(
+      guardCall({ resourceKind: 'notifications.notification', resourceId: notificationId, operation: 'update' }),
     )
-    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    expect(runAfterSuccessMock).toHaveBeenCalled()
   })
 
   it('guards execute action (POST /api/notifications/[id]/action)', async () => {
@@ -179,11 +169,10 @@ describe('notification write routes run the mutation guard lifecycle', () => {
 
     expect(response.status).toBe(200)
     expect(serviceMock.executeAction).toHaveBeenCalled()
-    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
-      container,
-      guardArgs({ resourceKind: 'notifications.notification', resourceId: notificationId, operation: 'custom' }),
+    expect(runRouteMutationGuardsMock).toHaveBeenCalledWith(
+      guardCall({ resourceKind: 'notifications.notification', resourceId: notificationId, operation: 'custom' }),
     )
-    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    expect(runAfterSuccessMock).toHaveBeenCalled()
   })
 
   it('guards mark-all-read (PUT /api/notifications/mark-all-read)', async () => {
@@ -193,11 +182,10 @@ describe('notification write routes run the mutation guard lifecycle', () => {
 
     expect(response.status).toBe(200)
     expect(serviceMock.markAllAsRead).toHaveBeenCalled()
-    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
-      container,
-      guardArgs({ resourceKind: 'notifications.notification', operation: 'update' }),
+    expect(runRouteMutationGuardsMock).toHaveBeenCalledWith(
+      guardCall({ resourceKind: 'notifications.notification', operation: 'update' }),
     )
-    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    expect(runAfterSuccessMock).toHaveBeenCalled()
   })
 
   it('guards settings update (POST /api/notifications/settings)', async () => {
@@ -209,15 +197,19 @@ describe('notification write routes run the mutation guard lifecycle', () => {
 
     expect(response.status).toBe(200)
     expect(saveNotificationDeliveryConfigMock).toHaveBeenCalled()
-    expect(validateCrudMutationGuardMock).toHaveBeenCalledWith(
-      container,
-      guardArgs({ resourceKind: 'notifications.settings', operation: 'update' }),
+    expect(runRouteMutationGuardsMock).toHaveBeenCalledWith(
+      guardCall({ resourceKind: 'notifications.settings', operation: 'update' }),
     )
-    expect(runCrudMutationGuardAfterSuccessMock).toHaveBeenCalled()
+    expect(runAfterSuccessMock).toHaveBeenCalled()
   })
 
   it('blocks the write and skips after-success hooks when the guard rejects', async () => {
-    validateCrudMutationGuardMock.mockResolvedValueOnce({ ok: false, status: 409, body: { error: 'conflict' } })
+    runRouteMutationGuardsMock.mockResolvedValueOnce({
+      ok: false,
+      errorStatus: 409,
+      errorBody: { error: 'conflict' },
+      response: Response.json({ error: 'conflict' }, { status: 409 }),
+    })
 
     const response = await markAllNotificationsRead(
       jsonRequest('http://localhost/api/notifications/mark-all-read', 'PUT'),
@@ -226,6 +218,6 @@ describe('notification write routes run the mutation guard lifecycle', () => {
     expect(response.status).toBe(409)
     await expect(response.json()).resolves.toEqual({ error: 'conflict' })
     expect(serviceMock.markAllAsRead).not.toHaveBeenCalled()
-    expect(runCrudMutationGuardAfterSuccessMock).not.toHaveBeenCalled()
+    expect(runAfterSuccessMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/notifications/lib/__tests__/routeHelpers.guard.test.ts
+++ b/packages/core/src/modules/notifications/lib/__tests__/routeHelpers.guard.test.ts
@@ -1,0 +1,77 @@
+import type { AwilixContainer } from 'awilix'
+import { registerMutationGuards } from '@open-mercato/shared/lib/crud/mutation-guard-store'
+import type { MutationGuard } from '@open-mercato/shared/lib/crud/mutation-guard-registry'
+import { runGuardedNotificationWrite } from '../routeHelpers'
+
+function makeContainer(registrations: Record<string, unknown> = {}): AwilixContainer {
+  return {
+    resolve: (name: string) => {
+      if (Object.prototype.hasOwnProperty.call(registrations, name)) return registrations[name]
+      throw new Error(`[test] no registration for ${name}`)
+    },
+  } as unknown as AwilixContainer
+}
+
+function makeRequest(method = 'POST'): Request {
+  return new Request('https://example.test/api/notifications', { method })
+}
+
+const scope = { tenantId: 'tenant-1', organizationId: 'org-1', userId: 'user-1' }
+
+afterEach(() => {
+  registerMutationGuards([])
+  jest.restoreAllMocks()
+})
+
+describe('notifications runGuardedNotificationWrite', () => {
+  it('runs the write and registry afterSuccess when guards pass', async () => {
+    const afterSuccess = jest.fn().mockResolvedValue(undefined)
+    const guard: MutationGuard = {
+      id: 'notification-guard',
+      targetEntity: 'notifications.notification',
+      operations: ['create'],
+      validate: jest.fn().mockResolvedValue({ ok: true, shouldRunAfterSuccess: true }),
+      afterSuccess,
+    }
+    registerMutationGuards([{ moduleId: 'notifications', guards: [guard] }])
+
+    const write = jest.fn().mockResolvedValue('written')
+    const result = await runGuardedNotificationWrite(
+      makeContainer(),
+      scope,
+      makeRequest(),
+      { resourceKind: 'notifications.notification', operation: 'create' },
+      write,
+    )
+
+    expect(guard.validate).toHaveBeenCalledTimes(1)
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(afterSuccess).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ ok: true, result: 'written' })
+  })
+
+  it('blocks via the registry and skips the write when a guard rejects', async () => {
+    const guard: MutationGuard = {
+      id: 'notification-block-guard',
+      targetEntity: 'notifications.notification',
+      operations: ['create'],
+      validate: jest.fn().mockResolvedValue({ ok: false, status: 422, body: { error: 'blocked' } }),
+    }
+    registerMutationGuards([{ moduleId: 'notifications', guards: [guard] }])
+
+    const write = jest.fn().mockResolvedValue('written')
+    const result = await runGuardedNotificationWrite(
+      makeContainer(),
+      scope,
+      makeRequest(),
+      { resourceKind: 'notifications.notification', operation: 'create' },
+      write,
+    )
+
+    expect(write).not.toHaveBeenCalled()
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected blocked result')
+    expect(result.response.status).toBe(422)
+    await expect(result.response.json()).resolves.toEqual({ error: 'blocked' })
+  })
+})

--- a/packages/core/src/modules/notifications/lib/routeHelpers.ts
+++ b/packages/core/src/modules/notifications/lib/routeHelpers.ts
@@ -2,10 +2,7 @@ import { z } from 'zod'
 import type { AwilixContainer } from 'awilix'
 import { resolveRequestContext } from '@open-mercato/shared/lib/api/context'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
-import {
-  runCrudMutationGuardAfterSuccess,
-  validateCrudMutationGuard,
-} from '@open-mercato/shared/lib/crud/mutation-guard'
+import { runRouteMutationGuards } from '@open-mercato/shared/lib/crud/route-mutation-guard'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveNotificationService, type NotificationService } from './notificationService'
 
@@ -106,33 +103,28 @@ export async function runGuardedNotificationWrite<T>(
   options: NotificationMutationGuardOptions,
   write: () => Promise<T>,
 ): Promise<GuardedNotificationWriteResult<T>> {
-  const guardScope = {
-    tenantId: scope.tenantId,
-    organizationId: scope.organizationId,
-    userId: scope.userId ?? '',
-    resourceKind: options.resourceKind,
-    resourceId: options.resourceId ?? '',
-    operation: options.operation,
-    requestMethod: req.method,
-    requestHeaders: req.headers,
-  }
-
-  const guardResult = await validateCrudMutationGuard(container, {
-    ...guardScope,
-    mutationPayload: options.payload ?? null,
+  const guarded = await runRouteMutationGuards({
+    container,
+    req,
+    auth: {
+      userId: scope.userId ?? '',
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+    },
+    input: {
+      resourceKind: options.resourceKind,
+      resourceId: options.resourceId ?? null,
+      operation: options.operation,
+      mutationPayload: options.payload ?? null,
+    },
   })
-  if (guardResult && !guardResult.ok) {
-    return { ok: false, response: Response.json(guardResult.body, { status: guardResult.status }) }
+  if (!guarded.ok) {
+    return { ok: false, response: guarded.response }
   }
 
   const result = await write()
 
-  if (guardResult?.ok && guardResult.shouldRunAfterSuccess) {
-    await runCrudMutationGuardAfterSuccess(container, {
-      ...guardScope,
-      metadata: guardResult.metadata ?? null,
-    })
-  }
+  await guarded.runAfterSuccess()
 
   return { ok: true, result }
 }

--- a/packages/shared/src/lib/crud/__tests__/route-mutation-guard.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/route-mutation-guard.test.ts
@@ -1,0 +1,260 @@
+import type { AwilixContainer } from 'awilix'
+import { registerMutationGuards } from '../mutation-guard-store'
+import type { MutationGuard } from '../mutation-guard-registry'
+import { runRouteMutationGuards, toRegistryMutationOperation } from '../route-mutation-guard'
+
+type Registrations = Record<string, unknown>
+
+function makeContainer(registrations: Registrations = {}): AwilixContainer {
+  return {
+    resolve: (name: string) => {
+      if (Object.prototype.hasOwnProperty.call(registrations, name)) return registrations[name]
+      throw new Error(`[test] no registration for ${name}`)
+    },
+  } as unknown as AwilixContainer
+}
+
+function makeRequest(method = 'POST'): Request {
+  return new Request('https://example.test/api/things', { method })
+}
+
+function makeGuard(overrides: Partial<MutationGuard> & { id: string }): MutationGuard {
+  return {
+    targetEntity: 'things.thing',
+    operations: ['create', 'update', 'delete'],
+    priority: 50,
+    validate: jest.fn().mockResolvedValue({ ok: true }),
+    ...overrides,
+  }
+}
+
+function registerStoreGuards(guards: MutationGuard[]) {
+  registerMutationGuards([{ moduleId: 'things', guards }])
+}
+
+const baseAuth = {
+  userId: 'user-1',
+  tenantId: 'tenant-1',
+  organizationId: 'org-1',
+  userFeatures: [] as string[],
+}
+const baseInput = {
+  resourceKind: 'things.thing',
+  resourceId: 'thing-1',
+  operation: 'update' as const,
+  mutationPayload: { title: 'Updated' },
+}
+
+afterEach(() => {
+  registerMutationGuards([])
+  jest.restoreAllMocks()
+})
+
+describe('toRegistryMutationOperation', () => {
+  it('passes create and delete through and maps update/custom/undefined to update', () => {
+    expect(toRegistryMutationOperation('create')).toBe('create')
+    expect(toRegistryMutationOperation('delete')).toBe('delete')
+    expect(toRegistryMutationOperation('update')).toBe('update')
+    expect(toRegistryMutationOperation('custom')).toBe('update')
+    expect(toRegistryMutationOperation(undefined)).toBe('update')
+  })
+})
+
+describe('runRouteMutationGuards', () => {
+  it('runs a registry-store guard the legacy bridge path would have skipped', async () => {
+    const guard = makeGuard({ id: 'store-guard' })
+    registerStoreGuards([guard])
+
+    const result = await runRouteMutationGuards({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth: baseAuth,
+      input: baseInput,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(guard.validate).toHaveBeenCalledTimes(1)
+  })
+
+  it('blocks and returns a ready response when a store guard rejects', async () => {
+    const guard = makeGuard({
+      id: 'blocking-guard',
+      validate: jest.fn().mockResolvedValue({ ok: false, status: 422, body: { error: 'nope' } }),
+    })
+    registerStoreGuards([guard])
+
+    const result = await runRouteMutationGuards({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth: baseAuth,
+      input: baseInput,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected blocked result')
+    expect(result.errorStatus).toBe(422)
+    expect(result.errorBody).toEqual({ error: 'nope' })
+    expect(result.response.status).toBe(422)
+    await expect(result.response.json()).resolves.toEqual({ error: 'nope' })
+  })
+
+  it('threads modifiedPayload from a store guard', async () => {
+    const guard = makeGuard({
+      id: 'transform-guard',
+      validate: jest.fn().mockResolvedValue({ ok: true, modifiedPayload: { extra: true } }),
+    })
+    registerStoreGuards([guard])
+
+    const result = await runRouteMutationGuards({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth: baseAuth,
+      input: baseInput,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected passed result')
+    expect(result.modifiedPayload).toEqual({ title: 'Updated', extra: true })
+  })
+
+  it('runs afterSuccess callbacks via runAfterSuccess()', async () => {
+    const afterSuccess = jest.fn().mockResolvedValue(undefined)
+    const guard = makeGuard({
+      id: 'after-guard',
+      validate: jest.fn().mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { ping: 1 } }),
+      afterSuccess,
+    })
+    registerStoreGuards([guard])
+
+    const result = await runRouteMutationGuards({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth: baseAuth,
+      input: baseInput,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected passed result')
+    expect(afterSuccess).not.toHaveBeenCalled()
+
+    await result.runAfterSuccess()
+
+    expect(afterSuccess).toHaveBeenCalledTimes(1)
+    expect(afterSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceKind: 'things.thing', resourceId: 'thing-1', metadata: { ping: 1 } }),
+    )
+  })
+
+  it('swallows afterSuccess callback errors so a committed write still succeeds', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const guard = makeGuard({
+      id: 'throwing-after-guard',
+      validate: jest.fn().mockResolvedValue({ ok: true, shouldRunAfterSuccess: true }),
+      afterSuccess: jest.fn().mockRejectedValue(new Error('after boom')),
+    })
+    registerStoreGuards([guard])
+
+    const result = await runRouteMutationGuards({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth: baseAuth,
+      input: baseInput,
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error('expected passed result')
+    await expect(result.runAfterSuccess()).resolves.toBeUndefined()
+    expect(consoleError).toHaveBeenCalled()
+  })
+
+  it('skips feature-gated guards when the caller lacks the feature', async () => {
+    const guard = makeGuard({
+      id: 'gated-guard',
+      features: ['premium.locks'],
+      validate: jest.fn().mockResolvedValue({ ok: false, message: 'should not run' }),
+    })
+    registerStoreGuards([guard])
+
+    const passes = await runRouteMutationGuards({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth: { ...baseAuth, userFeatures: [] },
+      input: baseInput,
+    })
+    expect(passes.ok).toBe(true)
+    expect(guard.validate).not.toHaveBeenCalled()
+
+    const blocks = await runRouteMutationGuards({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth: { ...baseAuth, userFeatures: ['premium.locks'] },
+      input: baseInput,
+    })
+    expect(blocks.ok).toBe(false)
+  })
+
+  it('resolves userFeatures from rbacService when not pre-supplied', async () => {
+    const getGrantedFeatures = jest.fn().mockResolvedValue(['premium.locks'])
+    const guard = makeGuard({
+      id: 'gated-guard',
+      features: ['premium.locks'],
+      validate: jest.fn().mockResolvedValue({ ok: false, message: 'blocked via rbac-resolved features' }),
+    })
+    registerStoreGuards([guard])
+
+    const result = await runRouteMutationGuards({
+      container: makeContainer({ rbacService: { getGrantedFeatures } }),
+      req: makeRequest(),
+      auth: { userId: 'user-1', tenantId: 'tenant-1', organizationId: 'org-1' },
+      input: baseInput,
+    })
+
+    expect(getGrantedFeatures).toHaveBeenCalledWith('user-1', { tenantId: 'tenant-1', organizationId: 'org-1' })
+    expect(result.ok).toBe(false)
+  })
+
+  it('maps a custom operation to update so update-scoped guards run', async () => {
+    const updateGuard = makeGuard({
+      id: 'update-only-guard',
+      operations: ['update'],
+      validate: jest.fn().mockResolvedValue({ ok: true }),
+    })
+    const createGuard = makeGuard({
+      id: 'create-only-guard',
+      operations: ['create'],
+      validate: jest.fn().mockResolvedValue({ ok: true }),
+    })
+    registerStoreGuards([updateGuard, createGuard])
+
+    const result = await runRouteMutationGuards({
+      container: makeContainer(),
+      req: makeRequest(),
+      auth: baseAuth,
+      input: { ...baseInput, operation: 'custom' },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(updateGuard.validate).toHaveBeenCalledTimes(1)
+    expect(createGuard.validate).not.toHaveBeenCalled()
+  })
+
+  it('includes the bridged legacy DI guard', async () => {
+    const legacyService = {
+      validateMutation: jest.fn().mockResolvedValue({ ok: false, status: 409, body: { error: 'locked' } }),
+      afterMutationSuccess: jest.fn().mockResolvedValue(undefined),
+    }
+
+    const result = await runRouteMutationGuards({
+      container: makeContainer({ crudMutationGuardService: legacyService }),
+      req: makeRequest('PUT'),
+      auth: baseAuth,
+      input: baseInput,
+    })
+
+    expect(legacyService.validateMutation).toHaveBeenCalledTimes(1)
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error('expected blocked result')
+    expect(result.errorStatus).toBe(409)
+    expect(result.errorBody).toEqual({ error: 'locked' })
+  })
+})

--- a/packages/shared/src/lib/crud/mutation-guard.ts
+++ b/packages/shared/src/lib/crud/mutation-guard.ts
@@ -58,8 +58,14 @@ function resolveCrudMutationGuardService(container: AwilixContainer): CrudMutati
 }
 
 /**
- * @deprecated Use `runMutationGuards()` from `@open-mercato/shared/lib/crud/mutation-guard-registry` instead.
- * This function is bridged internally via `bridgeLegacyGuard()` and will be removed in a future release.
+ * @deprecated Resolves ONLY the single DI-registered `crudMutationGuardService`,
+ * so it silently bypasses every guard in the global mutation-guard store
+ * (`getAllMutationGuardInstances()`). Use the full registry instead:
+ * `runRouteMutationGuards()` from `@open-mercato/shared/lib/crud/route-mutation-guard`
+ * for custom write routes, or `runMutationGuards()` from
+ * `@open-mercato/shared/lib/crud/mutation-guard-registry` directly. The legacy
+ * service is still honored on the modern path via `bridgeLegacyGuard()`. This
+ * function will be removed in a future release.
  */
 export async function validateCrudMutationGuard(
   container: AwilixContainer,
@@ -71,8 +77,13 @@ export async function validateCrudMutationGuard(
 }
 
 /**
- * @deprecated Use `runMutationGuards()` afterSuccess callbacks from `@open-mercato/shared/lib/crud/mutation-guard-registry` instead.
- * This function is bridged internally via `bridgeLegacyGuard()` and will be removed in a future release.
+ * @deprecated Runs ONLY the single DI-registered `crudMutationGuardService`'s
+ * after-success hook, skipping the registry guards' `afterSuccess` callbacks.
+ * Use the `runAfterSuccess()` returned by `runRouteMutationGuards()` from
+ * `@open-mercato/shared/lib/crud/route-mutation-guard`, or the
+ * `afterSuccessCallbacks` returned by `runMutationGuards()` from
+ * `@open-mercato/shared/lib/crud/mutation-guard-registry`. This function will be
+ * removed in a future release.
  */
 export async function runCrudMutationGuardAfterSuccess(
   container: AwilixContainer,

--- a/packages/shared/src/lib/crud/route-mutation-guard.ts
+++ b/packages/shared/src/lib/crud/route-mutation-guard.ts
@@ -1,0 +1,181 @@
+import type { AwilixContainer } from 'awilix'
+import {
+  bridgeLegacyGuard,
+  runMutationGuards,
+  type MutationGuard,
+} from './mutation-guard-registry'
+import { getAllMutationGuardInstances } from './mutation-guard-store'
+
+/**
+ * Shared registry-based mutation-guard wrapper for custom write routes that do
+ * not use `makeCrudRoute`.
+ *
+ * This mirrors `collectAndRunGuards()` in `factory.ts`: it runs **every** guard
+ * collected from the global mutation-guard store (`getAllMutationGuardInstances()`)
+ * plus the bridged legacy DI service (`bridgeLegacyGuard()`), so a custom route
+ * enforces the same guard set as every `makeCrudRoute` write.
+ *
+ * Prefer this over the deprecated `validateCrudMutationGuard()` /
+ * `runCrudMutationGuardAfterSuccess()` pair, which resolve only the single
+ * DI-registered `crudMutationGuardService` and silently skip registry guards.
+ */
+
+export type RouteMutationGuardOperation = 'create' | 'update' | 'delete' | 'custom'
+
+export type RouteMutationGuardAuth = {
+  userId: string
+  tenantId: string
+  organizationId?: string | null
+  /**
+   * Pre-resolved granted features for the caller. When omitted, the wrapper
+   * resolves them via `rbacService.getGrantedFeatures` (same source the CRUD
+   * factory uses). Feature-gated registry guards only run when their required
+   * features are present, so supplying the wrong set silently skips guards.
+   */
+  userFeatures?: string[]
+}
+
+export type RouteMutationGuardInput = {
+  resourceKind: string
+  resourceId?: string | null
+  /**
+   * The route's logical operation. `'custom'` (state-changing action endpoints)
+   * is mapped to the closest registry operation, `'update'`, because
+   * `runMutationGuards` only understands `create | update | delete`.
+   */
+  operation?: RouteMutationGuardOperation
+  mutationPayload?: Record<string, unknown> | null
+}
+
+export type RouteMutationGuardBlocked = {
+  ok: false
+  errorStatus: number
+  errorBody: Record<string, unknown>
+  /** Ready-to-return JSON response built from `errorBody` / `errorStatus`. */
+  response: Response
+}
+
+export type RouteMutationGuardPassed = {
+  ok: true
+  /** Merged payload when a guard transformed it; `undefined` when unchanged. */
+  modifiedPayload?: Record<string, unknown>
+  /**
+   * Runs every guard's `afterSuccess` callback that requested it. Callback
+   * failures are caught and logged so a committed write still succeeds — call
+   * this only after the mutation has committed.
+   */
+  runAfterSuccess: () => Promise<void>
+}
+
+export type RouteMutationGuardResult = RouteMutationGuardBlocked | RouteMutationGuardPassed
+
+type RbacServiceLike = {
+  getGrantedFeatures: (
+    userId: string,
+    opts: { tenantId: string | null; organizationId: string | null },
+  ) => Promise<string[]>
+}
+
+/**
+ * Map a route-level operation to the registry operation set. State-changing
+ * action endpoints (`'custom'`) and `'update'` both map to `'update'` per the
+ * `packages/core/AGENTS.md` → API Routes guidance.
+ */
+export function toRegistryMutationOperation(
+  operation: RouteMutationGuardOperation | undefined,
+): 'create' | 'update' | 'delete' {
+  if (operation === 'create' || operation === 'delete') return operation
+  return 'update'
+}
+
+async function resolveRouteUserFeatures(
+  container: AwilixContainer,
+  auth: RouteMutationGuardAuth,
+): Promise<string[]> {
+  if (auth.userFeatures) return auth.userFeatures
+  try {
+    const rbac = container.resolve('rbacService') as RbacServiceLike | undefined
+    if (rbac?.getGrantedFeatures) {
+      return await rbac.getGrantedFeatures(auth.userId, {
+        tenantId: auth.tenantId,
+        organizationId: auth.organizationId ?? null,
+      })
+    }
+  } catch {
+    // rbacService not available — guards without feature requirements still run.
+  }
+  return []
+}
+
+/**
+ * Collect every registered mutation guard plus the bridged legacy DI service,
+ * run them against the route's mutation, and return either a blocked result
+ * (with a ready response) or a passed result carrying the merged payload and an
+ * after-success runner.
+ */
+export async function runRouteMutationGuards(params: {
+  container: AwilixContainer
+  req: Request
+  auth: RouteMutationGuardAuth
+  input: RouteMutationGuardInput
+}): Promise<RouteMutationGuardResult> {
+  const { container, req, auth, input } = params
+  const operation = toRegistryMutationOperation(input.operation)
+
+  const allGuards: MutationGuard[] = [...getAllMutationGuardInstances()]
+  const legacyGuard = bridgeLegacyGuard(container)
+  if (legacyGuard) allGuards.push(legacyGuard)
+
+  const userFeatures = await resolveRouteUserFeatures(container, auth)
+
+  const guardResult = await runMutationGuards(
+    allGuards,
+    {
+      tenantId: auth.tenantId,
+      organizationId: auth.organizationId ?? null,
+      userId: auth.userId,
+      resourceKind: input.resourceKind,
+      resourceId: input.resourceId ?? null,
+      operation,
+      requestMethod: req.method,
+      requestHeaders: req.headers,
+      mutationPayload: input.mutationPayload ?? null,
+    },
+    { userFeatures },
+  )
+
+  if (!guardResult.ok) {
+    const errorStatus = guardResult.errorStatus ?? 422
+    const errorBody = guardResult.errorBody ?? { error: 'Operation blocked by guard' }
+    return {
+      ok: false,
+      errorStatus,
+      errorBody,
+      response: Response.json(errorBody, { status: errorStatus }),
+    }
+  }
+
+  return {
+    ok: true,
+    modifiedPayload: guardResult.modifiedPayload,
+    runAfterSuccess: async () => {
+      for (const { guard, metadata } of guardResult.afterSuccessCallbacks) {
+        try {
+          await guard.afterSuccess!({
+            tenantId: auth.tenantId,
+            organizationId: auth.organizationId ?? null,
+            userId: auth.userId,
+            resourceKind: input.resourceKind,
+            resourceId: input.resourceId ?? '',
+            operation,
+            requestMethod: req.method,
+            requestHeaders: req.headers,
+            metadata,
+          })
+        } catch (error) {
+          console.error(`[mutation-guard] afterSuccess failed for guard ${guard.id}`, error)
+        }
+      }
+    },
+  }
+}


### PR DESCRIPTION
Fixes #3619

## Problem
76 non-test source files call the `@deprecated` CRUD mutation-guard bridge functions `validateCrudMutationGuard()` / `runCrudMutationGuardAfterSuccess()`. Those helpers resolve **only** the single DI-registered `crudMutationGuardService`, so they silently bypass every guard in the global mutation-guard store (`getAllMutationGuardInstances()`). A registry guard registered against an entity one of these routes mutates is enforced on every `makeCrudRoute` write but skipped on the deprecated path — a latent tenant/org-scope gap that widens each time a module registers a new guard.

## Root Cause
The deprecated two-call API was built around a single service and has **no `userFeatures` parameter**, while the modern `runMutationGuards()` requires `{ userFeatures }` to ACL-gate registry guards. So the fix must migrate **callers** (which hold the auth/features context), mirroring `collectAndRunGuards()` in `factory.ts` — not patch the deprecated function. Per the issue, this is done **per module, not in one sweep**.

## What Changed
This is the first migration unit: the reusable wrapper the issue asks for, plus the two highest-leverage shared route helpers.

- **New** `packages/shared/src/lib/crud/route-mutation-guard.ts` — `runRouteMutationGuards()` collects `[...getAllMutationGuardInstances(), bridgeLegacyGuard(container)]` and runs `runMutationGuards()`. It resolves `userFeatures` via `rbacService.getGrantedFeatures` (same source as the CRUD factory), maps the `'custom'` action operation to `'update'`, surfaces `modifiedPayload`, and returns a `runAfterSuccess()` runner that isolates callback failures so a committed write still succeeds. On block it returns a ready `Response` plus `errorStatus`/`errorBody`.
- **Migrated** `communication_channels/lib/route-mutation-guard.ts` (`validateRouteMutationGuard`, fans out to 11 routes) onto the wrapper — its `{ result, afterSuccess } | { response }` contract is preserved, so the 11 consumers are untouched.
- **Migrated** `notifications/lib/routeHelpers.ts` (`runGuardedNotificationWrite`, used by all notification write routes) onto the wrapper — its `GuardedNotificationWriteResult<T>` contract is preserved.
- **Marked the divergence** with strengthened `@deprecated` JSDoc on the two bridge functions, pointing at `runRouteMutationGuards()` / `runMutationGuards()`.

Behavior is **additive and behavior-preserving today**: the OSS optimistic-lock guard short-circuits for any operation other than `update`/`delete`, and even then short-circuits when no lock header is present or no reader is registered (these action endpoints send neither), so mapping `custom→update` enforces the same outcome while closing the registry gap for the future.

## Tests
- New `packages/shared/src/lib/crud/__tests__/route-mutation-guard.test.ts` (10 cases): registry-store guard now runs, block returns a ready response, `modifiedPayload` threading, `runAfterSuccess` + failure isolation, ACL feature gating, `userFeatures` resolution via `rbacService`, `custom→update` mapping, legacy-bridge inclusion, and the `toRegistryMutationOperation` mapping.
- New per-helper regression tests for `communication_channels` and `notifications` proving the migrated helpers now hit the full registry (and block/afterSuccess thread correctly).
- Updated `notifications/__tests__/mutation-guard.test.ts` to assert the new registry path while keeping every behavioral check (per-route guard invocation, after-success runs, 409 block skips the write).
- Validation: `yarn typecheck` (21/21), `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`/`check-usage`, eslint, and targeted suites — shared crud (248), communication_channels (555), notifications (37), plus the deprecated-path suites for un-migrated routes (66) — all green.

## Backward Compatibility
- Deprecated `validateCrudMutationGuard()` / `runCrudMutationGuardAfterSuccess()` re-exports are **kept** (third-party modules may import them) — only their JSDoc changed.
- Public signatures of both migrated helpers are unchanged; the only type touched (`RouteMutationGuardContext.result`) is a module-internal helper not imported elsewhere and not read by any consumer.
- New shared import path is additive. No event IDs, widget spot IDs, ACL IDs, DI names, or API routes changed.

## Remaining work (follow-up, per the issue)
The other ~63 direct callers (auth, customers, customer_accounts, dashboards, data_sync, dictionaries, directory, entities, feature_toggles, inbox_ops, payment_gateways, perspectives, planner, query_index, resources, sales, shipping_carriers, translations, workflows) migrate onto `runRouteMutationGuards()` the same way and should land as separate per-module PRs, as the issue requests ("migrate and verify per module rather than in one sweep").
