### PR TITLE
docs(spec): add deferred implementation spec for purge-queues-on-db-wipe

### DIFF
--- a/.ai/specs/2026-06-26-purge-queues-on-db-wipe.md
+++ b/.ai/specs/2026-06-26-purge-queues-on-db-wipe.md
@@ -1,0 +1,58 @@
+# Queue Purge on DB Wipe
+
+- **Status:** Draft (deferred — not yet implemented)
+- **Scope:** OSS
+- **Owner module:** `@open-mercato/queue`, `@open-mercato/cli`, root scripts
+- **Tracking issue:** _added in a follow-up comment_
+
+## TLDR / Goal
+
+Purge background-job queues (driver-agnostic) whenever the database is wiped, so stale jobs from a previous DB can't be replayed against a freshly-reseeded one. Adds `mercato queue purge --all` + `yarn dev:purge-queue` alias.
+
+## Problem Statement / Why Now
+
+Whenever the database is wiped & reseeded (`yarn initialize --reinstall`, `yarn db:greenfield`, `standalone dev --setup --reinstall`), the persisted background-job queues are left untouched. Stale jobs/events from the old DB get replayed against the fresh DB on next boot, the search indexer fails to load now-missing records, and `yarn dev:greenfield` shows a false "Runtime error detected" splash on an otherwise-healthy app.
+
+Specifically, `yarn dev:greenfield` boots to a false "Runtime error detected" splash: greenfield wipes & reseeds the DB but leaves `.mercato/queue/` populated, so orphaned `customers.customer_person_profile.updated` events get replayed and the search indexer throws (`[SearchIndexer] Failed to load record for indexing`). Captured as a reviewable spec to implement later via `om-implement-spec` / `om-auto-fix-github`.
+
+## Proposed Solution / Scope Captured
+
+- **Driver-agnostic `purgeAllQueues()` helper:** Located in `@open-mercato/queue` (works for both local file + BullMQ/Redis drivers). Reuses the existing `Queue.clear()`.
+- **New CLI Command:** Expose a new command `mercato queue purge --all` in `@open-mercato/cli`.
+- **Wired into DB-wipe sites:** Called individually during:
+  - `init --reinstall`
+  - `db:greenfield`
+  - The `greenfield` dev flow (root `scripts/dev.mjs`)
+  - Standalone `dev --setup --reinstall`
+- **Aliases:** Add `yarn dev:purge-queue` alias to root `package.json` + `@open-mercato/create-app` template mirror.
+- **Optional defense-in-depth:** Add the indexer warning to the dev-splash non-blocking allowlist.
+
+**Non-goals:**
+- No purge on normal `mercato init` / `yarn dev`.
+- No change to queue strategy defaults, retry semantics, or worker concurrency.
+- No new queue strategy.
+
+**Risk & Priority:**
+- Risk: medium (touches every DB-wipe path + the queue layer across both drivers). 
+- Priority: medium (dev-experience papercut).
+
+## Open Questions
+
+Confirm these proposed answers with a maintainer before coding:
+
+1. **No-DI purge bootstrap:** To purge queues during DB wipes, we may not have the full DI container booted. **Proposed answer:** Ensure `purgeAllQueues()` can bootstrap the queue driver directly from env/config without requiring the full application DI container.
+2. **Events-queue coverage:** Should this purge cover the events queue as well? **Proposed answer:** Yes, the intent is to clear all pending processing, including standard queues and event streams, to ensure a truly clean slate.
+3. **Separate queue-Redis:** If Redis is used for queues but a different DB for main storage, how do we handle connection teardown? **Proposed answer:** `purgeAllQueues()` should cleanly open and close its own Redis connection if not passed one.
+4. **Splash-allowlist hardening:** Should we add the `SearchIndexer` missing-record warning to the dev splash non-blocking allowlist anyway as defense-in-depth? **Proposed answer:** Yes, this prevents the splash screen from triggering on transient async eventual-consistency issues during normal dev.
+
+## Implementation Plan
+
+1. **Queue Helper:** Create `purgeAllQueues()` in `@open-mercato/queue` that iterates over all registered queues and calls `Queue.clear()`. Ensure it supports both local and async drivers.
+2. **CLI Command:** Add `mercato queue purge --all` to `@open-mercato/cli`. Wire it to `purgeAllQueues()`.
+3. **Wipe Wiring:** Update `mercato init` (when `--reinstall` is passed), `mercato db:greenfield`, and `dev.mjs` setup scripts to invoke the purge command/helper.
+4. **Package.json Aliases:** Add `"dev:purge-queue": "mercato queue purge --all"` to the root `package.json` and the `create-app` template.
+5. **Splash Allowlist:** Add the indexer warning to the dev splash non-blocking allowlist.
+
+## Backward Compatibility
+
+No contract surface changes (this spec document only). The eventual implementation is additive (new CLI command, new script, new exported helper; reuses existing `Queue.clear()`).


### PR DESCRIPTION
Adds an implementation spec outlining the solution for purging background job queues when the database is wiped. This will prevent stale events from a previous DB state from causing runtime errors against a freshly reseeded database during local development.

The spec proposes:

- A driver-agnostic purgeAllQueues() helper.

- A mercato queue purge --all CLI command.

- Wiring the purge into DB-wipe sites (init --reinstall, db:greenfield).

Ref: #3660

<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [ ] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [ ] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [ ] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [ ] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons (`<IconButton>`)
- [ ] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
