### PR TITLE
fix(entities): hide inherited custom fields via scoped tombstones

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/definitions.api.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.api.test.ts
@@ -181,6 +181,50 @@ describe('entities/definitions API', () => {
     expect(body.items).toEqual([])
   })
 
+  it('does not hide inherited definitions with another organization tombstone', async () => {
+    mockEm.find
+      .mockResolvedValueOnce([
+        {
+          key: 'estimated_seats',
+          kind: 'integer',
+          entityId: 'customers:customer_person',
+          tenantId: 'tenant-1',
+          organizationId: null,
+          updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          configJson: { label: 'Estimated seats' },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          key: 'estimated_seats',
+          kind: 'integer',
+          entityId: 'customers:customer_person',
+          tenantId: 'tenant-1',
+          organizationId: 'org-2',
+          deletedAt: new Date('2026-06-26T00:00:00.000Z'),
+          updatedAt: new Date('2026-06-26T00:00:00.000Z'),
+          configJson: { label: 'Estimated seats' },
+        },
+      ])
+
+    const response = await GET(
+      new Request('http://x/api/entities/definitions?entityId=customers:customer_person'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockEm.find.mock.calls[1][1].$and[1].$or).toEqual([
+      { organizationId: 'org-1' },
+      { organizationId: null },
+    ])
+    const body = await response.json()
+    expect(body.items).toEqual([
+      expect.objectContaining({
+        key: 'estimated_seats',
+        label: 'Estimated seats',
+      }),
+    ])
+  })
+
   it('does not synchronize module-backed definitions for callers without manage permission', async () => {
     mockRbac.userHasAllFeatures.mockResolvedValue(false)
 

--- a/packages/core/src/modules/entities/api/__tests__/definitions.api.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.api.test.ts
@@ -10,6 +10,7 @@ const installCustomEntitiesFromModulesMock = jest.fn(async () => ({
 
 const loadEntityFieldsetConfigsMock = jest.fn(async () => new Map())
 const mockRbac = { userHasAllFeatures: jest.fn() }
+const mockResolveOrganizationScopeForRequest = jest.fn(async () => ({ tenantId: 'tenant-1', selectedId: 'org-1' }))
 
 const mockEm = {
   find: jest.fn(),
@@ -40,7 +41,7 @@ jest.mock('@open-mercato/shared/lib/auth/server', () => ({
 }))
 
 jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
-  resolveOrganizationScopeForRequest: async () => ({ tenantId: 'tenant-1', selectedId: 'org-1' }),
+  resolveOrganizationScopeForRequest: (...args: unknown[]) => mockResolveOrganizationScopeForRequest(...args),
 }))
 
 jest.mock('../../lib/fieldsets', () => ({
@@ -66,6 +67,7 @@ describe('entities/definitions API', () => {
     mockEm.find.mockResolvedValue([])
     mockEm.findOne.mockResolvedValue(null)
     mockRbac.userHasAllFeatures.mockResolvedValue(true)
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({ tenantId: 'tenant-1', selectedId: 'org-1' })
   })
 
   it('synchronizes module-backed definitions for requested entities when the caller can manage definitions', async () => {
@@ -221,6 +223,48 @@ describe('entities/definitions API', () => {
       expect.objectContaining({
         key: 'estimated_seats',
         label: 'Estimated seats',
+      }),
+    ])
+  })
+
+  it('keeps public definition reads in the auth tenant when selected scope points at another tenant', async () => {
+    mockResolveOrganizationScopeForRequest.mockResolvedValueOnce({ tenantId: 'tenant-2', selectedId: 'org-2' })
+    mockEm.find
+      .mockResolvedValueOnce([
+        {
+          key: 'implementation_complexity',
+          kind: 'text',
+          entityId: 'customers:customer_person',
+          tenantId: 'tenant-1',
+          organizationId: null,
+          updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          configJson: { label: 'Implementation complexity' },
+        },
+      ])
+      .mockResolvedValueOnce([])
+
+    const response = await GET(
+      new Request('http://x/api/entities/definitions?entityId=customers:customer_person'),
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockRbac.userHasAllFeatures).toHaveBeenCalledWith('user-1', ['entities.definitions.manage'], {
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+    expect(mockEm.find.mock.calls[0][1].$and[0].$or).toEqual([
+      { tenantId: 'tenant-1' },
+      { tenantId: null },
+    ])
+    expect(mockEm.find.mock.calls[0][1].$and[1].$or).toEqual([
+      { organizationId: 'org-1' },
+      { organizationId: null },
+    ])
+    const body = await response.json()
+    expect(body.items).toEqual([
+      expect.objectContaining({
+        key: 'implementation_complexity',
+        label: 'Implementation complexity',
       }),
     ])
   })

--- a/packages/core/src/modules/entities/api/__tests__/definitions.api.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.api.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { GET, POST } from '../definitions'
+import { DELETE, GET, POST } from '../definitions'
 
 const installCustomEntitiesFromModulesMock = jest.fn(async () => ({
   processed: 1,
@@ -144,6 +144,41 @@ describe('entities/definitions API', () => {
     expect(status?.defaultValue).toBe('customer')
     expect(isVip?.defaultValue).toBe(true)
     expect(notes?.defaultValue).toBeUndefined()
+  })
+
+  it('hides inherited definitions that have a scoped tombstone', async () => {
+    mockEm.find
+      .mockResolvedValueOnce([
+        {
+          key: 'estimated_seats',
+          kind: 'integer',
+          entityId: 'customers:customer_person',
+          tenantId: 'tenant-1',
+          organizationId: null,
+          updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          configJson: { label: 'Estimated seats' },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          key: 'estimated_seats',
+          kind: 'integer',
+          entityId: 'customers:customer_person',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+          deletedAt: new Date('2026-06-26T00:00:00.000Z'),
+          updatedAt: new Date('2026-06-26T00:00:00.000Z'),
+          configJson: { label: 'Estimated seats' },
+        },
+      ])
+
+    const response = await GET(
+      new Request('http://x/api/entities/definitions?entityId=customers:customer_person'),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.items).toEqual([])
   })
 
   it('does not synchronize module-backed definitions for callers without manage permission', async () => {
@@ -304,5 +339,74 @@ describe('entities/definitions POST — defaultValue validation', () => {
     expect(response.status).toBe(200)
     const body = await response.json()
     expect(body.ok).toBe(true)
+  })
+})
+
+describe('entities/definitions DELETE', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+    mockEm.find.mockResolvedValue([])
+    mockEm.findOne.mockResolvedValue(null)
+  })
+
+  const makeDeleteRequest = (body: Record<string, unknown>) =>
+    new Request('http://x/api/entities/definitions', {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+
+  it('creates a scoped tombstone when deleting an inherited definition', async () => {
+    const inherited = {
+      entityId: 'customers:customer_deal',
+      key: 'estimated_seats',
+      kind: 'integer',
+      tenantId: 'tenant-1',
+      organizationId: null,
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      configJson: { label: 'Estimated seats/licenses' },
+    }
+    mockEm.findOne.mockResolvedValueOnce(null)
+    mockEm.find.mockResolvedValueOnce([inherited])
+
+    const response = await DELETE(makeDeleteRequest({
+      entityId: 'customers:customer_deal',
+      key: 'estimated_seats',
+    }))
+
+    expect(response.status).toBe(200)
+    expect(mockEm.create).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        entityId: 'customers:customer_deal',
+        key: 'estimated_seats',
+        kind: 'integer',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        isActive: false,
+        deletedAt: expect.any(Date),
+      }),
+    )
+    expect(mockEm.persist).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'estimated_seats',
+      isActive: false,
+      deletedAt: expect.any(Date),
+    }))
+    expect(mockEm.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('still returns 404 when neither scoped nor inherited definition exists', async () => {
+    mockEm.findOne.mockResolvedValueOnce(null)
+    mockEm.find.mockResolvedValueOnce([])
+
+    const response = await DELETE(makeDeleteRequest({
+      entityId: 'customers:customer_deal',
+      key: 'missing_key',
+    }))
+
+    expect(response.status).toBe(404)
+    expect(mockEm.create).not.toHaveBeenCalled()
+    expect(mockEm.persist).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/entities/api/__tests__/definitions.batch.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.batch.test.ts
@@ -35,6 +35,10 @@ jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   }),
 }))
 
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: async () => ({ tenantId: 'tenant-1', selectedId: 'org-1' }),
+}))
+
 jest.mock('@open-mercato/core/modules/entities/data/entities', () => ({
   CustomFieldDef: 'CustomFieldDef',
   CustomFieldEntityConfig: 'CustomFieldEntityConfig',
@@ -107,6 +111,52 @@ describe('entities/definitions.batch POST (issue #1399)', () => {
     expect(mockEm.create).toHaveBeenCalledTimes(1)
     expect(mockEm.create.mock.calls[0][1]).toMatchObject({ key: 'beta' })
     expect(mockEm.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates a scoped tombstone when saving an inherited definition as inactive', async () => {
+    const inherited = {
+      entityId: 'test:entity',
+      key: 'alpha',
+      kind: 'text',
+      tenantId: 'tenant-1',
+      organizationId: null,
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      configJson: { label: 'Alpha' },
+    }
+    mockEm.find
+      .mockResolvedValueOnce([] as unknown[])
+      .mockResolvedValueOnce([inherited] as unknown[])
+
+    const body = {
+      entityId: 'test:entity',
+      definitions: [
+        { key: 'alpha', kind: 'text', isActive: false, configJson: { label: 'Alpha' } },
+      ],
+    }
+
+    const response = await POST(makeRequest(body))
+
+    expect(response.status).toBe(200)
+    expect(mockEm.create).toHaveBeenCalledTimes(1)
+    expect(mockEm.create).toHaveBeenCalledWith(
+      'CustomFieldDef',
+      expect.objectContaining({
+        entityId: 'test:entity',
+        key: 'alpha',
+        kind: 'text',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        isActive: false,
+        deletedAt: expect.any(Date),
+      }),
+    )
+    expect(mockEm.persist).toHaveBeenCalledWith(expect.objectContaining({
+      key: 'alpha',
+      isActive: false,
+      deletedAt: expect.any(Date),
+    }))
+    expect(mockEm.flush).toHaveBeenCalledTimes(1)
+    expect(mockEm.commit).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/core/src/modules/entities/api/__tests__/definitions.manage.parallel.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.manage.parallel.test.ts
@@ -64,4 +64,43 @@ describe('entities/definitions.manage GET (issue #1404)', () => {
     const latestStart = Math.max(...calls.map((c) => c.start))
     expect(latestStart).toBeLessThan(earliestEnd)
   })
+
+  it('hides inherited definitions that are shadowed by a scoped tombstone', async () => {
+    mockEm.find
+      .mockResolvedValueOnce([
+        {
+          id: 'def-1',
+          entityId: 'customers:customer_deal',
+          key: 'estimated_seats',
+          kind: 'integer',
+          tenantId: 'tenant-1',
+          organizationId: null,
+          isActive: true,
+          updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+          configJson: { label: 'Estimated seats' },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'def-2',
+          entityId: 'customers:customer_deal',
+          key: 'estimated_seats',
+          kind: 'integer',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+          isActive: false,
+          deletedAt: new Date('2026-06-26T00:00:00.000Z'),
+          updatedAt: new Date('2026-06-26T00:00:00.000Z'),
+          configJson: { label: 'Estimated seats' },
+        },
+      ])
+    loadEntityFieldsetConfigsMock.mockResolvedValueOnce(new Map())
+
+    const response = await GET(new Request('http://x/api/entities/definitions.manage?entityId=customers:customer_deal'))
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.items).toEqual([])
+    expect(body.deletedKeys).toEqual(['estimated_seats'])
+  })
 })

--- a/packages/core/src/modules/entities/api/definitions.batch.ts
+++ b/packages/core/src/modules/entities/api/definitions.batch.ts
@@ -12,6 +12,14 @@ import {
   beginEntitiesMutationGuard,
   FIELD_DEFINITION_RESOURCE_KIND,
 } from './definitions.mutation-guard'
+import {
+  createExactDefinitionWhere,
+  createScopedDefinitionTombstone,
+  createVisibleDefinitionWhere,
+  markDefinitionTombstoned,
+  resolveDefinitionMutationScope,
+  selectVisibleDefinitionWinner,
+} from '../lib/definition-scope'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['entities.definitions.manage'] },
@@ -64,6 +72,7 @@ export async function POST(req: Request) {
   const { entityId, definitions, fieldsets, singleFieldsetPerRecord } = parsed.data
 
   const container = await createRequestContainer()
+  const scope = await resolveDefinitionMutationScope({ auth, container, request: req })
   const { resolve } = container
   const em = resolve('em') as any
   let cache: CacheStrategy | undefined
@@ -90,27 +99,33 @@ export async function POST(req: Request) {
     const keys = definitions.map((d) => d.key)
     if (keys.length > 0) {
       const existingDefs = await em.find(CustomFieldDef, {
-        entityId,
-        key: { $in: keys },
-        organizationId: auth.orgId ?? null,
-        tenantId: auth.tenantId ?? null,
+        ...createExactDefinitionWhere(entityId, { $in: keys }, scope),
       })
       for (const existing of existingDefs) defByKey.set(existing.key, existing)
     }
 
-    for (const [idx, d] of definitions.entries()) {
-      const where: any = {
+    const inheritedByKey = new Map<string, any>()
+    const inactiveKeys = definitions.filter((d) => d.isActive === false).map((d) => d.key)
+    if (inactiveKeys.length > 0) {
+      const visibleDefs = await em.find(CustomFieldDef, createVisibleDefinitionWhere(
         entityId,
-        key: d.key,
-        organizationId: auth.orgId ?? null,
-        tenantId: auth.tenantId ?? null,
+        { $in: inactiveKeys },
+        scope,
+        { deletedAt: null, isActive: true },
+      ))
+      const grouped = new Map<string, any[]>()
+      for (const visible of visibleDefs) {
+        if (!grouped.has(visible.key)) grouped.set(visible.key, [])
+        grouped.get(visible.key)!.push(visible)
       }
+      for (const [key, group] of grouped) {
+        inheritedByKey.set(key, selectVisibleDefinitionWinner(group))
+      }
+    }
+
+    for (const [idx, d] of definitions.entries()) {
+      const where: any = createExactDefinitionWhere(entityId, d.key, scope)
       let def = defByKey.get(d.key)
-      if (!def) {
-        def = em.create(CustomFieldDef, { ...where, createdAt: new Date() })
-        defByKey.set(d.key, def)
-      }
-      def.kind = d.kind
 
       const inCfg = (d as any).configJson ?? {}
       const cfg: Record<string, any> = { ...inCfg }
@@ -120,15 +135,49 @@ export async function POST(req: Request) {
       if (d.kind === 'multiline' && (cfg.editor == null || String(cfg.editor).trim() === '')) cfg.editor = 'markdown'
       cfg.priority = idx
 
+      if (d.isActive === false) {
+        const now = new Date()
+        const inherited = inheritedByKey.get(d.key)
+        if (!def) {
+          def = createScopedDefinitionTombstone(
+            em,
+            {
+              entityId,
+              key: d.key,
+              kind: d.kind,
+              configJson: inherited?.configJson ?? cfg,
+            },
+            scope,
+            now,
+          )
+          defByKey.set(d.key, def)
+        } else {
+          markDefinitionTombstoned(def, now)
+        }
+        def.kind = d.kind
+        def.configJson = cfg
+        def.isActive = false
+        def.deletedAt = def.deletedAt ?? now
+        def.updatedAt = now
+        em.persist(def)
+        continue
+      }
+
+      if (!def) {
+        def = em.create(CustomFieldDef, { ...where, createdAt: new Date() })
+        defByKey.set(d.key, def)
+      }
+      def.kind = d.kind
       def.configJson = cfg
-      def.isActive = d.isActive ?? true
+      def.isActive = true
+      def.deletedAt = null
       def.updatedAt = new Date()
       em.persist(def)
     }
     if (fieldsets !== undefined || singleFieldsetPerRecord !== undefined) {
-      const scope: any = { entityId, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
-      let cfg = await em.findOne(CustomFieldEntityConfig, scope)
-      if (!cfg) cfg = em.create(CustomFieldEntityConfig, { ...scope, createdAt: new Date() })
+      const entityConfigScope: any = { entityId, organizationId: scope.organizationId, tenantId: scope.tenantId }
+      let cfg = await em.findOne(CustomFieldEntityConfig, entityConfigScope)
+      if (!cfg) cfg = em.create(CustomFieldEntityConfig, { ...entityConfigScope, createdAt: new Date() })
       const existing = normalizeEntityFieldsetConfig(cfg.configJson ?? {})
       const patch = mergeEntityFieldsetConfig(existing, {
         fieldsets: fieldsets !== undefined ? cloneFieldsets(fieldsets) ?? [] : undefined,
@@ -152,8 +201,8 @@ export async function POST(req: Request) {
   await guard.runAfterSuccess()
 
   await invalidateDefinitionsCache(cache, {
-    tenantId: auth.tenantId ?? null,
-    organizationId: auth.orgId ?? null,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
     entityIds: [entityId],
   })
 

--- a/packages/core/src/modules/entities/api/definitions.restore.ts
+++ b/packages/core/src/modules/entities/api/definitions.restore.ts
@@ -10,6 +10,7 @@ import {
   beginEntitiesMutationGuard,
   FIELD_DEFINITION_RESOURCE_KIND,
 } from './definitions.mutation-guard'
+import { createExactDefinitionWhere, resolveDefinitionMutationScope } from '../lib/definition-scope'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['entities.definitions.manage'] },
@@ -24,6 +25,7 @@ export async function POST(req: Request) {
   if (!entityId || !key) return NextResponse.json({ error: 'entityId and key are required' }, { status: 400 })
 
   const container = await createRequestContainer()
+  const scope = await resolveDefinitionMutationScope({ auth, container, request: req })
   const { resolve } = container
   const em = resolve('em') as any
   let cache: CacheStrategy | undefined
@@ -31,7 +33,7 @@ export async function POST(req: Request) {
     cache = resolve('cache') as CacheStrategy
   } catch {}
 
-  const where: any = { entityId, key, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
+  const where: any = createExactDefinitionWhere(entityId, key, scope)
   const def = await em.findOne(CustomFieldDef, where)
   if (!def) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
@@ -53,8 +55,8 @@ export async function POST(req: Request) {
   await em.flush()
   await guard.runAfterSuccess()
   await invalidateDefinitionsCache(cache, {
-    tenantId: auth.tenantId ?? null,
-    organizationId: auth.orgId ?? null,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
     entityIds: [entityId],
   })
   return NextResponse.json({ ok: true })

--- a/packages/core/src/modules/entities/api/definitions.ts
+++ b/packages/core/src/modules/entities/api/definitions.ts
@@ -29,6 +29,7 @@ import {
   createScopedDefinitionTombstone,
   createVisibleDefinitionWhere,
   markDefinitionTombstoned,
+  resolveDefinitionScopeFromOrganizationScope,
   resolveDefinitionMutationScope,
   selectVisibleDefinitionWinner,
 } from '../lib/definition-scope'
@@ -228,11 +229,12 @@ export async function GET(req: Request) {
 
   const container = await createRequestContainer()
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
-  const tenantId = scope.tenantId ?? auth.tenantId ?? null
+  const definitionScope = resolveDefinitionScopeFromOrganizationScope(auth, scope)
+  const tenantId = definitionScope.tenantId
   if (!tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
-  const organizationId = scope.selectedId ?? auth.orgId ?? null
+  const organizationId = definitionScope.organizationId
   const { resolve } = container
   const em = resolve('em') as any
   let cache: CacheStrategy | undefined

--- a/packages/core/src/modules/entities/api/definitions.ts
+++ b/packages/core/src/modules/entities/api/definitions.ts
@@ -24,6 +24,14 @@ import {
   beginEntitiesMutationGuard,
   FIELD_DEFINITION_RESOURCE_KIND,
 } from './definitions.mutation-guard'
+import {
+  createExactDefinitionWhere,
+  createScopedDefinitionTombstone,
+  createVisibleDefinitionWhere,
+  markDefinitionTombstoned,
+  resolveDefinitionMutationScope,
+  selectVisibleDefinitionWinner,
+} from '../lib/definition-scope'
 
 /**
  * Validate defaultValue against the field kind. Returns an error message string
@@ -468,6 +476,7 @@ export async function POST(req: Request) {
   }
 
   const container = await createRequestContainer()
+  const scope = await resolveDefinitionMutationScope({ auth, container, request: req })
   const { resolve } = container
   const em = resolve('em') as any
   let cache: CacheStrategy | undefined
@@ -475,7 +484,7 @@ export async function POST(req: Request) {
     cache = resolve('cache') as CacheStrategy
   } catch {}
 
-  const where: any = { entityId: input.entityId, key: input.key, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
+  const where: any = createExactDefinitionWhere(input.entityId, input.key, scope)
   let def = await em.findOne(CustomFieldDef, where)
 
   const guard = await beginEntitiesMutationGuard({
@@ -512,7 +521,7 @@ export async function POST(req: Request) {
   if (cfg.defaultValue !== undefined && cfg.defaultValue !== null) {
     const validationError = await validateDefaultValueByKind(
       cfg.defaultValue, input.kind, cfg, em,
-      { tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null },
+      { tenantId: scope.tenantId, organizationId: scope.organizationId },
     )
     if (validationError) {
       return NextResponse.json({ error: validationError }, { status: 400 })
@@ -521,13 +530,14 @@ export async function POST(req: Request) {
   }
   def.configJson = cfg
   def.isActive = input.isActive ?? true
+  def.deletedAt = def.isActive === false ? (def.deletedAt ?? new Date()) : null
   def.updatedAt = new Date()
   em.persist(def)
   await em.flush()
   await guard.runAfterSuccess()
   await invalidateDefinitionsCache(cache, {
-    tenantId: auth.tenantId ?? null,
-    organizationId: auth.orgId ?? null,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
     entityIds: [input.entityId],
   })
   // Changing field definitions may impact forms but not sidebar items; no nav cache touch
@@ -543,36 +553,48 @@ export async function DELETE(req: Request) {
   if (!entityId || !key) return NextResponse.json({ error: 'entityId and key are required' }, { status: 400 })
 
   const container = await createRequestContainer()
+  const scope = await resolveDefinitionMutationScope({ auth, container, request: req })
   const { resolve } = container
   const em = resolve('em') as any
   let cache: CacheStrategy | undefined
   try {
     cache = resolve('cache') as CacheStrategy
   } catch {}
-  const where: any = { entityId, key, organizationId: auth.orgId ?? null, tenantId: auth.tenantId ?? null }
-  const def = await em.findOne(CustomFieldDef, where)
-  if (!def) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  const where: any = createExactDefinitionWhere(entityId, key, scope)
+  let def = await em.findOne(CustomFieldDef, where)
+  let inherited: any | null = null
+  if (!def) {
+    inherited = selectVisibleDefinitionWinner(await em.find(CustomFieldDef, createVisibleDefinitionWhere(
+      entityId,
+      key,
+      scope,
+      { deletedAt: null, isActive: true },
+    )))
+    if (!inherited) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
 
   const guard = await beginEntitiesMutationGuard({
     container,
     auth,
     req,
     resourceKind: FIELD_DEFINITION_RESOURCE_KIND,
-    resourceId: def.id,
+    resourceId: def?.id ?? inherited?.id ?? `${entityId}:${key}`,
     operation: 'delete',
     mutationPayload: { entityId, key },
   })
   if (guard.blockedResponse) return guard.blockedResponse
 
-  def.isActive = false
-  def.updatedAt = new Date()
-  def.deletedAt = def.deletedAt ?? new Date()
+  if (!def) {
+    def = createScopedDefinitionTombstone(em, inherited, scope)
+  } else {
+    markDefinitionTombstoned(def)
+  }
   em.persist(def)
   await em.flush()
   await guard.runAfterSuccess()
   await invalidateDefinitionsCache(cache, {
-    tenantId: auth.tenantId ?? null,
-    organizationId: auth.orgId ?? null,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
     entityIds: [entityId],
   })
   // Changing field definitions may impact forms but not sidebar items; no nav cache touch

--- a/packages/core/src/modules/entities/api/definitions.ts
+++ b/packages/core/src/modules/entities/api/definitions.ts
@@ -196,6 +196,19 @@ function normalizeFieldGroup(raw: unknown): { code: string; title?: string; hint
   return group
 }
 
+function definitionMatchesReadScope(
+  definition: { tenantId?: string | null; organizationId?: string | null },
+  scope: { tenantId: string | null; organizationId: string | null },
+) {
+  const definitionTenantId = definition.tenantId ?? null
+  const definitionOrganizationId = definition.organizationId ?? null
+  const tenantMatches = definitionTenantId === null || definitionTenantId === scope.tenantId
+  const organizationMatches =
+    definitionOrganizationId === null ||
+    (scope.organizationId !== null && definitionOrganizationId === scope.organizationId)
+  return tenantMatches && organizationMatches
+}
+
 export async function GET(req: Request) {
   const url = new URL(req.url)
   const requestedEntityIds = parseEntityIds(url)
@@ -281,22 +294,29 @@ export async function GET(req: Request) {
     mode: 'public',
   })
 
-  // Tenant-only scoping: allow global (null) or exact tenant match; do not scope by organization here
+  const tenantCandidates = [{ tenantId }, { tenantId: null as string | null }]
+  const organizationCandidates = [{ organizationId: null as string | null }]
+  if (organizationId) organizationCandidates.unshift({ organizationId })
+  const readScope = { tenantId, organizationId }
+
   const whereActive = {
     entityId: { $in: entityIds as any },
     deletedAt: null,
     $and: [
-      { $or: [ { tenantId: tenantId ?? undefined as any }, { tenantId: null } ] },
+      { $or: tenantCandidates },
+      { $or: organizationCandidates },
     ],
   } as any
-  const defs = await em.find(CustomFieldDef, whereActive as any)
-  const tombstones = await em.find(CustomFieldDef, {
+  const defs = (await em.find(CustomFieldDef, whereActive as any))
+    .filter((definition: any) => definitionMatchesReadScope(definition, readScope))
+  const tombstones = (await em.find(CustomFieldDef, {
     entityId: { $in: entityIds as any },
     deletedAt: { $ne: null } as any,
     $and: [
-      { $or: [ { tenantId: tenantId ?? undefined as any }, { tenantId: null } ] },
+      { $or: tenantCandidates },
+      { $or: organizationCandidates },
     ],
-  } as any)
+  } as any)).filter((definition: any) => definitionMatchesReadScope(definition, readScope))
 
   const tombstonedByEntity = new Map<string, Set<string>>()
   for (const entry of tombstones as any[]) {

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -27,6 +27,7 @@ import { normalizeCustomFieldOptions } from '@open-mercato/shared/modules/entiti
 import { TranslationManager } from '@open-mercato/core/modules/translations/components/TranslationManager'
 
 type Def = FieldDefinition
+export type EntitySource = 'code' | 'custom'
 type EntitiesListResponse = { items?: Array<Record<string, unknown>> }
 type FieldsetGroup = { code: string; title?: string; hint?: string }
 type FieldsetDefinition = { code: string; label: string; icon?: string; description?: string; groups?: FieldsetGroup[] }
@@ -43,7 +44,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
   const queryClient = useQueryClient()
   const entityId = useMemo(() => decodeURIComponent((params?.entityId as any) || ''), [params])
   const [label, setLabel] = useState('')
-  const [entitySource, setEntitySource] = useState<'code'|'custom'>('custom')
+  const [entitySource, setEntitySource] = useState<EntitySource>('custom')
   const [entityFormLoading, setEntityFormLoading] = useState(true)
   const [entityInitial, setEntityInitial] = useState<{ label?: string; description?: string; labelField?: string; defaultEditor?: string; showInSidebar?: boolean; updatedAt?: string }>({})
   const [defs, setDefs] = useState<Def[]>([])
@@ -391,13 +392,15 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       showInSidebar: z.boolean().optional(),
     }) as z.ZodType<Record<string, unknown>>
 
+  const metadataFieldsReadOnly = entitySource === 'code'
   const fields: CrudField[] = [
-    { id: 'label', label: 'Label', type: 'text', required: true },
-    { id: 'description', label: 'Description', type: 'textarea' },
+    { id: 'label', label: 'Label', type: 'text', required: true, readOnly: metadataFieldsReadOnly },
+    { id: 'description', label: 'Description', type: 'textarea', readOnly: metadataFieldsReadOnly },
     {
       id: 'defaultEditor',
       label: 'Default Editor (multiline)',
       type: 'select',
+      readOnly: metadataFieldsReadOnly,
       options: [
         { value: '', label: 'Default (Markdown)' },
         { value: 'markdown', label: 'Markdown (UIW)' },
@@ -493,17 +496,12 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       }
       try { window.dispatchEvent(new Event('om:refresh-sidebar')) } catch {}
     }
-    const defsPayload = {
+    const defsPayload = buildDefinitionsBatchPayload({
       entityId,
-      definitions: defs.filter((d) => !!d.key).map((d) => ({
-        key: d.key,
-        kind: d.kind,
-        configJson: d.configJson,
-        isActive: d.isActive !== false,
-      })),
+      defs,
       fieldsets: buildFieldsetPayload(),
       singleFieldsetPerRecord,
-    }
+    })
     const callDefs = await apiCall('/api/entities/definitions.batch', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -607,12 +605,31 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
   )
 }
 
-export function shouldRegisterEntityMetadata(entitySource: 'code' | 'custom'): boolean {
+export function shouldRegisterEntityMetadata(entitySource: EntitySource): boolean {
   return entitySource === 'custom'
 }
 
+export function buildDefinitionsBatchPayload(options: {
+  entityId: string
+  defs: Array<Pick<Def, 'key' | 'kind' | 'configJson' | 'isActive'>>
+  fieldsets: FieldsetDefinition[]
+  singleFieldsetPerRecord: boolean
+}) {
+  return {
+    entityId: options.entityId,
+    definitions: options.defs.filter((d) => !!d.key).map((d) => ({
+      key: d.key,
+      kind: d.kind,
+      configJson: d.configJson,
+      isActive: d.isActive !== false,
+    })),
+    fieldsets: options.fieldsets,
+    singleFieldsetPerRecord: options.singleFieldsetPerRecord,
+  }
+}
+
 export function buildEntityMetadataPayload(
-  entitySource: 'code' | 'custom',
+  entitySource: EntitySource,
   vals: Record<string, unknown>,
 ): Record<string, unknown> | null {
   const partial = entitySource === 'custom'

--- a/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
+++ b/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
@@ -2,7 +2,7 @@ jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
   CrudForm: () => null,
 }))
 
-import { buildEntityMetadataPayload, shouldRegisterEntityMetadata } from '../[entityId]/page'
+import { buildDefinitionsBatchPayload, buildEntityMetadataPayload, shouldRegisterEntityMetadata } from '../[entityId]/page'
 
 describe('shouldRegisterEntityMetadata', () => {
   it('registers metadata for custom (user-defined) entities', () => {
@@ -85,5 +85,68 @@ describe('buildEntityMetadataPayload', () => {
   it('returns null when label is empty', () => {
     const result = buildEntityMetadataPayload('custom', { label: '' })
     expect(result).toBeNull()
+  })
+})
+
+describe('buildDefinitionsBatchPayload', () => {
+  it('preserves inactive definitions so inherited fields can be hidden', () => {
+    const result = buildDefinitionsBatchPayload({
+      entityId: 'customers:customer_deal',
+      defs: [
+        {
+          key: 'hide_me',
+          kind: 'text',
+          configJson: { label: 'Hide me' },
+          isActive: false,
+        },
+        {
+          key: 'keep_me',
+          kind: 'text',
+          configJson: { label: 'Keep me' },
+          isActive: true,
+        },
+      ],
+      fieldsets: [{ code: 'main', label: 'Main' }],
+      singleFieldsetPerRecord: true,
+    })
+
+    expect(result).toEqual({
+      entityId: 'customers:customer_deal',
+      definitions: [
+        {
+          key: 'hide_me',
+          kind: 'text',
+          configJson: { label: 'Hide me' },
+          isActive: false,
+        },
+        {
+          key: 'keep_me',
+          kind: 'text',
+          configJson: { label: 'Keep me' },
+          isActive: true,
+        },
+      ],
+      fieldsets: [{ code: 'main', label: 'Main' }],
+      singleFieldsetPerRecord: true,
+    })
+  })
+
+  it('omits incomplete definitions without keys', () => {
+    const result = buildDefinitionsBatchPayload({
+      entityId: 'customers:customer_deal',
+      defs: [
+        {
+          key: '',
+          kind: 'text',
+          configJson: {},
+          isActive: true,
+        },
+      ],
+      fieldsets: [],
+      singleFieldsetPerRecord: false,
+    })
+
+    expect(result.definitions).toEqual([])
+    expect(result.singleFieldsetPerRecord).toBe(false)
   })
 })

--- a/packages/core/src/modules/entities/lib/__tests__/definition-scope.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/definition-scope.test.ts
@@ -1,0 +1,33 @@
+import { resolveDefinitionScopeFromOrganizationScope } from '../definition-scope'
+
+describe('definition scope resolution', () => {
+  it('keeps an org-bound user in their auth tenant when the organization resolver returns another tenant', () => {
+    expect(resolveDefinitionScopeFromOrganizationScope(
+      { tenantId: 'auth-tenant', orgId: 'auth-org' },
+      { tenantId: 'selected-tenant', selectedId: 'selected-org' },
+    )).toEqual({
+      tenantId: 'auth-tenant',
+      organizationId: 'auth-org',
+    })
+  })
+
+  it('uses the resolved organization when it belongs to the same tenant', () => {
+    expect(resolveDefinitionScopeFromOrganizationScope(
+      { tenantId: 'tenant-1', orgId: 'org-1' },
+      { tenantId: 'tenant-1', selectedId: 'org-2' },
+    )).toEqual({
+      tenantId: 'tenant-1',
+      organizationId: 'org-2',
+    })
+  })
+
+  it('allows selected tenant scope when auth has no tenant context', () => {
+    expect(resolveDefinitionScopeFromOrganizationScope(
+      { tenantId: null, orgId: null },
+      { tenantId: 'selected-tenant', selectedId: 'selected-org' },
+    )).toEqual({
+      tenantId: 'selected-tenant',
+      organizationId: 'selected-org',
+    })
+  })
+})

--- a/packages/core/src/modules/entities/lib/definition-scope.ts
+++ b/packages/core/src/modules/entities/lib/definition-scope.ts
@@ -1,0 +1,142 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { CustomFieldDef } from '@open-mercato/core/modules/entities/data/entities'
+
+type AuthScope = {
+  tenantId?: string | null
+  orgId?: string | null
+}
+
+export type DefinitionMutationScope = {
+  tenantId: string | null
+  organizationId: string | null
+}
+
+type DefinitionKeySelector = string | { $in: string[] }
+
+type DefinitionVisibilityOptions = {
+  deletedAt?: null | { $ne: null }
+  isActive?: boolean
+}
+
+export async function resolveDefinitionMutationScope({
+  auth,
+  container,
+  request,
+}: {
+  auth: AuthScope
+  container: unknown
+  request: Request
+}): Promise<DefinitionMutationScope> {
+  const scope = await resolveOrganizationScopeForRequest({ container, auth, request } as any)
+  return {
+    tenantId: scope.tenantId ?? auth.tenantId ?? null,
+    organizationId: scope.selectedId ?? auth.orgId ?? null,
+  }
+}
+
+export function createExactDefinitionWhere(
+  entityId: string,
+  key: DefinitionKeySelector,
+  scope: DefinitionMutationScope,
+) {
+  return {
+    entityId,
+    key,
+    organizationId: scope.organizationId,
+    tenantId: scope.tenantId,
+  }
+}
+
+export function createVisibleDefinitionWhere(
+  entityId: string,
+  key: DefinitionKeySelector,
+  scope: DefinitionMutationScope,
+  options: DefinitionVisibilityOptions = {},
+) {
+  const organizationCandidates = [{ organizationId: null as string | null }]
+  if (scope.organizationId) organizationCandidates.unshift({ organizationId: scope.organizationId })
+
+  const tenantCandidates = [{ tenantId: null as string | null }]
+  if (scope.tenantId) tenantCandidates.unshift({ tenantId: scope.tenantId })
+
+  return {
+    entityId,
+    key,
+    ...options,
+    $and: [
+      { $or: organizationCandidates },
+      { $or: tenantCandidates },
+    ],
+  }
+}
+
+function definitionTimestamp(def: any) {
+  const updatedAt = def?.updatedAt instanceof Date
+    ? def.updatedAt.getTime()
+    : (def?.updatedAt ? new Date(def.updatedAt).getTime() : 0)
+  if (updatedAt) return updatedAt
+  return def?.createdAt instanceof Date
+    ? def.createdAt.getTime()
+    : (def?.createdAt ? new Date(def.createdAt).getTime() : 0)
+}
+
+function definitionScopeScore(def: any) {
+  return (def?.tenantId ? 2 : 0) + (def?.organizationId ? 1 : 0)
+}
+
+export function selectVisibleDefinitionWinner(definitions: any[]) {
+  let winner: any | null = null
+  for (const definition of definitions) {
+    if (!winner) {
+      winner = definition
+      continue
+    }
+    const nextScore = definitionScopeScore(definition)
+    const winnerScore = definitionScopeScore(winner)
+    if (nextScore > winnerScore) {
+      winner = definition
+      continue
+    }
+    if (nextScore < winnerScore) continue
+    if (definitionTimestamp(definition) >= definitionTimestamp(winner)) winner = definition
+  }
+  return winner
+}
+
+export function markDefinitionTombstoned(definition: any, now = new Date()) {
+  definition.isActive = false
+  definition.deletedAt = definition.deletedAt ?? now
+  definition.updatedAt = now
+  return definition
+}
+
+function cloneConfigJson(configJson: unknown) {
+  if (configJson == null) return configJson
+  return JSON.parse(JSON.stringify(configJson))
+}
+
+export function createScopedDefinitionTombstone(
+  em: Pick<EntityManager, 'create'>,
+  source: {
+    entityId: string
+    key: string
+    kind: string
+    configJson?: unknown
+  },
+  scope: DefinitionMutationScope,
+  now = new Date(),
+) {
+  return em.create(CustomFieldDef, {
+    entityId: source.entityId,
+    key: source.key,
+    kind: source.kind,
+    configJson: cloneConfigJson(source.configJson) ?? {},
+    organizationId: scope.organizationId,
+    tenantId: scope.tenantId,
+    isActive: false,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: now,
+  })
+}

--- a/packages/core/src/modules/entities/lib/definition-scope.ts
+++ b/packages/core/src/modules/entities/lib/definition-scope.ts
@@ -12,11 +12,32 @@ export type DefinitionMutationScope = {
   organizationId: string | null
 }
 
+type OrganizationScopeLike = {
+  tenantId?: string | null
+  selectedId?: string | null
+}
+
 type DefinitionKeySelector = string | { $in: string[] }
 
 type DefinitionVisibilityOptions = {
   deletedAt?: null | { $ne: null }
   isActive?: boolean
+}
+
+export function resolveDefinitionScopeFromOrganizationScope(
+  auth: AuthScope,
+  scope: OrganizationScopeLike,
+): DefinitionMutationScope {
+  const authTenantId = auth.tenantId ?? null
+  const scopeTenantId = scope.tenantId ?? null
+  const tenantMismatch = Boolean(authTenantId && scopeTenantId && authTenantId !== scopeTenantId)
+
+  return {
+    tenantId: tenantMismatch ? authTenantId : (scopeTenantId ?? authTenantId),
+    organizationId: tenantMismatch
+      ? (auth.orgId ?? null)
+      : (scope.selectedId ?? auth.orgId ?? null),
+  }
 }
 
 export async function resolveDefinitionMutationScope({
@@ -29,10 +50,7 @@ export async function resolveDefinitionMutationScope({
   request: Request
 }): Promise<DefinitionMutationScope> {
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request } as any)
-  return {
-    tenantId: scope.tenantId ?? auth.tenantId ?? null,
-    organizationId: scope.selectedId ?? auth.orgId ?? null,
-  }
+  return resolveDefinitionScopeFromOrganizationScope(auth, scope)
 }
 
 export function createExactDefinitionWhere(

--- a/packages/core/src/modules/entities/lib/definition-scope.ts
+++ b/packages/core/src/modules/entities/lib/definition-scope.ts
@@ -24,6 +24,18 @@ type DefinitionVisibilityOptions = {
   isActive?: boolean
 }
 
+type DefinitionScopeRecord = {
+  tenantId?: string | null
+  organizationId?: string | null
+  updatedAt?: Date | string | number | null
+  createdAt?: Date | string | number | null
+}
+
+type MutableDefinitionScopeRecord = DefinitionScopeRecord & {
+  isActive?: boolean
+  deletedAt?: Date | string | number | null
+}
+
 export function resolveDefinitionScopeFromOrganizationScope(
   auth: AuthScope,
   scope: OrganizationScopeLike,
@@ -89,7 +101,7 @@ export function createVisibleDefinitionWhere(
   }
 }
 
-function definitionTimestamp(def: any) {
+function definitionTimestamp(def: DefinitionScopeRecord) {
   const updatedAt = def?.updatedAt instanceof Date
     ? def.updatedAt.getTime()
     : (def?.updatedAt ? new Date(def.updatedAt).getTime() : 0)
@@ -99,12 +111,12 @@ function definitionTimestamp(def: any) {
     : (def?.createdAt ? new Date(def.createdAt).getTime() : 0)
 }
 
-function definitionScopeScore(def: any) {
+function definitionScopeScore(def: DefinitionScopeRecord) {
   return (def?.tenantId ? 2 : 0) + (def?.organizationId ? 1 : 0)
 }
 
-export function selectVisibleDefinitionWinner(definitions: any[]) {
-  let winner: any | null = null
+export function selectVisibleDefinitionWinner<T extends DefinitionScopeRecord>(definitions: T[]) {
+  let winner: T | null = null
   for (const definition of definitions) {
     if (!winner) {
       winner = definition
@@ -122,7 +134,7 @@ export function selectVisibleDefinitionWinner(definitions: any[]) {
   return winner
 }
 
-export function markDefinitionTombstoned(definition: any, now = new Date()) {
+export function markDefinitionTombstoned<T extends MutableDefinitionScopeRecord>(definition: T, now = new Date()) {
   definition.isActive = false
   definition.deletedAt = definition.deletedAt ?? now
   definition.updatedAt = now


### PR DESCRIPTION
## Summary
- make `DELETE /api/entities/definitions` resolve the selected definition scope and create a scoped tombstone when the visible field is inherited
- make inactive saves through `definitions.batch` and single-definition saves use the same tombstone semantics, and clear tombstones when saving active definitions
- make restore use the same resolved definition scope so deleted inherited fields can be brought back consistently

## Tests
- `corepack yarn workspace @open-mercato/core test --runTestsByPath src/modules/entities/api/__tests__/definitions.api.test.ts src/modules/entities/api/__tests__/definitions.batch.test.ts src/modules/entities/api/__tests__/definitions.manage.parallel.test.ts src/modules/entities/api/__tests__/definitions.mutation-guard.test.ts --runInBand`
- `corepack yarn workspace @open-mercato/core build`