### PR TITLE
fix(agent_orchestrator): default trace-ingest run input to {} (NOT NULL)

### DIFF
--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/trace-ingestion-service.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/trace-ingestion-service.test.ts
@@ -92,6 +92,17 @@ describe('ingestTrace', () => {
     expect(storeFor(AgentToolCall)).toHaveLength(1)
   })
 
+  it('defaults a created run input to {} when the payload omits it (agent_runs.input is NOT NULL)', async () => {
+    const { em, storeFor } = createFakeEm()
+    const payload = basePayload()
+    expect('input' in payload).toBe(false)
+    await ingestTrace(em, SCOPE, payload)
+
+    const run = storeFor(AgentRun)[0]
+    expect(run.input).not.toBeNull()
+    expect(run.input).toEqual({})
+  })
+
   it('is idempotent on (runtime, externalRunId): re-ingest appends nothing new', async () => {
     const { em, storeFor } = createFakeEm()
     await ingestTrace(em, SCOPE, basePayload())

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/trace/traceIngestionService.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/trace/traceIngestionService.ts
@@ -77,7 +77,10 @@ export async function ingestTrace(
       runtime: payload.runtime,
       externalRunId: payload.externalRunId,
       status: (payload.status ?? 'running') as AgentRunStatus,
-      input: payload.input ?? null,
+      // `agent_runs.input` is NOT NULL (the MVP runtime always supplies it). A
+      // trace ingested from an external runtime may omit it, so fall back to an
+      // empty object rather than inserting null and tripping a not-null violation.
+      input: payload.input ?? {},
     })
     em.persist(run)
   }


### PR DESCRIPTION
## Problem

`POST /api/agent_orchestrator/trace/ingest` returned **500** whenever the trace payload omitted `input` — including the `TC-AGENT-TRACE-001` integration spec, whose payload has no `input` (it was red: *Expected 202, Received 500*).

## Root cause

`agent_runs.input` is `jsonb NOT NULL` (the MVP runtime always supplies it), but the ingest validator makes `input` optional and `ingestTrace` created the run with `input: payload.input ?? null`. An absent input → `null` insert → not-null constraint violation → unhandled → 500.

## Fix

Fall back to an empty object on create:

```ts
// agent_runs.input is NOT NULL; a trace from an external runtime may omit it
input: payload.input ?? {},
```

One-line, behavior-preserving for runs that do carry input.

## Verification

- **`TC-AGENT-TRACE-001`** (ephemeral integration) — was 500, **now 202** and passes end-to-end (ingest → idempotent re-ingest → list → detail → HMAC gate). Full module suite: **8/8 green**.
- **Unit** — added an assertion locking the contract (*"defaults a created run input to `{}` when the payload omits it"*); `trace-ingestion-service.test.ts` 5/5 green.

## Scope note

Reported alongside two other cockpit symptoms (eval-assertion save 500, trace-detail 404). Those **did not reproduce** in a clean, freshly-generated single-org admin env (create→201, toggle→200, detail→200), so they appear environment/session-specific rather than a shared code bug — tracked separately, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)