### PR TITLE
fix(agent_orchestrator,ai_assistant): capture OpenCode native tool parts in traces

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/lib/opencode-client.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/opencode-client.ts
@@ -193,8 +193,11 @@ export class OpenCodeClient {
               try {
                 const data = JSON.parse(line.slice(6))
                 onEvent(data)
-              } catch {
-                // Ignore parse errors
+              } catch (error) {
+                // Malformed SSE payload — surface it instead of dropping the
+                // event silently (a silent drop previously hid the tool-part
+                // capture regression).
+                console.error('[OpenCode SSE] Failed to parse event payload:', (error as Error).message)
               }
             }
           }

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/opencode-handlers.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/opencode-handlers.ts
@@ -6,6 +6,7 @@
 
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { findApiKeyByOpencodeSessionId } from '@open-mercato/core/modules/api_keys/services/apiKeyService'
+import { normalizeOpenCodeToolPart } from '@open-mercato/shared/lib/ai/opencode-tool-parts'
 import {
   createOpenCodeClient,
   type OpenCodeClient,
@@ -344,6 +345,9 @@ export async function handleOpenCodeMessageStreaming(
     totalOutputTokens: 0,
     messageCount: 0,
   }
+  // OpenCode re-emits the same tool part on every state transition; track which
+  // call ids already streamed a `tool-call` so each tool surfaces once.
+  const seenToolCallIds = new Set<string>()
 
   if (!message) {
     await onEvent({ type: 'error', error: 'Message is required' })
@@ -666,6 +670,35 @@ export async function handleOpenCodeMessageStreaming(
                 }
                 const delta = properties.delta as string | undefined
 
+                // Tool invocations (native `type: 'tool'` state machine or the
+                // legacy `tool_use` / `tool_result` shape) are normalized to a
+                // single lifecycle update. OpenCode re-emits the same part on
+                // each transition, so a `tool-call` event is streamed once per
+                // call id and `tool-result` once it reaches a terminal status.
+                const toolUpdate = normalizeOpenCodeToolPart(part)
+                if (toolUpdate) {
+                  if (!seenToolCallIds.has(toolUpdate.callId) && toolUpdate.toolName) {
+                    seenToolCallIds.add(toolUpdate.callId)
+                    usageStats.toolCalls++
+                    usageStats.toolNames.push(toolUpdate.toolName)
+                    console.error(`[AI Usage] Tool call #${usageStats.toolCalls}: ${toolUpdate.toolName}`)
+                    await onEvent({
+                      type: 'tool-call',
+                      id: toolUpdate.callId,
+                      toolName: toolUpdate.toolName,
+                      args: toolUpdate.input,
+                    })
+                  }
+                  if (toolUpdate.phase === 'finish') {
+                    await onEvent({
+                      type: 'tool-result',
+                      id: toolUpdate.callId,
+                      result: toolUpdate.output,
+                    })
+                  }
+                  break
+                }
+
                 switch (part.type) {
                   case 'text':
                     // Use delta for streaming text if available
@@ -677,26 +710,6 @@ export async function handleOpenCodeMessageStreaming(
                     // Extended thinking blocks — route to debug panel only, never to chat
                     console.error(`[OpenCode SSE] Thinking block received (${(delta || part.text || '').length} chars)`)
                     await onEvent({ type: 'debug', partType: 'thinking', data: { text: delta || part.text } })
-                    break
-                  case 'tool_use':
-                    if (part.name) {
-                      usageStats.toolCalls++
-                      usageStats.toolNames.push(part.name)
-                      console.error(`[AI Usage] Tool call #${usageStats.toolCalls}: ${part.name}`)
-                      await onEvent({
-                        type: 'tool-call',
-                        id: part.id,
-                        toolName: part.name,
-                        args: part.input,
-                      })
-                    }
-                    break
-                  case 'tool_result':
-                    await onEvent({
-                      type: 'tool-result',
-                      id: part.tool_use_id || part.id,
-                      result: part.content,
-                    })
                     break
                   case 'step-start':
                   case 'step-finish':

--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/opencode-trace-ingest.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/opencode-trace-ingest.test.ts
@@ -1,8 +1,10 @@
 /**
  * #3628 — OpenCode-runtime runs must record the MCP tool calls they make as
- * trace spans/tool-calls. The runner captures `tool_use`/`tool_result` parts off
- * the SSE stream and, on a successful run, ingests them via `ingestTrace`
- * (correlated on runtime+externalRunId so they land on the run it created).
+ * trace spans/tool-calls. The runner captures tool parts off the SSE stream —
+ * OpenCode's native `type: 'tool'` state machine (`state.status` running →
+ * completed/error) as well as the legacy `tool_use` / `tool_result` shape — and,
+ * on a successful run, ingests them via `ingestTrace` (correlated on
+ * runtime+externalRunId so they land on the run it created).
  */
 const createSessionApiKeyMock = jest.fn()
 const deleteSessionApiKeyMock = jest.fn()
@@ -122,10 +124,12 @@ const validOutcome = {
 }
 
 /**
- * Fake client that emits the tool_use/tool_result SSE parts SYNCHRONOUSLY at the
- * top of sendMessage (before its first await), so they are captured before the
- * runner reads the outcome — mirroring how OpenCode streams tool parts mid-run
- * ahead of submit_outcome + idle.
+ * Fake client that emits OpenCode's native `type: 'tool'` SSE parts SYNCHRONOUSLY
+ * at the top of sendMessage (before its first await), so they are captured before
+ * the runner reads the outcome — mirroring how OpenCode streams tool parts mid-run
+ * ahead of submit_outcome + idle. The same part id is re-emitted as the tool's
+ * `state.status` advances (running → completed), exactly as the real server does;
+ * the session id rides on `part.sessionID`, not at the top level.
  */
 function makeFakeClient(opts: { container: { resolve: (name: string) => unknown } }): OpenCodeRunnerClient {
   let emit: ((event: { type: string; properties: Record<string, unknown> }) => void) | null = null
@@ -139,18 +143,19 @@ function makeFakeClient(opts: { container: { resolve: (name: string) => unknown 
       const tokenMatch = /Session Authorization: (sess_[a-z0-9_]+)/i.exec(message)
       if (tokenMatch) sessionTokenRef.value = tokenMatch[1]
       // Synchronous tool-part emission (before the first await) so the runner
-      // captures them prior to reading the outcome.
+      // captures them prior to reading the outcome. Native OpenCode shape: the
+      // call opens at `state.status: running` and closes at `completed`.
       emit?.({
         type: 'message.part.updated',
-        properties: { sessionID: sessionId, part: { type: 'tool_use', id: 'tc-1', name: 'load_skill', input: { skillId: 'resolution_playbook' } } },
+        properties: { part: { type: 'tool', id: 'prt-1', sessionID: sessionId, callID: 'tc-1', tool: 'load_skill', state: { status: 'running', input: { skillId: 'resolution_playbook' } } } },
       })
       emit?.({
         type: 'message.part.updated',
-        properties: { sessionID: sessionId, part: { type: 'tool_result', tool_use_id: 'tc-1', content: { ok: true } } },
+        properties: { part: { type: 'tool', id: 'prt-1', sessionID: sessionId, callID: 'tc-1', tool: 'load_skill', state: { status: 'completed', input: { skillId: 'resolution_playbook' }, output: { ok: true } } } },
       })
       emit?.({
         type: 'message.part.updated',
-        properties: { sessionID: sessionId, part: { type: 'tool_use', id: 'tc-2', name: 'run_skill_script', input: { scriptName: 'lookup_ticket_history' } } },
+        properties: { part: { type: 'tool', id: 'prt-2', sessionID: sessionId, callID: 'tc-2', tool: 'run_skill_script', state: { status: 'running', input: { scriptName: 'lookup_ticket_history' } } } },
       })
       await submitOutcomeTool.handler!(
         { outcome: validOutcome },
@@ -203,7 +208,61 @@ describe('OpenCodeAgentRunner — trace ingestion (#3628)', () => {
 
     const toolNames = payload.spans.flatMap((s) => (s.toolCalls ?? []).map((c) => c.toolName))
     expect(toolNames).toEqual(['load_skill', 'run_skill_script'])
-    // tool_result for tc-1 was folded back onto its tool_use span.
+    // The `completed` state for tc-1 folded its output back onto the same span.
+    const loadSkillSpan = payload.spans.find((s) => s.name === 'load_skill')
+    expect(loadSkillSpan?.toolCalls?.[0]?.responseSummary).toEqual({ ok: true })
+  })
+
+  it('still captures the legacy tool_use/tool_result shape from older OpenCode builds', async () => {
+    const entry = registerExampleFileAgent()
+    const { commandBus, container } = makeHarness()
+    let emit: ((event: { type: string; properties: Record<string, unknown> }) => void) | null = null
+    const sessionId = 'ses_trace_legacy'
+    const client: OpenCodeRunnerClient = {
+      async createSession() {
+        return { id: sessionId }
+      },
+      async sendMessage(_s, message) {
+        const tokenMatch = /Session Authorization: (sess_[a-z0-9_]+)/i.exec(message)
+        emit?.({
+          type: 'message.part.updated',
+          properties: { sessionID: sessionId, part: { type: 'tool_use', id: 'tc-1', name: 'load_skill', input: { skillId: 'resolution_playbook' } } },
+        })
+        emit?.({
+          type: 'message.part.updated',
+          properties: { sessionID: sessionId, part: { type: 'tool_result', tool_use_id: 'tc-1', content: { ok: true } } },
+        })
+        await submitOutcomeTool.handler!(
+          { outcome: validOutcome },
+          { sessionId: tokenMatch?.[1] ?? '', container } as unknown as Parameters<NonNullable<typeof submitOutcomeTool.handler>>[1],
+        )
+        setTimeout(() => {
+          emit?.({ type: 'session.status', properties: { sessionID: sessionId, status: { type: 'busy' } } })
+          emit?.({ type: 'session.status', properties: { sessionID: sessionId, status: { type: 'idle' } } })
+        }, 0)
+        return {}
+      },
+      subscribeToEvents(onEvent) {
+        emit = onEvent
+        return () => {
+          emit = null
+        }
+      },
+    }
+    const runner = new OpenCodeAgentRunner({
+      container: container as never,
+      commandBus: commandBus as never,
+      openCodeClient: client,
+    })
+
+    await runner.run(entry, { subject: 'legacy parts' }, runCtx)
+
+    expect(ingestTraceMock).toHaveBeenCalledTimes(1)
+    const [, , payload] = ingestTraceMock.mock.calls[0] as [
+      unknown,
+      unknown,
+      { spans: Array<{ name: string; toolCalls?: Array<{ toolName: string; responseSummary?: unknown }> }> },
+    ]
     const loadSkillSpan = payload.spans.find((s) => s.name === 'load_skill')
     expect(loadSkillSpan?.toolCalls?.[0]?.responseSummary).toEqual({ ok: true })
   })

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
@@ -8,6 +8,7 @@ import {
 } from '@open-mercato/core/modules/api_keys/services/apiKeyService'
 import { UserRole } from '@open-mercato/core/modules/auth/data/entities'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { normalizeOpenCodeToolPart } from '@open-mercato/shared/lib/ai/opencode-tool-parts'
 import type { AgentRegistryEntry } from '../sdk/defineAgent'
 import { type AgentResult } from '../../data/validators'
 import {
@@ -423,9 +424,16 @@ export class OpenCodeAgentRunner {
     const unsubscribe = this.client.subscribeToEvents(
       (event) => {
         const { type, properties } = event
+        // Match the chat path's session-id derivation: on `message.part.updated`
+        // OpenCode carries the session id on `properties.part.sessionID`, not at
+        // the top level, so a narrower lookup would mis-scope multi-session
+        // streams.
         const eventSessionId =
           (properties.sessionID as string | undefined) ||
-          (properties.session as { id?: string } | undefined)?.id
+          (properties.info as { sessionID?: string } | undefined)?.sessionID ||
+          (properties.part as { sessionID?: string } | undefined)?.sessionID ||
+          (properties.session as { id?: string } | undefined)?.id ||
+          (properties.status as { sessionID?: string } | undefined)?.sessionID
         if (eventSessionId && eventSessionId !== sessionId) return
         // Capture MCP tool/skill calls for the trace (#3628). The same SSE stream
         // that signals idle also carries the tool_use/tool_result parts; the chat
@@ -498,31 +506,47 @@ const NO_OUTCOME = Symbol('no-outcome')
 
 /**
  * Extract a tool invocation from an OpenCode `message.part.updated` part and fold
- * it into the run's tool-call sink. Mirrors the chat path's parser
- * (`opencode-handlers.ts`): a `tool_use` part opens the call, a later
- * `tool_result` part (matched by `tool_use_id`) closes it with the result.
+ * it into the run's tool-call sink. Delegates schema detection to the shared
+ * `normalizeOpenCodeToolPart` helper (`@open-mercato/shared/lib/ai`): OpenCode
+ * re-emits the same part on each state transition, so the call is opened on the
+ * first `progress` update (keyed by `callId`) and closed on the terminal
+ * `finish`. The legacy `tool_use` / `tool_result` shape is handled by the same
+ * helper for older OpenCode builds.
  */
 function captureToolPart(sink: CapturedToolCall[], rawPart: unknown): void {
-  const part = rawPart as
-    | { type?: string; name?: string; input?: unknown; tool_use_id?: string; content?: unknown; id?: string }
-    | undefined
-  if (!part || typeof part.type !== 'string') return
-  if (part.type === 'tool_use') {
-    if (!part.name) return
-    sink.push({
-      id: part.id ?? `tool-${sink.length}`,
-      toolName: part.name,
-      args: part.input,
-      status: 'ok',
-      startedAt: new Date().toISOString(),
-    })
-  } else if (part.type === 'tool_result') {
-    const id = part.tool_use_id ?? part.id
-    const existing = id ? sink.find((call) => call.id === id) : undefined
+  const update = normalizeOpenCodeToolPart(rawPart)
+  if (!update) return
+  const existing = sink.find((call) => call.id === update.callId)
+  if (update.phase === 'progress') {
     if (existing) {
-      existing.result = part.content
-      existing.endedAt = new Date().toISOString()
+      if (update.input !== undefined) existing.args = update.input
+    } else {
+      sink.push({
+        id: update.callId,
+        toolName: update.toolName,
+        args: update.input,
+        status: 'ok',
+        startedAt: new Date().toISOString(),
+      })
     }
+    return
+  }
+  if (existing) {
+    if (existing.args === undefined && update.input !== undefined) existing.args = update.input
+    existing.result = update.output
+    existing.status = update.status
+    existing.endedAt = new Date().toISOString()
+  } else {
+    const now = new Date().toISOString()
+    sink.push({
+      id: update.callId,
+      toolName: update.toolName ?? update.callId,
+      args: update.input,
+      result: update.output,
+      status: update.status,
+      startedAt: now,
+      endedAt: now,
+    })
   }
 }
 

--- a/packages/shared/src/lib/ai/__tests__/opencode-tool-parts.test.ts
+++ b/packages/shared/src/lib/ai/__tests__/opencode-tool-parts.test.ts
@@ -1,0 +1,81 @@
+import { normalizeOpenCodeToolPart } from '../opencode-tool-parts'
+
+describe('normalizeOpenCodeToolPart', () => {
+  it('opens a native tool part on a non-terminal state', () => {
+    const update = normalizeOpenCodeToolPart({
+      type: 'tool',
+      id: 'prt-1',
+      callID: 'call-1',
+      tool: 'load_skill',
+      state: { status: 'running', input: { skillId: 'x' } },
+    })
+    expect(update).toEqual({ phase: 'progress', callId: 'call-1', toolName: 'load_skill', input: { skillId: 'x' } })
+  })
+
+  it('finishes a native tool part on completed, carrying the output', () => {
+    const update = normalizeOpenCodeToolPart({
+      type: 'tool',
+      callID: 'call-1',
+      tool: 'load_skill',
+      state: { status: 'completed', input: { skillId: 'x' }, output: { ok: true } },
+    })
+    expect(update).toEqual({
+      phase: 'finish',
+      callId: 'call-1',
+      toolName: 'load_skill',
+      input: { skillId: 'x' },
+      output: { ok: true },
+      status: 'ok',
+    })
+  })
+
+  it('maps an errored native tool part to status error, preferring state.error', () => {
+    const update = normalizeOpenCodeToolPart({
+      type: 'tool',
+      callID: 'call-2',
+      tool: 'run_skill_script',
+      state: { status: 'error', error: 'boom' },
+    })
+    expect(update).toEqual({
+      phase: 'finish',
+      callId: 'call-2',
+      toolName: 'run_skill_script',
+      input: undefined,
+      output: 'boom',
+      status: 'error',
+    })
+  })
+
+  it('falls back to part.id when callID is absent', () => {
+    const update = normalizeOpenCodeToolPart({
+      type: 'tool',
+      id: 'prt-9',
+      tool: 'search',
+      state: { status: 'running' },
+    })
+    expect(update).toMatchObject({ phase: 'progress', callId: 'prt-9', toolName: 'search' })
+  })
+
+  it('handles the legacy tool_use / tool_result shape', () => {
+    expect(normalizeOpenCodeToolPart({ type: 'tool_use', id: 'tc-1', name: 'load_skill', input: { a: 1 } })).toEqual({
+      phase: 'progress',
+      callId: 'tc-1',
+      toolName: 'load_skill',
+      input: { a: 1 },
+    })
+    expect(normalizeOpenCodeToolPart({ type: 'tool_result', tool_use_id: 'tc-1', content: { ok: true } })).toEqual({
+      phase: 'finish',
+      callId: 'tc-1',
+      output: { ok: true },
+      status: 'ok',
+    })
+  })
+
+  it('ignores non-tool and malformed parts', () => {
+    expect(normalizeOpenCodeToolPart({ type: 'text', text: 'hi' })).toBeNull()
+    expect(normalizeOpenCodeToolPart({ type: 'thinking' })).toBeNull()
+    expect(normalizeOpenCodeToolPart({ type: 'tool' })).toBeNull() // no callID/tool
+    expect(normalizeOpenCodeToolPart(null)).toBeNull()
+    expect(normalizeOpenCodeToolPart('nope')).toBeNull()
+  })
+})

--- a/packages/shared/src/lib/ai/opencode-tool-parts.ts
+++ b/packages/shared/src/lib/ai/opencode-tool-parts.ts
@@ -1,0 +1,80 @@
+/**
+ * Normalizes an OpenCode `message.part.updated` part into a tool-call lifecycle
+ * update, shielding callers from OpenCode's wire schema.
+ *
+ * OpenCode (Go server) streams MCP tool invocations as parts of `type: 'tool'`
+ * carrying a `callID`, the `tool` name, and a `state` machine
+ * (`state.status: pending|running|completed|error`, `state.input`,
+ * `state.output`/`state.error`). The same part id is re-emitted on each state
+ * transition, so a tool call surfaces as one or more `progress` updates followed
+ * by a single `finish` once the state reaches a terminal status.
+ *
+ * Older OpenCode builds emitted Anthropic-style `tool_use` / `tool_result`
+ * blocks instead; those are still recognized as a fallback so a downgrade does
+ * not silently drop traces again.
+ *
+ * Returns `null` for any part that is not a tool invocation (text, thinking,
+ * step markers, …) so callers can ignore it.
+ */
+export type OpenCodeToolPartUpdate =
+  | { phase: 'progress'; callId: string; toolName: string; input?: unknown }
+  | {
+      phase: 'finish'
+      callId: string
+      toolName?: string
+      input?: unknown
+      output?: unknown
+      status: 'ok' | 'error'
+    }
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+export function normalizeOpenCodeToolPart(rawPart: unknown): OpenCodeToolPartUpdate | null {
+  if (!rawPart || typeof rawPart !== 'object') return null
+  const part = rawPart as Record<string, unknown>
+  const type = asString(part.type)
+  if (!type) return null
+
+  // Native OpenCode tool part with a state machine.
+  if (type === 'tool') {
+    const callId = asString(part.callID) ?? asString(part.id)
+    const toolName = asString(part.tool)
+    if (!callId || !toolName) return null
+    const state = asRecord(part.state)
+    const status = asString(state.status)
+    const input = 'input' in state ? state.input : undefined
+    if (status === 'completed' || status === 'error') {
+      const output = status === 'error' ? state.error ?? state.output : state.output
+      return {
+        phase: 'finish',
+        callId,
+        toolName,
+        input,
+        output,
+        status: status === 'error' ? 'error' : 'ok',
+      }
+    }
+    return { phase: 'progress', callId, toolName, input }
+  }
+
+  // Legacy Anthropic-style parts (older OpenCode builds).
+  if (type === 'tool_use') {
+    const callId = asString(part.id)
+    const toolName = asString(part.name)
+    if (!callId || !toolName) return null
+    return { phase: 'progress', callId, toolName, input: part.input }
+  }
+  if (type === 'tool_result') {
+    const callId = asString(part.tool_use_id) ?? asString(part.id)
+    if (!callId) return null
+    return { phase: 'finish', callId, output: part.content, status: 'ok' }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Problem

OpenCode agent runs recorded **no tool calls** in the observability traces (the agent_orchestrator traces page was empty for `runtime: 'opencode'` runs).

## Root cause

Both the orchestrator runner (`openCodeAgentRunner.ts`) and the chat handler (`opencode-handlers.ts`) parsed only **Anthropic-style** `tool_use` / `tool_result` SSE parts. The pinned OpenCode server (`OPENCODE_VERSION=1.1.21`) emits MCP tool invocations as `message.part.updated` parts of **`type: 'tool'`** carrying a `callID` + `tool` name + a `state` machine (`state.status: running → completed | error`, `state.input`, `state.output`).

The narrow parser silently dropped every part → `capturedToolCalls` stayed empty → `ingestSessionTrace` early-returned at `length === 0` → the trace tables were never written. The existing unit test masked this by mocking the *assumed* `tool_use` shape (circular).

`session.status` (busy/idle) rode the same stream and worked, which is why runs completed normally — only the tool parts were unrecognized.

## Changes

- **New shared normalizer** `@open-mercato/shared/lib/ai/opencode-tool-parts` — single source of truth that maps the native `type: 'tool'` state machine *and* the legacy `tool_use`/`tool_result` shape (fallback for older builds) into a `progress`/`finish` lifecycle update. Prevents the two parsers from drifting apart again.
- **Runner** — `captureToolPart` folds normalized updates (open on first `progress` keyed by `callId`, close on terminal `finish`); session-id derivation aligned with the chat path (`part.sessionID`, `info.sessionID`, `status.sessionID`).
- **Chat handler** — tool branch rewritten to use the normalizer with a per-call dedup set, so each tool streams exactly one `tool-call` + one `tool-result` despite OpenCode re-emitting the same part per state transition (also restores Command Palette tool debug/usage).
- **SSE client** — surface JSON parse failures instead of swallowing them silently.
- **Tests** — replaced circular fixtures with the real `type: 'tool'` shape, added a legacy-shape regression test, and added normalizer unit tests.

## Verification

- ✅ Normalizer unit tests 6/6
- ✅ Runner trace-ingest tests 3/3 (native + legacy fallback + no-tools)
- ✅ ai-assistant opencode tests 16/16
- ✅ Typecheck + lint clean for `shared`, `ai-assistant`, `enterprise`

(The `@open-mercato/app` typecheck OOM and its pre-existing `react-hooks/rules-of-hooks` lint errors are unrelated — no files I touched are in the app workspace.)

## Note for QA

The `type: 'tool'` + `state` schema is inferred from the repo's own `callID`/`messageID` types and OpenCode's known wire format — I could not capture a live event (no running container, SDK not vendored). Confirm against a live run:
```
docker logs opencode-mvp 2>&1 | grep -i '"type":"tool"'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)