### PR TITLE
fix: block stale message deletes

### DIFF
--- a/packages/core/src/__tests__/optimistic-lock-ui-coverage-workspace.test.ts
+++ b/packages/core/src/__tests__/optimistic-lock-ui-coverage-workspace.test.ts
@@ -104,10 +104,8 @@ const WORKSPACE_ALLOWLIST: Record<string, string> = {
     'exempt — timeline activity-log adapter; the shared `ActivitiesDataAdapter` interface (packages/ui/src/backend/detail/ActivitiesSection.tsx) does not thread a record `updatedAt` to `update`/`delete` (unlike `NotesDataAdapter`), so no per-record version is available to send. Server routes are `makeCrudRoute` floor-covered. Threading a version into the shared activities section is a separate UI-contract change.',
   'packages/core/src/modules/staff/components/detail/activitiesAdapter.ts':
     'exempt — timeline activity-log adapter; same as the resources activities adapter — the shared `ActivitiesDataAdapter` interface passes no `updatedAt` to `update`/`delete`, so no record version is available. Server routes are `makeCrudRoute` floor-covered.',
-  'packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts':
-    'exempt — message read/unread + archive are status transitions (exempt category); message/conversation delete is a non-audited single-owner inbox action. Documented in the Phase-7 cross-cutting delete sweep ("messages item/conversation deletes remain exempt").',
   'packages/core/src/modules/messages/components/useMessagesInboxBulkActions.ts':
-    'exempt — inbox bulk markRead/markUnread/archive are status transitions; bulk delete is a non-audited single-owner inbox action. Same decision as useMessageDetailsActions (Phase-7 sweep).',
+    'exempt — inbox bulk markRead/markUnread/archive are status transitions; bulk delete is a non-audited single-owner inbox action. Documented in the Phase-7 cross-cutting delete sweep.',
   'packages/enterprise/src/modules/security/components/hooks/useMfaStatus.ts':
     'exempt — removes the caller\'s OWN MFA method (single-owner security action), not a collaborative-edit record surface. Documented in the Phase-7 sweep ("mfa factor reset remain exempt").',
 }

--- a/packages/core/src/modules/messages/api/[id]/__tests__/route.test.ts
+++ b/packages/core/src/modules/messages/api/[id]/__tests__/route.test.ts
@@ -1,6 +1,10 @@
-import { GET, PATCH } from '@open-mercato/core/modules/messages/api/[id]/route'
+import { GET, PATCH, DELETE } from '@open-mercato/core/modules/messages/api/[id]/route'
 import { Message, MessageObject, MessageRecipient } from '@open-mercato/core/modules/messages/data/entities'
 import { User } from '@open-mercato/core/modules/auth/data/entities'
+import {
+  OPTIMISTIC_LOCK_CONFLICT_CODE,
+  OPTIMISTIC_LOCK_HEADER_NAME,
+} from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
 
 const resolveMessageContextMock = jest.fn()
 const hasOrganizationAccessMock = jest.fn(() => true)
@@ -38,6 +42,7 @@ describe('messages /api/messages/[id] GET', () => {
       organizationId,
       tenantId,
       deletedAt: null,
+      updatedAt: new Date('2026-06-18T00:00:00.000Z'),
       isDraft: false,
       type: 'system',
       visibility: 'internal',
@@ -224,6 +229,7 @@ describe('messages /api/messages/[id] GET', () => {
       organizationId,
       tenantId,
       deletedAt: null,
+      updatedAt: new Date('2026-06-18T00:00:00.000Z'),
       isDraft: false,
       type: 'system',
       visibility: 'internal',
@@ -311,6 +317,7 @@ describe('messages /api/messages/[id] GET', () => {
       organizationId,
       tenantId,
       deletedAt: null,
+      updatedAt: new Date('2026-06-18T00:00:00.000Z'),
       isDraft: false,
       type: 'system',
       visibility: 'internal',
@@ -465,5 +472,74 @@ describe('messages /api/messages/[id] PATCH', () => {
       organizationId,
       userId,
     }))
+  })
+})
+
+describe('messages /api/messages/[id] DELETE', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('blocks stale draft deletes before executing the delete command', async () => {
+    const tenantId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+    const organizationId = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+    const userId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const messageId = '22222222-2222-4222-8222-222222222222'
+    const staleUpdatedAt = '2026-06-18T00:00:00.000Z'
+    const currentUpdatedAt = '2026-06-19T00:00:00.000Z'
+
+    const draftMessage = {
+      id: messageId,
+      tenantId,
+      organizationId,
+      senderUserId: userId,
+      isDraft: true,
+      updatedAt: new Date(currentUpdatedAt),
+      deletedAt: null,
+    }
+
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      findOne: jest.fn(async (entity: unknown) => {
+        if (entity === Message) return draftMessage
+        return null
+      }),
+    }
+    const commandBus = {
+      execute: jest.fn().mockResolvedValue({ result: { ok: true }, logEntry: null }),
+    }
+    const container = {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'commandBus') return commandBus
+        return null
+      },
+    }
+
+    resolveMessageContextMock.mockResolvedValue({
+      ctx: {
+        container,
+        auth: { features: ['messages.view'] },
+      },
+      scope: { tenantId, organizationId, userId },
+    })
+
+    const request = new Request(`https://example.test/api/messages/${messageId}`, {
+      method: 'DELETE',
+      headers: {
+        [OPTIMISTIC_LOCK_HEADER_NAME]: staleUpdatedAt,
+      },
+    })
+
+    const response = await DELETE(request, { params: { id: messageId } })
+
+    expect(response.status).toBe(409)
+    await expect(response.json()).resolves.toEqual({
+      error: 'record_modified',
+      code: OPTIMISTIC_LOCK_CONFLICT_CODE,
+      currentUpdatedAt,
+      expectedUpdatedAt: staleUpdatedAt,
+    })
+    expect(commandBus.execute).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/messages/api/[id]/route.ts
+++ b/packages/core/src/modules/messages/api/[id]/route.ts
@@ -1,5 +1,10 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CommandBus } from '@open-mercato/shared/lib/commands/command-bus'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import {
+  enforceCommandOptimisticLockWithGuards,
+  enforceRecordGoneIsConflict,
+} from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi/types'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { User } from '../../../auth/data/entities'
@@ -31,6 +36,31 @@ type MessageObjectPreviewPayload = {
   statusColor?: string
   metadata?: Record<string, string>
 } | null
+
+function responseFromCrudHttpError(error: unknown): Response | null {
+  if (!isCrudHttpError(error)) return null
+  return Response.json(error.body, { status: error.status })
+}
+
+async function enforceMessageOptimisticLock(
+  container: Parameters<typeof enforceCommandOptimisticLockWithGuards>[0],
+  req: Request,
+  message: Message,
+): Promise<Response | null> {
+  try {
+    await enforceCommandOptimisticLockWithGuards(container, {
+      resourceKind: 'messages.message',
+      resourceId: message.id,
+      current: message.updatedAt,
+      request: req,
+    })
+  } catch (error) {
+    const response = responseFromCrudHttpError(error)
+    if (response) return response
+    throw error
+  }
+  return null
+}
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   const { ctx, scope } = await resolveMessageContext(req)
@@ -189,6 +219,7 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 
   return Response.json({
     id: message.id,
+    updatedAt: message.updatedAt.toISOString(),
     type: message.type,
     isDraft: message.isDraft,
     canEditDraft: message.isDraft && message.senderUserId === scope.userId,
@@ -278,6 +309,17 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
   })
 
   if (!message) {
+    try {
+      enforceRecordGoneIsConflict({
+        resourceKind: 'messages.message',
+        resourceId: params.id,
+        request: req,
+      })
+    } catch (error) {
+      const response = responseFromCrudHttpError(error)
+      if (response) return response
+      throw error
+    }
     return Response.json({ error: 'Message not found' }, { status: 404 })
   }
 
@@ -292,6 +334,9 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
   if (!message.isDraft) {
     return Response.json({ error: 'Only draft messages can be edited' }, { status: 409 })
   }
+
+  const optimisticLockResponse = await enforceMessageOptimisticLock(ctx.container, req, message)
+  if (optimisticLockResponse) return optimisticLockResponse
 
   const guardResult = await runMessageMutationGuards(
     ctx.container,
@@ -351,6 +396,8 @@ export async function PATCH(req: Request, { params }: { params: { id: string } }
     })
     return response
   } catch (error) {
+    const response = responseFromCrudHttpError(error)
+    if (response) return response
     if (error instanceof Error) {
       if (error.message === 'Message type cannot be created by users') {
         return Response.json({ error: error.message }, { status: 400 })
@@ -379,12 +426,26 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   })
 
   if (!message) {
+    try {
+      enforceRecordGoneIsConflict({
+        resourceKind: 'messages.message',
+        resourceId: params.id,
+        request: req,
+      })
+    } catch (error) {
+      const response = responseFromCrudHttpError(error)
+      if (response) return response
+      throw error
+    }
     return Response.json({ error: 'Message not found' }, { status: 404 })
   }
 
   if (!hasOrganizationAccess(scope.organizationId, message.organizationId)) {
     return Response.json({ error: 'Access denied' }, { status: 403 })
   }
+
+  const optimisticLockResponse = await enforceMessageOptimisticLock(ctx.container, req, message)
+  if (optimisticLockResponse) return optimisticLockResponse
 
   const guardResult = await runMessageMutationGuards(
     ctx.container,
@@ -443,6 +504,8 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
     })
     return response
   } catch (error) {
+    const response = responseFromCrudHttpError(error)
+    if (response) return response
     if (error instanceof Error && error.message === 'Access denied') {
       return Response.json({ error: 'Access denied' }, { status: 403 })
     }
@@ -477,7 +540,7 @@ export const openApi: OpenApiRouteDoc = {
       errors: [
         { status: 403, description: 'Access denied', schema: errorResponseSchema },
         { status: 404, description: 'Message not found', schema: errorResponseSchema },
-        { status: 409, description: 'Only drafts can be edited', schema: errorResponseSchema },
+        { status: 409, description: 'Only drafts can be edited or the draft changed concurrently', schema: errorResponseSchema },
       ],
     },
     DELETE: {
@@ -488,6 +551,7 @@ export const openApi: OpenApiRouteDoc = {
       errors: [
         { status: 403, description: 'Access denied', schema: errorResponseSchema },
         { status: 404, description: 'Message not found', schema: errorResponseSchema },
+        { status: 409, description: 'Message changed concurrently', schema: errorResponseSchema },
       ],
     },
   },

--- a/packages/core/src/modules/messages/api/openapi.ts
+++ b/packages/core/src/modules/messages/api/openapi.ts
@@ -62,6 +62,7 @@ export const messageThreadItemSchema = z.object({
 
 export const messageDetailResponseSchema = z.object({
   id: z.string().uuid(),
+  updatedAt: z.string(),
   type: z.string(),
   isDraft: z.boolean(),
   canEditDraft: z.boolean(),

--- a/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx
@@ -4,7 +4,12 @@
 
 import { act, renderHook } from '@testing-library/react'
 import type { UseQueryResult } from '@tanstack/react-query'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+import {
+  apiCall,
+  apiCallOrThrow,
+  withScopedApiRequestHeaders,
+} from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useMessageDetailsActions } from '../useMessageDetailsActions'
@@ -12,6 +17,8 @@ import type { MessageAction, MessageDetail } from '../../types'
 
 jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
   apiCall: jest.fn(),
+  apiCallOrThrow: jest.fn(),
+  withScopedApiRequestHeaders: jest.fn(async (_headers: Record<string, string>, run: () => Promise<unknown>) => run()),
 }))
 
 jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
@@ -29,6 +36,8 @@ jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
 }))
 
 const mockApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+const mockApiCallOrThrow = apiCallOrThrow as jest.MockedFunction<typeof apiCallOrThrow>
+const mockWithScopedApiRequestHeaders = withScopedApiRequestHeaders as jest.MockedFunction<typeof withScopedApiRequestHeaders>
 const mockFlash = flash as jest.MockedFunction<typeof flash>
 const mockUseGuardedMutation = useGuardedMutation as jest.MockedFunction<typeof useGuardedMutation>
 
@@ -47,6 +56,7 @@ function setup(detailOverrides: Partial<MessageDetail> = {}) {
   const detailQuery = { refetch } as unknown as UseQueryResult<MessageDetail | null, Error>
   const detail = {
     id: 'message-1',
+    updatedAt: '2026-06-18T00:00:00.000Z',
     isRead: false,
     actionTaken: null,
     ...detailOverrides,
@@ -71,6 +81,8 @@ function setup(detailOverrides: Partial<MessageDetail> = {}) {
 describe('useMessageDetailsActions guarded writes (#3258)', () => {
   beforeEach(() => {
     mockApiCall.mockReset()
+    mockApiCallOrThrow.mockReset()
+    mockWithScopedApiRequestHeaders.mockClear()
     mockFlash.mockReset()
     mockRunMutation.mockReset()
     mockRetryLastMutation.mockReset()
@@ -79,6 +91,7 @@ describe('useMessageDetailsActions guarded writes (#3258)', () => {
     // the underlying apiCall/refetch/success behavior is preserved.
     mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
     mockApiCall.mockResolvedValue(okResult({ ok: true }))
+    mockApiCallOrThrow.mockResolvedValue(okResult({ ok: true }))
   })
 
   it('routes message read toggle through runMutation and refetches', async () => {
@@ -122,9 +135,59 @@ describe('useMessageDetailsActions guarded writes (#3258)', () => {
     expect(mockRunMutation).toHaveBeenCalledWith(expect.objectContaining({
       context: expect.objectContaining({ resourceKind: 'message', action: 'delete' }),
     }))
-    expect(mockApiCall).toHaveBeenCalledWith('/api/messages/message-1', { method: 'DELETE' })
+    expect(mockWithScopedApiRequestHeaders).toHaveBeenCalledWith(
+      { [OPTIMISTIC_LOCK_HEADER_NAME]: '2026-06-18T00:00:00.000Z' },
+      expect.any(Function),
+    )
+    expect(mockApiCallOrThrow).toHaveBeenCalledWith(
+      '/api/messages/message-1',
+      { method: 'DELETE' },
+      { errorMessage: 'Failed to delete message.' },
+    )
     expect(onDeleted).toHaveBeenCalledTimes(1)
     expect(mockFlash).toHaveBeenCalledWith('Message deleted.', 'success')
+  })
+
+  it('keeps the page-load message version for delete when detail data refetches in the background', async () => {
+    const refetch = jest.fn().mockResolvedValue(null)
+    const detailQuery = { refetch } as unknown as UseQueryResult<MessageDetail | null, Error>
+    const onDeleted = jest.fn()
+    const onMarkedUnread = jest.fn()
+    const refreshDetailWithoutAutoMarkRead = jest.fn().mockResolvedValue(null)
+    const suppressAutoMarkRead = jest.fn()
+
+    const view = renderHook(
+      ({ updatedAt }: { updatedAt: string }) => useMessageDetailsActions({
+        id: 'message-1',
+        t: translate,
+        detail: {
+          id: 'message-1',
+          updatedAt,
+          isRead: false,
+          actionTaken: null,
+        } as MessageDetail,
+        detailQuery,
+        attachments: [],
+        isArchived: false,
+        onDeleted,
+        onMarkedUnread,
+        refreshDetailWithoutAutoMarkRead,
+        suppressAutoMarkRead,
+      }),
+      { initialProps: { updatedAt: '2026-06-18T00:00:00.000Z' } },
+    )
+
+    view.rerender({ updatedAt: '2026-06-19T00:00:00.000Z' })
+
+    await act(async () => {
+      await view.result.current.handleDelete()
+    })
+
+    expect(mockWithScopedApiRequestHeaders).toHaveBeenCalledWith(
+      { [OPTIMISTIC_LOCK_HEADER_NAME]: '2026-06-18T00:00:00.000Z' },
+      expect.any(Function),
+    )
+    expect(onDeleted).toHaveBeenCalledTimes(1)
   })
 
   it('routes conversation archive through runMutation with a conversation resource kind', async () => {
@@ -174,30 +237,31 @@ describe('useMessageDetailsActions guarded writes (#3258)', () => {
   })
 
   it('surfaces failures through the guarded path (conflict / error)', async () => {
-    mockApiCall.mockResolvedValue({
-      ok: false,
+    const conflict = Object.assign(new Error('record_modified'), {
       status: 409,
-      result: {
-        code: 'optimistic_lock_conflict',
-        error: 'record_modified',
-        currentUpdatedAt: '2026-06-19T00:00:00.000Z',
-        expectedUpdatedAt: '2026-06-18T00:00:00.000Z',
-      },
-      response: {} as Response,
-      cacheStatus: null,
+      code: 'optimistic_lock_conflict',
+      error: 'record_modified',
+      currentUpdatedAt: '2026-06-19T00:00:00.000Z',
+      expectedUpdatedAt: '2026-06-18T00:00:00.000Z',
     })
+    mockApiCallOrThrow.mockRejectedValue(conflict)
 
     const { result, onDeleted } = setup()
+
+    act(() => {
+      result.current.setDeleteConfirmationOpen(true)
+    })
 
     await act(async () => {
       await result.current.handleDelete()
     })
 
     // The mutation still flows through the guard (which owns conflict
-    // surfacing), and the failure is reported via flash rather than navigation.
+    // surfacing), and the dialog is closed so the stale delete cannot be retried.
     expect(mockRunMutation).toHaveBeenCalledTimes(1)
     expect(onDeleted).not.toHaveBeenCalled()
-    expect(mockFlash).toHaveBeenCalledWith(expect.any(String), 'error')
+    expect(result.current.deleteConfirmationOpen).toBe(false)
+    expect(mockFlash).not.toHaveBeenCalled()
   })
 
   it('maps sender archive failures to a domain-specific flash message', async () => {
@@ -225,12 +289,15 @@ describe('useMessageDetailsActions guarded writes (#3258)', () => {
 describe('useMessageDetailsActions mark-unread redirect (#3576)', () => {
   beforeEach(() => {
     mockApiCall.mockReset()
+    mockApiCallOrThrow.mockReset()
+    mockWithScopedApiRequestHeaders.mockClear()
     mockFlash.mockReset()
     mockRunMutation.mockReset()
     mockRetryLastMutation.mockReset()
     mockUseGuardedMutation.mockClear()
     mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
     mockApiCall.mockResolvedValue(okResult({ ok: true }))
+    mockApiCallOrThrow.mockResolvedValue(okResult({ ok: true }))
   })
 
   it('navigates back to the inbox after marking a read message unread', async () => {

--- a/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
+++ b/packages/core/src/modules/messages/components/message-detail/hooks/useMessageDetailsActions.ts
@@ -6,7 +6,11 @@ import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import type { MessageActionsProps, MessageContentProps } from '@open-mercato/shared/modules/messages/types'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCall, apiCallOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import {
+  buildOptimisticLockHeader,
+  extractOptimisticLockConflict,
+} from '@open-mercato/ui/backend/utils/optimisticLock'
 import type {
   ActionResult,
   MessageAction,
@@ -81,10 +85,22 @@ export function useMessageDetailsActions({
   const [pendingActionConfirmation, setPendingActionConfirmation] = React.useState<PendingActionConfirmation | null>(null)
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = React.useState(false)
   const [activeConversationAction, setActiveConversationAction] = React.useState<ConversationActionKind | null>(null)
+  const deleteOptimisticLockUpdatedAtRef = React.useRef<string | null>(null)
 
   const { runMutation, retryLastMutation } = useGuardedMutation<MessageDetailMutationContext>({
     contextId: 'messages-detail-actions',
   })
+
+  React.useEffect(() => {
+    deleteOptimisticLockUpdatedAtRef.current = null
+  }, [id])
+
+  React.useEffect(() => {
+    if (deleteOptimisticLockUpdatedAtRef.current) return
+    if (typeof detail?.updatedAt === 'string' && detail.updatedAt.trim().length > 0) {
+      deleteOptimisticLockUpdatedAtRef.current = detail.updatedAt
+    }
+  }, [detail?.updatedAt])
 
   const requestAndRefresh = React.useCallback(async (
     url: string,
@@ -129,12 +145,14 @@ export function useMessageDetailsActions({
     try {
       await runMutation({
         operation: async () => {
-          const call = await apiCall<{ ok?: boolean }>(`/api/messages/${encodeURIComponent(id)}`, {
-            method: 'DELETE',
-          })
-          if (!call.ok) {
-            throw new Error(toErrorMessage(call.result) ?? t('messages.errors.deleteFailed', 'Failed to delete message.'))
-          }
+          await withScopedApiRequestHeaders(
+            buildOptimisticLockHeader(deleteOptimisticLockUpdatedAtRef.current ?? detail?.updatedAt),
+            () => apiCallOrThrow<{ ok?: boolean }>(
+              `/api/messages/${encodeURIComponent(id)}`,
+              { method: 'DELETE' },
+              { errorMessage: t('messages.errors.deleteFailed', 'Failed to delete message.') },
+            ),
+          )
         },
         context: { resourceKind: 'message', messageId: id, action: 'delete', retryLastMutation },
         mutationPayload: { messageId: id, action: 'delete' },
@@ -142,6 +160,10 @@ export function useMessageDetailsActions({
       flash(t('messages.flash.deleted', 'Message deleted.'), 'success')
       onDeleted()
     } catch (err) {
+      if (extractOptimisticLockConflict(err)) {
+        setDeleteConfirmationOpen(false)
+        return
+      }
       flash(
         err instanceof Error
           ? err.message
@@ -151,7 +173,7 @@ export function useMessageDetailsActions({
     } finally {
       setUpdatingState(false)
     }
-  }, [id, onDeleted, retryLastMutation, runMutation, t])
+  }, [detail?.updatedAt, id, onDeleted, retryLastMutation, runMutation, t])
 
   const runConversationAction = React.useCallback(async (
     action: ConversationActionKind,

--- a/packages/core/src/modules/messages/components/message-detail/panels/__tests__/MessageHeader.test.tsx
+++ b/packages/core/src/modules/messages/components/message-detail/panels/__tests__/MessageHeader.test.tsx
@@ -25,6 +25,7 @@ jest.mock('@open-mercato/ui/backend/forms', () => ({
 function makeDetail(overrides: Partial<MessageDetail> = {}): MessageDetail {
   return {
     id: 'message-1',
+    updatedAt: '2026-06-25T10:00:00.000Z',
     type: 'default',
     isDraft: false,
     canEditDraft: false,

--- a/packages/core/src/modules/messages/components/message-detail/types.ts
+++ b/packages/core/src/modules/messages/components/message-detail/types.ts
@@ -46,6 +46,7 @@ export type MessageAction = {
 
 export type MessageDetail = {
   id: string
+  updatedAt: string
   type: string
   isDraft: boolean
   canEditDraft: boolean


### PR DESCRIPTION
## Summary
- return message detail updatedAt and send it as the delete optimistic-lock token
- block stale message PATCH/DELETE requests before command execution
- close the delete confirmation dialog on optimistic-lock conflicts so users must refresh before retrying

Fixes #3681

## Testing
- yarn.cmd workspace @open-mercato/core test --runTestsByPath src/modules/messages/api/[id]/__tests__/route.test.ts --runInBand
- yarn.cmd workspace @open-mercato/core test --runTestsByPath src/modules/messages/components/message-detail/hooks/__tests__/useMessageDetailsActions.test.tsx --runInBand
- yarn.cmd workspace @open-mercato/core typecheck
- git diff --check

## Manual QA
- Verified stale Tab B delete now returns 409 and shows the unified Record changed conflict banner instead of deleting the message.