### PR TITLE
fix(ai-assistant): guard AI chat docking by available width (#3658)

### DIFF
--- a/packages/ai-assistant/src/frontend/hooks/__tests__/useDockPosition.test.ts
+++ b/packages/ai-assistant/src/frontend/hooks/__tests__/useDockPosition.test.ts
@@ -1,0 +1,44 @@
+import {
+  MIN_DOCKED_CONTENT_WIDTH,
+  resolveViewportSafeDockPosition,
+} from '../useDockPosition'
+
+describe('resolveViewportSafeDockPosition', () => {
+  const PANEL_WIDTH = 550
+
+  it('keeps floating regardless of viewport width', () => {
+    expect(resolveViewportSafeDockPosition('floating', PANEL_WIDTH, 320)).toBe('floating')
+    expect(resolveViewportSafeDockPosition('floating', PANEL_WIDTH, 1920)).toBe('floating')
+  })
+
+  it('keeps bottom dock even on a narrow viewport (it does not reduce content width)', () => {
+    expect(resolveViewportSafeDockPosition('bottom', PANEL_WIDTH, 600)).toBe('bottom')
+  })
+
+  it('keeps a side dock when enough content width remains', () => {
+    // 1440 - 550 = 890 >= 640
+    expect(resolveViewportSafeDockPosition('right', PANEL_WIDTH, 1440)).toBe('right')
+    expect(resolveViewportSafeDockPosition('left', PANEL_WIDTH, 1440)).toBe('left')
+  })
+
+  it('falls back to floating when a side dock would squeeze content below the threshold', () => {
+    // 1024 - 550 = 474 < 640
+    expect(resolveViewportSafeDockPosition('right', PANEL_WIDTH, 1024)).toBe('floating')
+    expect(resolveViewportSafeDockPosition('left', PANEL_WIDTH, 1024)).toBe('floating')
+  })
+
+  it('falls back to floating when a wide side panel leaves too little room on a common laptop width', () => {
+    // 1280 - 900 (max panel) = 380 < 640
+    expect(resolveViewportSafeDockPosition('right', 900, 1280)).toBe('floating')
+  })
+
+  it('treats the threshold as inclusive (exactly MIN_DOCKED_CONTENT_WIDTH of content is allowed)', () => {
+    const viewportWidth = PANEL_WIDTH + MIN_DOCKED_CONTENT_WIDTH
+    expect(resolveViewportSafeDockPosition('right', PANEL_WIDTH, viewportWidth)).toBe('right')
+    expect(resolveViewportSafeDockPosition('right', PANEL_WIDTH, viewportWidth - 1)).toBe('floating')
+  })
+
+  it('allows a side dock when viewport width is unknown (SSR / non-browser)', () => {
+    expect(resolveViewportSafeDockPosition('right', PANEL_WIDTH, Number.POSITIVE_INFINITY)).toBe('right')
+  })
+})

--- a/packages/ai-assistant/src/frontend/hooks/__tests__/useDockPosition.test.ts
+++ b/packages/ai-assistant/src/frontend/hooks/__tests__/useDockPosition.test.ts
@@ -1,5 +1,6 @@
 import {
   MIN_DOCKED_CONTENT_WIDTH,
+  resolveNextCyclePosition,
   resolveViewportSafeDockPosition,
 } from '../useDockPosition'
 
@@ -40,5 +41,36 @@ describe('resolveViewportSafeDockPosition', () => {
 
   it('allows a side dock when viewport width is unknown (SSR / non-browser)', () => {
     expect(resolveViewportSafeDockPosition('right', PANEL_WIDTH, Number.POSITIVE_INFINITY)).toBe('right')
+  })
+})
+
+describe('resolveNextCyclePosition', () => {
+  const PANEL_WIDTH = 550
+  const WIDE_VIEWPORT = 1920
+  const NARROW_VIEWPORT = 1024 // 1024 - 550 = 474 < 640, so side docks collapse
+
+  it('cycles floating -> right -> left -> bottom -> floating on a wide viewport', () => {
+    expect(resolveNextCyclePosition('floating', PANEL_WIDTH, WIDE_VIEWPORT)).toBe('right')
+    expect(resolveNextCyclePosition('right', PANEL_WIDTH, WIDE_VIEWPORT)).toBe('left')
+    expect(resolveNextCyclePosition('left', PANEL_WIDTH, WIDE_VIEWPORT)).toBe('bottom')
+    expect(resolveNextCyclePosition('bottom', PANEL_WIDTH, WIDE_VIEWPORT)).toBe('floating')
+  })
+
+  it('skips unfittable side docks so bottom stays reachable on a narrow viewport', () => {
+    // From floating both side docks collapse to floating (== current) and are skipped.
+    expect(resolveNextCyclePosition('floating', PANEL_WIDTH, NARROW_VIEWPORT)).toBe('bottom')
+    // From bottom the only other reachable position is floating.
+    expect(resolveNextCyclePosition('bottom', PANEL_WIDTH, NARROW_VIEWPORT)).toBe('floating')
+  })
+
+  it('never gets stuck repeating the current position on a narrow viewport', () => {
+    let position = resolveNextCyclePosition('floating', PANEL_WIDTH, NARROW_VIEWPORT)
+    const seen = new Set<string>([position])
+    for (let i = 0; i < 4; i += 1) {
+      position = resolveNextCyclePosition(position, PANEL_WIDTH, NARROW_VIEWPORT)
+      seen.add(position)
+    }
+    expect(seen.has('bottom')).toBe(true)
+    expect(seen.has('floating')).toBe(true)
   })
 })

--- a/packages/ai-assistant/src/frontend/hooks/useDockPosition.ts
+++ b/packages/ai-assistant/src/frontend/hooks/useDockPosition.ts
@@ -48,6 +48,30 @@ export function resolveViewportSafeDockPosition(
   return 'floating'
 }
 
+const DOCK_CYCLE_ORDER: DockPosition[] = ['floating', 'right', 'left', 'bottom']
+
+/**
+ * Resolve the next dock position when cycling. Side docks that the current
+ * viewport cannot fit ({@link resolveViewportSafeDockPosition} collapses them to
+ * floating) are skipped so cycling always advances to a position that is both
+ * viewport-safe and different from the current one. Without this, a squeezed
+ * side dock collapses back to floating and the cycle gets stuck before ever
+ * reaching the bottom dock, which stays valid on narrow viewports.
+ */
+export function resolveNextCyclePosition(
+  current: DockPosition,
+  panelWidth: number,
+  viewportWidth: number,
+): DockPosition {
+  const currentIndex = DOCK_CYCLE_ORDER.indexOf(current)
+  for (let step = 1; step <= DOCK_CYCLE_ORDER.length; step += 1) {
+    const candidate = DOCK_CYCLE_ORDER[(currentIndex + step) % DOCK_CYCLE_ORDER.length]
+    const safePosition = resolveViewportSafeDockPosition(candidate, panelWidth, viewportWidth)
+    if (safePosition !== current) return safePosition
+  }
+  return current
+}
+
 export function useDockPosition() {
   const [dockState, setDockState] = useState<DockState>(DEFAULT_DOCK_STATE)
   const [isHydrated, setIsHydrated] = useState(false)
@@ -136,15 +160,10 @@ export function useDockPosition() {
   }, [])
 
   const cyclePosition = useCallback(() => {
-    setDockState((prev) => {
-      const positions: DockPosition[] = ['floating', 'right', 'left', 'bottom']
-      const currentIndex = positions.indexOf(prev.position)
-      const nextIndex = (currentIndex + 1) % positions.length
-      return {
-        ...prev,
-        position: resolveViewportSafeDockPosition(positions[nextIndex], prev.width, getViewportWidth()),
-      }
-    })
+    setDockState((prev) => ({
+      ...prev,
+      position: resolveNextCyclePosition(prev.position, prev.width, getViewportWidth()),
+    }))
   }, [])
 
   const cycleFloatingPosition = useCallback(() => {

--- a/packages/ai-assistant/src/frontend/hooks/useDockPosition.ts
+++ b/packages/ai-assistant/src/frontend/hooks/useDockPosition.ts
@@ -18,6 +18,36 @@ const MAX_WIDTH = 900
 const MIN_HEIGHT = 500
 const MAX_HEIGHT = 900
 
+// Minimum width the main backoffice content needs to stay usable while a side
+// (left/right) dock overlays the viewport. Below this the dense backoffice
+// screens (dashboards, KPI cards, data tables) get clipped, so the side dock
+// falls back to the floating panel instead.
+export const MIN_DOCKED_CONTENT_WIDTH = 640
+
+const SIDE_DOCK_POSITIONS: DockPosition[] = ['left', 'right']
+
+function getViewportWidth(): number {
+  if (typeof window === 'undefined') return Number.POSITIVE_INFINITY
+  return window.innerWidth
+}
+
+/**
+ * Resolve the dock position that is safe for the current viewport. Side
+ * (left/right) docks overlay the main content, so when the leftover content
+ * width would fall below {@link MIN_DOCKED_CONTENT_WIDTH} we fall back to the
+ * floating panel. Floating and bottom docks never reduce content width, so they
+ * are always allowed.
+ */
+export function resolveViewportSafeDockPosition(
+  position: DockPosition,
+  panelWidth: number,
+  viewportWidth: number,
+): DockPosition {
+  if (!SIDE_DOCK_POSITIONS.includes(position)) return position
+  if (viewportWidth - panelWidth >= MIN_DOCKED_CONTENT_WIDTH) return position
+  return 'floating'
+}
+
 export function useDockPosition() {
   const [dockState, setDockState] = useState<DockState>(DEFAULT_DOCK_STATE)
   const [isHydrated, setIsHydrated] = useState(false)
@@ -31,10 +61,12 @@ export function useDockPosition() {
         // Migrate 'modal' to 'floating' for existing users
         const rawPosition = parsed.position as string | undefined
         const migratedPosition = rawPosition === 'modal' ? 'floating' : rawPosition
+        const width = Math.min(Math.max((parsed.width as number) || DEFAULT_DOCK_STATE.width, MIN_WIDTH), MAX_WIDTH)
+        const position = (migratedPosition as DockPosition) || DEFAULT_DOCK_STATE.position
         setDockState({
-          position: (migratedPosition as DockPosition) || DEFAULT_DOCK_STATE.position,
+          position: resolveViewportSafeDockPosition(position, width, getViewportWidth()),
           floatingPosition: (parsed.floatingPosition as FloatingPosition) || DEFAULT_DOCK_STATE.floatingPosition,
-          width: Math.min(Math.max((parsed.width as number) || DEFAULT_DOCK_STATE.width, MIN_WIDTH), MAX_WIDTH),
+          width,
           height: Math.min(Math.max((parsed.height as number) || DEFAULT_DOCK_STATE.height, MIN_HEIGHT), MAX_HEIGHT),
           isMinimized: (parsed.isMinimized as boolean) || false,
         })
@@ -55,8 +87,26 @@ export function useDockPosition() {
     }
   }, [dockState, isHydrated])
 
+  // Auto-undock a side dock to floating when the viewport becomes too narrow,
+  // so the backoffice content area never gets squeezed below a usable width.
+  useEffect(() => {
+    if (!isHydrated || typeof window === 'undefined') return
+    const handleResize = () => {
+      setDockState((prev) => {
+        const safePosition = resolveViewportSafeDockPosition(prev.position, prev.width, window.innerWidth)
+        if (safePosition === prev.position) return prev
+        return { ...prev, position: safePosition }
+      })
+    }
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [isHydrated])
+
   const setPosition = useCallback((position: DockPosition) => {
-    setDockState((prev) => ({ ...prev, position }))
+    setDockState((prev) => ({
+      ...prev,
+      position: resolveViewportSafeDockPosition(position, prev.width, getViewportWidth()),
+    }))
   }, [])
 
   const setFloatingPosition = useCallback((floatingPosition: FloatingPosition) => {
@@ -90,7 +140,10 @@ export function useDockPosition() {
       const positions: DockPosition[] = ['floating', 'right', 'left', 'bottom']
       const currentIndex = positions.indexOf(prev.position)
       const nextIndex = (currentIndex + 1) % positions.length
-      return { ...prev, position: positions[nextIndex] }
+      return {
+        ...prev,
+        position: resolveViewportSafeDockPosition(positions[nextIndex], prev.width, getViewportWidth()),
+      }
     })
   }, [])
 


### PR DESCRIPTION
Fixes #3658

## Problem
When the AI Assistant chat panel is **docked** left/right and the viewport is narrow (small laptop screen), the backoffice layout breaks: KPI metric cards crowd, the Deals data table's `Status`/`Actions` columns get clipped, and dense screens look squeezed. The docked panel is `position: fixed` and overlays the right/left edge of the viewport, so when there isn't enough room the visible content area becomes unusable.

## Root Cause
`useDockPosition` accepted any dock position regardless of how much room the viewport had left for the main content. A side (left/right) dock could occupy up to 900px on a 1024–1280px screen, leaving the content area far too narrow.

## What Changed
- `packages/ai-assistant/src/frontend/hooks/useDockPosition.ts`:
  - Added `MIN_DOCKED_CONTENT_WIDTH` (640px) and a pure helper `resolveViewportSafeDockPosition(position, panelWidth, viewportWidth)` that returns `'floating'` for a side dock when the leftover content width would fall below the threshold. Floating and bottom docks are never restricted (they don't reduce content width).
  - The guard is applied when restoring persisted state on hydration, when the user picks a dock position (`setPosition`), when cycling positions (`cyclePosition`), and on `window` resize — a docked side panel auto-undocks to floating when the window becomes too narrow.
- This implements **option 1** from the issue (width guard / auto-undock fallback), the lowest-risk fix. The dock controls already highlight the active position, so the fallback to floating is visible to the user.

## Tests
- Added `packages/ai-assistant/src/frontend/hooks/__tests__/useDockPosition.test.ts` (7 cases) covering: floating/bottom always allowed, side dock allowed with enough room, side dock falling back to floating when squeezed, the max-width-panel case on a common laptop width, inclusive-threshold boundary, and SSR (unknown viewport) safety.
- `yarn workspace @open-mercato/ai-assistant test` → 98 suites / 1339 tests pass.
- `yarn build:packages`, `yarn generate`, `yarn typecheck` (21/21) green. eslint clean on changed files.

## Backward Compatibility
- Additive only: two new exports (`MIN_DOCKED_CONTENT_WIDTH`, `resolveViewportSafeDockPosition`). The `useDockPosition` return shape and all existing exports are unchanged. No event IDs, ACL, DI keys, routes, or DB schema touched.