### PR TITLE
fix(integrations): surface credentials save conflict on unified bar (#3676)

### DIFF
--- a/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-conflict.test.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-conflict.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression for #3676: when saving integration credentials hits an optimistic-lock
+ * 409, the credentials form must surface the conflict on the unified
+ * RecordConflictBanner with a localized message — not toast the raw `record_modified`
+ * code, and not silently swallow the conflict. The page hands the failure to its host
+ * CrudForm via raiseCrudError (status + body), so CrudForm's existing conflict path
+ * runs. Before the fix the handler threw createCrudFormError('record_modified'), which
+ * CrudForm could not recognize as a conflict, so no bar appeared and the toast showed
+ * the raw key.
+ */
+import * as React from 'react'
+import { act, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { OPTIMISTIC_LOCK_CONFLICT_CODE } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+const apiCallMock = jest.fn()
+const flashMock = jest.fn()
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a>,
+}))
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/backend/integrations/gateway_stripe',
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+jest.mock('remark-gfm', () => ({ __esModule: true, default: {} }))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PageBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  LoadingMessage: ({ label }: { label: string }) => <div>{label}</div>,
+  ErrorMessage: ({ label }: { label: string }) => <div>{label}</div>,
+  RecordNotFoundState: ({ label }: { label: string }) => <div>{label}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => {
+  const actual = jest.requireActual('@open-mercato/ui/backend/utils/apiCall')
+  return {
+    ...actual,
+    apiCall: (...args: unknown[]) => apiCallMock(...args),
+    withScopedApiRequestHeaders: (_headers: Record<string, string>, run: () => Promise<unknown>) => run(),
+  }
+})
+
+// runMutation must actually execute the operation so the credentials PUT (and its 409)
+// flows through to the page's failure handling — the bug lives in that handler.
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: async ({ operation }: { operation: () => Promise<unknown> }) => operation(),
+    retryLastMutation: jest.fn(),
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: (...args: unknown[]) => flashMock(...args),
+}))
+
+// CrudForm dependencies that need stubbing to render under jsdom.
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({ confirm: jest.fn().mockResolvedValue(true), ConfirmDialogElement: null }),
+}))
+jest.mock('@open-mercato/ui/backend/custom-fields/FieldDefinitionsManager', () => {
+  const ReactLocal = require('react')
+  return {
+    __esModule: true,
+    FieldDefinitionsManager: ReactLocal.forwardRef(() => <div>Field definitions manager</div>),
+  }
+})
+jest.mock('@open-mercato/ui/backend/utils/customFieldForms', () => ({
+  __esModule: true,
+  buildFormFieldFromCustomFieldDef: jest.fn(),
+  buildFormFieldsFromCustomFields: jest.fn(() => []),
+  fetchCustomFieldFormStructure: jest.fn(async () => ({
+    fields: [],
+    definitions: [],
+    metadata: { items: [], fieldsetsByEntity: {}, entitySettings: {} },
+  })),
+}))
+
+import IntegrationDetailPage from '../page'
+import { dismissRecordConflict, getRecordConflictForTest } from '@open-mercato/ui/backend/conflicts'
+
+const RECORD_MODIFIED_MESSAGE = 'This record was modified by someone else. Refresh and try again.'
+
+const dict = {
+  'ui.forms.flash.recordModified': RECORD_MODIFIED_MESSAGE,
+}
+
+const integrationDetail = {
+  integration: {
+    id: 'gateway_stripe',
+    title: 'Stripe',
+    category: 'payment',
+    credentials: {
+      fields: [{ key: 'publishableKey', label: 'Publishable Key', type: 'text', required: false }],
+    },
+  },
+  state: {
+    isEnabled: true,
+    apiVersion: null,
+    reauthRequired: false,
+    lastHealthStatus: null,
+    lastHealthCheckedAt: null,
+    lastHealthLatencyMs: null,
+    enabledAt: null,
+    updatedAt: '2026-06-29T09:00:00.000Z',
+  },
+  hasCredentials: true,
+  credentialsUpdatedAt: '2026-06-29T09:00:00.000Z',
+  healthStatus: 'unconfigured',
+  analytics: { lastActivityAt: null, totalCount: 0, errorCount: 0, errorRate: 0, dailyCounts: [0, 0, 0, 0, 0, 0, 0] },
+}
+
+const conflictBody = {
+  error: 'record_modified',
+  code: OPTIMISTIC_LOCK_CONFLICT_CODE,
+  currentUpdatedAt: '2026-06-29T10:00:00.000Z',
+  expectedUpdatedAt: '2026-06-29T09:00:00.000Z',
+}
+
+function makeResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    clone() {
+      return this
+    },
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as unknown as Response
+}
+
+function mockApiResponses() {
+  apiCallMock.mockImplementation((url: unknown, init?: RequestInit) => {
+    const href = typeof url === 'string' ? url : ''
+    const method = (init?.method ?? 'GET').toUpperCase()
+    if (href.includes('/credentials')) {
+      if (method === 'PUT') {
+        return Promise.resolve({
+          ok: false,
+          status: 409,
+          result: conflictBody,
+          response: makeResponse(409, conflictBody),
+        })
+      }
+      const body = { credentials: { publishableKey: 'pk_test_123' }, updatedAt: '2026-06-29T09:00:00.000Z' }
+      return Promise.resolve({ ok: true, status: 200, result: body, response: makeResponse(200, body) })
+    }
+    if (href.includes('/logs')) {
+      const body = { items: [] }
+      return Promise.resolve({ ok: true, status: 200, result: body, response: makeResponse(200, body) })
+    }
+    return Promise.resolve({ ok: true, status: 200, result: integrationDetail, response: makeResponse(200, integrationDetail) })
+  })
+}
+
+describe('Integration credentials — optimistic-lock conflict surfacing (#3676)', () => {
+  beforeEach(() => {
+    apiCallMock.mockReset()
+    flashMock.mockReset()
+    dismissRecordConflict()
+    mockApiResponses()
+  })
+
+  afterEach(() => {
+    dismissRecordConflict()
+  })
+
+  it('surfaces a stale-save 409 on the unified conflict bar with a localized message (no raw record_modified toast)', async () => {
+    const { container } = renderWithProviders(
+      <IntegrationDetailPage params={{ id: 'gateway_stripe' }} />,
+      { dict },
+    )
+
+    let form: HTMLFormElement | null = null
+    await waitFor(() => {
+      form = container.querySelector('form')
+      expect(form).not.toBeNull()
+    })
+
+    await act(async () => {
+      fireEvent.submit(form as unknown as HTMLFormElement)
+    })
+
+    await waitFor(() => {
+      const entry = getRecordConflictForTest()
+      expect(entry).not.toBeNull()
+      expect(entry?.message).toBe(RECORD_MODIFIED_MESSAGE)
+    })
+
+    // The raw enum string must never reach the user as a toast.
+    expect(flashMock).not.toHaveBeenCalledWith('record_modified', 'error')
+    expect(flashMock).not.toHaveBeenCalledWith(RECORD_MODIFIED_MESSAGE, 'error')
+
+    // Sanity: the credentials PUT was actually attempted.
+    const putCall = apiCallMock.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'PUT',
+    )
+    expect(putCall).toBeTruthy()
+  })
+})

--- a/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
@@ -27,7 +27,7 @@ import { JsonDisplay } from '@open-mercato/ui/backend/JsonDisplay'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { createCrudFormError } from '@open-mercato/ui/backend/utils/serverErrors'
+import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { cn } from '@open-mercato/shared/lib/utils'
 import {
@@ -748,14 +748,13 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
         return
       }
 
-      const result = call.result as {
-        error?: string
-        details?: { fieldErrors?: Record<string, string>; formErrors?: string[] }
-      } | null
-      throw createCrudFormError(
-        result?.error ?? t('integrations.detail.credentials.saveError', 'Failed to save credentials'),
-        result?.details?.fieldErrors,
-        { details: result?.details },
+      // Re-raise with status + response body (not a bare message) so the host CrudForm
+      // recognizes optimistic-lock 409s and surfaces them on the unified conflict bar
+      // with a localized message instead of toasting the raw `record_modified` code.
+      // apiCall reads the body via response.clone(), so call.response is still readable.
+      await raiseCrudError(
+        call.response,
+        t('integrations.detail.credentials.saveError', 'Failed to save credentials'),
       )
     } finally {
       setIsSavingCredentials(false)


### PR DESCRIPTION
Fixes #3676

## Problem
Saving integration credentials from two tabs concurrently correctly returns HTTP 409, but the UI handled it wrong on `/backend/integrations/<id>` → Credentials:
- the **unified conflict bar** never appeared, and
- a red toast showed the raw enum string **`record_modified`** instead of a human-readable message.

## Root Cause
The credentials form's `onSubmit` (`handleSaveCredentials`) caught the non-OK `apiCall` result and threw `createCrudFormError(result.error, …)`, where `result.error` is the raw `record_modified` code. That error carried **no HTTP status and no conflict body**, so the host `CrudForm`'s existing conflict handling (`extractOptimisticLockConflict` → `surfaceRecordConflict`) could not recognize it as an optimistic-lock 409. CrudForm therefore fell back to a plain error toast showing the raw key, and the conflict bar was never shown.

(`useGuardedMutation`'s `runMutation` also can't help here: `apiCall` returns `{ ok: false }` without throwing, so its catch-based conflict surfacing never fires.)

## What Changed
- `packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx`: on a failed credentials save, re-raise via `raiseCrudError(call.response, …)` — the **same path `createCrud`/`updateCrud` already use** — so the thrown error carries the HTTP status and the spread response body. CrudForm then:
  - recognizes the 409 and surfaces the **localized** message on the unified `RecordConflictBanner`,
  - suppresses the redundant raw toast, and
  - still maps 422 field-validation errors inline.
  - `apiCall` reads the body via `response.clone()`, so `call.response` is still readable here.

This is a UX-only fix — the server-side 409 (data integrity) was already correct.

## Tests
- New page-level regression test `…/[id]/__tests__/credentials-conflict.test.tsx`: drives a stale-save 409 through the credentials form and asserts the unified conflict bar shows the localized message with **no** raw `record_modified` toast. Verified it **fails** on the pre-fix code (no bar, raw-key toast) and passes after.
- `yarn workspace @open-mercato/core test` for `integrations/backend` + `credentials` → 10 suites / 55 tests pass.
- `yarn build:packages`, `yarn generate`, `yarn workspace @open-mercato/core typecheck` → clean; ESLint clean on changed files.

## Backward Compatibility
No contract surface changes. Internal swap of two public `@open-mercato/ui/backend/utils/serverErrors` helpers (`createCrudFormError` → `raiseCrudError`); both remain exported. No API response, event ID, widget spot ID, ACL, DI, or DB schema changes.

## Note (out of scope)
The **bundle** credentials page (`bundle/[id]/page.tsx`) uses a custom button (not CrudForm) and already flashes a localized generic error rather than the raw key, so it doesn't exhibit this issue's symptom; it could surface the conflict bar too as a small follow-up.