### PR TITLE
fix(encryption): restore decrypted JSON columns to objects on entity load (#3672)

### DIFF
--- a/packages/shared/src/lib/encryption/__tests__/subscriber.json-columns.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/subscriber.json-columns.test.ts
@@ -1,0 +1,95 @@
+import { TenantEncryptionSubscriber } from '../subscriber'
+import { registerEntityIds } from '../entityIds'
+import type { TenantDataEncryptionService } from '../tenantDataEncryptionService'
+
+// Regression coverage for issue #3672: an encrypted column declared as `type: 'json'`
+// (e.g. inbox_ops:inbox_proposal_action.payload) round-trips through encryption as a
+// JSON *string* — `decryptFields` intentionally never re-parses decrypted entity columns
+// so that string/text columns whose contents look like JSON stay raw. The entity-hydration
+// subscriber must restore json-typed columns back to objects/arrays, otherwise consumers
+// (the proposal Edit dialog) read `payload.orderNumber` off a string and render blank fields.
+
+function makeEm() {
+  return { getComparator: () => undefined, getMetadata: () => undefined }
+}
+
+const META = {
+  className: 'Thing',
+  tableName: 'things',
+  properties: {
+    payload: { name: 'payload', type: 'json' },
+    participants: { name: 'participants', type: 'json' },
+    description: { name: 'description', type: 'text' },
+  },
+} as any
+
+describe('TenantEncryptionSubscriber json-column restoration (issue #3672)', () => {
+  const originalToggle = process.env.TENANT_DATA_ENCRYPTION
+
+  beforeEach(() => {
+    delete process.env.TENANT_DATA_ENCRYPTION // default => encryption enabled
+    registerEntityIds({ test: { thing: 'test:thing' } })
+  })
+
+  afterEach(() => {
+    if (originalToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+    else process.env.TENANT_DATA_ENCRYPTION = originalToggle
+    jest.restoreAllMocks()
+  })
+
+  function makeService(
+    decryptEntityPayload: (entityId: string, target: Record<string, unknown>) => Record<string, unknown>,
+  ): TenantDataEncryptionService {
+    return {
+      isEnabled: () => true,
+      async decryptEntityPayload(entityId: string, target: Record<string, unknown>) {
+        return decryptEntityPayload(entityId, target)
+      },
+    } as unknown as TenantDataEncryptionService
+  }
+
+  it('parses decrypted json object columns back into objects', async () => {
+    const entity: Record<string, unknown> = { tenantId: 't1', payload: 'enc:cipher' }
+    const subscriber = new TenantEncryptionSubscriber(
+      makeService(() => ({ payload: '{"orderId":"o-1","orderNumber":"SO-100","noteAdditions":["hi"]}' })),
+    )
+
+    await subscriber.decryptEntityGraph(entity, META, makeEm(), { syncOriginal: true })
+
+    expect(entity.payload).toEqual({ orderId: 'o-1', orderNumber: 'SO-100', noteAdditions: ['hi'] })
+  })
+
+  it('parses decrypted json array columns back into arrays', async () => {
+    const entity: Record<string, unknown> = { tenantId: 't1', participants: 'enc:cipher' }
+    const subscriber = new TenantEncryptionSubscriber(
+      makeService(() => ({ participants: '[{"name":"Ada"},{"name":"Bo"}]' })),
+    )
+
+    await subscriber.decryptEntityGraph(entity, META, makeEm(), { syncOriginal: true })
+
+    expect(entity.participants).toEqual([{ name: 'Ada' }, { name: 'Bo' }])
+  })
+
+  it('leaves decrypted string/text columns untouched even when they look like JSON', async () => {
+    const entity: Record<string, unknown> = { tenantId: 't1', description: 'enc:cipher' }
+    const subscriber = new TenantEncryptionSubscriber(
+      makeService(() => ({ description: '{"this":"is a display name, not json"}' })),
+    )
+
+    await subscriber.decryptEntityGraph(entity, META, makeEm(), { syncOriginal: true })
+
+    expect(entity.description).toBe('{"this":"is a display name, not json"}')
+  })
+
+  it('leaves non-string json column values untouched', async () => {
+    const alreadyObject = { orderNumber: 'SO-200' }
+    const entity: Record<string, unknown> = { tenantId: 't1', payload: alreadyObject }
+    const subscriber = new TenantEncryptionSubscriber(
+      makeService((_id, target) => ({ payload: target.payload })),
+    )
+
+    await subscriber.decryptEntityGraph(entity, META, makeEm(), { syncOriginal: true })
+
+    expect(entity.payload).toBe(alreadyObject)
+  })
+})

--- a/packages/shared/src/lib/encryption/subscriber.ts
+++ b/packages/shared/src/lib/encryption/subscriber.ts
@@ -1,7 +1,7 @@
 import type { EntityMetadata, EventArgs, EventSubscriber } from '@mikro-orm/core'
 import { ReferenceKind } from '@mikro-orm/core'
 import { resolveEntityIdFromMetadata } from './entityIds'
-import { TenantDataEncryptionService } from './tenantDataEncryptionService'
+import { TenantDataEncryptionService, parseDecryptedFieldValue } from './tenantDataEncryptionService'
 import { isTenantDataEncryptionEnabled } from './toggles'
 import { isEncryptionDebugEnabled } from './toggles'
 import { resolveTenantEncryptionService } from './customFieldValues'
@@ -34,6 +34,17 @@ function debug(event: string, payload: Record<string, unknown>) {
   } catch {
     // ignore
   }
+}
+
+function isJsonColumnProperty(prop: unknown): boolean {
+  if (!prop || typeof prop !== 'object') return false
+  const candidate = prop as Record<string, unknown>
+  const type = typeof candidate.type === 'string' ? candidate.type.toLowerCase() : ''
+  if (type === 'json' || type === 'jsonb') return true
+  const columnTypes = Array.isArray(candidate.columnTypes) ? candidate.columnTypes : []
+  if (columnTypes.some((value) => typeof value === 'string' && value.toLowerCase().includes('json'))) return true
+  const customTypeName = (candidate.customType as { constructor?: { name?: string } } | undefined)?.constructor?.name
+  return typeof customTypeName === 'string' && customTypeName.toLowerCase().includes('json')
 }
 
 const registeredEventManagers = new WeakSet<object>()
@@ -99,6 +110,21 @@ export class TenantEncryptionSubscriber implements EventSubscriber<any> {
       return resolveEntityIdFromMetadata(meta)
     } catch {
       return null
+    }
+  }
+
+  private restoreDecryptedJsonColumns(
+    target: Record<string, unknown>,
+    meta: EntityMetadata<any> | undefined,
+  ) {
+    const properties = meta?.properties
+    if (!properties || typeof properties !== 'object') return
+    for (const [propertyName, prop] of Object.entries(properties)) {
+      if (!isJsonColumnProperty(prop)) continue
+      const value = target[propertyName]
+      if (typeof value !== 'string') continue
+      const parsed = parseDecryptedFieldValue(value)
+      if (parsed !== value) target[propertyName] = parsed
     }
   }
 
@@ -308,6 +334,7 @@ export class TenantEncryptionSubscriber implements EventSubscriber<any> {
     const hadPendingChanges = syncOriginal ? this.hasPendingChanges(target, resolvedMeta, em as any) : false
     const decrypted = await this.service.decryptEntityPayload(entityId, target, scopedTenantId, scopedOrgId)
     Object.assign(target, decrypted)
+    this.restoreDecryptedJsonColumns(target, resolvedMeta)
     if (syncOriginal && !hadPendingChanges) {
       this.syncOriginalEntityData(target, resolvedMeta, em as any)
     }


### PR DESCRIPTION
Fixes #3672

## Problem
After successfully saving an `update_order` action via the inbox-ops proposal Edit dialog (green toast, 200), reopening the dialog showed every field empty (Order Number, Notes, …) even though the data was saved server-side.

## Root Cause
`inbox_ops:inbox_proposal_action.payload` is a `type: 'json'` column **registered as an encrypted field**. Encrypted JSON columns round-trip through encryption as a JSON *string*:

- `encryptFields` JSON-stringifies non-string values before encrypting.
- `decryptFields` decrypts back to that string but **intentionally never re-parses** decrypted entity columns, so that string/text columns whose contents merely look like JSON stay raw (issue #1810 follow-up).

So once a row was (re-)encrypted on save, the entity-hydration path (`findWithDecryption`) returned `payload` as a **string**. The dialog initializes its state with `structuredClone(action.payload)` and reads `payload.orderNumber` — reading a property off a string yields `undefined`, so all fields render blank (and no error is thrown). On first load the values showed because the original row had been stored as plain (non-ciphertext) JSON, which `decryptFields` skips (`typeof value !== 'string'`).

This was a **latent, general** bug for every encrypted json column — `inbox_proposal.participants` / `translations` and `inbox_email.thread_messages` had the same exposure after re-encryption.

## What Changed
- `packages/shared/src/lib/encryption/subscriber.ts`: after decrypting an entity, restore json-typed columns (`type: 'json'`/`jsonb`, json `columnTypes`, or a JSON `customType`) back into objects/arrays via the existing `parseDecryptedFieldValue` helper (which only restructures unambiguous `{...}`/`[...]` payloads, leaving JSON-looking string/text columns untouched). The parse runs before the change-tracking re-baseline so the snapshot captures the object form.
- The query-engine (`query/engine.ts`) and search-index (`indexDoc.ts`) decryption paths call `decryptEntityPayload` directly and are **intentionally left unchanged** — the fix is scoped to the ORM entity-hydration path.

## Tests
- New `packages/shared/src/lib/encryption/__tests__/subscriber.json-columns.test.ts`: decrypted json object/array columns are parsed back to objects/arrays; string/text columns that look like JSON stay raw; non-string json values are left untouched. 4/4 pass.
- Full `@open-mercato/shared` suite (1327) and `@open-mercato/core` inbox_ops suite (371) green; shared + core typecheck clean; `build:packages` green.

## Backward Compatibility
- No contract surface change. Private subscriber method + module-local helper; reuses the already-exported `parseDecryptedFieldValue`. Behavior change is a bug fix restoring intended object shape on the entity path.

## Risk / QA
- `risk-high` (touches encryption / a shared hydration path used platform-wide). Scoped to the entity-decryption path with targeted tests; query-engine and search paths untouched.
- `needs-qa`: please re-verify the inbox-ops proposal Edit dialog round-trip (edit notes → save → reopen shows saved values).