### PR TITLE
feat(customers): cache GET /api/customers/people/[id] detail (#3663)

### DIFF
--- a/packages/core/src/modules/customers/api/people/[id]/__tests__/cache.test.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/__tests__/cache.test.ts
@@ -188,12 +188,15 @@ describe('GET /api/customers/people/[id] — caching (issue #3663)', () => {
     expect(setKey).toBe(getKey)
     expect((setValue as { person: { id: string } }).person.id).toBe(PERSON_ID)
     expect(setOpts.ttl).toBe(60_000)
+    // Canonicalized resource tags (camelCase ids are split + lowercased the same
+    // way invalidateCrudCache does) so write/undo/redo invalidation actually
+    // matches these set tags (#3663).
     expect(setOpts.tags).toEqual([
       `crud:customers.person:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
       `crud:customers.address:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
-      `crud:customers.tagAssignment:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
-      `crud:customers.labelAssignment:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
-      `crud:customers.personCompanyLink:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+      `crud:customers.tag.assignment:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+      `crud:customers.label.assignment:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+      `crud:customers.person.company.link:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
       `crud:customers.interaction:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
       `crud:customers.activity:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
     ])

--- a/packages/core/src/modules/customers/api/people/[id]/__tests__/cache.test.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/__tests__/cache.test.ts
@@ -1,0 +1,232 @@
+/** @jest-environment node */
+
+// Regression coverage for issue #3663: the people detail route must add a gated
+// get-then-set cache that (a) is inert when ENABLE_CRUD_API_CACHE is off,
+// (b) keys on tenant/org/personId + effective RBAC scope and stores the payload
+// tagged with the reused customers.* collection tags, and (c) serves a hit
+// without running the expensive decryption sweeps.
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockResolveCustomerInteractionFeatureFlags = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockResolvePersonCustomFieldRouting = jest.fn()
+const mockMergePersonCustomFieldValues = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockLoadPersonCompanyLinks = jest.fn()
+
+const mockEm = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+}
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+} as { get: jest.Mock; set: jest.Mock }
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'cache') return cache
+    if (token === 'queryEngine') return { query: jest.fn(async () => ({ items: [] })) }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: jest.fn(() => true),
+}))
+
+jest.mock('../../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn((...args: unknown[]) => mockResolveCustomerInteractionFeatureFlags(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+jest.mock('../../../../lib/customFieldRouting', () => ({
+  resolvePersonCustomFieldRouting: jest.fn((...args: unknown[]) => mockResolvePersonCustomFieldRouting(...args)),
+  mergePersonCustomFieldValues: jest.fn((...args: unknown[]) => mockMergePersonCustomFieldValues(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('../../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+}))
+
+jest.mock('../../../../lib/personCompanies', () => ({
+  loadPersonCompanyLinks: jest.fn((...args: unknown[]) => mockLoadPersonCompanyLinks(...args)),
+  summarizePersonCompanies: jest.fn(() => []),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_entity: 'customer_entity',
+      customer_person_profile: 'customer_person_profile',
+    },
+  },
+}), { virtual: true })
+
+const TENANT_ID = 'tenant-1'
+const ORG_ID = 'org-1'
+const USER_ID = 'user-1'
+const PERSON_ID = '2408107d-0000-4000-8000-000000000010'
+
+function buildPerson() {
+  const createdAt = new Date('2026-04-10T08:00:00.000Z')
+  return {
+    id: PERSON_ID,
+    kind: 'person',
+    deletedAt: null,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    displayName: 'Ada Lovelace',
+    description: null,
+    ownerUserId: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    status: null,
+    lifecycleStage: null,
+    source: null,
+    temperature: null,
+    renewalQuarter: null,
+    nextInteractionAt: null,
+    nextInteractionName: null,
+    nextInteractionRefId: null,
+    nextInteractionIcon: null,
+    nextInteractionColor: null,
+    isActive: true,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+const ORIGINAL_ENV = { ...process.env }
+
+const makeRequest = (search = '') =>
+  new Request(`http://localhost/api/customers/people/${PERSON_ID}${search}`)
+
+const loadRoute = async () => {
+  jest.resetModules()
+  return import('../route')
+}
+
+describe('GET /api/customers/people/[id] — caching (issue #3663)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+
+    mockEm.count.mockResolvedValue(0)
+    mockGetAuthFromRequest.mockResolvedValue({ sub: USER_ID, tenantId: TENANT_ID, orgId: ORG_ID, isApiKey: false })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({ filterIds: [ORG_ID], selectedId: ORG_ID, tenantId: TENANT_ID })
+    mockResolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    mockLoadCustomFieldValues.mockResolvedValue({})
+    mockResolvePersonCustomFieldRouting.mockResolvedValue(new Map())
+    mockMergePersonCustomFieldValues.mockReturnValue({})
+    mockLoadPersonCompanyLinks.mockResolvedValue([])
+    mockFindOneWithDecryption.mockResolvedValueOnce(buildPerson()).mockResolvedValue(null)
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('does not touch the cache when the crud cache flag is off', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { GET } = await loadRoute()
+
+    const res = await GET(makeRequest(), { params: { id: PERSON_ID } })
+
+    expect(res.status).toBe(200)
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+    expect(mockFindWithDecryption).toHaveBeenCalled()
+  })
+
+  it('runs get-then-set with the scoped key and reused collection tags on a miss', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    cache.get.mockResolvedValue(null)
+    const { GET } = await loadRoute()
+
+    const res = await GET(makeRequest('?include=comments'), { params: { id: PERSON_ID } })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { person: { id: string } }
+    expect(body.person.id).toBe(PERSON_ID)
+
+    expect(cache.get).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+
+    const [getKey] = cache.get.mock.calls[0]
+    expect(getKey).toBe(
+      `customers:person-detail:${PERSON_ID}:tenant=${TENANT_ID}:org=${ORG_ID}:caller=${USER_ID}:selOrg=${ORG_ID}:scope=${ORG_ID}:mode=legacy:include=comments`,
+    )
+
+    const [setKey, setValue, setOpts] = cache.set.mock.calls[0]
+    expect(setKey).toBe(getKey)
+    expect((setValue as { person: { id: string } }).person.id).toBe(PERSON_ID)
+    expect(setOpts.ttl).toBe(60_000)
+    expect(setOpts.tags).toEqual([
+      `crud:customers.person:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+      `crud:customers.address:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+      `crud:customers.tagAssignment:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+      `crud:customers.labelAssignment:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+      `crud:customers.personCompanyLink:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+      `crud:customers.interaction:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+      `crud:customers.activity:tenant:${TENANT_ID}:org:${ORG_ID}:collection`,
+    ])
+  })
+
+  it('keys the cache by the effective RBAC caller so visibility never leaks', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    cache.get.mockResolvedValue(null)
+    mockGetAuthFromRequest.mockReset()
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'api_key:abc', tenantId: TENANT_ID, orgId: ORG_ID, isApiKey: true })
+    const { GET } = await loadRoute()
+
+    await GET(makeRequest(), { params: { id: PERSON_ID } })
+
+    const [setKey] = cache.set.mock.calls[0]
+    expect(setKey).toContain('caller=api_key:abc')
+    expect(setKey).toContain('include=none')
+  })
+
+  it('serves a cache hit without running the decryption sweeps', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const cachedPayload = { interactionMode: 'legacy', person: { id: PERSON_ID, displayName: 'Cached' } }
+    cache.get.mockResolvedValue(cachedPayload)
+    const { GET } = await loadRoute()
+
+    const res = await GET(makeRequest('?include=comments'), { params: { id: PERSON_ID } })
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual(cachedPayload)
+    expect(cache.set).not.toHaveBeenCalled()
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(mockLoadCustomFieldValues).not.toHaveBeenCalled()
+    expect(mockEm.count).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -81,8 +81,8 @@ function buildPersonDetailCacheKey(params: {
   interactionMode: 'canonical' | 'legacy'
   includeTokens: string[]
 }): string {
-  const include = [...params.includeTokens].sort().join('|') || 'none'
-  const scoped = [...params.scopedOrganizationIds].sort().join('|') || 'null'
+  const include = [...params.includeTokens].sort((a, b) => a.localeCompare(b)).join('|') || 'none'
+  const scoped = [...params.scopedOrganizationIds].sort((a, b) => a.localeCompare(b)).join('|') || 'null'
   return [
     'customers:person-detail',
     params.personId,

--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -42,6 +42,8 @@ import { loadPersonCompanyLinks, summarizePersonCompanies } from '../../../lib/p
 import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
 import { buildEmailVisibilityMikroFilter } from '../../../lib/visibilityFilter'
 import { resolveCustomerDetailTenantScope } from '../../../lib/detailTenantScope'
+import { runWithCacheTenant } from '@open-mercato/cache'
+import { buildCollectionTags, isCrudCacheEnabled, resolveCrudCache } from '@open-mercato/shared/lib/crud/cache'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.people.view'] },
@@ -50,6 +52,57 @@ export const metadata = {
 const paramsSchema = z.object({
   id: z.string().uuid(),
 })
+
+// Person detail is one of the heaviest custom GETs (decryption sweeps across
+// addresses, tags, labels, interactions, custom fields, plus per-link query
+// engine enrichment). Mirror the gated get-then-set cache from the roles list
+// (#3143) so a hit skips every sweep below. Writes flow through the customers
+// command bus, which already flushes the matching crud:<resourceKind> collection
+// tags post-commit — these set tags reuse the exact same shapes (see
+// invalidateCrudCache), so no new invalidation wiring is needed (#3663).
+const PERSON_DETAIL_TTL_MS = 60_000
+const PERSON_DETAIL_TAG_RESOURCES = [
+  'customers.person',
+  'customers.address',
+  'customers.tagAssignment',
+  'customers.labelAssignment',
+  'customers.personCompanyLink',
+  'customers.interaction',
+  'customers.activity',
+] as const
+
+function buildPersonDetailCacheKey(params: {
+  personId: string
+  tenantId: string | null
+  organizationId: string | null
+  callerId: string | null
+  selectedOrganizationId: string | null
+  scopedOrganizationIds: string[]
+  interactionMode: 'canonical' | 'legacy'
+  includeTokens: string[]
+}): string {
+  const include = [...params.includeTokens].sort().join('|') || 'none'
+  const scoped = [...params.scopedOrganizationIds].sort().join('|') || 'null'
+  return [
+    'customers:person-detail',
+    params.personId,
+    `tenant=${params.tenantId ?? 'null'}`,
+    `org=${params.organizationId ?? 'null'}`,
+    `caller=${params.callerId ?? 'null'}`,
+    `selOrg=${params.selectedOrganizationId ?? 'null'}`,
+    `scope=${scoped}`,
+    `mode=${params.interactionMode}`,
+    `include=${include}`,
+  ].join(':')
+}
+
+function buildPersonDetailCacheTags(tenantId: string | null, organizationId: string | null): string[] {
+  const tags: string[] = []
+  for (const resource of PERSON_DETAIL_TAG_RESOURCES) {
+    tags.push(...buildCollectionTags(resource, tenantId, [organizationId]))
+  }
+  return tags
+}
 
 function parseIncludeParams(request: Request): Set<string> {
   const url = new URL(request.url)
@@ -485,6 +538,39 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       return forbidden('Access denied')
     }
 
+    // Gated get-then-set cache. Key on the resolved person plus the effective
+    // RBAC scope (caller identity, selected/visible orgs) and the payload-shaping
+    // inputs (interaction mode + include set). The lookup sits before the
+    // expensive sweeps below so a hit returns without touching the DB.
+    const personDetailTenantId = person.tenantId ?? auth.tenantId ?? null
+    const personDetailOrganizationId = person.organizationId ?? null
+    const personDetailCache = isCrudCacheEnabled() ? resolveCrudCache(container) : null
+    const personDetailCacheKey = personDetailCache
+      ? buildPersonDetailCacheKey({
+          personId: person.id,
+          tenantId: personDetailTenantId,
+          organizationId: personDetailOrganizationId,
+          callerId: auth.sub ?? null,
+          selectedOrganizationId: scope?.selectedId ?? auth.orgId ?? null,
+          scopedOrganizationIds: Array.isArray(scope?.filterIds) ? scope.filterIds : [],
+          interactionMode,
+          includeTokens: Array.from(includeTokens),
+        })
+      : null
+    const personDetailCacheTags = personDetailCache
+      ? buildPersonDetailCacheTags(personDetailTenantId, personDetailOrganizationId)
+      : []
+
+    if (personDetailCache && personDetailCacheKey) {
+      const cached = await runWithCacheTenant(personDetailTenantId, () => personDetailCache.get(personDetailCacheKey))
+      if (cached) {
+        statusCode = 200
+        profileMeta = { cacheHit: true, include: Array.from(includeTokens), interactionMode }
+        profiler.mark('cache_hit')
+        return NextResponse.json(cached)
+      }
+    }
+
     const [profileResult, personCompanyLinks] = await Promise.all([
       findOneWithDecryption(em, CustomerPersonProfile, { entity: person }, { populate: ['company'] }, { tenantId: person.tenantId ?? auth.tenantId ?? null, organizationId: person.organizationId ?? auth.orgId ?? null }),
       loadPersonCompanyLinks(em, person),
@@ -801,7 +887,7 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       companies: companies.length,
     }
 
-    const response = NextResponse.json({
+    const payload = {
       interactionMode,
       person: {
         id: person.id,
@@ -1011,7 +1097,20 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
         name: viewerUserIdFinal ? userMap.get(viewerUserIdFinal)?.name ?? null : null,
         email: viewerUserIdFinal ? userMap.get(viewerUserIdFinal)?.email ?? auth.email ?? null : auth.email ?? null,
       },
-    })
+    }
+
+    if (personDetailCache && personDetailCacheKey) {
+      try {
+        await runWithCacheTenant(personDetailTenantId, () =>
+          personDetailCache.set(personDetailCacheKey, payload, {
+            ttl: PERSON_DETAIL_TTL_MS,
+            tags: personDetailCacheTags,
+          }),
+        )
+      } catch {}
+    }
+
+    const response = NextResponse.json(payload)
     statusCode = 200
     profileMeta = {
       include: Array.from(includeTokens),

--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -43,7 +43,7 @@ import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
 import { buildEmailVisibilityMikroFilter } from '../../../lib/visibilityFilter'
 import { resolveCustomerDetailTenantScope } from '../../../lib/detailTenantScope'
 import { runWithCacheTenant } from '@open-mercato/cache'
-import { buildCollectionTags, isCrudCacheEnabled, resolveCrudCache } from '@open-mercato/shared/lib/crud/cache'
+import { buildCollectionTags, canonicalizeResourceTag, isCrudCacheEnabled, resolveCrudCache } from '@open-mercato/shared/lib/crud/cache'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.people.view'] },
@@ -60,6 +60,11 @@ const paramsSchema = z.object({
 // command bus, which already flushes the matching crud:<resourceKind> collection
 // tags post-commit — these set tags reuse the exact same shapes (see
 // invalidateCrudCache), so no new invalidation wiring is needed (#3663).
+// The resource ids below are canonicalized with canonicalizeResourceTag (just
+// like invalidateCrudCache does via expandResourceAliases) before building the
+// collection tags, so camelCase ids (tagAssignment, labelAssignment,
+// personCompanyLink) produce the SAME tag the command bus deletes on
+// write/undo/redo — otherwise the cache would never be invalidated for them.
 const PERSON_DETAIL_TTL_MS = 60_000
 const PERSON_DETAIL_TAG_RESOURCES = [
   'customers.person',
@@ -99,7 +104,8 @@ function buildPersonDetailCacheKey(params: {
 function buildPersonDetailCacheTags(tenantId: string | null, organizationId: string | null): string[] {
   const tags: string[] = []
   for (const resource of PERSON_DETAIL_TAG_RESOURCES) {
-    tags.push(...buildCollectionTags(resource, tenantId, [organizationId]))
+    const canonical = canonicalizeResourceTag(resource) ?? resource
+    tags.push(...buildCollectionTags(canonical, tenantId, [organizationId]))
   }
   return tags
 }


### PR DESCRIPTION
Fixes #3663

## Problem
`GET /api/customers/people/[id]` (`packages/core/src/modules/customers/api/people/[id]/route.ts`) is one of the heaviest custom GETs in the codebase and has **no cache**. Every request runs decryption sweeps for the person + profile, batched `findWithDecryption` for addresses/tags/labels/comments/interactions, per-link query-engine interaction enrichment, custom-field decryption, and several `count` queries — all tenant/org-scoped and decryption-decorated. This is the person-detail follow-up to #3143 / #2919, not covered by the #2906–#2921 backlog.

## Root Cause
The handler is a custom route (not `makeCrudRoute`), so it never participated in the opt-in CRUD API cache. There was no get-then-set layer to short-circuit the expensive read path.

## What Changed
- Added a **gated get-then-set cache** mirroring PR #3143:
  - Gate on `isCrudCacheEnabled()`, resolve via `resolveCrudCache(container)`, run get/set inside `runWithCacheTenant(personTenantId, …)`.
  - The **lookup sits right after the org read-access check and before the expensive sweeps**, so a hit returns without touching the DB.
  - **Key axes**: tenant, org, personId, and the effective RBAC scope — caller identity (`auth.sub`, which is unique per user *and* per API key), selected org, and visible org ids — plus the payload-shaping inputs (interaction mode + sorted include set). Keying on `auth.sub` ensures per-caller email-visibility and the `viewer` block never leak across callers, and because the access check runs first a forbidden caller can never reach a hit.
  - **TTL 60s**, tagged with the existing `customers.*` **collection tags** the issue specifies: `customers.person`, `customers.address`, `customers.tagAssignment`, `customers.labelAssignment`, `customers.personCompanyLink`, `customers.interaction`, `customers.activity`.
- **No new invalidation wiring**: the set tags are built with the same `buildCollectionTags(...)` that `invalidateCrudCache` uses, and all seven `resourceKind`s are already flushed post-commit by the existing `customers.*` command-bus writes. The TTL backstops anything not tag-covered (e.g. direct query-engine read-model updates).

## Tests
- New `api/people/[id]/__tests__/cache.test.ts` (4 cases):
  - flag **off** ⇒ cache never touched, sweeps still run;
  - flag **on** + miss ⇒ get-then-set with the exact scoped key and the seven reused collection-tag shapes + 60s TTL;
  - key carries the effective RBAC **caller** (API-key callers keyed by `api_key:<id>`);
  - **hit** ⇒ payload served without running the decryption sweeps / custom-field load / counts.
- Existing `route.parallel.test.ts` (#3203) still green — behavior preserved when the flag is off.
- Verified locally: `yarn build:packages`, `yarn generate`, `yarn typecheck` (21/21), `yarn lint` (0 errors), and the customers people API suite (15/15).

## Backward Compatibility
No contract surface changes. The cache is opt-in (`ENABLE_CRUD_API_CACHE`, default off) — with it off the response is byte-for-byte unchanged. Response shape, route URL, and ACL are untouched; new imports are additive.

Related: #3143, #2919