### PR TITLE
feat(customers): cache GET /api/customers/companies/[id] detail with reused crud tags (#3664)

### DIFF
--- a/packages/core/src/modules/customers/api/companies/[id]/__tests__/route-cache.test.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/__tests__/route-cache.test.ts
@@ -1,0 +1,240 @@
+/** @jest-environment node */
+
+const mockRunWithCacheTenant = jest.fn(
+  async <T>(_tenant: string | null, fn: () => Promise<T> | T) => fn(),
+)
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: (...args: unknown[]) =>
+    (mockRunWithCacheTenant as unknown as (...a: unknown[]) => unknown)(...args),
+}))
+
+let cacheEnabled = false
+const mockCache = {
+  get: jest.fn(),
+  set: jest.fn(),
+}
+jest.mock('@open-mercato/shared/lib/crud/cache', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/crud/cache')
+  return {
+    ...actual,
+    isCrudCacheEnabled: () => cacheEnabled,
+    resolveCrudCache: () => (cacheEnabled ? mockCache : null),
+  }
+})
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockResolveCustomerInteractionFeatureFlags = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockResolveCompanyCustomFieldRouting = jest.fn()
+const mockMergeCompanyCustomFieldValues = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+
+const mockEm = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+jest.mock('../../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn((...args: unknown[]) => mockResolveCustomerInteractionFeatureFlags(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+jest.mock('../../../../lib/customFieldRouting', () => ({
+  resolveCompanyCustomFieldRouting: jest.fn((...args: unknown[]) => mockResolveCompanyCustomFieldRouting(...args)),
+  mergeCompanyCustomFieldValues: jest.fn((...args: unknown[]) => mockMergeCompanyCustomFieldValues(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('../../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_entity: 'customer_entity',
+      customer_company_profile: 'customer_company_profile',
+    },
+  },
+}), { virtual: true })
+
+const COMPANY_ID = '2408107d-0000-4000-8000-000000000000'
+
+function buildCompany() {
+  const createdAt = new Date('2026-04-10T08:00:00.000Z')
+  return {
+    id: COMPANY_ID,
+    kind: 'company',
+    deletedAt: null,
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    companyProfile: null,
+    displayName: 'Acme Corp',
+    description: null,
+    ownerUserId: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    status: null,
+    lifecycleStage: null,
+    source: null,
+    nextInteractionAt: null,
+    nextInteractionName: null,
+    nextInteractionRefId: null,
+    nextInteractionIcon: null,
+    nextInteractionColor: null,
+    isActive: true,
+    temperature: null,
+    renewalQuarter: null,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+function makeRequest() {
+  return new Request(`http://localhost/api/customers/companies/${COMPANY_ID}`)
+}
+
+describe('GET /api/customers/companies/[id] — detail cache (#3664)', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    cacheEnabled = false
+    mockRunWithCacheTenant.mockClear()
+    mockCache.get.mockReset()
+    mockCache.set.mockReset()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockResolveCustomerInteractionFeatureFlags.mockReset()
+    mockLoadCustomFieldValues.mockReset()
+    mockResolveCompanyCustomFieldRouting.mockReset()
+    mockMergeCompanyCustomFieldValues.mockReset()
+    mockFindWithDecryption.mockReset()
+    mockFindOneWithDecryption.mockReset()
+    mockEm.findOne.mockReset()
+    mockEm.find.mockReset()
+    mockEm.count.mockReset()
+    mockEm.count.mockResolvedValue(0)
+    mockContainer.resolve.mockClear()
+
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      isApiKey: false,
+    })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      filterIds: ['org-1'],
+      selectedId: 'org-1',
+      tenantId: 'tenant-1',
+    })
+    mockResolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    mockLoadCustomFieldValues.mockResolvedValue({})
+    mockResolveCompanyCustomFieldRouting.mockResolvedValue({})
+    mockMergeCompanyCustomFieldValues.mockReturnValue({})
+    mockEm.find.mockResolvedValue([])
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('does not touch the cache when the CRUD cache flag is off', async () => {
+    cacheEnabled = false
+    mockFindOneWithDecryption.mockResolvedValueOnce(buildCompany()).mockResolvedValueOnce(null)
+
+    const { GET } = await import('../route')
+    const response = await GET(makeRequest(), { params: { id: COMPANY_ID } })
+
+    expect(response.status).toBe(200)
+    expect(mockCache.get).not.toHaveBeenCalled()
+    expect(mockCache.set).not.toHaveBeenCalled()
+    expect(mockRunWithCacheTenant).not.toHaveBeenCalled()
+  })
+
+  it('stores the detail payload with the reused collection tags on a cache miss', async () => {
+    cacheEnabled = true
+    mockCache.get.mockResolvedValue(null)
+    mockFindOneWithDecryption.mockResolvedValueOnce(buildCompany()).mockResolvedValueOnce(null)
+
+    const { GET } = await import('../route')
+    const response = await GET(makeRequest(), { params: { id: COMPANY_ID } })
+
+    expect(response.status).toBe(200)
+    expect(mockCache.get).toHaveBeenCalledTimes(1)
+    expect(mockCache.set).toHaveBeenCalledTimes(1)
+
+    const lookupKey = mockCache.get.mock.calls[0][0] as string
+    const [storedKey, , storeOptions] = mockCache.set.mock.calls[0] as [
+      string,
+      unknown,
+      { ttl: number; tags: string[] },
+    ]
+
+    expect(storedKey).toBe(lookupKey)
+    expect(lookupKey).toContain(`company:${COMPANY_ID}`)
+    expect(lookupKey).toContain('tenant:tenant-1')
+    expect(lookupKey).toContain('org:org-1')
+    expect(lookupKey).toContain('selected:org-1')
+    expect(lookupKey).toContain('filter:org-1')
+    expect(lookupKey).toContain('super:0')
+    expect(lookupKey).toContain('viewer:user-1')
+    expect(lookupKey).toContain('mode:legacy')
+
+    expect(storeOptions.ttl).toBe(60_000)
+    expect(storeOptions.tags).toEqual(
+      expect.arrayContaining([
+        'crud:customers.company:tenant:tenant-1:org:org-1:collection',
+        'crud:customers.address:tenant:tenant-1:org:org-1:collection',
+        'crud:customers.tag.assignment:tenant:tenant-1:org:org-1:collection',
+        'crud:customers.label.assignment:tenant:tenant-1:org:org-1:collection',
+        'crud:customers.person.company.link:tenant:tenant-1:org:org-1:collection',
+        'crud:customers.interaction:tenant:tenant-1:org:org-1:collection',
+        'crud:customers.activity:tenant:tenant-1:org:org-1:collection',
+      ]),
+    )
+    expect(storeOptions.tags).toHaveLength(7)
+  })
+
+  it('serves the cached payload and skips the detail sweeps on a cache hit', async () => {
+    cacheEnabled = true
+    const cachedPayload = { interactionMode: 'legacy', company: { id: COMPANY_ID, displayName: 'Cached Co' } }
+    mockCache.get.mockResolvedValue(cachedPayload)
+    mockFindOneWithDecryption.mockResolvedValueOnce(buildCompany())
+
+    const { GET } = await import('../route')
+    const response = await GET(makeRequest(), { params: { id: COMPANY_ID } })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toEqual(cachedPayload)
+    // The existence + org read-access check still runs (company findOne), but the
+    // expensive enrichment sweeps and the cache write are skipped on a hit.
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(mockCache.set).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/companies/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/route.ts
@@ -50,6 +50,13 @@ import {
 } from '../../../lib/personCompanyLinkTable'
 import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
 import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
+import { runWithCacheTenant } from '@open-mercato/cache'
+import {
+  buildCollectionTags,
+  canonicalizeResourceTag,
+  isCrudCacheEnabled,
+  resolveCrudCache,
+} from '@open-mercato/shared/lib/crud/cache'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.companies.view'] },
@@ -58,6 +65,64 @@ export const metadata = {
 const paramsSchema = z.object({
   id: z.string().uuid(),
 })
+
+const COMPANY_DETAIL_CACHE_TTL_MS = 60_000
+
+// The customers write commands already invalidate these resource collections via
+// invalidateCrudCache using these exact resourceKind strings. Reusing them as
+// cache tags means the cached detail is flushed by those existing commands with
+// no new wiring (#3664, mirroring #3143). Canonicalize each kind the same way
+// invalidateCrudCache does (camelCase split + lowercase) so the tag shapes match.
+const COMPANY_DETAIL_CACHE_RESOURCE_KINDS = [
+  'customers.company',
+  'customers.address',
+  'customers.tagAssignment',
+  'customers.labelAssignment',
+  'customers.personCompanyLink',
+  'customers.interaction',
+  'customers.activity',
+] as const
+
+function buildCompanyDetailCacheTags(tenantId: string | null, organizationId: string | null): string[] {
+  const tags = new Set<string>()
+  for (const resourceKind of COMPANY_DETAIL_CACHE_RESOURCE_KINDS) {
+    const resource = canonicalizeResourceTag(resourceKind) ?? resourceKind
+    for (const tag of buildCollectionTags(resource, tenantId, [organizationId])) {
+      tags.add(tag)
+    }
+  }
+  return Array.from(tags)
+}
+
+function buildCompanyDetailCacheKey(parts: {
+  tenantId: string | null
+  organizationId: string | null
+  companyId: string
+  selectedOrganizationId: string | null
+  filterIds: string[] | null
+  allowedIds: string[] | null
+  isSuperAdmin: boolean
+  viewerUserId: string | null
+  interactionMode: string
+  includeTokens: string[]
+}): string {
+  const filterIds = parts.filterIds ? [...parts.filterIds].sort().join(',') : 'all'
+  const allowedIds = parts.allowedIds ? [...parts.allowedIds].sort().join(',') : 'all'
+  const includeTokens = [...parts.includeTokens].sort().join(',')
+  return [
+    'customers:companies:detail',
+    `tenant:${parts.tenantId ?? 'null'}`,
+    `org:${parts.organizationId ?? 'null'}`,
+    `company:${parts.companyId}`,
+    `selected:${parts.selectedOrganizationId ?? 'null'}`,
+    `filter:${filterIds}`,
+    `allowed:${allowedIds}`,
+    `super:${parts.isSuperAdmin ? '1' : '0'}`,
+    `viewer:${parts.viewerUserId ?? 'null'}`,
+    `mode:${parts.interactionMode}`,
+    `include:${includeTokens}`,
+  ].join('|')
+}
 
 function parseIncludeParams(request: Request): Set<string> {
   const url = new URL(request.url)
@@ -413,6 +478,31 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
     currentUserId: viewerUserId,
     userFeatures: undefined,
   })
+
+  // Opt-in cache (#3664): the company existence + org read-access checks above
+  // always run, so authorization is never served from cache. Only the expensive
+  // detail sweeps below are cached. Key on tenant/org/company + the RBAC scope,
+  // viewer (email privacy), interaction mode, and the requested include set.
+  const cacheTenantId = companyScope.tenantId
+  const cache = isCrudCacheEnabled() ? resolveCrudCache(container) : null
+  const cacheKey = cache
+    ? buildCompanyDetailCacheKey({
+        tenantId: cacheTenantId,
+        organizationId: companyScope.organizationId,
+        companyId: company.id,
+        selectedOrganizationId: scope?.selectedId ?? auth.orgId ?? null,
+        filterIds: scope?.filterIds ?? null,
+        allowedIds: scope?.allowedIds ?? null,
+        isSuperAdmin: auth.isSuperAdmin === true,
+        viewerUserId,
+        interactionMode,
+        includeTokens: Array.from(includeTokens),
+      })
+    : null
+  if (cache && cacheKey) {
+    const cached = await runWithCacheTenant(cacheTenantId, () => cache.get(cacheKey))
+    if (cached) return NextResponse.json(cached)
+  }
 
   const shouldLoadCanonicalInteractions = includeInteractions || includeActivities || includeTodos
 
@@ -961,7 +1051,7 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
     addresses: addressesCount,
   }
 
-  return NextResponse.json({
+  const payload = {
     interactionMode,
     company: {
       id: company.id,
@@ -1170,7 +1260,22 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       name: viewerUserId ? userMap.get(viewerUserId)?.name ?? null : null,
       email: viewerUserId ? userMap.get(viewerUserId)?.email ?? auth.email ?? null : auth.email ?? null,
     },
-  })
+  }
+
+  if (cache && cacheKey) {
+    try {
+      await runWithCacheTenant(cacheTenantId, () =>
+        cache.set(cacheKey, payload, {
+          ttl: COMPANY_DETAIL_CACHE_TTL_MS,
+          tags: buildCompanyDetailCacheTags(cacheTenantId, companyScope.organizationId),
+        }),
+      )
+    } catch (err) {
+      console.warn('[customers:companies] Failed to set company detail cache', err)
+    }
+  }
+
+  return NextResponse.json(payload)
 }
 
 const companyDetailQuerySchema = z.object({

--- a/packages/core/src/modules/customers/api/companies/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/route.ts
@@ -106,9 +106,11 @@ function buildCompanyDetailCacheKey(parts: {
   interactionMode: string
   includeTokens: string[]
 }): string {
-  const filterIds = parts.filterIds ? [...parts.filterIds].sort().join(',') : 'all'
-  const allowedIds = parts.allowedIds ? [...parts.allowedIds].sort().join(',') : 'all'
-  const includeTokens = [...parts.includeTokens].sort().join(',')
+  const sortKeys = (values: string[]): string[] =>
+    [...values].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+  const filterIds = parts.filterIds ? sortKeys(parts.filterIds).join(',') : 'all'
+  const allowedIds = parts.allowedIds ? sortKeys(parts.allowedIds).join(',') : 'all'
+  const includeTokens = sortKeys(parts.includeTokens).join(',')
   return [
     'customers:companies:detail',
     `tenant:${parts.tenantId ?? 'null'}`,


### PR DESCRIPTION
Fixes #3664

## Problem
`GET /api/customers/companies/[id]` is a ~1.4k-line custom handler (not `makeCrudRoute`), with no cache. Every request runs `findOneWithDecryption` for the company + a large parallel sweep of decrypted reads (profile, addresses, tag/label assignments, comments, interactions), canonical-interaction hydration, per-link query-engine enrichment, custom-field decryption and several `em.count` calls. This is the same uncached/expensive pattern PR #3143 (#2919) addressed for the auth-roles list and the company-list path, but the company **detail** endpoint was not covered by the #2906–#2921 cache backlog.

## Root Cause
The detail handler had no `isCrudCacheEnabled()` / `resolveCrudCache()` gate, so repeated reads of the same company always re-ran every decryption sweep.

## What Changed
Added a gated get-then-set around the expensive sweeps in `companies/[id]/route.ts`, mirroring #3143:

- **No-op when `ENABLE_CRUD_API_CACHE` is off** — behavior is byte-for-byte identical.
- **Authorization is never served from cache.** The company existence check and `isOrganizationReadAccessAllowed` run on every request, before the cache lookup. Only the enrichment sweeps, hydration, per-link query, custom-field decryption and counts are cached/skipped on a hit.
- **Key axes:** tenant, org, companyId, the RBAC scope (`selectedId` / `filterIds` / `allowedIds` / `isSuperAdmin`), the viewer user id (per-user email privacy), interaction mode, and the requested `include` set.
- **Store:** 60s TTL, tagged with the **collection tags of every read entity** — `customers.company`, `customers.address`, `customers.tagAssignment`, `customers.labelAssignment`, `customers.personCompanyLink`, `customers.interaction`, `customers.activity`. The tags reuse the **exact `resourceKind` strings the customers write commands already pass to `invalidateCrudCache`** (canonicalized the same way, so e.g. `tagAssignment` → `customers.tag.assignment`). No new invalidation wiring — those commands already flush these tags; the TTL backstops the rest (comments/deals/todos).

## Tests
`api/companies/[id]/__tests__/route-cache.test.ts`:
- flag-off ⇒ no `cache.get`/`cache.set`/`runWithCacheTenant` touch;
- miss ⇒ `get` then `set` with the same key, correct key axes, 60s TTL, and the 7 expected collection-tag shapes;
- hit ⇒ serves the cached payload and skips the DB sweeps (`findWithDecryption` not called), no `set`.

Verification run in an isolated worktree: `@open-mercato/core` typecheck (clean), ESLint on the changed files (clean), and the full `customers/api/companies` jest slice (4 suites / 9 tests green, including the existing detail tests).

## Backward Compatibility
No contract-surface changes. The route response shape is unchanged; the feature is additive and opt-in behind `ENABLE_CRUD_API_CACHE`. No removed API fields, no new public exports, no event/DI/ACL/schema changes.

Related: #3143, #2919