### PR TITLE
feat(customers): cache GET /api/customers/deals/[id] detail (#3665)

### DIFF
--- a/packages/core/src/modules/customers/api/deals/[id]/__tests__/cache.test.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/__tests__/cache.test.ts
@@ -1,0 +1,274 @@
+/** @jest-environment node */
+
+const dealId = '550e8400-e29b-41d4-a716-446655440000'
+const tenantId = 'tenant-1'
+const organizationId = 'org-1'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockDecryptEntitiesWithFallbackScope = jest.fn()
+const mockUserHasAllFeatures = jest.fn()
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+}
+
+const mockEm = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return { userHasAllFeatures: mockUserHasAllFeatures }
+    if (token === 'cache') return cache
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/subscriber', () => ({
+  decryptEntitiesWithFallbackScope: jest.fn((...args: unknown[]) => mockDecryptEntitiesWithFallbackScope(...args)),
+}))
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: jest.fn((_tenantId: string | null, fn: () => unknown) => fn()),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_deal: 'customer_deal',
+    },
+  },
+}), { virtual: true })
+
+const ORIGINAL_ENV = { ...process.env }
+
+const makeDealRow = () => ({
+  id: dealId,
+  organizationId,
+  tenantId,
+  title: 'Expansion renewal',
+  description: null,
+  status: 'qualified',
+  pipelineStage: null,
+  pipelineId: null,
+  pipelineStageId: null,
+  valueAmount: '12000',
+  valueCurrency: 'USD',
+  probability: 65,
+  expectedCloseAt: null,
+  ownerUserId: null,
+  source: 'Referral',
+  closureOutcome: null,
+  lossReasonId: null,
+  lossNotes: null,
+  createdAt: new Date('2026-04-10T08:00:00.000Z'),
+  updatedAt: new Date('2026-04-14T16:30:00.000Z'),
+  deletedAt: null,
+})
+
+const loadRoute = async () => {
+  jest.resetModules()
+  return import('../route')
+}
+
+const makeRequest = () => new Request(`http://localhost/api/customers/deals/${dealId}`)
+const routeContext = { params: { id: dealId } }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  process.env = { ...ORIGINAL_ENV }
+
+  mockGetAuthFromRequest.mockResolvedValue({
+    sub: 'user-1',
+    tenantId,
+    orgId: organizationId,
+    email: 'viewer@example.com',
+    isApiKey: false,
+  })
+  mockResolveOrganizationScopeForRequest.mockResolvedValue({
+    selectedId: organizationId,
+    filterIds: [organizationId],
+    allowedIds: [organizationId],
+    tenantId,
+  })
+  mockUserHasAllFeatures.mockResolvedValue(true)
+  mockLoadCustomFieldValues.mockResolvedValue({ [dealId]: {} })
+  mockDecryptEntitiesWithFallbackScope.mockResolvedValue(undefined)
+  mockFindWithDecryption.mockResolvedValue([])
+  mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: { name?: string }, where: Record<string, unknown>) => {
+    if (entity?.name === 'CustomerDeal') return makeDealRow()
+    if (entity?.name === 'User') {
+      if (where?.id === 'user-1') return { id: 'user-1', name: 'Viewer User', email: 'viewer@example.com' }
+      return null
+    }
+    return null
+  })
+})
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV
+})
+
+describe('GET /api/customers/deals/[id] caching', () => {
+  it('does not touch the cache when the crud cache flag is off', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { GET } = await loadRoute()
+
+    const response = await GET(makeRequest(), routeContext)
+
+    expect(response.status).toBe(200)
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+    expect(mockContainer.resolve).not.toHaveBeenCalledWith('cache')
+  })
+
+  it('stores the detail payload with the command-bus collection tags on a miss', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+
+    const response = await GET(makeRequest(), routeContext)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.deal.id).toBe(dealId)
+    expect(body.viewer).toEqual({ userId: 'user-1', name: 'Viewer User', email: 'viewer@example.com' })
+
+    expect(cache.get).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+
+    const [key, value, opts] = cache.set.mock.calls[0]
+    expect(key).toBe(
+      `customers:deal:detail:tenant=${tenantId}:org=${organizationId}:deal=${dealId}:scope=filter:${organizationId}:view=full:include=none`,
+    )
+    // The request-specific viewer block is never cached.
+    expect(value).not.toHaveProperty('viewer')
+    expect((value as { deal: { id: string } }).deal.id).toBe(dealId)
+    expect(opts.ttl).toBe(60_000)
+    expect(opts.tags).toEqual([
+      `crud:customers.deal:tenant:${tenantId}:org:${organizationId}:collection`,
+      `crud:customers.pipeline:tenant:${tenantId}:org:${organizationId}:collection`,
+      `crud:customers.pipeline.stage:tenant:${tenantId}:org:${organizationId}:collection`,
+      `crud:customers.dictionary.entry:tenant:${tenantId}:org:${organizationId}:collection`,
+    ])
+  })
+
+  it('serves a cache hit without re-running the heavy sweeps and refreshes the viewer block', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    const cachedBody = {
+      deal: { id: dealId, title: 'Cached deal', organizationId, tenantId },
+      people: [{ id: 'p-1', label: 'Ada', subtitle: null, kind: 'person' }],
+      companies: [],
+      linkedPersonIds: ['p-1'],
+      linkedCompanyIds: [],
+      counts: { people: 1, companies: 0 },
+      customFields: { priority: 'high' },
+      pipelineStages: [],
+      pipelineName: null,
+      stageTransitions: [],
+      owner: null,
+    }
+    cache.get.mockResolvedValue(cachedBody)
+
+    const response = await GET(makeRequest(), routeContext)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.deal).toEqual(cachedBody.deal)
+    expect(body.people).toEqual(cachedBody.people)
+    expect(body.customFields).toEqual({ priority: 'high' })
+    // Viewer is always resolved fresh, never served from the cached value.
+    expect(body.viewer).toEqual({ userId: 'user-1', name: 'Viewer User', email: 'viewer@example.com' })
+
+    // The cache hit skips the association / custom-field / pipeline-stage / dictionary sweeps.
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(mockLoadCustomFieldValues).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('keys the cache by tenant, organization, deal, scope, view, and include axes', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+
+    await GET(
+      new Request(`http://localhost/api/customers/deals/${dealId}?include=stages&view=lite`),
+      routeContext,
+    )
+
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    const [key] = cache.set.mock.calls[0]
+    expect(key).toBe(
+      `customers:deal:detail:tenant=${tenantId}:org=${organizationId}:deal=${dealId}:scope=filter:${organizationId}:view=lite:include=stages`,
+    )
+  })
+
+  it('partitions the cache key per RBAC scope', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'admin-1',
+      tenantId,
+      orgId: organizationId,
+      email: 'admin@example.com',
+      isApiKey: false,
+      isSuperAdmin: true,
+    })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId,
+    })
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+
+    await GET(makeRequest(), routeContext)
+
+    const [key] = cache.set.mock.calls[0]
+    expect(key).toContain(':scope=super:')
+  })
+
+  it('falls back to a fresh read when the cache get throws', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockRejectedValue(new Error('cache backend down'))
+
+    const response = await GET(makeRequest(), routeContext)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.deal.id).toBe(dealId)
+    // A read error must degrade to the DB sweeps, not a 500.
+    expect(mockLoadCustomFieldValues).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/customers/api/deals/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/route.ts
@@ -366,7 +366,7 @@ function buildDealDetailScopeSignature(
   const filterIds = Array.isArray(scope?.filterIds)
     ? scope!.filterIds.filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
     : []
-  if (filterIds.length) return `filter:${[...filterIds].sort().join(',')}`
+  if (filterIds.length) return `filter:${[...filterIds].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0)).join(',')}`
   return `home:${auth?.orgId ?? 'null'}`
 }
 
@@ -489,7 +489,7 @@ export async function GET(request: Request, context: { params?: Record<string, u
   const cacheTenantId = deal.tenantId ?? auth.tenantId ?? null
   const cacheOrganizationId = deal.organizationId ?? null
   const detailCache = isCrudCacheEnabled() ? resolveCrudCache(container) : null
-  const includeKey = includeFlags.size ? Array.from(includeFlags).sort().join(',') : 'none'
+  const includeKey = includeFlags.size ? Array.from(includeFlags).sort((left, right) => (left < right ? -1 : left > right ? 1 : 0)).join(',') : 'none'
   const detailCacheKey = detailCache
     ? buildDealDetailCacheKey({
         tenantId: cacheTenantId,

--- a/packages/core/src/modules/customers/api/deals/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/route.ts
@@ -24,6 +24,15 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { decryptEntitiesWithFallbackScope } from '@open-mercato/shared/lib/encryption/subscriber'
+import { runWithCacheTenant } from '@open-mercato/cache'
+import {
+  buildCollectionTags,
+  debugCrudCache,
+  expandResourceAliases,
+  isCrudCacheEnabled,
+  resolveCrudCache,
+} from '@open-mercato/shared/lib/crud/cache'
+import type { OrganizationScope } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { isMissingDealStageTransitionTable, warnMissingDealStageTransitionTable } from '../../../lib/dealStageTransitionTable'
 
 export const metadata = {
@@ -324,6 +333,72 @@ async function resolveEffectivePipelineStage(
   return null
 }
 
+const DEAL_DETAIL_CACHE_RESOURCE = 'customers.deal'
+// Every entity the detail payload reads, expressed with the same resourceKind
+// strings the customers commands declare. `expandResourceAliases` canonicalizes
+// them exactly the way `invalidateCrudCache` does on the write side (camelCase is
+// split, `_`/`-` become `.`), so `customers.pipelineStage` resolves to
+// `customers.pipeline.stage` and `customers.dictionary_entry` to
+// `customers.dictionary.entry`. That guarantees the collection tags stored here
+// match the ones the deal/pipeline/stage/dictionary commands flush.
+const DEAL_DETAIL_CACHE_TAG_RESOURCES = [
+  'customers.pipeline',
+  'customers.pipelineStage',
+  'customers.dictionary_entry',
+]
+const DEAL_DETAIL_CACHE_TTL_MS = 60_000
+
+type DealDetailCacheAuth = {
+  isSuperAdmin?: boolean | null
+  orgId?: string | null
+}
+
+// Capture every input `isOrganizationReadAccessAllowed` consults, so two requests
+// that share a signature also share an authorization outcome for the same deal.
+// The lookup runs after the access check, so this is defense in depth plus the
+// per-scope cache partitioning the issue asks for.
+function buildDealDetailScopeSignature(
+  auth: DealDetailCacheAuth,
+  scope: Pick<OrganizationScope, 'allowedIds' | 'filterIds'> | null | undefined,
+): string {
+  if (auth?.isSuperAdmin === true) return 'super'
+  if (scope?.allowedIds === null) return 'all'
+  const filterIds = Array.isArray(scope?.filterIds)
+    ? scope!.filterIds.filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+    : []
+  if (filterIds.length) return `filter:${[...filterIds].sort().join(',')}`
+  return `home:${auth?.orgId ?? 'null'}`
+}
+
+function buildDealDetailCacheKey(params: {
+  tenantId: string | null
+  organizationId: string | null
+  dealId: string
+  scopeSignature: string
+  view: 'full' | 'lite'
+  includeKey: string
+}): string {
+  return [
+    'customers:deal:detail',
+    `tenant=${params.tenantId ?? 'null'}`,
+    `org=${params.organizationId ?? 'null'}`,
+    `deal=${params.dealId}`,
+    `scope=${params.scopeSignature}`,
+    `view=${params.view}`,
+    `include=${params.includeKey}`,
+  ].join(':')
+}
+
+function buildDealDetailCacheTags(tenantId: string | null, organizationId: string | null): string[] {
+  const tags = new Set<string>()
+  for (const key of expandResourceAliases(DEAL_DETAIL_CACHE_RESOURCE, DEAL_DETAIL_CACHE_TAG_RESOURCES)) {
+    for (const tag of buildCollectionTags(key, tenantId, [organizationId])) {
+      tags.add(tag)
+    }
+  }
+  return Array.from(tags)
+}
+
 export async function GET(request: Request, context: { params?: Record<string, unknown> }) {
   const parsedParams = paramsSchema.safeParse(context.params)
   if (!parsedParams.success) {
@@ -385,6 +460,69 @@ export async function GET(request: Request, context: { params?: Record<string, u
   const decryptionScope = {
     tenantId: deal.tenantId ?? auth.tenantId ?? null,
     organizationId: deal.organizationId ?? auth.orgId ?? null,
+  }
+
+  const viewerUserId = auth.isApiKey ? null : auth.sub ?? null
+  const resolveViewer = async (): Promise<{ name: string | null; email: string | null }> => {
+    if (!viewerUserId) {
+      return { name: null, email: auth.email ?? null }
+    }
+    const viewer = await findOneWithDecryption(
+      em,
+      User,
+      { id: viewerUserId, tenantId: auth.tenantId ?? null },
+      {},
+      { tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null },
+    )
+    return {
+      name: viewer?.name ?? null,
+      email: viewer?.email ?? auth.email ?? null,
+    }
+  }
+
+  // Opt-in detail cache (ENABLE_CRUD_API_CACHE). The lookup runs after the deal is
+  // resolved and the tenant + organization read-access checks pass, so the cache
+  // only ever memoizes a payload this caller is already authorized to see; it then
+  // skips the heavy association / custom-field / pipeline-stage / dictionary /
+  // audit-fallback sweeps below. The viewer block is request-specific, so it is
+  // excluded from the cached value and always resolved fresh.
+  const cacheTenantId = deal.tenantId ?? auth.tenantId ?? null
+  const cacheOrganizationId = deal.organizationId ?? null
+  const detailCache = isCrudCacheEnabled() ? resolveCrudCache(container) : null
+  const includeKey = includeFlags.size ? Array.from(includeFlags).sort().join(',') : 'none'
+  const detailCacheKey = detailCache
+    ? buildDealDetailCacheKey({
+        tenantId: cacheTenantId,
+        organizationId: cacheOrganizationId,
+        dealId: deal.id,
+        scopeSignature: buildDealDetailScopeSignature(auth, scope),
+        view: viewMode,
+        includeKey,
+      })
+    : null
+
+  if (detailCache && detailCacheKey) {
+    try {
+      const cached = await runWithCacheTenant(cacheTenantId, () => detailCache.get(detailCacheKey))
+      if (cached && typeof cached === 'object') {
+        const viewerInfo = await resolveViewer()
+        return NextResponse.json({
+          ...(cached as Record<string, unknown>),
+          viewer: {
+            userId: viewerUserId,
+            name: viewerInfo.name,
+            email: viewerInfo.email,
+          },
+        })
+      }
+    } catch (err) {
+      // A cache-backend read error must degrade to a fresh DB read, never a 500.
+      debugCrudCache('get', {
+        resource: DEAL_DETAIL_CACHE_RESOURCE,
+        key: detailCacheKey,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
   }
   // Issue #3175: the reads below only depend on the already-resolved deal +
   // organization scope + decryption scope, so they are grouped into Promise.all
@@ -535,24 +673,6 @@ export async function GET(request: Request, context: { params?: Record<string, u
     }
   }
 
-  const viewerUserId = auth.isApiKey ? null : auth.sub ?? null
-  const resolveViewer = async (): Promise<{ name: string | null; email: string | null }> => {
-    if (!viewerUserId) {
-      return { name: null, email: auth.email ?? null }
-    }
-    const viewer = await findOneWithDecryption(
-      em,
-      User,
-      { id: viewerUserId, tenantId: auth.tenantId ?? null },
-      {},
-      { tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null },
-    )
-    return {
-      name: viewer?.name ?? null,
-      email: viewer?.email ?? auth.email ?? null,
-    }
-  }
-
   const resolveOwner = async () =>
     deal.ownerUserId
       ? await findOneWithDecryption(
@@ -682,7 +802,15 @@ export async function GET(request: Request, context: { params?: Record<string, u
     fallbackTimestamp: deal.createdAt.toISOString(),
   })
 
-  return NextResponse.json({
+  const viewer = {
+    userId: viewerUserId,
+    name: viewerName,
+    email: viewerEmail,
+  }
+
+  // Everything except the request-specific viewer block is shareable across
+  // authorized callers, so it is what gets cached.
+  const cacheableBody = {
     deal: {
       id: deal.id,
       title: deal.title,
@@ -714,11 +842,6 @@ export async function GET(request: Request, context: { params?: Record<string, u
       companies: linkedCompanyIds.length,
     },
     customFields,
-    viewer: {
-      userId: viewerUserId,
-      name: viewerName,
-      email: viewerEmail,
-    },
     pipelineStages: pipelineStages.map((stage) => {
       const appearance = pipelineStageAppearanceMap.get(stage.label.trim().toLowerCase())
       return {
@@ -732,7 +855,28 @@ export async function GET(request: Request, context: { params?: Record<string, u
     pipelineName: pipeline?.name ?? null,
     stageTransitions: stageTransitionPayload,
     owner: ownerPayload,
-  })
+  }
+
+  if (detailCache && detailCacheKey) {
+    try {
+      await runWithCacheTenant(cacheTenantId, () =>
+        detailCache.set(detailCacheKey, cacheableBody, {
+          ttl: DEAL_DETAIL_CACHE_TTL_MS,
+          tags: buildDealDetailCacheTags(cacheTenantId, cacheOrganizationId),
+        }),
+      )
+    } catch (err) {
+      // A cache write must never break the request; log it for observability
+      // instead of failing the response (matches the CRUD factory).
+      debugCrudCache('store', {
+        resource: DEAL_DETAIL_CACHE_RESOURCE,
+        key: detailCacheKey,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  return NextResponse.json({ ...cacheableBody, viewer })
 }
 
 const dealDetailQuerySchema = z.object({


### PR DESCRIPTION
Fixes #3665

## Problem
`GET /api/customers/deals/[id]` is a custom (non-`makeCrudRoute`) handler with **no cache**. Every request runs the deal fetch plus a fan-out of expensive, decryption-decorated sweeps: people/company association queries, custom-field decryption, pipeline-stage resolution + scoped-stage sweeps, dictionary-entry lookups, and an audit-log fallback. This is the same uncached/expensive pattern PR #3143 fixed for `GET /api/auth/roles`, and it was not covered by the cache-perf backlog (#2906–#2921).

## Root Cause
The handler had no read-model cache, so the full sweep ran on every detail open even when nothing changed.

## What Changed
- Added an **opt-in** get-then-set cache (`ENABLE_CRUD_API_CACHE`) to `packages/core/src/modules/customers/api/deals/[id]/route.ts`, mirroring PR #3143 (`isCrudCacheEnabled()` → `resolveCrudCache(container)` → get/set inside `runWithCacheTenant(tenantId, …)`).
- The lookup is placed **after** the tenant + `isOrganizationReadAccessAllowed` checks, so the cache only ever memoizes a payload the caller is already authorized to see. On a hit it skips all the heavy association / custom-field / pipeline-stage / dictionary / audit-fallback sweeps.
- **Key axes**: `tenant`, deal `org`, `dealId`, an RBAC **scope signature** (captures every input the org-read-access guard consults), `view` (full/lite), and the `include` flags. The cache is tenant-partitioned via `runWithCacheTenant`.
- **Per-user safety**: the response embeds a request-specific `viewer` block (the caller's own id/name/email). That block is **excluded** from the cached value and resolved fresh on every request (hit and miss), so a scope-shared cache entry can never leak one user's identity to another. The `viewer` lookup is a single indexed PK read, not a sweep.
- **Cache flushing — exact tag parity**: the stored collection tags are produced with `expandResourceAliases`, the same canonicalization the command bus applies on the write side. The customers commands declare `resourceKind`s like `customers.pipelineStage` / `customers.dictionary_entry`, which `canonicalizeResourceTag` rewrites to `customers.pipeline.stage` / `customers.dictionary.entry`. Reusing `expandResourceAliases` guarantees the set-tags match the delete-tags 1:1, so a stored entry is tagged with:
  - `crud:customers.deal:tenant:<T>:org:<O>:collection`
  - `crud:customers.pipeline:tenant:<T>:org:<O>:collection`
  - `crud:customers.pipeline.stage:tenant:<T>:org:<O>:collection`
  - `crud:customers.dictionary.entry:tenant:<T>:org:<O>:collection`
  
  All flushed by the existing `customers.*` deal / pipeline / pipeline-stage / dictionary commands. TTL of 60s is the backstop. (Note: the issue text used the informal camelCase/underscore tag names; the real flushed strings are the canonical dotted forms above — the unit tests assert the canonical forms.)
- Cache read/write failures fail open (degrade to a fresh DB read, logged via `debugCrudCache`), never a 500.

The response shape is byte-identical; caching is a no-op when the flag is off.

## Tests
- New `packages/core/src/modules/customers/api/deals/[id]/__tests__/cache.test.ts` (6 cases): flag-off ⇒ no cache touch & identical behavior; miss ⇒ correct key axes + TTL + the four canonical collection tags, and the `viewer` block is never stored; hit ⇒ DB sweeps (`findWithDecryption`, `loadCustomFieldValues`) skipped and `viewer` refreshed fresh; key partitioned by view/include and by RBAC scope (`scope=super`); cache-read error falls back to a fresh read.
- Existing deal-detail route tests unchanged and green (`src/modules/customers/api/deals` → 9 suites / 46 tests).
- `tsc --noEmit` on `@open-mercato/core` clean; eslint clean on the changed files.

## Backward Compatibility
No contract-surface changes. Additive imports only; response fields unchanged; cache strictly opt-in via `ENABLE_CRUD_API_CACHE` (default off ⇒ identical behavior). No DB schema, event IDs, DI keys, ACL, or route-URL changes.