### PR TITLE
fix(entities): make system-entity settings read-only with notice (#3151)

### DIFF
--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -408,7 +408,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
         { value: 'htmlRichText', label: 'HTML Rich Text' },
       ],
     } as CrudField,
-    ...(entitySource === 'custom' ? [{ id: 'showInSidebar', label: 'Show in sidebar', type: 'checkbox' }] : []),
+    ...(entitySource === 'custom' ? [{ id: 'showInSidebar', label: 'Show in sidebar', type: 'checkbox' } as CrudField] : []),
   ]
   const renderFieldDefinitions = React.useCallback(() => (
       <FieldDefinitionsEditor

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -392,24 +392,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       showInSidebar: z.boolean().optional(),
     }) as z.ZodType<Record<string, unknown>>
 
-  const metadataFieldsReadOnly = entitySource === 'code'
-  const fields: CrudField[] = [
-    { id: 'label', label: 'Label', type: 'text', required: true, readOnly: metadataFieldsReadOnly },
-    { id: 'description', label: 'Description', type: 'textarea', readOnly: metadataFieldsReadOnly },
-    {
-      id: 'defaultEditor',
-      label: 'Default Editor (multiline)',
-      type: 'select',
-      readOnly: metadataFieldsReadOnly,
-      options: [
-        { value: '', label: 'Default (Markdown)' },
-        { value: 'markdown', label: 'Markdown (UIW)' },
-        { value: 'simpleMarkdown', label: 'Simple Markdown' },
-        { value: 'htmlRichText', label: 'HTML Rich Text' },
-      ],
-    } as CrudField,
-    ...(entitySource === 'custom' ? [{ id: 'showInSidebar', label: 'Show in sidebar', type: 'checkbox' } as CrudField] : []),
-  ]
+  const fields: CrudField[] = buildEntitySettingsFields(entitySource)
   const renderFieldDefinitions = React.useCallback(() => (
       <FieldDefinitionsEditor
         definitions={defs}
@@ -607,6 +590,36 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
 
 export function shouldRegisterEntityMetadata(entitySource: EntitySource): boolean {
   return entitySource === 'custom'
+}
+
+// System (code-declared) entities own their metadata in code — their label, description,
+// and default editor cannot be persisted from the UI (POST /api/entities/entities is
+// fail-closed for ORM-backed system ids, #3115). Render those fields as `disabled` (not
+// `readOnly`, which CrudForm ignores for text/textarea/select inputs, #3151) so they are
+// visibly non-editable and cannot accept keyboard input. Custom entities stay fully editable
+// and keep the sidebar toggle.
+export function buildEntitySettingsFields(entitySource: EntitySource): CrudField[] {
+  const metadataDisabled = entitySource === 'code'
+  const fields: CrudField[] = [
+    { id: 'label', label: 'Label', type: 'text', required: true, disabled: metadataDisabled },
+    { id: 'description', label: 'Description', type: 'textarea', disabled: metadataDisabled },
+    {
+      id: 'defaultEditor',
+      label: 'Default Editor (multiline)',
+      type: 'select',
+      disabled: metadataDisabled,
+      options: [
+        { value: '', label: 'Default (Markdown)' },
+        { value: 'markdown', label: 'Markdown (UIW)' },
+        { value: 'simpleMarkdown', label: 'Simple Markdown' },
+        { value: 'htmlRichText', label: 'HTML Rich Text' },
+      ],
+    } as CrudField,
+  ]
+  if (entitySource === 'custom') {
+    fields.push({ id: 'showInSidebar', label: 'Show in sidebar', type: 'checkbox' } as CrudField)
+  }
+  return fields
 }
 
 const SYSTEM_ENTITY_SETTINGS_NOTICE_FALLBACK =

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -391,22 +391,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       showInSidebar: z.boolean().optional(),
     }) as z.ZodType<Record<string, unknown>>
 
-  const fields: CrudField[] = [
-    { id: 'label', label: 'Label', type: 'text', required: true },
-    { id: 'description', label: 'Description', type: 'textarea' },
-    {
-      id: 'defaultEditor',
-      label: 'Default Editor (multiline)',
-      type: 'select',
-      options: [
-        { value: '', label: 'Default (Markdown)' },
-        { value: 'markdown', label: 'Markdown (UIW)' },
-        { value: 'simpleMarkdown', label: 'Simple Markdown' },
-        { value: 'htmlRichText', label: 'HTML Rich Text' },
-      ],
-    } as any,
-    ...(entitySource === 'custom' ? [{ id: 'showInSidebar', label: 'Show in sidebar', type: 'checkbox' }] : []),
-  ]
+  const fields: CrudField[] = buildEntitySettingsFields(entitySource)
   const renderFieldDefinitions = React.useCallback(() => (
       <FieldDefinitionsEditor
         definitions={defs}
@@ -464,7 +449,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
   const definitionsGroup: CrudFormGroup = { id: 'definitions', title: 'Field Definitions', column: 1, component: renderFieldDefinitions }
 
   const groups: CrudFormGroup[] = [
-    { id: 'settings', title: 'Entity Settings', column: 1, fields: entitySource === 'custom' ? ['label','description','defaultEditor','showInSidebar'] : ['label','description','defaultEditor'] },
+    { id: 'settings', title: 'Entity Settings', column: 1, description: getEntitySettingsNotice(entitySource), fields: entitySource === 'custom' ? ['label','description','defaultEditor','showInSidebar'] : ['label','description','defaultEditor'] },
     definitionsGroup,
   ]
 
@@ -609,6 +594,37 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
 
 export function shouldRegisterEntityMetadata(entitySource: 'code' | 'custom'): boolean {
   return entitySource === 'custom'
+}
+
+const SYSTEM_ENTITY_SETTINGS_NOTICE =
+  'This is a system entity defined in code. Its label and description are managed in code and cannot be edited here — only the field definitions below are editable.'
+
+export function buildEntitySettingsFields(entitySource: 'code' | 'custom'): CrudField[] {
+  const metadataEditable = shouldRegisterEntityMetadata(entitySource)
+  const fields: CrudField[] = [
+    { id: 'label', label: 'Label', type: 'text', required: true, disabled: !metadataEditable },
+    { id: 'description', label: 'Description', type: 'textarea', disabled: !metadataEditable },
+    {
+      id: 'defaultEditor',
+      label: 'Default Editor (multiline)',
+      type: 'select',
+      disabled: !metadataEditable,
+      options: [
+        { value: '', label: 'Default (Markdown)' },
+        { value: 'markdown', label: 'Markdown (UIW)' },
+        { value: 'simpleMarkdown', label: 'Simple Markdown' },
+        { value: 'htmlRichText', label: 'HTML Rich Text' },
+      ],
+    } as CrudField,
+  ]
+  if (entitySource === 'custom') {
+    fields.push({ id: 'showInSidebar', label: 'Show in sidebar', type: 'checkbox' })
+  }
+  return fields
+}
+
+export function getEntitySettingsNotice(entitySource: 'code' | 'custom'): string | undefined {
+  return shouldRegisterEntityMetadata(entitySource) ? undefined : SYSTEM_ENTITY_SETTINGS_NOTICE
 }
 
 export function buildEntityMetadataPayload(

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -16,7 +16,7 @@ import { loadGeneratedFieldRegistrations } from '@open-mercato/ui/backend/fields
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { createCrudFormError, raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { FieldDefinitionsEditor, type FieldDefinition, type FieldDefinitionError } from '@open-mercato/ui/backend/custom-fields/FieldDefinitionsEditor'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useT, type TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import {
   Dialog,
   DialogContent,
@@ -449,7 +449,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
   const definitionsGroup: CrudFormGroup = { id: 'definitions', title: 'Field Definitions', column: 1, component: renderFieldDefinitions }
 
   const groups: CrudFormGroup[] = [
-    { id: 'settings', title: 'Entity Settings', column: 1, description: getEntitySettingsNotice(entitySource), fields: entitySource === 'custom' ? ['label','description','defaultEditor','showInSidebar'] : ['label','description','defaultEditor'] },
+    { id: 'settings', title: 'Entity Settings', column: 1, description: getEntitySettingsNotice(entitySource, t), fields: entitySource === 'custom' ? ['label','description','defaultEditor','showInSidebar'] : ['label','description','defaultEditor'] },
     definitionsGroup,
   ]
 
@@ -596,7 +596,7 @@ export function shouldRegisterEntityMetadata(entitySource: 'code' | 'custom'): b
   return entitySource === 'custom'
 }
 
-const SYSTEM_ENTITY_SETTINGS_NOTICE =
+const SYSTEM_ENTITY_SETTINGS_NOTICE_FALLBACK =
   'This is a system entity defined in code. Its label and description are managed in code and cannot be edited here — only the field definitions below are editable.'
 
 export function buildEntitySettingsFields(entitySource: 'code' | 'custom'): CrudField[] {
@@ -623,8 +623,10 @@ export function buildEntitySettingsFields(entitySource: 'code' | 'custom'): Crud
   return fields
 }
 
-export function getEntitySettingsNotice(entitySource: 'code' | 'custom'): string | undefined {
-  return shouldRegisterEntityMetadata(entitySource) ? undefined : SYSTEM_ENTITY_SETTINGS_NOTICE
+export function getEntitySettingsNotice(entitySource: 'code' | 'custom', t: TranslateFn): string | undefined {
+  return shouldRegisterEntityMetadata(entitySource)
+    ? undefined
+    : t('entities.userEntities.form.systemEntityNotice', SYSTEM_ENTITY_SETTINGS_NOTICE_FALLBACK)
 }
 
 export function buildEntityMetadataPayload(

--- a/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
+++ b/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
@@ -2,7 +2,12 @@ jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
   CrudForm: () => null,
 }))
 
-import { buildEntityMetadataPayload, shouldRegisterEntityMetadata } from '../[entityId]/page'
+import {
+  buildEntityMetadataPayload,
+  buildEntitySettingsFields,
+  getEntitySettingsNotice,
+  shouldRegisterEntityMetadata,
+} from '../[entityId]/page'
 
 describe('shouldRegisterEntityMetadata', () => {
   it('registers metadata for custom (user-defined) entities', () => {
@@ -11,6 +16,53 @@ describe('shouldRegisterEntityMetadata', () => {
 
   it('does not register metadata for code-declared system entities (#3115)', () => {
     expect(shouldRegisterEntityMetadata('code')).toBe(false)
+  })
+})
+
+describe('buildEntitySettingsFields', () => {
+  const findField = (fields: ReturnType<typeof buildEntitySettingsFields>, id: string) =>
+    fields.find((field) => field.id === id)
+
+  describe('code-sourced (system) entities (#3151)', () => {
+    const fields = buildEntitySettingsFields('code')
+
+    it('disables label, description, and defaultEditor so code-owned metadata cannot be edited', () => {
+      expect(findField(fields, 'label')?.disabled).toBe(true)
+      expect(findField(fields, 'description')?.disabled).toBe(true)
+      expect(findField(fields, 'defaultEditor')?.disabled).toBe(true)
+    })
+
+    it('does not expose the showInSidebar field', () => {
+      expect(findField(fields, 'showInSidebar')).toBeUndefined()
+    })
+  })
+
+  describe('custom entities', () => {
+    const fields = buildEntitySettingsFields('custom')
+
+    it('keeps label, description, and defaultEditor editable', () => {
+      expect(findField(fields, 'label')?.disabled).toBeFalsy()
+      expect(findField(fields, 'description')?.disabled).toBeFalsy()
+      expect(findField(fields, 'defaultEditor')?.disabled).toBeFalsy()
+    })
+
+    it('exposes an editable showInSidebar field', () => {
+      const showInSidebar = findField(fields, 'showInSidebar')
+      expect(showInSidebar).toBeDefined()
+      expect(showInSidebar?.disabled).toBeFalsy()
+    })
+  })
+})
+
+describe('getEntitySettingsNotice', () => {
+  it('returns a read-only notice for code-declared system entities (#3151)', () => {
+    const notice = getEntitySettingsNotice('code')
+    expect(typeof notice).toBe('string')
+    expect(notice).toMatch(/cannot be edited/i)
+  })
+
+  it('returns no notice for custom entities', () => {
+    expect(getEntitySettingsNotice('custom')).toBeUndefined()
   })
 })
 

--- a/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
+++ b/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
@@ -55,14 +55,23 @@ describe('buildEntitySettingsFields', () => {
 })
 
 describe('getEntitySettingsNotice', () => {
-  it('returns a read-only notice for code-declared system entities (#3151)', () => {
-    const notice = getEntitySettingsNotice('code')
+  const fallbackTranslate = (_key: string, fallback?: unknown) =>
+    typeof fallback === 'string' ? fallback : _key
+
+  it('routes the system-entity notice through i18n with a code-declared key (#3151)', () => {
+    const keys: string[] = []
+    const recordingTranslate = (key: string, fallback?: unknown) => {
+      keys.push(key)
+      return typeof fallback === 'string' ? fallback : key
+    }
+    const notice = getEntitySettingsNotice('code', recordingTranslate as never)
+    expect(keys).toContain('entities.userEntities.form.systemEntityNotice')
     expect(typeof notice).toBe('string')
     expect(notice).toMatch(/cannot be edited/i)
   })
 
   it('returns no notice for custom entities', () => {
-    expect(getEntitySettingsNotice('custom')).toBeUndefined()
+    expect(getEntitySettingsNotice('custom', fallbackTranslate as never)).toBeUndefined()
   })
 })
 

--- a/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
+++ b/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts
@@ -5,6 +5,7 @@ jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
 import {
   buildDefinitionsBatchPayload,
   buildEntityMetadataPayload,
+  buildEntitySettingsFields,
   getEntitySettingsNotice,
   shouldRegisterEntityMetadata,
 } from '../[entityId]/page'
@@ -37,6 +38,35 @@ describe('getEntitySettingsNotice', () => {
 
   it('returns no notice for custom entities', () => {
     expect(getEntitySettingsNotice('custom', fallbackTranslate as never)).toBeUndefined()
+  })
+})
+
+describe('buildEntitySettingsFields', () => {
+  const byId = (fields: ReturnType<typeof buildEntitySettingsFields>) =>
+    Object.fromEntries(fields.map((field) => [field.id, field]))
+
+  it('disables Label, Description, and Default Editor for code-declared system entities (#3151)', () => {
+    // Regression guard for the QA failure: `readOnly` is a silent no-op for
+    // text/textarea/select in CrudForm, so the metadata fields must be `disabled`
+    // to actually reject keyboard input and read as non-editable.
+    const fields = byId(buildEntitySettingsFields('code'))
+    expect(fields.label.disabled).toBe(true)
+    expect(fields.description.disabled).toBe(true)
+    expect(fields.defaultEditor.disabled).toBe(true)
+  })
+
+  it('does not expose the sidebar toggle for system entities', () => {
+    const fields = byId(buildEntitySettingsFields('code'))
+    expect(fields.showInSidebar).toBeUndefined()
+  })
+
+  it('keeps metadata fields editable for custom entities and exposes the sidebar toggle', () => {
+    const fields = byId(buildEntitySettingsFields('custom'))
+    expect(fields.label.disabled).toBeFalsy()
+    expect(fields.description.disabled).toBeFalsy()
+    expect(fields.defaultEditor.disabled).toBeFalsy()
+    expect(fields.showInSidebar).toBeDefined()
+    expect(fields.showInSidebar.disabled).toBeFalsy()
   })
 })
 

--- a/packages/core/src/modules/entities/i18n/de.json
+++ b/packages/core/src/modules/entities/i18n/de.json
@@ -78,6 +78,7 @@
   "entities.userEntities.form.label.label": "Bezeichnung",
   "entities.userEntities.form.showInSidebar.label": "In der Seitenleiste anzeigen",
   "entities.userEntities.form.submit": "Erstellen",
+  "entities.userEntities.form.systemEntityNotice": "Dies ist eine im Code definierte Systementität. Ihr Label und ihre Beschreibung werden im Code verwaltet und können hier nicht bearbeitet werden — nur die Felddefinitionen unten sind bearbeitbar.",
   "entities.userEntities.form.title": "Entität erstellen",
   "entities.userEntities.records.errors.deleteFailed": "Datensatz konnte nicht gelöscht werden",
   "entities.userEntities.records.errors.entityIdRequired": "Entitätskennung ist erforderlich",

--- a/packages/core/src/modules/entities/i18n/en.json
+++ b/packages/core/src/modules/entities/i18n/en.json
@@ -78,6 +78,7 @@
   "entities.userEntities.form.label.label": "Label",
   "entities.userEntities.form.showInSidebar.label": "Show in sidebar",
   "entities.userEntities.form.submit": "Create",
+  "entities.userEntities.form.systemEntityNotice": "This is a system entity defined in code. Its label and description are managed in code and cannot be edited here — only the field definitions below are editable.",
   "entities.userEntities.form.title": "Create Entity",
   "entities.userEntities.records.errors.deleteFailed": "Failed to delete record",
   "entities.userEntities.records.errors.entityIdRequired": "Entity identifier is required",

--- a/packages/core/src/modules/entities/i18n/es.json
+++ b/packages/core/src/modules/entities/i18n/es.json
@@ -78,6 +78,7 @@
   "entities.userEntities.form.label.label": "Etiqueta",
   "entities.userEntities.form.showInSidebar.label": "Mostrar en la barra lateral",
   "entities.userEntities.form.submit": "Crear",
+  "entities.userEntities.form.systemEntityNotice": "Esta es una entidad de sistema definida en el código. Su etiqueta y descripción se gestionan en el código y no se pueden editar aquí — solo las definiciones de campos siguientes son editables.",
   "entities.userEntities.form.title": "Crear entidad",
   "entities.userEntities.records.errors.deleteFailed": "No se pudo eliminar el registro",
   "entities.userEntities.records.errors.entityIdRequired": "Se requiere el identificador de la entidad",

--- a/packages/core/src/modules/entities/i18n/pl.json
+++ b/packages/core/src/modules/entities/i18n/pl.json
@@ -78,6 +78,7 @@
   "entities.userEntities.form.label.label": "Etykieta",
   "entities.userEntities.form.showInSidebar.label": "Pokaż w panelu bocznym",
   "entities.userEntities.form.submit": "Utwórz",
+  "entities.userEntities.form.systemEntityNotice": "To jest encja systemowa zdefiniowana w kodzie. Jej etykieta i opis są zarządzane w kodzie i nie można ich tutaj edytować — edytowalne są tylko definicje pól poniżej.",
   "entities.userEntities.form.title": "Utwórz encję",
   "entities.userEntities.records.errors.deleteFailed": "Nie udało się usunąć rekordu",
   "entities.userEntities.records.errors.entityIdRequired": "Wymagany jest identyfikator encji",


### PR DESCRIPTION
Fixes #3151

## Problem
On `/backend/entities/system/<entityId>`, editing a system (code-sourced) entity's **Entity Settings** (label, description, default editor) showed a "Definitions saved" success toast, but those changes were silently discarded. Only the Field Definitions section actually persisted.

## Root Cause
PR #3123 introduced `shouldRegisterEntityMetadata(entitySource)`, which correctly skips `POST /api/entities/entities` for system entities (to fix the #3115 400 error). But that POST is also the only mechanism for persisting entity label/description. With it skipped, the Entity Settings fields were still rendered as editable, so users edited them, hit Save, and saw success — yet nothing was persisted, with no indication their changes were ignored.

System-entity metadata is code-owned and not meant to be UI-editable (acknowledged as a follow-up in #3123). This implements the recommended fix: make Entity Settings non-editable for system entities and explain why.

## What Changed
- `packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx`
  - Extracted `buildEntitySettingsFields(entitySource)` — for code (system) entities the `label`, `description`, and `defaultEditor` fields are now `disabled`; custom entities remain fully editable (and keep `showInSidebar`).
  - Added `getEntitySettingsNotice(entitySource)` — renders a notice on the Entity Settings group for system entities explaining their label/description are managed in code and only field definitions are editable.
  - Removed an `as any` cast on the `defaultEditor` field in favor of a typed `as CrudField`.
- Custom-entity editing behavior is unchanged; system-entity field-definition saving is unchanged. The "Definitions saved" toast is now accurate because the only editable section for system entities is the field definitions.

## Tests
- `packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-submit.test.ts`
  - New cases assert system entities get disabled `label`/`description`/`defaultEditor` and a read-only notice, while custom entities stay editable with an editable `showInSidebar`.
  - `yarn workspace @open-mercato/core test` → 7136 passed (1 pre-existing, locale-only failure in `DealsKpiStrip` unrelated to this change — passes under `en_US`).
  - `yarn build:packages` ✓, `tsc --noEmit` for `@open-mercato/core` ✓, `yarn i18n:check-sync` ✓, `yarn i18n:check-usage` ✓.

## Backward Compatibility
- No contract surface changes. Only additive exports (`buildEntitySettingsFields`, `getEntitySettingsNotice`); existing `shouldRegisterEntityMetadata`/`buildEntityMetadataPayload` signatures are unchanged. No API routes, event IDs, widget spot IDs, DI keys, ACL features, or DB schema touched.
