### PR TITLE
fix(scheduler): remove stale BullMQ repeatable jobs

### DIFF
--- a/packages/scheduler/src/modules/scheduler/services/__tests__/bullmqSchedulerService.test.ts
+++ b/packages/scheduler/src/modules/scheduler/services/__tests__/bullmqSchedulerService.test.ts
@@ -27,6 +27,9 @@ describe('BullMQSchedulerService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockQueue.add.mockResolvedValue({})
+    mockQueue.getRepeatableJobs.mockResolvedValue([])
+    mockQueue.removeRepeatableByKey.mockResolvedValue(true)
 
     // Create mock forked EM
     mockForkedEm = {
@@ -170,6 +173,44 @@ describe('BullMQSchedulerService', () => {
       )
     })
 
+    it('should remove stale repeatable jobs before registering an updated schedule', async () => {
+      const schedule = {
+        id: 'test-1',
+        name: 'Test',
+        isEnabled: true,
+        scheduleType: 'cron',
+        scheduleValue: '*/15 * * * *',
+        timezone: 'UTC',
+        scopeType: 'system',
+      } as ScheduledJob
+
+      mockQueue.getRepeatableJobs.mockResolvedValue([
+        { id: 'schedule-test-1', name: 'schedule-test-1', key: 'old-cron-key' },
+        { id: 'schedule-test-1', name: 'schedule-test-1', key: 'older-cron-key' },
+        { id: 'schedule-other', name: 'schedule-other', key: 'other-key' },
+      ])
+      mockQueue.removeRepeatableByKey.mockResolvedValue(true)
+      mockQueue.add.mockResolvedValue({})
+
+      await service.register(schedule)
+
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenCalledTimes(2)
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenNthCalledWith(1, 'old-cron-key')
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenNthCalledWith(2, 'older-cron-key')
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        'schedule-test-1',
+        expect.any(Object),
+        expect.objectContaining({
+          repeat: expect.objectContaining({
+            pattern: '*/15 * * * *',
+          }),
+        }),
+      )
+      expect(mockQueue.removeRepeatableByKey.mock.invocationCallOrder[1]).toBeLessThan(
+        mockQueue.add.mock.invocationCallOrder[0],
+      )
+    })
+
     it('should update nextRunAt when skipNextRunUpdate is false', async () => {
       const schedule = {
         id: 'test-1',
@@ -287,6 +328,23 @@ describe('BullMQSchedulerService', () => {
       consoleDebugSpy.mockRestore()
     })
 
+    it('should remove all repeatable jobs for the same schedule id', async () => {
+      mockQueue.getRepeatableJobs.mockResolvedValue([
+        { id: 'schedule-test-1', name: 'schedule-test-1', key: 'key-1' },
+        { id: 'schedule-test-1', name: 'schedule-test-1', key: 'key-2' },
+        { name: 'schedule-test-1', key: 'key-3' },
+        { id: 'schedule-other', name: 'schedule-other', key: 'other-key' },
+      ])
+      mockQueue.removeRepeatableByKey.mockResolvedValue(true)
+
+      await service.unregister('test-1')
+
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenCalledTimes(3)
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenNthCalledWith(1, 'key-1')
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenNthCalledWith(2, 'key-2')
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenNthCalledWith(3, 'key-3')
+    })
+
     it('should handle schedule not found', async () => {
       mockQueue.getRepeatableJobs.mockResolvedValue([
         { id: 'schedule-other', name: 'schedule-other', key: 'key-1' },
@@ -384,6 +442,38 @@ describe('BullMQSchedulerService', () => {
       expect(mockQueue.removeRepeatableByKey).toHaveBeenCalledWith('key-2')
       expect(consoleLogSpy).toHaveBeenCalledWith(
         '[scheduler:bullmq] Removing orphaned schedule: schedule-2'
+      )
+
+      consoleLogSpy.mockRestore()
+    })
+
+    it('should repair duplicate repeatable jobs for existing schedules', async () => {
+      const dbSchedules = [
+        { id: 'schedule-1', name: 'Schedule 1', isEnabled: true, scheduleType: 'cron', scheduleValue: '0 0 * * *', timezone: 'UTC', scopeType: 'system' },
+      ] as ScheduledJob[]
+
+      mockForkedEm.find.mockResolvedValue(dbSchedules)
+      mockQueue.getRepeatableJobs.mockResolvedValue([
+        { id: 'schedule-schedule-1', name: 'schedule-schedule-1', key: 'old-key-1' },
+        { id: 'schedule-schedule-1', name: 'schedule-schedule-1', key: 'old-key-2' },
+      ])
+      mockQueue.removeRepeatableByKey.mockResolvedValue(true)
+      mockQueue.add.mockResolvedValue({})
+
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+
+      await service.syncAll()
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        '[scheduler:bullmq] Repairing duplicate repeatable jobs for schedule: schedule-1'
+      )
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenCalledTimes(2)
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenNthCalledWith(1, 'old-key-1')
+      expect(mockQueue.removeRepeatableByKey).toHaveBeenNthCalledWith(2, 'old-key-2')
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        'schedule-schedule-1',
+        expect.any(Object),
+        expect.any(Object),
       )
 
       consoleLogSpy.mockRestore()

--- a/packages/scheduler/src/modules/scheduler/services/bullmqSchedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/bullmqSchedulerService.ts
@@ -63,6 +63,41 @@ export class BullMQSchedulerService {
     return this.queue
   }
 
+  private getScheduleJobName(scheduleId: string): string {
+    return `schedule-${scheduleId}`
+  }
+
+  private getScheduleIdFromRepeatableJob(job: BullRepeatableJob): string | null {
+    const candidate = job.id?.startsWith('schedule-')
+      ? job.id
+      : job.name?.startsWith('schedule-')
+        ? job.name
+        : null
+
+    return candidate ? candidate.slice('schedule-'.length) : null
+  }
+
+  private isRepeatableJobForSchedule(job: BullRepeatableJob, scheduleId: string): boolean {
+    const jobName = this.getScheduleJobName(scheduleId)
+    return job.id === jobName || job.name === jobName
+  }
+
+  private async removeRepeatableJobsForSchedule(queue: BullQueue, scheduleId: string): Promise<number> {
+    const repeatableJobs = await queue.getRepeatableJobs?.()
+    if (!repeatableJobs || typeof queue.removeRepeatableByKey !== 'function') {
+      return 0
+    }
+
+    let removed = 0
+    for (const job of repeatableJobs) {
+      if (!this.isRepeatableJobForSchedule(job, scheduleId)) continue
+      await queue.removeRepeatableByKey(job.key)
+      removed += 1
+    }
+
+    return removed
+  }
+
   /**
    * Register a schedule with BullMQ repeatable jobs
    * @param schedule - The schedule to register
@@ -98,7 +133,8 @@ export class BullMQSchedulerService {
       // BullMQ will store this in job.data, and the async strategy worker expects
       // job.data to be a QueuedJob with id, payload, and createdAt
       const queue = await this.getQueue()
-      const jobName = `schedule-${schedule.id}`
+      const jobName = this.getScheduleJobName(schedule.id)
+      await this.removeRepeatableJobsForSchedule(queue, schedule.id)
       
       // For repeatable jobs, we need to provide a stable ID in the data
       // that will be used for each repeat instance
@@ -159,21 +195,13 @@ export class BullMQSchedulerService {
   async unregister(scheduleId: string): Promise<void> {
     try {
       const queue = await this.getQueue()
-      
-      // Remove repeatable job by key
-      const repeatableJobs = await queue.getRepeatableJobs?.()
-      
-      if (repeatableJobs) {
-        for (const job of repeatableJobs) {
-          if (job.id === `schedule-${scheduleId}` || job.name === `schedule-${scheduleId}`) {
-            await queue.removeRepeatableByKey?.(job.key)
-            console.debug(`[scheduler:bullmq] Unregistered schedule: ${scheduleId}`)
-            return
-          }
-        }
-      }
 
-      console.debug(`[scheduler:bullmq] No repeatable job found for schedule: ${scheduleId}`)
+      const removed = await this.removeRepeatableJobsForSchedule(queue, scheduleId)
+      if (removed > 0) {
+        console.debug(`[scheduler:bullmq] Unregistered schedule: ${scheduleId}`)
+      } else {
+        console.debug(`[scheduler:bullmq] No repeatable job found for schedule: ${scheduleId}`)
+      }
     } catch (error: unknown) {
       console.error(`[scheduler:bullmq] Failed to unregister schedule: ${scheduleId}`, error)
       throw error
@@ -192,11 +220,14 @@ export class BullMQSchedulerService {
 
     // Get all BullMQ repeatable jobs
     const repeatableJobs = await queue.getRepeatableJobs?.() || []
-    const bullmqScheduleIds = new Set<string>(
-      repeatableJobs
-        .filter((j) => j.id?.startsWith('schedule-') || j.name?.startsWith('schedule-'))
-        .map((j) => String(j.id || j.name).replace('schedule-', ''))
-    )
+    const bullmqScheduleIds = new Set<string>()
+    const bullmqScheduleCounts = new Map<string, number>()
+    for (const job of repeatableJobs) {
+      const scheduleId = this.getScheduleIdFromRepeatableJob(job)
+      if (!scheduleId) continue
+      bullmqScheduleIds.add(scheduleId)
+      bullmqScheduleCounts.set(scheduleId, (bullmqScheduleCounts.get(scheduleId) ?? 0) + 1)
+    }
 
     // Get enabled schedules from database in batches to avoid unbounded loads
     const BATCH_SIZE = 500
@@ -218,6 +249,9 @@ export class BullMQSchedulerService {
     for (const schedule of dbSchedules) {
       if (!bullmqScheduleIds.has(schedule.id)) {
         console.debug(`[scheduler:bullmq] Registering missing schedule: ${schedule.name}`)
+        await this.register(schedule)
+      } else if ((bullmqScheduleCounts.get(schedule.id) ?? 0) > 1) {
+        console.log(`[scheduler:bullmq] Repairing duplicate repeatable jobs for schedule: ${schedule.id}`)
         await this.register(schedule)
       }
     }
@@ -243,7 +277,10 @@ export class BullMQSchedulerService {
 
     if (schedule.scheduleType === 'cron') {
       // Validate cron expression
-      parseCronExpression(schedule.scheduleValue, schedule.timezone || 'UTC')
+      const parsedCron = parseCronExpression(schedule.scheduleValue, schedule.timezone || 'UTC')
+      if (!parsedCron.isValid) {
+        throw new Error(parsedCron.error || 'Invalid cron expression')
+      }
       opts.pattern = schedule.scheduleValue
     } else if (schedule.scheduleType === 'interval') {
       // Parse interval (e.g., "15m", "2h", "1d")


### PR DESCRIPTION
## Summary

Fix stale BullMQ repeatable scheduler jobs accumulating when an existing schedule is updated.

Previously, `BullMQSchedulerService.register()` added a new repeatable job for the updated cron/interval but did not remove the old repeatable jobs for the same schedule id. Since BullMQ keys repeatable jobs by name and repeat options, old patterns stayed in Redis and kept firing.

## Changes

- Remove existing repeatable jobs for a schedule before registering the current definition.
- Make `unregister(scheduleId)` remove all matching repeatable jobs, not just the first one.
- Make `syncAll()` detect duplicate repeatable jobs for an existing schedule and repair them.
- Enforce cron validation when building BullMQ repeat options.
- Add regression tests for stale repeat cleanup, multi-match unregister, and duplicate repair.

## Testing

- `yarn workspace @open-mercato/scheduler test --runInBand --silent`
  - Passed: 14 suites, 324 tests.
- `yarn workspace @open-mercato/scheduler build`
  - Passed.
- `git show --check --stat --oneline HEAD`
  - Passed.
