### PR TITLE
feat(i18n): allow forcing a locale via OM_FORCE_LOCALE

### DIFF
--- a/apps/docs/docs/customization/standalone-app.mdx
+++ b/apps/docs/docs/customization/standalone-app.mdx
@@ -219,6 +219,11 @@ my-store/
 - **`src/modules.ts`** — lists every enabled module and where it comes from. Core modules use `from: '@open-mercato/core'`; your custom modules use `from: '@app'`.
 - **`src/modules/`** — drop custom modules here. Each folder is a full module with the standard structure (`index.ts`, `backend/`, `api/`, `data/`, etc.).
 - **`src/di.ts`** — register app-level DI overrides that run after all module registrars.
+- **`src/i18n/`** — locale files (`en`, `pl`, `es`, `de`). At runtime the active locale is resolved server-side by the `locale` cookie, then the `Accept-Language` header, then the default (`en`).
+
+### Forcing a single locale
+
+Set the `OM_FORCE_LOCALE` env var to pin the whole app to one supported locale (e.g. `OM_FORCE_LOCALE=pl` for Polish). When set, cookie and `Accept-Language` detection are bypassed, the in-app language switcher is hidden, and the locale-change endpoint returns `409`. Leave it unset (the default) for normal per-user detection.
 
 ### Docker Compose variants
 

--- a/apps/mercato/src/app/layout.tsx
+++ b/apps/mercato/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { AppProviders } from '@/components/AppProviders'
 // Bootstrap all package registrations at module load time
 bootstrap()
 import { detectLocale, loadDictionary } from '@open-mercato/shared/lib/i18n/server'
+import { resolveForcedLocale } from '@open-mercato/shared/lib/i18n/locale'
 
 export const metadata: Metadata = {
   title: 'Open Mercato',
@@ -22,6 +23,7 @@ export default async function RootLayout({
 }>) {
   const locale = await detectLocale()
   const dict = await loadDictionary(locale)
+  const localeLocked = resolveForcedLocale(process.env) !== null
   const demoModeEnabled = process.env.DEMO_MODE !== 'false'
   const noticeBarsEnabled = process.env.OM_INTEGRATION_TEST !== 'true'
   return (
@@ -45,7 +47,7 @@ export default async function RootLayout({
         />
       </head>
       <body className="antialiased" suppressHydrationWarning data-gramm="false">
-        <AppProviders locale={locale} dict={dict} demoModeEnabled={demoModeEnabled} noticeBarsEnabled={noticeBarsEnabled}>
+        <AppProviders locale={locale} dict={dict} localeLocked={localeLocked} demoModeEnabled={demoModeEnabled} noticeBarsEnabled={noticeBarsEnabled}>
           {children}
         </AppProviders>
       </body>

--- a/apps/mercato/src/components/AppProviders.tsx
+++ b/apps/mercato/src/components/AppProviders.tsx
@@ -13,13 +13,14 @@ type AppProvidersProps = {
   children: ReactNode
   locale: Locale
   dict: Dict
+  localeLocked: boolean
   demoModeEnabled: boolean
   noticeBarsEnabled: boolean
 }
 
-export function AppProviders({ children, locale, dict, demoModeEnabled, noticeBarsEnabled }: AppProvidersProps) {
+export function AppProviders({ children, locale, dict, localeLocked, demoModeEnabled, noticeBarsEnabled }: AppProvidersProps) {
   return (
-    <I18nProvider locale={locale} dict={dict}>
+    <I18nProvider locale={locale} dict={dict} localeLocked={localeLocked}>
       <ClientBootstrapProvider>
         <ComponentOverridesBootstrap>
           <ThemeProvider>

--- a/apps/mercato/src/i18n/de.json
+++ b/apps/mercato/src/i18n/de.json
@@ -9,6 +9,7 @@
   "api.errors.invalidJson": "Ungültige JSON-Nutzlast.",
   "api.errors.invalidLocale": "Ungültige Sprache",
   "api.errors.invalidPayload": "Ungültige Nutzlast.",
+  "api.errors.localeForced": "Die Sprache ist durch die Konfiguration festgelegt",
   "api.errors.notFound": "Nicht gefunden",
   "api.errors.rateLimit": "Zu viele Anfragen. Bitte versuchen Sie es später erneut.",
   "api.errors.unauthorized": "Nicht autorisiert",

--- a/apps/mercato/src/i18n/en.json
+++ b/apps/mercato/src/i18n/en.json
@@ -9,6 +9,7 @@
   "api.errors.invalidJson": "Invalid JSON payload.",
   "api.errors.invalidLocale": "Invalid locale",
   "api.errors.invalidPayload": "Invalid payload.",
+  "api.errors.localeForced": "Locale is fixed by configuration",
   "api.errors.notFound": "Not Found",
   "api.errors.rateLimit": "Too many requests. Please try again later.",
   "api.errors.unauthorized": "Unauthorized",

--- a/apps/mercato/src/i18n/es.json
+++ b/apps/mercato/src/i18n/es.json
@@ -9,6 +9,7 @@
   "api.errors.invalidJson": "Carga JSON no válida.",
   "api.errors.invalidLocale": "Idioma no válido",
   "api.errors.invalidPayload": "Carga no válida.",
+  "api.errors.localeForced": "El idioma está fijado por configuración",
   "api.errors.notFound": "No encontrado",
   "api.errors.rateLimit": "Demasiadas solicitudes. Inténtelo de nuevo más tarde.",
   "api.errors.unauthorized": "No autorizado",

--- a/apps/mercato/src/i18n/pl.json
+++ b/apps/mercato/src/i18n/pl.json
@@ -9,6 +9,7 @@
   "api.errors.invalidJson": "Nieprawidłowa ładunek JSON.",
   "api.errors.invalidLocale": "Nieprawidłowy język",
   "api.errors.invalidPayload": "Nieprawidłowa ładunek.",
+  "api.errors.localeForced": "Język jest ustalony w konfiguracji",
   "api.errors.notFound": "Nie znaleziono",
   "api.errors.rateLimit": "Zbyt wiele zapytań. Spróbuj ponownie później.",
   "api.errors.unauthorized": "Nieautoryzowany",

--- a/packages/core/src/modules/auth/api/locale/route.ts
+++ b/packages/core/src/modules/auth/api/locale/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { locales, type Locale } from '@open-mercato/shared/lib/i18n/config'
+import { resolveForcedLocale } from '@open-mercato/shared/lib/i18n/locale'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { sanitizeRedirectPath } from '@open-mercato/core/modules/auth/lib/safeRedirect'
 import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
@@ -21,6 +22,9 @@ export const metadata = {
 
 export async function POST(req: Request) {
   const { t } = await resolveTranslations()
+  if (resolveForcedLocale(process.env)) {
+    return NextResponse.json({ error: t('api.errors.localeForced', 'Locale is fixed by configuration') }, { status: 409 })
+  }
   try {
     const { locale } = await req.json()
     if (typeof locale !== 'string' || !supportedLocales.has(locale as Locale)) {
@@ -36,6 +40,9 @@ export async function POST(req: Request) {
 
 export async function GET(req: Request) {
   const { t } = await resolveTranslations()
+  if (resolveForcedLocale(process.env)) {
+    return NextResponse.json({ error: t('api.errors.localeForced', 'Locale is fixed by configuration') }, { status: 409 })
+  }
   const url = new URL(req.url)
   const locale = url.searchParams.get('locale')
   if (!locale || !supportedLocales.has(locale as Locale)) {

--- a/packages/create-app/template/src/app/layout.tsx
+++ b/packages/create-app/template/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { AppProviders } from '@/components/AppProviders'
 // Bootstrap all package registrations at module load time
 bootstrap()
 import { detectLocale, loadDictionary } from '@open-mercato/shared/lib/i18n/server'
+import { resolveForcedLocale } from '@open-mercato/shared/lib/i18n/locale'
 
 export const metadata: Metadata = {
   title: 'Open Mercato',
@@ -22,6 +23,7 @@ export default async function RootLayout({
 }>) {
   const locale = await detectLocale()
   const dict = await loadDictionary(locale)
+  const localeLocked = resolveForcedLocale(process.env) !== null
   const demoModeEnabled = process.env.DEMO_MODE !== 'false'
   const noticeBarsEnabled = process.env.OM_INTEGRATION_TEST !== 'true'
   return (
@@ -45,7 +47,7 @@ export default async function RootLayout({
         />
       </head>
       <body className="antialiased" suppressHydrationWarning data-gramm="false">
-        <AppProviders locale={locale} dict={dict} demoModeEnabled={demoModeEnabled} noticeBarsEnabled={noticeBarsEnabled}>
+        <AppProviders locale={locale} dict={dict} localeLocked={localeLocked} demoModeEnabled={demoModeEnabled} noticeBarsEnabled={noticeBarsEnabled}>
           {children}
         </AppProviders>
       </body>

--- a/packages/create-app/template/src/components/AppProviders.tsx
+++ b/packages/create-app/template/src/components/AppProviders.tsx
@@ -13,13 +13,14 @@ type AppProvidersProps = {
   children: ReactNode
   locale: Locale
   dict: Dict
+  localeLocked: boolean
   demoModeEnabled: boolean
   noticeBarsEnabled: boolean
 }
 
-export function AppProviders({ children, locale, dict, demoModeEnabled, noticeBarsEnabled }: AppProvidersProps) {
+export function AppProviders({ children, locale, dict, localeLocked, demoModeEnabled, noticeBarsEnabled }: AppProvidersProps) {
   return (
-    <I18nProvider locale={locale} dict={dict}>
+    <I18nProvider locale={locale} dict={dict} localeLocked={localeLocked}>
       <ClientBootstrapProvider>
         <ComponentOverridesBootstrap>
           <ThemeProvider>

--- a/packages/create-app/template/src/i18n/de.json
+++ b/packages/create-app/template/src/i18n/de.json
@@ -9,6 +9,7 @@
   "api.errors.invalidJson": "Ungültige JSON-Nutzlast.",
   "api.errors.invalidLocale": "Ungültige Sprache",
   "api.errors.invalidPayload": "Ungültige Nutzlast.",
+  "api.errors.localeForced": "Die Sprache ist durch die Konfiguration festgelegt",
   "api.errors.notFound": "Nicht gefunden",
   "api.errors.rateLimit": "Zu viele Anfragen. Bitte versuchen Sie es später erneut.",
   "api.errors.unauthorized": "Nicht autorisiert",

--- a/packages/create-app/template/src/i18n/en.json
+++ b/packages/create-app/template/src/i18n/en.json
@@ -9,6 +9,7 @@
   "api.errors.invalidJson": "Invalid JSON payload.",
   "api.errors.invalidLocale": "Invalid locale",
   "api.errors.invalidPayload": "Invalid payload.",
+  "api.errors.localeForced": "Locale is fixed by configuration",
   "api.errors.notFound": "Not Found",
   "api.errors.rateLimit": "Too many requests. Please try again later.",
   "api.errors.unauthorized": "Unauthorized",

--- a/packages/create-app/template/src/i18n/es.json
+++ b/packages/create-app/template/src/i18n/es.json
@@ -9,6 +9,7 @@
   "api.errors.invalidJson": "Carga JSON no válida.",
   "api.errors.invalidLocale": "Idioma no válido",
   "api.errors.invalidPayload": "Carga no válida.",
+  "api.errors.localeForced": "El idioma está fijado por configuración",
   "api.errors.notFound": "No encontrado",
   "api.errors.rateLimit": "Demasiadas solicitudes. Inténtelo de nuevo más tarde.",
   "api.errors.unauthorized": "No autorizado",

--- a/packages/create-app/template/src/i18n/pl.json
+++ b/packages/create-app/template/src/i18n/pl.json
@@ -9,6 +9,7 @@
   "api.errors.invalidJson": "Nieprawidłowa ładunek JSON.",
   "api.errors.invalidLocale": "Nieprawidłowy język",
   "api.errors.invalidPayload": "Nieprawidłowa ładunek.",
+  "api.errors.localeForced": "Język jest ustalony w konfiguracji",
   "api.errors.notFound": "Nie znaleziono",
   "api.errors.rateLimit": "Zbyt wiele zapytań. Spróbuj ponownie później.",
   "api.errors.unauthorized": "Nieautoryzowany",

--- a/packages/shared/src/lib/i18n/__tests__/forced-locale.test.ts
+++ b/packages/shared/src/lib/i18n/__tests__/forced-locale.test.ts
@@ -1,0 +1,25 @@
+import { resolveForcedLocale } from '../locale'
+
+describe('resolveForcedLocale', () => {
+  it('returns null when OM_FORCE_LOCALE is unset (default: no forcing)', () => {
+    expect(resolveForcedLocale({})).toBeNull()
+    expect(resolveForcedLocale({ OM_FORCE_LOCALE: '' })).toBeNull()
+    expect(resolveForcedLocale({ OM_FORCE_LOCALE: undefined })).toBeNull()
+  })
+
+  it('returns the forced locale when set to a supported value', () => {
+    expect(resolveForcedLocale({ OM_FORCE_LOCALE: 'pl' })).toBe('pl')
+    expect(resolveForcedLocale({ OM_FORCE_LOCALE: 'de' })).toBe('de')
+  })
+
+  it('normalizes region and casing to a supported base locale', () => {
+    expect(resolveForcedLocale({ OM_FORCE_LOCALE: 'PL' })).toBe('pl')
+    expect(resolveForcedLocale({ OM_FORCE_LOCALE: 'pl-PL' })).toBe('pl')
+    expect(resolveForcedLocale({ OM_FORCE_LOCALE: 'en_US' })).toBe('en')
+  })
+
+  it('returns null for unsupported locales rather than forcing garbage', () => {
+    expect(resolveForcedLocale({ OM_FORCE_LOCALE: 'fr' })).toBeNull()
+    expect(resolveForcedLocale({ OM_FORCE_LOCALE: 'not-a-locale' })).toBeNull()
+  })
+})

--- a/packages/shared/src/lib/i18n/context.tsx
+++ b/packages/shared/src/lib/i18n/context.tsx
@@ -15,6 +15,8 @@ export type TranslateFn = (
 export type I18nContextValue = {
   locale: Locale
   t: TranslateFn
+  /** True when the locale is pinned via `OM_FORCE_LOCALE`; UI should hide switchers. */
+  localeLocked: boolean
 }
 
 const I18N_CONTEXT_KEY = '__openMercatoI18nContext'
@@ -46,9 +48,10 @@ function format(template: string, params?: TranslateParams) {
   })
 }
 
-export function I18nProvider({ children, locale, dict }: { children: ReactNode; locale: Locale; dict: Dict }) {
+export function I18nProvider({ children, locale, dict, localeLocked = false }: { children: ReactNode; locale: Locale; dict: Dict; localeLocked?: boolean }) {
   const value = useMemo<I18nContextValue>(() => ({
     locale,
+    localeLocked,
     t: (key, fallbackOrParams, params) => {
       let fallback: string | undefined
       let resolvedParams: TranslateParams | undefined
@@ -63,7 +66,7 @@ export function I18nProvider({ children, locale, dict }: { children: ReactNode; 
       const template = dict[key] ?? fallback ?? key
       return format(template, resolvedParams)
     },
-  }), [locale, dict])
+  }), [locale, dict, localeLocked])
   return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>
 }
 
@@ -88,4 +91,13 @@ export function useLocale() {
   const ctx = useContext(I18nContext)
   if (!ctx) throw new Error('useLocale must be used within I18nProvider')
   return ctx.locale
+}
+
+/**
+ * True when the active locale is pinned via `OM_FORCE_LOCALE`. Returns `false`
+ * when no provider is in scope so callers can render unconditionally.
+ */
+export function useLocaleLocked() {
+  const ctx = useContext(I18nContext)
+  return ctx?.localeLocked ?? false
 }

--- a/packages/shared/src/lib/i18n/locale.ts
+++ b/packages/shared/src/lib/i18n/locale.ts
@@ -32,6 +32,18 @@ export function resolveLocaleFromCandidates(
   return null
 }
 
+/**
+ * Reads the optional `OM_FORCE_LOCALE` env override. When set to a supported
+ * locale (e.g. `pl`), the whole app is pinned to it and cookie/Accept-Language
+ * detection is bypassed. Unset (the default) → `null` → normal detection.
+ * Pure: pass the env bag so it stays testable and safe to call server-side only.
+ */
+export function resolveForcedLocale(
+  env: Record<string, string | undefined>,
+): Locale | null {
+  return resolveSupportedLocale(env.OM_FORCE_LOCALE)
+}
+
 export function resolveLocaleFromAcceptLanguage(
   acceptLanguage: string | null | undefined,
 ): Locale | null {

--- a/packages/shared/src/lib/i18n/server.ts
+++ b/packages/shared/src/lib/i18n/server.ts
@@ -1,6 +1,6 @@
 import { defaultLocale, locales, type Locale } from './config'
 import type { Dict } from './context'
-import { resolveLocaleFromAcceptLanguage } from './locale'
+import { resolveForcedLocale, resolveLocaleFromAcceptLanguage } from './locale'
 import { createFallbackTranslator, createTranslator } from './translate'
 import { getModules } from '../modules/registry'
 import { loadAppDictionary } from './app-dictionaries'
@@ -27,6 +27,9 @@ function flattenDictionary(source: unknown, prefix = ''): Dict {
 }
 
 export async function detectLocale(): Promise<Locale> {
+  // Ops-level override: pin the whole app to one locale (default: unset).
+  const forced = resolveForcedLocale(process.env)
+  if (forced) return forced
   // Dynamic import to avoid requiring Next.js in non-Next.js contexts (CLI, tests)
   try {
     const { cookies, headers } = await import('next/headers')

--- a/packages/ui/src/frontend/LanguageSwitcher.tsx
+++ b/packages/ui/src/frontend/LanguageSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client"
 import { useId, useTransition } from 'react'
-import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useLocaleLocked, useT } from '@open-mercato/shared/lib/i18n/context'
 import { useRouter } from 'next/navigation'
 import { locales, type Locale } from '@open-mercato/shared/lib/i18n/config'
 import {
@@ -13,6 +13,7 @@ import {
 
 export function LanguageSwitcher() {
   const current = useLocale()
+  const localeLocked = useLocaleLocked()
   const t = useT()
   const router = useRouter()
   const [pending, startTransition] = useTransition()
@@ -44,6 +45,9 @@ export function LanguageSwitcher() {
       // Ignore network errors; UX fallback keeps previous locale
     }
   }
+
+  // Locale is pinned via OM_FORCE_LOCALE — switching is a no-op, so hide the control.
+  if (localeLocked) return null
 
   return (
     <div className="flex items-center gap-2 text-xs text-muted-foreground">


### PR DESCRIPTION
## What & why
Adds an opt-in ops override to pin the whole app to one supported locale
(e.g. `OM_FORCE_LOCALE=pl`). Off by default — when unset, the existing
`locale` cookie → `Accept-Language` → default (`en`) detection is unchanged.

Answers "can we force a given locale (e.g. PL) and/or drop i18n?": forcing a
locale is the practical, low-risk equivalent of a single-language app without
ripping out the ~480 `useT()`/`resolveTranslations()` call sites.

## How
- **shared**: pure `resolveForcedLocale(env)` (validates + normalizes `pl-PL`/`PL` → `pl`, rejects unsupported → `null`); `detectLocale()` short-circuits to the forced locale before cookie/header detection.
- **shared**: expose `localeLocked` on the i18n context + `useLocaleLocked()` hook (additive/optional — backward compatible).
- **ui**: `LanguageSwitcher` hides itself when locked (no dead no-op control).
- **core**: `/api/auth/locale` (GET/POST) returns `409` when a locale is forced so a cookie write can't override the pin; new `api.errors.localeForced` key (en/pl/es/de).
- **app + create-app template**: thread `localeLocked` through `AppProviders → I18nProvider` (template synced per create-app rules).
- **docs**: "Forcing a single locale" note in the standalone-app guide.

## Usage
`OM_FORCE_LOCALE=pl` pins the app to Polish (switcher hidden, endpoint 409s); unset = normal per-user detection.

## Backward compatibility
Fully additive: new env (default unset), new optional context field/hook, new i18n key. No contract removed or changed.

## Testing
- `packages/shared/.../__tests__/forced-locale.test.ts` (unset / supported / normalized / unsupported).
- `@open-mercato/shared` i18n suite: 26 passed. `yarn i18n:check`: 0 missing across pl/es/de.
- typecheck clean (shared/ui/core/app); `yarn lint`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
