### PR TITLE
fix(auth): validate password policy on reset page before submit

### DIFF
--- a/packages/core/src/modules/auth/__tests__/resetWithTokenPage.test.tsx
+++ b/packages/core/src/modules/auth/__tests__/resetWithTokenPage.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, fireEvent, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+const apiCallMock = jest.fn()
+const routerReplaceMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: routerReplaceMock }),
+}))
+
+import ResetWithTokenPage from '../frontend/reset/[token]/page'
+
+const TOKEN = 'reset-token-0123456789abcdef'
+
+function fillForm(
+  getByLabelText: (matcher: string) => HTMLElement,
+  password: string,
+  confirm: string,
+) {
+  fireEvent.change(getByLabelText('New password'), { target: { value: password } })
+  fireEvent.change(getByLabelText('Confirm new password'), { target: { value: confirm } })
+}
+
+function readFormData(body: unknown): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (body instanceof FormData) {
+    for (const [key, value] of body.entries()) out[key] = String(value)
+  }
+  return out
+}
+
+describe('ResetWithTokenPage (staff password reset)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('blocks submission and surfaces the requirements error when the password fails the policy', async () => {
+    const { getByLabelText, getByRole, findByText } = renderWithProviders(
+      <ResetWithTokenPage params={{ token: TOKEN }} />,
+    )
+    // Meets the minLength=6 requirement but has no digit / uppercase / special char,
+    // which previously produced an opaque server-side "Invalid request".
+    fillForm(getByLabelText, 'password', 'password')
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: /update password/i }))
+    })
+
+    await findByText(/password must meet the requirements/i)
+    expect(apiCallMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks submission and surfaces a mismatch error when passwords do not match', async () => {
+    const { getByLabelText, getByRole, findByText } = renderWithProviders(
+      <ResetWithTokenPage params={{ token: TOKEN }} />,
+    )
+    fillForm(getByLabelText, 'Password1!', 'Password2!')
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: /update password/i }))
+    })
+
+    await findByText(/passwords do not match/i)
+    expect(apiCallMock).not.toHaveBeenCalled()
+  })
+
+  it('submits token + policy-compliant password to /api/auth/reset/confirm and redirects on success', async () => {
+    apiCallMock.mockResolvedValueOnce({ ok: true, result: { ok: true, redirect: '/login' } })
+
+    const { getByLabelText, getByRole } = renderWithProviders(
+      <ResetWithTokenPage params={{ token: TOKEN }} />,
+    )
+    fillForm(getByLabelText, 'Password1!', 'Password1!')
+
+    await act(async () => {
+      fireEvent.click(getByRole('button', { name: /update password/i }))
+    })
+
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalled())
+    const [url, options] = apiCallMock.mock.calls[0] as [string, { method: string; body: unknown }]
+    expect(url).toBe('/api/auth/reset/confirm')
+    expect(options.method).toBe('POST')
+    expect(readFormData(options.body)).toMatchObject({ token: TOKEN, password: 'Password1!' })
+    await waitFor(() => expect(routerReplaceMock).toHaveBeenCalledWith('/login'))
+  })
+})

--- a/packages/core/src/modules/auth/frontend/reset/[token]/page.tsx
+++ b/packages/core/src/modules/auth/frontend/reset/[token]/page.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
-import { formatPasswordRequirements, getPasswordPolicy } from '@open-mercato/shared/lib/auth/passwordPolicy'
+import { formatPasswordRequirements, getPasswordPolicy, validatePassword } from '@open-mercato/shared/lib/auth/passwordPolicy'
 
 export default function ResetWithTokenPage({ params }: { params: { token: string } }) {
   const router = useRouter()
@@ -42,6 +42,10 @@ export default function ResetWithTokenPage({ params }: { params: { token: string
     }
     if (password !== confirmPassword) {
       setError(t('auth.profile.form.errors.passwordMismatch', 'Passwords do not match.'))
+      return
+    }
+    if (!validatePassword(password, passwordPolicy).ok) {
+      setError(t('auth.profile.form.errors.passwordRequirements', 'Password must meet the requirements.'))
       return
     }
 


### PR DESCRIPTION
## Problem

The staff **"Set a new password"** page (`/reset/[token]`) shows the password requirements ("At least 6 characters, one number, one uppercase letter, one special character") but only validated **non-empty** and **matching** values on the client. A password that met the minimum length yet lacked a digit/uppercase/special character was submitted anyway, and the server rejected it with a generic **`Invalid request`** — see screenshot below. The user had no idea *what* was wrong.

<img width="571" height="484" alt="image" src="https://github.com/user-attachments/assets/8d3c3ea5-380c-4276-98fb-768b64f9a286" />


## Root cause

`confirmPasswordResetSchema` enforces the full password policy server-side via `buildPasswordSchema()`. When it fails, `api/auth/reset/confirm` returns `{ error: 'Invalid request' }`. The reset form never ran the same policy check client-side, so policy-failing passwords reached the server and surfaced the opaque error.

(Ruled out: the reset link/token is fine — 64-char hex token, resolved plain `params` object from the frontend catch-all.)

## Fix

Validate the password against the policy on the client before submit, mirroring the existing profile *change-password* form. Users now get the actionable **"Password must meet the requirements."** message instead of `Invalid request`.

- Reuses existing i18n keys (`auth.profile.form.errors.passwordRequirements`) already present in `en` + `pl` — no new strings.
- Single-file behavior change (`frontend/reset/[token]/page.tsx`).

## Tests (TDD)

Added `resetWithTokenPage.test.tsx` (jsdom, mirrors the portal reset test):

1. Policy-failing password is blocked with the requirements error and **never** calls the API. *(fails without the fix — verified red → green)*
2. Mismatched passwords are blocked.
3. Policy-compliant password submits `token + password` to `/api/auth/reset/confirm` and redirects to `/login`.

Full auth reset suite: **27 passed / 5 suites**.
