### PR TITLE
fix(data_sync): surface export item failures in run logs

### DIFF
--- a/packages/core/src/modules/data_sync/backend/data-sync/runs/[id]/__tests__/page.test.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/runs/[id]/__tests__/page.test.tsx
@@ -143,3 +143,63 @@ describe('SyncRunDetailPage logs pagination', () => {
     expect(logsCalls().every(([url]) => String(url).includes('page=2'))).toBe(true)
   })
 })
+
+describe('SyncRunDetailPage log payload rendering', () => {
+  function mockApiResponsesWithLogs(items: Array<Record<string, unknown>>) {
+    apiCallMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/data_sync/runs/')) {
+        return { ok: true, status: 200, result: runFixture }
+      }
+      if (url.startsWith('/api/integrations/logs')) {
+        return { ok: true, status: 200, result: { items, total: items.length } }
+      }
+      return { ok: false, status: 404, result: null }
+    })
+  }
+
+  it('renders only the summary for export-item-failure payloads', async () => {
+    mockApiResponsesWithLogs([
+      {
+        id: 'log-1',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        level: 'error',
+        message: 'Failed to export item SKU-1 (id: product-1)',
+        payload: { kind: 'export-item-failure', summary: 'Magento API request failed with status 400.' },
+      },
+    ])
+    renderWithProviders(<SyncRunDetailPage params={{ id: 'run-1' }} />)
+
+    const trigger = (await screen.findByText('Failed to export item SKU-1 (id: product-1)')).closest('button')
+    expect(trigger).not.toBeNull()
+    fireEvent.click(trigger!)
+
+    expect(await screen.findByText('Magento API request failed with status 400.')).toBeInTheDocument()
+    expect(screen.queryByText(/"kind"/)).toBeNull()
+  })
+
+  it('keeps the full JSON payload for operational logs that also carry a summary field', async () => {
+    mockApiResponsesWithLogs([
+      {
+        id: 'log-2',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        level: 'info',
+        message: 'Sync run completed',
+        payload: {
+          operationalStatus: 'completed',
+          summary: 'Sync completed with 5 created, 2 updated, 1 failed.',
+          createdCount: 5,
+          updatedCount: 2,
+          failedCount: 1,
+        },
+      },
+    ])
+    renderWithProviders(<SyncRunDetailPage params={{ id: 'run-1' }} />)
+
+    const trigger = (await screen.findByText('Sync run completed')).closest('button')
+    expect(trigger).not.toBeNull()
+    fireEvent.click(trigger!)
+
+    expect(await screen.findByText(/"operationalStatus"/)).toBeInTheDocument()
+    expect(await screen.findByText(/"createdCount"/)).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/modules/data_sync/backend/data-sync/runs/[id]/page.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/runs/[id]/page.tsx
@@ -431,7 +431,7 @@ export default function SyncRunDetailPage({ params }: SyncRunDetailPageProps) {
                   message: log.message,
                   body: log.payload ? (
                     <pre className="overflow-x-auto whitespace-pre-wrap rounded-md border bg-card p-3 text-xs">
-                      {JSON.stringify(log.payload, null, 2)}
+                      {typeof log.payload.summary === 'string' ? log.payload.summary : JSON.stringify(log.payload, null, 2)}
                     </pre>
                   ) : (
                     <p className="text-sm text-muted-foreground">

--- a/packages/core/src/modules/data_sync/backend/data-sync/runs/[id]/page.tsx
+++ b/packages/core/src/modules/data_sync/backend/data-sync/runs/[id]/page.tsx
@@ -431,7 +431,9 @@ export default function SyncRunDetailPage({ params }: SyncRunDetailPageProps) {
                   message: log.message,
                   body: log.payload ? (
                     <pre className="overflow-x-auto whitespace-pre-wrap rounded-md border bg-card p-3 text-xs">
-                      {typeof log.payload.summary === 'string' ? log.payload.summary : JSON.stringify(log.payload, null, 2)}
+                      {log.payload.kind === 'export-item-failure' && typeof log.payload.summary === 'string'
+                        ? log.payload.summary
+                        : JSON.stringify(log.payload, null, 2)}
                     </pre>
                   ) : (
                     <p className="text-sm text-muted-foreground">

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-export-failures.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-export-failures.test.ts
@@ -1,0 +1,158 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { CredentialsService } from '../../../integrations/lib/credentials-service'
+import type { IntegrationLogService } from '../../../integrations/lib/log-service'
+import type { ProgressService } from '../../../progress/lib/progressService'
+import type { DataSyncAdapter } from '../adapter'
+import type { SyncRunService } from '../sync-run-service'
+
+const mockGetDataSyncAdapter = jest.fn()
+const mockGetIntegration = jest.fn()
+const mockEmitDataSyncEvent = jest.fn(async () => undefined)
+
+jest.mock('../adapter-registry', () => ({
+  getDataSyncAdapter: (...args: unknown[]) => mockGetDataSyncAdapter(...args),
+}))
+
+jest.mock('@open-mercato/shared/modules/integrations/types', () => ({
+  getIntegration: (...args: unknown[]) => mockGetIntegration(...args),
+}))
+
+jest.mock('../../events', () => ({
+  emitDataSyncEvent: (...args: unknown[]) => mockEmitDataSyncEvent(...args),
+}))
+
+import { createSyncEngine } from '../sync-engine'
+
+describe('data sync engine export item failures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('counts and logs failed export items without failing the run', async () => {
+    const adapter: DataSyncAdapter = {
+      providerKey: 'magento_products',
+      direction: 'export',
+      supportedEntities: ['products'],
+      getMapping: jest.fn(async () => ({
+        entityType: 'products',
+        fields: [],
+        matchStrategy: 'externalId',
+      })),
+      streamExport: async function* () {
+        yield {
+          results: [
+            {
+              localId: 'product-1',
+              externalId: 'SKU-1',
+              status: 'error',
+              error: 'Magento API request failed with status 400: {"message":"URL key for specified store already exists."}',
+            },
+          ],
+          cursor: 'cursor-1',
+          hasMore: false,
+          batchIndex: 0,
+        }
+      },
+    }
+
+    mockGetIntegration.mockReturnValue({ providerKey: 'magento_products' })
+    mockGetDataSyncAdapter.mockReturnValue(adapter)
+
+    const syncRunService = {
+      getRun: jest.fn(async () => ({
+        id: 'run-1',
+        integrationId: 'sync_magento',
+        entityType: 'products',
+        direction: 'export',
+        status: 'pending',
+        cursor: null,
+        progressJobId: 'job-1',
+      })),
+      markStatus: jest
+        .fn()
+        .mockResolvedValueOnce({
+          id: 'run-1',
+          integrationId: 'sync_magento',
+          entityType: 'products',
+          direction: 'export',
+          status: 'running',
+          progressJobId: 'job-1',
+        })
+        .mockResolvedValueOnce({
+          id: 'run-1',
+          integrationId: 'sync_magento',
+          entityType: 'products',
+          direction: 'export',
+          status: 'completed',
+          progressJobId: 'job-1',
+          createdCount: 0,
+          updatedCount: 0,
+          skippedCount: 0,
+          failedCount: 1,
+          batchesCompleted: 1,
+        }),
+      commitBatchProgress: jest.fn(async () => undefined),
+    } as unknown as SyncRunService
+
+    const integrationCredentialsService = {
+      resolve: jest.fn(async () => ({ apiUrl: 'https://example.test' })),
+    } as unknown as CredentialsService
+
+    const integrationLogService = {
+      write: jest.fn(async () => undefined),
+    } as unknown as IntegrationLogService
+
+    const progressService = {
+      startJob: jest.fn(async () => undefined),
+      isCancellationRequested: jest.fn(async () => false),
+      updateProgress: jest.fn(async () => undefined),
+      completeJob: jest.fn(async () => undefined),
+    } as unknown as ProgressService
+
+    const engine = createSyncEngine({
+      em: {} as EntityManager,
+      syncRunService,
+      integrationCredentialsService,
+      integrationLogService,
+      integrationStateService: {
+        upsert: jest.fn(async () => undefined),
+      } as any,
+      progressService,
+    })
+
+    await engine.runExport('run-1', 100, {
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    })
+
+    expect((syncRunService as any).commitBatchProgress).toHaveBeenCalledWith('run-1', expect.objectContaining({
+      failedCount: 1,
+      updatedCount: 0,
+      skippedCount: 0,
+      batchesCompleted: 1,
+    }), 'cursor-1', {
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    })
+    expect((integrationLogService as any).write).toHaveBeenCalledWith(expect.objectContaining({
+      integrationId: 'sync_magento',
+      runId: 'run-1',
+      level: 'error',
+      message: expect.stringContaining('Failed to export item SKU-1 (id: product-1)'),
+      payload: {
+        summary: 'Magento API request failed with status 400: {"message":"URL key for specified store already exists."}',
+      },
+    }), {
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    })
+    expect((syncRunService as any).markStatus).toHaveBeenLastCalledWith('run-1', 'completed', {
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    }, undefined)
+  })
+})

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-export-failures.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-export-failures.test.ts
@@ -142,6 +142,7 @@ describe('data sync engine export item failures', () => {
       level: 'error',
       message: expect.stringContaining('Failed to export item SKU-1 (id: product-1)'),
       payload: {
+        kind: 'export-item-failure',
         summary: 'Magento API request failed with status 400: {"message":"URL key for specified store already exists."}',
       },
     }), {

--- a/packages/core/src/modules/data_sync/lib/adapter-registry.ts
+++ b/packages/core/src/modules/data_sync/lib/adapter-registry.ts
@@ -1,15 +1,27 @@
 import type { DataSyncAdapter } from './adapter'
 
-const adapters = new Map<string, DataSyncAdapter>()
+const DATA_SYNC_ADAPTER_REGISTRY_KEY = Symbol.for('@open-mercato/data-sync/adapter-registry')
+
+type GlobalWithDataSyncRegistry = typeof globalThis & {
+  [DATA_SYNC_ADAPTER_REGISTRY_KEY]?: Map<string, DataSyncAdapter>
+}
+
+function getAdapterRegistry(): Map<string, DataSyncAdapter> {
+  const globalScope = globalThis as GlobalWithDataSyncRegistry
+  if (!globalScope[DATA_SYNC_ADAPTER_REGISTRY_KEY]) {
+    globalScope[DATA_SYNC_ADAPTER_REGISTRY_KEY] = new Map<string, DataSyncAdapter>()
+  }
+  return globalScope[DATA_SYNC_ADAPTER_REGISTRY_KEY]
+}
 
 export function registerDataSyncAdapter(adapter: DataSyncAdapter): void {
-  adapters.set(adapter.providerKey, adapter)
+  getAdapterRegistry().set(adapter.providerKey, adapter)
 }
 
 export function getDataSyncAdapter(providerKey: string): DataSyncAdapter | undefined {
-  return adapters.get(providerKey)
+  return getAdapterRegistry().get(providerKey)
 }
 
 export function getAllDataSyncAdapters(): DataSyncAdapter[] {
-  return Array.from(adapters.values())
+  return Array.from(getAdapterRegistry().values())
 }

--- a/packages/core/src/modules/data_sync/lib/sync-engine.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-engine.ts
@@ -167,7 +167,7 @@ export function createSyncEngine(deps: EngineDeps) {
           runId,
           level: 'error',
           message,
-          payload: { summary: result.error },
+          payload: { kind: 'export-item-failure', summary: result.error },
         },
         scope,
       )

--- a/packages/core/src/modules/data_sync/lib/sync-engine.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-engine.ts
@@ -149,6 +149,31 @@ export function createSyncEngine(deps: EngineDeps) {
     }
   }
 
+  async function logExportItemFailures(
+    runId: string,
+    integrationId: string,
+    results: ExportBatch['results'],
+    scope: SyncScope,
+  ): Promise<void> {
+    const failedResults = results.filter((result) => result.status === 'error' && result.error)
+    for (const result of failedResults) {
+      const label = result.externalId ? `${result.externalId} (id: ${result.localId})` : result.localId
+      const errorMessage = result.error!.split('\n')[0]
+      const message = `Failed to export item ${label}: ${errorMessage}`
+
+      await integrationLogService.write(
+        {
+          integrationId,
+          runId,
+          level: 'error',
+          message,
+          payload: { summary: result.error },
+        },
+        scope,
+      )
+    }
+  }
+
   async function writeOperationalLog(params: {
     integrationId: string
     runId: string
@@ -600,6 +625,7 @@ export function createSyncEngine(deps: EngineDeps) {
             scope,
           )
           await updateProgress(run.progressJobId, processedCount, null, scope)
+          await logExportItemFailures(run.id, run.integrationId, batch.results, scope)
 
           await writeOperationalLog({
             integrationId: run.integrationId,


### PR DESCRIPTION
## Summary
- Export batches with per-item errors (`status: "error"`) were never written to the integration log, so the run detail page showed no indication of which items failed or why. Adds `logExportItemFailures` (mirroring the existing `logImportItemFailures`) and calls it after each export batch is committed.
- Moves the `data_sync` adapter registry onto `globalThis` (matching the existing `shipping_carriers` adapter registry pattern) so adapters registered by one module instance are visible to others.
- Run detail page now renders `log.payload.summary` when present, falling back to the full JSON dump otherwise — keeps existing import-failure log rendering intact while surfacing the new export failure summaries.

## Test plan
- [x] `yarn jest src/modules/data_sync/lib/__tests__` (new export-failures test + existing import-failures/run-id tests) — all passing
- [x] `yarn jest src/modules/data_sync/backend/data-sync/runs` — run detail page tests passing
- [x] `tsc --noEmit` — no new errors in changed files