### PR TITLE
feat: promote generic workflow/seeds/MCP improvements from claims branch to mvp

### DIFF
--- a/apps/docs/docs/framework/data-integrity/encrypted-seeding.md
+++ b/apps/docs/docs/framework/data-integrity/encrypted-seeding.md
@@ -105,6 +105,12 @@ OM_SEED_KEY=<key> yarn mercato seeds decrypt --in ./seed.enc.json --out ./seed.j
 OM_SEED_KEY=<key> yarn mercato seeds load \
   --in ./seed.enc.json --tenant <tenantId> --org <organizationId>
 
+#   In single-tenant/single-organization local setups, --tenant/--org can be
+#   omitted. The loader auto-detects scope only when exactly one active tenant
+#   and exactly one active organization are available; otherwise it fails closed
+#   and asks for explicit flags.
+OM_SEED_KEY=<key> yarn mercato seeds load --in ./seed.enc.json
+
 #   Dry run (validates + reports counts, rolls back the transaction):
 OM_SEED_KEY=<key> yarn mercato seeds load --in ./seed.enc.json --tenant <t> --org <o> --dry-run
 

--- a/apps/docs/docs/framework/data-integrity/encrypted-seeding.md
+++ b/apps/docs/docs/framework/data-integrity/encrypted-seeding.md
@@ -1,0 +1,162 @@
+---
+id: encrypted-seeding
+title: Encrypted Data Seeding
+sidebar_label: Encrypted Seeding
+---
+
+# Encrypted Data Seeding
+
+Load confidential, identical baseline data into every tenant **without committing
+the plaintext to the repo**. The data lives in git only as an opaque encrypted
+blob; the decryption key is distributed out-of-band (for example, handed to
+participants at the start of a hackathon).
+
+The `seeds` core module provides the CLI; the reusable logic lives in
+`@open-mercato/shared/lib/seed` and can be called from a `setup.ts`
+`seedExamples` hook if you prefer automatic loading during `mercato auth setup`.
+
+## Why this exists
+
+Putting confidential data in a `seedExamples` function or a SQL dump leaks it —
+the plaintext is readable in the source tree, including by any agent/LLM that
+browses it. This mechanism separates two independent concerns:
+
+1. **Distribution confidentiality** — the seed file is AES-256-GCM encrypted with
+   a key (`OM_SEED_KEY`) that is *not* in the repo. Only the ciphertext is
+   committed.
+2. **Encryption-at-rest** — records are inserted through the ORM, so the
+   platform's per-tenant field encryption (`TenantDataEncryptionService`)
+   automatically encrypts marked fields. You never touch tenant DEKs.
+
+These are different layers. The platform's field encryption alone does **not**
+solve distribution confidentiality: if the plaintext sits in a seed function, the
+*source* is readable even though the DB column ends up encrypted. `OM_SEED_KEY` is
+deliberately separate from the field-encryption keys (`TENANT_DATA_ENCRYPTION_*` /
+Vault) — rotating or sharing one never affects the other.
+
+### Why not a database dump?
+
+A `pg_dump` captures the **ciphertext as stored**, tied to one specific
+`tenantId` + DEK. Restoring it only decrypts correctly if every participant shares
+the same `TENANT_DATA_ENCRYPTION_FALLBACK_KEY` + `LOOKUP_HASH_PEPPER` and the
+`tenantId` is preserved (derived-key mode only — **impossible with Vault**, where
+the DEK is random and lives server-side). It also fights with migrations and
+multi-tenant scoping. The encrypted-seed approach avoids all of this: you insert
+plaintext through the ORM and whatever encryption backend is configured encrypts
+transparently.
+
+## File format
+
+The plaintext seed document (before encryption):
+
+```jsonc
+{
+  "format": "om-seed",
+  "version": 1,
+  "records": [
+    {
+      "entity": "customers:customer_entity",   // platform entity id (module:entity)
+      "match": ["id"],                          // optional idempotency keys
+      "data": { "id": "…", "displayName": "Jane Doe", "primaryEmail": "…" }
+    }
+  ]
+}
+```
+
+Rules:
+
+- `entity` is the platform entity id (`module:entity`).
+- `data` keys are the **entity's property names** (camelCase, as declared on the
+  MikroORM entity), e.g. `displayName`, `primaryEmail`.
+- **Do not** put `tenantId`/`organizationId` in `data` — the loader injects the
+  target scope at load time, so the same blob seeds any tenant.
+- Records apply **in array order**; create parents before children for foreign-key
+  references (use explicit `id`s in `data` to reference them).
+- `match` enables idempotent re-runs (skip if a row already matches). Match fields
+  **must be non-encrypted natural keys** (`id`, `slug`, `code`, `*_hash`) —
+  encrypted fields have non-deterministic ciphertext and cannot be matched.
+
+The committed, encrypted envelope is opaque:
+
+```json
+{
+  "format": "om-encrypted-seed",
+  "version": 1,
+  "algorithm": "aes-256-gcm",
+  "payload": "<iv:ct:tag:v1>"
+}
+```
+
+## CLI
+
+```bash
+# 1. Generate a key once; distribute it out-of-band, never commit it.
+yarn mercato seeds keygen
+#   → prints a base64 32-byte key. Set OM_SEED_KEY=<key> for every participant.
+
+# 2. Author plaintext seed data locally (NOT committed), then encrypt it.
+OM_SEED_KEY=<key> yarn mercato seeds encrypt --in ./seed.json --out ./seed.enc.json
+#   → commit seed.enc.json (opaque); keep seed.json out of git (.gitignore).
+
+# 3. Edit later: decrypt → edit → re-encrypt.
+OM_SEED_KEY=<key> yarn mercato seeds decrypt --in ./seed.enc.json --out ./seed.json
+
+# 4. Load into a tenant (after `mercato auth setup` created the tenant/org).
+OM_SEED_KEY=<key> yarn mercato seeds load \
+  --in ./seed.enc.json --tenant <tenantId> --org <organizationId>
+
+#   Dry run (validates + reports counts, rolls back the transaction):
+OM_SEED_KEY=<key> yarn mercato seeds load --in ./seed.enc.json --tenant <t> --org <o> --dry-run
+
+#   Load an unencrypted file (local dev only):
+yarn mercato seeds load --in ./seed.json --tenant <t> --org <o> --plain
+```
+
+`--key <base64>` overrides `OM_SEED_KEY` on any command.
+
+| Command | Touches DB? | Purpose |
+|---------|-------------|---------|
+| `keygen` | no | Generate a base64 32-byte `OM_SEED_KEY` |
+| `encrypt` | no | Plaintext seed → opaque encrypted envelope |
+| `decrypt` | no | Envelope → plaintext (for editing) |
+| `load` | **yes** | Decrypt + insert into a tenant (idempotent, auto-encrypts at rest) |
+
+## Hackathon flow
+
+1. **Maintainer:** `seeds keygen` → share the key privately with participants.
+2. **Maintainer:** author `seed.json`, `seeds encrypt` it, commit only
+   `seed.enc.json`. Add the plaintext file to `.gitignore`.
+3. **Each participant:** set `OM_SEED_KEY`, run `mercato auth setup …` to create
+   their tenant, then
+   `mercato seeds load --in seed.enc.json --tenant <t> --org <o>`.
+
+Every participant ends up with identical baseline data, encrypted at rest in their
+own tenant, and the confidential plaintext never enters the repository.
+
+## Encryption backend interaction
+
+Whether loaded data is encrypted at rest depends on the configured KMS backend
+(see [the encryption configuration](../security/)):
+
+- **Vault** (`VAULT_ADDR` + `VAULT_TOKEN`) or a **derived fallback key**
+  (`TENANT_DATA_ENCRYPTION_FALLBACK_KEY`) → marked fields are encrypted at rest
+  automatically as records are inserted.
+- **Nothing configured** → the platform falls back to a no-op KMS and fields are
+  stored as plaintext. Ensure participants have a key source configured if
+  at-rest encryption matters for the seeded data.
+
+The seed mechanism itself is agnostic to this — it always inserts plaintext
+through the ORM and lets the configured backend do (or skip) the encryption.
+
+## Programmatic use
+
+The library is exported from `@open-mercato/shared/lib/seed`:
+
+```ts
+import { decryptSeedEnvelope, resolveSeedKey } from '@open-mercato/shared/lib/seed/crypto'
+import { loadSeedDocument } from '@open-mercato/shared/lib/seed/loader'
+
+// e.g. inside a setup.ts seedExamples hook
+const doc = decryptSeedEnvelope(envelopeJson, resolveSeedKey())
+await loadSeedDocument(em, doc, { tenantId, organizationId })
+```

--- a/apps/mercato/src/modules.ts
+++ b/apps/mercato/src/modules.ts
@@ -77,6 +77,7 @@ export const enabledModules: ModuleEntry[] = [
   { id: 'sales', from: '@open-mercato/core' },
   { id: 'api_keys', from: '@open-mercato/core' },
   { id: 'dictionaries', from: '@open-mercato/core' },
+  { id: 'seeds', from: '@open-mercato/core' },
   { id: 'content', from: '@open-mercato/content' },
   { id: 'onboarding', from: '@open-mercato/onboarding' },
   { id: 'api_docs', from: '@open-mercato/core' },

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-registry.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-registry.ts
@@ -37,7 +37,10 @@ async function importGeneratedAiAgentsModule(): Promise<Record<string, unknown> 
   } catch {
     const tsPath = findGeneratedFile('ai-agents.generated.ts')
     if (!tsPath) return null
-    return compileAndImportGenerated(tsPath)
+    // App-source modules (apps/<app>/src/modules/*/ai-agents.ts) are .ts that
+    // node cannot import directly — bundle their sources so one app-source agent
+    // does not abort the whole registry.
+    return compileAndImportGenerated(tsPath, { bundleLocalModules: true })
   }
 }
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/generated-registry-loader.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/generated-registry-loader.ts
@@ -65,8 +65,32 @@ export function findGeneratedFile(fileName: string): string | null {
  * pulls Next.js / route-handler internals into the `.mjs` and breaks at runtime
  * (e.g. `next/server` package-exports map).
  */
-export async function compileAndImportGenerated(tsPath: string): Promise<Record<string, unknown>> {
-  const jsPath = tsPath.replace(/\.ts$/, '.mjs')
+export type CompileGeneratedOptions = {
+  /**
+   * Compile-and-inline LOCAL (relative / `@/`) module sources so app-source TS
+   * contributions — `apps/<app>/src/modules/<m>/ai-tools.ts` / `ai-agents.ts` —
+   * load in the standalone node MCP server. Bare package specifiers
+   * (`@open-mercato/*`, `next`, `zod`, `@mikro-orm/*`, …) stay EXTERNAL and are
+   * resolved at runtime against the workspace's compiled `dist`, so this neither
+   * pulls Next.js internals into the bundle nor duplicates package singletons.
+   *
+   * Without this, a generated registry that statically imports an app-source
+   * `.ts` file throws `ERR_MODULE_NOT_FOUND` under plain node (it cannot load a
+   * `.ts`), which aborts the WHOLE registry — not just the one module.
+   * Default `false` keeps transpile-only behaviour for registries whose imports
+   * are all packages (e.g. `api-routes.generated.ts`).
+   */
+  bundleLocalModules?: boolean
+}
+
+export async function compileAndImportGenerated(
+  tsPath: string,
+  options: CompileGeneratedOptions = {},
+): Promise<Record<string, unknown>> {
+  const bundle = options.bundleLocalModules === true
+  // Separate output filename per mode so switching strategies never reuses a
+  // stale artifact from the other path via the mtime cache.
+  const jsPath = tsPath.replace(/\.ts$/, bundle ? '.bundled.mjs' : '.mjs')
   // appRoot is two directories up from `.mercato/generated/<file>.ts`.
   const appRoot = path.dirname(path.dirname(path.dirname(tsPath)))
 
@@ -80,16 +104,34 @@ export async function compileAndImportGenerated(tsPath: string): Promise<Record<
 
   if (needsCompile) {
     const esbuild = await import('esbuild')
-    const tsSource = fs.readFileSync(tsPath, 'utf-8')
-    const aliasRewritten = rewriteGeneratedAliasImports(tsSource, appRoot)
-    const result = await esbuild.transform(aliasRewritten, {
-      loader: 'ts',
-      format: 'esm',
-      target: 'node18',
-      sourcemap: false,
-      sourcefile: tsPath,
-    })
-    fs.writeFileSync(jsPath, result.code)
+    if (bundle) {
+      const result = await esbuild.build({
+        entryPoints: [tsPath],
+        bundle: true,
+        // Keep every bare package specifier external (runtime resolution);
+        // only relative / aliased app-source files get compiled and inlined.
+        packages: 'external',
+        format: 'esm',
+        platform: 'node',
+        target: 'node18',
+        sourcemap: false,
+        write: false,
+        logLevel: 'silent',
+        alias: { '@': appRoot },
+      })
+      fs.writeFileSync(jsPath, result.outputFiles[0].text)
+    } else {
+      const tsSource = fs.readFileSync(tsPath, 'utf-8')
+      const aliasRewritten = rewriteGeneratedAliasImports(tsSource, appRoot)
+      const result = await esbuild.transform(aliasRewritten, {
+        loader: 'ts',
+        format: 'esm',
+        target: 'node18',
+        sourcemap: false,
+        sourcefile: tsPath,
+      })
+      fs.writeFileSync(jsPath, result.code)
+    }
   }
 
   return (await import(pathToFileURL(jsPath).href)) as Record<string, unknown>

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/tool-loader.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/tool-loader.ts
@@ -172,7 +172,10 @@ async function importGeneratedAiToolsModule(): Promise<Record<string, unknown> |
   } catch {
     const tsPath = findGeneratedFile('ai-tools.generated.ts')
     if (!tsPath) return null
-    return compileAndImportGenerated(tsPath)
+    // App-source modules (apps/<app>/src/modules/*/ai-tools.ts) are .ts that
+    // node cannot import directly — bundle their sources so one app-source tool
+    // does not abort the whole registry.
+    return compileAndImportGenerated(tsPath, { bundleLocalModules: true })
   }
 }
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/tool-test-runner.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/tool-test-runner.ts
@@ -73,7 +73,9 @@ async function loadGeneratedTools(): Promise<{ moduleId: string; tools: AiToolDe
     )
   }
   await ensureApiRouteManifestsRegistered()
-  const mod = (await compileAndImportGenerated(tsPath)) as RawAiToolsModule
+  const mod = (await compileAndImportGenerated(tsPath, {
+    bundleLocalModules: true,
+  })) as RawAiToolsModule
   const entries = mod.aiToolConfigEntriesRaw ?? mod.aiToolConfigEntries ?? []
   const result: { moduleId: string; tools: AiToolDefinition[] }[] = []
   for (const entry of entries) {

--- a/packages/core/src/modules/seeds/README.md
+++ b/packages/core/src/modules/seeds/README.md
@@ -1,0 +1,86 @@
+# Seeds module — encrypted data seeding
+
+Load confidential, identical baseline data into every tenant without committing the
+plaintext to the repo. The data lives in the repo only as an **opaque encrypted
+blob**; the decryption key is distributed out-of-band (e.g. at hackathon kickoff).
+
+## Why this exists
+
+Putting confidential data in a `seedExamples` function or a SQL dump leaks it: the
+plaintext is readable in the source tree (including by any agent/LLM that browses
+it). This module separates the two concerns:
+
+1. **Distribution confidentiality** — the seed file is AES-256-GCM encrypted with a
+   key (`OM_SEED_KEY`) that is *not* in the repo. Only the ciphertext is committed.
+2. **Encryption-at-rest** — records are inserted through the ORM, so the platform's
+   per-tenant field encryption (`TenantDataEncryptionService`) automatically
+   encrypts marked fields. You never touch tenant DEKs.
+
+`OM_SEED_KEY` is independent from the field-encryption keys
+(`TENANT_DATA_ENCRYPTION_*` / Vault) — rotating one never affects the other.
+
+## File format (plaintext, before encryption)
+
+```jsonc
+{
+  "format": "om-seed",
+  "version": 1,
+  "records": [
+    {
+      "entity": "customers:customer_entity",   // platform entity id (module:entity)
+      "match": ["id"],                          // optional idempotency keys (non-encrypted only)
+      "data": { "id": "…", "displayName": "Jane Doe", "primaryEmail": "…" }
+    }
+  ]
+}
+```
+
+- `data` keys are the **entity's property names** (camelCase, as declared on the
+  MikroORM entity), e.g. `displayName`, `primaryEmail`.
+- **Do not** put `tenantId`/`organizationId` in `data` — the loader injects the
+  target scope at load time, so the same blob seeds any tenant.
+- Records apply **in array order**; create parents before children for FK refs
+  (use explicit `id`s in `data` to reference them).
+- `match` enables idempotent re-runs (skip if a row already matches). Match fields
+  **must be non-encrypted natural keys** (`id`, `slug`, `code`, `*_hash`) —
+  encrypted fields have non-deterministic ciphertext and cannot be matched.
+
+See `examples/sample-seed.json` for a runnable template.
+
+## CLI
+
+```bash
+# 1. Generate a key once; distribute it out-of-band, never commit it.
+yarn mercato seeds keygen
+#   → prints a base64 32-byte key. Set OM_SEED_KEY=<key> for every participant.
+
+# 2. Author plaintext seed data locally (NOT committed), then encrypt it.
+OM_SEED_KEY=<key> yarn mercato seeds encrypt --in ./seed.json --out ./seed.enc.json
+#   → commit seed.enc.json (opaque); keep seed.json out of git (.gitignore).
+
+# 3. Edit later: decrypt → edit → re-encrypt.
+OM_SEED_KEY=<key> yarn mercato seeds decrypt --in ./seed.enc.json --out ./seed.json
+
+# 4. Load into a tenant (after `mercato auth setup` created the tenant/org).
+OM_SEED_KEY=<key> yarn mercato seeds load \
+  --in ./seed.enc.json --tenant <tenantId> --org <organizationId>
+
+#   Dry run (validates + reports counts, rolls back the transaction):
+OM_SEED_KEY=<key> yarn mercato seeds load --in ./seed.enc.json --tenant <t> --org <o> --dry-run
+
+#   Load an unencrypted file (local dev only):
+yarn mercato seeds load --in ./seed.json --tenant <t> --org <o> --plain
+```
+
+`--key <base64>` overrides `OM_SEED_KEY` on any command.
+
+## Hackathon flow
+
+1. Maintainer: `seeds keygen` → share the key privately with participants.
+2. Maintainer: author `seed.json`, `seeds encrypt` it, commit only `seed.enc.json`.
+3. Each participant: set `OM_SEED_KEY`, run `mercato auth setup …` to create their
+   tenant, then `mercato seeds load --in seed.enc.json --tenant <t> --org <o>`.
+
+The generic library lives in `@open-mercato/shared/lib/seed` (`crypto`, `loader`,
+`types`) and can be reused from a `setup.ts` `seedExamples` hook if you prefer
+automatic loading during `mercato auth setup --with-examples`.

--- a/packages/core/src/modules/seeds/__tests__/cli-load-scope.test.ts
+++ b/packages/core/src/modules/seeds/__tests__/cli-load-scope.test.ts
@@ -1,0 +1,74 @@
+/** @jest-environment node */
+import { resolveSeedLoadScope } from '../cli'
+
+type ExecuteCall = { sql: string; params?: unknown[] }
+
+function createEm(rows: Array<Array<Record<string, unknown>>>) {
+  const calls: ExecuteCall[] = []
+  const execute = jest.fn(async (sql: string, params?: unknown[]) => {
+    calls.push({ sql, params })
+    return rows.shift() ?? []
+  })
+  const em = {
+    getConnection: () => ({ execute }),
+  }
+  return { em: em as Parameters<typeof resolveSeedLoadScope>[0], execute, calls }
+}
+
+describe('seeds CLI load scope auto-detection', () => {
+  it('keeps explicit tenant and organization without querying', async () => {
+    const { em, execute } = createEm([])
+
+    await expect(
+      resolveSeedLoadScope(em, { tenantId: 'tenant-1', organizationId: 'org-1' }),
+    ).resolves.toEqual({ tenantId: 'tenant-1', organizationId: 'org-1', inferred: false })
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  it('infers the only active tenant and organization', async () => {
+    const { em } = createEm([[{ id: 'tenant-1' }], [{ id: 'org-1' }]])
+
+    await expect(resolveSeedLoadScope(em, {})).resolves.toEqual({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      inferred: true,
+    })
+  })
+
+  it('infers the only organization for an explicit tenant', async () => {
+    const { em, calls } = createEm([[{ id: 'org-1' }]])
+
+    await expect(resolveSeedLoadScope(em, { tenantId: 'tenant-1' })).resolves.toEqual({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      inferred: true,
+    })
+    expect(calls[0]?.params).toEqual(['tenant-1'])
+  })
+
+  it('infers tenant from an explicit organization', async () => {
+    const { em } = createEm([[{ id: 'org-1', tenant_id: 'tenant-1' }]])
+
+    await expect(resolveSeedLoadScope(em, { organizationId: 'org-1' })).resolves.toEqual({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      inferred: true,
+    })
+  })
+
+  it('fails closed when tenant detection is ambiguous', async () => {
+    const { em } = createEm([[{ id: 'tenant-1' }, { id: 'tenant-2' }]])
+
+    await expect(resolveSeedLoadScope(em, {})).rejects.toThrow(
+      'Cannot auto-detect tenant: found multiple active tenants.',
+    )
+  })
+
+  it('fails closed when organization detection is ambiguous', async () => {
+    const { em } = createEm([[{ id: 'org-1' }, { id: 'org-2' }]])
+
+    await expect(resolveSeedLoadScope(em, { tenantId: 'tenant-1' })).rejects.toThrow(
+      'Cannot auto-detect organization: found multiple active organizations.',
+    )
+  })
+})

--- a/packages/core/src/modules/seeds/cli.ts
+++ b/packages/core/src/modules/seeds/cli.ts
@@ -14,6 +14,13 @@ import { loadSeedDocument } from '@open-mercato/shared/lib/seed/loader'
 import { seedDocumentSchema, type SeedDocument } from '@open-mercato/shared/lib/seed/types'
 import { createProgressBar, type ProgressBar } from '@open-mercato/shared/lib/cli/progress'
 
+type ScopeRow = { id: string; tenant_id?: string | null }
+
+type SeedLoadScopeInput = {
+  tenantId?: string
+  organizationId?: string
+}
+
 function parseArgs(rest: string[]): Record<string, string> {
   const args: Record<string, string> = {}
   for (let i = 0; i < rest.length; i += 1) {
@@ -30,6 +37,61 @@ function parseArgs(rest: string[]): Record<string, string> {
 
 function flag(value: string | undefined): boolean {
   return value === 'true' || value === ''
+}
+
+function printableScopeUsage(): string {
+  return 'Usage: mercato seeds load --in <file.enc.json> [--tenant <tenantId>] [--org <organizationId>] [--plain] [--dry-run] [--key <base64>]'
+}
+
+function requireSingleRow(rows: ScopeRow[], label: string, explicitFlag: string): ScopeRow {
+  if (rows.length === 1) return rows[0]
+  if (rows.length === 0) {
+    throw new Error(`Cannot auto-detect ${label}: no active ${label} exists. Pass ${explicitFlag}.`)
+  }
+  throw new Error(
+    `Cannot auto-detect ${label}: found multiple active ${label}s. Pass ${explicitFlag}.`,
+  )
+}
+
+export async function resolveSeedLoadScope(
+  em: EntityManager,
+  input: SeedLoadScopeInput,
+): Promise<{ tenantId: string; organizationId: string; inferred: boolean }> {
+  const tenantId = input.tenantId?.trim() || ''
+  const organizationId = input.organizationId?.trim() || ''
+  if (tenantId && organizationId) return { tenantId, organizationId, inferred: false }
+
+  const conn = em.getConnection()
+  if (organizationId && !tenantId) {
+    const orgRows = (await conn.execute(
+      'select id, tenant_id from organizations where id = ? and deleted_at is null and is_active = true limit 1',
+      [organizationId],
+    )) as ScopeRow[]
+    const org = requireSingleRow(orgRows, 'organization', '--tenant')
+    if (!org.tenant_id) {
+      throw new Error(`Cannot auto-detect tenant: organization ${organizationId} has no tenant_id.`)
+    }
+    return { tenantId: org.tenant_id, organizationId, inferred: true }
+  }
+
+  const resolvedTenantId = tenantId || requireSingleRow(
+    (await conn.execute(
+      'select id from tenants where deleted_at is null and is_active = true order by created_at asc, id asc limit 2',
+    )) as ScopeRow[],
+    'tenant',
+    '--tenant',
+  ).id
+
+  const resolvedOrganizationId = organizationId || requireSingleRow(
+    (await conn.execute(
+      'select id from organizations where tenant_id = ? and deleted_at is null and is_active = true order by created_at asc, id asc limit 2',
+      [resolvedTenantId],
+    )) as ScopeRow[],
+    'organization',
+    '--org',
+  ).id
+
+  return { tenantId: resolvedTenantId, organizationId: resolvedOrganizationId, inferred: true }
 }
 
 async function readJsonFile(file: string): Promise<unknown> {
@@ -104,10 +166,8 @@ const load: ModuleCli = {
     const organizationId = String(args.org ?? args.orgId ?? args.organizationId ?? '')
     const plain = flag(args.plain)
     const dryRun = flag(args['dry-run']) || flag(args.dryRun)
-    if (!input || !tenantId || !organizationId) {
-      console.error(
-        'Usage: mercato seeds load --in <file.enc.json> --tenant <tenantId> --org <organizationId> [--plain] [--dry-run] [--key <base64>]',
-      )
+    if (!input) {
+      console.error(printableScopeUsage())
       process.exitCode = 1
       return
     }
@@ -123,11 +183,23 @@ const load: ModuleCli = {
 
     const { resolve } = await createRequestContainer()
     const em = resolve<EntityManager>('em')
+    let scope: { tenantId: string; organizationId: string; inferred: boolean }
+    try {
+      scope = await resolveSeedLoadScope(em, { tenantId, organizationId })
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err))
+      console.error(printableScopeUsage())
+      process.exitCode = 1
+      return
+    }
+    if (scope.inferred) {
+      console.log(`Auto-detected seed scope: tenant=${scope.tenantId}, org=${scope.organizationId}`)
+    }
     let bar: ProgressBar | null = null
     const result = await loadSeedDocument(
       em,
       document,
-      { tenantId, organizationId },
+      { tenantId: scope.tenantId, organizationId: scope.organizationId },
       {
         dryRun,
         onProgress: ({ index, total }) => {

--- a/packages/core/src/modules/seeds/cli.ts
+++ b/packages/core/src/modules/seeds/cli.ts
@@ -1,0 +1,148 @@
+import type { ModuleCli } from '@open-mercato/shared/modules/registry'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import {
+  decryptSeedEnvelope,
+  encryptSeedDocument,
+  generateSeedKey,
+  resolveSeedKey,
+  SEED_KEY_ENV,
+} from '@open-mercato/shared/lib/seed/crypto'
+import { loadSeedDocument } from '@open-mercato/shared/lib/seed/loader'
+import { seedDocumentSchema, type SeedDocument } from '@open-mercato/shared/lib/seed/types'
+import { createProgressBar, type ProgressBar } from '@open-mercato/shared/lib/cli/progress'
+
+function parseArgs(rest: string[]): Record<string, string> {
+  const args: Record<string, string> = {}
+  for (let i = 0; i < rest.length; i += 1) {
+    const part = rest[i]
+    if (!part?.startsWith('--')) continue
+    const [keyRaw, valueRaw] = part.slice(2).split('=')
+    if (!keyRaw) continue
+    if (valueRaw !== undefined) args[keyRaw] = valueRaw
+    else if (i + 1 < rest.length && !rest[i + 1].startsWith('--')) args[keyRaw] = rest[i + 1]
+    else args[keyRaw] = 'true'
+  }
+  return args
+}
+
+function flag(value: string | undefined): boolean {
+  return value === 'true' || value === ''
+}
+
+async function readJsonFile(file: string): Promise<unknown> {
+  const raw = await fs.readFile(path.resolve(file), 'utf8')
+  return JSON.parse(raw)
+}
+
+const keygen: ModuleCli = {
+  command: 'keygen',
+  run() {
+    const key = generateSeedKey()
+    // Key to stdout (capturable); guidance to stderr so it does not pollute the value.
+    console.log(key)
+    console.error(
+      `\nGenerated a 32-byte base64 seed key. Distribute it out-of-band and set it for every participant:\n  ${SEED_KEY_ENV}=${key}\n`,
+    )
+  },
+}
+
+const encrypt: ModuleCli = {
+  command: 'encrypt',
+  async run(rest) {
+    const args = parseArgs(rest)
+    const input = args.in ?? args.input
+    const output = args.out ?? args.output
+    if (!input || !output) {
+      console.error(
+        'Usage: mercato seeds encrypt --in <plaintext.json> --out <file.enc.json> [--key <base64>]',
+      )
+      process.exitCode = 1
+      return
+    }
+    const key = resolveSeedKey(args.key)
+    const document = seedDocumentSchema.parse(await readJsonFile(input))
+    const envelope = encryptSeedDocument(document, key)
+    await fs.writeFile(path.resolve(output), `${JSON.stringify(envelope, null, 2)}\n`, 'utf8')
+    console.log(`Encrypted ${document.records.length} seed record(s) → ${output}`)
+  },
+}
+
+const decrypt: ModuleCli = {
+  command: 'decrypt',
+  async run(rest) {
+    const args = parseArgs(rest)
+    const input = args.in ?? args.input
+    const output = args.out ?? args.output
+    if (!input) {
+      console.error(
+        'Usage: mercato seeds decrypt --in <file.enc.json> [--out <plaintext.json>] [--key <base64>]',
+      )
+      process.exitCode = 1
+      return
+    }
+    const key = resolveSeedKey(args.key)
+    const document = decryptSeedEnvelope(await readJsonFile(input), key)
+    const json = `${JSON.stringify(document, null, 2)}\n`
+    if (output) {
+      await fs.writeFile(path.resolve(output), json, 'utf8')
+      console.log(`Decrypted → ${output}`)
+    } else {
+      process.stdout.write(json)
+    }
+  },
+}
+
+const load: ModuleCli = {
+  command: 'load',
+  async run(rest) {
+    const args = parseArgs(rest)
+    const input = args.in ?? args.input ?? args.file
+    const tenantId = String(args.tenant ?? args.tenantId ?? '')
+    const organizationId = String(args.org ?? args.orgId ?? args.organizationId ?? '')
+    const plain = flag(args.plain)
+    const dryRun = flag(args['dry-run']) || flag(args.dryRun)
+    if (!input || !tenantId || !organizationId) {
+      console.error(
+        'Usage: mercato seeds load --in <file.enc.json> --tenant <tenantId> --org <organizationId> [--plain] [--dry-run] [--key <base64>]',
+      )
+      process.exitCode = 1
+      return
+    }
+
+    const raw = await readJsonFile(input)
+    let document: SeedDocument
+    if (plain) {
+      document = seedDocumentSchema.parse(raw)
+    } else {
+      const key = resolveSeedKey(args.key)
+      document = decryptSeedEnvelope(raw, key)
+    }
+
+    const { resolve } = await createRequestContainer()
+    const em = resolve<EntityManager>('em')
+    let bar: ProgressBar | null = null
+    const result = await loadSeedDocument(
+      em,
+      document,
+      { tenantId, organizationId },
+      {
+        dryRun,
+        onProgress: ({ index, total }) => {
+          if (!bar) bar = createProgressBar(dryRun ? 'Validating seed' : 'Loading seed', total)
+          bar.update(index + 1)
+        },
+      },
+    )
+    ;(bar as ProgressBar | null)?.complete()
+    console.log(
+      `${dryRun ? '[dry-run] ' : ''}Seed load complete: ${result.created} created, ${result.skipped} skipped (of ${result.total}).`,
+    )
+  },
+}
+
+const seedsCliCommands: ModuleCli[] = [keygen, encrypt, decrypt, load]
+
+export default seedsCliCommands

--- a/packages/core/src/modules/seeds/examples/sample-seed.json
+++ b/packages/core/src/modules/seeds/examples/sample-seed.json
@@ -1,0 +1,26 @@
+{
+  "format": "om-seed",
+  "version": 1,
+  "records": [
+    {
+      "entity": "customers:customer_entity",
+      "match": ["id"],
+      "data": {
+        "id": "00000000-0000-0000-0000-0000000000a1",
+        "kind": "person",
+        "displayName": "Jane Doe",
+        "primaryEmail": "jane.doe@example.com",
+        "primaryPhone": "+48 600 000 000"
+      }
+    },
+    {
+      "entity": "customers:customer_address",
+      "data": {
+        "name": "Jane Doe",
+        "addressLine1": "ul. Przykładowa 1",
+        "city": "Warszawa",
+        "postalCode": "00-001"
+      }
+    }
+  ]
+}

--- a/packages/core/src/modules/seeds/index.ts
+++ b/packages/core/src/modules/seeds/index.ts
@@ -1,0 +1,11 @@
+import type { ModuleInfo } from '@open-mercato/shared/modules/registry'
+
+export const metadata: ModuleInfo = {
+  name: 'seeds',
+  title: 'Seeds',
+  version: '0.1.0',
+  description:
+    'Encrypted data seeding: encrypt confidential seed files for the repo and load them into a tenant on setup.',
+  author: 'Open Mercato Team',
+  license: 'Proprietary',
+}

--- a/packages/core/src/modules/workflows/backend/instances/[id]/page.tsx
+++ b/packages/core/src/modules/workflows/backend/instances/[id]/page.tsx
@@ -268,7 +268,7 @@ export default function WorkflowInstanceDetailPage({ params }: { params?: { id?:
     const { nodes, edges } = definitionToGraph(workflowDefinition.definition, { autoLayout: true })
 
     // Determine step statuses from events
-    const stepStatuses = new Map<string, 'completed' | 'active' | 'pending' | 'failed' | 'skipped'>()
+    const stepStatuses = new Map<string, 'completed' | 'active' | 'pending' | 'failed' | 'skipped' | 'paused'>()
     const stepTimings = new Map<string, { startedAt?: Date; completedAt?: Date }>()
 
     // Process events to determine status
@@ -290,11 +290,21 @@ export default function WorkflowInstanceDetailPage({ params }: { params?: { id?:
       }
     }
 
-    // Mark current step as active
-    if (instance?.currentStepId && !stepStatuses.has(instance.currentStepId)) {
-      stepStatuses.set(instance.currentStepId, 'active')
-    } else if (instance?.currentStepId && stepStatuses.get(instance.currentStepId) !== 'completed') {
-      stepStatuses.set(instance.currentStepId, 'active')
+    // Paint the current step to reflect the live instance state: a failed
+    // instance shows its parked step red, a paused/waiting one yellow, and an
+    // otherwise-running one blue (active). Never override a step that already
+    // reached a terminal status from its own events.
+    if (instance?.currentStepId) {
+      const existing = stepStatuses.get(instance.currentStepId)
+      if (existing !== 'completed' && existing !== 'failed') {
+        const liveStatus =
+          instance.status === 'FAILED'
+            ? 'failed'
+            : instance.status === 'PAUSED' || instance.status === 'WAITING_FOR_ACTIVITIES'
+            ? 'paused'
+            : 'active'
+        stepStatuses.set(instance.currentStepId, liveStatus)
+      }
     }
 
     // Mark all other steps as pending, with special handling for START/END
@@ -378,6 +388,15 @@ export default function WorkflowInstanceDetailPage({ params }: { params?: { id?:
             backgroundColor: '#EF4444', // red-500
             color: 'white',
             borderColor: '#B91C1C', // red-700
+            borderWidth: '3px',
+            borderRadius: '16px',
+          }
+          break
+        case 'paused':
+          style = {
+            backgroundColor: '#FEF9C3', // yellow-100
+            color: '#713F12', // yellow-900
+            borderColor: '#EAB308', // yellow-500
             borderWidth: '3px',
             borderRadius: '16px',
           }

--- a/packages/core/src/modules/workflows/components/WorkflowGraphImpl.tsx
+++ b/packages/core/src/modules/workflows/components/WorkflowGraphImpl.tsx
@@ -23,7 +23,7 @@ import {
 import {StartNode, EndNode, UserTaskNode, AutomatedNode, SubWorkflowNode, WaitForSignalNode, WaitForTimerNode, ParallelForkNode, ParallelJoinNode, InvokeAgentNode} from './nodes'
 import { WorkflowTransitionEdge } from './WorkflowTransitionEdge'
 import { WorkflowDataMappingEdge } from './WorkflowDataMappingEdge'
-import { STATUS_COLORS } from '../lib/status-colors'
+import { STATUS_COLORS, toWorkflowStatus } from '../lib/status-colors'
 import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
 import { Edit3 } from 'lucide-react'
 import { useTheme } from '@open-mercato/ui/theme'
@@ -242,7 +242,7 @@ export default function WorkflowGraphImpl({
           <MiniMap
             nodeStrokeWidth={3}
             nodeColor={(node) => {
-              const status = (node.data?.status || 'not_started') as keyof typeof STATUS_COLORS
+              const status = toWorkflowStatus(node.data?.status as string | undefined)
               return STATUS_COLORS[status]?.hex || STATUS_COLORS.not_started.hex
             }}
             maskColor="rgba(0, 0, 0, 0.1)"

--- a/packages/core/src/modules/workflows/components/WorkflowNodeCard.tsx
+++ b/packages/core/src/modules/workflows/components/WorkflowNodeCard.tsx
@@ -1,4 +1,4 @@
-import { Check, Play, Pause, Circle, Trash2 } from 'lucide-react'
+import { Check, Play, Pause, Circle, XCircle, Trash2 } from 'lucide-react'
 import { STATUS_COLORS, WorkflowStatus } from '../lib/status-colors'
 import { NODE_TYPE_ICONS, NODE_TYPE_COLORS, NODE_TYPE_LABELS, NodeType } from '../lib/node-type-icons'
 
@@ -51,6 +51,8 @@ export function WorkflowNodeCard({
     completed: Check,
     in_progress: Play,
     pending: Pause,
+    failed: XCircle,
+    paused: Pause,
     not_started: Circle,
   }[status]
 

--- a/packages/core/src/modules/workflows/components/nodes/AutomatedNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/AutomatedNode.tsx
@@ -2,7 +2,7 @@
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 
 /**
  * AutomatedNode display data.
@@ -38,16 +38,7 @@ export interface AutomatedNodeData {
 export function AutomatedNode({ id, data, isConnectable, selected }: NodeProps) {
   const nodeData = data as unknown as AutomatedNodeData
 
-  // Map old status values to new WorkflowStatus types
-  const mapStatus = (status?: string): WorkflowStatus => {
-    if (!status || status === 'pending') return 'not_started'
-    if (status === 'running' || status === 'in_progress') return 'in_progress'
-    if (status === 'completed') return 'completed'
-    if (status === 'error') return 'not_started'
-    return 'not_started'
-  }
-
-  const workflowStatus = mapStatus(nodeData.status)
+  const workflowStatus = toWorkflowStatus(nodeData.status)
 
   return (
     <div className="automated-node" title={nodeData.tooltip}>

--- a/packages/core/src/modules/workflows/components/nodes/EndNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/EndNode.tsx
@@ -2,7 +2,7 @@
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 
 export interface EndNodeData {
   label: string
@@ -21,16 +21,7 @@ export interface EndNodeData {
 export function EndNode({ id, data, isConnectable, selected }: NodeProps) {
   const nodeData = data as unknown as EndNodeData
 
-  // Map old status values to new WorkflowStatus types
-  const mapStatus = (status?: string): WorkflowStatus => {
-    if (!status || status === 'pending') return 'not_started'
-    if (status === 'running' || status === 'in_progress') return 'in_progress'
-    if (status === 'completed') return 'completed'
-    if (status === 'error') return 'not_started'
-    return 'not_started'
-  }
-
-  const workflowStatus = mapStatus(nodeData.status)
+  const workflowStatus = toWorkflowStatus(nodeData.status)
 
   return (
     <div className="end-node" title={nodeData.tooltip}>

--- a/packages/core/src/modules/workflows/components/nodes/InvokeAgentNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/InvokeAgentNode.tsx
@@ -2,7 +2,7 @@
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 
 export interface InvokeAgentNodeData {
@@ -30,15 +30,7 @@ export function InvokeAgentNode({ id, data, isConnectable, selected }: NodeProps
   const t = useT()
   const nodeData = data as unknown as InvokeAgentNodeData
 
-  const mapStatus = (status?: string): WorkflowStatus => {
-    if (!status || status === 'pending') return 'not_started'
-    if (status === 'running' || status === 'in_progress') return 'in_progress'
-    if (status === 'completed') return 'completed'
-    if (status === 'error') return 'not_started'
-    return 'not_started'
-  }
-
-  const workflowStatus = mapStatus(nodeData.status)
+  const workflowStatus = toWorkflowStatus(nodeData.status)
 
   const agentId =
     nodeData.agentId ||

--- a/packages/core/src/modules/workflows/components/nodes/ParallelForkNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/ParallelForkNode.tsx
@@ -2,7 +2,7 @@
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 
 /**
  * ParallelForkNode display data.
@@ -20,13 +20,6 @@ export interface ParallelForkNodeData {
   badge?: string
   tooltip?: string
   executionStatus?: 'completed' | 'active' | 'pending' | 'failed' | 'skipped'
-}
-
-function mapStatus(status?: string): WorkflowStatus {
-  if (!status || status === 'pending') return 'not_started'
-  if (status === 'running' || status === 'in_progress') return 'in_progress'
-  if (status === 'completed') return 'completed'
-  return 'not_started'
 }
 
 /**
@@ -49,7 +42,7 @@ export function ParallelForkNode({ id, data, isConnectable, selected }: NodeProp
       <WorkflowNodeCard
         title={nodeData.label}
         description={nodeData.description}
-        status={mapStatus(nodeData.status)}
+        status={toWorkflowStatus(nodeData.status)}
         nodeType="parallelFork"
         selected={selected}
         nodeId={id}

--- a/packages/core/src/modules/workflows/components/nodes/ParallelJoinNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/ParallelJoinNode.tsx
@@ -2,7 +2,7 @@
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 
 /**
  * ParallelJoinNode display data.
@@ -20,13 +20,6 @@ export interface ParallelJoinNodeData {
   badge?: string
   tooltip?: string
   executionStatus?: 'completed' | 'active' | 'pending' | 'failed' | 'skipped'
-}
-
-function mapStatus(status?: string): WorkflowStatus {
-  if (!status || status === 'pending') return 'not_started'
-  if (status === 'running' || status === 'in_progress') return 'in_progress'
-  if (status === 'completed') return 'completed'
-  return 'not_started'
 }
 
 /**
@@ -49,7 +42,7 @@ export function ParallelJoinNode({ id, data, isConnectable, selected }: NodeProp
       <WorkflowNodeCard
         title={nodeData.label}
         description={nodeData.description}
-        status={mapStatus(nodeData.status)}
+        status={toWorkflowStatus(nodeData.status)}
         nodeType="parallelJoin"
         selected={selected}
         nodeId={id}

--- a/packages/core/src/modules/workflows/components/nodes/StartNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/StartNode.tsx
@@ -2,7 +2,7 @@
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 
 export interface StartNodeData {
   label: string
@@ -20,16 +20,7 @@ export interface StartNodeData {
 export function StartNode({ id, data, isConnectable, selected }: NodeProps) {
   const nodeData = data as unknown as StartNodeData
 
-  // Map old status values to new WorkflowStatus types
-  const mapStatus = (status?: string): WorkflowStatus => {
-    if (!status || status === 'pending') return 'not_started'
-    if (status === 'running' || status === 'in_progress') return 'in_progress'
-    if (status === 'completed') return 'completed'
-    if (status === 'error') return 'not_started'
-    return 'not_started'
-  }
-
-  const workflowStatus = mapStatus(nodeData.status)
+  const workflowStatus = toWorkflowStatus(nodeData.status)
 
   return (
     <div className="start-node" title={nodeData.tooltip}>

--- a/packages/core/src/modules/workflows/components/nodes/SubWorkflowNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/SubWorkflowNode.tsx
@@ -4,7 +4,7 @@ import { Handle, Position, NodeProps } from '@xyflow/react'
 import { ArrowUpRight } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 import type { PortField } from '../../data/validators'
 
 export interface SubWorkflowNodeData {
@@ -49,15 +49,7 @@ export function SubWorkflowNode({ id, data, isConnectable, selected }: NodeProps
   const childInstanceCount = Array.isArray(nodeData.childInstanceIds) ? nodeData.childInstanceIds.length : 0
   const isNavigable = childInstanceCount > 0
 
-  const mapStatus = (status?: string): WorkflowStatus => {
-    if (!status || status === 'pending') return 'not_started'
-    if (status === 'running' || status === 'in_progress') return 'in_progress'
-    if (status === 'completed') return 'completed'
-    if (status === 'error') return 'not_started'
-    return 'not_started'
-  }
-
-  const workflowStatus = mapStatus(nodeData.status)
+  const workflowStatus = toWorkflowStatus(nodeData.status)
 
   const description = nodeData.description ||
     (nodeData.subWorkflowName

--- a/packages/core/src/modules/workflows/components/nodes/UserTaskNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/UserTaskNode.tsx
@@ -2,7 +2,7 @@
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 
 export interface UserTaskNodeData {
   label: string
@@ -24,16 +24,7 @@ export interface UserTaskNodeData {
 export function UserTaskNode({ id, data, isConnectable, selected }: NodeProps) {
   const nodeData = data as unknown as UserTaskNodeData
 
-  // Map old status values to new WorkflowStatus types
-  const mapStatus = (status?: string): WorkflowStatus => {
-    if (!status || status === 'pending') return 'not_started'
-    if (status === 'running' || status === 'in_progress') return 'in_progress'
-    if (status === 'completed') return 'completed'
-    if (status === 'error') return 'not_started'
-    return 'not_started'
-  }
-
-  const workflowStatus = mapStatus(nodeData.status)
+  const workflowStatus = toWorkflowStatus(nodeData.status)
 
   return (
     <div className="user-task-node" title={nodeData.tooltip}>

--- a/packages/core/src/modules/workflows/components/nodes/WaitForSignalNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/WaitForSignalNode.tsx
@@ -2,7 +2,7 @@
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 
 export interface WaitForSignalNodeData {
   label: string
@@ -23,16 +23,7 @@ export interface WaitForSignalNodeData {
 export function WaitForSignalNode({ id, data, isConnectable, selected }: NodeProps) {
   const nodeData = data as unknown as WaitForSignalNodeData
 
-  // Map old status values to new WorkflowStatus types
-  const mapStatus = (status?: string): WorkflowStatus => {
-    if (!status || status === 'pending') return 'not_started'
-    if (status === 'running' || status === 'in_progress') return 'in_progress'
-    if (status === 'completed') return 'completed'
-    if (status === 'error') return 'not_started'
-    return 'not_started'
-  }
-
-  const workflowStatus = mapStatus(nodeData.status)
+  const workflowStatus = toWorkflowStatus(nodeData.status)
 
   const description = nodeData.description ||
     (nodeData.signalName  ? `Waiting for signal: ${nodeData.signalName}` : 'Signal invocation')

--- a/packages/core/src/modules/workflows/components/nodes/WaitForTimerNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/WaitForTimerNode.tsx
@@ -2,7 +2,7 @@
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
-import { WorkflowStatus } from '../../lib/status-colors'
+import { toWorkflowStatus } from '../../lib/status-colors'
 
 export interface WaitForTimerNodeData {
   label: string
@@ -25,15 +25,7 @@ export interface WaitForTimerNodeData {
 export function WaitForTimerNode({ id, data, isConnectable, selected }: NodeProps) {
   const nodeData = data as unknown as WaitForTimerNodeData
 
-  const mapStatus = (status?: string): WorkflowStatus => {
-    if (!status || status === 'pending') return 'not_started'
-    if (status === 'running' || status === 'in_progress') return 'in_progress'
-    if (status === 'completed') return 'completed'
-    if (status === 'error') return 'not_started'
-    return 'not_started'
-  }
-
-  const workflowStatus = mapStatus(nodeData.status)
+  const workflowStatus = toWorkflowStatus(nodeData.status)
 
   const duration = nodeData.duration || nodeData.config?.duration
   const until = nodeData.until || nodeData.config?.until

--- a/packages/core/src/modules/workflows/lib/signal-handler.ts
+++ b/packages/core/src/modules/workflows/lib/signal-handler.ts
@@ -328,6 +328,15 @@ export async function sendSignal(
     return
   }
 
+  // Resume from the paused wait: flip to RUNNING before executing the transition
+  // and re-entering executeWorkflow. Without this the executor's defense-in-depth
+  // PAUSED check stops the run after the first traversed step, so an intermediate
+  // AUTOMATED step (e.g. an emit-event "flag") between the waiting step and END
+  // leaves the instance permanently parked — and any parent sub-workflow waiting on
+  // its completion never resumes. The no-transition branches above already do this.
+  instance.status = 'RUNNING'
+  await em.flush()
+
   // Execute transition to next step
   const transitionResult = await transitionHandler.executeTransition(
     em,

--- a/packages/core/src/modules/workflows/lib/status-colors.ts
+++ b/packages/core/src/modules/workflows/lib/status-colors.ts
@@ -1,4 +1,10 @@
-export type WorkflowStatus = 'completed' | 'in_progress' | 'pending' | 'not_started'
+export type WorkflowStatus =
+  | 'completed'
+  | 'in_progress'
+  | 'pending'
+  | 'failed'
+  | 'paused'
+  | 'not_started'
 
 export const STATUS_COLORS = {
   completed: {
@@ -22,6 +28,20 @@ export const STATUS_COLORS = {
     icon: 'text-yellow-600',
     hex: '#eab308',
   },
+  failed: {
+    bg: 'bg-status-error-bg',
+    border: 'border-status-error-border',
+    text: 'text-status-error-text',
+    icon: 'text-status-error-icon',
+    hex: '#ef4444',
+  },
+  paused: {
+    bg: 'bg-status-warning-bg',
+    border: 'border-status-warning-border',
+    text: 'text-status-warning-text',
+    icon: 'text-status-warning-icon',
+    hex: '#eab308',
+  },
   not_started: {
     bg: 'bg-muted',
     border: 'border-border',
@@ -30,6 +50,21 @@ export const STATUS_COLORS = {
     hex: '#6b7280',
   },
 } as const
+
+/**
+ * Normalize a raw execution/step status (any of the vocabularies used across the
+ * instance viewer, events, and definition graph) into a `WorkflowStatus` for
+ * node/minimap coloring. Keep this the single source of truth so every node
+ * type colors failed (red) and paused (yellow) steps consistently.
+ */
+export function toWorkflowStatus(status?: string): WorkflowStatus {
+  if (!status || status === 'pending') return 'not_started'
+  if (status === 'running' || status === 'in_progress' || status === 'active') return 'in_progress'
+  if (status === 'completed') return 'completed'
+  if (status === 'failed' || status === 'error') return 'failed'
+  if (status === 'paused' || status === 'waiting' || status === 'waiting_for_activities') return 'paused'
+  return 'not_started'
+}
 
 export type EdgeState = 'completed' | 'pending'
 

--- a/packages/enterprise/src/modules/agent_orchestrator/ai-skills.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/ai-skills.ts
@@ -15,8 +15,14 @@ const __esmDirname = path.dirname(fileURLToPath(import.meta.url))
 
 function resolveSkillsDir(): string | null {
   const candidates = [
+    // Colocated: source execution (tsx) or a build that copies skills into dist.
     path.join(__esmDirname, 'skills'),
-    path.join(process.cwd(), 'packages', 'core', 'src', 'modules', 'agent_orchestrator', 'skills'),
+    // Dist execution (e.g. mcp:serve runs the compiled package): walk from
+    // `<pkg>/dist/modules/agent_orchestrator` back to the source `skills` dir.
+    path.join(__esmDirname, '..', '..', '..', 'src', 'modules', 'agent_orchestrator', 'skills'),
+    // Repo-root cwd (this module lives in @open-mercato/enterprise, not core).
+    path.join(process.cwd(), 'packages', 'enterprise', 'src', 'modules', 'agent_orchestrator', 'skills'),
+    // Standalone app cwd.
     path.join(process.cwd(), 'src', 'modules', 'agent_orchestrator', 'skills'),
   ]
   return candidates.find((candidate) => fs.existsSync(candidate)) ?? null

--- a/packages/enterprise/src/modules/agent_orchestrator/ai-tools.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/ai-tools.ts
@@ -215,6 +215,10 @@ const loadSkillTool: AiToolDefinition = {
     if (!agentId) {
       return { ok: false as const, code: 'no_active_run' as const, error: 'no active run for this session' }
     }
+    // Populate the file-agent skill registry before resolving — on a fresh
+    // process this tool can be the first agent_orchestrator call, so the
+    // registry would otherwise be empty and reject a valid skill.
+    await ensureAgentsLoaded()
     const skill = getAgentSkill(agentId, skillId)
     if (!skill) {
       return {
@@ -276,6 +280,10 @@ const runSkillScriptTool: AiToolDefinition = {
     if (!agentId) {
       return { ok: false as const, code: 'no_active_run' as const, error: 'no active run for this session' }
     }
+    // Populate the file-agent skill registry before resolving — on a fresh
+    // process this tool can be the first agent_orchestrator call, so the
+    // registry would otherwise be empty and reject a valid skill/script.
+    await ensureAgentsLoaded()
     if (!getAgentSkill(agentId, skillId)) {
       return {
         ok: false as const,

--- a/packages/shared/src/lib/seed/__tests__/seed-crypto.test.ts
+++ b/packages/shared/src/lib/seed/__tests__/seed-crypto.test.ts
@@ -1,0 +1,64 @@
+import {
+  decryptSeedEnvelope,
+  encryptSeedDocument,
+  generateSeedKey,
+  resolveSeedKey,
+  SEED_KEY_ENV,
+} from '../crypto'
+import { encryptedSeedEnvelopeSchema, type SeedDocument } from '../types'
+
+const sampleDocument: SeedDocument = {
+  format: 'om-seed',
+  version: 1,
+  records: [
+    { entity: 'customers:customer_entity', match: ['id'], data: { id: 'abc', displayName: 'Jane Doe' } },
+    { entity: 'customers:customer_address', data: { name: 'HQ', city: 'Warsaw' } },
+  ],
+}
+
+describe('seed crypto', () => {
+  const originalEnv = process.env[SEED_KEY_ENV]
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[SEED_KEY_ENV]
+    else process.env[SEED_KEY_ENV] = originalEnv
+  })
+
+  it('generates a 32-byte base64 key', () => {
+    const key = generateSeedKey()
+    expect(Buffer.from(key, 'base64')).toHaveLength(32)
+  })
+
+  it('round-trips a document through encrypt/decrypt', () => {
+    const key = generateSeedKey()
+    const envelope = encryptSeedDocument(sampleDocument, key)
+    expect(() => encryptedSeedEnvelopeSchema.parse(envelope)).not.toThrow()
+    // The envelope must not leak plaintext.
+    expect(envelope.payload).not.toContain('Jane Doe')
+    const decrypted = decryptSeedEnvelope(envelope, key)
+    expect(decrypted).toEqual(sampleDocument)
+  })
+
+  it('produces a different ciphertext each time (randomized IV)', () => {
+    const key = generateSeedKey()
+    const a = encryptSeedDocument(sampleDocument, key)
+    const b = encryptSeedDocument(sampleDocument, key)
+    expect(a.payload).not.toEqual(b.payload)
+  })
+
+  it('fails to decrypt with the wrong key', () => {
+    const envelope = encryptSeedDocument(sampleDocument, generateSeedKey())
+    expect(() => decryptSeedEnvelope(envelope, generateSeedKey())).toThrow()
+  })
+
+  it('resolves the key from OM_SEED_KEY', () => {
+    const key = generateSeedKey()
+    process.env[SEED_KEY_ENV] = key
+    expect(resolveSeedKey()).toBe(key)
+  })
+
+  it('rejects a missing or malformed key', () => {
+    delete process.env[SEED_KEY_ENV]
+    expect(() => resolveSeedKey()).toThrow()
+    expect(() => resolveSeedKey('not-32-bytes')).toThrow()
+  })
+})

--- a/packages/shared/src/lib/seed/crypto.ts
+++ b/packages/shared/src/lib/seed/crypto.ts
@@ -1,0 +1,87 @@
+import crypto from 'node:crypto'
+import { decryptWithAesGcm, encryptWithAesGcm } from '../encryption/aes'
+import {
+  ENCRYPTED_SEED_ALGORITHM,
+  ENCRYPTED_SEED_FORMAT,
+  ENCRYPTED_SEED_VERSION,
+  encryptedSeedEnvelopeSchema,
+  seedDocumentSchema,
+  type EncryptedSeedEnvelope,
+  type SeedDocument,
+} from './types'
+
+/**
+ * Distribution-layer key for encrypting seed blobs committed to the repo. This is
+ * deliberately separate from the platform's per-tenant field-encryption keys
+ * (Vault / TENANT_DATA_ENCRYPTION_*): rotating or sharing the seed key never
+ * touches data-at-rest encryption.
+ */
+export const SEED_KEY_ENV = 'OM_SEED_KEY'
+
+const SEED_KEY_BYTES = 32
+
+function normalizeKey(value: string): string {
+  return value.trim().replace(/(?:^['"]|['"]$)/g, '')
+}
+
+/** Generate a fresh base64-encoded 32-byte seed key. */
+export function generateSeedKey(): string {
+  return crypto.randomBytes(SEED_KEY_BYTES).toString('base64')
+}
+
+/**
+ * Resolve and validate the seed key from an explicit value or `OM_SEED_KEY`.
+ * Throws a clear, actionable error when missing or malformed.
+ */
+export function resolveSeedKey(explicit?: string | null): string {
+  const raw = normalizeKey(explicit ?? process.env[SEED_KEY_ENV] ?? '')
+  if (!raw) {
+    throw new Error(
+      `[internal] Seed key missing: set ${SEED_KEY_ENV} (base64, 32 bytes) or pass --key. Generate one with "mercato seeds keygen".`,
+    )
+  }
+  let decoded: Buffer
+  try {
+    decoded = Buffer.from(raw, 'base64')
+  } catch {
+    throw new Error(`[internal] ${SEED_KEY_ENV} must be base64-encoded.`)
+  }
+  if (decoded.length !== SEED_KEY_BYTES) {
+    throw new Error(
+      `[internal] ${SEED_KEY_ENV} must decode to ${SEED_KEY_BYTES} bytes (got ${decoded.length}). Generate one with "mercato seeds keygen".`,
+    )
+  }
+  return raw
+}
+
+/** Encrypt a validated seed document into the opaque, committable envelope. */
+export function encryptSeedDocument(document: SeedDocument, key: string): EncryptedSeedEnvelope {
+  const doc = seedDocumentSchema.parse(document)
+  const json = JSON.stringify(doc)
+  const { value } = encryptWithAesGcm(json, key)
+  if (!value) {
+    throw new Error('[internal] Seed encryption produced no payload.')
+  }
+  return {
+    format: ENCRYPTED_SEED_FORMAT,
+    version: ENCRYPTED_SEED_VERSION,
+    algorithm: ENCRYPTED_SEED_ALGORITHM,
+    payload: value,
+  }
+}
+
+/** Decrypt and validate an envelope back into a seed document. */
+export function decryptSeedEnvelope(envelope: unknown, key: string): SeedDocument {
+  const parsed = encryptedSeedEnvelopeSchema.parse(envelope)
+  const json = decryptWithAesGcm(parsed.payload, key)
+  if (json === null) {
+    throw new Error('[internal] Seed decryption failed — wrong key or corrupted payload.')
+  }
+  let raw: unknown
+  try {
+    raw = JSON.parse(json)
+  } catch {
+    throw new Error('[internal] Decrypted seed is not valid JSON.')
+  }
+  return seedDocumentSchema.parse(raw)
+}

--- a/packages/shared/src/lib/seed/index.ts
+++ b/packages/shared/src/lib/seed/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './crypto'
+export * from './loader'

--- a/packages/shared/src/lib/seed/loader.ts
+++ b/packages/shared/src/lib/seed/loader.ts
@@ -34,11 +34,17 @@ function resolveEntityClass(meta: EntityMetadata<any>): unknown {
 
 function buildEntityIdIndex(em: EntityManager): Map<string, EntityMetadata<any>> {
   const storage = em.getMetadata() as unknown as {
-    getAll?: () => Record<string, EntityMetadata<any>> | EntityMetadata<any>[]
+    getAll?: () =>
+      | Map<unknown, EntityMetadata<any>>
+      | Record<string, EntityMetadata<any>>
+      | EntityMetadata<any>[]
     metadata?: Record<string, EntityMetadata<any>>
   }
   const all = (typeof storage.getAll === 'function' ? storage.getAll() : storage.metadata) ?? {}
-  const list: EntityMetadata<any>[] = Array.isArray(all) ? all : Object.values(all)
+  // MikroORM v7's instance getAll() returns a Map; older shapes returned a plain
+  // object or array. Normalize all three to a flat list.
+  const list: EntityMetadata<any>[] =
+    all instanceof Map ? [...all.values()] : Array.isArray(all) ? all : Object.values(all)
   const index = new Map<string, EntityMetadata<any>>()
   for (const meta of list) {
     if (!meta || (meta as any).abstract) continue

--- a/packages/shared/src/lib/seed/loader.ts
+++ b/packages/shared/src/lib/seed/loader.ts
@@ -1,0 +1,118 @@
+import type { EntityManager, EntityMetadata } from '@mikro-orm/postgresql'
+import { resolveEntityIdFromMetadata } from '../encryption/entityIds'
+import { seedDocumentSchema, type SeedDocument } from './types'
+
+export type SeedLoadScope = {
+  tenantId: string
+  organizationId: string
+}
+
+export type SeedLoadProgress = {
+  index: number
+  total: number
+  entity: string
+  action: 'created' | 'skipped'
+}
+
+export type SeedLoadOptions = {
+  /** Apply inside a transaction and roll it back; reports what would happen. */
+  dryRun?: boolean
+  onProgress?: (progress: SeedLoadProgress) => void
+}
+
+export type SeedLoadResult = {
+  total: number
+  created: number
+  skipped: number
+}
+
+class SeedDryRunRollback extends Error {}
+
+function resolveEntityClass(meta: EntityMetadata<any>): unknown {
+  return (meta as any).class ?? meta.className ?? meta.name
+}
+
+function buildEntityIdIndex(em: EntityManager): Map<string, EntityMetadata<any>> {
+  const storage = em.getMetadata() as unknown as {
+    getAll?: () => Record<string, EntityMetadata<any>> | EntityMetadata<any>[]
+    metadata?: Record<string, EntityMetadata<any>>
+  }
+  const all = (typeof storage.getAll === 'function' ? storage.getAll() : storage.metadata) ?? {}
+  const list: EntityMetadata<any>[] = Array.isArray(all) ? all : Object.values(all)
+  const index = new Map<string, EntityMetadata<any>>()
+  for (const meta of list) {
+    if (!meta || (meta as any).abstract) continue
+    const entityId = resolveEntityIdFromMetadata(meta)
+    if (!entityId) continue
+    if (!index.has(entityId)) index.set(entityId, meta)
+  }
+  return index
+}
+
+function hasProperty(meta: EntityMetadata<any>, name: string): boolean {
+  return Boolean(meta.properties && (meta.properties as Record<string, unknown>)[name])
+}
+
+/**
+ * Insert seed records through the ORM so the tenant-data-encryption subscriber
+ * encrypts marked fields at rest automatically. Records are applied in order;
+ * `tenantId`/`organizationId` are injected from `scope` for every entity that
+ * declares them. Records with a `match` list are skipped when an existing row
+ * matches (idempotent re-runs); match fields MUST be non-encrypted natural keys.
+ */
+export async function loadSeedDocument(
+  em: EntityManager,
+  document: SeedDocument,
+  scope: SeedLoadScope,
+  options: SeedLoadOptions = {},
+): Promise<SeedLoadResult> {
+  const doc = seedDocumentSchema.parse(document)
+  const index = buildEntityIdIndex(em)
+  const total = doc.records.length
+  let created = 0
+  let skipped = 0
+
+  const run = async (tem: EntityManager) => {
+    for (let i = 0; i < doc.records.length; i += 1) {
+      const record = doc.records[i]
+      const meta = index.get(record.entity)
+      if (!meta) {
+        throw new Error(
+          `[internal] Unknown seed entity "${record.entity}" at record ${i}: not a registered entity id.`,
+        )
+      }
+      const entityClass = resolveEntityClass(meta)
+      const data: Record<string, unknown> = { ...record.data }
+      if (hasProperty(meta, 'tenantId')) data.tenantId = scope.tenantId
+      if (hasProperty(meta, 'organizationId')) data.organizationId = scope.organizationId
+
+      if (record.match && record.match.length) {
+        const where: Record<string, unknown> = {}
+        for (const field of record.match) where[field] = data[field]
+        if (hasProperty(meta, 'tenantId')) where.tenantId = scope.tenantId
+        if (hasProperty(meta, 'organizationId')) where.organizationId = scope.organizationId
+        const existing = await tem.findOne(entityClass as any, where as any)
+        if (existing) {
+          skipped += 1
+          options.onProgress?.({ index: i, total, entity: record.entity, action: 'skipped' })
+          continue
+        }
+      }
+
+      const entity = tem.create(entityClass as any, data as any)
+      tem.persist(entity)
+      await tem.flush()
+      created += 1
+      options.onProgress?.({ index: i, total, entity: record.entity, action: 'created' })
+    }
+    if (options.dryRun) throw new SeedDryRunRollback()
+  }
+
+  try {
+    await em.transactional(run)
+  } catch (err) {
+    if (!(err instanceof SeedDryRunRollback)) throw err
+  }
+
+  return { total, created, skipped }
+}

--- a/packages/shared/src/lib/seed/types.ts
+++ b/packages/shared/src/lib/seed/types.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod'
+
+export const SEED_DOCUMENT_FORMAT = 'om-seed'
+export const SEED_DOCUMENT_VERSION = 1
+
+export const ENCRYPTED_SEED_FORMAT = 'om-encrypted-seed'
+export const ENCRYPTED_SEED_VERSION = 1
+export const ENCRYPTED_SEED_ALGORITHM = 'aes-256-gcm'
+
+/**
+ * A single record to seed. `entity` is the platform entity id (`module:entity`,
+ * e.g. `customers:customer_entity`). `data` keys are the entity's own property
+ * names (camelCase, as declared on the MikroORM entity). `match`, when present,
+ * lists property names used for an idempotent existence check before insert —
+ * these MUST be non-encrypted natural keys (id, slug, code, *_hash); encrypted
+ * fields cannot be matched because their ciphertext is non-deterministic.
+ */
+export const seedRecordSchema = z.object({
+  entity: z.string().min(1),
+  match: z.array(z.string().min(1)).optional(),
+  data: z.record(z.string(), z.unknown()),
+})
+export type SeedRecord = z.infer<typeof seedRecordSchema>
+
+/**
+ * The plaintext seed document. Records are applied in array order so authors can
+ * satisfy foreign-key dependencies (create the parent before the child). The
+ * document MUST NOT hard-code `tenantId`/`organizationId` — the loader injects
+ * the target scope at load time so the same document seeds any tenant.
+ */
+export const seedDocumentSchema = z.object({
+  format: z.literal(SEED_DOCUMENT_FORMAT),
+  version: z.literal(SEED_DOCUMENT_VERSION),
+  records: z.array(seedRecordSchema),
+})
+export type SeedDocument = z.infer<typeof seedDocumentSchema>
+
+/**
+ * The committed-to-repo, opaque envelope. `payload` is the encrypted seed
+ * document in the shared AES-GCM `iv:ct:tag:v1` wire format.
+ */
+export const encryptedSeedEnvelopeSchema = z.object({
+  format: z.literal(ENCRYPTED_SEED_FORMAT),
+  version: z.literal(ENCRYPTED_SEED_VERSION),
+  algorithm: z.literal(ENCRYPTED_SEED_ALGORITHM),
+  payload: z.string().min(1),
+})
+export type EncryptedSeedEnvelope = z.infer<typeof encryptedSeedEnvelopeSchema>


### PR DESCRIPTION
## What & why

Promotes the **generic, domain-agnostic improvements** developed on the `feat/agentic-claims-branch` hackathon branch into `feat/agent-orchestrator-mvp`, decoupled from the claims demo. Everything claims-specific (the `claims` module, the claims operator-cockpit UI, hackathon docs, module-trim config) is intentionally **left behind**.

Each change is an independent, cherry-picked commit so it can be reviewed and reverted in isolation. `#3689` (INVOKE_AGENT outputMapping), `#3690` (parent↔child nav) and `#3691` (AGENTS.md) are **already on this base** and are not re-included.

## What's included (7 commits)

**Workflow engine**
- **Resume-signal fix** — an instance is now flipped to `RUNNING` before re-executing the resumed transition. Without this, an intermediate AUTOMATED step between a wait-step and END leaves the instance permanently parked. Real engine bug, affects any signal-resumed workflow.
- **Status colors** — adds `failed` (red) / `paused` (yellow) states and a central `toWorkflowStatus()` normalizer; the node components drop their duplicated local `mapStatus()` in favor of it (pure DRY cleanup, no functional change).

**Encrypted data seeding (new platform capability)**
- `@open-mercato/shared/lib/seed/*` + `@open-mercato/core` `seeds` module + CLI. AES-256-GCM (reuses existing `lib/encryption/aes.ts`), zod-validated, DI-clean, tenant-scope auto-detect, idempotent `match`, `--dry-run`. Ships tests + README + docs. Zero domain coupling.

**MCP / file-agent loading fixes**
- **ai-assistant** — `bundleLocalModules` esbuild option lets the MCP server load app-source `ai-tools.ts`/`ai-agents.ts` so one bad import no longer drops the whole tool registry (incl. `submit_outcome`).
- **agent_orchestrator** — `ensureAgentsLoaded()` before skill lookups, and resolve the skills dir from the enterprise package path. Unblocks file-defined agents on a fresh OpenCode process.

## Not included (stays on the hackathon branch)
- `claims` module (~20k lines) and its specs
- agent_orchestrator operator-cockpit UI (`backend/processes/`, `processTypes.ts`, etc.) — hardcoded to the claims domain
- `apps/mercato/src/modules.ts` hackathon module-trim, docker/OpenCode Azure config, Polish/English hackathon docs
- `AgentInvokeConfigField.tsx` — incomplete (missing outputMapping UI)

The claims-only `apps/mercato/src/modules/claims/ai-tools.ts` edit bundled in the ai-assistant commit was dropped during cherry-pick (file does not exist on this base).

## Validation
- `yarn generate` ✅
- `yarn typecheck` ✅ (21/21 packages)
- Targeted unit tests ✅ — `seed-crypto` (6), `cli-load-scope` + `agent-result-mapping` + `instances.route` (58), `DataTable.render` (6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
