### PR TITLE
feat(customers): add initialValues prop to CreateDealForm

### DIFF
--- a/.ai/specs/2026-07-02-deal-create-initial-values.md
+++ b/.ai/specs/2026-07-02-deal-create-initial-values.md
@@ -22,17 +22,20 @@ Add an optional, additive prop and use a lazy initializer that merges it over `E
 ```ts
 export type CreateDealFormProps = {
   returnTo: string
-  /** Seed values merged over EMPTY_VALUES for the initial form state. Additive: omitting it preserves current behavior. */
+  /** Seed values merged over EMPTY_VALUES for the initial form state. Entries set to `undefined` are ignored (the EMPTY_VALUES default wins), so a sparse `Partial<BaseValues>` can never unset a required field. Additive: omitting it preserves current behavior. */
   initialValues?: Partial<BaseValues>
 }
 
 export function CreateDealForm({ returnTo, initialValues }: CreateDealFormProps) {
-  const [values, setValues] = React.useState<BaseValues>(() => ({ ...EMPTY_VALUES, ...initialValues }))
+  const [values, setValues] = React.useState<BaseValues>(() => {
+    const definedSeedEntries = Object.entries(initialValues ?? {}).filter(([, seedValue]) => seedValue !== undefined)
+    return { ...EMPTY_VALUES, ...Object.fromEntries(definedSeedEntries) }
+  })
   // ...unchanged
 }
 ```
 
-Consumers can seed the simple fields (`status`, `valueCurrency`, `expectedCloseAt`, `title`, `description`). Pipeline/stage prefill is intentionally out of scope for this prop because it needs runtime resolution (env-specific IDs) plus the pipeline→stage cascade — see Proposed Follow-ups.
+Consumers can seed the simple fields (`status`, `valueCurrency`, `expectedCloseAt`, `title`, `description`). Explicitly-`undefined` entries are filtered before the merge — under `Partial<BaseValues>` a caller may legally pass `{ personIds: maybeIds }` where `maybeIds` is `undefined`, and a plain spread would override the non-optional `EMPTY_VALUES` invariant (crashing e.g. `values.personIds.length` on submit or flipping controlled selects to uncontrolled). Pipeline/stage prefill is intentionally out of scope for this prop because it needs runtime resolution (env-specific IDs) plus the pipeline→stage cascade — see Proposed Follow-ups.
 
 ## Backward Compatibility
 
@@ -51,3 +54,4 @@ Purely additive. When `initialValues` is omitted the initializer resolves to `EM
 ## Changelog
 
 - 2026-07-02 — Initial spec + additive `initialValues` prop on `CreateDealForm`. Follow-ups (auto-default-pipeline, pluggable page defaults) proposed for maintainer decision.
+- 2026-07-04 — Harden the merge: explicitly-`undefined` entries in `initialValues` are filtered out before spreading over `EMPTY_VALUES`, so a sparse `Partial<BaseValues>` cannot unset a required default (review finding).

--- a/.ai/specs/2026-07-02-deal-create-initial-values.md
+++ b/.ai/specs/2026-07-02-deal-create-initial-values.md
@@ -1,0 +1,53 @@
+# Deal create form: `initialValues` prop for prefilled defaults
+
+## TLDR
+
+`CreateDealForm` starts every new deal from `EMPTY_VALUES` and exposes only a `returnTo` prop, so downstream apps cannot pre-fill the "new deal" form (default status, currency, expected close date, etc.). This adds an additive, opt-in `initialValues?: Partial<BaseValues>` prop merged over `EMPTY_VALUES` for the initial form state. Omitting it preserves current behavior exactly. It also proposes two follow-ups — an opt-in auto-select of the default pipeline + first stage, and a pluggable way for `create/page.tsx` to source per-tenant defaults — for maintainer decision.
+
+## Problem
+
+Downstream apps frequently need new deals to open with sensible defaults (e.g. status = active, the org's default pipeline + first stage, a base currency, an expected close date N days out). Today that is not possible without forking the component:
+
+- `CreateDealForm` initializes local state to `EMPTY_VALUES` and takes only `returnTo`.
+- The form is bespoke (not a generic `CrudForm`), so there is no field-injection spot to seed values.
+- Overriding the page component via the component-replacement registry renders the swapped client component under a different React instance in the App Router server catch-all, which breaks all hooks (`Invalid hook call` / `Cannot read properties of null (reading 'useContext')`). `next/dynamic` does not resolve it.
+- Path-shadowing the route loses `findBackendMatch` (first-match by module order; a core route registered before an app module always wins).
+
+Net: there is no clean, upgrade-safe downstream mechanism to prefill this form.
+
+## Solution (this change)
+
+Add an optional, additive prop and use a lazy initializer that merges it over `EMPTY_VALUES`:
+
+```ts
+export type CreateDealFormProps = {
+  returnTo: string
+  /** Seed values merged over EMPTY_VALUES for the initial form state. Additive: omitting it preserves current behavior. */
+  initialValues?: Partial<BaseValues>
+}
+
+export function CreateDealForm({ returnTo, initialValues }: CreateDealFormProps) {
+  const [values, setValues] = React.useState<BaseValues>(() => ({ ...EMPTY_VALUES, ...initialValues }))
+  // ...unchanged
+}
+```
+
+Consumers can seed the simple fields (`status`, `valueCurrency`, `expectedCloseAt`, `title`, `description`). Pipeline/stage prefill is intentionally out of scope for this prop because it needs runtime resolution (env-specific IDs) plus the pipeline→stage cascade — see Proposed Follow-ups.
+
+## Backward Compatibility
+
+Purely additive. When `initialValues` is omitted the initializer resolves to `EMPTY_VALUES` — byte-for-byte the previous behavior. No change to the `returnTo` contract, the submit payload, or the rendered fields. No migration. Aligns with the additive-only classification for component props in `BACKWARD_COMPATIBILITY.md`.
+
+## Proposed Follow-ups (for maintainer decision)
+
+1. **Auto-select the default pipeline + first stage** (opt-in, e.g. `autoSelectDefaultPipeline?: boolean`). The form already loads pipelines via `useDealPipelines`; on create it could pick the `isDefault` pipeline (fallback: first) and its first stage (by `order`), driving `loadStages`. Generally useful — most CRMs want a new deal to land in the default pipeline's entry stage. Kept opt-in to preserve current behavior.
+2. **Pluggable per-tenant defaults in `create/page.tsx`.** The core create page renders `<CreateDealForm returnTo=… />` and does not pass `initialValues`, so a downstream app still cannot inject defaults without overriding the page (which hits the dual-React problem above). Proposal: have the create page source `initialValues` (and any auto-select flag) from a pluggable seam — e.g. `ModuleConfigService` (tenant-scoped `module_configs`), a DI-resolvable defaults provider, or a documented hook — so apps configure defaults declaratively without replacing the page. Final shape is a maintainer call.
+
+## Testing
+
+- `yarn typecheck` — the additive prop + functional initializer type-check.
+- Manual: render `CreateDealForm` with and without `initialValues`; confirm omitted → empty form (unchanged), provided → fields pre-filled and editable.
+
+## Changelog
+
+- 2026-07-02 — Initial spec + additive `initialValues` prop on `CreateDealForm`. Follow-ups (auto-default-pipeline, pluggable page defaults) proposed for maintainer decision.

--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -102,6 +102,7 @@ Specs awaiting implementation or partially complete. Focus here for actionable w
 | [Coding-Agent Session Collection](2026-06-15-coding-agent-session-collection.md) | 2026-06-15 | Coding-Agent Session Collection (Dev Session Insights) | Opt-in, consent-gated collection of sanitized Claude Code / Codex sessions: `create-mercato-app` hook installer, local PII/secret redaction (`@open-mercato/dev-session-kit`), fail-open shipper, and the OSS `coding_sessions` ingestion module (token `202` endpoint, async worker with server-side re-scan + quarantine, filesystem-first blobs + metadata index). Complements the telemetry/phone-home specs |
 | [Dictionary Custom Field Multiselect](2026-06-19-dictionary-custom-field-multiselect.md) | 2026-06-19 | Dictionary Custom Field Multiselect | Dictionary-backed custom fields can opt into multi-select CRUD form rendering while reusing existing EAV array persistence |
 | [Package Previews](2026-06-22-label-based-package-previews.md) | 2026-06-22 | Label-Based Package Previews | Label-triggered pkg.pr.new previews with npm canary snapshots moved behind a separate opt-in label |
+| [Deal Create Initial Values](2026-07-02-deal-create-initial-values.md) | 2026-07-02 | Deal Create Form `initialValues` Prop | Additive opt-in `initialValues` prop on `CreateDealForm` so downstream apps can prefill new-deal defaults; proposes auto-default-pipeline + pluggable per-tenant page defaults |
 
 ### Implemented Specifications
 

--- a/packages/core/src/modules/customers/components/detail/create/CreateDealForm.tsx
+++ b/packages/core/src/modules/customers/components/detail/create/CreateDealForm.tsx
@@ -27,7 +27,7 @@ const CUSTOM_FIELDS_MANAGE_HREF = `/backend/entities/system/${encodeURIComponent
 
 export type CreateDealFormProps = {
   returnTo: string
-  /** Seed values merged over EMPTY_VALUES for the initial form state. Additive: omitting it preserves current behavior. */
+  /** Seed values merged over EMPTY_VALUES for the initial form state. Entries set to `undefined` are ignored (the EMPTY_VALUES default wins), so a sparse `Partial<BaseValues>` can never unset a required field. Additive: omitting it preserves current behavior. */
   initialValues?: Partial<BaseValues>
 }
 
@@ -40,7 +40,10 @@ export function CreateDealForm({ returnTo, initialValues }: CreateDealFormProps)
     [t],
   )
 
-  const [values, setValues] = React.useState<BaseValues>(() => ({ ...EMPTY_VALUES, ...initialValues }))
+  const [values, setValues] = React.useState<BaseValues>(() => {
+    const definedSeedEntries = Object.entries(initialValues ?? {}).filter(([, seedValue]) => seedValue !== undefined)
+    return { ...EMPTY_VALUES, ...Object.fromEntries(definedSeedEntries) }
+  })
   const [errors, setErrors] = React.useState<Record<string, string>>({})
   const [isSubmitting, setIsSubmitting] = React.useState(false)
 

--- a/packages/core/src/modules/customers/components/detail/create/CreateDealForm.tsx
+++ b/packages/core/src/modules/customers/components/detail/create/CreateDealForm.tsx
@@ -27,9 +27,11 @@ const CUSTOM_FIELDS_MANAGE_HREF = `/backend/entities/system/${encodeURIComponent
 
 export type CreateDealFormProps = {
   returnTo: string
+  /** Seed values merged over EMPTY_VALUES for the initial form state. Additive: omitting it preserves current behavior. */
+  initialValues?: Partial<BaseValues>
 }
 
-export function CreateDealForm({ returnTo }: CreateDealFormProps) {
+export function CreateDealForm({ returnTo, initialValues }: CreateDealFormProps) {
   const t = useT()
   const router = useRouter()
   const tr = React.useCallback(
@@ -38,7 +40,7 @@ export function CreateDealForm({ returnTo }: CreateDealFormProps) {
     [t],
   )
 
-  const [values, setValues] = React.useState<BaseValues>(EMPTY_VALUES)
+  const [values, setValues] = React.useState<BaseValues>(() => ({ ...EMPTY_VALUES, ...initialValues }))
   const [errors, setErrors] = React.useState<Record<string, string>>({})
   const [isSubmitting, setIsSubmitting] = React.useState(false)
 


### PR DESCRIPTION
## What

Adds an additive, opt-in `initialValues?: Partial<BaseValues>` prop to `CreateDealForm`, merged over `EMPTY_VALUES` for the initial form state. Omitting it preserves current behavior exactly.

## Why (user impact)

Downstream apps need new deals to open with sensible defaults (status, currency, expected close date, …). Today that requires forking the component:

- `CreateDealForm` inits state to `EMPTY_VALUES` and takes only `returnTo`; it's bespoke (not a `CrudForm`), so there is no field-injection spot to seed values.
- Overriding the page via the component-replacement registry renders the swapped client component under a **different React instance** in the App Router server catch-all → every hook throws (`Invalid hook call` / `Cannot read properties of null (reading 'useContext')`); `next/dynamic` does not fix it.
- Path-shadowing the route loses `findBackendMatch` (first-match by module order; a core route registered before an app module always wins).

An additive prop is the clean, upgrade-safe seam.

## Change

```diff
 export type CreateDealFormProps = {
   returnTo: string
+  initialValues?: Partial<BaseValues>
 }
-  const [values, setValues] = React.useState<BaseValues>(EMPTY_VALUES)
+  const [values, setValues] = React.useState<BaseValues>(() => ({ ...EMPTY_VALUES, ...initialValues }))
```

## Backward compatibility

Purely additive. When `initialValues` is omitted the initializer resolves to `EMPTY_VALUES` — byte-for-byte the previous behavior. No change to the `returnTo` contract, the submit payload, or the rendered fields. No migration. Additive-only per `BACKWARD_COMPATIBILITY.md`.

## Testing

- Targeted typecheck of the changed file (additive prop + functional `useState` initializer are type-safe: `Partial<BaseValues>` spread over the full `EMPTY_VALUES` yields `BaseValues`).
- Manual: render `CreateDealForm` with and without `initialValues` → omitted = empty form (unchanged), provided = fields pre-filled and editable.
- Full `typecheck` / `lint` / `test` run in CI.

## Proposed follow-ups (maintainer decision — happy to implement here or separately)

1. **Auto-select the default pipeline + first stage** (opt-in, e.g. `autoSelectDefaultPipeline?: boolean`). The form already loads pipelines via `useDealPipelines`; on create it could pick the `isDefault` pipeline (fallback: first) and its first stage (by `order`), driving `loadStages`. Generally useful — most CRMs want a new deal to land in the default pipeline's entry stage. Kept opt-in to preserve current behavior. `initialValues` intentionally does not cover pipeline/stage, since those need runtime resolution (env-specific IDs) plus the pipeline→stage cascade.
2. **Pluggable per-tenant defaults in `create/page.tsx`.** The core create page renders `<CreateDealForm returnTo=… />` without `initialValues`, so a downstream app still cannot inject defaults without overriding the page (which hits the dual-React problem above). Proposal: source `initialValues` (and any auto-select flag) from a pluggable seam — e.g. `ModuleConfigService` (tenant-scoped `module_configs`), a DI-resolvable defaults provider, or a documented hook — so apps configure defaults declaratively without replacing the page. Final shape is your call.

## Spec

`.ai/specs/2026-07-02-deal-create-initial-values.md` (+ directory entry in `.ai/specs/README.md`).

Base branch: `develop` (per `CONTRIBUTING.md`).
