### PR TITLE
feat(currencies): move currency management into Settings

### DIFF
--- a/packages/core/src/modules/auth/lib/backendChrome.tsx
+++ b/packages/core/src/modules/auth/lib/backendChrome.tsx
@@ -95,8 +95,9 @@ const settingsSectionOrder: Record<string, number> = {
   'customer-portal': 3,
   'data-designer': 4,
   'module-configs': 5,
-  directory: 6,
-  'feature-toggles': 7,
+  currencies: 6,
+  directory: 7,
+  'feature-toggles': 8,
 }
 
 type NavGroupWithWeight = Omit<BackendChromeNavGroup, 'id' | 'defaultName' | 'items'> & {

--- a/packages/core/src/modules/currencies/backend/config/currency-fetching/page.meta.ts
+++ b/packages/core/src/modules/currencies/backend/config/currency-fetching/page.meta.ts
@@ -1,22 +1,11 @@
-import React from 'react'
-
-const exchangeRateIcon = React.createElement(
-  'svg',
-  { width: 16, height: 16, viewBox: '0 0 24 24', fill: 'none', stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round' },
-  React.createElement('path', { d: 'M7 16l-4-4 4-4' }),
-  React.createElement('path', { d: 'M3 12h11' }),
-  React.createElement('path', { d: 'M17 8l4 4-4 4' }),
-  React.createElement('path', { d: 'M21 12H10' }),
-)
-
 export const metadata = {
-  icon: exchangeRateIcon,
+  icon: 'download',
   requireAuth: true,
   requireFeatures: ['currencies.fetch.view'],
-  pageGroup: 'Module Configs',
-  pageGroupKey: 'settings.sections.moduleConfigs',
+  pageGroup: 'Currencies',
+  pageGroupKey: 'currencies.nav.group',
   pageTitle: 'Currency Rate Fetching',
   pageTitleKey: 'currencies.fetch.title',
-  pageOrder: 4,
+  pageOrder: 30,
   pageContext: 'settings' as const,
 }

--- a/packages/core/src/modules/currencies/backend/currencies/page.meta.ts
+++ b/packages/core/src/modules/currencies/backend/currencies/page.meta.ts
@@ -5,8 +5,8 @@ export const metadata = {
   pageTitleKey: 'currencies.page.title',
   pageGroup: 'Currencies',
   pageGroupKey: 'currencies.nav.group',
-  pagePriority: 60,
   pageOrder: 10,
+  pageContext: 'settings' as const,
   icon: 'coins',
   breadcrumb: [{ label: 'Currencies', labelKey: 'currencies.page.title' }],
 }

--- a/packages/core/src/modules/currencies/backend/exchange-rates/page.meta.ts
+++ b/packages/core/src/modules/currencies/backend/exchange-rates/page.meta.ts
@@ -6,6 +6,7 @@ export const metadata = {
   pageGroup: 'Currencies',
   pageGroupKey: 'currencies.nav.group',
   pageOrder: 20,
+  pageContext: 'settings' as const,
   icon: 'refresh-cw',
   breadcrumb: [
     { label: 'Currencies', labelKey: 'currencies.page.title', href: '/backend/currencies' },


### PR DESCRIPTION
## What

Declutters the top-level backend sidebar by moving currency management into the **Settings** section.

- **Currencies**, **Exchange Rates**, and **Currency Rate Fetching** now live under a dedicated **Currencies** group inside Settings (`pageContext: 'settings'`), instead of appearing as top-level / Module Configs entries.
- The Currencies settings group is ordered at position 6, ahead of Directory and Feature Toggles.
- Rate Fetching moves out of the generic "Module Configs" group into the Currencies group.

## Why

The top-level sidebar was getting crowded; currency config is administrative and belongs alongside other settings.

## Changes

- `auth/lib/backendChrome.tsx` — insert `currencies` into `settingsSectionOrder` (6), shift `directory`→7, `feature-toggles`→8.
- `currencies/backend/currencies/page.meta.ts` — `pageContext: 'settings'`, drop `pagePriority`.
- `currencies/backend/exchange-rates/page.meta.ts` — `pageContext: 'settings'`.
- `currencies/backend/config/currency-fetching/page.meta.ts` — repoint to the Currencies nav group, `pageOrder: 30`.

## Verification

Ran the dev server locally; confirmed the three currency pages render under Settings → Currencies and the app boots/serves 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)