### PR TITLE
fix(catalog): order Products before Categories in sidebar

### DIFF
--- a/packages/core/src/modules/catalog/backend/catalog/categories/page.meta.ts
+++ b/packages/core/src/modules/catalog/backend/catalog/categories/page.meta.ts
@@ -6,7 +6,7 @@ export const metadata = {
   pageGroup: 'Catalog',
   pageGroupKey: 'catalog.nav.group',
   pagePriority: 30,
-  pageOrder: 90,
+  pageOrder: 100,
   icon: 'folder-tree',
   breadcrumb: [{ label: 'Categories', labelKey: 'catalog.categories.page.title' }],
 }

--- a/packages/core/src/modules/catalog/backend/catalog/products/page.meta.ts
+++ b/packages/core/src/modules/catalog/backend/catalog/products/page.meta.ts
@@ -6,7 +6,7 @@ export const metadata = {
   pageGroup: 'Catalog',
   pageGroupKey: 'catalog.nav.group',
   pagePriority: 30,
-  pageOrder: 100,
+  pageOrder: 90,
   icon: 'package',
   breadcrumb: [{ label: 'Products & services', labelKey: 'catalog.products.page.title' }],
 }


### PR DESCRIPTION
## Summary

Swap the Catalog sidebar navigation ordering so **Products & services** renders above **Categories**.

The two entries live in the same `Catalog` nav group; ordering is driven by `pageOrder` (lower renders first). Previously Categories had `pageOrder: 90` and Products `100`, so Categories appeared first. This swaps the values.

## Changes

- `catalog/backend/catalog/products/page.meta.ts`: `pageOrder` 100 → 90
- `catalog/backend/catalog/categories/page.meta.ts`: `pageOrder` 90 → 100

## Test plan

- [ ] Open the backend sidebar and confirm **Products & services** now appears above **Categories** in the Catalog group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)