### PR TITLE
fix(inbox_ops): show status for non-pending proposal actions (#3671)

### DIFF
--- a/packages/core/src/modules/inbox_ops/components/proposals/ActionCard.tsx
+++ b/packages/core/src/modules/inbox_ops/components/proposals/ActionCard.tsx
@@ -324,6 +324,29 @@ export function ActionCard({
     )
   }
 
+  if (action.status !== 'pending') {
+    const isProcessing = action.status === 'processing'
+    const statusLabel = action.status === 'accepted'
+      ? t('inbox_ops.status.accepted', 'Accepted')
+      : isProcessing
+        ? t('inbox_ops.status.processing', 'Processing')
+        : action.status
+    return (
+      <div className="border rounded-lg p-3 md:p-4 bg-muted/50">
+        <div className="flex items-center gap-2 mb-2">
+          {isProcessing ? (
+            <RefreshCw className="h-5 w-5 text-muted-foreground flex-shrink-0 animate-spin" />
+          ) : (
+            <CheckCircle className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+          )}
+          <span className="text-sm font-medium">{label}</span>
+          <span className="text-xs text-muted-foreground">{statusLabel}</span>
+        </div>
+        <p className="text-sm text-muted-foreground">{displayDescription}</p>
+      </div>
+    )
+  }
+
   const hasNameIssue = hasContactNameIssue(action)
 
   return (

--- a/packages/core/src/modules/inbox_ops/components/proposals/__tests__/ActionCard.test.tsx
+++ b/packages/core/src/modules/inbox_ops/components/proposals/__tests__/ActionCard.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { ActionCard } from '../ActionCard'
+import type { ActionDetail } from '../types'
+
+function makeAction(overrides: Partial<ActionDetail> = {}): ActionDetail {
+  return {
+    id: 'action-1',
+    proposalId: 'proposal-1',
+    sortOrder: 0,
+    actionType: 'create_order',
+    description: 'Create sales order',
+    payload: {},
+    status: 'pending',
+    confidence: '0.95',
+    ...overrides,
+  }
+}
+
+function renderCard(action: ActionDetail, handlers: Partial<Record<'onAccept' | 'onReject' | 'onRetry' | 'onEdit', jest.Mock>> = {}) {
+  const onAccept = handlers.onAccept ?? jest.fn()
+  const onReject = handlers.onReject ?? jest.fn()
+  const onRetry = handlers.onRetry ?? jest.fn()
+  const onEdit = handlers.onEdit ?? jest.fn()
+  renderWithProviders(
+    <ActionCard
+      action={action}
+      discrepancies={[]}
+      actionTypeLabels={{ create_order: 'Create Sales Order' }}
+      onAccept={onAccept}
+      onReject={onReject}
+      onRetry={onRetry}
+      onEdit={onEdit}
+    />,
+  )
+  return { onAccept, onReject, onRetry, onEdit }
+}
+
+describe('ActionCard status visibility', () => {
+  it('renders Accept / Edit / Reject buttons for a pending action', () => {
+    renderCard(makeAction({ status: 'pending' }))
+    expect(screen.getByRole('button', { name: /Accept/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Edit/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Reject/i })).toBeInTheDocument()
+  })
+
+  it('shows an "Accepted" status badge and hides all action buttons for an accepted action', () => {
+    renderCard(makeAction({ status: 'accepted' }))
+    expect(screen.getByText('Accepted')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Accept/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Edit/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Reject/i })).not.toBeInTheDocument()
+  })
+
+  it('shows a "Processing" status badge and hides all action buttons for a processing action', () => {
+    renderCard(makeAction({ status: 'processing' }))
+    expect(screen.getByText('Processing')).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('keeps Retry / Edit / Reject available for a failed action', () => {
+    renderCard(makeAction({ status: 'failed', executionError: 'boom' }))
+    expect(screen.getByRole('button', { name: /Retry/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Edit/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Reject/i })).toBeInTheDocument()
+  })
+
+  it('renders no action buttons for an executed action', () => {
+    renderCard(makeAction({ status: 'executed', createdEntityId: 'order-1', createdEntityType: 'sales_order' }))
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('never fires an accept mutation because accepted actions expose no clickable buttons', () => {
+    const { onAccept } = renderCard(makeAction({ status: 'accepted' }))
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(onAccept).not.toHaveBeenCalled()
+  })
+
+  it('still lets a pending action be accepted', () => {
+    const onAccept = jest.fn()
+    renderCard(makeAction({ status: 'pending' }), { onAccept })
+    fireEvent.click(screen.getByRole('button', { name: /Accept/i }))
+    expect(onAccept).toHaveBeenCalledWith('action-1')
+  })
+})


### PR DESCRIPTION
Fixes #3671

## Problem
Completed/accepted (and mid-execution `processing`) inbox_ops actions looked identical to pending ones — same Accept / Edit / Reject buttons, no status badge. The only feedback was a red `Action already processed` (409) toast after the user clicked, so there was no way to tell which actions were still actionable.

## Root Cause
`ActionCard` had dedicated branches only for `executed`, `rejected` and `failed`. Every other `InboxActionStatus` value (`accepted`, `processing`, or any future value) fell through to the **pending** render, which exposes the mutating Accept / Edit / Reject buttons. The server correctly rejects those mutations (only `pending`/`failed` are actionable), but the UI never reflected the state.

## What Changed
- `packages/core/src/modules/inbox_ops/components/proposals/ActionCard.tsx`: added a read-only status card for any non-`pending` status not already handled by the `executed`/`rejected`/`failed` branches. It shows a status badge (`Accepted` / `Processing`, falling back to the raw status) and **no** mutating buttons. The actionable card is now reserved for `pending` actions only; `failed` keeps its existing Retry/Edit/Reject card.
- Reuses the existing `inbox_ops.status.accepted` / `inbox_ops.status.processing` i18n keys (present in all 4 locales) — no new strings.
- DS-compliant: neutral `bg-muted/50` + `text-muted-foreground` tokens, matching the existing `rejected` card; `RefreshCw` + `animate-spin` for `processing` (an established pattern in this module).

## Tests
- New `ActionCard.test.tsx`: pending renders Accept/Edit/Reject; `accepted` and `processing` render a status badge with no action buttons; `failed` keeps Retry/Edit/Reject; `executed` renders no buttons; plus a guarantee that an accepted action exposes no clickable accept path. The 3 status-specific assertions fail before the fix and pass after.
- Full `inbox_ops` suite: 378 + 7 new passing.
- Verified: `build:packages`, `generate`, `i18n:check-sync`, `i18n:check-usage`, core `typecheck`, ESLint (changed files), and `build:app` all green.

## Backward Compatibility
No contract-surface changes — `ActionCard` props, exports, i18n keys, API routes and event IDs are all unchanged.