### PR TITLE
feat(messages): add Unarchive bulk action to Archived folder (#3578)

### DIFF
--- a/packages/core/src/modules/messages/components/__tests__/useMessagesInboxBulkActions.test.tsx
+++ b/packages/core/src/modules/messages/components/__tests__/useMessagesInboxBulkActions.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { renderHook } from '@testing-library/react'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import {
   useMessagesInboxBulkActions,
   type MessageFolder,
@@ -25,15 +26,29 @@ jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
   }),
 }))
 
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(async () => ({ ok: true, result: {} })),
+}))
+
 jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
   useGuardedMutation: () => ({
-    runMutation: jest.fn(),
+    runMutation: jest.fn(async (options: { operation: () => Promise<unknown> }) => options.operation()),
     retryLastMutation: jest.fn(),
   }),
 }))
 
+const apiCallMock = apiCall as jest.MockedFunction<typeof apiCall>
+
 describe('useMessagesInboxBulkActions', () => {
-  function actionIdsFor(folder: MessageFolder): string[] {
+  beforeEach(() => {
+    apiCallMock.mockClear()
+  })
+
+  function bulkActionsFor(folder: MessageFolder) {
     const { result } = renderHook(() => useMessagesInboxBulkActions({
       folder,
       page: 1,
@@ -41,16 +56,30 @@ describe('useMessagesInboxBulkActions', () => {
       filterValues: {},
     }))
 
-    return result.current.bulkActions?.map((action) => action.id) ?? []
+    return result.current.bulkActions ?? []
+  }
+
+  function actionIdsFor(folder: MessageFolder): string[] {
+    return bulkActionsFor(folder).map((action) => action.id)
   }
 
   it.each([
     ['inbox', ['messages-mark-read', 'messages-mark-unread', 'messages-archive', 'messages-delete']],
-    ['archived', ['messages-mark-read', 'messages-mark-unread', 'messages-delete']],
+    ['archived', ['messages-mark-read', 'messages-mark-unread', 'messages-unarchive', 'messages-delete']],
     ['sent', ['messages-delete']],
     ['drafts', ['messages-delete']],
     ['all', []],
   ] satisfies Array<[MessageFolder, string[]]>)('exposes safe bulk actions in the %s folder', (folder, expectedIds) => {
     expect(actionIdsFor(folder)).toEqual(expectedIds)
+  })
+
+  it('routes the archived unarchive bulk action to DELETE /api/messages/{id}/archive', async () => {
+    const unarchive = bulkActionsFor('archived').find((action) => action.id === 'messages-unarchive')
+    expect(unarchive).toBeDefined()
+
+    await unarchive!.onExecute([{ id: 'msg-1' }, { id: 'msg-2' }])
+
+    expect(apiCallMock).toHaveBeenCalledWith('/api/messages/msg-1/archive', { method: 'DELETE' })
+    expect(apiCallMock).toHaveBeenCalledWith('/api/messages/msg-2/archive', { method: 'DELETE' })
   })
 })

--- a/packages/core/src/modules/messages/components/useMessagesInboxBulkActions.ts
+++ b/packages/core/src/modules/messages/components/useMessagesInboxBulkActions.ts
@@ -13,7 +13,7 @@ import { toErrorMessage } from './message-detail/utils'
 
 export type MessageFolder = 'inbox' | 'sent' | 'drafts' | 'archived' | 'all'
 
-export type MessageBulkActionId = 'markRead' | 'markUnread' | 'archive' | 'delete'
+export type MessageBulkActionId = 'markRead' | 'markUnread' | 'archive' | 'unarchive' | 'delete'
 
 type BulkExecutionSummary = {
   action: MessageBulkActionId
@@ -84,6 +84,14 @@ const MESSAGE_BULK_REQUESTS: Record<MessageBulkActionId, MessageBulkRequestConfi
     errorKey: 'messages.errors.stateChangeFailed',
     errorFallback: 'Failed to update message state.',
   },
+  unarchive: {
+    method: 'DELETE',
+    buildUrl: (messageId) => `/api/messages/${encodeURIComponent(messageId)}/archive`,
+    successKey: 'messages.bulk.flash.unarchiveSuccess',
+    successFallback: '{count} messages moved to inbox.',
+    errorKey: 'messages.errors.stateChangeFailed',
+    errorFallback: 'Failed to update message state.',
+  },
   delete: {
     method: 'DELETE',
     buildUrl: (messageId) => `/api/messages/${encodeURIComponent(messageId)}`,
@@ -110,6 +118,11 @@ const MESSAGE_BULK_ACTIONS: Record<MessageBulkActionId, MessageBulkActionDefinit
     labelKey: 'messages.actions.archive',
     labelFallback: 'Archive',
   },
+  unarchive: {
+    id: 'messages-unarchive',
+    labelKey: 'messages.actions.unarchive',
+    labelFallback: 'Unarchive',
+  },
   delete: {
     id: 'messages-delete',
     labelKey: 'messages.actions.delete',
@@ -120,7 +133,7 @@ const MESSAGE_BULK_ACTIONS: Record<MessageBulkActionId, MessageBulkActionDefinit
 
 const MESSAGE_BULK_ACTION_IDS_BY_FOLDER = {
   inbox: ['markRead', 'markUnread', 'archive', 'delete'],
-  archived: ['markRead', 'markUnread', 'delete'],
+  archived: ['markRead', 'markUnread', 'unarchive', 'delete'],
   sent: ['delete'],
   drafts: ['delete'],
   all: [],

--- a/packages/core/src/modules/messages/i18n/de.json
+++ b/packages/core/src/modules/messages/i18n/de.json
@@ -34,6 +34,7 @@
   "messages.bulk.flash.markReadSuccess": "{count} Nachrichten als gelesen markiert.",
   "messages.bulk.flash.markUnreadSuccess": "{count} Nachrichten als ungelesen markiert.",
   "messages.bulk.flash.partial": "{succeeded} von {total} Nachrichten verarbeitet; {failed} fehlgeschlagen.",
+  "messages.bulk.flash.unarchiveSuccess": "{count} Nachrichten in den Posteingang verschoben.",
   "messages.compose": "Nachricht verfassen",
   "messages.composeHint": "Erstelle eine Nachricht, hänge Objekte an und sende sie an ausgewählte Empfänger.",
   "messages.composer.attachmentPicker.confirm": "Auswahl anhängen",

--- a/packages/core/src/modules/messages/i18n/en.json
+++ b/packages/core/src/modules/messages/i18n/en.json
@@ -34,6 +34,7 @@
   "messages.bulk.flash.markReadSuccess": "{count} messages marked as read.",
   "messages.bulk.flash.markUnreadSuccess": "{count} messages marked as unread.",
   "messages.bulk.flash.partial": "{succeeded} of {total} messages processed; {failed} failed.",
+  "messages.bulk.flash.unarchiveSuccess": "{count} messages moved to inbox.",
   "messages.compose": "Compose message",
   "messages.composeHint": "Create a message, attach objects, and send it to selected recipients.",
   "messages.composer.attachmentPicker.confirm": "Attach selected",

--- a/packages/core/src/modules/messages/i18n/es.json
+++ b/packages/core/src/modules/messages/i18n/es.json
@@ -34,6 +34,7 @@
   "messages.bulk.flash.markReadSuccess": "{count} mensajes marcados como leídos.",
   "messages.bulk.flash.markUnreadSuccess": "{count} mensajes marcados como no leídos.",
   "messages.bulk.flash.partial": "Se procesaron {succeeded} de {total} mensajes; {failed} fallaron.",
+  "messages.bulk.flash.unarchiveSuccess": "{count} mensajes movidos a la bandeja de entrada.",
   "messages.compose": "Redactar mensaje",
   "messages.composeHint": "Crea un mensaje, adjunta objetos y envíalo a los destinatarios seleccionados.",
   "messages.composer.attachmentPicker.confirm": "Adjuntar seleccionados",

--- a/packages/core/src/modules/messages/i18n/pl.json
+++ b/packages/core/src/modules/messages/i18n/pl.json
@@ -34,6 +34,7 @@
   "messages.bulk.flash.markReadSuccess": "Oznaczono {count} wiadomości jako przeczytane.",
   "messages.bulk.flash.markUnreadSuccess": "Oznaczono {count} wiadomości jako nieprzeczytane.",
   "messages.bulk.flash.partial": "Przetworzono {succeeded} z {total} wiadomości; niepowodzeń: {failed}.",
+  "messages.bulk.flash.unarchiveSuccess": "Przeniesiono {count} wiadomości do skrzynki odbiorczej.",
   "messages.compose": "Napisz wiadomość",
   "messages.composeHint": "Utwórz wiadomość, dołącz obiekty i wyślij do wybranych odbiorców.",
   "messages.composer.attachmentPicker.confirm": "Dołącz wybrane",


### PR DESCRIPTION
Fixes #3578

## Problem
In the **Archived** folder (`/backend/messages?folder=archive`), the bulk-action toolbar offered the same options as the Inbox (Mark read, Mark unread, Delete) and was missing an "Unarchive" / "Move to inbox" action. Restoring several archived messages required opening each one individually and clicking "Przywróć z archiwum" from the Actions menu.

## Root Cause
`useMessagesInboxBulkActions` only wired `['markRead', 'markUnread', 'delete']` for the `archived` folder. There was no bulk request/definition for unarchiving, even though a single-message unarchive endpoint (`DELETE /api/messages/{id}/archive`) already exists.

## What Changed
- Added an `unarchive` bulk action to `useMessagesInboxBulkActions`:
  - New `MessageBulkActionId` member `unarchive` (internal helper type; additive union widening, not re-exported at package level).
  - Request config maps it to `DELETE /api/messages/{id}/archive` — the existing single-message unarchive endpoint (server unchanged).
  - Action definition reuses the existing `messages.actions.unarchive` label (id `messages-unarchive`); non-destructive, so no confirm dialog.
  - `archived` folder now exposes `['markRead', 'markUnread', 'unarchive', 'delete']`.
- Added the `messages.bulk.flash.unarchiveSuccess` flash string to all four locales (en/pl/de/es).
- Reuses the existing guarded-mutation + concurrency flow, so bulk unarchive is subject to the same mutation guard and partial-failure reporting as the other bulk actions.

## Tests
- Updated `useMessagesInboxBulkActions.test.tsx`:
  - The folder-set assertion now expects `messages-unarchive` in the `archived` folder (and confirms it is absent elsewhere).
  - Added a focused test proving the unarchive bulk action routes to `DELETE /api/messages/{id}/archive` (guards against a regression that would map it to a re-archive `PUT`).
  - Verified both new assertions **fail** against the pre-fix source and **pass** with the fix.
- `yarn workspace @open-mercato/core test -- src/modules/messages/components` → 9 suites / 60 tests pass.
- `yarn typecheck` → all 21 workspaces pass.
- `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync` → pass. `yarn i18n:check-usage` advisory; the new key is not newly flagged (bulk flash keys are referenced indirectly like their siblings).
- Skipped `yarn build:app` (full Next.js app build) as disproportionate for a small additive client-only wiring change; full cross-workspace typecheck already covers TS correctness for the app-consuming packages.

## Backward Compatibility
- No contract surface changes. Reuses the existing `DELETE /api/messages/{id}/archive` route and existing `messages.actions.unarchive` i18n key; only additive UI wiring plus one new i18n key per locale. `MessageBulkActionId` is an internal module-level type (not re-exported from the package index); widening the union is additive.