### PR TITLE
fix(events): Pass event name to persistent subscribers

### DIFF
--- a/packages/core/src/modules/workflows/subscribers/__tests__/event-trigger.test.ts
+++ b/packages/core/src/modules/workflows/subscribers/__tests__/event-trigger.test.ts
@@ -13,8 +13,34 @@ import { processEventTriggers } from '../../lib/event-trigger-service'
 const processEventTriggersMock = jest.mocked(processEventTriggers)
 
 describe('workflow event-trigger subscriber', () => {
+  const originalDebug = process.env.OM_WORKFLOW_TRIGGER_DEBUG
+
   beforeEach(() => {
     processEventTriggersMock.mockClear()
+  })
+
+  afterEach(() => {
+    if (originalDebug === undefined) delete process.env.OM_WORKFLOW_TRIGGER_DEBUG
+    else process.env.OM_WORKFLOW_TRIGGER_DEBUG = originalDebug
+    jest.restoreAllMocks()
+  })
+
+  it('warns and skips when subscriber context is missing eventName', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await handle(
+      { id: 'order-1' },
+      {
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        resolve: jest.fn(),
+      }
+    )
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[workflow-trigger] Skipping trigger evaluation because subscriber context is missing eventName'
+    )
+    expect(processEventTriggersMock).not.toHaveBeenCalled()
   })
 
   it('uses trusted scope from subscriber context instead of payload scope', async () => {
@@ -65,5 +91,28 @@ describe('workflow event-trigger subscriber', () => {
     )
 
     expect(processEventTriggersMock).not.toHaveBeenCalled()
+  })
+
+  it('logs opt-in trigger evaluation diagnostics', async () => {
+    process.env.OM_WORKFLOW_TRIGGER_DEBUG = 'true'
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    await handle(
+      { orderId: 'order-1' },
+      {
+        eventName: 'sales.order.created',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        resolve: jest.fn((name: string) => {
+          if (name === 'em') return {}
+          throw new Error(`Unexpected dependency: ${name}`)
+        }),
+      }
+    )
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '[workflow-trigger] Evaluated triggers for "sales.order.created": ' +
+      'tenant=tenant-1 organization=org-1 matched=0 triggered=0 skipped=0 errors=0'
+    )
   })
 })

--- a/packages/core/src/modules/workflows/subscribers/event-trigger.ts
+++ b/packages/core/src/modules/workflows/subscribers/event-trigger.ts
@@ -8,6 +8,7 @@
 
 import type { EntityManager } from '@mikro-orm/core'
 import type { AwilixContainer } from 'awilix'
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 
 export const metadata = {
   event: '*', // Subscribe to ALL events
@@ -23,6 +24,12 @@ const EXCLUDED_EVENT_PREFIXES = [
   'cache.', // Cache events
   'queue.', // Queue events
 ]
+
+const WORKFLOW_TRIGGER_DEBUG_ENV = 'OM_WORKFLOW_TRIGGER_DEBUG'
+
+function isWorkflowTriggerDebugEnabled(): boolean {
+  return parseBooleanWithDefault(process.env[WORKFLOW_TRIGGER_DEBUG_ENV], false)
+}
 
 /**
  * Check if an event should be excluded from trigger processing.
@@ -42,7 +49,7 @@ export default async function handle(
 ): Promise<void> {
   const eventName = ctx.eventName
   if (!eventName) {
-    // Skip if no event name (shouldn't happen, but be safe)
+    console.warn('[workflow-trigger] Skipping trigger evaluation because subscriber context is missing eventName')
     return
   }
 
@@ -97,6 +104,15 @@ export default async function handle(
       tenantId,
       organizationId,
     })
+
+    if (isWorkflowTriggerDebugEnabled()) {
+      const matched = result.triggered + result.skipped + result.errors.length
+      console.log(
+        `[workflow-trigger] Evaluated triggers for "${eventName}": ` +
+        `tenant=${tenantId} organization=${organizationId} matched=${matched} ` +
+        `triggered=${result.triggered} skipped=${result.skipped} errors=${result.errors.length}`
+      )
+    }
 
     if (result.triggered > 0) {
       console.log(

--- a/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
+++ b/packages/events/src/modules/events/workers/__tests__/events.worker.test.ts
@@ -453,9 +453,17 @@ describe('Events Worker', () => {
       else process.env.OM_EVENTS_SINGLE_DELIVERY = origFlag
     })
 
-    const createMockJob = (event: string, payload: unknown): QueuedJob<{ event: string; payload: unknown }> => ({
+    const createMockJob = (
+      event: string,
+      payload: unknown,
+      options?: { tenantId?: string | null; organizationId?: string | null },
+    ): QueuedJob<{
+      event: string
+      payload: unknown
+      options?: { tenantId?: string | null; organizationId?: string | null }
+    }> => ({
       id: 'test-job-id',
-      payload: { event, payload },
+      payload: { event, payload, options },
       createdAt: new Date().toISOString(),
     })
 
@@ -516,6 +524,48 @@ describe('Events Worker', () => {
       // Default-on: pattern dispatch reaches both the exact-match and the wildcard
       // persistent subscriber.
       expect(calls.sort()).toEqual(['p', 'w'])
+    })
+
+    it('default (unset): forwards eventName and trusted scope to persistent wildcard subscribers', async () => {
+      delete process.env.OM_EVENTS_SINGLE_DELIVERY
+      clearListenerCache()
+      const contexts: Array<{
+        eventName?: string
+        tenantId?: string | null
+        organizationId?: string | null
+      }> = []
+      registerCliModules([{
+        id: 'm',
+        subscribers: [
+          {
+            id: 'workflow:event-trigger',
+            event: '*',
+            persistent: true,
+            handler: (_payload, ctx) => {
+              contexts.push({
+                eventName: ctx.eventName,
+                tenantId: ctx.tenantId,
+                organizationId: ctx.organizationId,
+              })
+            },
+          },
+        ],
+      }])
+
+      await handle(
+        createMockJob(
+          'customers.deal.created',
+          { id: 'deal-1', tenantId: 'payload-tenant', organizationId: 'payload-org' },
+          { tenantId: 'trusted-tenant', organizationId: 'trusted-org' },
+        ),
+        createMockContext(),
+      )
+
+      expect(contexts).toEqual([{
+        eventName: 'customers.deal.created',
+        tenantId: 'trusted-tenant',
+        organizationId: 'trusted-org',
+      }])
     })
 
     it('flag explicitly OFF (legacy opt-out): preserves exact-match dispatch and never reaches wildcards', async () => {

--- a/packages/events/src/modules/events/workers/events.worker.ts
+++ b/packages/events/src/modules/events/workers/events.worker.ts
@@ -24,6 +24,7 @@ type EventJobPayload = {
 
 type HandlerContext = {
   resolve: <T = unknown>(name: string) => T
+  eventName?: string
   tenantId?: string | null
   organizationId?: string | null
 }
@@ -118,6 +119,7 @@ export default async function handle(
 
   const handlerCtx = {
     resolve: ctx.resolve,
+    eventName: event,
     tenantId: options?.tenantId ?? null,
     organizationId: options?.organizationId ?? null,
   }


### PR DESCRIPTION
## Summary

Persistent event subscribers now receive the dispatched event name in their subscriber context, matching the inline event bus delivery contract. This lets wildcard persistent subscribers evaluate queued events by name instead of silently skipping when `ctx.eventName` is absent.

The workflow event-trigger subscriber now logs a warning for a missing event name and supports opt-in trigger evaluation diagnostics with `OM_WORKFLOW_TRIGGER_DEBUG=true`.

## Changes

- Add `eventName` to the persistent events worker subscriber context.
- Add a worker regression test covering queued wildcard subscribers receiving `eventName`, `tenantId`, and `organizationId`.
- Add workflow trigger diagnostics for missing event names and optional debug evaluation logging.
- Add workflow subscriber tests for the warning/debug logging paths.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A. This is a focused bug fix that restores the existing persistent subscriber context contract; it does not add a new feature, schema, API route, event ID, or workflow model.

**Backward compatibility:**
The change is additive and backward-compatible. Existing subscribers can ignore `ctx.eventName`; wildcard persistent subscribers that already depended on the documented inline contract now receive the same value through queued delivery.

**Intended routing:**
- Priority: `priority-high` because this affects event-driven automation reliability.
- Risk: `risk-high` because it touches the shared persistent event subscriber context.
- QA: `skip-qa` because this is a non-UI fix covered by focused unit tests and package typechecks.

## Testing

- `corepack yarn install --immutable`
- `corepack yarn workspace @open-mercato/events test --runTestsByPath src/modules/events/workers/__tests__/events.worker.test.ts`
- `corepack yarn workspace @open-mercato/core test --runTestsByPath src/modules/workflows/subscribers/__tests__/event-trigger.test.ts`
- `corepack yarn workspace @open-mercato/events typecheck`
- `corepack yarn build:packages`
- `corepack yarn generate`
- `corepack yarn workspace @open-mercato/core typecheck`
- `git diff --check HEAD^ HEAD`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: intended `priority-high`.
- [ ] Risk set: intended `risk-high`.
- [ ] QA routing set: intended `skip-qa`.

### Design System Compliance

N/A: no UI files or visual surfaces changed.

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

N/A.