### PR TITLE
fix(entities): add optimistic locking to definition edit form (#3152)

### DIFF
--- a/packages/core/src/__tests__/optimistic-lock-command-coverage.test.ts
+++ b/packages/core/src/__tests__/optimistic-lock-command-coverage.test.ts
@@ -43,6 +43,8 @@ const COMMAND_GUARD_ALLOWLIST: Record<string, string> = {
     'OSS-only — organization branding is single-owner admin config (directory.organization); OSS floor guards concurrent edits. Enterprise record_locks migration deferred.',
   'packages/core/src/modules/entities/api/encryption.ts':
     'OSS-only — per-entity encryption-map admin config; OSS floor guards concurrent edits. Enterprise record_locks migration deferred.',
+  'packages/core/src/modules/entities/api/definitions.batch.ts':
+    'OSS-only — entity field-definition batch save is an admin schema-config surface (issue #3152) guarded by an aggregate updated_at version, not a per-row record; the OSS floor guards the two-tab schema-edit race. Enterprise record_locks migration deferred.',
   'packages/core/src/modules/integrations/api/[id]/credentials/route.ts':
     'OSS-only — integration credentials are single-admin config keyed by bundle id (integrations.integration); OSS floor guards concurrent admin edits. Enterprise record_locks migration deferred.',
   'packages/core/src/modules/integrations/api/[id]/state/route.ts':

--- a/packages/core/src/modules/entities/api/__tests__/definitions.batch.optimistic-lock.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.batch.optimistic-lock.test.ts
@@ -1,0 +1,142 @@
+/** @jest-environment node */
+import { POST } from '../definitions.batch'
+import {
+  OPTIMISTIC_LOCK_CONFLICT_CODE,
+  OPTIMISTIC_LOCK_HEADER_NAME,
+} from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+
+/**
+ * Optimistic locking for the entity definition edit form (issue #3152).
+ *
+ * The batch endpoint upserts a whole definition set, so two tabs saving the same
+ * entity used to silently overwrite each other. It now compares the client-sent
+ * expected schema version against the current aggregate version and returns the
+ * shared structured 409 on mismatch — while staying strictly additive for
+ * callers that do not send the header.
+ */
+
+const invalidateDefinitionsCacheMock = jest.fn()
+const resolveVersionMock = jest.fn(async () => '2026-06-01T00:00:00.000Z')
+
+type Where = Record<string, unknown>
+
+const mockEm = {
+  begin: jest.fn(async () => {}),
+  commit: jest.fn(async () => {}),
+  rollback: jest.fn(async () => {}),
+  find: jest.fn(async (_entity: unknown, _where: Where) => [] as unknown[]),
+  findOne: jest.fn(async () => null),
+  create: jest.fn((_entity: unknown, data: Where) => ({ ...data })),
+  persist: jest.fn(),
+  flush: jest.fn(async () => {}),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (key: string) => {
+      if (key === 'em') return mockEm
+      if (key === 'cache') throw new Error('no cache')
+      return null
+    },
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: async () => ({
+    sub: 'user-1',
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+    roles: ['admin'],
+  }),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: async () => ({ tenantId: 'tenant-1', selectedId: 'org-1' }),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/data/entities', () => ({
+  CustomFieldDef: 'CustomFieldDef',
+  CustomFieldEntityConfig: 'CustomFieldEntityConfig',
+}))
+
+jest.mock('../definitions.cache', () => ({
+  invalidateDefinitionsCache: (...args: unknown[]) => invalidateDefinitionsCacheMock(...args),
+}))
+
+jest.mock('../../lib/definitions-version', () => ({
+  resolveEntityDefinitionsVersion: (...args: unknown[]) => resolveVersionMock(...args),
+}))
+
+const makeRequest = (body: unknown, headers?: Record<string, string>) =>
+  new Request('http://x/api/entities/definitions/batch', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...(headers ?? {}) },
+    body: JSON.stringify(body),
+  })
+
+const body = { entityId: 'test:entity', definitions: [{ key: 'alpha', kind: 'text' }] }
+
+describe('entities/definitions.batch POST optimistic locking (issue #3152)', () => {
+  let previousEnv: string | undefined
+
+  beforeAll(() => {
+    previousEnv = process.env.OM_OPTIMISTIC_LOCK
+    process.env.OM_OPTIMISTIC_LOCK = 'all'
+  })
+
+  afterAll(() => {
+    if (previousEnv === undefined) delete process.env.OM_OPTIMISTIC_LOCK
+    else process.env.OM_OPTIMISTIC_LOCK = previousEnv
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.find.mockResolvedValue([] as unknown[])
+    resolveVersionMock.mockResolvedValue('2026-06-01T00:00:00.000Z')
+  })
+
+  it('rejects a stale save with a structured 409 before touching the transaction', async () => {
+    // Client loaded an older version than the current aggregate version.
+    const response = await POST(
+      makeRequest(body, { [OPTIMISTIC_LOCK_HEADER_NAME]: '2026-01-01T00:00:00.000Z' }),
+    )
+
+    expect(response.status).toBe(409)
+    const json = (await response.json()) as { code?: string }
+    expect(json.code).toBe(OPTIMISTIC_LOCK_CONFLICT_CODE)
+    // Conflict is detected before any write work.
+    expect(mockEm.begin).not.toHaveBeenCalled()
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockEm.commit).not.toHaveBeenCalled()
+  })
+
+  it('saves and returns the fresh version when the expected version matches', async () => {
+    const response = await POST(
+      makeRequest(body, { [OPTIMISTIC_LOCK_HEADER_NAME]: '2026-06-01T00:00:00.000Z' }),
+    )
+
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as { ok?: boolean; version?: string | null }
+    expect(json.ok).toBe(true)
+    expect(json.version).toBe('2026-06-01T00:00:00.000Z')
+    expect(mockEm.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays additive: a save without the header proceeds unchanged', async () => {
+    const response = await POST(makeRequest(body))
+
+    expect(response.status).toBe(200)
+    expect(mockEm.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not lock when there is no current version (empty schema edge case)', async () => {
+    resolveVersionMock.mockResolvedValue(null as unknown as string)
+
+    const response = await POST(
+      makeRequest(body, { [OPTIMISTIC_LOCK_HEADER_NAME]: '2026-01-01T00:00:00.000Z' }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockEm.commit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/entities/api/__tests__/definitions.batch.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.batch.test.ts
@@ -48,6 +48,13 @@ jest.mock('../definitions.cache', () => ({
   invalidateDefinitionsCache: (...args: unknown[]) => invalidateDefinitionsCacheMock(...args),
 }))
 
+// The aggregate version is exercised in definitions.batch.optimistic-lock.test.ts.
+// Stub it here so these prefetch/bounds tests keep asserting on the mutation-loop
+// query shape without the version reader adding its own em.findOne calls.
+jest.mock('../../lib/definitions-version', () => ({
+  resolveEntityDefinitionsVersion: jest.fn(async () => null),
+}))
+
 const makeRequest = (body: unknown) =>
   new Request('http://x/api/entities/definitions/batch', {
     method: 'POST',

--- a/packages/core/src/modules/entities/api/definitions.batch.ts
+++ b/packages/core/src/modules/entities/api/definitions.batch.ts
@@ -5,9 +5,12 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { CustomFieldDef, CustomFieldEntityConfig } from '@open-mercato/core/modules/entities/data/entities'
 import { customFieldEntityConfigSchema, upsertCustomFieldDefSchema } from '@open-mercato/core/modules/entities/data/validators'
 import { z } from 'zod'
+import { enforceCommandOptimisticLock } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
+import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { invalidateDefinitionsCache } from './definitions.cache'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { mergeEntityFieldsetConfig, normalizeEntityFieldsetConfig } from '../lib/fieldsets'
+import { resolveEntityDefinitionsVersion } from '../lib/definitions-version'
 import {
   beginEntitiesMutationGuard,
   FIELD_DEFINITION_RESOURCE_KIND,
@@ -90,6 +93,31 @@ export async function POST(req: Request) {
     mutationPayload: { entityId, definitionCount: definitions.length },
   })
   if (guard.blockedResponse) return guard.blockedResponse
+
+  // Optimistic locking (issue #3152): the batch upserts a whole definition set,
+  // so guard the entity's aggregate schema version (the newest updated_at across
+  // its field definitions and fieldset config). A stale save — another tab changed
+  // the schema after this form loaded — fails with the same structured 409 the CRUD
+  // path returns. Strictly additive: callers that do not send the expected version
+  // header pass through unchanged.
+  const currentVersion = await resolveEntityDefinitionsVersion(em, {
+    entityId,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+  })
+  try {
+    enforceCommandOptimisticLock({
+      resourceKind: FIELD_DEFINITION_RESOURCE_KIND,
+      resourceId: entityId,
+      current: currentVersion,
+      request: req,
+    })
+  } catch (err) {
+    if (isCrudHttpError(err) && err.status === 409) {
+      return NextResponse.json(err.body, { status: err.status })
+    }
+    throw err
+  }
 
   await em.begin()
   try {
@@ -206,11 +234,20 @@ export async function POST(req: Request) {
     entityIds: [entityId],
   })
 
-  return NextResponse.json({ ok: true })
+  // Return the post-save version so the form can round-trip the token for a
+  // subsequent save (reorder, delete, second save) without a false conflict.
+  const nextVersion = await resolveEntityDefinitionsVersion(em, {
+    entityId,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+  })
+
+  return NextResponse.json({ ok: true, version: nextVersion })
 }
 
 const batchResponseSchema = z.object({
   ok: z.literal(true),
+  version: z.string().nullable().optional(),
 })
 
 export const openApi: OpenApiRouteDoc = {

--- a/packages/core/src/modules/entities/api/definitions.manage.ts
+++ b/packages/core/src/modules/entities/api/definitions.manage.ts
@@ -5,6 +5,8 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { CustomFieldDef } from '@open-mercato/core/modules/entities/data/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { loadEntityFieldsetConfigs } from '../lib/fieldsets'
+import { resolveDefinitionMutationScope } from '../lib/definition-scope'
+import { resolveEntityDefinitionsVersion } from '../lib/definitions-version'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['entities.definitions.manage'] },
@@ -17,8 +19,12 @@ export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
   if (!auth || !auth.tenantId || (!auth.orgId && !auth.isSuperAdmin)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { resolve } = await createRequestContainer()
+  const container = await createRequestContainer()
+  const { resolve } = container
   const em = resolve('em') as any
+  // Resolve the same definition scope the mutating endpoints use so the version
+  // token round-trips consistently (issue #3152).
+  const versionScope = await resolveDefinitionMutationScope({ auth, container, request: req })
   // Load all scoped records (active/inactive/deleted) so that per-scope tombstones
   // can shadow global definitions. We'll filter out deleted winners later.
   const [defs, tombstones, configMap] = await Promise.all([
@@ -84,11 +90,17 @@ export async function GET(req: Request) {
   }))
   const deletedKeys = Array.from(tombstonedKeys)
   const cfg = configMap.get(entityId) ?? { fieldsets: [], singleFieldsetPerRecord: true }
+  const version = await resolveEntityDefinitionsVersion(em, {
+    entityId,
+    tenantId: versionScope.tenantId,
+    organizationId: versionScope.organizationId,
+  })
   return NextResponse.json({
     items,
     deletedKeys,
     fieldsets: cfg.fieldsets,
     settings: { singleFieldsetPerRecord: cfg.singleFieldsetPerRecord },
+    version,
   })
 }
 
@@ -125,6 +137,7 @@ const definitionsManageResponseSchema = z.object({
   deletedKeys: z.array(z.string()),
   fieldsets: z.array(manageFieldsetSchema).optional(),
   settings: z.object({ singleFieldsetPerRecord: z.boolean().optional() }).optional(),
+  version: z.string().nullable().optional(),
 })
 
 export const openApi: OpenApiRouteDoc = {

--- a/packages/core/src/modules/entities/api/definitions.ts
+++ b/packages/core/src/modules/entities/api/definitions.ts
@@ -33,6 +33,7 @@ import {
   resolveDefinitionMutationScope,
   selectVisibleDefinitionWinner,
 } from '../lib/definition-scope'
+import { resolveEntityDefinitionsVersion } from '../lib/definitions-version'
 
 /**
  * Validate defaultValue against the field kind. Returns an error message string
@@ -620,7 +621,14 @@ export async function DELETE(req: Request) {
     entityIds: [entityId],
   })
   // Changing field definitions may impact forms but not sidebar items; no nav cache touch
-  return NextResponse.json({ ok: true })
+  // Return the post-delete aggregate version so the edit form keeps its optimistic-lock
+  // token in sync after removing a field out-of-band (issue #3152).
+  const version = await resolveEntityDefinitionsVersion(em, {
+    entityId,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+  })
+  return NextResponse.json({ ok: true, version })
 }
 
 const definitionsQuerySchema = z
@@ -716,6 +724,7 @@ const deleteDefinitionRequestSchema = z.object({
 
 const deleteDefinitionResponseSchema = z.object({
   ok: z.literal(true),
+  version: z.string().nullable().optional(),
 })
 
 export const openApi: OpenApiRouteDoc = {

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -4,7 +4,9 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useQueryClient } from '@tanstack/react-query'
 import { CrudForm, type CrudField, type CrudFormGroup } from '@open-mercato/ui/backend/CrudForm'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
-import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCall, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
+import { surfaceRecordConflict } from '@open-mercato/ui/backend/conflicts'
 import { invalidateCustomFieldDefs } from '@open-mercato/ui/backend/utils/customFieldDefs'
 import { upsertCustomEntitySchema, upsertCustomFieldDefSchema } from '@open-mercato/core/modules/entities/data/validators'
 import { z } from 'zod'
@@ -31,7 +33,12 @@ export type EntitySource = 'code' | 'custom'
 type EntitiesListResponse = { items?: Array<Record<string, unknown>> }
 type FieldsetGroup = { code: string; title?: string; hint?: string }
 type FieldsetDefinition = { code: string; label: string; icon?: string; description?: string; groups?: FieldsetGroup[] }
-type DefinitionsManageResponse = { items?: any[]; deletedKeys?: string[]; fieldsets?: FieldsetDefinition[]; settings?: { singleFieldsetPerRecord?: boolean } }
+type DefinitionsManageResponse = { items?: any[]; deletedKeys?: string[]; fieldsets?: FieldsetDefinition[]; settings?: { singleFieldsetPerRecord?: boolean }; version?: string | null }
+type DefinitionsBatchResponse = { ok?: boolean; version?: string | null }
+
+function readVersionToken(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null
+}
 
 type DefErrors = FieldDefinitionError
 
@@ -48,6 +55,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
   const [entityFormLoading, setEntityFormLoading] = useState(true)
   const [entityInitial, setEntityInitial] = useState<{ label?: string; description?: string; labelField?: string; defaultEditor?: string; showInSidebar?: boolean; updatedAt?: string }>({})
   const [defs, setDefs] = useState<Def[]>([])
+  const [defsVersion, setDefsVersion] = useState<string | null>(null)
   const [orderDirty, setOrderDirty] = useState(false)
   const [orderSaving, setOrderSaving] = useState(false)
   const listRef = React.useRef<HTMLDivElement | null>(null)
@@ -197,6 +205,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
             (a, b) => Number(a.configJson?.priority ?? 0) - Number(b.configJson?.priority ?? 0)
           )
           setDefs(loaded)
+          setDefsVersion(readVersionToken(json.version))
           setDefErrors({})
           setDeletedKeys(Array.isArray(json.deletedKeys) ? json.deletedKeys : [])
           const loadedFieldsets = Array.isArray(json.fieldsets) ? json.fieldsets : []
@@ -253,6 +262,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
         (a, b) => Number(a.configJson?.priority ?? 0) - Number(b.configJson?.priority ?? 0)
       )
       setDefs(loaded)
+      setDefsVersion(readVersionToken(j2.version))
       setDeletedKeys(Array.isArray(j2.deletedKeys) ? j2.deletedKeys : [])
       flash(`Restored ${key}`, 'success')
       await invalidateCustomFieldDefs(queryClient, entityId)
@@ -278,14 +288,19 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
           isActive: d.isActive !== false,
         })),
       }
-      const call = await apiCall('/api/entities/definitions.batch', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify(payload),
-      })
+      const call = await withScopedApiRequestHeaders(
+        buildOptimisticLockHeader(defsVersion),
+        () => apiCall<DefinitionsBatchResponse>('/api/entities/definitions.batch', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(payload),
+        }),
+      )
       if (!call.ok) {
+        if (surfaceRecordConflict({ status: call.status, body: call.result }, t)) return
         await raiseCrudError(call.response, 'Failed to save definitions')
       }
+      setDefsVersion(readVersionToken(call.result?.version))
       await invalidateCustomFieldDefs(queryClient, entityId)
       router.push(`/backend/entities/user?flash=Definitions%20saved&type=success`)
     } catch (e: any) {
@@ -300,7 +315,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
     if (!def) return
     if (def.key) {
       try {
-        const call = await apiCall('/api/entities/definitions', {
+        const call = await apiCall<DefinitionsBatchResponse>('/api/entities/definitions', {
           method: 'DELETE',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ entityId, key: def.key }),
@@ -308,6 +323,9 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
         if (!call.ok) {
           await raiseCrudError(call.response, 'Failed to delete field')
         }
+        // Keep the optimistic-lock token in sync after an out-of-band delete so a
+        // later Save does not falsely 409 against our own change (issue #3152).
+        setDefsVersion(readVersionToken(call.result?.version))
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Failed to delete field'
         flash(message, 'error')
@@ -364,12 +382,23 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
           isActive: d.isActive !== false,
         })),
       }
-      const call = await apiCall('/api/entities/definitions.batch', {
-        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload)
-      })
+      const call = await withScopedApiRequestHeaders(
+        buildOptimisticLockHeader(defsVersion),
+        () => apiCall<DefinitionsBatchResponse>('/api/entities/definitions.batch', {
+          method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload),
+        }),
+      )
       if (!call.ok) {
+        // A stale reorder auto-save (another tab changed the schema first) returns a
+        // 409; surface the shared conflict bar and stop the retry loop instead of a
+        // generic flash (issue #3152).
+        if (surfaceRecordConflict({ status: call.status, body: call.result }, t)) {
+          setOrderDirty(false)
+          return
+        }
         await raiseCrudError(call.response, 'Failed to save order')
       }
+      setDefsVersion(readVersionToken(call.result?.version))
       setOrderDirty(false)
       flash('Order saved', 'success')
       await invalidateCustomFieldDefs(queryClient, entityId)
@@ -502,18 +531,25 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       fieldsets: buildFieldsetPayload(),
       singleFieldsetPerRecord,
     })
-    const callDefs = await apiCall('/api/entities/definitions.batch', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(defsPayload),
-    })
+    // Send the aggregate schema version so a concurrent edit is rejected with a 409
+    // instead of silently overwriting the other tab (issue #3152). CrudForm's submit
+    // catch detects the optimistic-lock conflict and shows the shared conflict bar.
+    const callDefs = await withScopedApiRequestHeaders(
+      buildOptimisticLockHeader(defsVersion),
+      () => apiCall<DefinitionsBatchResponse>('/api/entities/definitions.batch', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(defsPayload),
+      }),
+    )
     if (!callDefs.ok) {
       await raiseCrudError(callDefs.response, 'Failed to save definitions')
     }
+    setDefsVersion(readVersionToken(callDefs.result?.version))
     try { window.dispatchEvent(new Event('om:refresh-sidebar')) } catch {}
     await invalidateCustomFieldDefs(queryClient, entityId)
     flash('Definitions saved', 'success')
-  }, [buildFieldsetPayload, defs, entityId, entitySource, queryClient, singleFieldsetPerRecord, validateAll])
+  }, [buildFieldsetPayload, defs, defsVersion, entityId, entitySource, queryClient, singleFieldsetPerRecord, validateAll])
 
   if (!entityId) {
     return (

--- a/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-page-submit.test.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/__tests__/edit-entity-page-submit.test.tsx
@@ -3,7 +3,8 @@
  */
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import EditDefinitionsPage from '../[entityId]/page'
-import { apiCall, readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { apiCall, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
+import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
 
 const mockTranslate = (key: string, fallback?: string) => fallback ?? key
 
@@ -64,23 +65,35 @@ jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
 jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
   apiCall: jest.fn(),
   readApiResultOrThrow: jest.fn(),
+  // Real optimistic-lock header wiring flows through this scope, so record the
+  // headers each mutating call is wrapped with (issue #3152) and still run it.
+  withScopedApiRequestHeaders: jest.fn((_headers: Record<string, string>, run: () => Promise<unknown>) => run()),
+}))
+
+jest.mock('@open-mercato/ui/backend/conflicts', () => ({
+  surfaceRecordConflict: jest.fn(() => false),
 }))
 
 const apiCallMock = apiCall as jest.Mock
 const readApiResultOrThrowMock = readApiResultOrThrow as jest.Mock
+const withScopedApiRequestHeadersMock = withScopedApiRequestHeaders as jest.Mock
 
-function mockLoad(entityId: string, source: 'code' | 'custom') {
+function mockLoad(entityId: string, source: 'code' | 'custom', version?: string) {
   readApiResultOrThrowMock.mockImplementation((url: string) => {
     if (url.startsWith('/api/entities/entities')) {
       return Promise.resolve({ items: [{ entityId, label: entityId, description: '', source }] })
     }
-    return Promise.resolve({ items: [], deletedKeys: [], fieldsets: [], settings: {} })
+    return Promise.resolve({ items: [], deletedKeys: [], fieldsets: [], settings: {}, version })
   })
-  apiCallMock.mockResolvedValue({ ok: true, response: {} })
+  apiCallMock.mockResolvedValue({ ok: true, response: {}, result: { ok: true } })
 }
 
 function calledUrls(): string[] {
   return apiCallMock.mock.calls.map((call) => call[0] as string)
+}
+
+function scopedHeaderSets(): Array<Record<string, string>> {
+  return withScopedApiRequestHeadersMock.mock.calls.map((call) => call[0] as Record<string, string>)
 }
 
 describe('EditDefinitionsPage submit (#3115)', () => {
@@ -112,5 +125,22 @@ describe('EditDefinitionsPage submit (#3115)', () => {
 
     await waitFor(() => expect(calledUrls()).toContain('/api/entities/definitions.batch'))
     expect(calledUrls()).toContain('/api/entities/entities')
+  })
+
+  it('sends the loaded schema version as the optimistic-lock header on the definitions batch (#3152)', async () => {
+    const entityId = 'workflows:workflow_instance'
+    mockLoad(entityId, 'code', '2026-06-01T00:00:00.000Z')
+
+    render(<EditDefinitionsPage params={{ entityId }} />)
+    await waitFor(() => expect(screen.getByTestId('crud-form-loading')).toHaveTextContent('false'))
+
+    fireEvent.click(screen.getByTestId('submit-button'))
+
+    await waitFor(() => expect(calledUrls()).toContain('/api/entities/definitions.batch'))
+    // The batch mutation is wrapped with the expected-version header carrying the
+    // token the form loaded, so a concurrent edit is rejected server-side.
+    expect(scopedHeaderSets()).toContainEqual({
+      [OPTIMISTIC_LOCK_HEADER_NAME]: '2026-06-01T00:00:00.000Z',
+    })
   })
 })

--- a/packages/core/src/modules/entities/lib/__tests__/definitions-version.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/definitions-version.test.ts
@@ -1,0 +1,68 @@
+/** @jest-environment node */
+import { resolveEntityDefinitionsVersion } from '../definitions-version'
+
+jest.mock('@open-mercato/core/modules/entities/data/entities', () => ({
+  CustomFieldDef: 'CustomFieldDef',
+  CustomFieldEntityConfig: 'CustomFieldEntityConfig',
+}))
+
+type FindOneResult = { updatedAt: Date | string } | null
+
+function makeEm(byEntity: Record<string, FindOneResult>) {
+  const findOne = jest.fn(async (entity: unknown) => byEntity[entity as string] ?? null)
+  return { em: { findOne } as any, findOne }
+}
+
+const scope = { entityId: 'test:entity', tenantId: 'tenant-1', organizationId: 'org-1' }
+
+describe('resolveEntityDefinitionsVersion (issue #3152)', () => {
+  it('returns the newest updatedAt across definitions and config', async () => {
+    const { em } = makeEm({
+      CustomFieldDef: { updatedAt: new Date('2026-06-01T00:00:00.000Z') },
+      CustomFieldEntityConfig: { updatedAt: new Date('2026-05-01T00:00:00.000Z') },
+    })
+
+    const version = await resolveEntityDefinitionsVersion(em, scope)
+
+    expect(version).toBe('2026-06-01T00:00:00.000Z')
+  })
+
+  it('falls back to config when it is the only versioned row', async () => {
+    const { em } = makeEm({
+      CustomFieldDef: null,
+      CustomFieldEntityConfig: { updatedAt: new Date('2026-05-01T00:00:00.000Z') },
+    })
+
+    const version = await resolveEntityDefinitionsVersion(em, scope)
+
+    expect(version).toBe('2026-05-01T00:00:00.000Z')
+  })
+
+  it('returns null when the schema has no definitions or config', async () => {
+    const { em } = makeEm({ CustomFieldDef: null, CustomFieldEntityConfig: null })
+
+    const version = await resolveEntityDefinitionsVersion(em, scope)
+
+    expect(version).toBeNull()
+  })
+
+  it('scopes the query to the entity and the visible tenant/org union', async () => {
+    const { em, findOne } = makeEm({
+      CustomFieldDef: { updatedAt: new Date('2026-06-01T00:00:00.000Z') },
+      CustomFieldEntityConfig: null,
+    })
+
+    await resolveEntityDefinitionsVersion(em, scope)
+
+    const where = findOne.mock.calls[0][1] as Record<string, unknown>
+    expect(where.entityId).toBe('test:entity')
+    expect(where.$and).toEqual([
+      { $or: [{ organizationId: 'org-1' }, { organizationId: null }] },
+      { $or: [{ tenantId: 'tenant-1' }, { tenantId: null }] },
+    ])
+    // Only the timestamp column is projected so no other data materializes.
+    const options = findOne.mock.calls[0][2] as Record<string, unknown>
+    expect(options.fields).toEqual(['updatedAt'])
+    expect(options.orderBy).toEqual({ updatedAt: 'desc' })
+  })
+})

--- a/packages/core/src/modules/entities/lib/definitions-version.ts
+++ b/packages/core/src/modules/entities/lib/definitions-version.ts
@@ -1,0 +1,102 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import {
+  CustomFieldDef,
+  CustomFieldEntityConfig,
+} from '@open-mercato/core/modules/entities/data/entities'
+
+/**
+ * Aggregate optimistic-lock version for an entity's *definition schema*
+ * (issue #3152).
+ *
+ * The entity definition edit form (`/backend/entities/user|system/<entityId>`)
+ * saves a whole set of `CustomFieldDef` rows (plus fieldset config) via
+ * `POST /api/entities/definitions.batch`. There is no single row to lock, so the
+ * classic per-record `updated_at` guard cannot apply. Instead we derive one
+ * aggregate version token = the newest `updated_at` across the rows that make up
+ * the editable schema for the entity in the caller's scope:
+ *
+ *   - `CustomFieldDef` (active + tombstoned) — a field add/edit/delete bumps it,
+ *   - `CustomFieldEntityConfig` — a fieldset/settings change bumps it.
+ *
+ * The `CustomEntity` metadata row is deliberately NOT part of this token: the
+ * form's Save first PUTs entity metadata (`POST /api/entities/entities`, which
+ * bumps `CustomEntity.updatedAt` and enforces its own optimistic lock) and only
+ * then PUTs the definitions batch — folding the metadata row in here would make
+ * the batch 409 against the form's OWN just-completed metadata save. Custom
+ * entities therefore keep their concurrent-edit protection from the metadata
+ * lock (primary) with the definitions token as defense-in-depth; system/code
+ * entities (no metadata row, no metadata PUT) rely on the definitions token.
+ * A schema with zero definitions and no config yields `null`, so locking
+ * degrades to a no-op for that first-ever concurrent add edge case.
+ *
+ * Both the read path (`definitions.manage` GET) and the mutating endpoints must
+ * compute this with identical scope inputs so the token round-trips without
+ * false conflicts.
+ */
+export type EntityDefinitionsVersionScope = {
+  entityId: string
+  tenantId: string | null
+  organizationId: string | null
+}
+
+function buildVisibleScopeWhere(scope: EntityDefinitionsVersionScope): Record<string, unknown> {
+  const organizationCandidates: Array<{ organizationId: string | null }> = [{ organizationId: null }]
+  if (scope.organizationId) organizationCandidates.unshift({ organizationId: scope.organizationId })
+
+  const tenantCandidates: Array<{ tenantId: string | null }> = [{ tenantId: null }]
+  if (scope.tenantId) tenantCandidates.unshift({ tenantId: scope.tenantId })
+
+  return {
+    entityId: scope.entityId,
+    $and: [
+      { $or: organizationCandidates },
+      { $or: tenantCandidates },
+    ],
+  }
+}
+
+function toMillis(value: unknown): number {
+  if (value instanceof Date) {
+    const ms = value.getTime()
+    return Number.isFinite(ms) ? ms : 0
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    const ms = Date.parse(value)
+    return Number.isFinite(ms) ? ms : 0
+  }
+  return 0
+}
+
+async function latestUpdatedAtMillis(
+  em: EntityManager,
+  entity: unknown,
+  where: Record<string, unknown>,
+): Promise<number> {
+  if (!entity) return 0
+  try {
+    const row = await em.findOne(entity as never, where as never, {
+      orderBy: { updatedAt: 'desc' } as never,
+      fields: ['updatedAt'] as never,
+    })
+    if (!row || typeof row !== 'object') return 0
+    return toMillis((row as Record<string, unknown>).updatedAt)
+  } catch {
+    // Fail-open: a projection/schema hiccup must never 500 a save — it degrades
+    // to "no version available", which the guard treats as a no-op.
+    return 0
+  }
+}
+
+export async function resolveEntityDefinitionsVersion(
+  em: EntityManager,
+  scope: EntityDefinitionsVersionScope,
+): Promise<string | null> {
+  const where = buildVisibleScopeWhere(scope)
+  const [defMillis, configMillis] = await Promise.all([
+    latestUpdatedAtMillis(em, CustomFieldDef, where),
+    latestUpdatedAtMillis(em, CustomFieldEntityConfig, where),
+  ])
+  const newest = Math.max(defMillis, configMillis)
+  if (!newest) return null
+  return new Date(newest).toISOString()
+}


### PR DESCRIPTION
Fixes #3152

## Problem
The entity definition edit pages (`/backend/entities/user/<entityId>` and `/backend/entities/system/<entityId>`) had no conflict detection. Opening the same entity in two tabs and saving from both produced two success toasts and no conflict bar — the second save silently overwrote the first with no warning to either user.

## Root Cause
The edit form saves a whole field-definition set via `POST /api/entities/definitions.batch`, which:
1. did not read the `x-om-ext-optimistic-lock-expected-updated-at` header, and
2. the form did not send it.

There is no single row to lock (the "entity definition" is a set of `CustomFieldDef` rows plus fieldset config), so the per-record `updated_at` CRUD guard could not apply.

## What Changed
- **New `resolveEntityDefinitionsVersion` helper** derives an aggregate schema version = the newest `updated_at` across the entity's `CustomFieldDef` + `CustomFieldEntityConfig` rows in the caller's visible scope.
- **`GET /api/entities/definitions.manage`** returns this `version`; the form loads it.
- **`POST /api/entities/definitions.batch`** enforces the version via `enforceCommandOptimisticLock` (shared command-level guard) and returns the shared structured **409** (`code: optimistic_lock_conflict`) on a stale save. It returns the fresh `version` so the client can round-trip it.
- **`DELETE /api/entities/definitions`** also returns the fresh `version` so an out-of-band single-field delete keeps the client token in sync.
- **The edit form** sends the version as the optimistic-lock header on every batch write (Save, reorder auto-save, and the unused `saveAll`), surfaces the conflict on the shared conflict bar (`CrudForm` auto-detects it on the main Save; the reorder path calls `surfaceRecordConflict` directly), and updates its stored token after each successful batch/delete/restore.

### Design note — why `CustomEntity.updatedAt` is excluded
The form's Save first PUTs entity metadata (`POST /api/entities/entities`, which bumps `CustomEntity.updatedAt` and enforces its own lock) and only then PUTs the definitions batch. Folding the metadata row into the definitions token would make the batch 409 against the form's **own** just-completed metadata save. So:
- **Custom entities** keep concurrent-edit protection from the metadata PUT lock (primary) with the definitions token as defense-in-depth.
- **System/code entities** (no metadata PUT) rely on the definitions token.
- Known edge: a schema with zero definitions and no config yields a `null` token, so the very first concurrent field add on such an entity is not caught; every subsequent concurrent edit is.

Strictly additive — callers that do not send the header pass through unchanged (`OM_OPTIMISTIC_LOCK` env contract respected).

## Tests
- `definitions.batch.optimistic-lock.test.ts` — stale save → 409 before any transaction; matching version → 200 + fresh version; no header → additive 200; null current version → no-op.
- `definitions-version.test.ts` — aggregate version = max over defs/config, config-only fallback, null when empty, and the visible tenant/org scope + `updatedAt`-only projection.
- `edit-entity-page-submit.test.tsx` — new case asserts the batch call is wrapped with the loaded version header; existing cases updated for the new mocks.
- Existing `definitions.batch.test.ts` stubs the version helper so its prefetch/bounds assertions still hold.
- Full `packages/core` entities suite (27 suites / 177 tests) green; core typecheck 0 errors; core build OK; ESLint 0 errors on changed files.

## Backward Compatibility
Additive only: new optional `version` response fields, a new internal lib helper, and a guard that no-ops without the header. No removed fields, no changed public signatures, no touched event IDs / widget spots / ACL IDs / DI names / route URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
