### PR TITLE
fix(staff): stop TimerBar elapsed drift when tab is throttled (#3718)

### DIFF
--- a/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
@@ -82,13 +82,12 @@ export function TimerBar({ projects, staffMemberId, onTimerStopped }: TimerBarPr
 
   const startElapsedCounter = useCallback((startedAt: string) => {
     const startTime = new Date(startedAt).getTime()
-    const now = Date.now()
-    const initialElapsed = Math.max(0, Math.floor((now - startTime) / 1000))
-    setElapsedSeconds(initialElapsed)
+    const calcElapsed = () => Math.max(0, Math.floor((Date.now() - startTime) / 1000))
+    setElapsedSeconds(calcElapsed())
 
     if (intervalRef.current) clearInterval(intervalRef.current)
     intervalRef.current = setInterval(() => {
-      setElapsedSeconds((prev) => prev + 1)
+      setElapsedSeconds(calcElapsed())
     }, 1000)
   }, [])
 

--- a/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.elapsedDrift.test.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.elapsedDrift.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, render, screen } from '@testing-library/react'
+import { TimerBar } from '../TimerBar'
+import { apiCall, apiCallOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockRunMutation = jest.fn(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+const mockRetryLastMutation = jest.fn(async () => true)
+const mockTranslate = (_key: string, fallback?: string) => fallback ?? ''
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: mockRunMutation,
+    retryLastMutation: mockRetryLastMutation,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+  apiCallOrThrow: jest.fn(),
+}))
+
+const mockApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+const mockApiCallOrThrow = apiCallOrThrow as jest.MockedFunction<typeof apiCallOrThrow>
+
+const projects = [
+  { id: 'project-1', name: 'Build', code: 'BLD', color: null },
+]
+
+const START_ISO = '2026-07-02T10:00:00.000Z'
+const START_MS = Date.parse(START_ISO)
+
+async function flushMicrotasks() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+describe('TimerBar elapsed counter drift', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRunMutation.mockImplementation(async ({ operation }: { operation: () => Promise<unknown> }) => operation())
+    mockApiCallOrThrow.mockResolvedValue({ result: { id: 'entry-1' } } as any)
+    mockApiCall.mockResolvedValue({
+      ok: true,
+      result: {
+        items: [{
+          id: 'entry-1',
+          time_project_id: 'project-1',
+          notes: '',
+          started_at: START_ISO,
+          ended_at: null,
+        }],
+      },
+    } as any)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('recomputes elapsed from wall-clock time so it stays accurate when interval ticks are throttled', async () => {
+    let intervalCallback: (() => void) | null = null
+    jest.spyOn(global, 'setInterval').mockImplementation(((cb: () => void) => {
+      intervalCallback = cb
+      return 1 as unknown as ReturnType<typeof setInterval>
+    }) as typeof setInterval)
+    jest.spyOn(global, 'clearInterval').mockImplementation(() => undefined)
+
+    let currentNow = START_MS
+    jest.spyOn(Date, 'now').mockImplementation(() => currentNow)
+
+    render(<TimerBar projects={projects} staffMemberId="staff-1" onTimerStopped={jest.fn()} />)
+    await flushMicrotasks()
+
+    // Active timer detected on mount; elapsed initialised to zero.
+    expect(screen.getByRole('button', { name: 'Stop timer' })).toBeInTheDocument()
+    expect(screen.getByText('0:00:00')).toBeInTheDocument()
+    expect(intervalCallback).toBeTruthy()
+
+    // Simulate a backgrounded/minimized tab: two real minutes elapsed on the
+    // wall clock, but the throttled interval only got to fire a single tick.
+    currentNow = START_MS + 120_000
+    act(() => { intervalCallback!() })
+
+    // Tick-counting would show 0:00:01; recomputing from Date.now shows 0:02:00.
+    expect(screen.getByText('0:02:00')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #3718

## Problem
On `/backend/staff/timesheets`, the TimerBar elapsed counter progressively falls behind the sidebar indicator when the browser window is minimized or the tab is backgrounded. After a few minutes the split display can differ by 2+ minutes for the same running timer.

## Root Cause
`TimerBar.tsx`'s `startElapsedCounter` incremented the elapsed counter by `+1` per `setInterval` tick:

```js
setInterval(() => setElapsedSeconds((prev) => prev + 1), 1000)
```

Browsers throttle `setInterval` for minimized/backgrounded tabs, so the counter accumulates fewer ticks than real seconds elapsed and drifts. The sidebar indicator (`timer-sidebar-indicator/widget.tsx`) already avoids this by recomputing from `Date.now() - startTime` on every tick, which is why only the TimerBar fell behind.

## What Changed
- `TimerBar.tsx`: recompute elapsed from `(Date.now() - startTime)` on every tick (via a `calcElapsed` closure), mirroring the sidebar indicator. Throttling no longer causes drift because each tick reads the wall clock instead of counting ticks.

## Tests
- Added `TimerBar.elapsedDrift.test.tsx`: captures the interval callback and fires a single throttled tick after advancing the mocked wall clock by two minutes, asserting the display shows `0:02:00` (recomputed) rather than `0:00:01` (tick-counted). Verified it fails against the pre-fix code and passes after the fix.
- `TimerBar.guardedMutation.test.tsx` and the other timesheets-ui suites remain green.
- `tsc --project packages/core/tsconfig.json --noEmit` clean; ESLint clean on changed files.

## Backward Compatibility
No contract surface changes — the edit is confined to an internal client-component function; no types, imports, event IDs, widget spot IDs, ACL/DI names, API routes, or DB schema affected.