### PR TITLE
fix(staff): keep overnight timers visible and stoppable after midnight (#3717)

### DIFF
--- a/packages/core/src/modules/staff/api/timesheets/time-entries/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/route.ts
@@ -4,6 +4,7 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveCrudRecordId, parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
 import { StaffTimeEntry } from '../../../data/entities'
 import { staffTimeEntryCreateSchema, staffTimeEntryUpdateSchema } from '../../../data/validators'
+import { buildTimeEntryListFilters, isParseableDateFilter } from '../../../lib/timesheets/timeEntryListFilters'
 import { createStaffCrudOpenApi, createPagedListResponseSchema, defaultOkResponseSchema } from '../../openapi'
 
 const F = {
@@ -37,13 +38,6 @@ export const metadata = routeMetadata
 
 const rawBodySchema = z.object({}).passthrough()
 
-const isParseableDateFilter = (value: string): boolean => {
-  const trimmed = value.trim()
-  if (trimmed.length === 0) return true
-  if (!/^\d{4}-\d{2}-\d{2}([T ].*)?$/.test(trimmed)) return false
-  return !Number.isNaN(new Date(trimmed).getTime())
-}
-
 const dateFilterSchema = z
   .string()
   .refine(isParseableDateFilter, { message: 'Invalid date' })
@@ -58,6 +52,7 @@ const listSchema = z
     to: dateFilterSchema,
     projectId: z.string().uuid().optional(),
     ids: z.string().optional(),
+    running: z.string().optional(),
     sortField: z.string().optional(),
     sortDir: z.enum(['asc', 'desc']).optional(),
   })
@@ -100,31 +95,7 @@ const crud = makeCrudRoute({
       updatedAt: F.updated_at,
       durationMinutes: F.duration_minutes,
     },
-    buildFilters: async (query) => {
-      const filters: Record<string, unknown> = {}
-      if (typeof query.ids === 'string' && query.ids.trim().length > 0) {
-        const ids = query.ids
-          .split(',')
-          .map((value) => value.trim())
-          .filter((value) => value.length > 0)
-        if (ids.length > 0) {
-          filters[F.id] = { $in: ids }
-        }
-      }
-      if (typeof query.staffMemberId === 'string' && query.staffMemberId.length > 0) {
-        filters[F.staff_member_id] = query.staffMemberId
-      }
-      if (typeof query.from === 'string' && query.from.length > 0 && isParseableDateFilter(query.from)) {
-        filters[F.date] = { ...((filters[F.date] as Record<string, unknown>) ?? {}), $gte: query.from }
-      }
-      if (typeof query.to === 'string' && query.to.length > 0 && isParseableDateFilter(query.to)) {
-        filters[F.date] = { ...((filters[F.date] as Record<string, unknown>) ?? {}), $lte: query.to }
-      }
-      if (typeof query.projectId === 'string' && query.projectId.length > 0) {
-        filters[F.time_project_id] = query.projectId
-      }
-      return filters
-    },
+    buildFilters: async (query) => buildTimeEntryListFilters(query),
   },
   actions: {
     create: {

--- a/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/TimerBar.tsx
@@ -103,10 +103,9 @@ export function TimerBar({ projects, staffMemberId, onTimerStopped }: TimerBarPr
   useEffect(() => {
     if (!staffMemberId) return
 
-    const today = getToday()
     const checkActiveTimer = async () => {
       const response = await apiCall(
-        `/api/staff/timesheets/time-entries?staffMemberId=${staffMemberId}&from=${today}&to=${today}&pageSize=50`,
+        `/api/staff/timesheets/time-entries?staffMemberId=${staffMemberId}&running=true&pageSize=50`,
       )
       if (!response.ok) return
 

--- a/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.guardedMutation.test.tsx
+++ b/packages/core/src/modules/staff/lib/timesheets-ui/__tests__/TimerBar.guardedMutation.test.tsx
@@ -72,6 +72,33 @@ describe('TimerBar guarded mutations', () => {
     )
   })
 
+  it('surfaces the Stop button for a timer started before midnight and looks it up by running state (issue #3717)', async () => {
+    const startedYesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+    mockApiCall.mockResolvedValue({
+      ok: true,
+      result: {
+        items: [{
+          id: 'entry-overnight',
+          time_project_id: 'project-1',
+          notes: 'Overnight task',
+          started_at: startedYesterday,
+          ended_at: null,
+        }],
+      },
+    } as any)
+
+    render(<TimerBar projects={projects} staffMemberId="staff-1" onTimerStopped={jest.fn()} />)
+
+    // The orphaned overnight timer must be controllable: the Stop affordance appears
+    // even though the entry's date is no longer "today".
+    expect(await screen.findByRole('button', { name: 'Stop timer' })).toBeTruthy()
+
+    const lookupUrl = String(mockApiCall.mock.calls[0]?.[0] ?? '')
+    expect(lookupUrl).toContain('running=true')
+    expect(lookupUrl).not.toContain('from=')
+    expect(lookupUrl).not.toContain('to=')
+  })
+
   it('routes timer stop through guarded mutation context', async () => {
     mockApiCall.mockResolvedValue({
       ok: true,

--- a/packages/core/src/modules/staff/lib/timesheets/__tests__/timeEntryListFilters.test.ts
+++ b/packages/core/src/modules/staff/lib/timesheets/__tests__/timeEntryListFilters.test.ts
@@ -1,0 +1,40 @@
+import { buildTimeEntryListFilters } from '../timeEntryListFilters'
+
+describe('buildTimeEntryListFilters — running filter (issue #3717)', () => {
+  it('matches the open timer regardless of date when running=true', () => {
+    const filters = buildTimeEntryListFilters({ staffMemberId: 'staff-1', running: 'true' })
+
+    expect(filters.started_at).toEqual({ $ne: null })
+    expect(filters.ended_at).toBeNull()
+    // A running lookup must NOT scope by date — an overnight timer is off "today".
+    expect(filters.date).toBeUndefined()
+    expect(filters.staff_member_id).toBe('staff-1')
+  })
+
+  it('does not apply the running filter when running is absent or false', () => {
+    expect(buildTimeEntryListFilters({ staffMemberId: 'staff-1' }).started_at).toBeUndefined()
+    expect(buildTimeEntryListFilters({ staffMemberId: 'staff-1', running: 'false' }).started_at).toBeUndefined()
+    expect(buildTimeEntryListFilters({ staffMemberId: 'staff-1', running: 'false' }).ended_at).toBeUndefined()
+  })
+
+  it('keeps the date-window filter intact for the historical list view', () => {
+    const filters = buildTimeEntryListFilters({ from: '2026-06-30', to: '2026-06-30' })
+
+    expect(filters.date).toEqual({ $gte: '2026-06-30', $lte: '2026-06-30' })
+    expect(filters.started_at).toBeUndefined()
+    expect(filters.ended_at).toBeUndefined()
+  })
+
+  it('can combine a running lookup with a project filter', () => {
+    const filters = buildTimeEntryListFilters({ running: 'true', projectId: 'project-9' })
+
+    expect(filters.started_at).toEqual({ $ne: null })
+    expect(filters.ended_at).toBeNull()
+    expect(filters.time_project_id).toBe('project-9')
+  })
+
+  it('parses id lists and ignores blank entries', () => {
+    const filters = buildTimeEntryListFilters({ ids: 'a, ,b' })
+    expect(filters.id).toEqual({ $in: ['a', 'b'] })
+  })
+})

--- a/packages/core/src/modules/staff/lib/timesheets/timeEntryListFilters.ts
+++ b/packages/core/src/modules/staff/lib/timesheets/timeEntryListFilters.ts
@@ -1,0 +1,64 @@
+import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+
+export type TimeEntryListFilterQuery = {
+  ids?: string
+  staffMemberId?: string
+  from?: string
+  to?: string
+  projectId?: string
+  running?: string
+}
+
+const ID_COLUMN = 'id'
+const STAFF_MEMBER_COLUMN = 'staff_member_id'
+const DATE_COLUMN = 'date'
+const STARTED_AT_COLUMN = 'started_at'
+const ENDED_AT_COLUMN = 'ended_at'
+const PROJECT_COLUMN = 'time_project_id'
+
+export function isParseableDateFilter(value: string): boolean {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return true
+  if (!/^\d{4}-\d{2}-\d{2}([T ].*)?$/.test(trimmed)) return false
+  return !Number.isNaN(new Date(trimmed).getTime())
+}
+
+/**
+ * Builds the query-engine filter map for the time-entries list route.
+ *
+ * The `running` flag matches the currently-open timer regardless of its date
+ * (`started_at IS NOT NULL AND ended_at IS NULL`). A timer started before
+ * midnight is still running the next day, so a `from=today&to=today` lookup
+ * would miss it and leave the entry invisible/uncontrollable (issue #3717).
+ * This mirrors the single-active-timer check in the `start_timer` command so
+ * the UI can always surface and stop an orphaned overnight timer.
+ */
+export function buildTimeEntryListFilters(query: TimeEntryListFilterQuery): Record<string, unknown> {
+  const filters: Record<string, unknown> = {}
+  if (typeof query.ids === 'string' && query.ids.trim().length > 0) {
+    const ids = query.ids
+      .split(',')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+    if (ids.length > 0) {
+      filters[ID_COLUMN] = { $in: ids }
+    }
+  }
+  if (typeof query.staffMemberId === 'string' && query.staffMemberId.length > 0) {
+    filters[STAFF_MEMBER_COLUMN] = query.staffMemberId
+  }
+  if (typeof query.from === 'string' && query.from.length > 0 && isParseableDateFilter(query.from)) {
+    filters[DATE_COLUMN] = { ...((filters[DATE_COLUMN] as Record<string, unknown>) ?? {}), $gte: query.from }
+  }
+  if (typeof query.to === 'string' && query.to.length > 0 && isParseableDateFilter(query.to)) {
+    filters[DATE_COLUMN] = { ...((filters[DATE_COLUMN] as Record<string, unknown>) ?? {}), $lte: query.to }
+  }
+  if (typeof query.projectId === 'string' && query.projectId.length > 0) {
+    filters[PROJECT_COLUMN] = query.projectId
+  }
+  if (parseBooleanToken(query.running ?? null) === true) {
+    filters[STARTED_AT_COLUMN] = { $ne: null }
+    filters[ENDED_AT_COLUMN] = null
+  }
+  return filters
+}

--- a/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/__tests__/widget.client.test.tsx
@@ -71,6 +71,7 @@ type Deferred = { resolve: (value: unknown) => void }
 describe('staff TimeReportingWidget — issue #3306 parallel load', () => {
   let deferred: Partial<Record<LoadStage, Deferred>>
   let callCounts: Record<LoadStage, number>
+  let stageUrls: Partial<Record<LoadStage, string>>
 
   function callCount(stage: LoadStage): number {
     return callCounts[stage]
@@ -86,11 +87,14 @@ describe('staff TimeReportingWidget — issue #3306 parallel load', () => {
   beforeEach(() => {
     deferred = {}
     callCounts = { assignments: 0, self: 0, projects: 0, entries: 0 }
+    stageUrls = {}
     mockReadApiResult.mockReset()
     mockApiCall.mockReset()
     mockReadApiResult.mockImplementation((input: RequestInfo | URL) => {
-      const stage = classifyUrl(String(input))
+      const url = String(input)
+      const stage = classifyUrl(url)
       callCounts[stage] += 1
+      stageUrls[stage] = url
       return new Promise((resolve) => {
         deferred[stage] = { resolve }
       })
@@ -152,6 +156,27 @@ describe('staff TimeReportingWidget — issue #3306 parallel load', () => {
       expect(screen.getByText('Timer running')).toBeTruthy()
     })
     expect(screen.getByRole('button', { name: 'Stop Timer' })).toBeTruthy()
+  })
+
+  it('looks up the active timer by running state rather than today (issue #3717)', async () => {
+    renderWidget()
+
+    await waitFor(() => {
+      expect(callCount('assignments')).toBe(1)
+      expect(callCount('self')).toBe(1)
+    })
+    await resolveStage('assignments', { items: [] })
+    await resolveStage('self', { member: { id: 'member-1' } })
+
+    await waitFor(() => {
+      expect(callCount('entries')).toBe(1)
+    })
+
+    const entriesUrl = stageUrls.entries ?? ''
+    expect(entriesUrl).toContain('running=true')
+    // A date-scoped lookup hides a timer started before midnight after the date rolls over.
+    expect(entriesUrl).not.toContain('from=')
+    expect(entriesUrl).not.toContain('to=')
   })
 
   it('skips the project-details request and shows the empty state when no projects are assigned', async () => {

--- a/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/widget.client.tsx
+++ b/packages/core/src/modules/staff/widgets/dashboard/timesheets-time-reporting/widget.client.tsx
@@ -91,9 +91,7 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
       const memberId = selfRes.member?.id ?? null
       setStaffMemberId(memberId)
 
-      const today = new Date().toISOString().slice(0, 10)
-
-      // Project details depend on the assignment ids and active entries depend on the staff
+      // Project details depend on the assignment ids and the active timer depends on the staff
       // member id, but the two requests are independent of each other — fetch them together.
       const [projectsRes, entriesRes] = await Promise.all([
         projectIds.length > 0
@@ -105,7 +103,7 @@ const TimeReportingWidget: React.FC<DashboardWidgetComponentProps<TimeReportingS
           : Promise.resolve<{ items?: Array<Record<string, unknown>> }>({ items: [] }),
         memberId
           ? readApiResultOrThrow<{ items?: Array<Record<string, unknown>> }>(
-              `/api/staff/timesheets/time-entries?staffMemberId=${memberId}&from=${today}&to=${today}&pageSize=100`,
+              `/api/staff/timesheets/time-entries?staffMemberId=${memberId}&running=true&pageSize=100`,
               undefined,
               { errorMessage: '', fallback: { items: [] } },
             )

--- a/packages/core/src/modules/staff/widgets/injection/timer-sidebar-indicator/widget.tsx
+++ b/packages/core/src/modules/staff/widgets/injection/timer-sidebar-indicator/widget.tsx
@@ -39,11 +39,6 @@ function formatElapsed(seconds: number): string {
   return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
 }
 
-function getToday(): string {
-  const now = new Date()
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
-}
-
 function TimerSidebarIndicator() {
   const t = useT()
   // Initialise from sessionStorage so the indicator doesn't flash away on navigation
@@ -63,9 +58,8 @@ function TimerSidebarIndicator() {
       const memberId = selfRes.result?.member?.id
       if (!memberId) { updateTimer(null); return }
 
-      const today = getToday()
       const res = await apiCall<{ items?: Array<Record<string, unknown>> }>(
-        `/api/staff/timesheets/time-entries?staffMemberId=${memberId}&from=${today}&to=${today}&pageSize=50`,
+        `/api/staff/timesheets/time-entries?staffMemberId=${memberId}&running=true&pageSize=50`,
       )
       const items = (res.result?.items ?? []) as Array<Record<string, unknown>>
       const active = items.find((e) => e.started_at && !e.ended_at)


### PR DESCRIPTION
Fixes #3717

## Problem
A timesheets timer started before midnight becomes invisible and uncontrollable after the date changes: the TimerBar shows `0:00:00` with a **Play** button (no running timer), but clicking **Play** returns `409 Conflict` ("Another timer is already running…"), with no **Stop** affordance anywhere in the UI. The user is stuck without a direct API call.

## Root Cause
Every active-timer surface looked up the running entry with a `from=TODAY&to=TODAY` window:
- `TimerBar` (`checkActiveTimer` effect)
- the sidebar timer indicator widget
- the dashboard time-reporting widget

After midnight, `TODAY` is the new date, so the previous day's still-open entry (`ended_at = null`) is outside the range and the hook reports `running: false` → **Play** button. Meanwhile the `start_timer` command correctly checks for a running timer **globally** (`started_at IS NOT NULL AND ended_at IS NULL`, any date) and blocks the duplicate start with `409`. The UI and the server disagreed on what "running" means.

## What Changed
- Added a date-independent `running` filter to the `time-entries` list route. When `running=true`, it filters `started_at IS NOT NULL AND ended_at IS NULL` — the same definition the `start_timer` command uses for the single-active-timer invariant. Additive, optional query param.
- Extracted the route's filter-building into a small, pure, unit-testable lib (`lib/timesheets/timeEntryListFilters.ts`); the route now delegates to it.
- Pointed all three timer surfaces (`TimerBar`, sidebar indicator, dashboard time-reporting widget) at `running=true` instead of `from=today&to=today`, so an orphaned overnight timer is always found and its **Stop** control is shown. The running lookup flows through `makeCrudRoute` → query engine, which keeps automatic tenant/organization scoping intact.

## Tests
- New `timeEntryListFilters.test.ts` — proves `running=true` → `{ started_at: { $ne: null }, ended_at: null }` with **no** date filter; `running` absent/`false` applies neither; the historical date-window path is unchanged.
- `TimerBar.guardedMutation.test.tsx` — new regression: a timer started **before midnight** (prior day) still surfaces the **Stop timer** button, and the lookup URL uses `running=true` with no `from=`/`to=`.
- `timesheets-time-reporting/widget.client.test.tsx` — new regression: the dashboard active-timer lookup uses `running=true`, not a today-scoped window.
- Gate: `yarn build:packages`, `yarn generate`, full `yarn typecheck` (21/21), `yarn i18n:check-sync`, core `yarn test` (7162 passing; the one failing `customers/DealsKpiStrip` test is a pre-existing locale-formatting failure on `develop`, unchanged by this PR), `yarn build:app`. Full staff suite: 135 passing.

## Backward Compatibility
- No contract-surface breakage. `running` is a **new optional** query param on an existing route (additive); route exports (`GET`/`POST`/`PUT`/`DELETE`/`openApi`/`metadata`) are unchanged. `isParseableDateFilter` moved from route-local to an internal lib (no external consumers). No DB schema, event ID, DI key, ACL, or import-path changes.