### PR TITLE
feat(ui): allow hiding backend footer status bar

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -41,6 +41,9 @@ APP_URL=http://localhost:3000
 SELF_SERVICE_ONBOARDING_ENABLED=false
 DEMO_MODE=true
 
+# Hide the backend footer status bar (app version + terms/privacy links) (default: false)
+OM_HIDE_BACKEND_FOOTER=false
+
 # Enable enterprise-only optional modules (default: false)
 # Developer preview is free for local/dev usage.
 # Production usage requires a commercial enterprise license.

--- a/apps/mercato/src/app/(backend)/backend/layout.tsx
+++ b/apps/mercato/src/app/(backend)/backend/layout.tsx
@@ -82,6 +82,7 @@ export default async function BackendLayout({
   const collapsedCookie = cookieStore.get('om_sidebar_collapsed')?.value
   const initialCollapsed = collapsedCookie === '1'
   const demoModeEnabled = parseBooleanWithDefault(process.env.DEMO_MODE, true)
+  const hideBackendFooter = parseBooleanWithDefault(process.env.OM_HIDE_BACKEND_FOOTER, false)
   const deployEnv = process.env.DEPLOY_ENV
   const grantedFeatures = Array.isArray(auth?.features)
     ? auth.features.filter((feature): feature is string => typeof feature === 'string')
@@ -122,6 +123,7 @@ export default async function BackendLayout({
         )}
         adminNavApi="/api/auth/admin/nav"
         version={APP_VERSION}
+        hideFooter={hideBackendFooter}
         settingsPathPrefixes={collectStaticSettingsPathPrefixes()}
         settingsSections={[]}
         settingsSectionTitle={translate('backend.nav.settings', 'Settings')}

--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -139,6 +139,12 @@ export type AppShellProps = {
   profilePathPrefixes?: string[]
   mobileSidebarSlot?: React.ReactNode
   /**
+   * Hide the backend footer status bar (app version + terms/privacy links).
+   * Intended for app developers and whitelabel/embedded deployments that want to
+   * suppress the footer entirely. Defaults to `false` (footer shown).
+   */
+  hideFooter?: boolean
+  /**
    * How long (ms) to keep successfully completed progress operations visible
    * before auto-hiding. Pass `false` or `0` to disable. Defaults to 10 000 ms.
    */
@@ -454,7 +460,7 @@ export function AppShell(props: AppShellProps) {
   )
 }
 
-function AppShellBody({ productName, logo, email, canManageUpgradeActions = false, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot, progressCompletedAutoHideMs }: AppShellProps) {
+function AppShellBody({ productName, logo, email, canManageUpgradeActions = false, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot, hideFooter = false, progressCompletedAutoHideMs }: AppShellProps) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const t = useT()
@@ -1426,21 +1432,23 @@ function AppShellBody({ productName, logo, email, canManageUpgradeActions = fals
           </OrganizationScopeBoundary>
           <InjectionSpot spotId={BACKEND_LAYOUT_FOOTER_INJECTION_SPOT_ID} context={injectionContext} />
         </main>
-        <footer className="border-t bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/80 px-4 py-3 flex flex-wrap items-center justify-end gap-4">
-          {version ? (
-            <span className="text-xs text-muted-foreground">
-              {t('appShell.version', { version })}
-            </span>
-          ) : null}
-          <nav className="flex items-center gap-3 text-xs text-muted-foreground">
-            <Link href="/terms" className="transition hover:text-foreground">
-              {t('common.terms')}
-            </Link>
-            <Link href="/privacy" className="transition hover:text-foreground">
-              {t('common.privacy')}
-            </Link>
-          </nav>
-        </footer>
+        {hideFooter ? null : (
+          <footer className="border-t bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/80 px-4 py-3 flex flex-wrap items-center justify-end gap-4">
+            {version ? (
+              <span className="text-xs text-muted-foreground">
+                {t('appShell.version', { version })}
+              </span>
+            ) : null}
+            <nav className="flex items-center gap-3 text-xs text-muted-foreground">
+              <Link href="/terms" className="transition hover:text-foreground">
+                {t('common.terms')}
+              </Link>
+              <Link href="/privacy" className="transition hover:text-foreground">
+                {t('common.privacy')}
+              </Link>
+            </nav>
+          </footer>
+        )}
       </div>
 
       {/* Mobile drawer */}


### PR DESCRIPTION
## What

Adds the ability to hide the backend footer status bar (app version + Terms / Privacy links).

## Why

Whitelabel and embedded deployments — and app developers building on Open Mercato — want to suppress the footer entirely. Previously it was always rendered in the backend `AppShell`.

## Changes

- **`packages/ui/src/backend/AppShell.tsx`** — new `hideFooter?: boolean` prop on `AppShellProps` (defaults to `false`); the `<footer>` is only rendered when it's falsy. Available as a component prop for app developers.
- **`apps/mercato/src/app/(backend)/backend/layout.tsx`** — reads a new app-wide `OM_HIDE_BACKEND_FOOTER` env flag via `parseBooleanWithDefault(..., false)` and passes it as `hideFooter`.
- **`apps/mercato/.env.example`** — documents `OM_HIDE_BACKEND_FOOTER=false`.

## Usage

- Component: `<AppShell hideFooter ... />`
- Deployment-wide: `OM_HIDE_BACKEND_FOOTER=true`

## Notes

- Backward compatible — additive prop, default `false` preserves current behavior.
- Scope is the **backend** footer only; the login/onboarding `AuthFooter` is a separate component and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)