### PR TITLE
fix(ui): keep backend footer hiding in template

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -41,6 +41,9 @@ APP_URL=http://localhost:3000
 SELF_SERVICE_ONBOARDING_ENABLED=false
 DEMO_MODE=true
 
+# Hide the backend footer status bar (app version + terms/privacy links) (default: false)
+OM_HIDE_BACKEND_FOOTER=false
+
 # Enable enterprise-only optional modules (default: false)
 # Developer preview is free for local/dev usage.
 # Production usage requires a commercial enterprise license.

--- a/apps/mercato/src/app/(backend)/backend/layout.tsx
+++ b/apps/mercato/src/app/(backend)/backend/layout.tsx
@@ -82,6 +82,7 @@ export default async function BackendLayout({
   const collapsedCookie = cookieStore.get('om_sidebar_collapsed')?.value
   const initialCollapsed = collapsedCookie === '1'
   const demoModeEnabled = parseBooleanWithDefault(process.env.DEMO_MODE, true)
+  const hideBackendFooter = parseBooleanWithDefault(process.env.OM_HIDE_BACKEND_FOOTER, false)
   const deployEnv = process.env.DEPLOY_ENV
   const grantedFeatures = Array.isArray(auth?.features)
     ? auth.features.filter((feature): feature is string => typeof feature === 'string')
@@ -122,6 +123,7 @@ export default async function BackendLayout({
         )}
         adminNavApi="/api/auth/admin/nav"
         version={APP_VERSION}
+        hideFooter={hideBackendFooter}
         settingsPathPrefixes={collectStaticSettingsPathPrefixes()}
         settingsSections={[]}
         settingsSectionTitle={translate('backend.nav.settings', 'Settings')}

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -42,6 +42,9 @@ SELF_SERVICE_ONBOARDING_ENABLED=false
 # Enable Open Mercato demo widgets (default: false)
 DEMO_MODE=false
 
+# Hide the backend footer status bar (app version + terms/privacy links) (default: false)
+OM_HIDE_BACKEND_FOOTER=false
+
 # Enable enterprise-only optional modules (default: false)
 # Developer preview is free for local/dev usage.
 # Production usage requires a commercial enterprise license.

--- a/packages/create-app/template/src/app/(backend)/backend/layout.tsx
+++ b/packages/create-app/template/src/app/(backend)/backend/layout.tsx
@@ -82,6 +82,7 @@ export default async function BackendLayout({
   const collapsedCookie = cookieStore.get('om_sidebar_collapsed')?.value
   const initialCollapsed = collapsedCookie === '1'
   const demoModeEnabled = parseBooleanWithDefault(process.env.DEMO_MODE, true)
+  const hideBackendFooter = parseBooleanWithDefault(process.env.OM_HIDE_BACKEND_FOOTER, false)
   const deployEnv = process.env.DEPLOY_ENV
   const grantedFeatures = Array.isArray(auth?.features)
     ? auth.features.filter((feature): feature is string => typeof feature === 'string')
@@ -122,6 +123,7 @@ export default async function BackendLayout({
         )}
         adminNavApi="/api/auth/admin/nav"
         version={APP_VERSION}
+        hideFooter={hideBackendFooter}
         settingsPathPrefixes={collectStaticSettingsPathPrefixes()}
         settingsSections={[]}
         settingsSectionTitle={translate('backend.nav.settings', 'Settings')}

--- a/packages/ui/src/backend/AppShell.tsx
+++ b/packages/ui/src/backend/AppShell.tsx
@@ -139,6 +139,12 @@ export type AppShellProps = {
   profilePathPrefixes?: string[]
   mobileSidebarSlot?: React.ReactNode
   /**
+   * Hide the backend footer status bar (app version + terms/privacy links).
+   * Intended for app developers and whitelabel/embedded deployments that want to
+   * suppress the footer entirely. Defaults to `false` (footer shown).
+   */
+  hideFooter?: boolean
+  /**
    * How long (ms) to keep successfully completed progress operations visible
    * before auto-hiding. Pass `false` or `0` to disable. Defaults to 10 000 ms.
    */
@@ -454,7 +460,7 @@ export function AppShell(props: AppShellProps) {
   )
 }
 
-function AppShellBody({ productName, logo, email, canManageUpgradeActions = false, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot, progressCompletedAutoHideMs }: AppShellProps) {
+function AppShellBody({ productName, logo, email, canManageUpgradeActions = false, groups, rightHeaderSlot, children, sidebarCollapsedDefault = false, currentTitle, breadcrumb, version, settingsSectionTitle, settingsPathPrefixes = [], settingsSections, profileSections, profileSectionTitle, profilePathPrefixes = [], mobileSidebarSlot, hideFooter = false, progressCompletedAutoHideMs }: AppShellProps) {
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const t = useT()
@@ -1426,21 +1432,23 @@ function AppShellBody({ productName, logo, email, canManageUpgradeActions = fals
           </OrganizationScopeBoundary>
           <InjectionSpot spotId={BACKEND_LAYOUT_FOOTER_INJECTION_SPOT_ID} context={injectionContext} />
         </main>
-        <footer className="border-t bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/80 px-4 py-3 flex flex-wrap items-center justify-end gap-4">
-          {version ? (
-            <span className="text-xs text-muted-foreground">
-              {t('appShell.version', { version })}
-            </span>
-          ) : null}
-          <nav className="flex items-center gap-3 text-xs text-muted-foreground">
-            <Link href="/terms" className="transition hover:text-foreground">
-              {t('common.terms')}
-            </Link>
-            <Link href="/privacy" className="transition hover:text-foreground">
-              {t('common.privacy')}
-            </Link>
-          </nav>
-        </footer>
+        {hideFooter ? null : (
+          <footer className="border-t bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/80 px-4 py-3 flex flex-wrap items-center justify-end gap-4">
+            {version ? (
+              <span className="text-xs text-muted-foreground">
+                {t('appShell.version', { version })}
+              </span>
+            ) : null}
+            <nav className="flex items-center gap-3 text-xs text-muted-foreground">
+              <Link href="/terms" className="transition hover:text-foreground">
+                {t('common.terms')}
+              </Link>
+              <Link href="/privacy" className="transition hover:text-foreground">
+                {t('common.privacy')}
+              </Link>
+            </nav>
+          </footer>
+        )}
       </div>
 
       {/* Mobile drawer */}

--- a/packages/ui/src/backend/__tests__/AppShell.test.tsx
+++ b/packages/ui/src/backend/__tests__/AppShell.test.tsx
@@ -207,6 +207,25 @@ describe('AppShell', () => {
     )
   })
 
+  it('hides the backend footer status bar when requested', () => {
+    renderWithProviders(
+      <AppShell
+        email="demo@example.com"
+        groups={groups}
+        version="1.2.3"
+        hideFooter
+      >
+        <div>Child content</div>
+      </AppShell>,
+      { dict },
+    )
+
+    expect(screen.getByText('Child content')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Terms' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Privacy' })).not.toBeInTheDocument()
+    expect(screen.getByTestId('injection-spot:backend:layout:footer')).toBeInTheDocument()
+  })
+
   it('uses backend chrome brand logo when the selected organization has one', async () => {
     const previousFetch = global.fetch
     const previousWindowFetch = window.fetch


### PR DESCRIPTION
Supersedes #3745

Credit: original implementation by @jtomaszewski. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the fork branch.

## Included work
- Original changes from #3745: additive `AppShell hideFooter` prop plus `OM_HIDE_BACKEND_FOOTER` wiring in the backend layout
- Standalone create-app template parity for the same backend footer env flag
- Focused `AppShell` regression coverage for the hidden-footer path

## Validation
- `yarn workspace @open-mercato/ui test packages/ui/src/backend/__tests__/AppShell.test.tsx --runInBand` (passes; existing async act warnings from `AiAssistantLauncher` still print)
- `yarn build:packages`
- `yarn generate` (passes; OpenAPI bundling falls back because Node 25 has no `isolated-vm` native build in this worktree)
- `yarn workspace @open-mercato/ui typecheck`
- `yarn template:sync` (ran as parity check; still reports the existing unrelated 24 file / 5 dependency drift, but the backend layout/env files touched here are not listed)
