### PR TITLE
fix(search): portal top-bar search results out of the sticky header z-order trap (#3097)

### DIFF
--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-012.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-012.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth'
+
+/**
+ * TC-SEARCH-012: the global (top-bar) search results panel escapes the sticky
+ * header's stacking context so page content can never paint over it (#3097).
+ *
+ * The backend top bar is `position: sticky; z-index: 10`, which establishes a
+ * stacking context. Rendered inline, the results panel's `z-index` (z-popover)
+ * only ranked *within* that context, so relative to the page it was capped at the
+ * header's z-index — any page element with its own stacking context above 10
+ * (sticky table cells, cards, positioned widgets) bled over the results. The fix
+ * portals the panel to <body> with fixed positioning.
+ *
+ * Self-contained: needs no indexed data. A below-minimum query (< 3 chars) opens
+ * the panel in its "type more" hint state without issuing a search request, which
+ * is enough to assert both structure and stacking. A synthetic z-index:30 overlay
+ * proves the panel is painted on top — on the pre-fix inline markup that overlay
+ * painted over the trapped panel instead.
+ */
+test.describe('TC-SEARCH-012: global search results escape the sticky header stacking context', () => {
+  test('the results panel is portaled to <body> and stays above high z-index page content', async ({ page }) => {
+    await login(page, 'admin')
+    await page.goto('/backend')
+    await page.waitForLoadState('domcontentloaded')
+
+    // Open the collapsed top-bar search (icon button) and focus its input.
+    await page.locator('header').getByRole('button', { name: 'Open global search' }).click()
+    const input = page.locator('input[aria-controls="topbar-search-results"]')
+    await expect(input).toBeVisible()
+
+    // A 2-char query (below the 3-char minimum) opens the panel in its hint state
+    // — no search API call, so the assertion never depends on indexed records.
+    await input.fill('au')
+    const panel = page.locator('#topbar-search-results')
+    await expect(panel).toBeVisible()
+
+    // -- Structural guard: portaled to <body>, not nested inside the sticky header.
+    const structure = await panel.evaluate((el) => ({
+      parentIsBody: el.parentElement === document.body,
+      insideHeader: Boolean(el.closest('header')),
+      position: getComputedStyle(el).position,
+    }))
+    expect(structure.parentIsBody, 'results panel should be portaled directly under <body>').toBe(true)
+    expect(structure.insideHeader, 'results panel must not live inside the sticky header').toBe(false)
+    expect(structure.position, 'portaled panel is positioned relative to the viewport').toBe('fixed')
+
+    // -- Stacking guard: page content at z-index 30 overlapping the panel stays
+    //    BELOW it. Pre-fix, the panel was trapped at the header's z-index (10) and
+    //    this overlay painted over it.
+    const stacking = await panel.evaluate((el) => {
+      const rect = el.getBoundingClientRect()
+      const x = Math.round(rect.left + rect.width / 2)
+      const y = Math.round(rect.top + rect.height / 2)
+      const probe = document.createElement('div')
+      probe.id = '__zorder_probe__'
+      Object.assign(probe.style, {
+        position: 'fixed',
+        top: `${y - 25}px`,
+        left: `${x - 25}px`,
+        width: '50px',
+        height: '50px',
+        zIndex: '30',
+        background: 'rgba(255,0,0,0.5)',
+      })
+      document.body.appendChild(probe)
+      const stack = document.elementsFromPoint(x, y)
+      const panelIdx = stack.findIndex((node) => node === el || el.contains(node))
+      const probeIdx = stack.findIndex((node) => (node as HTMLElement).id === '__zorder_probe__')
+      probe.remove()
+      return { panelIdx, probeIdx }
+    })
+    // The panel must be present at the point and painted ABOVE the z-index:30
+    // overlay. Asserting the relative order (rather than "topmost") keeps the
+    // guard precise if some unrelated top-layer element ever overlaps the centre.
+    expect(stacking.panelIdx, 'the results panel should be hit at its own centre').toBeGreaterThanOrEqual(0)
+    expect(
+      stacking.probeIdx === -1 || stacking.panelIdx < stacking.probeIdx,
+      'a z-index:30 page element must not paint over the results panel',
+    ).toBe(true)
+  })
+})

--- a/packages/search/src/modules/search/frontend/components/TopbarSearchInline.tsx
+++ b/packages/search/src/modules/search/frontend/components/TopbarSearchInline.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import * as React from 'react'
+import { createPortal } from 'react-dom'
 import NextLink from 'next/link'
 import { useRouter } from 'next/navigation'
 import {
@@ -163,6 +164,7 @@ export function TopbarSearchInline({
   const [expanded, setExpanded] = React.useState(false)
   const [selectedIndex, setSelectedIndex] = React.useState(0)
   const [showScopeHint, setShowScopeHint] = React.useState<boolean>(() => hasActiveOrganizationSelection())
+  const [anchor, setAnchor] = React.useState<{ top: number; left: number; width: number } | null>(null)
   const inputRef = React.useRef<HTMLInputElement | null>(null)
   const popoverRef = React.useRef<HTMLDivElement | null>(null)
   const containerRef = React.useRef<HTMLElement | null>(null)
@@ -332,6 +334,29 @@ export function TopbarSearchInline({
     open && (loading || results.length > 0 || error !== null || tooShort || showVectorWarning)
   const showClear = query.length > 0
 
+  // The results panel is portaled to <body> so it escapes the sticky header's
+  // stacking context (z-sticky) — rendered inline it stays trapped at the
+  // header's z-index and page content with its own z-index paints over it
+  // (#3097). Anchor it under the input and keep it aligned on scroll/resize.
+  React.useEffect(() => {
+    if (!showPopover) return
+    const update = () => {
+      const el = containerRef.current
+      if (!el) return
+      const rect = el.getBoundingClientRect()
+      const width = Math.max(rect.width, 320)
+      const left = Math.min(Math.max(rect.left, 8), Math.max(window.innerWidth - width - 8, 8))
+      setAnchor({ top: rect.bottom + 4, left, width })
+    }
+    update()
+    window.addEventListener('resize', update)
+    window.addEventListener('scroll', update, true)
+    return () => {
+      window.removeEventListener('resize', update)
+      window.removeEventListener('scroll', update, true)
+    }
+  }, [showPopover])
+
   if (!expanded) {
     return (
       <span
@@ -412,12 +437,13 @@ export function TopbarSearchInline({
         )}
       </div>
 
-      {showPopover ? (
+      {showPopover && anchor ? createPortal(
         <div
           ref={popoverRef}
           id="topbar-search-results"
           role="listbox"
-          className="absolute left-0 right-0 top-[calc(100%+4px)] z-popover min-w-[320px] rounded-md border bg-popover text-popover-foreground shadow-md"
+          style={{ position: 'fixed', top: anchor.top, left: anchor.left, width: anchor.width }}
+          className="z-popover rounded-md border bg-popover text-popover-foreground shadow-md"
         >
           {error ? (
             <p className="border-b px-3 py-2 text-sm text-destructive">{error}</p>
@@ -509,7 +535,8 @@ export function TopbarSearchInline({
               })}
             </div>
           ) : null}
-        </div>
+        </div>,
+        document.body,
       ) : null}
     </div>
   )


### PR DESCRIPTION
## Summary

Fixes the z-order bleed-through in the backend top-bar global search (issue #3097): page content painted over the search results dropdown.

Closes #3097

## Root cause

The results panel was rendered **inline** (absolutely positioned) inside the backend top bar. That header is `position: sticky; z-index: 10`, which **establishes a stacking context**. So the panel's `z-popover` (z-index 45) only ranked *within* the header — relative to `<main>`, the entire header (and its dropdown) was capped at z-index 10. Any page content with its own stacking context above 10 (sticky table cells, positioned cards/widgets) therefore painted **over** the results.

Measured in-browser: the panel's ancestor stacking chain was `panel(z-45) → header(sticky, z-10)`, and a control element at `z-index: 30` overlapping the panel painted on top of it.

## Fix

Render the results panel through a **portal to `document.body`** with `position: fixed`, anchored under the input and kept aligned on scroll/resize. The panel now lives in the root stacking context at `z-popover`, so it sits above page content regardless of local stacking contexts.

- One file, +30/−3: `packages/search/src/modules/search/frontend/components/TopbarSearchInline.tsx`.
- Behavior preserved: outside-click dismissal already checked `popoverRef` (works across the portal), keyboard nav, `Cmd/Ctrl+K`, result-click navigation, and `aria-controls` (id-based, resolves across the portal) all unchanged.
- SSR-safe: the portal branch is gated behind `showPopover && anchor` (client-only state), and the component is a lazy client island — `document.body` is never touched on the server.

**Conscious decision (z-index vs modals):** the panel keeps the semantic `z-popover` token (45), which is above `z-modal` (40). Previously, trapped in the header, it could never cover a modal; now it can in the niche case of invoking `Cmd/Ctrl+K` while a modal is open. `z-popover` is the correct DS token for a popover and keeping it avoids arbitrary z-index values; the trade-off is intentional.

## Verification

Reproduced and verified in the browser (dev server) on list and product-detail pages:

| Check | Result |
|---|---|
| Panel portaled directly under `<body>`; stacking chain = only `[fixed, z-45]` | ✅ |
| Control element at `z-index: 30` overlapping the panel — **before:** painted over it; **after:** stays under it | ✅ reversed |
| Positioning under the input; mobile (375px) keeps the prior 12px gutters | ✅ |
| Result click navigates; outside-click dismisses | ✅ |

## Tests

Adds **`TC-SEARCH-012`** (Playwright integration): opens the top-bar search on a backend page and asserts the results panel (1) is portaled directly under `<body>` (not nested in the sticky header, `position: fixed`) and (2) stays painted above a synthetic `z-index: 30` overlay. Self-contained — a below-minimum (2-char) query opens the panel in its hint state with **no search request**, so it needs no seeded/indexed data.

Confirmed to be a genuine regression guard: against the pre-fix inline markup the test **fails** at the "portaled under `<body>`" assertion; against the fix it **passes**.

> Note: three unrelated `TC-SEARCH` specs (002, 006, 010) fail in the local dev environment — all are API-level (`request`) tests failing on `POST /api/customers/companies → 400` and `POST /api/search/settings/global-search → 500` (environment/data), independent of this frontend-only change.
