### PR TITLE
fix(cli): restore agentic:init parity with create-app fact-sheet scaffolding (TC-INT-008)

### DIFF
--- a/packages/cli/build.mjs
+++ b/packages/cli/build.mjs
@@ -1,6 +1,6 @@
-import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, readFileSync } from 'node:fs'
+import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { atomicWriteFileSync } from '../../scripts/lib/add-js-extension.mjs'
 import { buildPackage } from '../../scripts/build-package.mjs'
 
@@ -35,6 +35,18 @@ await buildPackage(packageDir, {
     const guidesDestDir = join(outdir, 'agentic', 'guides')
     mkdirSync(guidesDestDir, { recursive: true })
 
+    // Clean stale per-module artifacts before regenerating so an incremental dist never
+    // retains a removed module's full guide or fact-sheet — a removed `core.<module>.md`
+    // (two-dot, per-module) must come back as a redirect stub, not linger as a full guide.
+    // Mirrors packages/create-app/build.mjs; the conceptual `module-system.md` and the
+    // single-dot package guides are re-copied/re-discovered below.
+    rmSync(join(guidesDestDir, 'modules'), { recursive: true, force: true })
+    for (const entry of readdirSync(guidesDestDir)) {
+      if (/^core\..+\.md$/.test(entry)) {
+        rmSync(join(guidesDestDir, entry))
+      }
+    }
+
     let guidesFound = 0
     for (const pkg of readdirSync(packagesDir)) {
       const guideSource = join(packagesDir, pkg, 'agentic', 'standalone-guide.md')
@@ -57,6 +69,62 @@ await buildPackage(packageDir, {
 
     if (guidesFound > 0) {
       console.log(`Discovered ${guidesFound} standalone guides → dist/agentic/guides/`)
+    }
+
+    // Generate per-module fact-sheets (Layer 2) from core module sources via the
+    // freshly built ts-morph extractor, so `mercato agentic:init` bundles the same
+    // guides as a create-mercato-app scaffold (packages/create-app/build.mjs).
+    const coreSrcRoot = join(packagesDir, 'core', 'src', 'modules')
+    if (existsSync(coreSrcRoot)) {
+      const { extractAllModuleFacts, renderModuleFactsJson } = await import(
+        pathToFileURL(join(outdir, 'lib', 'generators', 'module-facts.js')).href
+      )
+      const registryPath = join(packagesDir, '..', 'apps', 'mercato', '.mercato', 'generated', 'modules.runtime.generated.ts')
+      let coreVersion = null
+      try {
+        coreVersion = JSON.parse(readFileSync(join(packagesDir, 'core', 'package.json'), 'utf8')).version ?? null
+      } catch {
+        coreVersion = null
+      }
+
+      const { factsByModule, markdownByModule, warnings } = extractAllModuleFacts({
+        coreSrcRoot,
+        registryPath: existsSync(registryPath) ? registryPath : null,
+        coreVersion,
+      })
+
+      const modulesGuidesDir = join(guidesDestDir, 'modules')
+      mkdirSync(modulesGuidesDir, { recursive: true })
+      for (const [moduleId, markdown] of Object.entries(markdownByModule)) {
+        writeFileSync(join(modulesGuidesDir, `${moduleId}.md`), markdown)
+      }
+      writeFileSync(join(guidesDestDir, 'module-facts.json'), renderModuleFactsJson(factsByModule))
+
+      for (const warning of warnings) console.warn(warning)
+      console.log(`Generated ${Object.keys(markdownByModule).length} module fact-sheets → dist/agentic/guides/modules/`)
+
+      // BC bridge (spec §7 generated-file contract): for any allowlisted module whose
+      // legacy full guide `core.<module>.md` is no longer bundled (its standalone-guide.md
+      // source was removed), emit a thin redirect stub pointing at the generated fact-sheet.
+      // Fresh scaffolds never link these names; they exist only for apps upgrading in place.
+      let stubsWritten = 0
+      for (const moduleId of Object.keys(markdownByModule)) {
+        const legacyGuidePath = join(guidesDestDir, `core.${moduleId}.md`)
+        if (!existsSync(legacyGuidePath)) {
+          writeFileSync(
+            legacyGuidePath,
+            `# core.${moduleId} — moved\n\n` +
+              `> This guide has moved. See [\`modules/${moduleId}.md\`](modules/${moduleId}.md) for the generated ` +
+              `\`${moduleId}\` fact-sheet, and [\`module-system.md\`](module-system.md) for conceptual module guidance.\n`,
+          )
+          stubsWritten++
+        }
+      }
+      if (stubsWritten > 0) {
+        console.log(`Wrote ${stubsWritten} legacy core.<module>.md redirect stubs → dist/agentic/guides/`)
+      }
+    } else {
+      console.warn(`[module-facts] core module sources not found at ${coreSrcRoot}; skipping fact-sheet generation`)
     }
   },
 })

--- a/packages/cli/src/lib/__integration__/TC-INT-008.spec.ts
+++ b/packages/cli/src/lib/__integration__/TC-INT-008.spec.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { MODULE_FACTS_ALLOWLIST } from '../generators/module-facts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, '..', '..', '..', '..', '..')
@@ -14,6 +15,11 @@ const cliIntegrationRunnerPath = path.join(cliDir, 'src', 'lib', 'testing', 'int
 const standaloneTemplatePackageJsonPath = path.join(repoRoot, 'packages', 'create-app', 'template', 'package.json.template')
 const agenticRoot = path.join(repoRoot, 'packages', 'create-app', 'agentic')
 const packagesRoot = path.join(repoRoot, 'packages')
+
+// Modules the standalone fixture enables in src/modules.ts. Both are on the
+// fact-sheet allowlist, so agentic:init must ship exactly their fact-sheets
+// (enabled ∩ allowlist — spec D6) and list them in the AGENTS.md marker block.
+const FIXTURE_ENABLED_MODULES = ['customers', 'sales']
 
 function normalizePath(value: string): string {
   return value.split(path.sep).join('/')
@@ -57,7 +63,8 @@ function createStandaloneFixture(rootDir: string): string {
       2,
     ),
   )
-  writeFile(path.join(appDir, 'src', 'modules.ts'), 'export const enabledModules = []\n')
+  const moduleEntries = FIXTURE_ENABLED_MODULES.map((moduleId) => `  { id: '${moduleId}' },`).join('\n')
+  writeFile(path.join(appDir, 'src', 'modules.ts'), `export const enabledModules = [\n${moduleEntries}\n]\n`)
   return appDir
 }
 
@@ -167,6 +174,17 @@ function readPlaywrightConfigPathFromCliRunner(): string {
 function expectedGuideOutputNames(): string[] {
   const collected = new Set<string>()
 
+  // Static conceptual guides checked into create-app (e.g. module-system.md) are
+  // bundled into dist/agentic/guides by the CLI build and copied wholesale.
+  const staticGuidesRoot = path.join(agenticRoot, 'guides')
+  if (fs.existsSync(staticGuidesRoot)) {
+    for (const entry of fs.readdirSync(staticGuidesRoot, { withFileTypes: true })) {
+      if (entry.isFile() && entry.name.endsWith('.md')) {
+        collected.add(entry.name)
+      }
+    }
+  }
+
   for (const packageName of fs.readdirSync(packagesRoot)) {
     const packageGuide = path.join(packagesRoot, packageName, 'agentic', 'standalone-guide.md')
     if (fs.existsSync(packageGuide)) {
@@ -183,6 +201,21 @@ function expectedGuideOutputNames(): string[] {
       if (fs.existsSync(moduleGuide)) {
         collected.add(`${packageName}.${moduleName}.md`)
       }
+    }
+  }
+
+  // Generated fact-sheet artifacts (spec 2026-06-27-ts-morph-module-fact-sheets):
+  // the module-facts.json sidecar is copied as-is, fact-sheets are filtered to the
+  // fixture's enabled modules, and every allowlisted module whose hand-written
+  // core.<module>.md guide no longer exists gets a legacy redirect stub.
+  collected.add('module-facts.json')
+  for (const moduleId of FIXTURE_ENABLED_MODULES) {
+    collected.add(normalizePath(path.join('modules', `${moduleId}.md`)))
+  }
+  for (const moduleId of MODULE_FACTS_ALLOWLIST) {
+    const legacyGuideSource = path.join(packagesRoot, 'core', 'src', 'modules', moduleId, 'agentic', 'standalone-guide.md')
+    if (!fs.existsSync(legacyGuideSource)) {
+      collected.add(`core.${moduleId}.md`)
     }
   }
 
@@ -229,6 +262,13 @@ test.describe('TC-INT-008: CLI agentic init mirrors standalone scaffolding asset
       const agentsSource = fs.readFileSync(path.join(appDir, 'AGENTS.md'), 'utf8')
       expect(agentsSource).toContain('<!-- CODEX_ENFORCEMENT_RULES_START -->')
       expect(agentsSource).toContain('.ai/guides/core.md')
+
+      // The Module-Specific Guides marker block lists exactly the enabled modules'
+      // fact-sheets (enabled ∩ allowlist), not the full bundled set.
+      for (const moduleId of FIXTURE_ENABLED_MODULES) {
+        expect(agentsSource).toContain(`.ai/guides/modules/${moduleId}.md`)
+      }
+      expect(agentsSource).not.toContain('.ai/guides/modules/auth.md')
 
       const specsReadmeSource = fs.readFileSync(path.join(appDir, '.ai', 'specs', 'README.md'), 'utf8')
       expect(specsReadmeSource).toContain('sample-store')

--- a/packages/cli/src/lib/agentic-setup.ts
+++ b/packages/cli/src/lib/agentic-setup.ts
@@ -9,6 +9,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync, symlinkSync, lstatSync, unlinkSync, readdirSync } from 'node:fs'
 import { join, dirname, basename } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { Project, SyntaxKind } from 'ts-morph'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 // In the built output (dist/lib/agentic-setup.js), __dirname is dist/lib/.
@@ -52,14 +53,125 @@ function copyFile(srcDir: string, srcRelative: string, destPath: string): void {
   copyFileSync(srcPath, destPath)
 }
 
+// ─── Module fact-sheet selection (mirrors packages/create-app/src/setup/tools/shared.ts) ──
+
+// AST-parse the static `enabledModules` array literal in the app's src/modules.ts
+// and collect each entry's `id`. Only the static literal is read (conditional
+// .push()/spread entries are intentionally not seen — see spec D6).
+function readEnabledModuleIds(modulesPath: string): string[] {
+  if (!existsSync(modulesPath)) return []
+  try {
+    const project = new Project({ useInMemoryFileSystem: true })
+    const sourceFile = project.createSourceFile('modules.ts', readFileSync(modulesPath, 'utf-8'))
+    const declaration = sourceFile.getVariableDeclaration('enabledModules')
+    const arrayLiteral = declaration?.getInitializerIfKind(SyntaxKind.ArrayLiteralExpression)
+    if (!arrayLiteral) return []
+    const ids: string[] = []
+    for (const element of arrayLiteral.getElements()) {
+      const objectLiteral = element.asKind(SyntaxKind.ObjectLiteralExpression)
+      if (!objectLiteral) continue
+      const idProperty = objectLiteral.getProperty('id')?.asKind(SyntaxKind.PropertyAssignment)
+      const idValue = idProperty?.getInitializerIfKind(SyntaxKind.StringLiteral)?.getLiteralValue()
+      if (idValue) ids.push(idValue)
+    }
+    return ids
+  } catch {
+    return []
+  }
+}
+
+// Resolve which per-module fact-sheets to ship: the intersection of the bundled
+// fact-sheets (the D5 allowlist, materialized by build.mjs) with the app's enabled
+// modules. Falls back to the full bundled set when the enabled set cannot be read
+// (R5 — degraded, never empty).
+function selectModuleFactSheets(targetDir: string, modulesSubdir: string): string[] {
+  const available = existsSync(modulesSubdir)
+    ? readdirSync(modulesSubdir)
+        .filter((file) => file.endsWith('.md'))
+        .map((file) => file.replace(/\.md$/, ''))
+    : []
+  if (available.length === 0) return []
+  const enabled = new Set(readEnabledModuleIds(join(targetDir, 'src', 'modules.ts')))
+  const selected = available.filter((moduleId) => enabled.has(moduleId))
+  return selected.length > 0 ? selected : available
+}
+
+const MODULE_GUIDES_START = '<!-- om:module-guides:start -->'
+const MODULE_GUIDES_END = '<!-- om:module-guides:end -->'
+
+// Read each module's guide label from the bundled `module-facts.json` (emitted by
+// build.mjs from the generator's extraction of each module's own `metadata`). The
+// label falls back description → title → generic, so the CLI never re-declares
+// specific module names or descriptions. A missing/malformed sidecar degrades to an
+// empty map (generic labels), never a throw.
+function readModuleGuideLabels(guidesDir: string): Record<string, string> {
+  const factsPath = join(guidesDir, 'module-facts.json')
+  if (!existsSync(factsPath)) return {}
+  try {
+    const parsed = JSON.parse(readFileSync(factsPath, 'utf-8')) as Record<
+      string,
+      { description?: unknown; title?: unknown }
+    >
+    const labels: Record<string, string> = {}
+    for (const [moduleId, entry] of Object.entries(parsed)) {
+      const label =
+        (entry && typeof entry.description === 'string' && entry.description) ||
+        (entry && typeof entry.title === 'string' && entry.title) ||
+        ''
+      if (label) labels[moduleId] = label
+    }
+    return labels
+  } catch {
+    return {}
+  }
+}
+
+function renderModuleGuidesBlock(selected: string[], labels: Record<string, string>): string {
+  if (selected.length === 0) return '_No module fact-sheets are bundled for this app._'
+  const rows = selected.map((moduleId) => {
+    const label = labels[moduleId] ?? `Use the ${moduleId} module`
+    return `| ${label} | \`.ai/guides/modules/${moduleId}.md\` |`
+  })
+  return ['| Task | Load |', '|---|---|', ...rows].join('\n')
+}
+
+// Regenerate the marker-delimited Module-Specific Guides block in the written
+// AGENTS.md from the selected module set. Replaces strictly between the markers so
+// surrounding prose is untouched and repeat runs are idempotent.
+function injectModuleGuides(
+  agentsMdPath: string,
+  selected: string[],
+  labels: Record<string, string> = {},
+): void {
+  if (!existsSync(agentsMdPath)) return
+  const content = readFileSync(agentsMdPath, 'utf-8')
+  const startIndex = content.indexOf(MODULE_GUIDES_START)
+  const endIndex = content.indexOf(MODULE_GUIDES_END)
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    console.warn(
+      `[agentic] Module-Specific Guides markers (${MODULE_GUIDES_START} … ${MODULE_GUIDES_END}) not found in ${agentsMdPath}; the per-module guide list was not generated.`,
+    )
+    return
+  }
+  const before = content.slice(0, startIndex + MODULE_GUIDES_START.length)
+  const after = content.slice(endIndex)
+  const next = `${before}\n${renderModuleGuidesBlock(selected, labels)}\n${after}`
+  if (next !== content) writeFileSync(agentsMdPath, next)
+}
+
 // ─── Generators ──────────────────────────────────────────────────────────
 
 function generateShared(config: AgenticConfig): void {
   const { targetDir } = config
   const srcDir = join(AGENTIC_DIR, 'shared')
 
+  // Resolve which per-module fact-sheets this app gets (enabled ∩ bundled allowlist).
+  const selectedModules = selectModuleFactSheets(targetDir, join(GUIDES_DIR, 'modules'))
+  const moduleGuideLabels = readModuleGuideLabels(GUIDES_DIR)
+
   // AGENTS.md
   writeTemplate(srcDir, 'AGENTS.md.template', join(targetDir, 'AGENTS.md'), config)
+  injectModuleGuides(join(targetDir, 'AGENTS.md'), selectedModules, moduleGuideLabels)
 
   // .ai/ structure
   writeTemplate(srcDir, 'ai/specs/README.md', join(targetDir, '.ai', 'specs', 'README.md'), config)
@@ -244,6 +356,9 @@ function generateShared(config: AgenticConfig): void {
 
   copyFile(srcDir, 'ai/qa/tests/playwright.config.ts', join(targetDir, '.ai', 'qa', 'tests', 'playwright.config.ts'))
 
+  // Package & conceptual guides are copied wholesale (framework-wide). Per-module
+  // fact-sheets (.ai/guides/modules/<module>.md) are filtered to the app's enabled
+  // module set; the combined module-facts.json sidecar is copied as-is.
   if (existsSync(GUIDES_DIR)) {
     const guidesDestDir = join(targetDir, '.ai', 'guides')
     for (const file of readdirSync(GUIDES_DIR)) {
@@ -252,6 +367,20 @@ function generateShared(config: AgenticConfig): void {
       const destPath = join(guidesDestDir, file)
       ensureDir(destPath)
       copyFileSync(srcPath, destPath)
+    }
+
+    const moduleFactsPath = join(GUIDES_DIR, 'module-facts.json')
+    if (existsSync(moduleFactsPath)) {
+      const destPath = join(guidesDestDir, 'module-facts.json')
+      ensureDir(destPath)
+      copyFileSync(moduleFactsPath, destPath)
+    }
+
+    const modulesSubdir = join(GUIDES_DIR, 'modules')
+    for (const moduleId of selectedModules) {
+      const destPath = join(guidesDestDir, 'modules', `${moduleId}.md`)
+      ensureDir(destPath)
+      copyFileSync(join(modulesSubdir, `${moduleId}.md`), destPath)
     }
   }
 }


### PR DESCRIPTION
## Problem

`packages/cli/src/lib/__integration__/TC-INT-008.spec.ts` ("CLI agentic init mirrors standalone scaffolding assets") fails deterministically on `develop`.

Root cause: #3715 (ts-morph module fact-sheets, spec `.ai/specs/2026-06-27-ts-morph-module-fact-sheets.md`) replaced the 9 hand-written per-module standalone guides with generated fact-sheets — but only on the create-app side (`packages/create-app/build.mjs` + `src/setup/tools/shared.ts`). The CLI's mirrored path (`packages/cli/build.mjs` + `src/lib/agentic-setup.ts`) was left untouched, even though spec D6 explicitly requires the retroactive `mercato agentic:init` path to share the same mechanism.

Two consequences:
1. **Test breakage**: the new static `module-system.md` is bundled into `dist/agentic/guides` (via the wholesale `create-app/agentic` copy) and copied into scaffolded apps, but `expectedGuideOutputNames()` only predicted `standalone-guide.md`-discovered names → deterministic mismatch. Locally it's worse: the CLI build never cleaned `dist/agentic/guides`, so the 9 deleted `core.<module>.md` guides lingered from stale dists and leaked into scaffolds.
2. **Product regression**: `mercato agentic:init` shipped no per-module fact-sheets, no `module-facts.json`, no legacy redirect stubs, and left the `om:module-guides` marker block in the generated `AGENTS.md` empty — while a fresh `create-mercato-app` scaffold gets all of these.

## Fix

Mirror the #3715 create-app changes into the CLI path (its `agentic-setup.ts` is already the intentional inlined mirror of create-app's generators, since standalone apps cannot import create-app at runtime):

- **`packages/cli/build.mjs`**: clean stale `core.<module>.md` guides + `modules/` before regenerating; generate fact-sheets, the `module-facts.json` sidecar, and legacy `core.<module>.md` redirect stubs into `dist/agentic/guides` via the freshly built `lib/generators/module-facts.js` extractor — same logic and console/warning contract as `packages/create-app/build.mjs`.
- **`packages/cli/src/lib/agentic-setup.ts`**: port `readEnabledModuleIds` (AST read of the static `enabledModules` literal), fact-sheet selection (enabled ∩ allowlist, R5 fallback to the full bundled set), `module-facts.json` copy, and the `om:module-guides` marker-block injection with metadata-derived labels — same behavior as create-app's `shared.ts`.
- **`TC-INT-008.spec.ts`**: expected guide names now derive from all three real sources — static `create-app/agentic/guides/*.md`, discovered `standalone-guide.md` files, and the `MODULE_FACTS_ALLOWLIST` (stubs + sidecar + fact-sheets). The fixture now enables `customers` + `sales` so the D6 filtering is actually exercised, and the AGENTS.md marker-block content is asserted (enabled modules listed, non-enabled ones absent).

## Notes

- There are two specs named `TC-INT-008` in the repo; the other (`packages/core/src/modules/integrations/__integration__/TC-INT-008.spec.ts`, credentials org isolation) is untouched and unrelated — the ID collision may be worth cleaning up separately.
- `skip-qa`: developer-tooling/build/test change, no customer-facing surface.

## Test plan

- `npx playwright test packages/cli/src/lib/__integration__/TC-INT-008.spec.ts --config .ai/qa/tests/playwright.config.ts` — was failing, now passes (includes a full CLI rebuild via `ensureCliBuilt`)
- Stale-dist simulation: planted `core.fakemod.md` + `modules/stale.md` in `dist/agentic/guides`, rebuilt — both removed
- `yarn workspace @open-mercato/cli test` — 1021 passed
- `yarn typecheck` — green
- eslint on the three changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)