### PR TITLE
test(customers): stabilize TC-CAL-005 for midnight-spanning events

### DIFF
--- a/.ai/runs/2026-07-05-cal-005-midnight-spanning-event.md
+++ b/.ai/runs/2026-07-05-cal-005-midnight-spanning-event.md
@@ -1,0 +1,76 @@
+# Execution plan: fix failing CI integration tests on PR #3594
+
+## Goal
+
+Fix the integration test failure that blocks the `ephemeral-integration` CI check on
+PR #3594 (release v0.6.6, develop → main) at the root cause, and document the chronic
+standalone-only failures so they can be tackled as a scoped follow-up.
+
+## Investigation summary
+
+PR #3594 CI shows two distinct failure clusters:
+
+1. **`ephemeral-integration (7/15)`** (the PR's own `ci.yml` required check) — a single
+   failure: `TC-CAL-005`. This is the only failure that is **new** to this release
+   (prior develop snapshot runs did not have it).
+   - Root cause: the calendar editor defaults a new event's start to the **next full
+     hour**. When CI runs late in the evening the default becomes `11:00 PM`, so the
+     90-minute meeting spans **past midnight** (`11:00 PM – 12:30 AM next day`). A
+     meeting that crosses midnight legitimately renders in **two** day cells (the day it
+     starts and the day it ends). The test's `itemLocator`
+     (`getByRole('button', { name: /^QA Cal Editor .../ })`) then matches **2 elements**
+     and `expect(locator).toBeVisible()` fails with a Playwright **strict-mode
+     violation**, not a real regression.
+   - The test already anticipates midnight/week-boundary rolling (it guards the week-grid
+     assertion behind an in-current-week check) but never made the locator tolerant of an
+     event rendering across two cells.
+
+2. **`Standalone App Integration Tests`** (the `snapshot.yml` post-merge job, **not** the
+   PR's blocking CI) — `TC-CRM-068 / 069 / 079`. These are **chronic** (red on develop
+   for many consecutive commits) and reproduce **only** in the standalone (scaffolded,
+   dist-package) environment where `AUTO_SPAWN_WORKERS=false`.
+   - Root cause (from the uploaded trace's `resultSummary`): the bulk-deal worker's
+     `commandBus.execute('customers.deals.update', …)` throws for every deal with
+     `"Command handler not registered for id customers.deals.update. No commands or
+     command loaders registered for module \"customers\""`, so the progress job completes
+     with `affectedCount: 0, failedCount: N`.
+   - The integration-test queue-drain harness (`bootstrapFromAppRoot` in
+     `packages/core/src/helpers/integration/queue-runner.ts`, and the inline `drainQueue`
+     in `TC-CRM-068`) bootstraps the app in a **CLI-style** context that registers
+     commands only through the generated **lazy command loaders**
+     (`command-loaders.generated.ts`). The Next.js app server works because it registers
+     commands eagerly via static imports; the drain does not. In the standalone
+     (dist-based) generated app the `customers` command loaders are absent, so any worker
+     that dispatches a command fails. This also implies a real gap for standalone
+     deployments running `yarn mercato worker`.
+   - Fixing this correctly is a deep generator/bootstrap change that cannot be verified in
+     this environment without publishing a snapshot and scaffolding a full standalone app
+     via `create-mercato-app`. It is **risk-high** and out of scope for the release
+     blocker. Tracked as a follow-up; the CRM tests are **not** weakened to force green.
+
+## Scope
+
+- In scope: root-cause fix for `TC-CAL-005` (unblocks the PR's `ephemeral-integration`
+  check).
+- Non-goal: the chronic standalone command-loader generator/bootstrap gap
+  (`TC-CRM-068/069/079`) — documented as a follow-up.
+
+## Risks
+
+- Low. The change is confined to one integration spec's assertion locators; it makes them
+  tolerant of an event that legitimately renders in two day cells, without loosening what
+  is actually asserted (the event still must render without a reload).
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fix TC-CAL-005 midnight-spanning locator
+
+- [ ] 1.1 Make the created-event locator assertions tolerant of the event rendering across two day cells
+- [ ] 1.2 Clarify the spec docblock to record why the locator uses `.first()`
+
+### Phase 2: Validate and ship
+
+- [ ] 2.1 Run targeted validation (core lint/typecheck for the changed spec)
+- [ ] 2.2 Open PR against develop, apply labels, run auto-review

--- a/.ai/runs/2026-07-05-cal-005-midnight-spanning-event.md
+++ b/.ai/runs/2026-07-05-cal-005-midnight-spanning-event.md
@@ -72,5 +72,5 @@ PR #3594 CI shows two distinct failure clusters:
 
 ### Phase 2: Validate and ship
 
-- [ ] 2.1 Run targeted validation (core lint/typecheck for the changed spec)
+- [x] 2.1 Run targeted validation (core lint/typecheck for the changed spec) — tsc: no syntax errors; `playwright test --list` collects the 1 test cleanly
 - [ ] 2.2 Open PR against develop, apply labels, run auto-review

--- a/.ai/runs/2026-07-05-cal-005-midnight-spanning-event.md
+++ b/.ai/runs/2026-07-05-cal-005-midnight-spanning-event.md
@@ -73,4 +73,8 @@ PR #3594 CI shows two distinct failure clusters:
 ### Phase 2: Validate and ship
 
 - [x] 2.1 Run targeted validation (core lint/typecheck for the changed spec) — tsc: no syntax errors; `playwright test --list` collects the 1 test cleanly
-- [ ] 2.2 Open PR against develop, apply labels, run auto-review
+- [x] 2.2 Open PR against develop, apply labels, run auto-review — PR #3773
+
+## Changelog
+
+- PR #3773 opened against develop (labels: review, skip-qa, bug, priority-high, risk-low). code-review skill: no actionable findings. Now monitoring CI.

--- a/.ai/runs/2026-07-05-cal-005-midnight-spanning-event.md
+++ b/.ai/runs/2026-07-05-cal-005-midnight-spanning-event.md
@@ -67,8 +67,8 @@ PR #3594 CI shows two distinct failure clusters:
 
 ### Phase 1: Fix TC-CAL-005 midnight-spanning locator
 
-- [ ] 1.1 Make the created-event locator assertions tolerant of the event rendering across two day cells
-- [ ] 1.2 Clarify the spec docblock to record why the locator uses `.first()`
+- [x] 1.1 Make the created-event locator assertions tolerant of the event rendering across two day cells — f54c73d91
+- [x] 1.2 Clarify the spec docblock to record why the locator uses `.first()` — f54c73d91
 
 ### Phase 2: Validate and ship
 

--- a/packages/core/src/modules/customers/__integration__/TC-CAL-005.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CAL-005.spec.ts
@@ -32,6 +32,13 @@ import {
  * asserted there; the week-grid assertion runs only when the expected start
  * deterministically falls inside the current Monday-start week.
  *
+ * A default start of the last full hour of the day (e.g. 11:00 PM) produces a
+ * 90-minute meeting that crosses midnight; such an event legitimately renders in
+ * two day cells (the day it starts and the day it ends), so the created-item
+ * locator can match more than one button. Presence assertions therefore target
+ * `.first()` to stay tolerant of that multi-cell rendering while still proving the
+ * event appeared without a reload.
+ *
  * Teardown resolves the created interaction id via the API (by exact title,
  * scoped to the fixture person) and deletes it along with the person.
  */
@@ -111,12 +118,12 @@ test.describe('TC-CAL-005: Create event via calendar editor', () => {
       const itemLocator = page.getByRole('button', { name: new RegExp(`^${escapeRegExp(eventTitle)}`) });
       const currentWeek = mondayWeekRange(new Date());
       if (defaultStart.getTime() >= currentWeek.from.getTime() && defaultStart.getTime() <= currentWeek.to.getTime()) {
-        await expect(itemLocator).toBeVisible();
+        await expect(itemLocator.first()).toBeVisible();
       }
       await pressKeyUntil(page, 'a', async () => {
         await expect(page.getByRole('heading', { name: 'Upcoming' })).toBeVisible({ timeout: 1_000 });
       });
-      await expect(itemLocator).toBeVisible();
+      await expect(itemLocator.first()).toBeVisible();
 
       // -- Resolve the created id for teardown ------------------------------------
       createdInteractionId = await findInteractionIdByTitle(request, adminToken, {


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-05-cal-005-midnight-spanning-event.md
Status: complete

## Goal
- Fix the integration test that blocks the `ephemeral-integration` CI check on the v0.6.6 release PR (#3594) at the root cause.

## What Changed
- `TC-CAL-005` (calendar editor create-event spec): the presence assertions now target `.first()` on the created-item locator so they tolerate an event that legitimately renders across two day cells.

## Root cause
The calendar editor defaults a new event's start to the **next full hour**. When the suite runs late in the evening the default becomes `11:00 PM`, so the 90-minute meeting crosses midnight (`11:00 PM – 12:30 AM next day`) and renders in **two** day cells (the day it starts and the day it ends). The locator `getByRole('button', { name: /^QA Cal Editor .../ })` then matched **2 elements** and `expect(locator).toBeVisible()` failed with a Playwright **strict-mode violation** — a test-robustness gap, not a product regression. The spec already anticipated midnight/week-boundary rolling (it guards the week-grid assertion) but never made the locator tolerant of the two-cell rendering.

This was the **only** failure new to the release on the PR's own `ci.yml` `ephemeral-integration` check (shard 7/15 failed on `TC-CAL-005` alone).

## Tests
- No new test needed — this **is** the integration-test fix. Verified the spec parses and Playwright collects the single test (`playwright test --list`), and tsc reports no syntax errors. Running the scenario end-to-end requires the ephemeral app + DB (CI).

## Out of scope / follow-up
- The `Standalone App Integration Tests` job (`snapshot.yml`, post-merge — **not** the PR's blocking CI) fails `TC-CRM-068/069/079`. These are **chronic** (red on develop for many commits) and reproduce **only** in the standalone scaffolded/dist app where `AUTO_SPAWN_WORKERS=false`. The uploaded trace shows the bulk-deal worker's `commandBus.execute('customers.deals.update', …)` throwing `"No commands or command loaders registered for module \"customers\""`, so the progress job completes with `affectedCount: 0`. Root cause: the integration-test queue-drain harness bootstraps a CLI-style context that registers commands only via generated lazy command loaders, and those are absent for the `customers` module in the standalone (dist) generated app. Fixing this correctly is a deep, risk-high generator/bootstrap change that can only be verified by scaffolding a full standalone app — filed as a follow-up rather than bundled into the release blocker. The CRM tests are **not** weakened here.

## Backward Compatibility
- No contract surface changes. Test-only.

## Progress
See [Progress section in the plan](.ai/runs/2026-07-05-cal-005-midnight-spanning-event.md#progress).
