### PR TITLE
feat(ui): DataTable interactive column resize + width persistence (#1835)

### DIFF
--- a/.ai/specs/2026-07-05-datatable-column-resize.md
+++ b/.ai/specs/2026-07-05-datatable-column-resize.md
@@ -1,0 +1,75 @@
+# DataTable interactive column resize + width persistence
+
+## TLDR
+**Key Points:**
+- Backend `DataTable` columns can now be **resized by dragging** a handle on the header's right edge, and the widths **persist per user** (in `PerspectiveSettings`, and across a plain refresh via the local perspective snapshot) — resolves #1835.
+- No new API route, no schema change: `columnSizing` is an additive optional field on the existing `PerspectiveSettings` contract, saved/loaded exactly like `columnOrder`/`columnVisibility`.
+- Additive and opt-out-free: only columns the user actually drags get an explicit width; every other column keeps today's auto-layout + `meta.maxWidth` behavior unchanged.
+
+**Scope:**
+- `PerspectiveSettings.columnSizing?: Record<string, number>` (px, keyed by column id).
+- A manual pointer-driven resize handle per data-column header (mirrors the deals-pipeline `LaneResizeHandle`), rAF-throttled, with a double-click reset.
+- Width applied inline (`width`/`minWidth`/`maxWidth`) to the resized column's header and body cells, and used as the truncation max-width so content truncates at the dragged width.
+- Persistence wired through the existing snapshot (`writePerspectiveSnapshot`) and the perspective save/apply paths; `sanitizePerspectiveSettings` validates + clamps untrusted widths to `[60, 900]` px.
+
+**Concerns (if any):**
+- Chose a manual resize handle over TanStack's built-in `columnSizing`/`table-layout: fixed` to avoid forcing fixed layout on every DataTable in the app (a broad regression surface). The manual approach keeps auto layout and touches only resized columns.
+
+## Overview
+`DataTable` already persists column order, visibility, sorting, filters, and page size via `PerspectiveSettings`. Column **width** was the one missing dimension: users could not drag column edges, and widths reset to code-defined `meta.maxWidth` defaults on every load. This adds interactive resizing and per-user width persistence.
+
+## Problem Statement
+- Columns cannot be resized; the only width control is the static, developer-set `meta.maxWidth` (truncation), which users cannot adjust (#1835, and the downstream symptom #2947 "Order number column too narrow").
+- Any manual width would reset on refresh — there was no `columnSizing` in `PerspectiveSettings` and no resize UI.
+
+## Proposed Solution
+1. **Persistence type** — add `columnSizing?: Record<string, number>` to `PerspectiveSettings` (`packages/shared/src/modules/perspectives/types.ts`).
+2. **State + wiring** (`packages/ui/src/backend/DataTable.tsx`) — a `columnSizing` React state (seeded from the initial/merged perspective settings) plus a ref mirror so the pointerup commit reads the latest widths without a stale closure.
+3. **Resize handle** — `ColumnResizeHandle` renders an absolutely-positioned right-edge grip on each data-column header. A short, always-visible vertical grip marks every column edge as resizable (the discoverability affordance); it grows to full height and brightens to the primary colour on header/handle hover and while dragging, over a comfortable 12px hit area. It measures the header's real current width on pointer-down (so there is no jump on the first drag), tracks the pointer (rAF-throttled) to update `columnSizing` live, and commits to the snapshot on pointer-up. `stopPropagation` keeps the header reorder-DnD and sort-toggle from firing; double-click resets that column's width.
+4. **Width application** — resized columns get inline `width`/`minWidth`/`maxWidth` on header (`SortableHeaderCell`/`TableHead`) and body cells, and the width overrides the truncation `maxWidth` so content truncates at the dragged width. Non-resized columns are untouched.
+5. **Persistence** — `getCurrentSettings` includes `columnSizing` (saved with perspectives); `applyPerspectiveSettings` restores/clears it (so applying a saved view or selecting "No view" behaves correctly); a live commit merges widths into the local snapshot so they survive a refresh even without saving a perspective — including a "No view + widths" snapshot that would otherwise be cleared.
+
+### Design Decisions
+| Decision | Rationale |
+|----------|-----------|
+| Manual pointer handle, not TanStack `columnSizing` + `table-layout: fixed` | The table uses auto layout + `TruncatedCell(maxWidth)`. Forcing fixed layout to make TanStack sizing visible would change every DataTable's column distribution app-wide (high regression risk). The manual handle keeps auto layout and only pins the columns the user actually resizes — mirroring the already-shipped `LaneResizeHandle` pattern. |
+| Widths in `PerspectiveSettings` | Matches `columnOrder`/`columnVisibility` exactly, so widths save per-user with perspectives and ride the same snapshot restore — pkarw's "store per user, similarly to perspectives". |
+| Resize offered only on perspective-enabled tables (`enableColumnResize = perspectiveEnabled`) | Because the feature lives in the shared `DataTable`, it reaches **every** consumer with no per-table migration. But resizing is only useful where it persists (widths need `perspectiveTableId`), so it is gated on the perspective config: the ~47 backoffice list tables that pass `perspective` get it automatically, while the ~39 that opt out (settings/sub-tables, logs, and customer **portal** tables — which by convention omit column-management features) get no handle instead of a live-only resize that silently resets on reload. No data migration is needed — `columnSizing` is an additive optional JSON field; existing perspectives/snapshots without it keep working. |
+| Clamp `[60, 900]` px in `sanitizePerspectiveSettings` | Widths come from untrusted sources (localStorage snapshot, saved-perspective API); clamping prevents a persisted/dragged value from collapsing a column or blowing out the table. |
+
+## Data Models
+`PerspectiveSettings` (additive, backward compatible):
+```typescript
+type PerspectiveSettings = {
+  columnOrder?: string[]
+  columnVisibility?: Record<string, boolean>
+  columnSizing?: Record<string, number> // NEW (#1835): px width per column id
+  filters?: Record<string, unknown>
+  sorting?: Array<{ id: string; desc?: boolean }>
+  pageSize?: number
+  searchValue?: string
+}
+```
+No DB/schema change: perspective settings are stored as JSON by the existing perspectives module; `columnSizing` is just another optional key. Old snapshots/perspectives without it keep working (widths simply default to auto).
+
+## API Contracts
+No new or changed endpoints. `GET/POST /api/perspectives/:tableId` carry the new optional `columnSizing` key inside `settings`. The server-side `perspectiveSettingsSchema` (`packages/core/src/modules/perspectives/data/validators.ts`) is extended to accept + validate it (`Record<columnId, int 60..900>`) — without that key zod would strip widths on save, so saved/role perspectives would never carry them. Old perspectives without the key remain valid.
+
+## Integration Test Coverage (required)
+- **TC-CRM-086** (`packages/core/src/modules/customers/__integration__/`): (1) on `/backend/customers/companies`, drags a column header's resize handle → the column widens; the width **survives a full page reload** (persisted snapshot); **double-click resets** the column to its auto width (self-contained — creates + deletes two companies); (2) on `/backend/logs` (a no-perspective table) asserts **no resize handle renders**, guarding the perspective gate.
+- Unit: `DataTable.columnSizing.test.ts` (sanitize validation/clamping of untrusted widths, prototype-key rejection) and a `columnSizing` round-trip case in `DataTable.perspectiveStorage.test.ts`.
+
+## Risks & Impact Review
+### Data Integrity Failures
+- Widths are presentation-only and clamped on read; a malformed/oversized persisted value cannot corrupt data or break layout (clamped to `[60, 900]`).
+
+### Cascading Failures & Side Effects
+- Change is additive and opt-out-free: unresized columns render exactly as before. Resize handle events `stopPropagation` so column reorder-DnD and sort remain intact (covered by existing DataTable tests, all green).
+- `sanitizePerspectiveSettings` is now exported for unit testing (additive; no behavior change).
+
+## Final Compliance Report
+- `yarn typecheck` clean; `yarn eslint` on touched files: 0 errors (pre-existing warnings only); `yarn i18n:check-sync` clean (new `ui.dataTable.resizeColumn` key in en/pl/es/de across app + create-app template).
+- `@open-mercato/ui` DataTable suite: 8 suites / 34 tests green (incl. the 2 new unit specs). TC-CRM-086 green against the dev server. Manually verified in-browser: persisted width applies to header + body cells after reload.
+
+## Changelog
+- 2026-07-05: Initial implementation (#1835). Added `PerspectiveSettings.columnSizing`; `ColumnResizeHandle` + width application + persistence in `DataTable.tsx`; `ui.dataTable.resizeColumn` i18n (4 locales, app + template); unit tests (`DataTable.columnSizing.test.ts`, storage round-trip) and integration test TC-CRM-086.

--- a/apps/mercato/src/i18n/de.json
+++ b/apps/mercato/src/i18n/de.json
@@ -842,6 +842,7 @@
   "ui.dataTable.perspectives.error.save": "Perspektive konnte nicht gespeichert werden",
   "ui.dataTable.perspectives.noView": "— No view —",
   "ui.dataTable.perspectives.warning.apiUnavailable": "Perspektiven-API ist noch nicht verfügbar. Führen Sie `yarn generate` aus, um Modulrouten neu zu generieren, und starten Sie dann den Server neu.",
+  "ui.dataTable.resizeColumn": "Spalte anpassen",
   "ui.dataTable.search.empty.clear": "Suche zurücksetzen",
   "ui.dataTable.search.empty.description": "Wir konnten keine {entity} finden, die zu „{query}” passen. Passe deine Suche oder Filter an.",
   "ui.dataTable.search.empty.genericEntity": "Ergebnisse",

--- a/apps/mercato/src/i18n/en.json
+++ b/apps/mercato/src/i18n/en.json
@@ -842,6 +842,7 @@
   "ui.dataTable.perspectives.error.save": "Failed to save perspective",
   "ui.dataTable.perspectives.noView": "— No view —",
   "ui.dataTable.perspectives.warning.apiUnavailable": "Perspectives API is not available yet. Run `yarn generate` to regenerate module routes, then restart the server.",
+  "ui.dataTable.resizeColumn": "Resize column",
   "ui.dataTable.search.empty.clear": "Clear search",
   "ui.dataTable.search.empty.description": "We couldn’t find any {entity} matching “{query}”. Try adjusting your search or filters.",
   "ui.dataTable.search.empty.genericEntity": "results",

--- a/apps/mercato/src/i18n/es.json
+++ b/apps/mercato/src/i18n/es.json
@@ -842,6 +842,7 @@
   "ui.dataTable.perspectives.error.save": "Error al guardar perspectiva",
   "ui.dataTable.perspectives.noView": "— No view —",
   "ui.dataTable.perspectives.warning.apiUnavailable": "La API de perspectivas aún no está disponible. Ejecute `yarn generate` para regenerar las rutas del módulo y luego reinicie el servidor.",
+  "ui.dataTable.resizeColumn": "Redimensionar columna",
   "ui.dataTable.search.empty.clear": "Borrar búsqueda",
   "ui.dataTable.search.empty.description": "No encontramos ningún {entity} que coincida con «{query}». Prueba a ajustar tu búsqueda o filtros.",
   "ui.dataTable.search.empty.genericEntity": "resultados",

--- a/apps/mercato/src/i18n/pl.json
+++ b/apps/mercato/src/i18n/pl.json
@@ -842,6 +842,7 @@
   "ui.dataTable.perspectives.error.save": "Nie udało się zapisać perspektywy",
   "ui.dataTable.perspectives.noView": "— No view —",
   "ui.dataTable.perspectives.warning.apiUnavailable": "API perspektyw nie jest jeszcze dostępne. Uruchom `yarn generate`, aby wygenerować ponownie trasy modułów, a następnie zrestartuj serwer.",
+  "ui.dataTable.resizeColumn": "Zmień szerokość kolumny",
   "ui.dataTable.search.empty.clear": "Wyczyść wyszukiwanie",
   "ui.dataTable.search.empty.description": "Nie znaleźliśmy żadnych {entity} pasujących do „{query}”. Spróbuj zmienić wyszukiwanie lub filtry.",
   "ui.dataTable.search.empty.genericEntity": "wyników",

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-086.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-086.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+import { login } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { deleteEntityIfExists, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+
+/**
+ * TC-CRM-086: DataTable interactive column resize + width persistence (#1835).
+ *
+ * A column header exposes a right-edge drag handle. Dragging it widens the
+ * column, the new width survives a full page reload (persisted in the local
+ * perspective snapshot), and double-clicking the handle resets the column back
+ * to its auto width.
+ *
+ * Self-contained: creates two companies so the grid has rows, drives the real
+ * DataTable on `/backend/customers/companies`, and deletes the fixtures in
+ * teardown.
+ */
+test.describe('TC-CRM-086: DataTable column resize + persistence', () => {
+  test('drag-resizes a column, persists the width across reload, and resets on double-click', async ({ page, request }) => {
+    test.slow();
+
+    let token: string | null = null;
+    const companyIds: string[] = [];
+    const prefix = `QA TC-CRM-086 ${Date.now()}`;
+
+    // Width of the resize handle's own column header (the `<th>` it lives in).
+    const handleColumnWidth = (handle: import('@playwright/test').Locator) =>
+      handle.evaluate((el) => Math.round((el.closest('th') as HTMLElement).getBoundingClientRect().width));
+
+    const waitForTableReady = async () => {
+      await page.getByText('Loading table', { exact: false })
+        .waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
+      await page.locator('tbody tr').first().waitFor({ state: 'visible', timeout: 10_000 });
+    };
+
+    // The resize handles are rendered on every data column header; target the
+    // second one so we never land on a (potentially sticky) first column.
+    const handleAt = () => page.locator('thead [role="separator"][aria-orientation="vertical"]').nth(1);
+
+    try {
+      token = await getAuthToken(request);
+      for (let i = 0; i < 2; i++) {
+        const createResponse = await apiRequest(request, 'POST', '/api/customers/companies', {
+          token,
+          data: { displayName: `${prefix} Co${i}` },
+        });
+        expect(createResponse.ok()).toBeTruthy();
+        const body = (await readJsonSafe<{ id?: unknown }>(createResponse)) ?? {};
+        const id = typeof body.id === 'string' ? body.id : null;
+        expect(id).toBeTruthy();
+        companyIds.push(id!);
+      }
+
+      await login(page, 'admin');
+      await page.goto('/backend/customers/companies', { waitUntil: 'domcontentloaded' });
+      await waitForTableReady();
+
+      const handle = handleAt();
+      await expect(handle).toBeAttached();
+      const before = await handleColumnWidth(handle);
+
+      // -- Drag the handle right by ~130px → the column widens --------------------
+      const box = await handle.boundingBox();
+      expect(box).not.toBeNull();
+      const cx = box!.x + box!.width / 2;
+      const cy = box!.y + box!.height / 2;
+      await page.mouse.move(cx, cy);
+      await page.mouse.down();
+      await page.mouse.move(cx + 130, cy, { steps: 10 });
+      await page.mouse.up();
+
+      const after = await handleColumnWidth(handle);
+      expect(after, 'dragging the handle should widen the column').toBeGreaterThan(before + 80);
+
+      // -- The width survives a full reload (persisted, not saved as a view) -----
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await waitForTableReady();
+      const afterReload = await handleColumnWidth(handleAt());
+      expect(afterReload, 'the resized width should survive a page reload').toBeGreaterThan(before + 80);
+
+      // -- Double-click resets the column back to its auto width ------------------
+      await handleAt().dblclick();
+      await expect
+        .poll(async () => handleColumnWidth(handleAt()), { timeout: 5_000 })
+        .toBeLessThan(afterReload - 60);
+    } finally {
+      for (const id of companyIds) {
+        await deleteEntityIfExists(request, token, '/api/customers/companies', id);
+      }
+    }
+  });
+
+  test('does not render resize handles on a table without perspectives', async ({ page }) => {
+    // Column resize is gated on the perspective config (#1835): tables that opt
+    // out of perspectives (settings, sub-tables, portal, audit logs) must not get
+    // a handle, so widths never silently reset on reload for them. The audit-log
+    // grid is a stable no-perspective backoffice table.
+    await login(page, 'admin');
+    await page.goto('/backend/logs', { waitUntil: 'domcontentloaded' });
+    await page.locator('thead th').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+    await expect(page.getByRole('button', { name: /Perspektywy|Perspectives/i })).toHaveCount(0);
+    await expect(page.locator('thead [role="separator"][aria-orientation="vertical"]')).toHaveCount(0);
+  });
+});

--- a/packages/core/src/modules/perspectives/data/__tests__/perspectiveSettingsSchema.columnSizing.test.ts
+++ b/packages/core/src/modules/perspectives/data/__tests__/perspectiveSettingsSchema.columnSizing.test.ts
@@ -1,0 +1,40 @@
+import { perspectiveSettingsSchema } from '../validators'
+
+// The perspective save route validates `settings` through this schema before
+// persisting. `columnSizing` (#1835) must survive that boundary — otherwise
+// saved/role perspectives silently drop user column widths.
+describe('perspectiveSettingsSchema — columnSizing (#1835)', () => {
+  it('round-trips valid column widths', () => {
+    const parsed = perspectiveSettingsSchema.parse({ columnSizing: { name: 240, status: 120 } })
+    expect(parsed.columnSizing).toEqual({ name: 240, status: 120 })
+  })
+
+  it('preserves columnSizing alongside the other settings', () => {
+    const parsed = perspectiveSettingsSchema.parse({
+      columnOrder: ['a', 'b'],
+      columnVisibility: { a: false },
+      columnSizing: { a: 300 },
+      pageSize: 50,
+    })
+    expect(parsed).toEqual({
+      columnOrder: ['a', 'b'],
+      columnVisibility: { a: false },
+      columnSizing: { a: 300 },
+      pageSize: 50,
+    })
+  })
+
+  it('rejects widths outside the [60, 900] bound', () => {
+    expect(() => perspectiveSettingsSchema.parse({ columnSizing: { a: 10 } })).toThrow()
+    expect(() => perspectiveSettingsSchema.parse({ columnSizing: { a: 5000 } })).toThrow()
+  })
+
+  it('rejects non-integer widths', () => {
+    expect(() => perspectiveSettingsSchema.parse({ columnSizing: { a: 199.7 } })).toThrow()
+  })
+
+  it('accepts settings without columnSizing (backward compatible)', () => {
+    const parsed = perspectiveSettingsSchema.parse({ columnOrder: ['a'] })
+    expect(parsed.columnSizing).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/perspectives/data/validators.ts
+++ b/packages/core/src/modules/perspectives/data/validators.ts
@@ -4,6 +4,10 @@ import type { PerspectiveSettings } from '@open-mercato/shared/modules/perspecti
 export const perspectiveSettingsSchema: z.ZodType<PerspectiveSettings> = z.object({
   columnOrder: z.array(z.string().min(1)).max(120).optional(),
   columnVisibility: z.record(z.string(), z.boolean()).optional(),
+  // User-resized column widths in pixels, keyed by column id (#1835). Clamped to
+  // the same [60, 900] bound the client enforces so a saved perspective cannot
+  // carry a column width that collapses or blows out the table.
+  columnSizing: z.record(z.string().min(1), z.number().int().min(60).max(900)).optional(),
   filters: z.record(z.string(), z.unknown()).optional(),
   sorting: z
     .array(z.object({ id: z.string().min(1), desc: z.boolean().optional() }))

--- a/packages/create-app/template/src/i18n/de.json
+++ b/packages/create-app/template/src/i18n/de.json
@@ -705,6 +705,7 @@
   "ui.dataTable.actionsColumn": "Aktionen",
   "ui.dataTable.bulkAction.error": "Bulk action failed.",
   "ui.dataTable.bulkAction.selectAll": "Select all",
+  "ui.dataTable.resizeColumn": "Spalte anpassen",
   "ui.dataTable.bulkAction.selectRow": "Select row",
   "ui.dataTable.bulkAction.selectedCount": "{count} selected",
   "ui.dataTable.bulkAction.started": "Massenaktion gestartet. Fortschritt in der oberen Leiste verfolgen.",

--- a/packages/create-app/template/src/i18n/en.json
+++ b/packages/create-app/template/src/i18n/en.json
@@ -705,6 +705,7 @@
   "ui.dataTable.actionsColumn": "Actions",
   "ui.dataTable.bulkAction.error": "Bulk action failed.",
   "ui.dataTable.bulkAction.selectAll": "Select all",
+  "ui.dataTable.resizeColumn": "Resize column",
   "ui.dataTable.bulkAction.selectRow": "Select row",
   "ui.dataTable.bulkAction.selectedCount": "{count} selected",
   "ui.dataTable.bulkAction.started": "Bulk action started. Track progress in the top bar.",

--- a/packages/create-app/template/src/i18n/es.json
+++ b/packages/create-app/template/src/i18n/es.json
@@ -705,6 +705,7 @@
   "ui.dataTable.actionsColumn": "Acciones",
   "ui.dataTable.bulkAction.error": "Bulk action failed.",
   "ui.dataTable.bulkAction.selectAll": "Select all",
+  "ui.dataTable.resizeColumn": "Redimensionar columna",
   "ui.dataTable.bulkAction.selectRow": "Select row",
   "ui.dataTable.bulkAction.selectedCount": "{count} selected",
   "ui.dataTable.bulkAction.started": "Acción masiva iniciada. Siga el progreso en la barra superior.",

--- a/packages/create-app/template/src/i18n/pl.json
+++ b/packages/create-app/template/src/i18n/pl.json
@@ -705,6 +705,7 @@
   "ui.dataTable.actionsColumn": "Akcje",
   "ui.dataTable.bulkAction.error": "Bulk action failed.",
   "ui.dataTable.bulkAction.selectAll": "Select all",
+  "ui.dataTable.resizeColumn": "Zmień szerokość kolumny",
   "ui.dataTable.bulkAction.selectRow": "Select row",
   "ui.dataTable.bulkAction.selectedCount": "{count} selected",
   "ui.dataTable.bulkAction.started": "Akcja zbiorcza rozpoczęta. Śledź postęp na górnym pasku.",

--- a/packages/shared/src/modules/perspectives/types.ts
+++ b/packages/shared/src/modules/perspectives/types.ts
@@ -1,6 +1,8 @@
 export type PerspectiveSettings = {
   columnOrder?: string[]
   columnVisibility?: Record<string, boolean>
+  /** User-resized column widths in pixels, keyed by column id (#1835). */
+  columnSizing?: Record<string, number>
   filters?: Record<string, unknown>
   sorting?: Array<{ id: string; desc?: boolean }>
   pageSize?: number

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -468,6 +468,12 @@ function resolveExportSections(config: DataTableExportConfig | null | undefined)
 const PERSPECTIVE_COOKIE_PREFIX = 'om_table_perspective'
 const PERSPECTIVE_STORAGE_PREFIX = 'om_table_perspective_snapshot'
 
+// Bounds for user-driven column resizing (#1835). Widths outside this range are
+// clamped so a persisted/dragged value can never collapse a column to nothing or
+// blow the table out horizontally.
+const COLUMN_MIN_WIDTH = 60
+const COLUMN_MAX_WIDTH = 900
+
 function formatDurationLabel(durationMs?: number | null): string {
   if (durationMs == null) return ''
   if (!Number.isFinite(durationMs)) return ''
@@ -541,7 +547,7 @@ export function writePerspectiveSnapshot(tableId: string, snapshot: PerspectiveS
   writeVersionedPreference(key, PERSPECTIVE_SNAPSHOT_VERSION, snapshot)
 }
 
-function sanitizePerspectiveSettings(source?: PerspectiveSettings | null): PerspectiveSettings | null {
+export function sanitizePerspectiveSettings(source?: PerspectiveSettings | null): PerspectiveSettings | null {
   if (!source || typeof source !== 'object') return null
   const forbidden = new Set(['__proto__', 'prototype', 'constructor'])
   const result: PerspectiveSettings = {}
@@ -562,6 +568,17 @@ function sanitizePerspectiveSettings(source?: PerspectiveSettings | null): Persp
       entries.forEach(([key, value]) => { visibility[key] = value })
       result.columnVisibility = visibility
     }
+  }
+
+  if (source.columnSizing && typeof source.columnSizing === 'object') {
+    const sizing: Record<string, number> = {}
+    for (const [key, value] of Object.entries(source.columnSizing)) {
+      const id = typeof key === 'string' ? key.trim() : ''
+      if (!id || forbidden.has(id)) continue
+      if (typeof value !== 'number' || !Number.isFinite(value)) continue
+      sizing[id] = Math.max(COLUMN_MIN_WIDTH, Math.min(COLUMN_MAX_WIDTH, Math.round(value)))
+    }
+    if (Object.keys(sizing).length) result.columnSizing = sizing
   }
 
   if (Array.isArray(source.sorting)) {
@@ -853,7 +870,99 @@ function HeaderDndWrapper({ enabled, contextId, sensors, columnIds, onDragEnd, c
   )
 }
 
-function SortableHeaderCell({ id, children, className }: { id: string; children: React.ReactNode; className?: string }) {
+// Drag handle on a column header's right edge (#1835). Uses manual pointer
+// tracking (mirrors the deals-pipeline LaneResizeHandle) rather than TanStack's
+// built-in resize so the table keeps its auto layout — only user-resized columns
+// get an explicit width, and dragging measures the header's real current width so
+// there is no jump. `stopPropagation` on pointer/click keeps the header's
+// reorder-DnD and sort-toggle from firing while resizing.
+function ColumnResizeHandle({
+  columnId,
+  onResize,
+  onCommit,
+  onReset,
+  ariaLabel,
+}: {
+  columnId: string
+  onResize: (columnId: string, width: number) => void
+  onCommit: () => void
+  onReset: (columnId: string) => void
+  ariaLabel: string
+}) {
+  const [active, setActive] = React.useState(false)
+  // Holds the current drag's teardown so an unmount mid-drag (perspective apply,
+  // data reload, column-visibility change) still removes the document listeners
+  // and restores the body cursor/selection instead of leaking them.
+  const dragCleanupRef = React.useRef<(() => void) | null>(null)
+  React.useEffect(() => () => { dragCleanupRef.current?.() }, [])
+
+  const handlePointerDown = React.useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return
+    event.preventDefault()
+    event.stopPropagation()
+    const headerCell = event.currentTarget.parentElement as HTMLElement | null
+    if (!headerCell) return
+    const startX = event.clientX
+    const startWidth = headerCell.getBoundingClientRect().width
+    setActive(true)
+    let frame = 0
+    let latest = startWidth
+    const onMove = (moveEvent: PointerEvent) => {
+      latest = Math.max(COLUMN_MIN_WIDTH, Math.min(COLUMN_MAX_WIDTH, Math.round(startWidth + (moveEvent.clientX - startX))))
+      if (frame) return
+      frame = window.requestAnimationFrame(() => {
+        frame = 0
+        onResize(columnId, latest)
+      })
+    }
+    const teardown = () => {
+      if (frame) window.cancelAnimationFrame(frame)
+      document.removeEventListener('pointermove', onMove)
+      document.removeEventListener('pointerup', onUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      dragCleanupRef.current = null
+    }
+    const onUp = () => {
+      onResize(columnId, latest)
+      teardown()
+      setActive(false)
+      onCommit()
+    }
+    dragCleanupRef.current = teardown
+    document.addEventListener('pointermove', onMove)
+    document.addEventListener('pointerup', onUp)
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }, [columnId, onResize, onCommit])
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      onPointerDown={handlePointerDown}
+      onClick={(event) => event.stopPropagation()}
+      onDoubleClick={(event) => { event.preventDefault(); event.stopPropagation(); onReset(columnId) }}
+      className="group/resize absolute right-0 top-0 z-10 flex h-full w-3 translate-x-1/2 cursor-col-resize touch-none select-none items-center justify-center"
+    >
+      {/* Always-visible short grip marks the column edge as resizable; it grows
+          to full height and brightens on header/handle hover and while dragging. */}
+      <span
+        aria-hidden
+        className={cn(
+          'w-0.5 rounded-full transition-all',
+          active
+            ? 'h-full bg-primary'
+            : 'h-3.5 bg-border group-hover:h-full group-hover:bg-border group-hover/resize:h-full group-hover/resize:bg-primary',
+        )}
+      />
+    </div>
+  )
+}
+
+function SortableHeaderCell({ id, children, className, width }: { id: string; children: React.ReactNode; className?: string; width?: number }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id })
   const isSticky = typeof className === 'string' && className.includes('sticky')
   const style: React.CSSProperties = {
@@ -862,6 +971,7 @@ function SortableHeaderCell({ id, children, className }: { id: string; children:
     opacity: isDragging ? 0.5 : 1,
     cursor: 'grab',
     position: isSticky ? 'sticky' : 'relative',
+    ...(typeof width === 'number' ? { width, minWidth: width, maxWidth: width } : {}),
   }
   return (
     <TableHead ref={setNodeRef} style={style} className={className} {...attributes} {...listeners}>
@@ -1108,6 +1218,11 @@ export function DataTable<T>({
   const [activePerspectiveId, setActivePerspectiveId] = React.useState<string | null>(initialActiveId)
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>(() => mergedInitialSettings?.columnVisibility ?? {})
   const [columnOrder, setColumnOrder] = React.useState<string[]>(() => mergedInitialSettings?.columnOrder ?? [])
+  const [columnSizing, setColumnSizing] = React.useState<Record<string, number>>(() => mergedInitialSettings?.columnSizing ?? {})
+  // Mirror of columnSizing so the resize commit (fired from a pointerup handler
+  // set up on drag start) always reads the latest widths without a stale closure.
+  const columnSizingRef = React.useRef(columnSizing)
+  React.useEffect(() => { columnSizingRef.current = columnSizing }, [columnSizing])
   const [deletingIds, setDeletingIds] = React.useState<string[]>([])
   const [roleClearingIds, setRoleClearingIds] = React.useState<string[]>([])
   const [perspectiveApiMissing, setPerspectiveApiMissing] = React.useState(false)
@@ -1598,12 +1713,13 @@ export function DataTable<T>({
     const candidate: PerspectiveSettings = {
       columnOrder,
       columnVisibility: visibility,
+      columnSizing,
       sorting,
       filters: filtersPayload,
       searchValue,
     }
     return sanitizePerspectiveSettings(candidate) ?? {}
-  }, [columnOrder, columnVisibility, sorting, filterValues, searchValue, advancedFilter])
+  }, [columnOrder, columnVisibility, columnSizing, sorting, filterValues, searchValue, advancedFilter])
 
   const applyPerspectiveSettings = React.useCallback((
     settings: PerspectiveSettings,
@@ -1637,6 +1753,13 @@ export function DataTable<T>({
     } else {
       setSorting([])
       onSortingChange?.([])
+    }
+    if (normalized.columnSizing) {
+      setColumnSizing(normalized.columnSizing)
+      columnSizingRef.current = normalized.columnSizing
+    } else {
+      setColumnSizing({})
+      columnSizingRef.current = {}
     }
     // Two filter shapes can live in `settings.filters`:
     //   1. Persisted advanced-filter tree: `{ v: 2, root: {...} }`
@@ -1674,12 +1797,63 @@ export function DataTable<T>({
         const snapshot: PerspectiveSnapshot = { perspectiveId: nextId, settings: normalized, updatedAt: Date.now() }
         writePerspectiveSnapshot(perspectiveTableId, snapshot)
         initialSnapshotRef.current = snapshot
+      } else if (normalized.columnSizing && Object.keys(normalized.columnSizing).length) {
+        // Preserve a "No view" snapshot that only carries user column widths so
+        // they survive refresh without an active perspective (#1835). A genuine
+        // "No view" clear passes empty settings (no columnSizing) and still clears.
+        const snapshot: PerspectiveSnapshot = {
+          perspectiveId: null,
+          settings: { columnSizing: normalized.columnSizing },
+          updatedAt: Date.now(),
+        }
+        writePerspectiveSnapshot(perspectiveTableId, snapshot)
+        initialSnapshotRef.current = snapshot
       } else {
         writePerspectiveSnapshot(perspectiveTableId, null)
         initialSnapshotRef.current = null
       }
     }
   }, [onFiltersApply, onSearchChange, onSortingChange, perspectiveTableId, table, advancedFilter])
+
+  // Persist the current column widths into the local snapshot so they survive a
+  // refresh even without saving a perspective (#1835). Widths are merged into the
+  // active perspective's other settings — resizing never disturbs the saved
+  // column order/visibility/filters.
+  const persistColumnSizingSnapshot = React.useCallback(() => {
+    if (!perspectiveTableId) return
+    const sizing = columnSizingRef.current
+    const existing = readPerspectiveSnapshot(perspectiveTableId) ?? initialSnapshotRef.current
+    const baseSettings: PerspectiveSettings = existing?.settings
+      ? { ...existing.settings }
+      : (mergedInitialSettings ? { ...mergedInitialSettings } : {})
+    if (sizing && Object.keys(sizing).length) baseSettings.columnSizing = sizing
+    else delete baseSettings.columnSizing
+    const snapshot: PerspectiveSnapshot = {
+      perspectiveId: existing?.perspectiveId ?? activePerspectiveId ?? null,
+      settings: baseSettings,
+      updatedAt: Date.now(),
+    }
+    writePerspectiveSnapshot(perspectiveTableId, snapshot)
+    initialSnapshotRef.current = snapshot
+  }, [perspectiveTableId, activePerspectiveId, mergedInitialSettings])
+
+  const handleColumnResize = React.useCallback((colId: string, width: number) => {
+    const next = { ...columnSizingRef.current, [colId]: width }
+    columnSizingRef.current = next
+    setColumnSizing(next)
+  }, [])
+
+  const commitColumnSizing = React.useCallback(() => {
+    persistColumnSizingSnapshot()
+  }, [persistColumnSizingSnapshot])
+
+  const resetColumnSize = React.useCallback((colId: string) => {
+    const next = { ...columnSizingRef.current }
+    delete next[colId]
+    columnSizingRef.current = next
+    setColumnSizing(next)
+    persistColumnSizingSnapshot()
+  }, [persistColumnSizingSnapshot])
 
   React.useLayoutEffect(() => {
     if (!perspectiveTableId) return
@@ -2015,6 +2189,10 @@ export function DataTable<T>({
 
   const dndSensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }))
   const enableHeaderDnd = Boolean(columnChooser)
+  // Column resize is offered only where widths can persist (#1835): tables with a
+  // perspective config. Portal / settings / sub-tables that opt out of perspectives
+  // get no handle, so resizing never silently resets on reload for them.
+  const enableColumnResize = perspectiveEnabled
   const stableDndContextId = React.useMemo(
     () => sanitizeDndContextId(
       extensionTableId
@@ -2848,13 +3026,30 @@ export function DataTable<T>({
                       ) : null}
                     </Button>
                   )
+                  const columnId = header.column.id
+                  const sizedWidth = enableColumnResize && columnId ? columnSizing[columnId] : undefined
+                  const resizeHandle = enableColumnResize && !header.isPlaceholder && columnId ? (
+                    <ColumnResizeHandle
+                      columnId={columnId}
+                      onResize={handleColumnResize}
+                      onCommit={commitColumnSizing}
+                      onReset={resetColumnSize}
+                      ariaLabel={t('ui.dataTable.resizeColumn', 'Resize column')}
+                    />
+                  ) : null
                   return enableHeaderDnd ? (
-                    <SortableHeaderCell key={header.id} id={header.id} className={responsiveClass(priority, columnMeta?.hidden) + stickyClass}>
+                    <SortableHeaderCell key={header.id} id={header.id} width={sizedWidth} className={cn('group', responsiveClass(priority, columnMeta?.hidden) + stickyClass)}>
                       {headerCellContent}
+                      {resizeHandle}
                     </SortableHeaderCell>
                   ) : (
-                    <TableHead key={header.id} className={responsiveClass(priority, columnMeta?.hidden) + stickyClass}>
+                    <TableHead
+                      key={header.id}
+                      className={cn('group relative', responsiveClass(priority, columnMeta?.hidden) + stickyClass)}
+                      style={typeof sizedWidth === 'number' ? { width: sizedWidth, minWidth: sizedWidth, maxWidth: sizedWidth } : undefined}
+                    >
                       {headerCellContent}
+                      {resizeHandle}
                     </TableHead>
                   )
                 })}
@@ -2977,14 +3172,22 @@ export function DataTable<T>({
                         tooltipText = cellValue != null ? String(cellValue) : undefined
                       }
 
+                      // A user-resized width (#1835) overrides the default truncation
+                      // max-width so the cell truncates at the dragged column width.
+                      const sizedWidth = enableColumnResize && columnId ? columnSizing[columnId] : undefined
+                      const effectiveMaxWidth = typeof sizedWidth === 'number' ? `${sizedWidth}px` : maxWidth
                       const wrappedContent = shouldTruncate ? (
-                        <TruncatedCell maxWidth={maxWidth} tooltipContent={tooltipText}>
+                        <TruncatedCell maxWidth={effectiveMaxWidth} tooltipContent={tooltipText}>
                           {content}
                         </TruncatedCell>
                       ) : content
 
                       return (
-                        <TableCell key={cell.id} className={responsiveClass(priority, columnMeta?.hidden) + (isStickyCell ? ` md:sticky md:left-0 md:z-10 md:bg-background ${STICKY_LEFT_SHADOW_CLASS}` : '')}>
+                        <TableCell
+                          key={cell.id}
+                          className={responsiveClass(priority, columnMeta?.hidden) + (isStickyCell ? ` md:sticky md:left-0 md:z-10 md:bg-background ${STICKY_LEFT_SHADOW_CLASS}` : '')}
+                          style={typeof sizedWidth === 'number' ? { width: sizedWidth, minWidth: sizedWidth, maxWidth: sizedWidth } : undefined}
+                        >
                           {wrappedContent}
                         </TableCell>
                       )

--- a/packages/ui/src/backend/__tests__/DataTable.columnSizing.test.ts
+++ b/packages/ui/src/backend/__tests__/DataTable.columnSizing.test.ts
@@ -1,0 +1,49 @@
+/** @jest-environment jsdom */
+import { sanitizePerspectiveSettings } from '../DataTable'
+
+// Column widths persisted in PerspectiveSettings come from untrusted sources
+// (localStorage snapshot, saved perspectives API), so `sanitizePerspectiveSettings`
+// must validate and clamp them before they drive layout (#1835).
+describe('sanitizePerspectiveSettings — columnSizing (#1835)', () => {
+  it('keeps valid integer widths keyed by column id', () => {
+    const result = sanitizePerspectiveSettings({ columnSizing: { name: 240, status: 120 } })
+    expect(result?.columnSizing).toEqual({ name: 240, status: 120 })
+  })
+
+  it('clamps widths into the [60, 900] bound and rounds fractional pixels', () => {
+    const result = sanitizePerspectiveSettings({
+      columnSizing: { tooSmall: 10, tooBig: 5000, fractional: 199.7 },
+    })
+    expect(result?.columnSizing).toEqual({ tooSmall: 60, tooBig: 900, fractional: 200 })
+  })
+
+  it('drops non-numeric, non-finite, and prototype-polluting entries', () => {
+    // JSON.parse creates genuine own `__proto__` / `constructor` keys (unlike an
+    // object literal, where `__proto__` sets the prototype), so the forbidden-key
+    // guard is actually exercised.
+    const columnSizing = JSON.parse('{"good":150,"__proto__":300,"constructor":400}')
+    columnSizing.nan = Number.NaN
+    columnSizing.inf = Number.POSITIVE_INFINITY
+    columnSizing.str = '200'
+    const result = sanitizePerspectiveSettings({ columnSizing })
+    expect(result?.columnSizing).toEqual({ good: 150 })
+  })
+
+  it('omits columnSizing entirely when no valid entry survives', () => {
+    const result = sanitizePerspectiveSettings({ columnSizing: { bad: Number.NaN } })
+    expect(result?.columnSizing).toBeUndefined()
+  })
+
+  it('preserves columnSizing alongside the other settings', () => {
+    const result = sanitizePerspectiveSettings({
+      columnOrder: ['a', 'b'],
+      columnVisibility: { a: false },
+      columnSizing: { a: 300 },
+    })
+    expect(result).toEqual({
+      columnOrder: ['a', 'b'],
+      columnVisibility: { a: false },
+      columnSizing: { a: 300 },
+    })
+  })
+})

--- a/packages/ui/src/backend/__tests__/DataTable.perspectiveStorage.test.ts
+++ b/packages/ui/src/backend/__tests__/DataTable.perspectiveStorage.test.ts
@@ -17,6 +17,16 @@ describe('DataTable perspective snapshot storage (versioned envelope)', () => {
     expect(readPerspectiveSnapshot('tbl')).toEqual(snapshot)
   })
 
+  it('round-trips user column widths (columnSizing) through the snapshot (#1835)', () => {
+    const snapshot = {
+      perspectiveId: 'p1',
+      settings: { columnOrder: ['a', 'b'], columnSizing: { a: 240, b: 120 } },
+      updatedAt: 456,
+    }
+    writePerspectiveSnapshot('tbl-sizing', snapshot)
+    expect(readPerspectiveSnapshot('tbl-sizing')).toEqual(snapshot)
+  })
+
   it('migrates a legacy bare (pre-envelope) snapshot on read', () => {
     const legacy = { perspectiveId: 'p2', settings: { columnOrder: ['x'] }, updatedAt: 7 }
     localStorage.setItem(`${PREFIX}:tbl2`, JSON.stringify(legacy))


### PR DESCRIPTION
## Summary

Adds interactive column resize + per-user width persistence to the shared backend `DataTable`.

Closes #1835

Columns now expose a drag handle on the header's right edge. Dragging resizes the column; the width persists per user (saved with perspectives and restored across a plain refresh via the local perspective snapshot); double-clicking the handle resets the column to its auto width.

## What & how

- **Persistence type** — `columnSizing?: Record<string, number>` added to `PerspectiveSettings` (additive, backward compatible; old perspectives/snapshots keep working).
- **Resize handle** — a manual pointer-driven `ColumnResizeHandle` on each data-column header (mirrors the deals-pipeline `LaneResizeHandle`; no TanStack `columnSizing`, so the table keeps its auto layout). It measures the header's real width on pointer-down (no jump), rAF-throttles live updates, commits on pointer-up, and resets on double-click. `stopPropagation` keeps the header reorder-DnD and sort-toggle from firing. An always-visible grip marks the edge as resizable and brightens on hover (the discoverability affordance).
- **Width application** — the resized width is applied inline (`width`/`minWidth`/`maxWidth`) to the column's header + body cells and used as the truncation max-width. Unresized columns are untouched, so the change is opt-out-free with no app-wide layout shift.
- **Persistence path** — `getCurrentSettings` includes `columnSizing` (saved with perspectives); `applyPerspectiveSettings` restores/clears it; a live commit merges widths into the local snapshot so they survive a refresh even without saving a perspective. Both the client `sanitizePerspectiveSettings` and the server `perspectiveSettingsSchema` validate + clamp widths to `[60, 900]` px.
- **Gated on perspective-enabled tables** (`enableColumnResize = perspectiveEnabled`) — because the feature lives in the shared `DataTable` it reaches every consumer with no per-table migration, but resizing is only offered where it can persist (widths need `perspectiveTableId`). The ~47 backoffice list tables that pass `perspective` get it automatically; the ~39 that opt out (settings/sub-tables, logs, customer **portal** tables) get no handle instead of a live-only resize that silently resets on reload.

### Why manual resize instead of TanStack `columnSizing`
The table uses auto layout + `TruncatedCell(maxWidth)`. Forcing `table-layout: fixed` to make TanStack sizing visible would change every DataTable's column distribution app-wide (a broad regression surface). The manual handle keeps auto layout and only pins the columns the user actually resizes.

## Tests

- Unit — `DataTable.columnSizing.test.ts` (sanitize validation/clamp + prototype-pollution guard), a `columnSizing` round-trip in `DataTable.perspectiveStorage.test.ts`, and `perspectiveSettingsSchema.columnSizing.test.ts` (server-schema round-trip + clamp). Full `@open-mercato/ui` DataTable suite green (8 suites / 34 tests).
- Integration — **TC-CRM-084**: (1) drag widens a column, the width survives a full reload, and double-click resets it; (2) `/backend/logs` (a no-perspective table) renders **no** handle, guarding the gate.
- Ran the DataTable/perspectives surface on a fresh **ephemeral** environment (Docker, isolated DB — the same runtime CI uses): **TC-PERSP 13/13** + **220 passed** across `TC-CRM` / `TC-STAFF` / `TC-ADMIN`, including the resize and deals-list tables. The few unrelated failures were environmental (a fixture FK violation, a missing example-module table, and one order-dependent redirect that passes in isolation) — none touch `DataTable`/`columnSizing`.

## Notes
- No new/changed endpoints and no DB/schema migration — `columnSizing` is an optional JSON key inside the existing `PerspectiveSettings`.
- Spec: `.ai/specs/2026-07-05-datatable-column-resize.md`.
