### PR TITLE
fix(ci): sync create-app dispatcher template + always-run parity guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,6 +489,17 @@ jobs:
         # Turbo never picks up root-level scripts — run explicitly.
         run: yarn test:scripts
 
+      - name: Check create-app template parity (always, unfiltered)
+        # The create-app package guards byte-parity between the monorepo app shell
+        # (apps/mercato/**) and the standalone template (packages/create-app/template/**).
+        # Those guards read files across BOTH trees, but the turbo-scoped "Test" step
+        # above uses --filter=[base]... which selects packages by the dependency graph
+        # and never pulls in create-mercato-app when only apps/mercato changes — so on
+        # PRs the parity tests can silently skip while the post-merge push build (full,
+        # unfiltered `yarn test`) turns develop red (see #3779). Run the create-app unit
+        # suite unconditionally here so template drift fails the PR, not develop.
+        run: yarn workspace create-mercato-app test
+
   # ── Integration tests ───────────────────────────────────────────────────────
   # Boots an ephemeral app server and runs the Playwright suite.
   # Starts as soon as 'prepare' completes — runs in PARALLEL with 'test' so

--- a/packages/create-app/template/src/app/api/[...slug]/route.ts
+++ b/packages/create-app/template/src/app/api/[...slug]/route.ts
@@ -16,6 +16,7 @@ import { getCachedRateLimiterService } from '@open-mercato/core/bootstrap'
 import { checkRateLimit, getClientIp, RATE_LIMIT_ERROR_KEY, RATE_LIMIT_ERROR_FALLBACK } from '@open-mercato/shared/lib/ratelimit/helpers'
 import { getGlobalEventBus } from '@open-mercato/shared/modules/events'
 import { applicationLifecycleEvents, type ApplicationLifecycleEventId } from '@open-mercato/shared/lib/runtime/events'
+import { withModuleResourceUsage } from '@open-mercato/shared/lib/modules/resource-usage'
 
 // Ensure all package registrations are initialized for API routes.
 bootstrap()
@@ -39,6 +40,10 @@ type MethodMetadata = {
   requireRoles?: string[]
   requireFeatures?: string[]
   rateLimit?: RateLimitConfig
+  /** Route-declared opt-out from module-resource-usage tracking (e.g. an endpoint that itself
+   * reads/clears that telemetry, so tracking it would perturb the data it just reported). Set
+   * `skipModuleResourceUsageTracking: true` in the route's `metadata` export for the method. */
+  skipModuleResourceUsageTracking?: boolean
 }
 
 type HandlerContext = {
@@ -121,6 +126,9 @@ function extractMethodMetadata(metadata: unknown, method: HttpMethod): MethodMet
         keyPrefix: typeof rl.keyPrefix === 'string' ? rl.keyPrefix : undefined,
       }
     }
+  }
+  if (typeof source.skipModuleResourceUsageTracking === 'boolean') {
+    normalized.skipModuleResourceUsageTracking = source.skipModuleResourceUsageTracking
   }
   return Object.keys(normalized).length > 0 ? normalized : null
 }
@@ -410,7 +418,18 @@ async function handleRequest(
 
   try {
     const handlerContext: HandlerContext = { params: match.params, auth }
-    const response = await runWithCacheTenant(auth?.tenantId ?? null, () => handler(req, handlerContext))
+    const runHandler = () => runWithCacheTenant(auth?.tenantId ?? null, () => handler(req, handlerContext))
+    const response = methodMetadata?.skipModuleResourceUsageTracking !== true
+      ? await withModuleResourceUsage(
+        {
+          moduleId: match.route.moduleId,
+          surface: 'api',
+          operation: `${method} ${match.route.path}`,
+          resourceId: `${method} ${match.route.path}`,
+        },
+        runHandler,
+      )
+      : await runHandler()
     const finalResponse = authResolution.status === 'invalid' && response.status === 401
       ? clearStaffAuthCookies(response)
       : response


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

PR #3760 extended the monorepo API dispatcher (`apps/mercato/src/app/api/[...slug]/route.ts`) with resource-usage tracking but did not mirror it into the create-app template copy, breaking the byte-parity guard and turning `develop` red on the unfiltered `push` build (every open PR inherited it via the merge ref). This copies the dispatcher verbatim into the template and adds an always-run create-app test step so this class of template drift fails on the PR instead of only after merge.

## Changes

- Restore byte-parity: copy `withModuleResourceUsage` wiring + `skipModuleResourceUsageTracking` opt-out into `packages/create-app/template/src/app/api/[...slug]/route.ts` (scaffolded apps now match the monorepo dispatcher).
- Add an unconditional `yarn workspace create-mercato-app test` step to the `test` CI job — turbo's `--filter=[base]...` never selects `create-mercato-app` for monorepo-only changes, so the cross-tree parity guards were silently skipped on PRs.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `node --test packages/create-app/src/lib/template-api-dispatcher-require-roles.test.ts` — both parity tests pass.
- `yarn workspace create-mercato-app test` — 72 tests pass (~4s); the new CI step.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3779