### PR TITLE
feat(skills): add scope-cohesion (anti-bundling) check to om-spec-writing

### DIFF
--- a/.ai/skills/om-spec-writing/SKILL.md
+++ b/.ai/skills/om-spec-writing/SKILL.md
@@ -16,13 +16,14 @@ Design and review specifications (SPECs) against Open Mercato's architecture, na
     - Use `YYYY-MM-DD` for `date` and kebab-case for `title`
 3.  **Start Minimal**: Write a **Skeleton Spec** first (TLDR + 2-3 key sections). Do NOT write the full spec in one pass.
     - Before writing the skeleton, scan the brief for **critical unknowns** — decisions that block architecture, data model, or scope. These are questions where a wrong assumption would require rewriting large parts of the spec.
+    - One unknown is always checked: if the brief bundles more than one independently deployable capability (test: would each function without the other?), splitting into separate specs MUST be raised as an Open Question.
     - If critical unknowns exist, add a numbered **Open Questions** block (`Q1`, `Q2`, …) directly in the skeleton, immediately after the TLDR. One question per line. Keep each question short and answerable (binary or multiple-choice where possible).
     - **STOP after presenting the skeleton.** Do not proceed to Step 5 (Research) or beyond until the user has answered all questions. This is a hard gate.
 4.  **Iterate**: Apply answers from the Open Questions gate to fill in the skeleton. Remove the Open Questions block once all are resolved. If new unknowns surface during research or design, repeat the gate for those questions only.
 5.  **Research**: Challenge requirements against open-source market leaders in the domain.
 6.  **Design**: Create the spec design and architecture.
 7.  **Implementation Breakdown**: Create implementation details broken down into **Phases** (stories) and **Steps** (testable tasks). Each step should result in a working application.
-8.  **Review**: Apply the [Spec Checklist](references/spec-checklist.md).
+8.  **Review**: Apply the [Spec Checklist](references/spec-checklist.md). Delegate its §1 scope-cohesion item to a fresh-context subagent that receives only the spec file path — the author cannot adversarially re-read its own spec.
 9.  **Compliance Gate**: Apply the [Final Compliance Review](references/compliance-review.md).
 10. **Output**: Finalize the specification file.
 

--- a/.ai/skills/om-spec-writing/references/spec-checklist.md
+++ b/.ai/skills/om-spec-writing/references/spec-checklist.md
@@ -27,6 +27,7 @@ Append to changelog:
 
 ## 1. Design Logic & Phasing
 - [ ] TLDR defines scope, value, and clear boundaries.
+- [ ] Spec covers ONE independently deployable capability. Bundle signals: the spec's own TLDR or Design Decisions admits parts function without each other ("separate module", "either functions without the other", "must run even if X is disabled") while the coupling is a single integration seam. A SPLIT verdict goes back to the maintainer as an Open Question, not an automatic rewrite. At review time, run this item in a fresh-context subagent given only the spec file.
 - [ ] MVP is explicit; future work is deferred and labeled.
 - [ ] User stories/use cases map to API/data/UI sections.
 - [ ] Terminology aligns with existing modules and AGENTS naming.


### PR DESCRIPTION
## Problem

Nothing in `om-spec-writing` guards against one spec bundling several independently deployable capabilities. The checklist requires "clear boundaries" (clarity, not singularity), "spec-bloat" appears in the review report severities without a definition, and the workflow takes the user's brief as given — if the brief bundles two topics, the skill writes one spec and no step ever asks whether it should be N specs.

Concrete instance: the automated-backups + GDPR-erasure spec (#3742) covers two modules whose own Design Decisions table states "either module functions without the other", and review never flagged it. The author is structurally the worst reviewer for this: after writing a joint spec it rationalizes the bundle, so the checklist's "re-read from scratch with adversarial intent" cannot be performed by the agent that wrote the file.

## Solution

3 insertions in 2 files, deliberately minimal (one canonical statement of the rule, short references elsewhere):

- `SKILL.md` step 3 (Skeleton): if the brief bundles more than one independently deployable capability (test: would each function without the other?), splitting into separate specs MUST be raised as an Open Question. Catches bundles at the cheapest moment, before the spec exists.
- `SKILL.md` step 8 (Review): the §1 scope-cohesion item is delegated to a fresh-context subagent that receives only the spec file path.
- `spec-checklist.md` §1 (canonical rule): spec covers ONE independently deployable capability. Bundle signals are the spec's own admissions ("separate module", "either functions without the other", "must run even if X is disabled") combined with a single thin integration seam. A SPLIT verdict returns to the maintainer as an Open Question, never an automatic rewrite.

The signals are worded after the observed failure: bundled specs tend to self-diagnose in their TLDR or Design Decisions, so the check mines the spec's own text first.

## Validation

Ran the checklist item exactly as specified — fresh subagent, spec file path only, no conversation context, no expected verdict hinted — against six pending specs:

| Spec | Verdict | Basis |
|---|---|---|
| `enterprise/2026-07-02-automated-backups-and-gdpr-erasure-propagation` | SPLIT | quoted the Design Decisions row containing all three bundle-signal phrases verbatim; identified the single manifest/restore-diff seam |
| `2026-05-21-email-integration-foundation` | SPLIT | foundation+IMAP vs Gmail provider; spec keeps a sibling provider (SPEC-056) separate citing the same anti-bundling principle it violates internally |
| `2026-04-28-push-notifications-and-devices` | SPLIT | `devices` registry is "Standalone — no dependents yet" with consumers beyond push (#539); recommended 2-way split, not 3-way |
| `2026-04-29-telemetry-and-otel` | KEEP | correctly distinguished layered phases (OTEL implements Phase 1's `Exporter` interface) from sibling capabilities, despite the "and" title |
| `2026-06-17-form-to-deals` | KEEP | dependency chain, not a bundle; classified "separate module" phrases pointing at already-excluded scope as the desired end state |
| `enterprise/2026-06-09-record-locks-unified-coverage` | SPLIT | OSS seam/foundation vs enterprise rollout; also surfaced that OSS STABLE contract-surface changes are documented only under the non-OSS-licensed `enterprise/` spec directory |

The two KEEP verdicts (one carrying "and" in its title) show the check discriminates real interdependence from bundling rather than keyword-matching. Verdicts double as useful review output: subagents surfaced internal contradictions in two specs and a licensing-visibility issue in a third. Cost per check: one file read, ~60–110k subagent tokens, 1–3 minutes.

### Behavior on spec families (parent + sub-specs)

A second blind round targeted the umbrella pattern, where a false positive would be most likely — a parent spec legitimately referencing many sub-specs:

| Spec | Role | Verdict | Basis |
|---|---|---|---|
| `SPEC-053-b2b-prm-starter` | parent | SPLIT (trim) | parent re-inlines full contracts (6 data models, ~25 endpoints) that its own changelog assigns to `SPEC-053b` as "source of truth"; proposal moves content to the owning child rather than creating new files |
| `SPEC-053a-b2b-prm-matching-data` | child | KEEP | recognized as the product of an already-performed split; further splitting rejected as duplication with "no deployment benefit" |
| `2026-04-21-crm-call-transcriptions` | parent | SPLIT (narrow) | provider phases correctly read as pointers to sub-specs; residual finding is Phase 0 — a `handleHandshake` extension to `@open-mercato/webhooks` that the spec itself calls a "platform-level contract change" with "no runtime dependency" on the feature |
| `2026-04-22-transcription-tldv-adapter` | child | KEEP | webhook vs polling read as redundant triggers of one capability (firewall fallback), not separable parts; parent coupling recognized as an already-performed split |

Children pass cleanly, and parents are not flagged for the family pattern itself — phases that point at sub-specs classify as excluded scope. What SPLIT means on a parent is residue: duplicated child-owned content (a drift hazard the SPEC-053 changelog shows already materialized once) or an unrelated platform contract change carried inside a feature spec. Accepted blind spot: the check reads a single file, so parent↔child consistency (drift, contradictions across the family) is out of its reach and would be a separate check.

Split verdicts for the specs above are Open Questions for the maintainer per the new rule; this PR changes only the skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
