### PR TITLE
fix(attachments): stop misleading 401 for superadmin all-orgs uploads/deletes (#3764)

### DIFF
--- a/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
+++ b/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
@@ -41,6 +41,7 @@ const mockEm = {
     create: jest.fn((data: any) => data),
   })),
   persist: jest.fn(function persist(this: any) { return this }),
+  remove: jest.fn(function remove(this: any) { return this }),
   flush: jest.fn(async () => {}),
   transactional: jest.fn(async (work: (tx: any) => unknown) => work(mockEm)),
   find: jest.fn(),
@@ -65,7 +66,9 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
   }),
 }))
 
-jest.mock('@open-mercato/shared/lib/auth/server', () => ({ getAuthFromRequest: () => ({ orgId: 'org', tenantId: 't1', roles: ['admin'] }) }))
+const defaultAuth = () => ({ orgId: 'org', tenantId: 't1', roles: ['admin'] })
+const mockGetAuthFromRequest = jest.fn(defaultAuth)
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({ getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args) }))
 
 jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   resolveTranslations: jest.fn(async () => ({
@@ -78,6 +81,7 @@ jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
 import { promises as fsp } from 'fs'
 jest.spyOn(fsp, 'mkdir').mockResolvedValue(undefined as any)
 jest.spyOn(fsp, 'writeFile').mockResolvedValue(undefined as any)
+jest.spyOn(fsp, 'rm').mockResolvedValue(undefined as any)
 
 jest.mock('@open-mercato/core/modules/attachments/lib/textExtraction', () => ({
   extractAttachmentContent: jest.fn(),
@@ -114,6 +118,8 @@ async function loadHandlers() {
 describe('attachments API', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockGetAuthFromRequest.mockReset()
+    mockGetAuthFromRequest.mockImplementation(defaultAuth)
     mockEm.findOne.mockReset()
     mockEm.findOne.mockImplementation(defaultFindOneImpl)
     mockEm.find.mockReset()
@@ -428,5 +434,79 @@ describe('attachments API', () => {
       expect.objectContaining({ entityId: 'example:todo', recordId: 'r1' }),
       expect.any(Object),
     )
+  })
+
+  it('rejects superadmin uploads with no organization selected using a 400 with a clear message instead of a 401 (#3764)', async () => {
+    mockGetAuthFromRequest.mockImplementation(() => ({
+      orgId: null,
+      tenantId: 't1',
+      roles: ['superadmin'],
+      isSuperAdmin: true,
+    }))
+    const { POST: upload } = await loadHandlers()
+    const file = new File([new Uint8Array([1, 2, 3])], 'doc.pdf', { type: 'application/pdf' })
+    const req = new Request('http://x/api/attachments', { method: 'POST', body: fdWith(file) as any })
+    const res = await upload(req)
+    // A 401 makes the client treat it as session expiry (misleading toast + form reset);
+    // a specific organization is required to store the file, so return 400.
+    expect(res.status).toBe(400)
+    const payload = await res.json()
+    expect(payload.error).toMatch(/organization/i)
+    expect(mockEm.create).not.toHaveBeenCalled()
+  })
+
+  it('still returns 401 for a non-superadmin upload with no organization', async () => {
+    mockGetAuthFromRequest.mockImplementation(() => ({
+      orgId: null,
+      tenantId: 't1',
+      roles: ['admin'],
+    }))
+    const { POST: upload } = await loadHandlers()
+    const file = new File([new Uint8Array([1, 2, 3])], 'doc.pdf', { type: 'application/pdf' })
+    const req = new Request('http://x/api/attachments', { method: 'POST', body: fdWith(file) as any })
+    const res = await upload(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('lets a superadmin with no organization delete tenant-wide by dropping the org filter (#3764)', async () => {
+    mockGetAuthFromRequest.mockImplementation(() => ({
+      orgId: null,
+      tenantId: 't1',
+      roles: ['superadmin'],
+      isSuperAdmin: true,
+    }))
+    mockEm.findOne.mockImplementation(async (entity: any) => {
+      if (entity?.name === 'Attachment') {
+        return {
+          id: 'att-1',
+          tenantId: 't1',
+          organizationId: 'org-owned-by-another-org',
+          partitionCode: 'privateAttachments',
+          storagePath: null,
+        }
+      }
+      return null
+    })
+    const { DELETE: remove } = await loadHandlers()
+    const req = new Request('http://x/api/attachments?id=att-1', { method: 'DELETE' })
+    const res = await remove(req)
+    expect(res.status).toBe(200)
+    expect(mockEm.findOne).toHaveBeenCalledWith(
+      expect.any(Function),
+      { id: 'att-1', tenantId: 't1' },
+    )
+    expect(mockEm.remove).toHaveBeenCalled()
+  })
+
+  it('still returns 401 for a non-superadmin delete with no organization', async () => {
+    mockGetAuthFromRequest.mockImplementation(() => ({
+      orgId: null,
+      tenantId: 't1',
+      roles: ['admin'],
+    }))
+    const { DELETE: remove } = await loadHandlers()
+    const req = new Request('http://x/api/attachments?id=att-1', { method: 'DELETE' })
+    const res = await remove(req)
+    expect(res.status).toBe(401)
   })
 })

--- a/packages/core/src/modules/attachments/api/route.ts
+++ b/packages/core/src/modules/attachments/api/route.ts
@@ -259,7 +259,18 @@ export async function GET(req: Request) {
 export async function POST(req: Request) {
   const { t } = await resolveTranslations()
   const auth = await getAuthFromRequest(req)
-  if (!auth || !auth.tenantId || !auth.orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!auth || !auth.tenantId || (!auth.orgId && !auth.isSuperAdmin)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  // A superadmin browsing with "All organizations" selected has no concrete
+  // organization scope, but an attachment must be stored under exactly one
+  // organization (the scope invariant forbids partial-null rows). Reject with a
+  // clear, actionable error instead of a 401 — a 401 makes the client-side
+  // fetch layer treat it as session expiry, show a misleading toast, and reset
+  // the in-progress form (#3764).
+  if (!auth.orgId) {
+    return NextResponse.json({
+      error: t('attachments.errors.selectOrganization', 'Select a specific organization before uploading an attachment.'),
+    }, { status: 400 })
+  }
   const tenantId = auth.tenantId
   const orgId = auth.orgId
 
@@ -527,7 +538,7 @@ async function readTenantAttachmentUsageBytes(em: EntityManager, tenantId: strin
 
 export async function DELETE(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth || !auth.tenantId || !auth.orgId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  if (!auth || !auth.tenantId || (!auth.orgId && !auth.isSuperAdmin)) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   const url = new URL(req.url)
   const id = url.searchParams.get('id') || ''
   if (!id) return NextResponse.json({ error: 'Attachment id is required' }, { status: 400 })
@@ -536,7 +547,12 @@ export async function DELETE(req: Request) {
   const dataEngine = resolve('dataEngine')
   const storageDriverFactory =
     (resolve('storageDriverFactory') as StorageDriverFactory | null) ?? new StorageDriverFactory(em)
-  const deleteFilter: Record<string, unknown> = { id, tenantId: auth.tenantId!, organizationId: auth.orgId }
+  // Mirror the GET handler's superadmin bypass: a superadmin browsing with "All
+  // organizations" selected has no concrete org, so scope the delete by tenant
+  // only and let them remove any attachment in the tenant. Non-superadmins stay
+  // scoped to their own organization (#3764).
+  const deleteFilter: Record<string, unknown> = { id, tenantId: auth.tenantId! }
+  if (auth.orgId) deleteFilter.organizationId = auth.orgId
   const record = await em.findOne(Attachment, deleteFilter)
   if (!record) return NextResponse.json({ error: 'Attachment not found' }, { status: 404 })
   await em.remove(record).flush()
@@ -546,7 +562,7 @@ export async function DELETE(req: Request) {
   if (record.storagePath) {
     const delDriver = await storageDriverFactory.resolveForPartition(record.partitionCode, {
       tenantId: record.tenantId ?? auth.tenantId!,
-      organizationId: record.organizationId ?? auth.orgId,
+      organizationId: record.organizationId ?? auth.orgId ?? '',
     })
     await delDriver.delete(record.partitionCode, record.storagePath)
   }

--- a/packages/core/src/modules/attachments/i18n/de.json
+++ b/packages/core/src/modules/attachments/i18n/de.json
@@ -5,6 +5,7 @@
   "attachments.errors.maxUploadSize": "Der Anhang überschreitet die maximal zulässige Upload-Größe.",
   "attachments.errors.publicPartitionBlocked": "Öffentliche Speicherpartitionen können für diesen Upload nicht explizit ausgewählt werden.",
   "attachments.errors.quotaExceeded": "Das Speicherlimit für Anhänge dieses Tenants wurde überschritten.",
+  "attachments.errors.selectOrganization": "Wählen Sie eine bestimmte Organisation aus, bevor Sie einen Anhang hochladen.",
   "attachments.library.actions.copied": "Link kopiert.",
   "attachments.library.actions.copyError": "Link konnte nicht kopiert werden.",
   "attachments.library.actions.copyUrl": "URL kopieren",

--- a/packages/core/src/modules/attachments/i18n/en.json
+++ b/packages/core/src/modules/attachments/i18n/en.json
@@ -5,6 +5,7 @@
   "attachments.errors.maxUploadSize": "Attachment exceeds the maximum upload size.",
   "attachments.errors.publicPartitionBlocked": "Public storage partitions cannot be selected explicitly for this upload.",
   "attachments.errors.quotaExceeded": "Attachment storage quota exceeded for this tenant.",
+  "attachments.errors.selectOrganization": "Select a specific organization before uploading an attachment.",
   "attachments.library.actions.copied": "Link copied.",
   "attachments.library.actions.copyError": "Unable to copy link.",
   "attachments.library.actions.copyUrl": "Copy URL",

--- a/packages/core/src/modules/attachments/i18n/es.json
+++ b/packages/core/src/modules/attachments/i18n/es.json
@@ -5,6 +5,7 @@
   "attachments.errors.maxUploadSize": "El archivo adjunto supera el tamaño máximo de carga permitido.",
   "attachments.errors.publicPartitionBlocked": "No se pueden seleccionar explícitamente particiones de almacenamiento públicas para esta carga.",
   "attachments.errors.quotaExceeded": "Se superó la cuota de almacenamiento de adjuntos para este tenant.",
+  "attachments.errors.selectOrganization": "Selecciona una organización específica antes de subir un adjunto.",
   "attachments.library.actions.copied": "Enlace copiado.",
   "attachments.library.actions.copyError": "No se pudo copiar el enlace.",
   "attachments.library.actions.copyUrl": "Copiar URL",

--- a/packages/core/src/modules/attachments/i18n/pl.json
+++ b/packages/core/src/modules/attachments/i18n/pl.json
@@ -5,6 +5,7 @@
   "attachments.errors.maxUploadSize": "Załącznik przekracza maksymalny dopuszczalny rozmiar przesyłania.",
   "attachments.errors.publicPartitionBlocked": "Nie można jawnie wybrać publicznej partycji do tego przesyłania.",
   "attachments.errors.quotaExceeded": "Przekroczono limit miejsca na załączniki dla tego tenantu.",
+  "attachments.errors.selectOrganization": "Wybierz konkretną organizację przed przesłaniem załącznika.",
   "attachments.library.actions.copied": "Link skopiowany.",
   "attachments.library.actions.copyError": "Nie można skopiować linku.",
   "attachments.library.actions.copyUrl": "Kopiuj URL",


### PR DESCRIPTION
Fixes #3764

## Problem
A superadmin with the header organization selector set to **"Wszystkie organizacje" (All organizations)** could *list* attachments but every **upload** (`POST /api/attachments`) and **delete** (`DELETE /api/attachments`) returned **401**. The client fetch layer interprets a 401 as session expiry, shows a misleading **"Session expired"** toast, and resets the in-progress form — discarding the user's input (subject/body/recipient in Messages compose; variant media in Catalog) — even though the session/JWT is perfectly valid. Re-submitting after picking a concrete organization works, confirming the session was never expired.

Both reported surfaces (Messages compose uploader and Catalog product-variant media uploader) funnel through this same route.

## Root Cause
`packages/core/src/modules/attachments/api/route.ts` had inconsistent superadmin handling across methods on the same route:
- `GET` allowed a superadmin with no org: `(!auth.orgId && !auth.isSuperAdmin)`
- `POST` and `DELETE` used `!auth.orgId` with **no** superadmin exception, so `auth.orgId == null` (All organizations) unconditionally 401'd.

## What Changed
- **POST (upload):** a superadmin with no concrete org now receives a clear, translated **400** — `attachments.errors.selectOrganization` ("Select a specific organization before uploading an attachment.") — instead of a 401. An attachment must be stored under exactly one organization (the scope invariant forbids partial-null rows), so uploading under "All organizations" is genuinely ambiguous. Returning 400 avoids the client's session-expiry code path, so the toast is accurate and the in-progress form is preserved. Non-superadmin-with-no-org still returns 401 (unchanged).
- **DELETE:** mirrors the `GET` handler — a superadmin with no org may delete tenant-wide (drop `organizationId` from the filter); non-superadmins stay scoped to their own organization. **Tenant scoping is always preserved** (the filter always includes `tenantId`), so there is no cross-tenant exposure, and a superadmin already sees every org in-tenant via `GET`/`checkAttachmentAccess`.
- Added the `attachments.errors.selectOrganization` key to all four locales (en/pl/de/es).

## Tests
- `packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts`:
  - POST superadmin + no org → **400** with an organization-related message (and no attachment created).
  - POST non-superadmin + no org → still **401** (guard preserved).
  - DELETE superadmin + no org → **200**, and `em.findOne` is called with `{ id, tenantId }` (org filter dropped).
  - DELETE non-superadmin + no org → still **401**.
- Full local validation: attachments suite 191/191 pass; `@open-mercato/core` typecheck ✅; ESLint on changed files ✅; `yarn i18n:check-sync` ✅; `yarn i18n:check-usage` recognizes the new key. (The full core suite shows 1 unrelated pre-existing failure in `customers/DealsKpiStrip.test.tsx` caused by this machine's Polish locale compact-number formatting; it passes under `en_US`, i.e. CI.)

## Follow-up (out of scope)
`packages/core/src/modules/attachments/api/transfer/route.ts` (POST) has the same GET-has-bypass-but-mutation-doesn't asymmetry, but neither reported surface uses it and its superadmin-no-org semantics need a separate design decision. Worth a follow-up issue. `library` (GET-only) and `file`/`image` (`checkAttachmentAccess`) are already superadmin-aware.

## Backward Compatibility
No contract-surface changes. Adds one additive i18n key; `POST` returns a more specific status (400 instead of 401) only for the previously-broken superadmin/all-orgs case; `DELETE` broadens a superadmin's reach within their own tenant only.