### PR TITLE
fix(messages): scope recipient picker to the sender's active organization (#3763)

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/users.route.test.ts
@@ -852,6 +852,56 @@ describe('GET /api/auth/users', () => {
     expect(body.isSuperAdmin).toBe(true)
   })
 
+  test('scopeToActiveOrganization=1 narrows non-superadmin results to the caller active organization', async () => {
+    mockEm.findAndCount.mockResolvedValueOnce([[], 0])
+
+    const response = await GET(makeRequest(
+      '/api/auth/users?page=1&pageSize=100&scopeToActiveOrganization=1',
+    ))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { tenantId },
+      { organizationId },
+    ]))
+    expect(body.isSuperAdmin).toBe(false)
+  })
+
+  test('omits the active-organization filter when scopeToActiveOrganization is not requested', async () => {
+    mockEm.findAndCount.mockResolvedValueOnce([[], 0])
+
+    await GET(makeRequest('/api/auth/users?page=1&pageSize=100'))
+
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { tenantId },
+    ]))
+    expect(where.$and).not.toEqual(expect.arrayContaining([
+      { organizationId: expect.anything() },
+    ]))
+  })
+
+  test('scopeToActiveOrganization=1 filters to organization-less users when the caller has no active organization', async () => {
+    mockGetAuthFromRequest.mockResolvedValueOnce({
+      sub: 'user-1',
+      tenantId,
+      orgId: null,
+      isSuperAdmin: false,
+      roles: ['admin'],
+    })
+    mockLoadAcl.mockResolvedValueOnce({ isSuperAdmin: false })
+    mockEm.findAndCount.mockResolvedValueOnce([[], 0])
+
+    await GET(makeRequest('/api/auth/users?page=1&pageSize=100&scopeToActiveOrganization=1'))
+
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([
+      { organizationId: null },
+    ]))
+  })
+
   test('allows assigning a role whose wildcard ACL is covered by actor wildcard ACL', async () => {
     const employeeRoleId = '323e4567-e89b-12d3-a456-426614174776'
     mockLoadAcl.mockResolvedValueOnce({

--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -22,6 +22,7 @@ import {
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { buildPasswordSchema } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { parseBooleanFlag } from '@open-mercato/shared/lib/boolean'
 import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
 import { sql } from 'kysely'
@@ -38,6 +39,7 @@ const querySchema = z.object({
   search: z.string().optional(),
   name: z.string().optional(),
   organizationId: z.string().uuid().optional(),
+  scopeToActiveOrganization: z.boolean().optional(),
   roleIds: z.array(z.string().uuid()).optional(),
 }).passthrough()
 
@@ -177,6 +179,7 @@ export async function GET(req: Request) {
     search: url.searchParams.get('search') || undefined,
     name: url.searchParams.get('name') || undefined,
     organizationId: url.searchParams.get('organizationId') || undefined,
+    scopeToActiveOrganization: parseBooleanFlag(url.searchParams.get('scopeToActiveOrganization') || undefined),
     roleIds: rawRoleIds.length ? rawRoleIds : undefined,
   })
   if (!parsed.success) return NextResponse.json({ items: [], total: 0, totalPages: 1 })
@@ -192,7 +195,7 @@ export async function GET(req: Request) {
   } catch (err) {
     console.error('users: failed to resolve rbac', err)
   }
-  const { id, page, pageSize, search, name, organizationId, roleIds } = parsed.data
+  const { id, page, pageSize, search, name, organizationId, scopeToActiveOrganization, roleIds } = parsed.data
   const filters: any[] = [{ deletedAt: null }]
   const actorTenantId = auth.tenantId ? String(auth.tenantId) : null
   let effectiveTenantId: string | null = null
@@ -241,6 +244,12 @@ export async function GET(req: Request) {
     ? effectiveSelectedOrganizationId
     : auth.orgId ?? null
   if (organizationId) filters.push({ organizationId })
+  // Recipient/assignee pickers scope to the caller's active organization so they never
+  // suggest users outside it. A message composed here is stamped with the caller's
+  // active org (auth.orgId), and the message detail endpoint enforces
+  // hasOrganizationAccess(scope.organizationId, message.organizationId); scoping the
+  // suggestions to the same org keeps a picked recipient able to open what they were sent.
+  if (scopeToActiveOrganization) filters.push({ organizationId: auth.orgId ?? null })
   const trimmedName = typeof name === 'string' ? name.trim() : ''
   if (trimmedName) {
     const searchPattern = `%${escapeLikePattern(trimmedName)}%`
@@ -617,7 +626,7 @@ export const openApi: OpenApiRouteDoc = {
     GET: {
       summary: 'List users',
       description:
-        'Returns users for the effective selected tenant and organization scope. Search matches email, organization name, and role name. Super administrators may scope the response via the topbar context, organization filters, or role filters.',
+        'Returns users for the effective selected tenant and organization scope. Search matches email, organization name, and role name. Super administrators may scope the response via the topbar context, organization filters, or role filters. Pass scopeToActiveOrganization=1 to restrict results to the caller\'s active organization (used by recipient/assignee pickers so suggestions stay within the org that owns the resulting record).',
       query: querySchema,
       responses: [
         { status: 200, description: 'User collection', schema: userListResponseSchema },

--- a/packages/ui/src/backend/messages/__tests__/useMessageCompose.test.tsx
+++ b/packages/ui/src/backend/messages/__tests__/useMessageCompose.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { useMessageCompose } from '../useMessageCompose'
+import { apiCall } from '../../utils/apiCall'
+
+jest.mock('../../utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+jest.mock('../../FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {/* @ts-expect-error shared provider accepts a loose dict shape */}
+        <I18nProvider locale="en" dict={{}}>
+          {children}
+        </I18nProvider>
+      </QueryClientProvider>
+    )
+  }
+}
+
+describe('useMessageCompose recipient suggestions', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    ;(apiCall as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      result: { items: [] },
+      response: { status: 200 },
+    })
+  })
+
+  it('scopes recipient suggestions to the composer active organization', async () => {
+    const { result } = renderHook(() => useMessageCompose({ variant: 'compose' }), {
+      wrapper: createWrapper(),
+    })
+
+    await result.current.loadRecipientSuggestions()
+
+    const authUsersCall = (apiCall as jest.Mock).mock.calls.find(
+      ([url]) => typeof url === 'string' && url.startsWith('/api/auth/users'),
+    )
+    expect(authUsersCall).toBeDefined()
+
+    const requestedUrl = new URL(`http://localhost${authUsersCall[0]}`)
+    expect(requestedUrl.searchParams.get('scopeToActiveOrganization')).toBe('1')
+  })
+})

--- a/packages/ui/src/backend/messages/useMessageCompose.ts
+++ b/packages/ui/src/backend/messages/useMessageCompose.ts
@@ -410,6 +410,10 @@ export function useMessageCompose({
     const params = new URLSearchParams()
     params.set('page', '1')
     params.set('pageSize', '100')
+    // Scope suggestions to the composer's active organization: a message is stamped with
+    // that org and its detail endpoint denies cross-org recipients, so a recipient from
+    // another org could never open what they were sent.
+    params.set('scopeToActiveOrganization', '1')
     // Recipient lookup is filtered in TagsInput because incremental auth user search is unreliable.
 
     const call = await apiCall<{ items?: UserListItem[] }>(


### PR DESCRIPTION
Fixes #3763

## Problem
Composing (or forwarding) an internal message, the recipient picker queried `GET /api/auth/users` with **tenant-only** scoping, so it suggested — and allowed selecting — users from a *different organization* within the same tenant. But a message is stamped with the sender's active `organizationId`, and the message detail endpoint enforces `hasOrganizationAccess(scope.organizationId, message.organizationId)` (`packages/core/src/modules/messages/api/[id]/route.ts`). A cross-org recipient therefore got a **403 Forbidden** opening a message they were validly named on — a confusing dead end (the same block also applies to forwarded messages/attachments).

## Root Cause
`useMessageCompose.loadRecipientSuggestions` called `/api/auth/users` without any organization filter, and for non-superadmins that endpoint scopes by tenant only. The whole messages module (inbox list, detail, thread, attachments) is org-scoped by the caller's active org, so the picker was the one surface that leaked cross-org users into a selection that could never resolve to a readable message.

Fix per option (a) in the issue: the recipient picker should not suggest users outside the sender's active organization.

## What Changed
- **`packages/core/src/modules/auth/api/users/route.ts`** — added an opt-in `scopeToActiveOrganization` query param. When set, results are restricted to the caller's active organization (`auth.orgId ?? null`) — which is exactly the org the composed/forwarded message is stamped with. The param is **additive**; every existing caller (user management page, role/assignee lookups) is unaffected because it defaults to off.
- **`packages/ui/src/backend/messages/useMessageCompose.ts`** — the recipient picker now requests `scopeToActiveOrganization=1`, so suggestions stay within the org that will own the message. Covers both compose and forward (they share the picker).

The server is the source of truth for the active org, so scoping there (rather than trying to read a not-reliably-available active org on the client) keeps the picker aligned with the actual message-access check for single-org users, which is the reported scenario.

## Tests
- `packages/core/src/modules/auth/api/__tests__/users.route.test.ts` — 3 new cases: `scopeToActiveOrganization=1` adds the caller-active-org filter for non-superadmins; the filter is omitted when the param is absent (baseline unchanged); and it narrows to organization-less users when the caller has no active org.
- `packages/ui/src/backend/messages/__tests__/useMessageCompose.test.tsx` — new suite asserting `loadRecipientSuggestions` requests `/api/auth/users` with `scopeToActiveOrganization=1`.
- All new tests fail before the fix and pass after (verified by stashing the source change).

## Checks
- `yarn build:packages`, `yarn generate`, `yarn build:packages`
- `yarn typecheck` — core ✅, ui ✅, app ✅
- Core auth+messages unit tests: 765 passed; full UI suite: only the pre-existing `format.test.ts` locale flake failed (unrelated to this change)
- `yarn i18n:check-sync` — all locales in sync (no i18n/locale files touched)

## Backward Compatibility
- **ADDITIVE-ONLY.** New optional query param; no removed query params, no removed API response fields, no changes to event IDs, widget spot IDs, ACL IDs, DI names, import paths, or DB schema. No tenant-isolation or encryption rules affected (no new `em.find`/`em.findOne`).