### PR TITLE
fix(sales): preserve order paid/refunded totals when creating a return (#3756)

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/returns.payment-totals.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/returns.payment-totals.test.ts
@@ -1,0 +1,189 @@
+/** @jest-environment node */
+
+// Regression coverage for #3756: creating a return must NOT reset the order's
+// recorded payment totals. The return command only recalculates the line /
+// adjustment math; `paidTotalAmount` / `refundedTotalAmount` live on the order
+// and must be carried through every `calculateDocumentTotals` call via
+// `existingTotals`. Without that, a full return of a fully-paid order zeroed the
+// paid amount and the outstanding balance jumped to the residual shipping cost
+// (implying the customer still owed money after already paying in full).
+
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { DefaultSalesCalculationService } from '../../services/salesCalculationService'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+const state: { order: any; lines: any[]; adjustments: any[]; shipments: any[]; shipmentItems: any[] } = {
+  order: null,
+  lines: [],
+  adjustments: [],
+  shipments: [],
+  shipmentItems: [],
+}
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async (_em: any, entity: any) => {
+    if (entity?.name === 'SalesOrder') return state.order
+    return null
+  }),
+  findWithDecryption: jest.fn(async (_em: any, entity: any) => {
+    if (entity?.name === 'SalesOrderLine') return [...state.lines]
+    if (entity?.name === 'SalesOrderAdjustment') return [...state.adjustments]
+    if (entity?.name === 'SalesShipment') return [...state.shipments]
+    if (entity?.name === 'SalesShipmentItem') return [...state.shipmentItems]
+    return []
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+}))
+
+let mockReturnNumberCounter = 0
+jest.mock('../../services/salesDocumentNumberGenerator', () => ({
+  SalesDocumentNumberGenerator: class {
+    async generate() {
+      mockReturnNumberCounter += 1
+      return { number: `RET-TEST-${mockReturnNumberCounter}` }
+    }
+  },
+}))
+
+const TEST_TENANT_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const TEST_ORG_ID = 'bbbbbbbb-bbbb-4bbb-abbb-bbbbbbbbbbbb'
+const TEST_ORDER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const LINE_A_ID = 'dddddddd-dddd-4ddd-9ddd-dddddddddddd'
+const SHIPMENT_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+
+function num(value: any): number {
+  return Number(value ?? 0)
+}
+
+function buildTx() {
+  return {
+    create: (_entity: any, data: Record<string, unknown>) => ({ ...data }),
+    persist: (entity: any) => {
+      if (entity && entity.kind === 'return' && entity.scope === 'line') {
+        state.adjustments.push(entity)
+      }
+    },
+    remove: jest.fn(),
+    flush: jest.fn().mockResolvedValue(undefined),
+    getReference: (_entity: any, id: unknown) => ({ id }),
+  }
+}
+
+function buildCtx() {
+  const calc = new DefaultSalesCalculationService(null)
+  const container = {
+    resolve: (name: string) => {
+      if (name === 'em') {
+        return {
+          fork: () => ({
+            transactional: async (cb: (tx: any) => Promise<any>) => cb(buildTx()),
+          }),
+        }
+      }
+      if (name === 'salesCalculationService') return calc
+      if (name === 'dataEngine') return {}
+      return {}
+    },
+  }
+  return {
+    container,
+    auth: { tenantId: TEST_TENANT_ID, orgId: TEST_ORG_ID },
+    selectedOrganizationId: TEST_ORG_ID,
+    organizationIds: [TEST_ORG_ID],
+    request: null,
+    organizationScope: null,
+  }
+}
+
+async function createReturn(lineId: string, quantity: number) {
+  const execute = commandRegistry.get('sales.returns.create')?.execute as any
+  expect(execute).toBeInstanceOf(Function)
+  await execute(
+    { tenantId: TEST_TENANT_ID, organizationId: TEST_ORG_ID, orderId: TEST_ORDER_ID, lines: [{ orderLineId: lineId, quantity }] },
+    buildCtx(),
+  )
+}
+
+describe('sales.returns.create — preserves order payment totals (#3756)', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../returns')
+  })
+
+  it('keeps paid/refunded totals and a zero outstanding balance after a full return of a fully-paid order', async () => {
+    // One product line (248.00 gross) plus a shipping adjustment (9.90 gross),
+    // fully paid at the 257.90 grand total. A full return of the product line
+    // leaves only the 9.90 shipping residual on the grand total.
+    state.order = {
+      id: TEST_ORDER_ID,
+      tenantId: TEST_TENANT_ID,
+      organizationId: TEST_ORG_ID,
+      currencyCode: 'USD',
+      shippingMethodSnapshot: null,
+      paymentMethodSnapshot: null,
+      // Customer already paid in full for the original 257.90 total.
+      paidTotalAmount: '257.90',
+      refundedTotalAmount: '0',
+      grandTotalNetAmount: '0',
+      grandTotalGrossAmount: '0',
+      updatedAt: new Date(),
+    }
+    state.lines = [
+      {
+        id: LINE_A_ID,
+        lineNumber: 1,
+        kind: 'product',
+        currencyCode: 'USD',
+        discountAmount: '0',
+        discountPercent: '0',
+        taxRate: '0',
+        returnedQuantity: '0',
+        quantity: '1',
+        unitPriceNet: '248',
+        unitPriceGross: '248',
+        totalNetAmount: '248',
+        totalGrossAmount: '248',
+      },
+    ]
+    state.adjustments = [
+      {
+        id: 'a0000000-0000-4000-8000-000000000001',
+        scope: 'order',
+        kind: 'shipping',
+        rate: '0',
+        amountNet: '9.90',
+        amountGross: '9.90',
+        currencyCode: 'USD',
+        position: 1,
+      },
+    ]
+    state.shipments = [{ id: SHIPMENT_ID }]
+    state.shipmentItems = state.lines.map((line) => ({
+      shipment: { id: SHIPMENT_ID },
+      orderLine: { id: line.id },
+      quantity: line.quantity,
+    }))
+
+    await createReturn(LINE_A_ID, 1)
+
+    // The payment record was never touched, so paid/refunded must survive.
+    expect(num(state.order.paidTotalAmount)).toBeCloseTo(257.9, 4)
+    expect(num(state.order.refundedTotalAmount)).toBeCloseTo(0, 4)
+
+    // Grand total dropped to the shipping residual, but the customer already
+    // paid in full — outstanding must be 0, NOT the 9.90 shipping residual.
+    expect(num(state.order.grandTotalGrossAmount)).toBeCloseTo(9.9, 4)
+    expect(num(state.order.outstandingAmount)).toBeCloseTo(0, 4)
+  })
+})

--- a/packages/core/src/modules/sales/commands/returns.ts
+++ b/packages/core/src/modules/sales/commands/returns.ts
@@ -78,6 +78,22 @@ function round(value: number): number {
   return Math.round((value + Number.EPSILON) * 1e4) / 1e4
 }
 
+/**
+ * Payment totals live on the order, not in the line/adjustment math a return
+ * recalculates. Every `calculateDocumentTotals` call that writes order totals
+ * back to the order MUST seed these so `buildBaseDocumentResult` preserves the
+ * recorded `paidTotalAmount` / `refundedTotalAmount` instead of defaulting them
+ * to 0 — otherwise creating/undoing/redoing a return silently zeroes the paid
+ * amount and the order's outstanding balance goes wrong on any paid order
+ * (#3756). Mirrors `resolveExistingPaymentTotals` in `commands/documents.ts`.
+ */
+function resolveExistingPaymentTotals(order: SalesOrder): { paidTotalAmount: number; refundedTotalAmount: number } {
+  return {
+    paidTotalAmount: toNumeric(order.paidTotalAmount),
+    refundedTotalAmount: toNumeric(order.refundedTotalAmount),
+  }
+}
+
 function applyOrderTotals(order: SalesOrder, totals: SalesDocumentCalculationResult['totals'], lineCount: number): void {
   order.subtotalNetAmount = toNumericString(totals.subtotalNetAmount) ?? '0'
   order.subtotalGrossAmount = toNumericString(totals.subtotalGrossAmount) ?? '0'
@@ -194,10 +210,7 @@ export async function recalculateOrderTotalsForDisplay(
     lines: lineSnapshots,
     adjustments: adjustmentDrafts,
     context: buildCalculationContext(order),
-    existingTotals: {
-      paidTotalAmount: toNumeric(order.paidTotalAmount),
-      refundedTotalAmount: toNumeric(order.refundedTotalAmount),
-    },
+    existingTotals: resolveExistingPaymentTotals(order),
   })
   return calculation.totals
 }
@@ -382,6 +395,7 @@ async function reverseReturnEffects(
           lines: lineSnapshots,
           adjustments: adjustmentDrafts,
           context: buildCalculationContext(order),
+          existingTotals: resolveExistingPaymentTotals(order),
         })
         applyOrderTotals(order, calculation.totals, calculation.lines.length)
         order.updatedAt = new Date()
@@ -531,6 +545,7 @@ async function restoreReturnEffects(
           lines: lineSnapshots,
           adjustments: adjustmentDrafts,
           context: buildCalculationContext(order),
+          existingTotals: resolveExistingPaymentTotals(order),
         })
         applyOrderTotals(order, calculation.totals, calculation.lines.length)
         order.updatedAt = new Date()
@@ -746,6 +761,7 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
         lines: lineSnapshots,
         adjustments: adjustmentDrafts,
         context: buildCalculationContext(order),
+        existingTotals: resolveExistingPaymentTotals(order),
       })
       applyOrderTotals(order, calculation.totals, calculation.lines.length)
       order.updatedAt = new Date()


### PR DESCRIPTION
Fixes #3756

## Problem
Creating a return on a paid order silently reset `paid_total_amount` and `refunded_total_amount` to `0.00` on the order, even though the payment row in `sales_payments` was untouched. The order's "Outstanding" (Do zapłaty) balance was then computed against a paid amount of 0, so after a full return of a fully-paid order the UI showed an outstanding balance equal to the residual shipping cost instead of `0,00`.

## Root Cause
The return commands recalculate the order's line/adjustment math via `salesCalculationService.calculateDocumentTotals(...)` and write the result back with `applyOrderTotals`. Payment totals (`paidTotalAmount`/`refundedTotalAmount`) live on the order, not in that math, so they must be seeded via the `existingTotals` option. Three call sites in `packages/core/src/modules/sales/commands/returns.ts` — create (`createReturnCommand.execute`), reverse (`reverseReturnEffects`, used by create-undo and delete), and restore (`restoreReturnEffects`, used by create-redo and delete-undo) — omitted `existingTotals`. `buildBaseDocumentResult` in `lib/calculations.ts` then defaulted both totals to `0`, and `applyOrderTotals` wrote that `0` straight back onto the order.

The correct pattern already existed a few lines away (`recalculateOrderTotalsForDisplay`) and in `commands/documents.ts` (`resolveExistingPaymentTotals`, used on every order-kind call there); the return command sites simply never adopted it.

## What Changed
- Added a small typed `resolveExistingPaymentTotals(order)` helper in `returns.ts` (mirrors the one in `commands/documents.ts`).
- Seeded `existingTotals: resolveExistingPaymentTotals(order)` on all four `calculateDocumentTotals` calls in `returns.ts`, and refactored the pre-existing display call to use the helper for consistency.

## Tests
- New `returns.payment-totals.test.ts` seeds a fully-paid order (product line + shipping adjustment), creates a full return of the line, and asserts `paidTotalAmount`/`refundedTotalAmount` are preserved and `outstandingAmount` stays `0` (not the residual shipping cost). Verified it fails on the pre-fix code (paid resets to 0) and passes with the fix.
- Full sales command suite green: 18 suites / 92 tests.
- `yarn workspace @open-mercato/core typecheck` clean.

## Backward Compatibility
No contract surface changes. The fix is internal to the sales returns command; no API response fields, event IDs, DI keys, import paths, or DB schema changed. Behavior change is limited to the intended correction (order payment totals are now preserved across return create/undo/redo).