### PR TITLE
fix(customers): support "All organizations" scope on deals filter-bar endpoints (#3768)

### DIFF
--- a/packages/core/src/modules/customers/api/pipeline-stages/__tests__/route.all-orgs.test.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/__tests__/route.all-orgs.test.ts
@@ -1,0 +1,127 @@
+/** @jest-environment node */
+
+import { CustomerPipelineStage, CustomerDictionaryEntry } from '../../../data/entities'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+
+const em = {
+  find: jest.fn(),
+}
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: (...args: unknown[]) =>
+    mockResolveOrganizationScopeForRequest(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+import { GET } from '../route'
+
+const makeStage = (overrides: Record<string, unknown> = {}) => ({
+  id: '33333333-3333-4333-8333-333333333333',
+  pipelineId: '44444444-4444-4444-8444-444444444444',
+  label: 'Prospecting',
+  order: 0,
+  organizationId,
+  tenantId,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+  ...overrides,
+})
+
+describe('customers pipeline-stages GET under All organizations scope (#3768)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId, orgId: null })
+  })
+
+  it('aggregates stages tenant-wide when no organization is selected (no organizationId filter)', async () => {
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId,
+    })
+    let stageWhere: Record<string, unknown> | undefined
+    let dictWhere: Record<string, unknown> | undefined
+    em.find.mockImplementation(async (entity: unknown, where: Record<string, unknown>) => {
+      if (entity === CustomerPipelineStage) {
+        stageWhere = where
+        return [makeStage()]
+      }
+      if (entity === CustomerDictionaryEntry) {
+        dictWhere = where
+        return []
+      }
+      return []
+    })
+
+    const response = await GET(new Request('http://localhost/api/customers/pipeline-stages'))
+
+    expect(response.status).toBe(200)
+    expect(stageWhere).toEqual({ tenantId })
+    expect(stageWhere).not.toHaveProperty('organizationId')
+    expect(dictWhere).toMatchObject({ tenantId, kind: 'pipeline_stage' })
+    expect(dictWhere).not.toHaveProperty('organizationId')
+  })
+
+  it('scopes stages to the selected organization when one is active', async () => {
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: organizationId,
+      filterIds: [organizationId],
+      allowedIds: null,
+      tenantId,
+    })
+    let stageWhere: Record<string, unknown> | undefined
+    em.find.mockImplementation(async (entity: unknown, where: Record<string, unknown>) => {
+      if (entity === CustomerPipelineStage) {
+        stageWhere = where
+        return []
+      }
+      return []
+    })
+
+    const response = await GET(new Request('http://localhost/api/customers/pipeline-stages'))
+
+    expect(response.status).toBe(200)
+    expect(stageWhere).toEqual({ tenantId, organizationId: { $in: [organizationId] } })
+  })
+
+  it('still returns 400 when tenant context is missing', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: null, orgId: null })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: null,
+    })
+
+    const response = await GET(new Request('http://localhost/api/customers/pipeline-stages'))
+
+    expect(response.status).toBe(400)
+    expect(em.find).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/pipeline-stages/route.ts
+++ b/packages/core/src/modules/customers/api/pipeline-stages/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
 import { CustomerPipelineStage, CustomerDictionaryEntry } from '../../data/entities'
@@ -56,15 +57,16 @@ async function buildContext(
 
 export async function GET(req: Request) {
   try {
-    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
-    if (!organizationId || !tenantId) {
+    const { ctx, tenantId, translate } = await buildContext(req)
+    if (!tenantId) {
       return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
+    const orgFilter = resolveOrganizationScopeFilter(ctx.organizationScope, ctx.auth)
     const url = new URL(req.url)
     const pipelineId = url.searchParams.get('pipelineId')
 
     const em = (ctx.container.resolve('em') as EntityManager)
-    const where: Record<string, unknown> = { organizationId, tenantId }
+    const where: Record<string, unknown> = { tenantId, ...orgFilter.where }
     if (pipelineId) where.pipelineId = pipelineId
 
     const stages = await em.find(CustomerPipelineStage, where, { orderBy: { order: 'ASC' } })
@@ -72,8 +74,8 @@ export async function GET(req: Request) {
     const stageLabels = stages.map((s) => s.label.trim().toLowerCase())
     const dictEntries = stageLabels.length
       ? await em.find(CustomerDictionaryEntry, {
-          organizationId,
           tenantId,
+          ...orgFilter.where,
           kind: 'pipeline_stage',
           normalizedValue: { $in: stageLabels },
         })

--- a/packages/core/src/modules/customers/api/pipelines/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/pipelines/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+/** @jest-environment node */
+
+const mockCreateRequestContainer = jest.fn()
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockFind = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => mockCreateRequestContainer(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: (...args: unknown[]) =>
+    mockResolveOrganizationScopeForRequest(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+describe('customers pipelines route (GET org scoping)', () => {
+  beforeEach(() => {
+    mockCreateRequestContainer.mockReset()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockFind.mockReset()
+    mockCreateRequestContainer.mockResolvedValue({
+      resolve: (token: string) => {
+        if (token === 'em') return { find: mockFind }
+        return null
+      },
+    })
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: null })
+  })
+
+  it('returns tenant-wide pipelines under the "All organizations" scope (no organizationId filter)', async () => {
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: 'tenant-1',
+    })
+    mockFind.mockResolvedValue([])
+
+    const { GET } = await import('../route')
+    const response = await GET(new Request('http://localhost/api/customers/pipelines'))
+
+    expect(response.status).toBe(200)
+    const [, where] = mockFind.mock.calls[0]
+    expect(where).toEqual({ tenantId: 'tenant-1' })
+    expect(where).not.toHaveProperty('organizationId')
+  })
+
+  it('scopes to the selected organization when one is active', async () => {
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: 'org-1',
+      filterIds: ['org-1'],
+      allowedIds: null,
+      tenantId: 'tenant-1',
+    })
+    mockFind.mockResolvedValue([])
+
+    const { GET } = await import('../route')
+    const response = await GET(new Request('http://localhost/api/customers/pipelines'))
+
+    expect(response.status).toBe(200)
+    const [, where] = mockFind.mock.calls[0]
+    expect(where).toEqual({ tenantId: 'tenant-1', organizationId: { $in: ['org-1'] } })
+  })
+
+  it('still returns 400 when tenant context is missing', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: null, orgId: null })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: null,
+    })
+
+    const { GET } = await import('../route')
+    const response = await GET(new Request('http://localhost/api/customers/pipelines'))
+
+    expect(response.status).toBe(400)
+    expect(mockFind).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/pipelines/route.ts
+++ b/packages/core/src/modules/customers/api/pipelines/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CommandRuntimeContext, CommandBus } from '@open-mercato/shared/lib/commands'
 import { CustomerPipeline } from '../../data/entities'
@@ -56,15 +57,16 @@ async function buildContext(
 
 export async function GET(req: Request) {
   try {
-    const { ctx, organizationId, tenantId, translate } = await buildContext(req)
-    if (!organizationId || !tenantId) {
+    const { ctx, tenantId, translate } = await buildContext(req)
+    if (!tenantId) {
       return NextResponse.json({ error: translate('customers.errors.context_required', 'Organization and tenant context required') }, { status: 400 })
     }
+    const orgFilter = resolveOrganizationScopeFilter(ctx.organizationScope, ctx.auth)
     const url = new URL(req.url)
     const isDefaultParam = url.searchParams.get('isDefault')
 
     const em = (ctx.container.resolve('em') as EntityManager)
-    const where: Record<string, unknown> = { organizationId, tenantId }
+    const where: Record<string, unknown> = { tenantId, ...orgFilter.where }
     if (isDefaultParam === 'true') where.isDefault = true
     if (isDefaultParam === 'false') where.isDefault = false
 

--- a/packages/core/src/modules/staff/api/team-members/assignable/__tests__/route.test.ts
+++ b/packages/core/src/modules/staff/api/team-members/assignable/__tests__/route.test.ts
@@ -42,6 +42,7 @@ describe('staff assignable team-members route', () => {
         tenantId: 'tenant-1',
         orgId: 'org-1',
       },
+      scope: { selectedId: 'org-1', filterIds: ['org-1'], allowedIds: null, tenantId: 'tenant-1' },
       selectedOrganizationId: 'org-1',
     })
   })
@@ -88,6 +89,13 @@ describe('staff assignable team-members route', () => {
       ['customers.roles.manage'],
       { tenantId: 'tenant-1', organizationId: 'org-1' },
     )
+    const [, , memberWhere] = mockFindWithDecryption.mock.calls[0]
+    expect(memberWhere).toEqual({
+      tenantId: 'tenant-1',
+      organizationId: { $in: ['org-1'] },
+      deletedAt: null,
+      isActive: true,
+    })
     expect(body.items).toEqual([
       {
         id: '11111111-1111-1111-1111-111111111111',
@@ -145,19 +153,42 @@ describe('staff assignable team-members route', () => {
     })
   })
 
-  it('returns 400 when no organization is selected', async () => {
+  it('aggregates tenant-wide staff under the "All organizations" scope (no organizationId filter)', async () => {
     mockResolveCustomersRequestContext.mockResolvedValueOnce({
-      container: { resolve: () => undefined },
+      container: {
+        resolve: (token: string) => {
+          if (token === 'rbacService') return { userHasAllFeatures: mockUserHasAllFeatures }
+          return null
+        },
+      },
       em: {},
       auth: { sub: 'user-actor', tenantId: 'tenant-1', orgId: null },
+      scope: { selectedId: null, filterIds: null, allowedIds: null, tenantId: 'tenant-1' },
       selectedOrganizationId: null,
     })
+    mockUserHasAllFeatures.mockResolvedValueOnce(true)
+    mockFindWithDecryption
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
 
     const { GET } = await import('../route')
-    const response = await GET(new Request('http://localhost/api/staff/team-members/assignable'))
-    const body = (await response.json()) as Record<string, unknown>
+    const response = await GET(new Request('http://localhost/api/staff/team-members/assignable?page=1&pageSize=100'))
 
-    expect(response.status).toBe(400)
-    expect(body).toMatchObject({ error: 'Organization context is required' })
+    expect(response.status).toBe(200)
+    // Tenant-wide feature check: no concrete organization is required.
+    expect(mockUserHasAllFeatures).toHaveBeenCalledWith(
+      'user-actor',
+      ['customers.roles.manage'],
+      { tenantId: 'tenant-1', organizationId: null },
+    )
+    // Query must stay tenant-scoped but must NOT pin a single organization.
+    const [, , memberWhere] = mockFindWithDecryption.mock.calls[0]
+    expect(memberWhere).toEqual({
+      tenantId: 'tenant-1',
+      deletedAt: null,
+      isActive: true,
+    })
+    expect(memberWhere).not.toHaveProperty('organizationId')
   })
 })

--- a/packages/core/src/modules/staff/api/team-members/assignable/route.ts
+++ b/packages/core/src/modules/staff/api/team-members/assignable/route.ts
@@ -6,6 +6,7 @@ import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { createPagedListResponseSchema as createSharedPagedListResponseSchema } from '@open-mercato/shared/lib/openapi/crud'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { User } from '@open-mercato/core/modules/auth/data/entities'
 import {
   resolveAuthActorId,
@@ -57,7 +58,7 @@ export const metadata = {
 async function canAccessAssignableStaff(
   rbac: RbacService | undefined,
   userId: string,
-  scope: { tenantId: string; organizationId: string },
+  scope: { tenantId: string; organizationId: string | null },
 ): Promise<boolean> {
   if (!rbac) return false
   if (
@@ -72,18 +73,13 @@ export async function GET(request: Request) {
   const { translate } = await resolveTranslations()
   try {
     const query = querySchema.parse(Object.fromEntries(new URL(request.url).searchParams))
-    const { container, em, auth, selectedOrganizationId } = await resolveCustomersRequestContext(request)
+    const { container, em, auth, scope: organizationScope } = await resolveCustomersRequestContext(request)
 
-    if (!selectedOrganizationId) {
-      throw new CrudHttpError(
-        400,
-        { error: translate('customers.errors.organization_required', 'Organization context is required') },
-      )
-    }
+    const orgFilter = resolveOrganizationScopeFilter(organizationScope, auth)
 
     const actorId = resolveAuthActorId(auth)
     const rbacService = container.resolve('rbacService') as RbacService | undefined
-    const scope = { tenantId: auth.tenantId, organizationId: selectedOrganizationId }
+    const scope = { tenantId: auth.tenantId, organizationId: orgFilter.rbacOrganizationId }
     const hasAccess = await canAccessAssignableStaff(rbacService, actorId, scope)
     if (!hasAccess) {
       throw new CrudHttpError(
@@ -104,7 +100,7 @@ export async function GET(request: Request) {
       StaffTeamMember,
       {
         tenantId: auth.tenantId,
-        organizationId: selectedOrganizationId,
+        ...orgFilter.where,
         deletedAt: null,
         isActive: true,
       },
@@ -136,7 +132,7 @@ export async function GET(request: Request) {
               id: { $in: userIds },
               deletedAt: null,
               tenantId: auth.tenantId,
-              organizationId: selectedOrganizationId,
+              ...orgFilter.where,
             },
             undefined,
             scope,
@@ -150,7 +146,7 @@ export async function GET(request: Request) {
               id: { $in: teamIds },
               deletedAt: null,
               tenantId: auth.tenantId,
-              organizationId: selectedOrganizationId,
+              ...orgFilter.where,
             },
             undefined,
             scope,


### PR DESCRIPTION
Fixes #3768.

Under the header **"All organizations"** scope, three endpoints backing the shared Deals filter bar / views returned `400 Bad Request`:

- `GET /api/customers/pipelines`
- `GET /api/customers/pipeline-stages`
- `GET /api/staff/team-members/assignable`

This broke the Kanban/Pipeline view and degraded the Deals Map view (empty Pipeline/Owner filters, no stage legend/colours) for multi-org operators.

**Root cause:** each GET hard-required a concrete `organizationId` and rejected the unrestricted org scope with 400 — whereas the CRUD list route and the deals map already adopt the `OrganizationScope` contract where `filterIds === null` means tenant-wide.

**Fix:** adopt the same contract via the existing `resolveOrganizationScopeFilter` helper. The GET handlers now require only tenant context and build a tenant-scoped `where` that pins the selected org when active, narrows to `filterIds` for a bounded multi-org set, and stays tenant-wide under "All organizations". Queries remain tenant-scoped (org_id only widened within the authenticated tenant — no cross-tenant exposure). `POST/PUT/DELETE` still require a concrete organization.

Regression tests cover all-orgs (tenant-wide), single-org, and missing-tenant cases for all three routes.

---
🤖 Salvaged by om-autofix-fleet — the worker completed and committed the fix but exited (waiting on `build:app`) before pushing; branch pushed and PR opened manually.