### PR TITLE
fix(query_index): batch search token rebuild silently loses all tokens on large batches

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/search-tokens-batch-stack-overflow.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/search-tokens-batch-stack-overflow.test.ts
@@ -1,0 +1,59 @@
+import {
+  Kysely,
+  DummyDriver,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+} from 'kysely'
+import { replaceSearchTokensForBatch } from '../lib/search-tokens'
+
+// A real Kysely backed by the DummyDriver: every query is COMPILED to SQL (the step that used to
+// overflow the call stack) but executed as a no-op, so the test needs no database.
+function makeCompilingDb(): Kysely<any> {
+  return new Kysely<any>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => new DummyDriver(),
+      createIntrospector: (db) => new PostgresIntrospector(db),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  })
+}
+
+describe('replaceSearchTokensForBatch — large batch delete (regression)', () => {
+  const prevEnabled = process.env.OM_SEARCH_ENABLED
+  const prevPartials = process.env.OM_SEARCH_ENABLE_PARTIAL
+
+  beforeAll(() => {
+    process.env.OM_SEARCH_ENABLED = 'true'
+    // Keep the generated token set small so the test is fast; the regression is in the DELETE, whose
+    // size depends on record×field count, not on how many tokens each field yields.
+    process.env.OM_SEARCH_ENABLE_PARTIAL = 'false'
+  })
+
+  afterAll(() => {
+    if (prevEnabled === undefined) delete process.env.OM_SEARCH_ENABLED
+    else process.env.OM_SEARCH_ENABLED = prevEnabled
+    if (prevPartials === undefined) delete process.env.OM_SEARCH_ENABLE_PARTIAL
+    else process.env.OM_SEARCH_ENABLE_PARTIAL = prevPartials
+  })
+
+  it('compiles the delete for a large record×field batch without overflowing the call stack', async () => {
+    // 200 records × 60 fields = ~12k (entity_id, field) pairs. The previous implementation deleted
+    // existing tokens by a nested `eb.or(pairs.map(([id, field]) => eb.and([...])))`, whose expression
+    // tree is deep enough to throw "Maximum call stack size exceeded" while Kysely compiles the SQL —
+    // and batch.ts swallowed it, silently losing every token in the batch. The fix deletes by
+    // `entity_id IN (ids)` instead. Regression guard: this call must resolve, not throw a RangeError.
+    const payloads = Array.from({ length: 200 }, (_, recordIdx) => ({
+      entityType: 'sales:sales_order',
+      recordId: `order-${recordIdx}`,
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      doc: Object.fromEntries(
+        Array.from({ length: 60 }, (_, fieldIdx) => [`field_${fieldIdx}`, `order ${recordIdx} field ${fieldIdx} value`]),
+      ),
+    }))
+
+    await expect(replaceSearchTokensForBatch(makeCompilingDb(), payloads)).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/query_index/lib/batch.ts
+++ b/packages/core/src/modules/query_index/lib/batch.ts
@@ -1,4 +1,5 @@
 import { type Kysely, sql } from 'kysely'
+import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
 import { buildIndexDocument, type IndexCustomFieldValue } from './document'
 import { replaceSearchTokensForBatch, isSearchDebugEnabled } from './search-tokens'
 
@@ -245,7 +246,13 @@ export async function upsertIndexBatch(
       .execute()
     try {
       await replaceSearchTokensForBatch(db, tokenPayloads)
-    } catch {}
+    } catch (searchTokenError) {
+      // Record instead of swallowing: a failed token write leaves fulltext search stale.
+      await recordIndexerError(
+        { db },
+        { source: 'fulltext', handler: 'query_index:reindex-batch', error: searchTokenError, entityType, tenantId: scope.tenantId ?? null, organizationId: scope.orgId ?? null },
+      ).catch(() => undefined)
+    }
     if (debugEnabled) {
       console.info('[reindex:batch:tokens]', {
         entityType,
@@ -298,5 +305,11 @@ export async function upsertIndexBatch(
   }
   try {
     await replaceSearchTokensForBatch(db, tokenPayloads)
-  } catch {}
+  } catch (searchTokenError) {
+    // Record instead of swallowing: a failed token write leaves fulltext search stale.
+    await recordIndexerError(
+      { db },
+      { source: 'fulltext', handler: 'query_index:reindex-batch', error: searchTokenError, entityType, tenantId: scope.tenantId ?? null, organizationId: scope.orgId ?? null },
+    ).catch(() => undefined)
+  }
 }

--- a/packages/core/src/modules/query_index/lib/search-tokens.ts
+++ b/packages/core/src/modules/query_index/lib/search-tokens.ts
@@ -212,8 +212,6 @@ export async function replaceSearchTokensForBatch(
 
   const scopeKey = (org: string | null, tenant: string | null) => `${org ?? '__null__'}|${tenant ?? '__null__'}`
   const scopeBuckets = new Map<string, { organizationId: string | null; tenantId: string | null; ids: Set<string> }>()
-  const fieldPairsByScope = new Map<string, EntityFieldPair[]>()
-  const seenPairsByScope = new Map<string, Set<string>>()
 
   for (const payload of payloads) {
     const org = payload.organizationId ?? null
@@ -224,41 +222,16 @@ export async function replaceSearchTokensForBatch(
     scopeBuckets.set(key, bucket)
   }
 
-  for (const payload of payloads) {
-    const org = payload.organizationId ?? null
-    const tenant = payload.tenantId ?? null
-    const key = scopeKey(org, tenant)
-    const pairs = fieldPairsByScope.get(key) ?? []
-    const seen = seenPairsByScope.get(key) ?? new Set<string>()
-    const fieldPairs = buildFieldPairs(String(payload.recordId), payload.doc)
-    for (const pair of fieldPairs) {
-      const dedupeKey = `${pair[0]}|${pair[1]}`
-      if (seen.has(dedupeKey)) continue
-      seen.add(dedupeKey)
-      pairs.push(pair)
-    }
-    fieldPairsByScope.set(key, pairs)
-    seenPairsByScope.set(key, seen)
-  }
-
   await db.transaction().execute(async (trx) => {
-    for (const [key, bucket] of scopeBuckets.entries()) {
-      const pairs = fieldPairsByScope.get(key) ?? []
-      let deleteQuery = trx
+    for (const [, bucket] of scopeBuckets.entries()) {
+      // Delete by entity_id: a batch replaces all of a record's tokens, and a per-field OR over the
+      // whole batch overflows the query compiler's call stack on large batches.
+      const deleteQuery = trx
         .deleteFrom('search_tokens' as any)
         .where('entity_type' as any, '=', payloads[0].entityType)
         .where(sql<boolean>`organization_id is not distinct from ${bucket.organizationId}`)
         .where(sql<boolean>`tenant_id is not distinct from ${bucket.tenantId}`)
-      if (pairs.length) {
-        deleteQuery = deleteQuery.where((eb: any) => eb.or(
-          pairs.map(([rid, field]) => eb.and([
-            eb('entity_id' as any, '=', rid),
-            eb('field' as any, '=', field),
-          ])),
-        ))
-      } else {
-        deleteQuery = deleteQuery.where('entity_id' as any, 'in', Array.from(bucket.ids))
-      }
+        .where('entity_id' as any, 'in', Array.from(bucket.ids))
       await deleteQuery.execute()
     }
     const payloadWithTimestamps = rows.map((row) => ({ ...row, created_at: sql`now()` }))


### PR DESCRIPTION
## Summary

`mercato query_index rebuild` / `reindex` reports `Rebuilt N rows` but writes **zero `search_tokens`** for those records on any realistically-sized batch, so fulltext search silently stays empty after a reindex — while the primary `entity_indexes` rows are written normally, which makes it easy to miss. `rebuild --record <id>` on a single record works, which further hid the bug.

## Root cause

`replaceSearchTokensForBatch` (`packages/core/src/modules/query_index/lib/search-tokens.ts`) deleted a scope's existing tokens before re-inserting by building a nested boolean over **every `(entity_id, field)` pair in the batch**:

```ts
deleteQuery.where(eb => eb.or(pairs.map(([id, field]) => eb.and([
  eb('entity_id', '=', id), eb('field', '=', field),
]))))
```

For a normal reindex batch (~200 records × ~60 indexed fields ≈ **12k pairs**) that expression tree is deep enough to throw `RangeError: Maximum call stack size exceeded` while Kysely compiles the SQL. The whole delete+insert transaction throws, and `batch.ts` swallowed it in a bare `try {} catch {}` — so the batch's tokens are lost with no error surfaced.

## Fix

- **`search-tokens.ts`** — delete a scope's tokens by `entity_id IN (ids)`. A batch rebuild regenerates *all* of a record's tokens, so scoping the delete to the record ids is sufficient and correct, and avoids the pathological per-field OR. Removes the now-unused field-pair accumulation. `replaceSearchTokensForRecord` (single record, bounded OR) is unchanged.
- **`batch.ts`** — stop swallowing the token-write error at both call sites. Record it via `recordIndexerError` (`source: 'fulltext'`) so a failure lands in the indexer error log instead of vanishing.

## Open question for maintainers

The token write was **deliberately best-effort** (its own `try/catch`, separate from the primary `entity_indexes` write), so this PR keeps it best-effort — it now **records** the error instead of swallowing it, but does **not** re-throw. If you'd prefer a failed token write to hard-fail the reindex (propagate so the CLI's top-level `recordIndexerError` + non-zero exit kick in), I'm happy to change the catches to re-throw — it's a semantics call I didn't want to make unilaterally.

## Testing

- **New regression test** (`search-tokens-batch-stack-overflow.test.ts`): a real Kysely with `DummyDriver` (SQL is compiled — the step that overflowed — but executed as a no-op) reindexes a 200×60 batch. **Fails with `Maximum call stack size exceeded` before the fix, passes after** (verified by stashing the fix and re-running).
- Full `query_index` suite: **75/75 pass**. `tsc --noEmit` clean for `@open-mercato/core`; `eslint` clean on touched files (0 errors).
- Verified end-to-end against a real import (≈1.4M orders): before, a full `query_index rebuild` left orders-with-tokens flat (silent fail); after, the rebuild restores `search_tokens` for previously-unindexed records.

## Notes

- OSS `packages/core` only — nothing under `packages/enterprise/`.
- No schema, API, or public-signature changes; behaviour-only fix.
- Found while implementing a bulk-import mode that defers per-record reindex and rebuilds once at the end — that pattern depends on the batch rebuild actually writing tokens.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
