### PR TITLE
feat(auth): add demo autologin via env vars

### DIFF
--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -18,6 +18,16 @@ AUTH_SECRET=change-me-dev-auth-secret
 # Optional alias used by some NextAuth/Auth.js setups.
 NEXTAUTH_SECRET=
 
+# Demo autologin (optional; leave blank to disable).
+# When both email and password are set, visitors landing on the homepage are
+# signed in automatically with these credentials and dropped into the app —
+# handy for demos with a single superadmin + tenant. NEVER set these in
+# production. OM_AUTOLOGIN_TENANT is only needed when the same email exists in
+# more than one tenant.
+# OM_AUTOLOGIN_EMAIL=superadmin@acme.com
+# OM_AUTOLOGIN_PASSWORD=secret
+# OM_AUTOLOGIN_TENANT=
+
 # Events transport (choose one)
 # REDIS_URL=redis://localhost:6379
 # or

--- a/apps/mercato/src/app/page.tsx
+++ b/apps/mercato/src/app/page.tsx
@@ -1,11 +1,23 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
+import { isAutoLoginEnabled } from '@open-mercato/core/modules/auth/lib/autologin'
 
 // The home route is a pure router: it never renders. Unless the visitor has
 // dismissed the start page, it sends them there; otherwise into the app
 // (backend when authenticated, login otherwise).
 export default async function Home() {
+  const auth = await getAuthFromCookies()
+
+  // Demo autologin: when OM_AUTOLOGIN_* credentials are configured and there is
+  // no active session, hand off to the autologin route which signs the visitor
+  // in and drops them into the app. Fully gated behind env vars — with them
+  // unset, behavior below is unchanged. The route falls back to /login when the
+  // credentials are invalid, so a misconfigured demo can never loop.
+  if (!auth && isAutoLoginEnabled()) {
+    redirect('/api/auth/autologin')
+  }
+
   const cookieStore = await cookies()
   const startPageDismissed = cookieStore.get('start_page_dismissed')?.value === '1'
 
@@ -13,6 +25,5 @@ export default async function Home() {
     redirect('/start')
   }
 
-  const auth = await getAuthFromCookies()
   redirect(auth ? '/backend' : '/login')
 }

--- a/packages/core/src/modules/auth/api/__tests__/autologin.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/autologin.test.ts
@@ -1,0 +1,152 @@
+/** @jest-environment node */
+import { randomUUID } from 'crypto'
+import { GET } from '@open-mercato/core/modules/auth/api/autologin'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+
+const tenantId = randomUUID()
+const orgId = randomUUID()
+
+const authServiceMock = {
+  findUsersByEmail: jest.fn(async (email: string) => ([{ id: 1, email, passwordHash: 'hash', tenantId, organizationId: orgId }])),
+  findUserByEmailAndTenant: jest.fn(async (email: string) => ({ id: 1, email, passwordHash: 'hash', tenantId, organizationId: orgId })),
+  verifyPassword: jest.fn(async () => true),
+  getUserRoles: jest.fn(async () => ['admin']),
+  updateLastLoginAt: jest.fn(async () => undefined),
+  createSession: jest.fn(async () => ({ session: { id: 'session-1' }, token: 'session-token' })),
+}
+
+const containerMock = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'authService') return authServiceMock
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => containerMock,
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/jwt', () => ({ signJwt: () => 'jwt-token' }))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => null),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/events', () => ({
+  emitAuthEvent: jest.fn(async () => undefined),
+}))
+
+const getAuthFromRequestMock = getAuthFromRequest as jest.MockedFunction<typeof getAuthFromRequest>
+
+function autologinRequest(path = '/api/auth/autologin') {
+  return new Request(`http://localhost${path}`, { method: 'GET' })
+}
+
+const ORIGINAL_ENV = { ...process.env }
+
+function setAutoLoginEnv(env: Record<string, string | undefined>) {
+  delete process.env.OM_AUTOLOGIN_EMAIL
+  delete process.env.OM_AUTOLOGIN_PASSWORD
+  delete process.env.OM_AUTOLOGIN_TENANT
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) continue
+    process.env[key] = value
+  }
+}
+
+describe('GET /api/auth/autologin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getAuthFromRequestMock.mockResolvedValue(null)
+    setAutoLoginEnv({})
+  })
+
+  afterAll(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  test('is a no-op that redirects to /login when the env credentials are unset', async () => {
+    const res = await GET(autologinRequest())
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/login')
+    // Never touches auth machinery when disabled.
+    expect(containerMock.resolve).not.toHaveBeenCalled()
+    expect(authServiceMock.createSession).not.toHaveBeenCalled()
+    expect(res.headers.get('set-cookie')).toBeNull()
+  })
+
+  test('signs the visitor in and sets the auth cookie when credentials resolve to one user', async () => {
+    setAutoLoginEnv({ OM_AUTOLOGIN_EMAIL: 'superadmin@acme.com', OM_AUTOLOGIN_PASSWORD: 'secret' })
+
+    const res = await GET(autologinRequest())
+
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/backend')
+    expect(res.headers.get('set-cookie') ?? '').toContain('auth_token=jwt-token')
+    expect(authServiceMock.findUsersByEmail).toHaveBeenCalledWith('superadmin@acme.com')
+    expect(authServiceMock.findUserByEmailAndTenant).not.toHaveBeenCalled()
+    expect(authServiceMock.createSession).toHaveBeenCalledTimes(1)
+  })
+
+  test('scopes the lookup by tenant when OM_AUTOLOGIN_TENANT is set', async () => {
+    setAutoLoginEnv({
+      OM_AUTOLOGIN_EMAIL: 'superadmin@acme.com',
+      OM_AUTOLOGIN_PASSWORD: 'secret',
+      OM_AUTOLOGIN_TENANT: tenantId,
+    })
+
+    const res = await GET(autologinRequest())
+
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/backend')
+    expect(authServiceMock.findUserByEmailAndTenant).toHaveBeenCalledWith('superadmin@acme.com', tenantId)
+    expect(authServiceMock.findUsersByEmail).not.toHaveBeenCalled()
+  })
+
+  test('redirects to /backend without re-issuing a session when already authenticated', async () => {
+    setAutoLoginEnv({ OM_AUTOLOGIN_EMAIL: 'superadmin@acme.com', OM_AUTOLOGIN_PASSWORD: 'secret' })
+    getAuthFromRequestMock.mockResolvedValueOnce({ sub: '1', tenantId, orgId } as never)
+
+    const res = await GET(autologinRequest())
+
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/backend')
+    expect(res.headers.get('set-cookie')).toBeNull()
+    expect(authServiceMock.createSession).not.toHaveBeenCalled()
+  })
+
+  test('falls back to /login without a cookie when the email resolves to no single user', async () => {
+    setAutoLoginEnv({ OM_AUTOLOGIN_EMAIL: 'ghost@acme.com', OM_AUTOLOGIN_PASSWORD: 'secret' })
+    authServiceMock.findUsersByEmail.mockResolvedValueOnce([])
+
+    const res = await GET(autologinRequest())
+
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/login')
+    expect(res.headers.get('set-cookie')).toBeNull()
+    expect(authServiceMock.createSession).not.toHaveBeenCalled()
+  })
+
+  test('falls back to /login when the password does not verify', async () => {
+    setAutoLoginEnv({ OM_AUTOLOGIN_EMAIL: 'superadmin@acme.com', OM_AUTOLOGIN_PASSWORD: 'wrong' })
+    authServiceMock.verifyPassword.mockResolvedValueOnce(false)
+
+    const res = await GET(autologinRequest())
+
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/login')
+    expect(res.headers.get('set-cookie')).toBeNull()
+    expect(authServiceMock.createSession).not.toHaveBeenCalled()
+  })
+
+  test('sanitizes an open-redirect bypass in the redirect param down to /backend', async () => {
+    setAutoLoginEnv({ OM_AUTOLOGIN_EMAIL: 'superadmin@acme.com', OM_AUTOLOGIN_PASSWORD: 'secret' })
+
+    const res = await GET(autologinRequest('/api/auth/autologin?redirect=/backend//evil.com'))
+
+    expect(res.status).toBe(307)
+    const location = res.headers.get('location') ?? ''
+    expect(location).toContain('/backend')
+    expect(location).not.toContain('evil.com')
+  })
+})

--- a/packages/core/src/modules/auth/api/autologin.ts
+++ b/packages/core/src/modules/auth/api/autologin.ts
@@ -1,0 +1,98 @@
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { AuthService } from '@open-mercato/core/modules/auth/services/authService'
+import { signJwt } from '@open-mercato/shared/lib/auth/jwt'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { buildSafeRedirectResponse, resolveTrustedRedirectBase } from '@open-mercato/core/modules/auth/lib/requestRedirect'
+import { sanitizeRedirectPath } from '@open-mercato/core/modules/auth/lib/safeRedirect'
+import { resolveAutoLoginCredentials } from '@open-mercato/core/modules/auth/lib/autologin'
+import { emitAuthEvent } from '@open-mercato/core/modules/auth/events'
+
+export const metadata = { requireAuth: false }
+
+const accessTokenMaxAgeSeconds = 60 * 60 * 8
+
+// Demo-only convenience: when OM_AUTOLOGIN_* credentials are configured, sign the
+// visitor in with those credentials and redirect into the app. Gated entirely
+// behind env vars — the homepage only routes here when they are set. On any
+// failure (feature off, bad credentials) it falls back to the manual login form
+// so a misconfigured demo can never loop.
+export async function GET(req: Request) {
+  const url = new URL(req.url)
+  const baseUrl = resolveTrustedRedirectBase(req) ?? url.origin
+  const redirectTo = sanitizeRedirectPath(url.searchParams.get('redirect'), baseUrl, '/backend')
+
+  const credentials = resolveAutoLoginCredentials()
+  if (!credentials) {
+    return buildSafeRedirectResponse(req, '/login')
+  }
+
+  // Already signed in — go straight to the app instead of re-issuing a session.
+  const existing = await getAuthFromRequest(req)
+  if (existing) {
+    return buildSafeRedirectResponse(req, redirectTo)
+  }
+
+  const container = await createRequestContainer()
+  const auth = container.resolve<AuthService>('authService')
+
+  let user = null
+  if (credentials.tenantId) {
+    user = await auth.findUserByEmailAndTenant(credentials.email, credentials.tenantId)
+  } else {
+    const users = await auth.findUsersByEmail(credentials.email)
+    user = users.length === 1 ? users[0] : null
+  }
+
+  const ok = await auth.verifyPassword(user, credentials.password)
+  if (!user || !ok) {
+    // Misconfigured demo credentials — never loop; drop to the manual form.
+    console.warn('[autologin] OM_AUTOLOGIN credentials did not resolve to a single valid user; falling back to /login')
+    return buildSafeRedirectResponse(req, '/login')
+  }
+
+  const resolvedTenantId = credentials.tenantId ?? (user.tenantId ? String(user.tenantId) : null)
+  const roles = await auth.getUserRoles(user, resolvedTenantId)
+  await auth.updateLastLoginAt(user)
+  const expiresAt = new Date(Date.now() + accessTokenMaxAgeSeconds * 1000)
+  const { session } = await auth.createSession(user, expiresAt)
+  const token = signJwt({
+    sub: String(user.id),
+    sid: String(session.id),
+    tenantId: resolvedTenantId,
+    orgId: user.organizationId ? String(user.organizationId) : null,
+    email: user.email,
+    roles,
+  })
+  void emitAuthEvent('auth.login.success', {
+    id: String(user.id),
+    email: user.email,
+    tenantId: resolvedTenantId,
+    organizationId: user.organizationId ? String(user.organizationId) : null,
+  }).catch(() => undefined)
+
+  const res = buildSafeRedirectResponse(req, redirectTo)
+  res.cookies.set('auth_token', token, {
+    httpOnly: true,
+    path: '/',
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: accessTokenMaxAgeSeconds,
+  })
+  return res
+}
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'Authentication & Accounts',
+  summary: 'Demo autologin',
+  methods: {
+    GET: {
+      summary: 'Auto sign-in using env-configured demo credentials',
+      description:
+        'When OM_AUTOLOGIN_EMAIL / OM_AUTOLOGIN_PASSWORD are configured, signs the visitor in with those credentials and redirects into the app. Intended for single-tenant demo instances only. Falls back to the login page when disabled or misconfigured.',
+      responses: [
+        { status: 307, description: 'Redirect into the app (or to /login on failure)', mediaType: 'text/html' },
+      ],
+    },
+  },
+}

--- a/packages/core/src/modules/auth/lib/__tests__/autologin.test.ts
+++ b/packages/core/src/modules/auth/lib/__tests__/autologin.test.ts
@@ -1,0 +1,43 @@
+import { resolveAutoLoginCredentials, isAutoLoginEnabled } from '@open-mercato/core/modules/auth/lib/autologin'
+
+describe('resolveAutoLoginCredentials', () => {
+  it('returns null when credentials are unset (default: disabled)', () => {
+    expect(resolveAutoLoginCredentials({})).toBeNull()
+    expect(isAutoLoginEnabled({})).toBe(false)
+  })
+
+  it('returns null when only one of email/password is set', () => {
+    expect(resolveAutoLoginCredentials({ OM_AUTOLOGIN_EMAIL: 'a@b.com' })).toBeNull()
+    expect(resolveAutoLoginCredentials({ OM_AUTOLOGIN_PASSWORD: 'secret' })).toBeNull()
+  })
+
+  it('returns null when email is blank/whitespace', () => {
+    expect(
+      resolveAutoLoginCredentials({ OM_AUTOLOGIN_EMAIL: '   ', OM_AUTOLOGIN_PASSWORD: 'secret' }),
+    ).toBeNull()
+  })
+
+  it('resolves email + password with tenant omitted', () => {
+    const env = { OM_AUTOLOGIN_EMAIL: ' a@b.com ', OM_AUTOLOGIN_PASSWORD: 'secret' }
+    expect(resolveAutoLoginCredentials(env)).toEqual({ email: 'a@b.com', password: 'secret', tenantId: null })
+    expect(isAutoLoginEnabled(env)).toBe(true)
+  })
+
+  it('preserves the password verbatim (no trimming of surrounding spaces)', () => {
+    const env = { OM_AUTOLOGIN_EMAIL: 'a@b.com', OM_AUTOLOGIN_PASSWORD: ' spaced ' }
+    expect(resolveAutoLoginCredentials(env)?.password).toBe(' spaced ')
+  })
+
+  it('includes tenant when provided', () => {
+    const env = {
+      OM_AUTOLOGIN_EMAIL: 'a@b.com',
+      OM_AUTOLOGIN_PASSWORD: 'secret',
+      OM_AUTOLOGIN_TENANT: ' tenant-1 ',
+    }
+    expect(resolveAutoLoginCredentials(env)).toEqual({
+      email: 'a@b.com',
+      password: 'secret',
+      tenantId: 'tenant-1',
+    })
+  })
+})

--- a/packages/core/src/modules/auth/lib/autologin.ts
+++ b/packages/core/src/modules/auth/lib/autologin.ts
@@ -1,0 +1,36 @@
+export type AutoLoginCredentials = {
+  email: string
+  password: string
+  tenantId: string | null
+}
+
+function readEnvValue(env: Record<string, string | undefined>, key: string): string {
+  const value = env[key]
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+/**
+ * Reads the optional demo-autologin credentials from env. When both
+ * `OM_AUTOLOGIN_EMAIL` and `OM_AUTOLOGIN_PASSWORD` are set, the homepage hands
+ * unauthenticated visitors to the autologin route which signs them in and drops
+ * them into the app. Unset (the default) → `null` → normal login flow.
+ *
+ * `OM_AUTOLOGIN_TENANT` is optional and only needed when the same email exists
+ * across multiple tenants. Pure: pass the env bag so it stays testable.
+ */
+export function resolveAutoLoginCredentials(
+  env: Record<string, string | undefined> = process.env,
+): AutoLoginCredentials | null {
+  const email = readEnvValue(env, 'OM_AUTOLOGIN_EMAIL')
+  const password = env.OM_AUTOLOGIN_PASSWORD ?? ''
+  if (!email || !password) return null
+  const tenantId = readEnvValue(env, 'OM_AUTOLOGIN_TENANT')
+  return { email, password, tenantId: tenantId || null }
+}
+
+/** True when demo autologin credentials are configured via env. */
+export function isAutoLoginEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return resolveAutoLoginCredentials(env) !== null
+}

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -18,6 +18,16 @@ AUTH_SECRET=change-me-dev-auth-secret
 # Optional alias used by some NextAuth/Auth.js setups.
 NEXTAUTH_SECRET=
 
+# Demo autologin (optional; leave blank to disable).
+# When both email and password are set, visitors landing on the homepage are
+# signed in automatically with these credentials and dropped into the app —
+# handy for demos with a single superadmin + tenant. NEVER set these in
+# production. OM_AUTOLOGIN_TENANT is only needed when the same email exists in
+# more than one tenant.
+# OM_AUTOLOGIN_EMAIL=superadmin@acme.com
+# OM_AUTOLOGIN_PASSWORD=secret
+# OM_AUTOLOGIN_TENANT=
+
 # Events transport (choose one)
 # REDIS_URL=redis://localhost:6379
 # or

--- a/packages/create-app/template/src/app/page.tsx
+++ b/packages/create-app/template/src/app/page.tsx
@@ -1,11 +1,23 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
+import { isAutoLoginEnabled } from '@open-mercato/core/modules/auth/lib/autologin'
 
 // The home route is a pure router: it never renders. Unless the visitor has
 // dismissed the start page, it sends them there; otherwise into the app
 // (backend when authenticated, login otherwise).
 export default async function Home() {
+  const auth = await getAuthFromCookies()
+
+  // Demo autologin: when OM_AUTOLOGIN_* credentials are configured and there is
+  // no active session, hand off to the autologin route which signs the visitor
+  // in and drops them into the app. Fully gated behind env vars — with them
+  // unset, behavior below is unchanged. The route falls back to /login when the
+  // credentials are invalid, so a misconfigured demo can never loop.
+  if (!auth && isAutoLoginEnabled()) {
+    redirect('/api/auth/autologin')
+  }
+
   const cookieStore = await cookies()
   const startPageDismissed = cookieStore.get('start_page_dismissed')?.value === '1'
 
@@ -13,6 +25,5 @@ export default async function Home() {
     redirect('/start')
   }
 
-  const auth = await getAuthFromCookies()
   redirect(auth ? '/backend' : '/login')
 }


### PR DESCRIPTION
## What

Adds an optional **demo autologin**: when `OM_AUTOLOGIN_EMAIL` and `OM_AUTOLOGIN_PASSWORD` are set, a visitor landing on the homepage is signed in automatically with those credentials and dropped into the app — no login form. Useful for demo instances with a single superadmin + tenant.

Fully gated behind env vars: **with them unset, behavior is unchanged.**

## How

- **`packages/core/src/modules/auth/lib/autologin.ts`** — pure, testable env resolver (`resolveAutoLoginCredentials` / `isAutoLoginEnabled`). Both email and password are required to enable it (value-gated, same pattern as `OM_FORCE_LOCALE`).
- **`packages/core/src/modules/auth/api/autologin.ts`** — new `GET /api/auth/autologin` route. Looks up the user via `AuthService`, verifies the password, creates a session, signs the JWT, sets the `auth_token` cookie, and redirects into the app. Mirrors the existing `session/refresh.ts` cookie+redirect pattern. On **any** failure (feature off, bad credentials, ambiguous multi-tenant email) it falls back to `/login`.
- **`apps/mercato/src/app/page.tsx`** — the homepage hands unauthenticated visitors off to the route **only** when the credentials are configured. Since only the homepage routes there (never `/login` itself), a misconfigured demo can never loop.
- **`OM_AUTOLOGIN_TENANT`** — optional; only needed when the same email exists in more than one tenant.

## Safety

- The password never reaches the browser (server-side only). Cookie flags match the real login (`httpOnly`, `sameSite=lax`, `secure` in production).
- `.env.example` documents the vars with an explicit **"NEVER set these in production"** warning.

## Tests

- `lib/__tests__/autologin.test.ts` — env resolver gating (both vars required, whitespace, password preserved verbatim, tenant parsing).
- `api/__tests__/autologin.test.ts` — route handler: enabled (sets cookie → `/backend`), disabled (no-op → `/login`), wrong password, no single user, tenant-scoped lookup, already-authenticated short-circuit, and open-redirect sanitization.

The enabled path was also verified manually end-to-end against a running dev server + database: `/` → `/api/auth/autologin` → sets `auth_token` → lands authenticated on `/backend`; the issued cookie authenticates against `/api/auth/profile` (superadmin). The Playwright e2e suite can't exercise the enabled path because the feature is gated by server-start env the shared QA server doesn't set — hence the handler-level coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)