### PR TITLE
docs(create-app): close template-sync gap that let PR #3799 ship unsynced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ IMPORTANT: Before any research or coding, match the task to the root `AGENTS.md`
 | Adding onboarding wizard steps, tenant setup hooks (`onTenantCreated`/`seedDefaults`), welcome/invitation emails | `packages/onboarding/AGENTS.md` |
 | Adding static content pages (privacy policies, terms, legal pages) | `packages/content/AGENTS.md` |
 | Testing standalone apps with Verdaccio, publishing packages, canary releases, template scaffolding | `packages/create-app/AGENTS.md` |
+| Editing files under `apps/mercato/src/app/**` or env vars in `apps/mercato/.env.example` — MUST mirror the change into the create-app template in the same task | `packages/create-app/AGENTS.md` → Template Sync Checklist |
 | Deploying a freshly scaffolded Open Mercato app to Railway with `mercato deploy railway` | [`.ai/specs/2026-05-12-railway-one-command-deploy.md`](.ai/specs/2026-05-12-railway-one-command-deploy.md) + [`apps/docs/docs/deployment/railway.mdx`](apps/docs/docs/deployment/railway.mdx) + `packages/cli/AGENTS.md` |
 | **Performance** | |
 | Profiling dev-mode memory (`yarn dev:profile`), ranking memory hogs, evaluating watcher / Vite-vs-Turbopack tradeoffs | `.ai/specs/2026-05-27-dev-mode-memory-quick-wins.md` + `scripts/profile-dev-rss.mjs` |

--- a/packages/create-app/AGENTS.md
+++ b/packages/create-app/AGENTS.md
@@ -8,7 +8,7 @@ Use `packages/create-app` to scaffold standalone Open Mercato applications via `
 2. **MUST keep `@types/*` in `dependencies`** (not `devDependencies`) — standalone apps need type declarations at runtime
 3. **MUST follow build order** — `yarn build:packages` → `yarn generate` → `yarn build:packages`
 4. **MUST build before publishing** — generators scan `node_modules/@open-mercato/*/dist/modules/` for `.js` files
-5. **MUST sync template equivalents when app shell/layout files change** — when touching `apps/mercato/src/app/**` bootstrap/layout/provider wiring, update matching files in `packages/create-app/template/src/app/**` (and required template components) in the same task
+5. **MUST sync template equivalents** — touching ANY file under `apps/mercato/src/app/**` (layouts, providers, and route/page behavior like a `page.tsx` handoff) or any env var in `apps/mercato/.env.example` means mirroring YOUR change into the template counterpart (`packages/create-app/template/src/app/**`, `packages/create-app/template/.env.example`) in the same task; if genuinely monorepo-only, say so in the PR. Some pairs intentionally diverge (`globals.css`, docs API routes, template-only `api/healthz`, env comments) — mirror your change, don't fix pre-existing drift
 6. **MUST keep template module registrations and package dependencies aligned** — if `packages/create-app/template/src/modules.ts` enables a package-backed module (for example `@open-mercato/webhooks`), `packages/create-app/template/package.json.template` must install that package in the same change, and the template lockfile must be reviewed when dependency shape changes
 7. **MUST preserve imported ready apps as raw source snapshots** — `--app` / `--app-url` imports may add only bootstrap-safe generated artifacts (for example `.mercato/generated/module-package-sources.css`)
 8. **MUST keep standalone agent guidance aligned with generator behavior** — if `yarn generate` gains post-steps such as structural cache purging, update `packages/create-app/template/AGENTS.md` and `packages/create-app/agentic/shared/AGENTS.md.template` in the same task
@@ -46,7 +46,7 @@ yarn test:create-app:integration
 
 ## Template Sync Checklist
 
-When changes affect app shell behavior, verify all relevant template files are reviewed and updated:
+When changes affect app shell behavior, verify all relevant template files are reviewed and updated. The list is a floor, not exhaustive — mirror any `src/app/**` file you touched; pre-existing intentional drift is fine:
 
 1. `apps/mercato/src/app/layout.tsx` ↔ `packages/create-app/template/src/app/layout.tsx`
 2. `apps/mercato/src/app/(backend)/backend/layout.tsx` ↔ `packages/create-app/template/src/app/(backend)/backend/layout.tsx`
@@ -56,6 +56,8 @@ When changes affect app shell behavior, verify all relevant template files are r
 6. `scripts/dev-splash.html` ↔ `packages/create-app/template/scripts/dev-splash.html`
 7. `scripts/dev-splash-helpers.mjs` ↔ `packages/create-app/template/scripts/dev-splash-helpers.mjs`
 8. `apps/mercato/scripts/dev.mjs` ↔ `packages/create-app/template/scripts/dev-runtime.mjs`
+9. `apps/mercato/src/app/page.tsx` ↔ `packages/create-app/template/src/app/page.tsx`
+10. `apps/mercato/.env.example` ↔ `packages/create-app/template/.env.example` (env var names + their doc comments)
 
 ## Dev Runtime Expectations
 


### PR DESCRIPTION
## What

Tightens agent guidance so the template-sync miss flagged in [PR #3799's review](https://github.com/open-mercato/open-mercato/pull/3799#pullrequestreview-4638356308) (autologin landed in `apps/mercato` but not in the create-app template) can't silently recur.

## Why the existing rule didn't catch it

A sync rule already existed in `packages/create-app/AGENTS.md`, but it failed on three counts:

1. It was scoped to *"bootstrap/layout/provider wiring"* — a `page.tsx` route handoff didn't read as wiring.
2. `.env.example` wasn't covered by any rule or checklist entry.
3. Nothing routed an auth-feature author to `packages/create-app/AGENTS.md` — the root Task Router only referenced it for "template scaffolding".

## How

- **Root `AGENTS.md`** (+1 row): Task Router entry that fires on edits to `apps/mercato/src/app/**` or env vars in `apps/mercato/.env.example`, pointing at the Template Sync Checklist — the trigger now lives at the point of contact.
- **`packages/create-app/AGENTS.md` rule 5**: broadened to ANY `src/app/**` file (route/page handoffs explicitly count) plus `.env.example` vars. Deliberately scoped to *mirror your change*, not tree equality — the trees intentionally diverge in places (`globals.css`, docs API routes, template-only `api/healthz`), which the rule now names so agents don't try to "fix" pre-existing drift. Monorepo-only changes get an explicit escape hatch: declare it in the PR instead of silently skipping.
- **Template Sync Checklist**: `page.tsx` and `.env.example` pairs appended (items 9–10); intro notes the list is a floor, not exhaustive.

Net diff: 5 insertions, 2 deletions across two AGENTS.md files. No code changes.

## Noted during analysis (not addressed here)

The two `.env.example` files have accumulated real drift: ~35 vars exist only in the monorepo file (all `RATE_LIMIT_*`, attachment quotas, `OM_OPTIMISTIC_LOCK`, …), and the template still carries a stale `OPENMERCATO_DEFAULT_ATTACHMENT_OCR_ENABLED` where the app uses `OM_DEFAULT_ATTACHMENT_OCR_ENABLED`. Worth a separate cleanup issue; a CI guard test (pair-diff with an intentional-drift allowlist, same pattern as the optimistic-lock guards) was prototyped and dropped from this PR to keep it docs-only, but would be the durable enforcement if the drift gets cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)