### PR TITLE
fix(directory): fail loud on stale org selection instead of orphaning writes

### DIFF
--- a/packages/core/src/modules/directory/__integration__/TC-DIR-014-stale-selected-org-orphan.spec.ts
+++ b/packages/core/src/modules/directory/__integration__/TC-DIR-014-stale-selected-org-orphan.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test } from '@playwright/test';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+
+/**
+ * TC-DIR-014: A stale/dead `om_selected_org` selection must not silently write
+ * to a fallback organization.
+ * Covers: organization scope resolution + create guard across
+ *   POST + GET /api/customers/companies.
+ *
+ * Background: an unrestricted (all-orgs) principal — e.g. superadmin — whose
+ * selected-org cookie points at an organization that no longer resolves (a dead
+ * UUID, as happens after a DB reset reassigns the org a new id while the browser
+ * keeps the old cookie) used to have the write land under the dead org while the
+ * read scope filtered by the caller's real accessible org: the record was
+ * created (201) but immediately unreadable — silently orphaned.
+ *
+ * Fix: the scope resolver drops a selection that does not resolve to a real,
+ * accessible org (keeping reads working) and flags it as rejected; the CRUD
+ * factory then refuses the create with HTTP 422 rather than writing it under a
+ * fallback org the caller never selected. This test drives the exact HTTP flow.
+ *
+ * Per-test metadata: needs both directory and customers modules enabled (the
+ * folder meta only requires directory).
+ */
+export const integrationMeta = {
+  dependsOnModules: ['directory', 'customers'],
+};
+
+// Syntactically valid v4 UUID that is not seeded — stands in for an org id that
+// no longer resolves after a reset. Not a real record in any tenant.
+const DEAD_SELECTED_ORG_ID = '00000000-0000-4000-8000-0000000000de';
+
+function extractId(payload: unknown): string | null {
+  if (payload && typeof payload === 'object') {
+    for (const key of ['id', 'entityId', 'companyId'] as const) {
+      const value = (payload as Record<string, unknown>)[key];
+      if (typeof value === 'string' && value.trim().length > 0) return value.trim();
+    }
+  }
+  return null;
+}
+
+function extractItems(payload: unknown): Array<Record<string, unknown>> {
+  if (payload && typeof payload === 'object') {
+    const items = (payload as Record<string, unknown>).items;
+    if (Array.isArray(items)) return items as Array<Record<string, unknown>>;
+  }
+  return [];
+}
+
+test.describe('TC-DIR-014: stale selected-org cookie must not orphan writes', () => {
+  let token: string;
+  let adminToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    // superadmin is unrestricted (allowedIds === null) yet has a real seeded
+    // account org — the precise shape that used to accept a dead selection.
+    token = await getAuthToken(request, 'superadmin');
+    // admin is scoped to a concrete org, so a plain create (no explicit org
+    // selection) resolves to that org — used for the positive control.
+    adminToken = await getAuthToken(request, 'admin');
+  });
+
+  test('rejects a create made under a dead om_selected_org cookie (422)', async ({ request }) => {
+    const displayName = `TC-DIR-014 Reject ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const staleCookie = `om_selected_org=${DEAD_SELECTED_ORG_ID}`;
+    let leakedId: string | null = null;
+
+    try {
+      const createRes = await request.fetch('/api/customers/companies', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Cookie: staleCookie,
+          'Content-Type': 'application/json',
+        },
+        data: { displayName },
+      });
+
+      // The write must be refused loudly, not silently redirected to a fallback org.
+      expect(
+        createRes.status(),
+        `create with a dead selected org should be rejected, got ${createRes.status()}`,
+      ).toBe(422);
+      const body = await readJsonSafe(createRes);
+      expect((body as Record<string, unknown>)?.code).toBe('organization_selection_invalid');
+      leakedId = extractId(body);
+      expect(leakedId, 'no record should be created').toBeFalsy();
+      // Writes must NOT auto-clear the selection — a mutation requires an
+      // explicit, valid re-selection, never a silent fallback org.
+      expect(
+        createRes.headers()['set-cookie'] ?? '',
+        'a rejected write must not clear the selected-org cookie',
+      ).not.toContain('om_selected_org=;');
+    } finally {
+      if (leakedId) {
+        await request
+          .fetch(`/api/customers/companies?id=${leakedId}`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${token}`, Cookie: staleCookie },
+          })
+          .catch(() => {});
+      }
+    }
+  });
+
+  test('rejects a list read made under a dead om_selected_org cookie (422)', async ({ request }) => {
+    // Reads are held to the same rule as writes: a stale selection must not
+    // silently serve a different org's data than the one selected.
+    const listRes = await request.fetch('/api/customers/companies?page=1&pageSize=1', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Cookie: `om_selected_org=${DEAD_SELECTED_ORG_ID}`,
+      },
+    });
+    expect(
+      listRes.status(),
+      `list with a dead selected org should be rejected, got ${listRes.status()}`,
+    ).toBe(422);
+    const body = await readJsonSafe(listRes);
+    expect((body as Record<string, unknown>)?.code).toBe('organization_selection_invalid');
+    // Reads self-heal: the stale selection cookie is expired so the caller's
+    // next request falls back to their home org (recovers even without a switcher).
+    const setCookie = listRes.headers()['set-cookie'] ?? '';
+    expect(setCookie, 'a rejected read should expire the stale selected-org cookie').toContain('om_selected_org=;');
+    expect(setCookie.toLowerCase()).toContain('max-age=0');
+  });
+
+  test('positive control: a normal create (no stale selection) succeeds and is readable', async ({ request }) => {
+    const displayName = `TC-DIR-014 Control ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const authHeaders = { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' };
+    let companyId: string | null = null;
+
+    try {
+      const createRes = await request.fetch('/api/customers/companies', {
+        method: 'POST',
+        headers: authHeaders,
+        data: { displayName },
+      });
+      expect(createRes.ok(), `create should succeed, got ${createRes.status()}`).toBeTruthy();
+      companyId = extractId(await readJsonSafe(createRes));
+      expect(companyId, 'create response should return an id').toBeTruthy();
+
+      const listRes = await request.fetch(`/api/customers/companies?id=${companyId}`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${adminToken}` },
+      });
+      expect(listRes.ok()).toBeTruthy();
+      const match = extractItems(await readJsonSafe(listRes)).find((item) => extractId(item) === companyId);
+      expect(match, 'a normally-created record must be readable back').toBeTruthy();
+    } finally {
+      if (companyId) {
+        await request
+          .fetch(`/api/customers/companies?id=${companyId}`, {
+            method: 'DELETE',
+            headers: { Authorization: `Bearer ${adminToken}` },
+          })
+          .catch(() => {});
+      }
+    }
+  });
+});

--- a/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
+++ b/packages/core/src/modules/directory/utils/__tests__/organizationScope.test.ts
@@ -221,6 +221,111 @@ describe('resolveOrganizationScope', () => {
     })
   })
 
+  // Regression: a selected-org cookie / JWT org that no longer
+  // resolves to a real organization (e.g. after a DB reset reassigns the org a
+  // new UUID) must NOT be honored as the write target. Otherwise writes derived
+  // from `selectedId` land under a dead org while reads filter by `filterIds`,
+  // silently orphaning the record. The write target (`selectedId`) and read
+  // scope (`filterIds`) must always agree on a real, accessible org.
+  describe('stale / non-existent selected org', () => {
+    it('drops a dead selection for an unrestricted user and falls back to the account org', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+        selectedId: 'org-dead',
+      })
+      expect(result.selectedId).not.toBe('org-dead')
+      // read scope degrades gracefully to a real, accessible org
+      expect(result.selectedId).toBe('org-home')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-home', 'org-home-child']))
+      expect(result.filterIds).toContain(result.selectedId)
+      expect(result.filterIds).not.toContain('org-dead')
+      // ...but the explicit selection was rejected, so writes must fail loud
+      expect(result.selectionRejected).toBe(true)
+    })
+
+    it('flags a dead selection as rejected for a superAdmin', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: true, orgId: 'org-home' }),
+        selectedId: 'org-dead',
+      })
+      expect(result.selectedId).not.toBe('org-dead')
+      expect(result.selectionRejected).toBe(true)
+    })
+
+    it('flags a selection outside a restricted ACL as rejected', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: ['org-a'] })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+        selectedId: 'org-b',
+      })
+      expect(result.selectedId).not.toBe('org-b')
+      expect(result.selectionRejected).toBe(true)
+    })
+
+    it('does NOT flag when no organization was explicitly selected', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+      })
+      expect(result.selectionRejected).toBeFalsy()
+    })
+
+    it('does NOT flag a valid, resolvable selection', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+        selectedId: 'org-a',
+      })
+      expect(result.selectedId).toBe('org-a')
+      expect(result.selectionRejected).toBeFalsy()
+    })
+
+    it('does not scope a superAdmin to a non-existent selected org', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: true, orgId: 'org-home' }),
+        selectedId: 'org-dead',
+      })
+      expect(result.selectedId).not.toBe('org-dead')
+      if (result.filterIds !== null) {
+        expect(result.filterIds).not.toContain('org-dead')
+      }
+    })
+
+    it('still honors a real selection for an unrestricted user', async () => {
+      const em = createMockEm(ALL_ORGS)
+      const rbac = createMockRbac({ isSuperAdmin: false, features: ['some.feature'], organizations: null })
+      const result = await resolveOrganizationScope({
+        em,
+        rbac,
+        auth: createAuth({ sub: 'user-1', isSuperAdmin: false, orgId: 'org-home' }),
+        selectedId: 'org-a',
+      })
+      expect(result.selectedId).toBe('org-a')
+      expect(result.filterIds).toEqual(expect.arrayContaining(['org-a']))
+    })
+  })
+
   describe('ACL-level superAdmin flag', () => {
     it('treats ACL-level isSuperAdmin same as auth-level for org scope widening', async () => {
       const em = createMockEm(ALL_ORGS)

--- a/packages/core/src/modules/directory/utils/organizationScope.ts
+++ b/packages/core/src/modules/directory/utils/organizationScope.ts
@@ -15,6 +15,13 @@ export type OrganizationScope = {
   filterIds: string[] | null
   allowedIds: string[] | null
   tenantId: string | null
+  // True when the caller explicitly selected a concrete organization (cookie /
+  // selectedId param) that could not be honored — it does not exist for the
+  // tenant or is not accessible. Reads degrade gracefully (filterIds/selectedId
+  // fall back to the caller's accessible orgs), but writes MUST fail loudly on
+  // this so a record never lands under an org the caller did not intend. Absent
+  // (undefined) means the selection — if any — was honored.
+  selectionRejected?: boolean
 }
 
 // Phase 4 — short-TTL cache for resolveOrganizationScopeForRequest.
@@ -76,7 +83,8 @@ function isValidCachedScope(value: unknown): value is OrganizationScope {
   const record = value as Partial<OrganizationScope>
   const idOk = (v: unknown) => v === null || typeof v === 'string'
   const arrOk = (v: unknown) => v === null || (Array.isArray(v) && v.every((entry) => typeof entry === 'string'))
-  return idOk(record.selectedId) && idOk(record.tenantId) && arrOk(record.filterIds) && arrOk(record.allowedIds)
+  const flagOk = record.selectionRejected === undefined || typeof record.selectionRejected === 'boolean'
+  return idOk(record.selectedId) && idOk(record.tenantId) && arrOk(record.filterIds) && arrOk(record.allowedIds) && flagOk
 }
 
 function resolveCacheFromContainer(container: AwilixContainer | null | undefined): CacheStrategy | null {
@@ -317,9 +325,18 @@ export async function resolveOrganizationScope({
   const initialSelected =
     normalizedSelectedId
     ?? (widenToAllOrgs ? null : accountOrgId ?? null)
+  // A selection is only honored when it resolves to a real, non-deleted org for
+  // this tenant. `orgDescendants` holds exactly the existing orgs among the
+  // candidate ids, so a stale/dead id (e.g. a selected-org cookie or JWT org
+  // that no longer resolves after a DB reset) has no entry and is dropped here.
+  // Without the existence guard an unrestricted (all-orgs) principal — whose
+  // `allowedSet` is null — would accept the dead id as `effectiveSelected`, and
+  // writes derived from `selectedId` would land under an org the read scope
+  // (`filterIds`) never filters to, silently orphaning the record.
+  const selectionResolvesToOrg = (id: string): boolean => orgDescendants.has(id)
   let effectiveSelected: string | null = null
   if (initialSelected) {
-    if (allowedSet === null || allowedSet.has(initialSelected)) {
+    if ((allowedSet === null || allowedSet.has(initialSelected)) && selectionResolvesToOrg(initialSelected)) {
       effectiveSelected = initialSelected
     }
   }
@@ -333,6 +350,13 @@ export async function resolveOrganizationScope({
     filterSet = null
   } else if (auth.orgId) {
     filterSet = loadFallbackSet()
+    // Keep the write target (`selectedId`) aligned with the read scope
+    // (`filterIds`): when an unrestricted principal's requested selection was
+    // dropped above, fall the selection back to the account org too so a record
+    // created here is always readable back by the same caller.
+    if (!effectiveSelected && fallbackOrgId && filterSet && filterSet.size > 0) {
+      effectiveSelected = fallbackOrgId
+    }
   }
 
   if ((!filterSet || filterSet.size === 0) && fallbackOrgId && !widenToAllOrgs) {
@@ -345,11 +369,21 @@ export async function resolveOrganizationScope({
     }
   }
 
+  // A concrete organization was explicitly requested (`normalizedSelectedId` is
+  // null for both "no selection" and the "all organizations" token) but the
+  // resolver could not honor it — it was dropped as non-existent/inaccessible
+  // and the effective selection fell back to something else. Surface this so the
+  // write layer can reject the request instead of silently creating the record
+  // under the fallback org. Only set the field when true to keep the scope shape
+  // unchanged for the common (honored) case.
+  const selectionRejected = normalizedSelectedId !== null && effectiveSelected !== normalizedSelectedId
+
   return {
     selectedId: effectiveSelected,
     filterIds: filterSet ? Array.from(filterSet) : null,
     allowedIds: allowedSet ? Array.from(allowedSet) : null,
     tenantId,
+    ...(selectionRejected ? { selectionRejected: true } : {}),
   }
 }
 

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -507,6 +507,14 @@ function json(data: any, init?: ResponseInit) {
   })
 }
 
+// Name of the selected-organization cookie (mirrors the directory module's
+// OrganizationSwitcher, which writes `om_selected_org=...; path=/; samesite=lax`).
+// Kept as a local literal so shared has no import dependency on a domain package.
+const SELECTED_ORG_COOKIE = 'om_selected_org'
+// Set-Cookie value that expires the stale selection so the next request falls
+// back to the caller's home org. Attributes mirror how the switcher sets it.
+const CLEAR_SELECTED_ORG_COOKIE = `${SELECTED_ORG_COOKIE}=; Path=/; Max-Age=0; SameSite=Lax`
+
 function attachOperationHeader(res: Response, logEntry: any) {
   if (!res || !(res instanceof Response)) return res
   if (!logEntry || typeof logEntry !== 'object') return res
@@ -1338,6 +1346,42 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
     return { container, auth: scopedAuth, organizationScope: scope, selectedOrganizationId, organizationIds, request }
   }
 
+  // The caller explicitly selected an organization (selected-org cookie) that no
+  // longer resolves to a real, accessible org — e.g. a stale cookie after a DB
+  // reset, or after the caller lost access to that org. Rather than silently
+  // acting against a fallback org the caller did not select (writes) or showing
+  // a different org's data than the one selected (reads), fail loud on every
+  // org-scoped record operation so the client re-selects. Recovery surfaces
+  // (org switcher, nav, profile) are custom routes, not this factory, so they
+  // keep working. Returns a 422 Response when rejected, otherwise null.
+  function rejectInvalidOrgSelection(ctx: CrudCtx, action: 'list' | 'create' | 'update' | 'delete'): Response | null {
+    if (!ormCfg.orgField) return null
+    if (!(ctx.organizationScope as OrganizationScope | null | undefined)?.selectionRejected) return null
+    logForbidden({
+      resourceKind,
+      action,
+      reason: 'organization_selection_invalid',
+      userId: ctx.auth?.sub ?? null,
+      tenantId: ctx.auth?.tenantId ?? null,
+      organizationIds: ctx.organizationIds,
+    })
+    // Self-heal reads: expire the stale selected-org cookie so the caller's next
+    // request falls back to their home org and the session recovers on its own
+    // (important for single-org users, who have no org switcher to re-select
+    // from). Writes intentionally do NOT clear it — a mutation must go through an
+    // explicit, valid re-selection, never silently target a fallback org.
+    const headers: Record<string, string> = action === 'list'
+      ? { 'set-cookie': CLEAR_SELECTED_ORG_COOKIE }
+      : {}
+    return json(
+      {
+        error: 'Your selected organization is no longer available. Please re-select an organization and try again.',
+        code: 'organization_selection_invalid',
+      },
+      { status: 422, headers },
+    )
+  }
+
   async function GET(request: Request) {
     const profiler = createCrudProfiler(resourceKind, 'list')
     const requestMeta: Record<string, unknown> = { method: request.method }
@@ -1364,6 +1408,11 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
       if (!ctx.auth) {
         finishProfile({ reason: 'unauthorized' })
         return json({ error: 'Unauthorized' }, { status: 401 })
+      }
+      const listSelectionRejected = rejectInvalidOrgSelection(ctx, 'list')
+      if (listSelectionRejected) {
+        finishProfile({ reason: 'organization_selection_invalid' })
+        return listSelectionRejected
       }
       if (!opts.list) {
         finishProfile({ reason: 'list_not_configured' })
@@ -2031,6 +2080,8 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
       if (!opts.create && !useCommand) return json({ error: 'Not implemented' }, { status: 501 })
       const ctx = await withCtx(request)
       if (!ctx.auth) return json({ error: 'Unauthorized' }, { status: 401 })
+      const createSelectionRejected = rejectInvalidOrgSelection(ctx, 'create')
+      if (createSelectionRejected) return createSelectionRejected
       if (ormCfg.orgField && ctx.organizationIds && ctx.organizationIds.length === 0) {
         logForbidden({
           resourceKind,
@@ -2301,6 +2352,8 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
       if (!opts.update && !useCommand) return json({ error: 'Not implemented' }, { status: 501 })
       const ctx = await withCtx(request)
       if (!ctx.auth) return json({ error: 'Unauthorized' }, { status: 401 })
+      const updateSelectionRejected = rejectInvalidOrgSelection(ctx, 'update')
+      if (updateSelectionRejected) return updateSelectionRejected
       if (ormCfg.orgField && ctx.organizationIds && ctx.organizationIds.length === 0) {
         logForbidden({
           resourceKind,
@@ -2630,6 +2683,8 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
     try {
       const ctx = await withCtx(request)
       if (!ctx.auth) return json({ error: 'Unauthorized' }, { status: 401 })
+      const deleteSelectionRejected = rejectInvalidOrgSelection(ctx, 'delete')
+      if (deleteSelectionRejected) return deleteSelectionRejected
       if (ormCfg.orgField && ctx.organizationIds && ctx.organizationIds.length === 0) {
         logForbidden({
           resourceKind,


### PR DESCRIPTION
## Problem

A write could silently persist to a **stale / non-existent organization**, making the record invisible on read (orphaned by org scope).

A user creates a record via a CRUD command. The `POST` returns `201` with an id and the UI redirects to the detail page, but the detail page shows "record not found". The row genuinely exists in the DB and the query index, but is invisible to the same user.

**Root cause:** the write path and read path resolved the org from different sources. For an **unrestricted (all-orgs) principal** (superadmin, or a user whose ACL grants all orgs, so `allowedSet === null`), `resolveOrganizationScope` accepted the `om_selected_org` cookie / JWT org **verbatim as the write target without checking it resolves to a real org**. After a `db:greenfield`/reset reassigns the org a new UUID while the browser keeps the old cookie, the write lands under the dead org (`selectedId`) while the read filters to the caller's real accessible org (`filterIds`) → silent orphan. `ensureOrganizationScope` also passed because `allowedIds === null` lets any target through.

## Fix

At the single source of truth (`resolveOrganizationScope`) and the CRUD write/read chokepoint (`makeCrudRoute`):

1. **Never honor a selection that doesn't resolve to a real, accessible org.** The org lookup already loaded is used as an existence check; a dead id is dropped. Reads still degrade gracefully to the caller's accessible orgs, and the write target is kept aligned with the read scope.
2. **Fail loud on record operations** when a concrete org was explicitly selected but couldn't be honored: `makeCrudRoute` returns **`422 organization_selection_invalid`** for `GET`/`POST`/`PUT`/`DELETE` on org-scoped entities. So a write never targets a fallback org, and a read never shows a different org's data than the one selected. Recovery surfaces (org switcher, nav — custom routes, not the factory) keep working.
3. **Reads self-heal.** A rejected read expires the stale `om_selected_org` cookie (`Set-Cookie … Max-Age=0`) so the next request falls back to the home org and the session recovers on its own — important for single-org users who have no switcher. **Writes keep the cookie**, requiring an explicit valid re-selection (never a silent fallback).

The default "no selection → home org" path is unchanged and stays silent.

## Behavior summary

| Situation | Before | After |
|---|---|---|
| Unrestricted principal, dead selected-org cookie, **write** | 201, orphaned under dead org | **422**, nothing written, cookie kept (reselect required) |
| Any principal, dead selection, **read** | silently shows a different org's data | **422**, stale cookie expired → next read self-heals to home |
| No explicit selection | home org | home org (unchanged) |
| Valid selection | honored | honored (unchanged) |

## Tests

- **Unit** — `organizationScope.test.ts`: new cases assert `selectionRejected` is `true` for a dead selection (superadmin / unrestricted / out-of-ACL) and falsy for no-selection / valid-selection, and that the write target stays aligned with the read scope.
- **Integration** — `TC-DIR-014-stale-selected-org-orphan.spec.ts`: create/list under a dead cookie → 422 (+ read expires the cookie, write does not); positive control that a normal create succeeds and is readable.

## Verification

Verified live against an ephemeral server and interactively via Playwright (logged-in browser):

- Read with dead cookie → `422 organization_selection_invalid`, cookie expired; **follow-up read → 200** (self-healed, no logout, no switcher).
- Write with dead cookie → `422`, cookie kept, **no record created**.
- Org switcher / organizations endpoints stay `200` with the dead cookie (recovery path intact).
- Executable spec `TC-DIR-014` passes against the live server.

## Notes / follow-ups (not in this PR)

- **Client polish (optional):** the data panel shows one error before the next request self-heals; `apiCall` could detect `code: organization_selection_invalid` and auto-retry once after the cookie clears.
- **Login-time session invalidation** (from the original report) remains a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)