### PR TITLE
security(workflows): prevent initiatedBy spoofing (#3931)

### DIFF
--- a/packages/core/src/modules/workflows/api/__tests__/instances.route.test.ts
+++ b/packages/core/src/modules/workflows/api/__tests__/instances.route.test.ts
@@ -362,6 +362,35 @@ describe('Workflow Instances API', () => {
       )
     })
 
+    test('should not trust caller supplied initiatedBy metadata', async () => {
+      (workflowExecutor.startWorkflow as jest.Mock).mockResolvedValue(mockInstance);
+      (workflowExecutor.executeWorkflow as jest.Mock).mockResolvedValue(mockExecutionResult)
+
+      const request = new NextRequest('http://localhost/api/workflows/instances', {
+        method: 'POST',
+        body: JSON.stringify({
+          workflowId: 'checkout',
+          initialContext: {},
+          metadata: {
+            entityType: 'order',
+            initiatedBy: 'admin-user-id',
+          },
+        }),
+      })
+
+      await startInstance(request)
+
+      expect(workflowExecutor.startWorkflow).toHaveBeenCalledWith(
+        mockEm,
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            entityType: 'order',
+            initiatedBy: testUserId,
+          }),
+        })
+      )
+    })
+
     test('should require create permission', async () => {
       mockRbacService.userHasAllFeatures.mockResolvedValue(false)
 

--- a/packages/core/src/modules/workflows/api/instances/route.ts
+++ b/packages/core/src/modules/workflows/api/instances/route.ts
@@ -193,10 +193,10 @@ export async function POST(request: NextRequest) {
 
     const input: StartWorkflowApiInput = validation.data
 
-    // Inject metadata.initiatedBy if not provided
+    // User-started instances must always record the authenticated caller.
     const metadata = {
       ...input.metadata,
-      initiatedBy: input.metadata?.initiatedBy || auth.sub,
+      initiatedBy: auth.sub,
     }
 
     // Start workflow


### PR DESCRIPTION
## Summary

Fix a workflows security bug where a caller with `workflows.instances.create` could spoof `metadata.initiatedBy` and cause later `CALL_API` activity execution to mint one-time API keys with another same-tenant user's active roles.

## Changes

- Force user-started workflow instances to persist `metadata.initiatedBy` from `auth.sub`, preserving other metadata fields.
- Add a regression test proving caller-supplied `metadata.initiatedBy` is overwritten before `workflowExecutor.startWorkflow()` is called.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — focused security bug fix for existing workflows API behavior.


## Testing

- `yarn workspace @open-mercato/core test --runInBand --testPathPatterns="src/modules/workflows/api/__tests__/instances.route.test.ts"` — passed, 41 tests.
- `yarn workspace @open-mercato/core test --runInBand --testPathPatterns="src/modules/workflows/lib/__tests__/resolve-call-api-role-ids.test.ts"` — passed, 7 tests.
- `yarn build:packages` — passed before and after `yarn generate`.
- `yarn generate` — passed.
- `yarn i18n:check-sync` — passed.
- `yarn typecheck` — passed.
- `yarn test` — passed.
- `yarn lint` — passed with existing warnings.
- `yarn build:app` — passed.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. N/A — no docs/locales/generator source changes required.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). N/A — covered by focused API unit regression.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A — no spec required.
- [x] Priority set: this PR carries exactly one `priority-*` label. Use `priority-high`.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). Use `risk-high`.
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. Use `needs-qa` due risk-high security path.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens. N/A — no UI.
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`. N/A — no UI.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A — no UI.
- [x] Loading state handled for async pages. N/A — no UI.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A — no UI.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements. N/A — no UI.

## Linked issues

Fixes #3931