### PR TITLE
security(workflows): restrict env interpolation (#3932)

### DIFF
--- a/packages/core/src/modules/workflows/AGENTS.md
+++ b/packages/core/src/modules/workflows/AGENTS.md
@@ -10,7 +10,7 @@ Use the workflows module for business process automation: defining step-based wo
 4. **MUST follow the instance state machine** — instances transition `RUNNING → COMPLETED|FAILED|CANCELLED`; intermediate states include `PAUSED`, `WAITING_FOR_ACTIVITIES`, `COMPENSATING`
 5. **MUST keep activity handlers idempotent** — check state before mutating; activities may be retried on failure
 6. **MUST use event sourcing** — log all workflow events via `eventLogger.logWorkflowEvent()`; never mutate instance state without a corresponding event
-7. **MUST use variable interpolation** for dynamic activity config — use `{{context.*}}`, `{{workflow.*}}`, `{{env.*}}`, `{{now}}`; never hardcode values
+7. **MUST use variable interpolation** for dynamic activity config — use `{{context.*}}`, `{{workflow.*}}`, server-allowlisted non-secret `{{env.*}}` keys such as `{{env.APP_URL}}`, and `{{now}}`; never hardcode values or read secrets from `{{env.*}}`
 8. **MUST use event triggers, signals, and widget injection** for cross-module integration.
 9. **MUST declare new events in `events.ts`** with `as const` — undeclared events trigger TypeScript errors and runtime warnings
 10. **MUST scope all queries by `organization_id`** — workflow data is tenant-scoped; never expose cross-tenant instances or tasks
@@ -99,6 +99,7 @@ Definition → startWorkflow() → Instance → executeWorkflow() loop
 | Variable | Effect | Default |
 |----------|--------|---------|
 | `OM_WORKFLOWS_ALLOW_PRIVATE_URLS` | When `1`/`true`/`yes`, bypasses the SSRF guard in `CALL_WEBHOOK` so workflow authors can hit `localhost`, RFC1918, and `.internal` targets. For dev only — MUST remain unset in production. | unset (guard enforced) |
+| `OM_WORKFLOWS_ENV_INTERPOLATION_ALLOWLIST` | Comma-separated non-secret process env keys allowed for `{{env.*}}` interpolation in workflow activity config. `APP_URL` is always allowed. Never include secrets. | unset (`APP_URL` only) |
 
 ## DI Services
 

--- a/packages/core/src/modules/workflows/examples/sales-pipeline-definition.json
+++ b/packages/core/src/modules/workflows/examples/sales-pipeline-definition.json
@@ -262,10 +262,10 @@
             "activityType": "CALL_API",
             "config": {
               "method": "POST",
-              "url": "{{env.CONTRACT_SERVICE_URL}}/api/contracts/generate",
+              "url": "{{context.integration.contractServiceUrl}}/api/contracts/generate",
               "headers": {
                 "Content-Type": "application/json",
-                "Authorization": "Bearer {{env.SERVICE_TOKEN}}"
+                "Authorization": "Bearer {{context.integration.serviceToken}}"
               },
               "body": {
                 "orderId": "{{context.order.id}}",
@@ -331,7 +331,7 @@
             "activityType": "CALL_API",
             "config": {
               "method": "POST",
-              "url": "{{env.CONTRACT_SERVICE_URL}}/api/contracts/verify",
+              "url": "{{context.integration.contractServiceUrl}}/api/contracts/verify",
               "body": {
                 "contractId": "{{context.contract.id}}",
                 "signatureId": "{{task.result.signatureId}}"
@@ -393,10 +393,10 @@
             "activityType": "CALL_API",
             "config": {
               "method": "POST",
-              "url": "{{env.BILLING_SERVICE_URL}}/api/invoices",
+              "url": "{{context.integration.billingServiceUrl}}/api/invoices",
               "headers": {
                 "Content-Type": "application/json",
-                "Authorization": "Bearer {{env.SERVICE_TOKEN}}"
+                "Authorization": "Bearer {{context.integration.serviceToken}}"
               },
               "body": {
                 "orderId": "{{context.order.id}}",
@@ -486,10 +486,10 @@
             "activityType": "CALL_API",
             "config": {
               "method": "POST",
-              "url": "{{env.WAREHOUSE_SERVICE_URL}}/api/fulfillment/orders",
+              "url": "{{context.integration.warehouseServiceUrl}}/api/fulfillment/orders",
               "headers": {
                 "Content-Type": "application/json",
-                "Authorization": "Bearer {{env.SERVICE_TOKEN}}"
+                "Authorization": "Bearer {{context.integration.serviceToken}}"
               },
               "body": {
                 "orderId": "{{context.order.id}}",

--- a/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
@@ -263,6 +263,58 @@ describe('Activity Executor (Unit Tests)', () => {
       )
     })
 
+    test('should not interpolate non-allowlisted env vars into event payloads', async () => {
+      const originalSecret = process.env.OM_WORKFLOWS_TEST_EVENT_SECRET
+      process.env.OM_WORKFLOWS_TEST_EVENT_SECRET = 'event-secret-value'
+
+      const mockEventBus = {
+        emitEvent: jest.fn().mockResolvedValue(undefined),
+      }
+
+      mockContainer.resolve.mockReturnValue(mockEventBus)
+
+      const activity: ActivityDefinition = {
+        activityId: 'activity-event-secret',
+        activityName: 'Sensitive Event',
+        activityType: 'EMIT_EVENT',
+        config: {
+          eventName: 'test.event',
+          payload: {
+            secret: '{{env.OM_WORKFLOWS_TEST_EVENT_SECRET}}',
+            message: 'prefix {{env.OM_WORKFLOWS_TEST_EVENT_SECRET}} suffix',
+          },
+        },
+      }
+
+      try {
+        const result = await activityExecutor.executeActivity(
+          mockEm,
+          mockContainer,
+          activity,
+          mockContext
+        )
+
+        expect(result.success).toBe(true)
+        expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+          'test.event',
+          expect.objectContaining({
+            secret: '',
+            message: 'prefix  suffix',
+          }),
+          {
+            organizationId: testOrgId,
+            tenantId: testTenantId,
+          },
+        )
+      } finally {
+        if (originalSecret === undefined) {
+          delete process.env.OM_WORKFLOWS_TEST_EVENT_SECRET
+        } else {
+          process.env.OM_WORKFLOWS_TEST_EVENT_SECRET = originalSecret
+        }
+      }
+    })
+
     test('should fail EMIT_EVENT if event bus not available', async () => {
       mockContainer.resolve.mockImplementation(() => {
         throw new Error('eventBus not registered')
@@ -568,6 +620,61 @@ describe('Activity Executor (Unit Tests)', () => {
           body: expect.any(String),
         })
       )
+    })
+
+    test('should not interpolate non-allowlisted env vars into webhook headers or body', async () => {
+      const originalSecret = process.env.OM_WORKFLOWS_TEST_WEBHOOK_SECRET
+      process.env.OM_WORKFLOWS_TEST_WEBHOOK_SECRET = 'webhook-secret-value'
+
+      ;(global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ success: true }),
+      })
+
+      const activity: ActivityDefinition = {
+        activityId: 'activity-webhook-secret',
+        activityName: 'Sensitive Webhook',
+        activityType: 'CALL_WEBHOOK',
+        config: {
+          url: 'https://example.com/webhook',
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer {{env.OM_WORKFLOWS_TEST_WEBHOOK_SECRET}}',
+          },
+          body: {
+            secret: '{{env.OM_WORKFLOWS_TEST_WEBHOOK_SECRET}}',
+          },
+        },
+      }
+
+      try {
+        const result = await activityExecutor.executeActivity(
+          mockEm,
+          mockContainer,
+          activity,
+          mockContext
+        )
+
+        expect(result.success).toBe(true)
+        expect(global.fetch).toHaveBeenCalledWith(
+          'https://example.com/webhook',
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Authorization: 'Bearer ',
+            }),
+            body: JSON.stringify({ secret: '' }),
+          })
+        )
+      } finally {
+        if (originalSecret === undefined) {
+          delete process.env.OM_WORKFLOWS_TEST_WEBHOOK_SECRET
+        } else {
+          process.env.OM_WORKFLOWS_TEST_WEBHOOK_SECRET = originalSecret
+        }
+      }
     })
 
     test('should handle non-JSON webhook responses', async () => {
@@ -1390,6 +1497,79 @@ describe('Activity Executor (Unit Tests)', () => {
 
       expect(result.success).toBe(true)
       expect(mockFunction).toHaveBeenCalled()
+    })
+
+    test('should interpolate allowlisted env vars only', async () => {
+      const originalAppUrl = process.env.APP_URL
+      const originalAllowlist = process.env.OM_WORKFLOWS_ENV_INTERPOLATION_ALLOWLIST
+      const originalEndpoint = process.env.OM_WORKFLOWS_TEST_PUBLIC_ENDPOINT
+      const originalSecret = process.env.OM_WORKFLOWS_TEST_TYPE_SECRET
+      process.env.APP_URL = 'https://app.example.com'
+      process.env.OM_WORKFLOWS_ENV_INTERPOLATION_ALLOWLIST =
+        'OM_WORKFLOWS_TEST_PUBLIC_ENDPOINT'
+      process.env.OM_WORKFLOWS_TEST_PUBLIC_ENDPOINT = 'https://endpoint.example.com'
+      process.env.OM_WORKFLOWS_TEST_TYPE_SECRET = 'type-secret-value'
+
+      const mockFunction = jest.fn().mockImplementation((args) => {
+        expect(args.appUrl).toBe('https://app.example.com')
+        expect(args.endpoint).toBe('https://endpoint.example.com')
+        expect(args.secret).toBe('')
+        expect(args.message).toBe(
+          'App https://app.example.com endpoint https://endpoint.example.com secret '
+        )
+        return { success: true }
+      })
+
+      mockContainer.resolve.mockReturnValue(mockFunction)
+
+      const activity: ActivityDefinition = {
+        activityId: 'activity-env-allowlist',
+        activityName: 'Test Env Allowlist',
+        activityType: 'EXECUTE_FUNCTION',
+        config: {
+          functionName: 'testFunction',
+          args: {
+            appUrl: '{{env.APP_URL}}',
+            endpoint: '{{env.OM_WORKFLOWS_TEST_PUBLIC_ENDPOINT}}',
+            secret: '{{env.OM_WORKFLOWS_TEST_TYPE_SECRET}}',
+            message:
+              'App {{env.APP_URL}} endpoint {{env.OM_WORKFLOWS_TEST_PUBLIC_ENDPOINT}} secret {{env.OM_WORKFLOWS_TEST_TYPE_SECRET}}',
+          },
+        },
+      }
+
+      try {
+        const result = await activityExecutor.executeActivity(
+          mockEm,
+          mockContainer,
+          activity,
+          mockContext
+        )
+
+        expect(result.success).toBe(true)
+        expect(mockFunction).toHaveBeenCalled()
+      } finally {
+        if (originalAppUrl === undefined) {
+          delete process.env.APP_URL
+        } else {
+          process.env.APP_URL = originalAppUrl
+        }
+        if (originalAllowlist === undefined) {
+          delete process.env.OM_WORKFLOWS_ENV_INTERPOLATION_ALLOWLIST
+        } else {
+          process.env.OM_WORKFLOWS_ENV_INTERPOLATION_ALLOWLIST = originalAllowlist
+        }
+        if (originalEndpoint === undefined) {
+          delete process.env.OM_WORKFLOWS_TEST_PUBLIC_ENDPOINT
+        } else {
+          process.env.OM_WORKFLOWS_TEST_PUBLIC_ENDPOINT = originalEndpoint
+        }
+        if (originalSecret === undefined) {
+          delete process.env.OM_WORKFLOWS_TEST_TYPE_SECRET
+        } else {
+          process.env.OM_WORKFLOWS_TEST_TYPE_SECRET = originalSecret
+        }
+      }
     })
 
     test('should handle nested objects with mixed type interpolations', async () => {

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -44,6 +44,34 @@ function isAllowPrivateWorkflowWebhookUrlsEnabled(): boolean {
   return false
 }
 
+const DEFAULT_WORKFLOW_ENV_INTERPOLATION_ALLOWLIST = new Set(['APP_URL'])
+const WORKFLOW_ENV_INTERPOLATION_ALLOWLIST_KEY = 'OM_WORKFLOWS_ENV_INTERPOLATION_ALLOWLIST'
+
+function getWorkflowEnvInterpolationAllowlist(): Set<string> {
+  const allowlist = new Set(DEFAULT_WORKFLOW_ENV_INTERPOLATION_ALLOWLIST)
+  const configuredKeys = process.env[WORKFLOW_ENV_INTERPOLATION_ALLOWLIST_KEY]
+  if (!configuredKeys) {
+    return allowlist
+  }
+
+  for (const key of configuredKeys.split(',')) {
+    const trimmedKey = key.trim()
+    if (trimmedKey) {
+      allowlist.add(trimmedKey)
+    }
+  }
+
+  return allowlist
+}
+
+function resolveWorkflowEnvInterpolation(envKey: string): string {
+  if (!getWorkflowEnvInterpolationAllowlist().has(envKey)) {
+    return ''
+  }
+
+  return process.env[envKey] ?? ''
+}
+
 // ============================================================================
 // Types and Interfaces
 // ============================================================================
@@ -857,7 +885,7 @@ export async function executeCallApi(
   container: AwilixContainer,
   signal?: AbortSignal
 ): Promise<any> {
-  // 1. Interpolate variables in config (including {{workflow.*}}, {{context.*}}, {{env.*}}, {{now}})
+  // 1. Interpolate variables in config (including {{workflow.*}}, {{context.*}}, allowlisted {{env.*}}, {{now}})
   const interpolatedConfig = interpolateVariables(config, context.workflowContext, context.workflowInstance)
 
   const {
@@ -1145,7 +1173,7 @@ function classifyAndThrowError(status: number, body: any, url: string): never {
  * - {{workflow.tenantId}} - tenant ID
  * - {{workflow.organizationId}} - organization ID
  * - {{workflow.currentStepId}} - current step ID
- * - {{env.VAR_NAME}} - environment variables
+ * - {{env.VAR_NAME}} - server-allowlisted environment variables
  * - {{now}} - current ISO timestamp
  */
 function interpolateVariables(
@@ -1185,7 +1213,7 @@ function interpolateVariables(
       // Handle {{env.*}} variables
       if (trimmedPath.startsWith('env.')) {
         const envKey = trimmedPath.substring('env.'.length)
-        return process.env[envKey] ?? config
+        return resolveWorkflowEnvInterpolation(envKey)
       }
 
       // Handle {{now}} - current timestamp
@@ -1230,8 +1258,7 @@ function interpolateVariables(
       // Handle {{env.*}} variables
       if (trimmedPath.startsWith('env.')) {
         const envKey = trimmedPath.substring('env.'.length)
-        const envValue = process.env[envKey]
-        return envValue !== undefined ? envValue : match
+        return resolveWorkflowEnvInterpolation(envKey)
       }
 
       // Handle {{now}} - current timestamp


### PR DESCRIPTION
## Summary

Fixes a workflow security issue where definition authors could interpolate arbitrary `process.env` values through `{{env.*}}` in activity config and exfiltrate secrets via webhook headers/bodies or emitted event payloads.

## Changes

- Restrict workflow `{{env.*}}` interpolation to `APP_URL` by default plus explicitly configured non-secret keys in `OM_WORKFLOWS_ENV_INTERPOLATION_ALLOWLIST`.
- Add regression coverage for `EMIT_EVENT`, `CALL_WEBHOOK`, single-token interpolation, embedded-token interpolation, default `APP_URL`, and configured allowlisted keys.
- Update workflows guidance and the sales pipeline example so secret process env interpolation is no longer taught.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — targeted security bugfix for existing workflow interpolation behavior.


## Testing

- `yarn workspace @open-mercato/core test packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts --runInBand` — failed before the fix with leaked env secrets; passed after the fix, 90 tests.
- `yarn build:packages` — passed.
- `yarn generate` — passed.
- `yarn i18n:check-sync` — passed.
- `yarn i18n:check-usage` — passed with existing unused-key advisories.
- `yarn lint` — passed with existing warnings.
- `yarn typecheck` — passed.
- `yarn test` — passed.
- `yarn build:app` — passed.
- `git diff --check` — passed.
- Fresh-context review — passed, no blockers.

Known unrelated: `yarn template:sync` reports pre-existing template/dependency drift.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). PR author must confirm.
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). N/A — executor unit coverage directly covers the security boundary; no UI/API integration path changed.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A — minor targeted bugfix.
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. `skip-qa` — backend-only security fix covered by automated tests.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens. N/A — no UI changes.
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`. N/A — no UI changes.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A — no UI changes.
- [x] Loading state handled for async pages. N/A — no UI changes.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A — no UI changes.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements. N/A — no UI changes.

## Linked issues

Fixes #3932