### PR TITLE
fix: guard workflow private webhook flag in production (#3934)

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
@@ -863,8 +863,13 @@ describe('Activity Executor (Unit Tests)', () => {
       }
 
       const prev = process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+      const prevLegacy = process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+      const prevNodeEnv = process.env.NODE_ENV
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
       try {
         process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = 'true'
+        delete process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+        process.env.NODE_ENV = 'test'
 
         const result = await activityExecutor.executeActivity(
           mockEm,
@@ -878,11 +883,85 @@ describe('Activity Executor (Unit Tests)', () => {
           'http://10.255.255.1/health',
           expect.any(Object)
         )
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('SSRF protection is bypassed')
+        )
       } finally {
+        warnSpy.mockRestore()
         if (prev === undefined) {
           delete process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
         } else {
           process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = prev
+        }
+        if (prevLegacy === undefined) {
+          delete process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+        } else {
+          process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = prevLegacy
+        }
+        if (prevNodeEnv === undefined) {
+          delete process.env.NODE_ENV
+        } else {
+          process.env.NODE_ENV = prevNodeEnv
+        }
+      }
+    })
+
+    test('should ignore OM_WORKFLOWS_ALLOW_PRIVATE_URLS in production', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ ok: true }),
+      })
+
+      const activity: ActivityDefinition = {
+        activityId: 'activity-14f',
+        activityName: 'Production Internal Webhook',
+        activityType: 'CALL_WEBHOOK',
+        config: {
+          url: 'http://10.255.255.1/health',
+        },
+      }
+
+      const prev = process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+      const prevLegacy = process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+      const prevNodeEnv = process.env.NODE_ENV
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = 'true'
+        delete process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+        process.env.NODE_ENV = 'production'
+
+        const result = await activityExecutor.executeActivity(
+          mockEm,
+          mockContainer,
+          activity,
+          mockContext
+        )
+
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('CALL_WEBHOOK rejected unsafe URL')
+        expect(global.fetch).not.toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('ignored in production')
+        )
+      } finally {
+        warnSpy.mockRestore()
+        if (prev === undefined) {
+          delete process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+        } else {
+          process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = prev
+        }
+        if (prevLegacy === undefined) {
+          delete process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+        } else {
+          process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = prevLegacy
+        }
+        if (prevNodeEnv === undefined) {
+          delete process.env.NODE_ENV
+        } else {
+          process.env.NODE_ENV = prevNodeEnv
         }
       }
     })
@@ -905,10 +984,14 @@ describe('Activity Executor (Unit Tests)', () => {
         },
       }
 
-      const prev = process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+      const prev = process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+      const prevLegacy = process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+      const prevNodeEnv = process.env.NODE_ENV
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
       try {
+        delete process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
         process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = 'true'
+        process.env.NODE_ENV = 'test'
 
         const result = await activityExecutor.executeActivity(
           mockEm,
@@ -928,9 +1011,79 @@ describe('Activity Executor (Unit Tests)', () => {
       } finally {
         warnSpy.mockRestore()
         if (prev === undefined) {
+          delete process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+        } else {
+          process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = prev
+        }
+        if (prevLegacy === undefined) {
           delete process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
         } else {
-          process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = prev
+          process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = prevLegacy
+        }
+        if (prevNodeEnv === undefined) {
+          delete process.env.NODE_ENV
+        } else {
+          process.env.NODE_ENV = prevNodeEnv
+        }
+      }
+    })
+
+    test('should ignore WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS in production', async () => {
+      ;(global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ ok: true }),
+      })
+
+      const activity: ActivityDefinition = {
+        activityId: 'activity-14g',
+        activityName: 'Production Legacy Internal Webhook',
+        activityType: 'CALL_WEBHOOK',
+        config: {
+          url: 'http://10.255.255.1/health',
+        },
+      }
+
+      const prev = process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+      const prevLegacy = process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+      const prevNodeEnv = process.env.NODE_ENV
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      try {
+        delete process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+        process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = 'true'
+        process.env.NODE_ENV = 'production'
+
+        const result = await activityExecutor.executeActivity(
+          mockEm,
+          mockContainer,
+          activity,
+          mockContext
+        )
+
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('CALL_WEBHOOK rejected unsafe URL')
+        expect(global.fetch).not.toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('deprecated and ignored in production')
+        )
+      } finally {
+        warnSpy.mockRestore()
+        if (prev === undefined) {
+          delete process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+        } else {
+          process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = prev
+        }
+        if (prevLegacy === undefined) {
+          delete process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS
+        } else {
+          process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS = prevLegacy
+        }
+        if (prevNodeEnv === undefined) {
+          delete process.env.NODE_ENV
+        } else {
+          process.env.NODE_ENV = prevNodeEnv
         }
       }
     })

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -31,10 +31,27 @@ export { isPrivateUrl } from '@open-mercato/shared/lib/network'
 
 function isAllowPrivateWorkflowWebhookUrlsEnabled(): boolean {
   if (parseBooleanWithDefault(process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS, false)) {
+    if (process.env.NODE_ENV === 'production') {
+      console.warn(
+        '[CALL_WEBHOOK] OM_WORKFLOWS_ALLOW_PRIVATE_URLS is set but ignored in production. SSRF protection remains enabled.'
+      )
+      return false
+    }
+
+    console.warn(
+      '[CALL_WEBHOOK] OM_WORKFLOWS_ALLOW_PRIVATE_URLS is enabled. SSRF protection is bypassed for workflow webhooks; use only in development.'
+    )
     return true
   }
 
   if (parseBooleanWithDefault(process.env.WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS, false)) {
+    if (process.env.NODE_ENV === 'production') {
+      console.warn(
+        '[CALL_WEBHOOK] WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS is deprecated and ignored in production. Use OM_WORKFLOWS_ALLOW_PRIVATE_URLS for development only. SSRF protection remains enabled.'
+      )
+      return false
+    }
+
     console.warn(
       '[CALL_WEBHOOK] WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS is deprecated. Use OM_WORKFLOWS_ALLOW_PRIVATE_URLS instead. SSRF protection is bypassed.'
     )


### PR DESCRIPTION
## Summary

Fixes a workflow `CALL_WEBHOOK` SSRF bypass where private-URL environment flags could disable the private URL guard in production.

## Changes

- Ignore `OM_WORKFLOWS_ALLOW_PRIVATE_URLS` in production and keep SSRF protection enabled.
- Ignore deprecated `WORKFLOW_WEBHOOK_ALLOW_PRIVATE_URLS` in production with a stronger warning.
- Preserve non-production private-URL bypass behavior for development.
- Add regression tests for primary and legacy flags in development and production modes.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

N/A

## Testing

- `yarn workspace @open-mercato/core test --runTestsByPath src/modules/workflows/lib/__tests__/activity-executor.test.ts --runInBand`
- `yarn build:packages`
- `yarn generate`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn build:app`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A: no UI changes.

## Linked issues

Fixes #3934
