### PR TITLE
fix: harden inbound webhook rate-limit IP keying (#3929)

### DIFF
--- a/packages/onboarding/src/__tests__/consentClientIp.test.ts
+++ b/packages/onboarding/src/__tests__/consentClientIp.test.ts
@@ -33,10 +33,10 @@ describe('resolveConsentClientIp', () => {
     expect(resolveConsentClientIp(req)).toBe('edge')
   })
 
-  it('falls back to X-Real-IP when X-Forwarded-For is untrusted', () => {
+  it('ignores X-Real-IP when no proxy is trusted', () => {
     getCachedRateLimiterService.mockReturnValue({ trustProxyDepth: 0 })
     const req = makeRequest({ 'x-forwarded-for': '6.6.6.6', 'x-real-ip': '10.0.0.5' })
-    expect(resolveConsentClientIp(req)).toBe('10.0.0.5')
+    expect(resolveConsentClientIp(req)).toBeNull()
   })
 
   it('returns null when the rate limiter service is unavailable', () => {

--- a/packages/onboarding/src/modules/onboarding/lib/consentClientIp.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/consentClientIp.ts
@@ -5,8 +5,8 @@ import { getClientIp } from '@open-mercato/shared/lib/ratelimit/helpers'
  * Resolve the client IP to persist on a legal-consent record, honoring the
  * deployment-wide reverse-proxy trust depth (`RATE_LIMIT_TRUST_PROXY_DEPTH`)
  * exposed by the rate limiter service instead of a hardcoded depth. When the
- * trust depth is unknown, return null so a spoofable `X-Forwarded-For` value is
- * never signed into the consent integrity hash.
+ * trust depth is unknown, return null so spoofable proxy headers are never
+ * signed into the consent integrity hash.
  */
 export function resolveConsentClientIp(req: Request): string | null {
   const rateLimiterService = getCachedRateLimiterService()

--- a/packages/shared/src/lib/ratelimit/__tests__/helpers.test.ts
+++ b/packages/shared/src/lib/ratelimit/__tests__/helpers.test.ts
@@ -101,14 +101,14 @@ describe('getClientIp', () => {
     expect(getClientIp(req)).toBeNull()
   })
 
-  it('falls back to x-real-ip when trustProxyDepth is 0', () => {
+  it('ignores x-real-ip when trustProxyDepth is 0', () => {
     const req = new Request('http://localhost', {
       headers: {
         'x-forwarded-for': 'spoofed-ip',
         'x-real-ip': '172.16.0.5',
       },
     })
-    expect(getClientIp(req, 0)).toBe('172.16.0.5')
+    expect(getClientIp(req, 0)).toBeNull()
   })
 
   it('extracts last IP with trustProxyDepth=1 (single proxy)', () => {

--- a/packages/shared/src/lib/ratelimit/helpers.ts
+++ b/packages/shared/src/lib/ratelimit/helpers.ts
@@ -45,15 +45,19 @@ export async function checkRateLimit(
  * Extract client IP from a request, respecting reverse proxy trust depth.
  *
  * @param trustProxyDepth Number of trusted reverse proxies between the client and the app.
- *   - 0 (default): Do not trust X-Forwarded-For; fall back to X-Real-IP or null.
+ *   - 0 (default): Do not trust proxy-provided IP headers; return null.
  *   - 1: One trusted proxy (e.g. nginx) — the last entry in X-Forwarded-For is the client IP.
  *   - N: N trusted proxies — the Nth-from-last entry is the client IP.
  *
- * With depth=0, X-Forwarded-For is ignored entirely to prevent spoofing.
+ * With depth=0, X-Forwarded-For and X-Real-IP are ignored entirely to prevent spoofing.
  */
 export function getClientIp(req: Request, trustProxyDepth: number = 0): string | null {
   const forwarded = req.headers.get('x-forwarded-for')
-  if (forwarded && trustProxyDepth > 0) {
+  if (trustProxyDepth <= 0) {
+    return null
+  }
+
+  if (forwarded) {
     const ips = forwarded.split(',').map((ip) => ip.trim())
     const clientIndex = ips.length - trustProxyDepth
     return clientIndex >= 0 ? ips[clientIndex] : ips[0]

--- a/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts
+++ b/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts
@@ -1,4 +1,28 @@
-import { resolveInboundReceiptMessageId } from '../route'
+import { buildInboundRateLimitKey, resolveInboundReceiptMessageId } from '../route'
+
+describe('buildInboundRateLimitKey', () => {
+  it('uses an endpoint-global bucket when proxy headers are untrusted', () => {
+    const request = new Request('http://localhost/api/webhooks/inbound/mock', {
+      headers: {
+        'x-forwarded-for': '203.0.113.1',
+        'x-real-ip': '198.51.100.10',
+      },
+    })
+
+    expect(buildInboundRateLimitKey('mock_inbound', request, 0)).toBe('mock_inbound:global')
+  })
+
+  it('uses a trusted proxy-derived IP when trust depth is configured', () => {
+    const request = new Request('http://localhost/api/webhooks/inbound/mock', {
+      headers: {
+        'x-forwarded-for': '203.0.113.1, 198.51.100.10',
+        'x-real-ip': '192.0.2.5',
+      },
+    })
+
+    expect(buildInboundRateLimitKey('mock_inbound', request, 1)).toBe('mock_inbound:ip:198.51.100.10')
+  })
+})
 
 describe('resolveInboundReceiptMessageId', () => {
   it('prefers explicit webhook ids when present', () => {

--- a/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/route.ts
+++ b/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
     const rateLimitResponse = await checkRateLimit(
       rateLimiterService,
       { points: 60, duration: 60, keyPrefix: `webhooks:inbound:${params.endpointId}` },
-      `${params.endpointId}:${getClientIp(request, rateLimiterService.trustProxyDepth) ?? 'unknown'}`,
+      buildInboundRateLimitKey(params.endpointId, request, rateLimiterService.trustProxyDepth),
       translate(RATE_LIMIT_ERROR_KEY, RATE_LIMIT_ERROR_FALLBACK),
     )
 
@@ -152,6 +152,11 @@ type ResolveInboundReceiptMessageIdInput = {
   providerKey: string
   headers: Record<string, string>
   body: string
+}
+
+export function buildInboundRateLimitKey(endpointId: string, request: Request, trustProxyDepth: number): string {
+  const clientIp = getClientIp(request, trustProxyDepth)
+  return clientIp ? `${endpointId}:ip:${clientIp}` : `${endpointId}:global`
 }
 
 export function resolveInboundReceiptMessageId(


### PR DESCRIPTION
## Summary

Fix inbound webhook rate-limit keying so untrusted proxy headers cannot partition the throttle when `RATE_LIMIT_TRUST_PROXY_DEPTH=0`. When no trusted client IP exists, inbound webhooks now use a per-endpoint global fallback bucket.

## Changes

- Ignore `X-Forwarded-For` and `X-Real-IP` when no reverse proxy trust depth is configured.
- Key inbound webhook rate limits by trusted client IP only when trust depth is positive.
- Add regression coverage for untrusted proxy headers, trusted proxy-derived IPs, and adjacent onboarding consent IP behavior.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor security fix, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn workspace @open-mercato/shared test packages/shared/src/lib/ratelimit/__tests__/helpers.test.ts` — passed
- `cd packages/webhooks && yarn test --runTestsByPath 'src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts'` — passed
- `cd packages/onboarding && yarn test --runTestsByPath src/__tests__/consentClientIp.test.ts` — passed
- `yarn build:packages` — passed
- `yarn generate` — passed; unrelated local generated registry churn was reverted
- `yarn i18n:check-sync` — passed
- `yarn i18n:check-usage` — passed with advisory unused-key report
- `yarn typecheck` — passed
- `yarn lint` — passed with existing cached warnings
- `yarn test` — passed
- `yarn build:app` — passed with existing Turbopack NFT-list warnings

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance

N/A — no UI was touched.

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3929