### PR TITLE
fix(webhooks): enforce inbound timestamp replay window (#3928)

### DIFF
--- a/.ai/specs/implemented/SPEC-057-2026-03-04-webhooks-module.md
+++ b/.ai/specs/implemented/SPEC-057-2026-03-04-webhooks-module.md
@@ -1104,6 +1104,8 @@ Phase 1 implements `HttpDeliveryStrategy`. Phase 2 adds `SqsDeliveryStrategy` an
 
 This endpoint receives webhooks from external systems. The `endpointId` resolves to a configured inbound endpoint (registered via `WebhookEndpointAdapter`).
 
+Inbound adapters remain responsible for provider-specific signature verification, including any provider-specific timestamp/staleness rules. The shared route also rejects stale Standard Webhooks/Svix timestamp headers (`webhook-timestamp` / `svix-timestamp`) before persisting an inbound receipt, using the shared Standard Webhooks tolerance by default and `OM_WEBHOOKS_INBOUND_TIMESTAMP_TOLERANCE_SECONDS` when a deployment needs a wider replay window.
+
 ```typescript
 // api/inbound/[endpointId]/route.ts
 

--- a/apps/docs/docs/framework/webhooks/overview.mdx
+++ b/apps/docs/docs/framework/webhooks/overview.mdx
@@ -111,6 +111,12 @@ Webhooks support pattern-based event subscriptions:
 | `POST` | `/api/webhooks/deliveries/:id/retry` | Retry failed delivery |
 | `GET` | `/api/webhooks/events` | List available event types |
 
+## Inbound Replay Protection
+
+Inbound webhook adapters must verify provider-specific signatures and any provider-specific timestamp rules before returning a verified event. The shared inbound route adds a provider-neutral backstop for Standard Webhooks and Svix-style timestamp headers: when `webhook-timestamp` or `svix-timestamp` is present, requests outside the replay window are rejected before the inbound receipt is persisted or emitted.
+
+The default replay window is 5 minutes. Set `OM_WEBHOOKS_INBOUND_TIMESTAMP_TOLERANCE_SECONDS` when a deployment needs to accept a wider delay.
+
 ## Verifying Webhooks (Consumer Guide)
 
 If you're building a service that receives webhooks from Open Mercato, verify the signature to ensure authenticity:

--- a/packages/shared/src/lib/webhooks/__tests__/verify.test.ts
+++ b/packages/shared/src/lib/webhooks/__tests__/verify.test.ts
@@ -1,6 +1,25 @@
 import { signWebhookPayload } from '../sign'
-import { verifyWebhookSignature } from '../verify'
+import { isWebhookTimestampWithinTolerance, verifyWebhookSignature } from '../verify'
 import { generateWebhookSecret } from '../secrets'
+
+describe('isWebhookTimestampWithinTolerance', () => {
+  it('accepts timestamps inside the configured tolerance', () => {
+    expect(isWebhookTimestampWithinTolerance('1700000000', 300, 1700000299)).toBe(true)
+  })
+
+  it('rejects stale timestamps outside the configured tolerance', () => {
+    expect(isWebhookTimestampWithinTolerance('1700000000', 300, 1700000301)).toBe(false)
+  })
+
+  it('rejects timestamps too far in the future', () => {
+    expect(isWebhookTimestampWithinTolerance('1700000601', 300, 1700000000)).toBe(false)
+  })
+
+  it('rejects malformed timestamps', () => {
+    expect(isWebhookTimestampWithinTolerance('not-a-timestamp', 300, 1700000000)).toBe(false)
+    expect(isWebhookTimestampWithinTolerance('1700000000abc', 300, 1700000000)).toBe(false)
+  })
+})
 
 describe('verifyWebhookSignature', () => {
   const msgId = 'msg_test123'

--- a/packages/shared/src/lib/webhooks/index.ts
+++ b/packages/shared/src/lib/webhooks/index.ts
@@ -1,4 +1,4 @@
 export { signWebhookPayload, buildWebhookHeaders, generateMessageId } from './sign'
-export { verifyWebhookSignature } from './verify'
+export { WEBHOOK_SIGNATURE_TOLERANCE_SECONDS, isWebhookTimestampWithinTolerance, verifyWebhookSignature } from './verify'
 export { generateWebhookSecret, parseWebhookSecret, isValidWebhookSecret } from './secrets'
 export type { StandardWebhookHeaders, WebhookSigningKey, WebhookVerificationResult, StandardWebhookPayload } from './types'

--- a/packages/shared/src/lib/webhooks/verify.ts
+++ b/packages/shared/src/lib/webhooks/verify.ts
@@ -2,7 +2,21 @@ import { timingSafeEqual, createHmac } from 'node:crypto'
 import { parseWebhookSecret } from './secrets'
 import type { WebhookVerificationResult } from './types'
 
-const TOLERANCE_SECONDS = 5 * 60 // 5 minutes
+export const WEBHOOK_SIGNATURE_TOLERANCE_SECONDS = 5 * 60 // 5 minutes
+
+export function isWebhookTimestampWithinTolerance(
+  timestamp: string,
+  toleranceSeconds: number = WEBHOOK_SIGNATURE_TOLERANCE_SECONDS,
+  nowSeconds: number = Math.floor(Date.now() / 1000),
+): boolean {
+  const normalizedTimestamp = timestamp.trim()
+  if (!/^\d+$/.test(normalizedTimestamp)) {
+    return false
+  }
+
+  const timestampNum = Number.parseInt(normalizedTimestamp, 10)
+  return Math.abs(nowSeconds - timestampNum) <= toleranceSeconds
+}
 
 /**
  * Verify a Standard Webhooks signature against one or more secrets.
@@ -14,15 +28,9 @@ export function verifyWebhookSignature(
   body: string,
   signatureHeader: string,
   secrets: string[],
-  toleranceSeconds: number = TOLERANCE_SECONDS,
+  toleranceSeconds: number = WEBHOOK_SIGNATURE_TOLERANCE_SECONDS,
 ): WebhookVerificationResult {
-  const timestampNum = parseInt(timestamp, 10)
-  if (isNaN(timestampNum)) {
-    return { valid: false }
-  }
-
-  const now = Math.floor(Date.now() / 1000)
-  if (Math.abs(now - timestampNum) > toleranceSeconds) {
+  if (!isWebhookTimestampWithinTolerance(timestamp, toleranceSeconds)) {
     return { valid: false }
   }
 

--- a/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-003.spec.ts
+++ b/packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-003.spec.ts
@@ -83,6 +83,22 @@ test.describe('TC-WEBHOOK-003: Inbound webhook receiver', () => {
     expect(replayWithoutMessageIdDuplicateResponse.status()).toBe(200);
     await expect(replayWithoutMessageIdDuplicateResponse.json()).resolves.toEqual({ ok: true, duplicate: true });
 
+    const staleTimestampResponse = await request.fetch(`${BASE_URL}/api/webhooks/inbound/mock_inbound`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-mock-webhook-signature': validSignature,
+        'webhook-id': `stale-${Date.now()}`,
+        'webhook-timestamp': String(Math.floor(Date.now() / 1000) - 10 * 60),
+        'webhook-signature': 'v1,mock',
+      },
+      data: rawBody,
+    });
+    expect(staleTimestampResponse.status()).toBe(400);
+    await expect(staleTimestampResponse.json()).resolves.toEqual({
+      error: 'Webhook timestamp is outside the allowed replay window',
+    });
+
     const invalidSignatureResponse = await request.fetch(`${BASE_URL}/api/webhooks/inbound/mock_inbound`, {
       method: 'POST',
       headers: {

--- a/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts
+++ b/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts
@@ -1,4 +1,122 @@
-import { resolveInboundReceiptMessageId } from '../route'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { clearWebhookEndpointAdapters, registerWebhookEndpointAdapter } from '../../../../lib/adapter-registry'
+import { emitWebhooksEvent } from '../../../../events'
+import { POST, resolveInboundReceiptMessageId } from '../route'
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ translate: (_key: string, fallback?: string) => fallback ?? '' })),
+}))
+
+jest.mock('../../../../events', () => ({
+  emitWebhooksEvent: jest.fn(async () => undefined),
+}))
+
+jest.mock('../../../../lib/integration-state', () => ({
+  isWebhookIntegrationEnabled: jest.fn(async () => true),
+}))
+
+const mockEm = {
+  create: jest.fn((Entity: new () => unknown, values: Record<string, unknown>) => Object.assign(new Entity(), values)),
+  fork: jest.fn(),
+  flush: jest.fn(async () => undefined),
+  persist: jest.fn(),
+}
+
+const mockCreateRequestContainer = createRequestContainer as jest.MockedFunction<typeof createRequestContainer>
+const mockEmitWebhooksEvent = emitWebhooksEvent as jest.MockedFunction<typeof emitWebhooksEvent>
+
+function request(headers: Record<string, string>): Request {
+  return new Request('http://localhost/api/webhooks/inbound/weak_inbound', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+    body: '{"ok":true}',
+  })
+}
+
+const routeContext = { params: Promise.resolve({ endpointId: 'weak_inbound' }) }
+
+describe('POST inbound timestamp replay protection', () => {
+  beforeEach(() => {
+    clearWebhookEndpointAdapters()
+    jest.clearAllMocks()
+    mockEm.fork.mockReturnValue(mockEm)
+    mockCreateRequestContainer.mockResolvedValue({
+      resolve: (name: string) => {
+        if (name === 'em') return mockEm
+        throw new Error('not registered')
+      },
+    } as Awaited<ReturnType<typeof createRequestContainer>>)
+    registerWebhookEndpointAdapter({
+      providerKey: 'weak_inbound',
+      subscribedEvents: ['weak.event'],
+      verifyWebhook: jest.fn(async () => ({
+        eventType: 'weak.event',
+        payload: { accepted: true },
+      })),
+      processInbound: jest.fn(async () => undefined),
+    })
+  })
+
+  afterEach(() => {
+    clearWebhookEndpointAdapters()
+  })
+
+  it('rejects stale Standard Webhooks timestamps before persisting a fresh message id', async () => {
+    const staleTimestamp = String(Math.floor(Date.now() / 1000) - 10 * 60)
+
+    const response = await POST(request({
+      'webhook-id': 'fresh-message-id',
+      'webhook-timestamp': staleTimestamp,
+      'webhook-signature': 'v1,mock',
+    }), routeContext)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Webhook timestamp is outside the allowed replay window' })
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockEm.flush).not.toHaveBeenCalled()
+    expect(mockEmitWebhooksEvent).not.toHaveBeenCalled()
+  })
+
+  it('rejects when any present Standard or Svix timestamp header is stale', async () => {
+    const now = Math.floor(Date.now() / 1000)
+
+    const response = await POST(request({
+      'webhook-id': 'fresh-message-id',
+      'webhook-timestamp': String(now),
+      'webhook-signature': 'v1,mock',
+      'svix-timestamp': String(now - 10 * 60),
+    }), routeContext)
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Webhook timestamp is outside the allowed replay window' })
+    expect(mockEm.persist).not.toHaveBeenCalled()
+    expect(mockEm.flush).not.toHaveBeenCalled()
+    expect(mockEmitWebhooksEvent).not.toHaveBeenCalled()
+  })
+
+  it('accepts fresh Standard Webhooks timestamps', async () => {
+    const freshTimestamp = String(Math.floor(Date.now() / 1000))
+
+    const response = await POST(request({
+      'webhook-id': 'fresh-message-id',
+      'webhook-timestamp': freshTimestamp,
+      'webhook-signature': 'v1,mock',
+    }), routeContext)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(mockEm.persist).toHaveBeenCalledTimes(1)
+    expect(mockEm.flush).toHaveBeenCalledTimes(1)
+    expect(mockEmitWebhooksEvent).toHaveBeenCalledTimes(1)
+  })
+})
 
 describe('resolveInboundReceiptMessageId', () => {
   it('prefers explicit webhook ids when present', () => {

--- a/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/route.ts
+++ b/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/route.ts
@@ -4,8 +4,10 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import { parseNumberWithDefault } from '@open-mercato/shared/lib/number'
 import { checkRateLimit, getClientIp, RATE_LIMIT_ERROR_FALLBACK, RATE_LIMIT_ERROR_KEY } from '@open-mercato/shared/lib/ratelimit/helpers'
 import type { RateLimiterService } from '@open-mercato/shared/lib/ratelimit/service'
+import { isWebhookTimestampWithinTolerance, WEBHOOK_SIGNATURE_TOLERANCE_SECONDS } from '@open-mercato/shared/lib/webhooks'
 import { emitWebhooksEvent } from '../../../events'
 import { getWebhookEndpointAdapter } from '../../../lib/adapter-registry'
 import { isWebhookIntegrationEnabled } from '../../../lib/integration-state'
@@ -26,6 +28,8 @@ const inboundResponseSchema = z.object({
 })
 
 const errorSchema = z.object({ error: z.string() })
+const INBOUND_TIMESTAMP_TOLERANCE_ENV = 'OM_WEBHOOKS_INBOUND_TIMESTAMP_TOLERANCE_SECONDS'
+const STALE_TIMESTAMP_ERROR = 'Webhook timestamp is outside the allowed replay window'
 
 export async function POST(request: Request, context: RouteContext): Promise<Response> {
   const params = await context.params
@@ -53,6 +57,10 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
 
   const body = await request.text()
   const headers = Object.fromEntries(request.headers.entries())
+  if (!isInboundWebhookTimestampFresh(headers)) {
+    return json({ error: STALE_TIMESTAMP_ERROR }, { status: 400 })
+  }
+
   let verified: Awaited<ReturnType<typeof adapter.verifyWebhook>>
   try {
     verified = await adapter.verifyWebhook({
@@ -122,7 +130,7 @@ export const openApi: OpenApiRouteDoc = {
       pathParams: z.object({ endpointId: z.string().min(1) }),
       responses: [{ status: 200, description: 'Inbound webhook accepted', schema: inboundResponseSchema }],
       errors: [
-        { status: 400, description: 'Verification failed', schema: errorSchema },
+        { status: 400, description: 'Verification failed or stale webhook timestamp', schema: errorSchema },
         { status: 404, description: 'Endpoint not found', schema: errorSchema },
         { status: 429, description: 'Rate limit exceeded', schema: errorSchema },
         { status: 503, description: 'Webhook integration disabled', schema: errorSchema },
@@ -145,6 +153,24 @@ function isUniqueViolation(error: unknown): boolean {
   if (maybeError.code === '23505') return true
   if (!maybeError.cause || typeof maybeError.cause !== 'object') return false
   return (maybeError.cause as { code?: string }).code === '23505'
+}
+
+function isInboundWebhookTimestampFresh(headers: Record<string, string>): boolean {
+  const timestamps = [
+    headers['webhook-timestamp'],
+    headers['svix-timestamp'],
+  ].filter((timestamp): timestamp is string => typeof timestamp === 'string' && timestamp.trim().length > 0)
+
+  if (timestamps.length === 0) {
+    return true
+  }
+
+  const toleranceSeconds = parseNumberWithDefault(
+    process.env[INBOUND_TIMESTAMP_TOLERANCE_ENV],
+    WEBHOOK_SIGNATURE_TOLERANCE_SECONDS,
+    { integer: true, min: 0 },
+  )
+  return timestamps.every((timestamp) => isWebhookTimestampWithinTolerance(timestamp.trim(), toleranceSeconds))
 }
 
 type ResolveInboundReceiptMessageIdInput = {


### PR DESCRIPTION
## Summary

Fixes #3928.

Inbound webhook replay protection relied on message-id deduplication at the route level. A stale Standard Webhooks or Svix timestamp could still be accepted when the request used a fresh message id and the endpoint adapter did not enforce a timestamp window itself.

## Changes

- Added a shared timestamp tolerance helper for Standard Webhooks verification.
- Added a route-level backstop that rejects stale `webhook-timestamp` or `svix-timestamp` headers before persisting the inbound receipt or emitting the inbound event.
- Kept providers without those timestamp headers compatible while requiring every present Standard/Svix timestamp header to be fresh.
- Documented the default five-minute replay window and `OM_WEBHOOKS_INBOUND_TIMESTAMP_TOLERANCE_SECONDS` override.
- Added route, helper, and integration coverage for stale timestamp replay attempts.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/implemented/SPEC-057-2026-03-04-webhooks-module.md`

## Testing

- `yarn workspace @open-mercato/shared test --runTestsByPath 'src/lib/webhooks/__tests__/verify.test.ts' --runInBand`
- `yarn workspace @open-mercato/webhooks test --runTestsByPath 'src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts' --runInBand`
- `yarn build:packages`
- `yarn typecheck`
- `yarn test`
- `yarn lint`
- `yarn build:app`

Integration coverage was added to `packages/webhooks/src/modules/webhooks/__integration__/TC-WEBHOOK-003.spec.ts`. Local execution was not completed because the ephemeral integration environment startup hung in `docker-credential-desktop get` before writing its environment file.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3928
