### PR TITLE
perf(sales): cache dictionary-entry value lookups on order create

### DIFF
--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -125,7 +125,7 @@ import {
   type SalesLineCalculationResult,
   type SalesDocumentCalculationResult,
 } from "../lib/types";
-import { resolveDictionaryEntryValue } from "../lib/dictionaries";
+import { resolveDictionaryEntryValue, resolveCachedDictionaryEntryValue } from "../lib/dictionaries";
 import type { CacheStrategy } from "@open-mercato/cache";
 import { resolveStatusEntryIdByValue } from "../lib/statusHelpers";
 import { SalesDocumentNumberGenerator } from "../services/salesDocumentNumberGenerator";
@@ -5429,9 +5429,9 @@ const createOrderCommand: CommandHandler<
       | CacheStrategy
       | undefined;
     const [status, fulfillmentStatus, paymentStatus] = await Promise.all([
-      resolveDictionaryEntryValue(em, parsed.statusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
-      resolveDictionaryEntryValue(em, parsed.fulfillmentStatusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
-      resolveDictionaryEntryValue(em, parsed.paymentStatusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
+      resolveCachedDictionaryEntryValue(em, parsed.statusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
+      resolveCachedDictionaryEntryValue(em, parsed.fulfillmentStatusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
+      resolveCachedDictionaryEntryValue(em, parsed.paymentStatusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
     ]);
     const {
       customerSnapshot: resolvedCustomerSnapshot,

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -5423,15 +5423,11 @@ const createOrderCommand: CommandHandler<
     }
     ensureOrderScope(ctx, parsed.organizationId, parsed.tenantId);
     const em = (ctx.container.resolve("em") as EntityManager).fork();
-    // Share the cache so the per-order status/fulfillment/payment dictionary lookups are memoized
-    // across a bulk import instead of re-reading the same few entries on every order.
-    let dictionaryCache: CacheStrategy | undefined;
-    try {
-      dictionaryCache = ctx.container.resolve("cache") as CacheStrategy;
-    } catch (err) {
-      console.warn("[sales.orders.create] cache resolve failed; reading dictionaries straight through", err);
-      dictionaryCache = undefined;
-    }
+    // Soft-resolve the cache so the per-order status/fulfillment/payment dictionary lookups are
+    // memoized across a bulk import; degrades to a straight EM read when no cache is registered.
+    const dictionaryCache = ctx.container.resolve("cache", { allowUnregistered: true }) as
+      | CacheStrategy
+      | undefined;
     const [status, fulfillmentStatus, paymentStatus] = await Promise.all([
       resolveDictionaryEntryValue(em, parsed.statusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
       resolveDictionaryEntryValue(em, parsed.fulfillmentStatusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -5423,13 +5423,14 @@ const createOrderCommand: CommandHandler<
     }
     ensureOrderScope(ctx, parsed.organizationId, parsed.tenantId);
     const em = (ctx.container.resolve("em") as EntityManager).fork();
-    // Share the cache service so the per-order status/fulfillment/payment dictionary lookups are
-    // memoized across a bulk import instead of re-reading the same few entries on every order.
-    let dictionaryCache: CacheStrategy | null = null;
+    // Share the cache so the per-order status/fulfillment/payment dictionary lookups are memoized
+    // across a bulk import instead of re-reading the same few entries on every order.
+    let dictionaryCache: CacheStrategy | undefined;
     try {
-      dictionaryCache = ctx.container.resolve("cacheService") as CacheStrategy;
-    } catch {
-      dictionaryCache = null;
+      dictionaryCache = ctx.container.resolve("cache") as CacheStrategy;
+    } catch (err) {
+      console.warn("[sales.orders.create] cache resolve failed; reading dictionaries straight through", err);
+      dictionaryCache = undefined;
     }
     const [status, fulfillmentStatus, paymentStatus] = await Promise.all([
       resolveDictionaryEntryValue(em, parsed.statusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -126,6 +126,7 @@ import {
   type SalesDocumentCalculationResult,
 } from "../lib/types";
 import { resolveDictionaryEntryValue } from "../lib/dictionaries";
+import type { CacheStrategy } from "@open-mercato/cache";
 import { resolveStatusEntryIdByValue } from "../lib/statusHelpers";
 import { SalesDocumentNumberGenerator } from "../services/salesDocumentNumberGenerator";
 import { loadSalesSettings } from "./settings";
@@ -5422,10 +5423,18 @@ const createOrderCommand: CommandHandler<
     }
     ensureOrderScope(ctx, parsed.organizationId, parsed.tenantId);
     const em = (ctx.container.resolve("em") as EntityManager).fork();
+    // Share the cache service so the per-order status/fulfillment/payment dictionary lookups are
+    // memoized across a bulk import instead of re-reading the same few entries on every order.
+    let dictionaryCache: CacheStrategy | null = null;
+    try {
+      dictionaryCache = ctx.container.resolve("cacheService") as CacheStrategy;
+    } catch {
+      dictionaryCache = null;
+    }
     const [status, fulfillmentStatus, paymentStatus] = await Promise.all([
-      resolveDictionaryEntryValue(em, parsed.statusEntryId ?? null, { tenantId: parsed.tenantId }),
-      resolveDictionaryEntryValue(em, parsed.fulfillmentStatusEntryId ?? null, { tenantId: parsed.tenantId }),
-      resolveDictionaryEntryValue(em, parsed.paymentStatusEntryId ?? null, { tenantId: parsed.tenantId }),
+      resolveDictionaryEntryValue(em, parsed.statusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
+      resolveDictionaryEntryValue(em, parsed.fulfillmentStatusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
+      resolveDictionaryEntryValue(em, parsed.paymentStatusEntryId ?? null, { tenantId: parsed.tenantId }, dictionaryCache),
     ]);
     const {
       customerSnapshot: resolvedCustomerSnapshot,

--- a/packages/core/src/modules/sales/lib/__tests__/dictionaries.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/dictionaries.test.ts
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 import { resolveDictionaryEntryValue, resolveCachedDictionaryEntryValue } from '../dictionaries'
 import { runWithCacheTenant } from '@open-mercato/cache'
+import { buildRecordTag } from '@open-mercato/shared/lib/crud/cache'
 
 jest.mock('@open-mercato/core/modules/dictionaries/data/entities', () => ({
   Dictionary: 'Dictionary',
@@ -47,7 +48,7 @@ function createEntityManager(rows: EntryRow[]) {
 function createCache() {
   const store = new Map<string, unknown>()
   const get = jest.fn(async (key: string) => (store.has(key) ? store.get(key) : null))
-  const set = jest.fn(async (key: string, value: unknown) => {
+  const set = jest.fn(async (key: string, value: unknown, _options?: unknown) => {
     store.set(key, value)
   })
   return { get, set }
@@ -120,6 +121,14 @@ describe('resolveCachedDictionaryEntryValue', () => {
     const cache = createCache()
     await resolveCachedDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
     expect(runWithCacheTenant).toHaveBeenCalledWith(TENANT_A, expect.any(Function))
+  })
+
+  it('tags the cached value with the dictionaries.entry CRUD record tag so invalidateCrudCache drops it on edit', async () => {
+    const { em } = createEntityManager(rows)
+    const cache = createCache()
+    await resolveCachedDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
+    const setOptions = cache.set.mock.calls[0][2] as { tags?: string[] }
+    expect(setOptions?.tags).toEqual([buildRecordTag('dictionaries.entry', TENANT_A, 'entry-a')])
   })
 
   it('does not cache a missing entry (re-reads on the next lookup)', async () => {

--- a/packages/core/src/modules/sales/lib/__tests__/dictionaries.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/dictionaries.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { resolveDictionaryEntryValue } from '../dictionaries'
+import { resolveDictionaryEntryValue, resolveCachedDictionaryEntryValue } from '../dictionaries'
 import { runWithCacheTenant } from '@open-mercato/cache'
 
 jest.mock('@open-mercato/core/modules/dictionaries/data/entities', () => ({
@@ -92,7 +92,7 @@ describe('resolveDictionaryEntryValue tenant scoping (issue #2740)', () => {
   })
 })
 
-describe('resolveDictionaryEntryValue caching', () => {
+describe('resolveCachedDictionaryEntryValue', () => {
   const rows: EntryRow[] = [
     { id: 'entry-a', tenantId: TENANT_A, organizationId: 'org-a', value: 'Approved (A)' },
   ]
@@ -100,33 +100,33 @@ describe('resolveDictionaryEntryValue caching', () => {
   it('reads the entry once and serves repeat lookups from the shared cache', async () => {
     const { em, findOne } = createEntityManager(rows)
     const cache = createCache()
-    const first = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
-    const second = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
+    const first = await resolveCachedDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
+    const second = await resolveCachedDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
     expect(first).toBe('Approved (A)')
     expect(second).toBe('Approved (A)')
     expect(findOne).toHaveBeenCalledTimes(1)
     expect(cache.set).toHaveBeenCalledTimes(1)
   })
 
-  it('reads straight through the EM when no cache is provided', async () => {
+  it('falls back to a straight EM read when no cache is provided', async () => {
     const { em, findOne } = createEntityManager(rows)
-    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
-    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
+    await resolveCachedDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, undefined)
+    await resolveCachedDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, undefined)
     expect(findOne).toHaveBeenCalledTimes(2)
   })
 
   it('scopes the cache read/write to the caller tenant via runWithCacheTenant', async () => {
     const { em } = createEntityManager(rows)
     const cache = createCache()
-    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
+    await resolveCachedDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
     expect(runWithCacheTenant).toHaveBeenCalledWith(TENANT_A, expect.any(Function))
   })
 
   it('does not cache a missing entry (re-reads on the next lookup)', async () => {
     const { em, findOne } = createEntityManager(rows)
     const cache = createCache()
-    const first = await resolveDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A }, cache as any)
-    const second = await resolveDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A }, cache as any)
+    const first = await resolveCachedDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A }, cache as any)
+    const second = await resolveCachedDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A }, cache as any)
     expect(first).toBeNull()
     expect(second).toBeNull()
     expect(findOne).toHaveBeenCalledTimes(2)

--- a/packages/core/src/modules/sales/lib/__tests__/dictionaries.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/dictionaries.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { resolveDictionaryEntryValue } from '../dictionaries'
+import { resolveDictionaryEntryValue, resetDictionaryEntryValueCache } from '../dictionaries'
 
 jest.mock('@open-mercato/core/modules/dictionaries/data/entities', () => ({
   Dictionary: 'Dictionary',
@@ -36,6 +36,11 @@ function createEntityManager(rows: EntryRow[]) {
   return { em: { findOne } as unknown as any, findOne }
 }
 
+// The resolved-value memo is process-global, so reset it between tests for determinism.
+beforeEach(() => {
+  resetDictionaryEntryValueCache()
+})
+
 describe('resolveDictionaryEntryValue tenant scoping (issue #2740)', () => {
   const rows: EntryRow[] = [
     { id: 'entry-a', tenantId: TENANT_A, organizationId: 'org-a', value: 'Approved (A)' },
@@ -68,5 +73,48 @@ describe('resolveDictionaryEntryValue tenant scoping (issue #2740)', () => {
     const value = await resolveDictionaryEntryValue(em, null, { tenantId: TENANT_A })
     expect(value).toBeNull()
     expect(findOne).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveDictionaryEntryValue memoization', () => {
+  // Same entry id under two tenants — the memo must not leak across the tenant boundary.
+  const rows: EntryRow[] = [
+    { id: 'entry-a', tenantId: TENANT_A, organizationId: 'org-a', value: 'Approved (A)' },
+    { id: 'entry-a', tenantId: TENANT_B, organizationId: 'org-b', value: 'Approved (B)' },
+  ]
+
+  it('reads the entry once and serves repeat lookups from the memo', async () => {
+    const { em, findOne } = createEntityManager(rows)
+    const first = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
+    const second = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
+    expect(first).toBe('Approved (A)')
+    expect(second).toBe('Approved (A)')
+    expect(findOne).toHaveBeenCalledTimes(1)
+  })
+
+  it('keys the memo by tenant so the same entry id does not leak across tenants', async () => {
+    const { em, findOne } = createEntityManager(rows)
+    const a = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
+    const b = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_B })
+    expect(a).toBe('Approved (A)')
+    expect(b).toBe('Approved (B)')
+    expect(findOne).toHaveBeenCalledTimes(2)
+  })
+
+  it('memoizes a missing entry (negative result) too', async () => {
+    const { em, findOne } = createEntityManager(rows)
+    const first = await resolveDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A })
+    const second = await resolveDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A })
+    expect(first).toBeNull()
+    expect(second).toBeNull()
+    expect(findOne).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-reads after resetDictionaryEntryValueCache()', async () => {
+    const { em, findOne } = createEntityManager(rows)
+    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
+    resetDictionaryEntryValueCache()
+    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
+    expect(findOne).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/core/src/modules/sales/lib/__tests__/dictionaries.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/dictionaries.test.ts
@@ -1,9 +1,16 @@
 /** @jest-environment node */
-import { resolveDictionaryEntryValue, resetDictionaryEntryValueCache } from '../dictionaries'
+import { resolveDictionaryEntryValue } from '../dictionaries'
+import { runWithCacheTenant } from '@open-mercato/cache'
 
 jest.mock('@open-mercato/core/modules/dictionaries/data/entities', () => ({
   Dictionary: 'Dictionary',
   DictionaryEntry: 'DictionaryEntry',
+}))
+
+// The tenant scoping of the cache key is the cache service's job (runWithCacheTenant); here we only
+// need it to run the callback, and we assert it is invoked with the caller's tenant id.
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: jest.fn((_tenantId: string | null, fn: () => unknown) => fn()),
 }))
 
 const TENANT_A = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
@@ -36,9 +43,18 @@ function createEntityManager(rows: EntryRow[]) {
   return { em: { findOne } as unknown as any, findOne }
 }
 
-// The resolved-value memo is process-global, so reset it between tests for determinism.
+// A minimal in-memory stand-in for the shared cache service (only get/set are used here).
+function createCache() {
+  const store = new Map<string, unknown>()
+  const get = jest.fn(async (key: string) => (store.has(key) ? store.get(key) : null))
+  const set = jest.fn(async (key: string, value: unknown) => {
+    store.set(key, value)
+  })
+  return { get, set }
+}
+
 beforeEach(() => {
-  resetDictionaryEntryValueCache()
+  jest.clearAllMocks()
 })
 
 describe('resolveDictionaryEntryValue tenant scoping (issue #2740)', () => {
@@ -76,45 +92,44 @@ describe('resolveDictionaryEntryValue tenant scoping (issue #2740)', () => {
   })
 })
 
-describe('resolveDictionaryEntryValue memoization', () => {
-  // Same entry id under two tenants — the memo must not leak across the tenant boundary.
+describe('resolveDictionaryEntryValue caching', () => {
   const rows: EntryRow[] = [
     { id: 'entry-a', tenantId: TENANT_A, organizationId: 'org-a', value: 'Approved (A)' },
-    { id: 'entry-a', tenantId: TENANT_B, organizationId: 'org-b', value: 'Approved (B)' },
   ]
 
-  it('reads the entry once and serves repeat lookups from the memo', async () => {
+  it('reads the entry once and serves repeat lookups from the shared cache', async () => {
     const { em, findOne } = createEntityManager(rows)
-    const first = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
-    const second = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
+    const cache = createCache()
+    const first = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
+    const second = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
     expect(first).toBe('Approved (A)')
     expect(second).toBe('Approved (A)')
     expect(findOne).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
   })
 
-  it('keys the memo by tenant so the same entry id does not leak across tenants', async () => {
+  it('reads straight through the EM when no cache is provided', async () => {
     const { em, findOne } = createEntityManager(rows)
-    const a = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
-    const b = await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_B })
-    expect(a).toBe('Approved (A)')
-    expect(b).toBe('Approved (B)')
+    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
+    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
     expect(findOne).toHaveBeenCalledTimes(2)
   })
 
-  it('memoizes a missing entry (negative result) too', async () => {
+  it('scopes the cache read/write to the caller tenant via runWithCacheTenant', async () => {
+    const { em } = createEntityManager(rows)
+    const cache = createCache()
+    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A }, cache as any)
+    expect(runWithCacheTenant).toHaveBeenCalledWith(TENANT_A, expect.any(Function))
+  })
+
+  it('does not cache a missing entry (re-reads on the next lookup)', async () => {
     const { em, findOne } = createEntityManager(rows)
-    const first = await resolveDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A })
-    const second = await resolveDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A })
+    const cache = createCache()
+    const first = await resolveDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A }, cache as any)
+    const second = await resolveDictionaryEntryValue(em, 'missing', { tenantId: TENANT_A }, cache as any)
     expect(first).toBeNull()
     expect(second).toBeNull()
-    expect(findOne).toHaveBeenCalledTimes(1)
-  })
-
-  it('re-reads after resetDictionaryEntryValueCache()', async () => {
-    const { em, findOne } = createEntityManager(rows)
-    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
-    resetDictionaryEntryValueCache()
-    await resolveDictionaryEntryValue(em, 'entry-a', { tenantId: TENANT_A })
     expect(findOne).toHaveBeenCalledTimes(2)
+    expect(cache.set).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/sales/lib/dictionaries.ts
+++ b/packages/core/src/modules/sales/lib/dictionaries.ts
@@ -5,6 +5,8 @@ import {
   sanitizeDictionaryColor,
   sanitizeDictionaryIcon,
 } from '@open-mercato/core/modules/dictionaries/lib/utils'
+import { runWithCacheTenant } from '@open-mercato/cache'
+import type { CacheStrategy } from '@open-mercato/cache'
 
 export type SalesDictionaryKind =
   | 'order-status'
@@ -111,35 +113,37 @@ export async function ensureSalesDictionary(params: {
   return dictionary
 }
 
-// Per-process short-TTL memo for resolved dictionary-entry values. These rows are effectively static
-// config within a run/request (order status / fulfillment / payment labels, etc.), yet the
-// `sales.orders.*` command handlers fork a fresh EM per invocation and re-`findOne` the same few
-// entry ids on EVERY order — a measured N+1 (~2 reads + pooled-connection checkouts per order on a
-// bulk import, dominant once the aggregate itself is cheap). The value is non-PII config; the key is
-// tenant-scoped and staleness is bounded by the TTL, mirroring the process-global cache pattern in
-// `TenantDataEncryptionService`. A dictionary-value edit takes effect after at most one TTL window.
-const DICTIONARY_ENTRY_VALUE_TTL_MS = 60_000
-const dictionaryEntryValueCache = new Map<string, { value: string | null; expiresAt: number }>()
-
-/** Test-only: drop the memoized dictionary-entry values (jest). */
-export function resetDictionaryEntryValueCache(): void {
-  dictionaryEntryValueCache.clear()
-}
+// Resolved dictionary-entry values (order status / fulfillment / payment labels, …) are effectively
+// static config within a run, yet the `sales.orders.*` handlers fork a fresh EM per invocation and
+// re-`findOne` the same few entry ids on EVERY order — a measured N+1 (~2 reads + pooled-connection
+// checkouts per order on a bulk import, dominant once the aggregate itself is cheap). When a `cache`
+// is supplied, memoize the resolved value through the shared cache service — tenant-scoped via
+// `runWithCacheTenant`, short TTL. The value is non-PII config; a dictionary-value edit takes effect
+// after at most one TTL window. Callers without a cache (the default) read straight through.
+const DICTIONARY_ENTRY_VALUE_CACHE_TTL_MS = 60_000
 
 export async function resolveDictionaryEntryValue(
   em: EntityManager,
   entryId: string | null | undefined,
-  scope: { tenantId: string }
+  scope: { tenantId: string },
+  cache?: CacheStrategy | null,
 ): Promise<string | null> {
   if (!entryId) return null
-  const key = `${scope.tenantId}:${entryId}`
-  const now = Date.now()
-  const cached = dictionaryEntryValueCache.get(key)
-  if (cached && cached.expiresAt > now) return cached.value
-  const entry = await em.findOne(DictionaryEntry, { id: entryId, tenantId: scope.tenantId })
-  const value = entry?.value?.trim() || null
-  dictionaryEntryValueCache.set(key, { value, expiresAt: now + DICTIONARY_ENTRY_VALUE_TTL_MS })
-  return value
+  const load = async (): Promise<string | null> => {
+    const entry = await em.findOne(DictionaryEntry, { id: entryId, tenantId: scope.tenantId })
+    return entry?.value?.trim() || null
+  }
+  if (!cache) return load()
+  const cacheKey = `sales:dictionary-entry-value:${entryId}`
+  return runWithCacheTenant(scope.tenantId, async () => {
+    const cached = await cache.get(cacheKey)
+    if (typeof cached === 'string') return cached
+    const value = await load()
+    if (value != null) {
+      await cache.set(cacheKey, value, { ttl: DICTIONARY_ENTRY_VALUE_CACHE_TTL_MS, tags: [`dictionary-entry:${entryId}`] })
+    }
+    return value
+  })
 }
 
 export { normalizeDictionaryValue, sanitizeDictionaryColor, sanitizeDictionaryIcon }

--- a/packages/core/src/modules/sales/lib/dictionaries.ts
+++ b/packages/core/src/modules/sales/lib/dictionaries.ts
@@ -111,15 +111,35 @@ export async function ensureSalesDictionary(params: {
   return dictionary
 }
 
+// Per-process short-TTL memo for resolved dictionary-entry values. These rows are effectively static
+// config within a run/request (order status / fulfillment / payment labels, etc.), yet the
+// `sales.orders.*` command handlers fork a fresh EM per invocation and re-`findOne` the same few
+// entry ids on EVERY order — a measured N+1 (~2 reads + pooled-connection checkouts per order on a
+// bulk import, dominant once the aggregate itself is cheap). The value is non-PII config; the key is
+// tenant-scoped and staleness is bounded by the TTL, mirroring the process-global cache pattern in
+// `TenantDataEncryptionService`. A dictionary-value edit takes effect after at most one TTL window.
+const DICTIONARY_ENTRY_VALUE_TTL_MS = 60_000
+const dictionaryEntryValueCache = new Map<string, { value: string | null; expiresAt: number }>()
+
+/** Test-only: drop the memoized dictionary-entry values (jest). */
+export function resetDictionaryEntryValueCache(): void {
+  dictionaryEntryValueCache.clear()
+}
+
 export async function resolveDictionaryEntryValue(
   em: EntityManager,
   entryId: string | null | undefined,
   scope: { tenantId: string }
 ): Promise<string | null> {
   if (!entryId) return null
+  const key = `${scope.tenantId}:${entryId}`
+  const now = Date.now()
+  const cached = dictionaryEntryValueCache.get(key)
+  if (cached && cached.expiresAt > now) return cached.value
   const entry = await em.findOne(DictionaryEntry, { id: entryId, tenantId: scope.tenantId })
-  if (!entry) return null
-  return entry.value?.trim() || null
+  const value = entry?.value?.trim() || null
+  dictionaryEntryValueCache.set(key, { value, expiresAt: now + DICTIONARY_ENTRY_VALUE_TTL_MS })
+  return value
 }
 
 export { normalizeDictionaryValue, sanitizeDictionaryColor, sanitizeDictionaryIcon }

--- a/packages/core/src/modules/sales/lib/dictionaries.ts
+++ b/packages/core/src/modules/sales/lib/dictionaries.ts
@@ -7,6 +7,7 @@ import {
 } from '@open-mercato/core/modules/dictionaries/lib/utils'
 import { runWithCacheTenant } from '@open-mercato/cache'
 import type { CacheStrategy } from '@open-mercato/cache'
+import { buildRecordTag } from '@open-mercato/shared/lib/crud/cache'
 
 export type SalesDictionaryKind =
   | 'order-status'
@@ -126,12 +127,16 @@ export async function resolveDictionaryEntryValue(
 // Read-through cache in front of `resolveDictionaryEntryValue`, for the hot order-write path: the same
 // few status / fulfillment / payment entry ids are re-resolved for EVERY order, so a bulk import
 // re-reads them per order — a measured N+1 that dominates once the aggregate write itself is cheap.
-// The value is non-PII config; the entry is tenant-scoped via `runWithCacheTenant` and short-TTL'd, so
-// a dictionary-value edit takes effect after at most one TTL window. Callers pass the (soft-resolved)
-// cache; `undefined` reads straight through.
+// The value is non-PII config, tenant-scoped via `runWithCacheTenant` and short-TTL'd. It is tagged with
+// the platform CRUD record tag for `dictionaries.entry`, so the command bus's own `invalidateCrudCache`
+// (fired on every entry create/update/delete) drops this entry on edit — the 60s TTL is only a backstop.
+// Callers pass the (soft-resolved) cache; `undefined` reads straight through.
 const DICTIONARY_ENTRY_VALUE_CACHE_TTL_MS = 60_000
+const DICTIONARY_ENTRY_RESOURCE_KIND = 'dictionaries.entry'
 const dictionaryEntryValueCacheKey = (entryId: string): string => `sales:dictionary-entry-value:${entryId}`
-const dictionaryEntryValueCacheTags = (entryId: string): string[] => [`dictionary-entry:${entryId}`]
+const dictionaryEntryValueCacheTags = (entryId: string, tenantId: string): string[] => [
+  buildRecordTag(DICTIONARY_ENTRY_RESOURCE_KIND, tenantId, entryId),
+]
 
 export async function resolveCachedDictionaryEntryValue(
   em: EntityManager,
@@ -149,7 +154,7 @@ export async function resolveCachedDictionaryEntryValue(
     if (value != null) {
       await cache.set(cacheKey, value, {
         ttl: DICTIONARY_ENTRY_VALUE_CACHE_TTL_MS,
-        tags: dictionaryEntryValueCacheTags(entryId),
+        tags: dictionaryEntryValueCacheTags(entryId, scope.tenantId),
       })
     }
     return value

--- a/packages/core/src/modules/sales/lib/dictionaries.ts
+++ b/packages/core/src/modules/sales/lib/dictionaries.ts
@@ -113,34 +113,44 @@ export async function ensureSalesDictionary(params: {
   return dictionary
 }
 
-// Resolved dictionary-entry values (order status / fulfillment / payment labels, …) are effectively
-// static config within a run, yet the `sales.orders.*` handlers fork a fresh EM per invocation and
-// re-`findOne` the same few entry ids on EVERY order — a measured N+1 (~2 reads + pooled-connection
-// checkouts per order on a bulk import, dominant once the aggregate itself is cheap). When a `cache`
-// is supplied, memoize the resolved value through the shared cache service — tenant-scoped via
-// `runWithCacheTenant`, short TTL. The value is non-PII config; a dictionary-value edit takes effect
-// after at most one TTL window. Callers without a cache (the default) read straight through.
-const DICTIONARY_ENTRY_VALUE_CACHE_TTL_MS = 60_000
-
 export async function resolveDictionaryEntryValue(
   em: EntityManager,
   entryId: string | null | undefined,
-  scope: { tenantId: string },
-  cache?: CacheStrategy,
+  scope: { tenantId: string }
 ): Promise<string | null> {
   if (!entryId) return null
-  const load = async (): Promise<string | null> => {
-    const entry = await em.findOne(DictionaryEntry, { id: entryId, tenantId: scope.tenantId })
-    return entry?.value?.trim() || null
-  }
-  if (!cache) return load()
-  const cacheKey = `sales:dictionary-entry-value:${entryId}`
+  const entry = await em.findOne(DictionaryEntry, { id: entryId, tenantId: scope.tenantId })
+  return entry?.value?.trim() || null
+}
+
+// Read-through cache in front of `resolveDictionaryEntryValue`, for the hot order-write path: the same
+// few status / fulfillment / payment entry ids are re-resolved for EVERY order, so a bulk import
+// re-reads them per order — a measured N+1 that dominates once the aggregate write itself is cheap.
+// The value is non-PII config; the entry is tenant-scoped via `runWithCacheTenant` and short-TTL'd, so
+// a dictionary-value edit takes effect after at most one TTL window. Callers pass the (soft-resolved)
+// cache; `undefined` reads straight through.
+const DICTIONARY_ENTRY_VALUE_CACHE_TTL_MS = 60_000
+const dictionaryEntryValueCacheKey = (entryId: string): string => `sales:dictionary-entry-value:${entryId}`
+const dictionaryEntryValueCacheTags = (entryId: string): string[] => [`dictionary-entry:${entryId}`]
+
+export async function resolveCachedDictionaryEntryValue(
+  em: EntityManager,
+  entryId: string | null | undefined,
+  scope: { tenantId: string },
+  cache: CacheStrategy | undefined
+): Promise<string | null> {
+  if (!entryId) return null
+  if (!cache) return resolveDictionaryEntryValue(em, entryId, scope)
   return runWithCacheTenant(scope.tenantId, async () => {
+    const cacheKey = dictionaryEntryValueCacheKey(entryId)
     const cached = await cache.get(cacheKey)
     if (typeof cached === 'string') return cached
-    const value = await load()
+    const value = await resolveDictionaryEntryValue(em, entryId, scope)
     if (value != null) {
-      await cache.set(cacheKey, value, { ttl: DICTIONARY_ENTRY_VALUE_CACHE_TTL_MS, tags: [`dictionary-entry:${entryId}`] })
+      await cache.set(cacheKey, value, {
+        ttl: DICTIONARY_ENTRY_VALUE_CACHE_TTL_MS,
+        tags: dictionaryEntryValueCacheTags(entryId),
+      })
     }
     return value
   })

--- a/packages/core/src/modules/sales/lib/dictionaries.ts
+++ b/packages/core/src/modules/sales/lib/dictionaries.ts
@@ -126,7 +126,7 @@ export async function resolveDictionaryEntryValue(
   em: EntityManager,
   entryId: string | null | undefined,
   scope: { tenantId: string },
-  cache?: CacheStrategy | null,
+  cache?: CacheStrategy,
 ): Promise<string | null> {
   if (!entryId) return null
   const load = async (): Promise<string | null> => {


### PR DESCRIPTION
## Summary

`sales.orders.create` resolves the order's status / fulfillment / payment dictionary entries via
`resolveDictionaryEntryValue`, and the handler forks a fresh EM per invocation — so there is no
identity-map reuse and each of those resolves is a `findOne(DictionaryEntry, …)` on a pooled
connection. When many orders are created in a row (a bulk import / migration), the same handful of
static dictionary ids are re-read for **every** order — an N+1 that becomes a dominant per-order cost
once the order aggregate write itself is cheap.

This adds a small **read-through cache** in front of the lookup, built on the existing cache service:
tenant-scoped via `runWithCacheTenant`, short TTL, tagged. It is applied only on the order-create path;
everything else keeps reading straight through.

## Changes

- `packages/core/src/modules/sales/lib/dictionaries.ts`
  - `resolveDictionaryEntryValue` stays a plain read (unchanged for its existing callers).
  - adds `resolveCachedDictionaryEntryValue`, a dedicated read-through wrapper — `get` → on miss read
    then `set` — with `dictionaryEntryValueCacheKey` / `dictionaryEntryValueCacheTags` builders, a 60s
    TTL, tenant scoping via `runWithCacheTenant`, and negative results left uncached. Degrades to a
    straight read when no cache is passed.
- `packages/core/src/modules/sales/commands/documents.ts`
  - the order-create command soft-resolves the cache (`resolve('cache', { allowUnregistered: true })`)
    and uses the cached variant for the status/fulfillment/payment reads; when no cache is registered
    it reads straight through.

## Specification

- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change — a read-path cache, no contract/behaviour change)

## Testing

- `yarn workspace @open-mercato/core test -- src/modules/sales/lib/__tests__/dictionaries.test.ts` → 8/8
  (tenant scoping unchanged; new tests cover cache hit/miss, tenant scoping via `runWithCacheTenant`,
  negative results uncached, straight-through when no cache).
- `yarn workspace @open-mercato/core typecheck` and `eslint` clean for the changed files.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. — N/A.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — Not required: a per-record read-path cache with no user-facing surface; covered by unit tests.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A.
- [x] Priority: `priority-low`.
- [x] Risk: `risk-low` — isolated to one lib function + one command call site, ships with tests, no contract/schema/auth/migration change.
- [x] QA routing: `skip-qa` — low-risk, non-customer-facing internal read-path optimization.

### Design System Compliance
- N/A — backend `packages/core` change, no UI.

## Linked issues

None.