### PR TITLE
fix: neutralize CSV formula cells in exports

### DIFF
--- a/packages/shared/src/lib/crud/__tests__/exporters.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/exporters.test.ts
@@ -1,0 +1,31 @@
+import { serializeExport } from '../exporters'
+
+describe('CRUD export serializers', () => {
+  it('neutralizes spreadsheet formula prefixes in CSV string cells', () => {
+    const serialized = serializeExport({
+      columns: [
+        { field: 'name', header: 'Name' },
+        { field: 'note', header: 'Note' },
+        { field: 'balance', header: 'Balance' },
+      ],
+      rows: [
+        {
+          name: "=cmd|'/c calc'!A1",
+          note: '@SUM(A1:A2)',
+          balance: -42,
+        },
+        {
+          name: '\t=HYPERLINK("https://example.invalid")',
+          note: '\r+1+1',
+          balance: '-7',
+        },
+      ],
+    }, 'csv')
+
+    expect(serialized.body.split('\n')).toEqual([
+      'Name,Note,Balance',
+      "'=cmd|'/c calc'!A1,'@SUM(A1:A2),-42",
+      '"\'\t=HYPERLINK(""https://example.invalid"")","\'\r+1+1",\'-7',
+    ])
+  })
+})

--- a/packages/shared/src/lib/crud/exporters.ts
+++ b/packages/shared/src/lib/crud/exporters.ts
@@ -39,6 +39,21 @@ function escapeCsv(value: string): string {
   return value
 }
 
+function neutralizeSpreadsheetFormula(value: string): string {
+  if (/^[=+\-@\t\r\n]/.test(value)) {
+    return `'${value}`
+  }
+  return value
+}
+
+function normalizeCsvValue(value: unknown): string {
+  const normalized = normalizeValue(value)
+  if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
+    return normalized
+  }
+  return neutralizeSpreadsheetFormula(normalized)
+}
+
 function escapeMarkdown(value: string): string {
   const escaped = value
     .replace(/\\/g, '\\\\')
@@ -70,7 +85,7 @@ function serializeCsv(prepared: PreparedExport): SerializedExport {
   const lines = [headers.join(',')]
   for (const row of prepared.rows) {
     const values = prepared.columns.map((col) => {
-      const raw = normalizeValue(row[col.field])
+      const raw = normalizeCsvValue(row[col.field])
       return escapeCsv(raw)
     })
     lines.push(values.join(','))


### PR DESCRIPTION
## Summary

Fixes CSV formula injection risk in shared CRUD exports by neutralizing string cell values that spreadsheet apps may interpret as formulas.

## Changes

- Prefixes risky CSV string cells with `'` when they start with `=`, `+`, `-`, `@`, tab, CR, or LF.
- Preserves real numeric, bigint, and boolean values so ordinary numeric exports keep their existing shape.
- Adds a shared serializer regression test covering direct formula prefixes, control-character prefixes, and numeric-looking strings.

## Specification

Existing sync_excel/customer import context was reviewed; no spec changes are needed for this shared export hardening.

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-03-29-sync-excel-customers-import-foundation.md`

## Testing

- [x] `yarn workspace @open-mercato/shared test packages/shared/src/lib/crud/__tests__/exporters.test.ts --runInBand`
- [x] `yarn workspace @open-mercato/shared test packages/shared/src/lib/crud/__tests__/exporters.test.ts packages/shared/src/lib/crud/__tests__/crud-factory.test.ts --runInBand`
- [x] `git diff --check`
- [x] `yarn workspace @open-mercato/shared typecheck`
- [x] `yarn workspace @open-mercato/shared build`
- [x] `yarn generate`
- [x] `yarn build:packages`
- [x] `yarn i18n:check-sync`
- [x] `yarn i18n:check-usage`
- [x] `yarn typecheck`
- [x] `yarn test`
- [x] `yarn lint`
- [x] `yarn build:app`

## Checklist

- [x] This pull request targets `develop`.
- [x] I accept the CLA terms in `docs/cla.md`.
- [x] Documentation was updated, or no documentation change is required.
- [x] Translations were updated, or no user-facing strings changed.
- [x] Generators were run where needed.
- [x] Tests were added or updated.
- [x] Integration tests are included, or this shared serializer change is covered by focused unit regression.
- [x] Spec changelog was updated, or no spec update is required.
- [x] Expected labels: `bug`, `security`, `priority-low`, `risk-medium`, `skip-qa`, `review`.

### Design System Compliance

N/A: shared serializer hardening only; no UI changes.

- [x] No hardcoded status colors were added.
- [x] No hardcoded typography or spacing primitives were added.
- [x] UI states and accessibility are unchanged.
- [x] Existing design-system patterns remain intact.

## Linked issues

Fixes #3925
