### PR TITLE
fix: scope sync_excel email dedupe index (#3924)

### DIFF
--- a/packages/core/src/modules/sync_excel/lib/__tests__/customers-adapter.test.ts
+++ b/packages/core/src/modules/sync_excel/lib/__tests__/customers-adapter.test.ts
@@ -449,6 +449,71 @@ describe('sync_excel customers adapter', () => {
     )
   })
 
+  it('builds the email dedupe index once for the remaining import rows', async () => {
+    mockReadSyncExcelUploadBuffer.mockResolvedValue(Buffer.from([
+      'Email,Lead Name',
+      'ada@example.com,Ada Lovelace',
+      'ADA@example.com,Augusta Ada',
+      'alan@example.com,Alan Turing',
+    ].join('\n')))
+    const personScanCriteria: Array<Record<string, unknown>> = []
+    mockFindWithDecryption.mockImplementation(async (_entityManager: unknown, _entity: unknown, criteria: Record<string, unknown>) => {
+      if (criteria?.entityId) return []
+      if (criteria?.kind === 'person') {
+        personScanCriteria.push(criteria)
+        return []
+      }
+      return []
+    })
+
+    const batches = []
+    for await (const batch of syncExcelCustomersAdapter.streamImport!({
+      entityType: 'customers.person',
+      batchSize: 1,
+      credentials: {},
+      mapping: {
+        entityType: 'customers.person',
+        matchStrategy: 'email',
+        matchField: 'person.primaryEmail',
+        fields: [
+          { externalField: 'Email', localField: 'person.primaryEmail', mappingKind: 'core', dedupeRole: 'secondary' },
+          { externalField: 'Lead Name', localField: 'person.displayName', mappingKind: 'core' },
+        ],
+      },
+      scope: {
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+      },
+      runId: 'run-1',
+    })) {
+      batches.push(batch)
+    }
+
+    expect(batches).toHaveLength(3)
+    expect(batches.map((batch) => batch.items[0]?.action)).toEqual(['create', 'update', 'create'])
+    const personCommands = mockCommandBus.execute.mock.calls.filter(([command]) => String(command).startsWith('customers.people.'))
+    expect(personCommands.map(([command]) => command)).toEqual([
+      'customers.people.create',
+      'customers.people.update',
+      'customers.people.create',
+    ])
+    expect(personCommands[1]?.[1]).toEqual(expect.objectContaining({
+      input: expect.objectContaining({
+        id: '33333333-3333-4333-8333-333333333333',
+        primaryEmail: 'ada@example.com',
+        displayName: 'Augusta Ada',
+      }),
+    }))
+    expect(personScanCriteria).toHaveLength(1)
+    expect(personScanCriteria[0]).toMatchObject({
+      kind: 'person',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      deletedAt: null,
+      isActive: true,
+    })
+  })
+
   it('prefers external-id mappings over decrypted email fallback matches', async () => {
     mockReadSyncExcelUploadBuffer.mockResolvedValue(Buffer.from([
       'Record Id,Email,Lead Name',

--- a/packages/core/src/modules/sync_excel/lib/adapters/customers.ts
+++ b/packages/core/src/modules/sync_excel/lib/adapters/customers.ts
@@ -1048,15 +1048,15 @@ export const syncExcelCustomersAdapter: DataSyncAdapter = {
       const startOffset = cursor?.uploadId === upload.id ? cursor.offset : 0
       const commandContext = buildCommandContext(container, input.scope)
       const customFieldDefinitions = await loadImportCustomFieldDefinitions(em, input.scope)
+      const emailDedupeIndex = await buildEmailDedupeIndex({
+        em,
+        rows: document.rows.slice(startOffset),
+        mapping: input.mapping,
+        scope: input.scope,
+      })
 
       for (let offset = startOffset, batchIndex = 0; offset < document.rows.length; offset += input.batchSize, batchIndex += 1) {
         const batchRows = document.rows.slice(offset, offset + input.batchSize)
-        const emailDedupeIndex = await buildEmailDedupeIndex({
-          em,
-          rows: batchRows,
-          mapping: input.mapping,
-          scope: input.scope,
-        })
         const items: ImportItem[] = []
 
         for (let index = 0; index < batchRows.length; index += 1) {


### PR DESCRIPTION
## Summary

Fixes a sync_excel customer import amplification issue where every import batch rebuilt the email dedupe index by scanning/decrypting all active people in the organization.

## Changes

- Move sync_excel customer email dedupe index construction outside the batch loop.
- Reuse the same mutable dedupe index across batches so same-run duplicate emails still update the earlier row.
- Add focused adapter regression coverage for one scan across multiple batches and cross-batch duplicate email dedupe.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A - focused security/performance bug fix.


## Testing

- `yarn workspace @open-mercato/core test packages/core/src/modules/sync_excel/lib/__tests__/customers-adapter.test.ts --runInBand`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn lint`
- `yarn build:app`

Note: `yarn template:sync` reports unrelated existing app/template dependency drift and was not synced into this scoped fix.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) - N/A, no UI changes
- [x] No arbitrary text sizes (`text-[Npx]`) - N/A, no UI changes
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) - N/A, no UI changes
- [x] Loading state handled for async pages - N/A, no UI changes
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) - N/A, no UI changes
- [x] Uses existing DS components (Alert, StatusBadge, FormField) - N/A, no UI changes

## Linked issues

Fixes #3924