### PR TITLE
fix(sync-akeneo): block redirect-hop SSRF (#3919)

### DIFF
--- a/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
@@ -19,6 +19,15 @@ function jsonResponse(body: unknown, init?: ResponseInit): Response {
   })
 }
 
+function redirectResponse(): Response {
+  return new Response('redirected', {
+    status: 302,
+    headers: {
+      location: 'http://169.254.169.254/latest/meta-data/',
+    },
+  })
+}
+
 describe('akeneo client helpers', () => {
   it('normalizes ISO timestamps to Akeneo query format', () => {
     expect(normalizeAkeneoDateTime('2026-03-10T12:15:30.000Z')).toBe('2026-03-10 12:15:30')
@@ -125,6 +134,60 @@ describe('akeneo client security', () => {
         authorization: 'Bearer token-123',
       }),
     }))
+  })
+
+  it('does not automatically follow redirects while acquiring an access token', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    fetchMock.mockImplementation(async (_input, init) => (
+      (init as RequestInit | undefined)?.redirect === 'manual'
+        ? redirectResponse()
+        : new Response('internal metadata leaked through redirect', { status: 500 })
+    ))
+
+    const client = createAkeneoClient(validCredentials)
+    await expect(client.getSystemProbe()).rejects.toThrow('Akeneo authentication failed (302)')
+  })
+
+  it('does not automatically follow redirects on authenticated API requests', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).endsWith('/api/oauth/v1/token')) {
+        return jsonResponse({ access_token: 'token-123', expires_in: 3600 })
+      }
+      return (init as RequestInit | undefined)?.redirect === 'manual'
+        ? redirectResponse()
+        : new Response('internal metadata leaked through redirect', { status: 500 })
+    })
+
+    const client = createAkeneoClient(validCredentials)
+    await expect(client.getSystemProbe()).rejects.toThrow('Akeneo request failed (302)')
+  })
+
+  it('does not automatically follow redirects on media downloads', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    fetchMock.mockImplementation(async (input, init) => {
+      const url = String(input)
+      if (url.endsWith('/api/oauth/v1/token')) {
+        return jsonResponse({ access_token: 'token-123', expires_in: 3600 })
+      }
+      if (url.endsWith('/api/rest/v1/media-files/asset-1')) {
+        return jsonResponse({
+          code: 'asset-1',
+          original_filename: 'asset.jpg',
+          _links: {
+            download: {
+              href: 'https://tenant.cloud.akeneo.com/api/rest/v1/media-files/asset-1/download',
+            },
+          },
+        })
+      }
+      return (init as RequestInit | undefined)?.redirect === 'manual'
+        ? redirectResponse()
+        : new Response('internal metadata leaked through redirect', { status: 500 })
+    })
+
+    const client = createAkeneoClient(validCredentials)
+    await expect(client.downloadMediaFile('asset-1')).rejects.toThrow('Akeneo request failed (302)')
   })
 
   it('falls back to the attributes reachability probe and reports an unknown version (issue #3621)', async () => {

--- a/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
@@ -254,6 +254,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     const response = await fetchWithTimeout(tokenEndpointUrl, {
       method: 'POST',
       timeoutMs: resolveAkeneoRequestTimeoutMs(),
+      redirect: 'manual',
       headers: {
         accept: 'application/json',
         'content-type': 'application/json',
@@ -293,6 +294,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     const response = await fetchWithTimeout(tokenEndpointUrl, {
       method: 'POST',
       timeoutMs: resolveAkeneoRequestTimeoutMs(),
+      redirect: 'manual',
       headers: {
         accept: 'application/json',
         'content-type': 'application/json',
@@ -342,6 +344,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     const response = await fetchWithTimeout(url, {
       ...init,
       timeoutMs: resolveAkeneoRequestTimeoutMs(),
+      redirect: 'manual',
       headers: {
         accept: 'application/json',
         authorization: `Bearer ${token}`,
@@ -391,6 +394,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     const response = await fetchWithTimeout(url, {
       ...init,
       timeoutMs: resolveAkeneoRequestTimeoutMs(),
+      redirect: 'manual',
       headers: {
         authorization: `Bearer ${token}`,
         ...init.headers,


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fixes an Akeneo redirect-hop SSRF risk by disabling automatic redirect following for Akeneo outbound fetches after the client has validated the configured/request URL origin.

## Changes

- Set `redirect: 'manual'` on Akeneo OAuth token, token refresh, authenticated JSON API, and binary media fetches.
- Added regression tests for token, API, and media redirect-hop behavior.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — issue-scoped security bug fix.


## Testing

- `yarn workspace @open-mercato/sync-akeneo test src/modules/sync_akeneo/__tests__/client.test.ts --runInBand --testNamePattern="does not automatically follow redirects"` — red before fix, green after fix.
- `yarn workspace @open-mercato/sync-akeneo test`
- `yarn workspace @open-mercato/sync-akeneo typecheck`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage` — advisory unused-key report only, exit 0.
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- `git diff --cached --check`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). N/A — backend client behavior is covered by package tests.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A — issue-scoped bug fix.
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens. N/A — no UI changes.
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`. N/A — no UI changes.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A — no UI changes.
- [x] Loading state handled for async pages. N/A — no UI changes.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A — no UI changes.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements. N/A — no UI changes.

## Linked issues

Fixes #3919
