### PR TITLE
fix: harden Akeneo URL DNS guard (#3920)

### DIFF
--- a/apps/docs/docs/user-guide/akeneo-pim.mdx
+++ b/apps/docs/docs/user-guide/akeneo-pim.mdx
@@ -35,22 +35,33 @@ Open Mercato validates the Akeneo API URL server-side before any network call to
 - The URL **must** use HTTPS.
 - Embedded credentials, custom ports, paths, query parameters, and fragments are rejected.
 - The hostname must match an operator-controlled allowlist.
+- Before each authenticated request, the hostname is resolved and loopback, link-local, RFC1918, and other private or reserved IP ranges are rejected.
+- The outbound fetch is pinned to the validated DNS address to prevent DNS rebinding between validation and connection.
 
 By default, only Akeneo SaaS hosts are allowed: `*.cloud.akeneo.com` and `*.akeneo.cloud`.
 
-### Self-hosted or private Akeneo instances
+### Self-hosted or custom Akeneo instances
 
 If your Akeneo PIM runs on a custom domain, set the `OM_INTEGRATION_AKENEO_ALLOWED_HOSTS` environment variable to a comma-separated list of allowed hostnames. Wildcard subdomains are supported:
 
 ```env
 # Single self-hosted instance
-OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=pim.example.internal
+OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=pim.example.com
 
 # Multiple hosts with wildcard
-OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=*.pim.corp.local,akeneo.staging.example.com
+OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=*.pim.example.com,akeneo.staging.example.com
 ```
 
 Legacy aliases `OPENMERCATO_AKENEO_ALLOWED_HOSTS` and `AKENEO_ALLOWED_HOSTS` are also accepted (checked in priority order).
+
+Allowed hosts must resolve to public, routable IP addresses by default. If your deployment intentionally reaches Akeneo over a trusted private network, combine an exact host allowlist with:
+
+```env
+OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=pim.example.internal
+OM_INTEGRATION_AKENEO_ALLOW_PRIVATE_URLS=true
+```
+
+Use this only for operator-controlled internal deployments; it disables the private-IP DNS guard for Akeneo requests.
 
 :::info
 All authenticated requests (OAuth token exchange, product pagination, media downloads) are pinned to the validated origin. If the remote API returns absolute URLs pointing to a different host, those requests are rejected to prevent token leakage.

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -525,10 +525,14 @@ OCR_MODEL=gpt-4o
 # Security:
 # The Akeneo client validates API URLs server-side to prevent SSRF and credential
 # exfiltration. By default only *.cloud.akeneo.com and *.akeneo.cloud hosts are
-# allowed. Override the allowlist for self-hosted or private instances:
-# OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=pim.example.internal,akeneo.corp.local
+# allowed. Override the allowlist for self-hosted public custom domains:
+# OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=pim.example.com,akeneo.staging.example.com
 # Aliases (checked in priority order): OM_INTEGRATION_AKENEO_ALLOWED_HOSTS,
 #   OPENMERCATO_AKENEO_ALLOWED_HOSTS, AKENEO_ALLOWED_HOSTS
+# Hostnames that resolve to private, loopback, link-local, or reserved IPs are
+# rejected before authenticated requests are sent. For trusted internal Akeneo
+# deployments only, combine an exact host allowlist with:
+# OM_INTEGRATION_AKENEO_ALLOW_PRIVATE_URLS=true
 #
 # Notes:
 # - Only one product locale is imported into base Open Mercato fields at a time.
@@ -541,6 +545,7 @@ OCR_MODEL=gpt-4o
 # OM_INTEGRATION_AKENEO_USERNAME=
 # OM_INTEGRATION_AKENEO_PASSWORD=
 # OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=
+# OM_INTEGRATION_AKENEO_ALLOW_PRIVATE_URLS=false
 # OM_INTEGRATION_AKENEO_FORCE_PRECONFIGURE=false
 # OM_INTEGRATION_AKENEO_PRODUCT_LOCALE=
 # OM_INTEGRATION_AKENEO_CATEGORY_LOCALE=

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -471,10 +471,14 @@ OCR_MODEL=gpt-4o
 # Security:
 # The Akeneo client validates API URLs server-side to prevent SSRF and credential
 # exfiltration. By default only *.cloud.akeneo.com and *.akeneo.cloud hosts are
-# allowed. Override the allowlist for self-hosted or private instances:
-# OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=pim.example.internal,akeneo.corp.local
+# allowed. Override the allowlist for self-hosted public custom domains:
+# OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=pim.example.com,akeneo.staging.example.com
 # Aliases (checked in priority order): OM_INTEGRATION_AKENEO_ALLOWED_HOSTS,
 #   OPENMERCATO_AKENEO_ALLOWED_HOSTS, AKENEO_ALLOWED_HOSTS
+# Hostnames that resolve to private, loopback, link-local, or reserved IPs are
+# rejected before authenticated requests are sent. For trusted internal Akeneo
+# deployments only, combine an exact host allowlist with:
+# OM_INTEGRATION_AKENEO_ALLOW_PRIVATE_URLS=true
 #
 # Notes:
 # - Only one product locale is imported into base Open Mercato fields at a time.
@@ -487,6 +491,7 @@ OCR_MODEL=gpt-4o
 # OM_INTEGRATION_AKENEO_USERNAME=
 # OM_INTEGRATION_AKENEO_PASSWORD=
 # OM_INTEGRATION_AKENEO_ALLOWED_HOSTS=
+# OM_INTEGRATION_AKENEO_ALLOW_PRIVATE_URLS=false
 # OM_INTEGRATION_AKENEO_FORCE_PRECONFIGURE=false
 # OM_INTEGRATION_AKENEO_PRODUCT_LOCALE=
 # OM_INTEGRATION_AKENEO_CATEGORY_LOCALE=

--- a/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
@@ -1,5 +1,5 @@
 import { FetchTimeoutError } from '@open-mercato/shared/lib/http/fetchWithTimeout'
-import { createAkeneoClient, encodeAkeneoPathParam, normalizeAkeneoDateTime, sanitizeAkeneoProductNextUrl, validateAkeneoApiUrl } from '../lib/client'
+import { createAkeneoClient, encodeAkeneoPathParam, normalizeAkeneoDateTime, sanitizeAkeneoProductNextUrl, validateAkeneoApiUrl, type AkeneoClientDeps } from '../lib/client'
 
 const validCredentials = {
   apiUrl: 'https://tenant.cloud.akeneo.com',
@@ -7,6 +7,18 @@ const validCredentials = {
   clientSecret: 'client-secret',
   username: 'api-user',
   password: 'api-password',
+}
+
+const publicAkeneoLookupHost: AkeneoClientDeps['lookupHost'] = async () => [{ address: '93.184.216.34', family: 4 }]
+
+function createTestAkeneoClient(
+  credentialsInput: Record<string, unknown> = validCredentials,
+  deps: AkeneoClientDeps = {},
+): ReturnType<typeof createAkeneoClient> {
+  return createAkeneoClient(credentialsInput, {
+    lookupHost: publicAkeneoLookupHost,
+    ...deps,
+  })
 }
 
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
@@ -74,7 +86,7 @@ describe('akeneo client security', () => {
 
   it('normalizes allowed Akeneo cloud urls to their origin', () => {
     expect(validateAkeneoApiUrl('https://tenant.cloud.akeneo.com/')).toBe('https://tenant.cloud.akeneo.com')
-    expect(createAkeneoClient(validCredentials).credentials.apiUrl).toBe('https://tenant.cloud.akeneo.com')
+    expect(createTestAkeneoClient(validCredentials).credentials.apiUrl).toBe('https://tenant.cloud.akeneo.com')
   })
 
   it.each([
@@ -95,6 +107,40 @@ describe('akeneo client security', () => {
     })).toBe('https://pim.example.internal')
   })
 
+  it('rejects allowlisted Akeneo hosts that resolve to private IPs before sending credentials', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    const lookupHost = jest.fn(async () => [{ address: '10.0.0.5', family: 4 }])
+    const client = createTestAkeneoClient(validCredentials, {
+      lookupHost,
+    })
+
+    await expect(client.getSystemProbe()).rejects.toMatchObject({ reason: 'private_ip_resolved' })
+    expect(lookupHost).toHaveBeenCalledWith('tenant.cloud.akeneo.com')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('allows private Akeneo DNS resolution only when the operator opts in', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
+    const lookupHost = jest.fn(async () => [{ address: '10.0.0.5', family: 4 }])
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        access_token: 'token-123',
+        expires_in: 3600,
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        pim_version: '7.0.0',
+      }))
+
+    const client = createTestAkeneoClient(validCredentials, {
+      lookupHost,
+      allowPrivate: true,
+    })
+
+    await expect(client.getSystemProbe()).resolves.toEqual({ version: '7.0.0' })
+    expect(lookupHost).not.toHaveBeenCalled()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
   it('uses the fixed oauth token endpoint on the validated Akeneo origin', async () => {
     const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
     fetchMock
@@ -106,7 +152,7 @@ describe('akeneo client security', () => {
         pim_version: '7.0.0',
       }))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     await expect(client.getSystemProbe()).resolves.toEqual({ version: '7.0.0' })
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
@@ -138,7 +184,7 @@ describe('akeneo client security', () => {
         items_count: 1,
       }))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     await expect(client.getSystemProbe()).resolves.toEqual({ version: null })
 
     expect(fetchMock).toHaveBeenCalledTimes(3)
@@ -156,7 +202,7 @@ describe('akeneo client security', () => {
         items_count: 0,
       }))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     await expect(client.getSystemProbe()).resolves.toEqual({ version: null })
   })
 
@@ -167,13 +213,13 @@ describe('akeneo client security', () => {
       .mockResolvedValueOnce(new Response('system information unavailable', { status: 404 }))
       .mockResolvedValueOnce(new Response('unreachable', { status: 500 }))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     await expect(client.getSystemProbe()).rejects.toThrow('Akeneo request failed (500)')
   })
 
   it('rejects cross-origin next urls before any authenticated request is sent', async () => {
     const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
 
     await expect(client.listProducts({
       nextUrl: 'https://attacker.test/api/rest/v1/products-uuid?search_after=abc',
@@ -202,7 +248,7 @@ describe('akeneo client security', () => {
         items_count: 0,
       }))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     await expect(client.listCategories(null, 1)).rejects.toThrow('configured host')
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
@@ -225,7 +271,7 @@ describe('akeneo client security', () => {
         },
       }))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     await expect(client.downloadMediaFile('asset-1')).rejects.toThrow('configured host')
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
@@ -251,7 +297,7 @@ describe('akeneo client security', () => {
         items_count: 1,
       }))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     const page = await client.listProducts({
       nextUrl: 'https://tenant.cloud.akeneo.com/api/rest/v1/products-uuid?search_after=abc',
       batchSize: 1,
@@ -318,7 +364,7 @@ describe('akeneo client resilience (issue #2976)', () => {
       return new Response('rate limited', { status: 429, headers: { 'retry-after': '1' } })
     })
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     await expect(client.listChannels()).rejects.toThrow('Akeneo request failed (429)')
 
     // 1 token + (maxRetries + 1) request attempts = 1 + 3 = 4 fetches; 2 sleeps.
@@ -340,7 +386,7 @@ describe('akeneo client resilience (issue #2976)', () => {
       return jsonResponse({ _embedded: { items: [{ code: 'web' }] }, _links: {}, items_count: 1 })
     })
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     const channels = await client.listChannels()
 
     expect(channels).toHaveLength(1)
@@ -353,7 +399,7 @@ describe('akeneo client resilience (issue #2976)', () => {
       .mockResolvedValueOnce(tokenResponse())
       .mockResolvedValueOnce(jsonResponse({ _embedded: { items: [] }, _links: {}, items_count: 0 }))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     await client.listChannels()
 
     const tokenInit = fetchMock.mock.calls[0][1] as RequestInit
@@ -368,7 +414,7 @@ describe('akeneo client resilience (issue #2976)', () => {
       .mockResolvedValueOnce(tokenResponse())
       .mockRejectedValueOnce(new FetchTimeoutError('https://tenant.cloud.akeneo.com/api/rest/v1/channels', 30_000))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient(validCredentials)
     await expect(client.listChannels()).rejects.toBeInstanceOf(FetchTimeoutError)
   })
 })

--- a/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/lib/client.ts
@@ -1,4 +1,15 @@
-import { fetchWithTimeout } from '@open-mercato/shared/lib/http/fetchWithTimeout'
+import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
+import {
+  FetchTimeoutError,
+  type FetchWithTimeoutInit,
+  resolveTimeoutMs,
+} from '@open-mercato/shared/lib/http/fetchWithTimeout'
+import {
+  safeOutboundFetch,
+  type HostLookup,
+  type SafeOutboundFetchOptions,
+  type UrlSafetyReason,
+} from '@open-mercato/shared/lib/url-safety'
 import { dedupeStrings, labelFromLocalizedRecord, safeRecord, type AkeneoAttribute, type AkeneoAttributeOption, type AkeneoCategory, type AkeneoChannel, type AkeneoCredentialShape, type AkeneoFamily, type AkeneoFamilyVariant, type AkeneoLocale, type AkeneoProduct, type AkeneoProductModel } from './shared'
 
 type TokenState = {
@@ -32,14 +43,39 @@ type AkeneoMediaFile = {
   }
 }
 
+export type AkeneoClientDeps = {
+  lookupHost?: HostLookup
+  allowPrivate?: boolean
+  fetchImpl?: SafeOutboundFetchOptions['fetchImpl']
+}
+
+export class UnsafeAkeneoUrlError extends Error {
+  public readonly reason: string
+
+  constructor(reason: UrlSafetyReason, message?: string) {
+    super(message ?? `Akeneo URL rejected: ${reason}`)
+    this.name = 'UnsafeAkeneoUrlError'
+    this.reason = reason
+  }
+}
+
 type AkeneoClient = ReturnType<typeof createAkeneoClient>
 
+const AKENEO_URL_SUBJECT = 'Akeneo URL'
 const DEFAULT_ALLOWED_AKENEO_HOST_PATTERNS = ['*.cloud.akeneo.com', '*.akeneo.cloud'] as const
 const ALLOWED_AKENEO_HOSTS_ENV_KEYS = [
   'OM_INTEGRATION_AKENEO_ALLOWED_HOSTS',
   'OPENMERCATO_AKENEO_ALLOWED_HOSTS',
   'AKENEO_ALLOWED_HOSTS',
 ] as const
+const ALLOW_PRIVATE_AKENEO_URLS_ENV_KEYS = [
+  'OM_INTEGRATION_AKENEO_ALLOW_PRIVATE_URLS',
+  'OPENMERCATO_AKENEO_ALLOW_PRIVATE_URLS',
+  'AKENEO_ALLOW_PRIVATE_URLS',
+] as const
+
+const akeneoUrlErrorFactory = (reason: UrlSafetyReason, message: string) =>
+  new UnsafeAkeneoUrlError(reason, message)
 
 function normalizeBaseUrl(url: string): string {
   return url.trim().replace(/\/+$/g, '')
@@ -59,6 +95,16 @@ function readAllowedAkeneoHostPatterns(env: NodeJS.ProcessEnv = process.env): st
   }
 
   return [...DEFAULT_ALLOWED_AKENEO_HOST_PATTERNS]
+}
+
+function isAllowPrivateAkeneoUrlsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  for (const key of ALLOW_PRIVATE_AKENEO_URLS_ENV_KEYS) {
+    const raw = env[key]
+    if (typeof raw === 'string' && raw.trim().length > 0) {
+      return parseBooleanWithDefault(raw, false)
+    }
+  }
+  return false
 }
 
 function matchesAkeneoHostPattern(hostname: string, pattern: string): boolean {
@@ -225,7 +271,52 @@ function clampAkeneoRetryAfterMs(retryAfterHeader: string | null, env: NodeJS.Pr
   return Math.min(Math.max(requestedMs, 0), cap)
 }
 
-export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
+async function safeAkeneoFetchWithTimeout(
+  input: string,
+  init: FetchWithTimeoutInit = {},
+  deps: AkeneoClientDeps = {},
+): Promise<Response> {
+  const { timeoutMs, signal, ...rest } = init
+  const effectiveTimeout = resolveTimeoutMs(timeoutMs)
+  const controller = new AbortController()
+  const timer: ReturnType<typeof setTimeout> = setTimeout(() => {
+    controller.abort(new FetchTimeoutError(input, effectiveTimeout))
+  }, effectiveTimeout)
+
+  const onExternalAbort = () => {
+    controller.abort((signal as AbortSignal | undefined)?.reason)
+  }
+
+  if (signal) {
+    if (signal.aborted) {
+      clearTimeout(timer)
+      throw signal.reason instanceof Error ? signal.reason : new DOMException('Aborted', 'AbortError')
+    }
+    signal.addEventListener('abort', onExternalAbort, { once: true })
+  }
+
+  try {
+    return await safeOutboundFetch(input, { ...rest, signal: controller.signal }, {
+      errorFactory: akeneoUrlErrorFactory,
+      subject: AKENEO_URL_SUBJECT,
+      allowPrivate: deps.allowPrivate ?? isAllowPrivateAkeneoUrlsEnabled(),
+      lookupHost: deps.lookupHost,
+      fetchImpl: deps.fetchImpl,
+    })
+  } catch (err) {
+    if ((err as { name?: string } | null)?.name === 'AbortError') {
+      const reason = (controller.signal as AbortSignal & { reason?: unknown }).reason
+      if (reason instanceof FetchTimeoutError) throw reason
+      if (reason instanceof Error) throw reason
+    }
+    throw err
+  } finally {
+    clearTimeout(timer)
+    if (signal) signal.removeEventListener('abort', onExternalAbort)
+  }
+}
+
+export function createAkeneoClient(credentialsInput: Record<string, unknown>, deps: AkeneoClientDeps = {}) {
   const credentials = coerceCredentials(credentialsInput)
   const akeneoBaseUrl = new URL(`${credentials.apiUrl}/`)
   const tokenEndpointUrl = new URL('/api/oauth/v1/token', akeneoBaseUrl).toString()
@@ -251,7 +342,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
   }
 
   async function acquirePasswordGrantToken(): Promise<TokenState> {
-    const response = await fetchWithTimeout(tokenEndpointUrl, {
+    const response = await safeAkeneoFetchWithTimeout(tokenEndpointUrl, {
       method: 'POST',
       timeoutMs: resolveAkeneoRequestTimeoutMs(),
       headers: {
@@ -265,7 +356,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
         username: credentials.username,
         password: credentials.password,
       }),
-    })
+    }, deps)
 
     if (!response.ok) {
       const message = await response.text()
@@ -290,7 +381,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
 
   async function refreshAccessToken(current: TokenState): Promise<TokenState> {
     if (!current.refreshToken) return acquirePasswordGrantToken()
-    const response = await fetchWithTimeout(tokenEndpointUrl, {
+    const response = await safeAkeneoFetchWithTimeout(tokenEndpointUrl, {
       method: 'POST',
       timeoutMs: resolveAkeneoRequestTimeoutMs(),
       headers: {
@@ -303,7 +394,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
         client_secret: credentials.clientSecret,
         refresh_token: current.refreshToken,
       }),
-    })
+    }, deps)
 
     if (!response.ok) {
       return acquirePasswordGrantToken()
@@ -339,7 +430,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     const url = resolveAkeneoRequestUrl(pathOrUrl)
     const token = await ensureToken()
 
-    const response = await fetchWithTimeout(url, {
+    const response = await safeAkeneoFetchWithTimeout(url, {
       ...init,
       timeoutMs: resolveAkeneoRequestTimeoutMs(),
       headers: {
@@ -347,7 +438,7 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
         authorization: `Bearer ${token}`,
         ...init.headers,
       },
-    })
+    }, deps)
 
     if (response.status === 401 && !retried) {
       await ensureToken(true)
@@ -388,14 +479,14 @@ export function createAkeneoClient(credentialsInput: Record<string, unknown>) {
     const url = resolveAkeneoRequestUrl(pathOrUrl)
     const token = await ensureToken()
 
-    const response = await fetchWithTimeout(url, {
+    const response = await safeAkeneoFetchWithTimeout(url, {
       ...init,
       timeoutMs: resolveAkeneoRequestTimeoutMs(),
       headers: {
         authorization: `Bearer ${token}`,
         ...init.headers,
       },
-    })
+    }, deps)
 
     if (response.status === 401 && !retried) {
       await ensureToken(true)


### PR DESCRIPTION
## Summary
Harden Akeneo outbound requests so allowlisted custom hostnames cannot bypass SSRF protections through private-IP DNS resolution or DNS rebinding.

Fixes #3920.

## Changes
- Route Akeneo token, API, refresh, and media requests through the shared safe outbound fetch helper.
- Reject private/reserved DNS answers by default and pin DNS for the actual request.
- Add deterministic unit tests for private-IP rejection and the explicit trusted-private-network opt-in.
- Update Akeneo docs and env examples for public custom hosts versus private deployments.

## Specification
- [x] N/A - issue-scoped security hardening, no new feature spec required.

## Testing
- [x] `yarn workspace @open-mercato/sync-akeneo test --runTestsByPath src/modules/sync_akeneo/__tests__/client.test.ts --runInBand`
- [x] `yarn workspace @open-mercato/sync-akeneo typecheck`
- [x] `yarn install`
- [x] `yarn build:packages`
- [x] `yarn generate`
- [x] `yarn i18n:check-sync`
- [x] `yarn i18n:check-usage`
- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test`
- [x] `yarn build:app`

## QA
- [x] `skip-qa` - backend client hardening plus docs/env examples, no manual UI flow.

## Labels
- `review` - ready for review.
- `bug`, `security` - inherited from issue #3920.
- `priority-low`, `risk-medium` - inherited from issue #3920.
- `skip-qa` - no customer-facing UI path to manually exercise.
