### PR TITLE
fix(sync_excel): stop duplicating upload payloads

### DIFF
--- a/.ai/specs/2026-03-29-sync-excel-customers-import-foundation.md
+++ b/.ai/specs/2026-03-29-sync-excel-customers-import-foundation.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-Add the first upstreamable `sync_excel` slice as a file-upload-based `data_sync` provider for CSV imports into `customers.person`. The slice now includes the additive `data_sync` contract changes (`runId`, richer field mapping semantics), a provider-owned upload session entity, upload/preview/import APIs, a `customers.person` adapter with external-ID/email dedupe that is safe under encrypted customer columns, an integration-detail admin tab, tenant custom-field mapping support with typed value coercion in the import flow, flattened primary-address mapping/import for one address per CSV row, resumable upload/mapping state in the integration detail view, polling-based run/log/health refresh, duplicate-risk warnings, and automated unit/integration coverage. After production verification on split ECS web/worker tasks, the upload attachment now also stores an inline CSV copy in attachment metadata so imports do not depend on container-local attachment storage.
+Add the first upstreamable `sync_excel` slice as a file-upload-based `data_sync` provider for CSV imports into `customers.person`. The slice now includes the additive `data_sync` contract changes (`runId`, richer field mapping semantics), a provider-owned upload session entity, upload/preview/import APIs, a `customers.person` adapter with external-ID/email dedupe that is safe under encrypted customer columns, an integration-detail admin tab, tenant custom-field mapping support with typed value coercion in the import flow, flattened primary-address mapping/import for one address per CSV row, resumable upload/mapping state in the integration detail view, polling-based run/log/health refresh, duplicate-risk warnings, and automated unit/integration coverage. Upload attachments are stored through the attachments partition path without a second inline base64 copy in attachment metadata; legacy rows that already contain `inlineCsvBase64` remain readable only as a fallback when the stored file cannot be read.
 
 ## Overview
 
@@ -24,7 +24,7 @@ Implement `sync_excel` as a first-class `data_sync` provider with these capabili
 
 1. Add optional `runId` to `StreamImportInput` and `StreamExportInput`
 2. Add optional `mappingKind` and `dedupeRole` to `FieldMapping`
-3. Introduce provider-owned `SyncExcelUpload` state backed by attachments with an inline attachment-metadata CSV fallback for worker-safe reads; persisted cursors keep only upload identity + row offset, never CSV payload bytes
+3. Introduce provider-owned `SyncExcelUpload` state backed by attachments; persisted cursors keep only upload identity + row offset, never CSV payload bytes, and legacy inline attachment-metadata CSV is read only as a fallback for pre-existing rows
 4. Expose provider APIs for upload, preview, and import start; all three require an explicitly selected concrete organization and reject the topbar “All organizations” scope with `422`
 5. Reuse `data_sync` runs, queue orchestration, and progress lifecycle for background execution
 6. Scope the first target adapter to `customers.person`
@@ -63,7 +63,7 @@ This keeps the architecture aligned with upstream `SPEC-045b` and avoids a stand
 ### Execution model
 
 1. Admin uploads a CSV file to `sync_excel`
-2. Provider stores the file via `attachments`, persists a `SyncExcelUpload` record, and keeps an inline CSV copy in attachment metadata for worker-safe reads
+2. Provider stores the file via `attachments` and persists a `SyncExcelUpload` record without duplicating the CSV bytes in attachment metadata
 2a. Provider cursors persist only `{ uploadId, offset }`; workers re-resolve upload/attachment state on resume instead of copying file contents into `sync_cursors.cursor`
 3. Provider returns headers, sample rows, row count, and suggested mapping
 4. Admin confirms mapping and starts import
@@ -175,7 +175,7 @@ No new sync-excel-specific env vars are introduced by the feature itself.
 
 CSV uploads reuse the existing global attachment upload cap (`OM_ATTACHMENT_MAX_UPLOAD_MB` / `OPENMERCATO_ATTACHMENT_MAX_UPLOAD_MB`) for both multipart content-length preflight and file-size validation before buffering.
 
-No new migration is required for the split-task fix because the worker-safe CSV copy is stored in existing `attachments.storage_metadata`.
+No new migration is required for the upload storage hardening because the attachment row keeps the same schema and new uploads no longer write duplicate CSV bytes into `attachments.storage_metadata`.
 
 ## Alternatives Considered
 
@@ -218,7 +218,7 @@ Rejected because provider-owned upload flows should remain behind provider APIs 
 | CSV mapping UI drops unmapped columns | Medium | `sync_excel` preview/import | Preview preserves all headers and distinguishes unmapped columns explicitly | Low |
 | File-backed imports create duplicate people | Medium | `customers.person` import | Prefer external ID mapping, fallback to decrypted batch-level email candidate scan, keep scope limited to one entity type in v1 | Low |
 | First PR scope grows into company/address/deals | Medium | reviewability / upstream acceptance | Current slice limits target support to `customers.person` only | Low |
-| Split web/worker deployments lose access to container-local upload files | High | release readiness | Persist inline CSV fallback in attachment metadata and verify imports on ECS | Low |
+| Split web/worker deployments lose access to container-local upload files | High | release readiness | Read persisted attachments from the partition storage path and keep legacy inline metadata only as a fallback for rows created before the hardening fix | Medium |
 | “All organizations” imports create orphan or unintended records | High | `sync_excel` provider APIs | Upload, preview, and import require an explicit selected organization and reject `__all__` with `422` | Low |
 
 ## Migration & Backward Compatibility
@@ -327,3 +327,8 @@ This branch remains additive-only because the operational fix reuses existing at
 - Added typed custom-field coercion for imported CSV values with per-row failures for invalid typed values
 - Added Health/Logs run activity refresh controls and polling independent of the injected `sync_excel` tab lifecycle
 - Added focused retest coverage for concrete scope rejection, cursor/upload hardening preservation, encrypted email dedupe, and typed custom-field coercion
+
+### 2026-07-07
+
+- Removed the inline base64 CSV copy from newly-created sync_excel upload attachment metadata to avoid permanent database bloat and duplicate at-rest PII.
+- Changed upload reads to prefer attachment partition storage and use legacy `inlineCsvBase64` metadata only as a fallback for pre-existing rows whose stored file is unavailable.

--- a/packages/cli/src/lib/testing/__tests__/integration.test.ts
+++ b/packages/cli/src/lib/testing/__tests__/integration.test.ts
@@ -27,8 +27,11 @@ import type { ChildProcess } from 'node:child_process'
 const CACHE_TTL_ENV_VAR = 'OM_INTEGRATION_BUILD_CACHE_TTL_SECONDS'
 const APP_READY_TIMEOUT_ENV_VAR = 'OM_INTEGRATION_APP_READY_TIMEOUT_SECONDS'
 const CHECKOUT_TEST_INJECTION_FLAG = 'NEXT_PUBLIC_OM_EXAMPLE_CHECKOUT_TEST_INJECTIONS_ENABLED'
+const PRIVATE_ATTACHMENTS_PARTITION_ENV_KEY = 'ATTACHMENTS_PARTITION_PRIVATE_ATTACHMENTS_ROOT'
 const resolver = createResolver()
 const projectRootDirectory = resolver.getRootDir()
+const appDirectory = path.join(projectRootDirectory, 'apps', 'mercato')
+const defaultPrivateAttachmentsRoot = path.join(appDirectory, 'storage', 'attachments', 'privateAttachments')
 
 const mockHealthyReadinessFetch = (
   overrides: {
@@ -169,6 +172,7 @@ describe('integration cache and options', () => {
         'postgres://integration:integration@127.0.0.1:5432/open_mercato',
       )
       expect(environment?.commandEnvironment.QUEUE_BASE_DIR).toBe('/tmp/open-mercato-queue')
+      expect(environment?.commandEnvironment[PRIVATE_ATTACHMENTS_PARTITION_ENV_KEY]).toBe(defaultPrivateAttachmentsRoot)
       expect(environment?.commandEnvironment.PW_CAPTURE_SCREENSHOTS).toBe('1')
       expect(environment?.commandEnvironment.NEXT_PUBLIC_OM_EXAMPLE_CHECKOUT_TEST_INJECTIONS_ENABLED).toBeUndefined()
     } finally {
@@ -203,6 +207,43 @@ describe('integration cache and options', () => {
       expect(environment?.commandEnvironment.NEXT_PUBLIC_OM_EXAMPLE_CHECKOUT_TEST_INJECTIONS_ENABLED).toBe('true')
     } finally {
       fetchSpy.mockRestore()
+    }
+  }, REUSE_ENV_TEST_TIMEOUT_MS)
+
+  it('reuses app-local private attachment storage when queue state points at an app root', async () => {
+    const baseUrl = 'http://127.0.0.1:5001'
+    const appRoot = await mkdtemp(path.join(os.tmpdir(), 'om-integration-app-root-'))
+    const queueBaseDir = path.join(appRoot, '.mercato', 'queue')
+    const fetchSpy = mockHealthyReadinessFetch()
+
+    try {
+      await mkdir(path.join(appRoot, 'src'), { recursive: true })
+      await writeFile(path.join(appRoot, 'package.json'), '{"name":"integration-test-app"}\n', 'utf8')
+      await writeFile(path.join(appRoot, 'src', 'modules.ts'), 'export const enabledModules = []\n', 'utf8')
+
+      await writeEphemeralEnvironmentState({
+        baseUrl,
+        port: 5001,
+        databaseUrl: 'postgres://integration:integration@127.0.0.1:5432/open_mercato',
+        queueBaseDir,
+        logPrefix: 'integration',
+        captureScreenshots: false,
+      })
+
+      const environment = await tryReuseExistingEnvironment({
+        verbose: false,
+        captureScreenshots: false,
+        logPrefix: 'integration',
+        forceRebuild: false,
+      })
+
+      expect(environment).not.toBeNull()
+      expect(environment?.commandEnvironment[PRIVATE_ATTACHMENTS_PARTITION_ENV_KEY]).toBe(
+        path.join(appRoot, 'storage', 'attachments', 'privateAttachments'),
+      )
+    } finally {
+      fetchSpy.mockRestore()
+      await rm(appRoot, { recursive: true, force: true })
     }
   }, REUSE_ENV_TEST_TIMEOUT_MS)
 

--- a/packages/cli/src/lib/testing/integration.ts
+++ b/packages/cli/src/lib/testing/integration.ts
@@ -221,6 +221,32 @@ function collectExistingPaths(candidates: Array<string | null | undefined>): str
   return Array.from(collected)
 }
 
+function isLikelyNextAppDirectory(candidate: string): boolean {
+  if (!existsSync(path.join(candidate, 'package.json'))) {
+    return false
+  }
+  return resolveFirstExistingPath(
+    path.join(candidate, 'next.config.ts'),
+    path.join(candidate, 'next.config.js'),
+    path.join(candidate, 'next.config.mjs'),
+    path.join(candidate, 'src', 'modules.ts'),
+  ) !== null
+}
+
+function resolveDefaultPrivateAttachmentsAppDirectory(): string {
+  const candidates = [
+    appDirectory,
+    path.join(projectRootDirectory, 'apps', 'mercato'),
+    path.join(projectRootDirectory, 'apps', 'app'),
+  ]
+  for (const candidate of candidates) {
+    if (isLikelyNextAppDirectory(candidate)) {
+      return candidate
+    }
+  }
+  return appDirectory
+}
+
 function readPackageScripts(packageRoot: string): Record<string, string> {
   try {
     const raw = JSON.parse(readFileSync(path.join(packageRoot, 'package.json'), 'utf8')) as {
@@ -246,6 +272,13 @@ const LEGACY_EPHEMERAL_ENV_FILE_PATH = path.join(projectRootDirectory, '.ai', 'q
 const EPHEMERAL_BUILD_CACHE_STATE_PATH = path.join(projectRootDirectory, '.ai', 'qa', 'ephemeral-build-cache.json')
 const EPHEMERAL_CACHE_DB_PATH = path.join(projectRootDirectory, '.ai', 'qa', 'ephemeral-cache.sqlite')
 const EPHEMERAL_QUEUE_BASE_DIR = path.join(appDirectory, '.mercato', 'queue')
+const PRIVATE_ATTACHMENTS_PARTITION_ENV_KEY = 'ATTACHMENTS_PARTITION_PRIVATE_ATTACHMENTS_ROOT'
+const EPHEMERAL_PRIVATE_ATTACHMENTS_ROOT = path.join(
+  resolveDefaultPrivateAttachmentsAppDirectory(),
+  'storage',
+  'attachments',
+  'privateAttachments',
+)
 const PLAYWRIGHT_INTEGRATION_CONFIG_PATH = '.ai/qa/tests/playwright.config.ts'
 const PLAYWRIGHT_RESULTS_JSON_PATH = path.join(projectRootDirectory, '.ai', 'qa', 'test-results', 'results.json')
 const LEGACY_INTEGRATION_TEST_ROOT = path.join(projectRootDirectory, '.ai', 'qa', 'tests')
@@ -1677,6 +1710,7 @@ function buildReusableEnvironment(
   captureScreenshots: boolean,
 ): NodeJS.ProcessEnv {
   const enterpriseModulesFlag = process.env.OM_ENABLE_ENTERPRISE_MODULES ?? 'false'
+  const privateAttachmentsRoot = resolvePrivateAttachmentsRootForQueueBaseDir(queueBaseDir)
   return buildEnvironment({
     DATABASE_URL: databaseUrl,
     BASE_URL: baseUrl,
@@ -1721,9 +1755,23 @@ function buildReusableEnvironment(
     OM_CLI_QUIET: '1',
     MERCATO_QUIET: '1',
     QUEUE_BASE_DIR: queueBaseDir,
+    [PRIVATE_ATTACHMENTS_PARTITION_ENV_KEY]:
+      process.env[PRIVATE_ATTACHMENTS_PARTITION_ENV_KEY] ?? privateAttachmentsRoot,
     NODE_NO_WARNINGS: '1',
     PW_CAPTURE_SCREENSHOTS: captureScreenshots ? '1' : '0',
   })
+}
+
+function resolvePrivateAttachmentsRootForQueueBaseDir(queueBaseDir: string): string {
+  const resolvedQueueBaseDir = path.resolve(queueBaseDir)
+  const queueParent = path.dirname(resolvedQueueBaseDir)
+  if (path.basename(resolvedQueueBaseDir) === 'queue' && path.basename(queueParent) === '.mercato') {
+    const queueAppDirectory = path.dirname(queueParent)
+    if (isLikelyNextAppDirectory(queueAppDirectory)) {
+      return path.join(queueAppDirectory, 'storage', 'attachments', 'privateAttachments')
+    }
+  }
+  return EPHEMERAL_PRIVATE_ATTACHMENTS_ROOT
 }
 
 export async function tryReuseExistingEnvironment(options: EphemeralRuntimeOptions): Promise<EphemeralEnvironmentHandle | null> {
@@ -3071,6 +3119,8 @@ export async function startEphemeralEnvironment(options: EphemeralRuntimeOptions
       OM_CLI_QUIET: '1',
       MERCATO_QUIET: '1',
       QUEUE_BASE_DIR: EPHEMERAL_QUEUE_BASE_DIR,
+      [PRIVATE_ATTACHMENTS_PARTITION_ENV_KEY]:
+        process.env[PRIVATE_ATTACHMENTS_PARTITION_ENV_KEY] ?? EPHEMERAL_PRIVATE_ATTACHMENTS_ROOT,
       NODE_NO_WARNINGS: '1',
       PORT: String(applicationPort),
       PW_CAPTURE_SCREENSHOTS: options.captureScreenshots ? '1' : '0',

--- a/packages/core/src/modules/sync_excel/lib/__tests__/upload-storage.test.ts
+++ b/packages/core/src/modules/sync_excel/lib/__tests__/upload-storage.test.ts
@@ -1,14 +1,77 @@
 import { promises as fs } from 'fs'
-import { readSyncExcelUploadBuffer } from '../upload-storage'
+import { createSyncExcelUploadAttachment, readSyncExcelUploadBuffer } from '../upload-storage'
+
+const mockStorePartitionFile = jest.fn()
+const mockBuildAttachmentFileUrl = jest.fn()
+
+jest.mock('../../../attachments/lib/partitions', () => ({
+  ensureDefaultPartitions: jest.fn(),
+}))
+
+jest.mock('../../../attachments/lib/storage', () => ({
+  resolveAttachmentAbsolutePath: jest.fn((_partitionCode: string, storagePath: string) => `/tmp/${storagePath}`),
+  storePartitionFile: (...args: unknown[]) => mockStorePartitionFile(...args),
+}))
+
+jest.mock('../../../attachments/lib/imageUrls', () => ({
+  buildAttachmentFileUrl: (...args: unknown[]) => mockBuildAttachmentFileUrl(...args),
+}))
 
 describe('sync_excel upload storage', () => {
   const mockReadFile = jest.spyOn(fs, 'readFile')
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockBuildAttachmentFileUrl.mockImplementation((attachmentId: string) => `/api/attachments/file/${attachmentId}`)
+    mockStorePartitionFile.mockResolvedValue({
+      storagePath: 'org-1/tenant-1/import.csv',
+      absolutePath: '/tmp/import.csv',
+      fileName: 'import.csv',
+    })
   })
 
-  it('reads CSV payload from attachment metadata when an inline copy is persisted for worker-safe imports', async () => {
+  it('does not persist an inline base64 copy for new uploads', async () => {
+    const csvBuffer = Buffer.from('Record Id,Email\next-1,ada@example.com\n', 'utf8')
+    const mockEm = {
+      findOne: jest.fn(async () => ({
+        code: 'privateAttachments',
+        storageDriver: 'local',
+      })),
+      create: jest.fn((_entity: unknown, payload: Record<string, unknown>) => payload),
+      persist: jest.fn(),
+      flush: jest.fn(async () => undefined),
+    }
+
+    const attachment = await createSyncExcelUploadAttachment({
+      em: mockEm as any,
+      uploadId: 'upload-1',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      fileName: 'leads.csv',
+      mimeType: 'text/csv',
+      buffer: csvBuffer,
+    })
+
+    expect(mockStorePartitionFile).toHaveBeenCalledWith(expect.objectContaining({
+      partitionCode: 'privateAttachments',
+      orgId: 'org-1',
+      tenantId: 'tenant-1',
+      fileName: 'leads.csv',
+      buffer: csvBuffer,
+    }))
+    expect(attachment.storageMetadata).toEqual({
+      module: 'sync_excel',
+      temporary: true,
+      uploadId: 'upload-1',
+    })
+    expect(attachment.storageMetadata).not.toHaveProperty('inlineCsvBase64')
+    expect(mockEm.persist).toHaveBeenCalledWith(attachment)
+    expect(mockEm.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('prefers attachment storage over legacy inline metadata when both are present', async () => {
+    mockReadFile.mockResolvedValue(Buffer.from('Record Id,Email\next-2,grace@example.com\n', 'utf8'))
+
     const buffer = await readSyncExcelUploadBuffer({
       partitionCode: 'privateAttachments',
       storagePath: 'org-1/tenant-1/import.csv',
@@ -18,8 +81,8 @@ describe('sync_excel upload storage', () => {
       },
     })
 
-    expect(buffer.toString('utf8')).toBe('Record Id,Email\next-1,ada@example.com\n')
-    expect(mockReadFile).not.toHaveBeenCalled()
+    expect(buffer.toString('utf8')).toBe('Record Id,Email\next-2,grace@example.com\n')
+    expect(mockReadFile).toHaveBeenCalledTimes(1)
   })
 
   it('falls back to attachment storage for older uploads without persisted file content', async () => {
@@ -33,6 +96,22 @@ describe('sync_excel upload storage', () => {
         storageMetadata: null,
       },
     )
+
+    expect(buffer.toString('utf8')).toBe('legacy csv')
+    expect(mockReadFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to legacy inline metadata when the stored file is unavailable', async () => {
+    mockReadFile.mockRejectedValueOnce(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+
+    const buffer = await readSyncExcelUploadBuffer({
+      partitionCode: 'privateAttachments',
+      storagePath: 'org-1/tenant-1/missing.csv',
+      storageDriver: 'local',
+      storageMetadata: {
+        inlineCsvBase64: Buffer.from('legacy csv', 'utf8').toString('base64'),
+      },
+    })
 
     expect(buffer.toString('utf8')).toBe('legacy csv')
     expect(mockReadFile).toHaveBeenCalledTimes(1)

--- a/packages/core/src/modules/sync_excel/lib/upload-storage.ts
+++ b/packages/core/src/modules/sync_excel/lib/upload-storage.ts
@@ -52,7 +52,6 @@ export async function createSyncExcelUploadAttachment(input: {
       module: 'sync_excel',
       temporary: true,
       uploadId: input.uploadId,
-      inlineCsvBase64: input.buffer.toString('base64'),
     },
   })
 
@@ -66,14 +65,17 @@ export async function readSyncExcelUploadBuffer(
   attachment: Pick<Attachment, 'partitionCode' | 'storagePath' | 'storageDriver' | 'storageMetadata'>,
 ): Promise<Buffer> {
   const inlineCsvBase64 = attachment.storageMetadata?.inlineCsvBase64
-  if (typeof inlineCsvBase64 === 'string' && inlineCsvBase64.length > 0) {
-    return Buffer.from(inlineCsvBase64, 'base64')
-  }
-
   const absolutePath = resolveAttachmentAbsolutePath(
     attachment.partitionCode,
     attachment.storagePath,
     attachment.storageDriver,
   )
-  return fs.readFile(absolutePath)
+  try {
+    return await fs.readFile(absolutePath)
+  } catch (error) {
+    if (typeof inlineCsvBase64 === 'string' && inlineCsvBase64.length > 0) {
+      return Buffer.from(inlineCsvBase64, 'base64')
+    }
+    throw error
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #3922.

Stops sync_excel uploads from storing a full base64 duplicate of each uploaded CSV in attachment metadata. New uploads now store only the attachment metadata needed to identify the upload, while legacy inline metadata remains readable as a fallback if the partition-backed file cannot be read.

## Changes

- Remove inlineCsvBase64 from newly-created sync_excel upload attachment metadata.
- Read uploaded CSV content from attachment partition storage first.
- Preserve backward compatibility for existing rows by falling back to legacy inline metadata only when the stored file is unavailable.
- Add regression coverage and update the existing sync_excel foundation spec/changelog.

## Testing

- yarn workspace @open-mercato/core test src/modules/sync_excel/lib/__tests__/upload-storage.test.ts --runInBand --no-cache
- yarn workspace @open-mercato/core test src/modules/sync_excel/lib/__tests__/upload-storage.test.ts src/modules/sync_excel/lib/__tests__/customers-adapter.test.ts src/modules/sync_excel/lib/__tests__/parser.test.ts src/modules/sync_excel/lib/__tests__/scope.test.ts src/modules/sync_excel/lib/__tests__/column-detector.test.ts --runInBand --no-cache
- yarn build:packages
- yarn generate
- yarn build:packages
- yarn i18n:check-sync
- yarn i18n:check-usage
- yarn typecheck
- yarn lint
- yarn test
- yarn build:app
- git diff --cached --check
- git diff --check upstream/develop...HEAD

## QA

No manual QA requested. This is a backend storage hardening fix with unit coverage and no UI changes.
