### PR TITLE
fix(sync-akeneo): scope option schema lookup (#3921)

### DIFF
--- a/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/catalog-importer.test.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/catalog-importer.test.ts
@@ -1,4 +1,5 @@
 import {
+  createAkeneoImporter,
   filterAkeneoAttributeMappingsByAvailableAttributes,
   normalizeAkeneoSelectValue,
   readLayeredAkeneoValue,
@@ -7,6 +8,21 @@ import {
   resolveAkeneoFieldsetMemberships,
   resolveAkeneoFieldKeysToDetach,
 } from '../lib/catalog-importer'
+
+const mockContainerResolve = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockFindWithDecryption = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: mockContainerResolve,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+}))
 
 describe('akeneo catalog importer value resolution', () => {
   it('does not fall back to a different locale when a base locale is selected', () => {
@@ -203,5 +219,57 @@ describe('akeneo catalog importer value resolution', () => {
       'akeneo_product_multifunctionals',
       'akeneo_product_digital_cameras',
     ])
+  })
+})
+
+describe('akeneo catalog importer option schemas', () => {
+  beforeEach(() => {
+    mockContainerResolve.mockReset()
+    mockFindOneWithDecryption.mockReset()
+    mockFindWithDecryption.mockReset()
+  })
+
+  it('scopes mapped option schema template lookups by tenant and organization', async () => {
+    const scope = { organizationId: 'org-1', tenantId: 'tenant-1' }
+    const commandBus = {
+      execute: jest.fn(async () => ({ result: undefined })),
+    }
+    const externalIdMappingService = {
+      lookupLocalId: jest.fn(async () => 'schema-1'),
+      storeExternalIdMapping: jest.fn(async () => undefined),
+    }
+
+    mockContainerResolve.mockImplementation((key: string) => {
+      if (key === 'em') return {}
+      if (key === 'commandBus') return commandBus
+      if (key === 'dataEngine') return {}
+      if (key === 'externalIdMappingService') return externalIdMappingService
+      if (key === 'cache') throw new Error('[internal] no cache in test')
+      throw new Error(`[internal] unexpected dependency: ${key}`)
+    })
+    mockFindOneWithDecryption.mockResolvedValue({ id: 'schema-1' })
+
+    const importer = await createAkeneoImporter({} as never, scope)
+    await importer.upsertAttributeFamily(
+      { code: 'family-a', labels: { en_US: 'Family A' }, attributes: [] } as never,
+      'en_US',
+      true,
+      true,
+    )
+
+    expect(externalIdMappingService.lookupLocalId).toHaveBeenCalledWith(
+      'sync_akeneo',
+      'catalog_option_schema',
+      'family-a',
+      scope,
+    )
+    const where = mockFindOneWithDecryption.mock.calls[0]?.[2] as Record<string, unknown>
+    expect(where).toMatchObject({
+      id: 'schema-1',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      deletedAt: null,
+    })
+    expect(commandBus.execute).toHaveBeenCalledWith('catalog.optionSchemas.update', expect.any(Object))
   })
 })

--- a/packages/sync-akeneo/src/modules/sync_akeneo/lib/catalog-importer.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/lib/catalog-importer.ts
@@ -1196,7 +1196,18 @@ export async function createAkeneoImporter(client: AkeneoClient, scope: ImportSc
         const schemaCode = slugifyAkeneoCode(`akeneo-${externalId}`)
         const mappedId = await externalIdMappingService.lookupLocalId('sync_akeneo', 'catalog_option_schema', externalId, scope)
         const existing = mappedId
-          ? await findOneWithDecryption(em, CatalogOptionSchemaTemplate, { id: mappedId, deletedAt: null }, undefined, scope)
+          ? await findOneWithDecryption(
+            em,
+            CatalogOptionSchemaTemplate,
+            {
+              id: mappedId,
+              organizationId: scope.organizationId,
+              tenantId: scope.tenantId,
+              deletedAt: null,
+            },
+            undefined,
+            scope,
+          )
           : await findOneWithDecryption(
             em,
             CatalogOptionSchemaTemplate,


### PR DESCRIPTION
## Summary

Fixes a defense-in-depth tenant-scope gap in the Akeneo catalog importer. The mapped external-id branch for `CatalogOptionSchemaTemplate` now filters by `organizationId` and `tenantId`, matching the sibling fallback lookup and the platform scoping rules.

## Changes

- Tightened the mapped option-schema template lookup in `sync_akeneo` to include tenant and organization predicates.
- Added a regression test that drives the mapped-id option-schema path and asserts scoped lookup filters.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — minor scoped security hardening for an existing issue.


## Testing

- `yarn workspace @open-mercato/sync-akeneo test src/modules/sync_akeneo/__tests__/catalog-importer.test.ts --runInBand`
- `yarn workspace @open-mercato/sync-akeneo typecheck`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check`
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI changes.

## Linked issues

Fixes #3921
