### PR TITLE
fix(storage_s3): allow shared S3 namespace reads (#3918)

### DIFF
--- a/packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts
@@ -1,0 +1,122 @@
+/** @jest-environment node */
+
+const mockGetAuthFromRequest = jest.fn()
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+const mockResolveCredentials = jest.fn()
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (name: string) => {
+      if (name === 'integrationCredentialsService') {
+        return { resolve: mockResolveCredentials }
+      }
+      throw new Error(`Unexpected dependency: ${name}`)
+    },
+  })),
+}))
+
+const mockRead = jest.fn()
+const mockDelete = jest.fn()
+const mockGetSignedUrl = jest.fn()
+jest.mock('../lib/s3-driver', () => ({
+  S3StorageDriver: jest.fn().mockImplementation(() => ({
+    read: (...args: unknown[]) => mockRead(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+    getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
+  })),
+}))
+
+import { DELETE } from '../api/delete/storage-providers/s3/delete'
+import { GET } from '../api/get/storage-providers/s3/download'
+import { POST } from '../api/post/storage-providers/s3/signed-url'
+
+const AUTH = { tenantId: 'tenant-1', orgId: 'org-1' }
+const SHARED_KEY = 'docs/org_shared/tenant_shared/shared.txt'
+const FOREIGN_KEY = 'docs/org_other/tenant_tenant-1/private.txt'
+const NESTED_FOREIGN_KEY = 'docs/org_other/tenant_tenant-1/org_org-1/tenant_tenant-1/private.txt'
+
+function jsonRequest(body: unknown): Request {
+  return new Request('http://example.test/api/storage-providers/s3', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('storage_s3 standalone route key scope', () => {
+  beforeEach(() => {
+    mockGetAuthFromRequest.mockResolvedValue(AUTH)
+    mockResolveCredentials.mockResolvedValue({ bucket: 'test-bucket', region: 'eu-central-1' })
+    mockRead.mockReset()
+    mockDelete.mockReset()
+    mockGetSignedUrl.mockReset()
+  })
+
+  it('downloads shared namespace objects for an authorized storage manager', async () => {
+    mockRead.mockResolvedValueOnce({
+      buffer: Buffer.from('shared-bytes'),
+      contentType: 'text/plain',
+    })
+
+    const response = await GET(
+      new Request(`http://example.test/api/storage-providers/s3/download?key=${encodeURIComponent(SHARED_KEY)}`),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toBe('shared-bytes')
+    expect(mockRead).toHaveBeenCalledWith('', SHARED_KEY)
+  })
+
+  it('generates signed URLs for shared namespace objects', async () => {
+    mockGetSignedUrl.mockResolvedValueOnce('https://s3.example.test/shared?sig=abc')
+
+    const response = await POST(jsonRequest({
+      key: SHARED_KEY,
+      operation: 'download',
+      expiresIn: 600,
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      url: 'https://s3.example.test/shared?sig=abc',
+    })
+    expect(mockGetSignedUrl).toHaveBeenCalledWith(SHARED_KEY, 'download', 600, undefined)
+  })
+
+  it('keeps shared namespace keys unavailable for signed upload URLs', async () => {
+    const response = await POST(jsonRequest({
+      key: SHARED_KEY,
+      operation: 'upload',
+      expiresIn: 600,
+    }))
+
+    expect(response.status).toBe(403)
+    expect(mockGetSignedUrl).not.toHaveBeenCalled()
+  })
+
+  it('deletes shared namespace objects for an authorized storage manager', async () => {
+    mockDelete.mockResolvedValueOnce(undefined)
+
+    const response = await DELETE(new Request('http://example.test/api/storage-providers/s3/delete', {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ key: SHARED_KEY }),
+    }))
+
+    expect(response.status).toBe(204)
+    expect(mockDelete).toHaveBeenCalledWith('', SHARED_KEY)
+  })
+
+  it('keeps rejecting keys scoped to another organization or tenant', async () => {
+    for (const key of [FOREIGN_KEY, NESTED_FOREIGN_KEY]) {
+      const response = await GET(
+        new Request(`http://example.test/api/storage-providers/s3/download?key=${encodeURIComponent(key)}`),
+      )
+
+      expect(response.status).toBe(403)
+    }
+    expect(mockRead).not.toHaveBeenCalled()
+  })
+})

--- a/packages/storage-s3/src/modules/storage_s3/api/delete/storage-providers/s3/delete.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/delete/storage-providers/s3/delete.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { isS3KeyAddressableByScope } from '../../../../lib/key-scope'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 
 export const metadata = {
@@ -24,11 +25,6 @@ async function resolveDriver(tenantId: string, orgId: string): Promise<S3Storage
   return new S3StorageDriver(creds)
 }
 
-function isKeyScoped(key: string, orgId: string, tenantId: string): boolean {
-  const parts = key.split('/')
-  return parts.length >= 3 && parts[1] === `org_${orgId}` && parts[2] === `tenant_${tenantId}`
-}
-
 export async function DELETE(req: Request) {
   const auth = await getAuthFromRequest(req)
   if (!auth?.tenantId || !auth.orgId) {
@@ -41,7 +37,7 @@ export async function DELETE(req: Request) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
   }
 
-  if (!isKeyScoped(parsed.data.key, auth.orgId, auth.tenantId)) {
+  if (!isS3KeyAddressableByScope(parsed.data.key, auth.orgId, auth.tenantId)) {
     return NextResponse.json({ error: 'Access denied: key is not scoped to this tenant.' }, { status: 403 })
   }
 

--- a/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download.ts
@@ -8,6 +8,7 @@ import {
   canRenderInlineAttachment,
   sanitizeUploadedFileName,
 } from '@open-mercato/core/modules/attachments/lib/security'
+import { isS3KeyAddressableByScope } from '../../../../lib/key-scope'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 
 export const metadata = {
@@ -25,11 +26,6 @@ async function resolveDriver(tenantId: string, orgId: string): Promise<S3Storage
   return new S3StorageDriver(creds)
 }
 
-function isKeyScoped(key: string, orgId: string, tenantId: string): boolean {
-  const parts = key.split('/')
-  return parts.length >= 3 && parts[1] === `org_${orgId}` && parts[2] === `tenant_${tenantId}`
-}
-
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
   if (!auth?.tenantId || !auth.orgId) {
@@ -41,7 +37,7 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'key query param is required' }, { status: 400 })
   }
 
-  if (!isKeyScoped(key, auth.orgId, auth.tenantId)) {
+  if (!isS3KeyAddressableByScope(key, auth.orgId, auth.tenantId)) {
     return NextResponse.json({ error: 'Access denied: key is not scoped to this tenant.' }, { status: 403 })
   }
 

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/signed-url.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/signed-url.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { isS3KeyAddressableByScope, isS3KeyScopedToTenant } from '../../../../lib/key-scope'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 
 export const metadata = {
@@ -32,11 +33,6 @@ async function resolveDriver(tenantId: string, orgId: string): Promise<S3Storage
   return new S3StorageDriver(creds)
 }
 
-function isKeyScoped(key: string, orgId: string, tenantId: string): boolean {
-  const parts = key.split('/')
-  return parts.length >= 3 && parts[1] === `org_${orgId}` && parts[2] === `tenant_${tenantId}`
-}
-
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)
   if (!auth?.tenantId || !auth.orgId) {
@@ -49,7 +45,11 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
   }
 
-  if (!isKeyScoped(parsed.data.key, auth.orgId, auth.tenantId)) {
+  const { key, operation, expiresIn, contentType } = parsed.data
+  const canAccessKey = operation === 'download'
+    ? isS3KeyAddressableByScope(key, auth.orgId, auth.tenantId)
+    : isS3KeyScopedToTenant(key, auth.orgId, auth.tenantId)
+  if (!canAccessKey) {
     return NextResponse.json({ error: 'Access denied: key is not scoped to this tenant.' }, { status: 403 })
   }
 
@@ -58,7 +58,6 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'S3 integration is not configured.' }, { status: 400 })
   }
 
-  const { key, operation, expiresIn, contentType } = parsed.data
   const url = await driver.getSignedUrl(key, operation, expiresIn, contentType)
   const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString()
 

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
@@ -13,6 +13,7 @@ import {
   resolveAttachmentMaxBytes,
   willExceedAttachmentTenantQuota,
 } from '@open-mercato/core/modules/attachments/lib/upload-limits'
+import { isS3KeyScopedToTenant } from '../../../../lib/key-scope'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 import { randomUUID } from 'crypto'
 
@@ -30,11 +31,6 @@ const responseSchema = z.object({
 
 function sanitizeFileName(name: string): string {
   return name.replace(/[^a-zA-Z0-9._-]/g, '_') || 'upload'
-}
-
-function isKeyScoped(key: string, orgId: string, tenantId: string): boolean {
-  const parts = key.split('/')
-  return parts.length >= 3 && parts[1] === `org_${orgId}` && parts[2] === `tenant_${tenantId}`
 }
 
 async function resolveDriver(
@@ -61,7 +57,7 @@ async function readTenantStorageUsageBytes(
   do {
     const page = await driver.listObjects('', 1000, continuationToken)
     for (const file of page.files) {
-      if (isKeyScoped(file.key, orgId, tenantId)) {
+      if (isS3KeyScopedToTenant(file.key, orgId, tenantId)) {
         totalBytes += file.size
       }
     }
@@ -94,7 +90,7 @@ export async function POST(req: Request) {
 
   const keyOverride = form.get('key') ? String(form.get('key')) : null
 
-  if (keyOverride !== null && !isKeyScoped(keyOverride, auth.orgId, auth.tenantId)) {
+  if (keyOverride !== null && !isS3KeyScopedToTenant(keyOverride, auth.orgId, auth.tenantId)) {
     return NextResponse.json(
       { error: 'Access denied: key override is not scoped to this tenant.' },
       { status: 403 },

--- a/packages/storage-s3/src/modules/storage_s3/lib/key-scope.ts
+++ b/packages/storage-s3/src/modules/storage_s3/lib/key-scope.ts
@@ -1,0 +1,29 @@
+const SHARED_ORG_SEGMENT = 'org_shared'
+const SHARED_TENANT_SEGMENT = 'tenant_shared'
+
+function findScopeSegmentIndex(parts: string[]): number {
+  return parts.findIndex((part, index) => (
+    part.startsWith('org_') && parts[index + 1]?.startsWith('tenant_')
+  ))
+}
+
+function hasScopeSegments(key: string, orgSegment: string, tenantSegment: string): boolean {
+  const parts = key.split('/')
+  const scopeIndex = findScopeSegmentIndex(parts)
+  return scopeIndex >= 0
+    && parts[scopeIndex] === orgSegment
+    && parts[scopeIndex + 1] === tenantSegment
+}
+
+export function isS3KeyScopedToTenant(key: string, orgId: string, tenantId: string): boolean {
+  if (!orgId || !tenantId) return false
+  return hasScopeSegments(key, `org_${orgId}`, `tenant_${tenantId}`)
+}
+
+export function isS3KeyShared(key: string): boolean {
+  return hasScopeSegments(key, SHARED_ORG_SEGMENT, SHARED_TENANT_SEGMENT)
+}
+
+export function isS3KeyAddressableByScope(key: string, orgId: string, tenantId: string): boolean {
+  return isS3KeyScopedToTenant(key, orgId, tenantId) || isS3KeyShared(key)
+}

--- a/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
+++ b/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
@@ -410,7 +410,7 @@ export function AdvancedFilterPanel(props: AdvancedFilterPanelProps) {
         align="end"
         sideOffset={8}
         data-testid="advanced-filter-panel"
-ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
+        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
         onFocusOutside={ignoreAdvancedFilterPortalInteractions}
         onInteractOutside={ignoreAdvancedFilterPortalInteractions}
       >


### PR DESCRIPTION
Fixes #3918

## Problem
Objects written by `S3StorageDriver.store()` without explicit organization and tenant context are stored under `org_shared/tenant_shared`, but the S3 download, delete, and signed-url routes only accepted keys scoped to the caller's concrete `org_<id>/tenant_<id>` prefix.

## Root Cause
The route guards treated tenant-scoped keys as the only addressable namespace. That preserved cross-tenant isolation, but it also made intentionally shared storage keys unreachable through the scoped routes.

## What Changed
- Added a small storage key-scope helper that recognizes caller tenant keys and the shared namespace while still rejecting foreign tenant keys.
- Allowed shared keys for download, delete, and signed download URLs.
- Kept signed upload URLs and upload key overrides restricted to concrete tenant-scoped keys.
- Added route regression coverage for shared access, foreign rejection, and shared signed-upload rejection.

## Tests
- `yarn workspace @open-mercato/storage-s3 test --runTestsByPath src/modules/storage_s3/__tests__/s3Routes.test.ts`
- `yarn workspace @open-mercato/storage-s3 typecheck`

## Backward Compatibility
Existing tenant-scoped keys continue to work unchanged. Foreign tenant keys remain rejected. Shared namespace support is additive for read/delete/download-url paths and does not broaden upload URL issuance.
