### PR TITLE
feat(dev): document OM_WATCH_SCOPE dev-memory lever + emoji watch-mode log

### DIFF
--- a/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
+++ b/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
@@ -1,0 +1,58 @@
+# Dev watch-scope: env docs + memory-optimization docs + emoji log
+
+## Goal
+
+Make the dev-mode watch-scope memory optimization discoverable and pleasant: document `OM_WATCH_SCOPE` in `.env.example`, point README/docs at it near `yarn dev`, and display the active watch mode with a friendly emoji in the dev log.
+
+## Overview
+
+The consolidated package watcher already supports narrowing which packages it tracks via `OM_WATCH_SCOPE` (`all` | `auto-optimized` | `popular` | `env`), which is the main lever for reducing dev-mode memory usage. The behavior is fully implemented (`scripts/watch-scope.mjs`, `scripts/watch-packages.mjs`, `scripts/dev.mjs`) and documented in `apps/docs/docs/appendix/troubleshooting.mdx`, but:
+
+- It is missing from `apps/mercato/.env.example` and the create-app template `.env.example`, so users never discover it.
+- README's `yarn dev` section does not mention the memory-optimization lever.
+- The dev log only prints the scope when it is non-`all`, and without any emoji/visual cue.
+
+### External References
+
+None (no `--skill-url` provided).
+
+## Scope
+
+- `apps/mercato/.env.example` — add a documented `OM_WATCH_SCOPE` block (+ related `OM_WATCH_*` vars).
+- `packages/create-app/template/.env.example` — mirror the same block (kept in sync with mercato).
+- `README.md` — add a short memory-optimization note near the `yarn dev` guidance, linking troubleshooting docs.
+- `apps/docs/docs/installation/setup.mdx` (or nearest `yarn dev` doc) — add a memory-optimization callout pointing at the watch-scope section.
+- `scripts/watch-scope.mjs` — add exported `describeWatchMode()` / emoji map (pure, testable). Mirror into `packages/create-app/template/scripts/watch-scope.mjs` (kept identical).
+- `scripts/dev.mjs` + `packages/create-app/template/scripts/dev.mjs` — always print the active watch mode with an emoji.
+- `scripts/watch-packages.mjs` — use the emoji-decorated mode in its scope log line.
+- `scripts/__tests__/watch-scope.test.mjs` — unit tests for `describeWatchMode()`.
+
+### Non-goals
+
+- No change to watch-scope selection logic or defaults (`all` stays the default).
+- No new env vars or CLI flags.
+- No rewrite of the existing troubleshooting doc section (only cross-links added).
+
+## Risks
+
+- Emoji rendering in non-UTF8 terminals — mitigated by keeping the plain mode name alongside the emoji.
+- Template/root drift for `watch-scope.mjs` (currently byte-identical) — mirror edits and keep them identical.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Emoji watch-mode log + tests
+
+- [ ] 1.1 Add `describeWatchMode()` + emoji map to `scripts/watch-scope.mjs`, mirror into create-app template
+- [ ] 1.2 Use emoji mode in `scripts/dev.mjs` + template `dev.mjs` (always show) and `scripts/watch-packages.mjs`
+- [ ] 1.3 Add unit tests for `describeWatchMode()` in `scripts/__tests__/watch-scope.test.mjs`
+
+### Phase 2: env.example documentation
+
+- [ ] 2.1 Add documented `OM_WATCH_SCOPE` block to `apps/mercato/.env.example` and template `.env.example`
+
+### Phase 3: README + docs memory-optimization guidance
+
+- [ ] 3.1 Add memory-optimization note near `yarn dev` in `README.md`
+- [ ] 3.2 Add memory-optimization callout/cross-link in the installation docs

--- a/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
+++ b/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
@@ -50,7 +50,7 @@ None (no `--skill-url` provided).
 
 ### Phase 2: env.example documentation
 
-- [ ] 2.1 Add documented `OM_WATCH_SCOPE` block to `apps/mercato/.env.example` and template `.env.example`
+- [x] 2.1 Add documented `OM_WATCH_SCOPE` block to `apps/mercato/.env.example` and template `.env.example` — 8080bad6d
 
 ### Phase 3: README + docs memory-optimization guidance
 

--- a/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
+++ b/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
@@ -56,3 +56,4 @@ None (no `--skill-url` provided).
 
 - [x] 3.1 Add memory-optimization note near `yarn dev` in `README.md` — 98a032be5
 - [x] 3.2 Add memory-optimization callout/cross-link in the installation docs — 98a032be5
+- [x] Post-review fix: remove stray `ded` token breaking `AdvancedFilterPanel` typecheck in the CI `test` job (pre-existing on develop) — 0c528c139

--- a/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
+++ b/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
@@ -54,5 +54,5 @@ None (no `--skill-url` provided).
 
 ### Phase 3: README + docs memory-optimization guidance
 
-- [ ] 3.1 Add memory-optimization note near `yarn dev` in `README.md`
-- [ ] 3.2 Add memory-optimization callout/cross-link in the installation docs
+- [x] 3.1 Add memory-optimization note near `yarn dev` in `README.md` — 98a032be5
+- [x] 3.2 Add memory-optimization callout/cross-link in the installation docs — 98a032be5

--- a/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
+++ b/.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
@@ -44,9 +44,9 @@ None (no `--skill-url` provided).
 
 ### Phase 1: Emoji watch-mode log + tests
 
-- [ ] 1.1 Add `describeWatchMode()` + emoji map to `scripts/watch-scope.mjs`, mirror into create-app template
-- [ ] 1.2 Use emoji mode in `scripts/dev.mjs` + template `dev.mjs` (always show) and `scripts/watch-packages.mjs`
-- [ ] 1.3 Add unit tests for `describeWatchMode()` in `scripts/__tests__/watch-scope.test.mjs`
+- [x] 1.1 Add `describeWatchMode()` + emoji map to `scripts/watch-scope.mjs`, mirror into create-app template — aaca79853
+- [x] 1.2 Use emoji mode in `scripts/dev.mjs` + template `dev.mjs` (always show) and `scripts/watch-packages.mjs` — aaca79853
+- [x] 1.3 Add unit tests for `describeWatchMode()` in `scripts/__tests__/watch-scope.test.mjs` — aaca79853
 
 ### Phase 2: env.example documentation
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,24 @@ yarn dev --database-name=review_1720 --no-update-env
 
 Without the flag, behavior is unchanged (no prompt, no `.env` mutation). See the [installation guides](https://docs.openmercato.com/installation/monorepo) and [`yarn setup`](https://docs.openmercato.com/installation/setup) for details.
 
+#### Reducing dev-mode memory usage
+
+`yarn dev` watches every workspace package by default, and the watcher's memory footprint scales with how many packages it tracks. On smaller machines you can narrow the watch scope so only the packages you actually touch stay live — the active mode is printed with an emoji at startup:
+
+```bash
+# Watch only packages you've touched recently (git working tree + branch diff)
+yarn dev --watch=auto-optimized
+OM_WATCH_SCOPE=auto-optimized yarn dev
+
+# Watch only an explicit set of packages
+OM_WATCH_SCOPE=env OM_WATCH_PACKAGES=core,ui yarn dev
+
+# Watch only the most frequently changed packages (default cap: 6)
+yarn dev --watch=popular
+```
+
+Set `OM_WATCH_SCOPE=all` (or `--watch=all`) to restore watching every package. See [Choosing which packages the watcher tracks](https://docs.openmercato.com/appendix/troubleshooting) for the full reference, including `OM_WATCH_POPULAR_LIMIT` and the `git`-detection toggles.
+
 ---
 
 ### Detailed guides (prerequisites, native services, troubleshooting)

--- a/apps/docs/docs/appendix/troubleshooting.mdx
+++ b/apps/docs/docs/appendix/troubleshooting.mdx
@@ -78,7 +78,9 @@ OM_WATCH_PACKAGES_MODE=legacy OM_PACKAGE_WATCH_MODE=persistent yarn dev
 
 In the monorepo, `yarn dev` watches **every** workspace package (`packages/*` plus any activated `external/official-modules/packages/*`). On large checkouts you rarely edit more than a handful of packages in one session, so the watcher can be narrowed to a subset. The watch unit is the workspace package (its short label — `core`, `ui`, `shared`, `ai-assistant`, …); the app itself is still watched in full by Next.js/Turbopack regardless of the scope.
 
-Pick a mode with the `OM_WATCH_SCOPE` env var or the `--watch=<mode>` flag on `yarn dev` / `yarn dev:greenfield` (the CLI flag wins over the env var):
+Narrowing the watch scope is the main lever for **reducing dev-mode memory usage**: the watcher's footprint scales with the number of packages it tracks, so watching only the packages you actually edit meaningfully lowers idle RSS on memory-constrained machines.
+
+Pick a mode with the `OM_WATCH_SCOPE` env var or the `--watch=<mode>` flag on `yarn dev` / `yarn dev:greenfield` (the CLI flag wins over the env var). The active mode is printed with an emoji at dev startup — e.g. `watch scope: 🌐 all — all packages` or `watch scope: ⚡ auto-optimized — recently touched` — so you can confirm at a glance which packages are live:
 
 | Mode | What it watches |
 |------|-----------------|

--- a/apps/docs/docs/installation/monorepo.mdx
+++ b/apps/docs/docs/installation/monorepo.mdx
@@ -149,6 +149,8 @@ Open **http://localhost:3000/backend** and sign in with the credentials printed 
 
 The compact runtime also serves a splash page at **http://localhost:4000** with live startup progress. Press `d` while `yarn dev` is running to toggle raw log output.
 
+On memory-constrained machines you can lower `yarn dev`'s footprint by narrowing which workspace packages the watcher tracks with `OM_WATCH_SCOPE` (e.g. `OM_WATCH_SCOPE=auto-optimized yarn dev`). The active mode is printed with an emoji at startup. See [Choosing which packages the watcher tracks](../appendix/troubleshooting#choosing-which-packages-the-watcher-tracks-watch-scope) for the full reference.
+
 ---
 
 ## Upgrading an existing checkout

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -108,6 +108,23 @@ AUTO_SPAWN_WORKERS=true
 # Set to false to run scheduler in a separate process
 AUTO_SPAWN_SCHEDULER=true
 
+# Dev-mode memory optimization: which workspace packages the `yarn dev`
+# package watcher tracks. The watcher's memory footprint scales with the
+# number of watched packages, so narrowing the scope is the main lever for
+# reducing dev-mode RAM usage. Modes (CLI flag `--watch=<mode>` wins over env):
+#   all            watch every package (default, unchanged)
+#   auto-optimized watch only packages touched recently (git working tree +
+#                  current-branch diff), re-checking every 2 minutes
+#   popular        watch only the most frequently changed packages (ranked
+#                  from recent git history; capped by OM_WATCH_POPULAR_LIMIT)
+#   env            watch exactly the packages listed in OM_WATCH_PACKAGES
+# The active mode is printed with an emoji at dev startup. See
+# apps/docs/docs/appendix/troubleshooting.mdx (Choosing which packages the
+# watcher tracks) for the full reference.
+# OM_WATCH_SCOPE=all
+# OM_WATCH_PACKAGES=core,ui,shared   # used when OM_WATCH_SCOPE=env
+# OM_WATCH_POPULAR_LIMIT=6           # cap for OM_WATCH_SCOPE=popular
+
 # Base directory for local file-backed queues (default: ./.mercato/queue)
 QUEUE_BASE_DIR=./.mercato/queue
 

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -141,6 +141,21 @@ NEXT_PUBLIC_OM_EXAMPLE_CHECKOUT_TEST_INJECTIONS_ENABLED=false
 # Set to false to run workers separately in production
 AUTO_SPAWN_WORKERS=true
 
+# Dev-mode memory optimization: which workspace packages the `yarn dev`
+# package watcher tracks. The watcher's memory footprint scales with the
+# number of watched packages, so narrowing the scope is the main lever for
+# reducing dev-mode RAM usage. Modes (CLI flag `--watch=<mode>` wins over env):
+#   all            watch every package (default, unchanged)
+#   auto-optimized watch only packages touched recently (git working tree +
+#                  current-branch diff), re-checking every 2 minutes
+#   popular        watch only the most frequently changed packages (ranked
+#                  from recent git history; capped by OM_WATCH_POPULAR_LIMIT)
+#   env            watch exactly the packages listed in OM_WATCH_PACKAGES
+# The active mode is printed with an emoji at dev startup.
+# OM_WATCH_SCOPE=all
+# OM_WATCH_PACKAGES=core,ui,shared   # used when OM_WATCH_SCOPE=env
+# OM_WATCH_POPULAR_LIMIT=6           # cap for OM_WATCH_SCOPE=popular
+
 # Base directory for local file-backed queues (default: ./.mercato/queue)
 QUEUE_BASE_DIR=./.mercato/queue
 

--- a/packages/create-app/template/scripts/dev.mjs
+++ b/packages/create-app/template/scripts/dev.mjs
@@ -35,7 +35,7 @@ import {
   resolveSplashUrl as resolveSplashAccessUrl,
 } from './dev-splash-url.mjs'
 import { resolveDatabaseNameOverride } from './dev-database-url.mjs'
-import { parseWatchScopeArgs, resolveWatchScope } from './watch-scope.mjs'
+import { describeWatchMode, parseWatchScopeArgs, resolveWatchScope } from './watch-scope.mjs'
 
 function detectDevRuntimeMode() {
   const cwd = process.cwd()
@@ -1612,14 +1612,16 @@ function startPackageWatch() {
   const stageCurrent = greenfield ? 5 : 2
   const stageTotal = greenfield ? 5 : 3
   console.log(`👀 ${formatProgressLine('Watching workspace packages', stageCurrent, stageTotal, resolveProgressPercent(stageCurrent, stageTotal))}`)
-  if (activeScope !== 'all') {
-    console.log(`   ↳ watch scope: ${activeScope} (set OM_WATCH_SCOPE=all or pass --watch=all to watch every package)`)
+  const watchMode = describeWatchMode(activeScope)
+  console.log(`   ↳ watch scope: ${watchMode.text}`)
+  if (watchMode.mode !== 'all') {
+    console.log('     tip: set OM_WATCH_SCOPE=all or pass --watch=all to watch every package')
   }
   updateSplashState({
     phase: 'Watching workspace packages',
-    detail: activeScope === 'all'
+    detail: watchMode.mode === 'all'
       ? 'Package watchers are running in the background'
-      : `Package watchers are running (watch scope: ${activeScope})`,
+      : `Package watchers are running (watch scope: ${watchMode.text})`,
     progressCurrent: stageCurrent,
     progressTotal: stageTotal,
     progressPercent: resolveProgressPercent(stageCurrent, stageTotal),

--- a/packages/create-app/template/scripts/watch-scope.mjs
+++ b/packages/create-app/template/scripts/watch-scope.mjs
@@ -36,6 +36,24 @@ export const WATCH_SCOPES = [
   WATCH_SCOPE_ENV,
 ]
 
+// Friendly emoji + short description for each watch scope, used when the dev
+// runtime announces the active mode in the log.
+export const WATCH_SCOPE_DESCRIPTIONS = {
+  [WATCH_SCOPE_ALL]: { emoji: '🌐', label: 'all packages' },
+  [WATCH_SCOPE_AUTO]: { emoji: '⚡', label: 'auto-optimized (recently touched)' },
+  [WATCH_SCOPE_POPULAR]: { emoji: '🔥', label: 'popular (most frequently changed)' },
+  [WATCH_SCOPE_ENV]: { emoji: '🎯', label: 'explicit selection' },
+}
+
+// Resolve an emoji-decorated description of a watch mode for log output.
+// Unknown modes fall back to the `all` description so callers always get a
+// stable `{ mode, emoji, label, text }` shape.
+export function describeWatchMode(mode) {
+  const normalized = WATCH_SCOPES.includes(mode) ? mode : WATCH_SCOPE_ALL
+  const { emoji, label } = WATCH_SCOPE_DESCRIPTIONS[normalized]
+  return { mode: normalized, emoji, label, text: `${emoji} ${normalized} — ${label}` }
+}
+
 // Re-check + expand interval for `auto-optimized`.
 export const AUTO_EXPAND_INTERVAL_MS = 120000
 

--- a/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
+++ b/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
@@ -410,7 +410,7 @@ export function AdvancedFilterPanel(props: AdvancedFilterPanelProps) {
         align="end"
         sideOffset={8}
         data-testid="advanced-filter-panel"
-ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
+        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
         onFocusOutside={ignoreAdvancedFilterPortalInteractions}
         onInteractOutside={ignoreAdvancedFilterPortalInteractions}
       >

--- a/scripts/__tests__/watch-packages-scope.test.mjs
+++ b/scripts/__tests__/watch-packages-scope.test.mjs
@@ -45,7 +45,7 @@ test('runConsolidatedWatch honors OM_WATCH_SCOPE=env and tracks only the listed 
 
     assert.deepEqual(packages.map((p) => p.shortLabel).sort(), ['alpha', 'charlie'])
     assert.ok(
-      logs.some((line) => line.includes('watch scope: env')),
+      logs.some((line) => /watch scope: \S+ env\b/.test(line)),
       `expected watch scope log, got: ${logs.join('\n')}`,
     )
   } finally {

--- a/scripts/__tests__/watch-scope.test.mjs
+++ b/scripts/__tests__/watch-scope.test.mjs
@@ -11,6 +11,9 @@ import {
   WATCH_SCOPE_AUTO,
   WATCH_SCOPE_ENV,
   WATCH_SCOPE_POPULAR,
+  WATCH_SCOPE_DESCRIPTIONS,
+  WATCH_SCOPES,
+  describeWatchMode,
   detectTouchedPackages,
   mapChangedPathsToPackages,
   matchPackagesByLabels,
@@ -219,4 +222,24 @@ test('selectWatchedPackages: auto mode seeds when nothing is touched', () => {
 
 test('AUTO_EXPAND_INTERVAL_MS is two minutes', () => {
   assert.equal(AUTO_EXPAND_INTERVAL_MS, 120000)
+})
+
+test('describeWatchMode returns emoji-decorated text for every known scope', () => {
+  for (const mode of WATCH_SCOPES) {
+    const described = describeWatchMode(mode)
+    const { emoji, label } = WATCH_SCOPE_DESCRIPTIONS[mode]
+    assert.equal(described.mode, mode)
+    assert.equal(described.emoji, emoji)
+    assert.equal(described.label, label)
+    assert.equal(described.text, `${emoji} ${mode} — ${label}`)
+    assert.ok(described.text.startsWith(emoji))
+  }
+})
+
+test('describeWatchMode falls back to the all description for unknown/empty modes', () => {
+  const fallback = describeWatchMode('nonsense')
+  assert.equal(fallback.mode, WATCH_SCOPE_ALL)
+  assert.equal(fallback.emoji, WATCH_SCOPE_DESCRIPTIONS[WATCH_SCOPE_ALL].emoji)
+  assert.deepEqual(describeWatchMode(undefined), fallback)
+  assert.deepEqual(describeWatchMode(''), fallback)
 })

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -35,7 +35,7 @@ import {
   resolveSplashUrl as resolveSplashAccessUrl,
 } from './dev-splash-url.mjs'
 import { resolveDatabaseNameOverride } from './dev-database-url.mjs'
-import { parseWatchScopeArgs, resolveWatchScope } from './watch-scope.mjs'
+import { describeWatchMode, parseWatchScopeArgs, resolveWatchScope } from './watch-scope.mjs'
 import {
   DEFAULT_MEMORY_TRACE_OUT_DIR,
   createMemoryTraceSession,
@@ -1678,14 +1678,16 @@ function startPackageWatch() {
   const stageCurrent = greenfield ? 5 : 2
   const stageTotal = greenfield ? 5 : 3
   console.log(`👀 ${formatProgressLine('Watching workspace packages', stageCurrent, stageTotal, resolveProgressPercent(stageCurrent, stageTotal))}`)
-  if (activeScope !== 'all') {
-    console.log(`   ↳ watch scope: ${activeScope} (set OM_WATCH_SCOPE=all or pass --watch=all to watch every package)`)
+  const watchMode = describeWatchMode(activeScope)
+  console.log(`   ↳ watch scope: ${watchMode.text}`)
+  if (watchMode.mode !== 'all') {
+    console.log('     tip: set OM_WATCH_SCOPE=all or pass --watch=all to watch every package')
   }
   updateSplashState({
     phase: 'Watching workspace packages',
-    detail: activeScope === 'all'
+    detail: watchMode.mode === 'all'
       ? 'Package watchers are running in the background'
-      : `Package watchers are running (watch scope: ${activeScope})`,
+      : `Package watchers are running (watch scope: ${watchMode.text})`,
     progressCurrent: stageCurrent,
     progressTotal: stageTotal,
     progressPercent: resolveProgressPercent(stageCurrent, stageTotal),

--- a/scripts/watch-packages.mjs
+++ b/scripts/watch-packages.mjs
@@ -32,6 +32,7 @@ import { fileURLToPath } from 'node:url'
 import { createAtomicWritePlugin } from './lib/add-js-extension.mjs'
 import {
   AUTO_EXPAND_INTERVAL_MS,
+  describeWatchMode,
   detectTouchedPackages,
   discoverWatchTargets,
   resolveWatchScope,
@@ -230,8 +231,9 @@ export async function runConsolidatedWatch({
   const selection = selectWatchedPackages({ packages: allPackages, config: scopeConfig, root, runGit })
   const selected = selection.selected.length ? selection.selected : allPackages
 
+  const watchMode = describeWatchMode(selection.mode)
+  log(`[watch] watch scope: ${watchMode.emoji} ${watchMode.mode} — ${selection.reason}`)
   if (selection.mode !== 'all') {
-    log(`[watch] watch scope: ${selection.mode} — ${selection.reason}`)
     const excluded = allPackages.length - selected.length
     if (excluded > 0) {
       log(`[watch] watch scope: ${excluded} of ${allPackages.length} package(s) are not watched (set OM_WATCH_SCOPE=all to watch everything)`)

--- a/scripts/watch-scope.mjs
+++ b/scripts/watch-scope.mjs
@@ -36,6 +36,24 @@ export const WATCH_SCOPES = [
   WATCH_SCOPE_ENV,
 ]
 
+// Friendly emoji + short description for each watch scope, used when the dev
+// runtime announces the active mode in the log.
+export const WATCH_SCOPE_DESCRIPTIONS = {
+  [WATCH_SCOPE_ALL]: { emoji: '🌐', label: 'all packages' },
+  [WATCH_SCOPE_AUTO]: { emoji: '⚡', label: 'auto-optimized (recently touched)' },
+  [WATCH_SCOPE_POPULAR]: { emoji: '🔥', label: 'popular (most frequently changed)' },
+  [WATCH_SCOPE_ENV]: { emoji: '🎯', label: 'explicit selection' },
+}
+
+// Resolve an emoji-decorated description of a watch mode for log output.
+// Unknown modes fall back to the `all` description so callers always get a
+// stable `{ mode, emoji, label, text }` shape.
+export function describeWatchMode(mode) {
+  const normalized = WATCH_SCOPES.includes(mode) ? mode : WATCH_SCOPE_ALL
+  const { emoji, label } = WATCH_SCOPE_DESCRIPTIONS[normalized]
+  return { mode: normalized, emoji, label, text: `${emoji} ${normalized} — ${label}` }
+}
+
 // Re-check + expand interval for `auto-optimized`.
 export const AUTO_EXPAND_INTERVAL_MS = 120000
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md
Status: complete

## Goal
- Make the dev-mode watch-scope memory optimization discoverable and pleasant: document `OM_WATCH_SCOPE` in `.env.example`, point README/docs at it near `yarn dev`, and show the active watch mode with a friendly emoji in the dev log.

## What Changed
- **Emoji watch-mode log** — new `describeWatchMode()` + `WATCH_SCOPE_DESCRIPTIONS` in `scripts/watch-scope.mjs` (mirrored byte-identical into the create-app template) map each `OM_WATCH_SCOPE` mode to an emoji + label. `scripts/dev.mjs` and `scripts/watch-packages.mjs` now **always** print the active watch scope with its emoji (previously only shown when non-`all`). Template `dev.mjs` mirrored per the create-app sync checklist.
- **env.example** — documented `OM_WATCH_SCOPE` (+ `OM_WATCH_PACKAGES`, `OM_WATCH_POPULAR_LIMIT`) dev-memory block added to `apps/mercato/.env.example` and the create-app template `.env.example`.
- **Docs** — new "Reducing dev-mode memory usage" subsection in `README.md` next to the `yarn dev` guidance; `troubleshooting.mdx` now frames watch scope explicitly as the main dev-memory lever and notes the startup emoji indicator; monorepo install guide cross-links the section.

## Tests
- Added unit tests for `describeWatchMode()` in `scripts/__tests__/watch-scope.test.mjs` (known modes + unknown/empty fallback). Full watch-scope suite: 21/21 pass.
- `node --check` on all edited `.mjs`; runtime smoke test of the emoji output for every mode; template/root `watch-scope.mjs` confirmed byte-identical.

## Backward Compatibility
- No contract surface changes. New exports are additive; env vars are commented-out defaults; log-line text is internal dev output, not a stable contract. Watch-scope default stays `all`.

## Progress
See [Progress section in the plan](.ai/runs/2026-07-07-dev-watch-scope-docs-and-emoji-log.md#progress).
