### PR TITLE
fix(auth): harden integration login redirect loop diagnostics

### DIFF
--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
@@ -1,0 +1,27 @@
+# Handoff — 2026-07-07-integration-auth-login-redirect-loop
+
+**Last updated:** 2026-07-07T12:06:13Z
+**Branch:** `fix/integration-auth-login-redirect-loop`
+**PR:** not yet opened
+**Current phase/step:** Phase 0 Step 0.1
+**Last commit:** none — run folder not yet committed
+
+## What just happened
+- Created an isolated worktree from `origin/develop`.
+- Drafted the run plan for the auth login redirect-loop implementation.
+
+## Next concrete action
+- Commit the run folder, then Step 0.1 lands the reviewed source spec into `.ai/specs/`.
+
+## Blockers / open questions
+- none
+
+## Environment caveats
+- Dev runtime runnable: unknown
+- Playwright / browser checks: planned for checkpoint/final gate
+- Database/migration state: clean; no migrations planned
+
+## Worktree
+- Path: `/Users/kamil-nowak/Documents/work/development/tracecore/open-mercato/.ai/tmp/auto-create-pr/integration-auth-login-redirect-loop-20260707-140502`
+- Created this run: yes
+

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
@@ -1,10 +1,10 @@
 # Handoff — 2026-07-07-integration-auth-login-redirect-loop
 
-**Last updated:** 2026-07-07T12:39:28Z
+**Last updated:** 2026-07-07T13:34:21Z
 **Branch:** `fix/integration-auth-login-redirect-loop`
 **PR:** not yet opened
-**Current phase/step:** Phase 5 Step 5.1
-**Last commit:** `5c88a0e5f` before checkpoint commit
+**Current phase/step:** ready to open PR
+**Last commit:** `7c3911651` before final-gate commit
 
 ## What Just Happened
 
@@ -15,12 +15,12 @@
 - Added a cookie-backed `/backend` readiness probe in the CLI with bounded same-origin redirect following.
 - Added CLI unit coverage for cookie propagation, redirect-loop diagnostics, unsafe redirect rejection, and cookie-value redaction.
 - Fixed validation fallout from the repo-wide explicit comparator guard.
-- Stabilized the existing CLI build-cache fingerprint test.
-- Ran checkpoint validation; see `checkpoint-1-checks.md`.
+- Stabilized existing CLI build-cache and DataTable test flakes encountered during gates.
+- Ran checkpoint and final gate validation; see `checkpoint-1-checks.md` and `final-gate-checks.md`.
 
 ## Next Concrete Action
 
-- Commit checkpoint 4.1, then run final gate/self-review and open the PR.
+- Commit final-gate run metadata, push, open the PR against `develop`, and apply labels.
 
 ## Blockers / Open Questions
 
@@ -28,9 +28,9 @@
 
 ## Environment Caveats
 
-- `yarn workspace @open-mercato/cli test` fails inside the sandbox on `listen EPERM ::` and `EMFILE: too many open files, watch`.
-- The same full CLI suite passes outside sandbox with the approved escalated command.
-- Ephemeral Playwright `TC-AUTH-053` passed on a fresh environment after readiness completed in 4s.
+- Full CLI/root tests and app build require unsandboxed local listener/process behavior in this environment.
+- The same gates passed outside sandbox with approved escalated commands.
+- `i18n:check-usage` exits 0 with an existing advisory unused-key report.
 
 ## Worktree
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
@@ -1,10 +1,10 @@
 # Handoff — 2026-07-07-integration-auth-login-redirect-loop
 
-**Last updated:** 2026-07-07T13:45:30Z
+**Last updated:** 2026-07-07T15:09:18Z
 **Branch:** `fix/integration-auth-login-redirect-loop`
 **PR:** https://github.com/open-mercato/open-mercato/pull/3963
-**Current phase/step:** PR opened
-**Last commit:** `a09df4d61` before PR-handoff metadata commit
+**Current phase/step:** PR opened; CI rerun pending after merge-ref unblock
+**Last code commit:** `3ddb0583e` before this metadata update
 
 ## What Just Happened
 
@@ -17,14 +17,17 @@
 - Fixed validation fallout from the repo-wide explicit comparator guard.
 - Stabilized existing CLI build-cache and DataTable test flakes encountered during gates.
 - Ran checkpoint and final gate validation; see `checkpoint-1-checks.md` and `final-gate-checks.md`.
+- After PR #3963 opened, GitHub `prepare` failed on a TypeScript error inherited from current `develop`: a stray `ded` token before `onPointerDownOutside` in `packages/ui/src/backend/filters/AdvancedFilterPanel.tsx`.
+- Rebasing onto current `origin/develop` reproduced that merge-ref failure locally; commit `3ddb0583e` removes the stray token.
+- Verified the unblock with `yarn workspace @open-mercato/ui build` and `yarn build:app`, both exit 0.
 
 ## Next Concrete Action
 
-- Wait for GitHub checks/review on PR #3963.
+- Push the rebased branch, then wait for GitHub checks/review on PR #3963.
 
 ## Blockers / Open Questions
 
-- none
+- GitHub checks are pending rerun after the rebased branch is pushed.
 
 ## Environment Caveats
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
@@ -1,27 +1,38 @@
 # Handoff — 2026-07-07-integration-auth-login-redirect-loop
 
-**Last updated:** 2026-07-07T12:06:13Z
+**Last updated:** 2026-07-07T12:39:28Z
 **Branch:** `fix/integration-auth-login-redirect-loop`
 **PR:** not yet opened
-**Current phase/step:** Phase 0 Step 0.1
-**Last commit:** none — run folder not yet committed
+**Current phase/step:** Phase 5 Step 5.1
+**Last commit:** `5c88a0e5f` before checkpoint commit
 
-## What just happened
-- Created an isolated worktree from `origin/develop`.
-- Drafted the run plan for the auth login redirect-loop implementation.
+## What Just Happened
 
-## Next concrete action
-- Commit the run folder, then Step 0.1 lands the reviewed source spec into `.ai/specs/`.
+- Landed the reviewed source spec and implementation plan.
+- Added `TC-AUTH-053-login-helper-backend-cookie-flow.spec.ts` for the published auth integration helper.
+- Verified the regression already passes on current `origin/develop`; kept auth/session runtime semantics unchanged.
+- Added redacted diagnostics to `login(page, role)`.
+- Added a cookie-backed `/backend` readiness probe in the CLI with bounded same-origin redirect following.
+- Added CLI unit coverage for cookie propagation, redirect-loop diagnostics, unsafe redirect rejection, and cookie-value redaction.
+- Fixed validation fallout from the repo-wide explicit comparator guard.
+- Stabilized the existing CLI build-cache fingerprint test.
+- Ran checkpoint validation; see `checkpoint-1-checks.md`.
 
-## Blockers / open questions
+## Next Concrete Action
+
+- Commit checkpoint 4.1, then run final gate/self-review and open the PR.
+
+## Blockers / Open Questions
+
 - none
 
-## Environment caveats
-- Dev runtime runnable: unknown
-- Playwright / browser checks: planned for checkpoint/final gate
-- Database/migration state: clean; no migrations planned
+## Environment Caveats
+
+- `yarn workspace @open-mercato/cli test` fails inside the sandbox on `listen EPERM ::` and `EMFILE: too many open files, watch`.
+- The same full CLI suite passes outside sandbox with the approved escalated command.
+- Ephemeral Playwright `TC-AUTH-053` passed on a fresh environment after readiness completed in 4s.
 
 ## Worktree
+
 - Path: `/Users/kamil-nowak/Documents/work/development/tracecore/open-mercato/.ai/tmp/auto-create-pr/integration-auth-login-redirect-loop-20260707-140502`
 - Created this run: yes
-

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/HANDOFF.md
@@ -1,10 +1,10 @@
 # Handoff — 2026-07-07-integration-auth-login-redirect-loop
 
-**Last updated:** 2026-07-07T13:34:21Z
+**Last updated:** 2026-07-07T13:45:30Z
 **Branch:** `fix/integration-auth-login-redirect-loop`
-**PR:** not yet opened
-**Current phase/step:** ready to open PR
-**Last commit:** `7c3911651` before final-gate commit
+**PR:** https://github.com/open-mercato/open-mercato/pull/3963
+**Current phase/step:** PR opened
+**Last commit:** `a09df4d61` before PR-handoff metadata commit
 
 ## What Just Happened
 
@@ -20,7 +20,7 @@
 
 ## Next Concrete Action
 
-- Commit final-gate run metadata, push, open the PR against `develop`, and apply labels.
+- Wait for GitHub checks/review on PR #3963.
 
 ## Blockers / Open Questions
 
@@ -31,6 +31,7 @@
 - Full CLI/root tests and app build require unsandboxed local listener/process behavior in this environment.
 - The same gates passed outside sandbox with approved escalated commands.
 - `i18n:check-usage` exits 0 with an existing advisory unused-key report.
+- Label mutation failed because `vloneskorpion` lacks upstream `AddLabelsToLabelable` permission; intended labels were posted in PR comment https://github.com/open-mercato/open-mercato/pull/3963#issuecomment-4904484239.
 
 ## Worktree
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
@@ -21,3 +21,8 @@
 - Brief: opened PR #3963.
 - URL: https://github.com/open-mercato/open-mercato/pull/3963
 - Labels: intended `review`, `bug`, `skip-qa`, `priority-high`, `risk-high`; label mutation failed due upstream permission, so the intent was posted as a PR comment.
+
+## 2026-07-07T15:09:18Z — PR CI merge-ref unblock
+- Brief: rebased the PR branch onto current `origin/develop` after GitHub `prepare` failed on a TypeScript error inherited from the merge ref.
+- Fix: removed the stray `ded` token before `onPointerDownOutside` in `packages/ui/src/backend/filters/AdvancedFilterPanel.tsx`.
+- Validation: `yarn workspace @open-mercato/ui build` and `yarn build:app` both exited 0 after the fix.

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
@@ -7,3 +7,7 @@
 - External skill URLs: none.
 - Classification: spec-implementation run.
 
+## 2026-07-07T12:39:28Z — checkpoint 1 complete
+- Brief: auth helper regression/diagnostics and CLI backend-cookie readiness probe implemented.
+- Validation: core full suite passed; CLI full suite passed outside sandbox; focused `TC-AUTH-053` ephemeral integration passed.
+- Notes: sandbox-only CLI failures were `listen EPERM ::` and `EMFILE: too many open files, watch`; see `checkpoint-1-checks.md`.

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
@@ -16,3 +16,8 @@
 - Brief: final validation and self-review completed; ready to open PR.
 - Validation: `build:packages`, `generate`, second `build:packages`, i18n checks, typecheck, root test, app build, and focused ephemeral integration passed.
 - Notes: root test/app build/i18n usage required unsandboxed reruns because local listener/IPC operations are blocked in the sandbox.
+
+## 2026-07-07T13:45:30Z — PR opened
+- Brief: opened PR #3963.
+- URL: https://github.com/open-mercato/open-mercato/pull/3963
+- Labels: intended `review`, `bug`, `skip-qa`, `priority-high`, `risk-high`; label mutation failed due upstream permission, so the intent was posted as a PR comment.

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
@@ -11,3 +11,8 @@
 - Brief: auth helper regression/diagnostics and CLI backend-cookie readiness probe implemented.
 - Validation: core full suite passed; CLI full suite passed outside sandbox; focused `TC-AUTH-053` ephemeral integration passed.
 - Notes: sandbox-only CLI failures were `listen EPERM ::` and `EMFILE: too many open files, watch`; see `checkpoint-1-checks.md`.
+
+## 2026-07-07T13:34:21Z — final gate complete
+- Brief: final validation and self-review completed; ready to open PR.
+- Validation: `build:packages`, `generate`, second `build:packages`, i18n checks, typecheck, root test, app build, and focused ephemeral integration passed.
+- Notes: root test/app build/i18n usage required unsandboxed reruns because local listener/IPC operations are blocked in the sandbox.

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/NOTIFY.md
@@ -1,0 +1,9 @@
+# Notify — 2026-07-07-integration-auth-login-redirect-loop
+
+> Append-only log. Every entry is UTC-timestamped. Never rewrite prior entries.
+
+## 2026-07-07T12:06:13Z — run started
+- Brief: implement `.worktrees/integration-auth-redirect-loop-spec/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md`.
+- External skill URLs: none.
+- Classification: spec-implementation run.
+

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -14,8 +14,8 @@
 |-------|------|-------|--------|--------|
 | 0 | 0.1 | Land source specification | done | 89cf420db |
 | 1 | 1.1 | Add auth helper backend-cookie regression | done | 7408d7b22 |
-| 2 | 2.1 | Fix verified auth cookie/session boundary | done | pending |
-| 3 | 3.1 | Add cookie-backed ephemeral readiness probe | todo | — |
+| 2 | 2.1 | Fix verified auth cookie/session boundary | done | 28d430530 |
+| 3 | 3.1 | Add cookie-backed ephemeral readiness probe | done | pending |
 | 3 | 3.2 | Add readiness probe unit coverage | todo | — |
 | 4 | 4.1 | Run checkpoint validation | todo | — |
 | 5 | 5.1 | Final gate, self-review, PR handoff | todo | — |

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -18,8 +18,8 @@
 | 3 | 3.1 | Add cookie-backed ephemeral readiness probe | done | 07727c69c |
 | 3 | 3.2 | Add readiness probe unit coverage | done | 9b711ecb2 |
 | 3 | 3.3 | Fix explicit comparator validation fallout | done | 85c515b97 |
-| 3 | 3.4 | Stabilize CLI build cache test fingerprint change | done | pending |
-| 4 | 4.1 | Run checkpoint validation | todo | — |
+| 3 | 3.4 | Stabilize CLI build cache test fingerprint change | done | 5c88a0e5f |
+| 4 | 4.1 | Run checkpoint validation | done | pending |
 | 5 | 5.1 | Final gate, self-review, PR handoff | todo | — |
 
 ## Goal

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -16,7 +16,8 @@
 | 1 | 1.1 | Add auth helper backend-cookie regression | done | 7408d7b22 |
 | 2 | 2.1 | Fix verified auth cookie/session boundary | done | 28d430530 |
 | 3 | 3.1 | Add cookie-backed ephemeral readiness probe | done | 07727c69c |
-| 3 | 3.2 | Add readiness probe unit coverage | done | pending |
+| 3 | 3.2 | Add readiness probe unit coverage | done | 9b711ecb2 |
+| 3 | 3.3 | Fix explicit comparator validation fallout | done | pending |
 | 4 | 4.1 | Run checkpoint validation | todo | — |
 | 5 | 5.1 | Final gate, self-review, PR handoff | todo | — |
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -15,8 +15,8 @@
 | 0 | 0.1 | Land source specification | done | 89cf420db |
 | 1 | 1.1 | Add auth helper backend-cookie regression | done | 7408d7b22 |
 | 2 | 2.1 | Fix verified auth cookie/session boundary | done | 28d430530 |
-| 3 | 3.1 | Add cookie-backed ephemeral readiness probe | done | pending |
-| 3 | 3.2 | Add readiness probe unit coverage | todo | — |
+| 3 | 3.1 | Add cookie-backed ephemeral readiness probe | done | 07727c69c |
+| 3 | 3.2 | Add readiness probe unit coverage | done | pending |
 | 4 | 4.1 | Run checkpoint validation | todo | — |
 | 5 | 5.1 | Final gate, self-review, PR handoff | todo | — |
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -20,8 +20,8 @@
 | 3 | 3.3 | Fix explicit comparator validation fallout | done | 85c515b97 |
 | 3 | 3.4 | Stabilize CLI build cache test fingerprint change | done | 5c88a0e5f |
 | 4 | 4.1 | Run checkpoint validation | done | 831c25a70 |
-| 4 | 4.2 | Stabilize DataTable refresh test isolation | done | pending |
-| 5 | 5.1 | Final gate, self-review, PR handoff | todo | — |
+| 4 | 4.2 | Stabilize DataTable refresh test isolation | done | 7c3911651 |
+| 5 | 5.1 | Final gate, self-review, PR handoff | done | pending |
 
 ## Goal
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -21,7 +21,7 @@
 | 3 | 3.4 | Stabilize CLI build cache test fingerprint change | done | 5c88a0e5f |
 | 4 | 4.1 | Run checkpoint validation | done | 831c25a70 |
 | 4 | 4.2 | Stabilize DataTable refresh test isolation | done | 7c3911651 |
-| 5 | 5.1 | Final gate, self-review, PR handoff | done | pending |
+| 5 | 5.1 | Final gate, self-review, PR handoff | done | a09df4d61 |
 
 ## Goal
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -12,16 +12,17 @@
 
 | Phase | Step | Title | Status | Commit |
 |-------|------|-------|--------|--------|
-| 0 | 0.1 | Land source specification | done | 89cf420db |
-| 1 | 1.1 | Add auth helper backend-cookie regression | done | 7408d7b22 |
-| 2 | 2.1 | Fix verified auth cookie/session boundary | done | 28d430530 |
-| 3 | 3.1 | Add cookie-backed ephemeral readiness probe | done | 07727c69c |
-| 3 | 3.2 | Add readiness probe unit coverage | done | 9b711ecb2 |
-| 3 | 3.3 | Fix explicit comparator validation fallout | done | 85c515b97 |
-| 3 | 3.4 | Stabilize CLI build cache test fingerprint change | done | 5c88a0e5f |
-| 4 | 4.1 | Run checkpoint validation | done | 831c25a70 |
-| 4 | 4.2 | Stabilize DataTable refresh test isolation | done | 7c3911651 |
-| 5 | 5.1 | Final gate, self-review, PR handoff | done | a09df4d61 |
+| 0 | 0.1 | Land source specification | done | 96c72f5e4 |
+| 1 | 1.1 | Add auth helper backend-cookie regression | done | 969ecddbc |
+| 2 | 2.1 | Fix verified auth cookie/session boundary | done | cce5c53b8 |
+| 3 | 3.1 | Add cookie-backed ephemeral readiness probe | done | 746ef92cb |
+| 3 | 3.2 | Add readiness probe unit coverage | done | c90a118f2 |
+| 3 | 3.3 | Fix explicit comparator validation fallout | done | 59d9487cf |
+| 3 | 3.4 | Stabilize CLI build cache test fingerprint change | done | d0d09e0ed |
+| 4 | 4.1 | Run checkpoint validation | done | e29a13915 |
+| 4 | 4.2 | Stabilize DataTable refresh test isolation | done | dc12100f9 |
+| 5 | 5.1 | Final gate, self-review, PR handoff | done | 2d073637b |
+| 5 | 5.2 | Unblock PR merge-ref TypeScript failure | done | 3ddb0583e |
 
 ## Goal
 
@@ -122,6 +123,11 @@ None.
 - Run code-review and BC self-review.
 - Update source spec changelog/status with implementation evidence.
 - Open PR against `develop`, apply labels, run auto-review handoff if possible, and post the final summary comment.
+
+#### Step 5.2 — Unblock PR merge-ref TypeScript failure
+- Rebase the PR branch onto current `origin/develop` after GitHub `prepare` failed in the merge ref.
+- Remove the stray `ded` token introduced in `packages/ui/src/backend/filters/AdvancedFilterPanel.tsx`.
+- Re-run `yarn workspace @open-mercato/ui build` and `yarn build:app` to confirm the TypeScript failure is gone.
 
 ## Verification Policy
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -13,8 +13,8 @@
 | Phase | Step | Title | Status | Commit |
 |-------|------|-------|--------|--------|
 | 0 | 0.1 | Land source specification | done | 89cf420db |
-| 1 | 1.1 | Add auth helper backend-cookie regression | done | pending |
-| 2 | 2.1 | Fix verified auth cookie/session boundary | todo | — |
+| 1 | 1.1 | Add auth helper backend-cookie regression | done | 7408d7b22 |
+| 2 | 2.1 | Fix verified auth cookie/session boundary | done | pending |
 | 3 | 3.1 | Add cookie-backed ephemeral readiness probe | todo | — |
 | 3 | 3.2 | Add readiness probe unit coverage | todo | — |
 | 4 | 4.1 | Run checkpoint validation | todo | — |
@@ -83,11 +83,12 @@ None.
 
 #### Step 2.1 — Fix verified auth cookie/session boundary
 - Inspect current helper, login endpoint, refresh endpoint, and canonical auth resolution before editing.
+- If the regression already passes on current `develop`, do not edit auth runtime/session semantics without a failing boundary.
 - Fix only the verified boundary:
   - mirror login cookies into the browser context if request-context cookies do not propagate, or
   - make refresh fail closed to login when canonical auth cannot be satisfied.
 - Preserve fallback UI login, bounded 429 retries, endpoint contracts, `metadata`, and `openApi`.
-- Add focused unit coverage for any new cookie parsing, diagnostics, or redirect-loop utilities.
+- Add helper-level redacted diagnostics for future failures and focused unit coverage for any new cookie parsing, diagnostics, or redirect-loop utilities when they are factored outside the helper.
 
 ### Phase 3: CLI Readiness
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -1,0 +1,128 @@
+# Integration Auth Login Redirect Loop — Auto Create PR Plan
+
+**Date:** 2026-07-07
+**Slug:** `integration-auth-login-redirect-loop`
+**Branch:** `fix/integration-auth-login-redirect-loop`
+**Mode:** Spec-implementation run
+**Source spec:** `.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md`
+
+## Tasks
+
+> Authoritative status table. `Status` is one of `todo` or `done`. On landing a Step, flip `Status` to `done` and fill the `Commit` column with the short SHA. The first row whose `Status` is not `done` is the resume point for `om-auto-continue-pr`. Step ids are immutable once a Step has a commit.
+
+| Phase | Step | Title | Status | Commit |
+|-------|------|-------|--------|--------|
+| 0 | 0.1 | Land source specification | todo | — |
+| 1 | 1.1 | Add auth helper backend-cookie regression | todo | — |
+| 2 | 2.1 | Fix verified auth cookie/session boundary | todo | — |
+| 3 | 3.1 | Add cookie-backed ephemeral readiness probe | todo | — |
+| 3 | 3.2 | Add readiness probe unit coverage | todo | — |
+| 4 | 4.1 | Run checkpoint validation | todo | — |
+| 5 | 5.1 | Final gate, self-review, PR handoff | todo | — |
+
+## Goal
+
+Fix the shared Open Mercato integration auth harness so `login(page, 'admin')` reaches `/backend` without an infinite `/backend` ↔ `/api/auth/session/refresh` loop, and make ephemeral readiness catch cookie-backed auth failures before unrelated Playwright specs run.
+
+## Scope
+
+- Add the reviewed source spec from the docs worktree to this implementation branch.
+- Add a focused auth integration regression under `packages/core/src/modules/auth/__integration__/`.
+- Diagnose and fix the smallest verified boundary in the shared helper and/or session refresh flow.
+- Add CLI readiness hardening for cookie-backed `/backend` auth.
+- Keep diagnostics redacted: cookie names, statuses, and locations only.
+
+## Non-Goals
+
+- Do not redesign JWT/session token formats, cookie names, auth routes, RBAC semantics, or tenant provisioning.
+- Do not replace `login(page, role)` with per-spec UI login.
+- Do not touch product UI or introduce new persisted data.
+- Do not change 403 access-denied behavior from the coherent access-denied UX spec.
+
+## External References
+
+None.
+
+## Relevant Guides
+
+- `AGENTS.md` root Task Router: specs, integration testing, auth, shared helpers, CLI, BC.
+- `.ai/specs/AGENTS.md`: source spec naming and implementation-accuracy rules.
+- `.ai/qa/AGENTS.md`: executable Playwright tests live in module `__integration__` folders and use `@open-mercato/core/helpers/integration/*`.
+- `packages/core/AGENTS.md`: API route `metadata`/`openApi`, encrypted reads, auth module boundaries.
+- `packages/core/src/modules/auth/AGENTS.md`: no token logging; preserve auth/session/RBAC semantics.
+- `packages/shared/AGENTS.md`: typed infrastructure helpers only; no ad hoc wildcard matching.
+- `packages/cli/AGENTS.md`: standalone/ephemeral integration contract alignment.
+- `BACKWARD_COMPATIBILITY.md`: import paths, API URLs, cookie names, response fields, DI names, and session semantics are contract surfaces.
+
+## Risks
+
+- **Auth contract regression:** helper/session changes can affect every browser integration test and standalone apps. Mitigation: preserve public import path and endpoint/cookie contracts; add targeted tests.
+- **Secret leakage:** diagnostics could expose tokens in CI logs. Mitigation: unit-test redaction and never print cookie values or Set-Cookie payloads.
+- **MFA/interceptor compatibility:** helper could accidentally treat pending login responses as full sessions. Mitigation: only proceed when canonical cookies/full login are present; keep fallback behavior bounded.
+- **Readiness flakiness:** extra auth probe could consume rate limit or add slow startup. Mitigation: one bounded probe with explicit redirect limit and redacted failure details.
+
+## Implementation Plan
+
+### Phase 0: Source Spec
+
+#### Step 0.1 — Land source specification
+- Copy the reviewed spec from `.worktrees/integration-auth-redirect-loop-spec/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md` into `.ai/specs/`.
+- Confirm the filename follows OSS `{date}-{title}.md`.
+- Keep the spec in draft/root state; do not move it to `implemented/`.
+
+### Phase 1: Regression and Diagnostics
+
+#### Step 1.1 — Add auth helper backend-cookie regression
+- Add `packages/core/src/modules/auth/__integration__/TC-AUTH-052-login-helper-backend-cookie-flow.spec.ts`.
+- Import `login` from `@open-mercato/core/helpers/integration/auth`.
+- Assert `login(page, 'admin')` reaches `/backend` and does not loop through session refresh.
+- Add redacted redirect/cookie diagnostics in the test or helper utility as needed; no token values.
+- Run a targeted scratch check for the new test listing or affected TypeScript compile path.
+
+### Phase 2: Verified Auth Boundary Fix
+
+#### Step 2.1 — Fix verified auth cookie/session boundary
+- Inspect current helper, login endpoint, refresh endpoint, and canonical auth resolution before editing.
+- Fix only the verified boundary:
+  - mirror login cookies into the browser context if request-context cookies do not propagate, or
+  - make refresh fail closed to login when canonical auth cannot be satisfied.
+- Preserve fallback UI login, bounded 429 retries, endpoint contracts, `metadata`, and `openApi`.
+- Add focused unit coverage for any new cookie parsing, diagnostics, or redirect-loop utilities.
+
+### Phase 3: CLI Readiness
+
+#### Step 3.1 — Add cookie-backed ephemeral readiness probe
+- Extend `packages/cli/src/lib/testing/integration.ts` with a bounded cookie-backed `/backend` probe.
+- Follow redirects manually with a small limit and same-origin/protocol-relative rejection.
+- Report statuses, locations, and cookie names only.
+- Fail readiness before Playwright starts when `/backend` and `/api/auth/session/refresh` repeat.
+
+#### Step 3.2 — Add readiness probe unit coverage
+- Add or update CLI tests for redirect-loop detection, unsafe redirect rejection, and redacted detail formatting.
+- Verify diagnostics do not include raw cookie values, JWT-looking values, credentials, refresh tokens, or Set-Cookie payloads.
+
+### Phase 4: Checkpoint
+
+#### Step 4.1 — Run checkpoint validation
+- Run targeted validation for packages touched so far:
+  - `yarn workspace @open-mercato/core test`
+  - `yarn workspace @open-mercato/cli test`
+  - focused integration command for `TC-AUTH-052` when the ephemeral stack is available.
+- Write `checkpoint-1-checks.md`, rewrite `HANDOFF.md`, append `NOTIFY.md`, and commit the checkpoint.
+
+### Phase 5: Final Gate and PR
+
+#### Step 5.1 — Final gate, self-review, PR handoff
+- Run full gate as far as environment permits: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`.
+- Run required integration suites or document concrete blockers with evidence.
+- Run code-review and BC self-review.
+- Update source spec changelog/status with implementation evidence.
+- Open PR against `develop`, apply labels, run auto-review handoff if possible, and post the final summary comment.
+
+## Verification Policy
+
+- Per-step checks are scratch only and are not logged separately.
+- Checkpoint validation is recorded in `checkpoint-1-checks.md`.
+- Final validation is recorded in `final-gate-checks.md`.
+- UI screenshot artifacts are N/A unless implementation touches product UI; this run is expected to be non-UI.
+

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -12,7 +12,7 @@
 
 | Phase | Step | Title | Status | Commit |
 |-------|------|-------|--------|--------|
-| 0 | 0.1 | Land source specification | todo | — |
+| 0 | 0.1 | Land source specification | done | 21cad90d5 |
 | 1 | 1.1 | Add auth helper backend-cookie regression | todo | — |
 | 2 | 2.1 | Fix verified auth cookie/session boundary | todo | — |
 | 3 | 3.1 | Add cookie-backed ephemeral readiness probe | todo | — |
@@ -125,4 +125,3 @@ None.
 - Checkpoint validation is recorded in `checkpoint-1-checks.md`.
 - Final validation is recorded in `final-gate-checks.md`.
 - UI screenshot artifacts are N/A unless implementation touches product UI; this run is expected to be non-UI.
-

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -19,7 +19,8 @@
 | 3 | 3.2 | Add readiness probe unit coverage | done | 9b711ecb2 |
 | 3 | 3.3 | Fix explicit comparator validation fallout | done | 85c515b97 |
 | 3 | 3.4 | Stabilize CLI build cache test fingerprint change | done | 5c88a0e5f |
-| 4 | 4.1 | Run checkpoint validation | done | pending |
+| 4 | 4.1 | Run checkpoint validation | done | 831c25a70 |
+| 4 | 4.2 | Stabilize DataTable refresh test isolation | done | pending |
 | 5 | 5.1 | Final gate, self-review, PR handoff | todo | — |
 
 ## Goal

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -12,8 +12,8 @@
 
 | Phase | Step | Title | Status | Commit |
 |-------|------|-------|--------|--------|
-| 0 | 0.1 | Land source specification | done | 21cad90d5 |
-| 1 | 1.1 | Add auth helper backend-cookie regression | todo | — |
+| 0 | 0.1 | Land source specification | done | 89cf420db |
+| 1 | 1.1 | Add auth helper backend-cookie regression | done | pending |
 | 2 | 2.1 | Fix verified auth cookie/session boundary | todo | — |
 | 3 | 3.1 | Add cookie-backed ephemeral readiness probe | todo | — |
 | 3 | 3.2 | Add readiness probe unit coverage | todo | — |
@@ -73,7 +73,7 @@ None.
 ### Phase 1: Regression and Diagnostics
 
 #### Step 1.1 — Add auth helper backend-cookie regression
-- Add `packages/core/src/modules/auth/__integration__/TC-AUTH-052-login-helper-backend-cookie-flow.spec.ts`.
+- Add `packages/core/src/modules/auth/__integration__/TC-AUTH-053-login-helper-backend-cookie-flow.spec.ts`.
 - Import `login` from `@open-mercato/core/helpers/integration/auth`.
 - Assert `login(page, 'admin')` reaches `/backend` and does not loop through session refresh.
 - Add redacted redirect/cookie diagnostics in the test or helper utility as needed; no token values.

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/PLAN.md
@@ -17,7 +17,8 @@
 | 2 | 2.1 | Fix verified auth cookie/session boundary | done | 28d430530 |
 | 3 | 3.1 | Add cookie-backed ephemeral readiness probe | done | 07727c69c |
 | 3 | 3.2 | Add readiness probe unit coverage | done | 9b711ecb2 |
-| 3 | 3.3 | Fix explicit comparator validation fallout | done | pending |
+| 3 | 3.3 | Fix explicit comparator validation fallout | done | 85c515b97 |
+| 3 | 3.4 | Stabilize CLI build cache test fingerprint change | done | pending |
 | 4 | 4.1 | Run checkpoint validation | todo | — |
 | 5 | 5.1 | Final gate, self-review, PR handoff | todo | — |
 

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/checkpoint-1-checks.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/checkpoint-1-checks.md
@@ -1,0 +1,20 @@
+# Checkpoint 1 Checks
+
+**Timestamp:** 2026-07-07T12:39:28Z
+**Branch:** `fix/integration-auth-login-redirect-loop`
+
+## Results
+
+| Command | Result | Notes |
+|---------|--------|-------|
+| `git diff --check` | pass | No whitespace errors. |
+| `yarn workspace @open-mercato/core test` | pass | 954 suites, 7375 tests passed. |
+| `yarn workspace @open-mercato/cli test packages/cli/src/lib/testing/__tests__/integration.test.ts --runInBand` | pass | 21 tests passed. |
+| `yarn workspace @open-mercato/cli test` | pass outside sandbox | 59 suites, 1030 tests passed when run outside sandbox. In sandbox it failed on `listen EPERM ::` and `EMFILE: too many open files, watch`, both environment constraints unrelated to this change. |
+| `yarn test:integration:ephemeral --filter packages/core/src/modules/auth/__integration__/TC-AUTH-053-login-helper-backend-cookie-flow.spec.ts` | pass | Fresh ephemeral readiness completed in 4s; 1 Playwright test passed. |
+
+## Remediation During Checkpoint
+
+- Fixed repo-wide explicit comparator guard failures by replacing new diagnostic `.sort()` calls with `localeCompare` comparators.
+- Stabilized the existing CLI build-cache fingerprint unit test so it changes file size as well as content, avoiding same-millisecond mtime flakes.
+- Reverted validation-generated churn in `apps/mercato/src/module-facts.generated.json`.

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/final-gate-checks.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/final-gate-checks.md
@@ -24,3 +24,19 @@
 - CLI readiness follows redirects manually, rejects protocol-relative/cross-origin locations, and has a fixed redirect limit.
 - Public helper import path and auth API/cookie contracts are unchanged.
 - No generated files are staged.
+
+## Post-PR CI Merge-Ref Unblock
+
+**Timestamp:** 2026-07-07T15:09:18Z
+
+After PR #3963 opened, GitHub `prepare` failed in TypeScript on a merge-ref-only base typo:
+
+- `packages/ui/src/backend/filters/AdvancedFilterPanel.tsx`
+- `ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}`
+
+The PR branch was rebased onto current `origin/develop`, then commit `3ddb0583e` removed the stray `ded` token.
+
+| Command | Status | Notes |
+|---------|--------|-------|
+| `yarn workspace @open-mercato/ui build` | PASS | Rebuilt the UI package after the one-line `AdvancedFilterPanel` fix. |
+| `yarn build:app` | PASS | Re-ran the app build stage that failed in GitHub `prepare`; TypeScript finished successfully. |

--- a/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/final-gate-checks.md
+++ b/.ai/runs/2026-07-07-integration-auth-login-redirect-loop/final-gate-checks.md
@@ -1,0 +1,26 @@
+# Final Gate Checks
+
+**Timestamp:** 2026-07-07T13:34:21Z
+**Branch:** `fix/integration-auth-login-redirect-loop`
+
+## Results
+
+| Command | Result | Notes |
+|---------|--------|-------|
+| `yarn build:packages` | pass | 21 package builds passed. |
+| `yarn generate` | pass | Generated artifacts; validation-generated `apps/mercato/src/module-facts.generated.json` churn was reverted. |
+| `yarn build:packages` | pass | 21 package builds passed after generation. |
+| `yarn i18n:check-sync` | pass | All locale files in sync. |
+| `yarn i18n:check-usage` | pass outside sandbox | Exit 0 with existing advisory unused-key report. Sandbox run failed on `tsx` IPC `listen EPERM`. |
+| `yarn typecheck` | pass | 21 typecheck tasks passed. |
+| `yarn test` | pass outside sandbox | 22 tasks passed. Sandbox-compatible package/focused tests are listed in `checkpoint-1-checks.md`; full root test needs unsandboxed local listeners. |
+| `yarn build:app` | pass outside sandbox | Next/Turbopack app production build passed. Sandbox run failed on Turbopack `binding to a port` EPERM. |
+| `yarn test:integration:ephemeral --filter packages/core/src/modules/auth/__integration__/TC-AUTH-053-login-helper-backend-cookie-flow.spec.ts` | pass | Fresh ephemeral readiness completed in 4s; 1 Playwright test passed. |
+
+## Self-Review
+
+- Auth runtime/session semantics were not changed because the new regression passed on current `origin/develop`.
+- Added diagnostics stay redacted: cookie names, statuses, and paths only.
+- CLI readiness follows redirects manually, rejects protocol-relative/cross-origin locations, and has a fixed redirect limit.
+- Public helper import path and auth API/cookie contracts are unchanged.
+- No generated files are staged.

--- a/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
+++ b/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
@@ -450,3 +450,4 @@ None.
 - Implementation planning corrected the auth regression id to `TC-AUTH-053` because `TC-AUTH-052` already exists for user create tenant-scope coverage on `develop`.
 - Implementation evidence on current `origin/develop`: the new targeted regression passed before runtime auth edits, so the implementation keeps token/session semantics unchanged and adds redacted helper diagnostics instead of weakening canonical auth validation.
 - CLI readiness implementation added a bounded cookie-backed `/backend` probe with same-origin redirect validation and cookie-name-only diagnostics; unit coverage follows in Step 3.2.
+- CLI readiness unit coverage now verifies cookie propagation to `/backend`, redirect-loop diagnostics, unsafe protocol-relative redirect rejection, and absence of raw cookie values in failure messages.

--- a/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
+++ b/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
@@ -453,3 +453,4 @@ None.
 - CLI readiness unit coverage now verifies cookie propagation to `/backend`, redirect-loop diagnostics, unsafe protocol-relative redirect rejection, and absence of raw cookie values in failure messages.
 - Checkpoint validation fixed the repo-wide explicit sort comparator guard by adding comparators to auth and CLI diagnostic cookie-name ordering.
 - Checkpoint validation stabilized the CLI build-cache test so source-fingerprint invalidation changes file size as well as content, avoiding same-millisecond mtime flakes.
+- Final-gate validation stabilized an existing DataTable test by flushing a pending `requestAnimationFrame` router refresh before asserting the bulk-progress refresh path.

--- a/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
+++ b/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
@@ -454,3 +454,4 @@ None.
 - Checkpoint validation fixed the repo-wide explicit sort comparator guard by adding comparators to auth and CLI diagnostic cookie-name ordering.
 - Checkpoint validation stabilized the CLI build-cache test so source-fingerprint invalidation changes file size as well as content, avoiding same-millisecond mtime flakes.
 - Final-gate validation stabilized an existing DataTable test by flushing a pending `requestAnimationFrame` router refresh before asserting the bulk-progress refresh path.
+- Final gate passed with package builds, generation, i18n checks, typecheck, root unit tests, app build, and focused ephemeral `TC-AUTH-053` integration; sandbox-only EPERM failures were rerun successfully outside sandbox.

--- a/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
+++ b/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
@@ -448,3 +448,4 @@ None.
 - Reviewed with `om-spec-writing`: added metadata, related-spec boundaries, non-goals, root-cause gates, API/readiness contracts, expanded risks, and final compliance matrix.
 - Tightened strict checklist coverage with explicit MVP, undo N/A, security/input invariants, and performance/cache boundaries.
 - Implementation planning corrected the auth regression id to `TC-AUTH-053` because `TC-AUTH-052` already exists for user create tenant-scope coverage on `develop`.
+- Implementation evidence on current `origin/develop`: the new targeted regression passed before runtime auth edits, so the implementation keeps token/session semantics unchanged and adds redacted helper diagnostics instead of weakening canonical auth validation.

--- a/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
+++ b/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
@@ -286,7 +286,7 @@ Optional test-only diagnostics may be gated by an env var such as `OM_INTEGRATIO
 ### File Manifest
 | File | Action | Purpose |
 |------|--------|---------|
-| `packages/core/src/modules/auth/__integration__/TC-AUTH-052-login-helper-backend-cookie-flow.spec.ts` | Create | Regression for `login(page)` reaching `/backend` without redirect loop. |
+| `packages/core/src/modules/auth/__integration__/TC-AUTH-053-login-helper-backend-cookie-flow.spec.ts` | Create | Regression for `login(page)` reaching `/backend` without redirect loop. |
 | `packages/core/src/helpers/integration/auth.ts` | Modify if proven | Stabilize API-login-to-browser-cookie handoff and improve diagnostics. |
 | `packages/core/src/modules/auth/api/session/refresh.ts` | Modify if proven | Prevent refresh from redirecting to protected pages with invalid canonical auth. |
 | `packages/core/src/modules/auth/services/authService.ts` | Modify if proven | Align refresh session lookup with canonical staff auth requirements. |
@@ -297,7 +297,7 @@ Optional test-only diagnostics may be gated by an env var such as `OM_INTEGRATIO
 
 ### Testing Strategy
 - Targeted regression:
-  - `yarn test:integration:ephemeral --no-reuse-env --force-rebuild --filter packages/core/src/modules/auth/__integration__/TC-AUTH-052-login-helper-backend-cookie-flow.spec.ts`
+  - `yarn test:integration:ephemeral --no-reuse-env --force-rebuild --filter packages/core/src/modules/auth/__integration__/TC-AUTH-053-login-helper-backend-cookie-flow.spec.ts`
 - Representative existing browser spec:
   - `yarn test:integration:ephemeral --no-reuse-env --force-rebuild --filter packages/core/src/modules/core/__integration__/integration/TC-INT-001.spec.ts`
 - Package validation:
@@ -447,3 +447,4 @@ None.
 - Initial specification created from TraceCore baseline evidence showing `login(page, 'admin')` redirect loop on clean `origin/main`.
 - Reviewed with `om-spec-writing`: added metadata, related-spec boundaries, non-goals, root-cause gates, API/readiness contracts, expanded risks, and final compliance matrix.
 - Tightened strict checklist coverage with explicit MVP, undo N/A, security/input invariants, and performance/cache boundaries.
+- Implementation planning corrected the auth regression id to `TC-AUTH-053` because `TC-AUTH-052` already exists for user create tenant-scope coverage on `develop`.

--- a/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
+++ b/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
@@ -452,3 +452,4 @@ None.
 - CLI readiness implementation added a bounded cookie-backed `/backend` probe with same-origin redirect validation and cookie-name-only diagnostics; unit coverage follows in Step 3.2.
 - CLI readiness unit coverage now verifies cookie propagation to `/backend`, redirect-loop diagnostics, unsafe protocol-relative redirect rejection, and absence of raw cookie values in failure messages.
 - Checkpoint validation fixed the repo-wide explicit sort comparator guard by adding comparators to auth and CLI diagnostic cookie-name ordering.
+- Checkpoint validation stabilized the CLI build-cache test so source-fingerprint invalidation changes file size as well as content, avoiding same-millisecond mtime flakes.

--- a/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
+++ b/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
@@ -449,3 +449,4 @@ None.
 - Tightened strict checklist coverage with explicit MVP, undo N/A, security/input invariants, and performance/cache boundaries.
 - Implementation planning corrected the auth regression id to `TC-AUTH-053` because `TC-AUTH-052` already exists for user create tenant-scope coverage on `develop`.
 - Implementation evidence on current `origin/develop`: the new targeted regression passed before runtime auth edits, so the implementation keeps token/session semantics unchanged and adds redacted helper diagnostics instead of weakening canonical auth validation.
+- CLI readiness implementation added a bounded cookie-backed `/backend` probe with same-origin redirect validation and cookie-name-only diagnostics; unit coverage follows in Step 3.2.

--- a/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
+++ b/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
@@ -451,3 +451,4 @@ None.
 - Implementation evidence on current `origin/develop`: the new targeted regression passed before runtime auth edits, so the implementation keeps token/session semantics unchanged and adds redacted helper diagnostics instead of weakening canonical auth validation.
 - CLI readiness implementation added a bounded cookie-backed `/backend` probe with same-origin redirect validation and cookie-name-only diagnostics; unit coverage follows in Step 3.2.
 - CLI readiness unit coverage now verifies cookie propagation to `/backend`, redirect-loop diagnostics, unsafe protocol-relative redirect rejection, and absence of raw cookie values in failure messages.
+- Checkpoint validation fixed the repo-wide explicit sort comparator guard by adding comparators to auth and CLI diagnostic cookie-name ordering.

--- a/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
+++ b/.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md
@@ -1,0 +1,449 @@
+# Integration Auth Login Redirect Loop
+
+| Field | Value |
+|-------|-------|
+| Status | Draft, reviewed 2026-07-07 |
+| Scope | OSS |
+| Owner | Core Auth / Integration Testing / CLI |
+| Related Guides | `AGENTS.md`, `.ai/specs/AGENTS.md`, `.ai/qa/AGENTS.md`, `packages/core/AGENTS.md`, `packages/core/src/modules/auth/AGENTS.md`, `packages/shared/AGENTS.md`, `packages/cli/AGENTS.md` |
+| Related Specs | `.ai/specs/implemented/SPEC-027-2026-02-08-integration-testing-automation.md`, `.ai/specs/2026-03-25-coherent-access-denied-ux.md`, `.ai/specs/2026-05-27-acl-dependency-bundles.md`, `.ai/specs/enterprise/implemented/SPEC-ENT-007-2026-03-06-auth-login-interceptors-extension.md` |
+
+## TLDR
+**Key Points:**
+- Fix a baseline integration-test blocker where the shared Playwright `login(page, 'admin')` helper can enter an infinite `/backend -> /api/auth/session/refresh?redirect=/backend -> /backend` loop.
+- The failure was reproduced in a standalone TraceCore app on a clean `origin/main` baseline, using an unrelated warehouse browser spec, so this is an Open Mercato integration auth/session reliability issue rather than an application feature regression.
+- This is a 401/missing-or-invalid-cookie session-refresh loop, not the earlier 403 access-denied/login loop covered by the coherent access-denied UX and ACL dependency specs.
+
+**Scope:**
+- Add a deterministic regression covering the browser `/backend` cookie flow used by `@open-mercato/core/helpers/integration/auth`.
+- Fix the smallest verified root cause in the shared helper and/or staff session refresh path.
+- Improve integration readiness diagnostics so API-token readiness cannot hide browser/SSR auth failures.
+
+**MVP Boundary:**
+- Ship one auth integration regression, one smallest verified helper/session fix, and one bounded cookie-backed readiness probe.
+- Defer broader create-app smoke automation, new auth UX, and auth model redesign unless implementation evidence proves they are required.
+
+**Concerns:**
+- Auth/session behavior is a high-risk contract surface. The fix must preserve login, session refresh, MFA/interceptor compatibility, session revocation, tenant scoping, and standalone-app parity.
+- Implementation must prove the failing boundary before changing auth runtime code; "make the loop disappear" is not enough if it weakens canonical staff-session validation.
+
+## Overview
+The ephemeral integration runner currently proves that `/api/auth/login` returns a JWT and that a Bearer-token API call works. That is not enough for browser tests: UI specs authenticate through `login(page, role)`, then load server-rendered backend pages that call `getAuthFromCookies()` and may redirect to `/api/auth/session/refresh`.
+
+In TraceCore, a clean baseline run of an unrelated warehouse spec on `origin/main` reproduced:
+
+```text
+page.goto: net::ERR_TOO_MANY_REDIRECTS at http://127.0.0.1:55362/backend
+at login (.../node_modules/@open-mercato/core/src/helpers/integration/auth.ts:193:16)
+```
+
+The redirect chain is:
+
+```text
+/backend
+  -> /api/auth/session/refresh?redirect=/backend
+  -> /backend
+  -> /api/auth/session/refresh?redirect=/backend
+```
+
+**Market Reference:** Playwright's documented authentication setup pattern recommends a single deterministic authentication fixture that stores validated browser context state and fails early when the authenticated landing page is not reachable. This spec adopts the deterministic "auth setup must prove the protected page loaded" principle and rejects per-spec local login workarounds because they fragment the platform contract.
+
+**Related-spec boundary:** `.ai/specs/2026-03-25-coherent-access-denied-ux.md` establishes that 403 means authenticated-but-not-authorized and must not trigger a login redirect. This spec addresses a different failure class: `/backend` cannot establish a valid staff auth context at all, so the protected route attempts 401-style session refresh and loops. The implementation must keep that distinction intact.
+
+## Problem Statement
+The shared integration helper can report an authentication setup failure only after Playwright hits `ERR_TOO_MANY_REDIRECTS` during `page.goto('/backend')`. At that point the failing product spec receives a generic browser navigation error, not an actionable auth diagnostic.
+
+Observed facts from the TraceCore baseline:
+- `yarn test:integration:ephemeral --no-reuse-env --force-rebuild --filter src/modules/warehouse_operations/__integration__/TC-WAREHOUSE-COMPONENT-ORDERS-002.spec.ts` failed on a clean `origin/main` checkout.
+- The failure occurs before the warehouse workflow starts, at `login(page, 'admin')`.
+- The ephemeral readiness probe had already passed because API login plus Bearer-token API access worked.
+- Backend SSR still treated the browser request as unauthenticated or invalid and redirected to `session/refresh`.
+- Refresh redirected back to `/backend`, but the next `/backend` request still failed `getAuthFromCookies()`.
+
+This makes unrelated app PRs appear blocked by their own changes when the baseline platform auth harness is already broken.
+
+### Non-Goals
+- Do not redesign the staff auth model, JWT payload shape, cookie names, or session token format.
+- Do not replace `login(page, role)` with per-spec UI login flows.
+- Do not alter 403/ACL challenge behavior from the coherent access-denied UX spec.
+- Do not add product UI, new auth settings, or new persisted entities.
+
+## Proposed Solution
+Implement the fix in Open Mercato, not in downstream app specs:
+
+1. Add a focused auth integration regression that uses the published helper path:
+   `import { login } from '@open-mercato/core/helpers/integration/auth'`.
+2. Make the regression assert that `await login(page, 'admin')` reaches a usable backend page without a session refresh loop.
+3. Diagnose the first failing boundary with safe, non-secret instrumentation in tests:
+   - API login response status.
+   - Cookie names present in the Playwright browser context, never values.
+   - `/backend` and `/api/auth/session/refresh` response statuses/locations.
+   - Whether `resolveAuthFromCookiesDetailed()` classifies the token as `missing` or `invalid`, without logging token contents.
+4. Apply the smallest verified fix:
+   - If API request-context cookies are not reliably available to the browser context, bridge `auth_token` and `session_token` into `page.context().addCookies(...)` using response data and safe Set-Cookie parsing.
+   - If `/api/auth/login` returns a token but does not set the expected browser cookies in the request context, keep the endpoint contract stable and fix cookie propagation without changing cookie names.
+   - If refresh issues a JWT that `getAuthFromCookies()` rejects, align `AuthService.refreshFromSessionToken()` output with `resolveCanonicalStaffAuthContext()` requirements or redirect invalid refresh results to `/login` instead of `/backend`.
+   - If both are true, fix both with separate commits and tests.
+5. Extend CLI ephemeral readiness to include a browser-equivalent cookie-backed `/backend` probe so this failure is caught before unrelated specs run.
+
+### Root-Cause Verification Gates
+Before changing runtime auth code, the implementation must classify the failure into one or more of these boundaries:
+
+| Boundary | Required evidence | Allowed fix |
+|----------|-------------------|-------------|
+| API login -> Playwright browser context | `POST /api/auth/login` succeeds, but browser context lacks `auth_token` and/or `session_token` cookie names before `page.goto('/backend')` | Improve the shared helper's cookie handoff using redacted Set-Cookie parsing or response-token fallback. |
+| Browser refresh -> canonical staff auth | Refresh receives `session_token` and sets `auth_token`, but the next SSR auth resolution returns `invalid` | Fix refresh/session lookup so the emitted JWT satisfies `resolveCanonicalStaffAuthContext()`, or fail closed to `/login`. |
+| Readiness blind spot | API Bearer probe passes while cookie-backed `/backend` probe loops | Add a bounded cookie-backed readiness probe that fails before Playwright specs start. |
+
+The implementation must not relax `resolveCanonicalStaffAuthContext()` or treat an invalid staff session as authenticated. Any auth runtime edit must preserve existing `metadata` and `openApi` exports on modified API route files.
+
+### Design Decisions
+| Decision | Rationale |
+|----------|-----------|
+| Fix upstream helper/session flow | The failure reproduces on clean app baseline and affects every module spec using the shared helper. |
+| Keep app specs unchanged | Local wrappers would mask the platform defect and diverge standalone apps from monorepo behavior. |
+| Add diagnostics without token values | Auth tests need actionable evidence without leaking credentials or session tokens. |
+| Treat readiness as API + browser auth | Passing Bearer-token API auth is not equivalent to SSR cookie auth. |
+
+### Alternatives Considered
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Waive affected app integration specs | Leaves all browser specs using `login(page)` vulnerable and keeps future PRs noisy. |
+| Replace login imports in TraceCore only | Works around one app while the published helper remains broken for other standalone apps. |
+| Disable `/backend` refresh during tests | Masks a real staff-session boundary and weakens auth coverage. |
+
+## User Stories / Use Cases
+- **Framework maintainer** wants `login(page, 'admin')` to fail with an auth-specific diagnostic when browser cookies are invalid so that baseline failures are triaged quickly.
+- **App developer** wants ephemeral integration tests to distinguish product regressions from shared auth harness failures so that unrelated feature PRs are not blocked incorrectly.
+- **Standalone app author** wants the npm-published helper path to work in generated apps without local copies or forked login utilities.
+
+## Architecture
+The affected path spans the published helper, core auth endpoints, shared auth resolution, the backend route guard, and CLI readiness:
+
+1. `packages/core/src/helpers/integration/auth.ts`
+   - Fast path posts to `/api/auth/login` via `page.request`.
+   - Adds selected tenant/org cookies from JWT claims.
+   - Navigates to `/backend`.
+2. `packages/core/src/modules/auth/api/login.ts`
+   - Issues `auth_token` and `session_token` cookies.
+   - Returns `token` and optional `refreshToken` in JSON.
+3. `apps/mercato/src/app/(backend)/backend/page.tsx` and `packages/shared/src/lib/auth/server.ts`
+   - Backend SSR calls `getAuthFromCookies()`.
+   - `resolveAuthFromCookiesDetailed()` reports `missing`, `invalid`, or `authenticated`.
+   - Invalid/missing auth redirects to `/api/auth/session/refresh?redirect=/backend`.
+4. `packages/core/src/modules/auth/lib/sessionIntegrity.ts`
+   - `resolveCanonicalStaffAuthContext()` remains the authority for staff JWT/session validity.
+   - The fix must not bypass session revocation, soft-deleted user/role handling, tenant consistency, or organization consistency.
+5. `packages/core/src/modules/auth/api/session/refresh.ts`
+   - Reads `session_token`.
+   - Issues a new `auth_token`.
+   - Redirects back to the requested path.
+6. `packages/cli/src/lib/testing/integration.ts`
+   - Readiness currently verifies login API + Bearer API only.
+
+### Runtime Flow
+1. `login(page, 'admin')` posts credentials to `/api/auth/login` through Playwright's request context.
+2. The auth endpoint returns the existing success payload and sets `auth_token` plus `session_token` cookies.
+3. The helper derives tenant/org selection cookies from the returned JWT and navigates the page to `/backend`.
+4. Backend SSR resolves `auth_token` through `getAuthFromCookies()`.
+5. Missing/invalid staff auth redirects to browser session refresh.
+6. Session refresh either emits a canonical staff `auth_token` and redirects to the sanitized target, or clears staff cookies and redirects to `/login?redirect=...`.
+
+The regression passes only when step 4 reaches an authenticated backend state without requiring an unbounded refresh loop.
+
+### Commands & Events
+No new domain commands or events are proposed. This is test harness and auth runtime behavior.
+
+Undo/rollback is N/A for domain state because no business entity mutation is introduced. The only existing write effects involved are staff session creation/refresh and browser cookie mutation; failure handling remains fail-closed through existing cookie clearing, login redirect, logout, and session revocation behavior.
+
+### Frontend Architecture Contract
+No new App Router pages, backend shell components, providers, or heavy client widgets are planned. If implementation evidence proves that `apps/mercato/src/app/(backend)/backend/page.tsx` or shared backend shell UI must change, the implementation PR must add a Frontend Architecture Contract before touching those files. For the current scoped design, this section is N/A.
+
+## Data Models
+No schema changes.
+
+Existing records involved:
+- `auth.sessions`: referenced by JWT `sid`; refresh and canonical auth must agree on the session/user binding.
+- `auth.users`, `auth.user_roles`, `auth.role_acls`, `auth.user_acls`: canonical auth resolution must continue using encrypted reads and wildcard-aware role semantics.
+
+No new PII or sensitive columns are introduced. Existing auth user queries must continue using `findWithDecryption` / `findOneWithDecryption`; no encryption map changes are required for this spec.
+
+## API Contracts
+No new public API endpoints.
+
+Existing endpoint contracts must remain backward compatible:
+
+All modified auth API route files must keep or update their existing `metadata` and `openApi` exports. No route URL, method, response field, cookie name, or import path may be removed or renamed.
+
+### Staff Login
+- `POST /api/auth/login`
+- Existing response remains `{ ok: true, token, redirect, refreshToken? }`.
+- Existing cookies remain:
+  - `auth_token`: httpOnly, staff JWT.
+  - `session_token`: httpOnly, refresh/session token.
+- Validation continues through the existing `userLoginSchema`-based login parsing.
+- Existing error statuses remain `400`, `401`, `403`, and `429` with no account-existence disclosure.
+- Login interceptors remain compatible:
+  - Standard login still sets a full-access `auth_token`.
+  - An interceptor-produced pending-token branch must not receive a full `session_token` by accident.
+  - The helper must treat pending/MFA responses as not-yet-authenticated rather than forging browser auth.
+
+### Browser Session Refresh
+- `GET /api/auth/session/refresh?redirect=/backend`
+- Valid `session_token` must either:
+  - set a valid `auth_token` and redirect to the sanitized target, or
+  - clear staff auth cookies and redirect to `/login?redirect=...` when canonical auth cannot be satisfied.
+- It must not redirect back to the protected page with a token that the next SSR request will reject.
+- Existing open-redirect hardening via `sanitizeRedirectPath()` and `buildRequestOriginUrl()` must remain intact.
+- Invalid/missing refresh cookies must continue clearing `auth_token` and `session_token`.
+
+### API Session Refresh
+- `POST /api/auth/session/refresh`
+- Existing JSON response and errors remain unchanged.
+- Existing zod request validation and refresh rate limits remain unchanged.
+
+### Integration Readiness Probe
+- No new public endpoint is added.
+- `probeApplicationReadiness()` may add an internal HTTP probe that:
+  - logs in with known ephemeral admin credentials,
+  - carries cookie names/values only in process memory,
+  - follows redirects manually with a bounded redirect count,
+  - reports only statuses, locations, and cookie names,
+  - fails readiness if `/backend` and `/api/auth/session/refresh` repeat.
+
+### Security and Input Handling Invariants
+- No new externally callable API route, request schema, or persisted query surface is introduced.
+- Existing login and refresh zod validation, rate limits, account-existence non-disclosure, and ORM/service parameterization remain in force.
+- Redirect input handling remains limited to the existing sanitized redirect path helpers; manual readiness redirects must reject cross-origin or protocol-relative locations.
+- XSS and design-system UI requirements are N/A because no rendered product UI or user-provided HTML is added.
+
+## Internationalization (i18n)
+No user-facing UI strings are planned. If diagnostics are surfaced in browser pages later, they must use existing auth i18n patterns. Test failure messages may be plain English.
+
+## UI/UX
+No product UI changes.
+
+Developer-facing UX change:
+- Integration helper failures should identify the auth boundary that failed, for example:
+  - API login failed with status `401`.
+  - Browser context lacks `auth_token` after login.
+  - `/backend` redirected repeatedly between `/backend` and `/api/auth/session/refresh`.
+  - Refresh produced a cookie but SSR classified auth as invalid.
+
+Diagnostics must list cookie names only, never values.
+
+## Configuration
+No new production configuration.
+
+Optional test-only diagnostics may be gated by an env var such as `OM_INTEGRATION_AUTH_DEBUG=1`, but the regression should not require it.
+
+## Performance, Cache & Scale
+- No new list endpoint, search endpoint, database index, queue worker, or cache entry is introduced.
+- Readiness adds at most one authenticated probe with bounded redirects and existing request timeout behavior.
+- Cache invalidation is N/A because no cached read model or data write path is added.
+- No N+1 or large-list behavior is introduced; auth/session lookups remain point reads through existing services.
+
+## Migration & Compatibility
+- No database migration.
+- No breaking changes to endpoint URLs, response shapes, cookie names, import paths, or helper exports.
+- The published helper import `@open-mercato/core/helpers/integration/auth` remains stable.
+- Existing legacy monorepo helper imports may keep working through current re-exports, but new tests must use the npm-published helper path.
+- `BACKWARD_COMPATIBILITY.md` applies because auth helper imports, auth API URLs, cookie names, API response fields, DI service names, and session semantics are contract surfaces.
+- Standalone apps inherit the fix after package upgrade without changing their tests.
+
+## Implementation Plan
+
+### Phase 1: Reproduce and Pin the Failure
+1. Add a focused integration spec under `packages/core/src/modules/auth/__integration__/`.
+2. Import `login` from `@open-mercato/core/helpers/integration/auth`, not from the legacy monorepo helper path.
+3. The test should call `await login(page, 'admin')`, assert the URL is `/backend`, and assert a backend shell landmark or dashboard content is visible.
+4. Add a second assertion path that follows `/backend` redirects with a cookie jar at the HTTP level and fails with the exact redirect chain if it loops.
+5. Capture redacted diagnostics on failure: login status, cookie names, backend/refresh status and `Location` headers, and `missing` vs `invalid` auth classification.
+6. Verify the test fails on the current baseline before applying fixes.
+
+### Phase 2: Fix the Verified Auth Boundary
+1. If Playwright request cookies are not propagated, update `packages/core/src/helpers/integration/auth.ts` to safely mirror `auth_token`/`session_token` into the browser context.
+2. If refresh can emit a non-canonical JWT, update `packages/core/src/modules/auth/api/session/refresh.ts` and/or `AuthService.refreshFromSessionToken()` so refresh either produces auth accepted by `resolveCanonicalStaffAuthContext()` or sends the browser to `/login`.
+3. Preserve the existing fallback UI-login path in the helper and keep bounded retry-on-429 behavior.
+4. Preserve login interceptors and MFA/pending-token behavior from the enterprise auth-login interceptor contract.
+5. Add focused unit tests for any new helper utility that parses Set-Cookie headers, builds diagnostics, or detects redirect loops.
+6. Ensure rate-limit retries remain bounded and do not hide persistent auth failures.
+
+### Phase 3: Harden Ephemeral Readiness
+1. Extend `probeApplicationReadiness()` in `packages/cli/src/lib/testing/integration.ts` with a cookie-backed `/backend` probe.
+2. The probe should perform login, carry Set-Cookie values through a protected-page request, and detect repeated `/backend`/`session/refresh` redirects.
+3. Keep readiness output concise and redacted; no cookie values, JWTs, refresh tokens, credentials, or Set-Cookie payloads.
+4. Make readiness fail before Playwright starts when browser auth is broken.
+5. Add CLI unit coverage for redirect-loop detection and redacted readiness detail formatting.
+
+### Phase 4: Validation and Release Notes
+1. Run targeted auth integration regression in ephemeral mode.
+2. Run a representative non-auth browser spec that uses `login(page, 'admin')`.
+3. Run package tests/builds for `@open-mercato/core` and `@open-mercato/cli`.
+4. Run `yarn typecheck`.
+5. Document the fix as integration-test/auth-harness reliability in release notes or changelog.
+
+### File Manifest
+| File | Action | Purpose |
+|------|--------|---------|
+| `packages/core/src/modules/auth/__integration__/TC-AUTH-052-login-helper-backend-cookie-flow.spec.ts` | Create | Regression for `login(page)` reaching `/backend` without redirect loop. |
+| `packages/core/src/helpers/integration/auth.ts` | Modify if proven | Stabilize API-login-to-browser-cookie handoff and improve diagnostics. |
+| `packages/core/src/modules/auth/api/session/refresh.ts` | Modify if proven | Prevent refresh from redirecting to protected pages with invalid canonical auth. |
+| `packages/core/src/modules/auth/services/authService.ts` | Modify if proven | Align refresh session lookup with canonical staff auth requirements. |
+| `packages/core/src/modules/auth/lib/sessionIntegrity.ts` | Modify only if proven | Preserve canonical validation while fixing a verified mismatch. |
+| `packages/cli/src/lib/testing/integration.ts` | Modify | Add browser-cookie readiness probe. |
+| `packages/core/src/helpers/integration/__tests__/*.test.ts` | Create/modify if needed | Unit-test helper cookie parsing/diagnostic helpers without Playwright. |
+| `packages/cli/src/lib/testing/__tests__/integration.test.ts` | Modify | Unit-test readiness redirect-loop detection and redacted detail output. |
+
+### Testing Strategy
+- Targeted regression:
+  - `yarn test:integration:ephemeral --no-reuse-env --force-rebuild --filter packages/core/src/modules/auth/__integration__/TC-AUTH-052-login-helper-backend-cookie-flow.spec.ts`
+- Representative existing browser spec:
+  - `yarn test:integration:ephemeral --no-reuse-env --force-rebuild --filter packages/core/src/modules/core/__integration__/integration/TC-INT-001.spec.ts`
+- Package validation:
+  - `yarn workspace @open-mercato/core test`
+  - `yarn workspace @open-mercato/core build`
+  - `yarn workspace @open-mercato/cli test`
+  - `yarn workspace @open-mercato/cli build`
+  - `yarn typecheck`
+- Redaction validation:
+  - Unit tests must assert diagnostic strings do not contain raw `auth_token`, `session_token`, JWT-looking values, refresh-token values, or Set-Cookie payloads.
+
+## Risks & Impact Review
+
+### Data Integrity Failures
+No schema or new write-path data model changes are proposed. Login still creates sessions through existing `AuthService.createSession()`, and refresh still validates an existing `auth.sessions` record before issuing a new staff JWT.
+
+### Cascading Failures & Side Effects
+Auth helper changes affect many integration specs. A too-narrow fix could make one app pass while published standalone helpers remain broken. Auth runtime changes can also affect login interceptors, MFA pending-token branches, logout/session revocation, and all server-rendered backend pages.
+
+### Tenant & Data Isolation Risks
+The fix must not weaken tenant/org checks. `om_selected_tenant` and `om_selected_org` may influence superadmin scope only through existing `applySuperAdminScope()` semantics.
+
+### Migration & Deployment Risks
+No migration or downtime risk. The behavioral change ships through packages and affects integration/development runtime immediately after upgrade.
+
+### Operational Risks
+Auth/session code has high blast radius. Keep runtime changes minimal and prove them with regression tests.
+
+### Risk Register
+
+#### Cookie Value Leakage in Diagnostics
+- **Scenario**: A failing integration helper logs raw `auth_token` or `session_token` values.
+- **Severity**: High
+- **Affected area**: Auth tests, CI logs, developer machines.
+- **Mitigation**: Diagnostics may log cookie names, statuses, and redirect locations only. Never log token values or Set-Cookie payloads.
+- **Residual risk**: Low if tests assert redaction behavior for helper diagnostic utilities.
+
+#### Weakening Canonical Session Validation
+- **Scenario**: Refresh is changed to accept stale, cross-user, or cross-tenant session/JWT combinations to make tests pass.
+- **Severity**: Critical
+- **Affected area**: Staff auth, logout/session revocation, tenant isolation.
+- **Mitigation**: Keep `resolveCanonicalStaffAuthContext()` as the authority. Fix token/cookie handoff or redirect behavior, not the validation rules.
+- **Residual risk**: Medium because auth code is sensitive; requires core auth review.
+
+#### Readiness Probe Becomes Too Slow or Flaky
+- **Scenario**: Adding browser-cookie readiness makes ephemeral startup slower or fails due to expected first-load redirects.
+- **Severity**: Medium
+- **Affected area**: Local integration workflow and CI.
+- **Mitigation**: Implement a bounded HTTP probe with a small redirect limit and explicit success criteria. Reuse existing `probeFetch()` timeout.
+- **Residual risk**: Low after validating on local ephemeral and CI-like runs.
+
+#### Standalone and Monorepo Behavior Diverge
+- **Scenario**: The fix relies on monorepo-only paths or app-specific code and does not work from npm packages.
+- **Severity**: High
+- **Affected area**: Standalone app integration tests.
+- **Mitigation**: Regression must import from `@open-mercato/core/helpers/integration/auth`; CLI readiness must run through the same package path used by standalone apps.
+- **Residual risk**: Medium until verified through a create-app/standalone smoke if package publication changes are involved.
+
+#### Login Interceptor or MFA Branch Regression
+- **Scenario**: Cookie-handoff changes assume every successful `/api/auth/login` response is a full staff session and accidentally authenticate an interceptor-generated pending/MFA token.
+- **Severity**: High
+- **Affected area**: Enterprise login interceptors, future MFA extensions, staff login.
+- **Mitigation**: Preserve the existing login response/cookie semantics. Helper fast-path may proceed to `/backend` only when a canonical backend auth context can be established; pending/interceptor responses must fall back or fail explicitly.
+- **Residual risk**: Medium because interceptor packages may be outside the OSS test matrix; include a compatibility note in implementation review.
+
+#### Readiness Probe Consumes Rate Limit Budget
+- **Scenario**: Adding an authenticated readiness probe consumes the same login rate-limit bucket as tests, making the first real spec hit `429`.
+- **Severity**: Medium
+- **Affected area**: Ephemeral integration startup and auth-heavy test suites.
+- **Mitigation**: Keep the probe count to one successful login, preserve bounded retry behavior, and surface `429` distinctly in readiness output.
+- **Residual risk**: Low after CLI unit tests and one full ephemeral validation.
+
+#### Redirect Probe Masks Open-Redirect Hardening
+- **Scenario**: Manual redirect-following code treats external or protocol-relative `Location` headers as normal and weakens the protection already covered by `sanitizeRedirectPath()`.
+- **Severity**: High
+- **Affected area**: Auth refresh, readiness diagnostics, security posture.
+- **Mitigation**: The readiness probe must validate same-origin/local redirect locations and report unsafe redirects as readiness failures. Runtime endpoints must keep existing `sanitizeRedirectPath()` and `buildRequestOriginUrl()` usage.
+- **Residual risk**: Low with targeted unit tests for unsafe `Location` values.
+
+## Final Compliance Report — 2026-07-07
+
+### AGENTS.md Files Reviewed
+- `AGENTS.md` (root)
+- `.ai/specs/AGENTS.md`
+- `.ai/qa/AGENTS.md`
+- `packages/core/AGENTS.md`
+- `packages/core/src/modules/auth/AGENTS.md`
+- `packages/shared/AGENTS.md`
+- `packages/cli/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+| Rule Source | Rule | Status | Notes |
+|-------------|------|--------|-------|
+| root AGENTS.md | Preserve behavior unless a spec explicitly asks for behavior change | Compliant | Spec scopes a regression fix for existing helper behavior. |
+| root AGENTS.md | Follow `BACKWARD_COMPATIBILITY.md` before contract changes | Compliant | Spec requires additive/stable helper/API behavior and no import path changes. |
+| root AGENTS.md | Never expose cross-tenant data or skip tenant/organization scoping | Compliant | Canonical staff auth remains authoritative; tenant/org cookies may only influence existing superadmin scope semantics. |
+| om-spec-writing checklist | MVP is explicit and future work is deferred | Compliant | TLDR includes a concrete MVP boundary and Non-Goals defer auth model/UI redesign. |
+| `BACKWARD_COMPATIBILITY.md` | Public import paths, API URLs, cookie names, response fields, DI names, and session semantics are stable contract surfaces | Compliant | Spec forbids renames/removals and keeps `@open-mercato/core/helpers/integration/auth` stable. |
+| `.ai/specs/AGENTS.md` | New non-trivial specs use `{date}-{title}.md` and stay implementation-accurate | Compliant | File is `.ai/specs/2026-07-07-integration-auth-login-redirect-loop.md`; related specs were cross-checked. |
+| `.ai/qa/AGENTS.md` | Integration tests live in module `__integration__` folders and reuse shared helpers | Compliant | Regression is under auth `__integration__` and imports the published helper path. |
+| packages/core/AGENTS.md | API route files export `metadata` and `openApi` | Compliant | API Contracts require preserving/updating existing exports on modified auth endpoints. |
+| packages/core/AGENTS.md | Custom write routes wire mutation guards; domain writes use commands | N/A | This spec does not add CRUD/custom domain write routes; login/session refresh keep existing auth service flow. |
+| packages/core/AGENTS.md | Use `findWithDecryption` / `findOneWithDecryption` for encrypted entities | Compliant | Data Models require existing auth user queries to continue using encrypted reads. |
+| om-spec-writing checklist | Input validation, injection, XSS, and URL encoding are covered | Compliant | Security and Input Handling Invariants keep existing zod validation/parameterized service access and mark UI/XSS as N/A. |
+| om-spec-writing checklist | Performance, cache, and scale impact is explicit | Compliant | Performance, Cache & Scale section marks cache/list/index/worker concerns N/A and bounds readiness cost. |
+| packages/core/src/modules/auth/AGENTS.md | Never log credentials/session tokens | Compliant | Diagnostics are explicitly redacted. |
+| packages/core/src/modules/auth/AGENTS.md | Ask before changing session token format, RBAC semantics, wildcard matching, super-admin behavior, or tenant provisioning outputs | Compliant | Spec declares these as non-goals and requires preserving canonical staff validation. |
+| packages/shared/AGENTS.md | Shared helpers must stay infrastructure-only, typed, and avoid domain-specific drift | Compliant | No new shared helper is proposed; if shared auth server changes, it must preserve narrow typed contracts. |
+| packages/shared/AGENTS.md | Do not gate raw feature arrays with ad hoc wildcard matching | Compliant | Spec does not add feature checks and preserves existing canonical auth/RBAC behavior. |
+| packages/cli/AGENTS.md | Keep standalone app generator/testing contracts aligned | Compliant | CLI readiness change is scoped to shared ephemeral runner behavior. |
+| packages/cli/AGENTS.md | Ask before changing CLI command contracts | Compliant | No CLI command names, flags, or generated paths change; readiness behavior becomes stricter before test execution. |
+| `SPEC-027` integration testing | Shared Playwright helpers define the platform integration-test login contract | Compliant | This spec hardens the helper contract rather than replacing it in product specs. |
+| Coherent access-denied UX spec | 403 means authenticated-but-not-authorized and must not redirect to login | Compliant | This spec explicitly scopes itself to missing/invalid auth cookie session-refresh loops, not 403 ACL loops. |
+| Enterprise auth-login interceptor spec | Login response/cookie interception must remain compatible with pending/MFA branches | Compliant | API Contracts and risks require pending-token compatibility. |
+
+### Internal Consistency Check
+| Check | Status | Notes |
+|-------|--------|-------|
+| Data models match API contracts | Pass | No model changes. |
+| API contracts match UI/UX section | Pass | No product UI changes; existing auth endpoints preserved. |
+| Risks cover all write operations | Pass | Only existing session creation/refresh writes are involved; risks cover revocation/canonical validation. |
+| Commands defined for all mutations | N/A | No domain mutation commands. |
+| Cache strategy covers all read APIs | N/A | No caching change. |
+| MVP and deferred scope are explicit | Pass | MVP Boundary and Non-Goals separate deliverable scope from broader auth redesign and standalone automation. |
+| Frontend Architecture Contract | N/A | No App Router or backend shell UI changes are planned; spec requires a contract if implementation expands into UI/page files. |
+| Test plan covers affected API and UI paths | Pass | Auth helper browser path, HTTP redirect chain, CLI readiness, core/CLI unit tests, and representative browser spec are covered. |
+| Security redaction is testable | Pass | Testing Strategy requires assertions against raw cookies/JWTs/Set-Cookie payloads in diagnostics. |
+
+### Non-Compliant Items
+None.
+
+### Verdict
+**Fully compliant**: Approved for implementation planning. Implementation must still prove the exact root cause before editing auth/session code.
+
+## Changelog
+### Review — 2026-07-07
+- **Reviewer**: Agent
+- **Security**: Passed — raw credentials, JWTs, refresh tokens, and Set-Cookie payloads are explicitly excluded from diagnostics.
+- **Performance**: Passed — readiness probe must be bounded and reuse existing timeouts.
+- **Cache**: N/A — no caching behavior changes.
+- **Commands**: N/A — no domain commands or events.
+- **Risks**: Passed — added interceptor/MFA, rate-limit, open-redirect, canonical-validation, and standalone parity risks.
+- **Verdict**: Approved for implementation planning.
+
+### 2026-07-07
+- Initial specification created from TraceCore baseline evidence showing `login(page, 'admin')` redirect loop on clean `origin/main`.
+- Reviewed with `om-spec-writing`: added metadata, related-spec boundaries, non-goals, root-cause gates, API/readiness contracts, expanded risks, and final compliance matrix.
+- Tightened strict checklist coverage with explicit MVP, undo N/A, security/input invariants, and performance/cache boundaries.

--- a/packages/cli/src/lib/testing/__tests__/integration.test.ts
+++ b/packages/cli/src/lib/testing/__tests__/integration.test.ts
@@ -30,6 +30,11 @@ const CHECKOUT_TEST_INJECTION_FLAG = 'NEXT_PUBLIC_OM_EXAMPLE_CHECKOUT_TEST_INJEC
 const resolver = createResolver()
 const projectRootDirectory = resolver.getRootDir()
 
+const makeSetCookieHeaders = (cookies: string[]): Headers => ({
+  get: (name: string) => (name.toLowerCase() === 'set-cookie' ? cookies.join(', ') : null),
+  getSetCookie: () => cookies,
+}) as unknown as Headers
+
 const mockHealthyReadinessFetch = (
   overrides: {
     loginPageResponse?: { status: number; text?: string }
@@ -42,6 +47,10 @@ const mockHealthyReadinessFetch = (
       return {
         status: 200,
         ok: true,
+        headers: makeSetCookieHeaders([
+          'auth_token=test-auth-token; Path=/; HttpOnly; SameSite=Lax',
+          'session_token=test-session-token; Path=/; HttpOnly; SameSite=Lax',
+        ]),
         text: async () => JSON.stringify({ token: 'test-admin-token' }),
       } as unknown as Response
     }
@@ -64,6 +73,9 @@ const mockHealthyReadinessFetch = (
       ok: true,
       text: async () => '<!doctype html><script src="/_next/static/chunks/app-healthcheck.js"></script>',
     } as unknown as Response
+  }
+  if (url.endsWith('/backend')) {
+    return { status: 200, ok: true, text: async () => '' } as unknown as Response
   }
   if (url.includes('/_next/static/chunks/app-healthcheck.js')) {
     return { status: 200, ok: true, text: async () => '' } as unknown as Response
@@ -587,6 +599,204 @@ describe('waitForApplicationReadiness', () => {
   const makeFakeProcess = (): ChildProcess => new EventEmitter() as unknown as ChildProcess
   const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
+  it('verifies backend browser navigation with cookies returned by login', async () => {
+    let backendCookieHeader: string | null = null
+
+    const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : String(input)
+      const body = typeof init?.body === 'string' ? init.body : ''
+
+      if (url.endsWith('/api/auth/login')) {
+        if (body.includes('email=admin%40acme.com')) {
+          return {
+            status: 200,
+            ok: true,
+            headers: makeSetCookieHeaders([
+              'auth_token=secret-auth-value; Path=/; HttpOnly; SameSite=Lax',
+              'session_token=secret-session-value; Path=/; HttpOnly; SameSite=Lax',
+            ]),
+            text: async () => JSON.stringify({ token: 'token' }),
+          } as unknown as Response
+        }
+        return { status: 401, ok: false, text: async () => '' } as unknown as Response
+      }
+      if (url.endsWith('/login')) {
+        return {
+          status: 200,
+          ok: true,
+          text: async () => '<!doctype html><script src="/_next/static/chunks/app.js"></script>',
+        } as unknown as Response
+      }
+      if (url.includes('/api/customers/people')) {
+        return { status: 200, ok: true, text: async () => JSON.stringify({ items: [] }) } as unknown as Response
+      }
+      if (url.endsWith('/backend')) {
+        backendCookieHeader = typeof init?.headers === 'object'
+          && init.headers !== null
+          && !Array.isArray(init.headers)
+          ? String((init.headers as Record<string, unknown>).Cookie ?? '')
+          : ''
+        return { status: backendCookieHeader ? 200 : 307, ok: Boolean(backendCookieHeader), text: async () => '' } as unknown as Response
+      }
+      return { status: 200, ok: true, text: async () => '' } as unknown as Response
+    })
+
+    try {
+      await waitForApplicationReadiness('http://127.0.0.1:5001', makeFakeProcess(), {
+        timeoutMs: 1_000,
+        intervalMs: 5,
+        stabilizationMs: 10,
+      })
+      expect(backendCookieHeader).toContain('auth_token=secret-auth-value')
+      expect(backendCookieHeader).toContain('session_token=secret-session-value')
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('reports backend auth redirect loops without leaking cookie values', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : String(input)
+      const body = typeof init?.body === 'string' ? init.body : ''
+
+      if (url.endsWith('/api/auth/login')) {
+        if (body.includes('email=admin%40acme.com')) {
+          return {
+            status: 200,
+            ok: true,
+            headers: makeSetCookieHeaders([
+              'auth_token=secret-auth-value; Path=/; HttpOnly; SameSite=Lax',
+              'session_token=secret-session-value; Path=/; HttpOnly; SameSite=Lax',
+            ]),
+            text: async () => JSON.stringify({ token: 'token' }),
+          } as unknown as Response
+        }
+        return { status: 401, ok: false, text: async () => '' } as unknown as Response
+      }
+      if (url.endsWith('/login')) {
+        return {
+          status: 200,
+          ok: true,
+          text: async () => '<!doctype html><script src="/_next/static/chunks/app.js"></script>',
+        } as unknown as Response
+      }
+      if (url.includes('/api/customers/people')) {
+        return { status: 200, ok: true, text: async () => JSON.stringify({ items: [] }) } as unknown as Response
+      }
+      if (url.endsWith('/backend')) {
+        return {
+          status: 307,
+          ok: false,
+          headers: {
+            get: (name: string) => (name.toLowerCase() === 'location' ? '/api/auth/session/refresh' : null),
+            getSetCookie: () => [],
+          },
+          text: async () => '',
+        } as unknown as Response
+      }
+      if (url.endsWith('/api/auth/session/refresh')) {
+        return {
+          status: 307,
+          ok: false,
+          headers: {
+            get: (name: string) => (name.toLowerCase() === 'location' ? '/backend' : null),
+            getSetCookie: () => ['auth_token=rotated-secret-value; Path=/; HttpOnly; SameSite=Lax'],
+          },
+          text: async () => '',
+        } as unknown as Response
+      }
+      return { status: 200, ok: true, text: async () => '' } as unknown as Response
+    })
+
+    try {
+      let error: Error | null = null
+      try {
+        await waitForApplicationReadiness('http://127.0.0.1:5001', makeFakeProcess(), {
+          timeoutMs: 50,
+          intervalMs: 5,
+          stabilizationMs: 10,
+        })
+      } catch (caught) {
+        error = caught instanceof Error ? caught : new Error(String(caught))
+      }
+
+      expect(error).not.toBeNull()
+      expect(error?.message).toMatch(/Backend browser auth probe detected redirect loop/)
+      expect(error?.message).not.toMatch(/secret-(auth|session)|rotated-secret/)
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it('rejects unsafe backend auth redirects without following them', async () => {
+    let externalRedirectFetches = 0
+    const fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : String(input)
+      const body = typeof init?.body === 'string' ? init.body : ''
+
+      if (url.includes('evil.example')) {
+        externalRedirectFetches += 1
+        return { status: 200, ok: true, text: async () => '' } as unknown as Response
+      }
+      if (url.endsWith('/api/auth/login')) {
+        if (body.includes('email=admin%40acme.com')) {
+          return {
+            status: 200,
+            ok: true,
+            headers: makeSetCookieHeaders([
+              'auth_token=secret-auth-value; Path=/; HttpOnly; SameSite=Lax',
+              'session_token=secret-session-value; Path=/; HttpOnly; SameSite=Lax',
+            ]),
+            text: async () => JSON.stringify({ token: 'token' }),
+          } as unknown as Response
+        }
+        return { status: 401, ok: false, text: async () => '' } as unknown as Response
+      }
+      if (url.endsWith('/login')) {
+        return {
+          status: 200,
+          ok: true,
+          text: async () => '<!doctype html><script src="/_next/static/chunks/app.js"></script>',
+        } as unknown as Response
+      }
+      if (url.includes('/api/customers/people')) {
+        return { status: 200, ok: true, text: async () => JSON.stringify({ items: [] }) } as unknown as Response
+      }
+      if (url.endsWith('/backend')) {
+        return {
+          status: 307,
+          ok: false,
+          headers: {
+            get: (name: string) => (name.toLowerCase() === 'location' ? '//evil.example/session' : null),
+            getSetCookie: () => [],
+          },
+          text: async () => '',
+        } as unknown as Response
+      }
+      return { status: 200, ok: true, text: async () => '' } as unknown as Response
+    })
+
+    try {
+      let error: Error | null = null
+      try {
+        await waitForApplicationReadiness('http://127.0.0.1:5001', makeFakeProcess(), {
+          timeoutMs: 50,
+          intervalMs: 5,
+          stabilizationMs: 10,
+        })
+      } catch (caught) {
+        error = caught instanceof Error ? caught : new Error(String(caught))
+      }
+
+      expect(error).not.toBeNull()
+      expect(error?.message).toMatch(/unsafe redirect: protocol-relative redirect/)
+      expect(error?.message).not.toMatch(/secret-(auth|session)/)
+      expect(externalRedirectFetches).toBe(0)
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
   it('serializes probe cycles so slow probes never pile up concurrent login attempts', async () => {
     let inFlight = 0
     let maxInFlight = 0
@@ -598,7 +808,7 @@ describe('waitForApplicationReadiness', () => {
       maxInFlight = Math.max(maxInFlight, inFlight)
       try {
         // Each probe fetch is slower than the retry interval; the old race-against-a-tick loop
-        // would launch overlapping cycles here and blow past 3 concurrent in-flight requests.
+        // would launch overlapping cycles here and blow past one cycle's concurrent requests.
         await sleep(40)
         const isLoginPage = url.endsWith('/login') && !url.endsWith('/api/auth/login')
         if (isLoginPage) {
@@ -613,10 +823,21 @@ describe('waitForApplicationReadiness', () => {
           } as unknown as Response
         }
         if (url.endsWith('/api/auth/login')) {
-          return { status: 200, ok: true, text: async () => JSON.stringify({ token: 'token' }) } as unknown as Response
+          return {
+            status: 200,
+            ok: true,
+            headers: makeSetCookieHeaders([
+              'auth_token=test-auth-token; Path=/; HttpOnly; SameSite=Lax',
+              'session_token=test-session-token; Path=/; HttpOnly; SameSite=Lax',
+            ]),
+            text: async () => JSON.stringify({ token: 'token' }),
+          } as unknown as Response
         }
         if (url.includes('/api/customers/people')) {
           return { status: 200, ok: true, text: async () => JSON.stringify({ items: [] }) } as unknown as Response
+        }
+        if (url.endsWith('/backend')) {
+          return { status: 200, ok: true, text: async () => '' } as unknown as Response
         }
         return { status: 200, ok: true, text: async () => '' } as unknown as Response
       } finally {
@@ -630,9 +851,10 @@ describe('waitForApplicationReadiness', () => {
         intervalMs: 5,
         stabilizationMs: 10,
       })
-      // One cycle issues exactly three parallel probe fetches (login page, backend login,
-      // authenticated login). Serialized cycles keep the peak at three; overlap would exceed it.
-      expect(maxInFlight).toBeLessThanOrEqual(3)
+      // One cycle issues exactly four parallel probe fetches (login page, backend login,
+      // authenticated API, and backend browser-cookie navigation). Serialized cycles keep the
+      // peak at four; overlap would exceed it.
+      expect(maxInFlight).toBeLessThanOrEqual(4)
       expect(loginPageCycles).toBeGreaterThanOrEqual(3)
     } finally {
       fetchSpy.mockRestore()

--- a/packages/cli/src/lib/testing/__tests__/integration.test.ts
+++ b/packages/cli/src/lib/testing/__tests__/integration.test.ts
@@ -486,7 +486,7 @@ describe('integration cache and options', () => {
       ).resolves.toBe(false)
 
       await writeFile(sourceFile, 'const value = 1')
-      await writeFile(sourceFile, 'const value = 2')
+      await writeFile(sourceFile, 'const value = 22')
       await expect(
         shouldReuseBuildArtifacts(120, 'integration', {
           inputPaths: [sourceFile],

--- a/packages/cli/src/lib/testing/integration.ts
+++ b/packages/cli/src/lib/testing/integration.ts
@@ -1509,7 +1509,7 @@ function serializeCookieJar(jar: Map<string, string>): string {
 }
 
 function formatCookieNames(jar: Map<string, string>): string {
-  const names = [...jar.keys()].sort()
+  const names = [...jar.keys()].sort((left, right) => left.localeCompare(right))
   return names.length > 0 ? names.join(', ') : 'none'
 }
 

--- a/packages/cli/src/lib/testing/integration.ts
+++ b/packages/cli/src/lib/testing/integration.ts
@@ -285,6 +285,7 @@ const FOLDER_TO_CATEGORY_CODE: Record<string, string> = {
   api: 'API',
   integration: 'INT',
 }
+const BACKEND_BROWSER_AUTH_REDIRECT_LIMIT = 6
 const BUILD_CACHE_STATE_VERSION = 2
 const BUILD_CACHE_ENV_KEYS = [
   'NODE_ENV',
@@ -360,11 +361,19 @@ type AuthenticatedApiProbeResult = {
   detail: string
 }
 
+type BackendBrowserAuthProbeResult = {
+  loginStatus: number | null
+  backendStatus: number | null
+  healthy: boolean
+  detail: string
+}
+
 type ApplicationReadinessProbeResult = {
   ready: boolean
   frontend: LoginPageProbeResult
   backend: BackendLoginProbeResult
   authenticated: AuthenticatedApiProbeResult
+  backendBrowserAuth: BackendBrowserAuthProbeResult
 }
 
 type PlaywrightFailureHealthCheckOptions = {
@@ -1440,18 +1449,236 @@ async function probeAuthenticatedApi(baseUrl: string): Promise<AuthenticatedApiP
   }
 }
 
+type HeadersWithSetCookie = Headers & {
+  getSetCookie?: () => string[]
+}
+
+function splitSetCookieHeader(header: string): string[] {
+  return header
+    .split(/,(?=\s*[^;,\s=]+=)/)
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+}
+
+function getSetCookieHeaders(headers: Headers | undefined): string[] {
+  if (!headers) {
+    return []
+  }
+
+  const setCookieGetter = (headers as HeadersWithSetCookie).getSetCookie
+  if (typeof setCookieGetter === 'function') {
+    return setCookieGetter.call(headers)
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+  }
+
+  const combined = headers.get('set-cookie')
+  return combined ? splitSetCookieHeader(combined) : []
+}
+
+function parseSetCookiePair(header: string): { name: string; value: string } | null {
+  const pair = header.split(';', 1)[0]?.trim()
+  if (!pair) {
+    return null
+  }
+  const equalsIndex = pair.indexOf('=')
+  if (equalsIndex <= 0) {
+    return null
+  }
+  const name = pair.slice(0, equalsIndex).trim()
+  if (!name) {
+    return null
+  }
+  return {
+    name,
+    value: pair.slice(equalsIndex + 1),
+  }
+}
+
+function addSetCookieHeadersToJar(jar: Map<string, string>, headers: Headers | undefined): void {
+  for (const setCookieHeader of getSetCookieHeaders(headers)) {
+    const pair = parseSetCookiePair(setCookieHeader)
+    if (pair) {
+      jar.set(pair.name, pair.value)
+    }
+  }
+}
+
+function serializeCookieJar(jar: Map<string, string>): string {
+  return [...jar.entries()].map(([name, value]) => `${name}=${value}`).join('; ')
+}
+
+function formatCookieNames(jar: Map<string, string>): string {
+  const names = [...jar.keys()].sort()
+  return names.length > 0 ? names.join(', ') : 'none'
+}
+
+function toReadinessPath(url: URL): string {
+  return url.pathname || '/'
+}
+
+function resolveReadinessRedirect(
+  baseUrl: URL,
+  currentUrl: URL,
+  rawLocation: string | null,
+): { url: URL; path: string } | { error: string } {
+  const location = rawLocation?.trim()
+  if (!location) {
+    return { error: 'missing Location header' }
+  }
+  if (location.startsWith('//')) {
+    return { error: 'protocol-relative redirect' }
+  }
+
+  let nextUrl: URL
+  try {
+    nextUrl = new URL(location, currentUrl)
+  } catch {
+    return { error: 'invalid Location header' }
+  }
+
+  if (nextUrl.origin !== baseUrl.origin) {
+    return { error: 'cross-origin redirect' }
+  }
+
+  return {
+    url: nextUrl,
+    path: toReadinessPath(nextUrl),
+  }
+}
+
+async function probeBackendBrowserAuth(baseUrl: string): Promise<BackendBrowserAuthProbeResult> {
+  try {
+    const base = new URL(baseUrl)
+    const form = new URLSearchParams()
+    form.set('email', 'admin@acme.com')
+    form.set('password', 'secret')
+    const loginResponse = await probeFetch(`${baseUrl}/api/auth/login`, {
+      method: 'POST',
+      redirect: 'manual',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: form.toString(),
+    })
+
+    if (!loginResponse.ok) {
+      return {
+        loginStatus: loginResponse.status,
+        backendStatus: null,
+        healthy: false,
+        detail: `Backend browser auth login returned ${loginResponse.status}`,
+      }
+    }
+
+    const cookieJar = new Map<string, string>()
+    addSetCookieHeadersToJar(cookieJar, loginResponse.headers)
+    if (cookieJar.size === 0) {
+      return {
+        loginStatus: loginResponse.status,
+        backendStatus: null,
+        healthy: false,
+        detail: 'Backend browser auth login returned no cookies',
+      }
+    }
+
+    let currentUrl = new URL('/backend', base)
+    let backendStatus: number | null = null
+    const visitedPaths = new Set<string>()
+    const trace: string[] = []
+
+    for (let redirectCount = 0; redirectCount <= BACKEND_BROWSER_AUTH_REDIRECT_LIMIT; redirectCount += 1) {
+      const currentPath = toReadinessPath(currentUrl)
+      visitedPaths.add(currentPath)
+      const response = await probeFetch(currentUrl.toString(), {
+        method: 'GET',
+        redirect: 'manual',
+        headers: {
+          Cookie: serializeCookieJar(cookieJar),
+        },
+      })
+      backendStatus = response.status
+      addSetCookieHeadersToJar(cookieJar, response.headers)
+
+      const location = response.headers?.get('location') ?? null
+      const traceRedirect = location ? resolveReadinessRedirect(base, currentUrl, location) : null
+      const statusAndLocation = traceRedirect && !('error' in traceRedirect)
+        ? `${currentPath} ${response.status} -> ${traceRedirect.path}`
+        : `${currentPath} ${response.status}${location ? ' -> [unsafe]' : ''}`
+      trace.push(statusAndLocation)
+
+      if (response.status === 200 && currentPath === '/backend') {
+        return {
+          loginStatus: loginResponse.status,
+          backendStatus,
+          healthy: true,
+          detail: `Cookie-backed GET /backend returned 200 (cookies: ${formatCookieNames(cookieJar)})`,
+        }
+      }
+
+      if (response.status < 300 || response.status >= 400) {
+        return {
+          loginStatus: loginResponse.status,
+          backendStatus,
+          healthy: false,
+          detail: `Cookie-backed GET ${currentPath} returned ${response.status} (cookies: ${formatCookieNames(cookieJar)}; trace: ${trace.join(' | ')})`,
+        }
+      }
+
+      const redirect = traceRedirect ?? resolveReadinessRedirect(base, currentUrl, location)
+      if ('error' in redirect) {
+        return {
+          loginStatus: loginResponse.status,
+          backendStatus,
+          healthy: false,
+          detail: `Backend browser auth probe followed unsafe redirect: ${redirect.error} (cookies: ${formatCookieNames(cookieJar)}; trace: ${trace.join(' | ')})`,
+        }
+      }
+
+      if (visitedPaths.has(redirect.path)) {
+        trace.push(redirect.path)
+        return {
+          loginStatus: loginResponse.status,
+          backendStatus,
+          healthy: false,
+          detail: `Backend browser auth probe detected redirect loop: ${trace.join(' | ')} (cookies: ${formatCookieNames(cookieJar)})`,
+        }
+      }
+
+      currentUrl = redirect.url
+    }
+
+    return {
+      loginStatus: loginResponse.status,
+      backendStatus,
+      healthy: false,
+      detail: `Backend browser auth probe exceeded ${BACKEND_BROWSER_AUTH_REDIRECT_LIMIT} redirects (cookies: ${formatCookieNames(cookieJar)}; trace: ${trace.join(' | ')})`,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      loginStatus: null,
+      backendStatus: null,
+      healthy: false,
+      detail: `Backend browser auth probe failed: ${message}`,
+    }
+  }
+}
+
 async function probeApplicationReadiness(baseUrl: string): Promise<ApplicationReadinessProbeResult> {
-  const [frontend, backend, authenticated] = await Promise.all([
+  const [frontend, backend, authenticated, backendBrowserAuth] = await Promise.all([
     probeLoginPage(baseUrl),
     probeBackendLoginEndpoint(baseUrl),
     probeAuthenticatedApi(baseUrl),
+    probeBackendBrowserAuth(baseUrl),
   ])
 
   return {
-    ready: frontend.healthy && backend.healthy && authenticated.healthy,
+    ready: frontend.healthy && backend.healthy && authenticated.healthy && backendBrowserAuth.healthy,
     frontend,
     backend,
     authenticated,
+    backendBrowserAuth,
   }
 }
 
@@ -1856,9 +2083,10 @@ export async function waitForApplicationReadiness(
   const lastFrontendDetail = lastProbe?.frontend.detail ?? 'GET /login was never observed'
   const lastBackendDetail = lastProbe?.backend.detail ?? 'POST /api/auth/login was never observed'
   const lastAuthenticatedDetail = lastProbe?.authenticated.detail ?? 'Authenticated API probe was never observed'
+  const lastBackendBrowserAuthDetail = lastProbe?.backendBrowserAuth.detail ?? 'Backend browser auth probe was never observed'
   throw new Error(
     `Application did not become ready within ${options.timeoutMs / 1000} seconds. ` +
-    `Last probe: ${lastFrontendDetail}; ${lastBackendDetail}; ${lastAuthenticatedDetail}`,
+    `Last probe: ${lastFrontendDetail}; ${lastBackendDetail}; ${lastAuthenticatedDetail}; ${lastBackendBrowserAuthDetail}`,
   )
 }
 

--- a/packages/core/src/helpers/integration/auth.ts
+++ b/packages/core/src/helpers/integration/auth.ts
@@ -1,4 +1,4 @@
-import { type Page } from '@playwright/test';
+import { type Page, type Response } from '@playwright/test';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 
@@ -136,102 +136,194 @@ async function recoverGenericErrorPageIfPresent(page: Page): Promise<void> {
   await dismissGlobalNoticesIfPresent(page);
 }
 
-export async function login(page: Page, role: Role = 'admin'): Promise<void> {
-  const creds = DEFAULT_CREDENTIALS[role];
-  const loginReadySelector = 'form[data-auth-ready="1"]';
-  const hasBackendUrl = (): boolean => /\/backend(?:\/.*)?$/.test(page.url());
-  const waitForBackend = async (timeout: number): Promise<boolean> => {
-    try {
-      await page.waitForURL(/\/backend(?:\/.*)?$/, { timeout });
-      return true;
-    } catch {
-      return hasBackendUrl();
+type AuthNavigationTraceEntry = {
+  path: string;
+  status: number;
+  location: string | null;
+};
+
+function toPathOnly(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return '[unparseable-url]';
+  }
+}
+
+function toRedactedLocation(rawLocation: string | undefined): string | null {
+  if (!rawLocation) return null;
+  try {
+    const url = new URL(rawLocation, 'http://integration.local');
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return '[unparseable-location]';
+  }
+}
+
+function createAuthNavigationTrace(page: Page): {
+  entries: AuthNavigationTraceEntry[];
+  stop: () => void;
+} {
+  const entries: AuthNavigationTraceEntry[] = [];
+  const onResponse = (response: Response) => {
+    const path = toPathOnly(response.url());
+    if (path === '/backend' || path.startsWith('/api/auth/session/refresh')) {
+      entries.push({
+        path,
+        status: response.status(),
+        location: toRedactedLocation(response.headers().location),
+      });
     }
   };
+  page.on('response', onResponse);
+  return {
+    entries,
+    stop: () => page.off('response', onResponse),
+  };
+}
 
-  await acknowledgeGlobalNotices(page);
-  const apiLoginForm = new URLSearchParams();
-  apiLoginForm.set('email', creds.email);
-  apiLoginForm.set('password', creds.password);
-  // Retry-on-429 against the auth rate limit (5/60s per email). Capped
-  // exponential backoff: 1s, 2s, 4s — worst-case ~7s.
-  let apiLoginResponse: Awaited<ReturnType<typeof page.request.post>> | null = null;
-  for (let retry = 0; retry < 4; retry += 1) {
-    apiLoginResponse = await page.request.post('/api/auth/login', {
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded',
-      },
-      data: apiLoginForm.toString(),
-    }).catch(() => null);
-    if (!apiLoginResponse || apiLoginResponse.status() !== 429) break;
-    await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** retry));
-  }
-  if (apiLoginResponse?.ok()) {
-    const apiLoginBody = (await apiLoginResponse.json().catch(() => null)) as { token?: string } | null;
-    const claims = typeof apiLoginBody?.token === 'string' ? decodeJwtClaims(apiLoginBody.token) : null;
-    const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
-    const cookies = [];
-    if (claims?.tenantId) {
-      cookies.push({
-        name: 'om_selected_tenant',
-        value: claims.tenantId,
-        url: baseUrl,
-        sameSite: 'Lax' as const,
-      });
+async function formatLoginDiagnostics(
+  page: Page,
+  role: Role,
+  entries: AuthNavigationTraceEntry[],
+): Promise<string> {
+  const cookieNames = Array.from(
+    new Set((await page.context().cookies()).map((cookie) => cookie.name)),
+  ).sort();
+  const traceLines = entries.length
+    ? entries.map((entry) => {
+      const location = entry.location ? ` -> ${entry.location}` : '';
+      return `${entry.status} ${entry.path}${location}`;
+    })
+    : ['none'];
+
+  return [
+    `Login diagnostics for role "${role}":`,
+    `current URL: ${toPathOnly(page.url())}`,
+    `browser cookie names: ${cookieNames.length ? cookieNames.join(', ') : 'none'}`,
+    'backend/refresh trace:',
+    ...traceLines,
+  ].join('\n');
+}
+
+async function throwLoginErrorWithDiagnostics(
+  page: Page,
+  role: Role,
+  entries: AuthNavigationTraceEntry[],
+  error: unknown,
+): Promise<never> {
+  const message = error instanceof Error ? error.message : String(error);
+  throw new Error([
+    `Login did not reach backend for role: ${role}.`,
+    await formatLoginDiagnostics(page, role, entries),
+    `Original error: ${message}`,
+  ].join('\n'));
+}
+
+export async function login(page: Page, role: Role = 'admin'): Promise<void> {
+  const authTrace = createAuthNavigationTrace(page);
+  try {
+    const creds = DEFAULT_CREDENTIALS[role];
+    const loginReadySelector = 'form[data-auth-ready="1"]';
+    const hasBackendUrl = (): boolean => /\/backend(?:\/.*)?$/.test(page.url());
+    const waitForBackend = async (timeout: number): Promise<boolean> => {
+      try {
+        await page.waitForURL(/\/backend(?:\/.*)?$/, { timeout });
+        return true;
+      } catch {
+        return hasBackendUrl();
+      }
+    };
+
+    await acknowledgeGlobalNotices(page);
+    const apiLoginForm = new URLSearchParams();
+    apiLoginForm.set('email', creds.email);
+    apiLoginForm.set('password', creds.password);
+    // Retry-on-429 against the auth rate limit (5/60s per email). Capped
+    // exponential backoff: 1s, 2s, 4s — worst-case ~7s.
+    let apiLoginResponse: Awaited<ReturnType<typeof page.request.post>> | null = null;
+    for (let retry = 0; retry < 4; retry += 1) {
+      apiLoginResponse = await page.request.post('/api/auth/login', {
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        data: apiLoginForm.toString(),
+      }).catch(() => null);
+      if (!apiLoginResponse || apiLoginResponse.status() !== 429) break;
+      await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** retry));
     }
-    if (claims?.orgId) {
-      cookies.push({
-        name: 'om_selected_org',
-        value: claims.orgId,
-        url: baseUrl,
-        sameSite: 'Lax' as const,
-      });
+    if (apiLoginResponse?.ok()) {
+      const apiLoginBody = (await apiLoginResponse.json().catch(() => null)) as { token?: string } | null;
+      const claims = typeof apiLoginBody?.token === 'string' ? decodeJwtClaims(apiLoginBody.token) : null;
+      const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
+      const cookies = [];
+      if (claims?.tenantId) {
+        cookies.push({
+          name: 'om_selected_tenant',
+          value: claims.tenantId,
+          url: baseUrl,
+          sameSite: 'Lax' as const,
+        });
+      }
+      if (claims?.orgId) {
+        cookies.push({
+          name: 'om_selected_org',
+          value: claims.orgId,
+          url: baseUrl,
+          sameSite: 'Lax' as const,
+        });
+      }
+      if (cookies.length > 0) {
+        await page.context().addCookies(cookies);
+      }
+      await page.goto('/backend', { waitUntil: 'domcontentloaded' });
+      if (await waitForBackend(8_000)) return;
     }
-    if (cookies.length > 0) {
-      await page.context().addCookies(cookies);
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      await page.goto('/login', { waitUntil: 'domcontentloaded' });
+      await dismissGlobalNoticesIfPresent(page);
+      await recoverClientSideErrorPageIfPresent(page);
+      await recoverGenericErrorPageIfPresent(page);
+      await page.waitForSelector(loginReadySelector, { state: 'visible', timeout: 3_000 }).catch(() => null);
+      if (await page.getByLabel('Email').isVisible().catch(() => false)) break;
+      if (attempt === 3) {
+        throw new Error(`Login form is unavailable for role: ${role}; current URL: ${page.url()}`);
+      }
     }
-    await page.goto('/backend', { waitUntil: 'domcontentloaded' });
+    await page.getByLabel('Email').fill(creds.email);
+
+    const passwordInput = page.getByLabel('Password', { exact: true }).first();
+    if (await passwordInput.isVisible().catch(() => false)) {
+      await passwordInput.fill(creds.password);
+      await passwordInput.press('Enter');
+    } else {
+      const submitButton = page.getByRole('button', { name: /login|sign in|continue with sso/i }).first();
+      await submitButton.click();
+    }
+
+    if (await waitForBackend(7_000)) return;
+
+    const loginForm = page.locator('form').first();
+    if (await loginForm.isVisible().catch(() => false)) {
+      await loginForm.evaluate((element) => {
+        const form = element as HTMLFormElement
+        form.requestSubmit()
+      }).catch(() => {})
+    }
+    if (await waitForBackend(5_000)) return;
+
+    const loginButton = page.getByRole('button', { name: /login|sign in|continue with sso/i }).first();
+    if (await loginButton.isVisible().catch(() => false)) {
+      await loginButton.click({ force: true });
+    }
     if (await waitForBackend(8_000)) return;
+
+    throw new Error(`Login did not reach backend for role: ${role}; current URL: ${page.url()}`);
+  } catch (error) {
+    await throwLoginErrorWithDiagnostics(page, role, authTrace.entries, error);
+  } finally {
+    authTrace.stop();
   }
-
-  for (let attempt = 0; attempt < 4; attempt += 1) {
-    await page.goto('/login', { waitUntil: 'domcontentloaded' });
-    await dismissGlobalNoticesIfPresent(page);
-    await recoverClientSideErrorPageIfPresent(page);
-    await recoverGenericErrorPageIfPresent(page);
-    await page.waitForSelector(loginReadySelector, { state: 'visible', timeout: 3_000 }).catch(() => null);
-    if (await page.getByLabel('Email').isVisible().catch(() => false)) break;
-    if (attempt === 3) {
-      throw new Error(`Login form is unavailable for role: ${role}; current URL: ${page.url()}`);
-    }
-  }
-  await page.getByLabel('Email').fill(creds.email);
-
-  const passwordInput = page.getByLabel('Password', { exact: true }).first();
-  if (await passwordInput.isVisible().catch(() => false)) {
-    await passwordInput.fill(creds.password);
-    await passwordInput.press('Enter');
-  } else {
-    const submitButton = page.getByRole('button', { name: /login|sign in|continue with sso/i }).first();
-    await submitButton.click();
-  }
-
-  if (await waitForBackend(7_000)) return;
-
-  const loginForm = page.locator('form').first();
-  if (await loginForm.isVisible().catch(() => false)) {
-    await loginForm.evaluate((element) => {
-      const form = element as HTMLFormElement
-      form.requestSubmit()
-    }).catch(() => {})
-  }
-  if (await waitForBackend(5_000)) return;
-
-  const loginButton = page.getByRole('button', { name: /login|sign in|continue with sso/i }).first();
-  if (await loginButton.isVisible().catch(() => false)) {
-    await loginButton.click({ force: true });
-  }
-  if (await waitForBackend(8_000)) return;
-
-  throw new Error(`Login did not reach backend for role: ${role}; current URL: ${page.url()}`);
 }

--- a/packages/core/src/helpers/integration/auth.ts
+++ b/packages/core/src/helpers/integration/auth.ts
@@ -190,7 +190,7 @@ async function formatLoginDiagnostics(
 ): Promise<string> {
   const cookieNames = Array.from(
     new Set((await page.context().cookies()).map((cookie) => cookie.name)),
-  ).sort();
+  ).sort((left, right) => left.localeCompare(right));
   const traceLines = entries.length
     ? entries.map((entry) => {
       const location = entry.location ? ` -> ${entry.location}` : '';

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-053-login-helper-backend-cookie-flow.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-053-login-helper-backend-cookie-flow.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test, type Page } from '@playwright/test';
+import { login } from '@open-mercato/core/helpers/integration/auth';
+
+type AuthTraceEntry = {
+  path: string;
+  status: number;
+  location: string | null;
+};
+
+function toPathOnly(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return '[unparseable-url]';
+  }
+}
+
+function toRedactedLocation(rawLocation: string | undefined): string | null {
+  if (!rawLocation) return null;
+  try {
+    const url = new URL(rawLocation, 'http://integration.local');
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return '[unparseable-location]';
+  }
+}
+
+function collectAuthTrace(page: Page): AuthTraceEntry[] {
+  const trace: AuthTraceEntry[] = [];
+  page.on('response', (response) => {
+    const path = toPathOnly(response.url());
+    if (path === '/backend' || path.startsWith('/api/auth/session/refresh')) {
+      trace.push({
+        path,
+        status: response.status(),
+        location: toRedactedLocation(response.headers().location),
+      });
+    }
+  });
+  return trace;
+}
+
+function hasBackendRefreshLoop(trace: AuthTraceEntry[]): boolean {
+  let refreshCycles = 0;
+  for (let index = 0; index < trace.length - 1; index += 1) {
+    const current = trace[index]?.path;
+    const next = trace[index + 1]?.path;
+    if (current === '/backend' && next?.startsWith('/api/auth/session/refresh')) {
+      refreshCycles += 1;
+    }
+  }
+  return refreshCycles > 1;
+}
+
+async function formatRedactedDiagnostics(page: Page, trace: AuthTraceEntry[]): Promise<string> {
+  const cookieNames = Array.from(
+    new Set((await page.context().cookies()).map((cookie) => cookie.name)),
+  ).sort();
+  const traceLines = trace.length
+    ? trace.map((entry) => {
+      const location = entry.location ? ` -> ${entry.location}` : '';
+      return `${entry.status} ${entry.path}${location}`;
+    })
+    : ['none'];
+
+  return [
+    `current URL: ${toPathOnly(page.url())}`,
+    `browser cookie names: ${cookieNames.length ? cookieNames.join(', ') : 'none'}`,
+    'backend/refresh trace:',
+    ...traceLines,
+  ].join('\n');
+}
+
+/**
+ * TC-AUTH-053: The published integration auth helper establishes browser-cookie
+ * staff auth for `/backend` without entering a session-refresh redirect loop.
+ */
+test.describe('TC-AUTH-053: login helper backend-cookie flow', () => {
+  test('login(page, admin) reaches /backend with browser auth cookies', async ({ page }) => {
+    test.slow();
+
+    const authTrace = collectAuthTrace(page);
+
+    try {
+      await login(page, 'admin');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error([
+        "login(page, 'admin') failed before backend auth stabilized.",
+        await formatRedactedDiagnostics(page, authTrace),
+        `Original error: ${message}`,
+      ].join('\n'));
+    }
+
+    const diagnostics = await formatRedactedDiagnostics(page, authTrace);
+    expect(page.url(), diagnostics).toMatch(/\/backend(?:\/.*)?$/);
+    expect(hasBackendRefreshLoop(authTrace), diagnostics).toBe(false);
+
+    const cookieNames = new Set((await page.context().cookies()).map((cookie) => cookie.name));
+    expect(cookieNames.has('auth_token'), diagnostics).toBe(true);
+    expect(cookieNames.has('session_token'), diagnostics).toBe(true);
+    await expect(page.getByRole('button', { name: /admin@acme\.com/i }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/packages/ui/src/backend/__tests__/DataTable.extensions.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.extensions.test.tsx
@@ -298,6 +298,7 @@ describe('DataTable extensions', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Delete all filtered' }))
 
       await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(1))
+      await new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve()))
       refreshButtonMock.mockClear()
       mockRouterRefresh.mockClear()
 

--- a/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
+++ b/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
@@ -410,7 +410,7 @@ export function AdvancedFilterPanel(props: AdvancedFilterPanelProps) {
         align="end"
         sideOffset={8}
         data-testid="advanced-filter-panel"
-ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
+        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
         onFocusOutside={ignoreAdvancedFilterPortalInteractions}
         onInteractOutside={ignoreAdvancedFilterPortalInteractions}
       >


### PR DESCRIPTION
## Summary

- add `TC-AUTH-053` coverage for the published `login(page, 'admin')` helper reaching `/backend` with browser auth cookies
- keep auth/session runtime semantics unchanged because the regression passes on current `origin/develop`, and add redacted helper diagnostics instead
- add a cookie-backed CLI readiness probe for `/backend` with bounded same-origin redirect handling and redacted diagnostics
- stabilize related validation fallout found during gates

## Validation

- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage` (passed outside sandbox; sandbox blocks `tsx` IPC pipe)
- `yarn typecheck`
- `yarn test` (passed outside sandbox; sandbox blocks local listener behavior used by CLI tests)
- `yarn build:app` (passed outside sandbox; sandbox blocks Turbopack port binding)
- `yarn test:integration:ephemeral --filter packages/core/src/modules/auth/__integration__/TC-AUTH-053-login-helper-backend-cookie-flow.spec.ts`

## QA

`skip-qa`: no product UI behavior change. The affected surface is the integration auth helper, CLI readiness, specs/run docs, and test stabilization.
