### PR TITLE
fix(ui): remove stray `ded` token breaking AdvancedFilterPanel typecheck

### DIFF
--- a/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
+++ b/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
@@ -410,7 +410,7 @@ export function AdvancedFilterPanel(props: AdvancedFilterPanelProps) {
         align="end"
         sideOffset={8}
         data-testid="advanced-filter-panel"
-ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
+        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
         onFocusOutside={ignoreAdvancedFilterPortalInteractions}
         onInteractOutside={ignoreAdvancedFilterPortalInteractions}
       >


### PR DESCRIPTION
## Problem
`packages/ui/src/backend/filters/AdvancedFilterPanel.tsx:413` has a stray `ded` token:

```tsx
        data-testid="advanced-filter-panel"
ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
```

TypeScript parses `ded` as an invalid boolean shorthand prop on `PopoverContent`, failing typecheck repo-wide:

```
packages/ui/src/backend/filters/AdvancedFilterPanel.tsx(413,1): error TS2322: … Property 'ded' does not exist on type … PopoverContentProps …
```

It was introduced ~today in develop commit `39cb68096` ("feat: CHANGELOG update") — an accidental corruption of the source line. Because `core`'s typecheck compiles `ui` sources, this breaks `develop`'s own typecheck and every open PR that merges current develop.

## Fix
Remove the stray `ded` and restore the intended 8-space indentation. One line, no behavior change.

## Validation
- `yarn workspace @open-mercato/ui typecheck` → **0 errors** (was 1).
- `yarn workspace @open-mercato/ui build` → built successfully.

Found while resolving the merge conflict on #3772; keeping this fix separate from that `build(deps)` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)