### PR TITLE
build(deps): bump mermaid from 11.12.2 to 11.16.0 in apps/docs

### DIFF
--- a/.ai/runs/2026-07-07-port-mermaid-11-16-to-develop.md
+++ b/.ai/runs/2026-07-07-port-mermaid-11-16-to-develop.md
@@ -45,10 +45,10 @@ onto `develop`, then close the original PR. `develop` currently pins `mermaid ^1
 
 ### Phase 1: Bump and lock
 
-- [ ] 1.1 Bump mermaid to ^11.16.0 in apps/docs/package.json
-- [ ] 1.2 Refresh yarn.lock via yarn install
+- [x] 1.1 Bump mermaid to ^11.16.0 in apps/docs/package.json — 0e384aa89
+- [x] 1.2 Refresh yarn.lock via yarn install — 0e384aa89
 
 ### Phase 2: Validate and ship
 
-- [ ] 2.1 Verify lockfile resolves mermaid@11.16.x
+- [x] 2.1 Verify lockfile resolves mermaid@11.16.x (re-resolve stable, clean tree) — 0e384aa89
 - [ ] 2.2 Open PR against develop, label, close original #3708

--- a/.ai/runs/2026-07-07-port-mermaid-11-16-to-develop.md
+++ b/.ai/runs/2026-07-07-port-mermaid-11-16-to-develop.md
@@ -51,4 +51,4 @@ onto `develop`, then close the original PR. `develop` currently pins `mermaid ^1
 ### Phase 2: Validate and ship
 
 - [x] 2.1 Verify lockfile resolves mermaid@11.16.x (re-resolve stable, clean tree) — 0e384aa89
-- [ ] 2.2 Open PR against develop, label, close original #3708
+- [x] 2.2 Open PR against develop, label, close original #3708 — PR #3967 (original #3708 closed)

--- a/.ai/runs/2026-07-07-port-mermaid-11-16-to-develop.md
+++ b/.ai/runs/2026-07-07-port-mermaid-11-16-to-develop.md
@@ -1,0 +1,54 @@
+# Port mermaid 11.16.0 bump to develop
+
+**Date:** 2026-07-07
+**Slug:** port-mermaid-11-16-to-develop
+**Branch:** feat/port-mermaid-11-16-to-develop
+**Source PR:** #3708 (Dependabot, based on `main`) — to be closed after this PR opens.
+
+## Goal
+
+Port the Dependabot dependency bump `mermaid` 11.15.0 → 11.16.0 (PR #3708, targeting `main`)
+onto `develop`, then close the original PR. `develop` currently pins `mermaid ^11.12.2` in
+`apps/docs/package.json`, so the ported version is `max(develop, target) = ^11.16.0`.
+
+## Scope
+
+- `apps/docs/package.json` — bump `mermaid` to `^11.16.0`.
+- `yarn.lock` — refresh resolutions for mermaid and its transitive deps.
+
+## Non-goals
+
+- No other dependency changes; no docs content changes; no code changes.
+
+## Risks
+
+- `mermaid` is used only by the docs site (`apps/docs`) for diagram rendering. Blast radius is
+  the docs build/render. Minor version bump within `^11`, low risk.
+- Per [[open-mercato-ai-sdk-v7-esm-jest-and-dep-port]] convention: apply max(develop, target),
+  skip eslint mismatch concerns; this is a docs-only workspace dependency.
+
+## Implementation Plan
+
+### Phase 1: Bump and lock
+
+- 1.1 Bump `mermaid` to `^11.16.0` in `apps/docs/package.json`.
+- 1.2 Refresh `yarn.lock` via `yarn install`.
+
+### Phase 2: Validate and ship
+
+- 2.1 Verify lockfile resolves mermaid@11.16.x; sanity-build docs types if feasible.
+- 2.2 Open PR against `develop`, label, close original #3708.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Bump and lock
+
+- [ ] 1.1 Bump mermaid to ^11.16.0 in apps/docs/package.json
+- [ ] 1.2 Refresh yarn.lock via yarn install
+
+### Phase 2: Validate and ship
+
+- [ ] 2.1 Verify lockfile resolves mermaid@11.16.x
+- [ ] 2.2 Open PR against develop, label, close original #3708

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,7 +20,7 @@
     "@mdx-js/react": "^3.0.0",
     "@mermaid-js/layout-elk": "~0.2.1",
     "clsx": "^2.1.0",
-    "mermaid": "^11.12.2",
+    "mermaid": "^11.16.0",
     "prism-react-renderer": "^2.3.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2446,6 +2446,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@braintree/sanitize-url@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "@braintree/sanitize-url@npm:7.1.2"
+  checksum: 10/d9626ff8f8eb5e192cd055e6e743449c21102c76bb59e405b7028fe56230fa080bfcc80dfb1e21850a6876e75adda9f7b3c888cf0685942bb74da4d2866d6ec3
+  languageName: node
+  linkType: hard
+
 "@chevrotain/cst-dts-gen@npm:11.0.3":
   version: 11.0.3
   resolution: "@chevrotain/cst-dts-gen@npm:11.0.3"
@@ -2481,7 +2488,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chevrotain/types@npm:~11.1.1":
+"@chevrotain/types@npm:~11.1.2":
   version: 11.1.2
   resolution: "@chevrotain/types@npm:11.1.2"
   checksum: 10/ad39d7651a20b05ead9b4374f98afc39915118dda29678c2b623571aa3da3018a0f3fb799d1809605cafcae59cba637d640855ea0f97b9b01d0900d77d6781fe
@@ -6759,12 +6766,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mermaid-js/parser@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@mermaid-js/parser@npm:1.1.1"
+"@mermaid-js/parser@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@mermaid-js/parser@npm:1.2.0"
   dependencies:
-    "@chevrotain/types": "npm:~11.1.1"
-  checksum: 10/9f3645fd055c0800c16a3e7eab1ce7f05736c352ab48996e9c64fb21b27c25a5987636040816b1bb16384a4434744cecbdf746c152ef80e0bc712972cb58deed
+    "@chevrotain/types": "npm:~11.1.2"
+  checksum: 10/278ae28edd452c9bcee3723a2d45a6a3f174700cb80fc907b9a5212f2ce449c9a5a6f7d45372bb18b6d633f8040dff4c4d2533b6a3c8d3f021903b3d6ccea799
   languageName: node
   linkType: hard
 
@@ -15587,10 +15594,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cytoscape@npm:^3.33.1":
-  version: 3.33.3
-  resolution: "cytoscape@npm:3.33.3"
-  checksum: 10/1a5aa931936bf7afb055ea0e26905b1fa7062fc34011f8da44d64514cc7b8142a3c6a944cf382e11950ac32d288bdadb85cce5bede45cf620da5be53424018b0
+"cytoscape@npm:^3.33.3":
+  version: 3.34.0
+  resolution: "cytoscape@npm:3.34.0"
+  checksum: 10/5bbc169798829b1a0eaadcad2707e7762e7ba1a2bcd5dbeaf75b89eb2d2ab9211e51d96b24c1f5807e329ac44c50913062464e2af11c528a1255969a36b45268
   languageName: node
   linkType: hard
 
@@ -16061,17 +16068,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.11.19, dayjs@npm:^1.11.7":
-  version: 1.11.20
-  resolution: "dayjs@npm:1.11.20"
-  checksum: 10/5347533f21a55b8bb1b1ef559be9b805514c3a8fb7e68b75fb7e73808131c59e70909c073aa44ce8a0d159195cd110cdd4081cf87ab96cb06fee3edacae791c6
-  languageName: node
-  linkType: hard
-
-"dayjs@npm:^1.11.21":
+"dayjs@npm:^1.11.20, dayjs@npm:^1.11.21":
   version: 1.11.21
   resolution: "dayjs@npm:1.11.21"
   checksum: 10/dd16f9f2706b61b90e3c346a3211ac3afd9e26193136ce0e87f70bf74d1c17a447bceb230a88b175467fc9f5e3243d8c1544b9897092a12d9c80ee44d338dcb6
+  languageName: node
+  linkType: hard
+
+"dayjs@npm:^1.11.7":
+  version: 1.11.20
+  resolution: "dayjs@npm:1.11.20"
+  checksum: 10/5347533f21a55b8bb1b1ef559be9b805514c3a8fb7e68b75fb7e73808131c59e70909c073aa44ce8a0d159195cd110cdd4081cf87ab96cb06fee3edacae791c6
   languageName: node
   linkType: hard
 
@@ -21302,14 +21309,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"katex@npm:^0.16.25":
-  version: 0.16.45
-  resolution: "katex@npm:0.16.45"
+"katex@npm:^0.16.45":
+  version: 0.16.47
+  resolution: "katex@npm:0.16.47"
   dependencies:
     commander: "npm:^8.3.0"
   bin:
     katex: cli.js
-  checksum: 10/8c82f9651c3615459722166a6ccb16f23ecd8323850a956568b69b1f641331a57679aa9f3ad4903c4be26089434cbbde850c0384b9b0dff022e4357b84a20ebc
+  checksum: 10/e0286b45d9e0c8443cf0381205619ecbab3919ea5fb6616408f46f0cb471ce2222e83f46aef52cdaacdcbfd4485e00fcfbcf36bd85a8a9a81e22b45827c27ced
   languageName: node
   linkType: hard
 
@@ -22489,32 +22496,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mermaid@npm:^11.12.2":
-  version: 11.15.0
-  resolution: "mermaid@npm:11.15.0"
+"mermaid@npm:^11.16.0":
+  version: 11.16.0
+  resolution: "mermaid@npm:11.16.0"
   dependencies:
-    "@braintree/sanitize-url": "npm:^7.1.1"
+    "@braintree/sanitize-url": "npm:^7.1.2"
     "@iconify/utils": "npm:^3.0.2"
-    "@mermaid-js/parser": "npm:^1.1.1"
+    "@mermaid-js/parser": "npm:^1.2.0"
     "@types/d3": "npm:^7.4.3"
     "@upsetjs/venn.js": "npm:^2.0.0"
-    cytoscape: "npm:^3.33.1"
+    cytoscape: "npm:^3.33.3"
     cytoscape-cose-bilkent: "npm:^4.1.0"
     cytoscape-fcose: "npm:^2.2.0"
     d3: "npm:^7.9.0"
     d3-sankey: "npm:^0.12.3"
     dagre-d3-es: "npm:7.0.14"
-    dayjs: "npm:^1.11.19"
-    dompurify: "npm:^3.3.1"
+    dayjs: "npm:^1.11.20"
+    dompurify: "npm:^3.3.3"
     es-toolkit: "npm:^1.45.1"
-    katex: "npm:^0.16.25"
+    katex: "npm:^0.16.45"
     khroma: "npm:^2.1.0"
     marked: "npm:^16.3.0"
     roughjs: "npm:^4.6.6"
     stylis: "npm:^4.3.6"
     ts-dedent: "npm:^2.2.0"
     uuid: "npm:^11.1.0 || ^12 || ^13 || ^14.0.0"
-  checksum: 10/4a3f8ac77aba326c96adc2325f550421b6f05f1592998fcf80dfeb9fbcd751e2a0a030092559bd258e45bba60c0ad1e7415ad46ff5c165b1d9a469835e927e9a
+  checksum: 10/9984131ac3e3c7d49dbbb7847a995d69766a26c88409188bbabce8775b93496a3e435e7b6407119342b8c429435184b81a361a43e12bca48650c108873e0d5bd
   languageName: node
   linkType: hard
 
@@ -24001,7 +24008,7 @@ __metadata:
     "@types/react": "npm:^19.2.17"
     "@types/react-dom": "npm:^19.2.3"
     clsx: "npm:^2.1.0"
-    mermaid: "npm:^11.12.2"
+    mermaid: "npm:^11.16.0"
     prism-react-renderer: "npm:^2.3.1"
     react: "npm:^19.2.7"
     react-dom: "npm:^19.2.7"


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-07-port-mermaid-11-16-to-develop.md
Status: complete

## Goal
- Port the Dependabot bump `mermaid` 11.15.0 → 11.16.0 (PR #3708, which targeted `main`) onto `develop`, and close the original.

`develop` pinned `mermaid ^11.12.2` in `apps/docs/package.json`, so the ported range is `max(develop, target) = ^11.16.0`. Original: #3708.

## What Changed
- `apps/docs/package.json`: `mermaid` `^11.12.2` → `^11.16.0`.
- `yarn.lock`: refreshed resolutions — `mermaid@11.16.0`, `@mermaid-js/parser@1.2.0`, `@chevrotain/types@~11.1.2`, `cytoscape@3.34.0`, `katex@0.16.47`, `dayjs@1.11.21`, plus new `@braintree/sanitize-url@7.1.2`.

## Tests
- No app code changed; `mermaid` is a docs-site (`apps/docs`) diagram dependency only, so no unit tests apply.
- Verified `yarn install --mode=update-lockfile` re-resolves with a stable lockfile (no pending changes) and mermaid resolves to `11.16.0`.

## Backward Compatibility
- No contract surface changes. Minor version bump within `^11` of a docs-only dependency.

## Progress
See [Progress section in the plan](.ai/runs/2026-07-07-port-mermaid-11-16-to-develop.md#progress).
