### PR TITLE
build(deps): bump actions/cache from 5 to 6

### DIFF
--- a/.ai/runs/2026-07-07-bump-actions-cache-v6-develop.md
+++ b/.ai/runs/2026-07-07-bump-actions-cache-v6-develop.md
@@ -33,4 +33,4 @@ change on top of `develop`, whose ci.yml has 15 cache steps (one more than main'
 
 ### Phase 2: Ship
 
-- [ ] 2.1 Open PR against `develop`, label, and close original #3695
+- [x] 2.1 Open PR against `develop`, label, and close original #3695 — PR #3968; #3695 closed

--- a/.ai/runs/2026-07-07-bump-actions-cache-v6-develop.md
+++ b/.ai/runs/2026-07-07-bump-actions-cache-v6-develop.md
@@ -29,7 +29,7 @@ change on top of `develop`, whose ci.yml has 15 cache steps (one more than main'
 
 ### Phase 1: Port the bump
 
-- [ ] 1.1 Bump all `actions/cache@v5` → `@v6` in `.github/workflows/ci.yml`
+- [x] 1.1 Bump all `actions/cache@v5` → `@v6` in `.github/workflows/ci.yml` — 8a0564d63
 
 ### Phase 2: Ship
 

--- a/.ai/runs/2026-07-07-bump-actions-cache-v6-develop.md
+++ b/.ai/runs/2026-07-07-bump-actions-cache-v6-develop.md
@@ -1,0 +1,36 @@
+# Execution Plan: bump actions/cache v5 → v6 (ported to develop)
+
+## Goal
+
+Port Dependabot PR #3695 (`build(deps): bump actions/cache from 5 to 6`, opened against `main`)
+to a PR against `develop`, then close the original #3695. The develop branch pins
+`actions/cache@v5` in 15 places in `.github/workflows/ci.yml`; bump them all to `@v6`.
+
+## Scope
+
+- `.github/workflows/ci.yml` only — bump every `uses: actions/cache@v5` to `@v6`.
+- Non-goals: no changes to job logic, cache keys, paths, or any other action version.
+
+## Rationale
+
+Dependabot targeted `main`. Team convention is to land dependency bumps on `develop`
+first (`max(develop, target)` = `max(v5, v6)` = `v6`). This recreates the equivalent
+change on top of `develop`, whose ci.yml has 15 cache steps (one more than main's diff).
+
+## Risks
+
+- CI-config-only change. Risk is limited to GitHub Actions cache behavior in CI.
+  actions/cache v6 is a routine major bump (Node runtime / internal deps); no workflow
+  syntax changes required. If v6 misbehaves the change is a one-line revert.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Port the bump
+
+- [ ] 1.1 Bump all `actions/cache@v5` → `@v6` in `.github/workflows/ci.yml`
+
+### Phase 2: Ship
+
+- [ ] 2.1 Open PR against `develop`, label, and close original #3695

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         run: corepack enable
 
       - name: Cache Yarn packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -138,7 +138,7 @@ jobs:
         # when .yarn/cache hits — the extraction alone is ~85s. Caching node_modules
         # directly and skipping install on hit eliminates that cost.
         id: nm-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -147,7 +147,7 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Cache Turbo build outputs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -284,7 +284,7 @@ jobs:
         run: corepack enable
 
       - name: Cache Yarn packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -294,7 +294,7 @@ jobs:
         # Keyed on package manifests and lockfiles — if none of these changed,
         # a prior passing audit is still valid.
         id: audit-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .audit-passed
           key: audit-${{ runner.os }}-${{ hashFiles('**/package.json', '**/yarn.lock', '**/package-lock.json', '**/npm-shrinkwrap.json', '**/pnpm-lock.yaml', '**/bun.lock', '**/bun.lockb') }}
@@ -304,7 +304,7 @@ jobs:
         # Shared key with other jobs — whichever runs first saves it.
         if: steps.audit-cache.outputs.cache-hit != 'true'
         id: nm-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -342,7 +342,7 @@ jobs:
         run: corepack enable
 
       - name: Cache Yarn packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -350,7 +350,7 @@ jobs:
 
       - name: Cache node_modules
         id: nm-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -395,7 +395,7 @@ jobs:
         run: corepack enable
 
       - name: Cache Yarn packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -403,7 +403,7 @@ jobs:
 
       - name: Cache node_modules
         id: nm-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -412,7 +412,7 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Cache pip packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/pip
           key: pip-markitdown-v2
@@ -437,7 +437,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Cache Turbo build outputs
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ github.sha }}
@@ -578,7 +578,7 @@ jobs:
         run: corepack enable
 
       - name: Cache Yarn packages
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: .yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
@@ -586,7 +586,7 @@ jobs:
 
       - name: Cache node_modules
         id: nm-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             node_modules
@@ -617,7 +617,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-chromium-${{ runner.os }}-v1.50.0


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-07-bump-actions-cache-v6-develop.md
Status: complete

## Goal
- Port Dependabot PR #3695 (`build(deps): bump actions/cache from 5 to 6`, opened against `main`) to `develop`, and close the original.

## What Changed
- Bumped all 15 `uses: actions/cache@v5` references in `.github/workflows/ci.yml` to `@v6`.
- No job logic, cache keys, paths, or other action versions were touched.

## Tests
- CI-config-only change (no application code). YAML validated with `yaml.safe_load`. No unit/integration tests apply; the real verification is a green CI run on this branch.

## Backward Compatibility
- No contract surface changes. GitHub Actions cache action major bump only.

## Progress
See [Progress section in the plan](.ai/runs/2026-07-07-bump-actions-cache-v6-develop.md#progress).
