### PR TITLE
fix(ui): remove stray 'ded' token breaking AdvancedFilterPanel type check

### DIFF
--- a/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
+++ b/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
@@ -410,7 +410,7 @@ export function AdvancedFilterPanel(props: AdvancedFilterPanelProps) {
         align="end"
         sideOffset={8}
         data-testid="advanced-filter-panel"
-ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
+        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
         onFocusOutside={ignoreAdvancedFilterPortalInteractions}
         onInteractOutside={ignoreAdvancedFilterPortalInteractions}
       >


### PR DESCRIPTION
## Problem

`develop` currently fails the `prepare` job (Next.js build → TypeScript type check):

```
packages/ui/src/backend/filters/AdvancedFilterPanel.tsx:413:1
Type error: Property 'ded' does not exist on type ... PopoverContentProps ...
> 413 | ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
```

A leftover `ded` fragment got glued to the front of the `onPointerDownOutside` prop on `<PopoverContent>`, so TypeScript parses it as an unknown `ded` prop and the build fails. This breaks `develop` and every PR based on it (e.g. #3972).

## Fix

Remove the stray `ded ` token. One-line change, no behavior difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)