### PR TITLE
fix: clarify workflow CALL_API execution identity

### DIFF
--- a/packages/core/src/modules/workflows/backend/instances/[id]/page.tsx
+++ b/packages/core/src/modules/workflows/backend/instances/[id]/page.tsx
@@ -7,6 +7,7 @@ import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { FormHeader } from '@open-mercato/ui/backend/forms'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
+import { Alert, AlertDescription, AlertTitle } from '@open-mercato/ui/primitives/alert'
 import { JsonDisplay } from '@open-mercato/ui/backend/JsonDisplay'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { apiFetch } from '@open-mercato/ui/backend/utils/api'
@@ -18,6 +19,7 @@ import { WorkflowLegend } from '../../../components/WorkflowLegend'
 import { MobileInstanceOverview } from '../../../components/mobile/MobileInstanceOverview'
 import { useIsMobile } from '@open-mercato/ui/hooks/useIsMobile'
 import { definitionToGraph } from '../../../lib/graph-utils'
+import { isCallApiIdentityResolutionError } from '../../../lib/call-api-identity-error'
 import type { Node } from '@xyflow/react'
 import { RecordNotFoundState, ErrorMessage } from '@open-mercato/ui/backend/detail'
 
@@ -413,6 +415,7 @@ export default function WorkflowInstanceDetailPage({ params }: { params?: { id?:
   const canCancel = ['RUNNING', 'PAUSED'].includes(instance.status)
   const canRetry = instance.status === 'FAILED'
   const actionLoading = cancelMutation.isPending || retryMutation.isPending
+  const showCallApiIdentityGuidance = isCallApiIdentityResolutionError(instance.errorMessage)
 
   if (isMobile) {
     return (
@@ -681,6 +684,16 @@ export default function WorkflowInstanceDetailPage({ params }: { params?: { id?:
               <pre className="text-sm text-destructive whitespace-pre-wrap font-mono">
                 {instance.errorMessage}
               </pre>
+              {showCallApiIdentityGuidance && (
+                <Alert status="warning" style="lighter" className="mt-4">
+                  <AlertTitle>
+                    {t('workflows.instances.callApiIdentity.title')}
+                  </AlertTitle>
+                  <AlertDescription>
+                    {t('workflows.instances.callApiIdentity.description')}
+                  </AlertDescription>
+                </Alert>
+              )}
               {instance.errorDetails && (
                 <div className="mt-4">
                   <JsonDisplay

--- a/packages/core/src/modules/workflows/i18n/de.json
+++ b/packages/core/src/modules/workflows/i18n/de.json
@@ -776,6 +776,8 @@
   "workflows.instances.actions.retry": "Wiederholen",
   "workflows.instances.actions.viewDetails": "Details anzeigen",
   "workflows.instances.backToList": "Zurück zu Instanzen",
+  "workflows.instances.callApiIdentity.description": "CALL_API wird mit den Rollen des Benutzers ausgeführt, der den Workflow gestartet hat. Ereignisgesteuerte Workflows verwenden den Autor oder letzten Bearbeiter der Workflow-Definition. Öffnen Sie die Workflow-Definition, speichern Sie sie als Benutzer mit den erforderlichen API-Berechtigungen und wiederholen Sie dann die Instanz.",
+  "workflows.instances.callApiIdentity.title": "CALL_API benötigt einen nachvollziehbaren Ausführungsbenutzer",
   "workflows.instances.cancelFailed": "Workflow-Instanz konnte nicht abgebrochen werden.",
   "workflows.instances.compensation.activities": "Kompensationsaktivitäten",
   "workflows.instances.compensation.completed": "Kompensation abgeschlossen",

--- a/packages/core/src/modules/workflows/i18n/en.json
+++ b/packages/core/src/modules/workflows/i18n/en.json
@@ -776,6 +776,8 @@
   "workflows.instances.actions.retry": "Retry",
   "workflows.instances.actions.viewDetails": "View Details",
   "workflows.instances.backToList": "Back to instances",
+  "workflows.instances.callApiIdentity.description": "CALL_API runs with the roles of the user who started the workflow. Event-triggered workflows use the workflow definition author or last editor. Open the workflow definition, save it as a user with the required API permissions, then retry the instance.",
+  "workflows.instances.callApiIdentity.title": "CALL_API needs a traceable execution user",
   "workflows.instances.cancelFailed": "Failed to cancel workflow instance.",
   "workflows.instances.compensation.activities": "Compensation Activities",
   "workflows.instances.compensation.completed": "Compensation Completed",

--- a/packages/core/src/modules/workflows/i18n/es.json
+++ b/packages/core/src/modules/workflows/i18n/es.json
@@ -776,6 +776,8 @@
   "workflows.instances.actions.retry": "Reintentar",
   "workflows.instances.actions.viewDetails": "Ver detalles",
   "workflows.instances.backToList": "Volver a instancias",
+  "workflows.instances.callApiIdentity.description": "CALL_API se ejecuta con los roles del usuario que inició el flujo de trabajo. Los flujos activados por eventos usan el autor o el último editor de la definición. Abre la definición del flujo, guárdala como un usuario con los permisos de API necesarios y luego reintenta la instancia.",
+  "workflows.instances.callApiIdentity.title": "CALL_API necesita un usuario de ejecución identificable",
   "workflows.instances.cancelFailed": "Error al cancelar la instancia de flujo de trabajo.",
   "workflows.instances.compensation.activities": "Actividades de compensación",
   "workflows.instances.compensation.completed": "Compensación completada",

--- a/packages/core/src/modules/workflows/i18n/pl.json
+++ b/packages/core/src/modules/workflows/i18n/pl.json
@@ -776,6 +776,8 @@
   "workflows.instances.actions.retry": "Ponów",
   "workflows.instances.actions.viewDetails": "Zobacz Szczegóły",
   "workflows.instances.backToList": "Powrót do instancji",
+  "workflows.instances.callApiIdentity.description": "CALL_API działa z rolami użytkownika, który uruchomił przepływ. Przepływy uruchamiane zdarzeniem używają autora definicji albo ostatniego edytora. Otwórz definicję przepływu, zapisz ją jako użytkownik z wymaganymi uprawnieniami API, a potem ponów instancję.",
+  "workflows.instances.callApiIdentity.title": "CALL_API potrzebuje rozpoznawalnego użytkownika wykonania",
   "workflows.instances.cancelFailed": "Nie udało się anulować instancji przepływu pracy.",
   "workflows.instances.compensation.activities": "Czynności kompensacyjne",
   "workflows.instances.compensation.completed": "Kompensacja zakończona",

--- a/packages/core/src/modules/workflows/lib/__tests__/call-api-identity-error.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/call-api-identity-error.test.ts
@@ -1,0 +1,16 @@
+import { isCallApiIdentityResolutionError } from '../call-api-identity-error'
+
+describe('isCallApiIdentityResolutionError', () => {
+  it('detects CALL_API execution identity resolution errors', () => {
+    expect(
+      isCallApiIdentityResolutionError(
+        'Activities failed: Activity failed after 3 attempts: [CALL_API] Refusing to execute CALL_API for workflow instance abc: no traceable user roles could be resolved from the workflow instance or definition. CALL_API activities must run under the identity of the user who triggered them.',
+      ),
+    ).toBe(true)
+  })
+
+  it('ignores unrelated workflow errors', () => {
+    expect(isCallApiIdentityResolutionError('CALL_API request failed with status 500')).toBe(false)
+    expect(isCallApiIdentityResolutionError(null)).toBe(false)
+  })
+})

--- a/packages/core/src/modules/workflows/lib/__tests__/resolve-call-api-role-ids.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/resolve-call-api-role-ids.test.ts
@@ -38,6 +38,7 @@ const ORG_ID = 'org-1'
 const DEFINITION_ID = 'def-1'
 const AUTHOR_ID = 'author-admin'
 const INITIATOR_ID = 'initiator-low-priv'
+const UPDATER_ID = '33333333-3333-4333-8333-333333333333'
 
 type FindOneCall = { entity: string; filter: Record<string, unknown> }
 
@@ -52,13 +53,21 @@ function entityName(arg: unknown): string {
 function setupCommonStubs({
   authorExists = true,
   initiatorExists = true,
+  updaterExists = true,
   authorRoleIds = ['role-admin'],
   initiatorRoleIds = ['role-low-priv'],
+  updaterRoleIds = ['role-editor'],
+  definitionCreatedBy = AUTHOR_ID,
+  definitionUpdatedBy = null,
 }: {
   authorExists?: boolean
   initiatorExists?: boolean
+  updaterExists?: boolean
   authorRoleIds?: string[]
   initiatorRoleIds?: string[]
+  updaterRoleIds?: string[]
+  definitionCreatedBy?: string | null
+  definitionUpdatedBy?: string | null
 } = {}) {
   mockFindOne.mockReset()
   mockFindMany.mockReset()
@@ -68,13 +77,15 @@ function setupCommonStubs({
     if (name === 'WorkflowDefinition') {
       return {
         id: filter.id,
-        createdBy: AUTHOR_ID,
+        createdBy: definitionCreatedBy,
+        updatedBy: definitionUpdatedBy,
         tenantId: filter.tenantId,
       }
     }
     if (name === 'User') {
       if (filter.id === AUTHOR_ID && authorExists) return { id: AUTHOR_ID }
       if (filter.id === INITIATOR_ID && initiatorExists) return { id: INITIATOR_ID }
+      if (filter.id === UPDATER_ID && updaterExists) return { id: UPDATER_ID }
       return null
     }
     return null
@@ -84,7 +95,11 @@ function setupCommonStubs({
     const name = entityName(Entity)
     if (name === 'UserRole') {
       const userFilter = filter.user as string | undefined
-      const ids = userFilter === INITIATOR_ID ? initiatorRoleIds : authorRoleIds
+      const ids = userFilter === INITIATOR_ID
+        ? initiatorRoleIds
+        : userFilter === UPDATER_ID
+          ? updaterRoleIds
+          : authorRoleIds
       return ids.map((id) => ({ role: { id } }))
     }
     if (name === 'Role') {
@@ -183,6 +198,63 @@ describe('resolveCallApiRoleIds', () => {
     const calls = findOneCalls()
     expect(calls.some((c) => c.entity === 'WorkflowDefinition')).toBe(true)
     expect(calls.some((c) => c.entity === 'User' && c.filter.id === AUTHOR_ID)).toBe(true)
+  })
+
+  test('falls back to the last editor when the author has no active scoped roles', async () => {
+    setupCommonStubs({
+      authorRoleIds: [],
+      updaterRoleIds: ['role-editor'],
+      definitionUpdatedBy: UPDATER_ID,
+    })
+
+    const result = await resolveCallApiRoleIds({}, {
+      id: 'inst-last-editor',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: DEFINITION_ID,
+      metadata: null,
+    })
+
+    expect(result).toEqual(['role-editor'])
+
+    const userCalls = findOneCalls().filter((c) => c.entity === 'User')
+    expect(userCalls.map((c) => c.filter.id)).toEqual([AUTHOR_ID, UPDATER_ID])
+  })
+
+  test('falls back to the last editor when the author user is missing', async () => {
+    setupCommonStubs({
+      authorExists: false,
+      updaterRoleIds: ['role-editor'],
+      definitionUpdatedBy: UPDATER_ID,
+    })
+
+    const result = await resolveCallApiRoleIds({}, {
+      id: 'inst-missing-author',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: DEFINITION_ID,
+      metadata: { initiatedBy: 'trigger:definition-id:deal_created_trigger' },
+    })
+
+    expect(result).toEqual(['role-editor'])
+  })
+
+  test('returns empty when neither author nor last editor has active scoped roles', async () => {
+    setupCommonStubs({
+      authorRoleIds: [],
+      updaterRoleIds: [],
+      definitionUpdatedBy: UPDATER_ID,
+    })
+
+    const result = await resolveCallApiRoleIds({}, {
+      id: 'inst-no-editor-roles',
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+      definitionId: DEFINITION_ID,
+      metadata: null,
+    })
+
+    expect(result).toEqual([])
   })
 
   test('falls back to the author when metadata exists but initiatedBy is empty', async () => {

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -898,8 +898,9 @@ export async function executeCallApi(
   //        current active roles are used — we never fall back to the author
   //        when the initiator is known, because that would escalate the
   //        initiator's privileges.
-  //     2. Fall back to the workflow definition's `createdBy` (author) only
-  //        when the instance was started by an event trigger with no user.
+  //     2. Fall back to the workflow definition's `createdBy` (author), then
+  //        `updatedBy` (last editor), only when the instance was started by
+  //        an event trigger with no user.
   //     3. If no traceable principal exists, the activity refuses to run —
   //        there is no "system" fallback that bypasses RBAC.
   const resolvedRoleIds = await resolveCallApiRoleIds(apiKeyEm, context.workflowInstance)
@@ -908,7 +909,7 @@ export async function executeCallApi(
     throw new Error(
       `[CALL_API] Refusing to execute CALL_API for workflow instance ${context.workflowInstance.id}: ` +
       `no traceable user roles could be resolved from the workflow instance or definition. ` +
-      `CALL_API activities must run under the identity of the user who triggered them.`
+      `CALL_API activities must run under the identity of the user who triggered them or a user who saved the workflow definition.`
     )
   }
 
@@ -1046,25 +1047,39 @@ export async function resolveCallApiRoleIds(
   // 1. Prefer the triggering user (whoever manually started this instance).
   //    WorkflowInstance.metadata.initiatedBy is the canonical record of that
   //    principal for user-started instances; use their current role set so
-  //    CALL_API never exceeds the initiator's permissions. Refuse if the
+  //    CALL_API never exceeds the initiator's permissions. Event triggers set
+  //    a `trigger:*` marker instead of a human user id. Refuse if a human
   //    initiator has no active scoped roles — do not fall back to the
   //    definition author, which would escalate the initiator's privileges.
   const initiatorUserId = instance.metadata?.initiatedBy ?? null
-  if (initiatorUserId) {
+  if (initiatorUserId && !initiatorUserId.startsWith('trigger:')) {
     return resolveActiveRoleIdsForUser(em, initiatorUserId, scope)
   }
 
-  // 2. Event-triggered instance with no human initiator: fall back to the
-  //    definition author. Soft-deleted definitions must not mint keys.
+  // 2. Event-triggered instance with no human initiator: fall back to a
+  //    traceable definition editor. Prefer the original author, then the last
+  //    editor as a repair path for imported/legacy definitions whose author is
+  //    missing or no longer has scoped roles. Soft-deleted definitions must
+  //    not mint keys.
   const definition = await findOneWithDecryption(em, WorkflowDefinition, {
     id: instance.definitionId,
     tenantId: instance.tenantId,
     deletedAt: null,
   }, {}, scope)
-  const authorUserId = definition?.createdBy
-  if (!authorUserId) return []
 
-  return resolveActiveRoleIdsForUser(em, authorUserId, scope)
+  const candidateUserIds = [definition?.createdBy, definition?.updatedBy]
+  const seen = new Set<string>()
+  for (const candidateUserId of candidateUserIds) {
+    if (!candidateUserId || seen.has(candidateUserId)) continue
+    seen.add(candidateUserId)
+
+    const roleIds = await resolveActiveRoleIdsForUser(em, candidateUserId, scope)
+    if (roleIds.length > 0) {
+      return roleIds
+    }
+  }
+
+  return []
 }
 
 /**

--- a/packages/core/src/modules/workflows/lib/call-api-identity-error.ts
+++ b/packages/core/src/modules/workflows/lib/call-api-identity-error.ts
@@ -1,0 +1,6 @@
+export const CALL_API_IDENTITY_ERROR_MARKER =
+  'no traceable user roles could be resolved from the workflow instance or definition'
+
+export function isCallApiIdentityResolutionError(errorMessage: string | null | undefined): boolean {
+  return typeof errorMessage === 'string' && errorMessage.includes(CALL_API_IDENTITY_ERROR_MARKER)
+}

--- a/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
+++ b/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
@@ -410,7 +410,7 @@ export function AdvancedFilterPanel(props: AdvancedFilterPanelProps) {
         align="end"
         sideOffset={8}
         data-testid="advanced-filter-panel"
-ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
+        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
         onFocusOutside={ignoreAdvancedFilterPortalInteractions}
         onInteractOutside={ignoreAdvancedFilterPortalInteractions}
       >


### PR DESCRIPTION
## Summary

Clarifies workflow `CALL_API` execution identity for event-triggered workflow instances and surfaces operator guidance when a failed instance hits the known identity-resolution error.

## Changes

- Treat workflow trigger metadata (`trigger:*`) as a non-human initiator so event-triggered `CALL_API` activities can use the workflow definition author, then the last editor, as traceable execution identities.
- Preserve the security boundary for user-started workflows: if a human initiator is known, the activity uses only that user's scoped roles and never falls back to the definition author/editor.
- Add a localized warning on workflow instance detail pages for the known `CALL_API` identity-resolution failure.
- Add focused regression coverage for role resolution and identity-error detection.
- Remove a stray advanced filter popover prop that blocked the app build on current `develop`.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `corepack yarn install --immutable` (completed with existing peer/native build warnings)
- `corepack yarn build:packages`
- `corepack yarn generate`
- `corepack yarn workspace @open-mercato/core test packages/core/src/modules/workflows/lib/__tests__/resolve-call-api-role-ids.test.ts packages/core/src/modules/workflows/lib/__tests__/call-api-identity-error.test.ts --runInBand`
- `corepack yarn workspace @open-mercato/core test packages/core/src/modules/workflows/lib/__tests__/call-api.test.ts --runInBand`
- `corepack yarn i18n:check-sync --fix`
- `corepack yarn i18n:check` (exit 0; advisory unused/hardcoded/identical-key findings remain)
- `corepack yarn workspace @open-mercato/core typecheck`
- `corepack yarn workspace @open-mercato/ui build`
- `corepack yarn lint` (passes with existing warnings)
- `corepack yarn build:app`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). Focused unit coverage covers the role-resolution behavior; no new `.ai/qa` case was added because this is a small workflow runtime/guidance bug fix covered by focused regression tests and the existing CI integration suite.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A: minor bug fix, no spec needed.
- [ ] Priority set: this PR carries exactly one `priority-*` label. Intended routing: `priority-medium`.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). Intended routing: `risk-medium` because the change touches workflow runtime execution identity and backend UI guidance.
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. Intended routing: `needs-qa`; repository labels are maintainer-applied. No public screenshot is attached; the UI change is limited to an existing localized workflow-instance warning path and is covered by focused regression tests plus the full CI suite.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). Not changed by this PR.
- [x] Loading state handled for async pages. Not changed by this PR.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). No icon-only buttons added.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

N/A