### PR TITLE
fix(ui): remove stray 'ded' token breaking AdvancedFilterPanel build

### DIFF
--- a/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
+++ b/packages/ui/src/backend/filters/AdvancedFilterPanel.tsx
@@ -410,7 +410,7 @@ export function AdvancedFilterPanel(props: AdvancedFilterPanelProps) {
         align="end"
         sideOffset={8}
         data-testid="advanced-filter-panel"
-ded        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
+        onPointerDownOutside={ignoreAdvancedFilterPortalInteractions}
         onFocusOutside={ignoreAdvancedFilterPortalInteractions}
         onInteractOutside={ignoreAdvancedFilterPortalInteractions}
       >


### PR DESCRIPTION
## Summary

A stray `ded` token on the `<PopoverContent>` opening tag in `packages/ui/src/backend/filters/AdvancedFilterPanel.tsx` became a boolean `ded` prop, which is not part of `PopoverContentProps`. This fails the type-check / app build on `develop`:

```
packages/ui/src/backend/filters/AdvancedFilterPanel.tsx:413
Type error: Property 'ded' does not exist on type ... PopoverContentProps ...
```

Because it breaks the `prepare` (Build app) job, **every open PR targeting `develop` is currently blocked** (e.g. #3972). Removing the one stray token unblocks them all.

## Changes

- `AdvancedFilterPanel.tsx`: drop the stray `ded` prefix on the `<PopoverContent>` tag. No behavior change.

## Specification
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (one-token build fix, no spec needed)

## Testing

- `tsc` / app build now type-checks `AdvancedFilterPanel.tsx` (the failing line compiles).

## Checklist
- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement.
- [x] I added or adjusted tests that cover the change. — N/A: removes an invalid token; existing panel tests cover render.
- [x] Priority: `high` (blocks CI on all develop PRs).
- [x] Risk: `low` — single invalid token removed, no behavior change.
- [x] QA routing: `skip-qa` (build-only fix, no runtime surface change).

Supersedes the earlier closed #3973 (same fix).