### PR TITLE
fix(staff): scope audit snapshot loaders

### DIFF
--- a/packages/core/src/modules/staff/commands/__tests__/snapshot-scoping.test.ts
+++ b/packages/core/src/modules/staff/commands/__tests__/snapshot-scoping.test.ts
@@ -1,0 +1,279 @@
+import type { AwilixContainer } from 'awilix'
+
+const mockFindOneWithDecryption = jest.fn()
+const mockLoadCustomFieldSnapshot = jest.fn()
+const mockSetCustomFieldsIfAny = jest.fn()
+const mockEmitCrudUndoSideEffects = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/customFieldSnapshots', () => ({
+  buildCustomFieldResetMap: jest.fn(() => ({})),
+  diffCustomFieldChanges: jest.fn(() => ({})),
+  loadCustomFieldSnapshot: jest.fn((...args: unknown[]) => mockLoadCustomFieldSnapshot(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/helpers')
+  return {
+    ...actual,
+    emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+    emitCrudUndoSideEffects: jest.fn((...args: unknown[]) => mockEmitCrudUndoSideEffects(...args)),
+    setCustomFieldsIfAny: jest.fn((...args: unknown[]) => mockSetCustomFieldsIfAny(...args)),
+  }
+})
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn().mockResolvedValue({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+type RegisteredCommand = {
+  prepare?: (input: unknown, ctx: unknown) => Promise<Record<string, unknown>>
+  captureAfter?: (input: unknown, result: unknown, ctx: unknown) => Promise<unknown>
+  buildLog?: (args: { input?: unknown; result?: unknown; ctx: unknown; snapshots: Record<string, unknown> }) => Promise<unknown>
+  undo?: (args: { input?: unknown; ctx: unknown; logEntry: unknown }) => Promise<void>
+  redo?: (args: { input?: unknown; ctx: unknown; logEntry: unknown }) => Promise<unknown>
+}
+
+const TENANT_ID = '11111111-1111-4111-8111-111111111111'
+const ORG_ID = '22222222-2222-4222-8222-222222222222'
+const TEAM_ID = '33333333-3333-4333-8333-333333333333'
+const OTHER_ORG_ID = '44444444-4444-4444-8444-444444444444'
+const LEAVE_REQUEST_ID = '55555555-5555-4555-8555-555555555555'
+const MEMBER_ID = '66666666-6666-4666-8666-666666666666'
+
+function makeTeam(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEAM_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    name: 'Engineering',
+    description: null,
+    isActive: true,
+    deletedAt: null,
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function makeTeamSnapshot(overrides: Record<string, unknown> = {}) {
+  return {
+    id: TEAM_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    name: 'Engineering',
+    description: null,
+    isActive: true,
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
+function makeLeaveRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    id: LEAVE_REQUEST_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    memberId: MEMBER_ID,
+    startDate: '2026-01-10T00:00:00.000Z',
+    endDate: '2026-01-11T00:00:00.000Z',
+    timezone: 'UTC',
+    status: 'pending',
+    unavailabilityReasonEntryId: null,
+    unavailabilityReasonValue: null,
+    note: null,
+    decisionComment: null,
+    submittedByUserId: null,
+    decidedByUserId: null,
+    decidedAt: null,
+    deletedAt: '2026-01-12T00:00:00.000Z',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function createCtx(em: unknown, overrides: Record<string, unknown> = {}) {
+  return {
+    auth: {
+      sub: 'user-1',
+      tenantId: TENANT_ID,
+      orgId: ORG_ID,
+      isSuperAdmin: false,
+    },
+    container: {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'dataEngine') return null
+        return null
+      },
+    } as unknown as AwilixContainer,
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: [ORG_ID],
+    ...overrides,
+  }
+}
+
+async function loadTeamCommands() {
+  jest.resetModules()
+  const { commandRegistry } = await import('@open-mercato/shared/lib/commands')
+  commandRegistry.clear()
+  await import('../teams')
+  return {
+    create: commandRegistry.get('staff.teams.create') as RegisteredCommand,
+    update: commandRegistry.get('staff.teams.update') as RegisteredCommand,
+  }
+}
+
+async function loadLeaveRequestCommands() {
+  jest.resetModules()
+  const { commandRegistry } = await import('@open-mercato/shared/lib/commands')
+  commandRegistry.clear()
+  await import('../leave-requests')
+  return {
+    create: commandRegistry.get('staff.leave-requests.create') as RegisteredCommand,
+  }
+}
+
+function expectTenantScopedSnapshotLoad(callIndex: number) {
+  const call = mockFindOneWithDecryption.mock.calls[callIndex]
+  expect(call?.[2]).toMatchObject({
+    id: TEAM_ID,
+    tenantId: TENANT_ID,
+  })
+  expect(call?.[2]).not.toHaveProperty('organizationId')
+  expect(call?.[4]).toEqual({
+    tenantId: TENANT_ID,
+    organizationId: null,
+  })
+}
+
+function expectSnapshotScopedTeamLoad(callIndex: number) {
+  const call = mockFindOneWithDecryption.mock.calls[callIndex]
+  expect(call?.[2]).toMatchObject({
+    id: TEAM_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+  })
+  expect(call?.[4]).toEqual({
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+  })
+}
+
+describe('staff command audit snapshot scoping (#3913)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFindOneWithDecryption.mockResolvedValue(makeTeam())
+    mockLoadCustomFieldSnapshot.mockResolvedValue({})
+    mockSetCustomFieldsIfAny.mockResolvedValue(undefined)
+    mockEmitCrudUndoSideEffects.mockResolvedValue(undefined)
+  })
+
+  it('keeps pre-validation snapshot reads tenant-scoped so all-organization users do not lose audit snapshots', async () => {
+    const { update } = await loadTeamCommands()
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      findOne: jest.fn().mockResolvedValue(makeTeam()),
+      flush: jest.fn().mockResolvedValue(undefined),
+    }
+    const ctx = createCtx(em, {
+      selectedOrganizationId: OTHER_ORG_ID,
+      organizationScope: {
+        selectedId: OTHER_ORG_ID,
+        tenantId: TENANT_ID,
+        allowedIds: [ORG_ID, OTHER_ORG_ID],
+        filterIds: [OTHER_ORG_ID],
+      },
+      organizationIds: [ORG_ID, OTHER_ORG_ID],
+    })
+
+    await update.prepare?.({ id: TEAM_ID }, ctx)
+
+    expectTenantScopedSnapshotLoad(0)
+  })
+
+  it('scopes after-log snapshot reads to the tenant and organization stored in the before snapshot', async () => {
+    const { update } = await loadTeamCommands()
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      findOne: jest.fn().mockResolvedValue(makeTeam()),
+      flush: jest.fn().mockResolvedValue(undefined),
+    }
+    const ctx = createCtx(em)
+
+    await update.buildLog?.({
+      input: { id: TEAM_ID },
+      result: { teamId: TEAM_ID },
+      ctx,
+      snapshots: { before: makeTeamSnapshot() },
+    })
+
+    expectSnapshotScopedTeamLoad(0)
+  })
+
+  it('scopes undo target loads to the tenant and organization stored in the undo snapshot', async () => {
+    const { update } = await loadTeamCommands()
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      findOne: jest.fn().mockResolvedValue(makeTeam()),
+      flush: jest.fn().mockResolvedValue(undefined),
+    }
+    const ctx = createCtx(em)
+    const before = makeTeamSnapshot({ name: 'Before' })
+    const after = makeTeamSnapshot({ name: 'After' })
+
+    await update.undo?.({
+      ctx,
+      logEntry: { commandPayload: { undo: { before, after, customBefore: null, customAfter: null } } },
+    })
+
+    expect(em.findOne).toHaveBeenCalledWith(expect.any(Function), {
+      id: TEAM_ID,
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+    })
+  })
+
+  it('scopes leave-request create redo lookup to the tenant and organization stored in the snapshot', async () => {
+    const { create } = await loadLeaveRequestCommands()
+    const leaveRequest = makeLeaveRequest({ deletedAt: new Date('2026-01-12T00:00:00.000Z') })
+    mockFindOneWithDecryption.mockResolvedValueOnce(leaveRequest)
+    const em = {
+      fork: jest.fn().mockReturnThis(),
+      flush: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn(),
+      persist: jest.fn(),
+    }
+    const ctx = createCtx(em)
+    const snapshot = makeLeaveRequest()
+
+    await create.redo?.({
+      ctx,
+      logEntry: {
+        resourceId: LEAVE_REQUEST_ID,
+        commandPayload: { undo: { after: snapshot } },
+      },
+    })
+
+    expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
+      em,
+      expect.any(Function),
+      {
+        id: LEAVE_REQUEST_ID,
+        tenantId: TENANT_ID,
+        organizationId: ORG_ID,
+      },
+      undefined,
+      {
+        tenantId: TENANT_ID,
+        organizationId: ORG_ID,
+      },
+    )
+  })
+})

--- a/packages/core/src/modules/staff/commands/activities.ts
+++ b/packages/core/src/modules/staff/commands/activities.ts
@@ -22,7 +22,16 @@ import {
   type StaffTeamMemberActivityUpdateInput,
 } from '../data/validators'
 import { staffTeamMemberActivityCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireTeamMember } from './shared'
+import {
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  requireTeamMember,
+  scopedStaffSnapshotWhere,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
+} from './shared'
 import { resolveRedoSnapshot } from '@open-mercato/shared/lib/commands/redo'
 import { E } from '#generated/entities.ids.generated'
 import {
@@ -62,8 +71,8 @@ type ActivityChangeMap = Record<string, { from: unknown; to: unknown }> & {
   custom?: CustomFieldChangeSet
 }
 
-async function loadActivitySnapshot(em: EntityManager, id: string): Promise<ActivitySnapshot | null> {
-  const activity = await em.findOne(StaffTeamMemberActivity, { id })
+async function loadActivitySnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<ActivitySnapshot | null> {
+  const activity = await em.findOne(StaffTeamMemberActivity, scopedStaffSnapshotWhere(id, scope))
   if (!activity) return null
   const custom = await loadCustomFieldSnapshot(em, {
     entityId: E.staff.staff_team_member_activity,
@@ -162,7 +171,7 @@ const createActivityCommand: CommandHandler<
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadActivitySnapshot(em, result.activityId)
+    return await loadActivitySnapshot(em, result.activityId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ result, snapshots }) => {
     const { translate } = await resolveTranslations()
@@ -184,10 +193,15 @@ const createActivityCommand: CommandHandler<
     }
   },
   undo: async ({ logEntry, ctx }) => {
-    const activityId = logEntry?.resourceId ?? null
+    const payload = extractUndoPayload<ActivityUndoPayload>(logEntry)
+    const after = payload?.after
+    const activityId = after?.activity.id ?? logEntry?.resourceId ?? null
     if (!activityId) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const existing = await em.findOne(StaffTeamMemberActivity, { id: activityId })
+    const existing = await em.findOne(
+      StaffTeamMemberActivity,
+      scopedStaffSnapshotWhere(activityId, staffSnapshotScopeFromSnapshot(after?.activity)),
+    )
     if (existing) {
       em.remove(existing)
       await em.flush()
@@ -199,8 +213,9 @@ const createActivityCommand: CommandHandler<
       throw new CrudHttpError(400, { error: '[internal] redo snapshot unavailable for activity create' })
     }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, after.activity.memberId, 'Team member not found')
-    let activity = await em.findOne(StaffTeamMemberActivity, { id: after.activity.id })
+    const snapshotScope = staffSnapshotScopeFromSnapshot(after.activity)
+    const member = await requireTeamMember(em, after.activity.memberId, 'Team member not found', snapshotScope)
+    let activity = await em.findOne(StaffTeamMemberActivity, scopedStaffSnapshotWhere(after.activity.id, snapshotScope))
     if (!activity) {
       activity = em.create(StaffTeamMemberActivity, {
         id: after.activity.id,
@@ -255,7 +270,7 @@ const updateActivityCommand: CommandHandler<StaffTeamMemberActivityUpdateInput, 
   async prepare(rawInput, ctx) {
     const parsed = staffTeamMemberActivityUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadActivitySnapshot(em, parsed.id)
+    const snapshot = await loadActivitySnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     return snapshot ? { before: snapshot } : {}
   },
   async execute(rawInput, ctx) {
@@ -302,7 +317,7 @@ const updateActivityCommand: CommandHandler<StaffTeamMemberActivityUpdateInput, 
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadActivitySnapshot(em, result.activityId)
+    return await loadActivitySnapshot(em, result.activityId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ snapshots }) => {
     const { translate } = await resolveTranslations()
@@ -353,8 +368,9 @@ const updateActivityCommand: CommandHandler<StaffTeamMemberActivityUpdateInput, 
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let activity = await em.findOne(StaffTeamMemberActivity, { id: before.activity.id })
-    const member = await requireTeamMember(em, before.activity.memberId, 'Team member not found')
+    const snapshotScope = staffSnapshotScopeFromSnapshot(before.activity)
+    let activity = await em.findOne(StaffTeamMemberActivity, scopedStaffSnapshotWhere(before.activity.id, snapshotScope))
+    const member = await requireTeamMember(em, before.activity.memberId, 'Team member not found', snapshotScope)
 
     if (!activity) {
       activity = em.create(StaffTeamMemberActivity, {
@@ -420,7 +436,7 @@ const deleteActivityCommand: CommandHandler<{ body?: Record<string, unknown>; qu
     async prepare(input, ctx) {
       const id = requireId(input, 'Activity id required')
       const em = (ctx.container.resolve('em') as EntityManager)
-      const snapshot = await loadActivitySnapshot(em, id)
+      const snapshot = await loadActivitySnapshot(em, id, staffSnapshotScopeFromContext(ctx))
       return snapshot ? { before: snapshot } : {}
     },
     async execute(input, ctx) {
@@ -473,8 +489,9 @@ const deleteActivityCommand: CommandHandler<{ body?: Record<string, unknown>; qu
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const member = await requireTeamMember(em, before.activity.memberId, 'Team member not found')
-      let activity = await em.findOne(StaffTeamMemberActivity, { id: before.activity.id })
+      const snapshotScope = staffSnapshotScopeFromSnapshot(before.activity)
+      const member = await requireTeamMember(em, before.activity.memberId, 'Team member not found', snapshotScope)
+      let activity = await em.findOne(StaffTeamMemberActivity, scopedStaffSnapshotWhere(before.activity.id, snapshotScope))
       if (!activity) {
         activity = em.create(StaffTeamMemberActivity, {
           id: before.activity.id,

--- a/packages/core/src/modules/staff/commands/addresses.ts
+++ b/packages/core/src/modules/staff/commands/addresses.ts
@@ -16,6 +16,10 @@ import {
   ensureTenantScope,
   extractUndoPayload,
   requireTeamMember,
+  scopedStaffSnapshotWhere,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
 } from './shared'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveRedoSnapshot } from '@open-mercato/shared/lib/commands/redo'
@@ -53,8 +57,8 @@ type AddressUndoPayload = {
   after?: AddressSnapshot | null
 }
 
-async function loadAddressSnapshot(em: EntityManager, id: string): Promise<AddressSnapshot | null> {
-  const address = await em.findOne(StaffTeamMemberAddress, { id })
+async function loadAddressSnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<AddressSnapshot | null> {
+  const address = await em.findOne(StaffTeamMemberAddress, scopedStaffSnapshotWhere(id, scope))
   if (!address) return null
   return {
     id: address.id,
@@ -145,7 +149,7 @@ const createAddressCommand: CommandHandler<StaffTeamMemberAddressCreateInput, { 
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadAddressSnapshot(em, result.addressId)
+    return await loadAddressSnapshot(em, result.addressId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ result, snapshots }) => {
     const { translate } = await resolveTranslations()
@@ -167,10 +171,12 @@ const createAddressCommand: CommandHandler<StaffTeamMemberAddressCreateInput, { 
     }
   },
   undo: async ({ logEntry, ctx }) => {
-    const addressId = logEntry?.resourceId ?? null
+    const payload = extractUndoPayload<AddressUndoPayload>(logEntry)
+    const after = payload?.after
+    const addressId = after?.id ?? logEntry?.resourceId ?? null
     if (!addressId) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const address = await em.findOne(StaffTeamMemberAddress, { id: addressId })
+    const address = await em.findOne(StaffTeamMemberAddress, scopedStaffSnapshotWhere(addressId, staffSnapshotScopeFromSnapshot(after)))
     if (address) {
       em.remove(address)
       await em.flush()
@@ -182,8 +188,9 @@ const createAddressCommand: CommandHandler<StaffTeamMemberAddressCreateInput, { 
       throw new CrudHttpError(400, { error: '[internal] redo snapshot unavailable for address create' })
     }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, after.memberId, 'Team member not found')
-    let address = await em.findOne(StaffTeamMemberAddress, { id: after.id })
+    const snapshotScope = staffSnapshotScopeFromSnapshot(after)
+    const member = await requireTeamMember(em, after.memberId, 'Team member not found', snapshotScope)
+    let address = await em.findOne(StaffTeamMemberAddress, scopedStaffSnapshotWhere(after.id, snapshotScope))
     if (!address) {
       address = em.create(StaffTeamMemberAddress, {
         id: after.id,
@@ -254,7 +261,7 @@ const updateAddressCommand: CommandHandler<StaffTeamMemberAddressUpdateInput, { 
   async prepare(rawInput, ctx) {
     const parsed = staffTeamMemberAddressUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadAddressSnapshot(em, parsed.id)
+    const snapshot = await loadAddressSnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     return snapshot ? { before: snapshot } : {}
   },
   async execute(rawInput, ctx) {
@@ -311,7 +318,7 @@ const updateAddressCommand: CommandHandler<StaffTeamMemberAddressUpdateInput, { 
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadAddressSnapshot(em, result.addressId)
+    return await loadAddressSnapshot(em, result.addressId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ snapshots }) => {
     const { translate } = await resolveTranslations()
@@ -366,8 +373,9 @@ const updateAddressCommand: CommandHandler<StaffTeamMemberAddressUpdateInput, { 
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let address = await em.findOne(StaffTeamMemberAddress, { id: before.id })
-    const member = await requireTeamMember(em, before.memberId, 'Team member not found')
+    const snapshotScope = staffSnapshotScopeFromSnapshot(before)
+    let address = await em.findOne(StaffTeamMemberAddress, scopedStaffSnapshotWhere(before.id, snapshotScope))
+    const member = await requireTeamMember(em, before.memberId, 'Team member not found', snapshotScope)
 
     if (!address) {
       address = em.create(StaffTeamMemberAddress, {
@@ -438,7 +446,7 @@ const deleteAddressCommand: CommandHandler<{ body?: Record<string, unknown>; que
     async prepare(input, ctx) {
       const id = requireId(input, 'Address id required')
       const em = (ctx.container.resolve('em') as EntityManager)
-      const snapshot = await loadAddressSnapshot(em, id)
+      const snapshot = await loadAddressSnapshot(em, id, staffSnapshotScopeFromContext(ctx))
       return snapshot ? { before: snapshot } : {}
     },
     async execute(input, ctx) {
@@ -491,8 +499,9 @@ const deleteAddressCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const member = await requireTeamMember(em, before.memberId, 'Team member not found')
-      let address = await em.findOne(StaffTeamMemberAddress, { id: before.id })
+      const snapshotScope = staffSnapshotScopeFromSnapshot(before)
+      const member = await requireTeamMember(em, before.memberId, 'Team member not found', snapshotScope)
+      let address = await em.findOne(StaffTeamMemberAddress, scopedStaffSnapshotWhere(before.id, snapshotScope))
       if (!address) {
         address = em.create(StaffTeamMemberAddress, {
           id: before.id,

--- a/packages/core/src/modules/staff/commands/comments.ts
+++ b/packages/core/src/modules/staff/commands/comments.ts
@@ -14,7 +14,16 @@ import {
   type StaffTeamMemberCommentUpdateInput,
 } from '../data/validators'
 import { staffTeamMemberCommentCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireTeamMember } from './shared'
+import {
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  requireTeamMember,
+  scopedStaffSnapshotWhere,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
+} from './shared'
 import { makeCreateRedo } from '@open-mercato/shared/lib/commands/redo'
 import { E } from '#generated/entities.ids.generated'
 
@@ -38,8 +47,8 @@ type CommentUndoPayload = {
   after?: CommentSnapshot | null
 }
 
-async function loadCommentSnapshot(em: EntityManager, id: string): Promise<CommentSnapshot | null> {
-  const comment = await em.findOne(StaffTeamMemberComment, { id })
+async function loadCommentSnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<CommentSnapshot | null> {
+  const comment = await em.findOne(StaffTeamMemberComment, scopedStaffSnapshotWhere(id, scope))
   if (!comment) return null
   return {
     id: comment.id,
@@ -101,7 +110,7 @@ const createCommentCommand: CommandHandler<
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadCommentSnapshot(em, result.commentId)
+    return await loadCommentSnapshot(em, result.commentId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ result, snapshots }) => {
     const { translate } = await resolveTranslations()
@@ -123,10 +132,12 @@ const createCommentCommand: CommandHandler<
     }
   },
   undo: async ({ logEntry, ctx }) => {
-    const commentId = logEntry?.resourceId ?? null
+    const payload = extractUndoPayload<CommentUndoPayload>(logEntry)
+    const after = payload?.after
+    const commentId = after?.id ?? logEntry?.resourceId ?? null
     if (!commentId) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const existing = await em.findOne(StaffTeamMemberComment, { id: commentId })
+    const existing = await em.findOne(StaffTeamMemberComment, scopedStaffSnapshotWhere(commentId, staffSnapshotScopeFromSnapshot(after)))
     if (existing) {
       em.remove(existing)
       await em.flush()
@@ -151,7 +162,12 @@ const createCommentCommand: CommandHandler<
       appearanceColor: snapshot.appearanceColor,
     }),
     beforeRestore: async ({ em, snapshot }) => {
-      const member = await requireTeamMember(em, snapshot.memberId, 'Team member not found')
+      const member = await requireTeamMember(
+        em,
+        snapshot.memberId,
+        'Team member not found',
+        staffSnapshotScopeFromSnapshot(snapshot),
+      )
       return { member }
     },
     buildResult: (entity) => ({ commentId: entity.id, authorUserId: entity.authorUserId ?? null }),
@@ -163,7 +179,7 @@ const updateCommentCommand: CommandHandler<StaffTeamMemberCommentUpdateInput, { 
   async prepare(rawInput, ctx) {
     const parsed = staffTeamMemberCommentUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadCommentSnapshot(em, parsed.id)
+    const snapshot = await loadCommentSnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     return snapshot ? { before: snapshot } : {}
   },
   async execute(rawInput, ctx) {
@@ -205,7 +221,7 @@ const updateCommentCommand: CommandHandler<StaffTeamMemberCommentUpdateInput, { 
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadCommentSnapshot(em, result.commentId)
+    return await loadCommentSnapshot(em, result.commentId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ snapshots }) => {
     const { translate } = await resolveTranslations()
@@ -244,8 +260,9 @@ const updateCommentCommand: CommandHandler<StaffTeamMemberCommentUpdateInput, { 
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let comment = await em.findOne(StaffTeamMemberComment, { id: before.id })
-    const member = await requireTeamMember(em, before.memberId, 'Team member not found')
+    const snapshotScope = staffSnapshotScopeFromSnapshot(before)
+    let comment = await em.findOne(StaffTeamMemberComment, scopedStaffSnapshotWhere(before.id, snapshotScope))
+    const member = await requireTeamMember(em, before.memberId, 'Team member not found', snapshotScope)
 
     if (!comment) {
       comment = em.create(StaffTeamMemberComment, {
@@ -292,7 +309,7 @@ const deleteCommentCommand: CommandHandler<{ body?: Record<string, unknown>; que
     async prepare(input, ctx) {
       const id = requireId(input, 'Comment id required')
       const em = (ctx.container.resolve('em') as EntityManager)
-      const snapshot = await loadCommentSnapshot(em, id)
+      const snapshot = await loadCommentSnapshot(em, id, staffSnapshotScopeFromContext(ctx))
       return snapshot ? { before: snapshot } : {}
     },
     async execute(input, ctx) {
@@ -345,8 +362,9 @@ const deleteCommentCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const member = await requireTeamMember(em, before.memberId, 'Team member not found')
-      let comment = await em.findOne(StaffTeamMemberComment, { id: before.id })
+      const snapshotScope = staffSnapshotScopeFromSnapshot(before)
+      const member = await requireTeamMember(em, before.memberId, 'Team member not found', snapshotScope)
+      let comment = await em.findOne(StaffTeamMemberComment, scopedStaffSnapshotWhere(before.id, snapshotScope))
       if (!comment) {
         comment = em.create(StaffTeamMemberComment, {
           id: before.id,

--- a/packages/core/src/modules/staff/commands/job-histories.ts
+++ b/packages/core/src/modules/staff/commands/job-histories.ts
@@ -16,6 +16,10 @@ import {
   ensureTenantScope,
   extractUndoPayload,
   requireTeamMember,
+  scopedStaffSnapshotWhere,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
 } from './shared'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveRedoSnapshot } from '@open-mercato/shared/lib/commands/redo'
@@ -51,8 +55,12 @@ type JobHistoryUndoPayload = {
   after?: JobHistorySnapshot | null
 }
 
-async function loadJobHistorySnapshot(em: EntityManager, id: string): Promise<JobHistorySnapshot | null> {
-  const record = await em.findOne(StaffTeamMemberJobHistory, { id })
+async function loadJobHistorySnapshot(
+  em: EntityManager,
+  id: string,
+  scope?: StaffSnapshotScope | null,
+): Promise<JobHistorySnapshot | null> {
+  const record = await em.findOne(StaffTeamMemberJobHistory, scopedStaffSnapshotWhere(id, scope))
   if (!record) return null
   return {
     id: record.id,
@@ -113,7 +121,7 @@ const createJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryCreateInp
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadJobHistorySnapshot(em, result.jobHistoryId)
+    return await loadJobHistorySnapshot(em, result.jobHistoryId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ result, snapshots }) => {
     const { translate } = await resolveTranslations()
@@ -135,10 +143,15 @@ const createJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryCreateInp
     }
   },
   undo: async ({ logEntry, ctx }) => {
-    const jobHistoryId = logEntry?.resourceId ?? null
+    const payload = extractUndoPayload<JobHistoryUndoPayload>(logEntry)
+    const after = payload?.after ?? null
+    const jobHistoryId = after?.id ?? logEntry?.resourceId ?? null
     if (!jobHistoryId) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const record = await em.findOne(StaffTeamMemberJobHistory, { id: jobHistoryId })
+    const record = await em.findOne(
+      StaffTeamMemberJobHistory,
+      scopedStaffSnapshotWhere(jobHistoryId, staffSnapshotScopeFromSnapshot(after)),
+    )
     if (record) {
       em.remove(record)
       await em.flush()
@@ -150,8 +163,9 @@ const createJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryCreateInp
       throw new CrudHttpError(400, { error: '[internal] redo snapshot unavailable for job history create' })
     }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, after.memberId, 'Team member not found')
-    let record = await em.findOne(StaffTeamMemberJobHistory, { id: after.id })
+    const snapshotScope = staffSnapshotScopeFromSnapshot(after)
+    const member = await requireTeamMember(em, after.memberId, 'Team member not found', snapshotScope)
+    let record = await em.findOne(StaffTeamMemberJobHistory, scopedStaffSnapshotWhere(after.id, snapshotScope))
     if (!record) {
       record = em.create(StaffTeamMemberJobHistory, {
         id: after.id,
@@ -200,7 +214,7 @@ const updateJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryUpdateInp
   async prepare(rawInput, ctx) {
     const parsed = staffTeamMemberJobHistoryUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadJobHistorySnapshot(em, parsed.id)
+    const snapshot = await loadJobHistorySnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     return snapshot ? { before: snapshot } : {}
   },
   async execute(rawInput, ctx) {
@@ -258,7 +272,7 @@ const updateJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryUpdateInp
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadJobHistorySnapshot(em, result.jobHistoryId)
+    return await loadJobHistorySnapshot(em, result.jobHistoryId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ snapshots }) => {
     const { translate } = await resolveTranslations()
@@ -297,8 +311,9 @@ const updateJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryUpdateInp
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let record = await em.findOne(StaffTeamMemberJobHistory, { id: before.id })
-    const member = await requireTeamMember(em, before.memberId, 'Team member not found')
+    const snapshotScope = staffSnapshotScopeFromSnapshot(before)
+    let record = await em.findOne(StaffTeamMemberJobHistory, scopedStaffSnapshotWhere(before.id, snapshotScope))
+    const member = await requireTeamMember(em, before.memberId, 'Team member not found', snapshotScope)
 
     if (!record) {
       record = em.create(StaffTeamMemberJobHistory, {
@@ -347,7 +362,7 @@ const deleteJobHistoryCommand: CommandHandler<{ id?: string; updatedAt?: string;
     async prepare(input, ctx) {
       const id = requireId(input, 'Job history id required')
       const em = (ctx.container.resolve('em') as EntityManager)
-      const snapshot = await loadJobHistorySnapshot(em, id)
+      const snapshot = await loadJobHistorySnapshot(em, id, staffSnapshotScopeFromContext(ctx))
       return snapshot ? { before: snapshot } : {}
     },
     async execute(input, ctx) {
@@ -416,8 +431,9 @@ const deleteJobHistoryCommand: CommandHandler<{ id?: string; updatedAt?: string;
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const member = await requireTeamMember(em, before.memberId, 'Team member not found')
-      let record = await em.findOne(StaffTeamMemberJobHistory, { id: before.id })
+      const snapshotScope = staffSnapshotScopeFromSnapshot(before)
+      const member = await requireTeamMember(em, before.memberId, 'Team member not found', snapshotScope)
+      let record = await em.findOne(StaffTeamMemberJobHistory, scopedStaffSnapshotWhere(before.id, snapshotScope))
       if (!record) {
         record = em.create(StaffTeamMemberJobHistory, {
           id: before.id,

--- a/packages/core/src/modules/staff/commands/leave-requests.ts
+++ b/packages/core/src/modules/staff/commands/leave-requests.ts
@@ -21,7 +21,17 @@ import {
   type StaffLeaveRequestDecisionInput,
   type StaffLeaveRequestUpdateInput,
 } from '../data/validators'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireTeamMember } from './shared'
+import {
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  requireTeamMember,
+  scopedStaffSnapshotWhere,
+  staffSnapshotDecryptionScope,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
+} from './shared'
 import { E } from '#generated/entities.ids.generated'
 import { resolveNotificationService } from '../../notifications/lib/notificationService'
 import { buildFeatureNotificationFromType, buildNotificationFromType } from '../../notifications/lib/notificationBuilder'
@@ -118,8 +128,14 @@ function buildFullDayRrule(date: string): string | null {
   return buildAvailabilityRrule(start, end)
 }
 
-async function loadLeaveRequestSnapshot(em: EntityManager, id: string): Promise<LeaveRequestSnapshot | null> {
-  const request = await findOneWithDecryption(em, StaffLeaveRequest, { id }, undefined, { tenantId: null, organizationId: null })
+async function loadLeaveRequestSnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<LeaveRequestSnapshot | null> {
+  const request = await findOneWithDecryption(
+    em,
+    StaffLeaveRequest,
+    scopedStaffSnapshotWhere(id, scope),
+    undefined,
+    staffSnapshotDecryptionScope(scope),
+  )
   if (!request) return null
   const memberId = typeof request.member === 'string' ? request.member : request.member.id
   return {
@@ -167,8 +183,14 @@ function leaveRequestSeedFromSnapshot(snapshot: LeaveRequestSnapshot): Record<st
   }
 }
 
-async function requireLeaveRequest(em: EntityManager, id: string): Promise<StaffLeaveRequest> {
-  const request = await findOneWithDecryption(em, StaffLeaveRequest, { id, deletedAt: null }, undefined, { tenantId: null, organizationId: null })
+async function requireLeaveRequest(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<StaffLeaveRequest> {
+  const request = await findOneWithDecryption(
+    em,
+    StaffLeaveRequest,
+    { ...scopedStaffSnapshotWhere(id, scope), deletedAt: null },
+    undefined,
+    staffSnapshotDecryptionScope(scope),
+  )
   if (!request) throw new CrudHttpError(404, { error: 'Leave request not found.' })
   return request
 }
@@ -323,12 +345,12 @@ const createLeaveRequestCommand: CommandHandler<StaffLeaveRequestCreateInput, { 
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadLeaveRequestSnapshot(em, result.requestId)
+    return await loadLeaveRequestSnapshot(em, result.requestId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ result, ctx }) => {
     const { translate } = await resolveTranslations()
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadLeaveRequestSnapshot(em, result.requestId)
+    const snapshot = await loadLeaveRequestSnapshot(em, result.requestId, staffSnapshotScopeFromContext(ctx))
     return {
       actionLabel: translate('staff.audit.leaveRequests.create', 'Create leave request'),
       resourceKind: 'staff.leave_request',
@@ -350,7 +372,7 @@ const createLeaveRequestCommand: CommandHandler<StaffLeaveRequestCreateInput, { 
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await em.findOne(StaffLeaveRequest, { id: after.id })
+    const request = await em.findOne(StaffLeaveRequest, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (request) {
       request.deletedAt = new Date()
       request.updatedAt = new Date()
@@ -379,7 +401,7 @@ const createLeaveRequestCommand: CommandHandler<StaffLeaveRequestCreateInput, { 
       findOneWithDecryption(
         em,
         StaffLeaveRequest,
-        { id },
+        scopedStaffSnapshotWhere(id, staffSnapshotScopeFromSnapshot(snapshot)),
         undefined,
         { tenantId: snapshot.tenantId, organizationId: snapshot.organizationId },
       ),
@@ -394,13 +416,13 @@ const updateLeaveRequestCommand: CommandHandler<StaffLeaveRequestUpdateInput, { 
   async prepare(rawInput, ctx) {
     const parsed = staffLeaveRequestUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadLeaveRequestSnapshot(em, parsed.id)
+    const snapshot = await loadLeaveRequestSnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     return snapshot ? { before: snapshot } : {}
   },
   async execute(rawInput, ctx) {
     const parsed = staffLeaveRequestUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await requireLeaveRequest(em, parsed.id)
+    const request = await requireLeaveRequest(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     ensureTenantScope(ctx, request.tenantId)
     ensureOrganizationScope(ctx, request.organizationId)
     ensurePendingStatus(request)
@@ -441,7 +463,7 @@ const updateLeaveRequestCommand: CommandHandler<StaffLeaveRequestUpdateInput, { 
     const before = snapshots.before as LeaveRequestSnapshot | undefined
     if (!before) return null
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const after = await loadLeaveRequestSnapshot(em, before.id)
+    const after = await loadLeaveRequestSnapshot(em, before.id, staffSnapshotScopeFromSnapshot(before))
     const changes = after
       ? buildChanges(before as unknown as Record<string, unknown>, after as unknown as Record<string, unknown>, [
           'memberId',
@@ -478,7 +500,7 @@ const updateLeaveRequestCommand: CommandHandler<StaffLeaveRequestUpdateInput, { 
     const after = payload?.after
     if (!before || !after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await em.findOne(StaffLeaveRequest, { id: after.id })
+    const request = await em.findOne(StaffLeaveRequest, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (!request) return
     request.startDate = new Date(before.startDate)
     request.endDate = new Date(before.endDate)
@@ -514,7 +536,7 @@ const deleteLeaveRequestCommand: CommandHandler<{ id: string }, { requestId: str
   async execute(rawInput, ctx) {
     const parsed = staffLeaveRequestDecisionSchema.pick({ id: true }).parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await requireLeaveRequest(em, parsed.id)
+    const request = await requireLeaveRequest(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     ensureTenantScope(ctx, request.tenantId)
     ensureOrganizationScope(ctx, request.organizationId)
     ensurePendingStatus(request)
@@ -541,12 +563,12 @@ const deleteLeaveRequestCommand: CommandHandler<{ id: string }, { requestId: str
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return await loadLeaveRequestSnapshot(em, result.requestId)
+    return await loadLeaveRequestSnapshot(em, result.requestId, staffSnapshotScopeFromContext(ctx))
   },
   buildLog: async ({ result, ctx }) => {
     const { translate } = await resolveTranslations()
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadLeaveRequestSnapshot(em, result.requestId)
+    const snapshot = await loadLeaveRequestSnapshot(em, result.requestId, staffSnapshotScopeFromContext(ctx))
     return {
       actionLabel: translate('staff.audit.leaveRequests.delete', 'Delete leave request'),
       resourceKind: 'staff.leave_request',
@@ -568,7 +590,7 @@ const deleteLeaveRequestCommand: CommandHandler<{ id: string }, { requestId: str
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await em.findOne(StaffLeaveRequest, { id: after.id })
+    const request = await em.findOne(StaffLeaveRequest, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (!request) return
     request.deletedAt = null
     request.updatedAt = new Date()
@@ -595,7 +617,7 @@ const acceptLeaveRequestCommand: CommandHandler<StaffLeaveRequestDecisionInput, 
   async execute(rawInput, ctx) {
     const parsed = staffLeaveRequestDecisionSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await requireLeaveRequest(em, parsed.id)
+    const request = await requireLeaveRequest(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     ensureTenantScope(ctx, request.tenantId)
     ensureOrganizationScope(ctx, request.organizationId)
     ensurePendingStatus(request)
@@ -701,7 +723,11 @@ const acceptLeaveRequestCommand: CommandHandler<StaffLeaveRequestDecisionInput, 
     const { translate } = await resolveTranslations()
     const before = snapshots.before as LeaveRequestSnapshot | undefined
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const after = await loadLeaveRequestSnapshot(em, result.requestId)
+    const after = await loadLeaveRequestSnapshot(
+      em,
+      result.requestId,
+      staffSnapshotScopeFromSnapshot(before) ?? staffSnapshotScopeFromContext(ctx),
+    )
     return {
       actionLabel: translate('staff.audit.leaveRequests.accept', 'Approve leave request'),
       resourceKind: 'staff.leave_request',
@@ -724,7 +750,7 @@ const acceptLeaveRequestCommand: CommandHandler<StaffLeaveRequestDecisionInput, 
   async prepare(rawInput, ctx) {
     const parsed = staffLeaveRequestDecisionSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadLeaveRequestSnapshot(em, parsed.id)
+    const snapshot = await loadLeaveRequestSnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     return snapshot ? { before: snapshot } : {}
   },
   undo: async ({ logEntry, ctx }) => {
@@ -733,7 +759,7 @@ const acceptLeaveRequestCommand: CommandHandler<StaffLeaveRequestDecisionInput, 
     const availabilityRuleIds = payload?.availabilityRuleIds ?? []
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await em.findOne(StaffLeaveRequest, { id: before.id })
+    const request = await em.findOne(StaffLeaveRequest, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!request) return
 
     // Fetch rules before mutating so the query cannot reset unit-of-work tracking
@@ -802,7 +828,7 @@ const rejectLeaveRequestCommand: CommandHandler<StaffLeaveRequestDecisionInput, 
   async execute(rawInput, ctx) {
     const parsed = staffLeaveRequestDecisionSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await requireLeaveRequest(em, parsed.id)
+    const request = await requireLeaveRequest(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     ensureTenantScope(ctx, request.tenantId)
     ensureOrganizationScope(ctx, request.organizationId)
     ensurePendingStatus(request)
@@ -864,14 +890,18 @@ const rejectLeaveRequestCommand: CommandHandler<StaffLeaveRequestDecisionInput, 
   async prepare(rawInput, ctx) {
     const parsed = staffLeaveRequestDecisionSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadLeaveRequestSnapshot(em, parsed.id)
+    const snapshot = await loadLeaveRequestSnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     return snapshot ? { before: snapshot } : {}
   },
   buildLog: async ({ result, ctx, snapshots }) => {
     const { translate } = await resolveTranslations()
     const before = snapshots.before as LeaveRequestSnapshot | undefined
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const after = await loadLeaveRequestSnapshot(em, result.requestId)
+    const after = await loadLeaveRequestSnapshot(
+      em,
+      result.requestId,
+      staffSnapshotScopeFromSnapshot(before) ?? staffSnapshotScopeFromContext(ctx),
+    )
     return {
       actionLabel: translate('staff.audit.leaveRequests.reject', 'Reject leave request'),
       resourceKind: 'staff.leave_request',
@@ -895,7 +925,7 @@ const rejectLeaveRequestCommand: CommandHandler<StaffLeaveRequestDecisionInput, 
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await em.findOne(StaffLeaveRequest, { id: before.id })
+    const request = await em.findOne(StaffLeaveRequest, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!request) return
     request.status = before.status
     request.decisionComment = before.decisionComment

--- a/packages/core/src/modules/staff/commands/shared.ts
+++ b/packages/core/src/modules/staff/commands/shared.ts
@@ -14,12 +14,51 @@ export function ensureTenantScope(ctx: CommandRuntimeContext, tenantId: string):
 
 export { ensureOrganizationScope, extractUndoPayload }
 
+export type StaffSnapshotScope = {
+  tenantId?: string | null
+  organizationId?: string | null
+}
+
+type StaffSnapshotScopeSource = {
+  tenantId?: string | null
+  organizationId?: string | null
+}
+
+const NULL_DECRYPTION_SCOPE = { tenantId: null, organizationId: null } as const
+
+export function staffSnapshotScopeFromContext(ctx: CommandRuntimeContext): StaffSnapshotScope | null {
+  const tenantId = ctx.auth?.tenantId ?? null
+  if (!tenantId) return null
+  return { tenantId }
+}
+
+export function staffSnapshotScopeFromSnapshot(source: StaffSnapshotScopeSource | null | undefined): StaffSnapshotScope | null {
+  if (!source?.tenantId || !source.organizationId) return null
+  return { tenantId: source.tenantId, organizationId: source.organizationId }
+}
+
+export function scopedStaffSnapshotWhere(id: string, scope?: StaffSnapshotScope | null) {
+  const where: { id: string; tenantId?: string; organizationId?: string } = { id }
+  if (scope?.tenantId) where.tenantId = scope.tenantId
+  if (scope?.organizationId) where.organizationId = scope.organizationId
+  return where
+}
+
+export function staffSnapshotDecryptionScope(scope?: StaffSnapshotScope | null) {
+  if (!scope) return NULL_DECRYPTION_SCOPE
+  return {
+    tenantId: scope.tenantId ?? null,
+    organizationId: scope.organizationId ?? null,
+  }
+}
+
 export async function requireTeamMember(
   em: EntityManager,
   memberId: string,
   message = 'Team member not found',
+  scope?: StaffSnapshotScope | null,
 ): Promise<StaffTeamMember> {
-  const member = await em.findOne(StaffTeamMember, { id: memberId })
+  const member = await em.findOne(StaffTeamMember, scopedStaffSnapshotWhere(memberId, scope))
   if (!member) throw new CrudHttpError(404, { error: message })
   return member
 }

--- a/packages/core/src/modules/staff/commands/tag-assignments.ts
+++ b/packages/core/src/modules/staff/commands/tag-assignments.ts
@@ -12,7 +12,14 @@ import {
   type StaffTeamMemberTagAssignmentInput,
 } from '../data/validators'
 import { staffTeamMemberCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopedStaffSnapshotWhere,
+  staffSnapshotDecryptionScope,
+  staffSnapshotScopeFromSnapshot,
+} from './shared'
 
 type TeamMemberTagAssignmentSnapshot = {
   tag: string
@@ -104,7 +111,14 @@ const assignTeamMemberTagCommand: CommandHandler<StaffTeamMemberTagAssignmentInp
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await em.findOne(StaffTeamMember, { id: before.memberId })
+    const snapshotScope = staffSnapshotScopeFromSnapshot(before)
+    const member = await findOneWithDecryption(
+      em,
+      StaffTeamMember,
+      scopedStaffSnapshotWhere(before.memberId, snapshotScope),
+      undefined,
+      staffSnapshotDecryptionScope(snapshotScope),
+    )
     if (!member) return
     const nextTags = normalizeTagList(
       Array.isArray(member.tags) ? member.tags.filter((tag) => tag !== before.tag) : [],
@@ -232,7 +246,14 @@ const unassignTeamMemberTagCommand: CommandHandler<StaffTeamMemberTagAssignmentI
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await em.findOne(StaffTeamMember, { id: before.memberId })
+    const snapshotScope = staffSnapshotScopeFromSnapshot(before)
+    const member = await findOneWithDecryption(
+      em,
+      StaffTeamMember,
+      scopedStaffSnapshotWhere(before.memberId, snapshotScope),
+      undefined,
+      staffSnapshotDecryptionScope(snapshotScope),
+    )
     if (!member) return
     const currentTags = Array.isArray(member.tags) ? member.tags : []
     if (!currentTags.includes(before.tag)) {

--- a/packages/core/src/modules/staff/commands/team-members.ts
+++ b/packages/core/src/modules/staff/commands/team-members.ts
@@ -19,7 +19,16 @@ import {
   type StaffTeamMemberUpdateInput,
 } from '../data/validators'
 import { staffTeamMemberCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopedStaffSnapshotWhere,
+  staffSnapshotDecryptionScope,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
+} from './shared'
 import { E } from '#generated/entities.ids.generated'
 
 const teamMemberCrudIndexer: CrudIndexerConfig<StaffTeamMember> = {
@@ -59,8 +68,14 @@ function normalizeStringList(value: unknown): string[] {
   return Array.from(set)
 }
 
-async function loadTeamMemberSnapshot(em: EntityManager, id: string): Promise<TeamMemberSnapshot | null> {
-  const member = await findOneWithDecryption(em, StaffTeamMember, { id }, undefined, { tenantId: null, organizationId: null })
+async function loadTeamMemberSnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<TeamMemberSnapshot | null> {
+  const member = await findOneWithDecryption(
+    em,
+    StaffTeamMember,
+    scopedStaffSnapshotWhere(id, scope),
+    undefined,
+    staffSnapshotDecryptionScope(scope),
+  )
   if (!member) return null
   return {
     id: member.id,
@@ -223,14 +238,14 @@ const createTeamMemberCommand: CommandHandler<StaffTeamMemberCreateInput, { memb
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTeamMemberSnapshot(em, result.memberId)
+    const snapshot = await loadTeamMemberSnapshot(em, result.memberId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const custom = await loadTeamMemberCustomSnapshot(em, snapshot)
     return { snapshot, custom }
   },
   buildLog: async ({ result, ctx }) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTeamMemberSnapshot(em, result.memberId)
+    const snapshot = await loadTeamMemberSnapshot(em, result.memberId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const custom = await loadTeamMemberCustomSnapshot(em, snapshot)
     const { translate } = await resolveTranslations()
@@ -254,7 +269,7 @@ const createTeamMemberCommand: CommandHandler<StaffTeamMemberCreateInput, { memb
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await em.findOne(StaffTeamMember, { id: after.id })
+    const member = await em.findOne(StaffTeamMember, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (member) {
       member.deletedAt = new Date()
       await em.flush()
@@ -297,7 +312,7 @@ const updateTeamMemberCommand: CommandHandler<StaffTeamMemberUpdateInput, { memb
   async prepare(rawInput, ctx) {
     const { parsed } = parseWithCustomFields(staffTeamMemberUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTeamMemberSnapshot(em, parsed.id)
+    const snapshot = await loadTeamMemberSnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     const custom = await loadTeamMemberCustomSnapshot(em, snapshot)
     return { before: snapshot, customBefore: custom }
@@ -377,7 +392,7 @@ const updateTeamMemberCommand: CommandHandler<StaffTeamMemberUpdateInput, { memb
     const before = snapshots.before as TeamMemberSnapshot | undefined
     if (!before) return null
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const after = await loadTeamMemberSnapshot(em, before.id)
+    const after = await loadTeamMemberSnapshot(em, before.id, staffSnapshotScopeFromSnapshot(before))
     if (!after) return null
     const customBefore = (snapshots as { customBefore?: CustomFieldSnapshot | null }).customBefore ?? undefined
     const customAfter = await loadTeamMemberCustomSnapshot(em, after)
@@ -420,7 +435,7 @@ const updateTeamMemberCommand: CommandHandler<StaffTeamMemberUpdateInput, { memb
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await em.findOne(StaffTeamMember, { id: before.id })
+    const member = await em.findOne(StaffTeamMember, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!member) return
     member.teamId = before.teamId ?? null
     member.displayName = before.displayName
@@ -467,7 +482,7 @@ const deleteTeamMemberCommand: CommandHandler<{ id?: string }, { memberId: strin
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Member id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTeamMemberSnapshot(em, id)
+    const snapshot = await loadTeamMemberSnapshot(em, id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     const custom = await loadTeamMemberCustomSnapshot(em, snapshot)
     return { before: snapshot, customBefore: custom }
@@ -531,7 +546,7 @@ const deleteTeamMemberCommand: CommandHandler<{ id?: string }, { memberId: strin
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let member = await em.findOne(StaffTeamMember, { id: before.id })
+    let member = await em.findOne(StaffTeamMember, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!member) {
       member = em.create(StaffTeamMember, {
         id: before.id,

--- a/packages/core/src/modules/staff/commands/team-roles.ts
+++ b/packages/core/src/modules/staff/commands/team-roles.ts
@@ -17,7 +17,16 @@ import {
   type StaffTeamRoleUpdateInput,
 } from '../data/validators'
 import { staffTeamRoleCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopedStaffSnapshotWhere,
+  staffSnapshotDecryptionScope,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
+} from './shared'
 import { E } from '#generated/entities.ids.generated'
 
 const teamRoleCrudIndexer: CrudIndexerConfig<StaffTeamRole> = {
@@ -43,8 +52,14 @@ type TeamRoleUndoPayload = {
   customAfter?: CustomFieldSnapshot | null
 }
 
-async function loadTeamRoleSnapshot(em: EntityManager, id: string): Promise<TeamRoleSnapshot | null> {
-  const role = await findOneWithDecryption(em, StaffTeamRole, { id }, undefined, { tenantId: null, organizationId: null })
+async function loadTeamRoleSnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<TeamRoleSnapshot | null> {
+  const role = await findOneWithDecryption(
+    em,
+    StaffTeamRole,
+    scopedStaffSnapshotWhere(id, scope),
+    undefined,
+    staffSnapshotDecryptionScope(scope),
+  )
   if (!role) return null
   return {
     id: role.id,
@@ -148,14 +163,14 @@ const createTeamRoleCommand: CommandHandler<StaffTeamRoleCreateInput, { roleId: 
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTeamRoleSnapshot(em, result.roleId)
+    const snapshot = await loadTeamRoleSnapshot(em, result.roleId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const custom = await loadTeamRoleCustomSnapshot(em, snapshot)
     return { snapshot, custom }
   },
   buildLog: async ({ result, ctx }) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTeamRoleSnapshot(em, result.roleId)
+    const snapshot = await loadTeamRoleSnapshot(em, result.roleId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const custom = await loadTeamRoleCustomSnapshot(em, snapshot)
     const { translate } = await resolveTranslations()
@@ -179,7 +194,7 @@ const createTeamRoleCommand: CommandHandler<StaffTeamRoleCreateInput, { roleId: 
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const role = await em.findOne(StaffTeamRole, { id: after.id })
+    const role = await em.findOne(StaffTeamRole, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (role) {
       role.deletedAt = new Date()
       await em.flush()
@@ -222,7 +237,7 @@ const updateTeamRoleCommand: CommandHandler<StaffTeamRoleUpdateInput, { roleId: 
   async prepare(rawInput, ctx) {
     const { parsed } = parseWithCustomFields(staffTeamRoleUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTeamRoleSnapshot(em, parsed.id)
+    const snapshot = await loadTeamRoleSnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     const custom = await loadTeamRoleCustomSnapshot(em, snapshot)
     return { before: snapshot, customBefore: custom }
@@ -283,7 +298,7 @@ const updateTeamRoleCommand: CommandHandler<StaffTeamRoleUpdateInput, { roleId: 
     const before = snapshots.before as TeamRoleSnapshot | undefined
     if (!before) return null
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const after = await loadTeamRoleSnapshot(em, before.id)
+    const after = await loadTeamRoleSnapshot(em, before.id, staffSnapshotScopeFromSnapshot(before))
     if (!after) return null
     const customBefore = (snapshots as { customBefore?: CustomFieldSnapshot | null }).customBefore ?? undefined
     const customAfter = await loadTeamRoleCustomSnapshot(em, after)
@@ -324,7 +339,7 @@ const updateTeamRoleCommand: CommandHandler<StaffTeamRoleUpdateInput, { roleId: 
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const role = await em.findOne(StaffTeamRole, { id: before.id })
+    const role = await em.findOne(StaffTeamRole, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!role) return
     role.teamId = before.teamId ?? null
     role.name = before.name
@@ -369,7 +384,7 @@ const deleteTeamRoleCommand: CommandHandler<{ id?: string }, { roleId: string }>
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Role id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTeamRoleSnapshot(em, id)
+    const snapshot = await loadTeamRoleSnapshot(em, id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     const custom = await loadTeamRoleCustomSnapshot(em, snapshot)
     return { before: snapshot, customBefore: custom }
@@ -453,7 +468,7 @@ const deleteTeamRoleCommand: CommandHandler<{ id?: string }, { roleId: string }>
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let role = await em.findOne(StaffTeamRole, { id: before.id })
+    let role = await em.findOne(StaffTeamRole, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!role) {
       role = em.create(StaffTeamRole, {
         id: before.id,

--- a/packages/core/src/modules/staff/commands/teams.ts
+++ b/packages/core/src/modules/staff/commands/teams.ts
@@ -17,7 +17,16 @@ import {
   type StaffTeamUpdateInput,
 } from '../data/validators'
 import { staffTeamCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopedStaffSnapshotWhere,
+  staffSnapshotDecryptionScope,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
+} from './shared'
 import { E } from '#generated/entities.ids.generated'
 
 const teamCrudIndexer: CrudIndexerConfig<StaffTeam> = {
@@ -41,8 +50,14 @@ type TeamUndoPayload = {
   customAfter?: CustomFieldSnapshot | null
 }
 
-async function loadTeamSnapshot(em: EntityManager, id: string): Promise<TeamSnapshot | null> {
-  const team = await findOneWithDecryption(em, StaffTeam, { id }, undefined, { tenantId: null, organizationId: null })
+async function loadTeamSnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<TeamSnapshot | null> {
+  const team = await findOneWithDecryption(
+    em,
+    StaffTeam,
+    scopedStaffSnapshotWhere(id, scope),
+    undefined,
+    staffSnapshotDecryptionScope(scope),
+  )
   if (!team) return null
   return {
     id: team.id,
@@ -120,14 +135,14 @@ const createTeamCommand: CommandHandler<StaffTeamCreateInput, { teamId: string }
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTeamSnapshot(em, result.teamId)
+    const snapshot = await loadTeamSnapshot(em, result.teamId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const custom = await loadTeamCustomSnapshot(em, snapshot)
     return { snapshot, custom }
   },
   buildLog: async ({ result, ctx }) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTeamSnapshot(em, result.teamId)
+    const snapshot = await loadTeamSnapshot(em, result.teamId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const custom = await loadTeamCustomSnapshot(em, snapshot)
     const { translate } = await resolveTranslations()
@@ -151,7 +166,7 @@ const createTeamCommand: CommandHandler<StaffTeamCreateInput, { teamId: string }
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const team = await em.findOne(StaffTeam, { id: after.id })
+    const team = await em.findOne(StaffTeam, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (team) {
       team.deletedAt = new Date()
       await em.flush()
@@ -194,7 +209,7 @@ const updateTeamCommand: CommandHandler<StaffTeamUpdateInput, { teamId: string }
   async prepare(rawInput, ctx) {
     const { parsed } = parseWithCustomFields(staffTeamUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTeamSnapshot(em, parsed.id)
+    const snapshot = await loadTeamSnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     const custom = await loadTeamCustomSnapshot(em, snapshot)
     return { before: snapshot, customBefore: custom }
@@ -248,7 +263,7 @@ const updateTeamCommand: CommandHandler<StaffTeamUpdateInput, { teamId: string }
     const before = snapshots.before as TeamSnapshot | undefined
     if (!before) return null
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const after = await loadTeamSnapshot(em, before.id)
+    const after = await loadTeamSnapshot(em, before.id, staffSnapshotScopeFromSnapshot(before))
     if (!after) return null
     const customBefore = (snapshots as { customBefore?: CustomFieldSnapshot | null }).customBefore ?? undefined
     const customAfter = await loadTeamCustomSnapshot(em, after)
@@ -287,7 +302,7 @@ const updateTeamCommand: CommandHandler<StaffTeamUpdateInput, { teamId: string }
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const team = await em.findOne(StaffTeam, { id: before.id })
+    const team = await em.findOne(StaffTeam, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!team) return
     team.name = before.name
     team.description = before.description ?? null
@@ -330,7 +345,7 @@ const deleteTeamCommand: CommandHandler<{ id?: string }, { teamId: string }> = {
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Team id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTeamSnapshot(em, id)
+    const snapshot = await loadTeamSnapshot(em, id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     const custom = await loadTeamCustomSnapshot(em, snapshot)
     return { before: snapshot, customBefore: custom }
@@ -407,7 +422,7 @@ const deleteTeamCommand: CommandHandler<{ id?: string }, { teamId: string }> = {
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let team = await em.findOne(StaffTeam, { id: before.id })
+    let team = await em.findOne(StaffTeam, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!team) {
       team = em.create(StaffTeam, {
         id: before.id,

--- a/packages/core/src/modules/staff/commands/timesheets-entries.ts
+++ b/packages/core/src/modules/staff/commands/timesheets-entries.ts
@@ -22,7 +22,16 @@ import {
   type StaffTimeEntryUpdateInput,
 } from '../data/validators'
 import { staffTimeEntryCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopedStaffSnapshotWhere,
+  staffSnapshotDecryptionScope,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
+} from './shared'
 import { getStaffMemberByUserId } from '../lib/staffMemberResolver'
 
 type RbacServiceLike = {
@@ -124,8 +133,14 @@ type TimeEntryUndoPayload = {
   after?: TimeEntrySnapshot | null
 }
 
-async function loadTimeEntrySnapshot(em: EntityManager, id: string): Promise<TimeEntrySnapshot | null> {
-  const entry = await findOneWithDecryption(em, StaffTimeEntry, { id }, undefined, { tenantId: null, organizationId: null })
+async function loadTimeEntrySnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<TimeEntrySnapshot | null> {
+  const entry = await findOneWithDecryption(
+    em,
+    StaffTimeEntry,
+    scopedStaffSnapshotWhere(id, scope),
+    undefined,
+    staffSnapshotDecryptionScope(scope),
+  )
   if (!entry) return null
   return {
     id: entry.id,
@@ -232,13 +247,13 @@ const createTimeEntryCommand: CommandHandler<StaffTimeEntryCreateInput, { timeEn
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId)
+    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     return { snapshot }
   },
   buildLog: async ({ result, ctx }) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId)
+    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const { translate } = await resolveTranslations()
     return {
@@ -260,7 +275,7 @@ const createTimeEntryCommand: CommandHandler<StaffTimeEntryCreateInput, { timeEn
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const entry = await em.findOne(StaffTimeEntry, { id: after.id })
+    const entry = await em.findOne(StaffTimeEntry, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (entry) {
       entry.deletedAt = new Date()
       await em.flush()
@@ -401,13 +416,13 @@ const startTimerCommand: CommandHandler<StaffTimeEntryStartTimerInput, { timeEnt
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId)
+    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     return { snapshot }
   },
   buildLog: async ({ result, ctx }) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId)
+    const snapshot = await loadTimeEntrySnapshot(em, result.timeEntryId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const { translate } = await resolveTranslations()
     return {
@@ -429,7 +444,7 @@ const startTimerCommand: CommandHandler<StaffTimeEntryStartTimerInput, { timeEnt
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const entry = await em.findOne(StaffTimeEntry, { id: after.id })
+    const entry = await em.findOne(StaffTimeEntry, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (entry) {
       entry.deletedAt = new Date()
       await em.flush()
@@ -450,7 +465,7 @@ const updateTimeEntryCommand: CommandHandler<StaffTimeEntryUpdateInput, { timeEn
   async prepare(rawInput, ctx) {
     const parsed = staffTimeEntryUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTimeEntrySnapshot(em, parsed.id)
+    const snapshot = await loadTimeEntrySnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     return { before: snapshot }
   },
@@ -510,7 +525,7 @@ const updateTimeEntryCommand: CommandHandler<StaffTimeEntryUpdateInput, { timeEn
     const before = snapshots.before as TimeEntrySnapshot | undefined
     if (!before) return null
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const after = await loadTimeEntrySnapshot(em, before.id)
+    const after = await loadTimeEntrySnapshot(em, before.id, staffSnapshotScopeFromSnapshot(before))
     if (!after) return null
     const changes = buildChanges(before as unknown as Record<string, unknown>, after as unknown as Record<string, unknown>, [
       'date',
@@ -545,7 +560,7 @@ const updateTimeEntryCommand: CommandHandler<StaffTimeEntryUpdateInput, { timeEn
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const entry = await em.findOne(StaffTimeEntry, { id: before.id })
+    const entry = await em.findOne(StaffTimeEntry, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!entry) return
     entry.date = before.date as unknown as Date
     entry.durationMinutes = before.durationMinutes
@@ -575,7 +590,7 @@ const deleteTimeEntryCommand: CommandHandler<{ id?: string }, { timeEntryId: str
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Time entry id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTimeEntrySnapshot(em, id)
+    const snapshot = await loadTimeEntrySnapshot(em, id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     return { before: snapshot }
   },
@@ -644,7 +659,7 @@ const deleteTimeEntryCommand: CommandHandler<{ id?: string }, { timeEntryId: str
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let entry = await em.findOne(StaffTimeEntry, { id: before.id })
+    let entry = await em.findOne(StaffTimeEntry, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!entry) {
       entry = em.create(StaffTimeEntry, {
         id: before.id,

--- a/packages/core/src/modules/staff/commands/timesheets-projects.ts
+++ b/packages/core/src/modules/staff/commands/timesheets-projects.ts
@@ -27,7 +27,16 @@ import {
   type StaffTimeProjectMemberUpdateInput,
 } from '../data/validators'
 import { staffTimeProjectCrudEvents, staffTimeProjectMemberCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopedStaffSnapshotWhere,
+  staffSnapshotDecryptionScope,
+  staffSnapshotScopeFromContext,
+  staffSnapshotScopeFromSnapshot,
+  type StaffSnapshotScope,
+} from './shared'
 
 function isUniqueViolation(error: unknown): boolean {
   if (error instanceof UniqueConstraintViolationException) return true
@@ -79,8 +88,14 @@ type TimeProjectMemberUndoPayload = {
   after?: TimeProjectMemberSnapshot | null
 }
 
-async function loadTimeProjectSnapshot(em: EntityManager, id: string): Promise<TimeProjectSnapshot | null> {
-  const project = await findOneWithDecryption(em, StaffTimeProject, { id }, undefined, { tenantId: null, organizationId: null })
+async function loadTimeProjectSnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<TimeProjectSnapshot | null> {
+  const project = await findOneWithDecryption(
+    em,
+    StaffTimeProject,
+    scopedStaffSnapshotWhere(id, scope),
+    undefined,
+    staffSnapshotDecryptionScope(scope),
+  )
   if (!project) return null
   return {
     id: project.id,
@@ -100,8 +115,14 @@ async function loadTimeProjectSnapshot(em: EntityManager, id: string): Promise<T
   }
 }
 
-async function loadTimeProjectMemberSnapshot(em: EntityManager, id: string): Promise<TimeProjectMemberSnapshot | null> {
-  const member = await findOneWithDecryption(em, StaffTimeProjectMember, { id }, undefined, { tenantId: null, organizationId: null })
+async function loadTimeProjectMemberSnapshot(em: EntityManager, id: string, scope?: StaffSnapshotScope | null): Promise<TimeProjectMemberSnapshot | null> {
+  const member = await findOneWithDecryption(
+    em,
+    StaffTimeProjectMember,
+    scopedStaffSnapshotWhere(id, scope),
+    undefined,
+    staffSnapshotDecryptionScope(scope),
+  )
   if (!member) return null
   return {
     id: member.id,
@@ -214,13 +235,13 @@ const createTimeProjectCommand: CommandHandler<StaffTimeProjectCreateInput, { ti
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTimeProjectSnapshot(em, result.timeProjectId)
+    const snapshot = await loadTimeProjectSnapshot(em, result.timeProjectId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     return { snapshot }
   },
   buildLog: async ({ result, ctx }) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTimeProjectSnapshot(em, result.timeProjectId)
+    const snapshot = await loadTimeProjectSnapshot(em, result.timeProjectId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const { translate } = await resolveTranslations()
     return {
@@ -242,7 +263,7 @@ const createTimeProjectCommand: CommandHandler<StaffTimeProjectCreateInput, { ti
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const project = await em.findOne(StaffTimeProject, { id: after.id })
+    const project = await em.findOne(StaffTimeProject, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (project) {
       project.deletedAt = new Date()
       await em.flush()
@@ -275,7 +296,7 @@ const updateTimeProjectCommand: CommandHandler<StaffTimeProjectUpdateInput, { ti
   async prepare(rawInput, ctx) {
     const parsed = staffTimeProjectUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTimeProjectSnapshot(em, parsed.id)
+    const snapshot = await loadTimeProjectSnapshot(em, parsed.id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     return { before: snapshot }
   },
@@ -336,7 +357,7 @@ const updateTimeProjectCommand: CommandHandler<StaffTimeProjectUpdateInput, { ti
     const before = snapshots.before as TimeProjectSnapshot | undefined
     if (!before) return null
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const after = await loadTimeProjectSnapshot(em, before.id)
+    const after = await loadTimeProjectSnapshot(em, before.id, staffSnapshotScopeFromSnapshot(before))
     if (!after) return null
     const changes = buildChanges(before as unknown as Record<string, unknown>, after as unknown as Record<string, unknown>, [
       'name',
@@ -374,7 +395,7 @@ const updateTimeProjectCommand: CommandHandler<StaffTimeProjectUpdateInput, { ti
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const project = await em.findOne(StaffTimeProject, { id: before.id })
+    const project = await em.findOne(StaffTimeProject, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!project) return
     project.name = before.name
     project.customerId = before.customerId ?? null
@@ -411,7 +432,7 @@ const deleteTimeProjectCommand: CommandHandler<{ id?: string }, { timeProjectId:
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Time project id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTimeProjectSnapshot(em, id)
+    const snapshot = await loadTimeProjectSnapshot(em, id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     return { before: snapshot }
   },
@@ -471,7 +492,7 @@ const deleteTimeProjectCommand: CommandHandler<{ id?: string }, { timeProjectId:
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let project = await em.findOne(StaffTimeProject, { id: before.id })
+    let project = await em.findOne(StaffTimeProject, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!project) {
       project = em.create(StaffTimeProject, {
         id: before.id,
@@ -592,13 +613,13 @@ const assignTimeProjectMemberCommand: CommandHandler<StaffTimeProjectMemberAssig
   },
   captureAfter: async (_input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTimeProjectMemberSnapshot(em, result.timeProjectMemberId)
+    const snapshot = await loadTimeProjectMemberSnapshot(em, result.timeProjectMemberId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     return { snapshot }
   },
   buildLog: async ({ result, ctx }) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadTimeProjectMemberSnapshot(em, result.timeProjectMemberId)
+    const snapshot = await loadTimeProjectMemberSnapshot(em, result.timeProjectMemberId, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return null
     const { translate } = await resolveTranslations()
     return {
@@ -620,7 +641,7 @@ const assignTimeProjectMemberCommand: CommandHandler<StaffTimeProjectMemberAssig
     const after = payload?.after
     if (!after) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await em.findOne(StaffTimeProjectMember, { id: after.id })
+    const member = await em.findOne(StaffTimeProjectMember, scopedStaffSnapshotWhere(after.id, staffSnapshotScopeFromSnapshot(after)))
     if (member) {
       member.deletedAt = new Date()
       await em.flush()
@@ -650,7 +671,7 @@ const unassignTimeProjectMemberCommand: CommandHandler<{ id?: string }, { timePr
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Time project member id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadTimeProjectMemberSnapshot(em, id)
+    const snapshot = await loadTimeProjectMemberSnapshot(em, id, staffSnapshotScopeFromContext(ctx))
     if (!snapshot) return {}
     return { before: snapshot }
   },
@@ -707,7 +728,7 @@ const unassignTimeProjectMemberCommand: CommandHandler<{ id?: string }, { timePr
     const before = payload?.before
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    let member = await em.findOne(StaffTimeProjectMember, { id: before.id })
+    let member = await em.findOne(StaffTimeProjectMember, scopedStaffSnapshotWhere(before.id, staffSnapshotScopeFromSnapshot(before)))
     if (!member) {
       member = em.create(StaffTimeProjectMember, {
         id: before.id,


### PR DESCRIPTION
## Summary
- Scope staff audit and undo snapshot loaders by tenant and organization.
- Reuse scoped snapshot options across staff command helpers.
- Add regression coverage for cross-scope snapshot isolation.

## Tests
- yarn workspace @open-mercato/core test packages/core/src/modules/staff/commands/__tests__/snapshot-scoping.test.ts

Fixes #3913