### PR TITLE
fix(shared): fail closed for null-tenant command scope

### DIFF
--- a/packages/core/src/modules/catalog/commands/__tests__/shared.test.ts
+++ b/packages/core/src/modules/catalog/commands/__tests__/shared.test.ts
@@ -50,7 +50,8 @@ describe('catalog command shared helpers', () => {
 
   it('enforces tenant scope when conflicting tenant id is provided', () => {
     expect(() => ensureTenantScope(createCtx(), 'tenant-1')).not.toThrow()
-    expect(() => ensureTenantScope(createCtx({ auth: { tenantId: null } }), 'tenant-2')).not.toThrow()
+    expect(() => ensureTenantScope(createCtx({ auth: { tenantId: null } }), 'tenant-2')).toThrow(CrudHttpError)
+    expect(() => ensureTenantScope(createCtx({ auth: null }), 'tenant-2')).not.toThrow()
     expect(() => ensureTenantScope(createCtx(), 'tenant-2')).toThrow(CrudHttpError)
   })
 

--- a/packages/core/src/modules/planner/commands/__tests__/shared.scope.test.ts
+++ b/packages/core/src/modules/planner/commands/__tests__/shared.scope.test.ts
@@ -1,0 +1,33 @@
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { ensureTenantScope } from '../shared'
+
+function buildCtx(overrides: {
+  tenantId?: string | null
+  isSuperAdmin?: boolean
+}): CommandRuntimeContext {
+  return {
+    container: {} as CommandRuntimeContext['container'],
+    auth: {
+      sub: 'user-1',
+      tenantId: overrides.tenantId === undefined ? 'tenant-1' : overrides.tenantId,
+      orgId: null,
+      isSuperAdmin: overrides.isSuperAdmin ?? false,
+    },
+    organizationScope: null,
+    selectedOrganizationId: null,
+    organizationIds: null,
+  }
+}
+
+describe('planner command scope helpers', () => {
+  it('denies a tenant-less non-superadmin acting on a tenant-scoped planner target (#3910)', () => {
+    const ctx = buildCtx({ tenantId: null, isSuperAdmin: false })
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).toThrow(CrudHttpError)
+  })
+
+  it('allows super admins with no tenant context to act on tenant-scoped planner targets', () => {
+    const ctx = buildCtx({ tenantId: null, isSuperAdmin: true })
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).not.toThrow()
+  })
+})

--- a/packages/core/src/modules/planner/commands/shared.ts
+++ b/packages/core/src/modules/planner/commands/shared.ts
@@ -1,13 +1,4 @@
-import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
-import { ensureOrganizationScope } from '@open-mercato/shared/lib/commands/scope'
+import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
 
-export function ensureTenantScope(ctx: CommandRuntimeContext, tenantId: string): void {
-  const currentTenant = ctx.auth?.tenantId ?? null
-  if (currentTenant && currentTenant !== tenantId) {
-    throw new CrudHttpError(403, { error: 'Forbidden' })
-  }
-}
-
-export { ensureOrganizationScope, extractUndoPayload }
+export { ensureOrganizationScope, ensureTenantScope, extractUndoPayload }

--- a/packages/core/src/modules/resources/commands/__tests__/shared.scope.test.ts
+++ b/packages/core/src/modules/resources/commands/__tests__/shared.scope.test.ts
@@ -1,0 +1,33 @@
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { ensureTenantScope } from '../shared'
+
+function buildCtx(overrides: {
+  tenantId?: string | null
+  isSuperAdmin?: boolean
+}): CommandRuntimeContext {
+  return {
+    container: {} as CommandRuntimeContext['container'],
+    auth: {
+      sub: 'user-1',
+      tenantId: overrides.tenantId === undefined ? 'tenant-1' : overrides.tenantId,
+      orgId: null,
+      isSuperAdmin: overrides.isSuperAdmin ?? false,
+    },
+    organizationScope: null,
+    selectedOrganizationId: null,
+    organizationIds: null,
+  }
+}
+
+describe('resources command scope helpers', () => {
+  it('denies a tenant-less non-superadmin acting on a tenant-scoped resources target (#3910)', () => {
+    const ctx = buildCtx({ tenantId: null, isSuperAdmin: false })
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).toThrow(CrudHttpError)
+  })
+
+  it('allows super admins with no tenant context to act on tenant-scoped resources targets', () => {
+    const ctx = buildCtx({ tenantId: null, isSuperAdmin: true })
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).not.toThrow()
+  })
+})

--- a/packages/core/src/modules/resources/commands/shared.ts
+++ b/packages/core/src/modules/resources/commands/shared.ts
@@ -1,18 +1,10 @@
-import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
-import { ensureOrganizationScope } from '@open-mercato/shared/lib/commands/scope'
+import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { ResourcesResource } from '../data/entities'
 
-export function ensureTenantScope(ctx: CommandRuntimeContext, tenantId: string): void {
-  const currentTenant = ctx.auth?.tenantId ?? null
-  if (currentTenant && currentTenant !== tenantId) {
-    throw new CrudHttpError(403, { error: 'Forbidden' })
-  }
-}
-
-export { ensureOrganizationScope, extractUndoPayload }
+export { ensureOrganizationScope, ensureTenantScope, extractUndoPayload }
 
 export async function requireResource(
   em: EntityManager,

--- a/packages/core/src/modules/staff/commands/__tests__/shared.scope.test.ts
+++ b/packages/core/src/modules/staff/commands/__tests__/shared.scope.test.ts
@@ -1,0 +1,33 @@
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { ensureTenantScope } from '../shared'
+
+function buildCtx(overrides: {
+  tenantId?: string | null
+  isSuperAdmin?: boolean
+}): CommandRuntimeContext {
+  return {
+    container: {} as CommandRuntimeContext['container'],
+    auth: {
+      sub: 'user-1',
+      tenantId: overrides.tenantId === undefined ? 'tenant-1' : overrides.tenantId,
+      orgId: null,
+      isSuperAdmin: overrides.isSuperAdmin ?? false,
+    },
+    organizationScope: null,
+    selectedOrganizationId: null,
+    organizationIds: null,
+  }
+}
+
+describe('staff command scope helpers', () => {
+  it('denies a tenant-less non-superadmin acting on a tenant-scoped staff target (#3910)', () => {
+    const ctx = buildCtx({ tenantId: null, isSuperAdmin: false })
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).toThrow(CrudHttpError)
+  })
+
+  it('allows super admins with no tenant context to act on tenant-scoped staff targets', () => {
+    const ctx = buildCtx({ tenantId: null, isSuperAdmin: true })
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).not.toThrow()
+  })
+})

--- a/packages/core/src/modules/staff/commands/shared.ts
+++ b/packages/core/src/modules/staff/commands/shared.ts
@@ -1,18 +1,10 @@
-import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
-import { ensureOrganizationScope } from '@open-mercato/shared/lib/commands/scope'
+import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { StaffTeamMember } from '../data/entities'
 
-export function ensureTenantScope(ctx: CommandRuntimeContext, tenantId: string): void {
-  const currentTenant = ctx.auth?.tenantId ?? null
-  if (currentTenant && currentTenant !== tenantId) {
-    throw new CrudHttpError(403, { error: 'Forbidden' })
-  }
-}
-
-export { ensureOrganizationScope, extractUndoPayload }
+export { ensureOrganizationScope, ensureTenantScope, extractUndoPayload }
 
 export async function requireTeamMember(
   em: EntityManager,

--- a/packages/shared/src/lib/commands/__tests__/scope.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/scope.test.ts
@@ -1,4 +1,4 @@
-import { ensureOrganizationScope } from '@open-mercato/shared/lib/commands/scope'
+import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 
@@ -6,21 +6,24 @@ type ScopeShape = NonNullable<CommandRuntimeContext['organizationScope']>
 
 function buildCtx(overrides: {
   isSuperAdmin?: boolean
+  tenantId?: string | null
   orgId?: string | null
   selectedOrganizationId?: string | null
   organizationScope?: ScopeShape | null
+  systemActor?: boolean
 }): CommandRuntimeContext {
   return {
     container: {} as CommandRuntimeContext['container'],
     auth: {
       sub: 'user-1',
-      tenantId: 'tenant-1',
+      tenantId: overrides.tenantId === undefined ? 'tenant-1' : overrides.tenantId,
       orgId: overrides.orgId ?? null,
       isSuperAdmin: overrides.isSuperAdmin ?? false,
     },
     organizationScope: overrides.organizationScope ?? null,
     selectedOrganizationId: overrides.selectedOrganizationId ?? null,
     organizationIds: null,
+    systemActor: overrides.systemActor,
   }
 }
 
@@ -33,6 +36,33 @@ function buildScope(overrides: Partial<ScopeShape>): ScopeShape {
     ...overrides,
   }
 }
+
+describe('ensureTenantScope', () => {
+  it('denies a tenant-less non-superadmin acting on a tenant-scoped target (#3910)', () => {
+    const ctx = buildCtx({ tenantId: null, isSuperAdmin: false })
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).toThrow(CrudHttpError)
+  })
+
+  it('allows super admins with no tenant context to act on tenant-scoped targets', () => {
+    const ctx = buildCtx({ tenantId: null, isSuperAdmin: true })
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).not.toThrow()
+  })
+
+  it('preserves legacy system contexts without an authenticated actor', () => {
+    const ctx = { ...buildCtx({}), auth: null }
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).not.toThrow()
+  })
+
+  it('denies authenticated tenant-less systemActor contexts unless they are superadmin (#3910)', () => {
+    const ctx = buildCtx({ tenantId: null, isSuperAdmin: false, systemActor: true })
+    expect(() => ensureTenantScope(ctx, 'tenant-2')).toThrow(CrudHttpError)
+  })
+
+  it('allows a scoped principal acting inside its own tenant', () => {
+    const ctx = buildCtx({ tenantId: 'tenant-1' })
+    expect(() => ensureTenantScope(ctx, 'tenant-1')).not.toThrow()
+  })
+})
 
 describe('ensureOrganizationScope', () => {
   it('denies a restricted floating user acting on an org outside allowedIds (#2239)', () => {
@@ -57,6 +87,43 @@ describe('ensureOrganizationScope', () => {
       organizationScope: buildScope({ allowedIds: null }),
     })
     expect(() => ensureOrganizationScope(ctx, 'org-b')).not.toThrow()
+  })
+
+  it('denies null-tenant organization scope for a non-superadmin (#3910)', () => {
+    const ctx = buildCtx({
+      tenantId: null,
+      organizationScope: buildScope({ tenantId: null, allowedIds: null, filterIds: null }),
+    })
+    expect(() => ensureOrganizationScope(ctx, 'org-b')).toThrow(CrudHttpError)
+  })
+
+  it('allows null-tenant organization scope for a superadmin', () => {
+    const ctx = buildCtx({
+      tenantId: null,
+      isSuperAdmin: true,
+      organizationScope: buildScope({ tenantId: null, allowedIds: null, filterIds: null }),
+    })
+    expect(() => ensureOrganizationScope(ctx, 'org-b')).not.toThrow()
+  })
+
+  it('preserves null-tenant organization scope for system contexts without an authenticated actor', () => {
+    const ctx = {
+      ...buildCtx({
+        tenantId: null,
+        organizationScope: buildScope({ tenantId: null, allowedIds: null, filterIds: null }),
+      }),
+      auth: null,
+    }
+    expect(() => ensureOrganizationScope(ctx, 'org-b')).not.toThrow()
+  })
+
+  it('denies authenticated null-tenant systemActor organization scopes unless they are superadmin (#3910)', () => {
+    const ctx = buildCtx({
+      tenantId: null,
+      systemActor: true,
+      organizationScope: buildScope({ tenantId: null, allowedIds: null, filterIds: null }),
+    })
+    expect(() => ensureOrganizationScope(ctx, 'org-b')).toThrow(CrudHttpError)
   })
 
   it('allows a restricted user acting on an org inside allowedIds (allow-path regression)', () => {

--- a/packages/shared/src/lib/commands/scope.ts
+++ b/packages/shared/src/lib/commands/scope.ts
@@ -122,6 +122,12 @@ export function ensureOrganizationScope(ctx: CommandRuntimeContext, organization
     return
   }
 
+  if (!scope.tenantId && organizationId && ctx.auth && !isSuperAdmin) {
+    const currentOrg = ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null
+    logScopeViolation(ctx, organizationId, currentOrg)
+    throw new CrudHttpError(403, { error: 'Forbidden' })
+  }
+
   if (
     isOrganizationAccessAllowed({
       isSuperAdmin,
@@ -138,8 +144,16 @@ export function ensureOrganizationScope(ctx: CommandRuntimeContext, organization
 }
 
 export function ensureTenantScope(ctx: CommandRuntimeContext, tenantId: string): void {
+  const isSuperAdmin = ctx.auth?.isSuperAdmin === true
   const currentTenant = ctx.auth?.tenantId ?? null
-  if (currentTenant && currentTenant !== tenantId) {
+  if (!currentTenant) {
+    if (tenantId && ctx.auth && !isSuperAdmin) {
+      logTenantScopeViolation(ctx, tenantId, currentTenant)
+      throw new CrudHttpError(403, { error: 'Forbidden' })
+    }
+    return
+  }
+  if (currentTenant !== tenantId) {
     logTenantScopeViolation(ctx, tenantId, currentTenant)
     throw new CrudHttpError(403, { error: 'Forbidden' })
   }


### PR DESCRIPTION
## Summary

Fixes #3910.

Authenticated non-superadmin principals with no tenant context could pass tenant and organization command scope checks for scoped command writes. This change fails closed for those authenticated null-tenant/null-org contexts while preserving superadmin access and legacy trusted system contexts that have no authenticated actor.

## Changes

- Harden shared tenant and organization command scope guards.
- Reuse the shared tenant scope guard in staff, resources, and planner command helpers.
- Add regressions for null-tenant authenticated principals, authenticated `systemActor` contexts, superadmin compatibility, trusted system contexts, and module wrapper behavior.

## Testing

- yarn workspace @open-mercato/shared test src/lib/commands/__tests__/scope.test.ts --runInBand
- yarn workspace @open-mercato/core test src/modules/catalog/commands/__tests__/shared.test.ts src/modules/sales/commands/__tests__/documents.convert-to-order.test.ts src/modules/staff/commands/__tests__/shared.scope.test.ts src/modules/resources/commands/__tests__/shared.scope.test.ts src/modules/planner/commands/__tests__/shared.scope.test.ts --runInBand
- yarn typecheck
- yarn test
- yarn lint
- yarn build:packages
- yarn build:app
- git diff --check

## QA

No manual QA requested. This is backend command-scope hardening with unit coverage and no UI changes.

## Linked issues

Fixes #3910