### PR TITLE
fix(staff): scope command target loads

### DIFF
--- a/packages/core/src/modules/staff/commands/__tests__/scoped-target-loads.test.ts
+++ b/packages/core/src/modules/staff/commands/__tests__/scoped-target-loads.test.ts
@@ -1,0 +1,213 @@
+import type { AwilixContainer } from 'awilix'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+
+const mockFindOneWithDecryption = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/helpers')
+  return {
+    ...actual,
+    emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+    emitCrudUndoSideEffects: jest.fn().mockResolvedValue(undefined),
+  }
+})
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn().mockResolvedValue({
+    translate: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+type RegisteredCommand = {
+  execute: (input: unknown, ctx: unknown) => Promise<unknown>
+}
+
+const TENANT_ID = '11111111-1111-4111-8111-111111111111'
+const ORG_ID = '22222222-2222-4222-8222-222222222222'
+const OTHER_ORG_ID = '33333333-3333-4333-8333-333333333333'
+const MEMBER_ID = '44444444-4444-4444-8444-444444444444'
+const TIME_PROJECT_ID = '55555555-5555-4555-8555-555555555555'
+
+async function loadTeamMemberUpdateCommand(): Promise<RegisteredCommand> {
+  jest.resetModules()
+  const { commandRegistry } = await import('@open-mercato/shared/lib/commands')
+  commandRegistry.clear()
+  await import('../team-members')
+  return commandRegistry.get('staff.team-members.update') as RegisteredCommand
+}
+
+async function loadTagAssignCommand(): Promise<RegisteredCommand> {
+  jest.resetModules()
+  const { commandRegistry } = await import('@open-mercato/shared/lib/commands')
+  commandRegistry.clear()
+  await import('../tag-assignments')
+  return commandRegistry.get('staff.team-members.tags.assign') as RegisteredCommand
+}
+
+async function loadTimeProjectMemberAssignCommand(): Promise<RegisteredCommand> {
+  jest.resetModules()
+  const { commandRegistry } = await import('@open-mercato/shared/lib/commands')
+  commandRegistry.clear()
+  await import('../timesheets-projects')
+  return commandRegistry.get('staff.timesheets.time_project_members.assign') as RegisteredCommand
+}
+
+function buildMember(overrides: Record<string, unknown> = {}) {
+  return {
+    id: MEMBER_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    teamId: null,
+    displayName: 'Before',
+    description: null,
+    userId: null,
+    roleIds: [],
+    tags: [],
+    availabilityRuleSetId: null,
+    isActive: true,
+    deletedAt: null,
+    updatedAt: new Date('2026-07-01T10:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function createEm() {
+  const em = {
+    fork: jest.fn(),
+    findOne: jest.fn().mockResolvedValue(null),
+    flush: jest.fn().mockResolvedValue(undefined),
+    begin: jest.fn().mockResolvedValue(undefined),
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+  }
+  em.fork.mockReturnValue(em)
+  return em
+}
+
+function createCtx(em: unknown, overrides: Record<string, unknown> = {}) {
+  return {
+    auth: {
+      sub: 'user-1',
+      tenantId: TENANT_ID,
+      orgId: OTHER_ORG_ID,
+      isSuperAdmin: false,
+    },
+    container: {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'dataEngine') return null
+        return null
+      },
+    } as unknown as AwilixContainer,
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: [ORG_ID],
+    ...overrides,
+  }
+}
+
+function createNullScopeCtx(em: unknown) {
+  return createCtx(em, {
+    auth: { sub: 'api-key-1', tenantId: null, orgId: null, isSuperAdmin: false },
+    selectedOrganizationId: null,
+    organizationIds: null,
+  })
+}
+
+describe('staff command target scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('loads team member update targets with the command tenant and selected organization scope', async () => {
+    const update = await loadTeamMemberUpdateCommand()
+    const em = createEm()
+    const member = buildMember()
+    mockFindOneWithDecryption.mockImplementation(async (_em, _entity, where: Record<string, unknown>) => {
+      if (where.id === MEMBER_ID && where.tenantId === TENANT_ID && where.organizationId === ORG_ID) {
+        return member
+      }
+      return null
+    })
+
+    await expect(
+      update.execute({ id: MEMBER_ID, displayName: 'After' }, createCtx(em)),
+    ).resolves.toEqual({ memberId: MEMBER_ID, updatedAt: expect.any(String) })
+
+    expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        id: MEMBER_ID,
+        tenantId: TENANT_ID,
+        organizationId: ORG_ID,
+        deletedAt: null,
+      }),
+      undefined,
+      { tenantId: TENANT_ID, organizationId: ORG_ID },
+    )
+    expect(member.displayName).toBe('After')
+  })
+
+  it('does not mutate an unscoped team member target for a null-scope non-superadmin principal', async () => {
+    const update = await loadTeamMemberUpdateCommand()
+    const em = createEm()
+    const foreignMember = buildMember({ organizationId: OTHER_ORG_ID })
+    mockFindOneWithDecryption.mockImplementation(async (_em, _entity, where: Record<string, unknown>) => {
+      if (where.id === MEMBER_ID && !('tenantId' in where) && !('organizationId' in where)) {
+        return foreignMember
+      }
+      return null
+    })
+
+    await expect(
+      update.execute(
+        { id: MEMBER_ID, displayName: 'After' },
+        createNullScopeCtx(em),
+      ),
+    ).rejects.toMatchObject<Partial<CrudHttpError>>({ status: 404 })
+
+    expect(foreignMember.displayName).toBe('Before')
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('does not let tag assignment choose a target scope from input under a null-scope principal', async () => {
+    const assign = await loadTagAssignCommand()
+    const em = createEm()
+
+    await expect(
+      assign.execute(
+        { tenantId: TENANT_ID, organizationId: ORG_ID, memberId: MEMBER_ID, tag: 'vip' },
+        createNullScopeCtx(em),
+      ),
+    ).rejects.toMatchObject<Partial<CrudHttpError>>({ status: 403 })
+
+    expect(mockFindOneWithDecryption).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('does not let project member assignment choose a target scope from input under a null-scope principal', async () => {
+    const assign = await loadTimeProjectMemberAssignCommand()
+    const em = createEm()
+
+    await expect(
+      assign.execute(
+        {
+          tenantId: TENANT_ID,
+          organizationId: ORG_ID,
+          timeProjectId: TIME_PROJECT_ID,
+          staffMemberId: MEMBER_ID,
+          assignedStartDate: '2026-07-01',
+        },
+        createNullScopeCtx(em),
+      ),
+    ).rejects.toMatchObject<Partial<CrudHttpError>>({ status: 403 })
+
+    expect(em.findOne).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/staff/commands/activities.ts
+++ b/packages/core/src/modules/staff/commands/activities.ts
@@ -22,7 +22,16 @@ import {
   type StaffTeamMemberActivityUpdateInput,
 } from '../data/validators'
 import { staffTeamMemberActivityCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireTeamMember } from './shared'
+import {
+  applyScopeToWhere,
+  commandActorScope,
+  commandInputScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  explicitStaffCommandScope,
+  extractUndoPayload,
+  requireTeamMember,
+} from './shared'
 import { resolveRedoSnapshot } from '@open-mercato/shared/lib/commands/redo'
 import { E } from '#generated/entities.ids.generated'
 import {
@@ -118,10 +127,16 @@ const createActivityCommand: CommandHandler<
     const { parsed, custom } = parseWithCustomFields(staffTeamMemberActivityCreateSchema, rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    const scope = commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
     const normalizedAuthor = normalizeAuthorUserId(parsed.authorUserId, ctx.auth)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, parsed.entityId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      parsed.entityId,
+      scope,
+      'Team member not found',
+    )
     ensureTenantScope(ctx, member.tenantId)
     ensureOrganizationScope(ctx, member.organizationId)
 
@@ -199,7 +214,12 @@ const createActivityCommand: CommandHandler<
       throw new CrudHttpError(400, { error: '[internal] redo snapshot unavailable for activity create' })
     }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, after.activity.memberId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      after.activity.memberId,
+      explicitStaffCommandScope(after.activity.tenantId, after.activity.organizationId),
+      'Team member not found',
+    )
     let activity = await em.findOne(StaffTeamMemberActivity, { id: after.activity.id })
     if (!activity) {
       activity = em.create(StaffTeamMemberActivity, {
@@ -261,13 +281,17 @@ const updateActivityCommand: CommandHandler<StaffTeamMemberActivityUpdateInput, 
   async execute(rawInput, ctx) {
     const { parsed, custom } = parseWithCustomFields(staffTeamMemberActivityUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const activity = await em.findOne(StaffTeamMemberActivity, { id: parsed.id })
+    const scope = commandActorScope(ctx)
+    const activity = await em.findOne(
+      StaffTeamMemberActivity,
+      applyScopeToWhere<StaffTeamMemberActivity>({ id: parsed.id }, scope),
+    )
     if (!activity) throw new CrudHttpError(404, { error: 'Activity not found' })
     ensureTenantScope(ctx, activity.tenantId)
     ensureOrganizationScope(ctx, activity.organizationId)
 
     if (parsed.entityId !== undefined) {
-      const member = await requireTeamMember(em, parsed.entityId, 'Team member not found')
+      const member = await requireTeamMember(em, parsed.entityId, scope, 'Team member not found')
       ensureTenantScope(ctx, member.tenantId)
       ensureOrganizationScope(ctx, member.organizationId)
       activity.member = member
@@ -354,7 +378,12 @@ const updateActivityCommand: CommandHandler<StaffTeamMemberActivityUpdateInput, 
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     let activity = await em.findOne(StaffTeamMemberActivity, { id: before.activity.id })
-    const member = await requireTeamMember(em, before.activity.memberId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      before.activity.memberId,
+      explicitStaffCommandScope(before.activity.tenantId, before.activity.organizationId),
+      'Team member not found',
+    )
 
     if (!activity) {
       activity = em.create(StaffTeamMemberActivity, {
@@ -426,7 +455,11 @@ const deleteActivityCommand: CommandHandler<{ body?: Record<string, unknown>; qu
     async execute(input, ctx) {
       const id = requireId(input, 'Activity id required')
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const activity = await em.findOne(StaffTeamMemberActivity, { id })
+      const scope = commandActorScope(ctx)
+      const activity = await em.findOne(
+        StaffTeamMemberActivity,
+        applyScopeToWhere<StaffTeamMemberActivity>({ id }, scope),
+      )
       if (!activity) throw new CrudHttpError(404, { error: 'Activity not found' })
       ensureTenantScope(ctx, activity.tenantId)
       ensureOrganizationScope(ctx, activity.organizationId)
@@ -473,7 +506,12 @@ const deleteActivityCommand: CommandHandler<{ body?: Record<string, unknown>; qu
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const member = await requireTeamMember(em, before.activity.memberId, 'Team member not found')
+      const member = await requireTeamMember(
+        em,
+        before.activity.memberId,
+        explicitStaffCommandScope(before.activity.tenantId, before.activity.organizationId),
+        'Team member not found',
+      )
       let activity = await em.findOne(StaffTeamMemberActivity, { id: before.activity.id })
       if (!activity) {
         activity = em.create(StaffTeamMemberActivity, {

--- a/packages/core/src/modules/staff/commands/addresses.ts
+++ b/packages/core/src/modules/staff/commands/addresses.ts
@@ -12,8 +12,12 @@ import {
 } from '../data/validators'
 import { staffTeamMemberAddressCrudEvents } from '../lib/crud'
 import {
+  applyScopeToWhere,
+  commandActorScope,
+  commandInputScope,
   ensureOrganizationScope,
   ensureTenantScope,
+  explicitStaffCommandScope,
   extractUndoPayload,
   requireTeamMember,
 } from './shared'
@@ -92,9 +96,15 @@ const createAddressCommand: CommandHandler<StaffTeamMemberAddressCreateInput, { 
     const parsed = staffTeamMemberAddressCreateSchema.parse(rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    const scope = commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, parsed.entityId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      parsed.entityId,
+      scope,
+      'Team member not found',
+    )
     ensureTenantScope(ctx, member.tenantId)
     ensureOrganizationScope(ctx, member.organizationId)
 
@@ -182,7 +192,12 @@ const createAddressCommand: CommandHandler<StaffTeamMemberAddressCreateInput, { 
       throw new CrudHttpError(400, { error: '[internal] redo snapshot unavailable for address create' })
     }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, after.memberId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      after.memberId,
+      explicitStaffCommandScope(after.tenantId, after.organizationId),
+      'Team member not found',
+    )
     let address = await em.findOne(StaffTeamMemberAddress, { id: after.id })
     if (!address) {
       address = em.create(StaffTeamMemberAddress, {
@@ -260,13 +275,17 @@ const updateAddressCommand: CommandHandler<StaffTeamMemberAddressUpdateInput, { 
   async execute(rawInput, ctx) {
     const parsed = staffTeamMemberAddressUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const address = await em.findOne(StaffTeamMemberAddress, { id: parsed.id })
+    const scope = commandActorScope(ctx)
+    const address = await em.findOne(
+      StaffTeamMemberAddress,
+      applyScopeToWhere<StaffTeamMemberAddress>({ id: parsed.id }, scope),
+    )
     if (!address) throw new CrudHttpError(404, { error: 'Address not found' })
     ensureTenantScope(ctx, address.tenantId)
     ensureOrganizationScope(ctx, address.organizationId)
 
     if (parsed.entityId !== undefined) {
-      const member = await requireTeamMember(em, parsed.entityId, 'Team member not found')
+      const member = await requireTeamMember(em, parsed.entityId, scope, 'Team member not found')
       ensureTenantScope(ctx, member.tenantId)
       ensureOrganizationScope(ctx, member.organizationId)
       address.member = member
@@ -367,7 +386,12 @@ const updateAddressCommand: CommandHandler<StaffTeamMemberAddressUpdateInput, { 
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     let address = await em.findOne(StaffTeamMemberAddress, { id: before.id })
-    const member = await requireTeamMember(em, before.memberId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      before.memberId,
+      explicitStaffCommandScope(before.tenantId, before.organizationId),
+      'Team member not found',
+    )
 
     if (!address) {
       address = em.create(StaffTeamMemberAddress, {
@@ -444,7 +468,11 @@ const deleteAddressCommand: CommandHandler<{ body?: Record<string, unknown>; que
     async execute(input, ctx) {
       const id = requireId(input, 'Address id required')
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const address = await em.findOne(StaffTeamMemberAddress, { id })
+      const scope = commandActorScope(ctx)
+      const address = await em.findOne(
+        StaffTeamMemberAddress,
+        applyScopeToWhere<StaffTeamMemberAddress>({ id }, scope),
+      )
       if (!address) throw new CrudHttpError(404, { error: 'Address not found' })
       ensureTenantScope(ctx, address.tenantId)
       ensureOrganizationScope(ctx, address.organizationId)
@@ -491,7 +519,12 @@ const deleteAddressCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const member = await requireTeamMember(em, before.memberId, 'Team member not found')
+      const member = await requireTeamMember(
+        em,
+        before.memberId,
+        explicitStaffCommandScope(before.tenantId, before.organizationId),
+        'Team member not found',
+      )
       let address = await em.findOne(StaffTeamMemberAddress, { id: before.id })
       if (!address) {
         address = em.create(StaffTeamMemberAddress, {

--- a/packages/core/src/modules/staff/commands/comments.ts
+++ b/packages/core/src/modules/staff/commands/comments.ts
@@ -14,7 +14,16 @@ import {
   type StaffTeamMemberCommentUpdateInput,
 } from '../data/validators'
 import { staffTeamMemberCommentCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireTeamMember } from './shared'
+import {
+  applyScopeToWhere,
+  commandActorScope,
+  commandInputScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  explicitStaffCommandScope,
+  extractUndoPayload,
+  requireTeamMember,
+} from './shared'
 import { makeCreateRedo } from '@open-mercato/shared/lib/commands/redo'
 import { E } from '#generated/entities.ids.generated'
 
@@ -62,10 +71,16 @@ const createCommentCommand: CommandHandler<
     const parsed = staffTeamMemberCommentCreateSchema.parse(rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    const scope = commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
     const normalizedAuthor = normalizeAuthorUserId(parsed.authorUserId, ctx.auth)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, parsed.entityId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      parsed.entityId,
+      scope,
+      'Team member not found',
+    )
     ensureTenantScope(ctx, member.tenantId)
     ensureOrganizationScope(ctx, member.organizationId)
 
@@ -151,7 +166,12 @@ const createCommentCommand: CommandHandler<
       appearanceColor: snapshot.appearanceColor,
     }),
     beforeRestore: async ({ em, snapshot }) => {
-      const member = await requireTeamMember(em, snapshot.memberId, 'Team member not found')
+      const member = await requireTeamMember(
+        em,
+        snapshot.memberId,
+        explicitStaffCommandScope(snapshot.tenantId, snapshot.organizationId),
+        'Team member not found',
+      )
       return { member }
     },
     buildResult: (entity) => ({ commentId: entity.id, authorUserId: entity.authorUserId ?? null }),
@@ -169,13 +189,17 @@ const updateCommentCommand: CommandHandler<StaffTeamMemberCommentUpdateInput, { 
   async execute(rawInput, ctx) {
     const parsed = staffTeamMemberCommentUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const comment = await em.findOne(StaffTeamMemberComment, { id: parsed.id })
+    const scope = commandActorScope(ctx)
+    const comment = await em.findOne(
+      StaffTeamMemberComment,
+      applyScopeToWhere<StaffTeamMemberComment>({ id: parsed.id }, scope),
+    )
     if (!comment) throw new CrudHttpError(404, { error: 'Comment not found' })
     ensureTenantScope(ctx, comment.tenantId)
     ensureOrganizationScope(ctx, comment.organizationId)
 
     if (parsed.entityId !== undefined) {
-      const member = await requireTeamMember(em, parsed.entityId, 'Team member not found')
+      const member = await requireTeamMember(em, parsed.entityId, scope, 'Team member not found')
       ensureTenantScope(ctx, member.tenantId)
       ensureOrganizationScope(ctx, member.organizationId)
       comment.member = member
@@ -245,7 +269,12 @@ const updateCommentCommand: CommandHandler<StaffTeamMemberCommentUpdateInput, { 
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     let comment = await em.findOne(StaffTeamMemberComment, { id: before.id })
-    const member = await requireTeamMember(em, before.memberId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      before.memberId,
+      explicitStaffCommandScope(before.tenantId, before.organizationId),
+      'Team member not found',
+    )
 
     if (!comment) {
       comment = em.create(StaffTeamMemberComment, {
@@ -298,7 +327,11 @@ const deleteCommentCommand: CommandHandler<{ body?: Record<string, unknown>; que
     async execute(input, ctx) {
       const id = requireId(input, 'Comment id required')
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const comment = await em.findOne(StaffTeamMemberComment, { id })
+      const scope = commandActorScope(ctx)
+      const comment = await em.findOne(
+        StaffTeamMemberComment,
+        applyScopeToWhere<StaffTeamMemberComment>({ id }, scope),
+      )
       if (!comment) throw new CrudHttpError(404, { error: 'Comment not found' })
       ensureTenantScope(ctx, comment.tenantId)
       ensureOrganizationScope(ctx, comment.organizationId)
@@ -345,7 +378,12 @@ const deleteCommentCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const member = await requireTeamMember(em, before.memberId, 'Team member not found')
+      const member = await requireTeamMember(
+        em,
+        before.memberId,
+        explicitStaffCommandScope(before.tenantId, before.organizationId),
+        'Team member not found',
+      )
       let comment = await em.findOne(StaffTeamMemberComment, { id: before.id })
       if (!comment) {
         comment = em.create(StaffTeamMemberComment, {

--- a/packages/core/src/modules/staff/commands/job-histories.ts
+++ b/packages/core/src/modules/staff/commands/job-histories.ts
@@ -12,8 +12,12 @@ import {
 } from '../data/validators'
 import { staffTeamMemberJobHistoryCrudEvents } from '../lib/crud'
 import {
+  applyScopeToWhere,
+  commandActorScope,
+  commandInputScope,
   ensureOrganizationScope,
   ensureTenantScope,
+  explicitStaffCommandScope,
   extractUndoPayload,
   requireTeamMember,
 } from './shared'
@@ -74,9 +78,15 @@ const createJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryCreateInp
     const parsed = staffTeamMemberJobHistoryCreateSchema.parse(rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    const scope = commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, parsed.entityId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      parsed.entityId,
+      scope,
+      'Team member not found',
+    )
     ensureTenantScope(ctx, member.tenantId)
     ensureOrganizationScope(ctx, member.organizationId)
 
@@ -150,7 +160,12 @@ const createJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryCreateInp
       throw new CrudHttpError(400, { error: '[internal] redo snapshot unavailable for job history create' })
     }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, after.memberId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      after.memberId,
+      explicitStaffCommandScope(after.tenantId, after.organizationId),
+      'Team member not found',
+    )
     let record = await em.findOne(StaffTeamMemberJobHistory, { id: after.id })
     if (!record) {
       record = em.create(StaffTeamMemberJobHistory, {
@@ -206,7 +221,11 @@ const updateJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryUpdateInp
   async execute(rawInput, ctx) {
     const parsed = staffTeamMemberJobHistoryUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const record = await em.findOne(StaffTeamMemberJobHistory, { id: parsed.id })
+    const scope = commandActorScope(ctx)
+    const record = await em.findOne(
+      StaffTeamMemberJobHistory,
+      applyScopeToWhere<StaffTeamMemberJobHistory>({ id: parsed.id }, scope),
+    )
     if (!record) {
       enforceRecordGoneIsConflict({
         resourceKind: JOB_HISTORY_LOCK_RESOURCE_KIND,
@@ -227,7 +246,7 @@ const updateJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryUpdateInp
     })
 
     if (parsed.entityId !== undefined) {
-      const member = await requireTeamMember(em, parsed.entityId, 'Team member not found')
+      const member = await requireTeamMember(em, parsed.entityId, scope, 'Team member not found')
       ensureTenantScope(ctx, member.tenantId)
       ensureOrganizationScope(ctx, member.organizationId)
       record.member = member
@@ -298,7 +317,12 @@ const updateJobHistoryCommand: CommandHandler<StaffTeamMemberJobHistoryUpdateInp
     if (!before) return
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     let record = await em.findOne(StaffTeamMemberJobHistory, { id: before.id })
-    const member = await requireTeamMember(em, before.memberId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      before.memberId,
+      explicitStaffCommandScope(before.tenantId, before.organizationId),
+      'Team member not found',
+    )
 
     if (!record) {
       record = em.create(StaffTeamMemberJobHistory, {
@@ -354,7 +378,11 @@ const deleteJobHistoryCommand: CommandHandler<{ id?: string; updatedAt?: string;
       const id = requireId(input, 'Job history id required')
       const expectedUpdatedAt = typeof input.updatedAt === 'string' ? input.updatedAt : undefined
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const record = await em.findOne(StaffTeamMemberJobHistory, { id })
+      const scope = commandActorScope(ctx)
+      const record = await em.findOne(
+        StaffTeamMemberJobHistory,
+        applyScopeToWhere<StaffTeamMemberJobHistory>({ id }, scope),
+      )
       if (!record) {
         enforceRecordGoneIsConflict({
           resourceKind: JOB_HISTORY_LOCK_RESOURCE_KIND,
@@ -416,7 +444,12 @@ const deleteJobHistoryCommand: CommandHandler<{ id?: string; updatedAt?: string;
       const before = payload?.before
       if (!before) return
       const em = (ctx.container.resolve('em') as EntityManager).fork()
-      const member = await requireTeamMember(em, before.memberId, 'Team member not found')
+      const member = await requireTeamMember(
+        em,
+        before.memberId,
+        explicitStaffCommandScope(before.tenantId, before.organizationId),
+        'Team member not found',
+      )
       let record = await em.findOne(StaffTeamMemberJobHistory, { id: before.id })
       if (!record) {
         record = em.create(StaffTeamMemberJobHistory, {

--- a/packages/core/src/modules/staff/commands/leave-requests.ts
+++ b/packages/core/src/modules/staff/commands/leave-requests.ts
@@ -21,7 +21,17 @@ import {
   type StaffLeaveRequestDecisionInput,
   type StaffLeaveRequestUpdateInput,
 } from '../data/validators'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireTeamMember } from './shared'
+import {
+  commandActorScope,
+  commandInputScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  explicitStaffCommandScope,
+  extractUndoPayload,
+  requireTeamMember,
+  scopeForDecryption,
+  applyScopeToWhere,
+} from './shared'
 import { E } from '#generated/entities.ids.generated'
 import { resolveNotificationService } from '../../notifications/lib/notificationService'
 import { buildFeatureNotificationFromType, buildNotificationFromType } from '../../notifications/lib/notificationBuilder'
@@ -167,8 +177,18 @@ function leaveRequestSeedFromSnapshot(snapshot: LeaveRequestSnapshot): Record<st
   }
 }
 
-async function requireLeaveRequest(em: EntityManager, id: string): Promise<StaffLeaveRequest> {
-  const request = await findOneWithDecryption(em, StaffLeaveRequest, { id, deletedAt: null }, undefined, { tenantId: null, organizationId: null })
+async function requireLeaveRequest(
+  em: EntityManager,
+  id: string,
+  scope: ReturnType<typeof explicitStaffCommandScope>,
+): Promise<StaffLeaveRequest> {
+  const request = await findOneWithDecryption(
+    em,
+    StaffLeaveRequest,
+    applyScopeToWhere<StaffLeaveRequest>({ id, deletedAt: null }, scope),
+    undefined,
+    scopeForDecryption(scope),
+  )
   if (!request) throw new CrudHttpError(404, { error: 'Leave request not found.' })
   return request
 }
@@ -245,9 +265,15 @@ const createLeaveRequestCommand: CommandHandler<StaffLeaveRequestCreateInput, { 
     const parsed = staffLeaveRequestCreateSchema.parse(rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    const scope = commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const member = await requireTeamMember(em, parsed.memberId, 'Team member not found')
+    const member = await requireTeamMember(
+      em,
+      parsed.memberId,
+      scope,
+      'Team member not found',
+    )
     ensureTenantScope(ctx, member.tenantId)
     ensureOrganizationScope(ctx, member.organizationId)
 
@@ -400,13 +426,14 @@ const updateLeaveRequestCommand: CommandHandler<StaffLeaveRequestUpdateInput, { 
   async execute(rawInput, ctx) {
     const parsed = staffLeaveRequestUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await requireLeaveRequest(em, parsed.id)
+    const scope = commandActorScope(ctx)
+    const request = await requireLeaveRequest(em, parsed.id, scope)
     ensureTenantScope(ctx, request.tenantId)
     ensureOrganizationScope(ctx, request.organizationId)
     ensurePendingStatus(request)
 
     if (parsed.memberId !== undefined) {
-      const member = await requireTeamMember(em, parsed.memberId, 'Team member not found')
+      const member = await requireTeamMember(em, parsed.memberId, scope, 'Team member not found')
       ensureTenantScope(ctx, member.tenantId)
       ensureOrganizationScope(ctx, member.organizationId)
       request.member = member
@@ -514,7 +541,7 @@ const deleteLeaveRequestCommand: CommandHandler<{ id: string }, { requestId: str
   async execute(rawInput, ctx) {
     const parsed = staffLeaveRequestDecisionSchema.pick({ id: true }).parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await requireLeaveRequest(em, parsed.id)
+    const request = await requireLeaveRequest(em, parsed.id, commandActorScope(ctx))
     ensureTenantScope(ctx, request.tenantId)
     ensureOrganizationScope(ctx, request.organizationId)
     ensurePendingStatus(request)
@@ -595,7 +622,7 @@ const acceptLeaveRequestCommand: CommandHandler<StaffLeaveRequestDecisionInput, 
   async execute(rawInput, ctx) {
     const parsed = staffLeaveRequestDecisionSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await requireLeaveRequest(em, parsed.id)
+    const request = await requireLeaveRequest(em, parsed.id, commandActorScope(ctx))
     ensureTenantScope(ctx, request.tenantId)
     ensureOrganizationScope(ctx, request.organizationId)
     ensurePendingStatus(request)
@@ -802,7 +829,7 @@ const rejectLeaveRequestCommand: CommandHandler<StaffLeaveRequestDecisionInput, 
   async execute(rawInput, ctx) {
     const parsed = staffLeaveRequestDecisionSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const request = await requireLeaveRequest(em, parsed.id)
+    const request = await requireLeaveRequest(em, parsed.id, commandActorScope(ctx))
     ensureTenantScope(ctx, request.tenantId)
     ensureOrganizationScope(ctx, request.organizationId)
     ensurePendingStatus(request)

--- a/packages/core/src/modules/staff/commands/shared.ts
+++ b/packages/core/src/modules/staff/commands/shared.ts
@@ -2,7 +2,7 @@ import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { ensureOrganizationScope } from '@open-mercato/shared/lib/commands/scope'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
-import type { EntityManager } from '@mikro-orm/postgresql'
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { StaffTeamMember } from '../data/entities'
 
 export function ensureTenantScope(ctx: CommandRuntimeContext, tenantId: string): void {
@@ -14,12 +14,83 @@ export function ensureTenantScope(ctx: CommandRuntimeContext, tenantId: string):
 
 export { ensureOrganizationScope, extractUndoPayload }
 
+export type StaffCommandScope = {
+  tenantId: string | null
+  organizationId: string | null
+  requireTenant: boolean
+  requireOrganization: boolean
+}
+
+export function commandActorScope(ctx: CommandRuntimeContext): StaffCommandScope {
+  const isPrivilegedActor = ctx.auth?.isSuperAdmin === true || ctx.systemActor === true
+  const tenantId = isPrivilegedActor ? null : (ctx.auth?.tenantId ?? ctx.organizationScope?.tenantId ?? null)
+  const organizationId = isPrivilegedActor ? null : (ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null)
+  const organizationUnrestricted =
+    isPrivilegedActor || (organizationId === null && tenantId !== null && ctx.organizationScope?.allowedIds === null)
+  return {
+    tenantId,
+    organizationId: organizationUnrestricted ? null : organizationId,
+    requireTenant: !isPrivilegedActor,
+    requireOrganization: !organizationUnrestricted,
+  }
+}
+
+export function explicitStaffCommandScope(tenantId: string | null, organizationId: string | null): StaffCommandScope {
+  return {
+    tenantId,
+    organizationId,
+    requireTenant: true,
+    requireOrganization: true,
+  }
+}
+
+export function commandInputScope(ctx: CommandRuntimeContext, tenantId: string, organizationId: string): StaffCommandScope {
+  if (ctx.auth?.isSuperAdmin === true || ctx.systemActor === true) {
+    return explicitStaffCommandScope(tenantId, organizationId)
+  }
+
+  ensureTenantScope(ctx, tenantId)
+  ensureOrganizationScope(ctx, organizationId)
+
+  const actorTenantId = ctx.auth?.tenantId ?? ctx.organizationScope?.tenantId ?? null
+  if (!actorTenantId || actorTenantId !== tenantId) {
+    throw new CrudHttpError(403, { error: 'Forbidden' })
+  }
+
+  if (!ctx.organizationScope) {
+    const currentOrganizationId = ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null
+    if (!currentOrganizationId || currentOrganizationId !== organizationId) {
+      throw new CrudHttpError(403, { error: 'Forbidden' })
+    }
+  }
+
+  return explicitStaffCommandScope(tenantId, organizationId)
+}
+
+export function applyScopeToWhere<TEntity extends object>(
+  where: FilterQuery<TEntity>,
+  scope: StaffCommandScope,
+): FilterQuery<TEntity> {
+  const scoped = { ...(where as Record<string, unknown>) }
+  if (scope.requireTenant || scope.tenantId !== null) scoped.tenantId = scope.tenantId
+  if (scope.requireOrganization || scope.organizationId !== null) scoped.organizationId = scope.organizationId
+  return scoped as FilterQuery<TEntity>
+}
+
+export function scopeForDecryption(scope: StaffCommandScope): { tenantId: string | null; organizationId: string | null } {
+  return { tenantId: scope.tenantId, organizationId: scope.organizationId }
+}
+
 export async function requireTeamMember(
   em: EntityManager,
   memberId: string,
+  scope: StaffCommandScope,
   message = 'Team member not found',
 ): Promise<StaffTeamMember> {
-  const member = await em.findOne(StaffTeamMember, { id: memberId })
+  const member = await em.findOne(
+    StaffTeamMember,
+    applyScopeToWhere<StaffTeamMember>({ id: memberId, deletedAt: null }, scope),
+  )
   if (!member) throw new CrudHttpError(404, { error: message })
   return member
 }

--- a/packages/core/src/modules/staff/commands/tag-assignments.ts
+++ b/packages/core/src/modules/staff/commands/tag-assignments.ts
@@ -12,7 +12,15 @@ import {
   type StaffTeamMemberTagAssignmentInput,
 } from '../data/validators'
 import { staffTeamMemberCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  applyScopeToWhere,
+  commandInputScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  explicitStaffCommandScope,
+  extractUndoPayload,
+  scopeForDecryption,
+} from './shared'
 
 type TeamMemberTagAssignmentSnapshot = {
   tag: string
@@ -43,12 +51,13 @@ const assignTeamMemberTagCommand: CommandHandler<StaffTeamMemberTagAssignmentInp
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
     const member = await findOneWithDecryption(
       em,
       StaffTeamMember,
-      { id: parsed.memberId, deletedAt: null },
+      applyScopeToWhere<StaffTeamMember>({ id: parsed.memberId, deletedAt: null }, scope),
       undefined,
-      { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
+      scopeForDecryption(scope),
     )
     if (!member) throw new CrudHttpError(404, { error: 'Team member not found.' })
     ensureTenantScope(ctx, member.tenantId)
@@ -131,12 +140,13 @@ const assignTeamMemberTagCommand: CommandHandler<StaffTeamMemberTagAssignmentInp
     const before = payload?.before
     if (!before) return { memberId: logEntry.resourceId ?? '' }
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = explicitStaffCommandScope(before.tenantId, before.organizationId)
     const member = await findOneWithDecryption(
       em,
       StaffTeamMember,
-      { id: before.memberId, deletedAt: null },
+      applyScopeToWhere<StaffTeamMember>({ id: before.memberId, deletedAt: null }, scope),
       undefined,
-      { tenantId: before.tenantId, organizationId: before.organizationId },
+      scopeForDecryption(scope),
     )
     if (!member) throw new CrudHttpError(404, { error: 'Team member not found.' })
     const currentTags = normalizeTagList(Array.isArray(member.tags) ? member.tags : [])
@@ -171,12 +181,13 @@ const unassignTeamMemberTagCommand: CommandHandler<StaffTeamMemberTagAssignmentI
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
     const member = await findOneWithDecryption(
       em,
       StaffTeamMember,
-      { id: parsed.memberId, deletedAt: null },
+      applyScopeToWhere<StaffTeamMember>({ id: parsed.memberId, deletedAt: null }, scope),
       undefined,
-      { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
+      scopeForDecryption(scope),
     )
     if (!member) throw new CrudHttpError(404, { error: 'Team member not found.' })
     ensureTenantScope(ctx, member.tenantId)

--- a/packages/core/src/modules/staff/commands/team-members.ts
+++ b/packages/core/src/modules/staff/commands/team-members.ts
@@ -19,7 +19,15 @@ import {
   type StaffTeamMemberUpdateInput,
 } from '../data/validators'
 import { staffTeamMemberCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  applyScopeToWhere,
+  commandActorScope,
+  commandInputScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopeForDecryption,
+} from './shared'
 import { E } from '#generated/entities.ids.generated'
 
 const teamMemberCrudIndexer: CrudIndexerConfig<StaffTeamMember> = {
@@ -165,6 +173,7 @@ const createTeamMemberCommand: CommandHandler<StaffTeamMemberCreateInput, { memb
     const { parsed, custom } = parseWithCustomFields(staffTeamMemberCreateSchema, rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const roleIds = normalizeStringList(parsed.roleIds)
@@ -305,12 +314,13 @@ const updateTeamMemberCommand: CommandHandler<StaffTeamMemberUpdateInput, { memb
   async execute(rawInput, ctx) {
     const { parsed, custom } = parseWithCustomFields(staffTeamMemberUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const member = await findOneWithDecryption(
       em,
       StaffTeamMember,
-      { id: parsed.id, deletedAt: null },
+      applyScopeToWhere<StaffTeamMember>({ id: parsed.id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!member) throw new CrudHttpError(404, { error: 'Team member not found.' })
     ensureTenantScope(ctx, member.tenantId)
@@ -476,12 +486,13 @@ const deleteTeamMemberCommand: CommandHandler<{ id?: string }, { memberId: strin
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Member id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const member = await findOneWithDecryption(
       em,
       StaffTeamMember,
-      { id, deletedAt: null },
+      applyScopeToWhere<StaffTeamMember>({ id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!member) throw new CrudHttpError(404, { error: 'Team member not found.' })
     ensureTenantScope(ctx, member.tenantId)

--- a/packages/core/src/modules/staff/commands/team-roles.ts
+++ b/packages/core/src/modules/staff/commands/team-roles.ts
@@ -17,7 +17,15 @@ import {
   type StaffTeamRoleUpdateInput,
 } from '../data/validators'
 import { staffTeamRoleCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  applyScopeToWhere,
+  commandActorScope,
+  commandInputScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopeForDecryption,
+} from './shared'
 import { E } from '#generated/entities.ids.generated'
 
 const teamRoleCrudIndexer: CrudIndexerConfig<StaffTeamRole> = {
@@ -100,6 +108,7 @@ const createTeamRoleCommand: CommandHandler<StaffTeamRoleCreateInput, { roleId: 
     const { parsed, custom } = parseWithCustomFields(staffTeamRoleCreateSchema, rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     if (parsed.teamId) {
@@ -230,12 +239,13 @@ const updateTeamRoleCommand: CommandHandler<StaffTeamRoleUpdateInput, { roleId: 
   async execute(rawInput, ctx) {
     const { parsed, custom } = parseWithCustomFields(staffTeamRoleUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const role = await findOneWithDecryption(
       em,
       StaffTeamRole,
-      { id: parsed.id, deletedAt: null },
+      applyScopeToWhere<StaffTeamRole>({ id: parsed.id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!role) throw new CrudHttpError(404, { error: 'Team role not found.' })
     ensureTenantScope(ctx, role.tenantId)
@@ -378,12 +388,13 @@ const deleteTeamRoleCommand: CommandHandler<{ id?: string }, { roleId: string }>
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Role id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const role = await findOneWithDecryption(
       em,
       StaffTeamRole,
-      { id, deletedAt: null },
+      applyScopeToWhere<StaffTeamRole>({ id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!role) throw new CrudHttpError(404, { error: 'Team role not found.' })
     ensureTenantScope(ctx, role.tenantId)

--- a/packages/core/src/modules/staff/commands/teams.ts
+++ b/packages/core/src/modules/staff/commands/teams.ts
@@ -17,7 +17,15 @@ import {
   type StaffTeamUpdateInput,
 } from '../data/validators'
 import { staffTeamCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  applyScopeToWhere,
+  commandActorScope,
+  commandInputScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopeForDecryption,
+} from './shared'
 import { E } from '#generated/entities.ids.generated'
 
 const teamCrudIndexer: CrudIndexerConfig<StaffTeam> = {
@@ -77,6 +85,7 @@ const createTeamCommand: CommandHandler<StaffTeamCreateInput, { teamId: string }
     const { parsed, custom } = parseWithCustomFields(staffTeamCreateSchema, rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const now = new Date()
@@ -202,12 +211,13 @@ const updateTeamCommand: CommandHandler<StaffTeamUpdateInput, { teamId: string }
   async execute(rawInput, ctx) {
     const { parsed, custom } = parseWithCustomFields(staffTeamUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const team = await findOneWithDecryption(
       em,
       StaffTeam,
-      { id: parsed.id, deletedAt: null },
+      applyScopeToWhere<StaffTeam>({ id: parsed.id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!team) throw new CrudHttpError(404, { error: 'Team not found.' })
     ensureTenantScope(ctx, team.tenantId)
@@ -339,12 +349,13 @@ const deleteTeamCommand: CommandHandler<{ id?: string }, { teamId: string }> = {
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Team id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const team = await findOneWithDecryption(
       em,
       StaffTeam,
-      { id, deletedAt: null },
+      applyScopeToWhere<StaffTeam>({ id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!team) throw new CrudHttpError(404, { error: 'Team not found.' })
     ensureTenantScope(ctx, team.tenantId)

--- a/packages/core/src/modules/staff/commands/timesheets-entries.ts
+++ b/packages/core/src/modules/staff/commands/timesheets-entries.ts
@@ -22,7 +22,15 @@ import {
   type StaffTimeEntryUpdateInput,
 } from '../data/validators'
 import { staffTimeEntryCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  applyScopeToWhere,
+  commandActorScope,
+  commandInputScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopeForDecryption,
+} from './shared'
 import { getStaffMemberByUserId } from '../lib/staffMemberResolver'
 
 type RbacServiceLike = {
@@ -174,6 +182,7 @@ const createTimeEntryCommand: CommandHandler<StaffTimeEntryCreateInput, { timeEn
     const parsed = staffTimeEntryCreateSchema.parse(rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
 
@@ -290,6 +299,7 @@ const startTimerCommand: CommandHandler<StaffTimeEntryStartTimerInput, { timeEnt
     const parsed = staffTimeEntryStartTimerSchema.parse(rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
 
@@ -457,12 +467,13 @@ const updateTimeEntryCommand: CommandHandler<StaffTimeEntryUpdateInput, { timeEn
   async execute(rawInput, ctx) {
     const parsed = staffTimeEntryUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const entry = await findOneWithDecryption(
       em,
       StaffTimeEntry,
-      { id: parsed.id, deletedAt: null },
+      applyScopeToWhere<StaffTimeEntry>({ id: parsed.id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!entry) throw new CrudHttpError(404, { error: 'Time entry not found.' })
     ensureTenantScope(ctx, entry.tenantId)
@@ -583,12 +594,13 @@ const deleteTimeEntryCommand: CommandHandler<{ id?: string }, { timeEntryId: str
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Time entry id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const entry = await findOneWithDecryption(
       em,
       StaffTimeEntry,
-      { id, deletedAt: null },
+      applyScopeToWhere<StaffTimeEntry>({ id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!entry) throw new CrudHttpError(404, { error: 'Time entry not found.' })
     ensureTenantScope(ctx, entry.tenantId)

--- a/packages/core/src/modules/staff/commands/timesheets-projects.ts
+++ b/packages/core/src/modules/staff/commands/timesheets-projects.ts
@@ -27,7 +27,15 @@ import {
   type StaffTimeProjectMemberUpdateInput,
 } from '../data/validators'
 import { staffTimeProjectCrudEvents, staffTimeProjectMemberCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  applyScopeToWhere,
+  commandActorScope,
+  commandInputScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  extractUndoPayload,
+  scopeForDecryption,
+} from './shared'
 
 function isUniqueViolation(error: unknown): boolean {
   if (error instanceof UniqueConstraintViolationException) return true
@@ -163,6 +171,7 @@ const createTimeProjectCommand: CommandHandler<StaffTimeProjectCreateInput, { ti
     const parsed = staffTimeProjectCreateSchema.parse(rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const now = new Date()
@@ -282,12 +291,13 @@ const updateTimeProjectCommand: CommandHandler<StaffTimeProjectUpdateInput, { ti
   async execute(rawInput, ctx) {
     const parsed = staffTimeProjectUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const project = await findOneWithDecryption(
       em,
       StaffTimeProject,
-      { id: parsed.id, deletedAt: null },
+      applyScopeToWhere<StaffTimeProject>({ id: parsed.id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!project) throw new CrudHttpError(404, { error: 'Time project not found.' })
     ensureTenantScope(ctx, project.tenantId)
@@ -419,12 +429,13 @@ const deleteTimeProjectCommand: CommandHandler<{ id?: string }, { timeProjectId:
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Time project id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const project = await findOneWithDecryption(
       em,
       StaffTimeProject,
-      { id, deletedAt: null },
+      applyScopeToWhere<StaffTimeProject>({ id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!project) throw new CrudHttpError(404, { error: 'Time project not found.' })
     ensureTenantScope(ctx, project.tenantId)
@@ -527,6 +538,7 @@ const assignTimeProjectMemberCommand: CommandHandler<StaffTimeProjectMemberAssig
     const parsed = staffTimeProjectMemberAssignSchema.parse(rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
+    const scope = commandInputScope(ctx, parsed.tenantId, parsed.organizationId)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
 
@@ -534,7 +546,7 @@ const assignTimeProjectMemberCommand: CommandHandler<StaffTimeProjectMemberAssig
     // Without this check a foreign or stale UUID would produce a dangling reference.
     const projectExists = await em.findOne(
       StaffTimeProject,
-      { id: parsed.timeProjectId, tenantId: parsed.tenantId, organizationId: parsed.organizationId, deletedAt: null },
+      applyScopeToWhere<StaffTimeProject>({ id: parsed.timeProjectId, deletedAt: null }, scope),
       { fields: ['id'] },
     )
     if (!projectExists) {
@@ -548,7 +560,7 @@ const assignTimeProjectMemberCommand: CommandHandler<StaffTimeProjectMemberAssig
     }
     const memberExists = await em.findOne(
       StaffTeamMember,
-      { id: parsed.staffMemberId, tenantId: parsed.tenantId, organizationId: parsed.organizationId, deletedAt: null },
+      applyScopeToWhere<StaffTeamMember>({ id: parsed.staffMemberId, deletedAt: null }, scope),
       { fields: ['id'] },
     )
     if (!memberExists) {
@@ -658,12 +670,13 @@ const unassignTimeProjectMemberCommand: CommandHandler<{ id?: string }, { timePr
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Time project member id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const member = await findOneWithDecryption(
       em,
       StaffTimeProjectMember,
-      { id, deletedAt: null },
+      applyScopeToWhere<StaffTimeProjectMember>({ id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!member) throw new CrudHttpError(404, { error: 'Time project member not found.' })
     ensureTenantScope(ctx, member.tenantId)


### PR DESCRIPTION
## Summary

Fixes staff command write paths that loaded target records by bare `id` before tenant/organization scoping. Target and input-scoped reference loads now apply actor/input scope before mutation.

## Changes

- Added shared staff command scope helpers for actor-derived and guarded input-derived scopes.
- Applied scoped target predicates across staff update/delete/decision commands.
- Guarded input-scoped reference writes such as tag assignment and time-project member assignment.
- Added regression tests for scoped update loads and null-scope input-scope rejection.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor security bug fix, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn build:packages`
- `yarn typecheck`
- `yarn test`
- `yarn lint`
- `yarn build:app`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] Integration coverage is not required; this is command-handler security coverage with unit regression tests.
- [x] Spec changelog is not applicable.
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [x] QA routing set: `skip-qa` for backend command/test-only change.

### Design System Compliance

N/A, backend command/test only.

## Linked issues

Fixes #3911
