### PR TITLE
fix(sso): enforce organization scope on SCIM logs

### DIFF
--- a/packages/enterprise/src/modules/sso/api/scim/logs/__tests__/route.test.ts
+++ b/packages/enterprise/src/modules/sso/api/scim/logs/__tests__/route.test.ts
@@ -1,0 +1,105 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const ssoConfigId = '33333333-3333-4333-8333-333333333333'
+
+const mockFindWithDecryption = jest.fn()
+const mockResolveSsoAdminContext = jest.fn()
+const mockEm = {
+  find: jest.fn(),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (token: string) => {
+      if (token === 'em') return mockEm
+      throw new Error(`Unexpected token: ${token}`)
+    },
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+}))
+
+jest.mock('../../../admin-context', () => ({
+  resolveSsoAdminContext: (...args: unknown[]) => mockResolveSsoAdminContext(...args),
+  SsoAdminAuthError: class SsoAdminAuthError extends Error {
+    constructor(
+      message: string,
+      public readonly statusCode: number,
+    ) {
+      super(message)
+      this.name = 'SsoAdminAuthError'
+    }
+  },
+}))
+
+describe('SCIM logs route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.find.mockResolvedValue([])
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('rejects non-superadmins without organization context before querying logs', async () => {
+    mockResolveSsoAdminContext.mockResolvedValue({
+      auth: { sub: 'user-1', tenantId, orgId: null },
+      scope: { isSuperAdmin: false, tenantId, organizationId: null },
+    })
+
+    const { GET } = await import('../route')
+    const response = await GET(new Request(`http://localhost/api/sso/scim/logs?ssoConfigId=${ssoConfigId}`))
+
+    await expect(response.json()).resolves.toEqual({ error: 'Organization context is required' })
+    expect(response.status).toBe(403)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(mockEm.find).not.toHaveBeenCalled()
+  })
+
+  it('scopes non-superadmin log reads to the caller organization', async () => {
+    mockResolveSsoAdminContext.mockResolvedValue({
+      auth: { sub: 'user-1', tenantId, orgId: organizationId },
+      scope: { isSuperAdmin: false, tenantId, organizationId },
+    })
+    const createdAt = new Date('2026-07-07T12:00:00.000Z')
+    mockFindWithDecryption.mockResolvedValue([
+      {
+        id: '44444444-4444-4444-8444-444444444444',
+        operation: 'create',
+        resourceType: 'User',
+        resourceId: null,
+        scimExternalId: 'external-1',
+        responseStatus: 201,
+        errorMessage: null,
+        createdAt,
+      },
+    ])
+
+    const { GET } = await import('../route')
+    const response = await GET(new Request(`http://localhost/api/sso/scim/logs?ssoConfigId=${ssoConfigId}`))
+
+    await expect(response.json()).resolves.toEqual({
+      items: [{
+        id: '44444444-4444-4444-8444-444444444444',
+        operation: 'create',
+        resourceType: 'User',
+        resourceId: null,
+        scimExternalId: 'external-1',
+        responseStatus: 201,
+        errorMessage: null,
+        createdAt: createdAt.toISOString(),
+      }],
+    })
+    expect(response.status).toBe(200)
+    expect(mockFindWithDecryption).toHaveBeenCalledWith(
+      mockEm,
+      expect.any(Function),
+      { ssoConfigId, organizationId },
+      { orderBy: { createdAt: 'desc' }, limit: 50 },
+      { tenantId, organizationId },
+    )
+    expect(mockEm.find).not.toHaveBeenCalled()
+  })
+})

--- a/packages/enterprise/src/modules/sso/api/scim/logs/route.ts
+++ b/packages/enterprise/src/modules/sso/api/scim/logs/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import type { EntityManager } from '@mikro-orm/postgresql'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { ScimProvisioningLog } from '../../../data/entities'
+import { SsoConfigError } from '../../../services/ssoConfigService'
 import { resolveSsoAdminContext } from '../../admin-context'
 import { handleSsoAdminApiError } from '../../error-handler'
 
@@ -20,18 +22,25 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: 'ssoConfigId is required' }, { status: 400 })
     }
 
-    const where: Record<string, unknown> = { ssoConfigId }
-    if (!scope.isSuperAdmin && scope.organizationId) {
+    const where: FilterQuery<ScimProvisioningLog> = { ssoConfigId }
+    if (!scope.isSuperAdmin) {
+      if (!scope.organizationId) throw new SsoConfigError('Organization context is required', 403)
       where.organizationId = scope.organizationId
     }
 
     const container = await createRequestContainer()
     const em = container.resolve<EntityManager>('em')
 
-    const logs = await em.find(ScimProvisioningLog, where, {
-      orderBy: { createdAt: 'desc' },
-      limit: 50,
-    })
+    const logs = await findWithDecryption(
+      em,
+      ScimProvisioningLog,
+      where,
+      {
+        orderBy: { createdAt: 'desc' },
+        limit: 50,
+      },
+      { tenantId: scope.tenantId, organizationId: scope.organizationId },
+    )
 
     return NextResponse.json({
       items: logs.map((log) => ({


### PR DESCRIPTION
## Summary

Fixes a SCIM provisioning-log tenant-scope bug where non-superadmin callers without an organization context could read logs using only `ssoConfigId`.

## Changes

- Fail closed with 403 when a non-superadmin SCIM logs request has no organization scope.
- Keep non-superadmin log reads scoped by `organizationId`.
- Use encrypted read helper for provisioning-log responses.
- Add regression tests for null-org denial and org-scoped log reads.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn workspace @open-mercato/enterprise test src/modules/sso/api/scim/logs/__tests__/route.test.ts --runInBand`
- `yarn workspace @open-mercato/enterprise build`
- `yarn build:packages && yarn generate && yarn build:packages`
- `yarn typecheck`
- `yarn test`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn lint`
- `yarn build:app`
- `yarn template:sync` reports unrelated existing template/package drift.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance

N/A: no UI changes.

## Linked issues

Fixes #3906
