### PR TITLE
fix: require verified SSO email before link or JIT (#3905)

### DIFF
--- a/packages/enterprise/src/modules/sso/services/__tests__/accountLinkingService.errors.test.ts
+++ b/packages/enterprise/src/modules/sso/services/__tests__/accountLinkingService.errors.test.ts
@@ -36,6 +36,27 @@ describe('OIDC callback unverified-email error mapping (#2741)', () => {
     expect(resolveSsoCallbackErrorCode(thrown)).toBe('sso_email_not_verified')
   })
 
+  it('treats omitted email_verified as unverified before link or JIT flows', async () => {
+    const service = new AccountLinkingService({} as unknown as EntityManager)
+    const payload: SsoIdentityPayload = {
+      subject: 'sub-2',
+      email: 'user@example.com',
+    }
+    const strictConfig = {
+      id: 'cfg-1',
+      organizationId: 'org-1',
+      allowedDomains: ['example.com'],
+      autoLinkByEmail: false,
+      jitEnabled: false,
+    } as unknown as SsoConfig
+
+    const thrown = await captureThrow(() => service.resolveUser(strictConfig, payload, 'tenant-1'))
+
+    expect(thrown).toBeInstanceOf(Error)
+    expect(isEmailNotVerifiedError(thrown)).toBe(true)
+    expect(resolveSsoCallbackErrorCode(thrown)).toBe('sso_email_not_verified')
+  })
+
   it('classifies unrelated callback failures as sso_failed', () => {
     expect(resolveSsoCallbackErrorCode(new Error('State mismatch — possible CSRF attack'))).toBe('sso_failed')
     expect(resolveSsoCallbackErrorCode(new Error('SSO configuration no longer active'))).toBe('sso_failed')

--- a/packages/enterprise/src/modules/sso/services/accountLinkingService.ts
+++ b/packages/enterprise/src/modules/sso/services/accountLinkingService.ts
@@ -21,8 +21,8 @@ export class AccountLinkingService {
       return existing
     }
 
-    if (idpPayload.emailVerified === false) {
-      throw new EmailNotVerifiedError('IdP explicitly reported email as unverified — cannot link or provision account')
+    if (idpPayload.emailVerified !== true) {
+      throw new EmailNotVerifiedError('IdP did not verify the email claim — cannot link or provision account')
     }
 
     const emailDomain = idpPayload.email.split('@')[1]?.toLowerCase()


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fixes a latent SSO account-linking security issue where an omitted `email_verified` claim was treated as acceptable for first-time email auto-linking or JIT provisioning. The account-linking boundary now requires `emailVerified === true` before link/JIT flows can run.

## Changes

- Require verified email claims before first-time SSO auto-linking or JIT provisioning.
- Add a regression test for omitted `email_verified` mapping to the existing `sso_email_not_verified` callback error.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
.ai/specs/enterprise/2026-06-23-entra-token-api-authentication.md


## Testing

- `yarn workspace @open-mercato/enterprise test --runTestsByPath src/modules/sso/services/__tests__/accountLinkingService.errors.test.ts --runInBand`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn lint`
- `yarn build:app`
- `git diff --check`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. N/A - no docs/locales/generator source changes required.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). Unit coverage is sufficient for this service boundary change; no UI/API integration path changed.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). Existing enterprise SSO security spec applies; no spec edit required for this narrow fix.
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. This PR uses `needs-qa` because it changes SSO login behavior.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens. N/A - no UI changes.
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`. N/A - no UI changes.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A - no UI changes.
- [x] Loading state handled for async pages. N/A - no UI changes.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A - no UI changes.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements. N/A - no UI changes.

## Linked issues

Fixes #3905
