### PR TITLE
fix(sso): prevent overlapping active domains

### DIFF
--- a/packages/enterprise/src/modules/sso/services/__tests__/domain-uniqueness.test.ts
+++ b/packages/enterprise/src/modules/sso/services/__tests__/domain-uniqueness.test.ts
@@ -1,0 +1,193 @@
+import { randomUUID } from 'node:crypto'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import type { TenantDataEncryptionService } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
+import { SsoConfig } from '../../data/entities'
+import type { SsoProviderRegistry } from '../../lib/registry'
+import { HrdService } from '../hrdService'
+import { SsoConfigError, SsoConfigService, type SsoAdminScope } from '../ssoConfigService'
+import { SsoService } from '../ssoService'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+const findWithDecryptionMock = findWithDecryption as jest.MockedFunction<typeof findWithDecryption>
+
+const scope: SsoAdminScope = {
+  isSuperAdmin: true,
+  organizationId: null,
+  tenantId: null,
+}
+
+function testDomain(): string {
+  return `sso-${randomUUID().slice(0, 8)}.example.com`
+}
+
+function makeConfig(overrides: Partial<SsoConfig> = {}): SsoConfig {
+  return {
+    id: randomUUID(),
+    tenantId: null,
+    organizationId: randomUUID(),
+    protocol: 'oidc',
+    issuer: 'https://accounts.google.com',
+    clientId: 'client',
+    clientSecretEnc: 'secret',
+    allowedDomains: [],
+    jitEnabled: true,
+    autoLinkByEmail: true,
+    isActive: false,
+    ssoRequired: false,
+    appRoleMappings: {},
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    deletedAt: null,
+    ...overrides,
+  } as SsoConfig
+}
+
+function createConfigServiceContext(config: SsoConfig) {
+  const calls: string[] = []
+  const lock = jest.fn().mockImplementation(async (_sql: string, params: string[]) => {
+    calls.push(`lock:${params[0]}`)
+  })
+  const txEm = {
+    findOne: jest.fn().mockResolvedValue(config),
+    count: jest.fn().mockResolvedValue(0),
+    flush: jest.fn().mockImplementation(async () => {
+      calls.push('flush')
+    }),
+    getConnection: jest.fn().mockReturnValue({ execute: lock }),
+  }
+  const em = {
+    ...txEm,
+    transactional: jest.fn().mockImplementation(async (fn: (tx: typeof txEm) => Promise<unknown>) => fn(txEm)),
+  }
+  const provider = { validateConfig: jest.fn().mockResolvedValue({ ok: true }) }
+  const registry = { resolve: jest.fn().mockReturnValue(provider) }
+
+  return {
+    service: new SsoConfigService(
+      em as unknown as EntityManager,
+      {} as unknown as TenantDataEncryptionService,
+      registry as unknown as SsoProviderRegistry,
+    ),
+    em,
+    txEm,
+    calls,
+    lock,
+  }
+}
+
+describe('SSO active domain uniqueness', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('rejects activating a config whose domain is already claimed by another active config', async () => {
+    const domain = testDomain()
+    const config = makeConfig({ allowedDomains: [domain], isActive: false })
+    const existing = makeConfig({ allowedDomains: [domain.toUpperCase()], isActive: true })
+    const { service, calls } = createConfigServiceContext(config)
+    findWithDecryptionMock.mockImplementation(async () => {
+      calls.push('check')
+      return [existing]
+    })
+
+    await expect(service.activate(scope, config.id, true)).rejects.toMatchObject({
+      statusCode: 409,
+    } satisfies Partial<SsoConfigError>)
+    expect(config.isActive).toBe(false)
+    expect(calls).toEqual([
+      `lock:sso:sso_config:${config.id}`,
+      `lock:sso:allowed_domain:${domain}`,
+      'check',
+    ])
+  })
+
+  it('rejects adding a conflicting domain to an already active config', async () => {
+    const domain = testDomain()
+    const config = makeConfig({ allowedDomains: [], isActive: true })
+    const existing = makeConfig({ allowedDomains: [domain], isActive: true })
+    const { service, calls } = createConfigServiceContext(config)
+    findWithDecryptionMock.mockImplementation(async () => {
+      calls.push('check')
+      return [existing]
+    })
+
+    await expect(service.addDomain(scope, config.id, domain.toUpperCase())).rejects.toMatchObject({
+      statusCode: 409,
+    } satisfies Partial<SsoConfigError>)
+    expect(config.allowedDomains).toEqual([])
+    expect(calls).toEqual([
+      `lock:sso:sso_config:${config.id}`,
+      `lock:sso:allowed_domain:${domain}`,
+      'check',
+    ])
+  })
+
+  it('serializes active domain writes before flushing the new domain', async () => {
+    const domain = testDomain()
+    const config = makeConfig({ allowedDomains: [], isActive: true })
+    const { service, calls } = createConfigServiceContext(config)
+    findWithDecryptionMock.mockImplementation(async () => {
+      calls.push('check')
+      return []
+    })
+
+    await expect(service.addDomain(scope, config.id, domain.toUpperCase())).resolves.toMatchObject({
+      allowedDomains: [domain],
+    })
+    expect(calls).toEqual([
+      `lock:sso:sso_config:${config.id}`,
+      `lock:sso:allowed_domain:${domain}`,
+      'check',
+      'flush',
+    ])
+  })
+
+  it('fails HRD closed when multiple active configs claim the same domain', async () => {
+    const domain = testDomain()
+    const rows = [
+      { id: randomUUID(), allowed_domains: [domain], is_active: true },
+      { id: randomUUID(), allowed_domains: [domain], is_active: true },
+    ]
+    const query = {
+      selectAll: jest.fn(),
+      where: jest.fn(),
+      limit: jest.fn(),
+      execute: jest.fn().mockResolvedValue(rows),
+      executeTakeFirst: jest.fn().mockResolvedValue(rows[0]),
+    }
+    query.selectAll.mockReturnValue(query)
+    query.where.mockReturnValue(query)
+    query.limit.mockReturnValue(query)
+
+    const em = {
+      getKysely: jest.fn().mockReturnValue({ selectFrom: jest.fn().mockReturnValue(query) }),
+      map: jest.fn((_entity: unknown, row: Record<string, unknown>) => row),
+    }
+    const service = new HrdService(em as unknown as EntityManager)
+
+    await expect(service.findActiveConfigByEmailDomain(`user@${domain}`)).resolves.toBeNull()
+  })
+
+  it('fails SSO email config lookup closed when multiple active configs claim the same domain', async () => {
+    const domain = testDomain()
+    const first = makeConfig({ allowedDomains: [domain], isActive: true })
+    const second = makeConfig({ allowedDomains: [domain], isActive: true })
+    findWithDecryptionMock.mockResolvedValue([first, second])
+
+    const service = new SsoService(
+      {} as EntityManager,
+      {} as SsoProviderRegistry,
+      {} as never,
+      {} as TenantDataEncryptionService,
+      {} as never,
+      {} as never,
+    )
+
+    await expect(service.findConfigByEmail(`user@${domain}`)).resolves.toBeNull()
+  })
+})

--- a/packages/enterprise/src/modules/sso/services/hrdService.ts
+++ b/packages/enterprise/src/modules/sso/services/hrdService.ts
@@ -10,16 +10,17 @@ export class HrdService {
     if (!domain) return null
 
     const db = (this.em as any).getKysely() as Kysely<any>
-    const row = await db
+    const rows = await db
       .selectFrom('sso_configs' as any)
       .selectAll()
       .where(sql<boolean>`allowed_domains @> ${JSON.stringify([domain])}::jsonb`)
       .where('is_active' as any, '=', true)
       .where('deleted_at' as any, 'is', null as any)
-      .executeTakeFirst()
+      .limit(2)
+      .execute()
 
-    if (!row) return null
+    if (rows.length !== 1) return null
 
-    return this.em.map(SsoConfig, row as Record<string, unknown>)
+    return this.em.map(SsoConfig, rows[0] as Record<string, unknown>)
   }
 }

--- a/packages/enterprise/src/modules/sso/services/ssoConfigService.ts
+++ b/packages/enterprise/src/modules/sso/services/ssoConfigService.ts
@@ -201,38 +201,45 @@ export class SsoConfigService {
   }
 
   async activate(scope: SsoAdminScope, id: string, active: boolean): Promise<SsoConfigPublic> {
-    const config = await this.resolveConfig(scope, id)
+    return this.em.transactional(async (txEm) => {
+      const tx = txEm as EntityManager
+      await this.lockActiveDomainMutation(tx, id)
+      const config = await this.resolveConfig(scope, id, tx)
 
-    if (active) {
-      if (config.allowedDomains.length === 0) {
-        throw new SsoConfigError('Cannot activate SSO configuration with no allowed domains', 400)
+      if (active) {
+        if (config.allowedDomains.length === 0) {
+          throw new SsoConfigError('Cannot activate SSO configuration with no allowed domains', 400)
+        }
+
+        await this.lockActiveDomains(tx, config.allowedDomains)
+        await this.assertActiveDomainAvailability(tx, config.allowedDomains, config.id)
+
+        const testResult = await this.testConnectionInternal(config)
+        if (!testResult.ok) {
+          throw new SsoConfigError(`Cannot activate — discovery failed: ${testResult.error}`, 400)
+        }
       }
 
-      const testResult = await this.testConnectionInternal(config)
-      if (!testResult.ok) {
-        throw new SsoConfigError(`Cannot activate — discovery failed: ${testResult.error}`, 400)
+      const wasActive = config.isActive
+      config.isActive = active
+      await tx.flush()
+
+      if (active && !wasActive) {
+        void emitSsoEvent('sso.config.activated', {
+          id: config.id,
+          tenantId: config.tenantId,
+          organizationId: config.organizationId,
+        }).catch((e) => console.error('[SSO Event]', e))
+      } else if (!active && wasActive) {
+        void emitSsoEvent('sso.config.deactivated', {
+          id: config.id,
+          tenantId: config.tenantId,
+          organizationId: config.organizationId,
+        }).catch((e) => console.error('[SSO Event]', e))
       }
-    }
 
-    const wasActive = config.isActive
-    config.isActive = active
-    await this.em.flush()
-
-    if (active && !wasActive) {
-      void emitSsoEvent('sso.config.activated', {
-        id: config.id,
-        tenantId: config.tenantId,
-        organizationId: config.organizationId,
-      }).catch((e) => console.error('[SSO Event]', e))
-    } else if (!active && wasActive) {
-      void emitSsoEvent('sso.config.deactivated', {
-        id: config.id,
-        tenantId: config.tenantId,
-        organizationId: config.organizationId,
-      }).catch((e) => console.error('[SSO Event]', e))
-    }
-
-    return this.toPublic(config)
+      return this.toPublic(config)
+    })
   }
 
   async testConnection(scope: SsoAdminScope, id: string): Promise<{ ok: boolean; error?: string }> {
@@ -245,26 +252,34 @@ export class SsoConfigService {
     const validation = validateDomain(normalized)
     if (!validation.valid) throw new SsoConfigError(validation.error!, 400)
 
-    const config = await this.resolveConfig(scope, id)
+    return this.em.transactional(async (txEm) => {
+      const tx = txEm as EntityManager
+      await this.lockActiveDomainMutation(tx, id, [normalized])
+      const config = await this.resolveConfig(scope, id, tx)
 
-    if (config.allowedDomains.includes(normalized)) {
+      if (config.allowedDomains.some((d) => normalizeDomain(d) === normalized)) {
+        return this.toPublic(config)
+      }
+
+      const limitCheck = checkDomainLimit(config.allowedDomains.length, 1)
+      if (!limitCheck.ok) throw new SsoConfigError(limitCheck.error!, 400)
+
+      if (config.isActive) {
+        await this.assertActiveDomainAvailability(tx, [...config.allowedDomains, normalized], config.id)
+      }
+
+      config.allowedDomains = [...config.allowedDomains, normalized]
+      await tx.flush()
+
+      void emitSsoEvent('sso.domain.added', {
+        id: config.id,
+        tenantId: config.tenantId,
+        organizationId: config.organizationId,
+        domain: normalized,
+      }).catch((e) => console.error('[SSO Event]', e))
+
       return this.toPublic(config)
-    }
-
-    const limitCheck = checkDomainLimit(config.allowedDomains.length, 1)
-    if (!limitCheck.ok) throw new SsoConfigError(limitCheck.error!, 400)
-
-    config.allowedDomains = [...config.allowedDomains, normalized]
-    await this.em.flush()
-
-    void emitSsoEvent('sso.domain.added', {
-      id: config.id,
-      tenantId: config.tenantId,
-      organizationId: config.organizationId,
-      domain: normalized,
-    }).catch((e) => console.error('[SSO Event]', e))
-
-    return this.toPublic(config)
+    })
   }
 
   async removeDomain(scope: SsoAdminScope, id: string, domain: string): Promise<SsoConfigPublic> {
@@ -305,14 +320,14 @@ export class SsoConfigService {
     }
   }
 
-  private async resolveConfig(scope: SsoAdminScope, id: string): Promise<SsoConfig> {
+  private async resolveConfig(scope: SsoAdminScope, id: string, em: EntityManager = this.em): Promise<SsoConfig> {
     const where: FilterQuery<SsoConfig> = { id, deletedAt: null }
     if (!scope.isSuperAdmin) {
       if (!scope.organizationId) throw new SsoConfigError('Organization context is required', 403)
       where.organizationId = scope.organizationId
     }
 
-    const config = await this.em.findOne(SsoConfig, where)
+    const config = await em.findOne(SsoConfig, where)
     if (!config) throw new SsoConfigError('SSO configuration not found', 404)
 
     return config
@@ -323,6 +338,58 @@ export class SsoConfigService {
     if (!provider) return { ok: false, error: `No provider for protocol: ${config.protocol}` }
 
     return provider.validateConfig(config)
+  }
+
+  private async lockActiveDomainMutation(em: EntityManager, configId: string, domains: string[] = []): Promise<void> {
+    const lockKeys = [
+      `sso:sso_config:${configId}`,
+      ...uniqueDomains(domains)
+        .sort((a, b) => a.localeCompare(b))
+        .map((domain) => `sso:allowed_domain:${domain}`),
+    ]
+
+    await this.lockKeys(em, lockKeys)
+  }
+
+  private async lockActiveDomains(em: EntityManager, domains: string[]): Promise<void> {
+    const lockKeys = uniqueDomains(domains)
+      .sort((a, b) => a.localeCompare(b))
+      .map((domain) => `sso:allowed_domain:${domain}`)
+    await this.lockKeys(em, lockKeys)
+  }
+
+  private async lockKeys(em: EntityManager, lockKeys: string[]): Promise<void> {
+    for (const lockKey of lockKeys) {
+      await em.getConnection().execute('select pg_advisory_xact_lock(hashtext(?::text))', [lockKey])
+    }
+  }
+
+  private async assertActiveDomainAvailability(
+    em: EntityManager,
+    domains: string[],
+    currentConfigId: string,
+  ): Promise<void> {
+    const requestedDomains = new Set(uniqueDomains(domains))
+    if (requestedDomains.size === 0) return
+
+    const activeConfigs = await findWithDecryption(
+      em,
+      SsoConfig,
+      { isActive: true, deletedAt: null },
+      {},
+      { tenantId: null },
+    )
+    const conflictDomain = activeConfigs
+      .filter((config) => config.id !== currentConfigId)
+      .flatMap((config) => config.allowedDomains.map(normalizeDomain))
+      .find((domain) => requestedDomains.has(domain))
+
+    if (conflictDomain) {
+      throw new SsoConfigError(
+        `SSO domain "${conflictDomain}" is already claimed by another active SSO configuration`,
+        409,
+      )
+    }
   }
 }
 

--- a/packages/enterprise/src/modules/sso/services/ssoService.ts
+++ b/packages/enterprise/src/modules/sso/services/ssoService.ts
@@ -32,7 +32,8 @@ export class SsoService {
       {},
       { tenantId: null },
     )
-    return configs.find((c) => c.allowedDomains.some((d) => d.toLowerCase() === domain)) ?? null
+    const matches = configs.filter((c) => c.allowedDomains.some((d) => d.toLowerCase() === domain))
+    return matches.length === 1 ? matches[0]! : null
   }
 
   async initiateLogin(


### PR DESCRIPTION
## Summary

Prevent active SSO configurations from sharing the same allowed email domain globally, and fail closed when legacy overlapping data would make pre-auth HRD or email lookup ambiguous.

## Changes

- Serialize active-domain activation/add-domain writes with transaction-scoped advisory locks.
- Reject active domain conflicts with 409 before enabling or extending active SSO configs.
- Return no SSO config when HRD/email-domain lookup sees multiple active matches.
- Add focused regression coverage for conflict rejection, ambiguity handling, and lock ordering.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
.ai/specs/enterprise/implemented/SPEC-ENT-002-2026-02-19-sso-directory-sync.md

## Testing

- `yarn generate`
- `yarn build:packages`
- `yarn typecheck`
- `yarn workspace @open-mercato/enterprise test src/modules/sso/services/__tests__/domain-uniqueness.test.ts --runInBand`
- `yarn workspace @open-mercato/core test src/__tests__/explicit-sort-comparators.test.ts --runInBand`
- `yarn test --output-logs=errors-only`
- `yarn lint`
- `yarn build:app`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Integration coverage note: this is service-level SSO domain ownership and ambiguous lookup behavior covered by focused unit regression tests; no UI path or new API surface was added.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

Design system note: no UI files changed.

## Linked issues

Fixes #3908