### PR TITLE
fix: scope SCIM token generation (#3907)

### DIFF
--- a/packages/enterprise/src/modules/sso/services/__tests__/scimTokenService.test.ts
+++ b/packages/enterprise/src/modules/sso/services/__tests__/scimTokenService.test.ts
@@ -1,0 +1,85 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { ScimToken, SsoConfig } from '../../data/entities'
+import type { SsoAdminScope } from '../ssoConfigService'
+import { ScimTokenError, ScimTokenService } from '../scimTokenService'
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn().mockResolvedValue('hashed-token'),
+  compare: jest.fn().mockResolvedValue(false),
+}))
+
+async function captureThrow(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn()
+  } catch (err) {
+    return err
+  }
+  throw new Error('Expected the call to throw, but it resolved')
+}
+
+function createEntityManagerMock() {
+  const flush = jest.fn().mockResolvedValue(undefined)
+  return {
+    flush,
+    em: {
+      findOne: jest.fn(),
+      create: jest.fn().mockReturnValue({
+        id: 'scim-token-1',
+        tokenPrefix: 'omscim_12345',
+      }),
+      persist: jest.fn().mockReturnValue({ flush }),
+    },
+  }
+}
+
+describe('ScimTokenService.generateToken', () => {
+  const sameOrgScope: SsoAdminScope = {
+    isSuperAdmin: false,
+    organizationId: 'org-1',
+    tenantId: 'tenant-1',
+  }
+
+  it('scopes non-superadmin config lookup to the caller organization', async () => {
+    const { em, flush } = createEntityManagerMock()
+    em.findOne.mockResolvedValue({
+      id: 'sso-config-1',
+      jitEnabled: false,
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+    })
+    const service = new ScimTokenService(em as unknown as EntityManager)
+
+    await service.generateToken('sso-config-1', 'Directory sync', sameOrgScope)
+
+    expect(em.findOne).toHaveBeenCalledWith(SsoConfig, {
+      id: 'sso-config-1',
+      deletedAt: null,
+      organizationId: 'org-1',
+    })
+    expect(em.create).toHaveBeenCalledWith(ScimToken, expect.objectContaining({
+      ssoConfigId: 'sso-config-1',
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+    }))
+    expect(flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed before lookup when a non-superadmin has no organization scope', async () => {
+    const { em } = createEntityManagerMock()
+    em.findOne.mockResolvedValue({ id: 'foreign-config', jitEnabled: false })
+    const service = new ScimTokenService(em as unknown as EntityManager)
+
+    const thrown = await captureThrow(() => service.generateToken('foreign-config', 'Foreign token', {
+      isSuperAdmin: false,
+      organizationId: null,
+      tenantId: 'tenant-1',
+    }))
+
+    expect(thrown).toBeInstanceOf(ScimTokenError)
+    expect((thrown as ScimTokenError).statusCode).toBe(403)
+    expect((thrown as ScimTokenError).message).toBe('Organization context is required')
+    expect(em.findOne).not.toHaveBeenCalled()
+    expect(em.create).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+  })
+})

--- a/packages/enterprise/src/modules/sso/services/scimTokenService.ts
+++ b/packages/enterprise/src/modules/sso/services/scimTokenService.ts
@@ -34,7 +34,8 @@ export class ScimTokenService {
     scope: SsoAdminScope,
   ): Promise<ScimTokenCreateResult> {
     const where: Record<string, unknown> = { id: ssoConfigId, deletedAt: null }
-    if (!scope.isSuperAdmin && scope.organizationId) {
+    if (!scope.isSuperAdmin) {
+      if (!scope.organizationId) throw new ScimTokenError('Organization context is required', 403)
       where.organizationId = scope.organizationId
     }
     const config = await this.em.findOne(SsoConfig, where)
@@ -54,8 +55,8 @@ export class ScimTokenService {
       tokenPrefix,
       isActive: true,
       createdBy: null,
-      tenantId: scope.tenantId,
-      organizationId: scope.organizationId!,
+      tenantId: config.tenantId ?? null,
+      organizationId: config.organizationId,
     } as RequiredEntityData<ScimToken>)
 
     await this.em.persist(token).flush()


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fixes a SCIM token generation tenant-scope bypass where a non-superadmin without organization context could generate a token for a foreign SSO config.

## Changes

- Require organization context before `ScimTokenService.generateToken` resolves configs for non-superadmins.
- Persist generated SCIM token tenant/org scope from the resolved `SsoConfig`.
- Add focused service regression tests for same-org generation and null-org fail-closed behavior.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
.ai/specs/enterprise/implemented/SPEC-ENT-002-2026-02-19-sso-directory-sync.md


## Testing

- `yarn workspace @open-mercato/enterprise test src/modules/sso/services/__tests__/scimTokenService.test.ts --runInBand --no-cache`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn workspace @open-mercato/enterprise typecheck`
- `yarn workspace @open-mercato/enterprise build`
- `yarn i18n:check-sync`
- `yarn typecheck`
- `yarn test`
- `yarn lint`
- `yarn i18n:check-usage` (advisory unused-key output only)
- `yarn build:app`
- `yarn template:sync` reported unrelated existing app/template drift; not changed in this PR.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. N/A — no docs/locales/generator output required.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). N/A — focused service regression covers the security boundary.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A — targeted bug fix under existing enterprise SSO spec.
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. `skip-qa` — backend service/test-only fix, no UI.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens. N/A — no UI.
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`. N/A — no UI.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A — no UI.
- [x] Loading state handled for async pages. N/A — no UI.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A — no UI.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements. N/A — no UI.

## Linked issues

Fixes #3907
