### PR TITLE
fix: require shipment ownership for tracking lookups (#3902)

### DIFF
--- a/packages/core/src/modules/shipping_carriers/api/tracking/__tests__/route.test.ts
+++ b/packages/core/src/modules/shipping_carriers/api/tracking/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+/** @jest-environment node */
+import { GET } from '@open-mercato/core/modules/shipping_carriers/api/tracking/route'
+import { CarrierShipmentNotFoundError } from '@open-mercato/core/modules/shipping_carriers/lib/shipping-service'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+
+const getTrackingMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    tenantId,
+    orgId: organizationId,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (name: string) => {
+      if (name === 'shippingCarrierService') {
+        return { getTracking: getTrackingMock }
+      }
+      throw new Error(`Unexpected container resolve: ${name}`)
+    },
+  })),
+}))
+
+function createMockRequest(query: string): Request {
+  return new Request(`http://localhost/api/shipping-carriers/tracking?${query}`, {
+    method: 'GET',
+  })
+}
+
+describe('shipping carrier tracking route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('maps missing scoped shipments to HTTP 404', async () => {
+    getTrackingMock.mockRejectedValueOnce(new CarrierShipmentNotFoundError())
+
+    const response = await GET(createMockRequest('providerKey=test-carrier&trackingNumber=TRACK-1'))
+    const body = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(body).toEqual({ error: 'Shipment not found' })
+    expect(getTrackingMock).toHaveBeenCalledWith({
+      providerKey: 'test-carrier',
+      trackingNumber: 'TRACK-1',
+      organizationId,
+      tenantId,
+    })
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/api/tracking/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/tracking/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import type { ShippingCarrierService } from '../../lib/shipping-service'
+import { CarrierShipmentNotFoundError, type ShippingCarrierService } from '../../lib/shipping-service'
 import { trackingQuerySchema } from '../../data/validators'
 import { shippingCarriersTag } from '../openapi'
 
@@ -35,7 +35,8 @@ export async function GET(req: Request) {
     return NextResponse.json(tracking)
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : 'Failed to fetch tracking'
-    return NextResponse.json({ error: message }, { status: 502 })
+    const status = error instanceof CarrierShipmentNotFoundError ? 404 : 502
+    return NextResponse.json({ error: message }, { status })
   }
 }
 
@@ -48,6 +49,7 @@ export const openApi = {
       tags: [shippingCarriersTag],
       responses: [
         { status: 200, description: 'Tracking returned' },
+        { status: 404, description: 'Shipment not found' },
         { status: 422, description: 'Validation failed' },
         { status: 502, description: 'Provider upstream error' },
       ],

--- a/packages/core/src/modules/shipping_carriers/lib/__tests__/shipping-service-tracking.test.ts
+++ b/packages/core/src/modules/shipping_carriers/lib/__tests__/shipping-service-tracking.test.ts
@@ -1,5 +1,6 @@
 import Chance from 'chance'
 import { createShippingCarrierService } from '../shipping-service'
+import { CarrierShipment } from '../../data/entities'
 
 const chance = new Chance()
 
@@ -68,7 +69,7 @@ const makeInput = (overrides: Record<string, unknown> = {}) => ({
 })
 
 describe('ShippingCarrierService.getTracking is read-only', () => {
-  afterEach(() => jest.clearAllMocks())
+  afterEach(() => jest.resetAllMocks())
 
   it('does not flush, mutate the shipment, or emit events on a read', async () => {
     const scope = makeScope()
@@ -92,10 +93,13 @@ describe('ShippingCarrierService.getTracking is read-only', () => {
     expect(tracking.status).toBe('in_transit')
   })
 
-  it('still returns provider tracking when no shipment row exists (tracking-number lookup)', async () => {
+  it('requires tracking-number lookup to resolve a scoped shipment before calling the adapter', async () => {
     const scope = makeScope()
-    // No shipmentId, so the service never queries the shipment row.
-    mockGetAdapter.mockReturnValueOnce(makeAdapter(makeTracking('delivered')) as any)
+    const providerKey = chance.word()
+    const trackingNumber = chance.string()
+    const adapter = makeAdapter(makeTracking('delivered'))
+    mockFindOne.mockResolvedValueOnce(null as any)
+    mockGetAdapter.mockReturnValueOnce(adapter as any)
 
     const em = makeEm()
     const service = createShippingCarrierService({
@@ -103,19 +107,62 @@ describe('ShippingCarrierService.getTracking is read-only', () => {
       integrationCredentialsService: makeCredentialsService() as any,
     })
 
-    const tracking = await service.getTracking({
-      providerKey: chance.word(),
-      trackingNumber: chance.string(),
+    await expect(service.getTracking({
+      providerKey,
+      trackingNumber,
+      ...scope,
+    })).rejects.toThrow('Shipment not found')
+
+    expect(mockFindOne).toHaveBeenCalledWith(
+      em,
+      CarrierShipment,
+      {
+        providerKey,
+        trackingNumber,
+        organizationId: scope.organizationId,
+        tenantId: scope.tenantId,
+        deletedAt: null,
+      },
+      undefined,
+      scope,
+    )
+    expect(adapter.getTracking).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('uses the scoped shipment row for tracking-number lookups', async () => {
+    const scope = makeScope()
+    const providerKey = chance.word()
+    const shipment = makeShipment({ providerKey, ...scope })
+    const tracking = makeTracking('delivered')
+    const adapter = makeAdapter(tracking)
+    mockFindOne.mockResolvedValueOnce(shipment as any)
+    mockGetAdapter.mockReturnValueOnce(adapter as any)
+
+    const em = makeEm()
+    const service = createShippingCarrierService({
+      em: em as any,
+      integrationCredentialsService: makeCredentialsService() as any,
+    })
+
+    const result = await service.getTracking({
+      providerKey,
+      trackingNumber: shipment.trackingNumber,
       ...scope,
     })
 
+    expect(result).toBe(tracking)
+    expect(adapter.getTracking).toHaveBeenCalledWith({
+      shipmentId: shipment.carrierShipmentId,
+      trackingNumber: shipment.trackingNumber,
+      credentials: {},
+    })
     expect(em.flush).not.toHaveBeenCalled()
-    expect(tracking.status).toBe('delivered')
   })
 })
 
 describe('ShippingCarrierService.refreshTracking is the guarded write path', () => {
-  afterEach(() => jest.clearAllMocks())
+  afterEach(() => jest.resetAllMocks())
 
   it('persists polling metadata, advances a valid status, and emits status_changed', async () => {
     const scope = makeScope()

--- a/packages/core/src/modules/shipping_carriers/lib/shipping-service.ts
+++ b/packages/core/src/modules/shipping_carriers/lib/shipping-service.ts
@@ -22,6 +22,13 @@ import {
   TERMINAL_SHIPPING_STATUSES,
 } from './status-sync'
 
+export class CarrierShipmentNotFoundError extends Error {
+  constructor() {
+    super('Shipment not found')
+    this.name = 'CarrierShipmentNotFoundError'
+  }
+}
+
 export function createShippingCarrierService(deps: {
   em: EntityManager
   integrationCredentialsService: CredentialsService
@@ -45,7 +52,31 @@ export function createShippingCarrierService(deps: {
       scope,
     )
     if (!shipment) {
-      throw new Error('Shipment not found')
+      throw new CarrierShipmentNotFoundError()
+    }
+    return shipment
+  }
+
+  async function findShipmentByTrackingNumberOrThrow(
+    providerKey: string,
+    trackingNumber: string,
+    scope: { organizationId: string; tenantId: string },
+  ): Promise<CarrierShipment> {
+    const shipment = await findOneWithDecryption(
+      em,
+      CarrierShipment,
+      {
+        providerKey,
+        trackingNumber,
+        organizationId: scope.organizationId,
+        tenantId: scope.tenantId,
+        deletedAt: null,
+      },
+      undefined,
+      scope,
+    )
+    if (!shipment) {
+      throw new CarrierShipmentNotFoundError()
     }
     return shipment
   }
@@ -189,30 +220,24 @@ export function createShippingCarrierService(deps: {
       organizationId: string
       tenantId: string
     }) {
-      const { adapter, credentials } = await resolveAdapter(input.providerKey, {
+      const scope = {
         organizationId: input.organizationId,
         tenantId: input.tenantId,
-      })
-      const shipment = input.shipmentId
-        ? await findOneWithDecryption(
-          em,
-          CarrierShipment,
-          {
-            id: input.shipmentId,
-            organizationId: input.organizationId,
-            tenantId: input.tenantId,
-            deletedAt: null,
-          },
-          undefined,
-          {
-            organizationId: input.organizationId,
-            tenantId: input.tenantId,
-          },
-        )
-        : null
+      }
+      const { adapter, credentials } = await resolveAdapter(input.providerKey, scope)
+      let shipment: CarrierShipment
+      if (input.shipmentId) {
+        shipment = await findShipmentOrThrow(input.shipmentId, scope)
+      } else {
+        const trackingNumber = input.trackingNumber
+        if (!trackingNumber) {
+          throw new CarrierShipmentNotFoundError()
+        }
+        shipment = await findShipmentByTrackingNumberOrThrow(input.providerKey, trackingNumber, scope)
+      }
       return adapter.getTracking({
-        shipmentId: shipment?.carrierShipmentId ?? input.shipmentId,
-        trackingNumber: input.trackingNumber ?? shipment?.trackingNumber,
+        shipmentId: shipment.carrierShipmentId,
+        trackingNumber: shipment.trackingNumber,
         credentials,
       })
     },


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fixes a shipping carrier tracking ownership gap where `GET /shipping-carriers/tracking?providerKey=...&trackingNumber=...` could query a carrier adapter with a caller-supplied tracking number before resolving an owned `CarrierShipment`.

## Changes

- Require raw tracking-number lookups to resolve a `CarrierShipment` scoped by `providerKey`, `organizationId`, `tenantId`, and `deletedAt: null`.
- Reuse the resolved shipment's stored carrier shipment id and tracking number for adapter calls.
- Return 404 when no scoped shipment exists.
- Add service and API route regression tests.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A - focused security bug fix for existing shipping_carriers API behavior.


## Testing

- `yarn workspace @open-mercato/core test packages/core/src/modules/shipping_carriers/lib/__tests__/shipping-service-tracking.test.ts --runInBand --no-cache` - pass
- `yarn workspace @open-mercato/core test packages/core/src/modules/shipping_carriers/api/tracking/__tests__/route.test.ts --runInBand --no-cache` - pass
- `yarn build:packages` - pass
- `yarn generate` - pass
- `yarn build:packages` - pass
- `yarn i18n:check-sync` - pass
- `yarn i18n:check-usage` - pass with advisory unused-key report
- `yarn typecheck` - pass
- `yarn test` - pass
- `yarn lint` - pass with existing cached warnings
- `yarn build:app` - pass

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). Unit-level API/service coverage is sufficient for this non-UI service guard.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) - use semantic tokens. N/A - no UI changes.
- [x] No arbitrary text sizes (`text-[Npx]`) - use typography scale or `text-overline`. N/A - no UI changes.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A - no UI changes.
- [x] Loading state handled for async pages. N/A - no UI changes.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A - no UI changes.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) - no custom replacements. N/A - no UI changes.

## Linked issues

Fixes #3902