### PR TITLE
fix: redact shipping carrier upstream errors (#3903)

### DIFF
--- a/packages/core/src/modules/shipping_carriers/api/__tests__/shipments-route.test.ts
+++ b/packages/core/src/modules/shipping_carriers/api/__tests__/shipments-route.test.ts
@@ -9,8 +9,15 @@ import { ShipmentIdempotencyConflictError } from '@open-mercato/core/modules/shi
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({ getAuthFromRequest: jest.fn() }))
 jest.mock('@open-mercato/shared/lib/di/container', () => ({ createRequestContainer: jest.fn() }))
 jest.mock('@open-mercato/shared/lib/http/readJsonSafe', () => ({ readJsonSafe: jest.fn() }))
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+    t: (_key: string, fallback: string) => fallback,
+  })),
+}))
 
 const createShipment = jest.fn()
+let consoleErrorSpy: jest.SpyInstance
 
 function validPayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -26,9 +33,14 @@ function validPayload(overrides: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
   ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId: 'tenant_1', orgId: 'org_1' })
   ;(createRequestContainer as jest.Mock).mockResolvedValue({ resolve: () => ({ createShipment }) })
   ;(readJsonSafe as jest.Mock).mockResolvedValue(validPayload({ idempotencyKey: 'idem-1' }))
+})
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore()
 })
 
 describe('POST /api/shipping-carriers/shipments idempotency contract', () => {

--- a/packages/core/src/modules/shipping_carriers/api/__tests__/upstream-errors.test.ts
+++ b/packages/core/src/modules/shipping_carriers/api/__tests__/upstream-errors.test.ts
@@ -1,0 +1,148 @@
+/** @jest-environment node */
+import { POST as cancelShipment } from '@open-mercato/core/modules/shipping_carriers/api/cancel/route'
+import { GET as searchDropOffPoints } from '@open-mercato/core/modules/shipping_carriers/api/points/route'
+import { POST as calculateRates } from '@open-mercato/core/modules/shipping_carriers/api/rates/route'
+import { POST as createShipment } from '@open-mercato/core/modules/shipping_carriers/api/shipments/route'
+import { GET as getTracking } from '@open-mercato/core/modules/shipping_carriers/api/tracking/route'
+import { POST as refreshTracking } from '@open-mercato/core/modules/shipping_carriers/api/tracking/refresh/route'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const orderId = '33333333-3333-4333-8333-333333333333'
+const shipmentId = '44444444-4444-4444-8444-444444444444'
+const sensitiveMessage = 'carrier failed with token=sk_live_secret at https://internal-carrier.local'
+
+const serviceMock = {
+  calculateRates: jest.fn(),
+  cancelShipment: jest.fn(),
+  createShipment: jest.fn(),
+  getTracking: jest.fn(),
+  refreshTracking: jest.fn(),
+  searchDropOffPoints: jest.fn(),
+}
+const mockTranslate = jest.fn((_key: string, fallback: string) => fallback)
+const validateCrudMutationGuardMock = jest.fn()
+const runCrudMutationGuardAfterSuccessMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({ getAuthFromRequest: jest.fn() }))
+jest.mock('@open-mercato/shared/lib/di/container', () => ({ createRequestContainer: jest.fn() }))
+jest.mock('@open-mercato/shared/lib/http/readJsonSafe', () => ({ readJsonSafe: jest.fn() }))
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({ translate: mockTranslate, t: mockTranslate })),
+}))
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: (...args: unknown[]) => validateCrudMutationGuardMock(...args),
+  runCrudMutationGuardAfterSuccess: (...args: unknown[]) => runCrudMutationGuardAfterSuccessMock(...args),
+}))
+
+function createJsonRequest(path: string, body: unknown): Request {
+  return new Request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+const address = { countryCode: 'PL', postalCode: '00-001', city: 'Warsaw', line1: 'Test 1' }
+const parcel = { weightKg: 1, lengthCm: 10, widthCm: 10, heightCm: 10 }
+
+const createPayload = {
+  providerKey: 'test-carrier',
+  orderId,
+  origin: address,
+  destination: { ...address, postalCode: '30-001', city: 'Krakow' },
+  packages: [parcel],
+  serviceCode: 'standard',
+}
+
+const ratePayload = {
+  providerKey: 'test-carrier',
+  origin: address,
+  destination: { ...address, postalCode: '30-001', city: 'Krakow' },
+  packages: [parcel],
+}
+
+describe('shipping carrier upstream errors', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined)
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({ tenantId, orgId: organizationId, sub: 'user_1' })
+    ;(createRequestContainer as jest.Mock).mockResolvedValue({
+      resolve: (name: string) => {
+        if (name === 'shippingCarrierService') return serviceMock
+        throw new Error(`[internal] Unexpected container resolve: ${name}`)
+      },
+    })
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: false })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  it.each([
+    {
+      name: 'shipment creation',
+      setup: () => {
+        ;(readJsonSafe as jest.Mock).mockResolvedValue(createPayload)
+        serviceMock.createShipment.mockRejectedValue(new Error(sensitiveMessage))
+        return createShipment(createJsonRequest('/api/shipping-carriers/shipments', createPayload))
+      },
+    },
+    {
+      name: 'rate calculation',
+      setup: () => {
+        ;(readJsonSafe as jest.Mock).mockResolvedValue(ratePayload)
+        serviceMock.calculateRates.mockRejectedValue(new Error(sensitiveMessage))
+        return calculateRates(createJsonRequest('/api/shipping-carriers/rates', ratePayload))
+      },
+    },
+    {
+      name: 'tracking lookup',
+      setup: () => {
+        serviceMock.getTracking.mockRejectedValue(new Error(sensitiveMessage))
+        return getTracking(new Request(`http://localhost/api/shipping-carriers/tracking?providerKey=test-carrier&shipmentId=${shipmentId}`))
+      },
+    },
+    {
+      name: 'tracking refresh',
+      setup: () => {
+        const payload = { providerKey: 'test-carrier', shipmentId }
+        ;(readJsonSafe as jest.Mock).mockResolvedValue(payload)
+        serviceMock.refreshTracking.mockRejectedValue(new Error(sensitiveMessage))
+        return refreshTracking(createJsonRequest('/api/shipping-carriers/tracking/refresh', payload))
+      },
+    },
+    {
+      name: 'drop-off point search',
+      setup: () => {
+        serviceMock.searchDropOffPoints.mockRejectedValue(new Error(sensitiveMessage))
+        return searchDropOffPoints(new Request('http://localhost/api/shipping-carriers/points?providerKey=test-carrier&query=KRA'))
+      },
+    },
+    {
+      name: 'shipment cancellation',
+      setup: () => {
+        const payload = { providerKey: 'test-carrier', shipmentId, reason: 'Customer requested' }
+        ;(readJsonSafe as jest.Mock).mockResolvedValue(payload)
+        serviceMock.cancelShipment.mockRejectedValue(new Error(sensitiveMessage))
+        return cancelShipment(createJsonRequest('/api/shipping-carriers/cancel', payload))
+      },
+    },
+  ])('returns a generic 502 response for $name without dropping the server-side error detail', async ({ setup }) => {
+    const response = await setup()
+    const body = await response.json()
+
+    expect(response.status).toBe(502)
+    expect(body.error).toBe('Carrier provider request failed. Try again later.')
+    expect(body.error).not.toContain('sk_live_secret')
+    expect(body.error).not.toContain('internal-carrier.local')
+    expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('[shipping_carriers.'), expect.any(Error))
+  })
+})

--- a/packages/core/src/modules/shipping_carriers/api/cancel/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/cancel/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { ShippingCarrierService } from '../../lib/shipping-service'
 import { isShipmentCancelNotAllowedError } from '../../lib/status-sync'
+import { shippingCarrierUpstreamErrorResponse } from '../../lib/upstream-error-response'
 import { cancelShipmentSchema } from '../../data/validators'
 import { shippingCarriersTag } from '../openapi'
 
@@ -81,8 +82,7 @@ export async function POST(req: Request) {
     if (isShipmentCancelNotAllowedError(error)) {
       return NextResponse.json({ error: error.message }, { status: 422 })
     }
-    const message = error instanceof Error ? error.message : 'Failed to cancel shipment'
-    return NextResponse.json({ error: message }, { status: 502 })
+    return shippingCarrierUpstreamErrorResponse('cancel.post', error)
   }
 }
 

--- a/packages/core/src/modules/shipping_carriers/api/points/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/points/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { ShippingCarrierService } from '../../lib/shipping-service'
+import { shippingCarrierUpstreamErrorResponse } from '../../lib/upstream-error-response'
 import { searchDropOffPointsQuerySchema } from '../../data/validators'
 import { shippingCarriersTag } from '../openapi'
 
@@ -35,8 +36,7 @@ export async function GET(req: Request) {
     })
     return NextResponse.json({ points })
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'Failed to search drop-off points'
-    return NextResponse.json({ error: message }, { status: 502 })
+    return shippingCarrierUpstreamErrorResponse('points.search', error)
   }
 }
 

--- a/packages/core/src/modules/shipping_carriers/api/rates/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/rates/route.ts
@@ -3,6 +3,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import type { ShippingCarrierService } from '../../lib/shipping-service'
+import { shippingCarrierUpstreamErrorResponse } from '../../lib/upstream-error-response'
 import { calculateRatesSchema } from '../../data/validators'
 import { shippingCarriersTag } from '../openapi'
 
@@ -31,8 +32,7 @@ export async function POST(req: Request) {
     })
     return NextResponse.json({ rates })
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'Failed to calculate rates'
-    return NextResponse.json({ error: message }, { status: 502 })
+    return shippingCarrierUpstreamErrorResponse('rates.calculate', error)
   }
 }
 

--- a/packages/core/src/modules/shipping_carriers/api/shipments/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/shipments/route.ts
@@ -8,6 +8,7 @@ import {
 } from '@open-mercato/shared/lib/crud/mutation-guard'
 import type { ShippingCarrierService } from '../../lib/shipping-service'
 import { isShipmentIdempotencyConflictError } from '../../lib/shipment-idempotency'
+import { shippingCarrierUpstreamErrorResponse } from '../../lib/upstream-error-response'
 import { createShipmentSchema } from '../../data/validators'
 import { shippingCarriersTag } from '../openapi'
 
@@ -90,8 +91,7 @@ export async function POST(req: Request) {
         { status: 409 },
       )
     }
-    const message = error instanceof Error ? error.message : 'Failed to create shipment'
-    return NextResponse.json({ error: message }, { status: 502 })
+    return shippingCarrierUpstreamErrorResponse('shipments.create', error)
   }
 }
 

--- a/packages/core/src/modules/shipping_carriers/api/tracking/refresh/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/tracking/refresh/route.ts
@@ -3,6 +3,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import type { ShippingCarrierService } from '../../../lib/shipping-service'
+import { shippingCarrierUpstreamErrorResponse } from '../../../lib/upstream-error-response'
 import { trackingRefreshSchema } from '../../../data/validators'
 import { shippingCarriersTag } from '../../openapi'
 
@@ -31,8 +32,7 @@ export async function POST(req: Request) {
     })
     return NextResponse.json(tracking)
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'Failed to refresh tracking'
-    return NextResponse.json({ error: message }, { status: 502 })
+    return shippingCarrierUpstreamErrorResponse('tracking.refresh', error)
   }
 }
 

--- a/packages/core/src/modules/shipping_carriers/api/tracking/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/tracking/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { ShippingCarrierService } from '../../lib/shipping-service'
+import { shippingCarrierUpstreamErrorResponse } from '../../lib/upstream-error-response'
 import { trackingQuerySchema } from '../../data/validators'
 import { shippingCarriersTag } from '../openapi'
 
@@ -34,8 +35,7 @@ export async function GET(req: Request) {
     })
     return NextResponse.json(tracking)
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : 'Failed to fetch tracking'
-    return NextResponse.json({ error: message }, { status: 502 })
+    return shippingCarrierUpstreamErrorResponse('tracking.get', error)
   }
 }
 

--- a/packages/core/src/modules/shipping_carriers/i18n/de.json
+++ b/packages/core/src/modules/shipping_carriers/i18n/de.json
@@ -69,6 +69,7 @@
   "shipping_carriers.create.summary.targetPoint": "Paketbox",
   "shipping_carriers.create.summary.to": "Nach",
   "shipping_carriers.create.title": "Sendung beim Transporteur erstellen",
+  "shipping_carriers.errors.upstreamFailed": "Anfrage an den Transporteur fehlgeschlagen. Versuchen Sie es spaeter erneut.",
   "shipping_carriers.feature.manage": "Versanddienstleister-Vorgaenge verwalten",
   "shipping_carriers.feature.view": "Sendungen der Versanddienstleister anzeigen",
   "shipping_carriers.status.cancelled": "Storniert",

--- a/packages/core/src/modules/shipping_carriers/i18n/en.json
+++ b/packages/core/src/modules/shipping_carriers/i18n/en.json
@@ -69,6 +69,7 @@
   "shipping_carriers.create.summary.targetPoint": "Locker point",
   "shipping_carriers.create.summary.to": "To",
   "shipping_carriers.create.title": "Create carrier shipment",
+  "shipping_carriers.errors.upstreamFailed": "Carrier provider request failed. Try again later.",
   "shipping_carriers.feature.manage": "Manage shipping carrier operations",
   "shipping_carriers.feature.view": "View shipping carrier shipments",
   "shipping_carriers.status.cancelled": "Cancelled",

--- a/packages/core/src/modules/shipping_carriers/i18n/es.json
+++ b/packages/core/src/modules/shipping_carriers/i18n/es.json
@@ -69,6 +69,7 @@
   "shipping_carriers.create.summary.targetPoint": "Casillero",
   "shipping_carriers.create.summary.to": "Hasta",
   "shipping_carriers.create.title": "Crear envio con transportista",
+  "shipping_carriers.errors.upstreamFailed": "Error en la solicitud al transportista. Intentalo de nuevo mas tarde.",
   "shipping_carriers.feature.manage": "Gestionar operaciones de transportistas",
   "shipping_carriers.feature.view": "Ver envios de transportistas",
   "shipping_carriers.status.cancelled": "Cancelado",

--- a/packages/core/src/modules/shipping_carriers/i18n/pl.json
+++ b/packages/core/src/modules/shipping_carriers/i18n/pl.json
@@ -69,6 +69,7 @@
   "shipping_carriers.create.summary.targetPoint": "Paczkomat",
   "shipping_carriers.create.summary.to": "Odbiór",
   "shipping_carriers.create.title": "Utwórz przesyłkę u przewoźnika",
+  "shipping_carriers.errors.upstreamFailed": "Żądanie do przewoźnika nie powiodło się. Spróbuj ponownie później.",
   "shipping_carriers.feature.manage": "Zarzadzanie operacjami przewoznikow",
   "shipping_carriers.feature.view": "Podglad przesylek przewoznikow",
   "shipping_carriers.status.cancelled": "Anulowano",

--- a/packages/core/src/modules/shipping_carriers/lib/upstream-error-response.ts
+++ b/packages/core/src/modules/shipping_carriers/lib/upstream-error-response.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+
+const upstreamFailedKey = 'shipping_carriers.errors.upstreamFailed'
+const upstreamFailedFallback = 'Carrier provider request failed. Try again later.'
+
+export async function shippingCarrierUpstreamErrorResponse(routeId: string, error: unknown) {
+  console.error(`[shipping_carriers.${routeId}] provider upstream error`, error)
+  const { translate } = await resolveTranslations()
+  return NextResponse.json({ error: translate(upstreamFailedKey, upstreamFailedFallback) }, { status: 502 })
+}


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Stop shipping carrier provider-upstream 502 responses from reflecting adapter-controlled exception messages to API callers.

## Changes

- Added a shared shipping-carrier upstream error response helper that logs raw provider exceptions server-side.
- Replaced provider-upstream 502 `error.message` responses across shipping carrier API routes with a translated generic error.
- Added route regression coverage proving sensitive upstream text is not returned to clients.
- Added synced `shipping_carriers.errors.upstreamFailed` locale entries.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
.ai/specs/implemented/SPEC-045c-payment-shipping-hubs.md

## Testing

- `yarn workspace @open-mercato/core test --runInBand --runTestsByPath src/modules/shipping_carriers/api/__tests__/upstream-errors.test.ts`
- `yarn workspace @open-mercato/core test --runInBand --runTestsByPath src/modules/shipping_carriers/api/__tests__/upstream-errors.test.ts src/modules/shipping_carriers/api/__tests__/shipments-route.test.ts src/modules/shipping_carriers/api/shipments/__tests__/route.test.ts src/modules/shipping_carriers/api/cancel/__tests__/route.test.ts`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn build:app`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). N/A - covered by focused module route tests; no browser flow changed.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A - minor hardening against the existing shipping-carrier upstream error contract.
- [x] Priority set: this PR carries exactly one `priority-*` label. Use `priority-low`.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). Use `risk-low`.
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`. Use `skip-qa`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) - use semantic tokens. N/A - no UI changes.
- [x] No arbitrary text sizes (`text-[Npx]`) - use typography scale or `text-overline`. N/A - no UI changes.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A - no UI changes.
- [x] Loading state handled for async pages. N/A - no UI changes.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A - no UI changes.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) - no custom replacements. N/A - no UI changes.

## Linked issues

Fixes #3903
