### PR TITLE
fix: bind scheduler command context to schedule scope (#3899)

### DIFF
--- a/packages/scheduler/jest.config.cjs
+++ b/packages/scheduler/jest.config.cjs
@@ -11,6 +11,7 @@ module.exports = {
   moduleNameMapper: {
     '^@open-mercato/core/(.*)$': '<rootDir>/../core/src/$1',
     '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',
+    '^@open-mercato/cache$': '<rootDir>/../cache/src/index.ts',
     '^@open-mercato/queue/(.*)$': '<rootDir>/../queue/src/$1',
     '^@open-mercato/events/(.*)$': '<rootDir>/../events/src/$1',
     '^@open-mercato/ui/(.*)$': '<rootDir>/../ui/src/$1',

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/commandContext.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/commandContext.test.ts
@@ -1,0 +1,60 @@
+import { buildScheduledCommandContext } from '../commandContext'
+
+describe('buildScheduledCommandContext', () => {
+  it('binds organization-scoped scheduled commands to the schedule tenant and organization', () => {
+    const ctx = buildScheduledCommandContext(
+      {
+        id: 'schedule-1',
+        tenantId: 'tenant-a',
+        organizationId: 'org-a',
+        scopeType: 'organization',
+        createdByUserId: 'user-a',
+      },
+      {} as Parameters<typeof buildScheduledCommandContext>[1],
+    )
+
+    expect(ctx.auth).toMatchObject({
+      sub: 'user-a',
+      userId: 'user-a',
+      tenantId: 'tenant-a',
+      orgId: 'org-a',
+      isSuperAdmin: false,
+    })
+    expect(ctx.organizationScope).toEqual({
+      selectedId: 'org-a',
+      filterIds: ['org-a'],
+      allowedIds: ['org-a'],
+      tenantId: 'tenant-a',
+    })
+    expect(ctx.selectedOrganizationId).toBe('org-a')
+    expect(ctx.organizationIds).toEqual(['org-a'])
+  })
+
+  it('uses a non-superadmin system actor when the schedule has no creator', () => {
+    const ctx = buildScheduledCommandContext(
+      {
+        id: 'schedule-2',
+        tenantId: 'tenant-a',
+        organizationId: null,
+        scopeType: 'tenant',
+        createdByUserId: null,
+      },
+      {} as Parameters<typeof buildScheduledCommandContext>[1],
+    )
+
+    expect(ctx.auth).toMatchObject({
+      sub: '00000000-0000-0000-0000-000000000000',
+      userId: '00000000-0000-0000-0000-000000000000',
+      tenantId: 'tenant-a',
+      orgId: null,
+      isSuperAdmin: false,
+    })
+    expect(ctx.organizationScope).toEqual({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: 'tenant-a',
+    })
+    expect(ctx.organizationIds).toBeNull()
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/lib/commandContext.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/commandContext.ts
@@ -1,0 +1,55 @@
+import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import type { AppContainer } from '@open-mercato/shared/lib/di/container'
+
+const SCHEDULER_SYSTEM_ACTOR_ID = '00000000-0000-0000-0000-000000000000'
+
+type ScheduledCommandContextSchedule = {
+  id: string
+  tenantId?: string | null
+  organizationId?: string | null
+  scopeType: 'system' | 'organization' | 'tenant'
+  createdByUserId?: string | null
+}
+
+function buildScheduledCommandAuth(schedule: ScheduledCommandContextSchedule): Exclude<AuthContext, null> {
+  const actorId = schedule.createdByUserId || SCHEDULER_SYSTEM_ACTOR_ID
+  return {
+    sub: actorId,
+    userId: actorId,
+    tenantId: schedule.tenantId ?? null,
+    orgId: schedule.organizationId ?? null,
+    isSuperAdmin: false,
+  }
+}
+
+export function buildScheduledCommandContext(
+  schedule: ScheduledCommandContextSchedule,
+  container: AppContainer,
+): CommandRuntimeContext {
+  const tenantId = schedule.tenantId ?? null
+  const organizationId = schedule.organizationId ?? null
+  const organizationIds = organizationId ? [organizationId] : null
+
+  return {
+    container,
+    auth: buildScheduledCommandAuth(schedule),
+    organizationScope:
+      schedule.scopeType === 'organization' && organizationId
+        ? {
+            selectedId: organizationId,
+            filterIds: [organizationId],
+            allowedIds: [organizationId],
+            tenantId,
+          }
+        : {
+            selectedId: null,
+            filterIds: null,
+            allowedIds: null,
+            tenantId,
+          },
+    selectedOrganizationId: organizationId,
+    organizationIds,
+    request: undefined,
+  }
+}

--- a/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
@@ -1,12 +1,13 @@
 import type { EntityManager } from '@mikro-orm/core'
 import type { Queue } from '@open-mercato/queue'
 import { CommandBus } from '@open-mercato/shared/lib/commands'
-import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import type { AppContainer } from '@open-mercato/shared/lib/di/container'
 import { ScheduledJob } from '../data/entities.js'
 import { LocalLockStrategy } from '../lib/localLockStrategy'
 import { recalculateNextRun } from '../lib/nextRunCalculator'
 import { emitSchedulerEvent } from '../events.js'
 import { getGlobalEventBus } from '@open-mercato/shared/modules/events'
+import { buildScheduledCommandContext } from '../lib/commandContext.js'
 
 export interface RbacServiceLike {
   tenantHasFeature(tenantId: string | null | undefined, feature: string, opts?: { organizationId?: string | null }): Promise<boolean>
@@ -277,10 +278,9 @@ export class LocalSchedulerService {
       organizationId: schedule.organizationId,
     }
     
-    // Build command context with tenant/org scope but no user
-    // Commands run without user authentication for scheduled jobs
-    const commandCtx: CommandRuntimeContext = {
-      container: {
+    const commandCtx = buildScheduledCommandContext(
+      schedule,
+      {
         resolve: (name: string) => {
           // Simple resolver that forwards to our dependencies
           if (name === 'em') return this.em()
@@ -288,13 +288,8 @@ export class LocalSchedulerService {
           if (name === 'rbacService') return this.rbacService
           throw new Error(`Service not available in scheduler context: ${name}`)
         },
-      } as CommandRuntimeContext['container'],
-      auth: null, // Scheduled commands run without user authentication
-      organizationScope: null,
-      selectedOrganizationId: schedule.organizationId || null,
-      organizationIds: schedule.organizationId ? [schedule.organizationId] : null,
-      request: undefined,
-    }
+      } as AppContainer,
+    )
 
     const result = await commandBus.execute(schedule.targetCommand, {
       input: commandInput,

--- a/packages/scheduler/src/modules/scheduler/workers/__tests__/execute-schedule.worker.test.ts
+++ b/packages/scheduler/src/modules/scheduler/workers/__tests__/execute-schedule.worker.test.ts
@@ -1,0 +1,102 @@
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
+import { ScheduledJob } from '../../data/entities'
+import executeScheduleWorker from '../execute-schedule.worker'
+
+const mockCommandExecute = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/commands', () => ({
+  CommandBus: jest.fn().mockImplementation(() => ({
+    execute: mockCommandExecute,
+  })),
+}))
+
+jest.mock('@open-mercato/queue', () => ({
+  createQueue: jest.fn(),
+}), { virtual: true })
+
+jest.mock('../../events', () => ({
+  emitSchedulerEvent: jest.fn(async () => undefined),
+}))
+
+const scheduleId = '11111111-1111-4111-8111-111111111111'
+
+function buildCommandSchedule(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
+  const schedule = new ScheduledJob()
+  schedule.id = scheduleId
+  schedule.name = 'Scoped command'
+  schedule.scopeType = 'organization'
+  schedule.tenantId = 'tenant-a'
+  schedule.organizationId = 'org-a'
+  schedule.isEnabled = true
+  schedule.targetType = 'command'
+  schedule.targetCommand = 'scheduler.test.assert-tenant-scope'
+  schedule.targetPayload = { checkedTenantId: 'tenant-b' }
+  schedule.scheduleType = 'cron'
+  schedule.scheduleValue = '* * * * *'
+  schedule.timezone = 'UTC'
+  schedule.sourceType = 'user'
+  schedule.createdAt = new Date('2026-01-01T00:00:00.000Z')
+  schedule.updatedAt = new Date('2026-01-01T00:00:00.000Z')
+  Object.assign(schedule, overrides)
+  return schedule
+}
+
+function buildWorkerContext(schedule: ScheduledJob) {
+  const em = {
+    findOne: jest.fn(async () => schedule),
+    flush: jest.fn(async () => undefined),
+  }
+  const rbacService = {
+    tenantHasFeature: jest.fn(async () => true),
+  }
+  return {
+    context: {
+      jobId: 'worker-job-1',
+      attemptNumber: 1,
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return em
+        if (name === 'rbacService') return rbacService
+        throw new Error(`Unexpected dependency: ${name}`)
+      }),
+    },
+    em,
+    rbacService,
+  }
+}
+
+describe('executeScheduleWorker command scope', () => {
+  afterEach(() => {
+    mockCommandExecute.mockReset()
+  })
+
+  it('runs scheduled commands with schedule-bound tenant auth so command guards enforce tenant scope (#3899)', async () => {
+    mockCommandExecute.mockImplementation(async (_commandId, { input, ctx }) => {
+      ensureTenantScope(ctx, String((input as { checkedTenantId: string }).checkedTenantId))
+      return { result: { ok: true }, logEntry: null }
+    })
+
+    const schedule = buildCommandSchedule()
+    const { context, em } = buildWorkerContext(schedule)
+
+    await expect(
+      executeScheduleWorker(
+        {
+          id: 'queued-job-1',
+          queue: 'scheduler-execution',
+          payload: {
+            scheduleId,
+            tenantId: 'tenant-a',
+            organizationId: 'org-a',
+            scopeType: 'organization',
+          },
+          attempts: 0,
+          createdAt: Date.now(),
+        },
+        context,
+      ),
+    ).rejects.toBeInstanceOf(CrudHttpError)
+
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/workers/execute-schedule.worker.ts
+++ b/packages/scheduler/src/modules/scheduler/workers/execute-schedule.worker.ts
@@ -4,9 +4,9 @@ import { getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/connection'
 import type { EntityManager } from '@mikro-orm/core'
 import { ScheduledJob } from '../data/entities.js'
 import { CommandBus } from '@open-mercato/shared/lib/commands'
-import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { AppContainer } from '@open-mercato/shared/lib/di/container'
 import { emitSchedulerEvent } from '../events.js'
+import { buildScheduledCommandContext } from '../lib/commandContext.js'
 
 // Worker metadata for auto-discovery
 export const metadata: WorkerMeta = {
@@ -211,16 +211,7 @@ export default async function executeScheduleWorker(
       organizationId: schedule.organizationId,
     }
     
-    // Build command runtime context
-    // Scheduled commands run without user auth but with proper tenant/org scope
-    const commandCtx: CommandRuntimeContext = {
-      container: ctx as unknown as AppContainer,
-      auth: null, // Scheduled commands run without user authentication
-      organizationScope: null, // No organization scope filtering for scheduled commands
-      selectedOrganizationId: schedule.organizationId || null,
-      organizationIds: schedule.organizationId ? [schedule.organizationId] : null,
-      request: undefined,
-    }
+    const commandCtx = buildScheduledCommandContext(schedule, ctx as unknown as AppContainer)
     
     const commandResult = await commandBus.execute(schedule.targetCommand, {
       input: commandInput,


### PR DESCRIPTION
## Summary

Fixes scheduled command execution so scheduler command contexts carry a schedule-bound, non-superadmin auth principal instead of `auth: null`. This makes command-level tenant and organization guards enforce against the DB-verified schedule scope.

## Changes

- Added a scheduler-local `buildScheduledCommandContext()` helper.
- Updated async and local scheduled command execution paths to use the shared helper.
- Added regression coverage for the original null-auth tenant-scope bypass.
- Added helper coverage for creator-bound and system-fallback scheduled principals.
- Added a scheduler Jest mapper for `@open-mercato/cache` so the scheduler package suite resolves existing shared command imports.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A - targeted security bugfix. Relevant prior context: `.ai/specs/implemented/2026-05-29-org-scope-fail-open-authorization-hardening.md`.


## Testing

- `yarn workspace @open-mercato/scheduler test --runTestsByPath src/modules/scheduler/workers/__tests__/execute-schedule.worker.test.ts src/modules/scheduler/lib/__tests__/commandContext.test.ts --runInBand` - PASS
- `yarn workspace @open-mercato/scheduler test --runInBand` - PASS
- `yarn workspace @open-mercato/scheduler typecheck` - PASS
- `yarn build:packages` - PASS
- `yarn generate` - PASS
- `yarn build:packages` - PASS
- `yarn i18n:check-sync` - PASS
- `yarn i18n:check-usage` - WARN advisory unused keys only
- `yarn typecheck` - PASS
- `yarn test` - PASS
- `yarn lint` - PASS with existing cached warnings
- `yarn build:app` - PASS with existing Turbopack NFT warnings

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. N/A - no docs/locales/generator output required.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). N/A - backend worker/unit-level security regression.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A - minor targeted bugfix.
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. `skip-qa` - no UI/customer-facing flow.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens. N/A - no UI.
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`. N/A - no UI.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A - no UI.
- [x] Loading state handled for async pages. N/A - no UI.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A - no UI.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements. N/A - no UI.

## Linked issues

Fixes #3899
