### PR TITLE
fix: harden scheduler interval limits

### DIFF
--- a/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-007.spec.ts
+++ b/packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-007.spec.ts
@@ -9,16 +9,18 @@ type ValidationError = { error?: string; details?: Array<{ path?: Array<string |
  * TC-SCHED-007: POST /api/scheduler/jobs rejects invalid cron and interval
  * `scheduleValue`s with 400 and an error scoped to the `scheduleValue` path.
  *
- * Interval format is `<number><unit>` with unit in s|m|h|d, so the inputs below
- * are genuinely malformed (the issue's "99h"/"0m" drafts are actually valid).
- * All cases are rejected at validation, so no records are created and no
- * teardown is required.
+ * Interval format is `<number><unit>` with unit in s|m|h|d and a minimum floor
+ * of one minute. All cases are rejected at validation, so no records are
+ * created and no teardown is required.
  */
 const invalidCases = [
   { label: 'cron: not a cron expression', scheduleType: 'cron' as const, scheduleValue: 'not-a-cron' },
   { label: 'cron: too few fields', scheduleType: 'cron' as const, scheduleValue: '* * *' },
   { label: 'interval: unsupported unit', scheduleType: 'interval' as const, scheduleValue: '15x' },
   { label: 'interval: missing unit', scheduleType: 'interval' as const, scheduleValue: '99' },
+  { label: 'interval: zero seconds', scheduleType: 'interval' as const, scheduleValue: '0s' },
+  { label: 'interval: one second', scheduleType: 'interval' as const, scheduleValue: '1s' },
+  { label: 'interval: below one minute', scheduleType: 'interval' as const, scheduleValue: '59s' },
 ]
 
 test.describe('TC-SCHED-007: POST /api/scheduler/jobs validates schedule value format', () => {

--- a/packages/scheduler/src/modules/scheduler/commands/__tests__/jobs.active-limit.test.ts
+++ b/packages/scheduler/src/modules/scheduler/commands/__tests__/jobs.active-limit.test.ts
@@ -1,0 +1,158 @@
+export {}
+
+const registerCommand = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/commands', () => ({
+  registerCommand,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn().mockResolvedValue({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+function loadCommands() {
+  let create: any
+  let update: any
+  jest.isolateModules(() => {
+    require('../jobs')
+    create = registerCommand.mock.calls.find(([cmd]) => cmd.id === 'scheduler.jobs.create')?.[0]
+    update = registerCommand.mock.calls.find(([cmd]) => cmd.id === 'scheduler.jobs.update')?.[0]
+  })
+  return { create, update }
+}
+
+function makeEm(schedule: Record<string, unknown> | null) {
+  return {
+    fork: jest.fn().mockReturnThis(),
+    findOne: jest.fn().mockResolvedValue(schedule),
+    count: jest.fn(),
+    create: jest.fn((_entity: unknown, data: Record<string, unknown>) => ({ id: 'new-job', ...data })),
+    persist: jest.fn(),
+    flush: jest.fn().mockResolvedValue(undefined),
+  }
+}
+
+function makeCtx(em: any) {
+  return {
+    auth: { isSuperAdmin: false, tenantId: 'tenant-a', orgId: 'org-a' },
+    container: { resolve: jest.fn(() => em) },
+  } as any
+}
+
+function createInput(overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'Tenant schedule',
+    scopeType: 'tenant',
+    tenantId: 'tenant-a',
+    scheduleType: 'interval',
+    scheduleValue: '15m',
+    targetType: 'queue',
+    targetQueue: 'scheduler',
+    isEnabled: true,
+    ...overrides,
+  }
+}
+
+describe('scheduler.jobs active schedule tenant limit', () => {
+  const originalLimit = process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetModules()
+    process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT = '2'
+  })
+
+  afterEach(() => {
+    if (originalLimit === undefined) delete process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT
+    else process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT = originalLimit
+  })
+
+  it('rejects creating an enabled tenant-scoped schedule after the tenant reaches the active cap', async () => {
+    const { create } = loadCommands()
+    const em = makeEm(null)
+    em.count.mockResolvedValue(2)
+
+    await expect(create.execute(createInput(), makeCtx(em))).rejects.toMatchObject({ status: 422 })
+
+    expect(em.count).toHaveBeenCalledWith(expect.any(Function), {
+      tenantId: 'tenant-a',
+      isEnabled: true,
+      deletedAt: null,
+    })
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('rejects enabling a disabled tenant-scoped schedule after the tenant reaches the active cap', async () => {
+    const { update } = loadCommands()
+    const schedule = {
+      id: 'job-1',
+      tenantId: 'tenant-a',
+      organizationId: null,
+      scopeType: 'tenant',
+      isEnabled: false,
+      scheduleType: 'interval',
+      scheduleValue: '15m',
+      timezone: 'UTC',
+    }
+    const em = makeEm(schedule)
+    em.count.mockResolvedValue(2)
+
+    await expect(update.execute({ id: 'job-1', isEnabled: true }, makeCtx(em))).rejects.toMatchObject({ status: 422 })
+
+    expect(em.count).toHaveBeenCalledWith(expect.any(Function), {
+      tenantId: 'tenant-a',
+      isEnabled: true,
+      deletedAt: null,
+    })
+    expect(schedule.isEnabled).toBe(false)
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('does not count an already-enabled schedule when updating other fields', async () => {
+    const { update } = loadCommands()
+    const schedule = {
+      id: 'job-1',
+      tenantId: 'tenant-a',
+      organizationId: null,
+      scopeType: 'tenant',
+      isEnabled: true,
+      scheduleType: 'interval',
+      scheduleValue: '15m',
+      timezone: 'UTC',
+    }
+    const em = makeEm(schedule)
+
+    await expect(update.execute({ id: 'job-1', name: 'Renamed' }, makeCtx(em))).resolves.toEqual({ ok: true })
+
+    expect(em.count).not.toHaveBeenCalled()
+    expect(schedule.name).toBe('Renamed')
+    expect(em.flush).toHaveBeenCalled()
+  })
+
+  it('rejects direct command interval updates below one minute', async () => {
+    const { update } = loadCommands()
+    const schedule = {
+      id: 'job-1',
+      tenantId: 'tenant-a',
+      organizationId: null,
+      scopeType: 'tenant',
+      isEnabled: true,
+      scheduleType: 'interval',
+      scheduleValue: '15m',
+      timezone: 'UTC',
+      nextRunAt: new Date('2026-01-01T00:15:00.000Z'),
+    }
+    const em = makeEm(schedule)
+
+    await expect(
+      update.execute({ id: 'job-1', scheduleType: 'interval', scheduleValue: '1s' }, makeCtx(em)),
+    ).rejects.toMatchObject({ status: 422 })
+
+    expect(schedule.scheduleValue).toBe('15m')
+    expect(schedule.nextRunAt).toEqual(new Date('2026-01-01T00:15:00.000Z'))
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/commands/jobs.ts
+++ b/packages/scheduler/src/modules/scheduler/commands/jobs.ts
@@ -7,6 +7,7 @@ import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import type { EntityManager } from '@mikro-orm/core'
 import { ScheduledJob } from '../data/entities.js'
 import { calculateNextRun } from '../lib/nextRunCalculator.js'
+import { enforceTenantActiveScheduleLimit } from '../lib/activeScheduleLimits.js'
 import type {
   ScheduleCreateInput,
   ScheduleUpdateInput,
@@ -188,6 +189,10 @@ const createScheduleCommand: CommandHandler<ScheduleCreateInput, { id: string }>
 
     const em = ctx.container.resolve<EntityManager>('em').fork()
 
+    if (input.isEnabled ?? true) {
+      await enforceTenantActiveScheduleLimit(em, input.tenantId)
+    }
+
     // Calculate next run time
     const nextRunAt = calculateNextRun(
       input.scheduleType,
@@ -297,6 +302,23 @@ const updateScheduleCommand: CommandHandler<ScheduleUpdateInput, { ok: boolean }
     if (schedule.organizationId) ensureOrganizationScope(ctx, schedule.organizationId)
     ensureCanManageSystemScopedJob(ctx, schedule)
 
+    if (input.isEnabled === true && schedule.isEnabled !== true) {
+      await enforceTenantActiveScheduleLimit(em, schedule.tenantId)
+    }
+
+    const scheduleChanged = input.scheduleType !== undefined || input.scheduleValue !== undefined || input.timezone !== undefined
+    const nextRunAt = scheduleChanged
+      ? calculateNextRun(
+        input.scheduleType ?? schedule.scheduleType,
+        input.scheduleValue ?? schedule.scheduleValue,
+        input.timezone ?? schedule.timezone,
+      )
+      : null
+
+    if (scheduleChanged && !nextRunAt) {
+      throw new CrudHttpError(422, { error: 'Invalid schedule value.' })
+    }
+
     // Update fields
     if (input.name !== undefined) schedule.name = input.name
     if (input.description !== undefined) schedule.description = input.description ?? null
@@ -326,16 +348,8 @@ const updateScheduleCommand: CommandHandler<ScheduleUpdateInput, { ok: boolean }
       if (input.targetCommand !== undefined) schedule.targetCommand = input.targetCommand
     }
 
-    // Recalculate next run if schedule changed
-    if (input.scheduleType !== undefined || input.scheduleValue !== undefined || input.timezone !== undefined) {
-      const nextRunAt = calculateNextRun(
-        schedule.scheduleType,
-        schedule.scheduleValue,
-        schedule.timezone
-      )
-      if (nextRunAt) {
-        schedule.nextRunAt = nextRunAt
-      }
+    if (nextRunAt) {
+      schedule.nextRunAt = nextRunAt
     }
 
     schedule.updatedAt = new Date()

--- a/packages/scheduler/src/modules/scheduler/data/__tests__/validators.test.ts
+++ b/packages/scheduler/src/modules/scheduler/data/__tests__/validators.test.ts
@@ -126,7 +126,8 @@ describe('scheduleCreateSchema', () => {
 
     it('should accept various interval formats', () => {
       const validIntervals = [
-        '30s',  // 30 seconds
+        '60s',  // 60 seconds
+        '1m',   // 1 minute
         '15m',  // 15 minutes
         '2h',   // 2 hours
         '1d',   // 1 day
@@ -324,6 +325,23 @@ describe('scheduleCreateSchema', () => {
         })
       ).toThrow(/Invalid schedule value/)
     })
+
+    it('should reject interval values below one minute', () => {
+      const subMinuteIntervals = ['0s', '1s', '59s', '0m']
+
+      subMinuteIntervals.forEach(scheduleValue => {
+        expect(() =>
+          scheduleCreateSchema.parse({
+            name: 'Invalid',
+            scopeType: 'system',
+            scheduleType: 'interval',
+            scheduleValue,
+            targetType: 'queue',
+            targetQueue: 'test',
+          })
+        ).toThrow(/Invalid schedule value/)
+      })
+    })
   })
 
   describe('field constraints', () => {
@@ -432,6 +450,16 @@ describe('scheduleUpdateSchema', () => {
         id: scheduleId,
         scheduleType: 'interval',
         scheduleValue: '15x',
+      })
+    ).toThrow(/Invalid schedule value/)
+  })
+
+  it('should reject interval values below one minute when updating', () => {
+    expect(() =>
+      scheduleUpdateSchema.parse({
+        id: scheduleId,
+        scheduleType: 'interval',
+        scheduleValue: '1s',
       })
     ).toThrow(/Invalid schedule value/)
   })

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/intervalParser.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/intervalParser.test.ts
@@ -10,9 +10,8 @@ describe('intervalParser', () => {
   describe('parseInterval', () => {
     describe('seconds', () => {
       it('should parse seconds correctly', () => {
-        expect(parseInterval('30s')).toBe(30 * 1000)
-        expect(parseInterval('1s')).toBe(1000)
         expect(parseInterval('60s')).toBe(60 * 1000)
+        expect(parseInterval('90s')).toBe(90 * 1000)
       })
     })
 
@@ -86,11 +85,13 @@ describe('intervalParser', () => {
     })
 
     describe('edge cases', () => {
-      it('should handle zero', () => {
-        expect(parseInterval('0s')).toBe(0)
-        expect(parseInterval('0m')).toBe(0)
-        expect(parseInterval('0h')).toBe(0)
-        expect(parseInterval('0d')).toBe(0)
+      it('should reject zero and intervals below one minute', () => {
+        expect(() => parseInterval('0s')).toThrow('Interval must be at least 60 seconds')
+        expect(() => parseInterval('1s')).toThrow('Interval must be at least 60 seconds')
+        expect(() => parseInterval('59s')).toThrow('Interval must be at least 60 seconds')
+        expect(() => parseInterval('0m')).toThrow('Interval must be at least 60 seconds')
+        expect(() => parseInterval('0h')).toThrow('Interval must be at least 60 seconds')
+        expect(() => parseInterval('0d')).toThrow('Interval must be at least 60 seconds')
       })
 
       it('should handle large numbers', () => {
@@ -122,9 +123,9 @@ describe('intervalParser', () => {
 
     it('should handle seconds intervals', () => {
       const baseDate = new Date('2025-01-27T12:00:00Z')
-      const nextRun = calculateNextRunFromInterval('30s', baseDate)
+      const nextRun = calculateNextRunFromInterval('60s', baseDate)
       
-      expect(nextRun).toEqual(new Date('2025-01-27T12:00:30Z'))
+      expect(nextRun).toEqual(new Date('2025-01-27T12:01:00Z'))
     })
 
     it('should handle minute intervals', () => {
@@ -179,15 +180,19 @@ describe('intervalParser', () => {
 
   describe('validateInterval', () => {
     it('should return true for valid intervals', () => {
-      expect(validateInterval('30s')).toBe(true)
+      expect(validateInterval('60s')).toBe(true)
+      expect(validateInterval('1m')).toBe(true)
       expect(validateInterval('15m')).toBe(true)
       expect(validateInterval('2h')).toBe(true)
       expect(validateInterval('1d')).toBe(true)
-      expect(validateInterval('0s')).toBe(true)
       expect(validateInterval('999d')).toBe(true)
     })
 
     it('should return false for invalid intervals', () => {
+      expect(validateInterval('0s')).toBe(false)
+      expect(validateInterval('1s')).toBe(false)
+      expect(validateInterval('59s')).toBe(false)
+      expect(validateInterval('0m')).toBe(false)
       expect(validateInterval('invalid')).toBe(false)
       expect(validateInterval('')).toBe(false)
       expect(validateInterval('15')).toBe(false)
@@ -202,9 +207,8 @@ describe('intervalParser', () => {
   describe('intervalToHuman', () => {
     describe('seconds', () => {
       it('should convert seconds to human readable', () => {
-        expect(intervalToHuman('1s')).toBe('1 second')
-        expect(intervalToHuman('30s')).toBe('30 seconds')
-        expect(intervalToHuman('59s')).toBe('59 seconds')
+        expect(intervalToHuman('60s')).toBe('60 seconds')
+        expect(intervalToHuman('90s')).toBe('90 seconds')
       })
     })
 
@@ -251,15 +255,13 @@ describe('intervalParser', () => {
 
     describe('singular vs plural', () => {
       it('should use singular for 1', () => {
-        expect(intervalToHuman('1s')).toBe('1 second')
         expect(intervalToHuman('1m')).toBe('1 minute')
         expect(intervalToHuman('1h')).toBe('1 hour')
         expect(intervalToHuman('1d')).toBe('1 day')
       })
 
       it('should use plural for other numbers', () => {
-        expect(intervalToHuman('0s')).toBe('0 seconds')
-        expect(intervalToHuman('2s')).toBe('2 seconds')
+        expect(intervalToHuman('60s')).toBe('60 seconds')
         expect(intervalToHuman('2m')).toBe('2 minutes')
         expect(intervalToHuman('2h')).toBe('2 hours')
         expect(intervalToHuman('2d')).toBe('2 days')
@@ -272,17 +274,13 @@ describe('intervalParser', () => {
         expect(intervalToHuman('')).toBe('')
         expect(intervalToHuman('15')).toBe('15')
         expect(intervalToHuman('15x')).toBe('15x')
+        expect(intervalToHuman('0s')).toBe('0s')
+        expect(intervalToHuman('1s')).toBe('1s')
+        expect(intervalToHuman('59s')).toBe('59s')
       })
     })
 
     describe('edge cases', () => {
-      it('should handle zero', () => {
-        expect(intervalToHuman('0s')).toBe('0 seconds')
-        expect(intervalToHuman('0m')).toBe('0 seconds')
-        expect(intervalToHuman('0h')).toBe('0 seconds')
-        expect(intervalToHuman('0d')).toBe('0 seconds')
-      })
-
       it('should prefer larger units', () => {
         expect(intervalToHuman('60s')).toBe('60 seconds') // Not converted to minutes
         expect(intervalToHuman('60m')).toBe('1 hour') // Exactly 1 hour
@@ -300,7 +298,7 @@ describe('intervalParser', () => {
 
   describe('integration', () => {
     it('should work end-to-end for various intervals', () => {
-      const intervals = ['30s', '15m', '2h', '1d']
+      const intervals = ['60s', '15m', '2h', '1d']
       
       intervals.forEach(interval => {
         expect(validateInterval(interval)).toBe(true)

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/nextRunCalculator.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/nextRunCalculator.test.ts
@@ -73,9 +73,9 @@ describe('nextRunCalculator', () => {
 
       it('should handle seconds', () => {
         const fromDate = new Date('2025-01-27T12:00:00Z')
-        const result = calculateNextRun('interval', '30s', 'UTC', fromDate)
+        const result = calculateNextRun('interval', '60s', 'UTC', fromDate)
         
-        expect(result).toEqual(new Date('2025-01-27T12:00:30Z'))
+        expect(result).toEqual(new Date('2025-01-27T12:01:00Z'))
       })
 
       it('should handle minutes', () => {
@@ -223,10 +223,10 @@ describe('nextRunCalculator', () => {
       it('should handle various intervals', () => {
         const before = Date.now()
         
-        const result30s = recalculateNextRun('interval', '30s')
-        const diff30s = result30s!.getTime() - before
-        expect(diff30s).toBeGreaterThanOrEqual(30 * 1000 - 500)
-        expect(diff30s).toBeLessThanOrEqual(30 * 1000 + 500)
+        const result60s = recalculateNextRun('interval', '60s')
+        const diff60s = result60s!.getTime() - before
+        expect(diff60s).toBeGreaterThanOrEqual(60 * 1000 - 500)
+        expect(diff60s).toBeLessThanOrEqual(60 * 1000 + 500)
         
         const result15m = recalculateNextRun('interval', '15m')
         const diff15m = result15m!.getTime() - before
@@ -310,6 +310,12 @@ describe('nextRunCalculator', () => {
         
         expect(result).toBeNull()
       })
+
+      it('should reject interval values below one minute', () => {
+        expect(recalculateNextRun('interval', '0s')).toBeNull()
+        expect(recalculateNextRun('interval', '1s')).toBeNull()
+        expect(recalculateNextRun('interval', '59s')).toBeNull()
+      })
     })
   })
 
@@ -341,7 +347,7 @@ describe('nextRunCalculator', () => {
         { type: 'cron' as const, value: '0 0 * * *' }, // Daily at midnight
         { type: 'cron' as const, value: '*/5 * * * *' }, // Every 5 minutes
         { type: 'cron' as const, value: '0 9-17 * * 1-5' }, // Weekdays 9am-5pm
-        { type: 'interval' as const, value: '30s' },
+        { type: 'interval' as const, value: '60s' },
         { type: 'interval' as const, value: '15m' },
         { type: 'interval' as const, value: '2h' },
         { type: 'interval' as const, value: '1d' },

--- a/packages/scheduler/src/modules/scheduler/lib/activeScheduleLimits.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/activeScheduleLimits.ts
@@ -1,0 +1,32 @@
+import type { EntityManager } from '@mikro-orm/core'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { ScheduledJob } from '../data/entities.js'
+
+export const DEFAULT_MAX_ACTIVE_SCHEDULES_PER_TENANT = 100
+const ACTIVE_SCHEDULE_LIMIT_ENV = 'OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT'
+
+export function getMaxActiveSchedulesPerTenant(): number {
+  const parsed = Number.parseInt(process.env[ACTIVE_SCHEDULE_LIMIT_ENV] ?? '', 10)
+  if (Number.isFinite(parsed) && parsed > 0) return parsed
+  return DEFAULT_MAX_ACTIVE_SCHEDULES_PER_TENANT
+}
+
+export async function enforceTenantActiveScheduleLimit(
+  em: EntityManager,
+  tenantId: string | null | undefined,
+): Promise<void> {
+  if (!tenantId) return
+
+  const maxActiveSchedules = getMaxActiveSchedulesPerTenant()
+  const activeScheduleCount = await em.count(ScheduledJob, {
+    tenantId,
+    isEnabled: true,
+    deletedAt: null,
+  })
+
+  if (activeScheduleCount >= maxActiveSchedules) {
+    throw new CrudHttpError(422, {
+      error: `Active scheduled job limit reached for this tenant (${maxActiveSchedules}).`,
+    })
+  }
+}

--- a/packages/scheduler/src/modules/scheduler/lib/intervalParser.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/intervalParser.ts
@@ -1,6 +1,9 @@
 /**
  * Parse simple interval strings like '15m', '2h', '1d' into milliseconds
  */
+export const MIN_SCHEDULE_INTERVAL_MS = 60 * 1000
+const MIN_SCHEDULE_INTERVAL_SECONDS = MIN_SCHEDULE_INTERVAL_MS / 1000
+
 export function parseInterval(interval: string): number {
   const regex = /^(\d+)(s|m|h|d)$/
   const match = interval.match(regex)
@@ -19,7 +22,12 @@ export function parseInterval(interval: string): number {
     d: 24 * 60 * 60 * 1000, // days
   }
   
-  return value * multipliers[unit]
+  const milliseconds = value * multipliers[unit]
+  if (milliseconds < MIN_SCHEDULE_INTERVAL_MS) {
+    throw new Error(`Interval must be at least ${MIN_SCHEDULE_INTERVAL_SECONDS} seconds`)
+  }
+
+  return milliseconds
 }
 
 /**

--- a/packages/scheduler/src/modules/scheduler/services/__tests__/schedulerService.test.ts
+++ b/packages/scheduler/src/modules/scheduler/services/__tests__/schedulerService.test.ts
@@ -171,6 +171,34 @@ describe('SchedulerService', () => {
         timezone: 'America/New_York',
       }))
     })
+
+    it('should reject a new enabled tenant schedule when the tenant active cap is reached', async () => {
+      const originalLimit = process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT
+      process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT = '2'
+      try {
+        mockForkedEm.findOne.mockResolvedValue(null)
+        mockForkedEm.count.mockResolvedValue(2)
+
+        await expect(service.register({
+          ...baseRegistration,
+          scopeType: 'tenant',
+          tenantId: 'tenant-1',
+          scheduleType: 'interval',
+          scheduleValue: '15m',
+        })).rejects.toThrow('Active scheduled job limit reached')
+
+        expect(mockForkedEm.count).toHaveBeenCalledWith(ScheduledJob, {
+          tenantId: 'tenant-1',
+          isEnabled: true,
+          deletedAt: null,
+        })
+        expect(mockForkedEm.create).not.toHaveBeenCalled()
+        expect(mockForkedEm.flush).not.toHaveBeenCalled()
+      } finally {
+        if (originalLimit === undefined) delete process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT
+        else process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT = originalLimit
+      }
+    })
   })
 
   describe('unregister', () => {
@@ -364,6 +392,65 @@ describe('SchedulerService', () => {
       await service.update('test-1', { isEnabled: false })
 
       expect(mockBullMQService.unregister).toHaveBeenCalledWith('test-1')
+    })
+
+    it('should reject enabling a tenant schedule when the tenant active cap is reached', async () => {
+      const originalLimit = process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT
+      process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT = '2'
+      try {
+        const schedule = {
+          id: 'test-1',
+          tenantId: 'tenant-1',
+          organizationId: null,
+          scopeType: 'tenant',
+          isEnabled: false,
+          scheduleType: 'interval',
+          scheduleValue: '15m',
+          timezone: 'UTC',
+        } as ScheduledJob
+
+        mockForkedEm.findOne.mockResolvedValue(schedule)
+        mockForkedEm.count.mockResolvedValue(2)
+
+        await expect(service.update('test-1', { isEnabled: true })).rejects.toThrow('Active scheduled job limit reached')
+
+        expect(mockForkedEm.count).toHaveBeenCalledWith(ScheduledJob, {
+          tenantId: 'tenant-1',
+          isEnabled: true,
+          deletedAt: null,
+        })
+        expect(schedule.isEnabled).toBe(false)
+        expect(mockForkedEm.flush).not.toHaveBeenCalled()
+      } finally {
+        if (originalLimit === undefined) delete process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT
+        else process.env.OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT = originalLimit
+      }
+    })
+
+    it('should reject interval updates below one minute', async () => {
+      const nextRunAt = new Date('2026-01-01T00:15:00.000Z')
+      const schedule = {
+        id: 'test-1',
+        tenantId: 'tenant-1',
+        organizationId: null,
+        scopeType: 'tenant',
+        isEnabled: true,
+        scheduleType: 'interval',
+        scheduleValue: '15m',
+        timezone: 'UTC',
+        nextRunAt,
+      } as ScheduledJob
+
+      mockForkedEm.findOne.mockResolvedValue(schedule)
+
+      await expect(service.update('test-1', {
+        scheduleType: 'interval',
+        scheduleValue: '1s',
+      })).rejects.toThrow('Failed to calculate next run time')
+
+      expect(schedule.scheduleValue).toBe('15m')
+      expect(schedule.nextRunAt).toBe(nextRunAt)
+      expect(mockForkedEm.flush).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/scheduler/src/modules/scheduler/services/schedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/schedulerService.ts
@@ -1,6 +1,7 @@
 import type { EntityManager } from '@mikro-orm/core'
 import { ScheduledJob } from '../data/entities.js'
 import { calculateNextRun } from '../lib/nextRunCalculator.js'
+import { enforceTenantActiveScheduleLimit } from '../lib/activeScheduleLimits.js'
 import type { BullMQSchedulerService } from './bullmqSchedulerService.js'
 
 export interface ScheduleRegistration {
@@ -54,6 +55,12 @@ export class SchedulerService {
     
     // Check if schedule already exists
     let schedule = await em.findOne(ScheduledJob, { id: registration.id })
+    const nextTenantId = registration.tenantId || null
+    const nextIsEnabled = registration.isEnabled !== undefined ? registration.isEnabled : (schedule?.isEnabled ?? true)
+    const tenantChanged = schedule ? (schedule.tenantId || null) !== nextTenantId : false
+    if (nextIsEnabled && (schedule?.isEnabled !== true || tenantChanged)) {
+      await enforceTenantActiveScheduleLimit(em, nextTenantId)
+    }
     
     if (schedule) {
       // Update existing
@@ -162,6 +169,22 @@ export class SchedulerService {
     if (!schedule) {
       throw new Error(`Schedule not found: ${scheduleId}`)
     }
+
+    if (changes.isEnabled === true && schedule.isEnabled !== true) {
+      await enforceTenantActiveScheduleLimit(em, schedule.tenantId)
+    }
+
+    const scheduleChanged = changes.scheduleType !== undefined || changes.scheduleValue !== undefined || changes.timezone !== undefined
+    const nextRunAt = scheduleChanged
+      ? calculateNextRun(
+        changes.scheduleType ?? schedule.scheduleType,
+        changes.scheduleValue ?? schedule.scheduleValue,
+        changes.timezone ?? schedule.timezone,
+      )
+      : null
+    if (scheduleChanged && !nextRunAt) {
+      throw new Error(`Failed to calculate next run time for schedule: ${scheduleId}`)
+    }
     
     // Apply changes
     if (changes.name !== undefined) schedule.name = changes.name
@@ -194,16 +217,8 @@ export class SchedulerService {
       if (changes.targetCommand !== undefined) schedule.targetCommand = changes.targetCommand || null
     }
     
-    // Recalculate next run if schedule changed
-    if (changes.scheduleType !== undefined || changes.scheduleValue !== undefined || changes.timezone !== undefined) {
-      const nextRunAt = calculateNextRun(
-        schedule.scheduleType,
-        schedule.scheduleValue,
-        schedule.timezone
-      )
-      if (nextRunAt) {
-        schedule.nextRunAt = nextRunAt
-      }
+    if (nextRunAt) {
+      schedule.nextRunAt = nextRunAt
     }
     
     schedule.updatedAt = new Date()


### PR DESCRIPTION
## Summary

Rejects sub-minute scheduler intervals and caps active tenant schedules to prevent tenant-triggerable scheduler exhaustion.

## Changes

- Enforce a 60-second minimum interval in shared interval parsing, validators, API integration, command, and service paths.
- Add a per-tenant active scheduled-job cap with an `OM_SCHEDULER_MAX_ACTIVE_SCHEDULES_PER_TENANT` override.
- Validate prospective schedule updates before mutating persisted entities.
- Add regression coverage for sub-minute interval rejection and active schedule cap behavior.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor security fix, no spec needed)

**Spec file path:** N/A

## Testing

- `yarn generate`
- `yarn build:packages`
- `yarn workspace @open-mercato/scheduler test --runInBand`
- `yarn workspace @open-mercato/scheduler typecheck`
- `yarn test:integration:ephemeral --filter packages/scheduler/src/modules/scheduler/__integration__/TC-SCHED-007.spec.ts`
- `yarn lint`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- `git diff --check`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration coverage for the affected scheduler API path.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry, if applicable.
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

### Design System Compliance

No UI changes.

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3898