### PR TITLE
Fix scoped search reindex cancellation

### DIFF
--- a/packages/queue/src/__tests__/async.strategy.test.ts
+++ b/packages/queue/src/__tests__/async.strategy.test.ts
@@ -6,6 +6,7 @@ const workerCtor = jest.fn()
 const queueAdd = jest.fn(async () => ({ id: 'bull-job-id' }))
 const queueClose = jest.fn(async () => {})
 const queueObliterate = jest.fn(async () => {})
+const queueGetJobs = jest.fn(async () => [])
 const queueGetJobCounts = jest.fn(async () => ({
   waiting: 2,
   active: 1,
@@ -29,6 +30,7 @@ jest.mock('bullmq', () => {
     close = queueClose
     obliterate = queueObliterate
     getJobCounts = queueGetJobCounts
+    getJobs = queueGetJobs
   }
 
   class MockWorker<T> {
@@ -110,6 +112,52 @@ describe('Queue - async strategy', () => {
     )
 
     await queue.close()
+  })
+
+  it('removeQueuedJobsByScope removes only queued jobs matching tenant scope', async () => {
+    const removeMatching = jest.fn(async () => {})
+    const removeAutoIndex = jest.fn(async () => {})
+    const removeOtherOrg = jest.fn(async () => {})
+    const removeOtherTenant = jest.fn(async () => {})
+    queueGetJobs.mockResolvedValueOnce([
+      {
+        data: { payload: { tenantId: 'tenant-1', organizationId: 'org-1', jobType: 'batch-index', value: 1 } },
+        remove: removeMatching,
+      },
+      {
+        data: { payload: { tenantId: 'tenant-1', organizationId: 'org-1', jobType: 'index', value: 2 } },
+        remove: removeAutoIndex,
+      },
+      {
+        data: { payload: { tenantId: 'tenant-1', organizationId: 'org-2', value: 2 } },
+        remove: removeOtherOrg,
+      },
+      {
+        data: { payload: { tenantId: 'tenant-2', organizationId: 'org-1', value: 3 } },
+        remove: removeOtherTenant,
+      },
+    ])
+    const queue = createQueue<{ tenantId: string; organizationId?: string | null; value: number }>(
+      'test-queue',
+      'async',
+    )
+
+    const result = await queue.removeQueuedJobsByScope!({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      jobTypes: ['batch-index'],
+    })
+
+    expect(queueGetJobs).toHaveBeenCalledWith(
+      ['waiting', 'delayed', 'prioritized', 'paused', 'waiting-children'],
+      0,
+      -1,
+    )
+    expect(result.removed).toBe(1)
+    expect(removeMatching).toHaveBeenCalledTimes(1)
+    expect(removeAutoIndex).not.toHaveBeenCalled()
+    expect(removeOtherOrg).not.toHaveBeenCalled()
+    expect(removeOtherTenant).not.toHaveBeenCalled()
   })
 
   it('keeps structured Redis options when host-based config is used', async () => {

--- a/packages/queue/src/__tests__/local.strategy.test.ts
+++ b/packages/queue/src/__tests__/local.strategy.test.ts
@@ -107,6 +107,83 @@ describe('Queue - local strategy', () => {
     await queue.close()
   })
 
+  test('removeQueuedJobsByScope removes only matching tenant scoped jobs', async () => {
+    const queue = createQueue<{
+      tenantId?: string
+      organizationId?: string | null
+      jobType?: string
+      value: number
+    }>('test-queue', 'local')
+    const queuePath = path.join('.mercato', 'queue', 'test-queue', 'queue.json')
+
+    await queue.enqueue({ tenantId: 'tenant-1', organizationId: 'org-1', jobType: 'batch-index', value: 1 })
+    await queue.enqueue({ tenantId: 'tenant-1', organizationId: 'org-1', jobType: 'index', value: 2 })
+    await queue.enqueue({ tenantId: 'tenant-1', organizationId: 'org-2', jobType: 'batch-index', value: 3 })
+    await queue.enqueue({ tenantId: 'tenant-2', organizationId: 'org-1', jobType: 'batch-index', value: 4 })
+    await queue.enqueue({ tenantId: 'tenant-1', organizationId: null, jobType: 'batch-index', value: 5 })
+    await queue.enqueue({ jobType: 'batch-index', value: 6 })
+
+    const scopedResult = await queue.removeQueuedJobsByScope!({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      jobTypes: ['batch-index'],
+    })
+
+    expect(scopedResult.removed).toBe(1)
+    let remaining = readJson(queuePath)
+    expect(remaining.map((job: { payload: { value: number } }) => job.payload.value)).toEqual([2, 3, 4, 5, 6])
+
+    const tenantResult = await queue.removeQueuedJobsByScope!({ tenantId: 'tenant-1', jobTypes: ['batch-index'] })
+
+    expect(tenantResult.removed).toBe(2)
+    remaining = readJson(queuePath)
+    expect(remaining.map((job: { payload: { value: number } }) => job.payload.value)).toEqual([2, 4, 6])
+
+    await queue.close()
+  })
+
+  test('removeQueuedJobsByScope preserves in-flight local jobs', async () => {
+    const queue = createQueue<{
+      tenantId: string
+      organizationId: string
+      jobType: string
+      value: number
+    }>('test-queue', 'local')
+    const queuePath = path.join('.mercato', 'queue', 'test-queue', 'queue.json')
+    let release!: () => void
+    const releasePromise = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let started!: () => void
+    const startedPromise = new Promise<void>((resolve) => {
+      started = resolve
+    })
+
+    await queue.enqueue({ tenantId: 'tenant-1', organizationId: 'org-1', jobType: 'batch-index', value: 1 })
+    await queue.enqueue({ tenantId: 'tenant-1', organizationId: 'org-1', jobType: 'batch-index', value: 2 })
+    const processing = queue.process(async () => {
+      started()
+      await releasePromise
+    }, { limit: 1 })
+
+    await startedPromise
+    const result = await queue.removeQueuedJobsByScope!({
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      jobTypes: ['batch-index'],
+    })
+
+    expect(result.removed).toBe(1)
+    let remaining = readJson(queuePath)
+    expect(remaining.map((job: { payload: { value: number } }) => job.payload.value)).toEqual([1])
+
+    release()
+    await processing
+    remaining = readJson(queuePath)
+    expect(remaining).toEqual([])
+    await queue.close()
+  })
+
   test('getJobCounts returns correct counts', async () => {
     const queue = createQueue<{ value: number }>('test-queue', 'local')
 

--- a/packages/queue/src/strategies/async.ts
+++ b/packages/queue/src/strategies/async.ts
@@ -1,4 +1,4 @@
-import type { Queue, QueuedJob, JobHandler, AsyncQueueOptions, ProcessResult, EnqueueOptions } from '../types'
+import type { Queue, QueuedJob, JobHandler, AsyncQueueOptions, ProcessResult, EnqueueOptions, QueueJobScope } from '../types'
 import { getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/connection'
 
 // BullMQ interface types - we define the shape we use to maintain type safety
@@ -28,6 +28,10 @@ interface BullQueueInterface<T> {
   obliterate: (opts?: { force?: boolean }) => Promise<void>
   close: () => Promise<void>
   getJobCounts: (...states: string[]) => Promise<Record<string, number>>
+  getJobs: (types: string[], start?: number, end?: number) => Promise<Array<{
+    data?: T
+    remove: () => Promise<void>
+  }>>
 }
 
 interface BullWorkerInterface {
@@ -42,6 +46,21 @@ interface BullMQModule {
     processor: (job: { id?: string; data: T; attemptsMade: number }) => Promise<void>,
     opts: { connection: ConnectionOptions; concurrency: number }
   ) => BullWorkerInterface
+}
+
+const REMOVABLE_JOB_STATES = ['waiting', 'delayed', 'prioritized', 'paused', 'waiting-children']
+
+function payloadMatchesScope(payload: unknown, scope: QueueJobScope): boolean {
+  if (!payload || typeof payload !== 'object') return false
+  const scopedPayload = payload as { tenantId?: unknown; organizationId?: unknown; jobType?: unknown }
+  if (scopedPayload.tenantId !== scope.tenantId) return false
+  if (scope.organizationId !== undefined) {
+    if ((scopedPayload.organizationId ?? null) !== scope.organizationId) return false
+  }
+  if (scope.jobTypes?.length) {
+    return typeof scopedPayload.jobType === 'string' && scope.jobTypes.includes(scopedPayload.jobType)
+  }
+  return true
 }
 
 /**
@@ -195,6 +214,25 @@ export function createAsyncQueue<T = unknown>(
     return { removed: -1 } // BullMQ obliterate doesn't return count
   }
 
+  async function removeQueuedJobsByScope(scope: QueueJobScope): Promise<{ removed: number }> {
+    const queue = await getQueue()
+    const jobs = await queue.getJobs(REMOVABLE_JOB_STATES, 0, -1)
+    let removed = 0
+
+    for (const job of jobs) {
+      if (!payloadMatchesScope(job.data?.payload, scope)) continue
+      try {
+        await job.remove()
+        removed++
+      } catch {
+        // The job may have started between enumeration and removal. In-flight
+        // cancellation is handled by the caller's lock/heartbeat contract.
+      }
+    }
+
+    return { removed }
+  }
+
   async function close(): Promise<void> {
     if (bullWorker) {
       await bullWorker.close()
@@ -228,6 +266,7 @@ export function createAsyncQueue<T = unknown>(
     enqueue,
     process,
     clear,
+    removeQueuedJobsByScope,
     close,
     getJobCounts,
   }

--- a/packages/queue/src/strategies/local.ts
+++ b/packages/queue/src/strategies/local.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import crypto from 'node:crypto'
-import type { Queue, QueuedJob, JobHandler, LocalQueueOptions, ProcessOptions, ProcessResult, EnqueueOptions } from '../types'
+import type { Queue, QueuedJob, JobHandler, LocalQueueOptions, ProcessOptions, ProcessResult, EnqueueOptions, QueueJobScope } from '../types'
 
 type LocalState = {
   lastProcessedId?: string
@@ -12,6 +12,19 @@ type LocalState = {
 type StoredJob<T> = QueuedJob<T> & {
   availableAt?: string
   attemptCount?: number
+}
+
+function payloadMatchesScope(payload: unknown, scope: QueueJobScope): boolean {
+  if (!payload || typeof payload !== 'object') return false
+  const scopedPayload = payload as { tenantId?: unknown; organizationId?: unknown; jobType?: unknown }
+  if (scopedPayload.tenantId !== scope.tenantId) return false
+  if (scope.organizationId !== undefined) {
+    if ((scopedPayload.organizationId ?? null) !== scope.organizationId) return false
+  }
+  if (scope.jobTypes?.length) {
+    return typeof scopedPayload.jobType === 'string' && scope.jobTypes.includes(scopedPayload.jobType)
+  }
+  return true
 }
 
 /** Default polling interval in milliseconds */
@@ -65,6 +78,7 @@ export function createLocalQueue<T = unknown>(
   let pollingTimer: ReturnType<typeof setInterval> | null = null
   let isProcessing = false
   let activeHandler: JobHandler<T> | null = null
+  const inFlightJobIds = new Set<string>()
 
   // Per-queue mutex. Serializes read-modify-write segments so async fs calls
   // cannot interleave and clobber each other's writes.
@@ -213,6 +227,10 @@ export function createLocalQueue<T = unknown>(
       ? pendingJobs.slice(0, options.limit)
       : pendingJobs
 
+    for (const job of jobsToProcess) {
+      inFlightJobIds.add(job.id)
+    }
+
     let processed = 0
     let failed = 0
     let lastJobId: string | undefined
@@ -220,58 +238,64 @@ export function createLocalQueue<T = unknown>(
     const deadJobIds = new Set<string>()
     const retryUpdates = new Map<string, StoredJob<T>>()
 
-    for (const job of jobsToProcess) {
-      const attemptNumber = (job.attemptCount ?? 0) + 1
-      try {
-        await Promise.resolve(
-          handler(job, {
-            jobId: job.id,
-            attemptNumber,
-            queueName: name,
-          })
-        )
-        processed++
-        lastJobId = job.id
-        completedJobIds.add(job.id)
-        console.log(`[queue:${name}] Job ${job.id} completed`)
-      } catch (error) {
-        console.error(`[queue:${name}] Job ${job.id} failed (attempt ${attemptNumber}/${DEFAULT_MAX_ATTEMPTS}):`, error)
-        failed++
-        lastJobId = job.id
-        if (attemptNumber >= DEFAULT_MAX_ATTEMPTS) {
-          console.error(`[queue:${name}] Job ${job.id} exhausted all ${DEFAULT_MAX_ATTEMPTS} attempts, moving to dead letter`)
-          deadJobIds.add(job.id)
-        } else {
-          const backoffMs = RETRY_BACKOFF_BASE_MS * Math.pow(2, attemptNumber - 1)
-          retryUpdates.set(job.id, {
-            ...job,
-            attemptCount: attemptNumber,
-            availableAt: new Date(Date.now() + backoffMs).toISOString(),
-          })
+    try {
+      for (const job of jobsToProcess) {
+        const attemptNumber = (job.attemptCount ?? 0) + 1
+        try {
+          await Promise.resolve(
+            handler(job, {
+              jobId: job.id,
+              attemptNumber,
+              queueName: name,
+            })
+          )
+          processed++
+          lastJobId = job.id
+          completedJobIds.add(job.id)
+          console.log(`[queue:${name}] Job ${job.id} completed`)
+        } catch (error) {
+          console.error(`[queue:${name}] Job ${job.id} failed (attempt ${attemptNumber}/${DEFAULT_MAX_ATTEMPTS}):`, error)
+          failed++
+          lastJobId = job.id
+          if (attemptNumber >= DEFAULT_MAX_ATTEMPTS) {
+            console.error(`[queue:${name}] Job ${job.id} exhausted all ${DEFAULT_MAX_ATTEMPTS} attempts, moving to dead letter`)
+            deadJobIds.add(job.id)
+          } else {
+            const backoffMs = RETRY_BACKOFF_BASE_MS * Math.pow(2, attemptNumber - 1)
+            retryUpdates.set(job.id, {
+              ...job,
+              attemptCount: attemptNumber,
+              availableAt: new Date(Date.now() + backoffMs).toISOString(),
+            })
+          }
         }
       }
+
+      const hasChanges = completedJobIds.size > 0 || deadJobIds.size > 0 || retryUpdates.size > 0
+      if (hasChanges) {
+        await withFileLock(async () => {
+          // Re-read so jobs enqueued during handler execution are preserved.
+          const currentJobs = await readQueue()
+          const updatedJobs = currentJobs
+            .filter((j) => !completedJobIds.has(j.id) && !deadJobIds.has(j.id))
+            .map((j) => retryUpdates.get(j.id) ?? j)
+          await writeQueue(updatedJobs)
+
+          const newState: LocalState = {
+            lastProcessedId: lastJobId,
+            completedCount: (state.completedCount ?? 0) + processed,
+            failedCount: (state.failedCount ?? 0) + deadJobIds.size,
+          }
+          await writeState(newState)
+        })
+      }
+
+      return { processed, failed, lastJobId }
+    } finally {
+      for (const job of jobsToProcess) {
+        inFlightJobIds.delete(job.id)
+      }
     }
-
-    const hasChanges = completedJobIds.size > 0 || deadJobIds.size > 0 || retryUpdates.size > 0
-    if (hasChanges) {
-      await withFileLock(async () => {
-        // Re-read so jobs enqueued during handler execution are preserved.
-        const currentJobs = await readQueue()
-        const updatedJobs = currentJobs
-          .filter((j) => !completedJobIds.has(j.id) && !deadJobIds.has(j.id))
-          .map((j) => retryUpdates.get(j.id) ?? j)
-        await writeQueue(updatedJobs)
-
-        const newState: LocalState = {
-          lastProcessedId: lastJobId,
-          completedCount: (state.completedCount ?? 0) + processed,
-          failedCount: (state.failedCount ?? 0) + deadJobIds.size,
-        }
-        await writeState(newState)
-      })
-    }
-
-    return { processed, failed, lastJobId }
   }
 
   /**
@@ -334,6 +358,18 @@ export function createLocalQueue<T = unknown>(
     })
   }
 
+  async function removeQueuedJobsByScope(scope: QueueJobScope): Promise<{ removed: number }> {
+    return withFileLock(async () => {
+      const jobs = await readQueue()
+      const retainedJobs = jobs.filter((job) => inFlightJobIds.has(job.id) || !payloadMatchesScope(job.payload, scope))
+      const removed = jobs.length - retainedJobs.length
+      if (removed > 0) {
+        await writeQueue(retainedJobs)
+      }
+      return { removed }
+    })
+  }
+
   async function close(): Promise<void> {
     // Stop polling timer
     if (pollingTimer) {
@@ -380,6 +416,7 @@ export function createLocalQueue<T = unknown>(
     enqueue,
     process,
     clear,
+    removeQueuedJobsByScope,
     close,
     getJobCounts,
   }

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -135,6 +135,12 @@ export type ProcessResult = {
   lastJobId?: string
 }
 
+export type QueueJobScope = {
+  tenantId: string
+  organizationId?: string | null
+  jobTypes?: readonly string[]
+}
+
 // ============================================================================
 // Queue Interface
 // ============================================================================
@@ -174,6 +180,13 @@ export interface Queue<T = unknown> {
    * @returns Promise with count of removed jobs
    */
   clear(): Promise<{ removed: number }>
+
+  /**
+   * Remove queued jobs whose payload belongs to the provided tenant/org scope.
+   * Active jobs are not forcibly terminated; callers should rely on their own
+   * cancellation/heartbeat contracts for in-flight work.
+   */
+  removeQueuedJobsByScope?(scope: QueueJobScope): Promise<{ removed: number }>
 
   /**
    * Close the queue and release resources.

--- a/packages/search/src/modules/search/api/__tests__/embeddings-reindex.routes.test.ts
+++ b/packages/search/src/modules/search/api/__tests__/embeddings-reindex.routes.test.ts
@@ -35,13 +35,16 @@ jest.mock('../../lib/reindex-lock', () => ({
 const mockEnsureReindexProgressJob = jest.fn().mockResolvedValue('progress-1')
 const mockCompleteReindexProgress = jest.fn().mockResolvedValue(undefined)
 const mockFailReindexProgress = jest.fn().mockResolvedValue(undefined)
+const mockCancelReindexProgress = jest.fn().mockResolvedValue(undefined)
 jest.mock('../../lib/reindex-progress', () => ({
   ensureReindexProgressJob: (...args: unknown[]) => mockEnsureReindexProgressJob(...args),
   completeReindexProgress: (...args: unknown[]) => mockCompleteReindexProgress(...args),
   failReindexProgress: (...args: unknown[]) => mockFailReindexProgress(...args),
+  cancelReindexProgress: (...args: unknown[]) => mockCancelReindexProgress(...args),
 }))
 
 import { POST as vectorReindexPost } from '../embeddings/reindex/route'
+import { POST as vectorReindexCancelPost } from '../embeddings/reindex/cancel/route'
 
 describe('POST /api/search/embeddings/reindex', () => {
   beforeEach(() => {
@@ -125,6 +128,110 @@ describe('POST /api/search/embeddings/reindex', () => {
     )
     expect(mockFailReindexProgress).not.toHaveBeenCalled()
     expect(mockClearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'vector', 'org-456')
+    expect(mockContainer.dispose).toHaveBeenCalled()
+  })
+
+  test('cancel removes only current tenant and organization vector queue jobs', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({
+      tenantId: 'tenant-123',
+      orgId: 'org-456',
+      sub: 'user-789',
+    })
+
+    const mockDb = { db: true }
+    const mockEm = { getKysely: jest.fn(() => mockDb) }
+    const mockProgressService = { progress: true }
+    const mockQueue = {
+      getJobCounts: jest.fn().mockResolvedValue({ waiting: 3, active: 1, completed: 0, failed: 0 }),
+      clear: jest.fn().mockResolvedValue({ removed: 4 }),
+      removeQueuedJobsByScope: jest.fn().mockResolvedValue({ removed: 2 }),
+    }
+    const mockContainer = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return mockEm
+        if (name === 'progressService') return mockProgressService
+        if (name === 'vectorIndexQueue') return mockQueue
+        throw new Error(`Unknown service: ${name}`)
+      }),
+      dispose: jest.fn().mockResolvedValue(undefined),
+    }
+    mockCreateRequestContainer.mockResolvedValue(mockContainer)
+
+    const res = await vectorReindexCancelPost(new Request(
+      'http://localhost/api/search/embeddings/reindex/cancel',
+      { method: 'POST' },
+    ))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true, jobsRemoved: 2 })
+    expect(mockQueue.removeQueuedJobsByScope).toHaveBeenCalledWith({
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      jobTypes: ['batch-index'],
+    })
+    expect(mockQueue.clear).not.toHaveBeenCalled()
+    expect(mockClearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'vector', 'org-456')
+    expect(mockCancelReindexProgress).toHaveBeenCalledWith(expect.objectContaining({
+      em: mockEm,
+      progressService: mockProgressService,
+      type: 'vector',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      userId: 'user-789',
+    }))
+    expect(mockRecordIndexerLog).toHaveBeenCalledWith(
+      { em: mockEm },
+      expect.objectContaining({
+        source: 'vector',
+        details: { jobsRemoved: 2 },
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+      }),
+    )
+    expect(mockContainer.dispose).toHaveBeenCalled()
+  })
+
+  test('cancel fails closed when scoped vector queue removal fails', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({
+      tenantId: 'tenant-123',
+      orgId: 'org-456',
+      sub: 'user-789',
+    })
+
+    const mockDb = { db: true }
+    const mockEm = { getKysely: jest.fn(() => mockDb) }
+    const mockQueue = {
+      clear: jest.fn().mockResolvedValue({ removed: 4 }),
+      removeQueuedJobsByScope: jest.fn().mockRejectedValue(new Error('redis unavailable')),
+    }
+    const mockContainer = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return mockEm
+        if (name === 'progressService') return { progress: true }
+        if (name === 'vectorIndexQueue') return mockQueue
+        throw new Error(`Unknown service: ${name}`)
+      }),
+      dispose: jest.fn().mockResolvedValue(undefined),
+    }
+    mockCreateRequestContainer.mockResolvedValue(mockContainer)
+
+    const res = await vectorReindexCancelPost(new Request(
+      'http://localhost/api/search/embeddings/reindex/cancel',
+      { method: 'POST' },
+    ))
+    const body = await res.json()
+
+    expect(res.status).toBe(503)
+    expect(body.error).toBe('Failed to cancel queued reindex jobs.')
+    expect(mockQueue.removeQueuedJobsByScope).toHaveBeenCalledWith({
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      jobTypes: ['batch-index'],
+    })
+    expect(mockQueue.clear).not.toHaveBeenCalled()
+    expect(mockClearReindexLock).not.toHaveBeenCalled()
+    expect(mockCancelReindexProgress).not.toHaveBeenCalled()
     expect(mockContainer.dispose).toHaveBeenCalled()
   })
 })

--- a/packages/search/src/modules/search/api/__tests__/reindex.routes.test.ts
+++ b/packages/search/src/modules/search/api/__tests__/reindex.routes.test.ts
@@ -35,13 +35,16 @@ jest.mock('../../lib/reindex-lock', () => ({
 const mockEnsureReindexProgressJob = jest.fn().mockResolvedValue('progress-1')
 const mockCompleteReindexProgress = jest.fn().mockResolvedValue(undefined)
 const mockFailReindexProgress = jest.fn().mockResolvedValue(undefined)
+const mockCancelReindexProgress = jest.fn().mockResolvedValue(undefined)
 jest.mock('../../lib/reindex-progress', () => ({
   ensureReindexProgressJob: (...args: unknown[]) => mockEnsureReindexProgressJob(...args),
   completeReindexProgress: (...args: unknown[]) => mockCompleteReindexProgress(...args),
   failReindexProgress: (...args: unknown[]) => mockFailReindexProgress(...args),
+  cancelReindexProgress: (...args: unknown[]) => mockCancelReindexProgress(...args),
 }))
 
 import { POST as fulltextReindexPost } from '../reindex/route'
+import { POST as fulltextReindexCancelPost } from '../reindex/cancel/route'
 
 function mockAuth() {
   mockGetAuthFromRequest.mockResolvedValue({
@@ -160,6 +163,90 @@ describe('POST /api/search/reindex', () => {
       }),
     )
     expect(mockClearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 'org-456')
+    expect(mockContainer.dispose).toHaveBeenCalled()
+  })
+
+  test('cancel removes only current tenant and organization fulltext queue jobs', async () => {
+    const mockDb = { db: true }
+    const mockEm = { getKysely: jest.fn(() => mockDb) }
+    const mockQueue = {
+      getJobCounts: jest.fn().mockResolvedValue({ waiting: 3, active: 1, completed: 0, failed: 0 }),
+      clear: jest.fn().mockResolvedValue({ removed: 4 }),
+      removeQueuedJobsByScope: jest.fn().mockResolvedValue({ removed: 2 }),
+    }
+    const mockProgressService = { progress: true }
+    const mockContainer = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return mockEm
+        if (name === 'progressService') return mockProgressService
+        if (name === 'fulltextIndexQueue') return mockQueue
+        throw new Error(`Unknown service: ${name}`)
+      }),
+      dispose: jest.fn().mockResolvedValue(undefined),
+    }
+    mockCreateRequestContainer.mockResolvedValue(mockContainer)
+
+    const res = await fulltextReindexCancelPost(new Request('http://localhost/api/search/reindex/cancel', {
+      method: 'POST',
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toEqual({ ok: true, jobsRemoved: 2 })
+    expect(mockQueue.removeQueuedJobsByScope).toHaveBeenCalledWith({
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      jobTypes: ['batch-index'],
+    })
+    expect(mockQueue.clear).not.toHaveBeenCalled()
+    expect(mockClearReindexLock).toHaveBeenCalledWith(mockDb, 'tenant-123', 'fulltext', 'org-456')
+    expect(mockCancelReindexProgress).toHaveBeenCalledWith(expect.objectContaining({
+      em: mockEm,
+      progressService: mockProgressService,
+      type: 'fulltext',
+      tenantId: 'tenant-123',
+      organizationId: 'org-456',
+      userId: 'user-789',
+    }))
+    expect(mockRecordIndexerLog).toHaveBeenCalledWith(
+      { em: mockEm },
+      expect.objectContaining({
+        source: 'fulltext',
+        details: { jobsRemoved: 2 },
+        tenantId: 'tenant-123',
+        organizationId: 'org-456',
+      }),
+    )
+    expect(mockContainer.dispose).toHaveBeenCalled()
+  })
+
+  test('cancel fails closed when scoped fulltext queue removal is unavailable', async () => {
+    const mockDb = { db: true }
+    const mockEm = { getKysely: jest.fn(() => mockDb) }
+    const mockQueue = {
+      clear: jest.fn().mockResolvedValue({ removed: 4 }),
+    }
+    const mockContainer = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return mockEm
+        if (name === 'progressService') return { progress: true }
+        if (name === 'fulltextIndexQueue') return mockQueue
+        throw new Error(`Unknown service: ${name}`)
+      }),
+      dispose: jest.fn().mockResolvedValue(undefined),
+    }
+    mockCreateRequestContainer.mockResolvedValue(mockContainer)
+
+    const res = await fulltextReindexCancelPost(new Request('http://localhost/api/search/reindex/cancel', {
+      method: 'POST',
+    }))
+    const body = await res.json()
+
+    expect(res.status).toBe(503)
+    expect(body.error).toBe('Scoped queue cancellation is not available.')
+    expect(mockQueue.clear).not.toHaveBeenCalled()
+    expect(mockClearReindexLock).not.toHaveBeenCalled()
+    expect(mockCancelReindexProgress).not.toHaveBeenCalled()
     expect(mockContainer.dispose).toHaveBeenCalled()
   })
 })

--- a/packages/search/src/modules/search/api/embeddings/reindex/cancel/route.ts
+++ b/packages/search/src/modules/search/api/embeddings/reindex/cancel/route.ts
@@ -12,6 +12,17 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
 import { embeddingsReindexCancelOpenApi } from '../../../openapi'
 
+async function disposeContainer(container: unknown): Promise<void> {
+  try {
+    const disposable = container as { dispose?: () => Promise<void> }
+    if (typeof disposable.dispose === 'function') {
+      await disposable.dispose()
+    }
+  } catch {
+    // Ignore disposal errors
+  }
+}
+
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['search.embeddings.manage'] },
 }
@@ -37,12 +48,24 @@ export async function POST(req: Request) {
 
   let jobsRemoved = 0
   if (queue) {
+    if (typeof queue.removeQueuedJobsByScope !== 'function') {
+      await disposeContainer(container)
+      return NextResponse.json({
+        error: t('search.api.errors.scopedQueueCancelUnavailable', 'Scoped queue cancellation is not available.'),
+      }, { status: 503 })
+    }
+
     try {
-      const countsBefore = await queue.getJobCounts()
-      jobsRemoved = countsBefore.waiting + countsBefore.active
-      await queue.clear()
+      const scope = typeof auth.orgId === 'string'
+        ? { tenantId: auth.tenantId, organizationId: auth.orgId, jobTypes: ['batch-index'] }
+        : { tenantId: auth.tenantId, jobTypes: ['batch-index'] }
+      const result = await queue.removeQueuedJobsByScope(scope)
+      jobsRemoved = result.removed
     } catch {
-      // Queue clear failed - continue to clear lock
+      await disposeContainer(container)
+      return NextResponse.json({
+        error: t('search.api.errors.scopedQueueCancelFailed', 'Failed to cancel queued reindex jobs.'),
+      }, { status: 503 })
     }
   }
 
@@ -74,14 +97,7 @@ export async function POST(req: Request) {
     // Logging failure should not fail the cancel operation
   }
 
-  try {
-    const disposable = container as unknown as { dispose?: () => Promise<void> }
-    if (typeof disposable.dispose === 'function') {
-      await disposable.dispose()
-    }
-  } catch {
-    // Ignore disposal errors
-  }
+  await disposeContainer(container)
 
   return NextResponse.json({
     ok: true,

--- a/packages/search/src/modules/search/api/reindex/cancel/route.ts
+++ b/packages/search/src/modules/search/api/reindex/cancel/route.ts
@@ -12,6 +12,17 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
 import { reindexCancelOpenApi } from '../../openapi'
 
+async function disposeContainer(container: unknown): Promise<void> {
+  try {
+    const disposable = container as { dispose?: () => Promise<void> }
+    if (typeof disposable.dispose === 'function') {
+      await disposable.dispose()
+    }
+  } catch {
+    // Ignore disposal errors
+  }
+}
+
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['search.reindex'] },
 }
@@ -37,12 +48,24 @@ export async function POST(req: Request) {
 
   let jobsRemoved = 0
   if (queue) {
+    if (typeof queue.removeQueuedJobsByScope !== 'function') {
+      await disposeContainer(container)
+      return NextResponse.json({
+        error: t('search.api.errors.scopedQueueCancelUnavailable', 'Scoped queue cancellation is not available.'),
+      }, { status: 503 })
+    }
+
     try {
-      const countsBefore = await queue.getJobCounts()
-      jobsRemoved = countsBefore.waiting + countsBefore.active
-      await queue.clear()
+      const scope = typeof auth.orgId === 'string'
+        ? { tenantId: auth.tenantId, organizationId: auth.orgId, jobTypes: ['batch-index'] }
+        : { tenantId: auth.tenantId, jobTypes: ['batch-index'] }
+      const result = await queue.removeQueuedJobsByScope(scope)
+      jobsRemoved = result.removed
     } catch {
-      // Queue clear failed - continue to clear lock
+      await disposeContainer(container)
+      return NextResponse.json({
+        error: t('search.api.errors.scopedQueueCancelFailed', 'Failed to cancel queued reindex jobs.'),
+      }, { status: 503 })
     }
   }
 
@@ -74,14 +97,7 @@ export async function POST(req: Request) {
     // Logging failure should not fail the cancel operation
   }
 
-  try {
-    const disposable = container as unknown as { dispose?: () => Promise<void> }
-    if (typeof disposable.dispose === 'function') {
-      await disposable.dispose()
-    }
-  } catch {
-    // Ignore disposal errors
-  }
+  await disposeContainer(container)
 
   return NextResponse.json({
     ok: true,

--- a/packages/search/src/modules/search/i18n/de.json
+++ b/packages/search/src/modules/search/i18n/de.json
@@ -17,6 +17,8 @@
   "search.api.errors.recreateFailed": "Fehler beim Neuerstellen der Vektortabelle mit neuer Dimension.",
   "search.api.errors.reindexFailed": "Neuindizierung fehlgeschlagen.",
   "search.api.errors.reindexInProgress": "Eine Neuindizierung wird bereits durchgeführt.",
+  "search.api.errors.scopedQueueCancelFailed": "Die eingereihten Reindexierungsaufträge konnten nicht abgebrochen werden.",
+  "search.api.errors.scopedQueueCancelUnavailable": "Die bereichsbezogene Warteschlangenstornierung ist nicht verfügbar.",
   "search.api.errors.searchFailed": "Suchvorgang fehlgeschlagen.",
   "search.api.errors.serviceUnavailable": "Suchdienst ist nicht verfügbar.",
   "search.api.errors.strategyUnavailable": "Angeforderte Suchstrategie ist nicht verfügbar.",

--- a/packages/search/src/modules/search/i18n/en.json
+++ b/packages/search/src/modules/search/i18n/en.json
@@ -17,6 +17,8 @@
   "search.api.errors.recreateFailed": "Failed to recreate vector table with new dimension.",
   "search.api.errors.reindexFailed": "Reindex operation failed.",
   "search.api.errors.reindexInProgress": "A reindex is already in progress.",
+  "search.api.errors.scopedQueueCancelFailed": "Failed to cancel queued reindex jobs.",
+  "search.api.errors.scopedQueueCancelUnavailable": "Scoped queue cancellation is not available.",
   "search.api.errors.searchFailed": "Search operation failed.",
   "search.api.errors.serviceUnavailable": "Search service is unavailable.",
   "search.api.errors.strategyUnavailable": "Requested search strategy is unavailable.",

--- a/packages/search/src/modules/search/i18n/es.json
+++ b/packages/search/src/modules/search/i18n/es.json
@@ -17,6 +17,8 @@
   "search.api.errors.recreateFailed": "No se pudo recrear la tabla vectorial con la nueva dimensión.",
   "search.api.errors.reindexFailed": "La operación de reindexación falló.",
   "search.api.errors.reindexInProgress": "Ya hay una reindexación en progreso.",
+  "search.api.errors.scopedQueueCancelFailed": "No se pudieron cancelar los trabajos de reindexación en cola.",
+  "search.api.errors.scopedQueueCancelUnavailable": "La cancelación de cola con alcance no está disponible.",
   "search.api.errors.searchFailed": "La operación de búsqueda falló.",
   "search.api.errors.serviceUnavailable": "El servicio de búsqueda no está disponible.",
   "search.api.errors.strategyUnavailable": "La estrategia de búsqueda solicitada no está disponible.",

--- a/packages/search/src/modules/search/i18n/pl.json
+++ b/packages/search/src/modules/search/i18n/pl.json
@@ -17,6 +17,8 @@
   "search.api.errors.recreateFailed": "Nie udało się odtworzyć tabeli wektorowej z nowym wymiarem.",
   "search.api.errors.reindexFailed": "Operacja reindeksacji nie powiodła się.",
   "search.api.errors.reindexInProgress": "Reindeksacja jest już w toku.",
+  "search.api.errors.scopedQueueCancelFailed": "Nie udało się anulować zakolejkowanych zadań reindeksacji.",
+  "search.api.errors.scopedQueueCancelUnavailable": "Zakresowe anulowanie kolejki jest niedostępne.",
   "search.api.errors.searchFailed": "Operacja wyszukiwania nie powiodła się.",
   "search.api.errors.serviceUnavailable": "Usługa wyszukiwania jest niedostępna.",
   "search.api.errors.strategyUnavailable": "Żądana strategia wyszukiwania jest niedostępna.",


### PR DESCRIPTION
## Summary

Fixes #3900.

Search reindex cancellation no longer clears the entire shared fulltext/vector queue. Cancel now removes only queued `batch-index` reindex jobs for the authenticated tenant and organization, and fails closed when scoped queue removal is unavailable or fails.

## Changes

- Add scoped queued-job removal to local and async queue strategies.
- Preserve same-scope normal auto-index jobs by filtering cancellation to `jobType: batch-index`.
- Keep local in-flight jobs out of scoped removal so retry/completion bookkeeping remains intact.
- Make fulltext/vector reindex cancel routes return 503 instead of clearing locks when scoped removal cannot safely run.
- Add regression coverage for scoped removal, same-tenant non-reindex job preservation, unavailable removal, failed removal, and local in-flight preservation.
- Add localized API error strings for scoped queue cancellation failures.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor bug fix, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn workspace @open-mercato/queue test packages/queue/src/__tests__/local.strategy.test.ts packages/queue/src/__tests__/async.strategy.test.ts --runInBand`
- `yarn workspace @open-mercato/search test packages/search/src/modules/search/api/__tests__/reindex.routes.test.ts packages/search/src/modules/search/api/__tests__/embeddings-reindex.routes.test.ts --runInBand`
- `yarn workspace @open-mercato/queue typecheck`
- `yarn workspace @open-mercato/search typecheck`
- `yarn workspace @open-mercato/queue build`
- `yarn workspace @open-mercato/search build`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn build:packages`
- `yarn typecheck`
- `yarn test`
- `yarn lint`
- `yarn build:app`

Integration coverage in `.ai/qa/tests/` is not required because this is a backend queue cancellation bug covered by focused queue and route regression tests, with no UI workflow change.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3900