### PR TITLE
fix: enforce sales document history ACL

### DIFF
--- a/packages/core/src/modules/sales/api/__tests__/document-history.route.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/document-history.route.test.ts
@@ -1,0 +1,106 @@
+/** @jest-environment node */
+
+const mockRbac = {
+  userHasAllFeatures: jest.fn(),
+}
+const mockActionLogService = {
+  list: jest.fn(),
+}
+const mockEm = {
+  fork: jest.fn(() => mockEm),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => {
+      if (token === 'rbacService') return mockRbac
+      if (token === 'actionLogService') return mockActionLogService
+      if (token === 'em') return mockEm
+      return null
+    },
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+}))
+
+jest.mock('@open-mercato/core/modules/audit_logs/api/audit-logs/display', () => ({
+  loadAuditLogDisplayMaps: jest.fn(async () => ({ users: new Map() })),
+}))
+
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { GET } from '../document-history/route'
+
+const DOCUMENT_ID = '22222222-2222-4222-8222-222222222222'
+
+function requestFor(kind: 'order' | 'quote') {
+  return new Request(`http://localhost/api/sales/document-history?kind=${kind}&id=${DOCUMENT_ID}`)
+}
+
+describe('sales document-history route authorization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: 'org-1',
+      allowedIds: ['org-1'],
+      filterIds: ['org-1'],
+    })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+    mockActionLogService.list.mockResolvedValue({ items: [] })
+  })
+
+  it.each([
+    ['order', 'sales.orders.view'],
+    ['quote', 'sales.quotes.view'],
+  ] as const)('requires %s history readers to have %s', async (kind, requiredFeature) => {
+    mockRbac.userHasAllFeatures.mockResolvedValueOnce(false)
+
+    const response = await GET(requestFor(kind))
+
+    expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' })
+    expect(mockRbac.userHasAllFeatures).toHaveBeenCalledWith('user-1', [requiredFeature], {
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+    expect(mockActionLogService.list).not.toHaveBeenCalled()
+    expect(findWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('continues to load history for a user with the matching document view feature', async () => {
+    const response = await GET(requestFor('quote'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ items: [] })
+    expect(mockRbac.userHasAllFeatures).toHaveBeenCalledWith('user-1', ['sales.quotes.view'], {
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+    expect(mockActionLogService.list).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'sales.quote',
+      resourceId: DOCUMENT_ID,
+    }))
+  })
+})

--- a/packages/core/src/modules/sales/api/document-history/route.ts
+++ b/packages/core/src/modules/sales/api/document-history/route.ts
@@ -9,6 +9,7 @@ import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/er
 import { NextResponse } from 'next/server'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { ActionLog } from '@open-mercato/core/modules/audit_logs/data/entities'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { buildHistoryEntries } from '../../lib/historyHelpers'
 import { SalesNote } from '../../data/entities'
@@ -68,6 +69,16 @@ export async function GET(req: Request) {
       throw new CrudHttpError(400, {
         error: translate('sales.documents.errors.organization_required', 'Organization context is required'),
       })
+    }
+
+    const requiredFeature = query.kind === 'order' ? 'sales.orders.view' : 'sales.quotes.view'
+    const rbac = container.resolve('rbacService') as RbacService
+    const hasAccess = await rbac.userHasAllFeatures(auth.sub, [requiredFeature], {
+      tenantId: auth.tenantId,
+      organizationId,
+    })
+    if (!hasAccess) {
+      throw new CrudHttpError(403, { error: translate('api.errors.forbidden', 'Forbidden') })
     }
 
     const resourceKind = query.kind === 'order' ? 'sales.order' : 'sales.quote'
@@ -175,6 +186,7 @@ export const openApi: OpenApiRouteDoc = {
         { status: 200, description: 'History entries', schema: documentHistoryResponseSchema },
         { status: 400, description: 'Invalid query', schema: z.object({ error: z.string() }) },
         { status: 401, description: 'Unauthorized', schema: z.object({ error: z.string() }) },
+        { status: 403, description: 'Forbidden', schema: z.object({ error: z.string() }) },
         { status: 404, description: 'Document not found', schema: z.object({ error: z.string() }) },
       ],
     },


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fixes sales document-history authorization so users must have the matching sales document view feature before history or notes are read.

## Changes

- Require `sales.orders.view` for order history requests.
- Require `sales.quotes.view` for quote history requests.
- Return the existing forbidden response before querying action logs or encrypted notes.
- Add regression tests for unauthorized order/quote access and authorized quote access.

## Specification

- [x] Yes - existing implemented spec covers this ACL requirement: `.ai/specs/implemented/SPEC-006-2026-01-23-order-status-history.md`
- [ ] No
- [ ] N/A

## Testing

- [x] Focused regression failed before the fix with `200` instead of expected `403`.
- [x] `yarn build:packages`
- [x] `yarn generate`
- [x] `yarn build:packages`
- [x] `yarn workspace @open-mercato/core test src/modules/sales/api/__tests__/document-history.route.test.ts src/modules/sales/api/__tests__/document-history.test.ts --runInBand`
- [x] `yarn i18n:check-sync`
- [x] `yarn i18n:check-usage`
- [x] `yarn typecheck`
- [x] `yarn lint`
- [x] `yarn test`
- [x] `yarn build:app`

## Checklist

- [x] This pull request targets the `develop` branch.
- [x] I accept the terms in `docs/cla.md`.
- [x] Documentation/locales/generators considered; OpenAPI 403 response updated and `yarn generate` run.
- [x] Tests added or updated.
- [x] Integration coverage considered; route-level regression covers the affected API authorization path.
- [x] Spec impact considered; existing implemented spec already requires this ACL behavior.
- [x] Priority label should be `priority-medium`.
- [x] Risk label should be `risk-medium`.
- [x] QA routing should be `skip-qa` because this is a backend API security fix covered by automated tests.

### Design System Compliance

- [x] N/A - no UI change.
- [x] N/A - no design token change.
- [x] N/A - no user-facing copy change.

## Linked issues

Fixes #3894
