### PR TITLE
security(sales): gate notes CRUD by document ACL (#3893)

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-037.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-037.spec.ts
@@ -8,6 +8,7 @@ import {
   setRoleAclFeatures,
 } from '@open-mercato/core/helpers/integration/authFixtures'
 import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { createSalesOrderFixture, deleteSalesEntityIfExists } from '@open-mercato/core/helpers/integration/salesFixtures'
 
 /**
  * TC-SALES-037: RBAC / feature gating on sales document queries.
@@ -127,6 +128,90 @@ test.describe('TC-SALES-037 sales RBAC / feature gating', () => {
       expect(createResponse.status(), 'view-only role POST /api/sales/orders should be 403').toBe(403)
       expect(requiredFeatures(await readJson(createResponse)), '403 should require the manage feature').toContain('sales.orders.manage')
     } finally {
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+    }
+  })
+
+  test('a role with no sales features cannot access sales notes', async ({ request }) => {
+    test.slow()
+    const adminToken = await getAuthToken(request, 'admin')
+    const scope = getTokenScope(adminToken)
+    const stamp = Date.now()
+    const email = `qa-sales-notes-denied-${stamp}@acme.com`
+    const password = `QaNotesDenied1!${stamp}`
+    let roleId: string | null = null
+    let userId: string | null = null
+    let orderId: string | null = null
+    let noteId: string | null = null
+
+    try {
+      orderId = await createSalesOrderFixture(request, adminToken)
+      const createNote = await apiRequest(request, 'POST', '/api/sales/notes', {
+        token: adminToken,
+        data: {
+          contextType: 'order',
+          contextId: orderId,
+          body: `QA sales note ACL ${stamp}`,
+        },
+      })
+      expect(createNote.status(), 'admin should create fixture sales note').toBe(201)
+      noteId = String(((await readJson(createNote)) as { id?: unknown }).id ?? '')
+      expect(noteId, 'fixture note id should be returned').toBeTruthy()
+
+      roleId = await createRoleFixture(request, adminToken, {
+        name: `QA Sales Notes Denied ${stamp}`,
+        tenantId: scope.tenantId ?? undefined,
+      })
+      await setRoleAclFeatures(request, adminToken, { roleId, features: [] })
+      userId = await createUserFixture(request, adminToken, {
+        email,
+        password,
+        organizationId: scope.organizationId!,
+        roles: [roleId],
+        name: `QA Sales Notes Denied ${stamp}`,
+      })
+
+      const deniedToken = await getAuthToken(request, email, password)
+
+      const list = await apiRequest(
+        request,
+        'GET',
+        `/api/sales/notes?contextType=order&contextId=${encodeURIComponent(orderId)}`,
+        { token: deniedToken },
+      )
+      expect(list.status(), 'zero-sales role GET /api/sales/notes should be 403').toBe(403)
+      expect(requiredFeatures(await readJson(list)), '403 should cite order view').toContain('sales.orders.view')
+
+      const create = await apiRequest(request, 'POST', '/api/sales/notes', {
+        token: deniedToken,
+        data: {
+          contextType: 'order',
+          contextId: orderId,
+          body: `QA blocked note ${stamp}`,
+        },
+      })
+      expect(create.status(), 'zero-sales role POST /api/sales/notes should be 403').toBe(403)
+      expect(requiredFeatures(await readJson(create)), '403 should cite order manage').toContain('sales.orders.manage')
+
+      const update = await apiRequest(request, 'PUT', '/api/sales/notes', {
+        token: deniedToken,
+        data: { id: noteId, body: `QA blocked note update ${stamp}` },
+      })
+      expect(update.status(), 'zero-sales role PUT /api/sales/notes should be 403').toBe(403)
+      expect(requiredFeatures(await readJson(update)), '403 should cite order manage').toContain('sales.orders.manage')
+
+      const del = await apiRequest(
+        request,
+        'DELETE',
+        `/api/sales/notes?id=${encodeURIComponent(noteId)}`,
+        { token: deniedToken },
+      )
+      expect(del.status(), 'zero-sales role DELETE /api/sales/notes should be 403').toBe(403)
+      expect(requiredFeatures(await readJson(del)), '403 should cite order manage').toContain('sales.orders.manage')
+    } finally {
+      await deleteSalesEntityIfExists(request, adminToken, '/api/sales/notes', noteId)
+      await deleteSalesEntityIfExists(request, adminToken, '/api/sales/orders', orderId)
       await deleteUserIfExists(request, adminToken, userId)
       await deleteRoleIfExists(request, adminToken, roleId)
     }

--- a/packages/core/src/modules/sales/api/notes/route.ts
+++ b/packages/core/src/modules/sales/api/notes/route.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod'
-import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { makeCrudRoute, type CrudCtx } from '@open-mercato/shared/lib/crud/factory'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { SalesNote } from '../../data/entities'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import { SalesNote, type SalesDocumentKind } from '../../data/entities'
 import { noteCreateSchema, noteUpdateSchema } from '../../data/validators'
 import { withScopedPayload } from '../utils'
 import { E } from '#generated/entities.ids.generated'
@@ -27,6 +30,91 @@ const listSchema = z
   })
   .passthrough()
 
+type NoteListQuery = z.infer<typeof listSchema>
+type NoteAction = 'view' | 'manage'
+
+const noteFeatureByContext: Record<SalesDocumentKind, Record<NoteAction, string>> = {
+  order: { view: 'sales.orders.view', manage: 'sales.orders.manage' },
+  quote: { view: 'sales.quotes.view', manage: 'sales.quotes.manage' },
+  invoice: { view: 'sales.invoices.manage', manage: 'sales.invoices.manage' },
+  credit_memo: { view: 'sales.credit_memos.manage', manage: 'sales.credit_memos.manage' },
+}
+
+const allNoteViewFeatures = Array.from(
+  new Set(Object.values(noteFeatureByContext).map((features) => features.view)),
+)
+const allNoteManageFeatures = Array.from(
+  new Set(Object.values(noteFeatureByContext).map((features) => features.manage)),
+)
+
+function resolveNoteListContextType(query: NoteListQuery): SalesDocumentKind | null {
+  if (query.contextType) return query.contextType
+  if (query.orderId) return 'order'
+  if (query.quoteId) return 'quote'
+  return null
+}
+
+function requiredNoteFeatures(action: NoteAction, contextType: SalesDocumentKind | null): string[] {
+  if (contextType) return [noteFeatureByContext[contextType][action]]
+  return action === 'view' ? allNoteViewFeatures : allNoteManageFeatures
+}
+
+async function ensureNotePermission(
+  ctx: CrudCtx,
+  action: NoteAction,
+  contextType: SalesDocumentKind | null,
+  translate: (key: string, fallback?: string) => string
+) {
+  const auth = ctx.auth
+  if (!auth?.sub) {
+    throw new CrudHttpError(401, { error: translate('api.errors.unauthorized', 'Unauthorized') })
+  }
+
+  const requiredFeatures = requiredNoteFeatures(action, contextType)
+  const rbac = ctx.container.resolve<RbacService>('rbacService')
+  const ok = await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
+    tenantId: auth.tenantId ?? null,
+    organizationId: ctx.selectedOrganizationId ?? auth.orgId ?? null,
+  })
+
+  if (!ok) {
+    throw new CrudHttpError(403, {
+      error: translate('api.errors.forbidden', 'Forbidden'),
+      requiredFeatures,
+    })
+  }
+}
+
+async function loadNoteForPermission(
+  ctx: CrudCtx,
+  id: string,
+  translate: (key: string, fallback?: string) => string
+): Promise<SalesNote> {
+  const em = ctx.container.resolve<EntityManager>('em')
+  const note = await findOneWithDecryption(em, SalesNote, { id }, {}, {
+    tenantId: ctx.auth?.tenantId ?? undefined,
+    organizationId: ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? undefined,
+  })
+
+  if (!note) {
+    throw new CrudHttpError(404, {
+      error: translate('sales.documents.detail.error', 'Document not found or inaccessible.'),
+    })
+  }
+
+  return note
+}
+
+async function ensureExistingNotePermission(
+  ctx: CrudCtx,
+  id: string,
+  action: NoteAction,
+  translate: (key: string, fallback?: string) => string
+) {
+  const note = await loadNoteForPermission(ctx, id, translate)
+  await ensureNotePermission(ctx, action, note.contextType, translate)
+}
+
 const routeMetadata = {
   GET: { requireAuth: true },
   POST: { requireAuth: true },
@@ -46,6 +134,12 @@ const crud = makeCrudRoute({
   },
   indexer: {
     entityType: E.sales.sales_note,
+  },
+  hooks: {
+    beforeList: async (query, ctx) => {
+      const { translate } = await resolveTranslations()
+      await ensureNotePermission(ctx, 'view', resolveNoteListContextType(query as NoteListQuery), translate)
+    },
   },
   list: {
     schema: listSchema,
@@ -84,7 +178,9 @@ const crud = makeCrudRoute({
       schema: rawBodySchema,
       mapInput: async ({ raw, ctx }) => {
         const { translate } = await resolveTranslations()
-        return noteCreateSchema.parse(withScopedPayload(raw ?? {}, ctx, translate))
+        const input = noteCreateSchema.parse(withScopedPayload(raw ?? {}, ctx, translate))
+        await ensureNotePermission(ctx, 'manage', input.contextType, translate)
+        return input
       },
       response: ({ result }) => ({
         id: result?.noteId ?? result?.id ?? null,
@@ -97,7 +193,9 @@ const crud = makeCrudRoute({
       schema: rawBodySchema,
       mapInput: async ({ raw, ctx }) => {
         const { translate } = await resolveTranslations()
-        return noteUpdateSchema.parse(withScopedPayload(raw ?? {}, ctx, translate))
+        const input = noteUpdateSchema.parse(withScopedPayload(raw ?? {}, ctx, translate))
+        await ensureExistingNotePermission(ctx, input.id, 'manage', translate)
+        return input
       },
       response: () => ({ ok: true }),
     },
@@ -114,6 +212,7 @@ const crud = makeCrudRoute({
         if (!id) {
           throw new CrudHttpError(400, { error: translate('sales.documents.detail.error', 'Document not found or inaccessible.') })
         }
+        await ensureExistingNotePermission(ctx, id, 'manage', translate)
         return { id }
       },
       response: () => ({ ok: true }),


### PR DESCRIPTION
## Summary

Fixes sales notes CRUD ACL bypass by enforcing context-aware sales permissions before notes can be listed, created, updated, or deleted.

## Changes

- Added dynamic sales-note RBAC checks based on the note document context.
- Ensured update/delete authorization is based on the stored note context, not caller-supplied input.
- Added integration regression coverage for no-sales-feature roles against `GET`/`POST`/`PUT`/`DELETE /api/sales/notes`.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor security bug fix, no spec needed)

**Spec file path:** N/A

## Testing

- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn build:app`
- `BASE_URL=http://127.0.0.1:5001 ENABLE_CRUD_API_CACHE=true npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/sales/__integration__/TC-SALES-037.spec.ts --retries=0`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3893
