### PR TITLE
fix: derive sales note authors from auth (#3896)

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/notes.authorship.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/notes.authorship.test.ts
@@ -1,0 +1,189 @@
+/** @jest-environment node */
+
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { SalesNote, SalesOrder } from '../../data/entities'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async (em: { findOne: (...args: unknown[]) => unknown }, entity: unknown, where: unknown) => {
+    return em.findOne(entity, where)
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/helpers')
+  return {
+    ...actual,
+    emitCrudSideEffects: jest.fn(async () => undefined),
+    emitCrudUndoSideEffects: jest.fn(async () => undefined),
+  }
+})
+
+const ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TENANT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const ORDER_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const NOTE_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const CALLER_USER_ID = '11111111-1111-4111-8111-111111111111'
+const SPOOFED_USER_ID = '22222222-2222-4222-8222-222222222222'
+const ORIGINAL_USER_ID = '33333333-3333-4333-8333-333333333333'
+
+function makeOrder() {
+  return {
+    id: ORDER_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+  }
+}
+
+function makeNote(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: NOTE_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    contextType: 'order',
+    contextId: ORDER_ID,
+    order: makeOrder(),
+    quote: null,
+    body: 'original',
+    authorUserId: ORIGINAL_USER_ID,
+    appearanceIcon: null,
+    appearanceColor: null,
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function makeEm(note?: ReturnType<typeof makeNote>) {
+  const created: Array<Record<string, unknown>> = []
+  const em: any = {
+    fork: jest.fn(function () {
+      return em
+    }),
+    findOne: jest.fn(async (entityClass: unknown, where: Record<string, unknown>) => {
+      if (entityClass === SalesOrder && where.id === ORDER_ID) return makeOrder()
+      if (entityClass === SalesNote && where.id === NOTE_ID) return note ?? null
+      return null
+    }),
+    create: jest.fn((_entityClass: unknown, data: Record<string, unknown>) => {
+      const row = { id: NOTE_ID, ...data }
+      created.push(row)
+      return row
+    }),
+    persist: jest.fn(),
+    flush: jest.fn(async () => undefined),
+    remove: jest.fn(),
+  }
+  return { em, created }
+}
+
+function makeCtx(
+  em: Record<string, unknown>,
+  auth: Record<string, unknown> = { tenantId: TENANT_ID, orgId: ORG_ID, sub: CALLER_USER_ID },
+) {
+  return {
+    container: {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return em
+        if (name === 'dataEngine') return {}
+        return {}
+      }),
+    },
+    auth,
+    selectedOrganizationId: ORG_ID,
+    organizationIds: [ORG_ID],
+    organizationScope: null,
+  }
+}
+
+describe('sales.notes command authorship', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../notes')
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('uses the authenticated user, not client input, when creating a note', async () => {
+    const execute = commandRegistry.get('sales.notes.create')?.execute
+    expect(execute).toBeInstanceOf(Function)
+    const { em, created } = makeEm()
+
+    const result = await execute?.(
+      {
+        organizationId: ORG_ID,
+        tenantId: TENANT_ID,
+        contextType: 'order',
+        contextId: ORDER_ID,
+        authorUserId: SPOOFED_USER_ID,
+        body: 'Forged create',
+      },
+      makeCtx(em) as never,
+    )
+
+    expect(created[0]?.authorUserId).toBe(CALLER_USER_ID)
+    expect(result?.authorUserId).toBe(CALLER_USER_ID)
+  })
+
+  it.each([
+    ['API key auth', { tenantId: TENANT_ID, orgId: ORG_ID, isApiKey: true, sub: CALLER_USER_ID }],
+    ['non-UUID auth subject', { tenantId: TENANT_ID, orgId: ORG_ID, sub: 'system-user' }],
+  ])('stores a null author for %s even when client input supplies authorUserId', async (_label, auth) => {
+    const execute = commandRegistry.get('sales.notes.create')?.execute
+    const { em, created } = makeEm()
+
+    const result = await execute?.(
+      {
+        organizationId: ORG_ID,
+        tenantId: TENANT_ID,
+        contextType: 'order',
+        contextId: ORDER_ID,
+        authorUserId: SPOOFED_USER_ID,
+        body: 'System create',
+      },
+      makeCtx(em, auth) as never,
+    )
+
+    expect(created[0]?.authorUserId).toBeNull()
+    expect(result?.authorUserId).toBeNull()
+  })
+
+  it('uses the authenticated user, not client input, when updating note authorship', async () => {
+    const execute = commandRegistry.get('sales.notes.update')?.execute
+    expect(execute).toBeInstanceOf(Function)
+    const note = makeNote()
+    const { em } = makeEm(note)
+
+    await execute?.(
+      {
+        id: NOTE_ID,
+        authorUserId: SPOOFED_USER_ID,
+        body: 'Updated',
+      },
+      makeCtx(em) as never,
+    )
+
+    expect(note.authorUserId).toBe(CALLER_USER_ID)
+    expect(findOneWithDecryption).toHaveBeenCalledWith(em, SalesNote, { id: NOTE_ID }, {})
+  })
+
+  it('preserves the existing author on body-only updates', async () => {
+    const execute = commandRegistry.get('sales.notes.update')?.execute
+    const note = makeNote()
+    const { em } = makeEm(note)
+
+    await execute?.({ id: NOTE_ID, body: 'Body-only edit' }, makeCtx(em) as never)
+
+    expect(note.authorUserId).toBe(ORIGINAL_USER_ID)
+  })
+})

--- a/packages/core/src/modules/sales/commands/notes.ts
+++ b/packages/core/src/modules/sales/commands/notes.ts
@@ -124,7 +124,13 @@ async function requireContext(
     }
   }
   const repo = contextType === 'invoice' ? SalesInvoice : SalesCreditMemo
-  const entity = await em.findOne(repo as any, { id: contextId }) as (SalesInvoice | SalesCreditMemo) | null
+  const entity = await findOneWithDecryption(
+    em,
+    repo as any,
+    { id: contextId },
+    {},
+    { tenantId, organizationId },
+  ) as (SalesInvoice | SalesCreditMemo) | null
   if (!entity) {
     throw new CrudHttpError(404, { error: 'sales.notes.context_not_found' })
   }
@@ -139,11 +145,11 @@ async function requireContext(
   }
 }
 
-function resolveAuthor(inputAuthor: string | undefined, authSub: string | null): string | null {
-  if (inputAuthor) return inputAuthor
-  if (!authSub) return null
+function resolveAuthor(authSub: string | null): string | null {
+  const sub = authSub?.trim()
+  if (!sub) return null
   const uuidRegex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/
-  return uuidRegex.test(authSub) ? authSub : null
+  return uuidRegex.test(sub) ? sub : null
 }
 
 const createNoteCommand: CommandHandler<NoteCreateInput, { noteId: string; authorUserId: string | null }> = {
@@ -154,7 +160,7 @@ const createNoteCommand: CommandHandler<NoteCreateInput, { noteId: string; autho
     ensureOrganizationScope(ctx, parsed.organizationId)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const context = await requireContext(em, parsed.contextType, parsed.contextId, parsed.organizationId, parsed.tenantId)
-    const authorUserId = resolveAuthor(parsed.authorUserId, ctx.auth?.isApiKey ? null : ctx.auth?.sub ?? null)
+    const authorUserId = resolveAuthor(ctx.auth?.isApiKey ? null : ctx.auth?.sub ?? null)
 
     const note = em.create(SalesNote, {
       organizationId: parsed.organizationId,
@@ -278,7 +284,9 @@ const updateNoteCommand: CommandHandler<NoteUpdateInput, { noteId: string }> = {
     ensureOrganizationScope(ctx, note.organizationId)
 
     if (parsed.body !== undefined) note.body = parsed.body
-    if (parsed.authorUserId !== undefined) note.authorUserId = parsed.authorUserId ?? null
+    if (parsed.authorUserId !== undefined) {
+      note.authorUserId = resolveAuthor(ctx.auth?.isApiKey ? null : ctx.auth?.sub ?? null)
+    }
     if (parsed.appearanceIcon !== undefined) note.appearanceIcon = parsed.appearanceIcon ?? null
     if (parsed.appearanceColor !== undefined) note.appearanceColor = parsed.appearanceColor ?? null
     note.updatedAt = new Date()


### PR DESCRIPTION
## Summary

Fixes sales note authorship spoofing by deriving note authors from authenticated request context instead of trusting client-supplied `authorUserId`.

## Changes

- Ignore client-supplied `authorUserId` when creating sales notes.
- Prevent sales note updates from assigning arbitrary author IDs from request bodies.
- Preserve existing note authors on body-only updates.
- Add command-level regression coverage for spoofed create/update attempts, API-key auth, and non-UUID auth subjects.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — issue-scoped security fix.

## Testing

- PASS: `yarn workspace @open-mercato/core test --runTestsByPath src/modules/sales/commands/__tests__/notes.authorship.test.ts --runInBand`
- PASS: `yarn build:packages`
- PASS: `yarn generate`
- PASS: `yarn build:packages`
- PASS: `yarn i18n:check-sync`
- PASS: `yarn i18n:check-usage` (advisory unused-key report only)
- PASS: `yarn typecheck`
- PASS: `yarn test`
- PASS: `yarn lint`
- PASS: `yarn build:app`
- WARN: `yarn template:sync` reports pre-existing app/template drift unrelated to this backend command fix.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. N/A — no docs/locales required; generator gate run.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). N/A — command-level security regression covered by unit tests.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A — minor issue-scoped fix.
- [x] Priority set: this PR carries exactly one `priority-*` label. Use `priority-low` from the issue.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). Use `risk-medium` from the issue.
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. Use `skip-qa` — backend command fix covered by tests.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens. N/A — no UI.
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`. N/A — no UI.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop). N/A — no UI.
- [x] Loading state handled for async pages. N/A — no UI.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`). N/A — no UI.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements. N/A — no UI.

## Linked issues

Fixes #3896