### PR TITLE
fix(data_sync): back adapter registry with globalThis to survive bundler duplication

### DIFF
--- a/packages/core/src/modules/data_sync/lib/__tests__/adapter-registry.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/adapter-registry.test.ts
@@ -1,0 +1,65 @@
+import type { DataSyncAdapter } from '../adapter'
+
+const REGISTRY_KEY = Symbol.for('@open-mercato/core/data_sync/adapter-registry')
+
+function makeAdapter(providerKey: string): DataSyncAdapter {
+  return {
+    providerKey,
+    direction: 'import',
+    supportedEntities: [],
+    getMapping: async () => ({ entityType: 'x', fields: [], matchStrategy: 'externalId' }),
+  }
+}
+
+function clearGlobalRegistry(): void {
+  delete (globalThis as Record<symbol, unknown>)[REGISTRY_KEY]
+}
+
+describe('data_sync adapter registry', () => {
+  beforeEach(() => {
+    clearGlobalRegistry()
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    clearGlobalRegistry()
+  })
+
+  it('registers and retrieves an adapter by providerKey', () => {
+    const { registerDataSyncAdapter, getDataSyncAdapter } = require('../adapter-registry')
+    const adapter = makeAdapter('subiekt')
+    registerDataSyncAdapter(adapter)
+    expect(getDataSyncAdapter('subiekt')).toBe(adapter)
+  })
+
+  it('returns undefined for an unknown providerKey', () => {
+    const { getDataSyncAdapter } = require('../adapter-registry')
+    expect(getDataSyncAdapter('nonexistent')).toBeUndefined()
+  })
+
+  it('lists all registered adapters', () => {
+    const { registerDataSyncAdapter, getAllDataSyncAdapters } = require('../adapter-registry')
+    const a = makeAdapter('subiekt')
+    const b = makeAdapter('akeneo')
+    registerDataSyncAdapter(a)
+    registerDataSyncAdapter(b)
+    expect(getAllDataSyncAdapters()).toEqual(expect.arrayContaining([a, b]))
+    expect(getAllDataSyncAdapters()).toHaveLength(2)
+  })
+
+  // Regression for the bundler module-duplication bug: when a bundler emits this
+  // file into more than one chunk, each copy holds its own module-local state.
+  // Loading the module twice simulates that. An adapter registered through one
+  // copy must be visible through the other because both resolve the same
+  // globalThis-backed Map — a plain module-local Map would fail this.
+  it('shares state across duplicated module instances via globalThis', () => {
+    jest.isolateModules(() => {
+      const first = require('../adapter-registry')
+      first.registerDataSyncAdapter(makeAdapter('subiekt'))
+    })
+    jest.isolateModules(() => {
+      const second = require('../adapter-registry')
+      expect(second.getDataSyncAdapter('subiekt')?.providerKey).toBe('subiekt')
+    })
+  })
+})

--- a/packages/core/src/modules/data_sync/lib/adapter-registry.ts
+++ b/packages/core/src/modules/data_sync/lib/adapter-registry.ts
@@ -1,15 +1,33 @@
 import type { DataSyncAdapter } from './adapter'
 
-const adapters = new Map<string, DataSyncAdapter>()
+// Back the registry with globalThis, keyed by a well-known Symbol, so it survives
+// bundler module duplication (Turbopack/esbuild/tsx). Those bundlers can emit the
+// same file into multiple chunks, each with its own module-local state — so an
+// adapter registered from a module's `di.ts` (one copy) would be invisible to
+// `/api/data_sync/run` (another copy), throwing "No registered sync adapter for
+// provider" in production builds. Mirrors shipping_carriers' adapter-registry.
+const DATA_SYNC_ADAPTER_REGISTRY_KEY = Symbol.for('@open-mercato/core/data_sync/adapter-registry')
+
+type GlobalWithAdapterRegistry = typeof globalThis & {
+  [DATA_SYNC_ADAPTER_REGISTRY_KEY]?: Map<string, DataSyncAdapter>
+}
+
+function getAdapterRegistry(): Map<string, DataSyncAdapter> {
+  const globalScope = globalThis as GlobalWithAdapterRegistry
+  if (!globalScope[DATA_SYNC_ADAPTER_REGISTRY_KEY]) {
+    globalScope[DATA_SYNC_ADAPTER_REGISTRY_KEY] = new Map<string, DataSyncAdapter>()
+  }
+  return globalScope[DATA_SYNC_ADAPTER_REGISTRY_KEY]
+}
 
 export function registerDataSyncAdapter(adapter: DataSyncAdapter): void {
-  adapters.set(adapter.providerKey, adapter)
+  getAdapterRegistry().set(adapter.providerKey, adapter)
 }
 
 export function getDataSyncAdapter(providerKey: string): DataSyncAdapter | undefined {
-  return adapters.get(providerKey)
+  return getAdapterRegistry().get(providerKey)
 }
 
 export function getAllDataSyncAdapters(): DataSyncAdapter[] {
-  return Array.from(adapters.values())
+  return Array.from(getAdapterRegistry().values())
 }


### PR DESCRIPTION
## Summary

Bundlers (Turbopack/esbuild/tsx) can emit `data_sync/lib/adapter-registry` into more than one chunk, each carrying its own module-local `Map`. An adapter registered from a module's `di.ts` (one bundled copy) is then invisible to `/api/data_sync/run` (another bundled copy), so production builds throw `No registered sync adapter for provider` and the sync run never starts.

This is a framework-level bug — it reproduces for any module that registers a data_sync adapter from its DI, not a specific integration.

The fix keys the registry off `globalThis` via a well-known `Symbol.for('@open-mercato/core/data_sync/adapter-registry')`, so every duplicated copy of the module resolves the same `Map`. It mirrors the existing `packages/core/src/modules/shipping_carriers/lib/adapter-registry.ts`, which already uses this exact pattern for the same reason. The public API (`registerDataSyncAdapter` / `getDataSyncAdapter` / `getAllDataSyncAdapters`) is unchanged, so all callers keep working without edits.

## Changes

- `packages/core/src/modules/data_sync/lib/adapter-registry.ts` — replace the module-local `Map` with a `globalThis`-backed one keyed by `Symbol.for(...)`.
- `packages/core/src/modules/data_sync/lib/__tests__/adapter-registry.test.ts` — new: register/get/list coverage plus a regression test that loads the module twice via `jest.isolateModules` to simulate bundler duplication and asserts registry state is shared.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

**Spec file path:** —

Self-contained bug fix to an existing lib; no behavioral or API-surface change.

## Testing

- `yarn jest src/modules/data_sync/lib/__tests__/adapter-registry.test.ts` (in `packages/core`) — 4/4 pass.
- Confirmed the regression test fails against the previous module-local `Map` and passes with the fix.
- `yarn jest src/modules/data_sync/lib` — full lib suite 20/20 pass.
- `tsc --noEmit` on `packages/core` — clean.
- eslint on the changed files — clean.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it. — N/A (no doc/locale/generator surface affected).
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/`. — N/A: this is an internal registry with no UI/API surface change; covered by unit tests.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A (minor fix).
- [ ] Priority set — deferring the `priority-*` label to maintainers.
- [ ] Risk set — low blast radius (single internal lib, public API unchanged); deferring the `risk-*` label to maintainers.
- [ ] QA routing — low-risk, non-customer-facing; suggest `skip-qa`, deferring to maintainers.

### Design System Compliance

N/A — no UI changes.