### PR TITLE
test(search): add TC-SEARCH-013 scoped reindex cancellation integration test

### DIFF
--- a/.ai/runs/2026-07-08-search-scoped-reindex-cancel-integration-test.md
+++ b/.ai/runs/2026-07-08-search-scoped-reindex-cancel-integration-test.md
@@ -1,0 +1,93 @@
+# Execution plan: integration test for scoped search reindex cancellation
+
+## Goal
+
+Add the integration test flagged as a follow-up in PR #3992 (Fixes #3900): lock in the
+tenant/org-scoped reindex-cancellation contract at the real HTTP API + real queue layer,
+closing the gap the mocked unit tests cannot cover.
+
+## Context
+
+PR #3992 changed `/api/search/reindex/cancel` and `/api/search/embeddings/reindex/cancel`
+so they no longer call `queue.clear()` (which wiped every tenant's queued indexing jobs).
+Cancel now calls `queue.removeQueuedJobsByScope({ tenantId, organizationId?, jobTypes: ['batch-index'] })`
+and **fails closed with 503** when that scoped method is unavailable or throws. The queue
+strategies (`packages/queue/src/strategies/{local,async}.ts`) gained `removeQueuedJobsByScope`.
+
+The PR shipped unit + route tests with a **mocked** queue. The follow-up comment
+(pkarw, 2026-07-07T23:36:10Z) asked for an integration test that exercises the cross-scope
+isolation guarantee through the **real** cancel API + **real** queue strategy.
+
+### External References
+
+None (`--skill-url` not used).
+
+### Environment constraints (drive the test design)
+
+- The ephemeral integration env has **no Meilisearch and no embedding provider** (documented
+  in `TC-SEARCH-007`). A fulltext/vector reindex therefore returns 503, holds no lock, and
+  enqueues **zero** `batch-index` jobs. So `jobsRemoved` is always `0` here and a persistent
+  reindex lock cannot be obtained via the API.
+- `QUEUE_STRATEGY=local` (jobs live under `.mercato/queue`); the local strategy **does**
+  implement `removeQueuedJobsByScope` (verified at develop tip 46e1a2ecf).
+- Full second-**tenant** provisioning is not available to integration fixtures; the established
+  isolation precedent (`TC-SEARCH-004`) provisions a **second organization** in the same tenant.
+  The scope object keys on `organizationId`, so two orgs still exercise the scoping dimension.
+
+### What the test deterministically asserts (and why it is non-redundant)
+
+1. **Scoped-cancel contract is wired on the real queue.** A real admin cancel of both the
+   fulltext and vector paths returns `200 { ok: true, jobsRemoved: <number> }` — **not** the
+   `503` fail-closed body. Under the old code cancel always returned 200 via `queue.clear()`;
+   under the new code the route returns 503 if the strategy lacks `removeQueuedJobsByScope`.
+   So this proves the running app's real local queue strategy actually implements the scoped
+   method — the queue-strategy half of #3992 that the mocked unit tests never touch. A revert
+   of just the strategy change would flip this to 503 and fail the test.
+2. **Per-scope isolation / no shared-state wipe.** A second organization (orgB) with its own
+   confined user cancels independently; admin (orgA) and orgB cancels interleave and every call
+   returns a clean `200 { ok: true }`. One scope's cancel neither errors nor 503s another
+   scope's cancel — the observable proxy for "cancel does not disrupt other scopes' queue state"
+   that is available without a live search backend.
+
+Fail-closed (503-on-missing-method) and cross-scope job survival with real enqueued jobs are
+**not** integration-observable in this backend-less env (no fault injection over black-box HTTP,
+no way to enqueue `batch-index` jobs); they remain covered by the PR's unit/route tests. The
+docblock states this limitation explicitly, mirroring `TC-SEARCH-007`.
+
+## Scope
+
+- **In:** one new file `packages/search/src/modules/search/__integration__/TC-SEARCH-013.spec.ts`.
+- **Out (non-goals):** no product-code changes; no new fixtures/helpers; no markdown scenario
+  (optional per `.ai/qa/AGENTS.md`); no changes to queue strategies or routes.
+
+## Risks
+
+- Env may not allow provisioning a second organization → guard with `test.skip(...)` exactly as
+  `TC-SEARCH-004` does; the single-scope contract assertions still run for the admin scope.
+- Cancel-without-prior-reindex must be safe (idempotent) → it is; `TC-SEARCH-003/007` already
+  call cancel defensively in teardown. Test cleans up org/role/user in `finally`.
+
+## Implementation Plan
+
+### Phase 1: Author the integration test
+
+- Add `TC-SEARCH-013.spec.ts` asserting the two properties above, self-contained with
+  `finally` teardown, `test.skip` fallback when orgB cannot be provisioned.
+
+### Phase 2: Validate
+
+- Typecheck the search package; run the full gate (`build:packages`, `generate`, i18n checks,
+  `typecheck`, `test`, `build:app`). Integration specs run in the ephemeral env on CI; locally
+  confirm the file typechecks and lints and does not regress the suite build.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Author the integration test
+
+- [ ] 1.1 Add `TC-SEARCH-013.spec.ts` (scoped-cancel contract + per-scope isolation)
+
+### Phase 2: Validate
+
+- [ ] 2.1 Typecheck search package + full validation gate

--- a/.ai/runs/2026-07-08-search-scoped-reindex-cancel-integration-test.md
+++ b/.ai/runs/2026-07-08-search-scoped-reindex-cancel-integration-test.md
@@ -80,14 +80,25 @@ docblock states this limitation explicitly, mirroring `TC-SEARCH-007`.
   `typecheck`, `test`, `build:app`). Integration specs run in the ephemeral env on CI; locally
   confirm the file typechecks and lints and does not regress the suite build.
 
+## Changelog
+
+- 2026-07-08 — PR #4000 (https://github.com/open-mercato/open-mercato/pull/4000), Status: complete.
+
 ## Progress
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Author the integration test
 
-- [ ] 1.1 Add `TC-SEARCH-013.spec.ts` (scoped-cancel contract + per-scope isolation)
+- [x] 1.1 Add `TC-SEARCH-013.spec.ts` (scoped-cancel contract + per-scope isolation) — 52ff4f607
 
 ### Phase 2: Validate
 
-- [ ] 2.1 Typecheck search package + full validation gate
+- [x] 2.1 Typecheck search package + full validation gate — 52ff4f607
+
+  Gate results: `yarn build:packages` ✓, `yarn generate` ✓, `yarn i18n:check-sync` ✓,
+  `yarn i18n:check-usage` ✓ (advisory), `yarn typecheck` ✓ (21/21), Playwright `--list`
+  discovers & parses the spec ✓. `yarn test` (jest) and `yarn build:app` do **not** compile
+  `__integration__/*.spec.ts` (jest testMatch = `__tests__/**/*.test.ts`; Next build ignores
+  Playwright specs), so they are unaffected by this test-only change. Runtime execution of the
+  spec requires a booted app + DB and runs in the ephemeral integration CI env.

--- a/packages/search/src/modules/search/__integration__/TC-SEARCH-013.spec.ts
+++ b/packages/search/src/modules/search/__integration__/TC-SEARCH-013.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { expectId, getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+
+type CancelBody = { ok?: boolean; jobsRemoved?: number; error?: string }
+
+const VALID_PASSWORD = 'Valid1!Pass'
+const FULLTEXT_CANCEL = '/api/search/reindex/cancel'
+const VECTOR_CANCEL = '/api/search/embeddings/reindex/cancel'
+
+/**
+ * TC-SEARCH-013: search reindex cancellation is tenant/organization scoped.
+ * Source: PR #3992 follow-up comment (Fixes #3900).
+ *
+ * PR #3992 replaced the shared-queue-wiping `queue.clear()` in the fulltext and
+ * vector reindex cancel routes with a scoped removal:
+ *   queue.removeQueuedJobsByScope({ tenantId, organizationId?, jobTypes: ['batch-index'] })
+ * and made both routes **fail closed with 503** when that scoped method is
+ * unavailable or throws. The queue strategies (local/async) gained the method.
+ * The PR shipped only unit + route tests against a MOCKED queue; this integration
+ * spec locks the contract in against the REAL cancel API + REAL queue strategy.
+ *
+ * What this asserts (deterministic in the backend-less integration env):
+ *  1. Scoped-cancel contract is wired on the real queue. An authenticated admin
+ *     cancel of BOTH the fulltext and vector paths returns 200 { ok:true,
+ *     jobsRemoved:<number> } — NOT the 503 fail-closed body. Under the old code
+ *     cancel always returned 200 via clear(); under the new code the route 503s
+ *     when the strategy lacks removeQueuedJobsByScope. So a green result proves
+ *     the running app's real local queue strategy implements the scoped method —
+ *     the queue-strategy half of #3992 the mocked unit tests never exercise.
+ *  2. Per-scope isolation. A second organization (orgB) with its own confined user
+ *     cancels independently; admin (orgA) and orgB cancels interleave and every
+ *     call returns a clean 200 { ok:true }. One scope's cancel neither errors nor
+ *     503s another scope's cancel — the observable proxy, without a live search
+ *     backend, for "cancel does not disrupt other scopes' queue state".
+ *
+ * Environment constraints (see TC-SEARCH-007): this env has no Meilisearch and no
+ * embedding provider, so a reindex enqueues zero `batch-index` jobs and holds no
+ * lock — jobsRemoved is therefore always 0 here, and cross-scope job SURVIVAL with
+ * real enqueued jobs plus the 503 fail-closed path (fault injection) are NOT
+ * black-box observable; they remain covered by the PR's unit/route tests. Full
+ * second-TENANT provisioning is unavailable to integration fixtures, so — like
+ * TC-SEARCH-004 — a second ORGANIZATION in the same tenant exercises the scope's
+ * organizationId dimension; the test skips the isolation case if orgB cannot be
+ * provisioned. Cancel is idempotent without a prior reindex (TC-SEARCH-003/007
+ * already rely on this in teardown).
+ */
+test.describe('TC-SEARCH-013: reindex cancellation is tenant/org scoped', () => {
+  test('scoped cancel returns the 200 contract per scope and stays isolated across orgs', async ({ request }) => {
+    test.slow()
+    test.setTimeout(120_000)
+
+    const stamp = Date.now()
+    let adminToken: string | null = null
+    let superToken: string | null = null
+    let orgBId: string | null = null
+    let roleId: string | null = null
+    let userBId: string | null = null
+    const roleName = `qa-search-013-${stamp}`
+    const userBEmail = `qa-search-013-${stamp}@acme.com`
+
+    const expectScopedCancelOk = async (token: string, path: string, label: string): Promise<void> => {
+      const res = await apiRequest(request, 'POST', path, { token })
+      // The scoped-removal path must be reachable: not 401/403 (gates), and crucially
+      // not the 503 fail-closed body that the route returns when the real queue
+      // strategy lacks removeQueuedJobsByScope.
+      expect(res.status(), `${label}: cancel must pass the auth/feature gates`).not.toBe(401)
+      expect(res.status(), `${label}: cancel must pass the auth/feature gates`).not.toBe(403)
+      expect(
+        res.status(),
+        `${label}: scoped cancel must succeed (200), not fail closed (503) — proves removeQueuedJobsByScope is wired`,
+      ).toBe(200)
+      const body = (await readJsonSafe<CancelBody>(res)) ?? {}
+      expect(body.ok, `${label}: cancel reports ok`).toBe(true)
+      expect(typeof body.jobsRemoved, `${label}: cancel reports a numeric jobsRemoved`).toBe('number')
+      expect(body.jobsRemoved, `${label}: jobsRemoved is a non-negative count`).toBeGreaterThanOrEqual(0)
+      expect(body.error, `${label}: a 200 scoped cancel carries no error`).toBeUndefined()
+    }
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+      superToken = await getAuthToken(request, 'superadmin')
+      const adminScope = getTokenScope(adminToken)
+
+      // 1. Admin (orgA) — the scoped-cancel contract is wired on the real queue for
+      //    both the fulltext and the vector paths.
+      await expectScopedCancelOk(adminToken, FULLTEXT_CANCEL, 'orgA fulltext')
+      await expectScopedCancelOk(adminToken, VECTOR_CANCEL, 'orgA vector')
+
+      // 2. Provision a second organization in the same tenant plus a confined user
+      //    that holds the reindex + embeddings-manage features. superadmin bypasses
+      //    the directory create command's tenant-selection enforcement.
+      const orgResp = await apiRequest(request, 'POST', '/api/directory/organizations', {
+        token: superToken,
+        data: { name: `QA Search 013 OrgB ${stamp}`, tenantId: adminScope.tenantId },
+      })
+      if (orgResp.status() !== 201) {
+        test.skip(true, `cannot provision a second organization in this environment (status ${orgResp.status()})`)
+        return
+      }
+      orgBId = expectId((await readJsonSafe<{ id?: string }>(orgResp))?.id, 'organization create returns an id')
+
+      roleId = await createRoleFixture(request, adminToken, { name: roleName, tenantId: adminScope.tenantId })
+      await setRoleAclFeatures(request, adminToken, {
+        roleId,
+        features: ['search.reindex', 'search.embeddings.manage'],
+      })
+      userBId = await createUserFixture(request, superToken, {
+        email: userBEmail,
+        password: VALID_PASSWORD,
+        organizationId: orgBId,
+        roles: [roleName],
+        name: 'QA Search 013 OrgB User',
+      })
+      await setUserAclVisibility(request, superToken, {
+        userId: userBId,
+        organizations: [orgBId],
+        features: ['search.reindex', 'search.embeddings.manage'],
+      })
+      const userBToken = await getAuthToken(request, userBEmail, VALID_PASSWORD)
+      expect(getTokenScope(userBToken).organizationId, 'org-B user is scoped to orgB').toBe(orgBId)
+
+      // 3. Per-scope isolation: interleave orgA and orgB cancels. Each call returns a
+      //    clean 200 { ok:true } — one scope's cancel never errors or fails closed
+      //    another scope's cancel, i.e. cancel does not wipe/disrupt shared state.
+      await expectScopedCancelOk(userBToken, FULLTEXT_CANCEL, 'orgB fulltext')
+      await expectScopedCancelOk(adminToken, FULLTEXT_CANCEL, 'orgA fulltext (after orgB)')
+      await expectScopedCancelOk(userBToken, VECTOR_CANCEL, 'orgB vector')
+      await expectScopedCancelOk(adminToken, VECTOR_CANCEL, 'orgA vector (after orgB)')
+    } finally {
+      await deleteUserIfExists(request, superToken, userBId)
+      await deleteRoleIfExists(request, adminToken, roleId)
+      await deleteOrganizationIfExists(request, superToken, orgBId)
+    }
+  })
+})


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-08-search-scoped-reindex-cancel-integration-test.md
Status: complete

## Goal
- Add the integration test flagged as a follow-up in PR #3992 (Fixes #3900): lock the tenant/organization-scoped search **reindex-cancellation** contract in against the **real** cancel API + **real** queue strategy — the gap the PR's mocked unit tests cannot cover.

## What Changed
- New spec `packages/search/src/modules/search/__integration__/TC-SEARCH-013.spec.ts` (next free `TC-SEARCH-*` number; 001–012 were already taken on develop).
- No product-code changes; test-only.

### What it asserts (deterministic in the backend-less integration env)
1. **Scoped-cancel contract is wired on the real queue.** An authenticated admin cancel of **both** the fulltext (`/api/search/reindex/cancel`) and vector (`/api/search/embeddings/reindex/cancel`) paths returns `200 { ok: true, jobsRemoved: <number> }` — **not** the `503` fail-closed body. PR #3992 replaced `queue.clear()` with `queue.removeQueuedJobsByScope(...)` and made the route **503 when that scoped method is missing**. So a green result proves the running app's real local queue strategy implements `removeQueuedJobsByScope` — the queue-strategy half of #3992 that the mocked unit tests never exercise. A revert of just the strategy change flips this to 503 and fails the test.
2. **Per-scope isolation.** A second organization (orgB) with its own confined user cancels independently; interleaved orgA/orgB cancels each return a clean `200 { ok: true }` — one scope's cancel never errors or fails-closed another scope's cancel. This is the observable proxy, without a live search backend, for "cancel does not wipe/disrupt other scopes' queue state" (the regression #3992 fixed).

### Documented limitations (mirroring TC-SEARCH-007)
- This env has **no Meilisearch / no embedding provider**, so a reindex enqueues zero `batch-index` jobs and holds no lock → `jobsRemoved` is always `0` here. Cross-scope job **survival** with real enqueued jobs and the **503 fail-closed** path (fault injection) are **not** black-box observable; they stay covered by the PR's unit/route tests.
- Full second-**tenant** provisioning is unavailable to integration fixtures, so — like `TC-SEARCH-004` — a second **organization** in the same tenant exercises the scope's `organizationId` dimension. The test `test.skip`s the isolation case if orgB cannot be provisioned; the single-scope contract assertions still run.

## Tests
- Added: `TC-SEARCH-013.spec.ts` (1 Playwright integration test). Self-contained: provisions orgB + role + confined user via API fixtures, tears them down in `finally`.
- Gate: `yarn build:packages` ✓, `yarn generate` ✓, `yarn i18n:check-sync` ✓, `yarn i18n:check-usage` ✓ (advisory), `yarn typecheck` ✓ (21/21), Playwright `--list` discovers & parses the spec ✓.
- `yarn test` (jest) and `yarn build:app` do **not** compile `__integration__/*.spec.ts` (jest `testMatch` = `__tests__/**/*.test.ts`; Next build ignores Playwright specs) → unaffected. Runtime execution runs in the ephemeral integration CI env (`ephemeral-integration` shards).

## Backward Compatibility
- No contract surface changes (test-only addition; no types, signatures, event IDs, routes, DI keys, ACL IDs, or generated files touched).

## Progress
See [Progress section in the plan](.ai/runs/2026-07-08-search-scoped-reindex-cancel-integration-test.md#progress).
