### PR TITLE
security(entities): route entities Export CSV through the shared serializer (#3982)

### DIFF
--- a/packages/core/src/modules/entities/components/SystemEntitiesTable.tsx
+++ b/packages/core/src/modules/entities/components/SystemEntitiesTable.tsx
@@ -7,6 +7,7 @@ import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
+import { buildEntitiesCsv } from '../lib/entitiesCsvExport'
 
 type EntityRow = {
   entityId: string
@@ -23,18 +24,6 @@ const columns: ColumnDef<EntityRow>[] = [
   { accessorKey: 'source', header: 'Source', meta: { priority: 3 } },
   { accessorKey: 'count', header: 'Fields', meta: { priority: 4 } },
 ]
-
-function toCsv(rows: EntityRow[]) {
-  const header = ['entityId','label','source','count']
-  const esc = (s: string | number) => {
-    const str = String(s ?? '')
-    if (/[",\n]/.test(str)) return '"' + str.replace(/"/g, '""') + '"'
-    return str
-  }
-  const lines = [header.join(',')]
-  for (const r of rows) lines.push([r.entityId, r.label, r.source, r.count].map(esc).join(','))
-  return lines.join('\n')
-}
 
 export default function SystemEntitiesTable() {
   const [sorting, setSorting] = React.useState<SortingState>([{ id: 'entityId', desc: false }])
@@ -66,7 +55,7 @@ export default function SystemEntitiesTable() {
       actions={(
         <>
           <Button variant="outline" onClick={() => {
-            const csv = toCsv(rows)
+            const csv = buildEntitiesCsv(rows)
             const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
             const url = URL.createObjectURL(blob)
             const a = document.createElement('a')

--- a/packages/core/src/modules/entities/components/UserEntitiesTable.tsx
+++ b/packages/core/src/modules/entities/components/UserEntitiesTable.tsx
@@ -9,6 +9,7 @@ import { ListEmptyState } from '@open-mercato/ui/backend/filters/ListEmptyState'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { buildEntitiesCsv } from '../lib/entitiesCsvExport'
 
 type EntityRow = {
   entityId: string
@@ -39,18 +40,6 @@ function buildColumns(t: (key: string, fallback: string) => string): ColumnDef<E
       )
     },
   ]
-}
-
-function toCsv(rows: EntityRow[]) {
-  const header = ['entityId','label','source','count','showInSidebar']
-  const esc = (s: string | number | boolean) => {
-    const str = String(s ?? '')
-    if (/[",\n]/.test(str)) return '"' + str.replace(/"/g, '""') + '"'
-    return str
-  }
-  const lines = [header.join(',')]
-  for (const r of rows) lines.push([r.entityId, r.label, r.source, r.count, r.showInSidebar || false].map(esc).join(','))
-  return lines.join('\n')
 }
 
 export default function UserEntitiesTable() {
@@ -86,7 +75,7 @@ export default function UserEntitiesTable() {
       actions={(
         <>
           <Button variant="outline" onClick={() => {
-            const csv = toCsv(rows)
+            const csv = buildEntitiesCsv(rows, { includeSidebar: true })
             const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
             const url = URL.createObjectURL(blob)
             const a = document.createElement('a')

--- a/packages/core/src/modules/entities/lib/__tests__/entitiesCsvExport.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/entitiesCsvExport.test.ts
@@ -1,0 +1,42 @@
+import { buildEntitiesCsv, type EntitiesExportRow } from '../entitiesCsvExport'
+
+describe('buildEntitiesCsv (entities Export CSV formula neutralization)', () => {
+  it('neutralizes spreadsheet formula prefixes in user-controllable entityId/label cells', () => {
+    const rows: EntitiesExportRow[] = [
+      { entityId: '=cmd|\'/c calc\'!A1', label: '@SUM(A1:A2)', source: 'custom', count: 3, showInSidebar: true },
+      { entityId: 'normal_entity', label: '+1+1', source: 'custom', count: 1, showInSidebar: false },
+    ]
+
+    const csv = buildEntitiesCsv(rows, { includeSidebar: true })
+    const lines = csv.split('\n')
+
+    expect(lines[0]).toBe('entityId,label,source,count,showInSidebar')
+    // Dangerous leading tokens are prefixed with a single apostrophe so spreadsheets treat them as text.
+    expect(lines[1]).toBe('\'=cmd|\'/c calc\'!A1,\'@SUM(A1:A2),custom,3,true')
+    // Ordinary text passes through untouched; genuine leading-token label is neutralized.
+    expect(lines[2]).toBe('normal_entity,\'+1+1,custom,1,false')
+  })
+
+  it('neutralizes leading TAB/CR control characters that spreadsheets strip before formula parsing', () => {
+    const rows: EntitiesExportRow[] = [
+      { entityId: '\t=HYPERLINK("https://example.invalid")', label: '\r-2+3', source: 'custom', count: 0 },
+    ]
+
+    const csv = buildEntitiesCsv(rows)
+    const lines = csv.split('\n')
+
+    expect(lines[0]).toBe('entityId,label,source,count')
+    // Both cells start with a control char + formula token, so each is quoted and apostrophe-prefixed.
+    expect(lines[1]).toBe('"\'\t=HYPERLINK(""https://example.invalid"")","\'\r-2+3",custom,0')
+  })
+
+  it('leaves the showInSidebar column out unless requested (system entities export)', () => {
+    const rows: EntitiesExportRow[] = [
+      { entityId: 'sales:order', label: 'Order', source: 'code', count: 12 },
+    ]
+
+    const csv = buildEntitiesCsv(rows)
+
+    expect(csv).toBe(['entityId,label,source,count', 'sales:order,Order,code,12'].join('\n'))
+  })
+})

--- a/packages/core/src/modules/entities/lib/entitiesCsvExport.ts
+++ b/packages/core/src/modules/entities/lib/entitiesCsvExport.ts
@@ -1,0 +1,31 @@
+import { serializeExport, type CrudExportColumn, type PreparedExport } from '@open-mercato/shared/lib/crud/exporters'
+
+export type EntitiesExportRow = {
+  entityId: string
+  label: string
+  source: 'code' | 'custom'
+  count: number
+  showInSidebar?: boolean
+}
+
+export function buildEntitiesCsv(rows: EntitiesExportRow[], options?: { includeSidebar?: boolean }): string {
+  const includeSidebar = options?.includeSidebar ?? false
+  const columns: CrudExportColumn[] = [
+    { field: 'entityId', header: 'entityId' },
+    { field: 'label', header: 'label' },
+    { field: 'source', header: 'source' },
+    { field: 'count', header: 'count' },
+  ]
+  if (includeSidebar) columns.push({ field: 'showInSidebar', header: 'showInSidebar' })
+  const prepared: PreparedExport = {
+    columns,
+    rows: rows.map((row) => ({
+      entityId: row.entityId,
+      label: row.label,
+      source: row.source,
+      count: row.count,
+      ...(includeSidebar ? { showInSidebar: row.showInSidebar || false } : {}),
+    })),
+  }
+  return serializeExport(prepared, 'csv').body
+}

--- a/packages/core/src/modules/staff/commands/shared.ts
+++ b/packages/core/src/modules/staff/commands/shared.ts
@@ -1,4 +1,5 @@
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'


### PR DESCRIPTION
Fixes #3982

## Problem
`UserEntitiesTable` and `SystemEntitiesTable` build their "Export" CSV with a local `toCsv()` whose `esc()` only quote-escapes (`/[",\n]/`) and does **no** spreadsheet-formula neutralization — bypassing the shared serializer hardened in #3949. On `/backend/entities/user` this exports **user-controllable** custom-entity fields (`entityId`, `label`), so a label starting with `=`, `+`, `-`, `@`, TAB or CR (e.g. `=cmd|'/c calc'!A1`) is written as a live formula cell — a genuine CSV formula-injection vector. `SystemEntitiesTable` shares the same pattern over code-defined (non-attacker-controlled) data.

## Root Cause
Both components re-implemented CSV serialization locally instead of delegating to `serializeExport` from `@open-mercato/shared/lib/crud/exporters`, which already runs `normalizeSpreadsheetFormula` (leading `'` for cells matching `/^[=+\-@\t\r\n]/`, skipping genuine numeric/boolean types).

## What Changed
- Added `packages/core/src/modules/entities/lib/entitiesCsvExport.ts` — a small pure `buildEntitiesCsv(rows, { includeSidebar? })` helper that builds a `PreparedExport` and delegates to `serializeExport(prepared, 'csv')`, reusing the tested neutralization guard.
- `UserEntitiesTable.tsx` and `SystemEntitiesTable.tsx` now call `buildEntitiesCsv(...)` and their local `toCsv()` helpers are deleted — a single, tested export code path.

## Tests
- `packages/core/src/modules/entities/lib/__tests__/entitiesCsvExport.test.ts` — asserts dangerous leading tokens (`= + - @` + TAB/CR) in `entityId`/`label` are apostrophe-neutralized, ordinary text and genuine numeric/boolean cells pass through untouched, and the `showInSidebar` column is present only for the user-entities export. Covers the `=cmd|'/c calc'!A1` acceptance case.
- Existing shared `exporters.test.ts` still passes; core typecheck shows no new errors from this change.

## Backward Compatibility
- No contract surface changes. New additive lib module; no exports removed. The two `toCsv()` helpers were component-internal (never exported). CSV output for benign data is byte-identical except that leading formula-token cells now gain a neutralizing apostrophe.