### PR TITLE
fix(staff): restore missing CommandRuntimeContext import (unblocks release PR #3594)

### DIFF
--- a/packages/core/src/modules/staff/commands/shared.ts
+++ b/packages/core/src/modules/staff/commands/shared.ts
@@ -1,3 +1,4 @@
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'


### PR DESCRIPTION
## Summary
The merge of #3978 dropped the type-only `CommandRuntimeContext` import from `packages/core/src/modules/staff/commands/shared.ts` while rewriting its import block. This breaks the app typecheck, failing the `prepare` CI step on `develop` and blocking the release PR #3594 (and the Standalone App Integration Tests, which hit the same error via `node_modules/@open-mercato/core`).

## Change
One-line fix: restore `import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'` — the same import used by every sibling command file (`activities.ts`, `leave-requests.ts`, `resources/commands/shared.ts`).

## Validation
- `yarn workspace @open-mercato/core typecheck` — clean
- `yarn workspace @open-mercato/core test --testPathPatterns 'staff/commands'` — 4 suites, 16 tests passed

Labels: `skip-qa` (typecheck-only, no behavior change), `priority-high` (release-blocking for v0.6.6), `risk-low` (one-line type import).

🤖 Generated with [Claude Code](https://claude.com/claude-code)