### PR TITLE
security(sales): gate document address access

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-035.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-035.spec.ts
@@ -1,6 +1,14 @@
 import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
 import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
 import { deleteSalesEntityIfExists } from '@open-mercato/core/helpers/integration/salesFixtures'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures'
 
 /**
  * TC-SALES-035: Document-address CRUD scoped to an order.
@@ -9,7 +17,8 @@ import { deleteSalesEntityIfExists } from '@open-mercato/core/helpers/integratio
  * Renumbered to 035: TC-SALES-030 is already taken (read-model totals, #2455/#2457).
  *
  * Document addresses (`/api/sales/document-addresses`) are polymorphic over a parent
- * `documentId` + `documentKind` (order|quote) and require auth only (no feature gate).
+ * `documentId` + `documentKind` (order|quote) and are feature-gated by the parent
+ * document kind (`sales.orders.*` / `sales.quotes.*`).
  * There is no `addressType` enum — the shipping/billing role is the free-text `purpose`
  * field, and the street is `addressLine1` (not `street`). `addressLine1` is the single
  * required address field; `country` is optional. PUT is a full replace (every required
@@ -30,6 +39,10 @@ async function readJson(response: APIResponse): Promise<JsonRecord> {
 
 function listItems(body: JsonRecord): JsonRecord[] {
   return Array.isArray(body.items) ? (body.items as JsonRecord[]) : []
+}
+
+function requiredFeatures(body: JsonRecord): string[] {
+  return Array.isArray(body.requiredFeatures) ? (body.requiredFeatures as string[]) : []
 }
 
 async function deleteDocumentAddress(
@@ -79,7 +92,12 @@ test.describe('TC-SALES-035 document address CRUD + order scoping', () => {
 
       const listed = listItems(
         await readJson(
-          await apiRequest(request, 'GET', `/api/sales/document-addresses?documentId=${encodeURIComponent(orderId)}`, { token }),
+          await apiRequest(
+            request,
+            'GET',
+            `/api/sales/document-addresses?documentId=${encodeURIComponent(orderId)}&documentKind=order`,
+            { token },
+          ),
         ),
       )
       const created = listed.find((row) => row.id === addressId) ?? {}
@@ -106,7 +124,12 @@ test.describe('TC-SALES-035 document address CRUD + order scoping', () => {
       expect(updateResponse.status(), 'PUT /api/sales/document-addresses should be 200').toBe(200)
       const afterUpdate = listItems(
         await readJson(
-          await apiRequest(request, 'GET', `/api/sales/document-addresses?documentId=${encodeURIComponent(orderId)}`, { token }),
+          await apiRequest(
+            request,
+            'GET',
+            `/api/sales/document-addresses?documentId=${encodeURIComponent(orderId)}&documentKind=order`,
+            { token },
+          ),
         ),
       ).find((row) => row.id === addressId) ?? {}
       expect(afterUpdate.address_line1).toBe('456 Oak Ave')
@@ -121,7 +144,12 @@ test.describe('TC-SALES-035 document address CRUD + order scoping', () => {
       expect(deleteResponse.status(), 'DELETE /api/sales/document-addresses should be 200').toBe(200)
       const afterDelete = listItems(
         await readJson(
-          await apiRequest(request, 'GET', `/api/sales/document-addresses?documentId=${encodeURIComponent(orderId)}`, { token }),
+          await apiRequest(
+            request,
+            'GET',
+            `/api/sales/document-addresses?documentId=${encodeURIComponent(orderId)}&documentKind=order`,
+            { token },
+          ),
         ),
       )
       expect(afterDelete.some((row) => row.id === addressId)).toBeFalsy()
@@ -129,6 +157,167 @@ test.describe('TC-SALES-035 document address CRUD + order scoping', () => {
     } finally {
       await deleteDocumentAddress(request, token, addressId, orderId)
       await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+
+  test('requires sales document-address features for order address reads and writes', async ({ request }) => {
+    test.slow()
+    const adminToken = await getAuthToken(request, 'admin')
+    const scope = getTokenScope(adminToken)
+    const stamp = Date.now()
+    const email = `qa-sales-address-denied-${stamp}@acme.com`
+    const password = `QaAddr1!${stamp}`
+    let roleId: string | null = null
+    let userId: string | null = null
+    let orderId: string | null = null
+    let quoteId: string | null = null
+    let addressId: string | null = null
+
+    try {
+      roleId = await createRoleFixture(request, adminToken, {
+        name: `QA Sales Address Denied ${stamp}`,
+        tenantId: scope.tenantId ?? undefined,
+      })
+      await setRoleAclFeatures(request, adminToken, { roleId, features: ['sales.settings.view', 'sales.quotes.manage'] })
+      userId = await createUserFixture(request, adminToken, {
+        email,
+        password,
+        organizationId: scope.organizationId!,
+        roles: [roleId],
+        name: `QA Sales Address Denied ${stamp}`,
+      })
+
+      const orderResponse = await apiRequest(request, 'POST', '/api/sales/orders', {
+        token: adminToken,
+        data: { currencyCode: 'USD' },
+      })
+      expect(orderResponse.status()).toBe(201)
+      orderId = (await readJson(orderResponse)).id as string
+
+      const quoteResponse = await apiRequest(request, 'POST', '/api/sales/quotes', {
+        token: adminToken,
+        data: { currencyCode: 'USD' },
+      })
+      expect(quoteResponse.status()).toBe(201)
+      quoteId = (await readJson(quoteResponse)).id as string
+
+      const createAddressResponse = await apiRequest(request, 'POST', '/api/sales/document-addresses', {
+        token: adminToken,
+        data: {
+          documentId: orderId,
+          documentKind: 'order',
+          purpose: 'billing',
+          addressLine1: '403 Guard Street',
+          city: 'Forbidden',
+          country: 'US',
+        },
+      })
+      expect(createAddressResponse.status()).toBe(201)
+      addressId = (await readJson(createAddressResponse)).id as string
+
+      const cachePrimingList = await apiRequest(
+        request,
+        'GET',
+        `/api/sales/document-addresses?documentId=${encodeURIComponent(orderId!)}&documentKind=order`,
+        { token: adminToken },
+      )
+      expect(cachePrimingList.status(), 'admin GET should be allowed before denied read').toBe(200)
+
+      const deniedToken = await getAuthToken(request, email, password)
+
+      const listDenied = await apiRequest(
+        request,
+        'GET',
+        `/api/sales/document-addresses?documentId=${encodeURIComponent(orderId!)}&documentKind=order`,
+        { token: deniedToken },
+      )
+      expect(listDenied.status(), 'GET without sales.orders.view should be 403').toBe(403)
+      expect(requiredFeatures(await readJson(listDenied))).toContain('sales.orders.view')
+
+      const createDenied = await apiRequest(request, 'POST', '/api/sales/document-addresses', {
+        token: deniedToken,
+        data: {
+          documentId: orderId,
+          documentKind: 'order',
+          purpose: 'shipping',
+          addressLine1: 'Blocked Create Street',
+        },
+      })
+      expect(createDenied.status(), 'POST without sales.orders.manage should be 403').toBe(403)
+      expect(requiredFeatures(await readJson(createDenied))).toContain('sales.orders.manage')
+
+      const updateDenied = await apiRequest(request, 'PUT', '/api/sales/document-addresses', {
+        token: deniedToken,
+        data: {
+          id: addressId,
+          documentId: orderId,
+          documentKind: 'order',
+          purpose: 'billing',
+          addressLine1: 'Blocked Update Street',
+        },
+      })
+      expect(updateDenied.status(), 'PUT without sales.orders.manage should be 403').toBe(403)
+      expect(requiredFeatures(await readJson(updateDenied))).toContain('sales.orders.manage')
+
+      const spoofedQuoteUpdateDenied = await apiRequest(request, 'PUT', '/api/sales/document-addresses', {
+        token: deniedToken,
+        data: {
+          id: addressId,
+          documentId: quoteId,
+          documentKind: 'quote',
+          purpose: 'billing',
+          addressLine1: 'Blocked Spoof Street',
+        },
+      })
+      expect(spoofedQuoteUpdateDenied.status(), 'PUT must authorize the stored order address kind').toBe(403)
+      expect(requiredFeatures(await readJson(spoofedQuoteUpdateDenied))).toContain('sales.orders.manage')
+
+      const spoofedQuoteUpdateAdminDenied = await apiRequest(request, 'PUT', '/api/sales/document-addresses', {
+        token: adminToken,
+        data: {
+          id: addressId,
+          documentId: quoteId,
+          documentKind: 'quote',
+          purpose: 'billing',
+          addressLine1: 'Blocked Admin Spoof Street',
+        },
+      })
+      expect(spoofedQuoteUpdateAdminDenied.status(), 'PUT must reject a parent-kind mismatch even for admin').toBe(404)
+
+      const deleteDenied = await apiRequest(
+        request,
+        'DELETE',
+        `/api/sales/document-addresses?id=${encodeURIComponent(addressId!)}&documentId=${encodeURIComponent(orderId!)}&documentKind=order`,
+        { token: deniedToken },
+      )
+      expect(deleteDenied.status(), 'DELETE without sales.orders.manage should be 403').toBe(403)
+      expect(requiredFeatures(await readJson(deleteDenied))).toContain('sales.orders.manage')
+
+      const spoofedQuoteDeleteDenied = await apiRequest(
+        request,
+        'DELETE',
+        `/api/sales/document-addresses?id=${encodeURIComponent(addressId!)}&documentId=${encodeURIComponent(quoteId!)}&documentKind=quote`,
+        { token: adminToken },
+      )
+      expect(spoofedQuoteDeleteDenied.status(), 'DELETE must reject a parent-kind mismatch even for admin').toBe(404)
+
+      const afterSpoofedDelete = listItems(
+        await readJson(
+          await apiRequest(
+            request,
+            'GET',
+            `/api/sales/document-addresses?documentId=${encodeURIComponent(orderId!)}&documentKind=order`,
+            { token: adminToken },
+          ),
+        ),
+      )
+      expect(afterSpoofedDelete.some((row) => row.id === addressId)).toBeTruthy()
+    } finally {
+      await deleteDocumentAddress(request, adminToken, addressId, orderId)
+      await deleteSalesEntityIfExists(request, adminToken, '/api/sales/orders', orderId)
+      await deleteSalesEntityIfExists(request, adminToken, '/api/sales/quotes', quoteId)
+      await deleteUserIfExists(request, adminToken, userId)
+      await deleteRoleIfExists(request, adminToken, roleId)
     }
   })
 

--- a/packages/core/src/modules/sales/api/document-addresses/route.ts
+++ b/packages/core/src/modules/sales/api/document-addresses/route.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod'
-import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
+import { makeCrudRoute, type CrudCtx } from '@open-mercato/shared/lib/crud/factory'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { createSalesCrudOpenApi, createPagedListResponseSchema, defaultOkResponseSchema } from '../openapi'
 import { withScopedPayload } from '../utils'
-import { SalesDocumentAddress } from '../../data/entities'
+import { SalesDocumentAddress, SalesOrder, SalesQuote } from '../../data/entities'
 import {
   documentAddressCreateSchema,
   documentAddressDeleteSchema,
@@ -34,8 +37,131 @@ const routeMetadata = {
 
 export const metadata = routeMetadata
 
+type DocumentKind = 'order' | 'quote'
+type DocumentAddressAccess = 'view' | 'manage'
+type Translate = (key: string, fallback?: string) => string
+
+const DOCUMENT_ADDRESS_FEATURES: Record<DocumentKind, Record<DocumentAddressAccess, string>> = {
+  order: { view: 'sales.orders.view', manage: 'sales.orders.manage' },
+  quote: { view: 'sales.quotes.view', manage: 'sales.quotes.manage' },
+}
+
+function toDocumentKind(value: unknown): DocumentKind | null {
+  return value === 'order' || value === 'quote' ? value : null
+}
+
+async function resolveDocumentKindForRead(query: { documentId?: string; documentKind?: DocumentKind }, ctx: CrudCtx) {
+  if (query.documentKind) return query.documentKind
+
+  const tenantId = ctx.auth?.tenantId ?? null
+  const organizationId =
+    ctx.selectedOrganizationId ??
+    ctx.auth?.orgId ??
+    (Array.isArray(ctx.organizationIds) && ctx.organizationIds.length === 1 ? ctx.organizationIds[0] : null)
+  if (!query.documentId || !tenantId || !organizationId) return null
+
+  const em = ctx.container.resolve('em') as EntityManager
+  const scope = { tenantId, organizationId }
+  const order = await findOneWithDecryption(em, SalesOrder, { id: query.documentId, tenantId, organizationId }, {}, scope)
+  if (order) return 'order'
+  const quote = await findOneWithDecryption(em, SalesQuote, { id: query.documentId, tenantId, organizationId }, {}, scope)
+  if (quote) return 'quote'
+  return null
+}
+
+async function ensureDocumentAddressReadAccess(query: { documentId?: string; documentKind?: DocumentKind }, ctx: CrudCtx) {
+  const documentKind = await resolveDocumentKindForRead(query, ctx)
+  const requiredFeatures = documentKind
+    ? [DOCUMENT_ADDRESS_FEATURES[documentKind].view]
+    : [DOCUMENT_ADDRESS_FEATURES.order.view, DOCUMENT_ADDRESS_FEATURES.quote.view]
+  await ensureDocumentAddressAccess(ctx, requiredFeatures)
+  return documentKind
+}
+
+async function resolveExistingAddressKind(
+  ctx: CrudCtx,
+  id: string,
+  scope: { tenantId: string; organizationId: string },
+): Promise<DocumentKind | null> {
+  const em = ctx.container.resolve('em') as EntityManager
+  const address = await findOneWithDecryption(
+    em,
+    SalesDocumentAddress,
+    { id, tenantId: scope.tenantId, organizationId: scope.organizationId },
+    {},
+    scope,
+  )
+  return toDocumentKind(address?.documentKind)
+}
+
+async function ensureDocumentAddressAccess(
+  ctx: CrudCtx,
+  requiredFeatures: string[],
+  translate?: Translate,
+): Promise<void> {
+  const resolvedTranslate = translate ?? (await resolveTranslations()).translate
+  const auth = ctx.auth
+  if (!auth?.sub) {
+    throw new CrudHttpError(401, { error: resolvedTranslate('api.errors.unauthorized', 'Unauthorized') })
+  }
+
+  let rbac: RbacService | null = null
+  try {
+    rbac = ctx.container.resolve('rbacService') as RbacService
+  } catch {
+    rbac = null
+  }
+
+  const ok = rbac
+    ? await rbac.userHasAllFeatures(auth.sub, requiredFeatures, {
+        tenantId: auth.tenantId ?? null,
+        organizationId: ctx.selectedOrganizationId ?? auth.orgId ?? null,
+      })
+    : false
+  if (!ok) {
+    throw new CrudHttpError(403, {
+      error: resolvedTranslate('api.errors.forbidden', 'Forbidden'),
+      requiredFeatures,
+    })
+  }
+}
+
+async function ensureDocumentAddressKindAccess(
+  ctx: CrudCtx,
+  documentKind: DocumentKind,
+  access: DocumentAddressAccess,
+  translate?: Translate,
+): Promise<void> {
+  await ensureDocumentAddressAccess(ctx, [DOCUMENT_ADDRESS_FEATURES[documentKind][access]], translate)
+}
+
+async function ensureDocumentAddressMutationAccess(
+  ctx: CrudCtx,
+  input: { id: string; documentKind: DocumentKind; tenantId: string; organizationId: string },
+  options: { includeTargetKind: boolean; translate?: Translate },
+): Promise<void> {
+  const existingKind = await resolveExistingAddressKind(ctx, input.id, {
+    tenantId: input.tenantId,
+    organizationId: input.organizationId,
+  })
+  const featureKinds = new Set<DocumentKind>()
+  if (existingKind) featureKinds.add(existingKind)
+  if (!existingKind || options.includeTargetKind) featureKinds.add(input.documentKind)
+
+  await ensureDocumentAddressAccess(
+    ctx,
+    [...featureKinds].map((kind) => DOCUMENT_ADDRESS_FEATURES[kind].manage),
+    options.translate,
+  )
+}
+
 const crud = makeCrudRoute({
   metadata: routeMetadata,
+  hooks: {
+    beforeList: async (query, ctx) => {
+      await ensureDocumentAddressReadAccess(query, ctx)
+    },
+  },
   orm: {
     entity: SalesDocumentAddress,
     idField: 'id',
@@ -76,12 +202,13 @@ const crud = makeCrudRoute({
       createdAt: 'created_at',
       updatedAt: 'updated_at',
     },
-    buildFilters: async (query: any) => {
+    buildFilters: async (query: any, ctx) => {
+      const documentKind = await resolveDocumentKindForRead(query, ctx)
       const filters: Record<string, any> = {
         document_id: { $eq: query.documentId },
       }
 
-      if (query.documentKind) filters.document_kind = { $eq: query.documentKind }
+      if (query.documentKind ?? documentKind) filters.document_kind = { $eq: query.documentKind ?? documentKind }
       return filters
     },
   },
@@ -91,7 +218,9 @@ const crud = makeCrudRoute({
       schema: rawBodySchema,
       mapInput: async ({ raw, ctx }) => {
         const { translate } = await resolveTranslations()
-        return documentAddressCreateSchema.parse(withScopedPayload(raw ?? {}, ctx, translate))
+        const input = documentAddressCreateSchema.parse(withScopedPayload(raw ?? {}, ctx, translate))
+        await ensureDocumentAddressKindAccess(ctx, input.documentKind, 'manage', translate)
+        return input
       },
       response: ({ result }) => ({ id: result?.id ?? null }),
       status: 201,
@@ -101,7 +230,9 @@ const crud = makeCrudRoute({
       schema: rawBodySchema,
       mapInput: async ({ raw, ctx }) => {
         const { translate } = await resolveTranslations()
-        return documentAddressUpdateSchema.parse(withScopedPayload(raw ?? {}, ctx, translate))
+        const input = documentAddressUpdateSchema.parse(withScopedPayload(raw ?? {}, ctx, translate))
+        await ensureDocumentAddressMutationAccess(ctx, input, { includeTargetKind: true, translate })
+        return input
       },
       response: () => ({ ok: true }),
     },
@@ -128,7 +259,9 @@ const crud = makeCrudRoute({
             error: translate('sales.documents.detail.error', 'Document not found or inaccessible.'),
           })
         }
-        return documentAddressDeleteSchema.parse(withScopedPayload({ id, documentId, documentKind }, ctx, translate))
+        const input = documentAddressDeleteSchema.parse(withScopedPayload({ id, documentId, documentKind }, ctx, translate))
+        await ensureDocumentAddressMutationAccess(ctx, input, { includeTargetKind: false, translate })
+        return input
       },
       response: () => ({ ok: true }),
     },

--- a/packages/core/src/modules/sales/commands/documentAddresses.ts
+++ b/packages/core/src/modules/sales/commands/documentAddresses.ts
@@ -104,6 +104,12 @@ function applyDocumentAddressSnapshot(em: EntityManager, entity: SalesDocumentAd
   entity.quote = snapshot.documentKind === 'quote' ? em.getReference(SalesQuote, snapshot.documentId) : null
 }
 
+function assertDocumentAddressParent(entity: SalesDocumentAddress, input: { documentId: string; documentKind: 'order' | 'quote' }): void {
+  if (entity.documentId !== input.documentId || entity.documentKind !== input.documentKind) {
+    throw new CrudHttpError(404, { error: 'sales.document.address.not_found' })
+  }
+}
+
 async function emitDocumentAddressIndexSideEffects(
   ctx: { container: { resolve: (name: string) => unknown } },
   action: 'created' | 'updated' | 'deleted',
@@ -256,6 +262,7 @@ const updateDocumentAddress: CommandHandler<DocumentAddressUpdateInput, { id: st
       'sales.document.address.not_found'
     )
     ensureSameScope(entity, input.organizationId, input.tenantId)
+    assertDocumentAddressParent(entity, input)
     const document = await requireDocument(em, input.documentKind, input.documentId, input.organizationId, input.tenantId)
     if (input.documentKind === 'order') {
       await assertAddressEditable(em, {
@@ -344,6 +351,7 @@ const deleteDocumentAddress: CommandHandler<
       'sales.document.address.not_found'
     )
     ensureSameScope(entity, input.organizationId, input.tenantId)
+    assertDocumentAddressParent(entity, input)
     const document = await requireDocument(em, input.documentKind, input.documentId, input.organizationId, input.tenantId)
     if (input.documentKind === 'order') {
       await assertAddressEditable(em, {


### PR DESCRIPTION
## Summary

Fixes #3895 by enforcing sales document-address ACL checks for reads and writes, including cache-hit read paths and spoofed parent fields on existing rows.

## Changes

- Gate document-address reads with the relevant order/quote view feature before CRUD cache lookup.
- Gate create/update/delete with the relevant order/quote manage feature, using the stored address kind for existing rows.
- Reject update/delete requests whose submitted document parent does not match the stored address parent.
- Add integration coverage for denied reads after cache priming, denied writes, and spoofed update/delete attempts.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor security fix, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn build:packages`
- `yarn typecheck`
- `yarn lint`
- `yarn i18n:check-sync`
- `ENABLE_CRUD_API_CACHE=true OM_OPTIMISTIC_LOCK=all yarn test:integration:ephemeral --no-reuse-env packages/core/src/modules/sales/__integration__/TC-SALES-035.spec.ts`
- `yarn test`
- `yarn build:app`
- Post-merge: `git diff --check HEAD~2..HEAD`
- Post-merge: `yarn typecheck`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

Backend-only API/command change; UI/DS checklist items are not applicable beyond no UI changes.

## Linked issues

Fixes #3895