### PR TITLE
security(resources): prevent timeline author spoofing

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-EMAIL-006.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-EMAIL-006.spec.ts
@@ -34,10 +34,9 @@ import {
  *   - email-admin: same as above PLUS customers.email.view_private — used here to
  *     PROVE the feature grants no write bypass in v1
  *
- * The interaction is created via admin token with authorUserId=userA.id so the
- * author ownership is established without requiring the compose route (which
- * needs a live channel fixture). The interactionCreateSchema accepts authorUserId
- * as an optional field.
+ * The interaction is created via User A's token so author ownership is derived
+ * from the authenticated caller without requiring the compose route (which needs
+ * a live channel fixture).
  */
 test.describe('TC-CRM-EMAIL-006: Email interaction visibility lifecycle', () => {
   test(
@@ -162,9 +161,6 @@ test.describe('TC-CRM-EMAIL-006: Email interaction visibility lifecycle', () => 
         });
         userAdminToken = await getAuthToken(request, userAdminEmail, userAdminPassword);
 
-        // -- Setup: derive User A's actual userId from their token --------------
-        const userAScope = getTokenScope(userAToken);
-
         // -- Setup: create a Person entity as the interaction target ------------
         personId = await createPersonFixture(request, adminToken, {
           firstName: 'CrmEmail006',
@@ -174,23 +170,21 @@ test.describe('TC-CRM-EMAIL-006: Email interaction visibility lifecycle', () => 
 
         // -- Setup: create a PRIVATE email interaction authored by User A ------
         //
-        // The interactionCreateSchema accepts authorUserId as an optional field.
-        // We POST as admin so the interaction is created without needing a live
-        // channel, and we explicitly set authorUserId to userA.id so the author
-        // ownership rule is established correctly.
+        // We POST through the interactions API as User A so the interaction is
+        // created without needing a live channel and the author ownership rule is
+        // established from the authenticated caller.
         const interactionResp = await apiRequest(
           request,
           'POST',
           '/api/customers/interactions',
           {
-            token: adminToken,
+            token: userAToken,
             data: {
               entityId: personId,
               interactionType: 'email',
               title: `TC-CRM-EMAIL-006 private email ${stamp}`,
               body: 'Private content',
               visibility: 'private',
-              authorUserId: userAScope.userId,
               status: 'done',
             },
           },

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-EMAIL-VISIBILITY-001.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-EMAIL-VISIBILITY-001.spec.ts
@@ -109,9 +109,6 @@ test.describe('TC-CRM-EMAIL-VISIBILITY-001: Email interaction visibility filter'
         });
         userBToken = await getAuthToken(request, userBEmail, userBPassword);
 
-        // -- Setup: derive User A's actual user ID from their token ----------
-        const userAScope = getTokenScope(userAToken);
-
         // -- Setup: create a Person entity as the interaction target ---------
         personId = await createPersonFixture(request, adminToken, {
           firstName: 'EmailVis',
@@ -125,14 +122,13 @@ test.describe('TC-CRM-EMAIL-VISIBILITY-001: Email interaction visibility filter'
           'POST',
           '/api/customers/interactions',
           {
-            token: adminToken,
+            token: userAToken,
             data: {
               entityId: personId,
               interactionType: 'email',
               title: `Private email subject ${stamp}`,
               body: 'Private body',
               visibility: 'private',
-              authorUserId: userAScope.userId,
               status: 'planned',
             },
           },
@@ -234,14 +230,13 @@ test.describe('TC-CRM-EMAIL-VISIBILITY-001: Email interaction visibility filter'
           'POST',
           '/api/customers/interactions',
           {
-            token: adminToken,
+            token: userAToken,
             data: {
               entityId: personId,
               interactionType: 'email',
               title: `Shared email subject ${stamp}`,
               body: 'Shared body',
               visibility: 'shared',
-              authorUserId: userAScope.userId,
               status: 'planned',
             },
           },
@@ -372,14 +367,13 @@ test.describe('TC-CRM-EMAIL-VISIBILITY-001: Email interaction visibility filter'
           'POST',
           '/api/customers/interactions',
           {
-            token: adminToken,
+            token: userAToken,
             data: {
               entityId: companyId,
               interactionType: 'email',
               title: `Company private email ${stamp}`,
               body: 'Company private body',
               visibility: 'private',
-              authorUserId: userAScope.userId,
               status: 'planned',
             },
           },

--- a/packages/core/src/modules/resources/commands/__tests__/comments-activities.authorship.test.ts
+++ b/packages/core/src/modules/resources/commands/__tests__/comments-activities.authorship.test.ts
@@ -1,0 +1,345 @@
+/** @jest-environment node */
+
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { User } from '@open-mercato/core/modules/auth/data/entities'
+import { ResourcesResource, ResourcesResourceActivity, ResourcesResourceComment } from '../../data/entities'
+import type {
+  ResourcesResourceActivityCreateInput,
+  ResourcesResourceActivityUpdateInput,
+  ResourcesResourceCommentCreateInput,
+  ResourcesResourceCommentUpdateInput,
+} from '../../data/validators'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/helpers')
+  return {
+    ...actual,
+    emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+    emitCrudUndoSideEffects: jest.fn().mockResolvedValue(undefined),
+    setCustomFieldsIfAny: jest.fn().mockResolvedValue(undefined),
+  }
+})
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async (em, entity, where) => em.findOne(entity, where)),
+}))
+
+const TENANT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const ORGANIZATION_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const RESOURCE_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+const COMMENT_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const ACTIVITY_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+const CALLER_USER_ID = '11111111-1111-4111-8111-111111111111'
+const SPOOFED_USER_ID = '22222222-2222-4222-8222-222222222222'
+const ORIGINAL_AUTHOR_ID = '33333333-3333-4333-8333-333333333333'
+
+type FakeResource = {
+  id: string
+  tenantId: string
+  organizationId: string
+}
+
+type FakeUser = {
+  id: string
+  tenantId: string | null
+  organizationId: string | null
+  deletedAt?: Date | null
+}
+
+type FakeComment = FakeResource & {
+  resource: FakeResource
+  body: string
+  authorUserId: string | null
+  appearanceIcon: string | null
+  appearanceColor: string | null
+}
+
+type FakeActivity = FakeResource & {
+  resource: FakeResource
+  activityType: string
+  subject: string | null
+  body: string | null
+  occurredAt: Date | null
+  authorUserId: string | null
+  appearanceIcon: string | null
+  appearanceColor: string | null
+}
+
+function buildResource(): FakeResource {
+  return {
+    id: RESOURCE_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORGANIZATION_ID,
+  }
+}
+
+function buildUser(overrides: Partial<FakeUser> = {}): FakeUser {
+  return {
+    id: SPOOFED_USER_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORGANIZATION_ID,
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
+function buildComment(overrides: Partial<FakeComment> = {}): FakeComment {
+  const resource = buildResource()
+  return {
+    id: COMMENT_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORGANIZATION_ID,
+    resource,
+    body: 'Initial comment',
+    authorUserId: ORIGINAL_AUTHOR_ID,
+    appearanceIcon: null,
+    appearanceColor: null,
+    ...overrides,
+  }
+}
+
+function buildActivity(overrides: Partial<FakeActivity> = {}): FakeActivity {
+  const resource = buildResource()
+  return {
+    id: ACTIVITY_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORGANIZATION_ID,
+    resource,
+    activityType: 'maintenance',
+    subject: 'Initial activity',
+    body: null,
+    occurredAt: null,
+    authorUserId: ORIGINAL_AUTHOR_ID,
+    appearanceIcon: null,
+    appearanceColor: null,
+    ...overrides,
+  }
+}
+
+function buildFakeEm(records: {
+  resource?: FakeResource
+  comment?: FakeComment | null
+  activity?: FakeActivity | null
+  user?: FakeUser | null
+} = {}) {
+  const resource = records.resource ?? buildResource()
+  const em = {
+    flush: jest.fn().mockResolvedValue(undefined),
+    persist: jest.fn(),
+    remove: jest.fn(),
+    findOne: jest.fn(async (entity: unknown, where?: Record<string, unknown>) => {
+      if (entity === ResourcesResource) return resource
+      if (entity === ResourcesResourceComment) return records.comment ?? null
+      if (entity === ResourcesResourceActivity) return records.activity ?? null
+      if (entity === User) {
+        const user = records.user ?? null
+        if (!user) return null
+        if (where?.id !== user.id) return null
+        if (where?.tenantId !== user.tenantId) return null
+        if (where?.organizationId !== user.organizationId) return null
+        if (where?.deletedAt !== user.deletedAt) return null
+        return user
+      }
+      return null
+    }),
+    create: jest.fn((entity: unknown, data: Record<string, unknown>) => {
+      if (entity === ResourcesResourceComment) return { id: COMMENT_ID, ...data }
+      if (entity === ResourcesResourceActivity) return { id: ACTIVITY_ID, ...data }
+      return { ...data }
+    }),
+  }
+  return em
+}
+
+function buildCtx(
+  em: ReturnType<typeof buildFakeEm>,
+  authOverrides: Partial<NonNullable<CommandRuntimeContext['auth']>> = {},
+): CommandRuntimeContext {
+  const emContainer = { fork: jest.fn().mockReturnValue(em) }
+  return {
+    container: {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return emContainer
+        if (name === 'dataEngine') return {}
+        return {}
+      }),
+    } as CommandRuntimeContext['container'],
+    auth: {
+      sub: CALLER_USER_ID,
+      tenantId: TENANT_ID,
+      orgId: ORGANIZATION_ID,
+      isSuperAdmin: false,
+      ...authOverrides,
+    },
+    organizationScope: null,
+    selectedOrganizationId: ORGANIZATION_ID,
+    organizationIds: [ORGANIZATION_ID],
+  }
+}
+
+describe('resources comment/activity authorship', () => {
+  beforeAll(async () => {
+    commandRegistry.clear()
+    await import('../comments')
+    await import('../activities')
+  })
+
+  it('derives created comment authors from auth instead of request input (#3891)', async () => {
+    const em = buildFakeEm()
+    const ctx = buildCtx(em)
+    const handler = commandRegistry.get<
+      ResourcesResourceCommentCreateInput,
+      { commentId: string; authorUserId: string | null }
+    >('resources.resource-comments.create')
+
+    const result = await handler!.execute(
+      {
+        tenantId: TENANT_ID,
+        organizationId: ORGANIZATION_ID,
+        entityId: RESOURCE_ID,
+        body: 'Forged comment author',
+        authorUserId: SPOOFED_USER_ID,
+      },
+      ctx,
+    )
+
+    expect(result.authorUserId).toBe(CALLER_USER_ID)
+    expect(em.create).toHaveBeenCalledWith(
+      ResourcesResourceComment,
+      expect.objectContaining({ authorUserId: CALLER_USER_ID }),
+    )
+  })
+
+  it('lets super admins delegate comment authorship to a live user in the resource scope (#3891)', async () => {
+    const em = buildFakeEm({ user: buildUser() })
+    const ctx = buildCtx(em, { isSuperAdmin: true })
+    const handler = commandRegistry.get<
+      ResourcesResourceCommentCreateInput,
+      { commentId: string; authorUserId: string | null }
+    >('resources.resource-comments.create')
+
+    const result = await handler!.execute(
+      {
+        tenantId: TENANT_ID,
+        organizationId: ORGANIZATION_ID,
+        entityId: RESOURCE_ID,
+        body: 'Delegated comment author',
+        authorUserId: SPOOFED_USER_ID,
+      },
+      ctx,
+    )
+
+    expect(result.authorUserId).toBe(SPOOFED_USER_ID)
+    expect(em.create).toHaveBeenCalledWith(
+      ResourcesResourceComment,
+      expect.objectContaining({ authorUserId: SPOOFED_USER_ID }),
+    )
+  })
+
+  it('falls back to the caller when a super admin delegates comment authorship outside resource scope (#3891)', async () => {
+    const em = buildFakeEm({
+      user: buildUser({ organizationId: '99999999-9999-4999-8999-999999999999' }),
+    })
+    const ctx = buildCtx(em, { isSuperAdmin: true })
+    const handler = commandRegistry.get<
+      ResourcesResourceCommentCreateInput,
+      { commentId: string; authorUserId: string | null }
+    >('resources.resource-comments.create')
+
+    const result = await handler!.execute(
+      {
+        tenantId: TENANT_ID,
+        organizationId: ORGANIZATION_ID,
+        entityId: RESOURCE_ID,
+        body: 'Out-of-scope delegated comment author',
+        authorUserId: SPOOFED_USER_ID,
+      },
+      ctx,
+    )
+
+    expect(result.authorUserId).toBe(CALLER_USER_ID)
+    expect(em.create).toHaveBeenCalledWith(
+      ResourcesResourceComment,
+      expect.objectContaining({ authorUserId: CALLER_USER_ID }),
+    )
+  })
+
+  it('does not let comment updates reassign the author from request input (#3891)', async () => {
+    const comment = buildComment()
+    const em = buildFakeEm({ comment })
+    const ctx = buildCtx(em)
+    const handler = commandRegistry.get<ResourcesResourceCommentUpdateInput, { commentId: string }>(
+      'resources.resource-comments.update',
+    )
+
+    await handler!.execute(
+      {
+        id: COMMENT_ID,
+        body: 'Updated comment body',
+        authorUserId: SPOOFED_USER_ID,
+      },
+      ctx,
+    )
+
+    expect(comment.body).toBe('Updated comment body')
+    expect(comment.authorUserId).toBe(ORIGINAL_AUTHOR_ID)
+  })
+
+  it('derives created activity authors from auth instead of request input (#3891)', async () => {
+    const em = buildFakeEm()
+    const ctx = buildCtx(em)
+    const handler = commandRegistry.get<
+      ResourcesResourceActivityCreateInput,
+      { activityId: string; authorUserId: string | null }
+    >('resources.resource-activities.create')
+
+    const result = await handler!.execute(
+      {
+        tenantId: TENANT_ID,
+        organizationId: ORGANIZATION_ID,
+        entityId: RESOURCE_ID,
+        activityType: 'maintenance',
+        subject: 'Forged activity author',
+        authorUserId: SPOOFED_USER_ID,
+      },
+      ctx,
+    )
+
+    expect(result.authorUserId).toBe(CALLER_USER_ID)
+    expect(em.create).toHaveBeenCalledWith(
+      ResourcesResourceActivity,
+      expect.objectContaining({ authorUserId: CALLER_USER_ID }),
+    )
+  })
+
+  it('does not let activity updates reassign the author from request input (#3891)', async () => {
+    const activity = buildActivity()
+    const em = buildFakeEm({ activity })
+    const ctx = buildCtx(em)
+    const handler = commandRegistry.get<ResourcesResourceActivityUpdateInput, { activityId: string }>(
+      'resources.resource-activities.update',
+    )
+
+    await handler!.execute(
+      {
+        id: ACTIVITY_ID,
+        subject: 'Updated activity subject',
+        authorUserId: SPOOFED_USER_ID,
+      },
+      ctx,
+    )
+
+    expect(activity.subject).toBe('Updated activity subject')
+    expect(activity.authorUserId).toBe(ORIGINAL_AUTHOR_ID)
+  })
+})

--- a/packages/core/src/modules/resources/commands/activities.ts
+++ b/packages/core/src/modules/resources/commands/activities.ts
@@ -7,7 +7,6 @@ import {
   emitCrudUndoSideEffects,
   buildChanges,
   requireId,
-  normalizeAuthorUserId,
 } from '@open-mercato/shared/lib/commands/helpers'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import type { EntityManager } from '@mikro-orm/postgresql'
@@ -30,7 +29,7 @@ import {
   type ResourcesResourceActivityUpdateInput,
 } from '../data/validators'
 import { resourcesResourceActivityCrudEvents } from '../lib/crud'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireResource } from './shared'
+import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireResource, resolveResourceAuthorUserId } from './shared'
 import { E } from '#generated/entities.ids.generated'
 
 const ACTIVITY_ENTITY_ID = E.resources.resources_resource_activity
@@ -117,12 +116,15 @@ const createActivityCommand: CommandHandler<ResourcesResourceActivityCreateInput
     const { parsed, custom } = parseWithCustomFields(resourcesResourceActivityCreateSchema, rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
-    const normalizedAuthor = normalizeAuthorUserId(parsed.authorUserId, ctx.auth)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const resource = await requireResource(em, parsed.entityId, 'Resource not found')
     ensureTenantScope(ctx, resource.tenantId)
     ensureOrganizationScope(ctx, resource.organizationId)
+    const normalizedAuthor = await resolveResourceAuthorUserId(em, parsed.authorUserId, ctx, {
+      tenantId: resource.tenantId,
+      organizationId: resource.organizationId,
+    })
 
     const activity = em.create(ResourcesResourceActivity, {
       organizationId: parsed.organizationId,
@@ -287,7 +289,6 @@ const updateActivityCommand: CommandHandler<ResourcesResourceActivityUpdateInput
     if (parsed.subject !== undefined) activity.subject = parsed.subject ?? null
     if (parsed.body !== undefined) activity.body = parsed.body ?? null
     if (parsed.occurredAt !== undefined) activity.occurredAt = parsed.occurredAt ?? null
-    if (parsed.authorUserId !== undefined) activity.authorUserId = parsed.authorUserId ?? null
     if (parsed.appearanceIcon !== undefined) activity.appearanceIcon = parsed.appearanceIcon ?? null
     if (parsed.appearanceColor !== undefined) activity.appearanceColor = parsed.appearanceColor ?? null
 

--- a/packages/core/src/modules/resources/commands/comments.ts
+++ b/packages/core/src/modules/resources/commands/comments.ts
@@ -1,6 +1,6 @@
 import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { CommandHandler } from '@open-mercato/shared/lib/commands'
-import { emitCrudSideEffects, emitCrudUndoSideEffects, buildChanges, requireId, normalizeAuthorUserId } from '@open-mercato/shared/lib/commands/helpers'
+import { emitCrudSideEffects, emitCrudUndoSideEffects, buildChanges, requireId } from '@open-mercato/shared/lib/commands/helpers'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
@@ -15,7 +15,7 @@ import {
 } from '../data/validators'
 import { resourcesResourceCommentCrudEvents } from '../lib/crud'
 import { makeCreateRedo } from '@open-mercato/shared/lib/commands/redo'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireResource } from './shared'
+import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload, requireResource, resolveResourceAuthorUserId } from './shared'
 import { E } from '#generated/entities.ids.generated'
 
 const commentCrudIndexer: CrudIndexerConfig<ResourcesResourceComment> = {
@@ -62,12 +62,15 @@ const createCommentCommand: CommandHandler<
     const parsed = resourcesResourceCommentCreateSchema.parse(rawInput)
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
-    const normalizedAuthor = normalizeAuthorUserId(parsed.authorUserId, ctx.auth)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const resource = await requireResource(em, parsed.entityId, 'Resource not found')
     ensureTenantScope(ctx, resource.tenantId)
     ensureOrganizationScope(ctx, resource.organizationId)
+    const normalizedAuthor = await resolveResourceAuthorUserId(em, parsed.authorUserId, ctx, {
+      tenantId: resource.tenantId,
+      organizationId: resource.organizationId,
+    })
 
     const comment = em.create(ResourcesResourceComment, {
       organizationId: parsed.organizationId,
@@ -177,7 +180,6 @@ const updateCommentCommand: CommandHandler<ResourcesResourceCommentUpdateInput, 
       comment.resource = resource
     }
     if (parsed.body !== undefined) comment.body = parsed.body
-    if (parsed.authorUserId !== undefined) comment.authorUserId = parsed.authorUserId ?? null
     if (parsed.appearanceIcon !== undefined) comment.appearanceIcon = parsed.appearanceIcon ?? null
     if (parsed.appearanceColor !== undefined) comment.appearanceColor = parsed.appearanceColor ?? null
 

--- a/packages/core/src/modules/resources/commands/shared.ts
+++ b/packages/core/src/modules/resources/commands/shared.ts
@@ -1,7 +1,11 @@
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
+import { normalizeAuthorUserId } from '@open-mercato/shared/lib/commands/helpers'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { User } from '@open-mercato/core/modules/auth/data/entities'
 import { ResourcesResource } from '../data/entities'
 
 export { ensureOrganizationScope, ensureTenantScope, extractUndoPayload }
@@ -14,4 +18,36 @@ export async function requireResource(
   const resource = await em.findOne(ResourcesResource, { id: resourceId })
   if (!resource) throw new CrudHttpError(404, { error: message })
   return resource
+}
+
+export async function resolveResourceAuthorUserId(
+  em: EntityManager,
+  explicitAuthorUserId: string | undefined | null,
+  ctx: CommandRuntimeContext,
+  scope: { tenantId: string; organizationId: string },
+): Promise<string | null> {
+  const normalizedAuthor = normalizeAuthorUserId(explicitAuthorUserId, ctx.auth)
+  const fallbackAuthor = normalizeAuthorUserId(null, ctx.auth)
+  const isExplicitSuperAdminAuthor =
+    Boolean(explicitAuthorUserId) &&
+    normalizedAuthor === explicitAuthorUserId &&
+    ctx.auth?.isApiKey !== true &&
+    (ctx.auth as { isSuperAdmin?: boolean } | null)?.isSuperAdmin === true
+
+  if (!isExplicitSuperAdminAuthor || !normalizedAuthor) return normalizedAuthor
+
+  const author = await findOneWithDecryption(
+    em,
+    User,
+    {
+      id: normalizedAuthor,
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      deletedAt: null,
+    },
+    undefined,
+    { tenantId: scope.tenantId, organizationId: scope.organizationId },
+  )
+
+  return author ? normalizedAuthor : fallbackAuthor
 }

--- a/packages/shared/src/lib/commands/__tests__/normalizeAuthorUserId.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/normalizeAuthorUserId.test.ts
@@ -3,8 +3,20 @@ import { normalizeAuthorUserId } from '@open-mercato/shared/lib/commands/helpers
 describe('normalizeAuthorUserId', () => {
   const validUuid = 'a1b2c3d4-e5f6-1a2b-9c3d-4e5f6a7b8c9d'
 
-  it('returns explicit authorUserId when provided', () => {
-    expect(normalizeAuthorUserId('explicit-id', { sub: validUuid })).toBe('explicit-id')
+  it('ignores explicit authorUserId for normal authenticated callers', () => {
+    const spoofedUuid = 'b1b2c3d4-e5f6-1a2b-9c3d-4e5f6a7b8c9d'
+
+    expect(normalizeAuthorUserId(spoofedUuid, { sub: validUuid })).toBe(validUuid)
+  })
+
+  it('honors explicit authorUserId for super admins', () => {
+    const delegatedUuid = 'b1b2c3d4-e5f6-1a2b-9c3d-4e5f6a7b8c9d'
+
+    expect(normalizeAuthorUserId(delegatedUuid, { sub: validUuid, isSuperAdmin: true })).toBe(delegatedUuid)
+  })
+
+  it('rejects non-UUID explicit authorUserId values for super admins', () => {
+    expect(normalizeAuthorUserId('not-a-uuid', { sub: validUuid, isSuperAdmin: true })).toBe(validUuid)
   })
 
   it('returns null when no explicit ID and auth is null', () => {

--- a/packages/shared/src/lib/commands/helpers.ts
+++ b/packages/shared/src/lib/commands/helpers.ts
@@ -170,9 +170,16 @@ const AUTHOR_UUID_REGEX = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[8
 
 export function normalizeAuthorUserId(
   explicitAuthorUserId: string | undefined | null,
-  auth: { isApiKey?: boolean; sub?: string | null } | undefined | null
+  auth: { isApiKey?: boolean; isSuperAdmin?: boolean; sub?: string | null } | undefined | null
 ): string | null {
-  if (explicitAuthorUserId) return explicitAuthorUserId
+  if (
+    explicitAuthorUserId &&
+    auth?.isSuperAdmin === true &&
+    auth.isApiKey !== true &&
+    AUTHOR_UUID_REGEX.test(explicitAuthorUserId)
+  ) {
+    return explicitAuthorUserId
+  }
   const authSub = auth?.isApiKey ? null : auth?.sub ?? null
   if (!authSub) return null
   return AUTHOR_UUID_REGEX.test(authSub) ? authSub : null


### PR DESCRIPTION
## Summary

Fixes a resource timeline integrity issue where comment and activity commands could trust client-supplied `authorUserId` values. Normal callers now derive authorship from the authenticated actor, and trusted delegation is constrained to live users in the target resource scope.

## Changes

- Harden `normalizeAuthorUserId` so normal callers cannot override authorship.
- Validate resource super-admin delegated authors against the resource tenant and organization.
- Preserve existing resource comment/activity authors on update even if `authorUserId` is supplied.
- Update CRM email visibility fixtures that previously relied on explicit author assignment.
- Add focused regression coverage for create spoofing, update reassignment, and delegated author validation.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor issue-scoped security fix, no spec needed)

**Spec file path:** N/A

## Testing

- `yarn workspace @open-mercato/shared test --runTestsByPath src/lib/commands/__tests__/normalizeAuthorUserId.test.ts --runInBand`
- `yarn workspace @open-mercato/core test --runTestsByPath src/modules/resources/commands/__tests__/comments-activities.authorship.test.ts --runInBand`
- `yarn typecheck`
- `yarn lint`
- `yarn test:integration:ephemeral "TC-RESO-005|TC-RESO-006|TC-CRM-EMAIL-006|TC-CRM-EMAIL-VISIBILITY-001" --no-screenshots`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3891