### PR TITLE
feat(commands): first-class bulk-import side-effect suppression

### DIFF
--- a/.ai/specs/2026-07-08-bulk-import-side-effect-suppression.md
+++ b/.ai/specs/2026-07-08-bulk-import-side-effect-suppression.md
@@ -1,0 +1,122 @@
+# Bulk-Import Side-Effect Suppression
+
+| Field | Value |
+|-------|-------|
+| **Status** | Draft |
+| **Created** | 2026-07-08 |
+| **Builds on** | SPEC-045b (Data Sync Hub), 2026-06-15-query-index-orm-backed-classification-hardening |
+| **Related** | Command bus (`@open-mercato/shared/lib/commands`), Data engine (`@open-mercato/shared/lib/data/engine.ts`) |
+
+## TLDR
+
+**Problem.** A large data-sync backfill executes the same write commands as interactive
+use — and pays the same per-record side effects: an inline `query_index` reindex (which
+rebuilds `search_tokens`, the dominant write cost), a `<module>.<entity>.<action>` domain
+event, and any per-record notification fan-out. Across hundreds of thousands of records
+this is the backfill's bottleneck, and most of it is wasted work: the index is far cheaper
+to rebuild once at the end, the events have no live consumer during a bulk import, and the
+notifications would spam users with backfilled history.
+
+**Solution.** An opt-in, additive `bulkImport` flag set on the command runtime context. When
+present, the command bus and data engine skip the flagged per-record side effects for that
+command's writes; the caller runs a single batched `query_index rebuild` for the affected
+entity types at end-of-run. Interactive (unflagged) writes are byte-for-byte unchanged.
+
+**Key property — concurrency safety.** The flags are read from the context and threaded as a
+**local parameter** through the side-effect flush. No suppression state is stored on the
+shared `dataEngine` instance, so two commands running concurrently with different flags can
+never observe or clobber each other's suppression.
+
+## Motivation
+
+`CommandBus.execute()` already exposes `skipCacheInvalidation` as a per-execution escape
+hatch for callers that will invalidate the cache themselves. Bulk backfills need the
+equivalent for the three heavy per-record side effects, for the same reason: the caller can
+restore the deferred work far more cheaply in one pass.
+
+Telemetry from a production data-sync order backfill attributed ~65% of per-order write
+cost to the inline `search_tokens` reindex alone. Deferring it (plus one batched rebuild)
+is the single biggest backfill throughput lever, and the events/notifications are pure
+waste during an import.
+
+## Design
+
+### Contract
+
+`CommandRuntimeContext` gains an optional `bulkImport` field:
+
+```ts
+export type BulkImportSuppression = {
+  /** Skip the inline `query_index.upsert_one` / `delete_one` reindex (rebuild after the run). */
+  skipReindex?: boolean
+  /** Skip the per-record `<module>.<entity>.<action>` domain event emission. */
+  skipEvents?: boolean
+  /** Advisory: handlers that fan out per-record notifications SHOULD honor this and skip them. */
+  skipNotifications?: boolean
+}
+
+export type CommandRuntimeContext = {
+  // …existing fields…
+  bulkImport?: BulkImportSuppression
+}
+```
+
+### Flow (no shared mutable state)
+
+1. A backfill caller sets `ctx.bulkImport = { skipReindex: true, skipEvents: true, skipNotifications: true }`.
+2. `CommandBus.execute()` reads `effectiveOptions.ctx?.bulkImport` after the handler runs and
+   passes it as a **local argument** into `flushCrudSideEffects(container, suppress)`.
+3. `flushCrudSideEffects` forwards it to `DataEngine.flushOrmEntityChanges(suppress)`, which
+   forwards it to each queued entry's `emitOrmEntityEvent({ …, suppress })`.
+4. `emitOrmEntityEvent` gates the domain event on `!suppress?.skipEvents` and the inline
+   reindex on `!suppress?.skipReindex`. When both are suppressed it bails before resolving the
+   event bus.
+5. Handlers that create per-record notifications (sales `create-order` / `create-quote`) gate
+   the `notificationService.createForFeature(...)` call on `!ctx.bulkImport?.skipNotifications`.
+   `skipNotifications` is **advisory** — there is no central notification choke point, so each
+   fan-out site opts in explicitly.
+
+The exported `flushCrudSideEffects(dataEngine, suppress?)` helper
+(`@open-mercato/shared/lib/commands/helpers`) takes the same optional `suppress`, so **direct
+bulk-write paths that flush there instead of going through the command bus** (e.g. the staff
+bulk timesheet route) can honor the same deferral. Both flush entry points forward to the one
+mechanism — `DataEngine.flushOrmEntityChanges(suppress)` — so suppression can never be silently
+ignored on one path.
+
+### Caller responsibility
+
+`skipReindex` leaves the `query_index` projection (and its `search_tokens`) stale for every
+record written under the flag. **The caller MUST run a batched `query_index rebuild` for the
+affected entity types at end-of-run.** A resumable backfill that re-runs to completion
+re-fires that rebuild, so a failed rebuild is recoverable by re-running.
+
+### Why `ctx` and not a top-level execution option
+
+`skipReindex` / `skipEvents` are consumed by the command bus, which sees the execution
+options. But `skipNotifications` is consumed **inside the handler** (`execute(input, ctx)`),
+which only receives `ctx` — never the execution options. Putting all three on `ctx` keeps a
+single, coherent home that both the bus and the handlers can read.
+
+## Backward compatibility
+
+Fully additive. With `bulkImport` unset (every interactive path), `emitOrmEntityEvent` keeps
+its original early-return and emits both the event and the reindex exactly as before; the
+sales notification calls are unchanged. No migration, no config, no behavior change for
+existing callers.
+
+## Testing
+
+- Unit (`packages/shared/src/lib/data/__tests__/engine.bulk-suppress.test.ts`): the four
+  suppression combinations on `emitOrmEntityEvent`, plus a non-leakage assertion proving
+  `flushOrmEntityChanges(suppress)` does not persist suppression across successive flushes on
+  the same engine instance (the concurrency-safety guarantee).
+- Regression: existing shared `commands`/`data` (130) and sales `commands`/`api` (150) suites
+  stay green — the unflagged path is unchanged.
+
+Integration coverage is intentionally omitted: this is an internal command-bus/data-engine
+contract with no HTTP or UI surface, fully exercised at the unit level.
+
+## Changelog
+
+- **2026-07-08** — Initial draft + implementation: `BulkImportSuppression` type, `ctx.bulkImport`,
+  command-bus → data-engine parameter threading, sales notification gating, unit coverage.

--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -102,6 +102,7 @@ Specs awaiting implementation or partially complete. Focus here for actionable w
 | [Coding-Agent Session Collection](2026-06-15-coding-agent-session-collection.md) | 2026-06-15 | Coding-Agent Session Collection (Dev Session Insights) | Opt-in, consent-gated collection of sanitized Claude Code / Codex sessions: `create-mercato-app` hook installer, local PII/secret redaction (`@open-mercato/dev-session-kit`), fail-open shipper, and the OSS `coding_sessions` ingestion module (token `202` endpoint, async worker with server-side re-scan + quarantine, filesystem-first blobs + metadata index). Complements the telemetry/phone-home specs |
 | [Dictionary Custom Field Multiselect](2026-06-19-dictionary-custom-field-multiselect.md) | 2026-06-19 | Dictionary Custom Field Multiselect | Dictionary-backed custom fields can opt into multi-select CRUD form rendering while reusing existing EAV array persistence |
 | [Package Previews](2026-06-22-label-based-package-previews.md) | 2026-06-22 | Label-Based Package Previews | Label-triggered pkg.pr.new previews with npm canary snapshots moved behind a separate opt-in label |
+| [Bulk-Import Side-Effect Suppression](2026-07-08-bulk-import-side-effect-suppression.md) | 2026-07-08 | Bulk-Import Side-Effect Suppression | Opt-in `ctx.bulkImport` flag lets a backfill defer per-record reindex/events/notifications (rebuilt in one batched pass); concurrency-safe via parameter threading, no shared engine state |
 
 ### Implemented Specifications
 

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -4735,10 +4735,14 @@ const createQuoteCommand: CommandHandler<
           linkHref: `/backend/sales/quotes/${quote.id}`,
         });
 
-        await notificationService.createForFeature(notificationInput, {
-          tenantId: quote.tenantId,
-          organizationId: quote.organizationId ?? null,
-        });
+        // Bulk-import backfills opt out of the per-record notification fan-out (and its inline
+        // e-mail delivery); interactive creates are unaffected.
+        if (!ctx.bulkImport?.skipNotifications) {
+          await notificationService.createForFeature(notificationInput, {
+            tenantId: quote.tenantId,
+            organizationId: quote.organizationId ?? null,
+          });
+        }
       }
     } catch (err) {
       // Notification creation is non-critical, don't fail the command
@@ -5741,10 +5745,14 @@ const createOrderCommand: CommandHandler<
           linkHref: `/backend/sales/orders/${order.id}`,
         });
 
-        await notificationService.createForFeature(notificationInput, {
-          tenantId: order.tenantId,
-          organizationId: order.organizationId ?? null,
-        });
+        // Bulk-import backfills opt out of the per-record notification fan-out (and its inline
+        // e-mail delivery); interactive creates are unaffected.
+        if (!ctx.bulkImport?.skipNotifications) {
+          await notificationService.createForFeature(notificationInput, {
+            tenantId: order.tenantId,
+            organizationId: order.organizationId ?? null,
+          });
+        }
       }
     } catch (err) {
       // Notification creation is non-critical, don't fail the command

--- a/packages/shared/src/lib/commands/command-bus.ts
+++ b/packages/shared/src/lib/commands/command-bus.ts
@@ -2,6 +2,7 @@ import type { ActionLog } from '@open-mercato/core/modules/audit_logs/data/entit
 import type { ActionLogCreateInput } from '@open-mercato/core/modules/audit_logs/data/validators'
 import { commandRegistry } from './registry'
 import type {
+  BulkImportSuppression,
   CommandExecutionOptions,
   CommandExecuteResult,
   CommandHandler,
@@ -293,7 +294,11 @@ export class CommandBus {
     if (!effectiveOptions.skipCacheInvalidation) {
       await this.invalidateCacheAfterExecute(commandId, effectiveOptions, finalResult, mergedMeta)
     }
-    await this.flushCrudSideEffects(effectiveOptions.ctx.container)
+    // Bulk-import backfills defer heavy per-record side effects: the ctx flags are read here and
+    // threaded as a local into the flush (never stored on the shared dataEngine), so a concurrent
+    // command with different flags can't observe them. Reindex is restored by the caller's
+    // end-of-run `query_index rebuild`. Mirrors `skipCacheInvalidation` above.
+    await this.flushCrudSideEffects(effectiveOptions.ctx.container, effectiveOptions.ctx?.bulkImport)
     return { result: finalResult, logEntry }
   }
 
@@ -662,10 +667,10 @@ export class CommandBus {
     }
   }
 
-  private async flushCrudSideEffects(container: AwilixContainer): Promise<void> {
+  private async flushCrudSideEffects(container: AwilixContainer, suppress?: BulkImportSuppression): Promise<void> {
     try {
       const dataEngine = (container.resolve('dataEngine') as DataEngine)
-      await dataEngine.flushOrmEntityChanges()
+      await dataEngine.flushOrmEntityChanges(suppress)
     } catch {
       // best-effort: failures should not block command execution
     }

--- a/packages/shared/src/lib/commands/helpers.ts
+++ b/packages/shared/src/lib/commands/helpers.ts
@@ -7,6 +7,7 @@ export { normalizeCustomFieldValues } from '../custom-fields/normalize'
 import type { CrudEventsConfig, CrudIndexerConfig, CrudEmitContext } from '@open-mercato/shared/lib/crud/types'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { CommandLogMetadata } from '@open-mercato/shared/lib/commands'
+import type { BulkImportSuppression } from '@open-mercato/shared/lib/commands'
 
 export type ParsedPayload<TSchema extends z.ZodTypeAny> = {
   parsed: z.infer<TSchema>
@@ -86,8 +87,11 @@ export async function emitCrudUndoSideEffects<TEntity>(opts: {
   })
 }
 
-export async function flushCrudSideEffects(dataEngine: DataEngine): Promise<void> {
-  await dataEngine.flushOrmEntityChanges()
+export async function flushCrudSideEffects(dataEngine: DataEngine, suppress?: BulkImportSuppression): Promise<void> {
+  // Direct-write bulk paths (those that flush here instead of going through the command bus) can
+  // pass the same `bulkImport` suppression so a bulk run defers per-record events/reindex on this
+  // path too. Omitted for normal writes → unchanged behavior. Mirrors the command bus's own flush.
+  await dataEngine.flushOrmEntityChanges(suppress)
 }
 
 export function buildChanges(

--- a/packages/shared/src/lib/commands/types.ts
+++ b/packages/shared/src/lib/commands/types.ts
@@ -4,6 +4,29 @@ import { randomUUID } from 'crypto'
 import type { AuthContext } from '../auth/server'
 import type { OrganizationScope } from '@open-mercato/core/modules/directory/utils/organizationScope'
 
+/**
+ * Bulk-import / backfill deferral flags. When a command runs under a context that
+ * carries this, the command bus and data engine suppress the heavy per-record side
+ * effects flagged below so a large backfill can defer them to a single batched pass.
+ *
+ * IMPORTANT — the caller owns restoring whatever it suppresses. With `skipReindex`
+ * the `query_index` projection (and its search tokens) is stale for every record
+ * written under this context until the caller runs a batched `query_index rebuild`
+ * for the affected entity types at end-of-run.
+ *
+ * Concurrency: these flags are read from the context and threaded as a local
+ * parameter through the side-effect flush — no shared engine state is mutated — so
+ * two commands running concurrently with different flags never clobber each other.
+ */
+export type BulkImportSuppression = {
+  /** Skip the inline `query_index.upsert_one` / `delete_one` reindex (rebuild after the run). */
+  skipReindex?: boolean
+  /** Skip the per-record `<module>.<entity>.<action>` domain event emission. */
+  skipEvents?: boolean
+  /** Advisory: handlers that fan out per-record notifications SHOULD honor this and skip them. */
+  skipNotifications?: boolean
+}
+
 export type CommandRuntimeContext = {
   container: AwilixContainer
   auth: AuthContext | null
@@ -12,6 +35,13 @@ export type CommandRuntimeContext = {
   organizationIds: string[] | null
   request?: Request
   syncOrigin?: string | null
+  /**
+   * See {@link BulkImportSuppression}. Set by bulk backfill callers to defer heavy
+   * per-record side effects (reindex, events, notifications). The caller MUST rebuild
+   * the `query_index` for the affected entity types after the run when `skipReindex`
+   * is set. Unset for normal (interactive) writes — they get all side effects.
+   */
+  bulkImport?: BulkImportSuppression
   /**
    * Marks a trusted server-side invocation (CLI seeding, tenant setup) that runs
    * without an authenticated end-user actor. Commands that gate writes behind a

--- a/packages/shared/src/lib/data/__tests__/engine.bulk-suppress.test.ts
+++ b/packages/shared/src/lib/data/__tests__/engine.bulk-suppress.test.ts
@@ -1,0 +1,75 @@
+import type { AwilixContainer } from 'awilix'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { DefaultDataEngine } from '../engine'
+import type { CrudEventsConfig, CrudIndexerConfig } from '../../crud/types'
+
+// The bulk-import deferral (`suppress`) must gate the two per-record side effects `emitOrmEntityEvent`
+// fans out — the `<module>.<entity>.<action>` domain event and the inline `query_index.upsert_one`
+// reindex — while leaving normal (unsuppressed) writes untouched. It is threaded as a call parameter,
+// never stored on the engine, so it must not leak between successive calls on the same instance.
+
+const EVENTS: CrudEventsConfig<unknown> = { module: 'sales', entity: 'order', persistent: false }
+const INDEXER: CrudIndexerConfig<unknown> = { entityType: 'sales:sales_order' }
+const IDENTIFIERS = { id: 'rec-1', organizationId: 'org-1', tenantId: 'tenant-1' }
+
+function buildEngine() {
+  const emitEvent = jest.fn().mockResolvedValue(undefined)
+  const container = {
+    resolve: (token: string) => {
+      if (token === 'eventBus') return { emitEvent }
+      throw new Error(`unexpected resolve(${token})`)
+    },
+  } as unknown as AwilixContainer
+  const engine = new DefaultDataEngine({} as EntityManager, container)
+  const emittedNames = () => emitEvent.mock.calls.map((c) => c[0] as string)
+  return { engine, emitEvent, emittedNames }
+}
+
+describe('DefaultDataEngine bulk-import suppression', () => {
+  // The test events are intentionally not registered in the event registry; silence the
+  // one-time "undeclared event" warning so it doesn't clutter the suite output.
+  let warnSpy: jest.SpyInstance
+  beforeAll(() => { warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined) })
+  afterAll(() => { warnSpy.mockRestore() })
+
+  it('emits both the domain event and the reindex when unsuppressed', async () => {
+    const { engine, emittedNames } = buildEngine()
+    await engine.emitOrmEntityEvent({ action: 'created', entity: {}, events: EVENTS, indexer: INDEXER, identifiers: IDENTIFIERS })
+    expect(emittedNames()).toEqual(expect.arrayContaining(['sales.order.created', 'query_index.upsert_one']))
+  })
+
+  it('skips the domain event but keeps the reindex with skipEvents', async () => {
+    const { engine, emittedNames } = buildEngine()
+    await engine.emitOrmEntityEvent({ action: 'created', entity: {}, events: EVENTS, indexer: INDEXER, identifiers: IDENTIFIERS, suppress: { skipEvents: true } })
+    const names = emittedNames()
+    expect(names).not.toContain('sales.order.created')
+    expect(names).toContain('query_index.upsert_one')
+  })
+
+  it('skips the reindex but keeps the domain event with skipReindex', async () => {
+    const { engine, emittedNames } = buildEngine()
+    await engine.emitOrmEntityEvent({ action: 'created', entity: {}, events: EVENTS, indexer: INDEXER, identifiers: IDENTIFIERS, suppress: { skipReindex: true } })
+    const names = emittedNames()
+    expect(names).toContain('sales.order.created')
+    expect(names).not.toContain('query_index.upsert_one')
+  })
+
+  it('emits nothing when both are suppressed', async () => {
+    const { engine, emitEvent } = buildEngine()
+    await engine.emitOrmEntityEvent({ action: 'created', entity: {}, events: EVENTS, indexer: INDEXER, identifiers: IDENTIFIERS, suppress: { skipEvents: true, skipReindex: true } })
+    expect(emitEvent).not.toHaveBeenCalled()
+  })
+
+  it('flushOrmEntityChanges threads suppress to every queued entry, and does not leak to later flushes', async () => {
+    const { engine, emitEvent, emittedNames } = buildEngine()
+    // Queue one change, flush it suppressed → nothing emitted.
+    engine.markOrmEntityChange({ action: 'created', entity: {}, events: EVENTS, indexer: INDEXER, identifiers: IDENTIFIERS })
+    await engine.flushOrmEntityChanges({ skipEvents: true, skipReindex: true })
+    expect(emitEvent).not.toHaveBeenCalled()
+
+    // A subsequent normal flush on the SAME engine must be unaffected (no stored suppression).
+    engine.markOrmEntityChange({ action: 'created', entity: {}, events: EVENTS, indexer: INDEXER, identifiers: { ...IDENTIFIERS, id: 'rec-2' } })
+    await engine.flushOrmEntityChanges()
+    expect(emittedNames()).toEqual(expect.arrayContaining(['sales.order.created', 'query_index.upsert_one']))
+  })
+})

--- a/packages/shared/src/lib/data/engine.ts
+++ b/packages/shared/src/lib/data/engine.ts
@@ -12,6 +12,7 @@ import type {
   CrudIndexerConfig,
   CrudEntityIdentifiers,
 } from '../crud/types'
+import type { BulkImportSuppression } from '../commands/types'
 import { CrudHttpError } from '../crud/errors'
 import { resolveRegisteredEntityTableName } from '../query/engine'
 import { getEntityIds } from '../encryption/entityIds'
@@ -124,6 +125,8 @@ export interface DataEngine {
     indexer?: CrudIndexerConfig<T>
     identifiers: CrudEntityIdentifiers
     syncOrigin?: string | null
+    /** Bulk-import deferral: skip the domain event and/or inline reindex for this emit. */
+    suppress?: BulkImportSuppression
   }): Promise<void>
 
   markOrmEntityChange<T>(opts: {
@@ -135,7 +138,12 @@ export interface DataEngine {
     syncOrigin?: string | null
   }): void
 
-  flushOrmEntityChanges(): Promise<void>
+  /**
+   * Drain queued side effects. When `suppress` is passed (a bulk-import backfill), the
+   * flagged per-record events / reindex are skipped for every drained entry; the caller
+   * is responsible for rebuilding the `query_index` afterwards.
+   */
+  flushOrmEntityChanges(suppress?: BulkImportSuppression): Promise<void>
 }
 
 export const SYSTEM_ENTITY_RECORDS_BLOCKED_CODE = 'system_entity_records_blocked'
@@ -545,9 +553,14 @@ export class DefaultDataEngine implements DataEngine {
     indexer?: CrudIndexerConfig<T>
     identifiers: CrudEntityIdentifiers
     syncOrigin?: string | null
+    suppress?: BulkImportSuppression
   }): Promise<void> {
-    const { action, entity, events, indexer, identifiers, syncOrigin } = opts
-    if (!events && !indexer) return
+    const { action, entity, events, indexer, identifiers, syncOrigin, suppress } = opts
+    // Bulk-import deferral: an entry may suppress its domain event and/or inline reindex. When both
+    // the config is absent AND (for the present one) suppressed, there is nothing left to do.
+    const emitEvents = !!events && !suppress?.skipEvents
+    const runIndexer = !!indexer && !suppress?.skipReindex
+    if (!emitEvents && !runIndexer) return
     if (!identifiers?.id) return
 
     let bus: EventBus | null = null
@@ -569,7 +582,7 @@ export class DefaultDataEngine implements DataEngine {
       syncOrigin: syncOrigin ?? null,
     }
 
-    if (events) {
+    if (events && !suppress?.skipEvents) {
       const eventName = `${events.module}.${events.entity}.${action}`
       warnIfUndeclaredEvent(eventName, 'emitOrmEntityEvent')
       const payload = events.buildPayload
@@ -591,7 +604,7 @@ export class DefaultDataEngine implements DataEngine {
       }
     }
 
-    if (indexer) {
+    if (indexer && !suppress?.skipReindex) {
       const resolveCoverageBaseDelta = (): number | undefined => {
         if (action === 'created') return 1
         if (action === 'deleted') return -1
@@ -694,7 +707,7 @@ export class DefaultDataEngine implements DataEngine {
     this.pendingSideEffects.set(key, entry)
   }
 
-  async flushOrmEntityChanges(): Promise<void> {
+  async flushOrmEntityChanges(suppress?: BulkImportSuppression): Promise<void> {
     if (!this.pendingSideEffects.size) return
     const entries = Array.from(this.pendingSideEffects.values())
     this.pendingSideEffects.clear()
@@ -707,6 +720,7 @@ export class DefaultDataEngine implements DataEngine {
           syncOrigin: entry.syncOrigin ?? null,
           events: entry.events as CrudEventsConfig<unknown>,
           indexer: entry.indexer as CrudIndexerConfig<unknown>,
+          suppress,
         })
       } catch {
         // best-effort; continue with remaining side effects


### PR DESCRIPTION
## Summary

A large data-sync backfill runs the same write commands as interactive use, and pays the same per-record side effects: an inline `query_index` reindex (which rebuilds `search_tokens` — the dominant write cost), a `<module>.<entity>.<action>` domain event, and per-record notification fan-out. Across hundreds of thousands of records this is the backfill's bottleneck, and most of it is wasted: the index is far cheaper to rebuild once at the end, the events have no live consumer during a bulk import, and the notifications would spam users with backfilled history. Production telemetry attributed ~65% of per-order write cost to the inline `search_tokens` reindex alone.

This adds an **opt-in, additive** `bulkImport` flag on the command runtime context — the side-effect analogue of the existing `skipCacheInvalidation` escape hatch. When set, the command bus and data engine skip the flagged per-record side effects; the caller runs a single batched `query_index rebuild` for the affected entity types at end-of-run. Interactive (unflagged) writes are byte-for-byte unchanged.

**Concurrency safety (the key design point):** the flags are read from the context and threaded as a **local parameter** through the side-effect flush — no suppression state is stored on the shared `dataEngine` instance — so two commands running concurrently with different flags can never observe or clobber each other's suppression.

## Changes

- **`packages/shared/src/lib/commands/types.ts`** — new `BulkImportSuppression` type (`skipReindex` / `skipEvents` / `skipNotifications`) and an optional `bulkImport?` field on `CommandRuntimeContext`, both documented (incl. the caller's rebuild responsibility).
- **`packages/shared/src/lib/commands/command-bus.ts`** — `execute()` reads `ctx.bulkImport` and threads it as a local arg into `flushCrudSideEffects(container, suppress)` → `DataEngine.flushOrmEntityChanges(suppress)`. Mirrors `skipCacheInvalidation`; no engine state mutated.
- **`packages/shared/src/lib/commands/helpers.ts`** — the exported `flushCrudSideEffects(dataEngine, suppress?)` takes the same optional `suppress`, so direct bulk-write paths that bypass the command bus honor the same deferral (both flush entry points forward to `flushOrmEntityChanges`).
- **`packages/shared/src/lib/data/engine.ts`** — `flushOrmEntityChanges(suppress?)` forwards `suppress` to each queued entry; `emitOrmEntityEvent` gates the domain event on `!suppress?.skipEvents` and the inline reindex on `!suppress?.skipReindex`, bailing before resolving the event bus when both are suppressed.
- **`packages/core/src/modules/sales/commands/documents.ts`** — `create-order` / `create-quote` gate the `notificationService.createForFeature(...)` fan-out on `!ctx.bulkImport?.skipNotifications` (advisory flag, opted into per fan-out site).
- **`packages/shared/src/lib/data/__tests__/engine.bulk-suppress.test.ts`** — new unit coverage.

## Specification

We follow spec-driven development.

**Does a spec exist for this feature/module?**
- [ ] Yes
- [x] No (created a new spec)
- [ ] N/A

**Spec file path:** `.ai/specs/2026-07-08-bulk-import-side-effect-suppression.md` (registered in `.ai/specs/README.md`)

## Testing

- `packages/shared` typecheck (`tsc --noEmit`) — clean
- `packages/shared`: `jest lib/commands lib/data` — 148 passed, including the new `engine.bulk-suppress.test.ts` (four suppression combinations + a non-leakage assertion proving `flushOrmEntityChanges(suppress)` never persists suppression across successive flushes on the same engine instance — the concurrency-safety guarantee)

Integration coverage is intentionally omitted: this is an internal command-bus/data-engine contract with no HTTP or UI surface, fully exercised at the unit level (documented in the spec's Testing section).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (spec added; no locale/generator impact — no user-facing copy)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — documented above (no HTTP/UI surface)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry.
- [ ] Priority / Risk / QA labels — for the record this is **risk-low** (additive, opt-in, default-off; the unflagged path is byte-for-byte unchanged) and **skip-qa** (no customer-facing surface).

### Design System Compliance

N/A — backend-only change, no UI surface (no colors, text sizes, list/loading/empty states, or icon buttons touched).

## Linked issues

None.
