### PR TITLE
fix(portal): bind customer auth to URL org (#3885)

### DIFF
--- a/apps/mercato/src/app/(frontend)/[...slug]/page.tsx
+++ b/apps/mercato/src/app/(frontend)/[...slug]/page.tsx
@@ -9,7 +9,9 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { CustomerRbacService } from '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
+import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import type { Metadata } from 'next'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import { resolveLocalizedTitleMetadata } from '@/lib/metadata'
 import { resolvePageMiddlewareRedirect } from '@open-mercato/shared/lib/middleware/page-executor'
 import { frontendMiddlewareEntries } from '@/.mercato/generated/frontend-middleware.generated'
@@ -62,16 +64,28 @@ export default async function SiteCatchAll({ params }: FrontendParams) {
   if (match.route.requireCustomerAuth) {
     const { getCustomerAuthFromCookies } = await import('@open-mercato/core/modules/customer_accounts/lib/customerAuthServer')
     const customerAuth = await getCustomerAuthFromCookies()
+    const segments = pathname.split('/').filter(Boolean)
+    const orgSlug = segments[0] ?? ''
     if (!customerAuth) {
-      // Extract orgSlug from pathname for redirect (e.g., /my-org/portal/orders → my-org)
-      const segments = pathname.split('/').filter(Boolean)
-      const orgSlug = segments[0] ?? ''
       redirect(`/${orgSlug}/portal/login`)
     }
+    await ensureServerBootstrap()
+    const portalContainer = await createRequestContainer()
+    const em = portalContainer.resolve('em') as EntityManager
+    const org = orgSlug
+      ? await em.findOne(Organization, { id: customerAuth.orgId, slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+      : null
+    const organizationId = org ? String(org.id) : null
+    const organizationTenant = (org as any)?.tenant
+    const organizationTenantId = typeof organizationTenant === 'string'
+      ? organizationTenant
+      : organizationTenant?.id
+        ? String(organizationTenant.id)
+        : null
+    if (!organizationId || organizationId !== customerAuth.orgId || organizationTenantId !== customerAuth.tenantId) return renderAccessDenied()
+
     const customerFeatures = match.route.requireCustomerFeatures
     if (customerFeatures && customerFeatures.length) {
-      await ensureServerBootstrap()
-      const portalContainer = await createRequestContainer()
       const customerRbac = portalContainer.resolve('customerRbacService') as CustomerRbacService
       const ok = await customerRbac.userHasAllFeatures(
         customerAuth.sub,

--- a/apps/mercato/src/app/(frontend)/[...slug]/page.tsx
+++ b/apps/mercato/src/app/(frontend)/[...slug]/page.tsx
@@ -73,16 +73,14 @@ export default async function SiteCatchAll({ params }: FrontendParams) {
     const portalContainer = await createRequestContainer()
     const em = portalContainer.resolve('em') as EntityManager
     const org = orgSlug
-      ? await em.findOne(Organization, { id: customerAuth.orgId, slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+      ? await em.findOne(Organization, {
+          id: customerAuth.orgId,
+          slug: orgSlug,
+          deletedAt: null,
+        } as any)
       : null
     const organizationId = org ? String(org.id) : null
-    const organizationTenant = (org as any)?.tenant
-    const organizationTenantId = typeof organizationTenant === 'string'
-      ? organizationTenant
-      : organizationTenant?.id
-        ? String(organizationTenant.id)
-        : null
-    if (!organizationId || organizationId !== customerAuth.orgId || organizationTenantId !== customerAuth.tenantId) return renderAccessDenied()
+    if (!organizationId || organizationId !== customerAuth.orgId) return renderAccessDenied()
 
     const customerFeatures = match.route.requireCustomerFeatures
     if (customerFeatures && customerFeatures.length) {

--- a/apps/mercato/src/app/(frontend)/__tests__/portal-org-binding.test.tsx
+++ b/apps/mercato/src/app/(frontend)/__tests__/portal-org-binding.test.tsx
@@ -163,7 +163,42 @@ describe('frontend customer portal org binding', () => {
       id: 'org-a-id',
       slug: 'org-b',
       deletedAt: null,
-    }, { populate: ['tenant'] })
+    })
+  })
+
+  it('allows protected portal page access when URL org matches the customer JWT org', async () => {
+    await SiteCatchAll({
+      params: Promise.resolve({ slug: ['org-a', 'portal', 'dashboard'] }),
+    })
+
+    expect(routeLoad).toHaveBeenCalled()
+    expect(mockCustomerRbac.userHasAllFeatures).toHaveBeenCalledWith(
+      'customer-user-1',
+      ['portal.dashboard.view'],
+      { tenantId: 'tenant-1', organizationId: 'org-a-id' },
+    )
+    expect(mockEm.findOne).toHaveBeenCalledWith(expect.any(Function), {
+      id: 'org-a-id',
+      slug: 'org-a',
+      deletedAt: null,
+    })
+  })
+
+  it('renders authenticated organization chrome when URL org matches the customer JWT org', async () => {
+    headerStore.get.mockReturnValue('/org-a/portal/dashboard')
+
+    const element = await FrontendLayout({ children: <div>child</div> })
+    renderToStaticMarkup(element as React.ReactElement)
+
+    expect(portalShellMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgSlug: 'org-a',
+      organizationId: 'org-a-id',
+      tenantId: 'tenant-1',
+      authenticated: true,
+      userName: 'Customer One',
+      userEmail: 'customer@example.com',
+      customerAuth,
+    }))
   })
 
   it('does not render mismatched organization chrome for authenticated protected portal routes', async () => {

--- a/apps/mercato/src/app/(frontend)/__tests__/portal-org-binding.test.tsx
+++ b/apps/mercato/src/app/(frontend)/__tests__/portal-org-binding.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+jest.mock('@/.mercato/generated/frontend-routes.generated', () => ({
+  frontendRoutes: [],
+}), { virtual: true })
+
+jest.mock('@/.mercato/generated/frontend-middleware.generated', () => ({
+  frontendMiddlewareEntries: [],
+}), { virtual: true })
+
+jest.mock('@/bootstrap', () => ({
+  bootstrap: jest.fn(),
+  isBootstrapped: jest.fn(() => true),
+}))
+
+const routeLoad = jest.fn(async () => (props: any) => (
+  <div data-testid="portal-page">{props.params.orgSlug}</div>
+))
+
+jest.mock('@open-mercato/shared/modules/registry', () => ({
+  findRouteManifestMatch: jest.fn(() => ({
+    route: {
+      requireCustomerAuth: true,
+      requireCustomerFeatures: ['portal.dashboard.view'],
+      title: 'Dashboard',
+      load: routeLoad,
+    },
+    params: { orgSlug: 'org-b' },
+  })),
+  getFrontendRouteManifests: jest.fn(() => []),
+  registerFrontendRouteManifests: jest.fn(),
+}))
+
+const headerStore = { get: jest.fn() }
+jest.mock('next/headers', () => ({
+  headers: jest.fn(() => headerStore),
+  cookies: jest.fn(),
+}))
+
+const mockGetCustomerAuthFromCookies = jest.fn()
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuthServer', () => ({
+  getCustomerAuthFromCookies: (...args: unknown[]) => mockGetCustomerAuthFromCookies(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/data/entities', () => ({
+  Organization: class Organization {},
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/data/entities', () => ({
+  CustomerUser: class CustomerUser {},
+}))
+
+const portalShellMock = jest.fn(({ children }: { children: React.ReactNode }) => (
+  <div data-testid="portal-shell">{children}</div>
+))
+jest.mock('@open-mercato/ui/portal/PortalLayoutShell', () => ({
+  PortalLayoutShell: (props: any) => portalShellMock(props),
+}))
+
+const redirect = jest.fn((href?: string) => {
+  throw new Error('REDIRECT ' + href)
+})
+const notFound = jest.fn(() => {
+  throw new Error('NOT_FOUND')
+})
+jest.mock('next/navigation', () => ({
+  redirect: (href?: string) => redirect(href),
+  notFound: () => notFound(),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromCookies: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (_key: string, fallback: string) => fallback,
+    translate: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  AccessDeniedMessage: (props: any) => (
+    <div data-testid="access-denied">
+      {props.label}
+      {props.action}
+    </div>
+  ),
+}))
+
+jest.mock('next/link', () => (props: any) => <a href={props.href}>{props.children}</a>)
+
+const orgs = new Map<string, { id: string; name: string; slug: string; tenant: { id: string } }>([
+  ['org-a', { id: 'org-a-id', name: 'Org A', slug: 'org-a', tenant: { id: 'tenant-1' } }],
+  ['org-b', { id: 'org-b-id', name: 'Org B', slug: 'org-b', tenant: { id: 'tenant-1' } }],
+])
+
+const mockEm = {
+  findOne: jest.fn(async (_entity: unknown, query: any) => {
+    if (query.id === 'customer-user-1') return { displayName: 'Customer One', email: 'customer@example.com' }
+    if (query.id) {
+      return Array.from(orgs.values()).find((org) => (
+        org.id === query.id
+        && (!query.slug || org.slug === query.slug)
+      )) ?? null
+    }
+    if (query.slug) return orgs.get(query.slug) ?? null
+    return null
+  }),
+}
+
+const mockCustomerRbac = {
+  userHasAllFeatures: jest.fn(async () => true),
+}
+
+const mockFeatureToggles = {
+  getBoolConfig: jest.fn(async () => ({ ok: true, value: true })),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (key: string) => {
+      if (key === 'em') return mockEm
+      if (key === 'customerRbacService') return mockCustomerRbac
+      if (key === 'featureTogglesService') return mockFeatureToggles
+      return null
+    },
+  })),
+}))
+
+import FrontendLayout from '../layout'
+import SiteCatchAll from '../[...slug]/page'
+
+const customerAuth = {
+  sub: 'customer-user-1',
+  sid: 'session-1',
+  type: 'customer' as const,
+  tenantId: 'tenant-1',
+  orgId: 'org-a-id',
+  email: 'customer@example.com',
+  displayName: 'Customer One',
+  customerEntityId: null,
+  personEntityId: null,
+  resolvedFeatures: ['portal.dashboard.view'],
+}
+
+describe('frontend customer portal org binding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    headerStore.get.mockReturnValue('/org-b/portal/dashboard')
+    mockGetCustomerAuthFromCookies.mockResolvedValue(customerAuth)
+  })
+
+  it('denies protected portal page access when URL org does not match the customer JWT org', async () => {
+    await SiteCatchAll({
+      params: Promise.resolve({ slug: ['org-b', 'portal', 'dashboard'] }),
+    })
+
+    expect(routeLoad).not.toHaveBeenCalled()
+    expect(mockCustomerRbac.userHasAllFeatures).not.toHaveBeenCalled()
+    expect(mockEm.findOne).toHaveBeenCalledWith(expect.any(Function), {
+      id: 'org-a-id',
+      slug: 'org-b',
+      deletedAt: null,
+    }, { populate: ['tenant'] })
+  })
+
+  it('does not render mismatched organization chrome for authenticated protected portal routes', async () => {
+    const element = await FrontendLayout({ children: <div>child</div> })
+    renderToStaticMarkup(element as React.ReactElement)
+
+    expect(portalShellMock).not.toHaveBeenCalled()
+  })
+
+  it.each(['/org-b/portal', '/org-b/portal/login', '/org-b/portal/signup', '/org-b/portal/verify', '/org-b/portal/reset-password'])(
+    'keeps public route %s bound to the URL org even when another customer session exists',
+    async (pathname) => {
+      headerStore.get.mockReturnValue(pathname)
+
+      const element = await FrontendLayout({ children: <div>public</div> })
+      renderToStaticMarkup(element as React.ReactElement)
+
+      expect(portalShellMock).toHaveBeenCalledWith(expect.objectContaining({
+        orgSlug: 'org-b',
+        organizationId: 'org-b-id',
+        authenticated: false,
+        userName: null,
+        userEmail: null,
+        customerAuth: null,
+      }))
+    },
+  )
+})

--- a/apps/mercato/src/app/(frontend)/layout.tsx
+++ b/apps/mercato/src/app/(frontend)/layout.tsx
@@ -1,4 +1,5 @@
 import { headers } from 'next/headers'
+import Link from 'next/link'
 import { PortalLayoutShell } from '@open-mercato/ui/portal/PortalLayoutShell'
 import { getCustomerAuthFromCookies } from '@open-mercato/core/modules/customer_accounts/lib/customerAuthServer'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
@@ -6,17 +7,38 @@ import { Organization } from '@open-mercato/core/modules/directory/data/entities
 import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { FeatureTogglesService } from '@open-mercato/core/modules/feature_toggles/lib/feature-flag-check'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import { AccessDeniedMessage } from '@open-mercato/ui/backend/detail'
 import type { EntityManager } from '@mikro-orm/postgresql'
 
 type LayoutProps = {
   children: React.ReactNode
 }
 
-const PUBLIC_SUFFIXES = ['/portal/login', '/portal/signup']
+const PUBLIC_SUFFIXES = ['/portal/login', '/portal/signup', '/portal/verify', '/portal/reset-password']
 
 function isPublicPortalRoute(pathname: string): boolean {
   if (/^\/[^/]+\/portal\/?$/.test(pathname)) return true
   return PUBLIC_SUFFIXES.some((s) => pathname.endsWith(s))
+}
+
+function getOrganizationTenantId(org: Organization): string | null {
+  const tenant = (org as any).tenant
+  return typeof tenant === 'string' ? tenant : tenant?.id ? String(tenant.id) : null
+}
+
+async function renderPortalAccessDenied() {
+  const { translate } = await resolveTranslations()
+  return (
+    <AccessDeniedMessage
+      label={translate('auth.accessDenied.title', 'Access Denied')}
+      description={translate('auth.accessDenied.message', 'You do not have permission to view this page. Please contact your administrator.')}
+      action={
+        <Link href="/" className="text-sm underline hover:opacity-80">
+          {translate('auth.accessDenied.home', 'Go to Home')}
+        </Link>
+      }
+    />
+  )
 }
 
 // Sits ABOVE the [...slug] dynamic segment so portal navigation does not
@@ -42,20 +64,39 @@ export default async function FrontendLayout({ children }: LayoutProps) {
   let userName: string | null = null
   let userEmail: string | null = null
   let portalEnabled = true
+  let portalAccessDenied = false
+  let customerAuthMatchesUrlOrg = false
 
   try {
     const container = await createRequestContainer()
     const em = container.resolve('em') as EntityManager
 
-    const org = await em.findOne(Organization, { slug: orgSlug, deletedAt: null })
+    const authOrg = customerAuth
+      ? await em.findOne(Organization, { id: customerAuth.orgId, slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+      : null
+    const authOrgTenantId = authOrg ? getOrganizationTenantId(authOrg) : null
+    customerAuthMatchesUrlOrg = !!customerAuth
+      && !!authOrg
+      && String(authOrg.id) === customerAuth.orgId
+      && authOrgTenantId === customerAuth.tenantId
+
+    const org = customerAuthMatchesUrlOrg
+      ? authOrg
+      : (!customerAuth || isPublic)
+        ? await em.findOne(Organization, { slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+        : null
+
     if (org) {
       orgName = org.name
       organizationId = String(org.id)
-      const tenant = (org as any).tenant
-      tenantId = typeof tenant === 'string' ? tenant : tenant?.id ? String(tenant.id) : null
+      tenantId = getOrganizationTenantId(org)
     }
 
-    if (tenantId) {
+    if (customerAuth && !isPublic && !customerAuthMatchesUrlOrg) {
+      portalAccessDenied = true
+    }
+
+    if (!portalAccessDenied && tenantId) {
       const featureTogglesService = container.resolve('featureTogglesService') as FeatureTogglesService
       const result = await featureTogglesService.getBoolConfig('portal_enabled', tenantId)
       if (result.ok && result.value === false) {
@@ -63,7 +104,7 @@ export default async function FrontendLayout({ children }: LayoutProps) {
       }
     }
 
-    if (customerAuth) {
+    if (!portalAccessDenied && customerAuthMatchesUrlOrg && customerAuth) {
       const user = await em.findOne(CustomerUser, { id: customerAuth.sub } as any)
       if (user) {
         userName = user.displayName || customerAuth.email
@@ -74,10 +115,17 @@ export default async function FrontendLayout({ children }: LayoutProps) {
       }
     }
   } catch {
-    if (customerAuth) {
+    if (customerAuth && !isPublic && !organizationId) {
+      portalAccessDenied = true
+    }
+    if (!portalAccessDenied && customerAuthMatchesUrlOrg && customerAuth) {
       userName = customerAuth.displayName || customerAuth.email
       userEmail = customerAuth.email
     }
+  }
+
+  if (portalAccessDenied) {
+    return renderPortalAccessDenied()
   }
 
   if (!portalEnabled) {
@@ -102,10 +150,10 @@ export default async function FrontendLayout({ children }: LayoutProps) {
       organizationName={orgName}
       tenantId={tenantId}
       organizationId={organizationId}
-      authenticated={!isPublic && !!customerAuth}
+      authenticated={!isPublic && customerAuthMatchesUrlOrg}
       userName={userName}
       userEmail={userEmail}
-      customerAuth={customerAuth}
+      customerAuth={customerAuthMatchesUrlOrg ? customerAuth : null}
     >
       {children}
     </PortalLayoutShell>

--- a/apps/mercato/src/app/(frontend)/layout.tsx
+++ b/apps/mercato/src/app/(frontend)/layout.tsx
@@ -72,13 +72,15 @@ export default async function FrontendLayout({ children }: LayoutProps) {
     const em = container.resolve('em') as EntityManager
 
     const authOrg = customerAuth
-      ? await em.findOne(Organization, { id: customerAuth.orgId, slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+      ? await em.findOne(Organization, {
+          id: customerAuth.orgId,
+          slug: orgSlug,
+          deletedAt: null,
+        } as any)
       : null
-    const authOrgTenantId = authOrg ? getOrganizationTenantId(authOrg) : null
     customerAuthMatchesUrlOrg = !!customerAuth
       && !!authOrg
       && String(authOrg.id) === customerAuth.orgId
-      && authOrgTenantId === customerAuth.tenantId
 
     const org = customerAuthMatchesUrlOrg
       ? authOrg
@@ -89,7 +91,7 @@ export default async function FrontendLayout({ children }: LayoutProps) {
     if (org) {
       orgName = org.name
       organizationId = String(org.id)
-      tenantId = getOrganizationTenantId(org)
+      tenantId = customerAuthMatchesUrlOrg && customerAuth ? customerAuth.tenantId : getOrganizationTenantId(org)
     }
 
     if (customerAuth && !isPublic && !customerAuthMatchesUrlOrg) {

--- a/packages/core/src/modules/portal/__integration__/TC-AUTH-033.spec.ts
+++ b/packages/core/src/modules/portal/__integration__/TC-AUTH-033.spec.ts
@@ -23,24 +23,14 @@ test.describe('TC-AUTH-033: portal dashboard waits for nav bootstrap', () => {
 
     try {
       adminToken = await getAuthToken(request, 'admin')
-      const { tenantId } = getTokenContext(adminToken)
-
-      const createOrgRes = await apiRequest(request, 'POST', '/api/directory/organizations', {
-        token: adminToken,
-        data: {
-          name: `QA Portal Org ${stamp}`,
-          tenantId,
-        },
-      })
-      expect(createOrgRes.status(), 'organization should be created').toBe(201)
-      const createOrgBody = (await createOrgRes.json()) as { id?: string }
-      organizationId = createOrgBody.id ?? null
-      expect(organizationId, 'organization id should be returned').toBeTruthy()
+      const { tenantId, organizationId: tokenOrganizationId } = getTokenContext(adminToken)
+      organizationId = tokenOrganizationId
+      expect(organizationId, 'admin organization id should be present').toBeTruthy()
 
       const orgDetailsRes = await apiRequest(
         request,
         'GET',
-        `/api/directory/organizations?view=manage&ids=${encodeURIComponent(organizationId!)}&tenantId=${encodeURIComponent(tenantId)}`,
+        `/api/directory/organizations?view=manage&ids=${encodeURIComponent(organizationId)}&tenantId=${encodeURIComponent(tenantId)}`,
         { token: adminToken },
       )
       expect(orgDetailsRes.ok(), 'organization lookup should succeed').toBeTruthy()
@@ -54,7 +44,6 @@ test.describe('TC-AUTH-033: portal dashboard waits for nav bootstrap', () => {
           email: customerEmail,
           password,
           displayName: `QA Auth 033 ${stamp}`,
-          organizationId,
         },
       })
       expect(createRes.status(), 'customer user should be created').toBe(201)
@@ -102,14 +91,6 @@ test.describe('TC-AUTH-033: portal dashboard waits for nav bootstrap', () => {
           request,
           'DELETE',
           `/api/customer_accounts/admin/users/${customerId}`,
-          { token: adminToken },
-        ).catch(() => {})
-      }
-      if (adminToken && organizationId) {
-        await apiRequest(
-          request,
-          'DELETE',
-          `/api/directory/organizations?id=${encodeURIComponent(organizationId)}`,
           { token: adminToken },
         ).catch(() => {})
       }

--- a/packages/create-app/template/src/app/(frontend)/[...slug]/page.tsx
+++ b/packages/create-app/template/src/app/(frontend)/[...slug]/page.tsx
@@ -73,16 +73,14 @@ export default async function SiteCatchAll({ params }: FrontendParams) {
     const portalContainer = await createRequestContainer()
     const em = portalContainer.resolve('em') as EntityManager
     const org = orgSlug
-      ? await em.findOne(Organization, { id: customerAuth.orgId, slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+      ? await em.findOne(Organization, {
+          id: customerAuth.orgId,
+          slug: orgSlug,
+          deletedAt: null,
+        } as any)
       : null
     const organizationId = org ? String(org.id) : null
-    const organizationTenant = (org as any)?.tenant
-    const organizationTenantId = typeof organizationTenant === 'string'
-      ? organizationTenant
-      : organizationTenant?.id
-        ? String(organizationTenant.id)
-        : null
-    if (!organizationId || organizationId !== customerAuth.orgId || organizationTenantId !== customerAuth.tenantId) return renderAccessDenied()
+    if (!organizationId || organizationId !== customerAuth.orgId) return renderAccessDenied()
 
     const customerFeatures = match.route.requireCustomerFeatures
     if (customerFeatures && customerFeatures.length) {

--- a/packages/create-app/template/src/app/(frontend)/[...slug]/page.tsx
+++ b/packages/create-app/template/src/app/(frontend)/[...slug]/page.tsx
@@ -1,7 +1,6 @@
 import { notFound, redirect } from 'next/navigation'
 import Link from 'next/link'
 import { findRouteManifestMatch, getFrontendRouteManifests, registerFrontendRouteManifests } from '@open-mercato/shared/modules/registry'
-import { bootstrap } from '@/bootstrap'
 import { frontendRoutes } from '@/.mercato/generated/frontend-routes.generated'
 import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
 import { AccessDeniedMessage } from '@open-mercato/ui/backend/detail'
@@ -10,15 +9,21 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { CustomerRbacService } from '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
+import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import type { Metadata } from 'next'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import { resolveLocalizedTitleMetadata } from '@/lib/metadata'
 import { resolvePageMiddlewareRedirect } from '@open-mercato/shared/lib/middleware/page-executor'
 import { frontendMiddlewareEntries } from '@/.mercato/generated/frontend-middleware.generated'
 
-bootstrap()
 registerFrontendRouteManifests(frontendRoutes)
 
 type FrontendParams = { params: Promise<{ slug: string[] }> }
+
+async function ensureServerBootstrap() {
+  const { bootstrap } = await import('@/bootstrap')
+  bootstrap()
+}
 
 async function renderAccessDenied() {
   const { translate } = await resolveTranslations()
@@ -59,15 +64,28 @@ export default async function SiteCatchAll({ params }: FrontendParams) {
   if (match.route.requireCustomerAuth) {
     const { getCustomerAuthFromCookies } = await import('@open-mercato/core/modules/customer_accounts/lib/customerAuthServer')
     const customerAuth = await getCustomerAuthFromCookies()
+    const segments = pathname.split('/').filter(Boolean)
+    const orgSlug = segments[0] ?? ''
     if (!customerAuth) {
-      // Extract orgSlug from pathname for redirect (e.g., /my-org/portal/orders → my-org)
-      const segments = pathname.split('/').filter(Boolean)
-      const orgSlug = segments[0] ?? ''
       redirect(`/${orgSlug}/portal/login`)
     }
+    await ensureServerBootstrap()
+    const portalContainer = await createRequestContainer()
+    const em = portalContainer.resolve('em') as EntityManager
+    const org = orgSlug
+      ? await em.findOne(Organization, { id: customerAuth.orgId, slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+      : null
+    const organizationId = org ? String(org.id) : null
+    const organizationTenant = (org as any)?.tenant
+    const organizationTenantId = typeof organizationTenant === 'string'
+      ? organizationTenant
+      : organizationTenant?.id
+        ? String(organizationTenant.id)
+        : null
+    if (!organizationId || organizationId !== customerAuth.orgId || organizationTenantId !== customerAuth.tenantId) return renderAccessDenied()
+
     const customerFeatures = match.route.requireCustomerFeatures
     if (customerFeatures && customerFeatures.length) {
-      const portalContainer = await createRequestContainer()
       const customerRbac = portalContainer.resolve('customerRbacService') as CustomerRbacService
       const ok = await customerRbac.userHasAllFeatures(
         customerAuth.sub,
@@ -85,6 +103,7 @@ export default async function SiteCatchAll({ params }: FrontendParams) {
   let container: Awaited<ReturnType<typeof createRequestContainer>> | null = null
   const ensureContainer = async () => {
     if (!container) {
+      await ensureServerBootstrap()
       container = await createRequestContainer()
     }
     return container

--- a/packages/create-app/template/src/app/(frontend)/__tests__/portal-org-binding.test.tsx
+++ b/packages/create-app/template/src/app/(frontend)/__tests__/portal-org-binding.test.tsx
@@ -163,7 +163,42 @@ describe('frontend customer portal org binding', () => {
       id: 'org-a-id',
       slug: 'org-b',
       deletedAt: null,
-    }, { populate: ['tenant'] })
+    })
+  })
+
+  it('allows protected portal page access when URL org matches the customer JWT org', async () => {
+    await SiteCatchAll({
+      params: Promise.resolve({ slug: ['org-a', 'portal', 'dashboard'] }),
+    })
+
+    expect(routeLoad).toHaveBeenCalled()
+    expect(mockCustomerRbac.userHasAllFeatures).toHaveBeenCalledWith(
+      'customer-user-1',
+      ['portal.dashboard.view'],
+      { tenantId: 'tenant-1', organizationId: 'org-a-id' },
+    )
+    expect(mockEm.findOne).toHaveBeenCalledWith(expect.any(Function), {
+      id: 'org-a-id',
+      slug: 'org-a',
+      deletedAt: null,
+    })
+  })
+
+  it('renders authenticated organization chrome when URL org matches the customer JWT org', async () => {
+    headerStore.get.mockReturnValue('/org-a/portal/dashboard')
+
+    const element = await FrontendLayout({ children: <div>child</div> })
+    renderToStaticMarkup(element as React.ReactElement)
+
+    expect(portalShellMock).toHaveBeenCalledWith(expect.objectContaining({
+      orgSlug: 'org-a',
+      organizationId: 'org-a-id',
+      tenantId: 'tenant-1',
+      authenticated: true,
+      userName: 'Customer One',
+      userEmail: 'customer@example.com',
+      customerAuth,
+    }))
   })
 
   it('does not render mismatched organization chrome for authenticated protected portal routes', async () => {

--- a/packages/create-app/template/src/app/(frontend)/__tests__/portal-org-binding.test.tsx
+++ b/packages/create-app/template/src/app/(frontend)/__tests__/portal-org-binding.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+jest.mock('@/.mercato/generated/frontend-routes.generated', () => ({
+  frontendRoutes: [],
+}), { virtual: true })
+
+jest.mock('@/.mercato/generated/frontend-middleware.generated', () => ({
+  frontendMiddlewareEntries: [],
+}), { virtual: true })
+
+jest.mock('@/bootstrap', () => ({
+  bootstrap: jest.fn(),
+  isBootstrapped: jest.fn(() => true),
+}))
+
+const routeLoad = jest.fn(async () => (props: any) => (
+  <div data-testid="portal-page">{props.params.orgSlug}</div>
+))
+
+jest.mock('@open-mercato/shared/modules/registry', () => ({
+  findRouteManifestMatch: jest.fn(() => ({
+    route: {
+      requireCustomerAuth: true,
+      requireCustomerFeatures: ['portal.dashboard.view'],
+      title: 'Dashboard',
+      load: routeLoad,
+    },
+    params: { orgSlug: 'org-b' },
+  })),
+  getFrontendRouteManifests: jest.fn(() => []),
+  registerFrontendRouteManifests: jest.fn(),
+}))
+
+const headerStore = { get: jest.fn() }
+jest.mock('next/headers', () => ({
+  headers: jest.fn(() => headerStore),
+  cookies: jest.fn(),
+}))
+
+const mockGetCustomerAuthFromCookies = jest.fn()
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuthServer', () => ({
+  getCustomerAuthFromCookies: (...args: unknown[]) => mockGetCustomerAuthFromCookies(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/data/entities', () => ({
+  Organization: class Organization {},
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/data/entities', () => ({
+  CustomerUser: class CustomerUser {},
+}))
+
+const portalShellMock = jest.fn(({ children }: { children: React.ReactNode }) => (
+  <div data-testid="portal-shell">{children}</div>
+))
+jest.mock('@open-mercato/ui/portal/PortalLayoutShell', () => ({
+  PortalLayoutShell: (props: any) => portalShellMock(props),
+}))
+
+const redirect = jest.fn((href?: string) => {
+  throw new Error('REDIRECT ' + href)
+})
+const notFound = jest.fn(() => {
+  throw new Error('NOT_FOUND')
+})
+jest.mock('next/navigation', () => ({
+  redirect: (href?: string) => redirect(href),
+  notFound: () => notFound(),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromCookies: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (_key: string, fallback: string) => fallback,
+    translate: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  AccessDeniedMessage: (props: any) => (
+    <div data-testid="access-denied">
+      {props.label}
+      {props.action}
+    </div>
+  ),
+}))
+
+jest.mock('next/link', () => (props: any) => <a href={props.href}>{props.children}</a>)
+
+const orgs = new Map<string, { id: string; name: string; slug: string; tenant: { id: string } }>([
+  ['org-a', { id: 'org-a-id', name: 'Org A', slug: 'org-a', tenant: { id: 'tenant-1' } }],
+  ['org-b', { id: 'org-b-id', name: 'Org B', slug: 'org-b', tenant: { id: 'tenant-1' } }],
+])
+
+const mockEm = {
+  findOne: jest.fn(async (_entity: unknown, query: any) => {
+    if (query.id === 'customer-user-1') return { displayName: 'Customer One', email: 'customer@example.com' }
+    if (query.id) {
+      return Array.from(orgs.values()).find((org) => (
+        org.id === query.id
+        && (!query.slug || org.slug === query.slug)
+      )) ?? null
+    }
+    if (query.slug) return orgs.get(query.slug) ?? null
+    return null
+  }),
+}
+
+const mockCustomerRbac = {
+  userHasAllFeatures: jest.fn(async () => true),
+}
+
+const mockFeatureToggles = {
+  getBoolConfig: jest.fn(async () => ({ ok: true, value: true })),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (key: string) => {
+      if (key === 'em') return mockEm
+      if (key === 'customerRbacService') return mockCustomerRbac
+      if (key === 'featureTogglesService') return mockFeatureToggles
+      return null
+    },
+  })),
+}))
+
+import FrontendLayout from '../layout'
+import SiteCatchAll from '../[...slug]/page'
+
+const customerAuth = {
+  sub: 'customer-user-1',
+  sid: 'session-1',
+  type: 'customer' as const,
+  tenantId: 'tenant-1',
+  orgId: 'org-a-id',
+  email: 'customer@example.com',
+  displayName: 'Customer One',
+  customerEntityId: null,
+  personEntityId: null,
+  resolvedFeatures: ['portal.dashboard.view'],
+}
+
+describe('frontend customer portal org binding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    headerStore.get.mockReturnValue('/org-b/portal/dashboard')
+    mockGetCustomerAuthFromCookies.mockResolvedValue(customerAuth)
+  })
+
+  it('denies protected portal page access when URL org does not match the customer JWT org', async () => {
+    await SiteCatchAll({
+      params: Promise.resolve({ slug: ['org-b', 'portal', 'dashboard'] }),
+    })
+
+    expect(routeLoad).not.toHaveBeenCalled()
+    expect(mockCustomerRbac.userHasAllFeatures).not.toHaveBeenCalled()
+    expect(mockEm.findOne).toHaveBeenCalledWith(expect.any(Function), {
+      id: 'org-a-id',
+      slug: 'org-b',
+      deletedAt: null,
+    }, { populate: ['tenant'] })
+  })
+
+  it('does not render mismatched organization chrome for authenticated protected portal routes', async () => {
+    const element = await FrontendLayout({ children: <div>child</div> })
+    renderToStaticMarkup(element as React.ReactElement)
+
+    expect(portalShellMock).not.toHaveBeenCalled()
+  })
+
+  it.each(['/org-b/portal', '/org-b/portal/login', '/org-b/portal/signup', '/org-b/portal/verify', '/org-b/portal/reset-password'])(
+    'keeps public route %s bound to the URL org even when another customer session exists',
+    async (pathname) => {
+      headerStore.get.mockReturnValue(pathname)
+
+      const element = await FrontendLayout({ children: <div>public</div> })
+      renderToStaticMarkup(element as React.ReactElement)
+
+      expect(portalShellMock).toHaveBeenCalledWith(expect.objectContaining({
+        orgSlug: 'org-b',
+        organizationId: 'org-b-id',
+        authenticated: false,
+        userName: null,
+        userEmail: null,
+        customerAuth: null,
+      }))
+    },
+  )
+})

--- a/packages/create-app/template/src/app/(frontend)/layout.tsx
+++ b/packages/create-app/template/src/app/(frontend)/layout.tsx
@@ -1,4 +1,5 @@
 import { headers } from 'next/headers'
+import Link from 'next/link'
 import { PortalLayoutShell } from '@open-mercato/ui/portal/PortalLayoutShell'
 import { getCustomerAuthFromCookies } from '@open-mercato/core/modules/customer_accounts/lib/customerAuthServer'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
@@ -6,17 +7,38 @@ import { Organization } from '@open-mercato/core/modules/directory/data/entities
 import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { FeatureTogglesService } from '@open-mercato/core/modules/feature_toggles/lib/feature-flag-check'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
+import { AccessDeniedMessage } from '@open-mercato/ui/backend/detail'
 import type { EntityManager } from '@mikro-orm/postgresql'
 
 type LayoutProps = {
   children: React.ReactNode
 }
 
-const PUBLIC_SUFFIXES = ['/portal/login', '/portal/signup']
+const PUBLIC_SUFFIXES = ['/portal/login', '/portal/signup', '/portal/verify', '/portal/reset-password']
 
 function isPublicPortalRoute(pathname: string): boolean {
   if (/^\/[^/]+\/portal\/?$/.test(pathname)) return true
   return PUBLIC_SUFFIXES.some((s) => pathname.endsWith(s))
+}
+
+function getOrganizationTenantId(org: Organization): string | null {
+  const tenant = (org as any).tenant
+  return typeof tenant === 'string' ? tenant : tenant?.id ? String(tenant.id) : null
+}
+
+async function renderPortalAccessDenied() {
+  const { translate } = await resolveTranslations()
+  return (
+    <AccessDeniedMessage
+      label={translate('auth.accessDenied.title', 'Access Denied')}
+      description={translate('auth.accessDenied.message', 'You do not have permission to view this page. Please contact your administrator.')}
+      action={
+        <Link href="/" className="text-sm underline hover:opacity-80">
+          {translate('auth.accessDenied.home', 'Go to Home')}
+        </Link>
+      }
+    />
+  )
 }
 
 // Sits ABOVE the [...slug] dynamic segment so portal navigation does not
@@ -42,20 +64,39 @@ export default async function FrontendLayout({ children }: LayoutProps) {
   let userName: string | null = null
   let userEmail: string | null = null
   let portalEnabled = true
+  let portalAccessDenied = false
+  let customerAuthMatchesUrlOrg = false
 
   try {
     const container = await createRequestContainer()
     const em = container.resolve('em') as EntityManager
 
-    const org = await em.findOne(Organization, { slug: orgSlug, deletedAt: null })
+    const authOrg = customerAuth
+      ? await em.findOne(Organization, { id: customerAuth.orgId, slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+      : null
+    const authOrgTenantId = authOrg ? getOrganizationTenantId(authOrg) : null
+    customerAuthMatchesUrlOrg = !!customerAuth
+      && !!authOrg
+      && String(authOrg.id) === customerAuth.orgId
+      && authOrgTenantId === customerAuth.tenantId
+
+    const org = customerAuthMatchesUrlOrg
+      ? authOrg
+      : (!customerAuth || isPublic)
+        ? await em.findOne(Organization, { slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+        : null
+
     if (org) {
       orgName = org.name
       organizationId = String(org.id)
-      const tenant = (org as any).tenant
-      tenantId = typeof tenant === 'string' ? tenant : tenant?.id ? String(tenant.id) : null
+      tenantId = getOrganizationTenantId(org)
     }
 
-    if (tenantId) {
+    if (customerAuth && !isPublic && !customerAuthMatchesUrlOrg) {
+      portalAccessDenied = true
+    }
+
+    if (!portalAccessDenied && tenantId) {
       const featureTogglesService = container.resolve('featureTogglesService') as FeatureTogglesService
       const result = await featureTogglesService.getBoolConfig('portal_enabled', tenantId)
       if (result.ok && result.value === false) {
@@ -63,7 +104,7 @@ export default async function FrontendLayout({ children }: LayoutProps) {
       }
     }
 
-    if (customerAuth) {
+    if (!portalAccessDenied && customerAuthMatchesUrlOrg && customerAuth) {
       const user = await em.findOne(CustomerUser, { id: customerAuth.sub } as any)
       if (user) {
         userName = user.displayName || customerAuth.email
@@ -74,10 +115,17 @@ export default async function FrontendLayout({ children }: LayoutProps) {
       }
     }
   } catch {
-    if (customerAuth) {
+    if (customerAuth && !isPublic && !organizationId) {
+      portalAccessDenied = true
+    }
+    if (!portalAccessDenied && customerAuthMatchesUrlOrg && customerAuth) {
       userName = customerAuth.displayName || customerAuth.email
       userEmail = customerAuth.email
     }
+  }
+
+  if (portalAccessDenied) {
+    return renderPortalAccessDenied()
   }
 
   if (!portalEnabled) {
@@ -102,10 +150,10 @@ export default async function FrontendLayout({ children }: LayoutProps) {
       organizationName={orgName}
       tenantId={tenantId}
       organizationId={organizationId}
-      authenticated={!isPublic && !!customerAuth}
+      authenticated={!isPublic && customerAuthMatchesUrlOrg}
       userName={userName}
       userEmail={userEmail}
-      customerAuth={customerAuth}
+      customerAuth={customerAuthMatchesUrlOrg ? customerAuth : null}
     >
       {children}
     </PortalLayoutShell>

--- a/packages/create-app/template/src/app/(frontend)/layout.tsx
+++ b/packages/create-app/template/src/app/(frontend)/layout.tsx
@@ -72,13 +72,15 @@ export default async function FrontendLayout({ children }: LayoutProps) {
     const em = container.resolve('em') as EntityManager
 
     const authOrg = customerAuth
-      ? await em.findOne(Organization, { id: customerAuth.orgId, slug: orgSlug, deletedAt: null }, { populate: ['tenant'] })
+      ? await em.findOne(Organization, {
+          id: customerAuth.orgId,
+          slug: orgSlug,
+          deletedAt: null,
+        } as any)
       : null
-    const authOrgTenantId = authOrg ? getOrganizationTenantId(authOrg) : null
     customerAuthMatchesUrlOrg = !!customerAuth
       && !!authOrg
       && String(authOrg.id) === customerAuth.orgId
-      && authOrgTenantId === customerAuth.tenantId
 
     const org = customerAuthMatchesUrlOrg
       ? authOrg
@@ -89,7 +91,7 @@ export default async function FrontendLayout({ children }: LayoutProps) {
     if (org) {
       orgName = org.name
       organizationId = String(org.id)
-      tenantId = getOrganizationTenantId(org)
+      tenantId = customerAuthMatchesUrlOrg && customerAuth ? customerAuth.tenantId : getOrganizationTenantId(org)
     }
 
     if (customerAuth && !isPublic && !customerAuthMatchesUrlOrg) {


### PR DESCRIPTION
## Summary

Fixes customer portal org binding so protected `/{orgSlug}/portal/...` routes only authenticate when the URL org slug matches the customer JWT organization and tenant.

## Changes

- Validate protected portal page access against the authenticated customer org id, URL org slug, and tenant before RBAC/page load.
- Prevent private cross-org portal layout chrome from rendering.
- Strip mismatched customer auth from public portal shell context.
- Mirror the runtime fix and regression test into the create-app template.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — security bug fix; existing portal/customer-account specs reviewed.

## Testing

- [x] `yarn install --immutable`
- [x] `yarn build:packages`
- [x] `yarn generate`
- [x] `yarn workspace @open-mercato/app test --runTestsByPath 'src/app/(frontend)/__tests__/portal-org-binding.test.tsx' --runInBand`
- [x] `yarn workspace @open-mercato/app typecheck`
- [x] `yarn workspace create-mercato-app typecheck`
- [x] `yarn build:app`
- [x] `git diff --check`
- [ ] `yarn template:sync` — still reports unrelated current-develop scaffold/dependency drift; the portal files changed here are not listed.

Known baseline checks observed during validation:
- `yarn typecheck` fails in unrelated workspace paths on current `develop` (`@mdxeditor/editor` missing from `MdxEditorImpl.tsx`, plus related baseline type errors before regeneration).
- Earlier validation also observed unrelated `yarn i18n:check-usage` missing-key reports and an existing `yarn lint` ESLint runtime error: `scopeManager.addGlobals is not a function`.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3885