### PR TITLE
fix(query_index): throttle status refresh (#3888)

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/status-coverage-waterfall.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/status-coverage-waterfall.test.ts
@@ -50,6 +50,13 @@ function staleSnapshot() {
   }
 }
 
+function snapshotWithRefreshedAt(refreshedAt: Date) {
+  return {
+    ...staleSnapshot(),
+    refreshed_at: refreshedAt,
+  }
+}
+
 function makeFakeDb(tableRows: Record<string, unknown[]>) {
   const build = (table: string) => {
     const rows = tableRows[String(table)] ?? []
@@ -136,12 +143,56 @@ describe('query_index status route — coverage waterfall (#3285)', () => {
     expect(mockRefreshCoverageSnapshot).not.toHaveBeenCalled()
   })
 
-  it('still blocks on a refresh when an explicit ?refresh action is requested', async () => {
-    const res = await GET(makeRequest('?refresh=1'))
-    expect(res.status).toBe(200)
-    expect(mockRefreshCoverageSnapshot).toHaveBeenCalledTimes(2)
-    const refreshedScopes = mockRefreshCoverageSnapshot.mock.calls.map(([, scope]) => (scope as { entityType: string }).entityType)
-    expect(refreshedScopes).toEqual(expect.arrayContaining([ENTITY_A, ENTITY_B]))
+  it('throttles repeated explicit refresh recomputes within the same tenant scope', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000)
+    let persistedRefreshedAt: Date | null = null
+    mockReadCoverageSnapshots.mockImplementation(async (_db: unknown, batch: { entityTypes: string[] }) => {
+      const map = new Map<string, unknown>()
+      for (const entityType of batch.entityTypes) {
+        map.set(entityType, persistedRefreshedAt ? snapshotWithRefreshedAt(persistedRefreshedAt) : staleSnapshot())
+      }
+      return map
+    })
+    try {
+      const first = await GET(makeRequest('?refresh=1'))
+      expect(first.status).toBe(200)
+      expect(mockRefreshCoverageSnapshot).toHaveBeenCalledTimes(2)
+      const refreshedScopes = mockRefreshCoverageSnapshot.mock.calls.map(([, scope]) => (scope as { entityType: string }).entityType)
+      expect(refreshedScopes).toEqual(expect.arrayContaining([ENTITY_A, ENTITY_B]))
+
+      mockRefreshCoverageSnapshot.mockClear()
+      persistedRefreshedAt = new Date(1_000_000)
+      nowSpy.mockReturnValue(1_001_000)
+      const immediateSecond = await GET(makeRequest('?refresh=1'))
+      expect(immediateSecond.status).toBe(200)
+      expect(mockRefreshCoverageSnapshot).not.toHaveBeenCalled()
+
+      nowSpy.mockReturnValue(1_061_000)
+      const afterCooldown = await GET(makeRequest('?refresh=1'))
+      expect(afterCooldown.status).toBe(200)
+      expect(mockRefreshCoverageSnapshot).toHaveBeenCalledTimes(2)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  it('uses fresh persisted coverage snapshots instead of recomputing explicit refreshes', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(2_000_000)
+    try {
+      mockReadCoverageSnapshots.mockImplementation(async (_db: unknown, batch: { entityTypes: string[] }) => {
+        const map = new Map<string, unknown>()
+        for (const entityType of batch.entityTypes) {
+          map.set(entityType, snapshotWithRefreshedAt(new Date(1_999_000)))
+        }
+        return map
+      })
+
+      const res = await GET(makeRequest('?refresh=1'))
+      expect(res.status).toBe(200)
+      expect(mockRefreshCoverageSnapshot).not.toHaveBeenCalled()
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('does not raise a partial-index warning when coverage is not yet computed', async () => {

--- a/packages/core/src/modules/query_index/api/status.ts
+++ b/packages/core/src/modules/query_index/api/status.ts
@@ -4,7 +4,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { sql } from 'kysely'
-import { readCoverageSnapshots, refreshCoverageSnapshot } from '../lib/coverage'
+import { readCoverageSnapshots, refreshCoverageSnapshot, type CoverageSnapshot } from '../lib/coverage'
 import { mapWithConcurrency } from '@open-mercato/shared/lib/query/bounded-decrypt'
 import type { FullTextSearchStrategy } from '@open-mercato/search/strategies'
 import type { SearchModuleConfig } from '@open-mercato/shared/modules/search'
@@ -15,6 +15,33 @@ import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/d
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['query_index.status.view'] },
+}
+
+const STATUS_REFRESH_COOLDOWN_MS = 60_000
+
+function getCoverageSnapshotRefreshedAt(snapshot: Pick<CoverageSnapshot, 'refreshed_at'> | null | undefined): number | null {
+  const value = snapshot?.refreshed_at
+  if (value instanceof Date) {
+    const time = value.getTime()
+    return Number.isFinite(time) ? time : null
+  }
+  if (typeof value === 'string') {
+    const time = new Date(value).getTime()
+    return Number.isFinite(time) ? time : null
+  }
+  return null
+}
+
+function hasFreshCoverageSnapshots(
+  snapshots: Map<string, CoverageSnapshot>,
+  entityIds: string[],
+  now: number,
+): boolean {
+  for (const entityId of entityIds) {
+    const refreshedAt = getCoverageSnapshotRefreshedAt(snapshots.get(entityId))
+    if (refreshedAt === null || now - refreshedAt >= STATUS_REFRESH_COOLDOWN_MS) return false
+  }
+  return entityIds.length > 0
 }
 
 export async function GET(req: Request) {
@@ -303,9 +330,10 @@ export async function GET(req: Request) {
   // event emitted below, never inline per entity.
   const snapshotByEntity = await readCoverageSnapshots(db, { entityTypes: entityIds, ...coverageScope })
 
-  // An explicit refresh action (?refresh) is allowed to block: recompute every entity's
-  // coverage with bounded concurrency, then re-read the freshly written snapshots.
-  if (forceRefresh && entityIds.length > 0) {
+  // An explicit refresh action (?refresh) may block, but only when the durable
+  // coverage snapshots are stale. Recent persisted snapshots survive workers/restarts,
+  // so repeated refresh requests use them instead of hammering base-table counts.
+  if (forceRefresh && entityIds.length > 0 && !hasFreshCoverageSnapshots(snapshotByEntity, entityIds, Date.now())) {
     await mapWithConcurrency(entityIds, COVERAGE_REFRESH_CONCURRENCY, (entityId) =>
       refreshCoverageSnapshot(em, { entityType: entityId, ...coverageScope }).catch(() => undefined),
     )


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Throttle the expensive `GET /api/query_index/status?refresh=1` path so repeated authenticated refreshes reuse fresh persisted coverage snapshots instead of synchronously recomputing coverage for every custom-field-enabled entity.

## Changes

- Added a 60s persisted freshness gate based on `entity_index_coverage.refreshed_at`.
- Preserved normal non-refresh polling behavior and existing auth/feature metadata.
- Added regression coverage for repeated explicit refreshes and fresh persisted snapshot suppression.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A - focused security hardening for one existing route; checked existing specs before implementation.

## Testing

- `yarn workspace @open-mercato/core test --runTestsByPath src/modules/query_index/__tests__/status-coverage-waterfall.test.ts`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn build:app`
- `git diff --check`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) - use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) - use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) - no custom replacements

N/A - backend-only API route/test change; no UI surface changed.

## Linked issues

Fixes #3888
