### PR TITLE
fix(customers): restore bulk-deal command dispatch in standalone CI

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -140,7 +140,11 @@ jobs:
     if: needs.snapshot.outputs.snapshot_version != ''
     services:
       postgres:
-        image: postgres:17
+        # MUST match the pgvector-enabled image used by local dev / prod
+        # (docker-compose.yml, docker-compose.fullapp.yml) — plain `postgres:17`
+        # lacks the `vector` extension, so `CREATE EXTENSION vector` fails and
+        # any vector-search codepath exercised by the integration suite breaks.
+        image: pgvector/pgvector:pg17-trixie
         env:
           POSTGRES_USER: mercato
           POSTGRES_PASSWORD: secret

--- a/packages/core/src/modules/customers/__tests__/bulkDeals-eager-command-registration.test.ts
+++ b/packages/core/src/modules/customers/__tests__/bulkDeals-eager-command-registration.test.ts
@@ -1,0 +1,19 @@
+import { commandRegistry } from '@open-mercato/shared/lib/commands'
+
+// Reproduces the standalone-harness failure mode: a queue worker dispatches
+// `customers.deals.update` without any lazy-loader bootstrap having run. The eager
+// side-effect import in bulkDeals.ts must have registered the handler synchronously
+// into the shared command registry the worker's bus reads.
+describe('bulkDeals eager command registration', () => {
+  it('registers customers.deals.* handlers when the bulk lib is imported (no lazy bootstrap)', async () => {
+    // Sanity: registry has no deals handler before importing the bulk lib.
+    expect(commandRegistry.get('customers.deals.update')).toBeNull()
+
+    // Importing the bulk lib should eagerly register the deal commands.
+    await import('../lib/bulkDeals')
+
+    expect(commandRegistry.get('customers.deals.update')).not.toBeNull()
+    expect(commandRegistry.get('customers.deals.create')).not.toBeNull()
+    expect(commandRegistry.get('customers.deals.delete')).not.toBeNull()
+  })
+})

--- a/packages/core/src/modules/customers/lib/bulkDeals.ts
+++ b/packages/core/src/modules/customers/lib/bulkDeals.ts
@@ -5,6 +5,18 @@ import { invalidateCrudCache } from '@open-mercato/shared/lib/crud/cache'
 import { runWithCacheTenant } from '@open-mercato/cache'
 import { createModuleQueue, type Queue } from '@open-mercato/queue'
 import type { ProgressService, ProgressServiceContext } from '../../progress/lib/progressService'
+// Eagerly register the deal command handlers into this module graph's command
+// registry. The bulk workers dispatch `customers.deals.update` through the command
+// bus, but command handlers became lazy-loaded (#3703): they are only reachable if
+// their generated loader was registered into the SAME `@open-mercato/shared` instance
+// the worker's bus reads. A queue worker runs in its own container/process and must
+// not depend on that external lazy registration having reached its instance — in the
+// standalone integration harness the loader registry and the worker's bus can resolve
+// to different `@open-mercato/shared` instances, leaving the lazy loader unreachable
+// (issue: bulk deal jobs fail with "Command handler not registered for id
+// customers.deals.update"). Importing the command module here registers the handlers
+// through the worker's own import graph, so the dispatch always resolves.
+import '../commands/deals'
 
 export const CUSTOMERS_DEALS_BULK_UPDATE_STAGE_QUEUE = 'customers-deals-bulk-update-stage'
 export const CUSTOMERS_DEALS_BULK_UPDATE_OWNER_QUEUE = 'customers-deals-bulk-update-owner'


### PR DESCRIPTION
## Summary

The `Snapshot Release` → `Standalone App Integration Tests` job has failed on every `develop` push since PR #3703 (lazy-loaded module commands, July 1). Bulk-deal queue workers dispatch `customers.deals.update` via the command bus, but lazy command handlers only resolve if their generated loader was registered into the *same* `@open-mercato/shared` `commandRegistry` instance the worker's bus reads. In the standalone integration harness the loader registry and the worker's bus resolve to different shared instances, so the lazy loader is unreachable and TC-CRM-068/069/079 fail with `Command handler not registered for id customers.deals.update`. This PR makes the bulk-deals worker self-sufficient by eagerly importing its command module through its own graph.

## Changes

- `customers/lib/bulkDeals.ts`: eager `import '../commands/deals'` so `customers.deals.*` handlers register through the worker's own import graph (scoped to the bulk-deals path — workers + bulk API routes — not app-wide).
- Added `bulkDeals-eager-command-registration.test.ts` regression guard (handlers register on import with no lazy bootstrap).
- `.github/workflows/snapshot.yml`: standalone Postgres service now uses `pgvector/pgvector:pg17-trixie` instead of plain `postgres:17`, matching dev/prod so `CREATE EXTENSION vector` works.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (bug fix restoring pre-#3703 behavior, no spec needed)

## Testing

- New unit test `bulkDeals-eager-command-registration.test.ts` ✅
- Reproduced the standalone generator in a unit test — confirmed the generated `command-loaders.generated.ts` is correct (ruled out the generator), isolating the failure to runtime module-instance split.
- `@open-mercato/core` typecheck ✅ and build ✅ (dist emits `import "../commands/deals.js"`, same file the lazy loader targets → no double-registration)
- `@open-mercato/shared` command tests (132) ✅, `@open-mercato/core` customers tests (1182) ✅, `@open-mercato/app` bootstrap test ✅

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it. (N/A)
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (existing TC-CRM-068/069/079 already cover this path).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (N/A — bug fix).
- [x] Priority set: `priority-high` (release-blocking CI regression on `develop`).
- [x] Risk set: `risk-low` (feature-scoped import + CI image bump; full unit/build coverage).
- [x] QA routing set: `skip-qa` (CI-only + internal registration fix, not customer-facing).

## Linked issues

N/A
