### PR TITLE
fix(staff): remove duplicate CommandRuntimeContext import breaking develop build

### DIFF
--- a/packages/core/src/modules/staff/commands/shared.ts
+++ b/packages/core/src/modules/staff/commands/shared.ts
@@ -1,6 +1,5 @@
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
-import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'


### PR DESCRIPTION
Develop's build is currently red: `d4b0c5432` (#4001) re-added the `CommandRuntimeContext` type import in `packages/core/src/modules/staff/commands/shared.ts` that `5b071f47f` (#4005) had already restored, producing a TS duplicate-identifier error. `yarn build:app` fails on develop's own CI (push + PR runs on `d4b0c5432` are both failing) and, since `pull_request` workflows build the merge ref, **every open PR's CI is failing with the same error**.

One-line fix: drop the duplicate import (pure deletion, restores the file to its pre-#4001 import block).

Labels rationale: `priority-high` (develop is release-blocked and all PR CI is red), `risk-low` (one-line type-only deletion), `skip-qa` (no runtime behavior, CI-unblocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)