### PR TITLE
fix(workflows): render user task field schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - 🔒 Complete report-high.md tracker (16 HIGH findings) + dev-DX password amendment. (#2635) *(@pat-lewczuk)*
 
 ## 🐛 Fixes
+- 🐛 Render workflow user task forms from visual-editor field schemas and enforce required completion data. *(@pmadajthey)*
 - 📦 Classify runtime @types as deps and harden OSM tile host check. (#3800) *(@patzick)*
 - 🔧 Batch search token rebuild silently loses all tokens on large batches. (#3791) *(@KamilGrocholski)*
 - 🐛 Support "All organizations" scope on deals filter-bar endpoints (#3768). (#3790) *(@adeptofvoltron)*

--- a/packages/core/src/modules/workflows/api/tasks/[id]/complete/route.ts
+++ b/packages/core/src/modules/workflows/api/tasks/[id]/complete/route.ts
@@ -11,7 +11,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
-import { completeUserTask } from '../../../../lib/task-handler'
+import { completeUserTask, UserTaskError } from '../../../../lib/task-handler'
 import {
   workflowsTag,
   completeTaskRequestSchema as openApiCompleteTaskSchema,
@@ -129,6 +129,21 @@ export async function POST(
     logger.error('Error completing user task', { err: error })
 
     // Handle specific error codes from task-handler
+    if (error instanceof UserTaskError) {
+      if (error.code === 'FORM_VALIDATION_FAILED') {
+        return NextResponse.json(
+          { error: error.message, code: error.code, details: error.details },
+          { status: 400 }
+        )
+      }
+      if (error.code === 'TASK_NOT_FOUND' || error.code === 'INSTANCE_NOT_FOUND' || error.code === 'DEFINITION_NOT_FOUND') {
+        return NextResponse.json(
+          { error: error.message, code: error.code, details: error.details },
+          { status: 404 }
+        )
+      }
+    }
+
     if (error instanceof Error) {
       if (error.message.includes('not found')) {
         return NextResponse.json(

--- a/packages/core/src/modules/workflows/backend/tasks/[id]/page.tsx
+++ b/packages/core/src/modules/workflows/backend/tasks/[id]/page.tsx
@@ -27,6 +27,7 @@ import { useIsMobile } from '@open-mercato/ui/hooks/useIsMobile'
 import type { UserTaskResponse, UserTaskStatus } from '../../../data/types'
 import { RecordNotFoundState, ErrorMessage } from '@open-mercato/ui/backend/detail'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { normalizeUserTaskFormSchema } from '../../../lib/user-task-form-schema'
 
 const logger = createLogger('workflows')
 
@@ -78,10 +79,12 @@ export default function UserTaskDetailPage({ params }: { params: { id: string } 
     // Validate required fields. Radix Select doesn't expose HTML `required`,
     // so we enforce constraint validation here and surface it visually via
     // `invalidField` + aria-invalid on the offending field.
-    if (task.formSchema?.required) {
-      for (const requiredField of task.formSchema.required) {
+    const normalizedFormSchema = normalizeUserTaskFormSchema(task.formSchema) ?? task.formSchema
+
+    if (normalizedFormSchema?.required) {
+      for (const requiredField of normalizedFormSchema.required) {
         if (!formData[requiredField] || formData[requiredField] === '') {
-          const fieldSchema = task.formSchema.properties?.[requiredField]
+          const fieldSchema = normalizedFormSchema.properties?.[requiredField]
           const fieldLabel = fieldSchema?.title ?? requiredField
           flash(t('workflows.tasks.detail.validation.requiredField', { field: fieldLabel }), 'error')
           setInvalidField(requiredField)
@@ -137,8 +140,10 @@ export default function UserTaskDetailPage({ params }: { params: { id: string } 
     const fieldType = fieldSchema.type || 'string'
     const fieldTitle = fieldSchema.title || fieldName
     const fieldDescription = fieldSchema.description
-    const required = task?.formSchema?.required?.includes(fieldName) || false
+    const normalizedFormSchema = normalizeUserTaskFormSchema(task?.formSchema) ?? task?.formSchema
+    const required = normalizedFormSchema?.required?.includes(fieldName) || false
     const enumValues = fieldSchema.enum
+    const placeholder = fieldSchema.placeholder || fieldSchema.description
 
     const inputClasses = "w-full px-3 py-2 border border-border rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     const labelClasses = "block text-sm font-medium text-foreground mb-1"
@@ -235,6 +240,7 @@ export default function UserTaskDetailPage({ params }: { params: { id: string } 
                 id={fieldName}
                 value={fieldValue(fieldName)}
                 onChange={(e) => handleFieldChange(fieldName, e.target.value)}
+                placeholder={placeholder}
                 required={required}
                 rows={4}
                 className={inputClasses}
@@ -256,6 +262,7 @@ export default function UserTaskDetailPage({ params }: { params: { id: string } 
               id={fieldName}
               value={fieldValue(fieldName)}
               onChange={(e) => handleFieldChange(fieldName, e.target.value)}
+              placeholder={placeholder}
               required={required}
             />
           </div>
@@ -277,6 +284,7 @@ export default function UserTaskDetailPage({ params }: { params: { id: string } 
               id={fieldName}
               value={fieldValue(fieldName)}
               onChange={(e) => handleFieldChange(fieldName, e.target.value ? Number(e.target.value) : '')}
+              placeholder={placeholder}
               required={required}
               step={fieldType === 'integer' ? 1 : 'any'}
             />
@@ -320,6 +328,7 @@ export default function UserTaskDetailPage({ params }: { params: { id: string } 
               id={fieldName}
               value={fieldValue(fieldName)}
               onChange={(e) => handleFieldChange(fieldName, e.target.value)}
+              placeholder={placeholder}
               required={required}
             />
           </div>
@@ -390,6 +399,7 @@ export default function UserTaskDetailPage({ params }: { params: { id: string } 
 
   const isCompletable = task.status === 'PENDING' || task.status === 'IN_PROGRESS'
   const isOverdue = task.dueDate && new Date(task.dueDate) < new Date() && isCompletable
+  const normalizedFormSchema = normalizeUserTaskFormSchema(task.formSchema) ?? task.formSchema
 
   if (isMobile) {
     return (
@@ -507,16 +517,16 @@ export default function UserTaskDetailPage({ params }: { params: { id: string } 
 
               {/* Dynamic Form */}
               <form onSubmit={handleSubmit} className="space-y-6">
-                {task.formSchema?.properties && (
+                {normalizedFormSchema?.properties && (
                   <div className="space-y-4">
                     <h2 className="text-lg font-semibold">{t('workflows.tasks.detail.sections.form')}</h2>
-                    {Object.keys(task.formSchema!.properties!).map((fieldName) =>
-                      renderFormField(fieldName, task.formSchema!.properties![fieldName])
+                    {Object.keys(normalizedFormSchema!.properties!).map((fieldName) =>
+                      renderFormField(fieldName, normalizedFormSchema!.properties![fieldName])
                     )}
                   </div>
                 )}
 
-                {!task.formSchema?.properties && (
+                {!normalizedFormSchema?.properties && (
                   <div className="bg-status-info-bg border border-status-info-border rounded-lg p-4">
                     <p className="text-sm text-status-info-text">
                       {t('workflows.tasks.detail.noFormSchema')}

--- a/packages/core/src/modules/workflows/components/mobile/MobileTaskForm.tsx
+++ b/packages/core/src/modules/workflows/components/mobile/MobileTaskForm.tsx
@@ -18,6 +18,7 @@ import { Separator } from '@open-mercato/ui/primitives/separator'
 import { JsonDisplay } from '@open-mercato/ui/backend/JsonDisplay'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { UserTaskResponse, UserTaskStatus, JsonSchemaField } from '../../data/types'
+import { normalizeUserTaskFormSchema } from '../../lib/user-task-form-schema'
 
 interface MobileTaskFormProps {
   task: UserTaskResponse
@@ -47,6 +48,7 @@ export function MobileTaskForm({
   getStatusBadgeClass,
 }: MobileTaskFormProps) {
   const t = useT()
+  const normalizedFormSchema = normalizeUserTaskFormSchema(task.formSchema) ?? task.formSchema
 
   const fieldValue = (fieldName: string): string | number => {
     const val = formData[fieldName]
@@ -59,8 +61,9 @@ export function MobileTaskForm({
     const fieldType = fieldSchema.type || 'string'
     const fieldTitle = fieldSchema.title || fieldName
     const fieldDescription = fieldSchema.description
-    const required = task.formSchema?.required?.includes(fieldName) || false
+    const required = normalizedFormSchema?.required?.includes(fieldName) || false
     const enumValues = fieldSchema.enum
+    const placeholder = fieldSchema.placeholder || fieldSchema.description
 
     if (enumValues && Array.isArray(enumValues)) {
       return (
@@ -101,6 +104,7 @@ export function MobileTaskForm({
                 id={fieldName}
                 value={fieldValue(fieldName)}
                 onChange={(e) => onFieldChange(fieldName, e.target.value)}
+                placeholder={placeholder}
                 required={required}
                 rows={4}
                 className="text-base"
@@ -120,6 +124,7 @@ export function MobileTaskForm({
               id={fieldName}
               value={fieldValue(fieldName)}
               onChange={(e) => onFieldChange(fieldName, e.target.value)}
+              placeholder={placeholder}
               required={required}
               className="h-11 text-base"
             />
@@ -140,6 +145,7 @@ export function MobileTaskForm({
               id={fieldName}
               value={fieldValue(fieldName)}
               onChange={(e) => onFieldChange(fieldName, e.target.value ? Number(e.target.value) : '')}
+              placeholder={placeholder}
               required={required}
               step={fieldType === 'integer' ? 1 : 'any'}
               className="h-11 text-base"
@@ -178,6 +184,7 @@ export function MobileTaskForm({
               id={fieldName}
               value={fieldValue(fieldName)}
               onChange={(e) => onFieldChange(fieldName, e.target.value)}
+              placeholder={placeholder}
               required={required}
               className="h-11 text-base"
             />
@@ -246,19 +253,19 @@ export function MobileTaskForm({
 
       {isCompletable && (
         <form onSubmit={onSubmit} className="space-y-4">
-          {task.formSchema?.properties && (
+          {normalizedFormSchema?.properties && (
             <>
               <Separator />
               <h2 className="text-base font-semibold">{t('workflows.tasks.detail.sections.form')}</h2>
               <div className="space-y-4">
-                {Object.keys(task.formSchema!.properties!).map((fieldName) =>
-                  renderFormField(fieldName, task.formSchema!.properties![fieldName])
+                {Object.keys(normalizedFormSchema.properties!).map((fieldName) =>
+                  renderFormField(fieldName, normalizedFormSchema.properties![fieldName])
                 )}
               </div>
             </>
           )}
 
-          {!task.formSchema?.properties && (
+          {!normalizedFormSchema?.properties && (
             <div className="bg-status-info-bg border border-status-info-border rounded-lg p-3">
               <p className="text-sm text-status-info-text">{t('workflows.tasks.detail.noFormSchema')}</p>
             </div>

--- a/packages/core/src/modules/workflows/data/types.ts
+++ b/packages/core/src/modules/workflows/data/types.ts
@@ -9,6 +9,7 @@ export interface JsonSchema {
   title?: string
   properties?: Record<string, JsonSchemaField>
   required?: string[]
+  fields?: UserTaskFormField[]
 }
 
 export interface JsonSchemaField {
@@ -17,7 +18,19 @@ export interface JsonSchemaField {
   enum?: string[]
   format?: string
   description?: string
+  placeholder?: string
+  default?: unknown
   maxLength?: number
+}
+
+export interface UserTaskFormField {
+  name: string
+  type: string
+  label: string
+  required?: boolean
+  placeholder?: string
+  options?: unknown[]
+  defaultValue?: unknown
 }
 
 // API response shape (serialized — string dates, proper formSchema/formData types)

--- a/packages/core/src/modules/workflows/lib/__tests__/step-handler.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/step-handler.test.ts
@@ -477,7 +477,16 @@ describe('Step Handler (Unit Tests)', () => {
       // Calls: step instance, event, user task, event
       expect(mockEm.create).toHaveBeenCalledTimes(4)
       const userTaskCall = (mockEm.create as jest.Mock).mock.calls[2] as [string, any] // Third call is user task
-      expect(userTaskCall[1].formSchema).toBeDefined()
+      expect(userTaskCall[1].formSchema).toMatchObject({
+        type: 'object',
+        required: ['approved'],
+        properties: {
+          approved: {
+            type: 'boolean',
+            title: 'Approved',
+          },
+        },
+      })
       expect(userTaskCall[1].assignedTo).toBe('manager@example.com')
       expect(userTaskCall[1].dueDate).toBeDefined()
     })

--- a/packages/core/src/modules/workflows/lib/__tests__/task-handler.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/task-handler.test.ts
@@ -1,0 +1,131 @@
+import { completeUserTask, UserTaskError } from '../task-handler'
+import {
+  UserTask,
+  WorkflowDefinition,
+  WorkflowInstance,
+  StepInstance,
+} from '../../data/entities'
+
+describe('task-handler', () => {
+  const tenantId = '00000000-0000-4000-8000-000000000001'
+  const organizationId = '00000000-0000-4000-8000-000000000002'
+  const taskId = '00000000-0000-4000-8000-000000000003'
+  const workflowInstanceId = '00000000-0000-4000-8000-000000000004'
+  const definitionId = '00000000-0000-4000-8000-000000000005'
+  const stepInstanceId = '00000000-0000-4000-8000-000000000006'
+
+  function createPendingTask(): UserTask {
+    return {
+      id: taskId,
+      workflowInstanceId,
+      stepInstanceId,
+      branchInstanceId: null,
+      taskName: 'Initial contact',
+      description: null,
+      status: 'PENDING',
+      formSchema: {
+        fields: [
+          {
+            name: 'contact_summary',
+            type: 'textarea',
+            label: 'Contact Summary',
+            required: true,
+          },
+        ],
+      },
+      formData: null,
+      assignedTo: null,
+      assignedToRoles: ['Sales Representative'],
+      claimedBy: null,
+      claimedAt: null,
+      dueDate: null,
+      escalatedAt: null,
+      escalatedTo: null,
+      completedBy: null,
+      completedAt: null,
+      comments: null,
+      tenantId,
+      organizationId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as UserTask
+  }
+
+  function createEntityManager(task: UserTask) {
+    const instance = {
+      id: workflowInstanceId,
+      definitionId,
+      workflowId: 'qa-user-task-form',
+      version: 1,
+      status: 'PAUSED',
+      currentStepId: 'initial_contact',
+      context: {},
+      tenantId,
+      organizationId,
+      updatedAt: new Date(),
+    } as WorkflowInstance
+
+    const definition = {
+      id: definitionId,
+      definition: {
+        transitions: [],
+      },
+      tenantId,
+      organizationId,
+    } as WorkflowDefinition
+
+    return {
+      instance,
+      em: {
+        findOne: jest.fn(async (entity: unknown) => {
+          if (entity === UserTask) return task
+          if (entity === WorkflowInstance) return instance
+          if (entity === StepInstance) return null
+          if (entity === WorkflowDefinition) return definition
+          return null
+        }),
+        create: jest.fn((_: unknown, payload: unknown) => payload),
+        persist: jest.fn(function persist(this: any) { return this }),
+        flush: jest.fn(),
+      },
+    }
+  }
+
+  test('rejects missing required data for visual-editor fields schema', async () => {
+    const task = createPendingTask()
+    const { em } = createEntityManager(task)
+
+    await expect(
+      completeUserTask(em as any, {} as any, {
+        taskId,
+        formData: {},
+        userId: 'qa-user',
+      })
+    ).rejects.toMatchObject({
+      name: 'UserTaskError',
+      code: 'FORM_VALIDATION_FAILED',
+      message: 'Required field missing: contact_summary',
+    } satisfies Partial<UserTaskError>)
+
+    expect(task.status).toBe('PENDING')
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  test('persists form data from visual-editor fields schema and merges it into workflow context', async () => {
+    const task = createPendingTask()
+    const { em, instance } = createEntityManager(task)
+
+    await completeUserTask(em as any, {} as any, {
+      taskId,
+      formData: { contact_summary: 'Reached the customer by phone.' },
+      userId: 'qa-user',
+      comments: 'Useful first call',
+    })
+
+    expect(task.status).toBe('COMPLETED')
+    expect(task.formData).toEqual({ contact_summary: 'Reached the customer by phone.' })
+    expect(task.comments).toBe('Useful first call')
+    expect(instance.context).toEqual({ contact_summary: 'Reached the customer by phone.' })
+    expect(em.flush).toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/workflows/lib/__tests__/user-task-form-schema.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/user-task-form-schema.test.ts
@@ -1,0 +1,55 @@
+import { normalizeUserTaskFormSchema } from '../user-task-form-schema'
+
+describe('user task form schema normalization', () => {
+  test('converts visual-editor fields into JSON Schema properties and required fields', () => {
+    const normalized = normalizeUserTaskFormSchema({
+      fields: [
+        {
+          name: 'contact_summary',
+          type: 'textarea',
+          label: 'Contact Summary',
+          required: true,
+          placeholder: 'Summarize the contact',
+          defaultValue: 'N/A',
+        },
+        {
+          name: 'follow_up_required',
+          type: 'checkbox',
+          label: 'Follow-up required',
+          required: false,
+        },
+      ],
+    })
+
+    expect(normalized).toMatchObject({
+      type: 'object',
+      required: ['contact_summary'],
+      properties: {
+        contact_summary: {
+          type: 'string',
+          title: 'Contact Summary',
+          description: 'Summarize the contact',
+          placeholder: 'Summarize the contact',
+          default: 'N/A',
+          maxLength: 2000,
+        },
+        follow_up_required: {
+          type: 'boolean',
+          title: 'Follow-up required',
+        },
+      },
+    })
+  })
+
+  test('keeps existing JSON Schema form definitions intact', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        email: { type: 'string', format: 'email', title: 'Email' },
+      },
+      required: ['email'],
+    }
+
+    expect(normalizeUserTaskFormSchema(schema)).toBe(schema)
+  })
+})

--- a/packages/core/src/modules/workflows/lib/step-handler.ts
+++ b/packages/core/src/modules/workflows/lib/step-handler.ts
@@ -23,6 +23,7 @@ import {
 import { parseDuration } from './duration'
 import { logWorkflowEvent } from './event-logger'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { normalizeUserTaskFormSchema } from './user-task-form-schema'
 
 const logger = createLogger('workflows')
 
@@ -567,7 +568,7 @@ async function handleUserTaskStep(
     taskName: stepDef.stepName,
     description: stepDef.description || null,
     status: 'PENDING',
-    formSchema: userTaskConfig.formSchema || null,
+    formSchema: normalizeUserTaskFormSchema(userTaskConfig.formSchema) ?? userTaskConfig.formSchema ?? null,
     formData: null,
     assignedTo: assignedTo,
     assignedToRoles: assignedToRoles,

--- a/packages/core/src/modules/workflows/lib/task-handler.ts
+++ b/packages/core/src/modules/workflows/lib/task-handler.ts
@@ -23,6 +23,7 @@ import { executeWorkflow } from './workflow-executor'
 import * as stepHandler from './step-handler'
 import * as transitionHandler from './transition-handler'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { normalizeUserTaskFormSchema } from './user-task-form-schema'
 
 const logger = createLogger('workflows')
 
@@ -372,12 +373,14 @@ function validateFormData(
   formData: Record<string, any>,
   formSchema: any
 ): void {
+  const normalizedSchema = normalizeUserTaskFormSchema(formSchema) ?? formSchema
+
   // For MVP: Basic validation - just check required fields exist
-  if (!formSchema || !formSchema.properties) {
+  if (!normalizedSchema || !normalizedSchema.properties) {
     return // No schema to validate against
   }
 
-  const requiredFields = formSchema.required || []
+  const requiredFields = normalizedSchema.required || []
 
   for (const field of requiredFields) {
     if (!(field in formData) || formData[field] === null || formData[field] === undefined) {

--- a/packages/core/src/modules/workflows/lib/user-task-form-schema.ts
+++ b/packages/core/src/modules/workflows/lib/user-task-form-schema.ts
@@ -1,0 +1,140 @@
+type UserTaskFormField = {
+  name?: unknown
+  type?: unknown
+  label?: unknown
+  required?: unknown
+  placeholder?: unknown
+  options?: unknown
+  defaultValue?: unknown
+}
+
+type JsonSchemaField = {
+  type?: string
+  title?: string
+  enum?: string[]
+  format?: string
+  description?: string
+  placeholder?: string
+  default?: unknown
+  maxLength?: number
+}
+
+export type NormalizedUserTaskFormSchema = {
+  type?: string
+  title?: string
+  properties: Record<string, JsonSchemaField>
+  required?: string[]
+  fields?: UserTaskFormField[]
+  [key: string]: unknown
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function fieldTypeToJsonSchema(fieldType: string): Pick<JsonSchemaField, 'type' | 'format' | 'maxLength'> {
+  switch (fieldType) {
+    case 'number':
+      return { type: 'number' }
+    case 'integer':
+      return { type: 'integer' }
+    case 'checkbox':
+    case 'boolean':
+      return { type: 'boolean' }
+    case 'email':
+      return { type: 'string', format: 'email' }
+    case 'url':
+      return { type: 'string', format: 'uri' }
+    case 'tel':
+      return { type: 'string', format: 'tel' }
+    case 'date':
+      return { type: 'string', format: 'date' }
+    case 'time':
+      return { type: 'string', format: 'time' }
+    case 'datetime-local':
+      return { type: 'string', format: 'date-time' }
+    case 'textarea':
+      return { type: 'string', maxLength: 2000 }
+    case 'select':
+    case 'radio':
+    case 'text':
+    default:
+      return { type: 'string' }
+  }
+}
+
+function normalizeFormField(field: UserTaskFormField): { name: string; schema: JsonSchemaField; required: boolean } | null {
+  if (typeof field.name !== 'string' || field.name.trim().length === 0) {
+    return null
+  }
+
+  const name = field.name.trim()
+  const fieldType = typeof field.type === 'string' ? field.type : 'text'
+  const schema: JsonSchemaField = {
+    ...fieldTypeToJsonSchema(fieldType),
+    title: typeof field.label === 'string' && field.label.trim().length > 0 ? field.label : name,
+  }
+
+  if (typeof field.placeholder === 'string' && field.placeholder.length > 0) {
+    schema.description = field.placeholder
+    schema.placeholder = field.placeholder
+  }
+
+  if (Array.isArray(field.options) && field.options.length > 0) {
+    schema.enum = field.options.map(String)
+  }
+
+  if (field.defaultValue !== undefined && field.defaultValue !== '') {
+    schema.default = field.defaultValue
+  }
+
+  return {
+    name,
+    schema,
+    required: field.required === true,
+  }
+}
+
+export function normalizeUserTaskFormSchema(schema: unknown): NormalizedUserTaskFormSchema | null {
+  if (!isRecord(schema)) {
+    return null
+  }
+
+  if (isRecord(schema.properties)) {
+    return schema as NormalizedUserTaskFormSchema
+  }
+
+  if (!Array.isArray(schema.fields)) {
+    return null
+  }
+
+  const properties: Record<string, JsonSchemaField> = {}
+  const required: string[] = []
+
+  for (const field of schema.fields) {
+    if (!isRecord(field)) {
+      continue
+    }
+
+    const normalized = normalizeFormField(field)
+    if (!normalized) {
+      continue
+    }
+
+    properties[normalized.name] = normalized.schema
+    if (normalized.required) {
+      required.push(normalized.name)
+    }
+  }
+
+  if (Object.keys(properties).length === 0) {
+    return null
+  }
+
+  return {
+    ...schema,
+    type: typeof schema.type === 'string' ? schema.type : 'object',
+    properties,
+    required,
+  } as NormalizedUserTaskFormSchema
+}


### PR DESCRIPTION
## Summary

User tasks can be created with the visual editor's `formSchema.fields[]` shape, but the task runtime only rendered and validated JSON Schema `properties`. This normalizes the field-array shape into JSON Schema-style properties before storing, rendering, and validating task forms, so configured forms appear on task detail pages and required fields are enforced.

This is a focused runtime fix. It complements #4019, which covers preserving the same user task configuration through the visual editor save/read-back flow.

## Changes

- Add a shared `normalizeUserTaskFormSchema` helper that converts visual-editor field arrays into JSON Schema-style `properties` and `required` metadata while passing existing JSON Schema through unchanged.
- Normalize user task form schemas when creating task rows, rendering desktop/mobile task forms, and validating completion payloads.
- Return structured `FORM_VALIDATION_FAILED` 400 responses for missing required form data.
- Cover the normalizer, user task creation, and completion validation with unit tests.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- `corepack yarn workspace @open-mercato/core test --runTestsByPath src/modules/workflows/lib/__tests__/user-task-form-schema.test.ts src/modules/workflows/lib/__tests__/step-handler.test.ts src/modules/workflows/lib/__tests__/task-handler.test.ts`
- `corepack yarn build:packages`
- `corepack yarn generate`
- `corepack yarn workspace @open-mercato/core typecheck`
- `git diff --cached --check`

UI behavior should be routed through `needs-qa` before merge; no public screenshot or recording is attached to this PR.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Intended maintainer-applied routing: `priority-medium`, `risk-medium`, `needs-qa`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — N/A, no list/data page changed
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) — N/A, no icon-only buttons added
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

N/A

