### PR TITLE
fix: enforce Ollama connection-time URL safety (#4038)

### DIFF
--- a/packages/search/src/__tests__/embedding.test.ts
+++ b/packages/search/src/__tests__/embedding.test.ts
@@ -2,10 +2,16 @@ jest.mock('ai', () => ({
   embed: jest.fn(),
 }))
 
+jest.mock('ai-sdk-ollama', () => ({
+  createOllama: jest.fn(() => ({ embedding: jest.fn(() => ({})) })),
+}))
+
 import { embed } from 'ai'
+import { createOllama } from 'ai-sdk-ollama'
 import { EmbeddingService } from '../vector/services/embedding'
 
 const mockedEmbed = jest.mocked(embed)
+const mockedCreateOllama = jest.mocked(createOllama)
 
 describe('EmbeddingService', () => {
   const originalEnv = { ...process.env }
@@ -78,6 +84,28 @@ describe('EmbeddingService', () => {
     })
 
     await expect(service.createEmbedding('test input')).resolves.toEqual([0.25, 0.5, 0.75])
+  })
+
+  it('injects the guarded fetch transport into the Ollama SDK client', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.VECTOR_EMBEDDING_TIMEOUT_MS = '100'
+    mockedEmbed.mockResolvedValue({ embedding: [0.25] } as Awaited<ReturnType<typeof embed>>)
+
+    const service = new EmbeddingService({
+      config: {
+        providerId: 'ollama',
+        model: 'nomic-embed-text',
+        dimension: 768,
+        baseUrl: 'https://ollama.example.com',
+        updatedAt: new Date().toISOString(),
+      },
+    })
+
+    await expect(service.createEmbedding('test input')).resolves.toEqual([0.25])
+    expect(mockedCreateOllama).toHaveBeenCalledWith({
+      baseURL: 'https://ollama.example.com',
+      fetch: expect.any(Function),
+    })
   })
 
   it('rejects persisted Ollama baseUrl pointing at a private IP in production', async () => {

--- a/packages/search/src/modules/search/api/embeddings/__tests__/route.ollama-base-url.test.ts
+++ b/packages/search/src/modules/search/api/embeddings/__tests__/route.ollama-base-url.test.ts
@@ -20,6 +20,7 @@ const mockSaveEmbeddingConfig = jest.fn()
 const mockGetConfiguredProviders = jest.fn()
 const mockDetectConfigChange = jest.fn()
 const mockGetEffectiveDimension = jest.fn()
+const mockCheckAvailability = jest.fn()
 jest.mock('../../../lib/embedding-config', () => ({
   resolveEmbeddingConfig: (...args: unknown[]) => mockResolveEmbeddingConfig(...args),
   resolveEmbeddingConfigResult: (...args: unknown[]) => mockResolveEmbeddingConfigResult(...args),
@@ -66,6 +67,9 @@ describe('POST /api/search/embeddings — Ollama baseUrl SSRF guard', () => {
     mockCreateRequestContainer.mockResolvedValue({
       resolve: jest.fn((name: string) => {
         if (name === 'moduleConfigService') return moduleConfigService
+        if (name === 'embeddingProviderProbe') {
+          return { checkAvailability: mockCheckAvailability }
+        }
         if (name === 'vectorDrivers') return []
         throw new Error(`unexpected resolve(${name})`)
       }),
@@ -76,6 +80,7 @@ describe('POST /api/search/embeddings — Ollama baseUrl SSRF guard', () => {
     mockResolveEmbeddingConfigResult.mockResolvedValue({ config: null, source: 'env' })
     mockGetConfiguredProviders.mockReturnValue(['ollama', 'openai'])
     mockGetEffectiveDimension.mockReturnValue(768)
+    mockCheckAvailability.mockResolvedValue({ available: true })
     mockDetectConfigChange.mockImplementation((_existing: unknown, next: unknown) => ({
       newConfig: next,
       requiresReindex: false,
@@ -124,6 +129,10 @@ describe('POST /api/search/embeddings — Ollama baseUrl SSRF guard', () => {
 
     expect(res.status).toBe(200)
     expect(mockSaveEmbeddingConfig).toHaveBeenCalledTimes(1)
+    expect(mockCheckAvailability).toHaveBeenCalledWith('ollama', {
+      force: true,
+      baseUrl: 'http://ollama.internal.example.com:11434',
+    })
     const savedConfig = mockSaveEmbeddingConfig.mock.calls[0][1] as { baseUrl?: string }
     expect(savedConfig.baseUrl).toBe('http://ollama.internal.example.com:11434')
   })

--- a/packages/search/src/modules/search/api/embeddings/route.ts
+++ b/packages/search/src/modules/search/api/embeddings/route.ts
@@ -271,7 +271,12 @@ export async function POST(req: Request) {
       // Save-time availability guard: never persist a provider the probe reports unreachable.
       const probe = resolveProbe(container)
       if (probe) {
-        const availability = await probe.checkAvailability(newConfig.providerId)
+        const availability = await probe.checkAvailability(
+          newConfig.providerId,
+          newConfig.providerId === 'ollama'
+            ? { force: true, baseUrl: newConfig.baseUrl }
+            : undefined,
+        )
         if (!availability.available) {
           return NextResponse.json(
             {

--- a/packages/search/src/modules/search/lib/__tests__/provider-probe.test.ts
+++ b/packages/search/src/modules/search/lib/__tests__/provider-probe.test.ts
@@ -102,6 +102,29 @@ describe('createEmbeddingProviderProbe', () => {
     expect(spy).toHaveBeenCalledTimes(2)
   })
 
+  it('probes a candidate Ollama base URL instead of the environment default', async () => {
+    const previous = process.env.OLLAMA_BASE_URL
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434'
+    const spy = mockFetch(async () => okTags(1))
+    const { container } = createContainerWithCache()
+    const probe = createEmbeddingProviderProbe(container)
+
+    try {
+      await probe.checkAvailability('ollama', {
+        force: true,
+        baseUrl: 'http://127.0.0.1:22434',
+      })
+    } finally {
+      if (previous === undefined) delete process.env.OLLAMA_BASE_URL
+      else process.env.OLLAMA_BASE_URL = previous
+    }
+
+    expect(spy).toHaveBeenCalledWith(
+      'http://127.0.0.1:22434/api/tags',
+      expect.objectContaining({ method: 'GET' }),
+    )
+  })
+
   it('gates key-based providers on env-key presence', async () => {
     const { container } = createContainerWithCache()
     const probe = createEmbeddingProviderProbe(container)

--- a/packages/search/src/modules/search/lib/provider-probe.ts
+++ b/packages/search/src/modules/search/lib/provider-probe.ts
@@ -2,6 +2,7 @@ import type { CacheStrategy } from '@open-mercato/cache'
 import type { AppContainer } from '@open-mercato/shared/lib/di/container'
 import type { EmbeddingProviderId } from '../../../vector'
 import { EMBEDDING_PROVIDERS } from '../../../vector'
+import { safeOllamaFetch } from '../../../vector/lib/ollama-url-safety'
 
 const CACHE_VERSION = 'v1'
 const CACHE_TTL_MS = 30_000
@@ -18,7 +19,10 @@ export type ProviderAvailabilityEntry = ProviderAvailability & {
 }
 
 export type EmbeddingProviderProbe = {
-  checkAvailability(providerId: EmbeddingProviderId, options?: { force?: boolean }): Promise<ProviderAvailability>
+  checkAvailability(
+    providerId: EmbeddingProviderId,
+    options?: { force?: boolean; baseUrl?: string },
+  ): Promise<ProviderAvailability>
 }
 
 const ALL_PROVIDERS: EmbeddingProviderId[] = ['openai', 'google', 'mistral', 'cohere', 'bedrock', 'ollama']
@@ -80,7 +84,7 @@ export async function probeOllama(baseUrl: string): Promise<ProviderAvailability
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), OLLAMA_PROBE_TIMEOUT_MS)
   try {
-    const response = await fetch(`${baseUrl.replace(/\/$/, '')}/api/tags`, {
+    const response = await safeOllamaFetch(`${baseUrl.replace(/\/$/, '')}/api/tags`, {
       method: 'GET',
       signal: controller.signal,
     })
@@ -104,10 +108,13 @@ export async function probeOllama(baseUrl: string): Promise<ProviderAvailability
   }
 }
 
-async function computeAvailability(providerId: EmbeddingProviderId): Promise<ProviderAvailability> {
+async function computeAvailability(
+  providerId: EmbeddingProviderId,
+  options?: { baseUrl?: string },
+): Promise<ProviderAvailability> {
   try {
     if (providerId === 'ollama') {
-      return await probeOllama(ollamaBaseUrl())
+      return await probeOllama(options?.baseUrl?.trim() || ollamaBaseUrl())
     }
     return keyPresence(providerId)
   } catch (error) {
@@ -119,11 +126,12 @@ async function computeAvailability(providerId: EmbeddingProviderId): Promise<Pro
 export function createEmbeddingProviderProbe(container: AppContainer): EmbeddingProviderProbe {
   const checkAvailability = async (
     providerId: EmbeddingProviderId,
-    options?: { force?: boolean },
+    options?: { force?: boolean; baseUrl?: string },
   ): Promise<ProviderAvailability> => {
     const cache = resolveCache(container)
     const key = cacheKey(providerId)
-    if (!options?.force && cache) {
+    const probesCandidateUrl = providerId === 'ollama' && options?.baseUrl !== undefined
+    if (!options?.force && !probesCandidateUrl && cache) {
       try {
         const cached = await cache.get(key)
         if (cached && typeof cached === 'object' && 'available' in cached) {
@@ -131,8 +139,8 @@ export function createEmbeddingProviderProbe(container: AppContainer): Embedding
         }
       } catch {}
     }
-    const result = await computeAvailability(providerId)
-    if (cache) {
+    const result = await computeAvailability(providerId, options)
+    if (cache && !probesCandidateUrl) {
       try {
         await cache.set(key, result, { ttl: CACHE_TTL_MS })
       } catch {}

--- a/packages/search/src/vector/lib/__tests__/ollama-url-safety.test.ts
+++ b/packages/search/src/vector/lib/__tests__/ollama-url-safety.test.ts
@@ -3,6 +3,7 @@ import {
   UnsafeOllamaBaseUrlError,
   getOllamaBaseUrlAllowlist,
   isAllowPrivateOllamaBaseUrlEnabled,
+  safeOllamaFetch,
 } from '../ollama-url-safety'
 
 const ORIGINAL_ENV = { ...process.env }
@@ -239,6 +240,83 @@ describe('assertSafeOllamaBaseUrl', () => {
       process.env.NODE_ENV = 'production'
       expect(() => assertSafeOllamaBaseUrl('https://ollama.example.com/')).not.toThrow()
     })
+  })
+})
+
+describe('safeOllamaFetch', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV, NODE_ENV: 'production' }
+    delete process.env.OM_SEARCH_OLLAMA_BASE_URL_ALLOWLIST
+    delete process.env.OM_SEARCH_OLLAMA_ALLOW_PRIVATE
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('rejects private DNS resolution before opening a connection', async () => {
+    const fetchImpl = jest.fn() as jest.MockedFunction<typeof fetch>
+
+    await expect(
+      safeOllamaFetch('https://ollama.example.com/api/embed', {}, {
+        lookupHost: async () => [{ address: '10.0.0.7', family: 4 }],
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ reason: 'private_ip_resolved' })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('rejects mixed public and private DNS answers', async () => {
+    const fetchImpl = jest.fn() as jest.MockedFunction<typeof fetch>
+
+    await expect(
+      safeOllamaFetch('https://ollama.example.com/api/embed', {}, {
+        lookupHost: async () => [
+          { address: '93.184.216.34', family: 4 },
+          { address: '127.0.0.1', family: 4 },
+        ],
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ reason: 'private_ip_resolved' })
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('revalidates redirects and rejects a public-to-private hop', async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 302,
+          headers: { location: 'http://169.254.169.254/latest/meta-data' },
+        }),
+      ) as jest.MockedFunction<typeof fetch>
+
+    await expect(
+      safeOllamaFetch('https://ollama.example.com/api/embed', {}, {
+        lookupHost: async () => [{ address: '93.184.216.34', family: 4 }],
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({ reason: 'private_ip_literal' })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://ollama.example.com/api/embed',
+      expect.objectContaining({ redirect: 'manual' }),
+    )
+  })
+
+  it('preserves explicitly allowlisted internal Ollama hosts', async () => {
+    process.env.OM_SEARCH_OLLAMA_BASE_URL_ALLOWLIST = 'ollama.internal.example.com:11434'
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(new Response('{}', { status: 200 })) as jest.MockedFunction<typeof fetch>
+
+    await expect(
+      safeOllamaFetch('http://ollama.internal.example.com:11434/api/embed', {}, {
+        lookupHost: async () => [{ address: '10.0.0.7', family: 4 }],
+        fetchImpl,
+      }),
+    ).resolves.toMatchObject({ status: 200 })
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/search/src/vector/lib/ollama-url-safety.ts
+++ b/packages/search/src/vector/lib/ollama-url-safety.ts
@@ -1,10 +1,14 @@
 import {
   assertStaticallySafeOutboundUrl,
+  safeOutboundFetch,
+  type HostLookup,
+  type SafeOutboundFetchOptions,
   type UrlSafetyReason,
 } from '@open-mercato/shared/lib/url-safety'
 import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 
 const SUBJECT = 'Ollama base URL'
+const MAX_OLLAMA_REDIRECTS = 5
 
 export class UnsafeOllamaBaseUrlError extends Error {
   public readonly reason: string
@@ -38,16 +42,94 @@ export function assertSafeOllamaBaseUrl(rawUrl: string): void {
     throw new UnsafeOllamaBaseUrlError('missing_host', `${SUBJECT} is required`)
   }
 
-  const allowPrivate =
-    allowlistMatches(rawUrl, getOllamaBaseUrlAllowlist()) ||
-    isAllowPrivateOllamaBaseUrlEnabled() ||
-    (process.env.NODE_ENV !== 'production' && isLoopbackOnlyUrl(rawUrl))
-
   assertStaticallySafeOutboundUrl(rawUrl, {
     errorFactory: ollamaErrorFactory,
     subject: SUBJECT,
-    allowPrivate,
+    allowPrivate: shouldAllowPrivateOllamaUrl(rawUrl),
   })
+}
+
+export type SafeOllamaFetchDeps = {
+  lookupHost?: HostLookup
+  fetchImpl?: SafeOutboundFetchOptions['fetchImpl']
+  maxRedirects?: number
+}
+
+export async function safeOllamaFetch(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  deps: SafeOllamaFetchDeps = {},
+): Promise<Response> {
+  const request = new Request(input, init)
+  const maxRedirects = deps.maxRedirects ?? MAX_OLLAMA_REDIRECTS
+  let currentUrl = request.url
+  let currentMethod = request.method
+  let currentHeaders = new Headers(request.headers)
+  let currentBody =
+    currentMethod === 'GET' || currentMethod === 'HEAD'
+      ? undefined
+      : await request.clone().arrayBuffer()
+
+  for (let redirectCount = 0; redirectCount <= maxRedirects; redirectCount += 1) {
+    const response = await safeOutboundFetch(
+      currentUrl,
+      {
+        method: currentMethod,
+        headers: currentHeaders,
+        body: currentBody,
+        signal: request.signal,
+        redirect: 'manual',
+      },
+      {
+        errorFactory: ollamaErrorFactory,
+        subject: SUBJECT,
+        allowPrivate: shouldAllowPrivateOllamaUrl(currentUrl),
+        lookupHost: deps.lookupHost,
+        fetchImpl: deps.fetchImpl,
+      },
+    )
+
+    if (![301, 302, 303, 307, 308].includes(response.status)) {
+      return response
+    }
+    const location = response.headers.get('location')
+    if (!location) return response
+    if (redirectCount === maxRedirects) {
+      throw new UnsafeOllamaBaseUrlError(
+        'too_many_redirects',
+        `${SUBJECT} exceeded ${maxRedirects} redirects`,
+      )
+    }
+
+    const nextUrl = new URL(location, currentUrl)
+    if (nextUrl.origin !== new URL(currentUrl).origin) {
+      currentHeaders = new Headers(currentHeaders)
+      currentHeaders.delete('authorization')
+      currentHeaders.delete('cookie')
+      currentHeaders.delete('proxy-authorization')
+    }
+    if (
+      (response.status === 303 && currentMethod !== 'GET' && currentMethod !== 'HEAD') ||
+      ((response.status === 301 || response.status === 302) && currentMethod === 'POST')
+    ) {
+      currentMethod = 'GET'
+      currentBody = undefined
+      currentHeaders.delete('content-length')
+      currentHeaders.delete('content-type')
+    }
+    await response.body?.cancel()
+    currentUrl = nextUrl.toString()
+  }
+
+  throw new UnsafeOllamaBaseUrlError('too_many_redirects')
+}
+
+function shouldAllowPrivateOllamaUrl(rawUrl: string): boolean {
+  return (
+    allowlistMatches(rawUrl, getOllamaBaseUrlAllowlist()) ||
+    isAllowPrivateOllamaBaseUrlEnabled() ||
+    (process.env.NODE_ENV !== 'production' && isLoopbackOnlyUrl(rawUrl))
+  )
 }
 
 function allowlistMatches(rawUrl: string, allowlist: ReadonlySet<string>): boolean {

--- a/packages/search/src/vector/services/embedding.ts
+++ b/packages/search/src/vector/services/embedding.ts
@@ -14,7 +14,11 @@ import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock'
 import { createOllama } from 'ai-sdk-ollama'
 import type { EmbeddingProviderId, EmbeddingProviderConfig } from '../types'
 import { EMBEDDING_PROVIDERS, DEFAULT_EMBEDDING_CONFIG } from '../types'
-import { assertSafeOllamaBaseUrl, UnsafeOllamaBaseUrlError } from '../lib/ollama-url-safety'
+import {
+  assertSafeOllamaBaseUrl,
+  safeOllamaFetch,
+  UnsafeOllamaBaseUrlError,
+} from '../lib/ollama-url-safety'
 
 export type EmbeddingServiceOptions = {
   apiKey?: string
@@ -177,7 +181,7 @@ export class EmbeddingService {
           }
           throw err
         }
-        client = createOllama({ baseURL })
+        client = createOllama({ baseURL, fetch: safeOllamaFetch })
         break
       }
       default:


### PR DESCRIPTION
## Summary

Enforce connection-time URL safety for Ollama embedding traffic. Ollama SDK requests and availability probes now use DNS-pinned outbound fetching with manually validated redirects, while explicit internal-host allowlists remain supported.

## Changes

- add guarded Ollama fetch transport backed by `safeOutboundFetch`
- revalidate every redirect and reject private, reserved, mixed, or rebound DNS targets
- remove authorization, cookie, and proxy authorization headers on cross-origin redirects
- inject the guarded fetch into `ai-sdk-ollama`
- probe submitted Ollama base URLs safely before persisting them
- add regression coverage for DNS resolution, redirects, allowlists, SDK wiring, and candidate probes

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

N/A — focused security fix to existing search-provider behavior with no public contract change.

## Testing

- focused regression suite: 61 tests passed
- `yarn workspace @open-mercato/search build`
- `yarn workspace @open-mercato/search test --runInBand` — 252 tests passed
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- scoped ESLint for all changed files

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Integration coverage note: no browser flow changed; connection-time network behavior and the API save guard are covered deterministically by module-local tests.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI or design-system files changed.

## Linked issues

Fixes #4038
