### PR TITLE
fix(attachments): bound multipart upload parsing (#4047)

### DIFF
--- a/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
+++ b/packages/core/src/modules/attachments/api/__tests__/attachments.api.test.ts
@@ -247,6 +247,35 @@ describe('attachments API', () => {
     expect(payload.error).toMatch(/maximum upload size/i)
   })
 
+  it('rejects an oversized multipart body without a content length before materializing metadata', async () => {
+    process.env.OM_ATTACHMENT_MAX_UPLOAD_MB = '0.000001'
+    const { POST: upload } = await loadHandlers()
+    const boundary = 'oversized-metadata'
+    const body = new TextEncoder().encode([
+      `--${boundary}\r\nContent-Disposition: form-data; name="entityId"\r\n\r\nexample:todo\r\n`,
+      `--${boundary}\r\nContent-Disposition: form-data; name="recordId"\r\n\r\nr1\r\n`,
+      `--${boundary}\r\nContent-Disposition: form-data; name="fieldKey"\r\n\r\nattachments\r\n`,
+      `--${boundary}\r\nContent-Disposition: form-data; name="customFields"\r\n\r\n`,
+      'x'.repeat(1024 * 1024),
+      `\r\n--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="small.pdf"\r\n`,
+      'Content-Type: application/pdf\r\n\r\n\u0001\r\n',
+      `--${boundary}--\r\n`,
+    ].join(''))
+    const req = new Request('http://x/api/attachments', {
+      method: 'POST',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+
+    expect(req.headers.get('content-length')).toBeNull()
+    const res = await upload(req)
+
+    expect(res.status).toBe(413)
+    await expect(res.json()).resolves.toMatchObject({
+      error: expect.stringMatching(/maximum upload size/i),
+    })
+  })
+
   it('rejects uploads that exceed the tenant storage quota', async () => {
     const { POST: upload } = await loadHandlers()
     process.env.OM_ATTACHMENT_TENANT_QUOTA_MB = '0.001'

--- a/packages/core/src/modules/attachments/api/route.ts
+++ b/packages/core/src/modules/attachments/api/route.ts
@@ -36,7 +36,9 @@ import {
   sanitizeUploadedFileName,
 } from '../lib/security'
 import {
+  isMultipartUploadLimitError,
   isMultipartRequestWithinUploadLimit,
+  parseMultipartFormDataWithinUploadLimit,
   resolveAttachmentMaxBytes,
   willExceedAttachmentTenantQuota,
 } from '../lib/upload-limits'
@@ -285,7 +287,15 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Attachment exceeds the maximum upload size.' }, { status: 413 })
   }
 
-  const form = await req.formData()
+  let form: FormData
+  try {
+    form = await parseMultipartFormDataWithinUploadLimit(req)
+  } catch (error) {
+    if (isMultipartUploadLimitError(error)) {
+      return NextResponse.json({ error: 'Attachment exceeds the maximum upload size.' }, { status: 413 })
+    }
+    throw error
+  }
   const formPayload = buildFormPayload(form)
   const customFieldValues = splitCustomFieldPayload(formPayload).custom
   const entityId = String(form.get('entityId') || '')

--- a/packages/core/src/modules/attachments/lib/__tests__/upload-limits.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/upload-limits.test.ts
@@ -1,5 +1,7 @@
 import {
   isMultipartRequestWithinUploadLimit,
+  MultipartUploadLimitError,
+  parseMultipartFormDataWithinUploadLimit,
   resolveAttachmentMaxBytes,
   resolveAttachmentTenantQuotaBytes,
   resolveDefaultAttachmentMaxUploadBytes,
@@ -61,5 +63,74 @@ describe('attachment upload limits', () => {
     process.env[legacyQuotaEnv] = '3'
     expect(resolveDefaultAttachmentMaxUploadBytes()).toBe(2 * 1024 * 1024)
     expect(resolveAttachmentTenantQuotaBytes()).toBe(3 * 1024 * 1024)
+  })
+
+  it('rejects a streamed multipart body that exceeds a missing or dishonest content length', async () => {
+    process.env[primaryMaxUploadEnv] = '0.000001'
+    const boundary = 'upload-limit'
+    const body = new TextEncoder().encode([
+      `--${boundary}\r\n`,
+      'Content-Disposition: form-data; name="metadata"\r\n\r\n',
+      'x'.repeat(1024 * 1024),
+      `\r\n--${boundary}--\r\n`,
+    ].join(''))
+
+    for (const contentLength of [null, 'invalid', '1']) {
+      const headers = new Headers({ 'content-type': `multipart/form-data; boundary=${boundary}` })
+      if (contentLength !== null) headers.set('content-length', contentLength)
+      const request = new Request('http://example.test/upload', { method: 'POST', headers, body })
+
+      await expect(parseMultipartFormDataWithinUploadLimit(request)).rejects.toBeInstanceOf(MultipartUploadLimitError)
+    }
+  })
+
+  it('parses a valid multipart body exactly at the total request limit', async () => {
+    process.env[primaryMaxUploadEnv] = '0.000001'
+    const boundary = 'exact-boundary'
+    const prefix = `--${boundary}\r\nContent-Disposition: form-data; name="metadata"\r\n\r\n`
+    const suffix = `\r\n--${boundary}--\r\n`
+    const maxBytes = resolveDefaultAttachmentMaxUploadBytes() + 1024 * 1024
+    const value = 'x'.repeat(maxBytes - Buffer.byteLength(prefix) - Buffer.byteLength(suffix))
+    const body = new TextEncoder().encode(`${prefix}${value}${suffix}`)
+    const request = new Request('http://example.test/upload', {
+      method: 'POST',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+        'content-length': String(body.byteLength),
+      },
+      body,
+    })
+
+    const form = await parseMultipartFormDataWithinUploadLimit(request)
+
+    expect(body.byteLength).toBe(maxBytes)
+    expect(form.get('metadata')).toBe(value)
+  })
+
+  it('stops pulling the request stream after the total request limit is crossed', async () => {
+    process.env[primaryMaxUploadEnv] = '0.000001'
+    let pulls = 0
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1
+        controller.enqueue(new Uint8Array(1024 * 1024 + 2))
+      },
+      cancel(error) {
+        cancelled = error instanceof MultipartUploadLimitError
+      },
+    }, { highWaterMark: 0 })
+    const request = new Request('http://example.test/upload', {
+      method: 'POST',
+      headers: { 'content-type': 'multipart/form-data; boundary=unused' },
+      body: stream,
+      duplex: 'half',
+    } as RequestInit & { duplex: 'half' })
+
+    await expect(parseMultipartFormDataWithinUploadLimit(request)).rejects.toBeInstanceOf(MultipartUploadLimitError)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(pulls).toBe(1)
+    expect(cancelled).toBe(true)
   })
 })

--- a/packages/core/src/modules/attachments/lib/upload-limits.ts
+++ b/packages/core/src/modules/attachments/lib/upload-limits.ts
@@ -46,6 +46,41 @@ export function isMultipartRequestWithinUploadLimit(contentLengthHeader: string 
   return contentLength <= (resolveDefaultAttachmentMaxUploadBytes() + MULTIPART_CONTENT_LENGTH_OVERHEAD_BYTES)
 }
 
+export class MultipartUploadLimitError extends Error {
+  constructor() {
+    super('Multipart request exceeds the maximum upload size.')
+    this.name = 'MultipartUploadLimitError'
+  }
+}
+
+export function isMultipartUploadLimitError(error: unknown): error is MultipartUploadLimitError {
+  return error instanceof MultipartUploadLimitError
+}
+
+export async function parseMultipartFormDataWithinUploadLimit(request: Request): Promise<FormData> {
+  if (!isMultipartRequestWithinUploadLimit(request.headers.get('content-length'))) {
+    throw new MultipartUploadLimitError()
+  }
+
+  if (!request.body) return request.formData()
+
+  const maxBytes = resolveDefaultAttachmentMaxUploadBytes() + MULTIPART_CONTENT_LENGTH_OVERHEAD_BYTES
+  let consumedBytes = 0
+  const boundedBody = request.body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, controller) {
+      consumedBytes += chunk.byteLength
+      if (consumedBytes > maxBytes) {
+        controller.error(new MultipartUploadLimitError())
+        return
+      }
+      controller.enqueue(chunk)
+    },
+  }))
+  const contentType = request.headers.get('content-type')
+  const headers = contentType ? { 'content-type': contentType } : undefined
+  return new Response(boundedBody, { headers }).formData()
+}
+
 export function willExceedAttachmentTenantQuota(currentUsageBytes: number, incomingFileBytes: number): boolean {
   return (currentUsageBytes + incomingFileBytes) > resolveAttachmentTenantQuotaBytes()
 }

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/upload.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/upload.test.ts
@@ -1,0 +1,82 @@
+/** @jest-environment node */
+
+const mockGetAuthFromRequest = jest.fn()
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+const mockResolveCredentials = jest.fn()
+const mockCreateRequestContainer = jest.fn(async () => ({
+  resolve: () => ({ resolve: mockResolveCredentials }),
+}))
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: () => mockCreateRequestContainer(),
+}))
+
+const mockListObjects = jest.fn()
+const mockPutObject = jest.fn()
+jest.mock('../lib/s3-driver', () => ({
+  S3StorageDriver: jest.fn().mockImplementation(() => ({
+    getBucket: () => 'test-bucket',
+    listObjects: (...args: unknown[]) => mockListObjects(...args),
+    putObject: (...args: unknown[]) => mockPutObject(...args),
+  })),
+}))
+
+import { POST } from '../api/post/storage-providers/s3/upload'
+
+describe('storage_s3 direct upload route', () => {
+  const originalMaxUploadMb = process.env.OM_ATTACHMENT_MAX_UPLOAD_MB
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue({ tenantId: 'tenant-1', orgId: 'org-1' })
+    mockResolveCredentials.mockResolvedValue({ bucket: 'test-bucket', region: 'eu-central-1' })
+    mockListObjects.mockResolvedValue({ files: [], truncated: false })
+    mockPutObject.mockResolvedValue(undefined)
+    delete process.env.OM_ATTACHMENT_MAX_UPLOAD_MB
+  })
+
+  afterAll(() => {
+    if (originalMaxUploadMb === undefined) delete process.env.OM_ATTACHMENT_MAX_UPLOAD_MB
+    else process.env.OM_ATTACHMENT_MAX_UPLOAD_MB = originalMaxUploadMb
+  })
+
+  it('rejects oversized streamed metadata without trusting content length', async () => {
+    process.env.OM_ATTACHMENT_MAX_UPLOAD_MB = '0.000001'
+    const boundary = 'oversized-key'
+    const body = new TextEncoder().encode([
+      `--${boundary}\r\nContent-Disposition: form-data; name="key"\r\n\r\n`,
+      'x'.repeat(1024 * 1024),
+      `\r\n--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="small.txt"\r\n`,
+      'Content-Type: text/plain\r\n\r\ns\r\n',
+      `--${boundary}--\r\n`,
+    ].join(''))
+    const request = new Request('http://example.test/api/storage-providers/s3/upload', {
+      method: 'POST',
+      headers: { 'content-type': `multipart/form-data; boundary=${boundary}` },
+      body,
+    })
+
+    expect(request.headers.get('content-length')).toBeNull()
+    const response = await POST(request)
+
+    expect(response.status).toBe(413)
+    await expect(response.json()).resolves.toEqual({ error: 'Attachment exceeds the maximum upload size.' })
+    expect(mockCreateRequestContainer).not.toHaveBeenCalled()
+    expect(mockPutObject).not.toHaveBeenCalled()
+  })
+
+  it('preserves valid multipart parsing for a normal upload', async () => {
+    const form = new FormData()
+    form.set('file', new File([new TextEncoder().encode('safe')], 'safe.txt', { type: 'text/plain' }))
+    const response = await POST(new Request('http://example.test/api/storage-providers/s3/upload', {
+      method: 'POST',
+      body: form,
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ bucket: 'test-bucket', size: 4 })
+    expect(mockPutObject).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
@@ -9,7 +9,9 @@ import {
   isActiveContentAttachment,
 } from '@open-mercato/core/modules/attachments/lib/security'
 import {
+  isMultipartUploadLimitError,
   isMultipartRequestWithinUploadLimit,
+  parseMultipartFormDataWithinUploadLimit,
   resolveAttachmentMaxBytes,
   willExceedAttachmentTenantQuota,
 } from '@open-mercato/core/modules/attachments/lib/upload-limits'
@@ -82,7 +84,15 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Expected multipart/form-data' }, { status: 400 })
   }
 
-  const form = await req.formData()
+  let form: FormData
+  try {
+    form = await parseMultipartFormDataWithinUploadLimit(req)
+  } catch (error) {
+    if (isMultipartUploadLimitError(error)) {
+      return NextResponse.json({ error: 'Attachment exceeds the maximum upload size.' }, { status: 413 })
+    }
+    throw error
+  }
   const file = form.get('file') as File | null
   if (!file) {
     return NextResponse.json({ error: 'file field is required' }, { status: 400 })


### PR DESCRIPTION
## Summary

Prevent authenticated multipart upload endpoints from buffering unbounded request bodies when `Content-Length` is missing, invalid, or dishonest.

## Changes

- Add a shared bounded streaming multipart parser using the existing attachment limit and multipart overhead budget.
- Apply it to core attachment uploads and direct S3 uploads.
- Preserve existing multipart fields, per-file limits, response formats, authentication, and tenant scoping.
- Add regression coverage for oversized metadata, misleading lengths, stream cancellation, exact-boundary requests, and normal uploads.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

N/A — focused security bug fix with no contract or schema change.

## Testing

- Focused core attachment tests: 31/31 passed.
- Focused storage-S3 upload tests: 2/2 passed.
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- Scoped ESLint on all changed files.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Integration coverage is not required because this is a server-side multipart boundary covered by focused route and stream-level tests; no UI or browser flow changed.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI changes.

## Linked issues

Fixes #4047
