### PR TITLE
fix(webhooks): bound public request bodies (#4044)

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -969,3 +969,5 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: Use `node:crypto` helpers (`randomInt`, `randomUUID`, or `randomBytes`) for any generated value that may touch auth, security checks, identifiers, request headers, or authenticated API calls. Reserve `Math.random()` only for explicitly non-security demo data, and prefer deterministic fixtures when uniqueness is not required.
 
 **Applies to**: integration helpers, auth tests, rate-limit tests, fixture factories, temporary IDs, generated emails/passwords, and any test utility that feeds API requests or security-sensitive code paths.
+
+- 2026-07-10 · webhooks: generic provider-route sweeps missed dedicated Gmail and source-specific InboxOps receivers → enumerate every public webhook path and preserve each source's effective limit in code, tests, specs, and ingress docs

--- a/.ai/specs/implemented/SPEC-057-2026-03-04-webhooks-module.md
+++ b/.ai/specs/implemented/SPEC-057-2026-03-04-webhooks-module.md
@@ -1377,14 +1377,15 @@ The `webhook_custom` provider enables admin-configurable webhooks without code. 
 | UT-WH-002 | `packages/shared/src/lib/webhooks/__tests__/verify.test.ts` | Signature verification: valid, invalid, expired timestamp, wrong key |
 | UT-WH-003 | `packages/shared/src/lib/webhooks/__tests__/secrets.test.ts` | Secret generation, parsing, validation |
 | UT-WH-004 | `packages/shared/src/lib/webhooks/__tests__/verify.test.ts` | Dual-key verification: both current and rotated key accepted |
+| UT-WH-005 | `packages/shared/src/lib/webhooks/__tests__/body.test.ts` | Declared and streamed byte limits, invalid/lying lengths, cancellation, boundary compatibility, configuration fallbacks |
 
 ---
 
 ## 12. Backward Compatibility Considerations
 
-### No Existing Contracts Modified
+### Initial Rollout Compatibility (2026-03)
 
-This spec introduces only new code:
+The initial rollout introduced only new code:
 - New module: `packages/core/src/modules/webhooks/` (no existing module modified)
 - New shared library: `packages/shared/src/lib/webhooks/` (no existing library modified)
 - New database tables: `webhooks`, `webhook_deliveries` (no existing table modified)
@@ -1406,7 +1407,15 @@ The `webhook_endpoints` hub referenced in SPEC-045e is implemented by this modul
 
 ### SPEC-045e Extraction
 
-The `inbox_ops` module's webhook handler (`packages/core/src/modules/inbox_ops/api/webhook/inbound.ts`) is NOT modified. It continues to function independently. The shared primitives in `packages/shared/src/lib/webhooks/` are offered as an alternative that `inbox_ops` can optionally migrate to in a future PR. No forced migration.
+The initial rollout did not modify the `inbox_ops` webhook handler. The 2026-07-10 security hardening migrates its raw-body read to the shared bounded reader while preserving its 2 MiB fallback when neither the global nor source-specific limit is configured.
+
+### 2026-07-10 Request-Body Hardening
+
+- Existing webhook URLs, methods, signature inputs, success responses, and provider adapter contracts remain unchanged.
+- Oversized generic, payment, shipping, communication-channel, Gmail Pub/Sub, and InboxOps webhook requests add an early `413` response before verification or parsing.
+- `readBoundedRequestBody`, `WebhookBodyTooLargeError`, and limit-resolution exports are additive shared-library contracts.
+- `OM_WEBHOOK_MAX_BODY_BYTES` defaults generic/provider routes to 1 MiB. InboxOps inherits it when configured, supports `INBOX_OPS_WEBHOOK_MAX_BODY_BYTES` as a source-specific override, and otherwise preserves its prior 2 MiB ceiling.
+- This is a deliberate additive security response; no deprecation bridge or data migration is required.
 
 ---
 
@@ -1472,6 +1481,7 @@ No existing spec contracts are broken. The updates are additive cross-references
 | 2026-03-18 | Phase 1 implemented: core outbound webhooks |
 | 2026-03-18 | Packaging, queue dispatch, retries, migration, inbound/events/test/retry APIs, and locale coverage completed for shippable rollout |
 | 2026-03-19 | Added pay-links alignment note: outbound webhooks must support checkout lifecycle automation through stable post-commit events |
+| 2026-07-10 | Bounded public webhook request bodies before signature verification with a configurable 1 MiB default and streamed-byte enforcement |
 
 ---
 

--- a/apps/docs/docs/framework/webhooks/overview.mdx
+++ b/apps/docs/docs/framework/webhooks/overview.mdx
@@ -213,8 +213,11 @@ interface WebhookEndpointAdapter {
 
 Inbound webhooks are:
 - **Rate limited** per endpoint
+- **Body limited** before signature verification (1 MiB by default)
 - **Deduplicated** by message ID
 - Processed via **fire-and-forget** (return 200 immediately, emit event for async processing)
+
+Set `OM_WEBHOOK_MAX_BODY_BYTES` to a positive byte count when providers legitimately need a different default. InboxOps inherits that value when it is set; `INBOX_OPS_WEBHOOK_MAX_BODY_BYTES` can override only the email-ingress source, whose legacy fallback remains 2 MiB when neither variable is configured. The bounded reader checks a valid declared `Content-Length` before reading and also counts streamed bytes, so missing, invalid, or understated lengths cannot bypass the cap. Requests over the limit return `413` without invoking provider verification. Keep the ingress or reverse-proxy limit scoped to the webhook paths and aligned with the effective application values.
 
 ## Shared Primitives
 

--- a/apps/docs/docs/installation/vps.mdx
+++ b/apps/docs/docs/installation/vps.mdx
@@ -63,6 +63,7 @@ JWT_SECRET=your-strong-jwt-secret
 APP_URL=https://your-domain.com
 NODE_ENV=production
 # NODE_OPTIONS=--max-old-space-size=3072  # default; raise for larger hosts — see Troubleshooting
+OM_WEBHOOK_MAX_BODY_BYTES=1048576
 
 # Cache
 CACHE_REDIS_URL=redis://redis:6379
@@ -164,6 +165,15 @@ server {
     ssl_certificate /etc/letsencrypt/live/your-domain.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/your-domain.com/privkey.pem;
 
+    location ~ ^/api/(webhooks/inbound/|payment_gateways/webhook/|shipping[-_]carriers/webhook/|communication_channels/webhooks?/|inbox_ops/webhook/inbound$) {
+        client_max_body_size 1m;
+        proxy_pass http://localhost:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location / {
         proxy_pass http://localhost:3000;
         proxy_set_header Host $host;
@@ -173,6 +183,8 @@ server {
     }
 }
 ```
+
+The webhook-only nginx `client_max_body_size` value matches the configured `OM_WEBHOOK_MAX_BODY_BYTES` application cap without restricting unrelated uploads. If you change the global value or set `INBOX_OPS_WEBHOOK_MAX_BODY_BYTES`, split or update the matching webhook location so each ingress ceiling matches its effective application value.
 
 Use [Certbot](https://certbot.eff.org/) for free Let's Encrypt certificates.
 

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -210,6 +210,12 @@ NEXT_PUBLIC_UMES_DEVTOOLS=true
 # In production, configure per-tenant webhook credentials instead.
 # MOCK_CARRIER_WEBHOOK_SECRET=open-mercato-mock-dev-carrier-webhook-secret
 
+# Default raw body limit for public webhook routes before verification.
+# InboxOps inherits this value when set; override only that source with
+# INBOX_OPS_WEBHOOK_MAX_BODY_BYTES (its legacy fallback is 2 MiB).
+OM_WEBHOOK_MAX_BODY_BYTES=1048576
+# INBOX_OPS_WEBHOOK_MAX_BODY_BYTES=2097152
+
 # Example cross-module injection widgets (default: false)
 # Enables example widgets injected into catalog/sales/crm pages.
 # Example module todo + menu injections stay enabled regardless of this flag.

--- a/packages/core/src/modules/communication_channels/api/post/webhook/[provider]/__tests__/route.test.ts
+++ b/packages/core/src/modules/communication_channels/api/post/webhook/[provider]/__tests__/route.test.ts
@@ -51,6 +51,22 @@ describe('POST /api/communication_channels/webhook/[provider]', () => {
     mockEnqueue.mockResolvedValue(undefined)
   })
 
+  it('rejects an oversized declared body before adapter verification', async () => {
+    const verifyWebhook = jest.fn()
+    mockRegistryGet.mockReturnValue({ verifyWebhook })
+    const request = new Request('http://localhost/api/communication_channels/webhook/test', {
+      method: 'POST',
+      headers: { 'content-length': String(1024 * 1024 + 1) },
+      body: '{}',
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ provider: 'test' }) })
+
+    expect(response.status).toBe(413)
+    expect(verifyWebhook).not.toHaveBeenCalled()
+    expect(mockCreateRequestContainer).not.toHaveBeenCalled()
+  })
+
   it('does not cap provider webhook verification to the newest 50 channels', async () => {
     const candidates = Array.from({ length: 60 }, (_, index) => {
       const n = String(index + 1).padStart(3, '0')

--- a/packages/core/src/modules/communication_channels/api/post/webhook/[provider]/route.ts
+++ b/packages/core/src/modules/communication_channels/api/post/webhook/[provider]/route.ts
@@ -12,6 +12,7 @@ import type { InboundMessage } from '../../../../lib/adapter'
 import type { InboundProcessorPayload } from '../../../../workers/inbound-processor'
 import type { ReactionInboundJob } from '../../../../lib/reaction-processor-types'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { readBoundedRequestBody, WebhookBodyTooLargeError } from '@open-mercato/shared/lib/webhooks'
 
 const logger = createLogger('communication_channels').child({ component: 'inbound-webhook' })
 
@@ -60,7 +61,15 @@ export async function POST(req: Request, { params }: RouteContext): Promise<Resp
     )
   }
 
-  const rawBody = await req.text()
+  let rawBody: string
+  try {
+    rawBody = await readBoundedRequestBody(req)
+  } catch (error) {
+    if (error instanceof WebhookBodyTooLargeError) {
+      return NextResponse.json({ error: 'Webhook payload too large' }, { status: 413 })
+    }
+    throw error
+  }
   const headers: Record<string, string> = {}
   req.headers.forEach((value, key) => {
     headers[key] = value
@@ -222,6 +231,7 @@ export const openApi = {
       responses: [
         { status: 202, description: 'Webhook accepted for async processing' },
         { status: 401, description: 'Signature verification failed against every candidate channel' },
+        { status: 413, description: 'Webhook payload too large' },
         { status: 404, description: 'Unknown provider' },
       ],
     },

--- a/packages/core/src/modules/communication_channels/api/post/webhooks/gmail/__tests__/route.test.ts
+++ b/packages/core/src/modules/communication_channels/api/post/webhooks/gmail/__tests__/route.test.ts
@@ -1,0 +1,42 @@
+/** @jest-environment node */
+
+const mockVerify = jest.fn()
+
+jest.mock('../../../../../lib/gmail-pubsub-jwt', () => ({
+  decodeGmailPubSubBody: jest.fn(),
+  getGmailPubSubVerifier: jest.fn(() => ({ verify: mockVerify })),
+  GmailPubSubJwtError: class GmailPubSubJwtError extends Error {},
+}))
+
+import { POST } from '../route'
+
+describe('POST /api/communication_channels/webhooks/gmail', () => {
+  const originalAudience = process.env.OM_GMAIL_PUBSUB_AUDIENCE
+  const originalEmail = process.env.OM_GMAIL_PUBSUB_SERVICE_ACCOUNT_EMAIL
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.OM_GMAIL_PUBSUB_AUDIENCE = 'https://app.example/api/communication_channels/webhooks/gmail'
+    process.env.OM_GMAIL_PUBSUB_SERVICE_ACCOUNT_EMAIL = 'gmail-push@example.iam.gserviceaccount.com'
+  })
+
+  afterAll(() => {
+    if (originalAudience === undefined) delete process.env.OM_GMAIL_PUBSUB_AUDIENCE
+    else process.env.OM_GMAIL_PUBSUB_AUDIENCE = originalAudience
+    if (originalEmail === undefined) delete process.env.OM_GMAIL_PUBSUB_SERVICE_ACCOUNT_EMAIL
+    else process.env.OM_GMAIL_PUBSUB_SERVICE_ACCOUNT_EMAIL = originalEmail
+  })
+
+  it('rejects an oversized declared body before JWT verification', async () => {
+    const request = new Request('http://localhost/api/communication_channels/webhooks/gmail', {
+      method: 'POST',
+      headers: { 'content-length': String(1024 * 1024 + 1) },
+      body: '{}',
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(413)
+    expect(mockVerify).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/communication_channels/api/post/webhooks/gmail/route.ts
+++ b/packages/core/src/modules/communication_channels/api/post/webhooks/gmail/route.ts
@@ -13,6 +13,7 @@ import {
   GmailPubSubJwtError,
 } from '../../../../lib/gmail-pubsub-jwt'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { readBoundedRequestBody, WebhookBodyTooLargeError } from '@open-mercato/shared/lib/webhooks'
 
 const logger = createLogger('communication_channels').child({ component: 'gmail-webhook' })
 
@@ -24,13 +25,14 @@ const logger = createLogger('communication_channels').child({ component: 'gmail-
  * header, which we verify against Google's public certs.
  *
  * Validation pipeline:
- *   1. Verify JWT signature, audience (`OM_GMAIL_PUBSUB_AUDIENCE`), and
+ *   1. Bound the raw request body before cryptographic work.
+ *   2. Verify JWT signature, audience (`OM_GMAIL_PUBSUB_AUDIENCE`), and
  *      email claim (`OM_GMAIL_PUBSUB_SERVICE_ACCOUNT_EMAIL`).
- *   2. Decode the Pub/Sub envelope → `{ emailAddress, historyId }`.
- *   3. Look up every active Gmail channel matching `emailAddress`. Multiple
+ *   3. Decode the Pub/Sub envelope → `{ emailAddress, historyId }`.
+ *   4. Look up every active Gmail channel matching `emailAddress`. Multiple
  *      tenants may have the same mailbox connected — we enqueue one sync
  *      job per matching channel (each tenant sees their own data).
- *   4. Return `204 No Content` even when no channels match — returning 4xx
+ *   5. Return `204 No Content` even when no channels match — returning 4xx
  *      would cause Pub/Sub to retry forever on a permanently-orphaned
  *      registration.
  */
@@ -58,6 +60,16 @@ export async function POST(req: Request): Promise<Response> {
     return NextResponse.json({ error: 'webhook not configured' }, { status: 503 })
   }
 
+  let rawBody: string
+  try {
+    rawBody = await readBoundedRequestBody(req)
+  } catch (error) {
+    if (error instanceof WebhookBodyTooLargeError) {
+      return NextResponse.json({ error: 'Webhook payload too large' }, { status: 413 })
+    }
+    return NextResponse.json({ error: 'unreadable_body' }, { status: 400 })
+  }
+
   const verifier = getGmailPubSubVerifier()
   try {
     await verifier.verify({
@@ -74,13 +86,6 @@ export async function POST(req: Request): Promise<Response> {
       return NextResponse.json({ error: err.code, message: err.message }, { status })
     }
     throw err
-  }
-
-  let rawBody: string
-  try {
-    rawBody = await req.text()
-  } catch {
-    return NextResponse.json({ error: 'unreadable_body' }, { status: 400 })
   }
 
   let payload: { emailAddress: string; historyId: string | number }
@@ -153,6 +158,7 @@ export const openApi = {
         { status: 400, description: 'Body not a valid Pub/Sub envelope' },
         { status: 401, description: 'Invalid JWT or email claim' },
         { status: 403, description: 'Wrong audience' },
+        { status: 413, description: 'Webhook payload too large' },
         { status: 503, description: 'Webhook not configured / Google certs unreachable' },
       ],
     },

--- a/packages/core/src/modules/inbox_ops/api/webhook/__tests__/inbound.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/webhook/__tests__/inbound.test.ts
@@ -180,6 +180,7 @@ describe('POST /api/inbox_ops/webhook/inbound', () => {
 
     const response = await POST(request)
     expect(response.status).toBe(413)
+    expect(mockContainer.resolve).not.toHaveBeenCalled()
   })
 
   it('returns 400 when missing recipient address', async () => {

--- a/packages/core/src/modules/inbox_ops/api/webhook/inbound.ts
+++ b/packages/core/src/modules/inbox_ops/api/webhook/inbound.ts
@@ -13,6 +13,11 @@ import { parseInboundEmail } from '../../lib/emailParser'
 import { checkRateLimit } from '../../lib/rateLimiter'
 import { emitInboxOpsEvent } from '../../events'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import {
+  readBoundedRequestBody,
+  resolveWebhookBodyLimitBytes,
+  WebhookBodyTooLargeError,
+} from '@open-mercato/shared/lib/webhooks'
 
 const logger = createLogger('inbox_ops').child({ component: 'webhook' })
 
@@ -20,7 +25,10 @@ export const metadata = {
   POST: { requireAuth: false },
 }
 
-const MAX_PAYLOAD_SIZE = 2 * 1024 * 1024 // 2MB
+const MAX_PAYLOAD_SIZE = resolveWebhookBodyLimitBytes(
+  process.env.INBOX_OPS_WEBHOOK_MAX_BODY_BYTES ?? process.env.OM_WEBHOOK_MAX_BODY_BYTES,
+  2 * 1024 * 1024,
+)
 const REPLAY_WINDOW_MS = 5 * 60 * 1000 // 5 minutes
 
 function isTimestampFresh(timestamp: string): boolean {
@@ -211,20 +219,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Service unavailable' }, { status: 503 })
   }
 
-  const contentLength = parseInt(req.headers.get('content-length') || '0', 10)
-  if (contentLength > MAX_PAYLOAD_SIZE) {
-    return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
-  }
-
   let rawBody: string
   try {
-    rawBody = await req.text()
-  } catch {
+    rawBody = await readBoundedRequestBody(req, { maxBytes: MAX_PAYLOAD_SIZE })
+  } catch (error) {
+    if (error instanceof WebhookBodyTooLargeError) {
+      return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
+    }
     return NextResponse.json({ error: 'Bad request' }, { status: 400 })
-  }
-
-  if (rawBody.length > MAX_PAYLOAD_SIZE) {
-    return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
   }
 
   const verified = await verifyAndParse(req, rawBody)

--- a/packages/core/src/modules/payment_gateways/api/__tests__/webhook-route.test.ts
+++ b/packages/core/src/modules/payment_gateways/api/__tests__/webhook-route.test.ts
@@ -33,11 +33,11 @@ jest.mock('@open-mercato/core/modules/payment_gateways/lib/webhook-processor', (
 }))
 
 function createMockRequest(body: string, headers: Record<string, string> = {}): Request {
-  return {
+  return new Request('http://localhost/api/payment_gateways/webhook/stripe', {
     method: 'POST',
-    headers: new Headers(headers),
-    text: jest.fn(async () => body),
-  } as unknown as Request
+    headers,
+    body,
+  })
 }
 
 describe('payment gateway webhook route security', () => {
@@ -63,6 +63,7 @@ describe('payment gateway webhook route security', () => {
 
   test('rate limits unauthenticated provider webhooks before parsing the body', async () => {
     const request = createMockRequest('{"session":"sess_1"}', { 'x-forwarded-for': '203.0.113.9' })
+    const getReaderSpy = jest.spyOn(request.body!, 'getReader')
     ;(getWebhookHandler as jest.Mock).mockReturnValue({
       handler: jest.fn(),
       readSessionIdHint: jest.fn(),
@@ -82,7 +83,26 @@ describe('payment gateway webhook route security', () => {
       duration: 60,
       keyPrefix: 'payment_gateways:webhook',
     })
-    expect(request.text).not.toHaveBeenCalled()
+    expect(getReaderSpy).not.toHaveBeenCalled()
+    expect(findWithDecryption).not.toHaveBeenCalled()
+  })
+
+  test('rejects an oversized declared body before verification', async () => {
+    const handler = jest.fn()
+    ;(getWebhookHandler as jest.Mock).mockReturnValue({
+      handler,
+      readSessionIdHint: jest.fn(),
+    })
+    const request = new Request('http://localhost/api/payment_gateways/webhook/stripe', {
+      method: 'POST',
+      headers: { 'content-length': String(1024 * 1024 + 1) },
+      body: '{}',
+    })
+
+    const response = await POST(request, { params: { provider: 'stripe' } })
+
+    expect(response.status).toBe(413)
+    expect(handler).not.toHaveBeenCalled()
     expect(findWithDecryption).not.toHaveBeenCalled()
   })
 

--- a/packages/core/src/modules/payment_gateways/api/webhook/[provider]/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/webhook/[provider]/route.ts
@@ -14,6 +14,7 @@ import { getPaymentGatewayQueue } from '../../../lib/queue'
 import { processPaymentGatewayWebhookJob } from '../../../lib/webhook-processor'
 import { paymentGatewaysTag } from '../../openapi'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { readBoundedRequestBody, WebhookBodyTooLargeError } from '@open-mercato/shared/lib/webhooks'
 
 const logger = createLogger('payment_gateways').child({ component: 'webhook' })
 
@@ -42,7 +43,15 @@ export async function POST(req: Request, { params }: { params: Promise<{ provide
   const rateLimitResponse = await checkProviderWebhookRateLimit(container, req, providerKey)
   if (rateLimitResponse) return rateLimitResponse
 
-  const rawBody = await req.text()
+  let rawBody: string
+  try {
+    rawBody = await readBoundedRequestBody(req)
+  } catch (error) {
+    if (error instanceof WebhookBodyTooLargeError) {
+      return NextResponse.json({ error: 'Webhook payload too large' }, { status: 413 })
+    }
+    throw error
+  }
   const headers: Record<string, string> = {}
   req.headers.forEach((value, key) => {
     headers[key] = value
@@ -164,6 +173,7 @@ export const openApi = {
       responses: [
         { status: 202, description: 'Webhook accepted for async processing' },
         { status: 401, description: 'Signature verification failed' },
+        { status: 413, description: 'Webhook payload too large' },
         { status: 404, description: 'Unknown provider' },
       ],
     },

--- a/packages/core/src/modules/shipping_carriers/api/__tests__/webhook-route.test.ts
+++ b/packages/core/src/modules/shipping_carriers/api/__tests__/webhook-route.test.ts
@@ -28,11 +28,11 @@ jest.mock('@open-mercato/core/modules/shipping_carriers/lib/queue', () => ({
 }))
 
 function createMockRequest(body: string, headers: Record<string, string> = {}): Request {
-  return {
+  return new Request('http://localhost/api/shipping_carriers/webhook/shippo', {
     method: 'POST',
-    headers: new Headers(headers),
-    text: jest.fn(async () => body),
-  } as unknown as Request
+    headers,
+    body,
+  })
 }
 
 describe('shipping carrier webhook route security', () => {
@@ -56,6 +56,7 @@ describe('shipping carrier webhook route security', () => {
 
   test('rate limits unauthenticated provider webhooks before parsing the body', async () => {
     const request = createMockRequest('{"shipmentId":"ship_1"}', { 'x-forwarded-for': '203.0.113.10' })
+    const getReaderSpy = jest.spyOn(request.body!, 'getReader')
     ;(getShippingAdapter as jest.Mock).mockReturnValue({
       verifyWebhook: jest.fn(),
     })
@@ -74,7 +75,21 @@ describe('shipping carrier webhook route security', () => {
       duration: 60,
       keyPrefix: 'shipping_carriers:webhook',
     })
-    expect(request.text).not.toHaveBeenCalled()
+    expect(getReaderSpy).not.toHaveBeenCalled()
+    expect(findWithDecryption).not.toHaveBeenCalled()
+  })
+
+  test('rejects an oversized declared body before adapter verification', async () => {
+    const verifyWebhook = jest.fn()
+    ;(getShippingAdapter as jest.Mock).mockReturnValue({ verifyWebhook })
+    const request = createMockRequest('{}', {
+      'content-length': String(1024 * 1024 + 1),
+    })
+
+    const response = await POST(request, { params: { provider: 'shippo' } })
+
+    expect(response.status).toBe(413)
+    expect(verifyWebhook).not.toHaveBeenCalled()
     expect(findWithDecryption).not.toHaveBeenCalled()
   })
 

--- a/packages/core/src/modules/shipping_carriers/api/webhook/[provider]/route.ts
+++ b/packages/core/src/modules/shipping_carriers/api/webhook/[provider]/route.ts
@@ -11,6 +11,7 @@ import { getShippingAdapter } from '../../../lib/adapter-registry'
 import { getShippingCarrierQueue } from '../../../lib/queue'
 import { shippingCarriersTag } from '../../openapi'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { readBoundedRequestBody, WebhookBodyTooLargeError } from '@open-mercato/shared/lib/webhooks'
 
 const logger = createLogger('shipping_carriers').child({ component: 'webhook' })
 
@@ -51,7 +52,15 @@ export async function POST(req: Request, { params }: { params: Promise<{ provide
   const rateLimitResponse = await checkProviderWebhookRateLimit(container, req, providerKey)
   if (rateLimitResponse) return rateLimitResponse
 
-  const rawBody = await req.text()
+  let rawBody: string
+  try {
+    rawBody = await readBoundedRequestBody(req)
+  } catch (error) {
+    if (error instanceof WebhookBodyTooLargeError) {
+      return NextResponse.json({ error: 'Webhook payload too large' }, { status: 413 })
+    }
+    throw error
+  }
   const headers: Record<string, string> = {}
   req.headers.forEach((value, key) => {
     headers[key] = value
@@ -156,6 +165,7 @@ export const openApi = {
       responses: [
         { status: 202, description: 'Webhook accepted for async processing' },
         { status: 401, description: 'Signature verification failed' },
+        { status: 413, description: 'Webhook payload too large' },
         { status: 404, description: 'Unknown provider' },
       ],
     },

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -121,6 +121,12 @@ NEXT_PUBLIC_OM_EXAMPLE_CHECKOUT_TEST_INJECTIONS_ENABLED=false
 # Required for webhook verification in standalone integration and local test flows.
 # MOCK_CARRIER_WEBHOOK_SECRET=open-mercato-mock-dev-carrier-webhook-secret
 
+# Default raw body limit for public webhook routes before verification.
+# InboxOps inherits this value when set; override only that source with
+# INBOX_OPS_WEBHOOK_MAX_BODY_BYTES (its legacy fallback is 2 MiB).
+OM_WEBHOOK_MAX_BODY_BYTES=1048576
+# INBOX_OPS_WEBHOOK_MAX_BODY_BYTES=2097152
+
 # Checkout origin allowlist (optional, comma-separated)
 # Extra origins allowed to submit payments via the public pay-link endpoint.
 # By default, only the server's own origin (derived from the request URL,

--- a/packages/shared/src/lib/webhooks/__tests__/body.test.ts
+++ b/packages/shared/src/lib/webhooks/__tests__/body.test.ts
@@ -1,0 +1,95 @@
+/** @jest-environment node */
+import {
+  DEFAULT_WEBHOOK_BODY_LIMIT_BYTES,
+  readBoundedRequestBody,
+  resolveWebhookBodyLimitBytes,
+  WebhookBodyTooLargeError,
+} from '../body'
+
+function makeStreamingRequest(chunks: Uint8Array[], headers?: HeadersInit) {
+  let index = 0
+  const cancel = jest.fn()
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      const chunk = chunks[index]
+      index += 1
+      if (chunk) controller.enqueue(chunk)
+      else controller.close()
+    },
+    cancel,
+  })
+  const request = new Request('http://localhost/webhook', {
+    method: 'POST',
+    headers,
+    body,
+    duplex: 'half',
+  } as RequestInit & { duplex: 'half' })
+  return { request, cancel }
+}
+
+describe('readBoundedRequestBody', () => {
+  const encoder = new TextEncoder()
+
+  it('rejects an oversized declared length before reading the body', async () => {
+    const request = new Request('http://localhost/webhook', {
+      method: 'POST',
+      headers: { 'content-length': '6' },
+      body: 'ok',
+    })
+
+    await expect(readBoundedRequestBody(request, { maxBytes: 5 })).rejects.toEqual(
+      expect.objectContaining<WebhookBodyTooLargeError>({ limitBytes: 5 }),
+    )
+  })
+
+  it('stops a chunked body when its actual byte count crosses the limit', async () => {
+    const { request, cancel } = makeStreamingRequest([
+      encoder.encode('abc'),
+      encoder.encode('def'),
+      encoder.encode('never-read'),
+    ])
+
+    await expect(readBoundedRequestBody(request, { maxBytes: 5 })).rejects.toBeInstanceOf(
+      WebhookBodyTooLargeError,
+    )
+    expect(cancel).toHaveBeenCalled()
+  })
+
+  it.each([
+    ['invalid', 'not-a-number'],
+    ['lying', '3'],
+  ])('does not let a %s Content-Length bypass the streamed cap', async (_case, contentLength) => {
+    const { request } = makeStreamingRequest(
+      [encoder.encode('abc'), encoder.encode('def')],
+      { 'content-length': contentLength },
+    )
+
+    await expect(readBoundedRequestBody(request, { maxBytes: 5 })).rejects.toBeInstanceOf(
+      WebhookBodyTooLargeError,
+    )
+  })
+
+  it('preserves the exact decoded body at the byte boundary', async () => {
+    const bytes = encoder.encode('a€')
+    const { request } = makeStreamingRequest([bytes.slice(0, 2), bytes.slice(2)])
+
+    await expect(readBoundedRequestBody(request, { maxBytes: bytes.byteLength })).resolves.toBe('a€')
+  })
+})
+
+describe('resolveWebhookBodyLimitBytes', () => {
+  it('uses the documented default for missing or invalid configuration', () => {
+    expect(resolveWebhookBodyLimitBytes(undefined)).toBe(DEFAULT_WEBHOOK_BODY_LIMIT_BYTES)
+    expect(resolveWebhookBodyLimitBytes('invalid')).toBe(DEFAULT_WEBHOOK_BODY_LIMIT_BYTES)
+    expect(resolveWebhookBodyLimitBytes('0')).toBe(DEFAULT_WEBHOOK_BODY_LIMIT_BYTES)
+  })
+
+  it('accepts a positive safe integer override', () => {
+    expect(resolveWebhookBodyLimitBytes('2097152')).toBe(2 * 1024 * 1024)
+  })
+
+  it('supports a source-specific fallback without weakening validation', () => {
+    expect(resolveWebhookBodyLimitBytes(undefined, 2 * 1024 * 1024)).toBe(2 * 1024 * 1024)
+    expect(resolveWebhookBodyLimitBytes('invalid', 2 * 1024 * 1024)).toBe(2 * 1024 * 1024)
+  })
+})

--- a/packages/shared/src/lib/webhooks/body.ts
+++ b/packages/shared/src/lib/webhooks/body.ts
@@ -1,0 +1,70 @@
+import { parseNumberWithDefault } from '../number'
+
+export const DEFAULT_WEBHOOK_BODY_LIMIT_BYTES = 1024 * 1024
+
+export class WebhookBodyTooLargeError extends Error {
+  readonly limitBytes: number
+
+  constructor(limitBytes: number) {
+    super(`Webhook body exceeds the ${limitBytes}-byte limit`)
+    this.name = 'WebhookBodyTooLargeError'
+    this.limitBytes = limitBytes
+  }
+}
+
+export function resolveWebhookBodyLimitBytes(
+  raw = typeof process === 'undefined' ? undefined : process.env.OM_WEBHOOK_MAX_BODY_BYTES,
+  fallbackBytes = DEFAULT_WEBHOOK_BODY_LIMIT_BYTES,
+): number {
+  const fallback = Number.isSafeInteger(fallbackBytes) && fallbackBytes > 0
+    ? fallbackBytes
+    : DEFAULT_WEBHOOK_BODY_LIMIT_BYTES
+  const parsed = parseNumberWithDefault(raw, fallback, { min: 1 })
+  return Number.isSafeInteger(parsed) ? parsed : fallback
+}
+
+export async function readBoundedRequestBody(
+  request: Request,
+  options?: { maxBytes?: number },
+): Promise<string> {
+  const configuredLimit = options?.maxBytes ?? resolveWebhookBodyLimitBytes()
+  const maxBytes = Number.isSafeInteger(configuredLimit) && configuredLimit > 0
+    ? configuredLimit
+    : DEFAULT_WEBHOOK_BODY_LIMIT_BYTES
+  const declaredLength = request.headers.get('content-length')?.trim()
+  if (declaredLength && /^\d+$/.test(declaredLength)) {
+    const declaredBytes = Number(declaredLength)
+    if (!Number.isSafeInteger(declaredBytes) || declaredBytes > maxBytes) {
+      throw new WebhookBodyTooLargeError(maxBytes)
+    }
+  }
+
+  if (!request.body) return ''
+
+  const reader = request.body.getReader()
+  const chunks: Uint8Array[] = []
+  let totalBytes = 0
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      totalBytes += value.byteLength
+      if (totalBytes > maxBytes) {
+        await reader.cancel().catch(() => undefined)
+        throw new WebhookBodyTooLargeError(maxBytes)
+      }
+      chunks.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  const body = new Uint8Array(totalBytes)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new TextDecoder().decode(body)
+}

--- a/packages/shared/src/lib/webhooks/index.ts
+++ b/packages/shared/src/lib/webhooks/index.ts
@@ -1,4 +1,10 @@
 export { signWebhookPayload, buildWebhookHeaders, generateMessageId } from './sign'
 export { verifyWebhookSignature } from './verify'
 export { generateWebhookSecret, parseWebhookSecret, isValidWebhookSecret } from './secrets'
+export {
+  DEFAULT_WEBHOOK_BODY_LIMIT_BYTES,
+  readBoundedRequestBody,
+  resolveWebhookBodyLimitBytes,
+  WebhookBodyTooLargeError,
+} from './body'
 export type { StandardWebhookHeaders, WebhookSigningKey, WebhookVerificationResult, StandardWebhookPayload } from './types'

--- a/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts
+++ b/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts
@@ -1,4 +1,47 @@
-import { buildInboundRateLimitKey, resolveInboundReceiptMessageId } from '../route'
+const mockVerifyWebhook = jest.fn()
+const mockFork = jest.fn(() => ({}))
+const mockResolve = jest.fn((token: string) => {
+  if (token === 'em') return { fork: mockFork }
+  throw new Error(`Unexpected token: ${token}`)
+})
+
+jest.mock('../../../../lib/adapter-registry', () => ({
+  getWebhookEndpointAdapter: jest.fn(() => ({
+    providerKey: 'mock',
+    verifyWebhook: mockVerifyWebhook,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({ resolve: mockResolve })),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+import { POST, buildInboundRateLimitKey, resolveInboundReceiptMessageId } from '../route'
+
+describe('POST /api/webhooks/inbound/[endpointId]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('rejects an oversized declared body before adapter verification', async () => {
+    const request = new Request('http://localhost/api/webhooks/inbound/mock', {
+      method: 'POST',
+      headers: { 'content-length': String(1024 * 1024 + 1) },
+      body: '{}',
+    })
+
+    const response = await POST(request, { params: Promise.resolve({ endpointId: 'mock' }) })
+
+    expect(response.status).toBe(413)
+    expect(mockVerifyWebhook).not.toHaveBeenCalled()
+  })
+})
 
 describe('buildInboundRateLimitKey', () => {
   it('uses an endpoint-global bucket when proxy headers are untrusted', () => {

--- a/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/route.ts
+++ b/packages/webhooks/src/modules/webhooks/api/inbound/[endpointId]/route.ts
@@ -6,6 +6,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { checkRateLimit, getClientIp, RATE_LIMIT_ERROR_FALLBACK, RATE_LIMIT_ERROR_KEY } from '@open-mercato/shared/lib/ratelimit/helpers'
 import type { RateLimiterService } from '@open-mercato/shared/lib/ratelimit/service'
+import { readBoundedRequestBody, WebhookBodyTooLargeError } from '@open-mercato/shared/lib/webhooks'
 import { emitWebhooksEvent } from '../../../events'
 import { getWebhookEndpointAdapter } from '../../../lib/adapter-registry'
 import { isWebhookIntegrationEnabled } from '../../../lib/integration-state'
@@ -51,7 +52,15 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
     if (rateLimitResponse) return rateLimitResponse
   }
 
-  const body = await request.text()
+  let body: string
+  try {
+    body = await readBoundedRequestBody(request)
+  } catch (error) {
+    if (error instanceof WebhookBodyTooLargeError) {
+      return json({ error: 'Webhook payload too large' }, { status: 413 })
+    }
+    throw error
+  }
   const headers = Object.fromEntries(request.headers.entries())
   let verified: Awaited<ReturnType<typeof adapter.verifyWebhook>>
   try {
@@ -120,7 +129,10 @@ export const openApi: OpenApiRouteDoc = {
       summary: 'Receive inbound webhook',
       description: 'Endpoint ids currently resolve to registered adapter provider keys.',
       pathParams: z.object({ endpointId: z.string().min(1) }),
-      responses: [{ status: 200, description: 'Inbound webhook accepted', schema: inboundResponseSchema }],
+      responses: [
+        { status: 200, description: 'Inbound webhook accepted', schema: inboundResponseSchema },
+        { status: 413, description: 'Webhook payload too large', schema: errorSchema },
+      ],
       errors: [
         { status: 400, description: 'Verification failed', schema: errorSchema },
         { status: 404, description: 'Endpoint not found', schema: errorSchema },


### PR DESCRIPTION
## Summary

Prevent public webhook routes from buffering arbitrarily large request bodies before signature or JWT verification. A shared streaming reader now enforces finite byte limits and returns `413` before parsing, hashing, verifier, database, or queue work.

## Changes

- Added `readBoundedRequestBody` with early declared-length rejection and streamed-byte enforcement.
- Applied the shared reader to generic webhooks, payment gateways, shipping carriers, communication-channel providers, Gmail Pub/Sub, and InboxOps.
- Added global `OM_WEBHOOK_MAX_BODY_BYTES` configuration plus an InboxOps-specific override while preserving its legacy fallback.
- Documented `413` responses in affected OpenAPI definitions.
- Added helper and route-level regression coverage for fixed-length, chunked, invalid, missing, and understated lengths.
- Added webhook-scoped nginx guidance, environment examples, and specification/backward-compatibility updates.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/implemented/SPEC-057-2026-03-04-webhooks-module.md`

## Testing

- `yarn workspace @open-mercato/shared test --runTestsByPath src/lib/webhooks/__tests__/body.test.ts --runInBand`
- `yarn workspace @open-mercato/webhooks test --runTestsByPath 'src/modules/webhooks/api/inbound/[endpointId]/__tests__/route.test.ts' --runInBand`
- Focused core webhook route suites: 27 tests passed
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- Scoped ESLint
- `yarn check:dep-versions`
- `yarn check:time-bombs:fail`
- `yarn logger:check-console:ci`

No Playwright integration test was added because rejection occurs at the raw `Request` stream boundary before application-container, database, or UI behavior. Direct route tests use real `Request` objects and assert `413` occurs before verifier invocation for every affected family.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI or Design System changes.

## Linked issues

Fixes #4044
