### PR TITLE
fix(cli): safely quote discovered table names (#4040)

### DIFF
--- a/packages/cli/src/lib/db/__tests__/commands.test.ts
+++ b/packages/cli/src/lib/db/__tests__/commands.test.ts
@@ -228,6 +228,57 @@ describe('db commands', () => {
       mockConsoleError.mockRestore()
       mockExit.mockRestore()
     })
+
+    it('quotes discovered table names as single PostgreSQL identifiers', async () => {
+      const dangerousTableName = 'orders"; SELECT pg_sleep(10); --'
+      const migrationQuery = jest.fn().mockResolvedValue({ rows: [] })
+      const discoveredTableQuery = jest.fn().mockImplementation(async (sql: string) => {
+        if (sql.includes('FROM pg_tables')) {
+          return { rows: [{ tablename: dangerousTableName }] }
+        }
+        return { rows: [] }
+      })
+
+      const Client = jest
+        .fn()
+        .mockImplementationOnce(() => ({
+          connect: jest.fn().mockResolvedValue(undefined),
+          query: migrationQuery,
+          end: jest.fn().mockResolvedValue(undefined),
+        }))
+        .mockImplementationOnce(() => ({
+          connect: jest.fn().mockResolvedValue(undefined),
+          query: discoveredTableQuery,
+          end: jest.fn().mockResolvedValue(undefined),
+        }))
+      jest.doMock('pg', () => ({ Client }))
+
+      const originalDatabaseUrl = process.env.DATABASE_URL
+      process.env.DATABASE_URL = 'postgres://postgres:secret@127.0.0.1:5432/open_mercato'
+      const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+      const resolver = {
+        loadEnabledModules: () => [],
+        getOutputDir: () => '/definitely/missing/generated',
+        getRootDir: () => '/definitely/missing',
+        getModulePaths: () => ({ appBase: '', pkgBase: '' }),
+      } as any
+
+      try {
+        await dbGreenfield(resolver, { yes: true })
+      } finally {
+        if (originalDatabaseUrl === undefined) {
+          delete process.env.DATABASE_URL
+        } else {
+          process.env.DATABASE_URL = originalDatabaseUrl
+        }
+        consoleLogSpy.mockRestore()
+        jest.dontMock('pg')
+      }
+
+      expect(discoveredTableQuery).toHaveBeenCalledWith(
+        'DROP TABLE IF EXISTS "orders""; SELECT pg_sleep(10); --" CASCADE',
+      )
+    })
   })
 
   describe('integration with sanitization', () => {

--- a/packages/cli/src/lib/db/commands.ts
+++ b/packages/cli/src/lib/db/commands.ts
@@ -8,6 +8,7 @@ import { Migrator } from '@mikro-orm/migrations'
 import { PostgreSqlDriver } from '@mikro-orm/postgresql'
 import { getSslConfig } from '@open-mercato/shared/lib/db/ssl'
 import type { PackageResolver, ModuleEntry } from '../resolver'
+import { quotePostgresIdentifier } from './identifiers'
 
 const QUIET_MODE = process.env.OM_CLI_QUIET === '1' || process.env.MERCATO_QUIET === '1'
 const PROGRESS_EMOJI = ''
@@ -528,7 +529,7 @@ export async function dbGreenfield(resolver: PackageResolver, options: Greenfiel
         try {
           await client.query("SET session_replication_role = 'replica'")
           for (const t of tables) {
-            await client.query(`DROP TABLE IF EXISTS "${t}" CASCADE`)
+            await client.query(`DROP TABLE IF EXISTS ${quotePostgresIdentifier(t)} CASCADE`)
           }
           await client.query("SET session_replication_role = 'origin'")
           await client.query('COMMIT')

--- a/packages/cli/src/lib/db/identifiers.ts
+++ b/packages/cli/src/lib/db/identifiers.ts
@@ -1,0 +1,3 @@
+export function quotePostgresIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`
+}

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -42,6 +42,7 @@ import { resolveNextBuildIdCandidate } from './lib/next-build-id'
 import { acquireServerStartLock } from './lib/server-start-lock'
 import { assertSingleInstanceStrategies } from './lib/single-instance-strategy-guard'
 import { createDevEnvReloader, watchDevEnvFiles } from './lib/dev-env-reload'
+import { quotePostgresIdentifier } from './lib/db/identifiers'
 // Lazy-imported to avoid pulling in `testcontainers` (devDependency) at startup
 const lazyIntegration = () => import('./lib/testing/integration')
 import type { ChildProcess } from 'node:child_process'
@@ -913,7 +914,7 @@ export async function run(argv = process.argv) {
             await client.query('BEGIN')
             try {
               for (const t of dropTargets) {
-                await client.query(`DROP TABLE IF EXISTS "${t}" CASCADE`)
+                await client.query(`DROP TABLE IF EXISTS ${quotePostgresIdentifier(t)} CASCADE`)
                 dropped += 1
               }
               await client.query('COMMIT')


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Prevent database-discovered table names from altering SQL structure during `db:greenfield` and `init --reinstall`. Embedded quotes are now escaped using PostgreSQL delimited-identifier rules before destructive statements are executed.

## Changes

- Add a central PostgreSQL identifier-quoting helper that doubles embedded double quotes.
- Use the helper for discovered table names in both destructive CLI flows.
- Add regression coverage proving an appended statement remains inside one quoted identifier.
- Preserve current-schema discovery and ordinary table-name behavior.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor isolated security fix, no spec needed)

**Spec file path:**
N/A

## Testing

- `yarn workspace @open-mercato/cli test --runInBand src/lib/db/__tests__/commands.test.ts` — 30/30 passed after reproducing the failure on vulnerable code.
- `yarn build:packages` — passed.
- `yarn generate` — passed.
- `yarn build:packages` — passed after generation.
- `yarn i18n:check-sync` — passed.
- `yarn i18n:check-usage` — exited 0 with the existing unused-key advisory.
- `yarn typecheck` — passed.
- `yarn test` — 22/22 package tasks passed.
- `yarn build:app` — passed.
- Scoped ESLint for all touched files — passed.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. — N/A; no documentation or locale changes, and generation completed without relevant tracked output.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — N/A; deterministic SQL construction is covered by a CLI unit test with a mocked PostgreSQL client.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A; isolated security fix with no contract or architectural change.
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-low`, inherited from #4040.)
- [x] Risk set: this PR carries exactly one risk label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`). (`risk-low`, inherited from #4040.)
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`. (`skip-qa`; CLI-only change covered by automated tests.)

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens — N/A, no UI.
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline` — N/A, no UI.
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — N/A, no UI.
- [x] Loading state handled for async pages — N/A, no UI.
- [x] `aria-label` on all icon-only buttons (`<IconButton>`) — N/A, no UI.
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements — N/A, no UI.

## Linked issues

Fixes #4040
