### PR TITLE
build(deps): bump js-yaml from 3.14.2 to 3.15.0

### DIFF
--- a/.ai/runs/2026-07-10-js-yaml-3.15.0-develop.md
+++ b/.ai/runs/2026-07-10-js-yaml-3.15.0-develop.md
@@ -1,0 +1,63 @@
+# Execution Plan — Port js-yaml 3.15.0 bump to develop
+
+**Slug:** js-yaml-3.15.0-develop
+**Date:** 2026-07-10
+**Branch:** fix/js-yaml-3.15.0-develop
+**Base:** develop
+
+## Overview
+
+Dependabot opened [#4028](https://github.com/open-mercato/open-mercato/pull/4028)
+against `main`, bumping the transitive dependency `js-yaml` from 3.14.2 to
+3.15.0 (a security backport that adds the `maxTotalMergeKeys` loader option).
+Open Mercato ships PRs against `develop`, not `main`, so the bump must be
+re-created on a `develop`-based branch and the original `main`-based PR closed.
+
+### Goal
+
+Apply the `js-yaml@npm:^3.13.1` → 3.15.0 lockfile bump on top of `develop`,
+verify the lockfile still resolves and the workspace still builds, open a PR
+against `develop`, and close #4028 pointing at the replacement.
+
+### Scope
+
+- `yarn.lock` — bump the `js-yaml@npm:^3.13.1` resolution from 3.14.2 to 3.15.0.
+
+### Non-goals
+
+- No changes to `package.json` (js-yaml is a transitive dep, not a direct one).
+- No changes to any other js-yaml resolution (`4.1.1`, `4.2.0` stay as-is).
+- No code, module, or behavior changes.
+
+### Risks
+
+- Lockfile-only churn; risk is that 3.15.0 fails to resolve or breaks a
+  consumer of js-yaml v3. Mitigated by running `yarn install` and a
+  packages/app build. Backported security patch — no breaking API changes.
+
+## Implementation Plan
+
+### Phase 1: Apply the lockfile bump
+
+- 1.1 Bump `js-yaml@npm:^3.13.1` resolution + checksum to 3.15.0 in `yarn.lock`.
+- 1.2 Run `yarn install --mode=skip-build` to confirm the lockfile is
+  internally consistent (no re-resolution churn).
+
+### Phase 2: Validate and ship
+
+- 2.1 Run the relevant validation gate (build:packages, typecheck, build:app).
+- 2.2 Open PR against `develop`; close #4028 with a pointer to the replacement.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Apply the lockfile bump
+
+- [ ] 1.1 Bump js-yaml resolution to 3.15.0 in yarn.lock
+- [ ] 1.2 Verify lockfile consistency with yarn install
+
+### Phase 2: Validate and ship
+
+- [ ] 2.1 Run validation gate
+- [ ] 2.2 Open replacement PR against develop and close #4028

--- a/.ai/runs/2026-07-10-js-yaml-3.15.0-develop.md
+++ b/.ai/runs/2026-07-10-js-yaml-3.15.0-develop.md
@@ -60,4 +60,4 @@ against `develop`, and close #4028 pointing at the replacement.
 ### Phase 2: Validate and ship
 
 - [x] 2.1 Run validation gate — install ✓ / build:packages 21/21 ✓ / generate ✓ / typecheck 21/21 ✓ / build:app ✓ (yarn test + i18n skipped: no source/locale changes)
-- [ ] 2.2 Open replacement PR against develop and close #4028
+- [x] 2.2 Open replacement PR against develop and close #4028 — PR #4075; #4028 closed

--- a/.ai/runs/2026-07-10-js-yaml-3.15.0-develop.md
+++ b/.ai/runs/2026-07-10-js-yaml-3.15.0-develop.md
@@ -54,8 +54,8 @@ against `develop`, and close #4028 pointing at the replacement.
 
 ### Phase 1: Apply the lockfile bump
 
-- [ ] 1.1 Bump js-yaml resolution to 3.15.0 in yarn.lock
-- [ ] 1.2 Verify lockfile consistency with yarn install
+- [x] 1.1 Bump js-yaml resolution to 3.15.0 in yarn.lock — d3852130e
+- [x] 1.2 Verify lockfile consistency with yarn install — d3852130e
 
 ### Phase 2: Validate and ship
 

--- a/.ai/runs/2026-07-10-js-yaml-3.15.0-develop.md
+++ b/.ai/runs/2026-07-10-js-yaml-3.15.0-develop.md
@@ -59,5 +59,5 @@ against `develop`, and close #4028 pointing at the replacement.
 
 ### Phase 2: Validate and ship
 
-- [ ] 2.1 Run validation gate
+- [x] 2.1 Run validation gate — install ✓ / build:packages 21/21 ✓ / generate ✓ / typecheck 21/21 ✓ / build:app ✓ (yarn test + i18n skipped: no source/locale changes)
 - [ ] 2.2 Open replacement PR against develop and close #4028

--- a/yarn.lock
+++ b/yarn.lock
@@ -20993,14 +20993,14 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: "npm:^1.0.7"
     esprima: "npm:^4.0.0"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10/172e0b6007b0bf0fc8d2469c94424f7dd765c64a047d2b790831fecef2204a4054eabf4d911eb73ab8c9a3256ab8ba1ee8d655b789bf24bf059c772acc2075a1
+  checksum: 10/2fdf3a1453ed93a8e06d6ca8054c0bec145cf40ab51f305d1071736a03668b95e40f47cfd0239d7d50019b4780a18cdaca3c935def935594c9876964c49f1185
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-10-js-yaml-3.15.0-develop.md
Status: complete

## Goal
- Port Dependabot PR #4028 (`js-yaml` 3.14.2 → 3.15.0) from `main` onto `develop`, and close the original since Open Mercato ships PRs against `develop`.

## What Changed
- Bumped the transitive `js-yaml@npm:^3.13.1` resolution in `yarn.lock` from 3.14.2 to 3.15.0 (identical to Dependabot's diff: 3 insertions, 3 deletions).
- 3.15.0 is a **security backport** that adds the `maxTotalMergeKeys` (10000) loader option to bound YAML merge-key processing. It is a semver-compatible patch within the v3 line; no API changes.
- Only consumer of the `^3.13.1` range is `@mdxeditor/editor`; the other `js-yaml` resolutions (4.1.1, 4.2.0) are untouched.

## Tests
- `yarn install --mode=skip-build` — lockfile resolves with no re-churn (resolution step 0ms; only pre-existing peer warnings).
- `yarn build:packages` — 21/21 ✓
- `yarn generate` + core `node build.mjs` ✓
- `yarn typecheck` — 21/21 ✓
- `yarn build:app` — ✓ (exercises the bundled `@mdxeditor/editor` consumer)
- `yarn test` and i18n checks skipped: lockfile-only change, no source or locale edits.

## Backward Compatibility
- No contract surface changes. Lockfile-only bump of a transitive dependency; semver-compatible security patch.

## Progress
See [Progress section in the plan](.ai/runs/2026-07-10-js-yaml-3.15.0-develop.md#progress).
