### PR TITLE
fix(ai-assistant): harden mcp dev config loading (#4039)

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -969,3 +969,5 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: Use `node:crypto` helpers (`randomInt`, `randomUUID`, or `randomBytes`) for any generated value that may touch auth, security checks, identifiers, request headers, or authenticated API calls. Reserve `Math.random()` only for explicitly non-security demo data, and prefer deterministic fixtures when uniqueness is not required.
 
 **Applies to**: integration helpers, auth tests, rate-limit tests, fixture factories, temporary IDs, generated emails/passwords, and any test utility that feeds API requests or security-sensitive code paths.
+
+- 2026-07-10 · ai_assistant: A TOCTOU test that swaps only before descriptor validation does not prove same-handle reads → also swap after identity validation and assert the validated descriptor content is returned.

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-dev-key-resolution.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-dev-key-resolution.test.ts
@@ -1,5 +1,36 @@
-import { resolve } from 'node:path'
-import { findProjectRoot, checkMcpConfigPermissions } from '../mcp-dev-key-resolution'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import * as fsPromises from 'node:fs/promises'
+import {
+  findProjectRoot,
+  checkMcpConfigPermissions,
+  getApiKeyFromMcpJson,
+} from '../mcp-dev-key-resolution'
+
+jest.mock('node:fs/promises', () => {
+  const actual = jest.requireActual<typeof import('node:fs/promises')>('node:fs/promises')
+  return {
+    ...actual,
+    lstat: jest.fn(actual.lstat),
+    open: jest.fn(actual.open),
+    stat: jest.fn(actual.stat),
+  }
+})
+
+const realFs = jest.requireActual<typeof import('node:fs/promises')>('node:fs/promises')
+const mockedLstat = jest.mocked(fsPromises.lstat)
+const mockedOpen = jest.mocked(fsPromises.open)
+const mockedStat = jest.mocked(fsPromises.stat)
+
+function mcpConfig(apiKey: string): string {
+  return JSON.stringify({
+    mcpServers: {
+      'open-mercato': {
+        headers: { 'x-api-key': apiKey },
+      },
+    },
+  })
+}
 
 describe('mcp:dev API key resolution (#2671)', () => {
   describe('findProjectRoot', () => {
@@ -51,7 +82,7 @@ describe('mcp:dev API key resolution (#2671)', () => {
       expect(warnings).toHaveLength(0)
     })
 
-    it('warns loudly but allows when the config is group/world accessible', () => {
+    it('refuses a config that is group/world accessible', () => {
       const warnings: string[] = []
       const result = checkMcpConfigPermissions(
         configPath,
@@ -59,7 +90,8 @@ describe('mcp:dev API key resolution (#2671)', () => {
         1000,
         (message) => warnings.push(message),
       )
-      expect(result.ok).toBe(true)
+      expect(result.ok).toBe(false)
+      expect(result.reason).toContain('accessible to group/other')
       expect(warnings).toHaveLength(1)
       expect(warnings[0]).toContain('accessible to group/other')
       expect(warnings[0]).toContain('chmod 600')
@@ -87,6 +119,128 @@ describe('mcp:dev API key resolution (#2671)', () => {
       )
       expect(result.ok).toBe(true)
       expect(warnings).toHaveLength(0)
+    })
+  })
+
+  describe('getApiKeyFromMcpJson', () => {
+    let projectRoot: string
+    let configPath: string
+    const originalEnvKey = process.env.OPEN_MERCATO_API_KEY
+
+    beforeEach(async () => {
+      projectRoot = await realFs.mkdtemp(join(tmpdir(), 'om-mcp-key-'))
+      configPath = join(projectRoot, '.mcp.json')
+      await realFs.mkdir(join(projectRoot, '.git'))
+      jest.spyOn(process, 'cwd').mockReturnValue(projectRoot)
+      delete process.env.OPEN_MERCATO_API_KEY
+      mockedLstat.mockImplementation(realFs.lstat)
+      mockedOpen.mockImplementation(realFs.open)
+      mockedStat.mockImplementation(realFs.stat)
+    })
+
+    afterEach(async () => {
+      jest.restoreAllMocks()
+      mockedLstat.mockReset()
+      mockedOpen.mockReset()
+      mockedStat.mockReset()
+      if (originalEnvKey === undefined) delete process.env.OPEN_MERCATO_API_KEY
+      else process.env.OPEN_MERCATO_API_KEY = originalEnvKey
+      await realFs.rm(projectRoot, { recursive: true, force: true })
+    })
+
+    it('keeps environment-key precedence without reading the config file', async () => {
+      process.env.OPEN_MERCATO_API_KEY = ' env-key '
+
+      await expect(getApiKeyFromMcpJson()).resolves.toBe('env-key')
+      expect(mockedOpen).not.toHaveBeenCalled()
+      expect(mockedStat).not.toHaveBeenCalled()
+    })
+
+    it('reads a valid owner-only config', async () => {
+      await realFs.writeFile(configPath, mcpConfig('file-key'), { mode: 0o600 })
+
+      await expect(getApiKeyFromMcpJson()).resolves.toBe('file-key')
+    })
+
+    it('rejects a symbolic-link config', async () => {
+      if (process.platform === 'win32') return
+      const targetPath = join(projectRoot, 'target.mcp.json')
+      await realFs.writeFile(targetPath, mcpConfig('symlink-key'), { mode: 0o600 })
+      await realFs.symlink(targetPath, configPath)
+
+      await expect(getApiKeyFromMcpJson()).resolves.toBeUndefined()
+    })
+
+    it.each(['linux', 'win32'] as const)(
+      'fails closed when the config path is replaced after open/validation (%s)',
+      async (platform) => {
+        const replacementPath = join(projectRoot, 'replacement.mcp.json')
+        const openedPath = join(projectRoot, 'opened.mcp.json')
+        await realFs.writeFile(configPath, mcpConfig('trusted-key'), { mode: 0o600 })
+        await realFs.writeFile(replacementPath, mcpConfig('replacement-key'), { mode: 0o600 })
+        const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+        Object.defineProperty(process, 'platform', { ...platformDescriptor, value: platform })
+
+        try {
+          let replaced = false
+          const replaceConfigPath = async () => {
+            if (replaced) return
+            replaced = true
+            await realFs.rename(configPath, openedPath)
+            await realFs.rename(replacementPath, configPath)
+          }
+          mockedStat.mockImplementation(async (...args) => {
+            const result = await realFs.stat(...args)
+            if (String(args[0]) === configPath) await replaceConfigPath()
+            return result
+          })
+          mockedOpen.mockImplementation(async (...args) => {
+            const handle = await realFs.open(...args)
+            if (String(args[0]) === configPath) await replaceConfigPath()
+            return handle
+          })
+
+          await expect(getApiKeyFromMcpJson()).resolves.toBeUndefined()
+          expect(replaced).toBe(true)
+        } finally {
+          if (platformDescriptor) Object.defineProperty(process, 'platform', platformDescriptor)
+        }
+      },
+    )
+
+    it('reads from the validated descriptor if the path changes after validation', async () => {
+      const replacementPath = join(projectRoot, 'replacement.mcp.json')
+      const openedPath = join(projectRoot, 'opened.mcp.json')
+      await realFs.writeFile(configPath, mcpConfig('trusted-key'), { mode: 0o600 })
+      await realFs.writeFile(replacementPath, mcpConfig('replacement-key'), { mode: 0o600 })
+
+      let replaced = false
+      mockedLstat.mockImplementation(async (...args) => {
+        const validatedPathStat = await realFs.lstat(...args)
+        if (String(args[0]) === configPath) {
+          await realFs.rename(configPath, openedPath)
+          await realFs.rename(replacementPath, configPath)
+          replaced = true
+        }
+        return validatedPathStat
+      })
+
+      await expect(getApiKeyFromMcpJson()).resolves.toBe('trusted-key')
+      expect(replaced).toBe(true)
+    })
+
+    it('rejects a non-regular config entry', async () => {
+      await realFs.mkdir(configPath)
+
+      await expect(getApiKeyFromMcpJson()).resolves.toBeUndefined()
+    })
+
+    it('rejects a group/world-accessible config before reading its key', async () => {
+      if (typeof process.getuid !== 'function') return
+      await realFs.writeFile(configPath, mcpConfig('unsafe-key'), { mode: 0o644 })
+      await realFs.chmod(configPath, 0o644)
+
+      await expect(getApiKeyFromMcpJson()).resolves.toBeUndefined()
     })
   })
 })

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-dev-key-resolution.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-dev-key-resolution.ts
@@ -37,9 +37,9 @@ export function findProjectRoot(startDir: string, exists: (path: string) => bool
 /**
  * Validate the ownership and permissions of `.mcp.json` before its secret is
  * read. Refuses when the file is owned by another user (a planted/shadowed
- * config) and warns loudly when it is accessible to group/other (the key is a
- * live secret). POSIX-only: when `currentUid` is null (e.g. Windows) the checks
- * are skipped.
+ * config) or accessible to group/other (the key is a live secret). POSIX-only:
+ * when `currentUid` is null (e.g. Windows) the ownership and mode checks are
+ * skipped; descriptor/path identity checks still apply.
  */
 export function checkMcpConfigPermissions(
   configPath: string,
@@ -55,11 +55,17 @@ export function checkMcpConfigPermissions(
     }
   }
   if ((fileStat.mode & 0o077) !== 0) {
-    warn(
-      `${configPath} is accessible to group/other (mode ${(fileStat.mode & 0o777).toString(8)}); it contains a live API key — restrict it with: chmod 600 ${configPath}`,
-    )
+    const reason = `${configPath} is accessible to group/other (mode ${(fileStat.mode & 0o777).toString(8)}); it contains a live API key — restrict it with: chmod 600 ${configPath}`
+    warn(reason)
+    return { ok: false, reason }
   }
   return { ok: true }
+}
+
+type FileIdentity = { dev: number; ino: number }
+
+function isSameFile(openedFile: FileIdentity, pathEntry: FileIdentity): boolean {
+  return openedFile.dev === pathEntry.dev && openedFile.ino === pathEntry.ino
 }
 
 /**
@@ -76,34 +82,50 @@ export async function getApiKeyFromMcpJson(): Promise<string | undefined> {
     return envKey.trim()
   }
 
-  const { readFile, stat } = await import('node:fs/promises')
-  const { existsSync } = await import('node:fs')
+  const { lstat, open } = await import('node:fs/promises')
+  const { constants, existsSync } = await import('node:fs')
 
   try {
     const projectRoot = findProjectRoot(process.cwd(), existsSync)
     const mcpJsonPath = resolve(projectRoot, MCP_CONFIG_FILENAME)
-    if (!existsSync(mcpJsonPath)) {
-      return undefined
+    let openFlags = constants.O_RDONLY
+    if (process.platform !== 'win32') {
+      openFlags |= constants.O_NOFOLLOW | constants.O_NONBLOCK
     }
 
-    const fileStat = await stat(mcpJsonPath)
-    const currentUid = typeof process.getuid === 'function' ? process.getuid() : null
-    const permissionCheck = checkMcpConfigPermissions(
-      mcpJsonPath,
-      { uid: fileStat.uid, mode: fileStat.mode },
-      currentUid,
-      (message) => log(`Warning: ${message}`),
-    )
-    if (!permissionCheck.ok) {
-      log(`Error: ${permissionCheck.reason}`)
-      return undefined
+    const fileHandle = await open(mcpJsonPath, openFlags)
+    try {
+      const [fileStat, pathStat] = await Promise.all([fileHandle.stat(), lstat(mcpJsonPath)])
+      if (
+        !fileStat.isFile() ||
+        pathStat.isSymbolicLink() ||
+        !pathStat.isFile() ||
+        !isSameFile(fileStat, pathStat)
+      ) {
+        log(`Error: refusing to read ${mcpJsonPath}: it is not the opened regular file`)
+        return undefined
+      }
+
+      const currentUid = typeof process.getuid === 'function' ? process.getuid() : null
+      const permissionCheck = checkMcpConfigPermissions(
+        mcpJsonPath,
+        { uid: fileStat.uid, mode: fileStat.mode },
+        currentUid,
+        (message) => log(`Warning: ${message}`),
+      )
+      if (!permissionCheck.ok) {
+        log(`Error: ${permissionCheck.reason}`)
+        return undefined
+      }
+
+      const content = await fileHandle.readFile({ encoding: 'utf-8' })
+      const config = JSON.parse(content)
+      const serverConfig = config?.mcpServers?.['open-mercato']
+
+      return serverConfig?.headers?.['x-api-key']
+    } finally {
+      await fileHandle.close()
     }
-
-    const content = await readFile(mcpJsonPath, 'utf-8')
-    const config = JSON.parse(content)
-    const serverConfig = config?.mcpServers?.['open-mercato']
-
-    return serverConfig?.headers?.['x-api-key']
   } catch {
     return undefined
   }


### PR DESCRIPTION
## Summary

Harden the development MCP `.mcp.json` API-key loader against pathname replacement between validation and use.

The loader now opens the configuration once, validates the opened descriptor and current path entry, and reads through that same handle. Symlinks, replacement races, non-regular entries, foreign ownership, and group/world-accessible modes fail closed while environment-key precedence and bounded project-root lookup remain unchanged.

## Changes

- open `.mcp.json` with no-follow and nonblocking flags on POSIX
- verify the opened descriptor is the same regular file still present at the project path
- retain descriptor/path identity validation as the Windows fallback
- read through the validated handle and close it in `finally`
- add deterministic coverage for symlinks, pre/post-validation replacements, non-regular entries, unsafe ownership/modes, valid configurations, and environment precedence

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

N/A — focused security fix for the existing development-only key loader.

## Testing

- focused regression suite: 16/16 passing after reproducing the original failures
- `yarn workspace @open-mercato/ai-assistant build`
- scoped ESLint for the changed AI-assistant files
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Integration coverage is not required because this is a development-only filesystem loader covered through deterministic module-level filesystem tests.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI files or behavior changed.

## Linked issues

Fixes #4039
