### PR TITLE
fix(planner): scope availability command target loads (#3884)

### DIFF
--- a/packages/core/src/modules/planner/commands/__tests__/scoped-target-loads.test.ts
+++ b/packages/core/src/modules/planner/commands/__tests__/scoped-target-loads.test.ts
@@ -1,0 +1,247 @@
+import type { AwilixContainer } from 'awilix'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+
+const mockFindOneWithDecryption = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/helpers')
+  return {
+    ...actual,
+    emitCrudSideEffects: jest.fn().mockResolvedValue(undefined),
+    emitCrudUndoSideEffects: jest.fn().mockResolvedValue(undefined),
+    setCustomFieldsIfAny: jest.fn().mockResolvedValue(undefined),
+  }
+})
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn().mockResolvedValue({
+    translate: (_key: string, fallback: string) => fallback,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+type RegisteredCommand = {
+  execute: (input: unknown, ctx: unknown) => Promise<unknown>
+}
+
+const TENANT_ID = '11111111-1111-4111-8111-111111111111'
+const ORG_ID = '22222222-2222-4222-8222-222222222222'
+const OTHER_ORG_ID = '33333333-3333-4333-8333-333333333333'
+const RULE_ID = '44444444-4444-4444-8444-444444444444'
+const RULE_SET_ID = '55555555-5555-4555-8555-555555555555'
+
+async function loadAvailabilityCommand(id: string): Promise<RegisteredCommand> {
+  jest.resetModules()
+  const { commandRegistry } = await import('@open-mercato/shared/lib/commands')
+  commandRegistry.clear()
+  await import('../availability')
+  return commandRegistry.get(id) as RegisteredCommand
+}
+
+async function loadRuleSetCommand(id: string): Promise<RegisteredCommand> {
+  jest.resetModules()
+  const { commandRegistry } = await import('@open-mercato/shared/lib/commands')
+  commandRegistry.clear()
+  await import('../availability-rule-sets')
+  return commandRegistry.get(id) as RegisteredCommand
+}
+
+function buildRule(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RULE_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    subjectType: 'ruleset',
+    subjectId: RULE_SET_ID,
+    timezone: 'UTC',
+    rrule: 'DTSTART:20260710T090000Z\nDURATION:PT8H',
+    exdates: [],
+    kind: 'availability',
+    note: 'Before',
+    unavailabilityReasonEntryId: null,
+    unavailabilityReasonValue: null,
+    deletedAt: null,
+    updatedAt: new Date('2026-07-01T10:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function buildRuleSet(overrides: Record<string, unknown> = {}) {
+  return {
+    id: RULE_SET_ID,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    name: 'Before',
+    description: null,
+    timezone: 'UTC',
+    deletedAt: null,
+    updatedAt: new Date('2026-07-01T10:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function createEm() {
+  const em = {
+    fork: jest.fn(),
+    findOne: jest.fn().mockResolvedValue(null),
+    flush: jest.fn().mockResolvedValue(undefined),
+  }
+  em.fork.mockReturnValue(em)
+  return em
+}
+
+function createCtx(em: unknown, overrides: Record<string, unknown> = {}) {
+  return {
+    auth: {
+      sub: 'user-1',
+      tenantId: TENANT_ID,
+      orgId: OTHER_ORG_ID,
+      isSuperAdmin: false,
+    },
+    container: {
+      resolve: (name: string) => {
+        if (name === 'em') return em
+        if (name === 'dataEngine') return {}
+        return null
+      },
+    } as unknown as AwilixContainer,
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: [ORG_ID],
+    ...overrides,
+  }
+}
+
+function createNullScopeCtx(em: unknown) {
+  return createCtx(em, {
+    auth: { sub: 'api-key-1', tenantId: null, orgId: null, isSuperAdmin: false },
+    selectedOrganizationId: null,
+    organizationIds: null,
+  })
+}
+
+describe('planner command target scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('loads availability update targets with the actor tenant and selected organization', async () => {
+    const update = await loadAvailabilityCommand('planner.availability.update')
+    const em = createEm()
+    const rule = buildRule()
+    em.findOne.mockImplementation(async (_entity: unknown, where: Record<string, unknown>) => {
+      if (where.id === RULE_ID && where.tenantId === TENANT_ID && where.organizationId === ORG_ID) return rule
+      return null
+    })
+
+    await expect(update.execute({ id: RULE_ID, note: 'After' }, createCtx(em))).resolves.toEqual({ ruleId: RULE_ID })
+
+    expect(em.findOne).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: RULE_ID,
+        tenantId: TENANT_ID,
+        organizationId: ORG_ID,
+        deletedAt: null,
+      }),
+    )
+    expect(rule.note).toBe('After')
+  })
+
+  it('scopes availability delete targets before applying the soft delete', async () => {
+    const remove = await loadAvailabilityCommand('planner.availability.delete')
+    const em = createEm()
+    const rule = buildRule()
+    em.findOne.mockImplementation(async (_entity: unknown, where: Record<string, unknown>) => {
+      if (where.id === RULE_ID && where.tenantId === TENANT_ID && where.organizationId === ORG_ID) return rule
+      return null
+    })
+
+    await expect(remove.execute({ id: RULE_ID }, createCtx(em))).resolves.toEqual({ ruleId: RULE_ID })
+
+    expect(rule.deletedAt).toBeInstanceOf(Date)
+    expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('loads rule-set update targets with query scope and matching decryption scope', async () => {
+    const update = await loadRuleSetCommand('planner.availability-rule-sets.update')
+    const em = createEm()
+    const ruleSet = buildRuleSet()
+    mockFindOneWithDecryption.mockImplementation(async (_em, _entity, where: Record<string, unknown>) => {
+      if (where.id === RULE_SET_ID && where.tenantId === TENANT_ID && where.organizationId === ORG_ID) return ruleSet
+      return null
+    })
+
+    await expect(update.execute({ id: RULE_SET_ID, name: 'After' }, createCtx(em))).resolves.toEqual({
+      ruleSetId: RULE_SET_ID,
+    })
+
+    expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        id: RULE_SET_ID,
+        tenantId: TENANT_ID,
+        organizationId: ORG_ID,
+        deletedAt: null,
+      }),
+      undefined,
+      { tenantId: TENANT_ID, organizationId: ORG_ID },
+    )
+    expect(ruleSet.name).toBe('After')
+  })
+
+  it('scopes rule-set delete targets before applying the soft delete', async () => {
+    const remove = await loadRuleSetCommand('planner.availability-rule-sets.delete')
+    const em = createEm()
+    const ruleSet = buildRuleSet()
+    mockFindOneWithDecryption.mockImplementation(async (_em, _entity, where: Record<string, unknown>) => {
+      if (where.id === RULE_SET_ID && where.tenantId === TENANT_ID && where.organizationId === ORG_ID) return ruleSet
+      return null
+    })
+
+    await expect(remove.execute({ id: RULE_SET_ID }, createCtx(em))).resolves.toEqual({ ruleSetId: RULE_SET_ID })
+
+    expect(ruleSet.deletedAt).toBeInstanceOf(Date)
+    expect(em.flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not resolve a foreign availability target for an unscoped non-superadmin principal', async () => {
+    const update = await loadAvailabilityCommand('planner.availability.update')
+    const em = createEm()
+    const foreignRule = buildRule({ tenantId: '66666666-6666-4666-8666-666666666666' })
+    em.findOne.mockImplementation(async (_entity: unknown, where: Record<string, unknown>) => {
+      if (where.id === RULE_ID && !('tenantId' in where) && !('organizationId' in where)) return foreignRule
+      return null
+    })
+
+    await expect(
+      update.execute({ id: RULE_ID, note: 'After' }, createNullScopeCtx(em)),
+    ).rejects.toMatchObject<Partial<CrudHttpError>>({ status: 404 })
+
+    expect(foreignRule.note).toBe('Before')
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('preserves unrestricted target resolution for explicit superadmin contexts', async () => {
+    const update = await loadAvailabilityCommand('planner.availability.update')
+    const em = createEm()
+    const rule = buildRule()
+    em.findOne.mockImplementation(async (_entity: unknown, where: Record<string, unknown>) => {
+      if (where.id === RULE_ID && !('tenantId' in where) && !('organizationId' in where)) return rule
+      return null
+    })
+    const ctx = createCtx(em, {
+      auth: { sub: 'superadmin-1', tenantId: null, orgId: null, isSuperAdmin: true },
+      selectedOrganizationId: null,
+      organizationIds: null,
+    })
+
+    await expect(update.execute({ id: RULE_ID, note: 'After' }, ctx)).resolves.toEqual({ ruleId: RULE_ID })
+
+    expect(rule.note).toBe('After')
+  })
+})

--- a/packages/core/src/modules/planner/commands/availability-rule-sets.ts
+++ b/packages/core/src/modules/planner/commands/availability-rule-sets.ts
@@ -17,7 +17,16 @@ import {
 } from '../data/validators'
 import { plannerAvailabilityRuleSetCrudEvents } from '../lib/crud'
 import { makeCreateRedo } from '@open-mercato/shared/lib/commands/redo'
-import { ensureOrganizationScope, ensureTenantScope, extractUndoPayload } from './shared'
+import {
+  applyScopeToWhere,
+  commandActorScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  explicitPlannerCommandScope,
+  extractUndoPayload,
+  scopeForDecryption,
+  type PlannerCommandScope,
+} from './shared'
 import { E } from '#generated/entities.ids.generated'
 
 const availabilityRuleSetCrudIndexer: CrudIndexerConfig<PlannerAvailabilityRuleSet> = {
@@ -43,13 +52,14 @@ type AvailabilityRuleSetUndoPayload = {
 async function loadAvailabilityRuleSetSnapshot(
   em: EntityManager,
   id: string,
+  scope: PlannerCommandScope,
 ): Promise<AvailabilityRuleSetSnapshot | null> {
   const ruleSet = await findOneWithDecryption(
     em,
     PlannerAvailabilityRuleSet,
-    { id },
+    applyScopeToWhere<PlannerAvailabilityRuleSet>({ id }, scope),
     undefined,
-    { tenantId: null, organizationId: null },
+    scopeForDecryption(scope),
   )
   if (!ruleSet) return null
   const custom = await loadCustomFieldSnapshot(em, {
@@ -114,15 +124,23 @@ const createAvailabilityRuleSetCommand: CommandHandler<PlannerAvailabilityRuleSe
     })
     return { ruleSetId: record.id }
   },
-  captureAfter: async (_input, result, ctx) => {
+  captureAfter: async (input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadAvailabilityRuleSetSnapshot(em, result.ruleSetId)
+    const snapshot = await loadAvailabilityRuleSetSnapshot(
+      em,
+      result.ruleSetId,
+      explicitPlannerCommandScope(input.tenantId, input.organizationId),
+    )
     if (!snapshot) return null
     return snapshot
   },
-  buildLog: async ({ result, ctx }) => {
+  buildLog: async ({ input, result, ctx }) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const snapshot = await loadAvailabilityRuleSetSnapshot(em, result.ruleSetId)
+    const snapshot = await loadAvailabilityRuleSetSnapshot(
+      em,
+      result.ruleSetId,
+      explicitPlannerCommandScope(input.tenantId, input.organizationId),
+    )
     if (!snapshot) return null
     const { translate } = await resolveTranslations()
     return {
@@ -190,19 +208,20 @@ const updateAvailabilityRuleSetCommand: CommandHandler<PlannerAvailabilityRuleSe
   async prepare(input, ctx) {
     const { parsed } = parseWithCustomFields(plannerAvailabilityRuleSetUpdateSchema, input)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadAvailabilityRuleSetSnapshot(em, parsed.id)
+    const snapshot = await loadAvailabilityRuleSetSnapshot(em, parsed.id, commandActorScope(ctx))
     if (!snapshot) return {}
     return { before: snapshot }
   },
   async execute(input, ctx) {
     const { parsed, custom } = parseWithCustomFields(plannerAvailabilityRuleSetUpdateSchema, input)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const record = await findOneWithDecryption(
       em,
       PlannerAvailabilityRuleSet,
-      { id: parsed.id, deletedAt: null },
+      applyScopeToWhere<PlannerAvailabilityRuleSet>({ id: parsed.id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!record) throw new CrudHttpError(404, { error: 'Planner availability rule set not found.' })
     ensureTenantScope(ctx, record.tenantId)
@@ -240,7 +259,11 @@ const updateAvailabilityRuleSetCommand: CommandHandler<PlannerAvailabilityRuleSe
     const before = snapshots.before as AvailabilityRuleSetSnapshot | undefined
     if (!before) return null
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const after = await loadAvailabilityRuleSetSnapshot(em, before.id)
+    const after = await loadAvailabilityRuleSetSnapshot(
+      em,
+      before.id,
+      explicitPlannerCommandScope(before.tenantId, before.organizationId),
+    )
     if (!after) return null
     const changes = buildChanges(before as unknown as Record<string, unknown>, after as unknown as Record<string, unknown>, [
       'name',
@@ -319,7 +342,7 @@ const deleteAvailabilityRuleSetCommand: CommandHandler<{ id?: string }, { ruleSe
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Availability rule set id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadAvailabilityRuleSetSnapshot(em, id)
+    const snapshot = await loadAvailabilityRuleSetSnapshot(em, id, commandActorScope(ctx))
     if (!snapshot) return {}
     return { before: snapshot }
   },
@@ -327,12 +350,13 @@ const deleteAvailabilityRuleSetCommand: CommandHandler<{ id?: string }, { ruleSe
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Availability rule set id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const scope = commandActorScope(ctx)
     const record = await findOneWithDecryption(
       em,
       PlannerAvailabilityRuleSet,
-      { id, deletedAt: null },
+      applyScopeToWhere<PlannerAvailabilityRuleSet>({ id, deletedAt: null }, scope),
       undefined,
-      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.auth?.orgId ?? null },
+      scopeForDecryption(scope),
     )
     if (!record) throw new CrudHttpError(404, { error: 'Planner availability rule set not found.' })
     ensureTenantScope(ctx, record.tenantId)

--- a/packages/core/src/modules/planner/commands/availability.ts
+++ b/packages/core/src/modules/planner/commands/availability.ts
@@ -10,9 +10,16 @@ import {
   type PlannerAvailabilityRuleCreateInput,
   type PlannerAvailabilityRuleUpdateInput,
 } from '../data/validators'
-import { ensureOrganizationScope, ensureTenantScope } from './shared'
+import {
+  applyScopeToWhere,
+  commandActorScope,
+  ensureOrganizationScope,
+  ensureTenantScope,
+  explicitPlannerCommandScope,
+  extractUndoPayload,
+  type PlannerCommandScope,
+} from './shared'
 import type { PlannerAvailabilityKind, PlannerAvailabilitySubjectType } from '../data/entities'
-import { extractUndoPayload } from './shared'
 import { resolveRedoSnapshot } from '@open-mercato/shared/lib/commands/redo'
 
 const AVAILABILITY_RULE_RESOURCE_KIND = 'planner.availability.rule'
@@ -38,8 +45,15 @@ type AvailabilityRuleUndoPayload = {
   after?: AvailabilityRuleSnapshot | null
 }
 
-async function loadAvailabilityRuleSnapshot(em: EntityManager, id: string): Promise<AvailabilityRuleSnapshot | null> {
-  const record = await em.findOne(PlannerAvailabilityRule, { id })
+async function loadAvailabilityRuleSnapshot(
+  em: EntityManager,
+  id: string,
+  scope: PlannerCommandScope,
+): Promise<AvailabilityRuleSnapshot | null> {
+  const record = await em.findOne(
+    PlannerAvailabilityRule,
+    applyScopeToWhere<PlannerAvailabilityRule>({ id }, scope),
+  )
   if (!record) return null
   return {
     id: record.id,
@@ -125,9 +139,13 @@ const createAvailabilityRuleCommand: CommandHandler<PlannerAvailabilityRuleCreat
     await em.flush()
     return { ruleId: record.id }
   },
-  captureAfter: async (_input, result, ctx) => {
+  captureAfter: async (input, result, ctx) => {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    return loadAvailabilityRuleSnapshot(em, result.ruleId)
+    return loadAvailabilityRuleSnapshot(
+      em,
+      result.ruleId,
+      explicitPlannerCommandScope(input.tenantId, input.organizationId),
+    )
   },
   buildLog: async ({ input, result, ctx, snapshots }) => {
     const snapshot = snapshots.after as AvailabilityRuleSnapshot | undefined
@@ -171,13 +189,19 @@ const updateAvailabilityRuleCommand: CommandHandler<PlannerAvailabilityRuleUpdat
   async prepare(input, ctx) {
     const parsed = plannerAvailabilityRuleUpdateSchema.parse(input)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadAvailabilityRuleSnapshot(em, parsed.id)
+    const snapshot = await loadAvailabilityRuleSnapshot(em, parsed.id, commandActorScope(ctx))
     return snapshot ? { before: snapshot } : {}
   },
   async execute(input, ctx) {
     const parsed = plannerAvailabilityRuleUpdateSchema.parse(input)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const record = await em.findOne(PlannerAvailabilityRule, { id: parsed.id, deletedAt: null })
+    const record = await em.findOne(
+      PlannerAvailabilityRule,
+      applyScopeToWhere<PlannerAvailabilityRule>(
+        { id: parsed.id, deletedAt: null },
+        commandActorScope(ctx),
+      ),
+    )
     if (!record) throw new CrudHttpError(404, { error: 'Planner availability rule not found.' })
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
@@ -208,7 +232,13 @@ const updateAvailabilityRuleCommand: CommandHandler<PlannerAvailabilityRuleUpdat
   buildLog: async ({ snapshots, input, result, ctx }) => {
     const before = snapshots.before as AvailabilityRuleSnapshot | undefined
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const afterSnapshot = before ? await loadAvailabilityRuleSnapshot(em, before.id) : null
+    const afterSnapshot = before
+      ? await loadAvailabilityRuleSnapshot(
+          em,
+          before.id,
+          explicitPlannerCommandScope(before.tenantId, before.organizationId),
+        )
+      : null
     const { translate } = await resolveTranslations()
     return {
       actionLabel: translate('planner.audit.availability.update', 'Update availability rule'),
@@ -242,14 +272,17 @@ const deleteAvailabilityRuleCommand: CommandHandler<{ id?: string }, { ruleId: s
     const id = input?.id
     if (!id) return {}
     const em = (ctx.container.resolve('em') as EntityManager)
-    const snapshot = await loadAvailabilityRuleSnapshot(em, id)
+    const snapshot = await loadAvailabilityRuleSnapshot(em, id, commandActorScope(ctx))
     return snapshot ? { before: snapshot } : {}
   },
   async execute(input, ctx) {
     const id = input?.id
     if (!id) throw new CrudHttpError(400, { error: 'Availability rule id is required.' })
     const em = (ctx.container.resolve('em') as EntityManager).fork()
-    const record = await em.findOne(PlannerAvailabilityRule, { id, deletedAt: null })
+    const record = await em.findOne(
+      PlannerAvailabilityRule,
+      applyScopeToWhere<PlannerAvailabilityRule>({ id, deletedAt: null }, commandActorScope(ctx)),
+    )
     if (!record) return { ruleId: id }
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)

--- a/packages/core/src/modules/planner/commands/shared.ts
+++ b/packages/core/src/modules/planner/commands/shared.ts
@@ -1,4 +1,55 @@
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
+import type { FilterQuery } from '@mikro-orm/postgresql'
 
 export { ensureOrganizationScope, ensureTenantScope, extractUndoPayload }
+
+export type PlannerCommandScope = {
+  tenantId: string | null
+  organizationId: string | null
+  requireTenant: boolean
+  requireOrganization: boolean
+}
+
+export function commandActorScope(ctx: CommandRuntimeContext): PlannerCommandScope {
+  const isPrivilegedActor = ctx.auth?.isSuperAdmin === true || ctx.systemActor === true
+  const tenantId = isPrivilegedActor ? null : (ctx.auth?.tenantId ?? ctx.organizationScope?.tenantId ?? null)
+  const organizationId = isPrivilegedActor ? null : (ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null)
+  const organizationUnrestricted =
+    isPrivilegedActor || (organizationId === null && tenantId !== null && ctx.organizationScope?.allowedIds === null)
+  return {
+    tenantId,
+    organizationId: organizationUnrestricted ? null : organizationId,
+    requireTenant: !isPrivilegedActor,
+    requireOrganization: !organizationUnrestricted,
+  }
+}
+
+export function explicitPlannerCommandScope(
+  tenantId: string | null,
+  organizationId: string | null,
+): PlannerCommandScope {
+  return {
+    tenantId,
+    organizationId,
+    requireTenant: true,
+    requireOrganization: true,
+  }
+}
+
+export function applyScopeToWhere<TEntity extends object>(
+  where: FilterQuery<TEntity>,
+  scope: PlannerCommandScope,
+): FilterQuery<TEntity> {
+  const scoped = { ...(where as Record<string, unknown>) }
+  if (scope.requireTenant || scope.tenantId !== null) scoped.tenantId = scope.tenantId
+  if (scope.requireOrganization || scope.organizationId !== null) scoped.organizationId = scope.organizationId
+  return scoped as FilterQuery<TEntity>
+}
+
+export function scopeForDecryption(
+  scope: PlannerCommandScope,
+): { tenantId: string | null; organizationId: string | null } {
+  return { tenantId: scope.tenantId, organizationId: scope.organizationId }
+}


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Planner availability-rule and rule-set update/delete commands loaded target records by ID before applying tenant and organization guards. Scope predicates are now included directly in target and snapshot queries, so accidental null-scope callers cannot resolve foreign records.

## Changes

- Added centralized planner command actor-scope and scoped-query helpers.
- Scoped availability-rule update/delete and snapshot queries.
- Scoped availability-rule-set update/delete queries and aligned their decryption scope.
- Preserved intentional unrestricted access for explicit superadmin and system-actor contexts.
- Added regression coverage for scoped, null-scope, and superadmin command execution.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->

N/A — focused security hardening with no public contract, schema, or wire-format change.

## Testing

- Regression test observed failing before the fix with five scope-related failures, then passing 6/6 after the fix.
- Planner suite: 12 suites, 51/51 tests passed.
- `yarn build:packages` passed before and after generation.
- `yarn generate` passed.
- `yarn i18n:check-sync` passed.
- `yarn i18n:check-usage` exited successfully with existing advisory findings.
- `yarn typecheck` passed, 21/21 tasks.
- `yarn test` passed, 22/22 tasks.
- `yarn build:app` passed.
- Scoped ESLint passed.

Integration coverage is not required because the reported null-scope condition is intentionally unreachable through current HTTP routes; the regression directly invokes the affected command boundary.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI or design-system files changed.

## Linked issues

Fixes #3884
