### PR TITLE
fix(onboarding): prevent anonymous feedback recipient emails (#3879)

### DIFF
--- a/apps/mercato/src/components/DemoFeedbackWidget.tsx
+++ b/apps/mercato/src/components/DemoFeedbackWidget.tsx
@@ -54,7 +54,6 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
   const [message, setMessage] = useState('')
   const [termsAccepted, setTermsAccepted] = useState(false)
   const [marketingConsent, setMarketingConsent] = useState(false)
-  const [sendCopy, setSendCopy] = useState(true)
   const [suppressPopup, setSuppressPopup] = useState(false)
   const [submitState, setSubmitState] = useState<SubmitState>('idle')
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -164,7 +163,6 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
             message: message.trim(),
             termsAccepted,
             marketingConsent,
-            sendCopy,
           }),
         },
       )
@@ -181,7 +179,7 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
       setSubmitError(t('demoFeedback.errors.generic', 'Something went wrong. Please try again.'))
       setSubmitState('error')
     }
-  }, [email, message, termsAccepted, marketingConsent, sendCopy, suppressPopup, t])
+  }, [email, message, termsAccepted, marketingConsent, suppressPopup, t])
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && submitState === 'idle') {
@@ -195,7 +193,6 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
     setMessage('')
     setTermsAccepted(false)
     setMarketingConsent(false)
-    setSendCopy(true)
     setSubmitState('idle')
     setSubmitError(null)
     setFieldErrors({})
@@ -355,16 +352,6 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
                       </span>
                     ))}
                 </span>
-              </label>
-
-              <label className="flex items-center gap-2.5 text-xs text-muted-foreground">
-                <Checkbox
-                  id="feedback-send-copy"
-                  checked={sendCopy}
-                  disabled={submitState === 'sending'}
-                  onCheckedChange={(v) => setSendCopy(v === true)}
-                />
-                <span>{t('demoFeedback.form.sendCopy', 'Send me a copy of this message')}</span>
               </label>
 
               <label className="flex items-center gap-2.5 text-xs text-muted-foreground">

--- a/packages/create-app/template/src/components/DemoFeedbackWidget.tsx
+++ b/packages/create-app/template/src/components/DemoFeedbackWidget.tsx
@@ -54,7 +54,6 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
   const [message, setMessage] = useState('')
   const [termsAccepted, setTermsAccepted] = useState(false)
   const [marketingConsent, setMarketingConsent] = useState(false)
-  const [sendCopy, setSendCopy] = useState(true)
   const [suppressPopup, setSuppressPopup] = useState(false)
   const [submitState, setSubmitState] = useState<SubmitState>('idle')
   const [submitError, setSubmitError] = useState<string | null>(null)
@@ -164,7 +163,6 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
             message: message.trim(),
             termsAccepted,
             marketingConsent,
-            sendCopy,
           }),
         },
       )
@@ -181,7 +179,7 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
       setSubmitError(t('demoFeedback.errors.generic', 'Something went wrong. Please try again.'))
       setSubmitState('error')
     }
-  }, [email, message, termsAccepted, marketingConsent, sendCopy, suppressPopup, t])
+  }, [email, message, termsAccepted, marketingConsent, suppressPopup, t])
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && submitState === 'idle') {
@@ -195,7 +193,6 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
     setMessage('')
     setTermsAccepted(false)
     setMarketingConsent(false)
-    setSendCopy(true)
     setSubmitState('idle')
     setSubmitError(null)
     setFieldErrors({})
@@ -355,16 +352,6 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
                       </span>
                     ))}
                 </span>
-              </label>
-
-              <label className="flex items-center gap-2.5 text-xs text-muted-foreground">
-                <Checkbox
-                  id="feedback-send-copy"
-                  checked={sendCopy}
-                  disabled={submitState === 'sending'}
-                  onCheckedChange={(v) => setSendCopy(v === true)}
-                />
-                <span>{t('demoFeedback.form.sendCopy', 'Send me a copy of this message')}</span>
               </label>
 
               <label className="flex items-center gap-2.5 text-xs text-muted-foreground">

--- a/packages/onboarding/src/__tests__/demo-feedback-email.test.ts
+++ b/packages/onboarding/src/__tests__/demo-feedback-email.test.ts
@@ -1,0 +1,64 @@
+const sendEmailMock = jest.fn()
+const checkAuthRateLimitMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/email/send', () => ({
+  sendEmail: jest.fn((args: unknown) => sendEmailMock(args)),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/lib/rateLimitCheck', () => ({
+  checkAuthRateLimit: jest.fn((args: unknown) => checkAuthRateLimitMock(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/ratelimit/config', () => ({
+  readEndpointRateLimitConfig: jest.fn(() => ({})),
+}))
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/emails/FeedbackEmail', () => ({
+  __esModule: true,
+  default: jest.fn(() => null),
+}))
+
+import { POST } from '../modules/onboarding/api/demo-feedback/route'
+
+function makeRequest(sendCopy?: boolean) {
+  return new Request('http://localhost/api/onboarding/demo-feedback', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      email: 'unverified@example.com',
+      message: 'Please contact me.',
+      termsAccepted: true,
+      marketingConsent: false,
+      ...(sendCopy === undefined ? {} : { sendCopy }),
+    }),
+  })
+}
+
+describe('POST /api/onboarding/demo-feedback', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...originalEnv, ADMIN_EMAIL: 'admin@example.com' }
+    checkAuthRateLimitMock.mockResolvedValue({ error: null })
+    sendEmailMock.mockResolvedValue(undefined)
+  })
+
+  afterAll(() => {
+    process.env = originalEnv
+  })
+
+  it.each([
+    ['when sendCopy is omitted', undefined],
+    ['when sendCopy is explicitly requested', true],
+  ])('sends feedback only to the configured admin %s', async (_label, sendCopy) => {
+    const response = await POST(makeRequest(sendCopy))
+
+    expect(response.status).toBe(200)
+    expect(sendEmailMock).toHaveBeenCalledTimes(1)
+    expect(sendEmailMock).toHaveBeenCalledWith(expect.objectContaining({ to: 'admin@example.com' }))
+    expect(sendEmailMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'unverified@example.com' }),
+    )
+  })
+})

--- a/packages/onboarding/src/modules/onboarding/api/demo-feedback/route.ts
+++ b/packages/onboarding/src/modules/onboarding/api/demo-feedback/route.ts
@@ -25,7 +25,6 @@ const feedbackSchema = z.object({
   message: z.string().max(5000).optional().default(''),
   termsAccepted: z.literal(true),
   marketingConsent: z.boolean().optional().default(false),
-  sendCopy: z.boolean().optional().default(true),
 })
 
 export async function POST(req: Request) {
@@ -47,7 +46,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: 'Please check the form and try again.' }, { status: 400 })
   }
 
-  const { email, message, marketingConsent, sendCopy } = parsed.data
+  const { email, message, marketingConsent } = parsed.data
   const adminEmail = process.env.ADMIN_EMAIL || 'piotr@catchthetornado.com'
 
   const marketingText = marketingConsent ? 'Marketing consent: Yes' : 'Marketing consent: No'
@@ -75,27 +74,6 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: 'Failed to send feedback. Please try again.' }, { status: 502 })
   }
 
-  if (sendCopy) {
-    const userCopy = {
-      preview: 'Your feedback to Open Mercato',
-      heading: 'Thank you for reaching out!',
-      body: 'We received your message and will get back to you shortly. Below is a copy of what you submitted.',
-      messageLabel: 'Your message:',
-      message: message || '(no message provided)',
-      marketingConsent: marketingText,
-      footer: 'Open Mercato \u00b7 demo.openmercato.com',
-    }
-    try {
-      await sendEmail({
-        to: email,
-        subject: 'Your feedback to Open Mercato',
-        react: FeedbackEmail({ copy: userCopy }),
-      })
-    } catch (err) {
-      logger.error('User copy email failed', { err })
-    }
-  }
-
   return NextResponse.json({ ok: true })
 }
 
@@ -105,7 +83,7 @@ const feedbackTag = 'Demo'
 
 const feedbackPostDoc: OpenApiMethodDoc = {
   summary: 'Submit demo feedback',
-  description: 'Sends a feedback/contact request from the demo environment to the admin and optionally to the user.',
+  description: 'Sends a feedback/contact request from the demo environment to the configured admin.',
   tags: [feedbackTag],
   requestBody: {
     contentType: 'application/json',

--- a/packages/onboarding/src/modules/onboarding/i18n/de.json
+++ b/packages/onboarding/src/modules/onboarding/i18n/de.json
@@ -14,7 +14,6 @@
   "demoFeedback.form.marketingLabel": "Ich stimme dem Erhalt von Direktmarketing von CT Tornado per E-Mail zu. Ich kann meine Einwilligung jederzeit widerrufen. Siehe {termsLink} und {privacyLink}.",
   "demoFeedback.form.message": "Ihre Nachricht (optional)",
   "demoFeedback.form.privacyLink": "Datenschutzerklärung",
-  "demoFeedback.form.sendCopy": "Kopie dieser Nachricht an mich senden",
   "demoFeedback.form.submit": "Kontaktieren Sie mich",
   "demoFeedback.form.suppressPopup": "Dieses Popup nicht automatisch anzeigen",
   "demoFeedback.form.termsAnd": " und ",

--- a/packages/onboarding/src/modules/onboarding/i18n/en.json
+++ b/packages/onboarding/src/modules/onboarding/i18n/en.json
@@ -14,7 +14,6 @@
   "demoFeedback.form.marketingLabel": "I consent to receiving direct marketing from CT Tornado by email. I can withdraw my consent at any time. See our {termsLink} and {privacyLink}.",
   "demoFeedback.form.message": "Your message (optional)",
   "demoFeedback.form.privacyLink": "Privacy Policy",
-  "demoFeedback.form.sendCopy": "Send me a copy of this message",
   "demoFeedback.form.submit": "Contact me",
   "demoFeedback.form.suppressPopup": "Do not show this popup automatically",
   "demoFeedback.form.termsAnd": " and ",

--- a/packages/onboarding/src/modules/onboarding/i18n/es.json
+++ b/packages/onboarding/src/modules/onboarding/i18n/es.json
@@ -14,7 +14,6 @@
   "demoFeedback.form.marketingLabel": "Doy mi consentimiento para recibir marketing directo de CT Tornado por correo electrónico. Puedo retirar mi consentimiento en cualquier momento. Consulte los {termsLink} y la {privacyLink}.",
   "demoFeedback.form.message": "Su mensaje (opcional)",
   "demoFeedback.form.privacyLink": "Política de privacidad",
-  "demoFeedback.form.sendCopy": "Enviarme una copia de este mensaje",
   "demoFeedback.form.submit": "Contácteme",
   "demoFeedback.form.suppressPopup": "No mostrar esta ventana automáticamente",
   "demoFeedback.form.termsAnd": " y la ",

--- a/packages/onboarding/src/modules/onboarding/i18n/pl.json
+++ b/packages/onboarding/src/modules/onboarding/i18n/pl.json
@@ -14,7 +14,6 @@
   "demoFeedback.form.marketingLabel": "Wyrażam zgodę na otrzymywanie marketingu bezpośredniego od CT Tornado drogą elektroniczną. Mogę wycofać zgodę w dowolnym momencie. Zobacz {termsLink} i {privacyLink}.",
   "demoFeedback.form.message": "Twoja wiadomość (opcjonalnie)",
   "demoFeedback.form.privacyLink": "Politykę prywatności",
-  "demoFeedback.form.sendCopy": "Wyślij mi kopię tej wiadomości",
   "demoFeedback.form.submit": "Skontaktuj się ze mną",
   "demoFeedback.form.suppressPopup": "Nie pokazuj tego okna automatycznie",
   "demoFeedback.form.termsAnd": " oraz ",


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Prevent the unauthenticated demo-feedback endpoint from sending email to an attacker-controlled recipient while preserving the admin notification and existing response contract.

## Changes

- Remove the anonymous user-copy email dispatch from the demo-feedback route.
- Remove the send-copy control and payload from the app and create-app template.
- Remove the unused send-copy translation key from all four locales.
- Add regression coverage for omitted and explicit `sendCopy:true` payloads.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->

N/A — isolated security bug fix with no architectural or public response-contract change.

## Testing

- Regression test reproduced two email calls before the fix and one admin-only call afterward.
- `yarn workspace @open-mercato/onboarding test --runInBand` — 93/93 passed.
- Scoped onboarding typecheck and touched-file ESLint — passed.
- `yarn build:packages` → `yarn generate` → `yarn build:packages` — passed.
- `yarn i18n:check-sync` and `yarn i18n:check-usage` — exited 0.
- `yarn typecheck` — 21/21 tasks passed.
- `yarn test` — 22/22 tasks passed.
- `yarn build:app` — passed.
- Ephemeral browser/API probe accepted a legacy `sendCopy:true` payload and returned HTTP 200 with email delivery disabled.
- Integration test N/A: the security invariant is isolated to email recipient dispatch and is covered directly by the route regression test.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A for empty/loading states — this change removes one existing checkbox and adds no data page or asynchronous UI state.

## Linked issues

Fixes #3879
