### PR TITLE
fix(payment_gateways): reject over-limit captures (#3880)

### DIFF
--- a/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.test.ts
+++ b/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.test.ts
@@ -27,6 +27,7 @@ function makeTransaction(status: UnifiedPaymentStatus): GatewayTransaction {
     providerKey: PROVIDER_KEY,
     providerSessionId: 'sess_1',
     unifiedStatus: status,
+    amount: '100.00',
     gatewayMetadata: {},
     gatewayRefundId: null,
     organizationId: scope.organizationId,
@@ -158,6 +159,19 @@ describe('payment gateway service — status-machine guard (#3271)', () => {
     expect(result.status).toBe('captured')
     expect(transaction.unifiedStatus).toBe('captured')
     expect(flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a capture above the authorized transaction amount before calling the adapter', async () => {
+    const transaction = makeTransaction('authorized')
+    const { service, captureFn, flush } = buildService(transaction, {
+      capture: { status: 'captured', capturedAmount: 125 },
+    })
+
+    await expect(service.capturePayment(transaction.id, 125, scope)).rejects.toMatchObject({ status: 409 })
+
+    expect(captureFn).not.toHaveBeenCalled()
+    expect(transaction.unifiedStatus).toBe('authorized')
+    expect(flush).not.toHaveBeenCalled()
   })
 
   it('treats a same-status capture as idempotent (double capture stays captured)', async () => {

--- a/packages/core/src/modules/payment_gateways/lib/gateway-service.ts
+++ b/packages/core/src/modules/payment_gateways/lib/gateway-service.ts
@@ -27,6 +27,12 @@ function assertManualActionAllowed(action: ManualGatewayAction, transaction: Gat
   }
 }
 
+function assertCaptureAmountAllowed(amount: number | undefined, transaction: GatewayTransaction): void {
+  if (amount !== undefined && amount > Number(transaction.amount)) {
+    throw conflict(`Capture amount ${amount} exceeds authorized transaction amount ${transaction.amount}`)
+  }
+}
+
 function applyAdapterResultStatus(
   action: ManualGatewayAction,
   transaction: GatewayTransaction,
@@ -223,6 +229,7 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
     async capturePayment(transactionId: string, amount: number | undefined, scope: { organizationId: string; tenantId: string }): Promise<CaptureResult> {
       const transaction = await findTransactionOrThrow(transactionId, scope)
       assertManualActionAllowed('capture', transaction)
+      assertCaptureAmountAllowed(amount, transaction)
       const { adapter, credentials } = await resolveAdapterAndCredentials(
         transaction.providerKey,
         { organizationId: transaction.organizationId, tenantId: transaction.tenantId },


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Prevent manual payment captures from exceeding the amount authorized on the persisted gateway transaction. Explicit over-limit captures now fail before credentials are resolved or the provider adapter is called, while full and partial captures remain supported.

## Changes

- Validate explicit capture amounts against `GatewayTransaction.amount`.
- Return a 409 conflict before provider invocation when the requested amount exceeds the authorized amount.
- Add regression coverage proving the adapter and entity manager remain untouched after rejection.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->

`.ai/specs/implemented/SPEC-044-2026-02-24-payment-gateway-integrations.md` and `.ai/specs/implemented/SPEC-045h-stripe-payment-gateway.md`

## Testing

- Regression test demonstrated red → green behavior: `yarn workspace @open-mercato/core test --runInBand packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.test.ts`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage` — existing unused-key advisory only
- `yarn typecheck`
- `yarn test` — 22/22 tasks; core 976 suites and 7,463 tests
- `yarn build:app`
- Scoped ESLint for both changed files

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Integration coverage rationale: the invariant is isolated in the gateway service and is covered directly with adapter and persistence assertions; existing route tests cover ACL and service delegation.

Spec rationale: the implemented payment-gateway specifications already define partial capture; this focused bug fix does not change that contract.

QA routing: `needs-qa` because the change affects payment capture behavior.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI changes.

## Linked issues

Fixes #3880
