### PR TITLE
fix(onboarding): close disabled self-service flow (#3878)

### DIFF
--- a/packages/onboarding/src/__tests__/self-service-enabled-endpoints.test.ts
+++ b/packages/onboarding/src/__tests__/self-service-enabled-endpoints.test.ts
@@ -1,0 +1,35 @@
+import { GET as getOnboardingStatus } from '../modules/onboarding/api/get/onboarding/status'
+import { GET as verifyOnboardingRequest } from '../modules/onboarding/api/get/onboarding/verify'
+
+jest.mock('@open-mercato/onboarding/modules/onboarding/lib/consentClientIp', () => ({
+  resolveConsentClientIp: jest.fn(),
+}))
+
+const originalSelfServiceOnboardingEnabled = process.env.SELF_SERVICE_ONBOARDING_ENABLED
+
+describe('self-service onboarding route gate', () => {
+  beforeEach(() => {
+    process.env.SELF_SERVICE_ONBOARDING_ENABLED = 'false'
+  })
+
+  afterAll(() => {
+    if (originalSelfServiceOnboardingEnabled === undefined) {
+      delete process.env.SELF_SERVICE_ONBOARDING_ENABLED
+    } else {
+      process.env.SELF_SERVICE_ONBOARDING_ENABLED = originalSelfServiceOnboardingEnabled
+    }
+  })
+
+  it.each([
+    ['verify', verifyOnboardingRequest, 'https://app.example.com/api/onboarding/onboarding/verify'],
+    ['status', getOnboardingStatus, 'https://app.example.com/api/onboarding/onboarding/status'],
+  ])('returns 404 from the %s route when self-service onboarding is disabled', async (_name, handler, url) => {
+    const response = await handler(new Request(url))
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: 'Self-service onboarding is disabled.',
+    })
+  })
+})

--- a/packages/onboarding/src/__tests__/status-endpoint-auth.test.ts
+++ b/packages/onboarding/src/__tests__/status-endpoint-auth.test.ts
@@ -5,6 +5,7 @@ const sendWorkspaceReadyEmail = jest.fn()
 const assertAllowedAppOrigin = jest.fn()
 const markCompleted = jest.fn()
 const runDeferredProvisioning = jest.fn()
+const originalSelfServiceOnboardingEnabled = process.env.SELF_SERVICE_ONBOARDING_ENABLED
 
 jest.mock('next/server', () => {
   const actual = jest.requireActual('next/server')
@@ -85,6 +86,7 @@ function buildRequest(args: { tenantId: string; cookie?: string }) {
 
 describe('onboarding status endpoint authorization', () => {
   beforeEach(() => {
+    process.env.SELF_SERVICE_ONBOARDING_ENABLED = 'true'
     findLatestByTenantId.mockReset()
     sendWorkspaceReadyEmail.mockReset()
     assertAllowedAppOrigin.mockReset()
@@ -103,6 +105,14 @@ describe('onboarding status endpoint authorization', () => {
       request.processingStartedAt = null
     })
     findLatestByTenantId.mockResolvedValue(makeRequest())
+  })
+
+  afterAll(() => {
+    if (originalSelfServiceOnboardingEnabled === undefined) {
+      delete process.env.SELF_SERVICE_ONBOARDING_ENABLED
+    } else {
+      process.env.SELF_SERVICE_ONBOARDING_ENABLED = originalSelfServiceOnboardingEnabled
+    }
   })
 
   it('returns 403 and does not look up tenant state when no om_login_tenant cookie is present', async () => {

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/status.ts
@@ -1,6 +1,7 @@
 import { after, NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 import { assertAllowedAppOrigin, mapSecurityEmailUrlError } from '@open-mercato/shared/lib/url'
@@ -47,6 +48,9 @@ function readCookie(req: Request, name: string): string | null {
 }
 
 export async function GET(req: Request) {
+  if (parseBooleanToken(process.env.SELF_SERVICE_ONBOARDING_ENABLED ?? '') !== true) {
+    return NextResponse.json({ ok: false, error: 'Self-service onboarding is disabled.' }, { status: 404 })
+  }
   const url = new URL(req.url)
   const tenantId = url.searchParams.get('tenantId') || url.searchParams.get('tenant') || ''
   const parsed = onboardingStatusQuerySchema.safeParse({ tenantId })

--- a/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
+++ b/packages/onboarding/src/modules/onboarding/api/get/onboarding/verify.ts
@@ -1,6 +1,7 @@
 import { after, NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
+import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { onboardingVerifySchema } from '@open-mercato/onboarding/modules/onboarding/data/validators'
 import type { OnboardingRequest } from '@open-mercato/onboarding/modules/onboarding/data/entities'
@@ -107,6 +108,9 @@ async function completeProvisionedRequest(args: {
 }
 
 export async function GET(req: Request) {
+  if (parseBooleanToken(process.env.SELF_SERVICE_ONBOARDING_ENABLED ?? '') !== true) {
+    return NextResponse.json({ ok: false, error: 'Self-service onboarding is disabled.' }, { status: 404 })
+  }
   const url = new URL(req.url)
   const baseUrlResult = resolveVerifyRedirectBaseUrl(req)
   if (!baseUrlResult.ok) {


### PR DESCRIPTION
## Summary

Prevent previously issued onboarding tokens or tenant cookies from continuing tenant provisioning after self-service onboarding has been disabled.

## Changes

- Gate the onboarding verify route with `SELF_SERVICE_ONBOARDING_ENABLED` before validation or provisioning.
- Gate the onboarding status route before cookie checks, database access, or deferred provisioning.
- Add route-level regression coverage for both disabled endpoints.
- Preserve enabled-path status behavior and stable route contracts.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — isolated security bug fix with no architecture or public-route change.

## Testing

- `yarn workspace @open-mercato/onboarding test --runInBand` — 93 tests passed
- `yarn workspace @open-mercato/onboarding build`
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- Scoped ESLint and `git diff --check`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). Route-level unit coverage exercises the environment gate directly; no UI or schema flow changed.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). N/A for this isolated fix.
- [x] Priority set: `priority-low`.
- [x] Risk set: `risk-low`.
- [x] QA routing set: `needs-qa` for the public onboarding flow.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI changes.

## Linked issues

Fixes #3878
