### PR TITLE
fix(notifications): return 400 for invalid restore status

### DIFF
--- a/packages/core/src/modules/notifications/__tests__/mutation-guard.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/mutation-guard.test.ts
@@ -161,6 +161,20 @@ describe('notification write routes run the mutation guard registry', () => {
     expect(runAfterSuccessMock).toHaveBeenCalled()
   })
 
+  it('returns 400 for an invalid restore status', async () => {
+    const response = await restoreNotification(
+      jsonRequest(`http://localhost/api/notifications/${notificationId}/restore`, 'PUT', { status: 'dismissed' }),
+      { params: Promise.resolve({ id: notificationId }) },
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: expect.stringContaining('Invalid request body'),
+    })
+    expect(serviceMock.restoreDismissed).not.toHaveBeenCalled()
+    expect(runRouteMutationGuardsMock).not.toHaveBeenCalled()
+  })
+
   it('guards execute action (POST /api/notifications/[id]/action)', async () => {
     const response = await executeNotificationAction(
       jsonRequest(`http://localhost/api/notifications/${notificationId}/action`, 'POST', { actionId: 'do' }),

--- a/packages/core/src/modules/notifications/api/[id]/restore/route.ts
+++ b/packages/core/src/modules/notifications/api/[id]/restore/route.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { restoreNotificationSchema } from '../../../data/validators'
 import {
   NOTIFICATION_RESOURCE_KIND,
+  notificationValidationErrorResponse,
   resolveNotificationContext,
   runGuardedNotificationWrite,
 } from '../../../lib/routeHelpers'
@@ -15,7 +16,11 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
   const { service, scope, ctx } = await resolveNotificationContext(req)
 
   const body = await req.json().catch(() => ({}))
-  const input = restoreNotificationSchema.parse(body)
+  const parsed = restoreNotificationSchema.safeParse(body)
+  if (!parsed.success) {
+    return notificationValidationErrorResponse(parsed.error)
+  }
+  const input = parsed.data
 
   const guarded = await runGuardedNotificationWrite(
     ctx.container,


### PR DESCRIPTION
## Summary

Malformed payloads sent to `PUT /api/notifications/[id]/restore` currently throw an uncaught Zod error and surface as a 500 response. This change returns the notifications module's standard 400 validation response instead.

## Changes

- Replace throwing restore-payload parsing with `safeParse()`.
- Reuse `notificationValidationErrorResponse()` for invalid payloads.
- Add regression coverage verifying invalid input does not reach mutation guards or persistence.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**

`.ai/specs/implemented/SPEC-003-2026-01-23-notifications-module.md`

## Testing

- `yarn workspace @open-mercato/core test src/modules/notifications/__tests__/mutation-guard.test.ts --runInBand`
- Scoped ESLint for the two changed files
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`

All checks passed. Integration coverage is not required because the focused route test directly exercises the malformed-payload path and verifies that neither mutation guards nor persistence execute.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance

N/A — no UI files or behavior changed.

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #3875
