### PR TITLE
fix(onboarding): encrypt pre-tenant request data (#3876)

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -969,3 +969,5 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: Use `node:crypto` helpers (`randomInt`, `randomUUID`, or `randomBytes`) for any generated value that may touch auth, security checks, identifiers, request headers, or authenticated API calls. Reserve `Math.random()` only for explicitly non-security demo data, and prefer deterministic fixtures when uniqueness is not required.
 
 **Applies to**: integration helpers, auth tests, rate-limit tests, fixture factories, temporary IDs, generated emails/passwords, and any test utility that feeds API requests or security-sensitive code paths.
+
+- 2026-07-10 · onboarding encryption: silently falling back when system encryption maps fail to load reopens plaintext writes → load security maps fail-closed before registering the encryption service.

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -1,6 +1,7 @@
 import type { AwilixContainer } from 'awilix'
 import { asValue } from 'awilix'
-import type { ModuleSubscriber } from '@open-mercato/shared/modules/registry'
+import { getDefaultEncryptionMaps, type ModuleSubscriber } from '@open-mercato/shared/modules/registry'
+import type { ModuleEncryptionMap } from '@open-mercato/shared/modules/encryption'
 import { createEventBus } from '@open-mercato/events/index'
 import { setGlobalEventBus } from '@open-mercato/shared/modules/events'
 import { createCacheService } from '@open-mercato/cache'
@@ -184,12 +185,26 @@ export async function bootstrap(container: AwilixContainer) {
   // KMS + tenant encryption
   const kmsService = createKmsService()
   container.register({ kmsService: asValue(kmsService) })
+  let defaultEncryptionMaps: ModuleEncryptionMap[] = []
+  if (isTenantDataEncryptionEnabled()) {
+    try {
+      const { getModules } = await import('@open-mercato/shared/lib/i18n/server')
+      defaultEncryptionMaps = getDefaultEncryptionMaps(getModules())
+    } catch (err) {
+      logger.error('Failed to load default encryption maps', { component: 'encryption', err })
+      throw err
+    }
+  }
   try {
     const em = container.resolve('em') as EntityManager
     const cacheService = (() => {
       try { return container.resolve('cache') as any } catch { return null }
     })()
-    const tenantEncryptionService = new TenantDataEncryptionService(em, { cache: cacheService, kms: kmsService })
+    const tenantEncryptionService = new TenantDataEncryptionService(em, {
+      cache: cacheService,
+      kms: kmsService,
+      defaultEncryptionMaps,
+    })
     container.register({ tenantEncryptionService: asValue(tenantEncryptionService) })
     if (isTenantDataEncryptionEnabled() && kmsService.isHealthy()) {
       try {

--- a/packages/core/src/modules/auth/lib/setup-app.ts
+++ b/packages/core/src/modules/auth/lib/setup-app.ts
@@ -5,7 +5,7 @@ import { Role, RoleAcl, User, UserRole } from '@open-mercato/core/modules/auth/d
 import { Tenant, Organization } from '@open-mercato/core/modules/directory/data/entities'
 import { rebuildHierarchyForTenant } from '@open-mercato/core/modules/directory/lib/hierarchy'
 import { normalizeTenantId } from './tenantAccess'
-import { computeEmailHash } from '@open-mercato/core/modules/auth/lib/emailHash'
+import { computeEmailHash, emailHashLookupValues } from '@open-mercato/core/modules/auth/lib/emailHash'
 import { getDefaultEncryptionMaps, type Module } from '@open-mercato/shared/modules/registry'
 import { isEncryptionDebugEnabled, isTenantDataEncryptionEnabled } from '@open-mercato/shared/lib/encryption/toggles'
 import { EncryptionMap } from '@open-mercato/core/modules/entities/data/entities'
@@ -190,7 +190,20 @@ export async function setupInitialTenant(
   const defaultEncryptionMaps = getDefaultEncryptionMaps(resolvedModules)
 
   const mainEmail = primaryUser.email
-  const existingUser = await findOneWithDecryption(em, User, { email: mainEmail }, {}, { tenantId: null, organizationId: null })
+  const existingUserByHash = await findOneWithDecryption(
+    em,
+    User,
+    { emailHash: { $in: emailHashLookupValues(mainEmail) }, deletedAt: null },
+    {},
+    { tenantId: null, organizationId: null },
+  )
+  const existingUser = existingUserByHash ?? await findOneWithDecryption(
+    em,
+    User,
+    { email: mainEmail, deletedAt: null },
+    {},
+    { tenantId: null, organizationId: null },
+  )
   if (existingUser && failIfUserExists) {
     throw new Error('USER_EXISTS')
   }

--- a/packages/onboarding/src/__tests__/encryption.test.ts
+++ b/packages/onboarding/src/__tests__/encryption.test.ts
@@ -1,0 +1,19 @@
+import { defaultEncryptionMaps } from '../modules/onboarding/encryption'
+
+describe('onboarding encryption map', () => {
+  it('protects pre-tenant PII and the transient password hash with a system key', () => {
+    expect(defaultEncryptionMaps).toEqual([
+      {
+        entityId: 'onboarding:onboarding_request',
+        keyScope: 'system',
+        fields: [
+          { field: 'email', hashField: 'email_hash' },
+          { field: 'first_name' },
+          { field: 'last_name' },
+          { field: 'organization_name' },
+          { field: 'password_hash' },
+        ],
+      },
+    ])
+  })
+})

--- a/packages/onboarding/src/__tests__/service.test.ts
+++ b/packages/onboarding/src/__tests__/service.test.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { OnboardingRequest } from '../modules/onboarding/data/entities'
 import { OnboardingService } from '../modules/onboarding/lib/service'
+import { hashForLookup, lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes'
 
 jest.mock('bcryptjs', () => ({
   hash: jest.fn().mockResolvedValue('hashed_password'),
@@ -127,6 +128,21 @@ describe('OnboardingService', () => {
       const result = await service.createOrUpdateRequest(makeStartInput())
       const createArgs = em.create.mock.calls[0][1]
       expect(createArgs.status).toBe('pending')
+      expect(createArgs.emailHash).toBe(hashForLookup('user@example.com'))
+    })
+
+    it('looks up encrypted and legacy plaintext emails without querying ciphertext as plaintext', async () => {
+      const em = createMockEm()
+      const service = new OnboardingService(em)
+
+      await service.createOrUpdateRequest(makeStartInput())
+
+      expect(em.findOne).toHaveBeenCalledWith(OnboardingRequest, {
+        $or: [
+          { emailHash: { $in: lookupHashCandidates('user@example.com') } },
+          { email: 'user@example.com', emailHash: null },
+        ],
+      }, undefined)
     })
 
     it('throws PENDING_REQUEST when within cooldown', async () => {

--- a/packages/onboarding/src/modules/onboarding/__integration__/TC-ONB-001-self-service-consent.spec.ts
+++ b/packages/onboarding/src/modules/onboarding/__integration__/TC-ONB-001-self-service-consent.spec.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { expect, test } from '@playwright/test';
 import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures';
+import { lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes';
 
 export const integrationMeta = {
   dependsOnModules: ['onboarding'],
@@ -26,6 +27,15 @@ type UserConsentRow = {
   granted_at: Date | null;
 };
 
+type PendingRequestAtRest = {
+  email: string;
+  email_hash: string | null;
+  first_name: string;
+  last_name: string;
+  organization_name: string;
+  password_hash: string;
+};
+
 const ONBOARDING_PASSWORD = 'IntegrationPass123!';
 const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000';
 
@@ -40,13 +50,30 @@ async function replaceVerificationToken(email: string, token: string): Promise<s
          set token_hash = $2,
              expires_at = now() + interval '24 hours',
              updated_at = now()
-       where email = $1
+       where email_hash = any($1::text[])
        returning id`,
-      [email, hashToken(token)],
+      [lookupHashCandidates(email), hashToken(token)],
     );
     expect(result.rowCount, 'onboarding request should exist after submitting the form').toBe(1);
     return result.rows[0].id;
   });
+}
+
+async function readPendingRequestAtRest(email: string): Promise<PendingRequestAtRest> {
+  return withClient(async (client) => {
+    const result = await client.query<PendingRequestAtRest>(
+      `select email, email_hash, first_name, last_name, organization_name, password_hash
+         from onboarding_requests
+        where email_hash = any($1::text[])`,
+      [lookupHashCandidates(email)],
+    );
+    expect(result.rowCount, 'onboarding request should be queryable by its lookup hash').toBe(1);
+    return result.rows[0];
+  });
+}
+
+function expectEncryptedPayload(value: string): void {
+  expect(value).toMatch(/^[^:]+:[^:]+:[^:]+:v1$/);
 }
 
 async function readCompletedRequest(requestId: string): Promise<OnboardingRequestRow> {
@@ -141,6 +168,14 @@ test.describe('TC-ONB-001: self-service onboarding with marketing consent', () =
 
     await expect(page.getByRole('status')).toContainText('Check your inbox');
     await expect(page.getByRole('status')).toContainText(email);
+
+    const pendingAtRest = await readPendingRequestAtRest(email);
+    expect(lookupHashCandidates(email)).toContain(pendingAtRest.email_hash);
+    expectEncryptedPayload(pendingAtRest.email);
+    expectEncryptedPayload(pendingAtRest.first_name);
+    expectEncryptedPayload(pendingAtRest.last_name);
+    expectEncryptedPayload(pendingAtRest.organization_name);
+    expectEncryptedPayload(pendingAtRest.password_hash);
 
     const requestId = await replaceVerificationToken(email, token);
     const verifyUrl = `${BASE_URL}/api/onboarding/onboarding/verify?token=${encodeURIComponent(token)}`;

--- a/packages/onboarding/src/modules/onboarding/__integration__/TC-ONB-002-multi-tenant-parallel-login.spec.ts
+++ b/packages/onboarding/src/modules/onboarding/__integration__/TC-ONB-002-multi-tenant-parallel-login.spec.ts
@@ -4,6 +4,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { expect, test, type APIRequestContext, type Browser, type BrowserContext, type Page } from '@playwright/test';
 import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures';
+import { lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes';
 
 export const integrationMeta = {
   dependsOnModules: ['onboarding'],
@@ -39,9 +40,9 @@ async function replaceVerificationToken(email: string, token: string): Promise<s
          set token_hash = $2,
              expires_at = now() + interval '24 hours',
              updated_at = now()
-       where email = $1
+       where email_hash = any($1::text[])
        returning id`,
-      [email, hashToken(token)],
+      [lookupHashCandidates(email), hashToken(token)],
     );
     expect(result.rowCount, `onboarding request should exist for ${email}`).toBe(1);
     return result.rows[0].id;

--- a/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
+++ b/packages/onboarding/src/modules/onboarding/api/post/onboarding.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { getSecurityEmailBaseUrl, mapSecurityEmailUrlError } from '@open-mercato/shared/lib/url'
 import { loadDictionary } from '@open-mercato/shared/lib/i18n/server'
 import { defaultLocale, locales, type Locale } from '@open-mercato/shared/lib/i18n/config'
@@ -107,7 +109,13 @@ export async function POST(req: Request) {
     const container = await createRequestContainer()
     const em = (container.resolve('em') as EntityManager)
 
-    const existingUser = await em.findOne(User, { email: parsed.data.email })
+    const existingUser = await findOneWithDecryption(em, User, {
+      deletedAt: null,
+      $or: [
+        { email: parsed.data.email },
+        { emailHash: { $in: lookupHashCandidates(parsed.data.email) } },
+      ],
+    })
     if (existingUser) {
       const message = translate('onboarding.errors.emailExists', 'We already have an account with this email. Try signing in or resetting your password.')
       return NextResponse.json({

--- a/packages/onboarding/src/modules/onboarding/data/entities.ts
+++ b/packages/onboarding/src/modules/onboarding/data/entities.ts
@@ -4,6 +4,7 @@ type OnboardingStatus = 'pending' | 'processing' | 'completed' | 'expired'
 
 @Entity({ tableName: 'onboarding_requests' })
 @Unique({ properties: ['email'] })
+@Unique({ properties: ['emailHash'] })
 @Unique({ properties: ['tokenHash'] })
 export class OnboardingRequest {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
@@ -11,6 +12,9 @@ export class OnboardingRequest {
 
   @Property({ type: 'text' })
   email!: string
+
+  @Property({ name: 'email_hash', type: 'text', nullable: true })
+  emailHash?: string | null
 
   @Property({ name: 'token_hash', type: 'text' })
   tokenHash!: string

--- a/packages/onboarding/src/modules/onboarding/encryption.ts
+++ b/packages/onboarding/src/modules/onboarding/encryption.ts
@@ -3,11 +3,13 @@ import type { ModuleEncryptionMap } from '@open-mercato/shared/modules/encryptio
 export const defaultEncryptionMaps: ModuleEncryptionMap[] = [
   {
     entityId: 'onboarding:onboarding_request',
+    keyScope: 'system',
     fields: [
-      { field: 'email' },
+      { field: 'email', hashField: 'email_hash' },
       { field: 'first_name' },
       { field: 'last_name' },
       { field: 'organization_name' },
+      { field: 'password_hash' },
     ],
   },
 ]

--- a/packages/onboarding/src/modules/onboarding/lib/service.ts
+++ b/packages/onboarding/src/modules/onboarding/lib/service.ts
@@ -1,6 +1,8 @@
 import { randomBytes, createHash } from 'node:crypto'
 import { hash } from 'bcryptjs'
 import { EntityManager } from '@mikro-orm/postgresql'
+import { hashForLookup, lookupHashCandidates } from '@open-mercato/shared/lib/encryption/aes'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { OnboardingRequest } from '../data/entities'
 import type { OnboardingStartInput } from '../data/validators'
 
@@ -18,8 +20,14 @@ export class OnboardingService {
     const expiresAt = new Date(Date.now() + expiresInHours * 60 * 60 * 1000)
     const now = new Date()
     const passwordHash = await hash(input.password, 10)
+    const emailHash = hashForLookup(input.email)
 
-    const existing = await this.em.findOne(OnboardingRequest, { email: input.email })
+    const existing = await findOneWithDecryption(this.em, OnboardingRequest, {
+      $or: [
+        { emailHash: { $in: lookupHashCandidates(input.email) } },
+        { email: input.email, emailHash: null },
+      ],
+    })
     if (existing) {
       const lastSentAt = existing.lastEmailSentAt ?? existing.updatedAt ?? existing.createdAt
       if (['pending', 'processing'].includes(existing.status) && lastSentAt && lastSentAt.getTime() > Date.now() - 10 * 60 * 1000) {
@@ -36,6 +44,7 @@ export class OnboardingService {
       existing.termsAccepted = true
       existing.marketingConsent = input.marketingConsent ?? false
       existing.passwordHash = passwordHash
+      existing.emailHash = emailHash
       existing.expiresAt = expiresAt
       existing.completedAt = null
       existing.processingStartedAt = null
@@ -52,6 +61,7 @@ export class OnboardingService {
 
     const request = this.em.create(OnboardingRequest, {
       email: input.email,
+      emailHash,
       tokenHash,
       status: 'pending',
       firstName: input.firstName,
@@ -74,7 +84,7 @@ export class OnboardingService {
   async findPendingByToken(token: string) {
     const tokenHash = hashToken(token)
     const now = new Date()
-    return this.em.findOne(OnboardingRequest, {
+    return findOneWithDecryption(this.em, OnboardingRequest, {
       tokenHash,
       status: 'pending',
       expiresAt: { $gt: now } as any,
@@ -83,18 +93,20 @@ export class OnboardingService {
 
   async findByToken(token: string) {
     const tokenHash = hashToken(token)
-    return this.em.findOne(OnboardingRequest, { tokenHash })
+    return findOneWithDecryption(this.em, OnboardingRequest, { tokenHash })
   }
 
   async findById(id: string) {
-    return this.em.findOne(OnboardingRequest, { id })
+    return findOneWithDecryption(this.em, OnboardingRequest, { id })
   }
 
   async findLatestByTenantId(tenantId: string) {
-    return this.em.findOne(
+    return findOneWithDecryption(
+      this.em,
       OnboardingRequest,
       { tenantId, deletedAt: null },
       { orderBy: { updatedAt: 'DESC', createdAt: 'DESC' } },
+      { tenantId, organizationId: null },
     )
   }
 

--- a/packages/onboarding/src/modules/onboarding/migrations/.snapshot-open-mercato.json
+++ b/packages/onboarding/src/modules/onboarding/migrations/.snapshot-open-mercato.json
@@ -25,6 +25,15 @@
           "nullable": false,
           "mappedType": "text"
         },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "mappedType": "text"
+        },
         "token_hash": {
           "name": "token_hash",
           "type": "text",
@@ -254,6 +263,16 @@
           "keyName": "onboarding_requests_email_unique",
           "columnNames": [
             "email"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": false,
+          "unique": true
+        },
+        {
+          "keyName": "onboarding_requests_email_hash_unique",
+          "columnNames": [
+            "email_hash"
           ],
           "composite": false,
           "constraint": true,

--- a/packages/onboarding/src/modules/onboarding/migrations/Migration20260710133207_onboarding.ts
+++ b/packages/onboarding/src/modules/onboarding/migrations/Migration20260710133207_onboarding.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260710133207_onboarding extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`alter table "onboarding_requests" add "email_hash" text null;`);
+    this.addSql(`alter table "onboarding_requests" add constraint "onboarding_requests_email_hash_unique" unique ("email_hash");`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`alter table "onboarding_requests" drop constraint if exists "onboarding_requests_email_hash_unique";`);
+    this.addSql(`alter table "onboarding_requests" drop column "email_hash";`);
+  }
+
+}

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -88,6 +88,8 @@ import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/
 const results = await findWithDecryption(em, 'Entity', filter, { tenantId, organizationId })
 ```
 
+Encryption maps default to tenant-scoped keys. Use the additive `keyScope: 'system'` option only for records that must exist before a tenant does; the system scope remains authoritative after a tenant id is later assigned so existing ciphertext stays readable.
+
 ### Boolean Parsing — MUST use instead of ad-hoc parsing
 
 ```typescript

--- a/packages/shared/src/lib/encryption/__tests__/subscriber.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/subscriber.test.ts
@@ -150,3 +150,53 @@ describe('decryptEntitiesWithFallbackScope per-row scope (multi-org safety)', ()
     expect(calls).toHaveLength(3)
   })
 })
+
+describe('tenant-less entity encryption delegation', () => {
+  const originalToggle = process.env.TENANT_DATA_ENCRYPTION
+
+  beforeEach(() => {
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+  })
+
+  afterEach(() => {
+    if (originalToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+    else process.env.TENANT_DATA_ENCRYPTION = originalToggle
+  })
+
+  it('lets the encryption service resolve an explicit system-scoped map', async () => {
+    const encryptEntityPayload = jest.fn(async (
+      _entityId: string,
+      target: Record<string, unknown>,
+    ) => ({ ...target, secret: 'encrypted' }))
+    const service = {
+      isEnabled: () => true,
+      encryptEntityPayload,
+    } as unknown as TenantDataEncryptionService
+    const subscriber = new TenantEncryptionSubscriber(service)
+    const entity = { secret: 'plaintext' }
+    const meta = {
+      className: 'OnboardingRequest',
+      tableName: 'onboarding_requests',
+      properties: {
+        secret: { name: 'secret', fieldName: 'secret' },
+      },
+    }
+    const changeSet = { payload: { secret: 'plaintext' } }
+
+    await subscriber.beforeCreate({
+      entity,
+      meta,
+      em: {},
+      changeSet,
+    } as never)
+
+    expect(encryptEntityPayload).toHaveBeenCalledWith(
+      'customers:customer_address',
+      expect.any(Object),
+      null,
+      null,
+    )
+    expect(entity.secret).toBe('encrypted')
+    expect(changeSet.payload.secret).toBe('encrypted')
+  })
+})

--- a/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
+++ b/packages/shared/src/lib/encryption/__tests__/tenantDataEncryptionService.test.ts
@@ -196,6 +196,64 @@ describe('TenantDataEncryptionService.encryptFields (issue #2720)', () => {
   })
 })
 
+describe('TenantDataEncryptionService system-scoped maps', () => {
+  const originalToggle = process.env.TENANT_DATA_ENCRYPTION
+
+  beforeEach(() => {
+    process.env.TENANT_DATA_ENCRYPTION = 'yes'
+  })
+
+  afterEach(() => {
+    if (originalToggle === undefined) delete process.env.TENANT_DATA_ENCRYPTION
+    else process.env.TENANT_DATA_ENCRYPTION = originalToggle
+  })
+
+  it('encrypts tenant-less payloads with a stable entity-scoped KMS key', async () => {
+    const entityId = 'onboarding:onboarding_request'
+    const systemKeyId = `system:${entityId}`
+    const getTenantDek = jest.fn(async (keyId: string) => (
+      keyId === systemKeyId
+        ? { tenantId: keyId, key: fixedKey, fetchedAt: new Date() }
+        : null
+    ))
+    const service = new TenantDataEncryptionService(
+      {
+        getConnection: () => ({ execute: jest.fn(async () => []) }),
+      } as never,
+      {
+        kms: {
+          getTenantDek,
+          createTenantDek: jest.fn(async () => null),
+          isHealthy: () => true,
+        },
+        defaultEncryptionMaps: [
+          {
+            entityId,
+            keyScope: 'system',
+            fields: [
+              { field: 'email', hashField: 'email_hash' },
+              { field: 'password_hash' },
+            ],
+          },
+        ],
+      } as never,
+    )
+
+    const encrypted = await service.encryptEntityPayload(entityId, {
+      email: 'person@example.com',
+      email_hash: null,
+      password_hash: 'bcrypt-value',
+    }, null, null)
+
+    expect(getTenantDek).toHaveBeenCalledWith(systemKeyId)
+    expect(encrypted.email).not.toBe('person@example.com')
+    expect(encrypted.password_hash).not.toBe('bcrypt-value')
+    expect(encrypted.email_hash).toBe(hashForLookup('person@example.com'))
+    expect(decryptWithAesGcm(encrypted.email as string, fixedKey)).toBe('person@example.com')
+    expect(decryptWithAesGcm(encrypted.password_hash as string, fixedKey)).toBe('bcrypt-value')
+  })
+})
+
 describe('TenantDataEncryptionService.getEncryptedFieldNames', () => {
   it('returns active encryption-map field names for query planning', async () => {
     const service = new TenantDataEncryptionService({} as never)

--- a/packages/shared/src/lib/encryption/subscriber.ts
+++ b/packages/shared/src/lib/encryption/subscriber.ts
@@ -224,10 +224,6 @@ export class TenantEncryptionSubscriber implements EventSubscriber<any> {
       return
     }
     const { tenantId, organizationId } = resolveScope(target)
-    if (!tenantId) {
-      debug('⚪️ subscriber.skip', { reason: 'no-tenant', entityId })
-      return
-    }
     const encrypted = await this.service.encryptEntityPayload(entityId, target, tenantId, organizationId)
     const metaProps: Record<string, unknown> = resolvedMeta?.properties && typeof resolvedMeta.properties === 'object'
       ? resolvedMeta.properties
@@ -325,10 +321,6 @@ export class TenantEncryptionSubscriber implements EventSubscriber<any> {
     const { tenantId, organizationId } = resolveScope(target)
     const scopedTenantId = tenantId ?? fallbackScope?.tenantId ?? null
     const scopedOrgId = organizationId ?? fallbackScope?.organizationId ?? null
-    if (!scopedTenantId) {
-      debug('⚪️ subscriber.skip', { reason: 'no-tenant', entityId })
-      return
-    }
     // Capture pending (un-flushed) changes BEFORE decrypt mutates the target. Re-baselining a
     // managed entity that a command already mutated would clear its dirty changeset and silently
     // drop the pending write (e.g. an undo handler that mutates an entity, then loads a related

--- a/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
+++ b/packages/shared/src/lib/encryption/tenantDataEncryptionService.ts
@@ -4,6 +4,7 @@ import { decryptWithAesGcm, encryptWithAesGcm, hashForLookup } from './aes'
 import { createKmsService, type KmsService, type TenantDek } from './kms'
 import { isTenantDataEncryptionEnabled, isEncryptionDebugEnabled } from './toggles'
 import { createLogger } from '../logger'
+import type { EncryptionKeyScope, ModuleEncryptionMap } from '../../modules/encryption'
 
 const logger = createLogger('shared').child({ component: 'tenant-encryption' })
 
@@ -14,6 +15,7 @@ export type EncryptedFieldRule = {
 
 export type EncryptionMapRecord = {
   entityId: string
+  keyScope?: EncryptionKeyScope
   fields: EncryptedFieldRule[]
 }
 
@@ -154,13 +156,23 @@ export class TenantDataEncryptionService {
   private readonly inflightDeks = TenantDataEncryptionService.globalInflightDeks
   private readonly inflightMaps = TenantDataEncryptionService.globalInflightMaps
   private readonly missCache = TenantDataEncryptionService.globalMissCache
+  private readonly systemDefaultMaps: Map<string, ModuleEncryptionMap>
 
   constructor(
     private em: EntityManager,
-    opts?: { cache?: CacheStrategy; kms?: KmsService }
+    opts?: {
+      cache?: CacheStrategy
+      kms?: KmsService
+      defaultEncryptionMaps?: readonly ModuleEncryptionMap[]
+    }
   ) {
     this.cache = opts?.cache
     this.kms = opts?.kms ?? createKmsService()
+    this.systemDefaultMaps = new Map(
+      (opts?.defaultEncryptionMaps ?? [])
+        .filter((map) => map.keyScope === 'system')
+        .map((map) => [map.entityId, map]),
+    )
   }
 
   isEnabled(): boolean {
@@ -239,6 +251,24 @@ export class TenantDataEncryptionService {
     }
   }
 
+  private applySystemDefault(record: EncryptionMapRecord | null, entityId: string): EncryptionMapRecord | null {
+    const declared = this.systemDefaultMaps.get(entityId)
+    if (!declared) return record
+    const fields: EncryptedFieldRule[] = declared.fields.map((field) => ({
+      field: field.field,
+      hashField: field.hashField ?? null,
+    }))
+    const declaredFields = new Set(fields.map((field) => field.field))
+    for (const field of record?.fields ?? []) {
+      if (!declaredFields.has(field.field)) fields.push(field)
+    }
+    return {
+      entityId,
+      keyScope: 'system',
+      fields,
+    }
+  }
+
   private async getMap(key: MapCacheKey): Promise<EncryptionMapRecord | null> {
     const shouldSkipLookup = (tag: string) => {
       const expiresAt = this.missCache.get(tag)
@@ -262,13 +292,13 @@ export class TenantDataEncryptionService {
       if (this.inflightMaps.has(tag)) {
         const pending = this.inflightMaps.get(tag)!
         const resolved = await pending
-        if (resolved) return resolved
+        if (resolved) return this.applySystemDefault(resolved, key.entityId)
       }
       const mem = this.memoryCache.get(tag)
-      if (mem) return mem
+      if (mem) return this.applySystemDefault(mem, key.entityId)
       if (this.cache && typeof this.cache.get === 'function') {
         const cached = await this.cache.get(tag)
-        if (cached) return cached as EncryptionMapRecord
+        if (cached) return this.applySystemDefault(cached as EncryptionMapRecord, key.entityId)
       }
       const pending = this.fetchMap(candidate)
       this.inflightMaps.set(tag, pending)
@@ -288,9 +318,9 @@ export class TenantDataEncryptionService {
       if (this.cache && typeof this.cache.set === 'function') {
         await this.cache.set(tag, loaded, { ttl: 300 })
       }
-      return loaded
+      return this.applySystemDefault(loaded, key.entityId)
     }
-    return null
+    return this.applySystemDefault(null, key.entityId)
   }
 
   private async fetchAllOrganizationFieldNames(entityId: string, tenantId: string | null): Promise<string[]> {
@@ -421,14 +451,15 @@ export class TenantDataEncryptionService {
       debug('⚪️ encrypt.skip.disabled', { entityId, tenantId })
       return payload
     }
-    const dek = await this.resolveDekForEncrypt(tenantId ?? null)
-    if (!dek) {
-      debug('⚠️ encrypt.skip.no-dek', { entityId, tenantId })
-      return payload
-    }
     const map = await this.getMap({ entityId, tenantId: tenantId ?? null, organizationId: organizationId ?? null })
     if (!map || !map.fields?.length) {
       debug('⚪️ encrypt.skip.no-map', { entityId, tenantId })
+      return payload
+    }
+    const keyId = map.keyScope === 'system' ? `system:${entityId}` : tenantId ?? null
+    const dek = await this.resolveDekForEncrypt(keyId)
+    if (!dek) {
+      debug('⚠️ encrypt.skip.no-dek', { entityId, tenantId, keyScope: map.keyScope ?? 'tenant' })
       return payload
     }
     debug('🔒 encrypt_entity', { entityId, tenantId, organizationId, fields: map.fields.length })
@@ -445,14 +476,15 @@ export class TenantDataEncryptionService {
       debug('⚪️ decrypt.skip.disabled', { entityId, tenantId })
       return payload
     }
-    const dek = await this.getDek(tenantId ?? null)
-    if (!dek) {
-      debug('⚠️ decrypt.skip.no-dek', { entityId, tenantId })
-      return payload
-    }
     const map = await this.getMap({ entityId, tenantId: tenantId ?? null, organizationId: organizationId ?? null })
     if (!map || !map.fields?.length) {
       debug('⚪️ decrypt.skip.no-map', { entityId, tenantId })
+      return payload
+    }
+    const keyId = map.keyScope === 'system' ? `system:${entityId}` : tenantId ?? null
+    const dek = await this.getDek(keyId)
+    if (!dek) {
+      debug('⚠️ decrypt.skip.no-dek', { entityId, tenantId, keyScope: map.keyScope ?? 'tenant' })
       return payload
     }
     debug('🔓 decrypt_entity', { entityId, tenantId, organizationId, fields: map.fields.length })

--- a/packages/shared/src/modules/__tests__/registry.test.ts
+++ b/packages/shared/src/modules/__tests__/registry.test.ts
@@ -94,7 +94,11 @@ describe('CLI Modules Registry', () => {
         {
           id: 'auth',
           defaultEncryptionMaps: [
-            { entityId: 'auth:user', fields: [{ field: 'email', hashField: 'email_hash' }] },
+            {
+              entityId: 'auth:user',
+              keyScope: 'system',
+              fields: [{ field: 'email', hashField: 'email_hash' }],
+            },
           ],
         },
         {
@@ -106,7 +110,11 @@ describe('CLI Modules Registry', () => {
       ])
 
       expect(maps).toEqual([
-        { entityId: 'auth:user', fields: [{ field: 'email', hashField: 'email_hash' }] },
+        {
+          entityId: 'auth:user',
+          keyScope: 'system',
+          fields: [{ field: 'email', hashField: 'email_hash' }],
+        },
         { entityId: 'customers:customer_comment', fields: [{ field: 'body', hashField: null }] },
       ])
     })

--- a/packages/shared/src/modules/encryption.ts
+++ b/packages/shared/src/modules/encryption.ts
@@ -3,7 +3,10 @@ export type ModuleEncryptionFieldRule = {
   hashField?: string | null
 }
 
+export type EncryptionKeyScope = 'tenant' | 'system'
+
 export type ModuleEncryptionMap = {
   entityId: string
+  keyScope?: EncryptionKeyScope
   fields: ModuleEncryptionFieldRule[]
 }

--- a/packages/shared/src/modules/registry.ts
+++ b/packages/shared/src/modules/registry.ts
@@ -513,6 +513,7 @@ export function getDefaultEncryptionMaps(modules: Module[]): import('./encryptio
         moduleId: mod.id,
         map: {
           entityId: entry.entityId,
+          ...(entry.keyScope ? { keyScope: entry.keyScope } : {}),
           fields: entry.fields.map((field) => ({
             field: field.field,
             hashField: field.hashField ?? null,


### PR DESCRIPTION
## Summary

Encrypt pre-tenant onboarding PII and pending password hashes at rest. Tenantless onboarding requests now use an explicit system-scoped encryption key, while keyed email hashes preserve exact lookup and legacy plaintext records remain discoverable during migration.

## Changes

- Add an optional system encryption scope while preserving existing tenant-scoped behavior.
- Protect onboarding email, first name, last name, organization name, and pending password hash.
- Add the nullable, uniquely indexed `email_hash` column through a generated migration.
- Use keyed email hashes in onboarding and initial-user lookup paths, with legacy plaintext fallback.
- Fail closed if system encryption declarations cannot be loaded.
- Add unit and browser integration coverage, including raw-database ciphertext assertions.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — security bug fix tracked by #3876 and #3877.

## Testing

- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- Focused shared, onboarding, and auth tests: 92 passed
- `TC-ONB-001-self-service-consent.spec.ts`: 3 passed against the ephemeral environment
- Raw-database probe confirmed all declared onboarding fields were encrypted and `email_hash` was populated

`yarn template:sync` reports unrelated pre-existing template drift; no affected template paths are changed by this PR.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

### Design System Compliance

N/A — no UI or design-system components changed.

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Backward Compatibility

The encryption-map contract change is additive. Existing tenant-scoped maps retain their behavior, the new database column is nullable, and legacy rows remain discoverable through the constrained plaintext fallback until they are upgraded.

## Linked issues

Fixes #3876
Fixes #3877
