### PR TITLE
feat(skills): ephemeral-first test-env run mode in monorepo and create-app template

### DIFF
--- a/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
+++ b/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
@@ -1,0 +1,96 @@
+# Test-env skills: prefer the ephemeral runner and ask the user for the run mode
+
+## Overview
+
+**Goal:** Make the test-env skill overrides in both the monorepo and the standalone
+create-app template prefer `test:integration:ephemeral` over plain `test:integration`
+(the ephemeral variant provisions its own isolated environment — more autonomous and
+safer for data), document `test:integration:ephemeral:start` as the reuse path for
+small iterative test loops, and have the skills ask the user which run mode they want
+when a human is present.
+
+**Scope:**
+- Monorepo repo-local skill overrides: `.ai/skills/om-prepare-test-env/SKILL.md`,
+  `.ai/skills/om-integration-tests/SKILL.md`.
+- Standalone override shipped by create-app:
+  `packages/create-app/agentic/shared/ai/skills/om-prepare-test-env/SKILL.md`.
+- Standalone template scripts: re-add the cross-platform mercato-CLI aliases
+  `test:integration:ephemeral:start[:verbose]` to
+  `packages/create-app/template/package.json.template` (they were removed by
+  bf38ceb3d together with the sh-based scripts, but they are plain mercato CLI
+  wrappers — multiplatform — and the skills need a stable name for the reuse loop).
+- Template docs that enumerate these commands: `packages/create-app/template/AGENTS.md`,
+  `packages/create-app/agentic/shared/AGENTS.md.template`.
+- Guard test: extend `packages/create-app/src/lib/agentic-skills-standalone-overlays.test.ts`
+  so the template keeps the start alias wired to the mercato CLI and the standalone
+  override keeps documenting the ephemeral-first + ask-the-user contract.
+
+**Non-goals:**
+- No changes to the external shared skills in `.agents/skills/` (they come from
+  open-mercato/skills; overrides carry the repo-specific deltas).
+- No new `om-integration-tests` override folder for the standalone app (the
+  standalone contract intentionally ships no override for it; `om-prepare-test-env`
+  is the single place the environment policy lives and other skills defer to it).
+- No changes to the mercato CLI runner behavior itself.
+
+**Risks:**
+- The overlay guard test enumerates the exact override set — extending assertions
+  must not break the existing contract.
+- Template `package.json.template` has a dependency-pin drift guard (5707c167e);
+  script additions do not touch dependency pins.
+
+## Implementation Plan
+
+### Phase 1: Monorepo skill overrides
+
+- 1.1 `.ai/skills/om-prepare-test-env/SKILL.md`: add a "Choosing the run mode"
+  section — always prefer `yarn test:integration:ephemeral` over plain
+  `yarn test:integration`; use `yarn test:integration:ephemeral:start` +
+  filtered `yarn mercato test:integration <filter>` for small iterative loops
+  reusing the running env; ask the user which mode they want when interactive,
+  defaulting to fully-managed ephemeral when unattended.
+- 1.2 `.ai/skills/om-integration-tests/SKILL.md`: reorder the Quick Reference so
+  the ephemeral commands lead, add the run-mode question to the workflow and
+  Running Existing Tests sections, and add MUST rules (prefer ephemeral; never
+  plain `yarn test:integration` without the runner env block; ask the user for
+  the mode when interactive).
+
+### Phase 2: Standalone create-app template
+
+- 2.1 Re-add cross-platform ephemeral start aliases to
+  `packages/create-app/template/package.json.template`
+  (`test:integration:ephemeral:start`, `test:integration:ephemeral:start:verbose`).
+- 2.2 Update `packages/create-app/agentic/shared/ai/skills/om-prepare-test-env/SKILL.md`
+  with the same run-mode selection contract using the standalone command names.
+- 2.3 Update `packages/create-app/template/AGENTS.md` and
+  `packages/create-app/agentic/shared/AGENTS.md.template` to document the start
+  alias and the ephemeral-first policy.
+- 2.4 Extend `agentic-skills-standalone-overlays.test.ts` to guard the new
+  contract (start alias wired to mercato CLI; override documents ephemeral-first
+  + run-mode question).
+
+### Phase 3: Validation gate and PR
+
+- 3.1 Run the full validation gate (`validation.commands`) and fix fallout.
+- 3.2 Self code-review + breaking-change review, open PR, labels, autofix pass.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Monorepo skill overrides
+
+- [ ] 1.1 Update .ai/skills/om-prepare-test-env/SKILL.md (run-mode choice, ephemeral-first)
+- [ ] 1.2 Update .ai/skills/om-integration-tests/SKILL.md (ephemeral-first quick ref, rules, ask step)
+
+### Phase 2: Standalone create-app template
+
+- [ ] 2.1 Re-add test:integration:ephemeral:start aliases to package.json.template
+- [ ] 2.2 Update standalone om-prepare-test-env override (run-mode choice, ephemeral-first)
+- [ ] 2.3 Document start alias in template AGENTS.md + AGENTS.md.template
+- [ ] 2.4 Extend agentic-skills-standalone-overlays guard test
+
+### Phase 3: Validation gate and PR
+
+- [ ] 3.1 Full validation gate green
+- [ ] 3.2 Self-review, PR, labels, autofix pass

--- a/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
+++ b/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
@@ -85,10 +85,10 @@ when a human is present.
 
 ### Phase 2: Standalone create-app template
 
-- [ ] 2.1 Re-add test:integration:ephemeral:start aliases to package.json.template
-- [ ] 2.2 Update standalone om-prepare-test-env override (run-mode choice, ephemeral-first)
-- [ ] 2.3 Document start alias in template AGENTS.md + AGENTS.md.template
-- [ ] 2.4 Extend agentic-skills-standalone-overlays guard test
+- [x] 2.1 Re-add test:integration:ephemeral:start aliases to package.json.template — fda2e145c
+- [x] 2.2 Update standalone om-prepare-test-env override (run-mode choice, ephemeral-first) — c01437860
+- [x] 2.3 Document start alias in template AGENTS.md + AGENTS.md.template — 6eb3f9ca6
+- [x] 2.4 Extend agentic-skills-standalone-overlays guard test — ad96cd888
 
 ### Phase 3: Validation gate and PR
 

--- a/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
+++ b/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
@@ -38,6 +38,12 @@ when a human is present.
   must not break the existing contract.
 - Template `package.json.template` has a dependency-pin drift guard (5707c167e);
   script additions do not touch dependency pins.
+- Local gate note: `packages/cli/src/lib/__tests__/dev-env-reload.test.ts`
+  ("watches generated runtime files when explicitly requested") fails with
+  `EMFILE: too many open files, watch` on this machine — reproduced identically
+  on untouched `origin/develop`, so it is a pre-existing machine-level watcher
+  limit, unrelated to this change (which touches no CLI code). CI is the
+  authority for this suite.
 
 ## Implementation Plan
 
@@ -92,5 +98,5 @@ when a human is present.
 
 ### Phase 3: Validation gate and PR
 
-- [ ] 3.1 Full validation gate green
+- [x] 3.1 Full validation gate green (build:packages, generate, build:packages, i18n:check-sync, i18n:check-usage, typecheck, test 22/22, build:app)
 - [ ] 3.2 Self-review, PR, labels, autofix pass

--- a/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
+++ b/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
@@ -80,8 +80,8 @@ when a human is present.
 
 ### Phase 1: Monorepo skill overrides
 
-- [ ] 1.1 Update .ai/skills/om-prepare-test-env/SKILL.md (run-mode choice, ephemeral-first)
-- [ ] 1.2 Update .ai/skills/om-integration-tests/SKILL.md (ephemeral-first quick ref, rules, ask step)
+- [x] 1.1 Update .ai/skills/om-prepare-test-env/SKILL.md (run-mode choice, ephemeral-first) — 62157f9f7
+- [x] 1.2 Update .ai/skills/om-integration-tests/SKILL.md (ephemeral-first quick ref, rules, ask step) — d7a47e2b3
 
 ### Phase 2: Standalone create-app template
 

--- a/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
+++ b/.ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
@@ -82,6 +82,8 @@ when a human is present.
 
 ## Progress
 
+PR: #4095
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Monorepo skill overrides
@@ -99,4 +101,4 @@ when a human is present.
 ### Phase 3: Validation gate and PR
 
 - [x] 3.1 Full validation gate green (build:packages, generate, build:packages, i18n:check-sync, i18n:check-usage, typecheck, test 22/22, build:app)
-- [ ] 3.2 Self-review, PR, labels, autofix pass
+- [x] 3.2 Self-review, PR #4095, labels, om-auto-review-pr pass (APPROVED — no findings; self-approval blocked by GitHub, report posted as comment review)

--- a/.ai/skills/om-integration-tests/SKILL.md
+++ b/.ai/skills/om-integration-tests/SKILL.md
@@ -13,18 +13,38 @@ This skill generates executable Playwright tests in module-local `__integration_
 
 | Action | Command |
 |--------|---------|
-| Run all tests | `yarn test:integration` |
-| Run single test | `npx playwright test --config .ai/qa/tests/playwright.config.ts <path>` |
+| Run all tests (**preferred**) | `yarn test:integration:ephemeral` — provisions or safely reuses the ephemeral env itself |
 | Run tests matching a path substring with the managed env | `yarn mercato test:integration <substring>` (no `--retries` support) |
-| Run in ephemeral containers | `yarn test:integration:ephemeral` |
+| Iterate against a running ephemeral env (small test loops) | `yarn test:integration:ephemeral:start` once, then filtered `yarn mercato test:integration <filter>` runs |
 | Run interactive ephemeral mode | `yarn test:integration:ephemeral:interactive` |
 | Start ephemeral app only (for MCP exploration, tests development, and debugging) | `yarn test:integration:ephemeral:start` |
+| Run all tests against an already-running app (low-level — needs the full runner env block) | `yarn test:integration` |
+| Run single test (against an attached env, with the runner env block) | `npx playwright test --config .ai/qa/tests/playwright.config.ts <path>` |
 | Run standalone create-app integration parity from monorepo | `yarn test:create-app:integration` |
 | View report | `yarn test:integration:report` |
 | Test files location | `<module>/__integration__/TC-XXX.spec.ts` |
 | Scenario sources (optional) | `.ai/qa/scenarios/TC-XXX-*.md` |
 | Shared env descriptor (attach here) | `.ai/qa/test-env.json` (written by `om-prepare-test-env`) |
 | Underlying repo env state file | `.ai/qa/ephemeral-env.json` (managed by `om-prepare-test-env`) |
+
+## Run Mode — prefer ephemeral, ask the user
+
+Always prefer `yarn test:integration:ephemeral` over plain `yarn test:integration`: the ephemeral
+runner prepares (or safely reuses) its own isolated app + database and injects the full runner env
+block, so it is more autonomous and cannot touch the developer's dev data. Plain
+`yarn test:integration` is a low-level command that only works with the full env block exported —
+never reach for it first.
+
+Before the first run in a session, when a user is present and has not already chosen, ask which
+mode they want (recommend the first — more autonomous, safer regarding data):
+
+1. **Fully managed ephemeral per run** — `yarn test:integration:ephemeral [filter]`.
+2. **Boot once, iterate against the running ephemeral env** — `yarn test:integration:ephemeral:start`,
+   then small filtered `yarn mercato test:integration <filter>` batches; best for short
+   author/debug loops.
+
+When running unattended, default to the fully managed ephemeral mode. The reuse/TTL/lock
+semantics live in the repo-local `om-prepare-test-env` skill (`.ai/skills/om-prepare-test-env/SKILL.md`).
 
 ## Runtime Policy
 
@@ -277,6 +297,8 @@ If the run fails, apply the shared failure-analysis section above.
 ## Rules
 
 - MUST explore the running app before writing — never guess selectors or flows
+- MUST prefer `yarn test:integration:ephemeral` over plain `yarn test:integration` — the ephemeral runner provisions/reuses its own isolated env and injects the runner env block; plain `yarn test:integration` is low-level and unsafe without that block
+- MUST ask the user which run mode they want (fully managed ephemeral per run vs boot-once via `yarn test:integration:ephemeral:start` + filtered iteration) before the first run when interactive, recommending fully managed ephemeral; default to fully managed ephemeral when unattended
 - MUST defer environment boot/reuse to `om-prepare-test-env`; never re-implement PID/reuse/freshness/lock logic here
 - MUST read the shared descriptor `.ai/qa/test-env.json` first and attach to that running instance; invoke `om-prepare-test-env` to discover/provision when no valid descriptor exists (it manages the underlying `.ai/qa/ephemeral-env.json` state file)
 - MUST use the active `baseUrl` from `.ai/qa/test-env.json` (never assume `localhost:3000`)
@@ -327,16 +349,21 @@ Given SPEC-017 (Version History Panel), the skill would produce:
 
 ## Running Existing Tests
 
-Bring up / reuse the environment via `om-prepare-test-env` first (see "Open Mercato environment"); then run tests against the attached instance:
+Pick the run mode first (see "Run Mode — prefer ephemeral, ask the user"); the environment
+itself is `om-prepare-test-env`'s job (see "Open Mercato environment"):
 
 ```bash
-# Run all integration tests headlessly (zero token cost)
-yarn test:integration
+# Run all integration tests headlessly (preferred — provisions/reuses the ephemeral env itself)
+yarn test:integration:ephemeral
 
-# Run tests matching a module/category path fragment
-npx playwright test --config .ai/qa/tests/playwright.config.ts sales
+# Run tests matching a module/category path fragment with the managed env
+yarn mercato test:integration sales
 
-# Run a single test, fail-fast while debugging
+# Iterate: boot the ephemeral env once, then run small filtered batches against it
+yarn test:integration:ephemeral:start
+yarn mercato test:integration auth
+
+# Run a single test, fail-fast while debugging (requires an attached env + runner env block)
 npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/auth/__integration__/TC-AUTH-001.spec.ts --retries=0
 ```
 

--- a/.ai/skills/om-prepare-test-env/SKILL.md
+++ b/.ai/skills/om-prepare-test-env/SKILL.md
@@ -47,6 +47,32 @@ suites is needed — it changes the app build fingerprint and forces a rebuild).
   the substring. The `test:integration` subcommand does NOT accept `--retries`; retries live in
   `.ai/qa/tests/playwright.config.ts`.
 
+## Choosing the run mode — prefer ephemeral, ask the user
+
+`yarn test:integration:ephemeral` is ALWAYS preferred over plain `yarn test:integration`: the
+ephemeral variant provisions (or safely reuses) its own isolated app + database, so it is more
+autonomous and cannot touch the developer's dev data. Plain `yarn test:integration` only works
+when the caller supplies the full runner env block (see the MUST below) — treat it as an internal
+detail of the CLI runner, never as the command you reach for first.
+
+Two supported run modes:
+
+1. **Fully managed ephemeral (default, safest):** `yarn test:integration:ephemeral [filter]` —
+   one command provisions the env, runs the tests, and leaves teardown to the CLI's own
+   lifecycle. Best for full-suite runs, CI parity, and unattended/autonomous work.
+2. **Reuse a running ephemeral env (fast iteration):** boot once with
+   `yarn test:integration:ephemeral:start`, then run small filtered batches with
+   `yarn mercato test:integration <filter>` against the same env. Best for short
+   author/debug loops where re-provisioning per run would dominate wall-clock time. Reuse is
+   still gated by the TTL and source-freshness rules below.
+
+When a user is present and has not already said which mode they want, ASK before the first run
+(one question, two options): fully managed ephemeral per run, or boot-once-and-reuse for
+iterative loops. Recommend the fully managed ephemeral mode — it is more autonomous and safer
+regarding data. When running unattended (no user to ask), default to the fully managed ephemeral
+mode. Do not re-ask once the user has chosen; keep using their answer for the rest of the
+session unless they change it.
+
 ## MUST: never run the Playwright suite outside the CLI runner
 
 `yarn test:integration` with only `BASE_URL` exported is a trap: the CLI runner

--- a/packages/create-app/agentic/shared/AGENTS.md.template
+++ b/packages/create-app/agentic/shared/AGENTS.md.template
@@ -294,8 +294,9 @@ import type { ApiInterceptor } from '@open-mercato/shared/lib/crud/api-intercept
 | `yarn initialize` | Bootstrap DB + first admin account |
 | `yarn build` | Build for production |
 | `yarn mercato eject <module>` | Copy a core module into `src/modules/` |
-| `yarn test:integration:ephemeral` | Run Playwright integration tests against a fresh ephemeral app + DB (reuses a healthy running env) |
-| `yarn mercato test:ephemeral` | Start the ephemeral app only (manual QA; admin@acme.com / secret) — the `om-prepare-test-env` skill wraps this and shares the env via `.ai/qa/test-env.json` |
+| `yarn test:integration:ephemeral` | Run Playwright integration tests against a fresh ephemeral app + DB (reuses a healthy running env) — always prefer this over plain `yarn test:integration` |
+| `yarn test:integration:ephemeral:start` | Start the ephemeral app only (manual QA or iterative test loops; admin@acme.com / secret) — the `om-prepare-test-env` skill wraps this and shares the env via `.ai/qa/test-env.json` |
+| `yarn mercato test:integration <filter>` | Run small filtered test batches against the running ephemeral env (fast iteration) |
 | `npx playwright show-report .ai/qa/test-results/html` | Open the HTML integration test report |
 
 ## Architecture Rules

--- a/packages/create-app/agentic/shared/ai/skills/om-prepare-test-env/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-prepare-test-env/SKILL.md
@@ -17,9 +17,9 @@ these `package.json` / CLI commands instead of inventing a boot procedure. They 
 caching, database provisioning (testcontainers), seeding, readiness waits, and their own
 owner lock — never re-implement any of that.
 
-- Boot app-only ephemeral env: `yarn mercato test:ephemeral`. Preferred app port `5001`; the
-  actual port and database URL land in `.ai/qa/ephemeral-env.json` (CLI-owned and authoritative
-  for its own reuse decisions — never write it by hand).
+- Boot app-only ephemeral env: `yarn test:integration:ephemeral:start` (= `yarn mercato test:ephemeral`).
+  Preferred app port `5001`; the actual port and database URL land in `.ai/qa/ephemeral-env.json`
+  (CLI-owned and authoritative for its own reuse decisions — never write it by hand).
 - Full suite with managed env: `yarn test:integration:ephemeral` (= `yarn mercato test:integration`).
   It reuses a healthy running ephemeral env from the state file, else provisions one.
 - Filtered run: `yarn mercato test:integration <substring>` — batches all specs whose path
@@ -28,6 +28,32 @@ owner lock — never re-implement any of that.
 - Readiness marker in the boot log: `Application is ready at <baseUrl>`.
 - Reuse TTL: `OM_INTEGRATION_BUILD_CACHE_TTL_SECONDS` (default 600s) gates the CLI's own reuse;
   keep any wrapper TTL in lockstep with it.
+
+## Choosing the run mode — prefer ephemeral, ask the user
+
+`yarn test:integration:ephemeral` is ALWAYS preferred over plain `yarn test:integration`: the
+ephemeral variant provisions (or safely reuses) its own isolated app + database, so it is more
+autonomous and cannot touch the developer's dev data. Plain `yarn test:integration` only works
+with the full runner env block exported (see the MUST below) — treat it as an internal detail
+of the CLI runner, never as the command you reach for first.
+
+Two supported run modes:
+
+1. **Fully managed ephemeral (default, safest):** `yarn test:integration:ephemeral [filter]` —
+   one command provisions the env, runs the tests, and leaves teardown to the CLI's own
+   lifecycle. Best for full-suite runs and unattended/autonomous work.
+2. **Reuse a running ephemeral env (fast iteration):** boot once with
+   `yarn test:integration:ephemeral:start`, then run small filtered batches with
+   `yarn mercato test:integration <filter>` against the same env. Best for short author/debug
+   loops where re-provisioning per run would dominate wall-clock time; reuse is still gated by
+   the CLI's TTL and freshness checks.
+
+When a user is present and has not already said which mode they want, ASK before the first run
+(one question, two options): fully managed ephemeral per run, or boot-once-and-reuse for
+iterative loops. Recommend the fully managed ephemeral mode — it is more autonomous and safer
+regarding data. When running unattended (no user to ask), default to the fully managed ephemeral
+mode. Do not re-ask once the user has chosen; keep their answer for the rest of the session
+unless they change it.
 
 ## MUST: suite runs go through the CLI runner
 

--- a/packages/create-app/src/lib/agentic-skills-standalone-overlays.test.ts
+++ b/packages/create-app/src/lib/agentic-skills-standalone-overlays.test.ts
@@ -86,6 +86,36 @@ test('the repo ships no generated test-env shell entrypoints (machine-bound, git
   )
 })
 
+test('the template wires the ephemeral runner scripts and the override keeps the ephemeral-first run-mode contract', () => {
+  const templatePackageJson = JSON.parse(
+    fs.readFileSync(new URL('../../template/package.json.template', import.meta.url), 'utf8'),
+  ) as { scripts?: Record<string, string> }
+  const scripts = templatePackageJson.scripts ?? {}
+  assert.equal(
+    scripts['test:integration:ephemeral'],
+    'mercato test:integration',
+    'test:integration:ephemeral must run the cross-platform mercato CLI suite runner',
+  )
+  assert.equal(
+    scripts['test:integration:ephemeral:start'],
+    'mercato test:ephemeral',
+    'test:integration:ephemeral:start must boot the app-only ephemeral env via the mercato CLI (reused by iterative filtered runs)',
+  )
+  const override = readOverrideSkill('om-prepare-test-env')
+  assert.ok(
+    override.includes('test:integration:ephemeral:start'),
+    'the om-prepare-test-env override must document the boot-once start script for iterative reuse',
+  )
+  assert.ok(
+    /prefer(red)? over plain `yarn test:integration`/i.test(override),
+    'the om-prepare-test-env override must state that test:integration:ephemeral is preferred over plain test:integration',
+  )
+  assert.ok(
+    /ASK before the first run/.test(override),
+    'the om-prepare-test-env override must instruct skills to ask the user which run mode they want',
+  )
+})
+
 test('override folders do not also ship a stale STANDALONE.md', () => {
   const stale = [...skillsShippingOverrideFolder, ...skillsShippingKnowledgeOverrideFolder].filter((skill) => {
     const url = new URL(`${skill}/STANDALONE.md`, skillsDir)

--- a/packages/create-app/template/AGENTS.md
+++ b/packages/create-app/template/AGENTS.md
@@ -84,11 +84,14 @@ yarn test
 # Run a single unit test
 yarn test path/to/test.spec.ts
 
-# Run integration tests (spins up fresh ephemeral app + DB, runs Playwright)
+# Run integration tests (preferred: provisions/reuses an ephemeral app + DB, runs Playwright)
 yarn test:integration:ephemeral
 
-# Start ephemeral app only (for manual QA exploration; admin@acme.com / secret)
-yarn mercato test:ephemeral
+# Start ephemeral app only (manual QA exploration or iterative test loops; admin@acme.com / secret)
+yarn test:integration:ephemeral:start
+
+# Iterate against the running ephemeral env with small filtered batches
+yarn mercato test:integration <filter>
 
 # View HTML integration test report
 npx playwright show-report .ai/qa/test-results/html

--- a/packages/create-app/template/package.json.template
+++ b/packages/create-app/template/package.json.template
@@ -21,6 +21,8 @@
     "test": "jest --config jest.config.cjs",
     "test:integration": "npx playwright test --config .ai/qa/tests/playwright.config.ts",
     "test:integration:ephemeral": "mercato test:integration",
+    "test:integration:ephemeral:start": "mercato test:ephemeral",
+    "test:integration:ephemeral:start:verbose": "mercato test:ephemeral --verbose",
     "generate": "mercato generate",
     "install-skills": "sh scripts/install-skills.sh",
     "db:generate": "mercato db generate",


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-10-test-env-skills-prefer-ephemeral.md
Status: complete

## Goal
- Make the test-env skill overrides (monorepo + standalone create-app template) prefer `test:integration:ephemeral` over plain `test:integration`, document `test:integration:ephemeral:start` for iterative reuse of a running ephemeral env, and have the skills ask the user which run mode they want.

## What Changed
- `.ai/skills/om-prepare-test-env/SKILL.md` (monorepo): new "Choosing the run mode — prefer ephemeral, ask the user" section — fully managed ephemeral is the recommended/unattended default; boot-once (`test:integration:ephemeral:start`) + filtered `yarn mercato test:integration <filter>` is the documented fast-iteration mode.
- `.ai/skills/om-integration-tests/SKILL.md` (monorepo): Quick Reference now leads with the ephemeral commands and demotes plain `yarn test:integration` to a low-level command that needs the full runner env block; new "Run Mode" section plus two MUST rules (prefer ephemeral; ask the user for the mode when interactive, default to ephemeral unattended); "Running Existing Tests" examples rewritten ephemeral-first.
- `packages/create-app/agentic/shared/ai/skills/om-prepare-test-env/SKILL.md` (standalone override): same run-mode contract using the standalone command names.
- `packages/create-app/template/package.json.template`: re-added the cross-platform mercato-CLI aliases `test:integration:ephemeral:start[:verbose]` (removed by bf38ceb3d together with the sh-based scripts, but these are plain CLI wrappers and multiplatform — the skills need a stable script name for the reuse loop).
- `packages/create-app/template/AGENTS.md` + `packages/create-app/agentic/shared/AGENTS.md.template`: document the start alias, the filtered-iteration loop, and the ephemeral-first preference.
- `packages/create-app/src/lib/agentic-skills-standalone-overlays.test.ts`: new guard asserting the template wires `test:integration:ephemeral[:start]` to the mercato CLI and the standalone override keeps the ephemeral-first + ask-the-user contract.

## Tests
- Extended `agentic-skills-standalone-overlays.test.ts` (new guard test; all 11 tests pass).
- Full validation gate (`yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`).

## Breaking Changes
- None. Template script additions are additive; skill-override changes are documentation/policy; no contract surface from BACKWARD_COMPATIBILITY.md is touched. Existing scaffolded apps without the new alias keep working — the override documents the `yarn mercato test:ephemeral` equivalence inline.

## Progress
See the Progress section in the tracking plan.
