### PR TITLE
fix(communication_channels): guard message enrichment by participant (#3872)

### DIFF
--- a/packages/core/src/modules/communication_channels/data/__tests__/channel-payload-enricher.test.ts
+++ b/packages/core/src/modules/communication_channels/data/__tests__/channel-payload-enricher.test.ts
@@ -18,19 +18,34 @@ function getPayloadEnricher(): ResponseEnricher {
   return enricher
 }
 
-function makeContext(): EnricherContext {
+function makeContext(messageId: string): EnricherContext {
+  const joinBuilder: any = {
+    onRef: jest.fn(() => joinBuilder),
+    on: jest.fn(() => joinBuilder),
+  }
+  const participantQuery: any = {
+    selectFrom: jest.fn(() => participantQuery),
+    leftJoin: jest.fn((_table: string, join: (builder: any) => unknown) => {
+      join(joinBuilder)
+      return participantQuery
+    }),
+    select: jest.fn(() => participantQuery),
+    distinct: jest.fn(() => participantQuery),
+    where: jest.fn(() => participantQuery),
+    execute: jest.fn(async () => [{ id: messageId }]),
+  }
   return {
     organizationId: 'org-1',
     tenantId: 'tenant-1',
     userId: 'user-1',
-    em: {},
+    em: { getKysely: () => participantQuery },
     container: {},
   }
 }
 
 async function enrichOne(record: Record<string, unknown>): Promise<Record<string, unknown>> {
   const enricher = getPayloadEnricher()
-  const [out] = await enricher.enrichMany!([record], makeContext())
+  const [out] = await enricher.enrichMany!([record], makeContext(String(record.id)))
   return out as Record<string, unknown>
 }
 

--- a/packages/core/src/modules/communication_channels/data/__tests__/enrichers.test.ts
+++ b/packages/core/src/modules/communication_channels/data/__tests__/enrichers.test.ts
@@ -130,6 +130,30 @@ describe('communication_channels enrichers — no duplicate MessageChannelLink l
   // em.find branches on the entity argument so we can count per-entity queries.
   // findWithDecryption is a thin wrapper over em.find(entity, where, options),
   // so each entity passed to findWithDecryption surfaces here as call[0].
+  function makeParticipantQuery(rows: Array<{ id: string }>) {
+    const joinBuilder: any = {
+      onRef: jest.fn(() => joinBuilder),
+      on: jest.fn(() => joinBuilder),
+    }
+    const expressionBuilder: any = jest.fn((...args: unknown[]) => args)
+    expressionBuilder.or = jest.fn((expressions: unknown[]) => expressions)
+    const query: any = {
+      selectFrom: jest.fn(() => query),
+      leftJoin: jest.fn((_table: string, join: (builder: any) => unknown) => {
+        join(joinBuilder)
+        return query
+      }),
+      select: jest.fn(() => query),
+      distinct: jest.fn(() => query),
+      where: jest.fn((...args: unknown[]) => {
+        if (typeof args[0] === 'function') args[0](expressionBuilder)
+        return query
+      }),
+      execute: jest.fn(async () => rows),
+    }
+    return { expressionBuilder, joinBuilder, query }
+  }
+
   function makeFind() {
     return jest.fn(async (entity: unknown) => {
       if (entity === MessageChannelLink) {
@@ -173,11 +197,12 @@ describe('communication_channels enrichers — no duplicate MessageChannelLink l
 
   it('runs the full enrichment pass with a single MessageChannelLink (and ExternalConversation) query', async () => {
     const find = makeFind()
+    const { query: participantQuery } = makeParticipantQuery([{ id: 'm1' }, { id: 'm2' }])
     const ctx = {
       organizationId: 'org',
       tenantId: 'tenant',
       userId: 'user-1',
-      em: { find },
+      em: { find, getKysely: () => participantQuery },
       container: { resolve: () => null },
     } as any
 
@@ -200,11 +225,12 @@ describe('communication_channels enrichers — no duplicate MessageChannelLink l
 
   it('the merged channel enricher produces _channel, _channelPayload and _channelContact in one pass', async () => {
     const find = makeFind()
+    const { query: participantQuery } = makeParticipantQuery([{ id: 'm1' }, { id: 'm2' }, { id: 'm3' }])
     const ctx = {
       organizationId: 'org',
       tenantId: 'tenant',
       userId: 'user-1',
-      em: { find },
+      em: { find, getKysely: () => participantQuery },
       container: { resolve: () => null },
     } as any
 
@@ -241,5 +267,37 @@ describe('communication_channels enrichers — no duplicate MessageChannelLink l
     expect(out[2]._channel).toBeNull()
     expect(out[2]._channelPayload).toBeNull()
     expect(out[2]._channelContact).toBeNull()
+  })
+
+  it('does not enrich channel data for a same-organization non-participant', async () => {
+    const find = makeFind()
+    const { expressionBuilder, joinBuilder, query: participantQuery } = makeParticipantQuery([{ id: 'm1' }])
+    const ctx = {
+      organizationId: 'org',
+      tenantId: 'tenant',
+      userId: 'user-1',
+      em: { find, getKysely: () => participantQuery },
+      container: { resolve: () => null },
+    } as any
+
+    const enricher = findEnricher('communication_channels.message-channel')
+    const out = (await enricher.enrichMany!([{ id: 'm1' }, { id: 'm2' }] as any, ctx)) as any[]
+
+    expect(out[0]._channelPayload).toMatchObject({ channelPayload: { blocks: [] } })
+    expect(out[1]).toMatchObject({
+      _channel: null,
+      _channelPayload: null,
+      _channelContact: null,
+    })
+
+    const linkQuery = find.mock.calls.find(([entity]) => entity === MessageChannelLink)
+    expect(linkQuery?.[1]).toMatchObject({ messageId: { $in: ['m1'] } })
+    expect(joinBuilder.on).toHaveBeenCalledWith('r.recipient_user_id', '=', 'user-1')
+    expect(joinBuilder.on).toHaveBeenCalledWith('r.deleted_at', 'is', null)
+    expect(participantQuery.where).toHaveBeenCalledWith('m.tenant_id', '=', 'tenant')
+    expect(participantQuery.where).toHaveBeenCalledWith('m.organization_id', '=', 'org')
+    expect(participantQuery.where).toHaveBeenCalledWith('m.deleted_at', 'is', null)
+    expect(expressionBuilder).toHaveBeenCalledWith('m.sender_user_id', '=', 'user-1')
+    expect(expressionBuilder).toHaveBeenCalledWith('r.message_id', 'is not', null)
   })
 })

--- a/packages/core/src/modules/communication_channels/data/enrichers.ts
+++ b/packages/core/src/modules/communication_channels/data/enrichers.ts
@@ -43,6 +43,21 @@ type MessageRecord = Record<string, unknown> & {
   threadId?: string | null
 }
 
+type MessageParticipantDatabase = {
+  messages: {
+    id: string
+    tenant_id: string
+    organization_id: string | null
+    sender_user_id: string
+    deleted_at: Date | null
+  }
+  message_recipients: {
+    message_id: string
+    recipient_user_id: string
+    deleted_at: Date | null
+  }
+}
+
 type ResolvedCtx = EnricherContext & {
   em: EntityManager
 }
@@ -126,6 +141,41 @@ const messageChannelEnricher: ResponseEnricher<
     const organizationId = ctx.organizationId ?? null
     const dscope = { tenantId, organizationId }
 
+    const userId = typeof ctx.userId === 'string' ? ctx.userId : null
+    if (!userId) {
+      return records.map((record) => ({
+        ...record,
+        _channel: null,
+        _channelPayload: null,
+        _channelContact: null,
+      }))
+    }
+
+    const db = em.getKysely<MessageParticipantDatabase>()
+    let participantQuery = db
+      .selectFrom('messages as m')
+      .leftJoin('message_recipients as r', (join) => join
+        .onRef('m.id', '=', 'r.message_id')
+        .on('r.recipient_user_id', '=', userId)
+        .on('r.deleted_at', 'is', null))
+      .select('m.id')
+      .distinct()
+      .where('m.id', 'in', messageIds)
+      .where('m.tenant_id', '=', tenantId)
+      .where('m.deleted_at', 'is', null)
+      .where((eb) => eb.or([
+        eb('m.sender_user_id', '=', userId),
+        eb('r.message_id', 'is not', null),
+      ]))
+
+    participantQuery = organizationId !== null
+      ? participantQuery.where('m.organization_id', '=', organizationId)
+      : participantQuery.where('m.organization_id', 'is', null)
+
+    const participantRows = await participantQuery.execute()
+    const participantMessageIds = participantRows.map((row) => row.id)
+    const participantMessageIdSet = new Set(participantMessageIds)
+
     // 1) MessageChannelLink — one bounded `$in` query for the whole page, shared by
     // all three enrichments (channel metadata, channel payload, conversation
     // contact). The result set is already bounded by the `messageId $in messageIds`
@@ -135,7 +185,7 @@ const messageChannelEnricher: ResponseEnricher<
       em,
       MessageChannelLink,
       {
-        messageId: { $in: messageIds },
+        messageId: { $in: participantMessageIds },
         tenantId,
         organizationId,
       },
@@ -201,6 +251,10 @@ const messageChannelEnricher: ResponseEnricher<
     }
 
     return records.map((r) => {
+      if (!participantMessageIdSet.has(r.id)) {
+        return { ...r, _channel: null, _channelPayload: null, _channelContact: null }
+      }
+
       const link = linksByMessage.get(r.id)
       if (!link) {
         return { ...r, _channel: null, _channelPayload: null, _channelContact: null }


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Prevent the communication-channels message enricher from returning channel-native data for messages where the authenticated user is neither the sender nor an active recipient.

## Changes

- Add one batched, tenant- and organization-scoped participant query before channel enrichment.
- Restrict `MessageChannelLink` loading to participant-authorized message IDs.
- Fail closed for missing authenticated users while preserving the stable `_channel*` fallback shape.
- Add regression coverage for same-organization nonparticipants and authorized payload rendering.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->

`.ai/specs/implemented/SPEC-045d-communication-notification-hubs.md`

## Testing

- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- Focused communication-channel enricher tests: 14/14 passed
- Scoped ESLint: zero errors

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Integration coverage: N/A — the reported risk is latent and no current route opts into this enricher; direct unit coverage exercises the complete enrichment boundary.

Spec changelog: N/A — minor security hardening within the existing SPEC-045d contract.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

Design System Compliance: N/A — no UI changes.

## Linked issues

Fixes #3872
