### PR TITLE
fix(notifications): validate direct recipient scope (#3873)

### DIFF
--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-003.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-003.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { randomUUID } from 'node:crypto'
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
 import {
   getTokenScope,
@@ -103,6 +104,55 @@ test.describe('TC-NOTIF-003: Notification bulk targeting APIs', () => {
       await dismissNotificationsByType(request, recipientToken, batchType)
       await deleteUserIfExists(request, superadminToken, userId)
       await deleteRoleIfExists(request, superadminToken, roleId)
+    }
+  })
+
+  test('should reject unknown recipients without partially creating a batch', async ({ request }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const scope = getTokenScope(superadminToken)
+    const userEmail = `qa-notif-scope-${Date.now()}@acme.com`
+    const userPassword = 'Valid1!Pass'
+
+    let userId: string | null = null
+    let recipientToken: string | null = null
+    let batchType: string | null = null
+
+    try {
+      userId = await createUserFixture(request, superadminToken, {
+        email: userEmail,
+        password: userPassword,
+        organizationId: scope.organizationId,
+        roles: [],
+      })
+      recipientToken = await getAuthToken(request, userEmail, userPassword)
+
+      const unknownRecipientUserId = randomUUID()
+      const directResponse = await apiRequest(request, 'POST', '/api/notifications', {
+        token: superadminToken,
+        data: {
+          type: `qa.notifications.invalid.${Date.now()}`,
+          title: 'Invalid recipient notification',
+          recipientUserId: unknownRecipientUserId,
+        },
+      })
+      expect(directResponse.status()).toBe(404)
+
+      batchType = `qa.notifications.invalid-batch.${Date.now()}`
+      const batchResponse = await apiRequest(request, 'POST', '/api/notifications/batch', {
+        token: superadminToken,
+        data: {
+          type: batchType,
+          title: 'Invalid batch recipient notification',
+          recipientUserIds: [userId, unknownRecipientUserId],
+        },
+      })
+      expect(batchResponse.status()).toBe(404)
+
+      const notifications = await listNotifications(request, recipientToken, { type: batchType })
+      expect(notifications.items.some((item) => item.type === batchType)).toBe(false)
+    } finally {
+      await dismissNotificationsByType(request, recipientToken, batchType)
+      await deleteUserIfExists(request, superadminToken, userId)
     }
   })
 })

--- a/packages/core/src/modules/notifications/__tests__/notificationRecipients.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/notificationRecipients.test.ts
@@ -1,0 +1,42 @@
+import { getScopedNotificationRecipientUserIds } from '../lib/notificationRecipients'
+
+describe('getScopedNotificationRecipientUserIds', () => {
+  it('filters recipients by id, live status, tenant, and organization', async () => {
+    const execute = jest.fn().mockResolvedValue([{ user_id: 'user-1' }])
+    const query: Record<string, jest.Mock> = {}
+    query.where = jest.fn(() => query)
+    query.select = jest.fn(() => query)
+    query.execute = execute
+    const db = {
+      selectFrom: jest.fn(() => query),
+    }
+
+    const result = await getScopedNotificationRecipientUserIds(
+      db as never,
+      'tenant-1',
+      'org-1',
+      ['user-1', 'user-2'],
+    )
+
+    expect(db.selectFrom).toHaveBeenCalledWith('users')
+    expect(query.where).toHaveBeenCalledWith('users.id', 'in', ['user-1', 'user-2'])
+    expect(query.where).toHaveBeenCalledWith('users.deleted_at', 'is', null)
+    expect(query.where).toHaveBeenCalledWith('users.tenant_id', '=', 'tenant-1')
+    expect(query.where).toHaveBeenCalledWith('users.organization_id', '=', 'org-1')
+    expect(result).toEqual(['user-1'])
+  })
+
+  it('does not add an organization predicate when the caller has no organization scope', async () => {
+    const query: Record<string, jest.Mock> = {}
+    query.where = jest.fn(() => query)
+    query.select = jest.fn(() => query)
+    query.execute = jest.fn().mockResolvedValue([])
+    const db = {
+      selectFrom: jest.fn(() => query),
+    }
+
+    await getScopedNotificationRecipientUserIds(db as never, 'tenant-1', null, ['user-1'])
+
+    expect(query.where).not.toHaveBeenCalledWith('users.organization_id', '=', expect.anything())
+  })
+})

--- a/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/notificationService.test.ts
@@ -7,6 +7,7 @@ import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/
 jest.mock('../lib/notificationRecipients', () => ({
   getRecipientUserIdsForRole: jest.fn(),
   getRecipientUserIdsForFeature: jest.fn(),
+  getScopedNotificationRecipientUserIds: jest.fn(),
 }))
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
@@ -64,6 +65,12 @@ const buildEm = () => {
 describe('notification service', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    const recipients = jest.requireMock('../lib/notificationRecipients') as {
+      getScopedNotificationRecipientUserIds: jest.Mock
+    }
+    recipients.getScopedNotificationRecipientUserIds.mockImplementation(
+      async (_db: unknown, _tenantId: string, _organizationId: string | null, recipientUserIds: string[]) => recipientUserIds,
+    )
   })
 
   it('creates a notification and emits event', async () => {
@@ -89,6 +96,23 @@ describe('notification service', () => {
         tenantId: baseCtx.tenantId,
       })
     )
+  })
+
+  it('rejects a notification whose recipient is outside the caller scope', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+    const recipients = jest.requireMock('../lib/notificationRecipients') as {
+      getScopedNotificationRecipientUserIds: jest.Mock
+    }
+
+    recipients.getScopedNotificationRecipientUserIds.mockResolvedValue([])
+    em.create.mockImplementation((_entity, data: Notification) => ({ id: 'note-invalid', ...data }))
+
+    const service = createNotificationService({ em, eventBus })
+
+    await expect(service.create(baseNotificationInput, baseCtx)).rejects.toMatchObject({ status: 404 })
+    expect(em.create).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
   })
 
   it('reuses grouped notification instead of creating duplicates', async () => {
@@ -160,6 +184,36 @@ describe('notification service', () => {
         count: 2,
       }),
     )
+  })
+
+  it('rejects an entire batch when any recipient is outside the caller scope', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+    const recipients = jest.requireMock('../lib/notificationRecipients') as {
+      getScopedNotificationRecipientUserIds: jest.Mock
+    }
+
+    recipients.getScopedNotificationRecipientUserIds.mockResolvedValue([
+      'e2c9ac54-ecdb-4d79-8d73-8328ca0f16f0',
+    ])
+    em.create.mockImplementation((_entity, data: Notification) => ({
+      id: `note-${data.recipientUserId}`,
+      ...data,
+    }))
+
+    const service = createNotificationService({ em, eventBus })
+
+    await expect(service.createBatch(
+      {
+        type: 'system',
+        title: 'Hello',
+        recipientUserIds: ['e2c9ac54-ecdb-4d79-8d73-8328ca0f16f0', 'e2d9e79c-3f2f-4b8c-9455-6c19b671dc5c'],
+      },
+      baseCtx,
+    )).rejects.toMatchObject({ status: 404 })
+    expect(em.create).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
   })
 
   it('returns empty list when no recipients match feature', async () => {

--- a/packages/core/src/modules/notifications/lib/notificationRecipients.ts
+++ b/packages/core/src/modules/notifications/lib/notificationRecipients.ts
@@ -34,6 +34,30 @@ function collectUsersWithFeature(
   }
 }
 
+export async function getScopedNotificationRecipientUserIds(
+  db: Kysely<any>,
+  tenantId: string,
+  organizationId: string | null,
+  recipientUserIds: string[],
+): Promise<string[]> {
+  const builder: any = db
+  let query = builder
+    .selectFrom('users')
+    .where('users.id', 'in', recipientUserIds)
+    .where('users.deleted_at', 'is', null)
+    .where('users.tenant_id', '=', tenantId)
+
+  if (organizationId) {
+    query = query.where('users.organization_id', '=', organizationId)
+  }
+
+  const users = await query
+    .select('users.id as user_id')
+    .execute() as Array<{ user_id: string }>
+
+  return users.map((user) => user.user_id)
+}
+
 export async function getRecipientUserIdsForRole(
   db: Kysely<any>,
   tenantId: string,

--- a/packages/core/src/modules/notifications/lib/notificationService.ts
+++ b/packages/core/src/modules/notifications/lib/notificationService.ts
@@ -14,7 +14,11 @@ import {
   type NotificationTenantContext,
 } from './notificationFactory'
 import { toNotificationDto } from './notificationMapper'
-import { getRecipientUserIdsForFeature, getRecipientUserIdsForRole } from './notificationRecipients'
+import {
+  getRecipientUserIdsForFeature,
+  getRecipientUserIdsForRole,
+  getScopedNotificationRecipientUserIds,
+} from './notificationRecipients'
 import { assertSafeNotificationHref, sanitizeNotificationActions } from './safeHref'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
@@ -32,6 +36,23 @@ const UNIQUE_NOTIFICATION_ACTIVE_STATUSES: NotificationStatus[] = ['unread', 're
 
 function normalizeOrgScope(organizationId: string | null | undefined): string | null {
   return organizationId ?? null
+}
+
+async function assertNotificationRecipientsInScope(
+  em: EntityManager,
+  recipientUserIds: string[],
+  ctx: NotificationServiceContext,
+): Promise<void> {
+  const scopedRecipientUserIds = await getScopedNotificationRecipientUserIds(
+    getDb(em),
+    ctx.tenantId,
+    normalizeOrgScope(ctx.organizationId),
+    recipientUserIds,
+  )
+
+  if (scopedRecipientUserIds.length !== recipientUserIds.length) {
+    throw new CrudHttpError(404, { error: 'Notification recipient not found' })
+  }
 }
 
 function applyNotificationContent(
@@ -214,6 +235,7 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
       const { recipientUserId, ...content } = input
       const writeEm = rootEm.fork()
       const notification = await writeEm.transactional(async (tx) => {
+        await assertNotificationRecipientsInScope(tx, [recipientUserId], ctx)
         const entity = await createOrRefreshNotification(tx, content, recipientUserId, ctx)
         await tx.flush()
         return entity
@@ -237,6 +259,7 @@ export function createNotificationService(deps: NotificationServiceDeps): Notifi
       const writeEm = rootEm.fork()
 
       await writeEm.transactional(async (tx) => {
+        await assertNotificationRecipientsInScope(tx, recipientUserIds, ctx)
         for (const recipientUserId of recipientUserIds) {
           const notification = await createOrRefreshNotification(tx, content, recipientUserId, ctx)
           notifications.push(notification)


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Prevent direct notification create and batch APIs from targeting arbitrary, deleted, cross-tenant, or cross-organization user IDs. Recipients are now resolved against live users in the caller's server-derived scope before any notification is persisted.

## Changes

- Added set-based live recipient resolution scoped by tenant and conditional organization.
- Validate direct and batch recipients inside the write transaction.
- Return the same non-enumerating 404 for missing and out-of-scope recipients.
- Keep batch creation all-or-nothing and leave role/feature targeting unchanged.
- Added unit and Playwright API regression coverage.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — issue-scoped security fix; existing module reference is `.ai/specs/implemented/SPEC-003-2026-01-23-notifications-module.md`.


## Testing

- `yarn workspace @open-mercato/core test --runInBand src/modules/notifications/__tests__/notificationService.test.ts src/modules/notifications/__tests__/notificationRecipients.test.ts` — 15 passed
- `yarn workspace @open-mercato/core test --runInBand src/modules/notifications` — 41 passed
- `yarn mercato test:integration TC-NOTIF-003` — 2 passed
- `yarn build:packages` — passed
- `yarn generate` — passed
- `yarn i18n:check-sync` — passed
- `yarn i18n:check-usage` — completed with advisory unused-key report
- `yarn typecheck` — passed, including after rebase onto current `develop`
- `yarn test` — 22 tasks passed
- `yarn build:app` — passed
- `yarn template:sync` — dependency parity passed; unrelated existing source-template drift remains outside this change

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI or visual components changed.

## Linked issues

Fixes #3873
