### PR TITLE
fix: redact integration credential URL userinfo (#3870)

### DIFF
--- a/packages/core/src/modules/integrations/AGENTS.md
+++ b/packages/core/src/modules/integrations/AGENTS.md
@@ -11,6 +11,7 @@ The `integrations` module is the foundation layer for all external connectors (p
 - **Always scope by organizationId + tenantId** — every entity query and service call
 - **Use `findWithDecryption`/`findOneWithDecryption`** for credential reads
 - **New providers MUST support provider-owned env preconfiguration** when credentials/settings are deployment-managed; implement it in the provider package, not in core
+- **Secret-bearing credential fields MUST use `secret`, `oauth`, or `ssh_keypair`** — never declare tokens, passwords, or private keys as `text`, and never embed credentials in a `url` field
 - **Health check services** must be registered in DI by the provider module, not by integrations
 - **API routes must export `openApi`** for documentation generation
 - **All user-facing strings** via i18n keys in `i18n/en.json`

--- a/packages/core/src/modules/integrations/api/__tests__/credentials-route.test.ts
+++ b/packages/core/src/modules/integrations/api/__tests__/credentials-route.test.ts
@@ -150,6 +150,22 @@ describe('integrations credentials route — secret masking (issue #2253)', () =
     expect(body.secretFieldsConfigured).toEqual({ clientSecret: true })
   })
 
+  it('GET never returns credentials embedded in a legacy URL', async () => {
+    resolveMock.mockResolvedValue({
+      apiUrl: 'https://user:legacy-token@akeneo.example/path',
+      clientSecret: 'top-secret-value',
+    })
+    const response = await GET(
+      new Request('http://localhost/api/integrations/sync_akeneo/credentials'),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.credentials.apiUrl).toBe('https://akeneo.example/path')
+    expect(JSON.stringify(body)).not.toContain('legacy-token')
+    expect(JSON.stringify(body)).not.toContain('top-secret-value')
+  })
+
   it('PUT preserves the stored secret when the masked sentinel is round-tripped', async () => {
     resolveMock.mockResolvedValue({ apiUrl: 'https://akeneo.example', clientSecret: 'stored-secret' })
     const response = await PUT(

--- a/packages/core/src/modules/integrations/lib/__tests__/credentials-field-validation.test.ts
+++ b/packages/core/src/modules/integrations/lib/__tests__/credentials-field-validation.test.ts
@@ -25,6 +25,11 @@ describe('isValidCredentialUrl', () => {
     expect(isValidCredentialUrl('ftp://example.com')).toBe(false)
     expect(isValidCredentialUrl('')).toBe(false)
   })
+
+  it('rejects URLs containing embedded credentials', () => {
+    expect(isValidCredentialUrl('https://user:token@example.com/path')).toBe(false)
+    expect(isValidCredentialUrl('https://user@example.com/path')).toBe(false)
+  })
 })
 
 describe('collectCredentialUrlValidationErrors', () => {

--- a/packages/core/src/modules/integrations/lib/__tests__/credentials-masking.test.ts
+++ b/packages/core/src/modules/integrations/lib/__tests__/credentials-masking.test.ts
@@ -53,6 +53,16 @@ describe('maskSecretCredentials', () => {
     expect(credentials).toEqual({ foo: 'bar' })
     expect(secretFieldsConfigured).toEqual({})
   })
+
+  it('removes URL userinfo from legacy stored credentials', () => {
+    const { credentials } = maskSecretCredentials(schema, {
+      apiUrl: 'https://user:token@example.com/path?query=1',
+    })
+
+    expect(credentials.apiUrl).toBe('https://example.com/path?query=1')
+    expect(JSON.stringify(credentials)).not.toContain('user')
+    expect(JSON.stringify(credentials)).not.toContain('token')
+  })
 })
 
 describe('mergeMaskedSecretCredentials', () => {

--- a/packages/core/src/modules/integrations/lib/credentials-field-validation.ts
+++ b/packages/core/src/modules/integrations/lib/credentials-field-validation.ts
@@ -17,6 +17,7 @@ export function isValidCredentialUrl(value: string): boolean {
   }
   if (!ALLOWED_CREDENTIAL_URL_PROTOCOLS.has(parsed.protocol)) return false
   if (!parsed.hostname) return false
+  if (parsed.username || parsed.password) return false
   return true
 }
 

--- a/packages/core/src/modules/integrations/lib/credentials-masking.ts
+++ b/packages/core/src/modules/integrations/lib/credentials-masking.ts
@@ -26,6 +26,19 @@ function isSecretField(type: CredentialFieldType): boolean {
   return SECRET_CREDENTIAL_FIELD_TYPES.has(type)
 }
 
+function redactUrlUserinfo(value: unknown): unknown {
+  if (typeof value !== 'string') return value
+  try {
+    const parsed = new URL(value)
+    if (!parsed.username && !parsed.password) return value
+    parsed.username = ''
+    parsed.password = ''
+    return parsed.toString()
+  } catch {
+    return value
+  }
+}
+
 function hasPresentValue(value: unknown): boolean {
   if (value === undefined || value === null) return false
   if (typeof value === 'string') return value.length > 0
@@ -53,6 +66,10 @@ export function maskSecretCredentials(
   const secretFieldsConfigured: Record<string, boolean> = {}
 
   for (const field of schema?.fields ?? []) {
+    if (field.type === 'url') {
+      credentials[field.key] = redactUrlUserinfo(credentials[field.key])
+      continue
+    }
     if (!isSecretField(field.type)) continue
     const configured = hasPresentValue(credentials[field.key])
     secretFieldsConfigured[field.key] = configured


### PR DESCRIPTION
## Summary

Prevent integration credentials embedded in URL userinfo from being returned in plaintext by the credentials API.

## Changes

- Reject new integration credential URLs containing a username or password.
- Strip userinfo from legacy stored URL credentials before returning them from GET credentials.
- Document that tokens, passwords, and private keys must use `secret`, `oauth`, or `ssh_keypair` fields.
- Add focused validation, masking, and route regression tests.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/implemented/SPEC-045a-foundation.md`

## Testing

- Targeted integrations credential tests: 3 suites, 26 tests passed.
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- Scoped ESLint for changed TypeScript files

Browser integration coverage is not required because this is an isolated server-side validation and redaction change covered at helper and API-route boundaries.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

### Design System Compliance

- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI changes.

## Linked issues

Fixes #3870
