### PR TITLE
fix(inbox_ops): require manage permission for proposal translation (#3867)

### DIFF
--- a/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-008.spec.ts
+++ b/packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-008.spec.ts
@@ -90,6 +90,14 @@ test.describe('TC-INBOX-008: Permission gates', () => {
     );
     expect(edit.status()).toBe(403);
 
+    const translate = await apiRequest(
+      request,
+      'POST',
+      `/api/inbox_ops/proposals/${FAKE_ID}/translate`,
+      { token: viewerToken, data: { targetLocale: 'de' } },
+    );
+    expect(translate.status()).toBe(403);
+
     const reprocess = await apiRequest(
       request,
       'POST',

--- a/packages/core/src/modules/inbox_ops/api/proposals/[id]/translate/__tests__/route.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/[id]/translate/__tests__/route.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment node */
 
-import { POST } from '@open-mercato/core/modules/inbox_ops/api/proposals/[id]/translate/route'
+import { metadata, POST } from '@open-mercato/core/modules/inbox_ops/api/proposals/[id]/translate/route'
 
 const mockFindOneWithDecryption = jest.fn()
 const mockFindWithDecryption = jest.fn()
@@ -53,6 +53,10 @@ describe('POST /api/inbox_ops/proposals/[id]/translate', () => {
     mockEm.fork.mockReturnValue(mockEm)
     mockFlush.mockResolvedValue(undefined)
     mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('requires proposal management permission', () => {
+    expect(metadata.POST.requireFeatures).toEqual(['inbox_ops.proposals.manage'])
   })
 
   it('returns cached translation when available', async () => {

--- a/packages/core/src/modules/inbox_ops/api/proposals/[id]/translate/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/[id]/translate/route.ts
@@ -13,7 +13,7 @@ import {
 } from '../../../routeHelpers'
 
 export const metadata = {
-  POST: { requireAuth: true, requireFeatures: ['inbox_ops.proposals.view'] },
+  POST: { requireAuth: true, requireFeatures: ['inbox_ops.proposals.manage'] },
 }
 
 export async function POST(req: Request) {


### PR DESCRIPTION
## Summary

Require proposal management permission before triggering proposal translation. This prevents view-only users from causing a paid LLM request and a persisted translation-cache write.

## Changes

- Changed the proposal translation POST guard from `inbox_ops.proposals.view` to `inbox_ops.proposals.manage`.
- Added a unit regression test covering the route metadata.
- Extended the module-local permission integration test to verify view-only users receive 403.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**

`.ai/specs/implemented/SPEC-037-2026-02-15-inbox-ops-agent.md`

No spec update was required because this is a focused correction aligning the endpoint with the existing proposal-management permission boundary.

## Testing

- Translation route regression test: red before the fix, then 7/7 passed.
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- Scoped ESLint for the changed files
- `OM_INTEGRATION_BUILD_CACHE_TTL_SECONDS=86400 yarn mercato test:integration TC-INBOX-008` — 4/4 passed

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

Integration coverage is module-local at `packages/core/src/modules/inbox_ops/__integration__/TC-INBOX-008.spec.ts`, following the current repository convention.

### Design System Compliance

- [x] No hardcoded status colors — N/A, no UI changes.
- [x] No arbitrary text sizes — N/A, no UI changes.
- [x] Empty state handled for list/data pages — N/A, no UI changes.
- [x] Loading state handled for async pages — N/A, no UI changes.
- [x] `aria-label` on all icon-only buttons — N/A, no UI changes.
- [x] Uses existing DS components — N/A, no UI changes.

## Linked issues

Fixes #3867
