### PR TITLE
fix(inbox_ops): restrict email body access (#3868)

### DIFF
--- a/packages/core/src/modules/inbox_ops/api/emails/[id]/__tests__/route.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/emails/[id]/__tests__/route.test.ts
@@ -1,0 +1,106 @@
+/** @jest-environment node */
+
+import { GET } from '../route'
+import { InboxEmail } from '../../../../data/entities'
+
+const mockFindOneWithDecryption = jest.fn()
+const mockUserHasAllFeatures = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: 'user-1',
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+  })),
+}))
+
+const mockEm = { fork: jest.fn() }
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return { userHasAllFeatures: mockUserHasAllFeatures }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+const email = {
+  id: 'email-1',
+  subject: 'Operational subject',
+  forwardedByAddress: 'sender@example.test',
+  status: 'processed',
+  receivedAt: new Date('2026-07-11T10:00:00.000Z'),
+  rawText: 'sensitive plain body',
+  rawHtml: '<p>sensitive html body</p>',
+  cleanedText: 'sensitive cleaned body',
+  threadMessages: [{ body: 'sensitive thread' }],
+  metadata: { sensitive: true },
+  organizationId: 'org-1',
+  tenantId: 'tenant-1',
+}
+
+describe('GET /api/inbox_ops/emails/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.fork.mockReturnValue(mockEm)
+    mockFindOneWithDecryption.mockResolvedValue(email)
+  })
+
+  it('redacts correspondence fields from log-only viewers', async () => {
+    mockUserHasAllFeatures.mockResolvedValue(false)
+
+    const response = await GET(new Request('http://localhost/api/inbox_ops/emails/email-1'))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.email).toMatchObject({
+      id: 'email-1',
+      subject: 'Operational subject',
+      forwardedByAddress: 'sender@example.test',
+      status: 'processed',
+      rawText: null,
+      rawHtml: null,
+      cleanedText: null,
+      threadMessages: null,
+      metadata: null,
+      organizationId: null,
+      tenantId: null,
+    })
+    expect(JSON.stringify(payload)).not.toContain('sensitive')
+    expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
+      mockEm,
+      InboxEmail,
+      expect.objectContaining({
+        id: 'email-1',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        deletedAt: null,
+      }),
+      undefined,
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+  })
+
+  it('preserves the full response for viewers allowed to read email threads', async () => {
+    mockUserHasAllFeatures.mockResolvedValue(true)
+
+    const response = await GET(new Request('http://localhost/api/inbox_ops/emails/email-1'))
+    const payload = await response.json()
+
+    expect(payload.email).toMatchObject({
+      rawText: 'sensitive plain body',
+      rawHtml: '<p>sensitive html body</p>',
+      cleanedText: 'sensitive cleaned body',
+      threadMessages: [{ body: 'sensitive thread' }],
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+  })
+})

--- a/packages/core/src/modules/inbox_ops/api/emails/[id]/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/emails/[id]/route.ts
@@ -12,6 +12,7 @@ import {
   UnauthorizedError,
 } from '../../routeHelpers'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { canViewEmailContent, serializeInboxEmail } from '../response'
 
 const logger = createLogger('inbox_ops').child({ component: 'emails' })
 
@@ -48,7 +49,8 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: 'Email not found' }, { status: 404 })
     }
 
-    return NextResponse.json({ email })
+    const includeContent = await canViewEmailContent(ctx)
+    return NextResponse.json({ email: serializeInboxEmail(email, includeContent) })
   } catch (err) {
     if (err instanceof UnauthorizedError) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/packages/core/src/modules/inbox_ops/api/emails/__tests__/route.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/emails/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+/** @jest-environment node */
+
+import { GET } from '../route'
+import { InboxEmail } from '../../../data/entities'
+
+const mockFindAndCountWithDecryption = jest.fn()
+const mockUserHasAllFeatures = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findAndCountWithDecryption: (...args: unknown[]) => mockFindAndCountWithDecryption(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: 'user-1',
+    tenantId: 'tenant-1',
+    orgId: 'org-1',
+  })),
+}))
+
+const mockEm = { fork: jest.fn() }
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'rbacService') return { userHasAllFeatures: mockUserHasAllFeatures }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+const email = {
+  id: 'email-1',
+  messageId: 'message-1',
+  contentHash: 'content-hash',
+  forwardedByAddress: 'sender@example.test',
+  forwardedByName: 'Sender',
+  toAddress: 'inbox@example.test',
+  subject: 'Operational subject',
+  replyTo: 'reply@example.test',
+  inReplyTo: 'previous-message',
+  emailReferences: ['previous-message'],
+  rawText: 'sensitive plain body',
+  rawHtml: '<p>sensitive html body</p>',
+  cleanedText: 'sensitive cleaned body',
+  threadMessages: [{ body: 'sensitive thread' }],
+  detectedLanguage: 'en',
+  attachmentIds: ['attachment-1'],
+  receivedAt: new Date('2026-07-11T10:00:00.000Z'),
+  status: 'processed',
+  processingError: null,
+  isActive: true,
+  metadata: { sensitive: true },
+  organizationId: 'org-1',
+  tenantId: 'tenant-1',
+  createdAt: new Date('2026-07-11T10:00:00.000Z'),
+  updatedAt: new Date('2026-07-11T10:00:00.000Z'),
+  deletedAt: null,
+}
+
+describe('GET /api/inbox_ops/emails', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.fork.mockReturnValue(mockEm)
+    mockFindAndCountWithDecryption.mockResolvedValue([[email], 1])
+  })
+
+  it('redacts correspondence fields from log-only viewers while preserving metadata and keys', async () => {
+    mockUserHasAllFeatures.mockResolvedValue(false)
+
+    const response = await GET(new Request('http://localhost/api/inbox_ops/emails'))
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload.items[0]).toMatchObject({
+      id: 'email-1',
+      subject: 'Operational subject',
+      forwardedByAddress: 'sender@example.test',
+      forwardedByName: 'Sender',
+      status: 'processed',
+      processingError: null,
+      receivedAt: '2026-07-11T10:00:00.000Z',
+      rawText: null,
+      rawHtml: null,
+      cleanedText: null,
+      threadMessages: null,
+      toAddress: null,
+      replyTo: null,
+      metadata: null,
+      organizationId: null,
+      tenantId: null,
+    })
+    expect(JSON.stringify(payload)).not.toContain('sensitive')
+    expect(mockUserHasAllFeatures).toHaveBeenCalledWith(
+      'user-1',
+      ['inbox_ops.proposals.view'],
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+    expect(mockFindAndCountWithDecryption).toHaveBeenCalledWith(
+      mockEm,
+      InboxEmail,
+      expect.objectContaining({ tenantId: 'tenant-1', organizationId: 'org-1', deletedAt: null }),
+      expect.any(Object),
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+  })
+
+  it('preserves the full response for viewers allowed to read email threads', async () => {
+    mockUserHasAllFeatures.mockResolvedValue(true)
+
+    const response = await GET(new Request('http://localhost/api/inbox_ops/emails'))
+    const payload = await response.json()
+
+    expect(payload.items[0]).toMatchObject({
+      rawText: 'sensitive plain body',
+      rawHtml: '<p>sensitive html body</p>',
+      cleanedText: 'sensitive cleaned body',
+      threadMessages: [{ body: 'sensitive thread' }],
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+  })
+})

--- a/packages/core/src/modules/inbox_ops/api/emails/response.ts
+++ b/packages/core/src/modules/inbox_ops/api/emails/response.ts
@@ -1,0 +1,51 @@
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import type { InboxEmail } from '../../data/entities'
+import type { RequestContext } from '../routeHelpers'
+
+const EMAIL_CONTENT_FIELDS = [
+  'messageId',
+  'contentHash',
+  'toAddress',
+  'replyTo',
+  'inReplyTo',
+  'emailReferences',
+  'rawText',
+  'rawHtml',
+  'cleanedText',
+  'threadMessages',
+  'detectedLanguage',
+  'attachmentIds',
+  'isActive',
+  'metadata',
+  'organizationId',
+  'tenantId',
+  'createdAt',
+  'updatedAt',
+  'deletedAt',
+] as const
+
+export async function canViewEmailContent(ctx: RequestContext): Promise<boolean> {
+  try {
+    const rbac = ctx.container.resolve<RbacService>('rbacService')
+    return await rbac.userHasAllFeatures(
+      ctx.userId,
+      ['inbox_ops.proposals.view'],
+      { tenantId: ctx.tenantId, organizationId: ctx.organizationId },
+    )
+  } catch {
+    return false
+  }
+}
+
+export function serializeInboxEmail(
+  email: InboxEmail,
+  includeContent: boolean,
+): InboxEmail | Record<string, unknown> {
+  if (includeContent) return email
+
+  const redacted: Record<string, unknown> = { ...email }
+  for (const field of EMAIL_CONTENT_FIELDS) {
+    redacted[field] = null
+  }
+  return redacted
+}

--- a/packages/core/src/modules/inbox_ops/api/emails/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/emails/route.ts
@@ -5,6 +5,7 @@ import { InboxEmail } from '../../data/entities'
 import { emailListQuerySchema } from '../../data/validators'
 import { resolveRequestContext, UnauthorizedError } from '../routeHelpers'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { canViewEmailContent, serializeInboxEmail } from './response'
 
 const logger = createLogger('inbox_ops').child({ component: 'emails' })
 
@@ -34,6 +35,7 @@ export async function GET(req: Request) {
     }
 
     const offset = (query.page - 1) * query.pageSize
+    const includeContent = await canViewEmailContent(ctx)
 
     const [items, total] = await findAndCountWithDecryption(
       ctx.em,
@@ -48,7 +50,7 @@ export async function GET(req: Request) {
     )
 
     return NextResponse.json({
-      items,
+      items: items.map((email) => serializeInboxEmail(email, includeContent)),
       total,
       page: query.page,
       pageSize: query.pageSize,


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Prevent processing-log-only users from receiving decrypted inbound email bodies and internal email fields. Callers with `inbox_ops.proposals.view` retain the existing full response, while log-only callers receive operational metadata with restricted keys preserved as `null`.

## Changes

- Add a shared permission-aware `InboxEmail` response serializer.
- Check `inbox_ops.proposals.view` through the tenant- and organization-scoped RBAC service.
- Redact correspondence and internal fields from list and detail responses for log-only users.
- Add focused regression coverage for redacted and full-access responses.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/implemented/SPEC-037-2026-02-15-inbox-ops-agent.md`

## Testing

- Focused inbox email route tests: 2 suites, 4 tests passed.
- `yarn build:packages` passed before and after `yarn generate`.
- `yarn i18n:check-sync` passed.
- `yarn i18n:check-usage` passed with the existing advisory unused-key report.
- `yarn typecheck` passed: 21 tasks.
- `yarn test` passed: 22 tasks; core includes 978 suites and 7,466 tests.
- `yarn build:app` passed.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Focused route tests cover the authorization and serialization boundary. No browser or UI path changed, so integration and manual UI coverage are not required.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — backend API-only change; no UI or design-system code changed.

## Linked issues

Fixes #3868
