### PR TITLE
fix(example): scope todo command snapshots (#3863)

### DIFF
--- a/apps/mercato/src/modules/example/commands/__tests__/todos.prepare-scope.test.ts
+++ b/apps/mercato/src/modules/example/commands/__tests__/todos.prepare-scope.test.ts
@@ -1,0 +1,77 @@
+jest.mock('@open-mercato/shared/lib/commands/customFieldSnapshots', () => ({
+  loadCustomFieldSnapshot: jest.fn().mockResolvedValue({}),
+  buildCustomFieldResetMap: jest.fn(() => ({})),
+  diffCustomFieldChanges: jest.fn(() => ({})),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn().mockResolvedValue({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+import '../todos'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import type { EntityManager } from '@mikro-orm/postgresql'
+
+const TODO_ID = '11111111-1111-4111-8111-111111111111'
+const TENANT_ID = '22222222-2222-4222-8222-222222222222'
+const ORG_ID = '33333333-3333-4333-8333-333333333333'
+
+function getCommand(id: string): CommandHandler<unknown, unknown> {
+  const handler = commandRegistry.get(id)
+  if (!handler) throw new Error(`Command ${id} not registered`)
+  return handler as CommandHandler<unknown, unknown>
+}
+
+function createCtx() {
+  const findOne = jest.fn().mockResolvedValue({
+    id: TODO_ID,
+    title: 'Scoped todo',
+    isDone: false,
+    tenantId: TENANT_ID,
+    organizationId: ORG_ID,
+    deletedAt: null,
+  })
+  const em = { findOne } as unknown as EntityManager
+  const ctx = {
+    container: {
+      resolve: (token: string) => {
+        if (token === 'em') return em
+        throw new Error(`Unexpected dependency: ${token}`)
+      },
+    },
+    auth: { tenantId: TENANT_ID, orgId: ORG_ID },
+    selectedOrganizationId: ORG_ID,
+    organizationIds: [ORG_ID],
+    organizationScope: null,
+  } as unknown as CommandRuntimeContext
+
+  return { ctx, findOne }
+}
+
+describe('example todo prepare snapshot scoping (#3863)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it.each([
+    ['update', 'example.todos.update', { id: TODO_ID }],
+    ['delete', 'example.todos.delete', { id: TODO_ID }],
+  ])('scopes %s pre-image reads to the active tenant and organization', async (_name, commandId, input) => {
+    const { ctx, findOne } = createCtx()
+
+    await getCommand(commandId).prepare?.(input, ctx)
+
+    expect(findOne).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        id: TODO_ID,
+        tenantId: TENANT_ID,
+        organizationId: ORG_ID,
+        deletedAt: null,
+      }),
+    )
+  })
+})

--- a/apps/mercato/src/modules/example/commands/todos.ts
+++ b/apps/mercato/src/modules/example/commands/todos.ts
@@ -214,8 +214,14 @@ const updateTodoCommand: CommandHandler<Record<string, unknown>, Todo> = {
   isUndoable: true,
   async prepare(rawInput, ctx) {
     const { parsed } = parseWithCustomFields(todoUpdateSchema, rawInput)
+    const scope = ensureScope(ctx)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const existing = await em.findOne(Todo, { id: parsed.id, deletedAt: null } as FilterQuery<Todo>)
+    const existing = await em.findOne(Todo, {
+      id: parsed.id,
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      deletedAt: null,
+    } as FilterQuery<Todo>)
     if (!existing) throw new CrudHttpError(404, { error: 'Todo not found' })
     const custom = await loadTodoCustomSnapshot(
       em,
@@ -356,8 +362,14 @@ const deleteTodoCommand: CommandHandler<{ body?: Record<string, unknown>; query?
   isUndoable: true,
   async prepare(input, ctx) {
     const id = requireId(input, 'Todo id required')
+    const scope = ensureScope(ctx)
     const em = (ctx.container.resolve('em') as EntityManager)
-    const existing = await em.findOne(Todo, { id, deletedAt: null } as FilterQuery<Todo>)
+    const existing = await em.findOne(Todo, {
+      id,
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      deletedAt: null,
+    } as FilterQuery<Todo>)
     if (!existing) return {}
     const custom = await loadTodoCustomSnapshot(
       em,


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Scope example todo update and delete pre-image snapshot reads to the active tenant and organization, preventing records outside the caller's scope from being loaded during command preparation.

## Changes

- Add tenant and organization predicates to both todo `prepare()` snapshot queries.
- Add regression coverage for update and delete command preparation.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — minor predicate-only security hardening with no contract change.


## Testing

- `yarn workspace @open-mercato/app test src/modules/example/commands/__tests__/todos.prepare-scope.test.ts --runInBand`
- `yarn workspace @open-mercato/app test src/modules/example/commands/__tests__ --runInBand`
- Scoped ESLint for both changed files
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`

All blocking checks passed.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Integration coverage is not required because this is a predicate-only command-unit change with focused coverage. This backend-only hardening is routed with `skip-qa`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI files or behavior changed.

## Linked issues

Fixes #3863
