### PR TITLE
fix(example): annotate unauthenticated override probe (#3864)

### DIFF
--- a/apps/mercato/src/modules/example/api/override-probe/route.ts
+++ b/apps/mercato/src/modules/example/api/override-probe/route.ts
@@ -3,6 +3,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { exampleTag } from '../openapi'
 
 export const metadata = {
+  // Test-only public probe: do not copy `requireAuth: false` to data-bearing routes.
   GET: { requireAuth: false },
 }
 
@@ -35,4 +36,3 @@ export const openApi: OpenApiRouteDoc = {
     },
   },
 }
-

--- a/packages/cli/src/lib/generators/__tests__/example-public-route-safety.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/example-public-route-safety.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const repoRoot = join(__dirname, '..', '..', '..', '..', '..', '..')
+const probeRoutes = [
+  'apps/mercato/src/modules/example/api/override-probe/route.ts',
+  'packages/create-app/template/src/modules/example/api/override-probe/route.ts',
+]
+
+describe('example public route safety guidance (#3864)', () => {
+  it.each(probeRoutes)('%s warns against copying unauthenticated metadata to data-bearing routes', (route) => {
+    const source = readFileSync(join(repoRoot, route), 'utf8')
+
+    expect(source).toContain('Test-only public probe: do not copy `requireAuth: false` to data-bearing routes.')
+  })
+})

--- a/packages/create-app/template/src/modules/example/api/override-probe/route.ts
+++ b/packages/create-app/template/src/modules/example/api/override-probe/route.ts
@@ -3,6 +3,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { exampleTag } from '../openapi'
 
 export const metadata = {
+  // Test-only public probe: do not copy `requireAuth: false` to data-bearing routes.
   GET: { requireAuth: false },
 }
 
@@ -35,4 +36,3 @@ export const openApi: OpenApiRouteDoc = {
     },
   },
 }
-


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Marks the intentionally unauthenticated example override probe as test-only and warns developers not to copy `requireAuth: false` onto data-bearing routes.

## Changes

- Added the warning beside the probe metadata in the monorepo example module.
- Mirrored the warning in the create-app template.
- Added source-contract regression coverage for both copies.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — annotation-only security guidance with no behavior or contract change.


## Testing

- Focused regression test: failed before the annotation and passed afterward (2 tests).
- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- Scoped ESLint
- Direct app/template route parity comparison

`yarn template:sync` continues to report unrelated pre-existing drift; the two changed probe routes are identical and are not among the reported mismatches.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified`). See `.github/QA-DEPLOYMENT.md`.

Integration coverage is not required because the route behavior and authentication metadata are unchanged. Existing `TC-UMES-022` continues to cover the override behavior.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI files or behavior changed.

## Linked issues

Fixes #3864
