### PR TITLE
security(gateway_stripe): drop metadata-trust scope fallback + dead helper (#3866, #3865)

### DIFF
--- a/packages/gateway-stripe/src/modules/gateway_stripe/__tests__/webhook-processor.test.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/__tests__/webhook-processor.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment node */
+import handle from '../workers/webhook-processor'
+import { claimWebhookProcessing } from '@open-mercato/core/modules/payment_gateways/lib/webhook-utils'
+import { mapWebhookEventToStatus, mapStripeStatus } from '../lib/status-map'
+import type { WebhookEvent } from '@open-mercato/shared/modules/payment_gateways/types'
+
+jest.mock('@open-mercato/core/modules/payment_gateways/lib/webhook-utils', () => ({
+  claimWebhookProcessing: jest.fn(async () => true),
+  releaseWebhookClaim: jest.fn(async () => {}),
+}))
+
+jest.mock('../lib/status-map', () => ({
+  mapWebhookEventToStatus: jest.fn(() => 'paid'),
+  mapStripeStatus: jest.fn(() => 'paid'),
+  mapRefundReason: jest.fn(() => undefined),
+}))
+
+type WorkerJob = Parameters<typeof handle>[0]
+type WorkerCtx = Parameters<typeof handle>[1]
+
+const paymentGatewayService = {
+  findTransaction: jest.fn(),
+  findTransactionBySessionId: jest.fn(),
+  syncTransactionStatus: jest.fn(),
+}
+
+const integrationLogService = {
+  scoped: jest.fn(() => ({ info: jest.fn(async () => {}) })),
+  write: jest.fn(async () => {}),
+}
+
+const resolve = (token: string): unknown => {
+  if (token === 'em') return {}
+  if (token === 'paymentGatewayService') return paymentGatewayService
+  if (token === 'integrationLogService') return integrationLogService
+  throw new Error(`Unexpected token: ${token}`)
+}
+
+const ctx = { resolve } as unknown as WorkerCtx
+
+function makeEvent(overrides: Partial<WebhookEvent> = {}): WebhookEvent {
+  return {
+    eventType: 'checkout.session.completed',
+    eventId: 'evt_1',
+    idempotencyKey: 'idem_1',
+    timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    data: {},
+    ...overrides,
+  }
+}
+
+function makeJob(payload: {
+  event: WebhookEvent
+  scope?: { organizationId: string; tenantId: string } | null
+  transactionId?: string | null
+}): WorkerJob {
+  return {
+    id: 'job_1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    payload: { providerKey: 'stripe', ...payload },
+  } as unknown as WorkerJob
+}
+
+describe('gateway_stripe webhook worker scope handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(claimWebhookProcessing as jest.Mock).mockResolvedValue(true)
+    ;(mapWebhookEventToStatus as jest.Mock).mockReturnValue('paid')
+    ;(mapStripeStatus as jest.Mock).mockReturnValue('paid')
+  })
+
+  it('never derives tenant scope from event.data.metadata (fails closed on a scope-less job)', async () => {
+    const event = makeEvent({
+      data: {
+        id: 'cs_test_attacker',
+        metadata: { organizationId: 'org-attacker', tenantId: 'tenant-attacker' },
+      },
+    })
+
+    await handle(makeJob({ event, scope: null, transactionId: null }), ctx)
+
+    expect(paymentGatewayService.findTransaction).not.toHaveBeenCalled()
+    expect(paymentGatewayService.findTransactionBySessionId).not.toHaveBeenCalled()
+    expect(paymentGatewayService.syncTransactionStatus).not.toHaveBeenCalled()
+  })
+
+  it('processes the webhook using the trusted scope from the job payload, ignoring event metadata', async () => {
+    const scope = { organizationId: 'org-trusted', tenantId: 'tenant-trusted' }
+    const event = makeEvent({
+      data: {
+        id: 'cs_test_ok',
+        status: 'complete',
+        metadata: { organizationId: 'org-attacker', tenantId: 'tenant-attacker' },
+      },
+    })
+    paymentGatewayService.findTransactionBySessionId.mockResolvedValue({
+      id: 'txn_1',
+      organizationId: scope.organizationId,
+      tenantId: scope.tenantId,
+    })
+
+    await handle(makeJob({ event, scope, transactionId: null }), ctx)
+
+    expect(paymentGatewayService.findTransactionBySessionId).toHaveBeenCalledWith('cs_test_ok', scope, 'stripe')
+    expect(paymentGatewayService.syncTransactionStatus).toHaveBeenCalledWith(
+      'txn_1',
+      expect.objectContaining({ unifiedStatus: 'paid' }),
+      { organizationId: scope.organizationId, tenantId: scope.tenantId },
+    )
+  })
+})

--- a/packages/gateway-stripe/src/modules/gateway_stripe/workers/webhook-processor.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/workers/webhook-processor.ts
@@ -37,28 +37,14 @@ function readSessionIdFromEvent(event: WebhookEvent): string | null {
   return null
 }
 
-function readScopeFromEvent(event: WebhookEvent): { organizationId: string; tenantId: string } | null {
-  const metadata = event.data.metadata
-  if (!metadata || typeof metadata !== 'object') return null
-
-  const metadataRecord = metadata as Record<string, unknown>
-  const organizationId = typeof metadataRecord.organizationId === 'string'
-    ? metadataRecord.organizationId.trim()
-    : ''
-  const tenantId = typeof metadataRecord.tenantId === 'string'
-    ? metadataRecord.tenantId.trim()
-    : ''
-
-  if (!organizationId || !tenantId) return null
-  return { organizationId, tenantId }
-}
-
 export default async function handle(job: QueuedJob<WebhookJobPayload>, ctx: HandlerContext): Promise<void> {
   const em = ctx.resolve<EntityManager>('em')
   const paymentGatewayService = ctx.resolve<PaymentGatewayService>('paymentGatewayService')
   const integrationLogService = ctx.resolve<IntegrationLogService>('integrationLogService')
   const event = job.payload.event
-  const scope = job.payload.scope ?? readScopeFromEvent(event)
+  // Scope MUST come from the trusted enqueuer (a signature-verified transaction), never from
+  // attacker-controlled `event.data.metadata` — that fallback was the cross-tenant-write vector.
+  const scope = job.payload.scope ?? null
 
   try {
     let transaction = job.payload.transactionId && scope


### PR DESCRIPTION
## Summary

The Stripe webhook worker kept `readScopeFromEvent`, which derived tenant/org scope
from the **unverified** webhook body (`event.data.metadata`), reachable via the
`?? readScopeFromEvent(event)` fallback. That is a latent cross-tenant-write primitive:
the worker never re-verifies the event signature, so scope is the only guardrail, and any
future/alternate `stripe-webhook` producer that enqueues a scope-less job would let attacker
metadata select the victim tenant.

This removes the helper and its sole reference (the fallback), so no code path derives scope
from `event.data.metadata`. The worker now fails closed when `job.payload.scope` is absent —
mirroring the hardened core processor (`packages/core/src/modules/payment_gateways/lib/webhook-processor.ts`).
Because deleting the helper (#3866) requires deleting the fallback (#3865), and #3866 explicitly
permits doing both in one change, this PR resolves both paired issues.

## Changes

- `packages/gateway-stripe/.../workers/webhook-processor.ts`: delete `readScopeFromEvent`; replace
  `job.payload.scope ?? readScopeFromEvent(event)` with `job.payload.scope ?? null` (worker already
  no-ops via `if (!sessionId || !scope) return`); add a comment documenting the trusted-scope-only contract.
- `packages/gateway-stripe/.../__tests__/webhook-processor.test.ts` (new): guard test — a scope-less job
  carrying foreign `event.data.metadata` no-ops (no lookup/mutation); a scoped job processes using the
  trusted payload scope, ignoring metadata.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — security dead-code/fallback removal; no spec required.

## Testing

- `turbo run build --filter=./packages/*` — 21/21 ✅
- `turbo run generate` — ✅ (no generated-file drift)
- `yarn i18n:check-sync` — in sync ✅
- `turbo run typecheck` — 21/21 ✅
- `turbo run test` — 22/22 packages ✅ (gateway-stripe 18/18, app 163/163)
- `turbo run build --filter=@open-mercato/app` — ✅ (0 module-not-found)
- New guard test verified red (pre-fix: metadata-derived scope drove a cross-tenant lookup) → green (post-fix).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (None required — no locale/doc/generator surface touched; `i18n:check-sync` green, generators emit no drift.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). (N/A — a scope-less `stripe-webhook` job is unreachable via HTTP, so this fail-closed behavior has no Playwright/UI surface; the correct seam is the jest worker guard test added here.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). (N/A — minor security fix.)
- [x] Priority set: this PR carries exactly one `priority-*` label. (`priority-medium` — security hardening, but latent/unreachable via HTTP today.)
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. (`risk-medium` — touches tenant-scope on the payment path, but no real traffic is affected and it is fully test-covered.)
- [x] QA routing set: `skip-qa` — backend queue-worker security guard, no customer-facing behavior change, covered by the jest test.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI
- [x] No arbitrary text sizes — N/A, no UI
- [x] Empty state handled for list/data pages — N/A, no UI
- [x] Loading state handled for async pages — N/A, no UI
- [x] `aria-label` on all icon-only buttons — N/A, no UI
- [x] Uses existing DS components — N/A, no UI

## Linked issues

Fixes #3866
Fixes #3865
