### PR TITLE
fix(sales): preserve customer addresses in shipments (#4058)

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-4053-inline-customer-address.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-4053-inline-customer-address.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test'
+import { apiRequest } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+type JsonRecord = Record<string, unknown>
+
+function readId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null
+  const record = payload as JsonRecord
+  for (const key of ['entityId', 'id', 'result']) {
+    const value = record[key]
+    if (typeof value === 'string' && value.length > 0) return value
+    const nested = readId(value)
+    if (nested) return nested
+  }
+  return null
+}
+
+async function deleteCustomerEntity(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  id: string | null,
+): Promise<void> {
+  if (!id) return
+  await apiRequest(request, 'DELETE', `${path}?id=${encodeURIComponent(id)}`, { token }).catch(() => undefined)
+}
+
+async function loginAdmin(page: Page): Promise<string> {
+  const response = await page.request.post('/api/auth/login', {
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    data: new URLSearchParams({ email: 'admin@acme.com', password: 'secret' }).toString(),
+  })
+  expect(response.ok(), `Admin login failed: ${response.status()}`).toBeTruthy()
+  const payload = await readJsonSafe<{ token?: string }>(response)
+  expect(payload?.token).toBeTruthy()
+  const token = payload!.token!
+  const scope = getTokenScope(token)
+  const baseUrl = process.env.BASE_URL ?? 'http://localhost:3000'
+  await page.context().addCookies([
+    { name: 'om_demo_notice_ack', value: 'ack', url: baseUrl },
+    { name: 'om_cookie_notice_ack', value: 'ack', url: baseUrl },
+    { name: 'om_feedback_suppress', value: '1', url: baseUrl },
+    { name: 'om_selected_tenant', value: scope.tenantId, url: baseUrl },
+    { name: 'om_selected_org', value: scope.organizationId, url: baseUrl },
+  ])
+  return token
+}
+
+test.describe('TC-SALES-4053: inline customer address persistence', () => {
+  test('persists an address added while creating a person from the order form', async ({ page, request }) => {
+    const token = await loginAdmin(page)
+    const stamp = Date.now()
+    const displayName = `QA Inline ${stamp}`
+    const addressLine = `${stamp} Persist Street`
+    let personId: string | null = null
+    let addressId: string | null = null
+
+    try {
+      await page.goto('/backend/sales/documents/create', { waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: 'Create customer' }).click()
+      await page.getByRole('button', { name: /(?:New|Create) person/ }).click()
+
+      const dialog = page.getByRole('dialog', { name: /(?:New|Create) person/ })
+      await expect(dialog).toBeVisible()
+      await dialog.getByText('First name *').locator('..').getByRole('textbox').fill('QA')
+      await dialog.getByText('Last name *').locator('..').getByRole('textbox').fill(`Inline ${stamp}`)
+      await dialog.getByRole('button', { name: 'Add address' }).click()
+      await dialog.getByRole('textbox', { name: /Address line 1|Street/ }).fill(addressLine)
+      await dialog.getByRole('textbox', { name: 'City' }).fill('Warsaw')
+      await dialog.getByRole('button', { name: /Save address/ }).click()
+      await expect(dialog.getByText(addressLine)).toBeVisible()
+
+      const personResponsePromise = page.waitForResponse((response) => {
+        const url = new URL(response.url())
+        return url.pathname === '/api/customers/people' && response.request().method() === 'POST'
+      })
+      const addressResponsePromise = page.waitForResponse((response) => {
+        const url = new URL(response.url())
+        return url.pathname === '/api/customers/addresses' && response.request().method() === 'POST'
+      })
+      await dialog.getByRole('button', { name: 'Save', exact: true }).click()
+
+      const personResponse = await personResponsePromise
+      expect(personResponse.ok(), `Inline person create failed: ${personResponse.status()}`).toBeTruthy()
+      personId = readId(await personResponse.json())
+      expect(personId).toBeTruthy()
+
+      const addressResponse = await addressResponsePromise
+      expect(addressResponse.ok(), `Inline address create failed: ${addressResponse.status()}`).toBeTruthy()
+      addressId = readId(await addressResponse.json())
+      expect(addressResponse.request().postDataJSON()).toMatchObject({
+        entityId: personId,
+        addressLine1: addressLine,
+      })
+      await expect(dialog).toBeHidden()
+
+      const listResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/addresses?entityId=${encodeURIComponent(personId!)}`,
+        { token },
+      )
+      expect(listResponse.ok()).toBeTruthy()
+      const payload = await readJsonSafe<{ items?: JsonRecord[] }>(listResponse)
+      expect(payload?.items?.some((item) => item.address_line1 === addressLine || item.addressLine1 === addressLine)).toBe(true)
+      await expect(page.getByText(displayName).first()).toBeVisible()
+    } finally {
+      await deleteCustomerEntity(request, token, '/api/customers/addresses', addressId)
+      await deleteCustomerEntity(request, token, '/api/customers/people', personId)
+    }
+  })
+})

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-4057-additional-address-shipment.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-4057-additional-address-shipment.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test, type APIRequestContext, type Page, type Request } from '@playwright/test'
+import { apiRequest } from '@open-mercato/core/helpers/integration/api'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createOrderLineFixture,
+  createSalesOrderFixture,
+  deleteSalesEntityIfExists,
+} from '@open-mercato/core/helpers/integration/salesFixtures'
+
+function readId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null
+  const record = payload as Record<string, unknown>
+  for (const key of ['id', 'entityId', 'result']) {
+    const value = record[key]
+    if (typeof value === 'string' && value.length > 0) return value
+    const nested = readId(value)
+    if (nested) return nested
+  }
+  return null
+}
+
+async function deleteDocumentAddress(
+  request: APIRequestContext,
+  token: string,
+  addressId: string | null,
+  orderId: string | null,
+): Promise<void> {
+  if (!addressId || !orderId) return
+  const query = `id=${encodeURIComponent(addressId)}&documentId=${encodeURIComponent(orderId)}&documentKind=order`
+  await apiRequest(request, 'DELETE', `/api/sales/document-addresses?${query}`, { token }).catch(() => undefined)
+}
+
+async function loginAdmin(page: Page): Promise<string> {
+  const response = await page.request.post('/api/auth/login', {
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    data: new URLSearchParams({ email: 'admin@acme.com', password: 'secret' }).toString(),
+  })
+  expect(response.ok(), `Admin login failed: ${response.status()}`).toBeTruthy()
+  const payload = await readJsonSafe<{ token?: string }>(response)
+  expect(payload?.token).toBeTruthy()
+  const token = payload!.token!
+  const scope = getTokenScope(token)
+  const baseUrl = process.env.BASE_URL ?? 'http://localhost:3000'
+  await page.context().addCookies([
+    { name: 'om_demo_notice_ack', value: 'ack', url: baseUrl },
+    { name: 'om_cookie_notice_ack', value: 'ack', url: baseUrl },
+    { name: 'om_feedback_suppress', value: '1', url: baseUrl },
+    { name: 'om_selected_tenant', value: scope.tenantId, url: baseUrl },
+    { name: 'om_selected_org', value: scope.organizationId, url: baseUrl },
+  ])
+  return token
+}
+
+test.describe('TC-SALES-4057: additional document address in shipment dialog', () => {
+  test('loads an additional address once without trapping the shipment dialog in a request loop', async ({ page, request }) => {
+    const token = await loginAdmin(page)
+    const stamp = Date.now()
+    const addressLine = `${stamp} Shipment Lane`
+    let orderId: string | null = null
+    let orderLineId: string | null = null
+    let addressId: string | null = null
+    let addressRequests = 0
+    let countAddressRequest: ((request: Request) => void) | null = null
+
+    try {
+      orderId = await createSalesOrderFixture(request, token)
+      orderLineId = await createOrderLineFixture(request, token, orderId, { name: `QA shipment line ${stamp}` })
+      const createResponse = await apiRequest(request, 'POST', '/api/sales/document-addresses', {
+        token,
+        data: {
+          documentId: orderId,
+          documentKind: 'order',
+          purpose: 'additional',
+          name: `QA Shipment Address ${stamp}`,
+          addressLine1: addressLine,
+          city: 'Warsaw',
+          country: 'PL',
+        },
+      })
+      expect(createResponse.ok(), `Document address create failed: ${createResponse.status()}`).toBeTruthy()
+      addressId = readId(await readJsonSafe(createResponse))
+      expect(addressId).toBeTruthy()
+
+      await page.goto(`/backend/sales/orders/${encodeURIComponent(orderId)}?kind=order`, { waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: 'Shipments' }).click()
+      countAddressRequest = (candidate) => {
+        const url = new URL(candidate.url())
+        if (
+          candidate.method() === 'GET'
+          && url.pathname === '/api/sales/document-addresses'
+          && url.searchParams.get('documentId') === orderId
+          && url.searchParams.get('documentKind') === 'order'
+        ) {
+          addressRequests += 1
+        }
+      }
+      page.on('request', countAddressRequest)
+      await page.getByRole('button', { name: 'Add shipment' }).first().click()
+
+      const dialog = page.getByRole('dialog', { name: 'Add shipment' })
+      await expect(dialog).toBeVisible()
+      await expect(dialog.getByText(addressLine)).toBeVisible()
+      await expect(dialog.getByText(/Loading shipments/)).toHaveCount(0)
+      await expect(dialog.getByRole('textbox').first()).toBeEnabled()
+      await page.waitForTimeout(750)
+      expect(addressRequests, 'Document address lookup should settle after one request').toBe(1)
+    } finally {
+      if (countAddressRequest) page.off('request', countAddressRequest)
+      await deleteDocumentAddress(request, token, addressId, orderId)
+      await deleteSalesEntityIfExists(request, token, '/api/sales/order-lines', orderLineId)
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+    }
+  })
+})

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-4057-main-address-shipment.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-4057-main-address-shipment.spec.ts
@@ -91,7 +91,9 @@ test.describe('TC-SALES-4057: main address selected after order creation', () =>
       await page.goto(`/backend/sales/orders/${encodeURIComponent(orderId)}?kind=order`, { waitUntil: 'domcontentloaded' })
       await page.getByRole('button', { name: 'Addresses' }).click()
 
-      const shippingCard = page.getByText('Shipping address', { exact: true }).locator('..').locator('..').locator('..')
+      const shippingCard = page
+        .getByText('Shipping address', { exact: true })
+        .locator('xpath=ancestor::div[contains(@class,"rounded")][1]')
       const shippingSelect = shippingCard.getByRole('combobox')
       await expect(shippingSelect).toBeEnabled()
       await shippingSelect.click()
@@ -107,6 +109,7 @@ test.describe('TC-SALES-4057: main address selected after order creation', () =>
       const updateBody = updateResponse.request().postDataJSON() as Record<string, unknown>
       expect(updateBody.shippingAddressId).toBe(customerAddressId)
       expect(Object.prototype.hasOwnProperty.call(updateBody, 'shippingAddressSnapshot')).toBe(false)
+      await expect(page.getByRole('button', { name: 'Update addresses' })).toBeEnabled()
 
       await page.getByRole('button', { name: 'Shipments' }).click()
       await page.getByRole('button', { name: 'Add shipment' }).first().click()

--- a/packages/core/src/modules/sales/__integration__/TC-SALES-4057-main-address-shipment.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-4057-main-address-shipment.spec.ts
@@ -1,0 +1,124 @@
+import { expect, test, type APIRequestContext, type Page } from '@playwright/test'
+import { apiRequest } from '@open-mercato/core/helpers/integration/api'
+import { createCompanyFixture, deleteEntityIfExists } from '@open-mercato/core/helpers/integration/crmFixtures'
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { createOrderLineFixture, deleteSalesEntityIfExists } from '@open-mercato/core/helpers/integration/salesFixtures'
+
+function readId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null
+  const record = payload as Record<string, unknown>
+  for (const key of ['id', 'entityId', 'orderId', 'result']) {
+    const value = record[key]
+    if (typeof value === 'string' && value.length > 0) return value
+    const nested = readId(value)
+    if (nested) return nested
+  }
+  return null
+}
+
+async function createEntity(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  data: Record<string, unknown>,
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', path, { token, data })
+  expect(response.ok(), `Failed POST ${path}: ${response.status()}`).toBeTruthy()
+  const id = readId(await readJsonSafe(response))
+  expect(id, `No id in POST ${path} response`).toBeTruthy()
+  return id!
+}
+
+async function loginAdmin(page: Page): Promise<string> {
+  const response = await page.request.post('/api/auth/login', {
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    data: new URLSearchParams({ email: 'admin@acme.com', password: 'secret' }).toString(),
+  })
+  expect(response.ok(), `Admin login failed: ${response.status()}`).toBeTruthy()
+  const payload = await readJsonSafe<{ token?: string }>(response)
+  expect(payload?.token).toBeTruthy()
+  const token = payload!.token!
+  const scope = getTokenScope(token)
+  const baseUrl = process.env.BASE_URL ?? 'http://localhost:3000'
+  await page.context().addCookies([
+    { name: 'om_demo_notice_ack', value: 'ack', url: baseUrl },
+    { name: 'om_cookie_notice_ack', value: 'ack', url: baseUrl },
+    { name: 'om_feedback_suppress', value: '1', url: baseUrl },
+    { name: 'om_selected_tenant', value: scope.tenantId, url: baseUrl },
+    { name: 'om_selected_org', value: scope.organizationId, url: baseUrl },
+  ])
+  return token
+}
+
+test.describe('TC-SALES-4057: main address selected after order creation', () => {
+  test('resolves the selected customer address and offers it in the shipment dialog', async ({ page, request }) => {
+    const token = await loginAdmin(page)
+    const scope = getTokenScope(token)
+    const stamp = Date.now()
+    const addressName = `QA Main Address ${stamp}`
+    const addressLine = `${stamp} Main Shipping Street`
+    let customerId: string | null = null
+    let customerAddressId: string | null = null
+    let orderId: string | null = null
+    let orderLineId: string | null = null
+
+    try {
+      customerId = await createCompanyFixture(request, token, `QA Main Address Customer ${stamp}`)
+      customerAddressId = await createEntity(request, token, '/api/customers/addresses', {
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        entityId: customerId,
+        name: addressName,
+        addressLine1: addressLine,
+        city: 'Warsaw',
+        country: 'PL',
+      })
+      const addressListResponse = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/addresses?entityId=${encodeURIComponent(customerId)}`,
+        { token },
+      )
+      const addressList = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(addressListResponse)
+      expect(addressListResponse.ok()).toBeTruthy()
+      expect(addressList?.items?.some((item) => item.id === customerAddressId)).toBe(true)
+      orderId = await createEntity(request, token, '/api/sales/orders', {
+        currencyCode: 'USD',
+        customerEntityId: customerId,
+      })
+      orderLineId = await createOrderLineFixture(request, token, orderId, { name: `QA main address line ${stamp}` })
+
+      await page.goto(`/backend/sales/orders/${encodeURIComponent(orderId)}?kind=order`, { waitUntil: 'domcontentloaded' })
+      await page.getByRole('button', { name: 'Addresses' }).click()
+
+      const shippingCard = page.getByText('Shipping address', { exact: true }).locator('..').locator('..').locator('..')
+      const shippingSelect = shippingCard.getByRole('combobox')
+      await expect(shippingSelect).toBeEnabled()
+      await shippingSelect.click()
+      await page.getByRole('option').filter({ hasText: addressLine }).click()
+
+      const updateResponsePromise = page.waitForResponse((response) => {
+        const url = new URL(response.url())
+        return url.pathname === '/api/sales/orders' && response.request().method() === 'PUT'
+      })
+      await page.getByRole('button', { name: 'Update addresses' }).click()
+      const updateResponse = await updateResponsePromise
+      expect(updateResponse.ok(), `Order address update failed: ${updateResponse.status()}`).toBeTruthy()
+      const updateBody = updateResponse.request().postDataJSON() as Record<string, unknown>
+      expect(updateBody.shippingAddressId).toBe(customerAddressId)
+      expect(Object.prototype.hasOwnProperty.call(updateBody, 'shippingAddressSnapshot')).toBe(false)
+
+      await page.getByRole('button', { name: 'Shipments' }).click()
+      await page.getByRole('button', { name: 'Add shipment' }).first().click()
+      const dialog = page.getByRole('dialog', { name: 'Add shipment' })
+      await expect(dialog).toBeVisible()
+      await expect(dialog.getByText(addressLine)).toBeVisible()
+      await expect(dialog.getByText(/No results/)).toHaveCount(0)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/order-lines', orderLineId)
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', orderId)
+      await deleteEntityIfExists(request, token, '/api/customers/addresses', customerAddressId)
+      await deleteEntityIfExists(request, token, '/api/customers/companies', customerId)
+    }
+  })
+})

--- a/packages/core/src/modules/sales/components/__tests__/salesDocumentFormQuickCreate.test.tsx
+++ b/packages/core/src/modules/sales/components/__tests__/salesDocumentFormQuickCreate.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+jest.setTimeout(20000)
+
+const mockApiCall = jest.fn()
+const mockCreateCrud = jest.fn()
+const mockSetValue = jest.fn()
+const mockT = (key: string, fallback?: string) => fallback ?? key
+const mockRefetchCurrencyDictionary = jest.fn()
+const personValues = {
+  displayName: 'Jane Doe',
+  firstName: 'Jane',
+  lastName: 'Doe',
+  primaryEmail: 'jane@example.com',
+  addresses: [
+    {
+      id: 'draft-address',
+      name: ' Home ',
+      purpose: ' billing ',
+      companyName: ' Not serialized by the reference flow ',
+      addressLine1: '  Main Street 1  ',
+      addressLine2: '  Apartment 2  ',
+      buildingNumber: ' 1 ',
+      flatNumber: ' 2 ',
+      city: ' Warsaw ',
+      region: '   ',
+      postalCode: ' 00-001 ',
+      country: ' pl ',
+      latitude: 52.2297,
+      longitude: 21.0122,
+      isPrimary: true,
+    },
+  ],
+}
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: any[]) => mockApiCall(...args),
+  apiCallOrThrow: jest.fn().mockResolvedValue({ items: [] }),
+  readApiResultOrThrow: jest.fn().mockResolvedValue({ items: [] }),
+}))
+
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: ({ entityIds, groups, initialValues, onSubmit }: any) => {
+    if (entityIds?.includes('customers:customer_person_profile')) {
+      return (
+        <button type="button" onClick={() => void onSubmit(personValues)}>
+          Submit inline person
+        </button>
+      )
+    }
+    const customerGroup = (groups ?? []).find((group: any) => group.id === 'customer')
+    return (
+      <div data-testid="crud-form">
+        {customerGroup?.component?.({
+          values: initialValues ?? {},
+          setValue: mockSetValue,
+          errors: {},
+        })}
+      </div>
+    )
+  },
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  createCrud: (...args: any[]) => mockCreateCrud(...args),
+  updateCrud: jest.fn().mockResolvedValue({ ok: true }),
+  deleteCrud: jest.fn().mockResolvedValue({ ok: true }),
+  buildCrudExportUrl: () => '/export.csv',
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({ flash: jest.fn() }))
+jest.mock('@open-mercato/ui/backend/inputs', () => ({
+  LookupSelect: ({ actionSlot }: any) => <div>{actionSlot}</div>,
+}))
+jest.mock('@open-mercato/ui/primitives/input', () => ({ Input: (props: any) => <input {...props} /> }))
+jest.mock('@open-mercato/ui/primitives/email-input', () => ({ EmailInput: (props: any) => <input {...props} /> }))
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+jest.mock('@open-mercato/ui/primitives/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <div>{children}</div>,
+  SelectValue: () => <span />,
+}))
+jest.mock('@open-mercato/ui/primitives/switch-field', () => ({ SwitchField: () => <div /> }))
+jest.mock('@open-mercato/ui/primitives/dialog', () => ({
+  Dialog: ({ children }: any) => <div>{children}</div>,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <p>{children}</p>,
+  DialogFooter: ({ children }: any) => <div>{children}</div>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <h3>{children}</h3>,
+  DialogTrigger: ({ children }: any) => <div>{children}</div>,
+}))
+jest.mock('@open-mercato/ui/backend/utils/customFieldValues', () => ({
+  collectCustomFieldValues: jest.fn().mockReturnValue({}),
+}))
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  createCrudFormError: (message: string) => new Error(message),
+}))
+jest.mock('@open-mercato/core/modules/dictionaries/components/DictionaryEntrySelect', () => ({
+  DictionaryEntrySelect: () => <select />,
+}))
+jest.mock('@open-mercato/core/modules/customers/components/detail/hooks/useCurrencyDictionary', () => ({
+  useCurrencyDictionary: () => ({ data: { entries: [] }, refetch: mockRefetchCurrencyDictionary }),
+}))
+jest.mock('@open-mercato/core/modules/customers/backend/hooks/useEmailDuplicateCheck', () => ({
+  useEmailDuplicateCheck: () => ({ checking: false, duplicate: false, check: jest.fn() }),
+}))
+jest.mock('@open-mercato/core/modules/customers/components/formConfig', () => ({
+  createPersonFormFields: () => [],
+  createPersonFormGroups: () => [],
+  createPersonFormSchema: () => ({}),
+  createCompanyFormFields: () => [],
+  createCompanyFormGroups: () => [],
+  createCompanyFormSchema: () => ({}),
+  buildPersonPayload: () => ({ displayName: 'Jane Doe' }),
+  buildCompanyPayload: jest.fn(),
+}))
+jest.mock('@open-mercato/core/modules/customers/components/AddressEditor', () => ({ AddressEditor: () => <div /> }))
+jest.mock('@open-mercato/core/modules/customers/utils/addressFormat', () => ({ formatAddressString: () => '' }))
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockT,
+}))
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 1,
+  useOrganizationScopeDetail: () => ({ organizationId: 'organization-1', tenantId: 'tenant-1' }),
+}))
+jest.mock('@open-mercato/shared/lib/logger', () => ({
+  createLogger: () => ({ error: jest.fn() }),
+}))
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    sales: { sales_quote: 'sales:sales_quote', sales_order: 'sales:sales_order' },
+    customers: {
+      customer_entity: 'customers:customer_entity',
+      customer_person_profile: 'customers:customer_person_profile',
+      customer_company_profile: 'customers:customer_company_profile',
+    },
+  },
+}))
+jest.mock('lucide-react', () => ({
+  Building2: () => <span />,
+  Mail: () => <span />,
+  Plus: () => <span />,
+  Store: () => <span />,
+  UserRound: () => <span />,
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { SalesDocumentForm } = require('../documents/SalesDocumentForm')
+
+describe('SalesDocumentForm person quick create', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockApiCall.mockResolvedValue({ ok: true, result: { items: [], number: 'ORD-001' } })
+    mockCreateCrud.mockImplementation((resource: string) => {
+      if (resource === 'customers/people') {
+        return Promise.resolve({ ok: true, result: { entityId: 'customer-entity-1' } })
+      }
+      return Promise.resolve({ ok: true, result: { id: 'address-1' } })
+    })
+  })
+
+  it('persists normalized addresses against the created customer entity', async () => {
+    render(<SalesDocumentForm onCreated={jest.fn()} initialKind="order" />)
+
+    await waitFor(() => expect(mockApiCall).toHaveBeenCalled())
+    fireEvent.click(screen.getByRole('button', { name: 'Submit inline person' }))
+
+    await waitFor(() => expect(mockCreateCrud).toHaveBeenCalledTimes(2))
+    expect(mockCreateCrud).toHaveBeenNthCalledWith(
+      1,
+      'customers/people',
+      { displayName: 'Jane Doe' },
+      { errorMessage: 'Failed to create customer.' },
+    )
+    expect(mockCreateCrud).toHaveBeenNthCalledWith(2, 'customers/addresses', {
+      entityId: 'customer-entity-1',
+      organizationId: 'organization-1',
+      addressLine1: 'Main Street 1',
+      isPrimary: true,
+      name: 'Home',
+      purpose: 'billing',
+      addressLine2: 'Apartment 2',
+      buildingNumber: '1',
+      flatNumber: '2',
+      city: 'Warsaw',
+      postalCode: '00-001',
+      country: 'PL',
+      latitude: 52.2297,
+      longitude: 21.0122,
+    })
+    expect(mockSetValue).toHaveBeenCalledWith('customerEntityId', 'customer-entity-1')
+    expect(mockCreateCrud.mock.invocationCallOrder[1]).toBeLessThan(
+      mockSetValue.mock.invocationCallOrder[0],
+    )
+  })
+})

--- a/packages/core/src/modules/sales/components/documents/AddressesSection.tsx
+++ b/packages/core/src/modules/sales/components/documents/AddressesSection.tsx
@@ -890,8 +890,12 @@ export function SalesDocumentAddressesSection({
         if (res?.result?.id) billingId = res.result.id
       }
 
-      payload.shippingAddressSnapshot = shippingSnapshot ?? null
-      payload.billingAddressSnapshot = billingSnapshot ?? null
+      if (shippingSnapshot || !shippingId) {
+        payload.shippingAddressSnapshot = shippingSnapshot ?? null
+      }
+      if (billingSnapshot || !billingId) {
+        payload.billingAddressSnapshot = billingSnapshot ?? null
+      }
       payload.shippingAddressId = shippingSnapshot ? null : shippingId
       payload.billingAddressId = billingSnapshot ? null : billingId
 

--- a/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
+++ b/packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx
@@ -168,6 +168,7 @@ function CustomerQuickCreate({ t, onCreated }: CustomerQuickCreateProps) {
     async (values: PersonFormValues) => {
       setSaving(true)
       try {
+        const addresses = Array.isArray(values.addresses) ? values.addresses : []
         const payload = buildPersonPayload(values, organizationId)
         const { result } = await createCrud<{ id?: string; entityId?: string }>('customers/people', payload, {
           errorMessage: t('sales.documents.form.customer.quick.error', 'Failed to create customer.'),
@@ -177,6 +178,51 @@ function CustomerQuickCreate({ t, onCreated }: CustomerQuickCreateProps) {
           (result && typeof result.id === 'string' && result.id) ||
           null
         if (!id) throw new Error('Missing customer id')
+        if (addresses.length) {
+          const normalize = (value?: string | null) => {
+            if (typeof value !== 'string') return undefined
+            const trimmed = value.trim()
+            return trimmed.length ? trimmed : undefined
+          }
+          for (const entry of addresses) {
+            const normalizedLine1 = normalize(entry.addressLine1)
+            if (!normalizedLine1) continue
+            const body: Record<string, unknown> = {
+              entityId: id,
+              ...(organizationId ? { organizationId } : {}),
+              addressLine1: normalizedLine1,
+              isPrimary: entry.isPrimary ?? false,
+            }
+            const name = normalize(entry.name)
+            if (name !== undefined) body.name = name
+            const purpose = normalize(entry.purpose)
+            if (purpose !== undefined) body.purpose = purpose
+            const line2 = normalize(entry.addressLine2)
+            if (line2 !== undefined) body.addressLine2 = line2
+            const buildingNumber = normalize(entry.buildingNumber)
+            if (buildingNumber !== undefined) body.buildingNumber = buildingNumber
+            const flatNumber = normalize(entry.flatNumber)
+            if (flatNumber !== undefined) body.flatNumber = flatNumber
+            const city = normalize(entry.city)
+            if (city !== undefined) body.city = city
+            const region = normalize(entry.region)
+            if (region !== undefined) body.region = region
+            const postalCode = normalize(entry.postalCode)
+            if (postalCode !== undefined) body.postalCode = postalCode
+            const country = normalize(entry.country)
+            if (country !== undefined) body.country = country.toUpperCase()
+            if (typeof entry.latitude === 'number') body.latitude = entry.latitude
+            if (typeof entry.longitude === 'number') body.longitude = entry.longitude
+            try {
+              await createCrud('customers/addresses', body)
+            } catch (addressErr) {
+              const message =
+                (addressErr instanceof Error && addressErr.message ? addressErr.message : null) ||
+                t('customers.people.detail.addresses.error')
+              flash(message, 'error')
+            }
+          }
+        }
         const displayName =
           typeof values.displayName === 'string' && values.displayName.trim().length
             ? values.displayName.trim()

--- a/packages/core/src/modules/sales/components/documents/ShipmentDialog.tsx
+++ b/packages/core/src/modules/sales/components/documents/ShipmentDialog.tsx
@@ -296,6 +296,13 @@ export function ShipmentDialog({
   const [addressOptions, setAddressOptions] = React.useState<ShipmentAddressOption[]>([])
   const [addressLoading, setAddressLoading] = React.useState(false)
   const [addressError, setAddressError] = React.useState<string | null>(null)
+  const addressLoadPromiseRef = React.useRef<{
+    orderId: string
+    promise: Promise<ShipmentAddressOption[]>
+  } | null>(null)
+  const currentAddressOrderIdRef = React.useRef(orderId)
+  currentAddressOrderIdRef.current = orderId
+  const initializedDialogKeyRef = React.useRef<string | null>(null)
   const [documentStatuses, setDocumentStatuses] = React.useState<StatusOption[]>([])
   const [lineStatuses, setLineStatuses] = React.useState<StatusOption[]>([])
   const [shipmentStatuses, setShipmentStatuses] = React.useState<StatusOption[]>([])
@@ -479,37 +486,52 @@ export function ShipmentDialog({
     [],
   )
 
-  const loadAddressOptions = React.useCallback(async () => {
+  const loadAddressOptions = React.useCallback((): Promise<ShipmentAddressOption[]> => {
+    const activeRequest = addressLoadPromiseRef.current
+    if (activeRequest?.orderId === orderId) return activeRequest.promise
+
     setAddressLoading(true)
-    try {
-      const params = new URLSearchParams({
-        page: '1',
-        pageSize: '100',
-        documentId: orderId,
-        documentKind: 'order',
-      })
-      const response = await apiCall<{ items?: Array<Record<string, unknown>> }>(
-        `/api/sales/document-addresses?${params.toString()}`,
-        undefined,
-        { fallback: { items: [] } },
-      )
-      const items = Array.isArray(response.result?.items) ? response.result.items : []
-      const mapped = items
-        .map((item) => mapDocumentAddressOption(item))
-        .filter((entry): entry is ShipmentAddressOption => Boolean(entry))
-      mergeAddressOptions(mapped)
-      setAddressError(null)
-      return mapped
-    } catch (err) {
-      logger.error('sales.shipments.addresses.load', { err })
-      setAddressError(
-        t('sales.documents.shipments.addressLoadError', 'Failed to load addresses.'),
-      )
-      return []
-    } finally {
-      setAddressLoading(false)
-    }
-  }, [mapDocumentAddressOption, mergeAddressOptions, orderId, t])
+    const request = (async () => {
+      try {
+        const params = new URLSearchParams({
+          page: '1',
+          pageSize: '100',
+          documentId: orderId,
+          documentKind: 'order',
+        })
+        const response = await apiCall<{ items?: Array<Record<string, unknown>> }>(
+          `/api/sales/document-addresses?${params.toString()}`,
+          undefined,
+          { fallback: { items: [] } },
+        )
+        const items = Array.isArray(response.result?.items) ? response.result.items : []
+        const mapped = items
+          .map((item) => mapDocumentAddressOption(item))
+          .filter((entry): entry is ShipmentAddressOption => Boolean(entry))
+        const loadedOptions = dedupeAddressOptions([...baseAddressOptions, ...mapped])
+        if (currentAddressOrderIdRef.current !== orderId) return baseAddressOptions
+        mergeAddressOptions(loadedOptions)
+        setAddressError(null)
+        return loadedOptions
+      } catch (err) {
+        logger.error('sales.shipments.addresses.load', { err })
+        if (currentAddressOrderIdRef.current === orderId) {
+          setAddressError(
+            t('sales.documents.shipments.addressLoadError', 'Failed to load addresses.'),
+          )
+        }
+        return baseAddressOptions
+      }
+    })()
+    addressLoadPromiseRef.current = { orderId, promise: request }
+    void request.then(() => {
+      if (addressLoadPromiseRef.current?.promise === request) {
+        addressLoadPromiseRef.current = null
+        setAddressLoading(false)
+      }
+    })
+    return request
+  }, [baseAddressOptions, mapDocumentAddressOption, mergeAddressOptions, orderId, t])
 
   const buildPriceSubtitle = React.useCallback(
     (option: ShippingMethodOption): string | undefined => {
@@ -851,16 +873,20 @@ export function ShipmentDialog({
   )
 
   React.useEffect(() => {
-    if (!open) return
+    if (!open) {
+      initializedDialogKeyRef.current = null
+      return
+    }
+    const dialogKey = `${orderId}:${mode}:${shipment?.id ?? 'new'}`
+    if (initializedDialogKeyRef.current === dialogKey) return
+    initializedDialogKeyRef.current = dialogKey
     setFormResetKey((prev) => prev + 1)
     if (!shippingMethods.length) {
       void loadShippingMethods()
     }
     setAddressOptions(baseAddressOptions)
     setAddressError(null)
-    if (!addressOptions.length) {
-      void loadAddressOptions()
-    }
+    void loadAddressOptions()
     if (!shipmentStatuses.length) {
       void loadShipmentStatuses()
     }
@@ -871,7 +897,6 @@ export function ShipmentDialog({
       void loadLineStatuses()
     }
   }, [
-    addressOptions.length,
     baseAddressOptions,
     documentStatuses.length,
     loadAddressOptions,
@@ -881,6 +906,8 @@ export function ShipmentDialog({
     loadShippingMethods,
     mode,
     open,
+    orderId,
+    shipment?.id,
     lineStatuses.length,
     shipmentStatuses.length,
     shippingMethods.length,
@@ -939,11 +966,9 @@ export function ShipmentDialog({
 
   const fetchAddressItems = React.useCallback(
     async (query?: string): Promise<LookupSelectItem[]> => {
-      if (!addressOptions.length && !addressLoading) {
-        await loadAddressOptions()
-      }
+      const options = addressOptions.length ? addressOptions : await loadAddressOptions()
       const needle = query?.trim().toLowerCase() ?? ''
-      return addressOptions
+      return options
         .filter((option) => {
           if (!needle) return true
           return (
@@ -962,7 +987,7 @@ export function ShipmentDialog({
           ),
         }))
     },
-    [addressLoading, addressOptions, loadAddressOptions],
+    [addressOptions, loadAddressOptions],
   )
 
   const validateItems = React.useCallback(

--- a/packages/core/src/modules/sales/components/documents/__tests__/AddressesSection.test.tsx
+++ b/packages/core/src/modules/sales/components/documents/__tests__/AddressesSection.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { SalesDocumentAddressesSection } from '../AddressesSection'
+
+const mockApiCall = jest.fn()
+const mockApiCallOrThrow = jest.fn()
+const mockTranslate = (_key: string, fallback?: string) => fallback ?? _key
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: any[]) => mockApiCall(...args),
+  apiCallOrThrow: (...args: any[]) => mockApiCallOrThrow(...args),
+  withScopedApiRequestHeaders: async (_headers: unknown, operation: () => Promise<unknown>) => operation(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  createCrud: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: async ({ operation }: { operation: () => Promise<unknown> }) => operation(),
+    retryLastMutation: jest.fn(),
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  ErrorMessage: () => null,
+  LoadingMessage: () => null,
+  TabEmptyState: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn().mockResolvedValue(true),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/select', () => ({
+  Select: ({ children, value, onValueChange, disabled }: any) => (
+    <select
+      value={value ?? ''}
+      disabled={disabled}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    >
+      <option value="">Select address</option>
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: any) => <>{children}</>,
+  SelectItem: ({ children, value }: any) => <option value={value}>{children}</option>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/switch-field', () => ({
+  SwitchField: ({ label, checked, onCheckedChange, disabled }: any) => (
+    <label>
+      {label}
+      <input
+        type="checkbox"
+        checked={Boolean(checked)}
+        disabled={disabled}
+        onChange={(event) => onCheckedChange?.(event.target.checked)}
+      />
+    </label>
+  ),
+}))
+
+jest.mock('@open-mercato/core/modules/customers/components/AddressEditor', () => ({
+  AddressEditor: () => null,
+}))
+
+jest.mock('@open-mercato/core/modules/customers/utils/addressFormat', () => ({
+  AddressView: () => null,
+  formatAddressString: (value: Record<string, unknown>) =>
+    [value.addressLine1, value.city].filter(Boolean).join(', '),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => mockTranslate,
+}))
+
+jest.mock('lucide-react', () => ({
+  Pencil: () => null,
+  Plus: () => null,
+  Save: () => null,
+  Trash2: () => null,
+}))
+
+describe('SalesDocumentAddressesSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockApiCall.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/customers/addresses?')) {
+        return {
+          ok: true,
+          result: {
+            items: [{
+              id: 'customer-address-1',
+              name: 'Main warehouse',
+              address_line1: '12 Market Street',
+              city: 'London',
+              postal_code: 'SW1A 1AA',
+              country: 'GB',
+            }],
+          },
+        }
+      }
+      if (url === '/api/customers/settings/address-format') {
+        return { ok: true, result: { addressFormat: 'line_first' } }
+      }
+      return { ok: true, result: { items: [] } }
+    })
+  })
+
+  it('omits null snapshots for a saved address and adopts the server-resolved snapshot', async () => {
+    const resolvedSnapshot = {
+      id: 'customer-address-1',
+      addressLine1: '12 Market Street',
+      city: 'London',
+      postalCode: 'SW1A 1AA',
+      country: 'GB',
+    }
+    mockApiCallOrThrow.mockResolvedValue({
+      ok: true,
+      result: {
+        shippingAddressId: 'customer-address-1',
+        billingAddressId: 'customer-address-1',
+        shippingAddressSnapshot: resolvedSnapshot,
+        billingAddressSnapshot: resolvedSnapshot,
+      },
+    })
+    const onUpdated = jest.fn()
+
+    render(
+      <SalesDocumentAddressesSection
+        documentId="order-1"
+        kind="order"
+        customerId="customer-1"
+        onUpdated={onUpdated}
+      />,
+    )
+
+    await screen.findByRole('combobox')
+    await waitFor(() => expect(screen.getByRole('option', { name: /Main warehouse/ })).toBeTruthy())
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'customer-address-1' } })
+    await waitFor(() => expect(screen.getByRole('combobox')).toHaveValue('customer-address-1'))
+    fireEvent.click(screen.getByRole('button', { name: 'Update addresses' }))
+
+    await waitFor(() => expect(mockApiCallOrThrow).toHaveBeenCalledTimes(1))
+    const [, request] = mockApiCallOrThrow.mock.calls[0]
+    const payload = JSON.parse(request.body)
+    expect(payload).toMatchObject({
+      id: 'order-1',
+      shippingAddressId: 'customer-address-1',
+      billingAddressId: 'customer-address-1',
+    })
+    expect(payload).not.toHaveProperty('shippingAddressSnapshot')
+    expect(payload).not.toHaveProperty('billingAddressSnapshot')
+    expect(onUpdated).toHaveBeenCalledWith(expect.objectContaining({
+      shippingAddressId: 'customer-address-1',
+      shippingAddressSnapshot: resolvedSnapshot,
+    }))
+  })
+})

--- a/packages/core/src/modules/sales/components/documents/__tests__/ShipmentDialog.reRenderLoop.test.tsx
+++ b/packages/core/src/modules/sales/components/documents/__tests__/ShipmentDialog.reRenderLoop.test.tsx
@@ -14,7 +14,7 @@
  * NOT re-fire on every render.
  */
 import * as React from 'react'
-import { act, render } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { ShipmentDialog } from '../ShipmentDialog'
 
 jest.setTimeout(20000)
@@ -98,11 +98,27 @@ jest.mock('@open-mercato/ui/primitives/switch', () => ({
 }))
 
 jest.mock('@open-mercato/ui/backend/inputs', () => ({
-  LookupSelect: ({ value, onChange }: any) => (
-    <select value={value ?? ''} onChange={(event) => onChange?.(event.target.value || null)}>
-      <option value="">Select</option>
-    </select>
-  ),
+  LookupSelect: ({ value, onChange, fetchItems }: any) => {
+    const ReactLib = require('react')
+    const [items, setItems] = ReactLib.useState([])
+    ReactLib.useEffect(() => {
+      let cancelled = false
+      fetchItems().then((next: any[]) => {
+        if (!cancelled) setItems(next)
+      })
+      return () => {
+        cancelled = true
+      }
+    }, [fetchItems])
+    return (
+      <select value={value ?? ''} onChange={(event) => onChange?.(event.target.value || null)}>
+        <option value="">Select</option>
+        {items.map((item: any) => (
+          <option key={item.id} value={item.id}>{item.title}</option>
+        ))}
+      </select>
+    )
+  },
 }))
 
 // CrudForm receives `key={formResetKey}` from ShipmentDialog, so every time the
@@ -121,11 +137,11 @@ jest.mock('@open-mercato/ui/backend/CrudForm', () => {
           throw new Error('[test] ShipmentDialog bootstrap effect re-render loop detected')
         }
       }, [])
+      const addressField = fields.find((field: any) => field.id === 'shipmentAddressId')
+      const AddressField = addressField?.component
       return (
         <form>
-          {fields.map((field: any) => (
-            <div key={field.id ?? field.name} data-testid={`crud-field-${field.id ?? field.name}`} />
-          ))}
+          {AddressField ? <AddressField value="" setValue={() => {}} /> : null}
         </form>
       )
     },
@@ -206,5 +222,52 @@ describe('ShipmentDialog re-render stability (issue #3529)', () => {
     // bumped `formResetKey`, remounting the form once per pass. With stable
     // `baseAddressOptions`, none of those rerenders should remount the form.
     expect(crudFormMountCount).toBe(baselineMounts)
+  })
+
+  it('loads a document address once and returns the freshly loaded option to the lookup', async () => {
+    mockApiCall.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/sales/document-addresses?')) {
+        return {
+          ok: true,
+          result: {
+            items: [{
+              id: 'document-address-1',
+              name: 'Warehouse',
+              address_line1: '10 Shipping Lane',
+              city: 'Portland',
+              postal_code: '97201',
+              country: 'US',
+            }],
+          },
+        }
+      }
+      return { ok: true, result: { items: [] } }
+    })
+
+    render(
+      <ShipmentDialog
+        open
+        mode="create"
+        shipment={null}
+        lines={baseLines}
+        orderId="order-with-additional-address"
+        currencyCode="USD"
+        organizationId="org-1"
+        tenantId="tenant-1"
+        computeAvailable={computeAvailable}
+        shippingAddressSnapshot={null}
+        onClose={noop}
+        onSaved={noopAsync}
+      />,
+    )
+
+    expect(await screen.findByRole('option', { name: 'Warehouse' })).toBeInTheDocument()
+    await waitFor(() => {
+      const addressRequests = mockApiCall.mock.calls.filter(([url]) =>
+        String(url).startsWith('/api/sales/document-addresses?'),
+      )
+      expect(addressRequests).toHaveLength(1)
+    })
+    expect(crudFormMountCount).toBe(2)
   })
 })


### PR DESCRIPTION
Fixes #4058
Fixes #4053
Fixes #4057

## Problem
Inline customer creation from the sales order form displayed draft addresses but did not persist them. Orders whose shipping address was assigned after creation could also leave the Add Shipment dialog looping on address loads or showing no results.

## Root Cause
The inline person flow created only the customer record and discarded address form state. Separately, the shipment dialog bootstrap depended on asynchronously changing option length and reset the options it had just loaded, while the Addresses tab sent explicit null snapshots that disabled server-side snapshot resolution.

## What Changed
- Persist normalized inline-created customer addresses after the customer entity ID is returned.
- Let saved address IDs resolve their snapshots server-side.
- Make shipment address loading idempotent, deduplicated, stale-order safe, and return freshly loaded options.
- Add focused unit and browser integration coverage for all reported paths.

## Tests
- Focused sales unit regressions: 3 suites, 4 tests passed.
- `yarn mercato test:integration 4053` → 1/1 passed.
- `yarn mercato test:integration 4057` → 2/2 passed.
- `yarn build:packages` → passed.
- `yarn generate` → passed.
- `yarn i18n:check-sync` / `yarn i18n:check-usage` → passed.
- `yarn typecheck` → passed.
- Full workspace tests passed serialized: `yarn exec cross-env NODE_OPTIONS=--max-old-space-size=768 turbo run test --concurrency=1` (22/22 tasks). Default local parallel runs hit nondeterministic unrelated Jest worker SIGSEGVs; each affected suite passed in-band.
- `yarn build:app` → passed.
- `yarn template:sync` reports 24 pre-existing app/template drift files outside this PR; no sync was applied.

Runner: local app validation; ephemeral Docker-backed integration environment for Playwright.

## Breaking Changes
None.

🤖 Generated by autofix.
