### PR TITLE
fix(ci): use a cross-process cache strategy in standalone integration lanes

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -240,7 +240,12 @@ jobs:
           OM_ENABLE_ENTERPRISE_MODULES_SECURITY=true
           AUTO_SPAWN_WORKERS=false
           AUTO_SPAWN_SCHEDULER=false
-          CACHE_STRATEGY=memory
+          # MUST be a cross-process strategy (sqlite/redis), never `memory`:
+          # with AUTO_SPAWN_WORKERS=false the integration tests drain queue jobs
+          # in separate child processes, and a per-process memory cache leaves the
+          # server serving stale ENABLE_CRUD_API_CACHE entries after those jobs
+          # mutate records (TC-CRM-079, TC-SX-001). Mirrors the ephemeral runner.
+          CACHE_STRATEGY=sqlite
           OM_OPTIMISTIC_LOCK=all
           EOF
 
@@ -317,6 +322,10 @@ jobs:
           MOCK_GATEWAY_WEBHOOK_SECRET: open-mercato-mock-dev-webhook-secret
           MOCK_CARRIER_WEBHOOK_SECRET: open-mercato-mock-dev-carrier-webhook-secret
           MOCK_INBOUND_WEBHOOK_SECRET: open-mercato-mock-dev-inbound-webhook-secret
+          # Queue-drain child processes inherit this env (they do NOT read the
+          # app's .env) — keep the strategy aligned with the app so their cache
+          # invalidations land in the same shared sqlite store the server reads.
+          CACHE_STRATEGY: sqlite
         run: yarn test:integration
 
       - name: Print standalone app log on test failure

--- a/packages/create-app/src/lib/standalone-cache-strategy-guard.test.ts
+++ b/packages/create-app/src/lib/standalone-cache-strategy-guard.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+// The standalone integration lanes run the app server and the queue-drain
+// helpers in SEPARATE processes (AUTO_SPAWN_WORKERS=false): mutations applied
+// by a drained job can only invalidate the server's ENABLE_CRUD_API_CACHE
+// entries when the cache store is shared across processes. A per-process
+// `memory` strategy makes the server serve stale records forever after a
+// drained job mutates them (TC-CRM-079 owner reassignment, TC-SX-001 import
+// update). These guards fail the moment either lane regresses to a
+// process-local cache strategy — or drops the strategy entirely, because the
+// cache service defaults to `memory` when CACHE_STRATEGY is unset.
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..')
+
+const CROSS_PROCESS_STRATEGIES = new Set(['sqlite', 'redis'])
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, ...relativePath.split('/')), 'utf8')
+}
+
+function collectCacheStrategyValues(source: string): string[] {
+  const matches = source.matchAll(/CACHE_STRATEGY['"]?\s*[:=]\s*['"]?([a-z]+)['"]?/g)
+  return Array.from(matches, (match) => match[1])
+}
+
+test('snapshot workflow standalone lane uses a cross-process cache strategy', () => {
+  const workflow = readRepoFile('.github/workflows/snapshot.yml')
+  const values = collectCacheStrategyValues(workflow)
+  assert.ok(
+    values.length >= 2,
+    'snapshot.yml must pin CACHE_STRATEGY for both the standalone app .env and the integration-test step (drain child processes inherit the step env, not the app .env)',
+  )
+  for (const value of values) {
+    assert.ok(
+      CROSS_PROCESS_STRATEGIES.has(value),
+      `snapshot.yml sets CACHE_STRATEGY=${value}; the standalone lane drains queue jobs in child processes and requires a cross-process strategy (${Array.from(CROSS_PROCESS_STRATEGIES).join(', ')})`,
+    )
+  }
+})
+
+test('local standalone integration script uses a cross-process cache strategy', () => {
+  const script = readRepoFile('scripts/test-create-app-integration.ts')
+  const values = collectCacheStrategyValues(script)
+  assert.ok(
+    values.length >= 2,
+    'test-create-app-integration.ts must pin CACHE_STRATEGY for both the standalone app .env and the integration-test process env',
+  )
+  for (const value of values) {
+    assert.ok(
+      CROSS_PROCESS_STRATEGIES.has(value),
+      `test-create-app-integration.ts sets CACHE_STRATEGY=${value}; the standalone lane drains queue jobs in child processes and requires a cross-process strategy (${Array.from(CROSS_PROCESS_STRATEGIES).join(', ')})`,
+    )
+  }
+})

--- a/scripts/test-create-app-integration.ts
+++ b/scripts/test-create-app-integration.ts
@@ -84,7 +84,9 @@ function writeStandaloneEnv(appDir: string): void {
     'OM_ENABLE_ENTERPRISE_MODULES_SECURITY=true',
     'AUTO_SPAWN_WORKERS=false',
     'AUTO_SPAWN_SCHEDULER=false',
-    'CACHE_STRATEGY=memory',
+    // Cross-process strategy required: queue jobs drain in child processes, so a
+    // per-process memory cache would leave the server serving stale CRUD entries.
+    'CACHE_STRATEGY=sqlite',
   ].filter(Boolean)
 
   fs.writeFileSync(envPath, `${envLines.join('\n')}\n`)
@@ -202,7 +204,7 @@ async function main(): Promise<void> {
     OM_ENABLE_ENTERPRISE_MODULES_SECURITY: 'true',
     AUTO_SPAWN_WORKERS: 'false',
     AUTO_SPAWN_SCHEDULER: 'false',
-    CACHE_STRATEGY: 'memory',
+    CACHE_STRATEGY: 'sqlite',
     OM_INTEGRATION_APP_READY_TIMEOUT_SECONDS: '180',
     OM_TEST_APP_ROOT: appDir,
     NODE_OPTIONS: withStandaloneBuildNodeOptions(process.env.NODE_OPTIONS),


### PR DESCRIPTION
## Problem

The **Standalone App Integration Tests** job (Snapshot Release workflow) has failed on every develop run since ~Jul 5, deterministically on the same two tests, blocking release PR #3594:

- `TC-CRM-079` — bulk deal **owner** reassignment never became visible (stage update did)
- `TC-SX-001` — the second import run reported `updatedCount: 1` / `completed`, yet the person detail GET still returned the pre-update values

## Root cause

The standalone lane runs the app server and the integration **queue-drain helpers in separate processes** (`AUTO_SPAWN_WORKERS=false` → `drainIntegrationQueue` spawns a child `queue-runner`). With `CACHE_STRATEGY=memory`, each process has its own cache — a drained job's tag invalidation lands in the **child's** memory cache, and the server keeps serving its stale `ENABLE_CRUD_API_CACHE` entry forever. The DB writes themselves succeeded (TC-SX-001's run summary proves it); only the reads were stale.

The misconfiguration is latent since February but became fatal when detail-GET caching landed for exactly the routes these tests poll:
- #3709 `GET /api/customers/people/[id]` (TC-SX-001's poll target)
- #3712 `GET /api/customers/deals/[id]` (TC-CRM-079's poll target)
- #3711 companies detail

TC-CRM-079's *stage* phase passes only because the server's cache is still cold at that point; the *owner* phase reads the now-warm cache. The monorepo ephemeral lane never failed because it already uses `CACHE_STRATEGY=sqlite`.

## Fix

- Switch both standalone lanes (`.github/workflows/snapshot.yml` + `scripts/test-create-app-integration.ts`) to `CACHE_STRATEGY=sqlite` — the shared, file-backed strategy the ephemeral runner already uses. Server and drain children share cwd (the app root), so they open the same `.mercato/cache/cache.db`.
- Also pass `CACHE_STRATEGY: sqlite` through the workflow's integration-test **step env**: drain child processes inherit that env (they do **not** read the app's `.env`), and the cache service defaults to `memory` when the var is unset.
- Add a guard test (`packages/create-app/src/lib/standalone-cache-strategy-guard.test.ts`, node:test style mirroring the existing dependency-drift guard) that fails if either lane regresses to a process-local strategy or drops the pin.

## Validation

- `packages/create-app` test suite: 84/84 pass (incl. the 2 new guards); guard verified to fail against the pre-fix files (`memory` detected).
- `snapshot.yml` YAML parse check passes.
- Runner: local.

Labels: `bug` + `skip-qa` (CI-config-only, no runtime surface) + `priority-high` (release-blocking — gates #3594) + `risk-low` (two env values + a guard test).

Workflow file touched: `.github/workflows/snapshot.yml` — env values only; no check removed, skipped, or weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)