### PR TITLE
ci(standalone): surface drain-child diagnostics + pin absolute sqlite cache path

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -245,7 +245,10 @@ jobs:
           # in separate child processes, and a per-process memory cache leaves the
           # server serving stale ENABLE_CRUD_API_CACHE entries after those jobs
           # mutate records (TC-CRM-079, TC-SX-001). Mirrors the ephemeral runner.
+          # The sqlite path is pinned absolute so the server and every drain
+          # child open the same store regardless of process cwd.
           CACHE_STRATEGY=sqlite
+          CACHE_SQLITE_PATH=/tmp/standalone-app/.mercato/cache/cache.db
           OM_OPTIMISTIC_LOCK=all
           EOF
 
@@ -326,6 +329,13 @@ jobs:
           # app's .env) — keep the strategy aligned with the app so their cache
           # invalidations land in the same shared sqlite store the server reads.
           CACHE_STRATEGY: sqlite
+          CACHE_SQLITE_PATH: /tmp/standalone-app/.mercato/cache/cache.db
+          # Surface drain-child stdout/stderr in the Playwright output. Without
+          # this, per-job failures and cache-fallback warnings inside the drain
+          # children are silently discarded, making standalone-only failures
+          # (like the TC-CRM-079 / TC-SX-001 stale-read investigation)
+          # undiagnosable from CI logs.
+          OM_DRAIN_DEBUG: '1'
         run: yarn test:integration
 
       - name: Print standalone app log on test failure

--- a/packages/core/src/helpers/integration/queue-runner.ts
+++ b/packages/core/src/helpers/integration/queue-runner.ts
@@ -55,6 +55,11 @@ export async function drainQueueFromAppRoot(
       )
       const handled = result.processed + result.failed
       processedJobs += handled
+      if (result.failed > 0) {
+        process.stderr.write(
+          `[queue-drain] ${result.failed} job(s) FAILED in "${queueName}" (processed ${result.processed}); failed jobs retry with backoff and dead-letter after max attempts\n`,
+        )
+      }
       if (handled === 0) return processedJobs
     }
   } finally {

--- a/packages/core/src/helpers/integration/queue.ts
+++ b/packages/core/src/helpers/integration/queue.ts
@@ -43,6 +43,17 @@ function drainQueueInAppProcess(queueName: string, options: Required<DrainQueueO
     child.stderr.on('data', (chunk) => { stderr += chunk.toString() })
     child.on('error', reject)
     child.on('close', (code) => {
+      // The child's diagnostics (pino job logs on stdout, cache-fallback
+      // console.warn on stderr) are otherwise discarded on exit 0, which makes
+      // silently-failing jobs and silent memory-cache fallbacks in the drain
+      // child undebuggable from CI logs. OM_DRAIN_DEBUG=1 forwards everything;
+      // a non-empty stderr is forwarded unconditionally because it only carries
+      // warning/error-class output.
+      if (process.env.OM_DRAIN_DEBUG === '1') {
+        process.stderr.write(`[drain-child ${queueName} exit=${code}] STDOUT:\n${stdout}\nSTDERR:\n${stderr}\n`)
+      } else if (stderr.trim().length > 0) {
+        process.stderr.write(`[drain-child ${queueName} exit=${code}] STDERR:\n${stderr}\n`)
+      }
       if (code !== 0) {
         reject(new Error(`Queue drain failed for "${queueName}" in ${options.appRoot} (exit ${code}).\n${stderr || stdout}`))
         return

--- a/scripts/test-create-app-integration.ts
+++ b/scripts/test-create-app-integration.ts
@@ -86,7 +86,9 @@ function writeStandaloneEnv(appDir: string): void {
     'AUTO_SPAWN_SCHEDULER=false',
     // Cross-process strategy required: queue jobs drain in child processes, so a
     // per-process memory cache would leave the server serving stale CRUD entries.
+    // The path is pinned absolute so every process opens the same store.
     'CACHE_STRATEGY=sqlite',
+    `CACHE_SQLITE_PATH=${path.join(appDir, '.mercato', 'cache', 'cache.db')}`,
   ].filter(Boolean)
 
   fs.writeFileSync(envPath, `${envLines.join('\n')}\n`)
@@ -205,6 +207,8 @@ async function main(): Promise<void> {
     AUTO_SPAWN_WORKERS: 'false',
     AUTO_SPAWN_SCHEDULER: 'false',
     CACHE_STRATEGY: 'sqlite',
+    CACHE_SQLITE_PATH: path.join(appDir, '.mercato', 'cache', 'cache.db'),
+    OM_DRAIN_DEBUG: '1',
     OM_INTEGRATION_APP_READY_TIMEOUT_SECONDS: '180',
     OM_TEST_APP_ROOT: appDir,
     NODE_OPTIONS: withStandaloneBuildNodeOptions(process.env.NODE_OPTIONS),


### PR DESCRIPTION
## Context

Follow-up to #4117 (release PR #3594 stabilization). The post-merge Snapshot Release run still failed on the same two tests (TC-CRM-079 owner phase, TC-SX-001 update phase), so the investigation moved to a full local reproduction of the standalone lane (Verdaccio scaffold → ephemeral Docker Postgres → child-process queue drains).

## What the local reproduction established

- With `CACHE_STRATEGY=memory` (pre-#4117 config) the failure reproduces exactly: a live DB watcher shows the drained job's write **lands in Postgres within ~1.5s**, while the server's API keeps returning the pre-update value for the whole 30s poll — and a `POST /api/configs/cache purgeAll` immediately unsticks it. The cache is the **only** stale layer.
- With `CACHE_STRATEGY=sqlite` end-to-end (post-#4117 parity), **both failing tests pass locally** (TC-CRM-079 in 6.3s, TC-SX-001 in 13.3s), and direct cross-process probes confirm `deleteByTags` from a second process evicts entries the first process stored.
- Therefore the remaining CI-only failure needs evidence from inside the CI drain children — which today is **discarded whenever the child exits 0**, including per-job failure logs and the `[cache] sqlite strategy unavailable … falling back to memory` warning class that would silently re-create the per-process-cache bug.

## Changes

- `packages/core/src/helpers/integration/queue.ts` — forward the drain child's full stdout/stderr when `OM_DRAIN_DEBUG=1`; always forward non-empty child stderr (it only carries warning/error-class output).
- `packages/core/src/helpers/integration/queue-runner.ts` — report failed-job counts per drain batch on stderr (failed jobs currently retry with backoff and dead-letter invisibly).
- `.github/workflows/snapshot.yml` — set `OM_DRAIN_DEBUG: '1'` in the integration-test step, and pin `CACHE_SQLITE_PATH=/tmp/standalone-app/.mercato/cache/cache.db` in **both** the app `.env` and the step env so the server and every drain child provably open the same store regardless of process cwd.
- `scripts/test-create-app-integration.ts` — mirror both env additions for the local lane.

No test is weakened, skipped, or retried differently; the workflow edit is env-only.

## Outcome

Either the next develop Snapshot run goes green (if the cwd/pathing class was the residue), or the run's Playwright output now contains the drain children's actual errors — pinpointing the root cause instead of another blind iteration.

## Validation

- TC-CRM-079 and TC-SX-001 pass against the locally scaffolded standalone app with this exact helper code and env (debug output verified flowing).
- `packages/create-app` guard tests pass; `snapshot.yml` YAML parse check passes.
- Runner: local.

Labels: `bug` + `skip-qa` (CI/test-harness-only) + `priority-high` (still gating release PR #3594) + `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)