### PR TITLE
perf(dev): share scheduler with lazy worker

### DIFF
--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -1771,7 +1771,10 @@ function classifyServerLine(line) {
       progressLabel: 'Background services (lazy)',
     }
   }
-  if (line.match(/^\[lazy-supervisor\] Pending job detected(?: .*)? — starting shared worker for all queues$/)) {
+  if (
+    line.match(/^\[lazy-supervisor\] Pending job detected(?: .*)? — starting shared worker for all queues$/)
+    || line === '[lazy-supervisor] Enabled schedule detected — starting shared worker for all queues'
+  ) {
     const status = 'Starting shared worker (lazy shared)'
     return {
       type: 'status',

--- a/packages/cli/src/lib/__tests__/queue-worker-supervisor.test.ts
+++ b/packages/cli/src/lib/__tests__/queue-worker-supervisor.test.ts
@@ -212,6 +212,55 @@ describe('startLazyWorkerSupervisor', () => {
     await handle.close()
   })
 
+  it('restarts the shared worker when an embedded scheduler remains enabled', async () => {
+    const firstChild = createFakeChild()
+    const secondChild = createFakeChild()
+    const spawnFn = jest
+      .fn()
+      .mockImplementationOnce(() => firstChild)
+      .mockImplementationOnce(() => secondChild) as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
+    const probeFn = jest.fn(async (queueName, strategy) =>
+      emptyProbe(queueName, strategy),
+    ) as jest.MockedFunction<LazySupervisorProbeFn>
+    const shouldStartSharedWorker = jest.fn(async () => true)
+    const shouldRestartSharedWorker = jest.fn(async () => true)
+
+    const handle = startLazyWorkerSupervisor({
+      mercatoBin: '/tmp/mercato',
+      appDir: '/tmp/app',
+      runtimeEnv: { ...process.env },
+      workers: [makeWorker('events')],
+      pollMs: 250,
+      restartOnUnexpectedExit: true,
+      strategy: 'local',
+      spawnMode: 'shared',
+      sharedWorkerArgs: ['--with-scheduler'],
+      shouldStartSharedWorker,
+      shouldRestartSharedWorker,
+      spawnFn,
+      probeFn,
+      logger: silentLogger,
+    })
+
+    await flushAsync(20)
+    expect(spawnFn).toHaveBeenCalledTimes(1)
+
+    firstChild.triggerExit(1)
+    await flushAsync(40)
+
+    expect(shouldRestartSharedWorker).toHaveBeenCalled()
+    expect(spawnFn).toHaveBeenCalledTimes(2)
+    expect(spawnFn.mock.calls[1][1]).toEqual([
+      '/tmp/mercato',
+      'queue',
+      'worker',
+      '--all',
+      '--with-scheduler',
+    ])
+
+    await handle.close()
+  })
+
   it('does not spawn when probe reports an error', async () => {
     const spawnFn = jest.fn() as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
     const probeFn = jest.fn(async (queueName, strategy) => ({

--- a/packages/cli/src/lib/__tests__/queue-worker-supervisor.test.ts
+++ b/packages/cli/src/lib/__tests__/queue-worker-supervisor.test.ts
@@ -170,6 +170,48 @@ describe('startLazyWorkerSupervisor', () => {
     expect((child as any).kill).toHaveBeenCalledWith('SIGTERM')
   })
 
+  it('starts the shared worker with extra arguments when an embedded scheduler needs it', async () => {
+    const child = createFakeChild()
+    const spawnFn = jest.fn(() => child) as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
+    const probeFn = jest.fn(async (queueName, strategy) =>
+      emptyProbe(queueName, strategy),
+    ) as jest.MockedFunction<LazySupervisorProbeFn>
+    const shouldStartSharedWorker = jest.fn(async () => true)
+
+    const handle = startLazyWorkerSupervisor({
+      mercatoBin: '/tmp/mercato',
+      appDir: '/tmp/app',
+      runtimeEnv: { ...process.env },
+      workers: [makeWorker('events')],
+      pollMs: 250,
+      restartOnUnexpectedExit: false,
+      strategy: 'local',
+      spawnMode: 'shared',
+      sharedWorkerArgs: ['--with-scheduler'],
+      shouldStartSharedWorker,
+      spawnFn,
+      probeFn,
+      logger: silentLogger,
+    })
+
+    await flushAsync(20)
+
+    expect(shouldStartSharedWorker).toHaveBeenCalled()
+    expect(spawnFn).toHaveBeenCalledTimes(1)
+    expect(spawnFn.mock.calls[0][1]).toEqual([
+      '/tmp/mercato',
+      'queue',
+      'worker',
+      '--all',
+      '--with-scheduler',
+    ])
+    expect(silentLogger.log).toHaveBeenCalledWith(
+      '[lazy-supervisor] Enabled schedule detected — starting shared worker for all queues',
+    )
+
+    await handle.close()
+  })
+
   it('does not spawn when probe reports an error', async () => {
     const spawnFn = jest.fn() as unknown as jest.MockedFunction<LazySupervisorSpawnFn>
     const probeFn = jest.fn(async (queueName, strategy) => ({

--- a/packages/cli/src/lib/queue-worker-supervisor.ts
+++ b/packages/cli/src/lib/queue-worker-supervisor.ts
@@ -54,6 +54,8 @@ export type LazyWorkerSupervisorOptions = {
   strategy?: QueueStrategyType
   /** Start the shared worker even with no ready queue jobs (for an embedded scheduler). */
   shouldStartSharedWorker?: () => Promise<boolean>
+  /** Restart the shared worker with no ready queue jobs after an unexpected exit. */
+  shouldRestartSharedWorker?: () => Promise<boolean>
   /** Extra arguments for the shared worker command only. */
   sharedWorkerArgs?: readonly string[]
   /** Override for tests. Defaults to `child_process.spawn`. */
@@ -314,6 +316,18 @@ export function startLazyWorkerSupervisor(
         if (readyQueues.length > 0) {
           logger.warn('[lazy-supervisor] Restarting shared worker because jobs remain pending.')
           spawnSharedWorker(readyQueues)
+          return
+        }
+        if (options.shouldRestartSharedWorker) {
+          try {
+            if (await options.shouldRestartSharedWorker()) {
+              logger.warn('[lazy-supervisor] Restarting shared worker because an enabled schedule remains.')
+              spawnSharedWorker([], true)
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err)
+            logger.warn(`[lazy-supervisor] Shared-worker restart condition failed: ${message}`)
+          }
         }
       })()
     })

--- a/packages/cli/src/lib/queue-worker-supervisor.ts
+++ b/packages/cli/src/lib/queue-worker-supervisor.ts
@@ -52,6 +52,10 @@ export type LazyWorkerSupervisorOptions = {
   restartOnUnexpectedExit: boolean
   spawnMode?: LazyWorkerSpawnMode
   strategy?: QueueStrategyType
+  /** Start the shared worker even with no ready queue jobs (for an embedded scheduler). */
+  shouldStartSharedWorker?: () => Promise<boolean>
+  /** Extra arguments for the shared worker command only. */
+  sharedWorkerArgs?: readonly string[]
   /** Override for tests. Defaults to `child_process.spawn`. */
   spawnFn?: LazySupervisorSpawnFn
   /** Override for tests. Defaults to `getQueuePendingProbe`. */
@@ -236,21 +240,25 @@ export function startLazyWorkerSupervisor(
     })
   }
 
-  function spawnSharedWorker(triggerQueueNames: string[]): void {
+  function spawnSharedWorker(triggerQueueNames: string[], schedulerTriggered = false): void {
     if (stopping) return
     if (activeSharedChild) return
     if (startingSharedWorker) return
     startingSharedWorker = true
 
-    const triggerSummary = triggerQueueNames.length > 0
-      ? ` after pending job(s) on ${triggerQueueNames.join(', ')}`
-      : ''
-    logger.log(`[lazy-supervisor] Pending job detected${triggerSummary} — starting shared worker for all queues`)
+    if (schedulerTriggered) {
+      logger.log('[lazy-supervisor] Enabled schedule detected — starting shared worker for all queues')
+    } else {
+      const triggerSummary = triggerQueueNames.length > 0
+        ? ` in ${triggerQueueNames.join(', ')}`
+        : ''
+      logger.log(`[lazy-supervisor] Pending job detected${triggerSummary} — starting shared worker for all queues`)
+    }
     let child: ChildProcess
     try {
       child = spawnFn(
         'node',
-        [options.mercatoBin, 'queue', 'worker', '--all'],
+        [options.mercatoBin, 'queue', 'worker', '--all', ...(options.sharedWorkerArgs ?? [])],
         {
           stdio: 'inherit',
           env: options.runtimeEnv,
@@ -355,8 +363,21 @@ export function startLazyWorkerSupervisor(
         spawnQueueWorker(group.queueName)
       }
     }
-    if (spawnMode === 'shared' && readySharedQueues.length > 0) {
-      spawnSharedWorker(readySharedQueues)
+    if (spawnMode === 'shared') {
+      if (readySharedQueues.length > 0) {
+        spawnSharedWorker(readySharedQueues)
+        return
+      }
+      if (options.shouldStartSharedWorker) {
+        try {
+          if (await options.shouldStartSharedWorker()) {
+            spawnSharedWorker([], true)
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          logger.warn(`[lazy-supervisor] Shared-worker start condition failed: ${message}`)
+        }
+      }
     }
   }
 

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -1,7 +1,7 @@
 // Note: Generated files and DI container are imported statically to avoid ESM/CJS interop issues.
 // Commands that need to run before generation (e.g., `init`) handle missing modules gracefully.
 
-import { runWorker } from '@open-mercato/queue/worker'
+import { registerWorkerShutdownHook, runWorker } from '@open-mercato/queue/worker'
 import type { Module, ModuleWorker } from '@open-mercato/shared/modules/registry'
 import { getCliModules, hasCliModules, registerCliModules } from './registry'
 export { getCliModules, hasCliModules, registerCliModules }
@@ -28,7 +28,7 @@ import {
   resolveLazySchedulerPollMs,
   resolveLazySchedulerRestart,
 } from './lib/auto-spawn-scheduler'
-import { startLazySchedulerSupervisor } from './lib/scheduler-supervisor'
+import { probeEnabledSchedules, startLazySchedulerSupervisor } from './lib/scheduler-supervisor'
 import {
   startInProcessGenerateWatcher,
   type GenerateWatcherHandle,
@@ -75,6 +75,10 @@ function getRegisteredCliWorkers(modules: Module[] = getCliModules()): ModuleWor
     }
   }
   return allWorkers
+}
+
+function shouldEmbedLocalSchedulerInSharedWorker(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseBooleanToken(env.OM_DEV_EMBED_SCHEDULER_IN_SHARED_WORKER) === true
 }
 
 export function padByCodePointWidth(value: string, targetWidth: number): string {
@@ -1548,6 +1552,7 @@ export async function run(argv = process.argv) {
         command: 'worker',
         run: async (args: string[]) => {
           const isAllQueues = args.includes('--all')
+          const runSchedulerInWorker = isAllQueues && args.includes('--with-scheduler')
           const queueName = isAllQueues ? null : args[0]
 
           // Collect all discovered workers from modules
@@ -1615,6 +1620,26 @@ export async function run(argv = process.argv) {
             })
 
             await Promise.all(workerPromises)
+
+            if (runSchedulerInWorker) {
+              const queueStrategy = process.env.QUEUE_STRATEGY || 'local'
+              if (queueStrategy !== 'local') {
+                throw new Error('[worker] --with-scheduler is supported only with QUEUE_STRATEGY=local.')
+              }
+              const schedulerContainer = await createRequestContainer()
+              const localScheduler = schedulerContainer.resolve('localSchedulerService') as {
+                start?: () => Promise<void>
+                stop?: () => Promise<void>
+              } | undefined
+              if (!localScheduler?.start || !localScheduler.stop) {
+                throw new Error('[worker] Local scheduler service is unavailable.')
+              }
+              await localScheduler.start()
+              registerWorkerShutdownHook(async () => {
+                await localScheduler.stop?.()
+              })
+              console.log('[worker] Local scheduler started in the shared worker process.')
+            }
 
             console.log('[worker] All workers started. Press Ctrl+C to stop')
 
@@ -2088,6 +2113,13 @@ export async function run(argv = process.argv) {
               const autoSpawnSchedulerMode = resolveAutoSpawnSchedulerMode(process.env)
               const queueStrategy = process.env.QUEUE_STRATEGY || 'local'
               const schedulerCommand = lookupModuleCommand(getCliModules(), 'scheduler', 'start')
+              const embedSchedulerInSharedWorker =
+                shouldEmbedLocalSchedulerInSharedWorker(process.env)
+                && queueStrategy === 'local'
+                && autoSpawnWorkersMode === 'lazy'
+                && resolveLazySpawnMode(process.env) === 'shared'
+                && autoSpawnSchedulerMode !== 'off'
+                && schedulerCommand.status === 'ok'
               const nextRuntime = startNextDev(runtimeEnv)
               const restartPromise = waitForDevRestart()
               const backgroundStartAbort = new AbortController()
@@ -2139,6 +2171,15 @@ export async function run(argv = process.argv) {
                       pollMs: resolveLazyPollMs(process.env),
                       restartOnUnexpectedExit: resolveLazyRestart(process.env),
                       spawnMode: lazySpawnMode,
+                      ...(embedSchedulerInSharedWorker
+                        ? {
+                            sharedWorkerArgs: ['--with-scheduler'],
+                            shouldStartSharedWorker: async () => {
+                              const schedules = await probeEnabledSchedules(runtimeEnv)
+                              return !schedules.error && schedules.enabledSchedules > 0
+                            },
+                          }
+                        : {}),
                     })
                   } else {
                     console.log('[server] Eager worker auto-spawn enabled - starting workers for all queues...')
@@ -2152,7 +2193,9 @@ export async function run(argv = process.argv) {
                   }
                 }
 
-                if (autoSpawnSchedulerMode !== 'off' && queueStrategy === 'local') {
+                if (embedSchedulerInSharedWorker) {
+                  console.log('[server] Local scheduler will run inside the lazy shared worker process.')
+                } else if (autoSpawnSchedulerMode !== 'off' && queueStrategy === 'local') {
                   if (schedulerCommand.status !== 'ok') {
                     console.log(`[server] Skipping scheduler auto-start — ${describeMissingModuleCommand(schedulerCommand)}`)
                   } else if (autoSpawnSchedulerMode === 'lazy') {

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -2178,6 +2178,14 @@ export async function run(argv = process.argv) {
                               const schedules = await probeEnabledSchedules(runtimeEnv)
                               return !schedules.error && schedules.enabledSchedules > 0
                             },
+                            ...(resolveLazySchedulerRestart(process.env)
+                              ? {
+                                  shouldRestartSharedWorker: async () => {
+                                    const schedules = await probeEnabledSchedules(runtimeEnv)
+                                    return !schedules.error && schedules.enabledSchedules > 0
+                                  },
+                                }
+                              : {}),
                           }
                         : {}),
                     })
@@ -2193,7 +2201,7 @@ export async function run(argv = process.argv) {
                   }
                 }
 
-                if (embedSchedulerInSharedWorker) {
+                if (embedSchedulerInSharedWorker && activeLazySupervisor) {
                   console.log('[server] Local scheduler will run inside the lazy shared worker process.')
                 } else if (autoSpawnSchedulerMode !== 'off' && queueStrategy === 'local') {
                   if (schedulerCommand.status !== 'ok') {

--- a/packages/queue/src/worker/__tests__/runner.test.ts
+++ b/packages/queue/src/worker/__tests__/runner.test.ts
@@ -1,6 +1,6 @@
 import { createQueue } from '../../factory'
 import type { Queue } from '../../types'
-import { runWorker } from '../runner'
+import { registerWorkerShutdownHook, runWorker } from '../runner'
 
 jest.mock('../../factory', () => ({
   createQueue: jest.fn(),
@@ -31,6 +31,7 @@ describe('runWorker', () => {
     createQueueMock.mockReturnValueOnce(queueA).mockReturnValueOnce(queueB)
 
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never)
+    const shutdownHook = jest.fn(async () => {})
     const initialSigtermListeners = process.listenerCount('SIGTERM')
     const initialSigintListeners = process.listenerCount('SIGINT')
 
@@ -47,6 +48,7 @@ describe('runWorker', () => {
       background: true,
       gracefulShutdown: true,
     })
+    registerWorkerShutdownHook(shutdownHook)
 
     expect(process.listenerCount('SIGTERM')).toBe(initialSigtermListeners + 1)
     expect(process.listenerCount('SIGINT')).toBe(initialSigintListeners + 1)
@@ -57,6 +59,7 @@ describe('runWorker', () => {
 
     expect(queueA.close).toHaveBeenCalledTimes(1)
     expect(queueB.close).toHaveBeenCalledTimes(1)
+    expect(shutdownHook).toHaveBeenCalledTimes(1)
     expect(exitSpy).toHaveBeenCalledWith(0)
     expect(process.listenerCount('SIGTERM')).toBe(initialSigtermListeners)
     expect(process.listenerCount('SIGINT')).toBe(initialSigintListeners)

--- a/packages/queue/src/worker/runner.ts
+++ b/packages/queue/src/worker/runner.ts
@@ -25,6 +25,7 @@ export type WorkerRunnerOptions<T = unknown> = {
 }
 
 const managedQueues = new Set<Queue<unknown>>()
+const managedShutdownHooks = new Set<() => Promise<void> | void>()
 let shutdownHandlersRegistered = false
 let shutdownInProgress = false
 
@@ -54,6 +55,15 @@ function registerShutdownHandlers(): void {
     }
 
     managedQueues.clear()
+    for (const hook of managedShutdownHooks) {
+      try {
+        await hook()
+      } catch (error) {
+        hasError = true
+        console.error('[worker] Error during shutdown hook:', error)
+      }
+    }
+    managedShutdownHooks.clear()
     unregisterShutdownHandlers(sigtermHandler, sigintHandler)
     shutdownInProgress = false
 
@@ -75,6 +85,15 @@ function registerShutdownHandlers(): void {
   process.on('SIGTERM', sigtermHandler)
   process.on('SIGINT', sigintHandler)
   shutdownHandlersRegistered = true
+}
+
+/**
+ * Register a process-local service that must stop before a worker exits.
+ * The returned callback removes the hook when the service is stopped early.
+ */
+export function registerWorkerShutdownHook(hook: () => Promise<void> | void): () => void {
+  managedShutdownHooks.add(hook)
+  return () => managedShutdownHooks.delete(hook)
 }
 
 /**

--- a/packages/queue/src/worker/runner.ts
+++ b/packages/queue/src/worker/runner.ts
@@ -60,7 +60,7 @@ function registerShutdownHandlers(): void {
         await hook()
       } catch (error) {
         hasError = true
-        console.error('[worker] Error during shutdown hook:', error)
+        logger.error('Error during shutdown hook', { err: error })
       }
     }
     managedShutdownHooks.clear()

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -619,6 +619,12 @@ function applyLocalDevBackgroundServiceDefaults(childEnv) {
   ) {
     env.OM_AUTO_SPAWN_SCHEDULER_LAZY = 'true'
   }
+  if (
+    typeof process.env.OM_DEV_EMBED_SCHEDULER_IN_SHARED_WORKER !== 'string'
+    || process.env.OM_DEV_EMBED_SCHEDULER_IN_SHARED_WORKER.trim() === ''
+  ) {
+    env.OM_DEV_EMBED_SCHEDULER_IN_SHARED_WORKER = 'true'
+  }
   return env
 }
 


### PR DESCRIPTION
## Summary
- run the local scheduler inside the existing shared lazy queue worker in dev mode
- retain worker and scheduler behavior, including graceful shutdown and scheduled-job startup
- remove the unrelated generated module-facts update from this focused branch

## Validation
- yarn workspace @open-mercato/queue test --runInBand src/worker/__tests__/runner.test.ts
- yarn workspace @open-mercato/cli test --runInBand src/lib/__tests__/queue-worker-supervisor.test.ts src/lib/__tests__/scheduler-supervisor.test.ts src/__tests__/mercato.test.ts
- yarn workspace @open-mercato/cli build
- yarn workspace @open-mercato/queue typecheck
- yarn workspace @open-mercato/cli typecheck
- manual dev-mode login, page navigation, edit reflection, and CPU/RSS observation

## Measured result
Post-precompile RSS peak: 6,777.57 MB versus 10,551.68 MB baseline (35.8% reduction).