### PR TITLE
fix(cache): back tenant-context AsyncLocalStorage with globalThis to survive bundler duplication

### DIFF
--- a/packages/cache/src/__tests__/tenantContext.test.ts
+++ b/packages/cache/src/__tests__/tenantContext.test.ts
@@ -1,0 +1,52 @@
+const TENANT_STORAGE_KEY = Symbol.for('@open-mercato/cache/tenant-context')
+
+function clearGlobalStorage(): void {
+  delete (globalThis as Record<symbol, unknown>)[TENANT_STORAGE_KEY]
+}
+
+describe('cache tenant context', () => {
+  beforeEach(() => {
+    clearGlobalStorage()
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    clearGlobalStorage()
+  })
+
+  it('exposes the tenant inside runWithCacheTenant and null outside', () => {
+    const { runWithCacheTenant, getCurrentCacheTenant } = require('../tenantContext')
+    expect(getCurrentCacheTenant()).toBeNull()
+    runWithCacheTenant('tenant-a', () => {
+      expect(getCurrentCacheTenant()).toBe('tenant-a')
+    })
+    expect(getCurrentCacheTenant()).toBeNull()
+  })
+
+  it('shares the storage across duplicated module copies via globalThis', () => {
+    // Simulate a bundler emitting the module into two chunks: two separate
+    // module instances must still observe one shared AsyncLocalStorage,
+    // otherwise a tenant entered through one copy (an API route) is invisible
+    // to the other (the cache service wrapper) and entries get stored under
+    // the tenant:global prefix that tenant-scoped invalidations never target.
+    const copyA = require('../tenantContext')
+    jest.resetModules()
+    const copyB = require('../tenantContext')
+    expect(copyB).not.toBe(copyA)
+
+    copyA.runWithCacheTenant('tenant-shared', () => {
+      expect(copyB.getCurrentCacheTenant()).toBe('tenant-shared')
+    })
+    expect(copyB.getCurrentCacheTenant()).toBeNull()
+  })
+
+  it('nested contexts restore the outer tenant', () => {
+    const { runWithCacheTenant, getCurrentCacheTenant } = require('../tenantContext')
+    runWithCacheTenant('outer', () => {
+      runWithCacheTenant('inner', () => {
+        expect(getCurrentCacheTenant()).toBe('inner')
+      })
+      expect(getCurrentCacheTenant()).toBe('outer')
+    })
+  })
+})

--- a/packages/cache/src/tenantContext.ts
+++ b/packages/cache/src/tenantContext.ts
@@ -1,6 +1,29 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
 
-const tenantStorage = new AsyncLocalStorage<string | null>()
+// Bundlers (Turbopack/esbuild/tsx) can emit this module into multiple chunks,
+// each with its own module-local AsyncLocalStorage. A tenant context entered
+// through one copy (e.g. an API route's `runWithCacheTenant`) is then invisible
+// to the copy the cache service's tenant-aware wrapper reads, so entries get
+// stored under the `tenant:global:` prefix while invalidations that DO carry
+// the tenant (queue workers, cross-process drains) target `tenant:<id>:` —
+// tag-based eviction silently misses and reads stay stale until TTL.
+// Key the storage off globalThis via Symbol.for so every duplicated copy
+// resolves the same instance. Mirrors the data_sync adapter-registry fix.
+const TENANT_STORAGE_KEY = Symbol.for('@open-mercato/cache/tenant-context')
+
+type GlobalWithTenantStorage = typeof globalThis & {
+  [TENANT_STORAGE_KEY]?: AsyncLocalStorage<string | null>
+}
+
+function resolveTenantStorage(): AsyncLocalStorage<string | null> {
+  const scope = globalThis as GlobalWithTenantStorage
+  if (!scope[TENANT_STORAGE_KEY]) {
+    scope[TENANT_STORAGE_KEY] = new AsyncLocalStorage<string | null>()
+  }
+  return scope[TENANT_STORAGE_KEY]
+}
+
+const tenantStorage = resolveTenantStorage()
 
 export function runWithCacheTenant<T>(tenantId: string | null, fn: () => T): T
 export function runWithCacheTenant<T>(tenantId: string | null, fn: () => Promise<T>): Promise<T>


### PR DESCRIPTION
## Root cause of the standalone Snapshot Release failures (TC-CRM-079 / TC-SX-001)

Third and final piece of the #3594 stabilization chain (#4117 → #4118 → this).

Turbopack emits `@open-mercato/cache` into multiple server chunks, each with its own module-local `AsyncLocalStorage`. A tenant context entered through one copy (an API route's `runWithCacheTenant`) is invisible to the copy the cache service's tenant-aware wrapper reads, so cached entries are keyed under the **`tenant:global:`** prefix. Tenant-scoped invalidations issued from queue workers or cross-process drains target **`tenant:<id>:`** — tag eviction silently deletes nothing, and the detail-GET caches added in #3709/#3711/#3712 serve pre-mutation records until TTL. That is exactly the CI failure signature: DB write lands, drain child completes cleanly, API stays stale for the whole 30s poll.

**Why only the standalone lane failed:** in-process lanes (ephemeral shards, dev) run invalidation through the *same duplicated copy*, so both the write and the delete drift to `tenant:global:` — still matching each other. Only when the invalidation runs in a separate plain-Node process (the integration drain children, or any future external worker) do the prefixes diverge. This also means the bug silently weakens tenant scoping of cache keys in every bundled server — fixing it is correctness, not just CI hygiene.

## Live evidence (scaffolded standalone app, Verdaccio build)

- Pre-fix: detail entry stored as `tenant:global:tag:t:99e99158…` while the worker deletes `tenant:69bbf72e…:tag:t:99e99158…` — identical raw tag hash, mismatched prefix; cross-process `deleteByTags` → `deleted: 0`.
- Post-fix (patched package, app rebuilt): same probe stores under `tenant:69bbf72e…`, `deleteByTags` → `deleted: 1`, and **both previously failing tests pass** (TC-CRM-079 4.8s, TC-SX-001 11.9s). The full ~1750-spec suite run locally reproduced both CI failures pre-fix, confirming environment parity.

## Change

`Symbol.for`-keyed `globalThis` singleton for the tenant-context storage — the established pattern from the data_sync adapter-registry fix (#4025). Public API unchanged. Regression test simulates duplicated module copies (`jest.resetModules`) and asserts the context crosses instances.

## Validation

- `yarn workspace @open-mercato/cache test`: 58/58 pass (3 new).
- End-to-end against the standalone app as above.
- Runner: local.

After merge, the next develop Snapshot Release run is expected green — which unblocks release PR #3594.

Labels: `bug` + `skip-qa` (no customer-facing surface; validated E2E against a scaffolded standalone app) + `priority-high` (release-blocking) + `risk-medium` (shared cache infra, single-module change with tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)