### PR TITLE
fix(sales): invalidate order cache after return mutations

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-033.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-033.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
 import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readUpdatedAt } from '@open-mercato/core/helpers/integration/optimisticLockUi'
 import { createShipmentFixture, deleteSalesEntityIfExists } from '@open-mercato/core/helpers/integration/salesFixtures'
 
 /**
@@ -15,11 +16,9 @@ import { createShipmentFixture, deleteSalesEntityIfExists } from '@open-mercato/
  * asserts the quantity increment (the key fulfilment contract) and the detail read-back.
  * Returns require whole-integer quantities >= 1 and reject over-returns.
  *
- * Cache note: the order line's `returned_quantity` is read back exactly once, after the
- * return — and never before it. The return command updates the line column but does not
- * invalidate the order-lines list cache, so a read taken before the return would be served
- * stale from cache (`ENABLE_CRUD_API_CACHE`, on in CI). Reading only after the return keeps
- * the request a cache miss for this freshly created order, so it reflects the live value.
+ * Cache coverage: prime both the order and its order-lines cache before creating
+ * a return. The committed return must invalidate the parent order resource so
+ * the immediate reads receive its new optimistic-lock version and returned quantity.
  */
 
 type JsonRecord = Record<string, unknown>
@@ -84,6 +83,8 @@ test.describe('TC-SALES-033 return creation + quantity tracking', () => {
       orderLineId = (await readJson(lineResponse)).id as string
       expect(orderLineId).toBeTruthy()
       await createShipmentFixture(request, token, orderId, [{ orderLineId: orderLineId!, quantity: 5 }])
+      const updatedAtBeforeReturn = await readUpdatedAt(request, token, '/api/sales/orders', orderId)
+      await readOrderLine(request, token, orderId, orderLineId)
 
       const returnResponse = await apiRequest(request, 'POST', '/api/sales/returns', {
         token,
@@ -115,6 +116,12 @@ test.describe('TC-SALES-033 return creation + quantity tracking', () => {
         await readJson(await apiRequest(request, 'GET', `/api/sales/returns?orderId=${encodeURIComponent(orderId)}`, { token })),
       )
       expect(byOrder.some((row) => row.id === returnId)).toBeTruthy()
+
+      const updatedAtAfterReturn = await readUpdatedAt(request, token, '/api/sales/orders', orderId)
+      expect(
+        updatedAtAfterReturn,
+        'return must invalidate the cached parent order version',
+      ).not.toBe(updatedAtBeforeReturn)
 
       // The source line now reports 2 returned of 5.
       const after = await readOrderLine(request, token, orderId!, orderLineId!)

--- a/packages/core/src/modules/sales/commands/__tests__/returns.shipment-guard.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/returns.shipment-guard.test.ts
@@ -14,6 +14,7 @@
 import { createContainer, asValue, InjectionMode } from 'awilix'
 import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { invalidateCrudCache } from '@open-mercato/shared/lib/crud/cache'
 import { SalesOrder, SalesOrderLine, SalesShipment, SalesShipmentItem, SalesOrderAdjustment } from '../../data/entities'
 
 jest.mock('../../services/salesDocumentNumberGenerator', () => ({
@@ -31,6 +32,10 @@ jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
     t: (key: string, fallback?: string) => fallback ?? key,
     translate: (key: string, fallback?: string) => fallback ?? key,
   }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/cache', () => ({
+  invalidateCrudCache: jest.fn(),
 }))
 
 const ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
@@ -134,6 +139,7 @@ describe('sales.returns.create shipment guard (issue #3034)', () => {
 
   afterEach(() => {
     delete (globalThis as any).__returnsWorld
+    ;(invalidateCrudCache as jest.MockedFunction<typeof invalidateCrudCache>).mockClear()
   })
 
   it('rejects a return when the order has no shipments', async () => {
@@ -182,9 +188,17 @@ describe('sales.returns.create shipment guard (issue #3034)', () => {
       calculateDocumentTotals: jest.fn(async () => ({ totals: {}, lines: [{}] })),
     }
     const handler = commandRegistry.get('sales.returns.create')!
-    const result = await handler.execute(baseInput(2), makeCtx(em, calc) as never)
+    const ctx = makeCtx(em, calc)
+    const result = await handler.execute(baseInput(2), ctx as never)
     expect(result).toMatchObject({ returnId: expect.any(String) })
     expect(calc.calculateDocumentTotals).toHaveBeenCalled()
     expect(em.flush).toHaveBeenCalled()
+    expect(invalidateCrudCache).toHaveBeenCalledWith(
+      ctx.container,
+      'sales.order',
+      { id: ORDER_ID, organizationId: ORG_ID, tenantId: TENANT_ID },
+      TENANT_ID,
+      'updated',
+    )
   })
 })

--- a/packages/core/src/modules/sales/commands/returns.ts
+++ b/packages/core/src/modules/sales/commands/returns.ts
@@ -4,6 +4,7 @@ import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
 import { LockMode } from '@mikro-orm/core'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { invalidateCrudCache } from '@open-mercato/shared/lib/crud/cache'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { emitCrudSideEffects } from '@open-mercato/shared/lib/commands/helpers'
 import type { CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
@@ -63,6 +64,28 @@ const returnCrudEvents: CrudEventsConfig = {
     organizationId: ctx.identifiers.organizationId,
     tenantId: ctx.identifiers.tenantId,
   }),
+}
+
+type OrderCacheRecord = Pick<SalesOrder, 'id' | 'organizationId' | 'tenantId'>
+
+/**
+ * Return mutations update the order aggregate, which is also the cache resource
+ * used by the order-lines and order-adjustments routes. Invalidate it after
+ * each committed return lifecycle change so reloads receive its fresh
+ * `updatedAt` optimistic-lock token.
+ */
+async function invalidateOrderCache(
+  container: Parameters<typeof invalidateCrudCache>[0],
+  order: OrderCacheRecord,
+  fallbackTenant: string | null,
+): Promise<void> {
+  await invalidateCrudCache(
+    container,
+    SALES_RESOURCE_KIND_ORDER,
+    { id: order.id, organizationId: order.organizationId, tenantId: order.tenantId },
+    fallbackTenant,
+    'updated',
+  )
 }
 
 function toNumeric(value: unknown): number {
@@ -618,7 +641,7 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
     }
 
     const salesCalculationService = ctx.container.resolve<SalesCalculationService>('salesCalculationService')
-    const { header, createdLines } = await em.transactional(async (tx) => {
+    const { header, createdLines, order } = await em.transactional(async (tx) => {
       const order = await findOneWithDecryption(
         tx,
         SalesOrder,
@@ -769,8 +792,10 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
 
       await tx.flush()
 
-      return { header: entity, createdLines: createdReturnLines }
+      return { header: entity, createdLines: createdReturnLines, order }
     })
+
+    await invalidateOrderCache(ctx.container, order, ctx.auth?.tenantId ?? null)
 
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     await emitCrudSideEffects({
@@ -827,6 +852,11 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const salesCalculationService = ctx.container.resolve<SalesCalculationService>('salesCalculationService')
     await reverseReturnEffects(em, salesCalculationService, after)
+    await invalidateOrderCache(ctx.container, {
+      id: after.orderId,
+      organizationId: after.organizationId,
+      tenantId: after.tenantId,
+    }, ctx.auth?.tenantId ?? null)
   },
   redo: async ({ ctx, logEntry }) => {
     const after = resolveRedoSnapshot<ReturnSnapshot>(logEntry)
@@ -848,6 +878,12 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
     if (!header) {
       throw new CrudHttpError(404, { error: 'sales.returns.orderMissing' })
     }
+
+    await invalidateOrderCache(ctx.container, {
+      id: after.orderId,
+      organizationId: after.organizationId,
+      tenantId: after.tenantId,
+    }, ctx.auth?.tenantId ?? null)
 
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     await emitCrudSideEffects({
@@ -1047,6 +1083,11 @@ const deleteReturnCommand: CommandHandler<ReturnDeleteInput, { returnId: string 
     await enforceSalesDocumentOptimisticLock(ctx, header, SALES_RESOURCE_KIND_RETURN)
 
     await reverseReturnEffects(em, salesCalculationService, snapshot)
+    await invalidateOrderCache(ctx.container, {
+      id: snapshot.orderId,
+      organizationId: snapshot.organizationId,
+      tenantId: snapshot.tenantId,
+    }, ctx.auth?.tenantId ?? null)
 
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     await emitCrudSideEffects({
@@ -1109,6 +1150,12 @@ const deleteReturnCommand: CommandHandler<ReturnDeleteInput, { returnId: string 
       { tenantId: before.tenantId, organizationId: before.organizationId },
     )
     if (!header) return
+
+    await invalidateOrderCache(ctx.container, {
+      id: before.orderId,
+      organizationId: before.organizationId,
+      tenantId: before.tenantId,
+    }, ctx.auth?.tenantId ?? null)
 
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     await emitCrudSideEffects({


### PR DESCRIPTION
## Summary
- invalidate the parent sales-order cache after every return lifecycle mutation
- ensure refreshed order, line, and adjustment reads receive the current optimistic-lock version
- add unit and integration cache-regression coverage

Closes #4055

## Validation
- yarn workspace @open-mercato/core test packages/core/src/modules/sales/commands/__tests__/returns.shipment-guard.test.ts --runInBand
- yarn build:packages
- yarn generate
- yarn workspace @open-mercato/core typecheck
- yarn eslint packages/core/src/modules/sales/commands/returns.ts packages/core/src/modules/sales/commands/__tests__/returns.shipment-guard.test.ts packages/core/src/modules/sales/__integration__/TC-SALES-033.spec.ts