### PR TITLE
fix(ui): integrations tabs use DS underline variant + violet hover (#2015)

### DIFF
--- a/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
@@ -1199,84 +1199,41 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
           </section>
         ) : null}
 
-        <Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-5">
-          <TabsList className="h-auto w-full justify-start overflow-x-auto rounded-none border-b border-border bg-transparent p-0">
+        <Tabs value={activeTab} onValueChange={handleTabChange} variant="underline" className="space-y-5">
+          <TabsList className="w-full overflow-x-auto">
             {showCredentialsTab ? (
-              <TabsTrigger
-                value="credentials"
-                className="mr-8 h-auto rounded-none border-b-2 border-transparent bg-transparent px-0 py-2.5 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground aria-selected:border-accent-indigo aria-selected:bg-transparent aria-selected:text-foreground aria-selected:shadow-none last:mr-0"
-              >
-                <span className="inline-flex items-center gap-2">
-                  <Key className="h-4 w-4" />
-                  <span>{t('integrations.detail.tabs.credentials')}</span>
-                </span>
+              <TabsTrigger value="credentials" leading={<Key className="h-4 w-4" />}>
+                {t('integrations.detail.tabs.credentials')}
               </TabsTrigger>
             ) : null}
             {leadingInjectedTab ? (
-              <TabsTrigger
-                value={leadingInjectedTab.id}
-                className="mr-8 h-auto rounded-none border-b-2 border-transparent bg-transparent px-0 py-2.5 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground aria-selected:border-accent-indigo aria-selected:bg-transparent aria-selected:text-foreground aria-selected:shadow-none last:mr-0"
-              >
-                <span className="inline-flex items-center gap-2">
-                  <Settings className="h-4 w-4" />
-                  <span>{leadingInjectedTab.label}</span>
-                </span>
+              <TabsTrigger value={leadingInjectedTab.id} leading={<Settings className="h-4 w-4" />}>
+                {leadingInjectedTab.label}
               </TabsTrigger>
             ) : null}
             {showVersionTab ? (
-              <TabsTrigger
-                value="version"
-                className="mr-8 h-auto rounded-none border-b-2 border-transparent bg-transparent px-0 py-2.5 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground aria-selected:border-accent-indigo aria-selected:bg-transparent aria-selected:text-foreground aria-selected:shadow-none last:mr-0"
-              >
-                <span className="inline-flex items-center gap-2">
-                  <RefreshCw className="h-4 w-4" />
-                  <span>{t('integrations.detail.tabs.version')}</span>
-                </span>
+              <TabsTrigger value="version" leading={<RefreshCw className="h-4 w-4" />}>
+                {t('integrations.detail.tabs.version')}
               </TabsTrigger>
             ) : null}
             {showDataSyncScheduleTab ? (
-              <TabsTrigger
-                value="data-sync-schedule"
-                className="mr-8 h-auto rounded-none border-b-2 border-transparent bg-transparent px-0 py-2.5 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground aria-selected:border-accent-indigo aria-selected:bg-transparent aria-selected:text-foreground aria-selected:shadow-none last:mr-0"
-              >
-                <span className="inline-flex items-center gap-2">
-                  <Calendar className="h-4 w-4" />
-                  <span>{t('data_sync.integrationTab.title', 'Sync schedules')}</span>
-                </span>
+              <TabsTrigger value="data-sync-schedule" leading={<Calendar className="h-4 w-4" />}>
+                {t('data_sync.integrationTab.title', 'Sync schedules')}
               </TabsTrigger>
             ) : null}
             {showHealthTab ? (
-              <TabsTrigger
-                value="health"
-                className="mr-8 h-auto rounded-none border-b-2 border-transparent bg-transparent px-0 py-2.5 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground aria-selected:border-accent-indigo aria-selected:bg-transparent aria-selected:text-foreground aria-selected:shadow-none last:mr-0"
-              >
-                <span className="inline-flex items-center gap-2">
-                  <Activity className="h-4 w-4" />
-                  <span>{t('integrations.detail.tabs.health')}</span>
-                </span>
+              <TabsTrigger value="health" leading={<Activity className="h-4 w-4" />}>
+                {t('integrations.detail.tabs.health')}
               </TabsTrigger>
             ) : null}
             {showLogsTab ? (
-              <TabsTrigger
-                value="logs"
-                className="mr-8 h-auto rounded-none border-b-2 border-transparent bg-transparent px-0 py-2.5 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground aria-selected:border-accent-indigo aria-selected:bg-transparent aria-selected:text-foreground aria-selected:shadow-none last:mr-0"
-              >
-                <span className="inline-flex items-center gap-2">
-                  <FileText className="h-4 w-4" />
-                  <span>{t('integrations.detail.tabs.logs')}</span>
-                </span>
+              <TabsTrigger value="logs" leading={<FileText className="h-4 w-4" />}>
+                {t('integrations.detail.tabs.logs')}
               </TabsTrigger>
             ) : null}
             {trailingInjectedTabs.map((tab) => (
-              <TabsTrigger
-                key={tab.id}
-                value={tab.id}
-                className="mr-8 h-auto rounded-none border-b-2 border-transparent bg-transparent px-0 py-2.5 text-sm font-medium text-muted-foreground shadow-none transition-colors hover:bg-transparent hover:text-foreground aria-selected:border-accent-indigo aria-selected:bg-transparent aria-selected:text-foreground aria-selected:shadow-none last:mr-0"
-              >
-                <span className="inline-flex items-center gap-2">
-                  <Settings className="h-4 w-4" />
-                  <span>{tab.label}</span>
-                </span>
+              <TabsTrigger key={tab.id} value={tab.id} leading={<Settings className="h-4 w-4" />}>
+                {tab.label}
               </TabsTrigger>
             ))}
           </TabsList>

--- a/packages/ui/src/primitives/tabs.tsx
+++ b/packages/ui/src/primitives/tabs.tsx
@@ -177,15 +177,19 @@ export function TabsTrigger({
           // Underline trigger — flat, bottom-border accent when active.
           // Negative margin-bottom -1px so the active accent sits on
           // top of the rail's border-bottom (rather than below it).
+          // Hover fills a subtle violet background wash (+ violet text and icon),
+          // token-driven so it holds in light and dark. The selected tab still
+          // owns the solid accent-indigo underline, so the filled hover never gets
+          // confused with the active state.
           orientation === 'vertical'
-            ? 'group relative inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground outline-none transition-colors'
-            : 'group relative -mb-px inline-flex items-center gap-2 border-b-2 border-transparent px-1 py-2 text-sm font-medium text-muted-foreground outline-none transition-colors',
-          'hover:text-foreground focus-visible:shadow-focus',
+            ? 'group relative inline-flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground outline-none transition-colors hover:bg-accent-indigo/10 hover:text-accent-indigo'
+            : 'group relative -mb-px inline-flex items-center gap-2 rounded-t-md border-b-2 border-transparent px-3 py-2 text-sm font-medium text-muted-foreground outline-none transition-colors hover:bg-accent-indigo/10 hover:text-accent-indigo',
+          'focus-visible:shadow-focus',
           'disabled:pointer-events-none disabled:opacity-50',
           isSelected
             ? orientation === 'vertical'
-              ? 'bg-muted/40 text-foreground'
-              : 'border-accent-indigo font-semibold text-foreground'
+              ? 'bg-muted/40 text-foreground hover:bg-muted/40 hover:text-foreground'
+              : 'border-accent-indigo font-semibold text-foreground hover:border-accent-indigo hover:bg-transparent hover:text-foreground'
             : '',
           className,
         )}
@@ -196,7 +200,7 @@ export function TabsTrigger({
             aria-hidden="true"
             className={cn(
               'inline-flex shrink-0 items-center justify-center',
-              isSelected ? 'text-accent-indigo' : 'text-muted-foreground',
+              isSelected ? 'text-accent-indigo' : 'text-muted-foreground group-hover:text-accent-indigo',
             )}
           >
             {leading}


### PR DESCRIPTION
Fixes #2015.

## Problem
The integrations detail page (`/backend/integrations/[id]`) hand-rolled an underline tab strip **on top of** the pill `Tabs` variant — a `TabsList` + 7× `TabsTrigger` each carrying ~30 override classes (`h-auto px-0 py-2.5 border-b-2 … aria-selected:border-accent-indigo …`) fighting the pill `Button` base. That mismatch caused the reported padding glitch, and it was the only place in the module bypassing the shared component.

## Change
- **Integrations detail**: switch to the shared `Tabs variant="underline"` and move the tab icons to the `leading` slot. −59/+16 lines; the strip now renders through the design system instead of around it (fixes the padding bug).
- **Shared `tabs.tsx` (underline variant)**: polish the hover so tabs read as one system — a subtle **violet (`accent-indigo`) background wash** with violet text and icon, token-driven for light and dark. The background rounds only at the top (`rounded-t-md`) so the active tab's **straight** accent underline stays intact, and the selected tab is pinned on hover so it never gets confused with a hovered one.

## Blast radius
The hover polish lives in the `underline` variant, so it reaches the three underline-variant tab strips: **integrations, calendar, translations**. Pill-variant tabs (job logs, checkout link template, search sections, AI playground) are unchanged.

## Validation
- DS tabs unit: 10/10 · UI unit: 1626/1627 (the 1 fail is a pre-existing `DataTable.extensions` `act()` flake, passes in isolation, unrelated to tabs)
- Core integrations unit: 76/76 · Typecheck: 21/21 packages · Lint: clean
- Integration (ephemeral): integrations suite **27 passed, 1 skipped**
- Manual QA in browser: light + dark, hover (violet bg + text + icon), active straight underline, active-tab pinned on hover