### PR TITLE
refactor(messages): extract shared participant-scope helper to prevent enricher/list-route drift (#4133)

### DIFF
--- a/packages/core/src/modules/communication_channels/data/__tests__/enrichers.test.ts
+++ b/packages/core/src/modules/communication_channels/data/__tests__/enrichers.test.ts
@@ -1,6 +1,7 @@
 import { enrichers } from '../enrichers'
 import { CommunicationChannel, ExternalConversation, MessageChannelLink } from '../entities'
 import type { ResponseEnricher } from '@open-mercato/shared/lib/crud/response-enricher'
+import { applyMessageParticipantScope } from '../../../messages/lib/participantScope'
 
 const findEnricher = (id: string): ResponseEnricher => {
   const e = enrichers.find((x) => x.id === id)
@@ -299,5 +300,66 @@ describe('communication_channels enrichers — no duplicate MessageChannelLink l
     expect(participantQuery.where).toHaveBeenCalledWith('m.deleted_at', 'is', null)
     expect(expressionBuilder).toHaveBeenCalledWith('m.sender_user_id', '=', 'user-1')
     expect(expressionBuilder).toHaveBeenCalledWith('r.message_id', 'is not', null)
+  })
+})
+
+describe('message-channel enricher — participant scope agrees with the list route (#4133)', () => {
+  // Records the join conditions and OR-expression terms a Kysely builder emits,
+  // so the participant predicate can be compared regardless of call site.
+  function makeScopeRecorder() {
+    const onRef: unknown[][] = []
+    const on: unknown[][] = []
+    const or: unknown[][] = []
+    const joinBuilder: any = {
+      onRef: (...args: unknown[]) => { onRef.push(args); return joinBuilder },
+      on: (...args: unknown[]) => { on.push(args); return joinBuilder },
+    }
+    const expressionBuilder: any = (...args: unknown[]) => { or.push(args); return args }
+    expressionBuilder.or = (expressions: unknown[]) => expressions
+    const query: any = {
+      selectFrom: () => query,
+      leftJoin: (_table: string, join: (builder: any) => unknown) => { join(joinBuilder); return query },
+      select: () => query,
+      distinct: () => query,
+      where: (...args: unknown[]) => {
+        if (typeof args[0] === 'function') (args[0] as (eb: unknown) => unknown)(expressionBuilder)
+        return query
+      },
+      execute: async () => [{ id: 'm1' }],
+    }
+    return { query, signature: () => ({ onRef, on, or }) }
+  }
+
+  it('the enricher guard and the list route all-folder derive one participant set', async () => {
+    const enricher = findEnricher('communication_channels.message-channel')
+
+    // List route `all` folder: it calls the shared helper directly on its query.
+    const routeRecorder = makeScopeRecorder()
+    applyMessageParticipantScope(routeRecorder.query.selectFrom('messages as m'), 'user-1')
+
+    // Enricher: run its participant guard through a recording Kysely builder.
+    const enricherRecorder = makeScopeRecorder()
+    await enricher.enrichMany!([{ id: 'm1' }] as any, {
+      organizationId: 'org',
+      tenantId: 'tenant',
+      userId: 'user-1',
+      em: { find: jest.fn(async () => []), getKysely: () => enricherRecorder.query },
+      container: { resolve: () => null },
+    } as any)
+
+    // Both must emit the exact same sender-OR-recipient predicate — a drift in
+    // either call site would break this equality.
+    expect(enricherRecorder.signature()).toEqual(routeRecorder.signature())
+    expect(routeRecorder.signature()).toEqual({
+      onRef: [['m.id', '=', 'r.message_id']],
+      on: [
+        ['r.recipient_user_id', '=', 'user-1'],
+        ['r.deleted_at', 'is', null],
+      ],
+      or: [
+        ['m.sender_user_id', '=', 'user-1'],
+        ['r.message_id', 'is not', null],
+      ],
+    })
   })
 })

--- a/packages/core/src/modules/communication_channels/data/enrichers.ts
+++ b/packages/core/src/modules/communication_channels/data/enrichers.ts
@@ -1,6 +1,10 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { EnricherContext, ResponseEnricher } from '@open-mercato/shared/lib/crud/response-enricher'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import {
+  applyMessageParticipantScope,
+  type MessagesParticipantScopeDatabase,
+} from '../../messages/lib/participantScope'
 import { sanitizeChannelHtml } from '../lib/sanitize-channel-html'
 import {
   CommunicationChannel,
@@ -41,21 +45,6 @@ import {
 type MessageRecord = Record<string, unknown> & {
   id: string
   threadId?: string | null
-}
-
-type MessageParticipantDatabase = {
-  messages: {
-    id: string
-    tenant_id: string
-    organization_id: string | null
-    sender_user_id: string
-    deleted_at: Date | null
-  }
-  message_recipients: {
-    message_id: string
-    recipient_user_id: string
-    deleted_at: Date | null
-  }
 }
 
 type ResolvedCtx = EnricherContext & {
@@ -151,22 +140,13 @@ const messageChannelEnricher: ResponseEnricher<
       }))
     }
 
-    const db = em.getKysely<MessageParticipantDatabase>()
-    let participantQuery = db
-      .selectFrom('messages as m')
-      .leftJoin('message_recipients as r', (join) => join
-        .onRef('m.id', '=', 'r.message_id')
-        .on('r.recipient_user_id', '=', userId)
-        .on('r.deleted_at', 'is', null))
+    const db = em.getKysely<MessagesParticipantScopeDatabase>()
+    let participantQuery = applyMessageParticipantScope(db.selectFrom('messages as m'), userId)
       .select('m.id')
       .distinct()
       .where('m.id', 'in', messageIds)
       .where('m.tenant_id', '=', tenantId)
       .where('m.deleted_at', 'is', null)
-      .where((eb) => eb.or([
-        eb('m.sender_user_id', '=', userId),
-        eb('r.message_id', 'is not', null),
-      ]))
 
     participantQuery = organizationId !== null
       ? participantQuery.where('m.organization_id', '=', organizationId)

--- a/packages/core/src/modules/messages/api/route.ts
+++ b/packages/core/src/modules/messages/api/route.ts
@@ -13,6 +13,7 @@ import { getMessageType } from '../lib/message-types-registry'
 import { validateMessageObjectsForType } from '../lib/object-validation'
 import { attachOperationMetadataHeader } from '../lib/operationMetadata'
 import { canUseMessageEmailFeature, resolveMessageContext } from '../lib/routeHelpers'
+import { applyMessageParticipantScope } from '../lib/participantScope'
 import { resolveUserFeatures, runMessageMutationGuardAfterSuccess, runMessageMutationGuards } from './guards'
 import { findMessageIdsBySearchTokens } from '../lib/searchLookup'
 import { MessageCommandExecuteResult } from '../commands/shared'
@@ -120,11 +121,9 @@ export async function GET(req: Request) {
         joinRecipient()
         break
       case 'all':
-        joinRecipient()
-        q = q.where((eb: any) => eb.or([
-          eb('m.sender_user_id', '=', scope.userId),
-          eb('r.message_id', 'is not', null),
-        ]))
+        // Sender-OR-recipient participant scope shared with the
+        // communication_channels message enricher — see participantScope.ts (#4133).
+        q = applyMessageParticipantScope(q, scope.userId)
         break
       default: {
         const unsupportedFolder: never = input.folder

--- a/packages/core/src/modules/messages/lib/__tests__/participantScope.test.ts
+++ b/packages/core/src/modules/messages/lib/__tests__/participantScope.test.ts
@@ -1,0 +1,70 @@
+import { applyMessageParticipantScope } from '../participantScope'
+
+// A minimal recording Kysely builder: it captures the join conditions and the
+// OR-expression terms the helper emits so the participant-scope predicate can be
+// asserted without a live database.
+function makeRecorder() {
+  const joinOnRefCalls: unknown[][] = []
+  const joinOnCalls: unknown[][] = []
+  const orExpressionCalls: unknown[][] = []
+  const joinBuilder: any = {
+    onRef: (...args: unknown[]) => { joinOnRefCalls.push(args); return joinBuilder },
+    on: (...args: unknown[]) => { joinOnCalls.push(args); return joinBuilder },
+  }
+  const expressionBuilder: any = (...args: unknown[]) => { orExpressionCalls.push(args); return args }
+  expressionBuilder.or = (expressions: unknown[]) => expressions
+  const query: any = {
+    selectFrom: () => query,
+    leftJoin: (_table: string, join: (builder: any) => unknown) => { join(joinBuilder); return query },
+    select: () => query,
+    distinct: () => query,
+    where: (...args: unknown[]) => {
+      if (typeof args[0] === 'function') (args[0] as (eb: unknown) => unknown)(expressionBuilder)
+      return query
+    },
+    execute: async () => [] as Array<{ id: string }>,
+  }
+  return { query, joinOnRefCalls, joinOnCalls, orExpressionCalls }
+}
+
+describe('applyMessageParticipantScope (#4133)', () => {
+  it('joins message_recipients on the current user, excluding soft-deleted rows', () => {
+    const recorder = makeRecorder()
+    applyMessageParticipantScope(recorder.query.selectFrom('messages as m'), 'user-1')
+
+    expect(recorder.joinOnRefCalls).toContainEqual(['m.id', '=', 'r.message_id'])
+    expect(recorder.joinOnCalls).toContainEqual(['r.recipient_user_id', '=', 'user-1'])
+    // Recipient soft-delete is part of the shared visibility boundary — it lives
+    // in the helper, not the call sites, so it cannot drift.
+    expect(recorder.joinOnCalls).toContainEqual(['r.deleted_at', 'is', null])
+  })
+
+  it('scopes visibility to sender OR matched recipient', () => {
+    const recorder = makeRecorder()
+    applyMessageParticipantScope(recorder.query.selectFrom('messages as m'), 'user-1')
+
+    expect(recorder.orExpressionCalls).toContainEqual(['m.sender_user_id', '=', 'user-1'])
+    expect(recorder.orExpressionCalls).toContainEqual(['r.message_id', 'is not', null])
+  })
+
+  it('emits exactly the sender-OR-recipient predicate and nothing else', () => {
+    const recorder = makeRecorder()
+    applyMessageParticipantScope(recorder.query.selectFrom('messages as m'), 'user-42')
+
+    expect({
+      onRef: recorder.joinOnRefCalls,
+      on: recorder.joinOnCalls,
+      or: recorder.orExpressionCalls,
+    }).toEqual({
+      onRef: [['m.id', '=', 'r.message_id']],
+      on: [
+        ['r.recipient_user_id', '=', 'user-42'],
+        ['r.deleted_at', 'is', null],
+      ],
+      or: [
+        ['m.sender_user_id', '=', 'user-42'],
+        ['r.message_id', 'is not', null],
+      ],
+    })
+  })
+})

--- a/packages/core/src/modules/messages/lib/participantScope.ts
+++ b/packages/core/src/modules/messages/lib/participantScope.ts
@@ -1,0 +1,64 @@
+import type { SelectQueryBuilder } from 'kysely'
+
+/**
+ * Minimal Kysely schema contract the message participant-scope predicate depends
+ * on. Both the messages list route (`api/route.ts`, `all` folder) and the
+ * `communication_channels.message-channel` response enricher build their
+ * sender-OR-recipient access filter from {@link applyMessageParticipantScope},
+ * so a column rename (`sender_user_id`, `recipient_user_id`, `deleted_at`) or a
+ * change to the recipient-visibility rules updates both call sites at once
+ * instead of silently desyncing the enricher's security boundary from the list
+ * route (#4133, follow-up to #4099).
+ */
+export type MessagesParticipantScopeDatabase = {
+  messages: {
+    id: string
+    tenant_id: string
+    organization_id: string | null
+    sender_user_id: string
+    deleted_at: Date | null
+  }
+  message_recipients: {
+    message_id: string
+    recipient_user_id: string
+    deleted_at: Date | null
+  }
+}
+
+type MessagesTable = MessagesParticipantScopeDatabase['messages']
+type MessageRecipientsTable = MessagesParticipantScopeDatabase['message_recipients']
+
+type MessagesFrom = MessagesParticipantScopeDatabase & { m: MessagesTable }
+type MessagesJoinedFrom = MessagesFrom & { r: MessageRecipientsTable }
+
+/**
+ * Apply the shared message participant-scope predicate to a query already built
+ * from `messages as m`. A message is visible to `userId` when they are the
+ * sender OR a non-deleted recipient. The recipient soft-delete rule
+ * (`r.deleted_at is null`) lives inside the recipient join, so it is part of the
+ * single source of truth — the recipient-visibility boundary cannot drift
+ * between the list route and the enricher.
+ *
+ * Message-level tenant / organization / soft-delete scoping stays with the
+ * caller (both call sites already apply it uniformly to every query), but the
+ * shared {@link MessagesParticipantScopeDatabase} type keeps those column names
+ * coupled at compile time as well.
+ */
+export function applyMessageParticipantScope<O>(
+  query: SelectQueryBuilder<MessagesFrom, 'm', O>,
+  userId: string,
+): SelectQueryBuilder<MessagesJoinedFrom, 'm' | 'r', O> {
+  return query
+    .leftJoin('message_recipients as r', (join) =>
+      join
+        .onRef('m.id', '=', 'r.message_id')
+        .on('r.recipient_user_id', '=', userId)
+        .on('r.deleted_at', 'is', null),
+    )
+    .where((eb) =>
+      eb.or([
+        eb('m.sender_user_id', '=', userId),
+        eb('r.message_id', 'is not', null),
+      ]),
+    ) as unknown as SelectQueryBuilder<MessagesJoinedFrom, 'm' | 'r', O>
+}


### PR DESCRIPTION
Fixes #4133

## Problem
The sender-OR-recipient message access predicate was duplicated across two places after #4099:
- `packages/core/src/modules/messages/api/route.ts` — the list route `all` folder.
- `packages/core/src/modules/communication_channels/data/enrichers.ts` — the participant guard added in #4099.

The enricher's copy is a **security boundary** (it decides which messages get channel-native data). A column rename (`sender_user_id`, `recipient_user_id`, `deleted_at`) or a change to recipient-visibility rules in one place would silently desync the two and could re-open the cross-participant leak (#3872) or over-restrict enrichment. Nothing linked them at compile time.

## Root Cause
Two independent hand-written Kysely predicates encoding the same participant-scope rule, with no shared source of truth.

## What Changed
- New `packages/core/src/modules/messages/lib/participantScope.ts` owned by the `messages` module:
  - `applyMessageParticipantScope(query, userId)` — a Kysely applier that adds the recipient `leftJoin` (`recipient_user_id` match, non-deleted rows) and the sender-OR-recipient `where` predicate to any query built from `messages as m`.
  - `MessagesParticipantScopeDatabase` — a shared typed schema that pins the coupled column names (`sender_user_id`, `recipient_user_id`, `deleted_at`, `tenant_id`, `organization_id`) at compile time.
- The enricher and the list route `all` folder now both derive their participant scoping from this single helper. Cross-module use is a reusable query-fragment/type import (no ORM relationship), mirroring how the enricher already reuses the messages access model.
- The list route `all` folder additionally gains the recipient soft-delete condition (`r.deleted_at is null`), aligning it with the enricher and the existing `inbox`/`archived` folders.
- Enricher fail-closed behavior for a missing `userId` is unchanged — non-participants still get `{ _channel: null, _channelPayload: null, _channelContact: null }`.

## Tests
- `messages/lib/__tests__/participantScope.test.ts` — unit tests for the helper's join conditions and sender-OR-recipient predicate (the single source of truth).
- `communication_channels/data/__tests__/enrichers.test.ts` — new test asserting the enricher's participant guard and the list route `all` folder emit the **identical** participant predicate (drift in either call site fails the equality).
- Existing enricher regression tests (`enrichers.test.ts`, `channel-payload-enricher.test.ts`) still pass unchanged.
- Full `@open-mercato/core` suite: 7492 tests pass. `typecheck` and `eslint` clean.

## Backward Compatibility
No contract-surface changes. No API response fields, event IDs, DI names, ACL IDs, or import paths removed. Stays within the implemented SPEC-045d contract; no new spec required.