### PR TITLE
feat(ui): native inline row-expand in DataTable (rowDetail)

### DIFF
--- a/.ai/specs/implemented/2026-04-03-advanced-datatable-ux.md
+++ b/.ai/specs/implemented/2026-04-03-advanced-datatable-ux.md
@@ -339,6 +339,42 @@ type ColumnChooserField = {
 
 **Search placeholder** updated to "Search by name, email, phone…" to indicate broader scope.
 
+### F12 — Native Inline Row-Expand (Sub-Row Detail)
+
+> Added 2026-07-10. DataTable had no native way to reveal a row's detail in place.
+
+**Problem**: Clicking a row could not expand its detail inline. Hosts that wanted an in-place detail panel (e.g. an order or line-item breakdown) had to fall back to a popover/drawer, or hand-roll their own `<table>` with a full-width `<tr colSpan>` — losing DataTable's perspectives, injection, sticky columns, and virtualization.
+
+**Solution**: A `rowDetail` prop renders a full-width `<tr>` with a single `colSpan` cell immediately beneath every row for which `isExpanded(row)` returns true, containing `render(row)`. The detail is an accordion (pushes following rows down), not an overlay. `colSpan` is computed from the row's visible cells plus the optional bulk-selection and row-actions spacer columns, so the panel always spans the full table width.
+
+DataTable stays presentational: the host owns expansion state (typically a `Set` of expanded row ids). Backward compatible — no extra `<tr>` is rendered while a row is collapsed or when the prop is unset.
+
+**Toggle affordance.** By default the host wires its own toggle (an `onRowClick` handler, a custom column, or a kebab action). As an opt-in convenience, `toggleColumn` adds a built-in leading toggle column (a `w-8` cell after the bulk-selection column, before the data columns), rendered outside the TanStack column model so the host's own `columns` still render untouched:
+
+- `toggleColumn: true` → a default chevron button (▸/▾) reflecting `isExpanded`, calling `onToggle(row)` on click.
+- `toggleColumn: (ctx) => ReactNode` → render **anything** in that cell (icon, label, badge, custom button). The callback gets `{ row, expanded, toggle }`; call `toggle()` to flip the row (delegates to `onToggle`).
+
+The cell stops click propagation, so a custom control there never also fires `onRowClick`.
+
+**New prop**:
+```tsx
+<DataTable
+  rowDetail={{
+    isExpanded: (row) => expandedIds.has(row.id),
+    render: (row) => <RowDetailPanel row={row} />,
+    onToggle: (row) => toggleExpanded(row.id),
+    toggleColumn: true, // built-in chevron
+    // …or render your own toggle cell:
+    // toggleColumn: ({ row, expanded, toggle }) => (
+    //   <button onClick={toggle}>{expanded ? 'Hide' : `Show (${row.lineCount})`}</button>
+    // ),
+    // className?: optional override for the detail <td> (default: subtle muted panel)
+  }}
+/>
+```
+
+**Caveat**: Not measured under `virtualized` — the row virtualizer estimates a uniform row height, so a detail taller than a normal row can clip or offset virtualized scrolling. Prefer a non-virtualized table when using `rowDetail`.
+
 ---
 
 ## Backward Compatibility
@@ -357,6 +393,7 @@ All features are opt-in via new props. Existing pages that don't pass these prop
 | Virtual scrolling | `virtualized` | `false` |
 | Auto-discovery | `advancedFilter.auto` / `columnChooser.auto` | Manual fields |
 | Full-text search | Server-side `$or` in `buildFilters` | Name only |
+| Inline row-expand | `rowDetail={{ isExpanded, render }}` | `undefined` (no sub-row) |
 
 The existing `filters`/`filterValues`/`onFiltersApply`/`onFiltersClear` props remain functional for pages using the old filter model. The `advancedFilter` prop is a separate code path.
 
@@ -623,3 +660,5 @@ No other new dependencies. All other features built on existing TanStack React T
 | 2026-04-04 | Added F9 (auto-discovery) and F10 (full-text search). Post-implementation requirements documented. |
 | 2026-04-04 | Phase 5: useAutoDiscoveredFields hook, auto mode props, $or query engine support, customer pages migrated to auto mode |
 | 2026-04-04 | Phase 6: UX bug fixes — sticky column, bulk action visibility, column chooser dedup, filter UX, page size dropdown, DnD persistence, hydration fix |
+| 2026-07-10 | Added F12 — native inline row-expand (`rowDetail`): full-width `<tr colSpan>` accordion sub-row beneath expanded rows, host-owned expansion state, backward compatible (no `<tr>` when collapsed/unset) |
+| 2026-07-10 | F12 — optional built-in chevron toggle column (`rowDetail.toggleColumn` + `onToggle`): leading ▸/▾ cell that reflects `isExpanded` and delegates the toggle, composes with the host's own `columns` |

--- a/packages/create-app/template/src/i18n/de.json
+++ b/packages/create-app/template/src/i18n/de.json
@@ -717,6 +717,8 @@
   "ui.dataTable.export.label": "Exportieren",
   "ui.dataTable.fieldset.label": "Columns",
   "ui.dataTable.loading": "Loading table…",
+  "ui.dataTable.rowDetail.expand": "Zeile ausklappen",
+  "ui.dataTable.rowDetail.collapse": "Zeile einklappen",
   "ui.dataTable.pagination.cache.ariaLabel": "Cache {status}",
   "ui.dataTable.pagination.cache.srOnly": "Cache {status}",
   "ui.dataTable.pagination.cache.title": "Cache {status}",

--- a/packages/create-app/template/src/i18n/en.json
+++ b/packages/create-app/template/src/i18n/en.json
@@ -717,6 +717,8 @@
   "ui.dataTable.export.label": "Export",
   "ui.dataTable.fieldset.label": "Columns",
   "ui.dataTable.loading": "Loading table…",
+  "ui.dataTable.rowDetail.expand": "Expand row",
+  "ui.dataTable.rowDetail.collapse": "Collapse row",
   "ui.dataTable.pagination.cache.ariaLabel": "Cache {status}",
   "ui.dataTable.pagination.cache.srOnly": "Cache {status}",
   "ui.dataTable.pagination.cache.title": "Cache {status}",

--- a/packages/create-app/template/src/i18n/es.json
+++ b/packages/create-app/template/src/i18n/es.json
@@ -717,6 +717,8 @@
   "ui.dataTable.export.label": "Exportar",
   "ui.dataTable.fieldset.label": "Columns",
   "ui.dataTable.loading": "Loading table…",
+  "ui.dataTable.rowDetail.expand": "Expandir fila",
+  "ui.dataTable.rowDetail.collapse": "Contraer fila",
   "ui.dataTable.pagination.cache.ariaLabel": "Caché {status}",
   "ui.dataTable.pagination.cache.srOnly": "Caché {status}",
   "ui.dataTable.pagination.cache.title": "Caché {status}",

--- a/packages/create-app/template/src/i18n/pl.json
+++ b/packages/create-app/template/src/i18n/pl.json
@@ -717,6 +717,8 @@
   "ui.dataTable.export.label": "Eksportuj",
   "ui.dataTable.fieldset.label": "Columns",
   "ui.dataTable.loading": "Loading table…",
+  "ui.dataTable.rowDetail.expand": "Rozwiń wiersz",
+  "ui.dataTable.rowDetail.collapse": "Zwiń wiersz",
   "ui.dataTable.pagination.cache.ariaLabel": "Pamięć podręczna {status}",
   "ui.dataTable.pagination.cache.srOnly": "Pamięć podręczna {status}",
   "ui.dataTable.pagination.cache.title": "Pamięć podręczna {status}",

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { useRouter } from 'next/navigation'
 import { useReactTable, getCoreRowModel, getSortedRowModel, flexRender, type ColumnDef, type SortingState, type Column as TableColumn, type VisibilityState, type RowSelectionState } from '@tanstack/react-table'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { RefreshCw, Loader2, SlidersHorizontal, MoreHorizontal, Circle, Filter, Columns3, ChevronUp, ChevronDown, ChevronsUpDown, Check, Inbox } from 'lucide-react'
+import { RefreshCw, Loader2, SlidersHorizontal, MoreHorizontal, Circle, Filter, Columns3, ChevronUp, ChevronDown, ChevronRight, ChevronsUpDown, Check, Inbox } from 'lucide-react'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../primitives/table'
 import { Button } from '../primitives/button'
 import { Checkbox } from '../primitives/checkbox'
@@ -235,6 +235,58 @@ export type DataTableProps<T> = {
   onRowClick?: (row: T) => void
   rowClickActionIds?: string[]
   disableRowClick?: boolean
+  /**
+   * Native inline row-expand (sub-row detail). When set, DataTable renders a
+   * full-width `<tr>` with a single `colSpan` cell immediately beneath every
+   * row for which `isExpanded(row)` returns true, containing `render(row)`.
+   * The expanded detail pushes the following rows down (accordion) rather than
+   * overlaying them, so hosts no longer need a popover/drawer workaround to
+   * reveal a row's detail in place.
+   *
+   * DataTable stays presentational: the host owns expansion state and decides
+   * how it toggles (e.g. an `onRowClick` handler, or a dedicated chevron column
+   * whose cell flips a `Set` of expanded row ids). Backward compatible — no
+   * extra `<tr>` is rendered while a row is collapsed or when the prop is unset.
+   *
+   * Not measured under `virtualized`: the row virtualizer estimates a uniform
+   * row height, so a detail taller than a normal row can clip or offset
+   * virtualized scrolling. Prefer a non-virtualized table when using
+   * `rowDetail`, or keep the detail height close to a single row.
+   */
+  rowDetail?: {
+    /** Renders the detail content for an expanded row. */
+    render: (row: T) => React.ReactNode
+    /** Returns true when the given row's detail should be shown. */
+    isExpanded: (row: T) => boolean
+    /**
+     * Opt-in built-in leading toggle column — a `w-8` cell before the data
+     * columns (after the bulk-selection column). It composes with the host's
+     * own `columns`, which still render untouched.
+     * - `true` → a default chevron button (▸/▾) reflecting `isExpanded` that
+     *   calls `onToggle` on click.
+     * - a render function → render your own cell content instead of the chevron.
+     *   You receive `{ row, expanded, toggle }` — call `toggle()` to flip the
+     *   row (it delegates to `onToggle`). Put anything here: an icon, a label,
+     *   a badge, a custom button.
+     * Leave it off (default) to own the toggle affordance elsewhere (e.g.
+     * `onRowClick`, a custom column, or a kebab action). The cell stops click
+     * propagation so it never also fires `onRowClick`.
+     */
+    toggleColumn?: boolean | ((ctx: { row: T; expanded: boolean; toggle: () => void }) => React.ReactNode)
+    /**
+     * Called when the built-in toggle column is activated — the default chevron
+     * click, or `toggle()` from a custom `toggleColumn` renderer. The host
+     * updates its own expansion state here (e.g. flip a `Set` of expanded ids).
+     * Ignored when `toggleColumn` is unset.
+     */
+    onToggle?: (row: T) => void
+    /**
+     * Optional className applied to the full-width detail `<td>`. Defaults to a
+     * subtle muted panel (`bg-muted/30`). The cell carries no padding so the
+     * rendered content controls its own spacing.
+     */
+    className?: string
+  }
   bulkActions?: BulkAction<T>[]
   selectionScopeKey?: string
 
@@ -991,6 +1043,7 @@ export function DataTable<T>({
   onRowClick,
   rowClickActionIds,
   disableRowClick = false,
+  rowDetail,
   bulkActions: bulkActionsProp,
   selectionScopeKey,
   searchValue,
@@ -1480,6 +1533,10 @@ export function DataTable<T>({
   }, [data, injectedClientFilters, filterValues])
   const hasPropBulkActions = Array.isArray(bulkActionsProp) && bulkActionsProp.length > 0
   const hasInjectedBulkActions = injectedBulkActions.length > 0 || hasPropBulkActions
+  // Opt-in native chevron toggle column for row-detail (leading, after the
+  // bulk-selection column). Rendered outside the TanStack column model so the
+  // host's own columns are unaffected.
+  const rowDetailToggleColumn = Boolean(rowDetail?.toggleColumn)
   const [rowSelection, setRowSelection] = React.useState<RowSelectionState>({})
   const selectionScopeKeyRef = React.useRef<string | undefined>(selectionScopeKey)
   const enableClientSorting = sortable && !manualSorting
@@ -2822,6 +2879,7 @@ export function DataTable<T>({
                     />
                   </TableHead>
                 ) : null}
+                {rowDetailToggleColumn ? <TableHead className="w-8" aria-hidden /> : null}
                 {hg.headers.map((header, headerIndex) => {
                   const columnMeta = (header.column.columnDef as any)?.meta
                   const priority = resolvePriority(header.column)
@@ -2871,7 +2929,7 @@ export function DataTable<T>({
           <TableBody>
             {isLoading ? (
               <TableRow>
-                <TableCell colSpan={mergedColumns.length + (rowActions || injectedRowActions.length > 0 ? 1 : 0) + (hasInjectedBulkActions ? 1 : 0)} className="h-24 text-center">
+                <TableCell colSpan={mergedColumns.length + (rowActions || injectedRowActions.length > 0 ? 1 : 0) + (hasInjectedBulkActions ? 1 : 0) + (rowDetailToggleColumn ? 1 : 0)} className="h-24 text-center">
                   <div className="flex items-center justify-center gap-2">
                     <Spinner size="md" />
                     <span className="text-muted-foreground">{t('ui.dataTable.loading', 'Loading data...')}</span>
@@ -2880,7 +2938,7 @@ export function DataTable<T>({
               </TableRow>
             ) : error ? (
               <TableRow>
-                <TableCell colSpan={mergedColumns.length + (rowActions || injectedRowActions.length > 0 ? 1 : 0) + (hasInjectedBulkActions ? 1 : 0)} className="h-24 text-center text-destructive">
+                <TableCell colSpan={mergedColumns.length + (rowActions || injectedRowActions.length > 0 ? 1 : 0) + (hasInjectedBulkActions ? 1 : 0) + (rowDetailToggleColumn ? 1 : 0)} className="h-24 text-center text-destructive">
                   {error}
                 </TableCell>
               </TableRow>
@@ -2900,10 +2958,17 @@ export function DataTable<T>({
                 const rowActionsElement = resolvedRowActions(row.original as T)
                 const defaultRowAction = onRowClick ? null : pickDefaultRowAction(rowActionsElement, resolvedRowClickActionIds)
                 const isClickable = !disableRowClick && (onRowClick || defaultRowAction)
-                
+                const rowDetailExpanded = Boolean(rowDetail && rowDetail.isExpanded(row.original as T))
+                const rowDetailNode = rowDetailExpanded ? rowDetail!.render(row.original as T) : null
+                const rowDetailColSpan =
+                  row.getVisibleCells().length
+                  + (hasInjectedBulkActions ? 1 : 0)
+                  + (rowDetailToggleColumn ? 1 : 0)
+                  + (rowActions || injectedRowActions.length > 0 ? 1 : 0)
+
                 return (
-                  <TableRow 
-                    key={row.id} 
+                  <React.Fragment key={row.id}>
+                  <TableRow
                     data-state={row.getIsSelected() && 'selected'}
                     className={isClickable ? 'cursor-pointer hover:bg-muted/50 transition-colors' : ''}
                     onClick={isClickable ? (e) => {
@@ -2931,6 +2996,29 @@ export function DataTable<T>({
                           aria-label={t('ui.dataTable.bulkAction.selectRow', 'Select row')}
                           onClick={(event) => event.stopPropagation()}
                         />
+                      </TableCell>
+                    ) : null}
+                    {rowDetailToggleColumn ? (
+                      <TableCell className="w-8" onClick={(event) => event.stopPropagation()}>
+                        {typeof rowDetail!.toggleColumn === 'function' ? (
+                          rowDetail!.toggleColumn({
+                            row: row.original as T,
+                            expanded: rowDetailExpanded,
+                            toggle: () => rowDetail?.onToggle?.(row.original as T),
+                          })
+                        ) : (
+                          <button
+                            type="button"
+                            aria-expanded={rowDetailExpanded}
+                            aria-label={rowDetailExpanded
+                              ? t('ui.dataTable.rowDetail.collapse', 'Collapse row')
+                              : t('ui.dataTable.rowDetail.expand', 'Expand row')}
+                            onClick={() => rowDetail?.onToggle?.(row.original as T)}
+                            className="flex items-center rounded text-muted-foreground transition-colors hover:text-foreground"
+                          >
+                            {rowDetailExpanded ? <ChevronDown className="size-4" aria-hidden /> : <ChevronRight className="size-4" aria-hidden />}
+                          </button>
+                        )}
                       </TableCell>
                     ) : null}
                     {row.getVisibleCells().map((cell, cellIndex) => {
@@ -2998,6 +3086,14 @@ export function DataTable<T>({
                       </TableCell>
                     ) : null}
                   </TableRow>
+                  {rowDetailNode != null ? (
+                    <TableRow className="hover:bg-transparent" data-row-detail={row.id}>
+                      <TableCell colSpan={rowDetailColSpan} className={cn('bg-muted/30 p-0', rowDetail?.className)}>
+                        {rowDetailNode}
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
+                  </React.Fragment>
                 )
               })}
               {virtualized && rowVirtualizer ? (() => {
@@ -3009,7 +3105,7 @@ export function DataTable<T>({
               </>
             ) : (
               <TableRow>
-                <TableCell colSpan={mergedColumns.length + (rowActions || injectedRowActions.length > 0 ? 1 : 0) + (hasInjectedBulkActions ? 1 : 0)} className="p-0">
+                <TableCell colSpan={mergedColumns.length + (rowActions || injectedRowActions.length > 0 ? 1 : 0) + (hasInjectedBulkActions ? 1 : 0) + (rowDetailToggleColumn ? 1 : 0)} className="p-0">
                   <div
                     className={cn('sticky left-0 flex justify-center py-6', emptyStateViewportWidth ? '' : 'w-fit')}
                     style={emptyStateViewportWidth ? { width: emptyStateViewportWidth } : undefined}

--- a/packages/ui/src/backend/__tests__/DataTable.render.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.render.test.tsx
@@ -128,4 +128,228 @@ describe('DataTable SSR render', () => {
       queryClient.clear()
     }
   })
+
+  it('renders a full-width detail row beneath an expanded row via rowDetail', () => {
+    const columns: ColumnDef<Row>[] = [
+      { accessorKey: 'name', header: 'Name' },
+      { accessorKey: 'id', header: 'Id' },
+    ]
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    try {
+      const { container } = render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider locale="en" dict={{}}>
+            <DataTable
+              columns={columns}
+              data={[{ id: '1', name: 'Ada' }, { id: '2', name: 'Zed' }]}
+              rowDetail={{
+                isExpanded: (row) => row.id === '1',
+                render: (row) => <div>Detail for {row.name}</div>,
+              }}
+            />
+          </I18nProvider>
+        </QueryClientProvider>,
+      )
+      const detailRow = container.querySelector('tr[data-row-detail="1"]')
+      expect(detailRow).not.toBeNull()
+      expect(detailRow?.textContent).toContain('Detail for Ada')
+      // Only the expanded row gets a detail sub-row.
+      expect(container.querySelector('tr[data-row-detail="2"]')).toBeNull()
+      expect(container.textContent).not.toContain('Detail for Zed')
+      // Detail cell spans every column (2 data columns, no bulk/actions column).
+      const detailCell = detailRow?.querySelector('td')
+      expect(detailCell?.getAttribute('colspan')).toBe('2')
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('toggles the detail row when host expansion state changes (accordion)', () => {
+    const columns: ColumnDef<Row>[] = [
+      { accessorKey: 'name', header: 'Name' },
+    ]
+    function Harness() {
+      const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
+      return (
+        <>
+          <button onClick={() => setExpanded(new Set(['1']))}>expand-1</button>
+          <button onClick={() => setExpanded(new Set())}>collapse-all</button>
+          <DataTable
+            columns={columns}
+            data={[{ id: '1', name: 'Ada' }, { id: '2', name: 'Zed' }]}
+            rowDetail={{
+              isExpanded: (row) => expanded.has(row.id),
+              render: (row) => <div>Detail for {row.name}</div>,
+            }}
+          />
+        </>
+      )
+    }
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    try {
+      const { container } = render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider locale="en" dict={{}}>
+            <Harness />
+          </I18nProvider>
+        </QueryClientProvider>,
+      )
+      // Collapsed initially — no detail sub-row.
+      expect(container.querySelector('tr[data-row-detail]')).toBeNull()
+      // Expanding row 1 reveals exactly its detail.
+      fireEvent.click(screen.getByText('expand-1'))
+      expect(container.querySelector('tr[data-row-detail="1"]')).not.toBeNull()
+      expect(container.querySelector('tr[data-row-detail="2"]')).toBeNull()
+      expect(container.textContent).toContain('Detail for Ada')
+      // Collapsing removes the detail sub-row again.
+      fireEvent.click(screen.getByText('collapse-all'))
+      expect(container.querySelector('tr[data-row-detail]')).toBeNull()
+      expect(container.textContent).not.toContain('Detail for Ada')
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('renders a built-in chevron toggle column that calls onToggle and reflects isExpanded', () => {
+    const columns: ColumnDef<Row>[] = [
+      { accessorKey: 'name', header: 'Name' },
+    ]
+    const onToggle = jest.fn()
+    function Harness() {
+      const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
+      return (
+        <DataTable
+          columns={columns}
+          data={[{ id: '1', name: 'Ada' }, { id: '2', name: 'Zed' }]}
+          rowDetail={{
+            toggleColumn: true,
+            isExpanded: (row) => expanded.has(row.id),
+            onToggle: (row) => { onToggle(row.id); setExpanded((prev) => { const n = new Set(prev); if (n.has(row.id)) n.delete(row.id); else n.add(row.id); return n }) },
+            render: (row) => <div>Detail for {row.name}</div>,
+          }}
+        />
+      )
+    }
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    try {
+      const { container } = render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider locale="en" dict={{}}>
+            <Harness />
+          </I18nProvider>
+        </QueryClientProvider>,
+      )
+      // One chevron per data row, all collapsed → all labelled "Expand row".
+      const chevrons = screen.getAllByRole('button', { name: 'Expand row' })
+      expect(chevrons).toHaveLength(2)
+      expect(container.querySelector('tr[data-row-detail]')).toBeNull()
+
+      // Click row 1's chevron → onToggle fires and its detail appears.
+      fireEvent.click(chevrons[0])
+      expect(onToggle).toHaveBeenCalledWith('1')
+      expect(container.querySelector('tr[data-row-detail="1"]')).not.toBeNull()
+      // That row's chevron now reads "Collapse row"; the other stays "Expand row".
+      expect(screen.getByRole('button', { name: 'Collapse row' })).toBeTruthy()
+      expect(screen.getAllByRole('button', { name: 'Expand row' })).toHaveLength(1)
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('renders custom toggle-column content when toggleColumn is a function', () => {
+    const columns: ColumnDef<Row>[] = [{ accessorKey: 'name', header: 'Name' }]
+    const onToggle = jest.fn()
+    function Harness() {
+      const [expanded, setExpanded] = React.useState<Set<string>>(new Set())
+      return (
+        <DataTable
+          columns={columns}
+          data={[{ id: '1', name: 'Ada' }]}
+          rowDetail={{
+            isExpanded: (row) => expanded.has(row.id),
+            onToggle: (row) => { onToggle(row.id); setExpanded(new Set([row.id])) },
+            toggleColumn: ({ row, expanded, toggle }) => (
+              <button onClick={toggle}>{expanded ? 'Hide' : `Show ${row.name}`}</button>
+            ),
+            render: (row) => <div>Detail for {row.name}</div>,
+          }}
+        />
+      )
+    }
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    try {
+      const { container } = render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider locale="en" dict={{}}>
+            <Harness />
+          </I18nProvider>
+        </QueryClientProvider>,
+      )
+      // No built-in chevron; custom content is used instead.
+      expect(screen.queryByRole('button', { name: /expand row|collapse row/i })).toBeNull()
+      const custom = screen.getByRole('button', { name: 'Show Ada' })
+      expect(container.querySelector('tr[data-row-detail]')).toBeNull()
+      // The provided `toggle` helper delegates to onToggle and expands the row.
+      fireEvent.click(custom)
+      expect(onToggle).toHaveBeenCalledWith('1')
+      expect(container.querySelector('tr[data-row-detail="1"]')).not.toBeNull()
+      expect(screen.getByRole('button', { name: 'Hide' })).toBeTruthy()
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('renders no chevron toggle column when toggleColumn is unset', () => {
+    const columns: ColumnDef<Row>[] = [{ accessorKey: 'name', header: 'Name' }]
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    try {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider locale="en" dict={{}}>
+            <DataTable
+              columns={columns}
+              data={[{ id: '1', name: 'Ada' }]}
+              rowDetail={{ isExpanded: () => false, render: () => <div>x</div> }}
+            />
+          </I18nProvider>
+        </QueryClientProvider>,
+      )
+      expect(screen.queryByRole('button', { name: /expand row|collapse row/i })).toBeNull()
+    } finally {
+      queryClient.clear()
+    }
+  })
+
+  it('renders no detail row when rowDetail is unset or every row is collapsed', () => {
+    const columns: ColumnDef<Row>[] = [
+      { accessorKey: 'name', header: 'Name' },
+    ]
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    try {
+      const { container, rerender } = render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider locale="en" dict={{}}>
+            <DataTable columns={columns} data={[{ id: '1', name: 'Ada' }]} />
+          </I18nProvider>
+        </QueryClientProvider>,
+      )
+      expect(container.querySelector('tr[data-row-detail]')).toBeNull()
+
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider locale="en" dict={{}}>
+            <DataTable
+              columns={columns}
+              data={[{ id: '1', name: 'Ada' }]}
+              rowDetail={{ isExpanded: () => false, render: () => <div>never</div> }}
+            />
+          </I18nProvider>
+        </QueryClientProvider>,
+      )
+      expect(container.querySelector('tr[data-row-detail]')).toBeNull()
+      expect(container.textContent).not.toContain('never')
+    } finally {
+      queryClient.clear()
+    }
+  })
 })


### PR DESCRIPTION
## Summary

`DataTable` (`@open-mercato/ui`) had no native inline row-expand. Revealing a row's detail in place meant a popover/drawer workaround, or hand-rolling a custom `<table>` with a full-width `<tr colSpan>` — which **loses DataTable's perspectives, injection, sticky columns, and virtualization**.

This adds an opt-in, backward-compatible native `rowDetail` prop: a full-width accordion sub-row rendered beneath expanded rows, plus an optional built-in toggle column. Nothing changes for existing tables until a caller opts in.

```tsx
<DataTable
  columns={columns}
  data={data}
  rowDetail={{
    isExpanded: (row) => expandedIds.has(row.id),
    render: (row) => <RowDetailPanel row={row} />,
    onToggle: (row) => toggle(row.id),
    toggleColumn: true, // default chevron — or ({ row, expanded, toggle }) => <YourControl/>
  }}
/>
```

## Changes

- `packages/ui/src/backend/DataTable.tsx`:
  - `render(row)` + `isExpanded(row)` render a full-width `<tr>` with a single `colSpan` cell beneath every expanded row. `colSpan` derives from the row's visible cells plus the optional bulk-selection / actions / toggle spacer columns, so the panel always spans the full table width. DataTable stays presentational — the host owns expansion state and how it toggles (`onRowClick`, a custom column, a kebab action, URL state…).
  - `toggleColumn` adds an optional built-in leading `w-8` toggle column, rendered **outside** the TanStack column model (mirroring the bulk-selection column) so the host's own `columns` render untouched. `true` renders a default chevron (▸/▾) reflecting `isExpanded`; a function `({ row, expanded, toggle }) => ReactNode` renders arbitrary content. The cell stops click propagation so it never also fires `onRowClick`.
  - `onToggle(row)` is called by the built-in toggle; `className` overrides the detail `<td>`. Header/body and the loading/error/empty and detail-row `colSpan`s all account for the extra leading column.
  - JSDoc on the prop documenting the API, the presentational contract, and the virtualization caveat.
- `packages/ui/src/backend/__tests__/DataTable.render.test.tsx`: detail-row + `colSpan`, only-expanded-rows get a sub-row, interactive toggle, built-in chevron column (click → `onToggle`, aria-label flips), custom `toggleColumn` render function, and the unset/no-op paths.
- `packages/create-app/template/src/i18n/{en,pl,es,de}.json`: `ui.dataTable.rowDetail.expand` / `.collapse` for the default chevron's aria-labels.
- `.ai/specs/implemented/2026-04-03-advanced-datatable-ux.md`: F12 (native inline row-expand) — feature section, backward-compat table, changelog.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:** `.ai/specs/implemented/2026-04-03-advanced-datatable-ux.md` (added F12 — native inline row-expand, a backward-compatible DataTable addition consistent with F1–F10).

## Testing

- `yarn jest src/backend/__tests__/DataTable` (packages/ui) — **34/34 pass**, incl. the new row-expand tests.
- `tsc --noEmit` (packages/ui) — clean. No new lint.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Spec + locales en/pl/es/de for the new aria-labels.)
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` — N/A: shared UI primitive with no route/flow of its own; covered by unit tests. Consuming pages own their integration coverage.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry.
- [x] Priority set: `priority-medium`.
- [x] Risk set: `risk-low` — additive, opt-in, isolated to one primitive; dormant until a caller sets `rowDetail`.
- [x] QA routing set: `needs-qa` (customer-facing UI primitive).

### Design System Compliance
- [x] No hardcoded status colors — the chevron uses `text-muted-foreground` / `hover:text-foreground`.
- [x] No arbitrary text sizes — icons use `size-4`; no `text-[Npx]`.
- [x] Empty state handled — unchanged; the detail row is independent of the empty-state row (colSpan updated for the toggle column).
- [x] Loading state handled — unchanged (colSpan updated for the toggle column).
- [x] `aria-label` on all icon-only buttons — the default chevron carries `aria-label` + `aria-expanded` (i18n keys).
- [x] Uses existing DS components — `TableRow` / `TableCell` primitives + `lucide-react` icons; no custom replacements.

## Linked issues

No existing issue.
