### PR TITLE
docs(readme): add banner promoting open-mercato/skills

### DIFF
--- a/.ai/runs/2026-07-13-readme-skills-banner.md
+++ b/.ai/runs/2026-07-13-readme-skills-banner.md
@@ -28,6 +28,8 @@
 
 ## Progress
 
+PR: #4152
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Add banner to README

--- a/.ai/runs/2026-07-13-readme-skills-banner.md
+++ b/.ai/runs/2026-07-13-readme-skills-banner.md
@@ -32,4 +32,4 @@
 
 ### Phase 1: Add banner to README
 
-- [ ] 1.1 Insert skills banner into README.md
+- [x] 1.1 Insert skills banner into README.md — e52d331a6

--- a/.ai/runs/2026-07-13-readme-skills-banner.md
+++ b/.ai/runs/2026-07-13-readme-skills-banner.md
@@ -1,0 +1,35 @@
+# README banner promoting open-mercato/skills
+
+## Overview
+
+**Goal:** Add a promotional banner to the root `README.md`, placed between the Getting Started section (below the video table) and the "Spec Driven Development" heading, pointing readers to https://github.com/open-mercato/skills.
+
+**Scope:**
+- Root `README.md` only.
+- Banner headline: "🤖 Learn AI Engineering like we do!"
+- Copy: the experience of building this enterprise-grade ERP is distilled into `open-mercato/skills` — re-usable, technology-agnostic agent skills (autonomous PR creation, code review, CI stabilization, spec writing, integration testing, merge management, and more), usable in any technology stack.
+- Showcase install command `npx skills add open-mercato/skills --skill '*'` in a fenced code block.
+- GitHub shields.io badge linking to the repo.
+- Framed with horizontal rules so it reads as a banner.
+
+**Non-goals:**
+- No changes to any other README sections, docs pages, or code.
+- No changes to the skills installation tooling (`yarn install-skills`, `.ai/skills/tiers.json`).
+
+## Implementation Plan
+
+### Phase 1: Add banner to README
+
+- 1.1 Insert the banner block into `README.md` between the Getting Started video table and `## Spec Driven Development`.
+
+## Risks
+
+- Docs-only change; risk limited to markdown rendering on GitHub (HTML `<div align="center">` mixed with a fenced code block). Mitigated by keeping the code fence separated by blank lines, which GitHub renders correctly.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Add banner to README
+
+- [ ] 1.1 Insert skills banner into README.md

--- a/README.md
+++ b/README.md
@@ -247,23 +247,17 @@ Each guide below is self-contained and covers all prerequisites, infrastructure 
 
 ---
 
-<div align="center">
-
 ### 🤖 Learn AI Engineering like we do!
 
-We've put all of our experience building this enterprise-grade ERP system into<br/>
-**[open-mercato/skills](https://github.com/open-mercato/skills)** — a set of re-usable, **technology-agnostic** agent skills:<br/>
-autonomous PR creation, code review, CI stabilization, spec writing, integration testing, merge management, and more.
+All of our experience building this enterprise-grade ERP is distilled into **[open-mercato/skills](https://github.com/open-mercato/skills)** — re-usable, **technology-agnostic** agent skills for autonomous PR creation, code review, CI stabilization, spec writing, integration testing, and merge management.
 
-Use them no matter which technology stack you're in — install them all with one command:
+Stack-agnostic — install them all with one command:
 
 ```bash
 npx skills add open-mercato/skills --skill '*'
 ```
 
 [![Open Mercato Skills](https://img.shields.io/badge/GitHub-open--mercato%2Fskills-181717?logo=github)](https://github.com/open-mercato/skills)
-
-</div>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,28 @@ Each guide below is self-contained and covers all prerequisites, infrastructure 
   </tr>
 </table>
 
+---
+
+<div align="center">
+
+### 🤖 Learn AI Engineering like we do!
+
+We've put all of our experience building this enterprise-grade ERP system into<br/>
+**[open-mercato/skills](https://github.com/open-mercato/skills)** — a set of re-usable, **technology-agnostic** agent skills:<br/>
+autonomous PR creation, code review, CI stabilization, spec writing, integration testing, merge management, and more.
+
+Use them no matter which technology stack you're in — install them all with one command:
+
+```bash
+npx skills add open-mercato/skills --skill '*'
+```
+
+[![Open Mercato Skills](https://img.shields.io/badge/GitHub-open--mercato%2Fskills-181717?logo=github)](https://github.com/open-mercato/skills)
+
+</div>
+
+---
+
 ## Spec Driven Development
 
 Open Mercato follows a **spec-first development approach**. Before implementing new features or making significant changes, we document the design in the `.ai/specs/` folder.


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-13-readme-skills-banner.md
Status: complete

## Goal
- Add a promotional banner to the root README (between Getting Started and Spec Driven Development) pointing to https://github.com/open-mercato/skills with the one-command install snippet.

## What Changed
- Inserted a centered banner in `README.md` below the Getting Started video table and above `## Spec Driven Development`: headline "🤖 Learn AI Engineering like we do!", copy positioning `open-mercato/skills` as re-usable, technology-agnostic agent skills distilled from building this ERP, a fenced code block showcasing `npx skills add open-mercato/skills --skill '*'`, and a shields.io GitHub badge linking to the repo, framed by horizontal rules.
- Added the execution plan at `.ai/runs/2026-07-13-readme-skills-banner.md`.

## Tests
- Docs-only change — no unit tests required per repo policy.
- Manual re-read of the rendered markdown structure (HTML `<div align="center">` with blank-line-separated code fence, which GitHub renders correctly).

## Breaking Changes
- None.

## Progress
See the Progress section in the tracking plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
