### PR TITLE
fix(shared): use "Turkey" in the default English country dictionary (#4127)

### DIFF
--- a/packages/shared/src/lib/location/__tests__/countries.test.ts
+++ b/packages/shared/src/lib/location/__tests__/countries.test.ts
@@ -1,0 +1,56 @@
+import { buildCountryOptions, resolveCountryName } from '../countries'
+
+describe('resolveCountryName', () => {
+  it('returns the English name for TR when no locale is given', () => {
+    expect(resolveCountryName('TR')).toBe('Turkey')
+  })
+
+  it('returns the English name for TR when the English locale is requested', () => {
+    expect(resolveCountryName('TR', { locale: 'en' })).toBe('Turkey')
+  })
+
+  it('returns the English name for TR for regional English locales', () => {
+    expect(resolveCountryName('TR', { locale: 'en-US' })).toBe('Turkey')
+    expect(resolveCountryName('TR', { locale: 'en-GB' })).toBe('Turkey')
+    expect(resolveCountryName('TR', { locale: 'EN' })).toBe('Turkey')
+  })
+
+  it('accepts a lowercase country code', () => {
+    expect(resolveCountryName('tr')).toBe('Turkey')
+  })
+
+  it('keeps localized names for explicitly requested non-English locales', () => {
+    expect(resolveCountryName('TR', { locale: 'pl' })).toBe('Turcja')
+    expect(resolveCountryName('TR', { locale: 'de' })).toBe('Türkei')
+  })
+
+  it('leaves other countries on their default English names', () => {
+    expect(resolveCountryName('PL')).toBe('Poland')
+    expect(resolveCountryName('DE')).toBe('Germany')
+    expect(resolveCountryName('GB')).toBe('United Kingdom')
+  })
+})
+
+describe('buildCountryOptions', () => {
+  it('labels TR as Turkey in the default English dictionary', () => {
+    const options = buildCountryOptions()
+    expect(options.find((option) => option.code === 'TR')?.label).toBe('Turkey')
+  })
+
+  it('exposes no country labelled with the Türkiye endonym in English', () => {
+    const options = buildCountryOptions()
+    expect(options.some((option) => option.label === 'Türkiye')).toBe(false)
+  })
+
+  it('still labels TR in the requested non-English locale', () => {
+    const options = buildCountryOptions({ locale: 'pl' })
+    expect(options.find((option) => option.code === 'TR')?.label).toBe('Turcja')
+  })
+
+  it('lets transformLabel override the English default', () => {
+    const options = buildCountryOptions({
+      transformLabel: (code, defaultLabel) => (code === 'TR' ? 'Republic of Türkiye' : defaultLabel),
+    })
+    expect(options.find((option) => option.code === 'TR')?.label).toBe('Republic of Türkiye')
+  })
+})

--- a/packages/shared/src/lib/location/countries.ts
+++ b/packages/shared/src/lib/location/countries.ts
@@ -34,6 +34,15 @@ export const ISO_COUNTRIES: IsoCountry[] = [...RAW_COUNTRIES].sort((a, b) =>
 
 export const COUNTRY_PRIORITY: string[] = ['PL', 'DE', 'ES', 'FR', 'IT', 'US', 'GB', 'CA']
 
+const ENGLISH_COUNTRY_NAME_OVERRIDES: Record<string, string> = {
+  TR: 'Turkey',
+}
+
+function isEnglishLocale(locale?: string): boolean {
+  if (!locale) return true
+  return locale.toLowerCase().split(/[-_]/)[0] === 'en'
+}
+
 const displayNameCache = new Map<string, Intl.DisplayNames>()
 
 function getDisplayNames(locale: string): Intl.DisplayNames | null {
@@ -53,6 +62,10 @@ function getDisplayNames(locale: string): Intl.DisplayNames | null {
 
 export function resolveCountryName(code: string, options: { locale?: string } = {}): string {
   const normalized = code.toUpperCase()
+  if (isEnglishLocale(options.locale)) {
+    const override = ENGLISH_COUNTRY_NAME_OVERRIDES[normalized]
+    if (override) return override
+  }
   const fallback = ISO_COUNTRIES.find((entry) => entry.code === normalized)?.name ?? normalized
   const displayNames = getDisplayNames(options.locale ?? 'en')
   if (!displayNames) return fallback


### PR DESCRIPTION
Fixes #4127

## Problem

The shared country dictionary displayed `TR — Türkiye` in the default English locale. The dictionary is presented in English, so `TR` should read `Turkey`. This affects every country selector built from the shared helper, including the customer address editors.

## Root Cause

`resolveCountryName()` in `packages/shared/src/lib/location/countries.ts` resolved every label straight from `Intl.DisplayNames([locale], { type: 'region' })`, defaulting the locale to `en`. Modern ICU returns the endonym `Türkiye` for `TR` in *all* English variants (`en`, `en-US`, `en-GB`), so the raw ICU label leaked into the default English dictionary. `buildCountryOptions()` builds every option through that same function, so both `AddressEditor` call sites inherited it. Neither call site passes a locale, and their `transformLabel` hook looks up `customers.countries.<code>` — but the customers locale files only define the 8 `COUNTRY_PRIORITY` codes, so `TR` fell straight through to the ICU label.

The registry fallback was affected too: `RAW_COUNTRIES` comma-joins the IANA descriptions, which resolves `TR` to `"Türkiye, Turkey"`.

## What Changed

- Added a module-private `ENGLISH_COUNTRY_NAME_OVERRIDES` map (`TR: 'Turkey'`) and an `isEnglishLocale()` predicate that treats an absent locale and any `en*` language subtag (case-insensitive, so `en`, `en-US`, `en-GB`, `EN` all match) as English.
- `resolveCountryName()` now consults the override **before** the `Intl` lookup when the locale is English. Placing it first also protects the registry-fallback path, where `TR` previously resolved to `"Türkiye, Turkey"`.
- Callers that explicitly request a non-English locale keep ICU's localized name (`pl` → `Turcja`, `de` → `Türkei`), and the existing `transformLabel` hook still takes precedence — both as the issue requires.

The override map is the extension point if the team later wants to normalize other ICU English oddities (e.g. `MM` → `Myanmar (Burma)`); those are deliberately out of scope here.

## Tests

- New `packages/shared/src/lib/location/__tests__/countries.test.ts` (10 cases): the `TR` label for the default/`en`/regional-English locales, lowercase codes, preserved non-English locales, unchanged labels for other countries, `buildCountryOptions()` output (including an assertion that no English option is labelled `Türkiye`), and `transformLabel` precedence.
- Verified as a real regression guard: **6 of the new tests fail without the production change**, all pass with it.
- Full validation gate ran locally in config order (`build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`) — all green. `@open-mercato/shared` is 1456/1456 across 135 suites.
- One **pre-existing, unrelated** local failure: `packages/ui/src/utils/__tests__/format.test.ts` (`formatCurrency` expects `1,234.5`, gets `1234,50 USD`). That file is untouched by this diff and passes 10/10 under `LC_ALL=en_US.UTF-8` — it is the dev machine's Polish system locale, not a regression.

## Breaking Changes

None. `resolveCountryName`/`buildCountryOptions` signatures and the exported `ISO_COUNTRIES`/`COUNTRY_PRIORITY` surfaces are unchanged; both new symbols are module-private. The only behavioral delta is the intended one — `TR`'s English label and its resulting alphabetical position among the options.

🤖 Generated by autofix.

