### PR TITLE
docs(changelog): amend 0.6.6 entry with PRs merged 2026-07-10 → 2026-07-13

### DIFF
--- a/.ai/runs/2026-07-13-changelog-0.6.7.md
+++ b/.ai/runs/2026-07-13-changelog-0.6.7.md
@@ -37,3 +37,7 @@ PR: #4154
 
 - [x] 1.1 Prepend the 0.6.7 entry to CHANGELOG.md — 3d20966bb
 - [x] 1.2 Verify diff is additive-only and matches repo changelog format — 3d20966bb
+
+### Phase 2: Fold into unreleased 0.6.6 (rework requested 2026-07-13)
+
+- [ ] 2.1 Merge the 0.6.7 block into the existing 0.6.6 entry (0.6.6 is not yet released), bump its heading date to 2026-07-13, drop the 0.6.7 heading

--- a/.ai/runs/2026-07-13-changelog-0.6.7.md
+++ b/.ai/runs/2026-07-13-changelog-0.6.7.md
@@ -33,5 +33,5 @@
 
 ### Phase 1: Changelog entry
 
-- [ ] 1.1 Prepend the 0.6.7 entry to CHANGELOG.md
-- [ ] 1.2 Verify diff is additive-only and matches repo changelog format
+- [x] 1.1 Prepend the 0.6.7 entry to CHANGELOG.md — 3d20966bb
+- [x] 1.2 Verify diff is additive-only and matches repo changelog format — 3d20966bb

--- a/.ai/runs/2026-07-13-changelog-0.6.7.md
+++ b/.ai/runs/2026-07-13-changelog-0.6.7.md
@@ -40,4 +40,4 @@ PR: #4154
 
 ### Phase 2: Fold into unreleased 0.6.6 (rework requested 2026-07-13)
 
-- [ ] 2.1 Merge the 0.6.7 block into the existing 0.6.6 entry (0.6.6 is not yet released), bump its heading date to 2026-07-13, drop the 0.6.7 heading
+- [x] 2.1 Merge the 0.6.7 block into the existing 0.6.6 entry (0.6.6 is not yet released), bump its heading date to 2026-07-13, drop the 0.6.7 heading — f0c4cb4ab

--- a/.ai/runs/2026-07-13-changelog-0.6.7.md
+++ b/.ai/runs/2026-07-13-changelog-0.6.7.md
@@ -1,0 +1,37 @@
+# Execution Plan: CHANGELOG entry for 0.6.7
+
+## Overview
+
+**Goal:** Add the `0.6.7 (2026-07-13)` release entry to `CHANGELOG.md`, covering every PR merged to `develop` between 2026-07-10 and 2026-07-13 that is not already listed in the amended 0.6.6 entry.
+
+**Scope:** `CHANGELOG.md` only. Docs-only change.
+
+**Non-goals:** No manifest version bump (package.json stays 0.6.5 — out of scope per om-auto-update-changelog rules), no git tag, no Highlights authoring (left as TODO for a human maintainer).
+
+**Source:** Drafted by the `om-auto-update-changelog` skill.
+
+### Window resolution
+
+- `--since last-release` resolved to the topmost heading `# 0.6.6 (2026-07-10)`. The last git tag `v0.6.5` (2026-06-15) disagrees by >3 days, but using the tag date would duplicate every entry already listed under 0.6.6 (which was amended through 2026-07-10 by #4071), so the heading date is authoritative.
+- Window: 2026-07-10 → 2026-07-13. 39 merged PRs found; 7 excluded as already present in 0.6.6 (#4016, #4014, #4013, #4011, #3998, #3997, #3996); #4071 excluded as a prior changelog run. 31 PRs consumed.
+
+### Supersede credits (Paths A+B)
+
+- #4029 supersedes #4009 → primary @jtomaszewski, via @pkarw
+- #4025 supersedes #3999 → primary @KamilGrocholski, via @pkarw
+- #3675 supersedes #3341 → primary @matgren, via @patzick
+- Path C scan of closed-unmerged PRs in the window found one pointer (#4072 → #4076), but #4076 is not in the merged window, so no credit change.
+
+## Risks
+
+- Emoji/section categorization is judgment-based; a maintainer may want to re-shelve individual lines. Low impact.
+- Highlights paragraph intentionally left blank (TODO marker) per skill rules.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Changelog entry
+
+- [ ] 1.1 Prepend the 0.6.7 entry to CHANGELOG.md
+- [ ] 1.2 Verify diff is additive-only and matches repo changelog format

--- a/.ai/runs/2026-07-13-changelog-0.6.7.md
+++ b/.ai/runs/2026-07-13-changelog-0.6.7.md
@@ -29,6 +29,8 @@
 
 ## Progress
 
+PR: #4154
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Changelog entry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,63 @@
 
+# 0.6.7 (2026-07-13)
+
+## Highlights
+<!-- TODO: Highlights — auto-update-changelog leaves this blank for the human author to fill in. -->
+
+## ✨ Features
+- ✨ Adopt skills mixin in the standalone create-app template (stacked on #4008). (#4026) *(@pkarw)*
+- ✨ Install shared om-* skills from open-mercato/skills (mixin). (#4008) *(@pkarw)*
+- ✨ Configurable, dictionary-backed CRM interaction statuses (supersedes #3341). (#3675) *(@matgren, via @patzick)*
+
+## 🐛 Fixes
+- 🔐 Restrict event catalog access (#3860). (#4136) *(@haxiorz)*
+- 🔐 Honor trusted SSE organization scope (#3861). (#4135) *(@haxiorz)*
+- 💰 Invalidate order cache after return mutations. (#4130) *(@andrzejewsky)*
+- 🔧 Back tenant-context AsyncLocalStorage with globalThis to survive bundler duplication. (#4126) *(@pkarw)*
+- 🔧 Surface drain-child diagnostics + pin absolute sqlite cache path in standalone CI. (#4118) *(@pkarw)*
+- 🔧 Use a cross-process cache strategy in standalone integration lanes. (#4117) *(@pkarw)*
+- 💰 Drop Stripe metadata-trust scope fallback + dead helper (#3866, #3865). (#4115) *(@haxiorz)*
+- 🐛 Annotate unauthenticated override probe (#3864). (#4114) *(@haxiorz)*
+- 🔐 Scope todo command snapshots (#3863). (#4113) *(@haxiorz)*
+- 🔐 Restrict email body access (#3868). (#4111) *(@haxiorz)*
+- 🔐 Require manage permission for proposal translation (#3867). (#4110) *(@haxiorz)*
+- 🔐 Redact integration credential URL userinfo (#3870). (#4108) *(@haxiorz)*
+- 🔐 Validate direct notification recipient scope (#3873). (#4100) *(@haxiorz)*
+- 🔐 Guard message enrichment by participant (#3872). (#4099) *(@haxiorz)*
+- 🐛 Return 400 for invalid notification restore status. (#4090) *(@haxiorz)*
+- 💰 Align payment gateway status guard resource kind (#3881). (#4081) *(@haxiorz)*
+- 🔐 Prevent planner availability authorization regression (#3883). (#4079) *(@haxiorz)*
+- 🔧 Harden MCP dev config loading (#4039). (#4077) *(@haxiorz)*
+- 🔧 Safely quote discovered table names (#4040). (#4069) *(@haxiorz)*
+- 🔐 Secure attachment temp files (#4045). (#4067) *(@haxiorz)*
+- 🐛 Route vendor-prefixed model ids to OpenAI-compatible gateways (OpenRouter) (supersedes #4009). (#4029) *(@jtomaszewski, via @pkarw)*
+- 🔄 Back data_sync adapter registry with globalThis to survive bundler duplication (supersedes #3999). (#4025) *(@KamilGrocholski, via @pkarw)*
+- 🐛 Calendar activity types from dictionary + CrudForm event editor with resources/staff (#3552). (#3747) *(@zielivia)*
+
+## 🛠️ Improvements
+- 🛠️ Share scheduler with lazy worker in dev mode. (#4125) *(@andrzejewsky)*
+- 🛠️ Retire legacy core.<module>.md redirect-stub layer (#3754). (#4080) *(@adeptofvoltron)*
+- 🛠️ Bump js-yaml from 3.14.2 to 3.15.0. (#4075) *(@pkarw)*
+
+## 📝 Specs & Documentation
+- 📝 Add Exporting Data REST API guide (#59). (#4144) *(@DarrenStasiakDev4You)*
+- 📝 Ephemeral-first test-env run mode in monorepo and create-app template. (#4095) *(@pkarw)*
+
+## 👥 Contributors
+
+- @pkarw
+- @matgren
+- @haxiorz
+- @andrzejewsky
+- @jtomaszewski
+- @KamilGrocholski
+- @zielivia
+- @adeptofvoltron
+- @DarrenStasiakDev4You
+- @patzick
+
+---
+
 # 0.6.6 (2026-07-10)
 
 ## Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-# 0.6.7 (2026-07-13)
+# 0.6.6 (2026-07-13)
 
 ## Highlights
 <!-- TODO: Highlights — auto-update-changelog leaves this blank for the human author to fill in. -->
@@ -8,62 +8,6 @@
 - ✨ Adopt skills mixin in the standalone create-app template (stacked on #4008). (#4026) *(@pkarw)*
 - ✨ Install shared om-* skills from open-mercato/skills (mixin). (#4008) *(@pkarw)*
 - ✨ Configurable, dictionary-backed CRM interaction statuses (supersedes #3341). (#3675) *(@matgren, via @patzick)*
-
-## 🐛 Fixes
-- 🔐 Restrict event catalog access (#3860). (#4136) *(@haxiorz)*
-- 🔐 Honor trusted SSE organization scope (#3861). (#4135) *(@haxiorz)*
-- 💰 Invalidate order cache after return mutations. (#4130) *(@andrzejewsky)*
-- 🔧 Back tenant-context AsyncLocalStorage with globalThis to survive bundler duplication. (#4126) *(@pkarw)*
-- 🔧 Surface drain-child diagnostics + pin absolute sqlite cache path in standalone CI. (#4118) *(@pkarw)*
-- 🔧 Use a cross-process cache strategy in standalone integration lanes. (#4117) *(@pkarw)*
-- 💰 Drop Stripe metadata-trust scope fallback + dead helper (#3866, #3865). (#4115) *(@haxiorz)*
-- 🐛 Annotate unauthenticated override probe (#3864). (#4114) *(@haxiorz)*
-- 🔐 Scope todo command snapshots (#3863). (#4113) *(@haxiorz)*
-- 🔐 Restrict email body access (#3868). (#4111) *(@haxiorz)*
-- 🔐 Require manage permission for proposal translation (#3867). (#4110) *(@haxiorz)*
-- 🔐 Redact integration credential URL userinfo (#3870). (#4108) *(@haxiorz)*
-- 🔐 Validate direct notification recipient scope (#3873). (#4100) *(@haxiorz)*
-- 🔐 Guard message enrichment by participant (#3872). (#4099) *(@haxiorz)*
-- 🐛 Return 400 for invalid notification restore status. (#4090) *(@haxiorz)*
-- 💰 Align payment gateway status guard resource kind (#3881). (#4081) *(@haxiorz)*
-- 🔐 Prevent planner availability authorization regression (#3883). (#4079) *(@haxiorz)*
-- 🔧 Harden MCP dev config loading (#4039). (#4077) *(@haxiorz)*
-- 🔧 Safely quote discovered table names (#4040). (#4069) *(@haxiorz)*
-- 🔐 Secure attachment temp files (#4045). (#4067) *(@haxiorz)*
-- 🐛 Route vendor-prefixed model ids to OpenAI-compatible gateways (OpenRouter) (supersedes #4009). (#4029) *(@jtomaszewski, via @pkarw)*
-- 🔄 Back data_sync adapter registry with globalThis to survive bundler duplication (supersedes #3999). (#4025) *(@KamilGrocholski, via @pkarw)*
-- 🐛 Calendar activity types from dictionary + CrudForm event editor with resources/staff (#3552). (#3747) *(@zielivia)*
-
-## 🛠️ Improvements
-- 🛠️ Share scheduler with lazy worker in dev mode. (#4125) *(@andrzejewsky)*
-- 🛠️ Retire legacy core.<module>.md redirect-stub layer (#3754). (#4080) *(@adeptofvoltron)*
-- 🛠️ Bump js-yaml from 3.14.2 to 3.15.0. (#4075) *(@pkarw)*
-
-## 📝 Specs & Documentation
-- 📝 Add Exporting Data REST API guide (#59). (#4144) *(@DarrenStasiakDev4You)*
-- 📝 Ephemeral-first test-env run mode in monorepo and create-app template. (#4095) *(@pkarw)*
-
-## 👥 Contributors
-
-- @pkarw
-- @matgren
-- @haxiorz
-- @andrzejewsky
-- @jtomaszewski
-- @KamilGrocholski
-- @zielivia
-- @adeptofvoltron
-- @DarrenStasiakDev4You
-- @patzick
-
----
-
-# 0.6.6 (2026-07-10)
-
-## Highlights
-<!-- TODO: Highlights — auto-update-changelog leaves this blank for the human author to fill in. -->
-
-## ✨ Features
 - ✨ First-class bulk-import side-effect suppression. (#4014) *(@KamilGrocholski)*
 - ✨ Document OM_WATCH_SCOPE dev-memory lever + emoji watch-mode log. (#3962) *(@pkarw)*
 - ✨ Auto-discover module fact-sheets beyond the core allowlist (#3752). (#3798) *(@adeptofvoltron)*
@@ -125,6 +69,29 @@
 - 🔒 Complete report-high.md tracker (16 HIGH findings) + dev-DX password amendment. (#2635) *(@pat-lewczuk)*
 
 ## 🐛 Fixes
+- 🔐 Restrict event catalog access (#3860). (#4136) *(@haxiorz)*
+- 🔐 Honor trusted SSE organization scope (#3861). (#4135) *(@haxiorz)*
+- 💰 Invalidate order cache after return mutations. (#4130) *(@andrzejewsky)*
+- 🔧 Back tenant-context AsyncLocalStorage with globalThis to survive bundler duplication. (#4126) *(@pkarw)*
+- 🔧 Surface drain-child diagnostics + pin absolute sqlite cache path in standalone CI. (#4118) *(@pkarw)*
+- 🔧 Use a cross-process cache strategy in standalone integration lanes. (#4117) *(@pkarw)*
+- 💰 Drop Stripe metadata-trust scope fallback + dead helper (#3866, #3865). (#4115) *(@haxiorz)*
+- 🐛 Annotate unauthenticated override probe (#3864). (#4114) *(@haxiorz)*
+- 🔐 Scope todo command snapshots (#3863). (#4113) *(@haxiorz)*
+- 🔐 Restrict email body access (#3868). (#4111) *(@haxiorz)*
+- 🔐 Require manage permission for proposal translation (#3867). (#4110) *(@haxiorz)*
+- 🔐 Redact integration credential URL userinfo (#3870). (#4108) *(@haxiorz)*
+- 🔐 Validate direct notification recipient scope (#3873). (#4100) *(@haxiorz)*
+- 🔐 Guard message enrichment by participant (#3872). (#4099) *(@haxiorz)*
+- 🐛 Return 400 for invalid notification restore status. (#4090) *(@haxiorz)*
+- 💰 Align payment gateway status guard resource kind (#3881). (#4081) *(@haxiorz)*
+- 🔐 Prevent planner availability authorization regression (#3883). (#4079) *(@haxiorz)*
+- 🔧 Harden MCP dev config loading (#4039). (#4077) *(@haxiorz)*
+- 🔧 Safely quote discovered table names (#4040). (#4069) *(@haxiorz)*
+- 🔐 Secure attachment temp files (#4045). (#4067) *(@haxiorz)*
+- 🐛 Route vendor-prefixed model ids to OpenAI-compatible gateways (OpenRouter) (supersedes #4009). (#4029) *(@jtomaszewski, via @pkarw)*
+- 🔄 Back data_sync adapter registry with globalThis to survive bundler duplication (supersedes #3999). (#4025) *(@KamilGrocholski, via @pkarw)*
+- 🐛 Calendar activity types from dictionary + CrudForm event editor with resources/staff (#3552). (#3747) *(@zielivia)*
 - 🔧 Remove duplicate CommandRuntimeContext import breaking develop build. (#4022) *(@pat-lewczuk)*
 - 🐛 Restore bulk-deal command dispatch in standalone CI. (#4020) *(@patzick)*
 - 🔧 Throttle query-index status refresh (#3888). (#4017) *(@haxiorz)*
@@ -370,6 +337,9 @@
 - 🐛 Surface per-field validation errors on signup form (#2081). (#2088) *(@pat-lewczuk)*
 
 ## 🛠️ Improvements
+- 🛠️ Share scheduler with lazy worker in dev mode. (#4125) *(@andrzejewsky)*
+- 🛠️ Retire legacy core.<module>.md redirect-stub layer (#3754). (#4080) *(@adeptofvoltron)*
+- 🛠️ Bump js-yaml from 3.14.2 to 3.15.0. (#4075) *(@pkarw)*
 - 🛠️ Structured logging facade backed by pino (fixes #3743). (#4003) *(@pat-lewczuk)*
 - 🛠️ Bump actions/cache from 5 to 6. (#3968) *(@pkarw)*
 - 🛠️ Bump mermaid from 11.12.2 to 11.16.0 in apps/docs. (#3967) *(@pkarw)*
@@ -452,6 +422,8 @@
 - 🧪 Migrate core integration specs to public helper imports. (#3237) *(@adeptofvoltron)*
 
 ## 📝 Specs & Documentation
+- 📝 Add Exporting Data REST API guide (#59). (#4144) *(@DarrenStasiakDev4You)*
+- 📝 Ephemeral-first test-env run mode in monorepo and create-app template. (#4095) *(@pkarw)*
 - 📝 Retire RELEASE_NOTES.md — migrate deprecations to UPGRADE_NOTES (#4024). (#4027) *(@adeptofvoltron)*
 - 📝 Remove obsolete ISSUE_LOG.md. (#4006) *(@pkarw)*
 - 📝 Add informational screenshots meta-label to auto-verify-pr-ui. (#3965) *(@adeptofvoltron)*


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-13-changelog-0.6.7.md
Status: complete

## Goal
- Amend the existing, not-yet-released 0.6.6 CHANGELOG entry with the PRs merged to develop between 2026-07-10 and 2026-07-13 (originally drafted as a separate 0.6.7 entry; folded into 0.6.6 per maintainer request).

## What Changed
- 31 new changelog lines merged into the tops of the 0.6.6 entry's ✨ Features / 🐛 Fixes / 🛠️ Improvements / 📝 Specs & Documentation sections.
- 0.6.6 heading date bumped `2026-07-10` → `2026-07-13` so the next changelog run's `last-release` boundary does not double-count this window.
- Supersede Credit Rule applied: #4029 credits @jtomaszewski (supersedes #4009), #4025 credits @KamilGrocholski (supersedes #3999), #3675 credits @matgren (supersedes #3341) — each `via` the merging author.
- Contributors block unchanged — all 10 credited handles were already listed under 0.6.6.

## Tests
- Docs-only change: no unit tests apply. Programmatic check confirms all 31 consumed PRs appear exactly once in the merged 0.6.6 block and no `0.6.7` heading remains.

## Breaking Changes
- None (docs-only).

## Progress
See the Progress section in the tracking plan.
