### PR TITLE
fix(sales): make primary email fit the order details summary card (#4148)

### DIFF
--- a/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
+++ b/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
@@ -37,6 +37,7 @@ import { mapCrudServerErrorToFormErrors } from '@open-mercato/ui/backend/utils/s
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { cn } from '@open-mercato/shared/lib/utils'
+import { ContactEmailDisplay } from '@open-mercato/core/modules/sales/components/ContactEmailDisplay'
 import { DocumentCustomerCard } from '@open-mercato/core/modules/sales/components/DocumentCustomerCard'
 import { SalesDocumentAddressesSection } from '@open-mercato/core/modules/sales/components/documents/AddressesSection'
 import { SalesDocumentItemsSection } from '@open-mercato/core/modules/sales/components/documents/ItemsSection'
@@ -3974,21 +3975,9 @@ export default function SalesDocumentDetailPage({
   ]
 
   const renderEmailDisplay = React.useCallback(
-    ({ value, emptyLabel }: { value: string | null | undefined; emptyLabel: string }) => {
-      const emailValue = typeof value === 'string' ? value.trim() : ''
-      if (!emailValue.length) {
-        return <span className="text-sm text-muted-foreground">{emptyLabel}</span>
-      }
-      return (
-        <a
-          className="inline-flex items-center gap-2 text-sm text-primary hover:text-primary/80 hover:underline"
-          href={`mailto:${emailValue}`}
-        >
-          <Mail className="h-4 w-4" aria-hidden />
-          <span className="truncate">{emailValue}</span>
-        </a>
-      )
-    },
+    ({ value, emptyLabel }: { value: string | null | undefined; emptyLabel: string }) => (
+      <ContactEmailDisplay value={value} emptyLabel={emptyLabel} />
+    ),
     []
   )
 

--- a/packages/core/src/modules/sales/components/ContactEmailDisplay.tsx
+++ b/packages/core/src/modules/sales/components/ContactEmailDisplay.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import * as React from 'react'
+import { Mail } from 'lucide-react'
+
+type ContactEmailDisplayProps = {
+  value: string | null | undefined
+  emptyLabel: string
+}
+
+export function ContactEmailDisplay({ value, emptyLabel }: ContactEmailDisplayProps) {
+  const emailValue = typeof value === 'string' ? value.trim() : ''
+  if (!emailValue.length) {
+    return <span className="text-sm text-muted-foreground">{emptyLabel}</span>
+  }
+  return (
+    <a
+      className="inline-flex max-w-full items-center gap-2 text-sm text-primary hover:text-primary/80 hover:underline"
+      href={`mailto:${emailValue}`}
+    >
+      <Mail className="h-4 w-4 shrink-0" aria-hidden />
+      <span className="min-w-0 truncate" title={emailValue}>
+        {emailValue}
+      </span>
+    </a>
+  )
+}

--- a/packages/core/src/modules/sales/components/__tests__/ContactEmailDisplay.test.tsx
+++ b/packages/core/src/modules/sales/components/__tests__/ContactEmailDisplay.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for #4148: on tablet widths the sales document detail view
+ * renders its summary cards in a 4-column grid, so the "Primary email" card is
+ * narrow. A long address used to overflow and get clipped mid-string because the
+ * link was a shrink-to-fit `inline-flex` with no width cap and the label was a
+ * flex item at the default `min-width: auto` — so `truncate` never engaged.
+ */
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { ContactEmailDisplay } from '../ContactEmailDisplay'
+
+const LONG_EMAIL = 'info@harborviewanalytics.com'
+
+describe('ContactEmailDisplay', () => {
+  it('constrains the link so a long address can ellipsize instead of overflowing the card', () => {
+    render(<ContactEmailDisplay value={LONG_EMAIL} emptyLabel="Not set" />)
+
+    const link = screen.getByRole('link')
+    // Cap the shrink-to-fit link at the card width, otherwise it grows to the
+    // full nowrap width of the address and spills out of the card.
+    expect(link).toHaveClass('max-w-full')
+
+    const label = screen.getByText(LONG_EMAIL)
+    // `truncate` only ellipsizes once the flex item may shrink below its
+    // min-content (nowrap) width.
+    expect(label).toHaveClass('truncate')
+    expect(label).toHaveClass('min-w-0')
+  })
+
+  it('keeps the icon from being squeezed once the row is width-capped', () => {
+    const { container } = render(<ContactEmailDisplay value={LONG_EMAIL} emptyLabel="Not set" />)
+
+    const icon = container.querySelector('svg')
+    expect(icon).not.toBeNull()
+    expect(icon).toHaveClass('shrink-0')
+  })
+
+  it('exposes the full address via mailto and title while truncated', () => {
+    render(<ContactEmailDisplay value={LONG_EMAIL} emptyLabel="Not set" />)
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', `mailto:${LONG_EMAIL}`)
+    expect(screen.getByText(LONG_EMAIL)).toHaveAttribute('title', LONG_EMAIL)
+  })
+
+  it('trims surrounding whitespace before building the mailto link', () => {
+    render(<ContactEmailDisplay value={`  ${LONG_EMAIL}  `} emptyLabel="Not set" />)
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', `mailto:${LONG_EMAIL}`)
+  })
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['blank', '   '],
+  ])('renders the empty label and no link when the value is %s', (_label, value) => {
+    render(<ContactEmailDisplay value={value} emptyLabel="Not set" />)
+
+    expect(screen.getByText('Not set')).toBeInTheDocument()
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #4148

## Problem

On smaller (tablet) resolutions the **Primary email** card in the sales document
detail view clips the address mid-string instead of truncating it — as reported,
`info@harborviewanalytic…` spills out of the card rather than ellipsizing inside it.

## Root Cause

The four summary cards render in a `md:grid-cols-4` grid, so each card is roughly a
quarter of the container — narrow on a tablet. The email was rendered as:

```jsx
<a className="inline-flex items-center gap-2 …">
  <Mail className="h-4 w-4" />
  <span className="truncate">{email}</span>
</a>
```

`truncate` implies `white-space: nowrap`, so the label's **min-content width is the
entire address**. Neither box could shrink below it:

- the `<a>` is `inline-flex` — its used width is shrink-to-fit, and it had no `max-width` cap;
- the `<span>` is a flex item at the default `min-width: auto`, so it cannot shrink under its min-content width.

The anchor therefore grew past the card's padding box and the text was clipped —
`truncate` never got the chance to engage. The card wrapper itself was already
correct (`<div className="flex-1 min-w-0">`); the bug lived entirely inside the anchor.

Notably `DocumentCustomerCard` — the customer card that renders *correctly* in the
reporter's screenshot — already uses the right pattern (`min-w-0` + `truncate` + `title`).
This change brings the summary card in line with it.

## What Changed

- **New** `packages/core/src/modules/sales/components/ContactEmailDisplay.tsx` — a mechanical
  extraction of the email-display markup (the sales module already keeps such pieces under
  `components/`), which makes it unit-testable without mounting the ~5k-line page component. It
  caps the anchor with `max-w-full`, lets the label shrink via `min-w-0`, holds the icon at
  `shrink-0` so it is not squeezed once the row is width-capped, and exposes the full address
  through `title` while truncated.
- `packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx` — `renderEmailDisplay`
  now delegates to that component. The `ContactEmailInlineEditor` `renderDisplay` prop contract
  is unchanged.

Short emails are unaffected: the anchor stays `inline-flex`, so its click target does not widen.

## Tests

- **New** `ContactEmailDisplay.test.tsx` (jsdom + Testing Library, 7 tests): width-constraint
  markup, the non-squeezed icon, `mailto:` + `title` exposure, whitespace trimming, and the
  null / undefined / blank empty-label branches.
- Verified it is a true regression test: against the pre-fix markup **3 of the 7 fail** (exactly
  the layout assertions); with the fix all 7 pass.
- Sales module suite fully green: **60 suites / 410 tests**.
- Full validation gate (Runner: local), all 8 commands in order: `build:packages` ✅ · `generate` ✅ ·
  `build:packages` ✅ · `i18n:check-sync` ✅ · `i18n:check-usage` ✅ (advisory) · `typecheck` ✅ ·
  `test` ⚠️ · `build:app` ✅.
- The one `yarn test` failure is **pre-existing and unrelated**:
  `customers/components/__tests__/DealsKpiStrip.test.tsx` expects compact `1K`. I reproduced it on
  pristine `develop` with my changes stashed — it is a locale artifact of the dev machine
  (`LANG=pl_PL.UTF-8` renders `1 tys.`), not a regression from this change.

## Breaking Changes

None. `ContactEmailDisplay` is a new additive export; no public contract, API response, event, or
schema surface is touched.

## Note for the reviewer (deliberately out of scope)

The same latent `truncate`-without-`min-w-0` pattern exists elsewhere and would benefit from a
follow-up issue rather than widening this PR:

- `sales/backend/sales/documents/[id]/page.tsx:566-571` — draft-email preview in the customer-selection editor
- `customers/components/detail/CompanyDetailHeader.tsx:132`
- `customers/components/detail/PersonDetailHeader.tsx:167`
- `customers/components/detail/CustomerFormHighlights.tsx`

🤖 Generated by autofix.
