### PR TITLE
fix(shared): add Kosovo (XK) to the country dictionary (#4128)

### DIFF
--- a/packages/shared/src/lib/location/__tests__/countries.test.ts
+++ b/packages/shared/src/lib/location/__tests__/countries.test.ts
@@ -1,0 +1,82 @@
+import {
+  COUNTRY_PRIORITY,
+  ISO_COUNTRIES,
+  buildCountryOptions,
+  resolveCountryName,
+} from '../countries'
+
+describe('ISO_COUNTRIES', () => {
+  it('includes Kosovo, which the language-subtag registry does not list', () => {
+    const kosovo = ISO_COUNTRIES.filter((entry) => entry.code === 'XK')
+    expect(kosovo).toEqual([{ code: 'XK', name: 'Kosovo' }])
+  })
+
+  it('does not duplicate any country code', () => {
+    const codes = ISO_COUNTRIES.map((entry) => entry.code)
+    expect(codes).toHaveLength(new Set(codes).size)
+  })
+
+  it('keeps registry-derived countries intact', () => {
+    expect(ISO_COUNTRIES).toEqual(
+      expect.arrayContaining([
+        { code: 'PL', name: 'Poland' },
+        { code: 'DE', name: 'Germany' },
+      ])
+    )
+  })
+
+  it('stays sorted by name', () => {
+    const names = ISO_COUNTRIES.map((entry) => entry.name)
+    const sorted = [...names].sort((a, b) => a.localeCompare(b, 'en', { sensitivity: 'base' }))
+    expect(names).toEqual(sorted)
+  })
+})
+
+describe('resolveCountryName', () => {
+  it('resolves Kosovo for XK', () => {
+    expect(resolveCountryName('XK')).toBe('Kosovo')
+  })
+
+  it('resolves Kosovo for a lowercase xk', () => {
+    expect(resolveCountryName('xk')).toBe('Kosovo')
+  })
+
+  it('still resolves registry-backed countries', () => {
+    expect(resolveCountryName('PL')).toBe('Poland')
+  })
+
+  it('falls back to the raw code for an unknown region', () => {
+    expect(resolveCountryName('ZZZ')).toBe('ZZZ')
+  })
+})
+
+describe('buildCountryOptions', () => {
+  it('offers Kosovo as a selectable option', () => {
+    const options = buildCountryOptions()
+    expect(options).toEqual(expect.arrayContaining([{ code: 'XK', label: 'Kosovo' }]))
+  })
+
+  it('offers exactly one Kosovo option', () => {
+    const options = buildCountryOptions().filter((option) => option.code === 'XK')
+    expect(options).toHaveLength(1)
+  })
+
+  it('lists Kosovo after the prioritized countries', () => {
+    const options = buildCountryOptions()
+    const kosovoIndex = options.findIndex((option) => option.code === 'XK')
+    expect(kosovoIndex).toBeGreaterThanOrEqual(COUNTRY_PRIORITY.length)
+  })
+
+  it('keeps the prioritized countries at the top', () => {
+    const options = buildCountryOptions()
+    const leading = options.slice(0, COUNTRY_PRIORITY.length).map((option) => option.code)
+    expect(leading.slice().sort()).toEqual(COUNTRY_PRIORITY.slice().sort())
+  })
+
+  it('applies transformLabel to the supplemental country too', () => {
+    const options = buildCountryOptions({
+      transformLabel: (code, defaultLabel) => `${defaultLabel} (${code})`,
+    })
+    expect(options).toEqual(expect.arrayContaining([{ code: 'XK', label: 'Kosovo (XK)' }]))
+  })
+})

--- a/packages/shared/src/lib/location/countries.ts
+++ b/packages/shared/src/lib/location/countries.ts
@@ -28,9 +28,18 @@ const RAW_COUNTRIES: IsoCountry[] = (registry as RegistryEntry[])
     name: entry.Description.join(', '),
   }))
 
-export const ISO_COUNTRIES: IsoCountry[] = [...RAW_COUNTRIES].sort((a, b) =>
-  a.name.localeCompare(b.name, 'en', { sensitivity: 'base' })
-)
+// Codes in common use that the language-subtag registry does not list as region subtags.
+// XK is user-assigned rather than ISO 3166-1 assigned, so it never appears in the registry.
+const SUPPLEMENTAL_COUNTRIES: IsoCountry[] = [
+  { code: 'XK', name: 'Kosovo' },
+]
+
+const RAW_COUNTRY_CODES = new Set(RAW_COUNTRIES.map((entry) => entry.code))
+
+export const ISO_COUNTRIES: IsoCountry[] = [
+  ...RAW_COUNTRIES,
+  ...SUPPLEMENTAL_COUNTRIES.filter((entry) => !RAW_COUNTRY_CODES.has(entry.code)),
+].sort((a, b) => a.name.localeCompare(b.name, 'en', { sensitivity: 'base' }))
 
 export const COUNTRY_PRIORITY: string[] = ['PL', 'DE', 'ES', 'FR', 'IT', 'US', 'GB', 'CA']
 
@@ -58,7 +67,9 @@ export function resolveCountryName(code: string, options: { locale?: string } = 
   if (!displayNames) return fallback
   try {
     const label = displayNames.of(normalized as any)
-    return typeof label === 'string' ? label : fallback
+    // Intl echoes the raw code back when its ICU data cannot resolve the region.
+    if (typeof label !== 'string' || label === normalized) return fallback
+    return label
   } catch {
     return fallback
   }


### PR DESCRIPTION
Fixes #4128

## Problem

Kosovo was missing from the shared country dictionary, so `XK` could not be selected in any country picker — including the customer address editors. Searching for "Kosovo" or `XK` in an address selector returned no option.

## Root Cause

`packages/shared/src/lib/location/countries.ts` builds `ISO_COUNTRIES` exclusively from the `language-subtag-registry`. `XK` is a *user-assigned* code rather than an ISO 3166-1 assigned one, so it does not exist in that registry at all — the only `X*` region record is the range subtag `XA..XZ` with description `Private use`, which `isIsoAlpha2()` rejects twice over (its `^[A-Z]{2}$` subtag test and its explicit `Private use` guard). Since `buildCountryOptions()` maps only over `ISO_COUNTRIES`, it could never emit a Kosovo option, and both `AddressEditor` components that source their country list from it (`packages/ui/src/backend/detail/AddressEditor.tsx`, `packages/core/src/modules/customers/components/AddressEditor.tsx`) therefore offered none.

## What Changed

- Added a `SUPPLEMENTAL_COUNTRIES` list in `packages/shared/src/lib/location/countries.ts` holding `{ code: 'XK', name: 'Kosovo' }`, merged into `ISO_COUNTRIES` and filtered against a `Set` of registry-derived codes so a future upstream addition of `XK` cannot produce a duplicate option. The existing `localeCompare` sort is preserved, so placement stays alphabetical.
- Hardened `resolveCountryName()` to fall back to the known name when `Intl.DisplayNames` echoes the raw code back — its documented behavior for a region its ICU data cannot resolve — so `XK` still labels as "Kosovo" on trimmed-ICU runtimes. (Node's full-ICU `Intl` already maps `XK` → "Kosovo", and "Kosowo" in `pl`, so localized labels work automatically.)
- Exported types, `COUNTRY_PRIORITY`, and every function signature are unchanged.

Acceptance criteria from the issue: `buildCountryOptions()` returns `{ code: 'XK', label: 'Kosovo' }` ✅, the country appears in customer address selectors ✅ (both editors consume this helper), existing country options remain unchanged ✅, regression test added ✅.

## Tests

- New `packages/shared/src/lib/location/__tests__/countries.test.ts` (13 cases): the `XK` entry, no duplicate codes, registry countries intact, sort order, `resolveCountryName` for `XK`/`xk`/`PL`/unknown, the `XK` option in `buildCountryOptions()`, exactly one `XK` option, `XK` ordered after the prioritized block, the priority block intact, and `transformLabel` applied to the supplemental entry.
- Verified as a true regression guard: 5 of the new cases **fail** against the original `countries.ts` and all pass with the fix.
- Full validation gate (runner: local), in order: `build:packages` ✅, `generate` ✅ (no generator churn), `build:packages` ✅, `i18n:check-sync` ✅, `i18n:check-usage` ✅, `typecheck` ✅, `test` ⚠️, `build:app` ✅.
- The one `test` failure is **pre-existing and environment-caused, not a regression**: `@open-mercato/ui` › `formatCurrency` › "formats a numeric value with an ISO currency code" (1 of 1631) expects `/1,234\.5/` but the test host's Polish locale renders `"1234,50 USD"`. It fails identically on a clean `develop` checkout with zero modified files and does not touch `location/countries`. Shared package: 1459/1459 pass, including 30/30 location tests.

## Breaking Changes

None. The change is purely additive — one new option appears in country selectors. No exported API, response shape, DB schema, or config format changes.

🤖 Generated by autofix.
