### PR TITLE
fix(dev): recognize structured-logger noise in dev log policies

### DIFF
--- a/.ai/runs/2026-07-13-dev-log-policy-structured-format.md
+++ b/.ai/runs/2026-07-13-dev-log-policy-structured-format.md
@@ -59,6 +59,8 @@ Separately, `scripts/watch-packages.mjs` emits `[watch] watch scope: ...` lines 
 
 ## Progress
 
+PR: #4158
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Runtime log-policy fix (apps/mercato)

--- a/.ai/runs/2026-07-13-dev-log-policy-structured-format.md
+++ b/.ai/runs/2026-07-13-dev-log-policy-structured-format.md
@@ -1,0 +1,75 @@
+# Fix dev log-policy allowlists for the structured-logging format
+
+Date: 2026-07-13
+Slug: dev-log-policy-structured-format
+Branch: fix/dev-log-policy-structured-format
+
+## Overview
+
+### Goal
+
+Stop the compact dev runtime (`yarn dev` / `yarn dev:greenfield`) from auto-revealing raw debug logs on benign Vault-fallback noise, and stop the package watcher's watch-scope announcement from printing `❌ Package watch emitted raw output`.
+
+### Background
+
+The structured-logging facade (`.ai/specs/2026-07-02-structured-logging-facade.md`, `@open-mercato/shared/lib/logger`) changed how the KMS/Vault dev-fallback warnings render. The pretty transport emits `HH:MM:SS.mmm LEVEL [scope] message key=value`, and an `err` binding appends the error stack on following lines (first line e.g. `TypeError: fetch failed`).
+
+The noise allowlist in `apps/mercato/scripts/dev-runtime-log-policy.mjs` still matches the pre-facade formats only:
+
+- `⚠️ [encryption][kms] Vault read error` — now `12:16:22.204 WARN  [shared:kms] Vault read error path=... timeoutMs=1000`
+- `error: 'fetch failed'` (old object dump) — now a bare `TypeError: fetch failed` stack line
+- `Secret: ` — the banner line is actually `Secret fingerprint (sha256, truncated): ...`
+
+Consequence: `looksLikeFailure` in `apps/mercato/scripts/dev.mjs` matches `TypeError: fetch failed` (and the `Vault read failed` / `Vault write failed` message variants) via `/\bfailed\b/i`, flips the reporter into permanent passthrough, and auto-opens the raw log panel on every dev boot where Vault is unreachable — the intended dev fallback path.
+
+Separately, `scripts/watch-packages.mjs` emits `[watch] watch scope: ...` lines that `isIgnorableConsolidatedWatchLine` in `scripts/dev-orchestration-log-policy.mjs` does not cover, producing a spurious `❌ Package watch emitted raw output` line.
+
+### Scope
+
+- `apps/mercato/scripts/dev-runtime-log-policy.mjs` — recognize the structured-log pretty format for the KMS/Vault fallback lines (strip the `HH:MM:SS.mmm LEVEL ` prefix before matching), cover the new message texts (`[shared:kms] Vault read|write error|failed`, `No tenant DEK found in Vault`, bare `TypeError: fetch failed` stack head, `Secret fingerprint (sha256, truncated):`, `Source: dev default secret`), keep all old-format matches for backward compatibility.
+- `scripts/dev-orchestration-log-policy.mjs` — add `[watch] watch scope: ...` lines to `isIgnorableConsolidatedWatchLine`.
+- Unit tests in `apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs` and `scripts/__tests__/dev-orchestration-log-policy.test.mjs` (run via `yarn test:scripts`).
+- Template mirror: `packages/create-app/template/scripts/dev-runtime-log-policy.mjs` and `packages/create-app/template/scripts/dev-orchestration-log-policy.mjs` are byte-identical copies today and must stay in sync (create-app Template Sync Checklist).
+
+### Non-goals
+
+- No changes to the structured-logging facade or the KMS/Vault code in `packages/shared`.
+- No changes to `looksLikeFailure` / `classifyServerLine` heuristics in `apps/mercato/scripts/dev.mjs` — the fix is confined to the noise allowlist predicates.
+- No broader migration of other legacy predicates (queue/scheduler/bootstrap) to the structured prefix beyond what the Vault-fallback fix requires.
+
+## Implementation Plan
+
+### Phase 1: Runtime log-policy fix (apps/mercato)
+
+1.1 Add a structured-log prefix helper and extend `isIgnorableDerivedKeyWarningLine` to match both old and new formats, including the bare `TypeError: fetch failed` stack head and the current banner lines.
+1.2 Extend `apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs` with cases for every new-format line observed in a real `yarn dev:greenfield` boot, plus negative cases proving real failures still surface.
+
+### Phase 2: Orchestration log-policy fix (root scripts)
+
+2.1 Add `[watch] watch scope: ...` to `isIgnorableConsolidatedWatchLine` and extend `scripts/__tests__/dev-orchestration-log-policy.test.mjs`.
+
+### Phase 3: Template sync
+
+3.1 Mirror both edited policy files verbatim into `packages/create-app/template/scripts/`.
+
+## Risks
+
+- Over-suppression: blanket-ignoring `TypeError: fetch failed` could hide a real fetch failure in the raw panel trigger. Accepted: in the dev reporter context this line is overwhelmingly the Vault health probe; the line still lands in the raw log buffer (visible via `[d]`), and genuine failures print additional non-allowlisted lines that still trigger the reveal.
+- Format drift: the pretty-transport format could change again. Mitigated by matching a tolerant prefix regex and by unit tests that copy real observed lines.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Runtime log-policy fix (apps/mercato)
+
+- [ ] 1.1 Extend dev-runtime-log-policy predicates for structured-log format
+- [ ] 1.2 Extend dev-runtime-log-policy unit tests
+
+### Phase 2: Orchestration log-policy fix (root scripts)
+
+- [ ] 2.1 Ignore watch-scope announcements in isIgnorableConsolidatedWatchLine + tests
+
+### Phase 3: Template sync
+
+- [ ] 3.1 Mirror updated policy files into packages/create-app/template/scripts

--- a/.ai/runs/2026-07-13-dev-log-policy-structured-format.md
+++ b/.ai/runs/2026-07-13-dev-log-policy-structured-format.md
@@ -26,7 +26,7 @@ Separately, `scripts/watch-packages.mjs` emits `[watch] watch scope: ...` lines 
 
 ### Scope
 
-- `apps/mercato/scripts/dev-runtime-log-policy.mjs` — recognize the structured-log pretty format for the KMS/Vault fallback lines (strip the `HH:MM:SS.mmm LEVEL ` prefix before matching), cover the new message texts (`[shared:kms] Vault read|write error|failed`, `No tenant DEK found in Vault`, bare `TypeError: fetch failed` stack head, `Secret fingerprint (sha256, truncated):`, `Source: dev default secret`), keep all old-format matches for backward compatibility.
+- `apps/mercato/scripts/dev-runtime-log-policy.mjs` — recognize the structured-log pretty format for the KMS/Vault fallback lines (strip the `HH:MM:SS.mmm LEVEL` prefix before matching), cover the new message texts (`[shared:kms] Vault read|write error|failed`, `No tenant DEK found in Vault`, bare `TypeError: fetch failed` stack head, `Secret fingerprint (sha256, truncated):`, `Source: dev default secret`), keep all old-format matches for backward compatibility.
 - `scripts/dev-orchestration-log-policy.mjs` — add `[watch] watch scope: ...` lines to `isIgnorableConsolidatedWatchLine`.
 - Unit tests in `apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs` and `scripts/__tests__/dev-orchestration-log-policy.test.mjs` (run via `yarn test:scripts`).
 - Template mirror: `packages/create-app/template/scripts/dev-runtime-log-policy.mjs` and `packages/create-app/template/scripts/dev-orchestration-log-policy.mjs` are byte-identical copies today and must stay in sync (create-app Template Sync Checklist).
@@ -63,13 +63,13 @@ Separately, `scripts/watch-packages.mjs` emits `[watch] watch scope: ...` lines 
 
 ### Phase 1: Runtime log-policy fix (apps/mercato)
 
-- [ ] 1.1 Extend dev-runtime-log-policy predicates for structured-log format
-- [ ] 1.2 Extend dev-runtime-log-policy unit tests
+- [x] 1.1 Extend dev-runtime-log-policy predicates for structured-log format — 73146de34
+- [x] 1.2 Extend dev-runtime-log-policy unit tests — 73146de34
 
 ### Phase 2: Orchestration log-policy fix (root scripts)
 
-- [ ] 2.1 Ignore watch-scope announcements in isIgnorableConsolidatedWatchLine + tests
+- [x] 2.1 Ignore watch-scope announcements in isIgnorableConsolidatedWatchLine + tests — 59abc32ea
 
 ### Phase 3: Template sync
 
-- [ ] 3.1 Mirror updated policy files into packages/create-app/template/scripts
+- [x] 3.1 Mirror updated policy files into packages/create-app/template/scripts — 6c73c8b3b

--- a/apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs
+++ b/apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs
@@ -12,6 +12,7 @@ import {
   isInteractivePromptHintLine,
   isStatelessRuntimeNoiseLine,
   shouldIgnoreSplashPassthroughLine,
+  stripStructuredLogPrefix,
 } from '../dev-runtime-log-policy.mjs'
 
 test('ignores derived tenant key fallback lines', () => {
@@ -24,6 +25,72 @@ test('ignores derived tenant key fallback lines', () => {
     true,
   )
   assert.equal(isIgnorableDerivedKeyWarningLine('Error: database unavailable'), false)
+})
+
+test('stripStructuredLogPrefix removes the pretty transport timestamp and level', () => {
+  assert.equal(
+    stripStructuredLogPrefix('12:16:22.204 WARN  [shared:kms] Vault read error path=secret/data/tenant_key_123 timeoutMs=1000'),
+    '[shared:kms] Vault read error path=secret/data/tenant_key_123 timeoutMs=1000',
+  )
+  assert.equal(stripStructuredLogPrefix('TypeError: fetch failed'), 'TypeError: fetch failed')
+  assert.equal(stripStructuredLogPrefix(undefined), '')
+})
+
+test('ignores structured-logger KMS Vault fallback lines', () => {
+  assert.equal(
+    isIgnorableDerivedKeyWarningLine('12:16:22.204 WARN  [shared:kms] Vault read error path=secret/data/tenant_key_61905439-c148-4818-97e0-7a92bf469379 timeoutMs=1000'),
+    true,
+  )
+  assert.equal(
+    isIgnorableDerivedKeyWarningLine('12:16:22.204 WARN  [shared:kms] Vault read failed path=secret/data/tenant_key_123 status=503'),
+    true,
+  )
+  assert.equal(
+    isIgnorableDerivedKeyWarningLine('12:16:22.204 WARN  [shared:kms] Vault write error path=secret/data/tenant_key_123 timeoutMs=1000'),
+    true,
+  )
+  assert.equal(
+    isIgnorableDerivedKeyWarningLine('12:16:22.204 WARN  [shared:kms] No tenant DEK found in Vault tenantId=61905439-c148-4818-97e0-7a92bf469379 path=secret/data/tenant_key_61905439-c148-4818-97e0-7a92bf469379'),
+    true,
+  )
+  assert.equal(
+    isIgnorableDerivedKeyWarningLine('12:16:22.204 WARN  [shared:kms] Using derived tenant encryption keys (Vault unavailable / no DEK) secretFingerprint=c7eabc7b8d9e7cd0'),
+    true,
+  )
+  assert.equal(isIgnorableDerivedKeyWarningLine('TypeError: fetch failed'), true)
+  assert.equal(
+    isIgnorableDerivedKeyWarningLine('12:16:22.204 ERROR [sales:orders] Payment capture failed orderId=42'),
+    false,
+  )
+  assert.equal(isIgnorableDerivedKeyWarningLine('TypeError: cannot read properties of undefined'), false)
+})
+
+test('ignores the derived-key fallback banner body lines', () => {
+  assert.equal(
+    isIgnorableDerivedKeyWarningLine(' 🚨 Using derived tenant encryption keys (Vault unavailable / no DEK)'),
+    true,
+  )
+  assert.equal(isIgnorableDerivedKeyWarningLine(' Source: TENANT_DATA_ENCRYPTION_FALLBACK_KEY'), true)
+  assert.equal(isIgnorableDerivedKeyWarningLine(' Source: TENANT_DATA_ENCRYPTION_KEY'), true)
+  assert.equal(isIgnorableDerivedKeyWarningLine(' Source: dev default secret (do NOT use in production)'), true)
+  assert.equal(isIgnorableDerivedKeyWarningLine(' Secret fingerprint (sha256, truncated): c7eabc7b8d9e7cd0'), true)
+  assert.equal(
+    isIgnorableDerivedKeyWarningLine(' Persist this secret securely. Without it, encrypted tenant data cannot be recovered after restart.'),
+    true,
+  )
+})
+
+test('structured-logger KMS fallback lines count as stateless runtime noise', () => {
+  assert.equal(
+    isStatelessRuntimeNoiseLine('12:16:22.204 WARN  [shared:kms] Vault read error path=secret/data/tenant_key_123 timeoutMs=1000'),
+    true,
+  )
+  assert.equal(isStatelessRuntimeNoiseLine('TypeError: fetch failed'), true)
+  assert.equal(isStatelessRuntimeNoiseLine('Secret fingerprint (sha256, truncated): c7eabc7b8d9e7cd0'), true)
+  assert.equal(
+    isStatelessRuntimeNoiseLine('12:16:22.204 ERROR [sales:orders] Payment capture failed orderId=42'),
+    false,
+  )
 })
 
 test('treats search strategy failures as non-blocking warnings', () => {

--- a/apps/mercato/scripts/dev-runtime-log-policy.mjs
+++ b/apps/mercato/scripts/dev-runtime-log-policy.mjs
@@ -1,16 +1,35 @@
+// Mirrors the pretty transport format in packages/shared/src/lib/logger/transport.pretty.ts:
+// `HH:MM:SS.mmm LEVEL [scope] message key=value`, with an `err` binding appended
+// as the error stack on the following lines (first line e.g. `TypeError: fetch failed`).
+const STRUCTURED_PRETTY_LOG_PREFIX = /^\d{2}:\d{2}:\d{2}\.\d{3}\s+(?:DEBUG|INFO|WARN|ERROR)\s+/
+
+export function stripStructuredLogPrefix(line) {
+  if (typeof line !== 'string') return ''
+  return line.replace(STRUCTURED_PRETTY_LOG_PREFIX, '')
+}
+
+const KMS_VAULT_FALLBACK_MESSAGE_PATTERN = /^\[shared:kms\] (?:Vault (?:read|write) (?:error|failed)\b|Vault write CAS conflict\b|No tenant DEK found in Vault\b|Failed to store tenant DEK in Vault\b)/
+
 export function isIgnorableDerivedKeyWarningLine(line) {
   if (typeof line !== 'string') return false
 
-  return line.startsWith('⚠️ [encryption][kms] Vault read error')
-    || line.startsWith('⚠️ [encryption][kms] No tenant DEK found in Vault')
-    || line.startsWith("path: 'secret/data/tenant_key_")
-    || line.startsWith("error: 'fetch failed'")
-    || line === '}'
-    || line.startsWith('━━━━━━━━')
-    || line.includes('Using derived tenant encryption keys')
-    || line.startsWith('Source: TENANT_DATA_ENCRYPTION_FALLBACK_KEY')
-    || line.startsWith('Secret: ')
-    || line.startsWith('Persist this secret securely.')
+  const normalized = stripStructuredLogPrefix(line.trim())
+
+  return normalized.startsWith('⚠️ [encryption][kms] Vault read error')
+    || normalized.startsWith('⚠️ [encryption][kms] No tenant DEK found in Vault')
+    || KMS_VAULT_FALLBACK_MESSAGE_PATTERN.test(normalized)
+    || normalized.startsWith("path: 'secret/data/tenant_key_")
+    || normalized.startsWith("error: 'fetch failed'")
+    || normalized === 'TypeError: fetch failed'
+    || normalized === '}'
+    || normalized.startsWith('━━━━━━━━')
+    || normalized.includes('Using derived tenant encryption keys')
+    || normalized.startsWith('Source: TENANT_DATA_ENCRYPTION_FALLBACK_KEY')
+    || normalized.startsWith('Source: TENANT_DATA_ENCRYPTION_KEY')
+    || normalized.startsWith('Source: dev default secret')
+    || normalized.startsWith('Secret: ')
+    || normalized.startsWith('Secret fingerprint (sha256, truncated):')
+    || normalized.startsWith('Persist this secret securely.')
 }
 
 function isIgnorableStructuredWarningBlockStartLine(line) {

--- a/packages/create-app/template/scripts/dev-orchestration-log-policy.mjs
+++ b/packages/create-app/template/scripts/dev-orchestration-log-policy.mjs
@@ -71,6 +71,7 @@ export function isIgnorableConsolidatedWatchLine(line) {
   const plain = normalize(line)
   if (!plain.startsWith('[watch]')) return false
   return /^\[watch\] consolidated watcher: /.test(plain)
+    || /^\[watch\] watch scope: /.test(plain)
     || /^\[watch\] [^:]+: rebuilding\.\.\.$/.test(plain)
     || /^\[watch\] [^:]+: rebuild complete$/.test(plain)
     || /^\[watch\] [^:]+: no source files found, skipping rebuild$/.test(plain)

--- a/packages/create-app/template/scripts/dev-runtime-log-policy.mjs
+++ b/packages/create-app/template/scripts/dev-runtime-log-policy.mjs
@@ -1,16 +1,35 @@
+// Mirrors the pretty transport format in packages/shared/src/lib/logger/transport.pretty.ts:
+// `HH:MM:SS.mmm LEVEL [scope] message key=value`, with an `err` binding appended
+// as the error stack on the following lines (first line e.g. `TypeError: fetch failed`).
+const STRUCTURED_PRETTY_LOG_PREFIX = /^\d{2}:\d{2}:\d{2}\.\d{3}\s+(?:DEBUG|INFO|WARN|ERROR)\s+/
+
+export function stripStructuredLogPrefix(line) {
+  if (typeof line !== 'string') return ''
+  return line.replace(STRUCTURED_PRETTY_LOG_PREFIX, '')
+}
+
+const KMS_VAULT_FALLBACK_MESSAGE_PATTERN = /^\[shared:kms\] (?:Vault (?:read|write) (?:error|failed)\b|Vault write CAS conflict\b|No tenant DEK found in Vault\b|Failed to store tenant DEK in Vault\b)/
+
 export function isIgnorableDerivedKeyWarningLine(line) {
   if (typeof line !== 'string') return false
 
-  return line.startsWith('⚠️ [encryption][kms] Vault read error')
-    || line.startsWith('⚠️ [encryption][kms] No tenant DEK found in Vault')
-    || line.startsWith("path: 'secret/data/tenant_key_")
-    || line.startsWith("error: 'fetch failed'")
-    || line === '}'
-    || line.startsWith('━━━━━━━━')
-    || line.includes('Using derived tenant encryption keys')
-    || line.startsWith('Source: TENANT_DATA_ENCRYPTION_FALLBACK_KEY')
-    || line.startsWith('Secret: ')
-    || line.startsWith('Persist this secret securely.')
+  const normalized = stripStructuredLogPrefix(line.trim())
+
+  return normalized.startsWith('⚠️ [encryption][kms] Vault read error')
+    || normalized.startsWith('⚠️ [encryption][kms] No tenant DEK found in Vault')
+    || KMS_VAULT_FALLBACK_MESSAGE_PATTERN.test(normalized)
+    || normalized.startsWith("path: 'secret/data/tenant_key_")
+    || normalized.startsWith("error: 'fetch failed'")
+    || normalized === 'TypeError: fetch failed'
+    || normalized === '}'
+    || normalized.startsWith('━━━━━━━━')
+    || normalized.includes('Using derived tenant encryption keys')
+    || normalized.startsWith('Source: TENANT_DATA_ENCRYPTION_FALLBACK_KEY')
+    || normalized.startsWith('Source: TENANT_DATA_ENCRYPTION_KEY')
+    || normalized.startsWith('Source: dev default secret')
+    || normalized.startsWith('Secret: ')
+    || normalized.startsWith('Secret fingerprint (sha256, truncated):')
+    || normalized.startsWith('Persist this secret securely.')
 }
 
 function isIgnorableStructuredWarningBlockStartLine(line) {

--- a/scripts/__tests__/dev-orchestration-log-policy.test.mjs
+++ b/scripts/__tests__/dev-orchestration-log-policy.test.mjs
@@ -118,6 +118,9 @@ test('isIgnorableConsolidatedWatchLine catches consolidated watcher progress onl
   assert.equal(isIgnorableConsolidatedWatchLine('[watch] shared: rebuild complete'), true)
   assert.equal(isIgnorableConsolidatedWatchLine('[watch] shared: no source files found, skipping rebuild'), true)
   assert.equal(isIgnorableConsolidatedWatchLine('[watch] no workspace packages with a `watch` script and `src/` directory were found'), true)
+  assert.equal(isIgnorableConsolidatedWatchLine('[watch] watch scope: 🌐 all — watching all packages'), true)
+  assert.equal(isIgnorableConsolidatedWatchLine('[watch] watch scope: 3 of 19 package(s) are not watched (set OM_WATCH_SCOPE=all to watch everything)'), true)
+  assert.equal(isIgnorableConsolidatedWatchLine('[watch] watch scope: expanded to newly-touched package shared'), true)
   // Real errors must NOT be filtered — they pass through to the failure surface
   assert.equal(isIgnorableConsolidatedWatchLine('[watch] shared: rebuild failed: ENOENT'), false)
   assert.equal(isIgnorableConsolidatedWatchLine('[watch] shared: failed to start fs.watch: EMFILE'), false)

--- a/scripts/dev-orchestration-log-policy.mjs
+++ b/scripts/dev-orchestration-log-policy.mjs
@@ -71,6 +71,7 @@ export function isIgnorableConsolidatedWatchLine(line) {
   const plain = normalize(line)
   if (!plain.startsWith('[watch]')) return false
   return /^\[watch\] consolidated watcher: /.test(plain)
+    || /^\[watch\] watch scope: /.test(plain)
     || /^\[watch\] [^:]+: rebuilding\.\.\.$/.test(plain)
     || /^\[watch\] [^:]+: rebuild complete$/.test(plain)
     || /^\[watch\] [^:]+: no source files found, skipping rebuild$/.test(plain)


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-13-dev-log-policy-structured-format.md
Status: complete

## Goal
- Stop the compact dev runtime (`yarn dev` / `yarn dev:greenfield`) from auto-revealing raw debug logs on benign Vault-fallback noise, and stop the package watcher's watch-scope announcement from printing `❌ Package watch emitted raw output`.

## What Changed
- `apps/mercato/scripts/dev-runtime-log-policy.mjs`: `isIgnorableDerivedKeyWarningLine` now recognizes the structured-logging pretty format (`HH:MM:SS.mmm LEVEL [scope] message`) via a new exported `stripStructuredLogPrefix` helper. It covers the `[shared:kms]` Vault fallback messages (`Vault read/write error|failed`, `Vault write CAS conflict`, `No tenant DEK found in Vault`, `Failed to store tenant DEK in Vault`), the bare `TypeError: fetch failed` stack head the logger appends for `err` bindings, and the current derived-key banner lines (`Secret fingerprint (sha256, truncated):`, `Source: TENANT_DATA_ENCRYPTION_KEY`, `Source: dev default secret`). All old-format matches are kept for backward compatibility.
- `scripts/dev-orchestration-log-policy.mjs`: `isIgnorableConsolidatedWatchLine` now ignores `[watch] watch scope: ...` announcements from `scripts/watch-packages.mjs`.
- Both files mirrored byte-identically into `packages/create-app/template/scripts/` per the Template Sync Checklist.
- Execution plan committed at `.ai/runs/2026-07-13-dev-log-policy-structured-format.md`.

## Why
The structured-logging facade changed how the KMS/Vault dev-fallback warnings render, so the noise allowlist no longer matched them. `looksLikeFailure` in `apps/mercato/scripts/dev.mjs` then matched the `TypeError: fetch failed` line (and the `Vault read/write failed` variants) via `/\bfailed\b/i`, flipped the compact reporter into permanent passthrough, and auto-opened the raw log panel on every dev boot where Vault is unreachable — the intended dev fallback path. This matches the documented lesson "Startup splash must distinguish blocking bootstrap failures from non-blocking runtime warnings" in `.ai/lessons.md`.

## Tests
- Extended `apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs` with the real lines observed in a `yarn dev:greenfield` boot (structured KMS warnings, `TypeError: fetch failed`, banner body lines) plus negative cases proving real failures (`12:16:22.204 ERROR [sales:orders] Payment capture failed ...`, `TypeError: cannot read properties of undefined`) still surface.
- Extended `scripts/__tests__/dev-orchestration-log-policy.test.mjs` with the three watch-scope announcement variants; rebuild-failure lines still pass through.
- `yarn test:scripts`: 319/319 pass.

## Breaking Changes
- None. Dev-tooling scripts only; the one export change is additive (`stripStructuredLogPrefix`), existing predicate signatures unchanged. No contract surface from `BACKWARD_COMPATIBILITY.md` touched.

## Progress
See the Progress section in the tracking plan.
