### PR TITLE
fix(customers): hide Company V2 Deals tab without customers.deals.view (#4124)

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/companies-v2/[id]/page.tsx
@@ -31,6 +31,7 @@ import type { TagsSectionController } from '@open-mercato/ui/backend/detail'
 import { coerceDisplayName } from '../../../../lib/displayName'
 import { CompanyDetailHeader } from '../../../../components/detail/CompanyDetailHeader'
 import { CompanyDetailTabs, resolveLegacyTab, type CompanyTabId } from '../../../../components/detail/CompanyDetailTabs'
+import { useDealsAccess } from '../../../../components/detail/useDealsAccess'
 import { CompanyKpiBar } from '../../../../components/detail/CompanyKpiBar'
 import { ScheduleActivityDialog, type ScheduleActivityEditData } from '../../../../components/detail/ScheduleActivityDialog'
 import { ChangelogTab } from '../../../../components/detail/ChangelogTab'
@@ -69,6 +70,7 @@ export default function CompanyDetailV2Page({ params }: { params?: { id?: string
   }, [searchParams])
   const [activeTab, setActiveTab] = React.useState<CompanyTabId>(initialTab)
   const [sectionAction, setSectionAction] = React.useState<SectionAction | null>(null)
+  const { canViewDeals, isReady: isDealsAccessReady } = useDealsAccess()
 
   // Form state
   const [isDirty, setIsDirty] = React.useState(false)
@@ -328,6 +330,14 @@ export default function CompanyDetailV2Page({ params }: { params?: { id?: string
     setSectionAction(null)
   }, [activeTab])
 
+  // A `?tab=deals` deep link must not strand users without `customers.deals.view`
+  // on a tab that no longer exists for them. Wait for the granted features to load
+  // so a permitted user is never bounced off the tab mid-fetch.
+  React.useEffect(() => {
+    if (!isDealsAccessReady || canViewDeals) return
+    setActiveTab((current) => (current === 'deals' ? 'people' : current))
+  }, [isDealsAccessReady, canViewDeals])
+
   // Deals scope
   const dealsScope = React.useMemo(
     () => (currentCompanyId ? ({ kind: 'company', entityId: currentCompanyId } as const) : null),
@@ -544,7 +554,7 @@ export default function CompanyDetailV2Page({ params }: { params?: { id?: string
                   />
                 )}
 
-                {activeTab === 'deals' && (
+                {activeTab === 'deals' && canViewDeals && (
                   <DealsSection
                     scope={dealsScope}
                     emptyLabel={t('customers.companies.detail.empty.deals', 'No deals linked to this company.')}

--- a/packages/core/src/modules/customers/components/detail/CompanyDetailTabs.tsx
+++ b/packages/core/src/modules/customers/components/detail/CompanyDetailTabs.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
 } from 'lucide-react'
 import type { SectionAction } from '@open-mercato/ui/backend/detail'
+import { useDealsAccess } from './useDealsAccess'
 
 export type CompanyTabId =
   | 'people'
@@ -87,6 +88,7 @@ export function CompanyDetailTabs({
   children,
 }: CompanyDetailTabsProps) {
   const t = useT()
+  const { canViewDeals } = useDealsAccess()
 
   const builtInTabs: TabDef[] = React.useMemo(
     () => [
@@ -96,12 +98,16 @@ export function CompanyDetailTabs({
         icon: <Users className="size-4" />,
         badge: <CountBadge count={peopleCount} />,
       },
-      {
-        id: 'deals',
-        label: t('customers.companies.detail.tabs.deals', 'Deals'),
-        icon: <Handshake className="size-4" />,
-        badge: <CountBadge count={dealsCount} />,
-      },
+      ...(canViewDeals
+        ? [
+            {
+              id: 'deals' as CompanyTabId,
+              label: t('customers.companies.detail.tabs.deals', 'Deals'),
+              icon: <Handshake className="size-4" />,
+              badge: <CountBadge count={dealsCount} />,
+            },
+          ]
+        : []),
       {
         id: 'activity-log',
         label: t('customers.companies.detail.tabs.activityLog', 'Activity log'),
@@ -121,7 +127,7 @@ export function CompanyDetailTabs({
         badge: <CountBadge count={filesCount} />,
       },
     ],
-    [t, peopleCount, dealsCount, activitiesCount, filesCount],
+    [t, canViewDeals, peopleCount, dealsCount, activitiesCount, filesCount],
   )
 
   const allTabs: TabDef[] = React.useMemo(

--- a/packages/core/src/modules/customers/components/detail/__tests__/CompanyDetailTabs.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/CompanyDetailTabs.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import { CompanyDetailTabs } from '../CompanyDetailTabs'
+
+let mockGrantedFeatures: string[] = []
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => <button {...props}>{children}</button>,
+}))
+
+jest.mock('@open-mercato/ui/backend/BackendChromeProvider', () => ({
+  useBackendChrome: () => ({
+    payload: { grantedFeatures: mockGrantedFeatures },
+    isReady: true,
+  }),
+}))
+
+function renderTabs() {
+  return render(
+    <CompanyDetailTabs activeTab="people" onTabChange={() => {}}>
+      <div>content</div>
+    </CompanyDetailTabs>,
+  )
+}
+
+describe('CompanyDetailTabs', () => {
+  it('renders the Deals tab when the user has customers.deals.view', () => {
+    mockGrantedFeatures = ['customers.companies.view', 'customers.deals.view']
+    renderTabs()
+    expect(screen.getByRole('tab', { name: /deals/i })).toBeInTheDocument()
+  })
+
+  it('hides the Deals tab when the user lacks customers.deals.view', () => {
+    mockGrantedFeatures = ['customers.companies.view']
+    renderTabs()
+    expect(screen.queryByRole('tab', { name: /deals/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /people/i })).toBeInTheDocument()
+  })
+
+  it('renders the Deals tab for a wildcard customers.* grant', () => {
+    mockGrantedFeatures = ['customers.*']
+    renderTabs()
+    expect(screen.getByRole('tab', { name: /deals/i })).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/useDealsAccess.ts
+++ b/packages/core/src/modules/customers/components/detail/useDealsAccess.ts
@@ -1,0 +1,19 @@
+"use client"
+
+import * as React from 'react'
+import { useBackendChrome } from '@open-mercato/ui/backend/BackendChromeProvider'
+import { hasFeature } from '@open-mercato/shared/security/features'
+
+export type DealsAccess = {
+  canViewDeals: boolean
+  isReady: boolean
+}
+
+export function useDealsAccess(): DealsAccess {
+  const { payload, isReady } = useBackendChrome()
+  const canViewDeals = React.useMemo(
+    () => hasFeature(payload?.grantedFeatures ?? [], 'customers.deals.view'),
+    [payload?.grantedFeatures],
+  )
+  return { canViewDeals, isReady }
+}


### PR DESCRIPTION
Fixes #4124

## Problem

The Company V2 detail page (`/backend/customers/companies-v2/<id>`) rendered the **Deals** tab for every user, including those without `customers.deals.view`. Every surface behind that tab is properly gated — `backend/customers/deals/page.meta.ts` and `GET /api/customers/deals` both require the feature — so a user with company-view but not deal-view access saw a navigation item they could only bounce off, and selecting it fired reads that could only return 403.

## Root Cause

`CompanyDetailTabs` built `builtInTabs` as a static array with the `deals` entry hardcoded, consulting no ACL information; its call site passed none either. Separately, the tab body was driven purely by tab state seeded from the `?tab=` query param, so a deep link to `?tab=deals` mounted `DealsSection` regardless of grants.

## What Changed

- **New `useDealsAccess` hook** (`components/detail/useDealsAccess.ts`) — resolves the caller's granted features from `useBackendChrome()` and tests them with the wildcard-aware `hasFeature` from `@open-mercato/shared/security/features`. This is the same idiom `RolesSection.tsx` uses one directory over, and the one `ProgressTopBar` / `UpgradeActionBanner` use to avoid firing reads that can only 403. Using `hasFeature` (rather than `includes`/`Set.has`) is required by `packages/ui/AGENTS.md` so a `customers.*` wildcard grant still matches.
- **`CompanyDetailTabs`** — omits the `deals` tab entirely unless the feature is granted.
- **Company V2 page** — guards the `activeTab === 'deals'` body on the same check so `?tab=deals` cannot mount `DealsSection`, and falls back to the People tab. The fallback waits on the chrome payload's `isReady` flag, so a *permitted* user deep-linking `?tab=deals` is never bounced off the tab while features are still loading; the gate fails closed during load rather than open.

This is UI gating only and is not a substitute for the server-side ACL, which already holds.

## Tests

- New `__tests__/CompanyDetailTabs.test.tsx` with three cases: Deals tab renders with `customers.deals.view`, is absent without it (People remains), and still renders for a wildcard `customers.*` grant. The middle case was verified to fail without the fix and pass with it.
- Full validation gate ran locally: `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `build:app` all green. `shared` 1446/1446; `core` 7536/7537.
- Two suites fail (`packages/ui/.../format.test.ts`, `packages/core/.../DealsKpiStrip.test.tsx`) — both reproduce identically on pristine `develop` with none of these changes applied. They are pre-existing locale artifacts of a `pl-PL` machine default (`1234.5` → `"1234,50 USD"`; `1000` → `"1 tys."` not `"1K"`), unrelated to this change.

## Breaking Changes

None. `CompanyDetailTabs`'s prop shape is unchanged and `useDealsAccess` is purely additive. Note for reviewers: the component now reads backend-chrome context, and `useBackendChrome()` returns `{ payload: null }` outside a provider — so any consumer rendering `CompanyDetailTabs` without the backend shell fails closed and sees no Deals tab. The only call site is the companies-v2 page, which is inside the shell.

`PersonDetailTabs.tsx` carries the identical unconditional `deals` entry, but the reporter explicitly scoped this issue to Company V2, so it is left alone — the shared hook reduces that to a two-line follow-up if you want it folded in.

🤖 Generated by autofix.
