### PR TITLE
fix(customer_accounts): drop unreachable legacy widget injection spots (#3952)

### DIFF
--- a/packages/core/src/modules/customer_accounts/AGENTS.md
+++ b/packages/core/src/modules/customer_accounts/AGENTS.md
@@ -306,14 +306,16 @@ Both link to `/backend/customer_accounts/{sourceEntityId}` for staff review.
 
 | Spot ID | Widget | Purpose |
 |---------|--------|---------|
-| `customers.person` | `account-status` | Shows portal account status on Customers v2 person detail forms |
-| `crud-form:customers.person` | `account-status` | Alias for CrudForm hosts deriving the spot from `customers.person` |
-| `crud-form:customers:customer_person_profile:fields` | `account-status` | Shows portal account status on CRM person detail page |
-| `customers.company` | `company-users` | Shows portal users on Customers v2 company detail forms |
-| `crud-form:customers.company` | `company-users` | Alias for CrudForm hosts deriving the spot from `customers.company` |
-| `crud-form:customers:customer_company_profile:fields` | `company-users` | Shows portal users linked to a CRM company |
+| `customers.person` | `account-status` | Alias for hosts requesting the bare `customers.person` entity spot |
+| `crud-form:customers.person` | `account-status` | Shows portal account status on the person v2 detail page (`people-v2/[id]`) |
+| `customers.company` | `company-users` | Alias for hosts requesting the bare `customers.company` entity spot |
+| `crud-form:customers.company` | `company-users` | Shows portal users on the company v2 detail page (`companies-v2/[id]`) |
 
 Both inject as column 2 groups with priority 200, gated by `customer_accounts.view` feature.
+
+CrudForm derives its spot id as `crud-form:${entityId}` with every `:` normalized to `.`, so a
+registered `crud-form:` key whose entity segment still contains `:` can never be requested by any
+host. Register against the normalized (dot) form only — `injection-table.test.ts` enforces this.
 
 ## Backend Pages
 

--- a/packages/core/src/modules/customer_accounts/widgets/__tests__/injection-table.test.ts
+++ b/packages/core/src/modules/customer_accounts/widgets/__tests__/injection-table.test.ts
@@ -6,6 +6,24 @@ import type { ModuleInjectionSlot, ModuleInjectionTable } from '@open-mercato/sh
 
 import { injectionTable } from '../injection-table'
 
+const CRUD_FORM_PREFIX = 'crud-form:'
+
+// Suffixes CrudForm appends after the normalized entity id (see CrudFormInjectionSpots).
+const CRUD_FORM_SUFFIXES = [
+  'fields',
+  'header',
+  'footer',
+  'sidebar',
+  'before-fields',
+  'after-fields',
+]
+
+function entitySegmentOf(spotId: string): string {
+  const rest = spotId.slice(CRUD_FORM_PREFIX.length)
+  const suffix = CRUD_FORM_SUFFIXES.find((candidate) => rest.endsWith(`:${candidate}`))
+  return suffix ? rest.slice(0, -(suffix.length + 1)) : rest
+}
+
 function expectSingleGroupWidget(
   table: ModuleInjectionTable,
   spotId: string,
@@ -25,12 +43,8 @@ function expectSingleGroupWidget(
 }
 
 describe('customer_accounts injection table', () => {
-  it('registers the account-status widget on current v2 and legacy customer person form spots', () => {
-    for (const spotId of [
-      'customers.person',
-      'crud-form:customers.person',
-      'crud-form:customers:customer_person_profile:fields',
-    ]) {
+  it('registers the account-status widget on the spots the person detail host requests', () => {
+    for (const spotId of ['customers.person', 'crud-form:customers.person']) {
       expectSingleGroupWidget(
         injectionTable,
         spotId,
@@ -40,12 +54,8 @@ describe('customer_accounts injection table', () => {
     }
   })
 
-  it('registers the company-users widget on current v2 and legacy customer company form spots', () => {
-    for (const spotId of [
-      'customers.company',
-      'crud-form:customers.company',
-      'crud-form:customers:customer_company_profile:fields',
-    ]) {
+  it('registers the company-users widget on the spots the company detail host requests', () => {
+    for (const spotId of ['customers.company', 'crud-form:customers.company']) {
       expectSingleGroupWidget(
         injectionTable,
         spotId,
@@ -53,5 +63,17 @@ describe('customer_accounts injection table', () => {
         'customer_accounts.widgets.portalUsers',
       )
     }
+  })
+
+  // Regression guard for #3952: CrudForm builds its spot id as `crud-form:${entityId}` with
+  // every ':' normalized to '.', so a registered key whose entity segment still contains ':'
+  // is unreachable by construction — no host can ever request it. Two such keys shipped as
+  // dead "backward compatible" registrations.
+  it('registers crud-form spots only in the normalized form CrudForm can emit', () => {
+    const unreachable = Object.keys(injectionTable)
+      .filter((spotId) => spotId.startsWith(CRUD_FORM_PREFIX))
+      .filter((spotId) => entitySegmentOf(spotId).includes(':'))
+
+    expect(unreachable).toEqual([])
   })
 })

--- a/packages/core/src/modules/customer_accounts/widgets/__tests__/injection-table.test.ts
+++ b/packages/core/src/modules/customer_accounts/widgets/__tests__/injection-table.test.ts
@@ -8,20 +8,21 @@ import { injectionTable } from '../injection-table'
 
 const CRUD_FORM_PREFIX = 'crud-form:'
 
-// Suffixes CrudForm appends after the normalized entity id (see CrudFormInjectionSpots).
-const CRUD_FORM_SUFFIXES = [
-  'fields',
-  'header',
-  'footer',
-  'sidebar',
-  'before-fields',
-  'after-fields',
+// The suffix grammar CrudFormInjectionSpots can append after the entity id. CrudForm normalizes
+// every ':' in the entity id to '.', so the entity id is always the first ':'-delimited token and
+// anything after it must match one of these shapes.
+const CRUD_FORM_SUFFIX_PATTERNS = [
+  /^$/,
+  /^(fields|header|footer|sidebar|before-fields|after-fields)$/,
+  /^group:[^:]+$/,
+  /^field:[^:]+:(before|after)$/,
 ]
 
-function entitySegmentOf(spotId: string): string {
+function isReachableCrudFormSpot(spotId: string): boolean {
   const rest = spotId.slice(CRUD_FORM_PREFIX.length)
-  const suffix = CRUD_FORM_SUFFIXES.find((candidate) => rest.endsWith(`:${candidate}`))
-  return suffix ? rest.slice(0, -(suffix.length + 1)) : rest
+  const separatorIndex = rest.indexOf(':')
+  const suffix = separatorIndex === -1 ? '' : rest.slice(separatorIndex + 1)
+  return CRUD_FORM_SUFFIX_PATTERNS.some((pattern) => pattern.test(suffix))
 }
 
 function expectSingleGroupWidget(
@@ -65,15 +66,28 @@ describe('customer_accounts injection table', () => {
     }
   })
 
-  // Regression guard for #3952: CrudForm builds its spot id as `crud-form:${entityId}` with
-  // every ':' normalized to '.', so a registered key whose entity segment still contains ':'
-  // is unreachable by construction — no host can ever request it. Two such keys shipped as
-  // dead "backward compatible" registrations.
+  // Regression guard for #3952: CrudForm builds its spot id as `crud-form:${entityId}` with every
+  // ':' normalized to '.', so a key carrying an un-normalized (colon-form) entity id is unreachable
+  // by construction — no host can ever request it. Two such keys shipped as dead "backward
+  // compatible" registrations.
   it('registers crud-form spots only in the normalized form CrudForm can emit', () => {
     const unreachable = Object.keys(injectionTable)
       .filter((spotId) => spotId.startsWith(CRUD_FORM_PREFIX))
-      .filter((spotId) => entitySegmentOf(spotId).includes(':'))
+      .filter((spotId) => !isReachableCrudFormSpot(spotId))
 
     expect(unreachable).toEqual([])
+  })
+
+  it('accepts the structured crud-form suffixes CrudFormInjectionSpots can emit', () => {
+    for (const spotId of [
+      'crud-form:customers.person',
+      'crud-form:customers.person:fields',
+      'crud-form:customers.person:group:details',
+      'crud-form:customers.person:field:email:before',
+    ]) {
+      expect(isReachableCrudFormSpot(spotId)).toBe(true)
+    }
+
+    expect(isReachableCrudFormSpot('crud-form:customers:customer_person_profile:fields')).toBe(false)
   })
 })

--- a/packages/core/src/modules/customer_accounts/widgets/injection-table.ts
+++ b/packages/core/src/modules/customer_accounts/widgets/injection-table.ts
@@ -19,10 +19,8 @@ const companyUsersWidget = {
 export const injectionTable: ModuleInjectionTable = {
   'customers.person': [accountStatusWidget],
   'crud-form:customers.person': [accountStatusWidget],
-  'crud-form:customers:customer_person_profile:fields': [accountStatusWidget],
   'customers.company': [companyUsersWidget],
   'crud-form:customers.company': [companyUsersWidget],
-  'crud-form:customers:customer_company_profile:fields': [companyUsersWidget],
   // Step 4.10 — Portal AiChat injection example.
   // Mapped to the portal profile page's `pageAfter('profile')` spot;
   // third-party modules targeting other portal pages can copy this entry.


### PR DESCRIPTION
Fixes #3952

## Problem

`customer_accounts` registered two widget injection spots — `crud-form:customers:customer_person_profile:fields` and `crud-form:customers:customer_company_profile:fields` — documented as backward-compatible support so the Account Status / Portal Users widgets would "still render on the legacy CRM detail pages". They render on neither, and the registrations are dead.

## Root Cause

The keys are unreachable **by construction**, not merely uncalled:

- Spot resolution (`packages/shared/src/modules/widgets/injection-loader.ts:549`) is an exact-key match; wildcards are honored only when the *registered* key contains `*`, and these do not.
- `CrudForm` derives its spot id as `` crud-form:${entityId} `` with every `:` normalized to `.` (`packages/ui/src/backend/CrudForm.tsx:818`). A colon-form entity segment can therefore never be emitted by any CrudForm host, for any entity.

The documented BC claim was also false on a second count: the legacy pages request `customers.person.detail:details` / `customers.company.detail:details` (`people/[id]/page.tsx:925`, `companies/[id]/page.tsx:970`), which were never registered. And per SPEC-046 the people/companies lists now row-click to `people-v2/[id]` / `companies-v2/[id]`, leaving the legacy routes orphaned.

The widgets do render where users actually go: the v2 pages pass `injectionSpotId="crud-form:customers.person"` / `"crud-form:customers.company"` explicitly, and those registrations are untouched by this PR.

The existing test only asserted the table *contained* the keys — never that any host requests them — which is exactly why this shipped.

## What Changed

- `widgets/injection-table.ts` — removed the two unreachable colon-form registrations. The live v2 spots (`crud-form:customers.person`, `crud-form:customers.company`), the bare entity aliases, and `portal:profile:after` are unchanged.
- `AGENTS.md` — the injection table now names the v2 detail pages as the real host instead of claiming legacy CRM-page support, and documents the `:` → `.` normalization rule so nobody re-adds a colon-form key.
- `widgets/__tests__/injection-table.test.ts` — replaced the tautological assertions with a structural reachability guard.

### Why not wire the legacy pages instead?

The issue offered that alternative. It would require editing the `customers` module: the widgets read `context.recordId`, but the legacy pages' `injectionContext` supplies only `personId` / `resourceId`, so a registration there would render an inert, empty card — cross-module scope creep for routes nothing links to.

## Tests

- New guard: for every `crud-form:*` key, strip the known suffix and assert the entity segment contains no `:`. Verified it genuinely regresses — against the pre-fix table it **fails**, naming both dead keys; against the fixed table it passes.
- Retained assertions that the live v2 spots still map to `account-status` / `company-users`, so the working rendering cannot regress.
- Full validation gate green (Runner: local): `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test` (22/22 tasks), `build:app`.

## Breaking Changes

None under the documented contract, but flagging it since it touches a listed surface. `BACKWARD_COMPATIBILITY.md` §6 protects spot IDs **exposed by pages** ("MUST NOT remove an existing spot ID from a page") and spot-ID resolution / table type — this PR changes neither. It removes two registrations this module made *onto* addresses that no page exposes and that `CrudForm` cannot emit. The only consumer that could notice is a third party hand-writing `<InjectionSpot spotId="crud-form:customers:customer_person_profile:fields">`, which is implausible precisely because CrudForm cannot produce that id.

🤖 Generated by autofix.
