### PR TITLE
security(dashboards): bound dashboard layout and widget-assignment arrays (#3844)

### DIFF
--- a/packages/core/src/modules/dashboards/__tests__/layout-payload-bounds.test.ts
+++ b/packages/core/src/modules/dashboards/__tests__/layout-payload-bounds.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @jest-environment node
+ */
+import {
+  MAX_DASHBOARD_LAYOUT_ITEMS,
+  MAX_DASHBOARD_WIDGET_ASSIGNMENTS,
+  dashboardLayoutSchema,
+  roleWidgetSettingsSchema,
+  userWidgetSettingsSchema,
+} from '@open-mercato/core/modules/dashboards/data/validators'
+
+// Zod v4 .uuid() requires versioned UUID (v1-v8 variant bits).
+const uuidAt = (index: number) => `00000000-0000-4000-8000-${index.toString(16).padStart(12, '0')}`
+
+const buildItems = (count: number, widgetId = 'widget-a') =>
+  Array.from({ length: count }, (_, index) => ({
+    id: uuidAt(index),
+    widgetId,
+    order: index,
+  }))
+
+describe('dashboardLayoutSchema — items array bounds', () => {
+  test('rejects an items array above the cap', () => {
+    const result = dashboardLayoutSchema.safeParse({
+      items: buildItems(MAX_DASHBOARD_LAYOUT_ITEMS + 1),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects the duplicate-widgetId inflation vector that survives the allowedIds filter', () => {
+    const result = dashboardLayoutSchema.safeParse({
+      items: buildItems(5000, 'allowed-widget'),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('accepts an items array at the cap', () => {
+    const result = dashboardLayoutSchema.safeParse({
+      items: buildItems(MAX_DASHBOARD_LAYOUT_ITEMS),
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('accepts a realistic layout', () => {
+    const result = dashboardLayoutSchema.safeParse({
+      items: [
+        { id: uuidAt(1), widgetId: 'revenue-kpi', order: 0, size: 'md' },
+        { id: uuidAt(2), widgetId: 'orders-kpi', order: 1, size: 'sm' },
+      ],
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.items).toHaveLength(2)
+  })
+
+  test('accepts an empty layout', () => {
+    expect(dashboardLayoutSchema.safeParse({ items: [] }).success).toBe(true)
+  })
+})
+
+describe('role/user widget settings — widgetIds array bounds', () => {
+  const validRoleId = '11111111-1111-4111-8111-111111111111'
+  const validUserId = '22222222-2222-4222-8222-222222222222'
+  const buildWidgetIds = (count: number) => Array.from({ length: count }, () => 'widget-a')
+
+  test('roleWidgetSettingsSchema rejects widgetIds above the cap', () => {
+    const result = roleWidgetSettingsSchema.safeParse({
+      roleId: validRoleId,
+      widgetIds: buildWidgetIds(MAX_DASHBOARD_WIDGET_ASSIGNMENTS + 1),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('roleWidgetSettingsSchema accepts widgetIds at the cap', () => {
+    const result = roleWidgetSettingsSchema.safeParse({
+      roleId: validRoleId,
+      widgetIds: buildWidgetIds(MAX_DASHBOARD_WIDGET_ASSIGNMENTS),
+    })
+    expect(result.success).toBe(true)
+  })
+
+  test('userWidgetSettingsSchema rejects widgetIds above the cap', () => {
+    const result = userWidgetSettingsSchema.safeParse({
+      userId: validUserId,
+      mode: 'override',
+      widgetIds: buildWidgetIds(MAX_DASHBOARD_WIDGET_ASSIGNMENTS + 1),
+    })
+    expect(result.success).toBe(false)
+  })
+
+  test('userWidgetSettingsSchema accepts a realistic assignment list', () => {
+    const result = userWidgetSettingsSchema.safeParse({
+      userId: validUserId,
+      mode: 'override',
+      widgetIds: ['revenue-kpi', 'orders-kpi'],
+    })
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    expect(result.data.widgetIds).toEqual(['revenue-kpi', 'orders-kpi'])
+  })
+})

--- a/packages/core/src/modules/dashboards/data/validators.ts
+++ b/packages/core/src/modules/dashboards/data/validators.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod'
 
+export const MAX_DASHBOARD_LAYOUT_ITEMS = 100
+export const MAX_DASHBOARD_WIDGET_ASSIGNMENTS = 200
+
 export const dashboardWidgetIdSchema = z.string().min(1)
 
 export const dashboardLayoutItemSchema = z.object({
@@ -12,7 +15,7 @@ export const dashboardLayoutItemSchema = z.object({
 })
 
 export const dashboardLayoutSchema = z.object({
-  items: z.array(dashboardLayoutItemSchema),
+  items: z.array(dashboardLayoutItemSchema).max(MAX_DASHBOARD_LAYOUT_ITEMS),
 })
 
 export const dashboardLayoutItemPatchSchema = z.object({
@@ -23,13 +26,13 @@ export const dashboardLayoutItemPatchSchema = z.object({
 
 export const roleWidgetSettingsSchema = z.object({
   roleId: z.string().uuid(),
-  widgetIds: z.array(dashboardWidgetIdSchema),
+  widgetIds: z.array(dashboardWidgetIdSchema).max(MAX_DASHBOARD_WIDGET_ASSIGNMENTS),
 })
 
 export const userWidgetSettingsSchema = z.object({
   userId: z.string().uuid(),
   mode: z.enum(['inherit', 'override']).default('inherit'),
-  widgetIds: z.array(dashboardWidgetIdSchema),
+  widgetIds: z.array(dashboardWidgetIdSchema).max(MAX_DASHBOARD_WIDGET_ASSIGNMENTS),
 })
 
 export type DashboardLayoutPayload = z.infer<typeof dashboardLayoutSchema>


### PR DESCRIPTION
Fixes #3844

## Problem

`dashboardLayoutSchema.items` was an unbounded `z.array(dashboardLayoutItemSchema)`. Any authenticated user holding `dashboards.configure` could `PUT /api/dashboards/layout` with an arbitrarily large `items` array, inflating their own `layout_json` JSON column and the cost of every subsequent GET/normalize pass on that row. The same unbounded-array shape existed in `roleWidgetSettingsSchema.widgetIds` and `userWidgetSettingsSchema.widgetIds` (the `dashboards.admin.assign-widgets` surface).

Self-scoped (one row per user, keyed on `auth.sub`), so the blast radius is the caller's own row and request — a storage-inflation / self-DoS rather than a cross-tenant issue.

## Root Cause

The PUT handler (`api/layout/route.ts:259-288`) does bound *which* widgets may appear — it filters items against `allowedSet` and rejects duplicate `item.id` UUIDs — but neither step bounds array **length**. `Array.prototype.filter` does not dedupe, and the uniqueness check only looks at `item.id`, so the *same* allowed `widgetId` repeated across thousands of distinct UUIDs survives both checks and the whole array is written to `layout.layoutJson` and flushed. The role/user widget-assignment routes filter against a valid-id set with the same non-deduping, non-capping semantics.

## What Changed

- `packages/core/src/modules/dashboards/data/validators.ts`:
  - Added `MAX_DASHBOARD_LAYOUT_ITEMS = 100` and `MAX_DASHBOARD_WIDGET_ASSIGNMENTS = 200`, following the module's existing `MAX_BATCH_SIZE` constant convention (`api/widgets/data/batch/route.ts`).
  - Applied `.max(...)` to `dashboardLayoutSchema.items`, `roleWidgetSettingsSchema.widgetIds`, and `userWidgetSettingsSchema.widgetIds`.

No route code changed: all three PUT handlers already return `400 Invalid payload` with `parsed.error.issues` when `safeParse` fails, so the cap surfaces as a normal validation error.

**Cap sizing:** 24 dashboard widgets are registered across the entire repo today, so 100 layout items and 200 assignment entries leave large headroom — no realistic layout, and no admin "enable everything" on a large install, can be falsely rejected.

## Tests

- New `packages/core/src/modules/dashboards/__tests__/layout-payload-bounds.test.ts` (9 tests): over-cap rejection, the specific duplicate-`widgetId` inflation vector (5000 items) that survives the `allowedIds` filter, at-cap acceptance, realistic and empty layouts, and both `widgetIds` assignment schemas.
- Verified as genuine regression coverage: with the validator change reverted, exactly the 4 "rejects over-cap" tests fail while the 5 acceptance tests still pass; with the fix, all 9 pass.
- Full validation gate (local runner) green in order: `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`. Core suite: 987 suites / 7566 tests passing.
- Two failures were confirmed **pre-existing and unrelated** — they reproduce identically on a pristine `develop` with zero changes applied: `packages/ui` `format.test.ts` and `packages/core` `DealsKpiStrip.test.tsx`, both caused by the dev machine's Polish locale formatting currency as `1234,50 USD`.

## Breaking Changes

None. The `z.infer` types (`DashboardLayoutPayload`, `RoleWidgetSettingsPayload`, `UserWidgetSettingsPayload`) are unchanged, no API route or response field changed, and the two new exported constants are additive. `dashboardLayoutSchema` is re-exported through `api/openapi.ts` into `dashboardLayoutStateSchema`, so the generated OpenAPI gains an additive `maxItems` annotation (not runtime-enforced on responses). Input validation is strictly tighter by design; only payloads far beyond any real use case are rejected.

🤖 Generated by autofix.
