### PR TITLE
security(dictionaries): make entry command ensureScope fail closed on null org/tenant (#3846)

### DIFF
--- a/packages/core/src/modules/dictionaries/commands/__tests__/ensure-scope.test.ts
+++ b/packages/core/src/modules/dictionaries/commands/__tests__/ensure-scope.test.ts
@@ -1,0 +1,104 @@
+import { ensureDictionaryEntryScope } from '@open-mercato/core/modules/dictionaries/commands/factory'
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+
+type ScopeShape = NonNullable<CommandRuntimeContext['organizationScope']>
+
+function buildCtx(overrides: {
+  auth?: CommandRuntimeContext['auth']
+  isSuperAdmin?: boolean
+  tenantId?: string | null
+  orgId?: string | null
+  selectedOrganizationId?: string | null
+  organizationScope?: ScopeShape | null
+}): CommandRuntimeContext {
+  const auth =
+    overrides.auth === null
+      ? null
+      : {
+          sub: 'user-1',
+          tenantId: overrides.tenantId === undefined ? 'tenant-1' : overrides.tenantId,
+          orgId: overrides.orgId ?? null,
+          isSuperAdmin: overrides.isSuperAdmin ?? false,
+        }
+  return {
+    container: {} as CommandRuntimeContext['container'],
+    auth: auth as CommandRuntimeContext['auth'],
+    organizationScope: overrides.organizationScope ?? null,
+    selectedOrganizationId: overrides.selectedOrganizationId ?? null,
+    organizationIds: null,
+  }
+}
+
+function buildOrganizationScope(overrides: Partial<ScopeShape>): ScopeShape {
+  return {
+    selectedId: null,
+    filterIds: null,
+    allowedIds: null,
+    tenantId: 'tenant-1',
+    ...overrides,
+  } as ScopeShape
+}
+
+const targetScope = { tenantId: 'tenant-1', organizationId: 'org-victim' }
+
+describe('ensureDictionaryEntryScope', () => {
+  it('denies a restricted user with no resolved organization acting on another organization (#3846)', () => {
+    const ctx = buildCtx({
+      selectedOrganizationId: null,
+      orgId: null,
+      organizationScope: buildOrganizationScope({ allowedIds: ['org-attacker'] }),
+    })
+
+    expect(() => ensureDictionaryEntryScope(ctx, targetScope)).toThrow(CrudHttpError)
+    try {
+      ensureDictionaryEntryScope(ctx, targetScope)
+    } catch (err) {
+      expect((err as CrudHttpError).status).toBe(403)
+    }
+  })
+
+  it('denies a cross-tenant actor', () => {
+    const ctx = buildCtx({
+      tenantId: 'tenant-other',
+      selectedOrganizationId: 'org-victim',
+      organizationScope: buildOrganizationScope({ tenantId: 'tenant-other', allowedIds: ['org-victim'] }),
+    })
+
+    expect(() => ensureDictionaryEntryScope(ctx, targetScope)).toThrow(CrudHttpError)
+  })
+
+  it('denies a restricted user acting on an organization outside their allowed set', () => {
+    const ctx = buildCtx({
+      selectedOrganizationId: 'org-attacker',
+      organizationScope: buildOrganizationScope({ allowedIds: ['org-attacker'] }),
+    })
+
+    expect(() => ensureDictionaryEntryScope(ctx, targetScope)).toThrow(CrudHttpError)
+  })
+
+  it('allows a super admin with no resolved organization', () => {
+    const ctx = buildCtx({
+      isSuperAdmin: true,
+      selectedOrganizationId: null,
+      organizationScope: buildOrganizationScope({ allowedIds: ['org-attacker'] }),
+    })
+
+    expect(() => ensureDictionaryEntryScope(ctx, targetScope)).not.toThrow()
+  })
+
+  it('allows a user whose allowed set contains the target organization', () => {
+    const ctx = buildCtx({
+      selectedOrganizationId: 'org-victim',
+      organizationScope: buildOrganizationScope({ allowedIds: ['org-victim', 'org-other'] }),
+    })
+
+    expect(() => ensureDictionaryEntryScope(ctx, targetScope)).not.toThrow()
+  })
+
+  it('preserves system contexts without an authenticated actor', () => {
+    const ctx = buildCtx({ auth: null, organizationScope: null })
+
+    expect(() => ensureDictionaryEntryScope(ctx, targetScope)).not.toThrow()
+  })
+})

--- a/packages/core/src/modules/dictionaries/commands/__tests__/ensure-scope.test.ts
+++ b/packages/core/src/modules/dictionaries/commands/__tests__/ensure-scope.test.ts
@@ -1,4 +1,7 @@
-import { ensureDictionaryEntryScope } from '@open-mercato/core/modules/dictionaries/commands/factory'
+import {
+  ensureDictionaryEntryScope,
+  toScopeEnsurer,
+} from '@open-mercato/core/modules/dictionaries/commands/factory'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 
@@ -100,5 +103,25 @@ describe('ensureDictionaryEntryScope', () => {
     const ctx = buildCtx({ auth: null, organizationScope: null })
 
     expect(() => ensureDictionaryEntryScope(ctx, targetScope)).not.toThrow()
+  })
+})
+
+describe('toScopeEnsurer', () => {
+  it('falls back to the fail-closed ensurer when a registrar omits ensureScope (#3846)', () => {
+    const ctx = buildCtx({
+      selectedOrganizationId: null,
+      orgId: null,
+      organizationScope: buildOrganizationScope({ allowedIds: ['org-attacker'] }),
+    })
+
+    expect(() => toScopeEnsurer(undefined)(ctx, targetScope)).toThrow(CrudHttpError)
+  })
+
+  it('uses the ensurer a registrar provides', () => {
+    const provided = jest.fn()
+
+    toScopeEnsurer(provided)(buildCtx({}), targetScope)
+
+    expect(provided).toHaveBeenCalledWith(expect.anything(), targetScope)
   })
 })

--- a/packages/core/src/modules/dictionaries/commands/entries.ts
+++ b/packages/core/src/modules/dictionaries/commands/entries.ts
@@ -4,21 +4,12 @@ import {
   dictionaryEntryCommandCreateSchema,
   dictionaryEntryCommandUpdateSchema,
 } from '@open-mercato/core/modules/dictionaries/data/validators'
-import { registerDictionaryEntryCommands } from '@open-mercato/core/modules/dictionaries/commands/factory'
-import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import {
+  ensureDictionaryEntryScope,
+  registerDictionaryEntryCommands,
+} from '@open-mercato/core/modules/dictionaries/commands/factory'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-
-function ensureScope(ctx: CommandRuntimeContext, scope: { tenantId: string; organizationId: string }): void {
-  const tenantId = ctx.auth?.tenantId ?? null
-  if (tenantId && tenantId !== scope.tenantId) {
-    throw new CrudHttpError(403, { error: 'Forbidden' })
-  }
-  const organizationId = ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null
-  if (organizationId && organizationId !== scope.organizationId) {
-    throw new CrudHttpError(403, { error: 'Forbidden' })
-  }
-}
 
 async function ensureDictionary(em: EntityManager, id: string): Promise<Dictionary> {
   const dictionary = await em.findOne(Dictionary, {
@@ -37,12 +28,12 @@ registerDictionaryEntryCommands({
   translationKeyPrefix: 'dictionaries.entries',
   createSchema: dictionaryEntryCommandCreateSchema,
   updateSchema: dictionaryEntryCommandUpdateSchema,
-  ensureScope,
+  ensureScope: ensureDictionaryEntryScope,
   duplicateError: 'An entry with this value already exists.',
   resolveDictionaryForCreate: async ({ em, ctx, parsed }) => {
     const dictionary = await ensureDictionary(em, parsed.dictionaryId)
     const scope = { tenantId: dictionary.tenantId, organizationId: dictionary.organizationId }
-    ensureScope(ctx, scope)
+    ensureDictionaryEntryScope(ctx, scope)
     return { dictionary, scope }
   },
   resolveEntry: async ({ em, ctx, id }) => {
@@ -54,7 +45,7 @@ registerDictionaryEntryCommands({
       throw new CrudHttpError(404, { error: 'Dictionary not found' })
     }
     const scope = { tenantId: entry.tenantId, organizationId: entry.organizationId }
-    ensureScope(ctx, scope)
+    ensureDictionaryEntryScope(ctx, scope)
     return { entry, dictionary: entry.dictionary, scope }
   },
   ensureDictionaryForUndo: async ({ em, snapshot }) => {

--- a/packages/core/src/modules/dictionaries/commands/entry-operations.ts
+++ b/packages/core/src/modules/dictionaries/commands/entry-operations.ts
@@ -7,7 +7,7 @@ import {
   type SetDefaultDictionaryEntryCommandInput,
 } from '@open-mercato/core/modules/dictionaries/data/validators'
 import { ensureDictionaryEntryScope } from '@open-mercato/core/modules/dictionaries/commands/factory'
-import { registerCommand, type CommandHandler, type CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/commands'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
 import { emitCrudSideEffects, emitCrudUndoSideEffects } from '@open-mercato/shared/lib/commands/helpers'
@@ -35,10 +35,6 @@ const dictionaryCrudEvents: CrudEventsConfig = {
     tenantId: ctx.identifiers.tenantId,
     ...(ctx.syncOrigin ? { syncOrigin: ctx.syncOrigin } : {}),
   }),
-}
-
-function ensureScope(ctx: CommandRuntimeContext, scope: DictionaryScope): void {
-  ensureDictionaryEntryScope(ctx, scope)
 }
 
 async function requireDictionary(
@@ -78,7 +74,7 @@ const reorderDictionaryEntriesCommand: CommandHandler<
   async prepare(rawInput, ctx) {
     const parsed = reorderDictionaryEntriesCommandSchema.parse(rawInput)
     const scope: DictionaryScope = { tenantId: parsed.tenantId, organizationId: parsed.organizationId }
-    ensureScope(ctx, scope)
+    ensureDictionaryEntryScope(ctx, scope)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const ids = parsed.entries.map((e) => e.id)
     const existing = await findWithDecryption(
@@ -102,7 +98,7 @@ const reorderDictionaryEntriesCommand: CommandHandler<
   async execute(rawInput, ctx) {
     const parsed = reorderDictionaryEntriesCommandSchema.parse(rawInput)
     const scope: DictionaryScope = { tenantId: parsed.tenantId, organizationId: parsed.organizationId }
-    ensureScope(ctx, scope)
+    ensureDictionaryEntryScope(ctx, scope)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const dictionary = await requireDictionary(em, parsed.dictionaryId, scope)
@@ -195,7 +191,7 @@ const reorderDictionaryEntriesCommand: CommandHandler<
     const undo = extractUndoPayload<ReorderUndoPayload>(logEntry)
     const before = undo?.before ?? (logEntry?.snapshotBefore as ReorderSnapshot | null | undefined) ?? null
     if (!before) return
-    ensureScope(ctx, before.scope)
+    ensureDictionaryEntryScope(ctx, before.scope)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const ids = before.positions.map((p) => p.id)
@@ -259,7 +255,7 @@ const setDefaultDictionaryEntryCommand: CommandHandler<
   async prepare(rawInput, ctx) {
     const parsed = setDefaultDictionaryEntryCommandSchema.parse(rawInput)
     const scope: DictionaryScope = { tenantId: parsed.tenantId, organizationId: parsed.organizationId }
-    ensureScope(ctx, scope)
+    ensureDictionaryEntryScope(ctx, scope)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const dictionary = await requireDictionary(em, parsed.dictionaryId, scope)
     const previousDefaults = await findWithDecryption(
@@ -285,7 +281,7 @@ const setDefaultDictionaryEntryCommand: CommandHandler<
   async execute(rawInput, ctx) {
     const parsed = setDefaultDictionaryEntryCommandSchema.parse(rawInput)
     const scope: DictionaryScope = { tenantId: parsed.tenantId, organizationId: parsed.organizationId }
-    ensureScope(ctx, scope)
+    ensureDictionaryEntryScope(ctx, scope)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const dictionary = await requireDictionary(em, parsed.dictionaryId, scope)
@@ -393,7 +389,7 @@ const setDefaultDictionaryEntryCommand: CommandHandler<
     const undo = extractUndoPayload<DefaultUndoPayload>(logEntry)
     const before = undo?.before ?? (logEntry?.snapshotBefore as DefaultSnapshot | null | undefined) ?? null
     if (!before) return
-    ensureScope(ctx, before.scope)
+    ensureDictionaryEntryScope(ctx, before.scope)
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const dictionary = await requireDictionary(em, before.dictionaryId, before.scope)

--- a/packages/core/src/modules/dictionaries/commands/entry-operations.ts
+++ b/packages/core/src/modules/dictionaries/commands/entry-operations.ts
@@ -6,6 +6,7 @@ import {
   type ReorderDictionaryEntriesCommandInput,
   type SetDefaultDictionaryEntryCommandInput,
 } from '@open-mercato/core/modules/dictionaries/data/validators'
+import { ensureDictionaryEntryScope } from '@open-mercato/core/modules/dictionaries/commands/factory'
 import { registerCommand, type CommandHandler, type CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
@@ -37,14 +38,7 @@ const dictionaryCrudEvents: CrudEventsConfig = {
 }
 
 function ensureScope(ctx: CommandRuntimeContext, scope: DictionaryScope): void {
-  const tenantId = ctx.auth?.tenantId ?? null
-  if (tenantId && tenantId !== scope.tenantId) {
-    throw new CrudHttpError(403, { error: 'Forbidden' })
-  }
-  const organizationId = ctx.selectedOrganizationId ?? ctx.auth?.orgId ?? null
-  if (organizationId && organizationId !== scope.organizationId) {
-    throw new CrudHttpError(403, { error: 'Forbidden' })
-  }
+  ensureDictionaryEntryScope(ctx, scope)
 }
 
 async function requireDictionary(

--- a/packages/core/src/modules/dictionaries/commands/factory.ts
+++ b/packages/core/src/modules/dictionaries/commands/factory.ts
@@ -93,7 +93,7 @@ export type DictionaryEntryCommandConfig<TCreate, TUpdate> = {
   labels?: DictionaryEntryCommandLabels
 }
 
-function toScopeEnsurer(fn: EnsureScopeFn | undefined): EnsureScopeFn {
+export function toScopeEnsurer(fn: EnsureScopeFn | undefined): EnsureScopeFn {
   return typeof fn === 'function' ? fn : ensureDictionaryEntryScope
 }
 

--- a/packages/core/src/modules/dictionaries/commands/factory.ts
+++ b/packages/core/src/modules/dictionaries/commands/factory.ts
@@ -12,6 +12,7 @@ import {
 } from '@open-mercato/shared/lib/commands'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
 import { buildChanges, requireId } from '@open-mercato/shared/lib/commands/helpers'
+import { ensureOrganizationScope, ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { z } from 'zod'
@@ -20,6 +21,11 @@ import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 type DictionaryScope = {
   tenantId: string
   organizationId: string
+}
+
+export function ensureDictionaryEntryScope(ctx: CommandRuntimeContext, scope: DictionaryScope): void {
+  ensureTenantScope(ctx, scope.tenantId)
+  ensureOrganizationScope(ctx, scope.organizationId)
 }
 
 export type DictionaryEntrySnapshot = {
@@ -88,7 +94,7 @@ export type DictionaryEntryCommandConfig<TCreate, TUpdate> = {
 }
 
 function toScopeEnsurer(fn: EnsureScopeFn | undefined): EnsureScopeFn {
-  return typeof fn === 'function' ? fn : () => {}
+  return typeof fn === 'function' ? fn : ensureDictionaryEntryScope
 }
 
 async function loadSnapshot(em: EntityManager, id: string): Promise<DictionaryEntrySnapshot | null> {


### PR DESCRIPTION
Fixes #3846

## Problem
`ensureScope` — the shared command-layer authorization primitive for dictionary-entry create/update/delete/reorder/set-default — skipped its comparison whenever the resolved organization (or tenant) was `null`, making command-layer authz **fail open** rather than fail closed.

### Reachability — precisely scoped
`dictionaries/api/context.ts:45` resolves `organizationId = scope?.selectedId ?? auth.orgId ?? null`, so a null organization is a real request state. But it does **not** reach the command layer on every route, and the honest picture is narrower than "all five commands were exposed":

- **`POST /entries` (create) — genuinely exploitable.** It calls `commandBus.execute('dictionaries.entries.create')` directly (`route.ts:193`) with **no route-level null-org guard**, and the command's `ensureDictionary` (`commands/entries.ts:15`) loads the dictionary **by id alone, with no tenant/org filter**. So `ensureScope` was the *only* authorization boundary — and with a null org it was a no-op. An org-restricted principal with no selected organization could create entries in any dictionary in their tenant. (Cross-*tenant* was never open: `context.ts` 401s without `auth.tenantId`, so the tenant comparison always ran.)
- **The other three routes already 400 on a null org** before the command bus: `[entryId]/route.ts:33` (update/delete), `reorder/route.ts:46`, `set-default/route.ts:46` all raise `dictionaries.errors.organization_required`. For them the command-layer fix is **defense in depth**, not the removal of a live hole.

The fix is worth landing on the strength of the create path alone, plus the fact that the guard is the sole boundary there — but the blast radius is one route, not five.

## Root Cause
Both copies of the guard — `commands/entries.ts:12-21` and `commands/entry-operations.ts:39-48` — used the pattern `if (organizationId && organizationId !== scope.organizationId)`. When `organizationId` (or `tenantId`) resolved `null`, the comparison was skipped entirely and no 403 was raised.

This was a departure from the platform convention. Sales, customers, and translations all route command scope checks through the shared, fail-closed primitives in `packages/shared/src/lib/commands/scope.ts` (`ensureTenantScope` / `ensureOrganizationScope`), which were already hardened for exactly this bug class (#2441 fail-open-by-omission, #2239, #3910) and are backed by the `isOrganizationAccessAllowed` predicate. Dictionaries was the last hand-rolled outlier — and decisively, `sales/commands/statuses.ts:37-40` registers **the same `registerDictionaryEntryCommands` factory** with the correct body already.

## What Changed
- **`commands/factory.ts`** — added a canonical `ensureDictionaryEntryScope` that delegates to `ensureTenantScope` + `ensureOrganizationScope`, mirroring the sales implementation.
- **`commands/entries.ts` / `commands/entry-operations.ts`** — replaced both hand-rolled fail-open bodies with that primitive (covers create, update, delete, reorder, set-default, and both undo handlers).
- **`commands/factory.ts` — second fail-open-by-omission closed:** `toScopeEnsurer` defaulted to a no-op `() => {}`, so any future registrar omitting `ensureScope` would silently get **zero** command-layer authz. It now defaults to the fail-closed ensurer. This is the "harden the primitive itself" part of the issue.

### Behavior changes — both directions, stated plainly
This PR is **not** a pure tightening. Replacing the hand-rolled check with the platform decision table changes behavior in two directions, and both are intentional:

**Tightened (the fix).** An org-restricted principal acting on an organization outside their allowed set — or with **no resolved organization at all** — now gets a 403 where it previously passed. This is #3846.

**Loosened.** The old check compared the target org against the *currently selected* organization (`ctx.selectedOrganizationId ?? ctx.auth?.orgId`). The new one compares it against the principal's **allowed org set** (`isOrganizationAccessAllowed`). So a user whose RBAC scope includes orgs A and B, with A selected, previously could not mutate an entry in B and now can. Two reasons this is correct rather than a regression:
- `selectedOrganizationId` is a **view filter, not a permission boundary** — it is derived from the request, so defending on it was incidental, not designed. It never constituted a real authz check.
- `allowedIds === null` (the "unrestricted" branch that allows any org) is reached only when `organizationScope.ts:300-306` resolves `accessibleList === null`, i.e. RBAC itself deems the principal org-unrestricted (superadmin or an account with no org restriction). The tenant check still holds in every case, so nothing crosses a tenant boundary.

This is exactly the decision table `sales`, `customers`, and `translations` already enforce; dictionaries was the outlier in *both* directions.

### Contract-surface note on the `toScopeEnsurer` default
Flipping the default from a no-op to the fail-closed ensurer is behavior-neutral for all three in-repo callers (each passes `ensureScope` explicitly), but it **is** a contract change for third parties: an external module registering dictionary-entry commands *without* `ensureScope` — e.g. because it had its own scope semantics — will now start getting 403s. I consider that the right call (a silently-unguarded registrar is the exact hole this issue is about, and fail-closed is the platform default), but it is a behavior change for downstream registrars rather than a no-op, and reviewers should weigh it as such. `ensureScope` itself remains **optional** on `DictionaryEntryCommandConfig` — making it required would be a hard compile break under `BACKWARD_COMPATIBILITY.md`.

### Known adjacent weakness (pre-existing, not introduced here — follow-up)
`commands/entries.ts` resolves its targets **without a tenant/org filter**: `ensureDictionary` (`:15`) does `em.findOne(Dictionary, { id, deletedAt: null })` and `resolveEntry` (`:40`) fetches the entry by id. That is why `ensureScope` is load-bearing rather than a second line of defense. `entry-operations.ts` already does this correctly (`requireDictionary` filters on `tenantId`/`organizationId`). This PR does not change that lookup — it hardens the guard that currently backstops it — but the lookups should be scope-filtered too, so a future guard regression cannot re-open the same hole. Worth a follow-up issue.

### On the issue's open question
The issue asked to "verify no legitimate flow depends on a null-scope call succeeding (e.g. a superadmin/global operation) before making it hard-reject." Verified: **none does.** Only the four HTTP routes invoke `dictionaries.entries.*` through the command bus — no seed, worker, CLI, or data_sync caller does. And the shared helpers preserve every legitimate path by design: superadmins allow, truly unrestricted principals (`allowedIds === null`) allow, and system contexts without an authenticated actor keep the load-bearing legacy fallback. So the hard-reject is gated explicitly by the shared decision table rather than by the null no-op.

## Tests
- New `commands/__tests__/ensure-scope.test.ts` — 6 unit tests: restricted user with **no resolved organization** acting on another org → 403 (the #3846 regression); cross-tenant → 403; org outside the allowed set → 403; superadmin with null org → allowed; target org inside `allowedIds` → allowed; system context without an authenticated actor → allowed.
- **Proved non-vacuous:** temporarily restoring the old fail-open body flips exactly one test — the #3846 null-org case — from pass to fail. The other five pin behavior that must *not* change.
- Full validation gate run locally (Runner: local), all 8 commands in `.ai/agentic.config.json` order: `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `build:app` all pass. Core: **987/988 suites, 7563/7564 tests**.
- Two failures appeared and **both are pre-existing on the dev machine, not regressions** — confirmed by stashing the fix and reproducing them on clean `develop`: `packages/ui` `format.test.ts` (`formatCurrency` → `"1234,50 USD"`) and `customers` `DealsKpiStrip.test.tsx` (`findByText('1K')`). Both are locale-dependent `Intl` formatting under a Polish system locale; green in CI's `en` environment and unreachable from the dictionaries command layer.

## Breaking Changes
No compile-time or wire-format breaks: no change to HTTP routes, response shapes, event IDs, or DB schema, `ensureScope` stays optional on `DictionaryEntryCommandConfig`, and `ensureDictionaryEntryScope` is a purely additive export. The runtime behavior changes are the two described above — the intended security tightening, and the `toScopeEnsurer` default flip that can newly 403 an external registrar that omitted `ensureScope`.

🤖 Generated by autofix.
