### PR TITLE
refactor(shared): add parseCommaSeparatedList() helper and adopt it across CLI/API handlers (#2363)

### DIFF
--- a/packages/core/src/modules/api_keys/cli.ts
+++ b/packages/core/src/modules/api_keys/cli.ts
@@ -3,6 +3,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { createApiKey } from './services/apiKeyService'
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import { Role } from '@open-mercato/core/modules/auth/data/entities'
+import { parseCommaSeparatedList } from '@open-mercato/shared/lib/string'
 
 function parseArgs(rest: string[]): Record<string, string> {
   const args: Record<string, string> = {}
@@ -47,9 +48,7 @@ const addApiKey: ModuleCli = {
       return
     }
 
-    const roleInputs = rolesCsv
-      ? rolesCsv.split(',').map((value) => value.trim()).filter(Boolean)
-      : []
+    const roleInputs = parseCommaSeparatedList(rolesCsv)
     const roleIds: string[] = []
     if (roleInputs.length) {
       for (const token of roleInputs) {

--- a/packages/core/src/modules/auth/cli.ts
+++ b/packages/core/src/modules/auth/cli.ts
@@ -9,6 +9,7 @@ import { Tenant, Organization } from '@open-mercato/core/modules/directory/data/
 import { rebuildHierarchyForTenant } from '@open-mercato/core/modules/directory/lib/hierarchy'
 import { ensureRoles, setupInitialTenant, ensureDefaultRoleAcls, ensureCustomRoleAcls, OrgSlugExistsError, DerivedUserPasswordRequiredError } from './lib/setup-app'
 import { normalizeTenantId } from './lib/tenantAccess'
+import { parseCommaSeparatedList } from '@open-mercato/shared/lib/string'
 import { computeEmailHash, emailHashLookupValues } from './lib/emailHash'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { isTenantDataEncryptionEnabled } from '@open-mercato/shared/lib/encryption/toggles'
@@ -71,7 +72,7 @@ const addUser: ModuleCli = {
     })
     await em.persist(u).flush()
     if (rolesCsv) {
-      const names = rolesCsv.split(',').map(s => s.trim()).filter(Boolean)
+      const names = parseCommaSeparatedList(rolesCsv)
       for (const name of names) {
         const role = await resolveTenantScopedRole(em, name, normalizedTenantId)
         const link = em.create(UserRole, { user: u, role })
@@ -493,7 +494,7 @@ const setupApp: ModuleCli = {
     const container = await createRequestContainer()
     const em = container.resolve<EntityManager>('em')
     const roleNames = rolesCsv
-      ? rolesCsv.split(',').map((s) => s.trim()).filter(Boolean)
+      ? parseCommaSeparatedList(rolesCsv)
       : undefined
 
     try {

--- a/packages/core/src/modules/dashboards/cli.ts
+++ b/packages/core/src/modules/dashboards/cli.ts
@@ -6,6 +6,7 @@ import { Role } from '@open-mercato/core/modules/auth/data/entities'
 import { loadAllWidgets } from '@open-mercato/core/modules/dashboards/lib/widgets'
 import { appendWidgetsToRoles, resolveAnalyticsWidgetIds } from '@open-mercato/core/modules/dashboards/lib/role-widgets'
 import { seedAnalyticsData } from './seed/analytics'
+import { parseCommaSeparatedList } from '@open-mercato/shared/lib/string'
 
 type Args = Record<string, string>
 
@@ -108,10 +109,7 @@ const seedDefaults: ModuleCli = {
       return
     }
 
-    const roleNames = roleCsv
-      .split(',')
-      .map((name) => name.trim())
-      .filter(Boolean)
+    const roleNames = parseCommaSeparatedList(roleCsv)
 
     if (!roleNames.length) {
       console.log('No roles provided, nothing to seed.')
@@ -125,7 +123,7 @@ const seedDefaults: ModuleCli = {
       tenantId,
       organizationId,
       roleNames,
-      widgetIds: widgetCsv ? widgetCsv.split(',').map((id) => id.trim()).filter(Boolean) : undefined,
+      widgetIds: widgetCsv ? parseCommaSeparatedList(widgetCsv) : undefined,
       logger: (message) => console.log(message),
     })
   },
@@ -143,10 +141,7 @@ const enableAnalyticsWidgets: ModuleCli = {
       return
     }
 
-    const roleNames = roleCsv
-      .split(',')
-      .map((name) => name.trim())
-      .filter(Boolean)
+    const roleNames = parseCommaSeparatedList(roleCsv)
 
     if (!roleNames.length) {
       console.log('No roles provided, nothing to update.')

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -8,6 +8,7 @@ import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacS
 import { resolveOrganizationScope, getSelectedOrganizationFromRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { SYSTEM_ENTITY_RECORDS_BLOCKED_CODE, isOrmBackedSystemEntityId } from '@open-mercato/shared/lib/data/engine'
 import { parseBooleanToken, parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
+import { parseCommaSeparatedList } from '@open-mercato/shared/lib/string'
 import { setRecordCustomFields } from '../lib/helpers'
 import { CustomFieldValue } from '../data/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -151,10 +152,7 @@ export async function GET(req: Request) {
   const sortDir = (url.searchParams.get('sortDir') || 'asc').toLowerCase() === 'desc' ? 'desc' : 'asc'
   const withDeleted = parseBooleanWithDefault(url.searchParams.get('withDeleted'), false)
   const searchTerm = (url.searchParams.get('search') || '').trim()
-  const searchFields = (url.searchParams.get('searchFields') || '')
-    .split(',')
-    .map((field) => field.trim())
-    .filter(Boolean)
+  const searchFields = parseCommaSeparatedList(url.searchParams.get('searchFields'))
 
   const qpEntries: Array<[string, string]> = []
   for (const [key, val] of url.searchParams.entries()) {
@@ -211,11 +209,11 @@ export async function GET(req: Request) {
       if (key.startsWith('cf_')) {
         if (key.endsWith('In')) {
           const base = key.slice(0, -2)
-          const values = val.split(',').map((s) => s.trim()).filter(Boolean)
+          const values = parseCommaSeparatedList(val)
           ;(filtersObj as any)[base] = { $in: values }
         } else {
           if (val.includes(',')) {
-            const values = val.split(',').map((s) => s.trim()).filter(Boolean)
+            const values = parseCommaSeparatedList(val)
             ;(filtersObj as any)[key] = { $in: values }
           } else {
             const parsed = parseBooleanToken(val)
@@ -224,7 +222,7 @@ export async function GET(req: Request) {
         }
       } else if (allowAnyKey) {
         if (val.includes(',')) {
-          const values = val.split(',').map((s) => s.trim()).filter(Boolean)
+          const values = parseCommaSeparatedList(val)
           ;(filtersObj as any)[key] = { $in: values }
         } else {
           const parsed = parseBooleanToken(val)

--- a/packages/core/src/modules/entities/cli.ts
+++ b/packages/core/src/modules/entities/cli.ts
@@ -10,6 +10,7 @@ import readline from 'node:readline/promises'
 import { stdin as input, stdout as output } from 'node:process'
 import { isTenantDataEncryptionEnabled } from '@open-mercato/shared/lib/encryption/toggles'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { parseCommaSeparatedList } from '@open-mercato/shared/lib/string'
 import { createKmsService, type KmsService, type TenantDek } from '@open-mercato/shared/lib/encryption/kms'
 import {
   decryptWithAesGcm,
@@ -193,7 +194,7 @@ const addField: ModuleCli = {
       let options: string[] | undefined
       if (kind === 'select') {
         const raw = (args.options as string) || await ask('Options (comma-separated)', 'low,medium,high')
-        options = raw.split(',').map((s) => s.trim()).filter(Boolean)
+        options = parseCommaSeparatedList(raw)
       }
       let defaultValue: any = undefined
       const defRaw = (args.default as string) ?? (args.defaultValue as string)

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -52,6 +52,7 @@ yarn workspace @open-mercato/shared build
 | `number.ts` | When parsing numeric strings from env/query params with a fallback and optional min/integer constraint | `@open-mercato/shared/lib/number` |
 | `openapi/` | When generating CRUD OpenAPI specs | `@open-mercato/shared/lib/openapi/crud` |
 | `profiler/` | When profiling with `OM_PROFILE` env flag | `@open-mercato/shared/lib/profiler` |
+| `string.ts` | When parsing comma-separated lists from CLI args/query params, or coercing a string to `undefined` when blank | `@open-mercato/shared/lib/string` |
 | `testing/` | When bootstrapping tests — register only what the test needs | `@open-mercato/shared/lib/testing/bootstrap` |
 
 ## Module Types (`src/modules/`)
@@ -92,6 +93,23 @@ const results = await findWithDecryption(em, 'Entity', filter, { tenantId, organ
 
 ```typescript
 import { parseBooleanToken, parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
+```
+
+### Comma-Separated List Parsing — MUST use instead of ad-hoc splitting
+
+```typescript
+import { parseCommaSeparatedList } from '@open-mercato/shared/lib/string'
+```
+
+`parseCommaSeparatedList(value)` splits on commas, trims each entry, and drops blanks. Non-string
+inputs (`null`/`undefined`) yield `[]`. MUST use it instead of hand-rolling
+`value.split(',').map((s) => s.trim()).filter(Boolean)` when reading CLI flags or query params.
+
+Keep the surrounding guard when a call site distinguishes "not supplied" (`undefined`) from
+"supplied but empty" (`[]`) — the helper always returns an array:
+
+```typescript
+const roleNames = rolesCsv ? parseCommaSeparatedList(rolesCsv) : undefined
 ```
 
 ### Browser Storage — use the shared helpers instead of raw `localStorage`

--- a/packages/shared/src/lib/__tests__/string.test.ts
+++ b/packages/shared/src/lib/__tests__/string.test.ts
@@ -1,0 +1,49 @@
+import { parseCommaSeparatedList, trimToUndefined } from '../string'
+
+describe('parseCommaSeparatedList', () => {
+  it('splits a comma-separated string into entries', () => {
+    expect(parseCommaSeparatedList('low,medium,high')).toEqual(['low', 'medium', 'high'])
+  })
+
+  it('trims surrounding whitespace from every entry', () => {
+    expect(parseCommaSeparatedList(' admin ,  editor,viewer  ')).toEqual(['admin', 'editor', 'viewer'])
+  })
+
+  it('drops empty entries produced by repeated or trailing separators', () => {
+    expect(parseCommaSeparatedList('a,,b,')).toEqual(['a', 'b'])
+    expect(parseCommaSeparatedList(',a, ,b')).toEqual(['a', 'b'])
+  })
+
+  it('returns an empty array when every entry is blank', () => {
+    expect(parseCommaSeparatedList(',,')).toEqual([])
+    expect(parseCommaSeparatedList('  ,  ')).toEqual([])
+  })
+
+  it('returns an empty array for blank or non-string inputs', () => {
+    expect(parseCommaSeparatedList('')).toEqual([])
+    expect(parseCommaSeparatedList('   ')).toEqual([])
+    expect(parseCommaSeparatedList(null)).toEqual([])
+    expect(parseCommaSeparatedList(undefined)).toEqual([])
+  })
+
+  it('returns a single entry when the input has no separator', () => {
+    expect(parseCommaSeparatedList('admin')).toEqual(['admin'])
+    expect(parseCommaSeparatedList('  admin  ')).toEqual(['admin'])
+  })
+
+  it('preserves interior whitespace within an entry', () => {
+    expect(parseCommaSeparatedList('order created, order shipped')).toEqual(['order created', 'order shipped'])
+  })
+})
+
+describe('trimToUndefined', () => {
+  it('returns the trimmed value when it is a non-blank string', () => {
+    expect(trimToUndefined('  value  ')).toBe('value')
+  })
+
+  it('returns undefined for blank or non-string values', () => {
+    expect(trimToUndefined('   ')).toBeUndefined()
+    expect(trimToUndefined(null)).toBeUndefined()
+    expect(trimToUndefined(42)).toBeUndefined()
+  })
+})

--- a/packages/shared/src/lib/string.ts
+++ b/packages/shared/src/lib/string.ts
@@ -6,3 +6,11 @@ export function trimToUndefined(value: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined
 }
 
+export function parseCommaSeparatedList(value: string | null | undefined): string[] {
+  if (typeof value !== 'string') return []
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+}
+


### PR DESCRIPTION
Fixes #2363

## Problem

The comma-separated-list parse `.split(',').map((s) => s.trim()).filter(Boolean)` was hand-rolled **11 times across 5 files**, with no shared helper. Each call site independently re-implemented trimming and empty-entry rejection, so the copies could drift apart over time.

## Root Cause

`packages/shared/src/lib/` already exposes parsing helpers for every other scalar input type — `boolean.ts` (`parseBooleanToken`), `number.ts`, `phone.ts` — but had no equivalent for delimited lists. Absent that helper, CLI argument handlers and API query parsers each inlined the same three-step chain.

`entities/api/records.ts` made the gap obvious: it already imports `parseBooleanToken` / `parseBooleanWithDefault` from `@open-mercato/shared/lib/boolean` to parse scalars, then fell back to an inline chain four times to parse lists.

This is a maintainability defect, not a behavioral one — all 11 copies were semantically identical, and this PR keeps them that way.

## What Changed

- **`packages/shared/src/lib/string.ts`** — added `parseCommaSeparatedList(value: string | null | undefined): string[]`. Non-string input yields `[]`. It lives in `string.ts` (rather than a new file) because that is the generic string-utility module and already holds its close cousin `trimToUndefined`. No `package.json` change was needed — the shared `exports` map already resolves `./lib/string` via its `./*/*` wildcard.
- **Adopted it at all 11 call sites**: `entities/cli.ts` (1), `auth/cli.ts` (2), `dashboards/cli.ts` (3), `api_keys/cli.ts` (1), `entities/api/records.ts` (4). `records.ts` also sheds its now-redundant `|| ''` guard on `searchParams.get()`.
- **`packages/shared/AGENTS.md`** — documented the helper (library-map row + a "Comma-Separated List Parsing" pattern section mirroring the existing Boolean Parsing one), so future code adopts it instead of re-inlining the chain. This is what makes the DRY fix stick.

### Behavior preservation — the one trap

Three call sites fall back to `undefined`, **not** `[]`, and `undefined` is semantically distinct downstream ("not specified" vs "specified as empty"). Those ternaries are preserved verbatim; only the inner chain was replaced:

```ts
const roleNames = rolesCsv ? parseCommaSeparatedList(rolesCsv) : undefined   // auth/cli.ts
widgetIds: widgetCsv ? parseCommaSeparatedList(widgetCsv) : undefined        // dashboards/cli.ts
```

Where the fallback was already `[]` (`api_keys/cli.ts`), the guard safely collapsed into the helper. All 11 replacements are semantically identical to what they replaced.

## Tests

- **NEW** `packages/shared/src/lib/__tests__/string.test.ts` — 9 tests: basic split, whitespace trimming, empty-entry rejection (`'a,,b,'`), all-blank input (`',,'` → `[]`), `null` / `undefined` / `''` → `[]`, single value with no separator, and interior-whitespace preservation. Also adds coverage for the previously untested `trimToUndefined`.
- Full validation gate passed in order (runner: local): `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck` (21/21 packages), `test` (22/22 tasks), `build:app`. `yarn lint` also clean.

> Two unrelated tests (`packages/ui` `format.test.ts`, `customers` `DealsKpiStrip.test.tsx`) fail on my local machine only, due to its Polish system locale (`"1234,50 USD"` vs expected `/1,234\.5/`). They are **pre-existing** — they fail identically on a pristine `develop` with these changes stashed, this branch touches zero files in either area, and both pass under `LC_ALL=en_US.UTF-8` (which CI uses). The gate result above is from the en_US run that mirrors CI.

## Breaking Changes

None. Purely additive — one new exported function in `shared`. No exported signature, import path, API route, event ID, DB schema, CLI flag, or response shape was changed or removed. No data-scoping or permission logic touched.

Scope note: the same chain appears ~19 more times outside the files this issue enumerates (workflows, customers, directory, customer_accounts, inbox_ops, attachments, search, cli). Those are deliberately left alone — several are React `onChange` handlers and typed casts with a wider blast radius. Happy to follow up in a separate PR if wanted.

🤖 Generated by autofix.
