### PR TITLE
security(directory): cap the organizations list pageSize at the platform 100 (#3851)

### DIFF
--- a/packages/core/src/modules/directory/api/organizations/__tests__/route.test.ts
+++ b/packages/core/src/modules/directory/api/organizations/__tests__/route.test.ts
@@ -215,3 +215,56 @@ describe('directory organizations GET — manage view exposes updatedAt for opti
     expect(body.items[0].updatedAt).toBe(orgUpdatedAt.toISOString())
   })
 })
+
+describe('directory organizations GET — pageSize honors the ≤100 platform cap (#3851)', () => {
+  const tenantOrgId = '77777777-7777-4777-8777-777777777777'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    emFind.mockResolvedValue([])
+    emFindOne.mockResolvedValue(null)
+    findWithDecryptionMock.mockResolvedValue([])
+  })
+
+  it('rejects a pageSize above the 100-row platform cap', async () => {
+    authMock.mockResolvedValue({ sub: superAdminUserId, tenantId: foreignTenantId, orgId: tenantOrgId })
+
+    const response = await GET(
+      new Request(
+        `http://localhost/api/directory/organizations?view=manage&tenantId=${foreignTenantId}&page=1&pageSize=101`,
+      ),
+    )
+
+    // Schema rejection short-circuits before any org query runs, so no oversized
+    // page is ever assembled (#3851).
+    expect(response.status).toBe(400)
+    expect(emFind).not.toHaveBeenCalled()
+    expect(findWithDecryptionMock).not.toHaveBeenCalled()
+  })
+
+  it('still accepts a pageSize at the 100-row cap', async () => {
+    authMock.mockResolvedValue({ sub: superAdminUserId, tenantId: foreignTenantId, orgId: tenantOrgId })
+    resolveIsSuperAdminMock.mockResolvedValue(false)
+    emFind.mockResolvedValue([
+      {
+        id: tenantOrgId,
+        name: 'Tenant Org',
+        slug: 'tenant-org',
+        parentId: null,
+        isActive: true,
+        updatedAt: new Date('2026-06-01T10:20:30.000Z'),
+        tenantId: foreignTenantId,
+      },
+    ])
+
+    const response = await GET(
+      new Request(
+        `http://localhost/api/directory/organizations?view=manage&tenantId=${foreignTenantId}&page=1&pageSize=100`,
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.pageSize).toBe(100)
+  })
+})

--- a/packages/core/src/modules/directory/api/organizations/route.ts
+++ b/packages/core/src/modules/directory/api/organizations/route.ts
@@ -52,7 +52,7 @@ type TreeNode = {
 
 const viewSchema = z.object({
   page: z.coerce.number().min(1).default(1),
-  pageSize: z.coerce.number().min(1).max(200).default(50),
+  pageSize: z.coerce.number().min(1).max(100).default(50),
   search: z.string().optional(),
   view: z.enum(['options', 'manage', 'tree']).default('options'),
   ids: z.string().optional(),


### PR DESCRIPTION
Fixes #3851

## Problem

`viewSchema.pageSize` in the directory organizations list was `z.coerce.number().min(1).max(200)`, twice the platform's documented cap ("Keep `pageSize` at or below 100", root `AGENTS.md`). A caller could request 200-row pages, doubling the per-page query cost and response payload.

The route is tenant/org-scoped and defended in depth, so this is a resource-amplification deviation within the caller's own scope, not a data-isolation break — it is simply the one place the module exceeds the documented cap.

## Root Cause

The schema bound was written as `max(200)` and never reconciled with the ≤100 project rule.

## What Changed

- `packages/core/src/modules/directory/api/organizations/route.ts`: `viewSchema.pageSize` bound lowered from `max(200)` to `max(100)`. No handler code changed — an over-cap request now fails `safeParse` and returns the route's existing `400` before any organization query runs.

## Tests

- `packages/core/src/modules/directory/api/organizations/__tests__/route.test.ts`: two new cases — a `pageSize=101` request is rejected with `400` and never reaches the ORM (asserted via `emFind` / `findWithDecryption` not being called), and `pageSize=100` still succeeds and echoes `pageSize: 100`.
- `yarn typecheck` green; `@open-mercato/core` directory suite green (18 suites / 106 tests).

## Breaking Changes

None in-tree. No caller in the repository requests a pageSize above 100. An external client explicitly asking for 101–200 rows would now receive a `400` instead of an oversized page and must page at ≤100 — which is the documented contract.

Note the `manage`/`tree` aggregate views still load the full tenant org set into memory regardless of `pageSize`; that is a separate consideration called out in the issue and left untouched here.

🤖 Generated by autofix.