### PR TITLE
security(dashboards): fail closed on null-tenant widget-assignment ownership checks (#3843)

### DIFF
--- a/packages/core/src/modules/dashboards/__tests__/widget-assignments-tenant-isolation.test.ts
+++ b/packages/core/src/modules/dashboards/__tests__/widget-assignments-tenant-isolation.test.ts
@@ -5,7 +5,10 @@ import {
   roleWidgetSettingsSchema,
   userWidgetSettingsSchema,
 } from '@open-mercato/core/modules/dashboards/data/validators'
-import { resolveWidgetAssignmentReadScope } from '@open-mercato/core/modules/dashboards/lib/widgetAssignmentScope'
+import {
+  resolveWidgetAssignmentReadScope,
+  resolveWidgetAssignmentTargetAccess,
+} from '@open-mercato/core/modules/dashboards/lib/widgetAssignmentScope'
 
 describe('dashboards role/user widget settings schema — mass-assign scope', () => {
   // Zod v4 .uuid() requires versioned UUID (v1-v8 variant bits).
@@ -108,5 +111,73 @@ describe('resolveWidgetAssignmentReadScope — GET scope hardening', () => {
       queryOrganizationId: '',
     })
     expect(scope).toEqual({ tenantId: callerTenant, organizationId: callerOrg })
+  })
+})
+
+describe('resolveWidgetAssignmentTargetAccess — null-tenant fail-open hardening', () => {
+  const callerTenant = '55555555-5555-4555-8555-555555555555'
+  const foreignTenant = '77777777-7777-4777-8777-777777777777'
+
+  test('non-superadmin without a tenant scope is rejected, never allowed through', () => {
+    const access = resolveWidgetAssignmentTargetAccess({
+      isSuperAdmin: false,
+      scopeTenantId: null,
+      target: { tenantId: foreignTenant },
+    })
+    expect(access).toBe('forbidden')
+  })
+
+  test('non-superadmin without a tenant scope is rejected even for a tenant-less target', () => {
+    const access = resolveWidgetAssignmentTargetAccess({
+      isSuperAdmin: false,
+      scopeTenantId: null,
+      target: { tenantId: null },
+    })
+    expect(access).toBe('forbidden')
+  })
+
+  test('tenant-scoped caller cannot reach a target in another tenant', () => {
+    const access = resolveWidgetAssignmentTargetAccess({
+      isSuperAdmin: false,
+      scopeTenantId: callerTenant,
+      target: { tenantId: foreignTenant },
+    })
+    expect(access).toBe('not-found')
+  })
+
+  test('tenant-scoped caller reaches a target in its own tenant', () => {
+    const access = resolveWidgetAssignmentTargetAccess({
+      isSuperAdmin: false,
+      scopeTenantId: callerTenant,
+      target: { tenantId: callerTenant },
+    })
+    expect(access).toBe('allowed')
+  })
+
+  test('missing target is not-found rather than allowed', () => {
+    const access = resolveWidgetAssignmentTargetAccess({
+      isSuperAdmin: false,
+      scopeTenantId: callerTenant,
+      target: null,
+    })
+    expect(access).toBe('not-found')
+  })
+
+  test('superadmin without a tenant scope still reaches any tenant', () => {
+    const access = resolveWidgetAssignmentTargetAccess({
+      isSuperAdmin: true,
+      scopeTenantId: null,
+      target: { tenantId: foreignTenant },
+    })
+    expect(access).toBe('allowed')
+  })
+
+  test('superadmin pinned to a scope is still limited to that scope', () => {
+    const access = resolveWidgetAssignmentTargetAccess({
+      isSuperAdmin: true,
+      scopeTenantId: callerTenant,
+      target: { tenantId: foreignTenant },
+    })
+    expect(access).toBe('not-found')
   })
 })

--- a/packages/core/src/modules/dashboards/api/roles/widgets/__tests__/route.test.ts
+++ b/packages/core/src/modules/dashboards/api/roles/widgets/__tests__/route.test.ts
@@ -25,13 +25,14 @@ const container = {
 
 const validateCrudMutationGuardMock = jest.fn()
 const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const getAuthFromRequestMock = jest.fn()
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => container),
 }))
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
-  getAuthFromRequest: jest.fn(async () => ({ sub: userId, tenantId, orgId: organizationId })),
+  getAuthFromRequest: (...args: unknown[]) => getAuthFromRequestMock(...args),
 }))
 
 jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
@@ -43,7 +44,10 @@ jest.mock('@open-mercato/core/modules/dashboards/lib/widgets', () => ({
   loadAllWidgets: jest.fn(async () => [{ metadata: { id: 'sales-summary' } }]),
 }))
 
-import { PUT } from '../route'
+import { GET, PUT } from '../route'
+
+const foreignTenantId = '66666666-6666-4666-8666-666666666666'
+const assignFeature = 'dashboards.admin.assign-widgets'
 
 function buildRequest(body: unknown): Request {
   return new Request('http://localhost/api/dashboards/roles/widgets', {
@@ -51,6 +55,10 @@ function buildRequest(body: unknown): Request {
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   })
+}
+
+function buildGetRequest(): Request {
+  return new Request(`http://localhost/api/dashboards/roles/widgets?roleId=${roleId}`)
 }
 
 describe('dashboards role widgets route mutation guard', () => {
@@ -61,6 +69,7 @@ describe('dashboards role widgets route mutation guard', () => {
     em.create.mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({ id: 'rec', ...payload }))
     rbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [] })
     em.findOne.mockResolvedValue({ id: roleId, tenantId })
+    getAuthFromRequestMock.mockResolvedValue({ sub: userId, tenantId, orgId: organizationId })
     validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
     runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
   })
@@ -92,5 +101,64 @@ describe('dashboards role widgets route mutation guard', () => {
       container,
       expect.objectContaining({ resourceKind: 'dashboards.roleWidgets', resourceId: roleId, operation: 'update' }),
     )
+  })
+})
+
+describe('dashboards role widgets route tenant ownership', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.flush.mockResolvedValue(undefined)
+    em.remove.mockReturnValue({ flush: jest.fn().mockResolvedValue(undefined) })
+    em.create.mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({ id: 'rec', ...payload }))
+    em.find.mockResolvedValue([])
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  it('rejects a null-tenant non-superadmin write instead of writing across tenants', async () => {
+    getAuthFromRequestMock.mockResolvedValue({ sub: userId, tenantId: null, orgId: null })
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: false, features: [assignFeature] })
+    em.findOne.mockResolvedValue({ id: roleId, tenantId: foreignTenantId })
+
+    const response = await PUT(buildRequest({ roleId, widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(403)
+    expect(validateCrudMutationGuardMock).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('rejects a null-tenant non-superadmin read of a foreign role', async () => {
+    getAuthFromRequestMock.mockResolvedValue({ sub: userId, tenantId: null, orgId: null })
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: false, features: [assignFeature] })
+    em.findOne.mockResolvedValue({ id: roleId, tenantId: foreignTenantId })
+
+    const response = await GET(buildGetRequest())
+
+    expect(response.status).toBe(403)
+    expect(em.find).not.toHaveBeenCalled()
+  })
+
+  it('keeps rejecting a tenant-scoped caller targeting a foreign role', async () => {
+    getAuthFromRequestMock.mockResolvedValue({ sub: userId, tenantId, orgId: organizationId })
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: false, features: [assignFeature] })
+    em.findOne.mockResolvedValue({ id: roleId, tenantId: foreignTenantId })
+
+    const response = await PUT(buildRequest({ roleId, widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(404)
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('still lets a superadmin with no tenant scope assign widgets across tenants', async () => {
+    getAuthFromRequestMock.mockResolvedValue({ sub: userId, tenantId: null, orgId: null })
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [] })
+    em.findOne.mockResolvedValueOnce({ id: roleId, tenantId: foreignTenantId })
+    em.findOne.mockResolvedValueOnce(null)
+
+    const response = await PUT(buildRequest({ roleId, widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(200)
+    expect(em.flush).toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/dashboards/api/roles/widgets/route.ts
+++ b/packages/core/src/modules/dashboards/api/roles/widgets/route.ts
@@ -6,7 +6,10 @@ import { DashboardRoleWidgets } from '@open-mercato/core/modules/dashboards/data
 import { Role } from '@open-mercato/core/modules/auth/data/entities'
 import { roleWidgetSettingsSchema } from '@open-mercato/core/modules/dashboards/data/validators'
 import { loadAllWidgets } from '@open-mercato/core/modules/dashboards/lib/widgets'
-import { resolveWidgetAssignmentReadScope } from '@open-mercato/core/modules/dashboards/lib/widgetAssignmentScope'
+import {
+  resolveWidgetAssignmentReadScope,
+  resolveWidgetAssignmentTargetAccess,
+} from '@open-mercato/core/modules/dashboards/lib/widgetAssignmentScope'
 import { hasFeature } from '@open-mercato/shared/security/features'
 import {
   runCrudMutationGuardAfterSuccess,
@@ -70,7 +73,15 @@ export async function GET(req: Request) {
   })
 
   const role = await em.findOne(Role, { id: roleId, deletedAt: null })
-  if (!role || (tenantId && role.tenantId !== tenantId)) {
+  const access = resolveWidgetAssignmentTargetAccess({
+    isSuperAdmin: !!acl.isSuperAdmin,
+    scopeTenantId: tenantId,
+    target: role,
+  })
+  if (access === 'forbidden') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (access === 'not-found') {
     return NextResponse.json({ error: 'Role not found' }, { status: 404 })
   }
 
@@ -121,7 +132,15 @@ export async function PUT(req: Request) {
   const organizationId = auth.orgId ?? null
 
   const role = await em.findOne(Role, { id: parsed.data.roleId, deletedAt: null })
-  if (!role || (tenantId && role.tenantId !== tenantId)) {
+  const access = resolveWidgetAssignmentTargetAccess({
+    isSuperAdmin: !!acl.isSuperAdmin,
+    scopeTenantId: tenantId,
+    target: role,
+  })
+  if (access === 'forbidden') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (access === 'not-found') {
     return NextResponse.json({ error: 'Role not found' }, { status: 404 })
   }
 

--- a/packages/core/src/modules/dashboards/api/users/widgets/__tests__/route.test.ts
+++ b/packages/core/src/modules/dashboards/api/users/widgets/__tests__/route.test.ts
@@ -25,13 +25,14 @@ const container = {
 
 const validateCrudMutationGuardMock = jest.fn()
 const runCrudMutationGuardAfterSuccessMock = jest.fn()
+const getAuthFromRequestMock = jest.fn()
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => container),
 }))
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
-  getAuthFromRequest: jest.fn(async () => ({ sub: adminUserId, tenantId, orgId: organizationId })),
+  getAuthFromRequest: (...args: unknown[]) => getAuthFromRequestMock(...args),
 }))
 
 jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
@@ -43,7 +44,10 @@ jest.mock('@open-mercato/core/modules/dashboards/lib/widgets', () => ({
   loadAllWidgets: jest.fn(async () => [{ metadata: { id: 'sales-summary' } }]),
 }))
 
-import { PUT } from '../route'
+import { GET, PUT } from '../route'
+
+const foreignTenantId = '66666666-6666-4666-8666-666666666666'
+const assignFeature = 'dashboards.admin.assign-widgets'
 
 function buildRequest(body: unknown): Request {
   return new Request('http://localhost/api/dashboards/users/widgets', {
@@ -51,6 +55,10 @@ function buildRequest(body: unknown): Request {
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   })
+}
+
+function buildGetRequest(): Request {
+  return new Request(`http://localhost/api/dashboards/users/widgets?userId=${targetUserId}`)
 }
 
 describe('dashboards user widgets route mutation guard', () => {
@@ -61,6 +69,7 @@ describe('dashboards user widgets route mutation guard', () => {
     em.create.mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({ id: 'rec', ...payload }))
     rbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [] })
     em.findOne.mockResolvedValue({ id: targetUserId, tenantId })
+    getAuthFromRequestMock.mockResolvedValue({ sub: adminUserId, tenantId, orgId: organizationId })
     validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
     runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
   })
@@ -92,5 +101,62 @@ describe('dashboards user widgets route mutation guard', () => {
       container,
       expect.objectContaining({ resourceKind: 'dashboards.userWidgets', resourceId: targetUserId, operation: 'update' }),
     )
+  })
+})
+
+describe('dashboards user widgets route tenant ownership', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.flush.mockResolvedValue(undefined)
+    em.remove.mockReturnValue({ flush: jest.fn().mockResolvedValue(undefined) })
+    em.create.mockImplementation((_entity: unknown, payload: Record<string, unknown>) => ({ id: 'rec', ...payload }))
+    validateCrudMutationGuardMock.mockResolvedValue({ ok: true, shouldRunAfterSuccess: true, metadata: { token: 'guard' } })
+    runCrudMutationGuardAfterSuccessMock.mockResolvedValue(undefined)
+  })
+
+  it('rejects a null-tenant non-superadmin write instead of writing across tenants', async () => {
+    getAuthFromRequestMock.mockResolvedValue({ sub: adminUserId, tenantId: null, orgId: null })
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: false, features: [assignFeature] })
+    em.findOne.mockResolvedValue({ id: targetUserId, tenantId: foreignTenantId })
+
+    const response = await PUT(buildRequest({ userId: targetUserId, mode: 'override', widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(403)
+    expect(validateCrudMutationGuardMock).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('rejects a null-tenant non-superadmin read of a foreign user', async () => {
+    getAuthFromRequestMock.mockResolvedValue({ sub: adminUserId, tenantId: null, orgId: null })
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: false, features: [assignFeature] })
+    em.findOne.mockResolvedValue({ id: targetUserId, tenantId: foreignTenantId })
+
+    const response = await GET(buildGetRequest())
+
+    expect(response.status).toBe(403)
+  })
+
+  it('keeps rejecting a tenant-scoped caller targeting a foreign user', async () => {
+    getAuthFromRequestMock.mockResolvedValue({ sub: adminUserId, tenantId, orgId: organizationId })
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: false, features: [assignFeature] })
+    em.findOne.mockResolvedValue({ id: targetUserId, tenantId: foreignTenantId })
+
+    const response = await PUT(buildRequest({ userId: targetUserId, mode: 'override', widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(404)
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('still lets a superadmin with no tenant scope assign widgets across tenants', async () => {
+    getAuthFromRequestMock.mockResolvedValue({ sub: adminUserId, tenantId: null, orgId: null })
+    rbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [] })
+    em.findOne.mockResolvedValueOnce({ id: targetUserId, tenantId: foreignTenantId })
+    em.findOne.mockResolvedValueOnce(null)
+
+    const response = await PUT(buildRequest({ userId: targetUserId, mode: 'override', widgetIds: ['sales-summary'] }))
+
+    expect(response.status).toBe(200)
+    expect(em.flush).toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/dashboards/api/users/widgets/route.ts
+++ b/packages/core/src/modules/dashboards/api/users/widgets/route.ts
@@ -7,7 +7,10 @@ import { User } from '@open-mercato/core/modules/auth/data/entities'
 import { userWidgetSettingsSchema } from '@open-mercato/core/modules/dashboards/data/validators'
 import { loadAllWidgets } from '@open-mercato/core/modules/dashboards/lib/widgets'
 import { resolveAllowedWidgetIds } from '@open-mercato/core/modules/dashboards/lib/access'
-import { resolveWidgetAssignmentReadScope } from '@open-mercato/core/modules/dashboards/lib/widgetAssignmentScope'
+import {
+  resolveWidgetAssignmentReadScope,
+  resolveWidgetAssignmentTargetAccess,
+} from '@open-mercato/core/modules/dashboards/lib/widgetAssignmentScope'
 import { hasFeature } from '@open-mercato/shared/security/features'
 import {
   runCrudMutationGuardAfterSuccess,
@@ -53,7 +56,15 @@ export async function GET(req: Request) {
   })
 
   const targetUserForRead = await em.findOne(User, { id: userId, deletedAt: null })
-  if (!targetUserForRead || (tenantId && (targetUserForRead.tenantId ?? null) !== tenantId)) {
+  const readAccess = resolveWidgetAssignmentTargetAccess({
+    isSuperAdmin: !!acl.isSuperAdmin,
+    scopeTenantId: tenantId,
+    target: targetUserForRead,
+  })
+  if (readAccess === 'forbidden') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (readAccess === 'not-found') {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
@@ -121,7 +132,15 @@ export async function PUT(req: Request) {
   const organizationId = auth.orgId ?? null
 
   const targetUser = await em.findOne(User, { id: parsed.data.userId, deletedAt: null })
-  if (!targetUser || (tenantId && (targetUser.tenantId ?? null) !== tenantId)) {
+  const writeAccess = resolveWidgetAssignmentTargetAccess({
+    isSuperAdmin: !!acl.isSuperAdmin,
+    scopeTenantId: tenantId,
+    target: targetUser,
+  })
+  if (writeAccess === 'forbidden') {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+  if (writeAccess === 'not-found') {
     return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 

--- a/packages/core/src/modules/dashboards/lib/widgetAssignmentScope.ts
+++ b/packages/core/src/modules/dashboards/lib/widgetAssignmentScope.ts
@@ -8,6 +8,24 @@ export type ResolvedAssignmentScope = {
   organizationId: string | null
 }
 
+export type WidgetAssignmentTarget = {
+  tenantId?: string | null
+}
+
+export type WidgetAssignmentTargetAccess = 'allowed' | 'forbidden' | 'not-found'
+
+export function resolveWidgetAssignmentTargetAccess(params: {
+  isSuperAdmin: boolean
+  scopeTenantId: string | null
+  target: WidgetAssignmentTarget | null | undefined
+}): WidgetAssignmentTargetAccess {
+  const { isSuperAdmin, scopeTenantId, target } = params
+  if (!isSuperAdmin && !scopeTenantId) return 'forbidden'
+  if (!target) return 'not-found'
+  if (scopeTenantId && (target.tenantId ?? null) !== scopeTenantId) return 'not-found'
+  return 'allowed'
+}
+
 export function resolveWidgetAssignmentReadScope(params: {
   auth: AuthScopeInput
   isSuperAdmin: boolean


### PR DESCRIPTION
Fixes #3843

## Problem

The dashboard widget-assignment routes guarded target ownership with:

```ts
if (!role || (tenantId && role.tenantId !== tenantId)) return notFound()
```

where `tenantId = auth.tenantId ?? null`. The cross-tenant comparison is gated on `tenantId` being truthy, so for a **non-superadmin caller whose `auth.tenantId` is null**, the expression short-circuits to `false` and the ownership check is skipped altogether: such a caller holding `dashboards.admin.assign-widgets` could GET and PUT widget assignments for a Role or User in **any** tenant (the rows are then written with `tenantId: null` against the foreign target).

Latent rather than exploitable today — the feature is granted by default only to the tenant-scoped `admin` role and staff normally carry a tenantId — but it rests on the unenforced invariant "non-superadmin ⇒ has tenantId", and the `tenant_id` columns on `DashboardRoleWidgets` / `DashboardUserWidgets` are nullable, so the null-scope data shape is real.

## Root Cause

`tenantId && target.tenantId !== tenantId` conflates "no tenant scope" with "scope check passes". `resolveWidgetAssignmentReadScope` already blocks non-superadmins from spoofing a scope via query params (covered by `tenant-isolation.test.ts`), so the null-tenant caller was the one remaining hole.

## What Changed

- `packages/core/src/modules/dashboards/lib/widgetAssignmentScope.ts`: new `resolveWidgetAssignmentTargetAccess({ isSuperAdmin, scopeTenantId, target })` returning `'allowed' | 'forbidden' | 'not-found'`. A non-superadmin without a tenant scope is `forbidden`; the target's tenant is then compared **unconditionally**, so a mismatch is `not-found`.
- `packages/core/src/modules/dashboards/api/roles/widgets/route.ts` and `api/users/widgets/route.ts`: all four paths (GET + PUT on each) now route through the helper — `forbidden` returns `403`, `not-found` keeps the existing `404`.

Superadmins are unaffected and keep their intended cross-tenant access; a normal tenant-scoped admin sees no behavior change.

## Tests

- `api/roles/widgets/__tests__/route.test.ts` and `api/users/widgets/__tests__/route.test.ts`: a non-superadmin with `tenantId: null` is now rejected with `403` on both GET and PUT, and the superadmin cross-tenant path is asserted to still work.
- `__tests__/widget-assignments-tenant-isolation.test.ts`: extended with the null-tenant caller against a foreign-tenant role/user.
- `yarn typecheck` green; `@open-mercato/core` dashboards suite green (13 suites / 116 tests).

## Breaking Changes

None for the supported paths. The only behavior change is for a caller that should never have been served: a non-superadmin with no tenant scope now gets `403` where it previously received data. Response shapes and status codes are otherwise unchanged.

🤖 Generated by autofix.