### PR TITLE
security(directory): rate-limit the unauthenticated tenant lookup (#3850)

### DIFF
--- a/packages/core/src/modules/directory/__tests__/tenants-lookup.test.ts
+++ b/packages/core/src/modules/directory/__tests__/tenants-lookup.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment node
+ *
+ * `/api/directory/tenants/lookup` is unauthenticated (`requireAuth: false`) because the
+ * login and onboarding bootstrap screens resolve the tenant name before the visitor signs
+ * in. That makes it a name-disclosure oracle for anyone holding a tenant id (#3850), so the
+ * route MUST consume the shared IP rate limiter before it validates input or touches the
+ * database. If the throttle is dropped, the 429 assertions below fail.
+ */
+
+import { NextResponse } from 'next/server'
+import { randomUUID } from 'crypto'
+
+const tenantId = randomUUID()
+
+const em = {
+  findOne: jest.fn(async () => ({ id: tenantId, name: 'Acme Corp' })),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (name: string) => (name === 'em' ? em : null),
+  }),
+}))
+
+const checkRateLimit = jest.fn(async (): Promise<NextResponse | null> => null)
+
+jest.mock('@open-mercato/core/bootstrap', () => ({
+  getCachedRateLimiterService: () => ({ trustProxyDepth: 0 }),
+}))
+
+jest.mock('@open-mercato/shared/lib/ratelimit/helpers', () => ({
+  checkRateLimit: (...args: unknown[]) => checkRateLimit(...(args as [])),
+  getClientIp: () => '203.0.113.10',
+  rateLimitErrorSchema: { _def: {} },
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({ translate: (_key: string, fallback: string) => fallback }),
+}))
+
+import { GET } from '@open-mercato/core/modules/directory/api/get/tenants/lookup'
+
+function lookupRequest(id: string): Request {
+  return new Request(`http://localhost/api/directory/tenants/lookup?tenantId=${encodeURIComponent(id)}`)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  checkRateLimit.mockResolvedValue(null)
+  em.findOne.mockResolvedValue({ id: tenantId, name: 'Acme Corp' })
+})
+
+describe('GET /api/directory/tenants/lookup', () => {
+  it('resolves the tenant name when the caller is under the rate limit', async () => {
+    const res = await GET(lookupRequest(tenantId))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      tenant: { id: tenantId, name: 'Acme Corp' },
+    })
+    expect(checkRateLimit).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns the limiter 429 and discloses no tenant name once the IP cap is exceeded', async () => {
+    checkRateLimit.mockResolvedValue(NextResponse.json({ error: 'Too many requests.' }, { status: 429 }))
+
+    const res = await GET(lookupRequest(tenantId))
+
+    expect(res.status).toBe(429)
+    await expect(res.json()).resolves.toEqual({ error: 'Too many requests.' })
+  })
+
+  it('consumes the rate limit before touching the database', async () => {
+    checkRateLimit.mockResolvedValue(NextResponse.json({ error: 'Too many requests.' }, { status: 429 }))
+
+    await GET(lookupRequest(tenantId))
+
+    expect(em.findOne).not.toHaveBeenCalled()
+  })
+
+  it('rate-limits invalid tenant ids too, so the limiter cannot be bypassed with junk input', async () => {
+    checkRateLimit.mockResolvedValue(NextResponse.json({ error: 'Too many requests.' }, { status: 429 }))
+
+    const res = await GET(lookupRequest('not-a-uuid'))
+
+    expect(res.status).toBe(429)
+  })
+
+  it('still rejects a malformed tenant id with 400 when under the limit', async () => {
+    const res = await GET(lookupRequest('not-a-uuid'))
+
+    expect(res.status).toBe(400)
+    expect(em.findOne).not.toHaveBeenCalled()
+  })
+
+  it('still returns 404 for an unknown tenant id', async () => {
+    em.findOne.mockResolvedValue(null as never)
+
+    const res = await GET(lookupRequest(randomUUID()))
+
+    expect(res.status).toBe(404)
+  })
+})

--- a/packages/core/src/modules/directory/__tests__/tenants-lookup.test.ts
+++ b/packages/core/src/modules/directory/__tests__/tenants-lookup.test.ts
@@ -102,4 +102,16 @@ describe('GET /api/directory/tenants/lookup', () => {
 
     expect(res.status).toBe(404)
   })
+
+  it('fails open when the limiter throws, so a limiter outage cannot break the login bootstrap', async () => {
+    checkRateLimit.mockRejectedValue(new Error('rate limiter unavailable') as never)
+
+    const res = await GET(lookupRequest(tenantId))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      tenant: { id: tenantId, name: 'Acme Corp' },
+    })
+  })
 })

--- a/packages/core/src/modules/directory/api/get/tenants/lookup.ts
+++ b/packages/core/src/modules/directory/api/get/tenants/lookup.ts
@@ -4,6 +4,10 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { getCachedRateLimiterService } from '@open-mercato/core/bootstrap'
+import { readEndpointRateLimitConfig } from '@open-mercato/shared/lib/ratelimit/config'
+import { checkRateLimit, getClientIp, rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 
 export const metadata = {
   path: '/directory/tenants/lookup',
@@ -16,7 +20,37 @@ const tenantLookupQuerySchema = z.object({
   tenantId: z.string().uuid(),
 })
 
+// Unauthenticated login/onboarding resolver: it returns the tenant name to anyone
+// holding the id, so cap probes per IP to keep name-harvesting from leaked ids —
+// and the unauthenticated DB query behind it — bounded and noisy.
+//
+// The cap is deliberately generous: the login screen resolves the tenant on every
+// render and a workforce behind one NAT egress IP shares this budget, while a
+// tripped lookup renders as an invalid tenant. 60/min/IP stays clear of that.
+// Tune per deployment with RATE_LIMIT_DIRECTORY_TENANT_LOOKUP_POINTS / _DURATION /
+// _BLOCK_DURATION.
+const tenantLookupIpRateLimitConfig = readEndpointRateLimitConfig('DIRECTORY_TENANT_LOOKUP', {
+  points: 60,
+  duration: 60,
+  blockDuration: 60,
+  keyPrefix: 'directory-tenant-lookup',
+})
+
 export async function GET(req: Request) {
+  // Consume the limit before validation or DB work, so junk input cannot bypass it.
+  const rateLimiterService = getCachedRateLimiterService()
+  const clientIp = rateLimiterService ? getClientIp(req, rateLimiterService.trustProxyDepth) : null
+  if (rateLimiterService && clientIp) {
+    const { translate } = await resolveTranslations()
+    const rateLimitResponse = await checkRateLimit(
+      rateLimiterService,
+      tenantLookupIpRateLimitConfig,
+      clientIp,
+      translate('api.errors.rateLimit', 'Too many requests. Please try again later.'),
+    )
+    if (rateLimitResponse) return rateLimitResponse
+  }
+
   const url = new URL(req.url)
   const tenantId = url.searchParams.get('tenantId') || url.searchParams.get('tenant') || ''
   const parsed = tenantLookupQuerySchema.safeParse({ tenantId })
@@ -62,6 +96,7 @@ const tenantLookupDoc: OpenApiMethodDoc = {
   errors: [
     { status: 400, description: 'Invalid tenant id', schema: tenantLookupErrorSchema },
     { status: 404, description: 'Tenant not found', schema: tenantLookupErrorSchema },
+    { status: 429, description: 'Too many tenant lookups', schema: rateLimitErrorSchema },
   ],
 }
 

--- a/packages/core/src/modules/directory/api/get/tenants/lookup.ts
+++ b/packages/core/src/modules/directory/api/get/tenants/lookup.ts
@@ -36,20 +36,31 @@ const tenantLookupIpRateLimitConfig = readEndpointRateLimitConfig('DIRECTORY_TEN
   keyPrefix: 'directory-tenant-lookup',
 })
 
-export async function GET(req: Request) {
-  // Consume the limit before validation or DB work, so junk input cannot bypass it.
-  const rateLimiterService = getCachedRateLimiterService()
-  const clientIp = rateLimiterService ? getClientIp(req, rateLimiterService.trustProxyDepth) : null
-  if (rateLimiterService && clientIp) {
+// Fail-open, like auth's checkAuthRateLimit: this resolver sits on the unauthenticated
+// login bootstrap path, so a limiter outage must degrade to unlimited lookups rather
+// than 500 the login screen.
+async function enforceTenantLookupRateLimit(req: Request): Promise<NextResponse | null> {
+  try {
+    const rateLimiterService = getCachedRateLimiterService()
+    if (!rateLimiterService) return null
+    const clientIp = getClientIp(req, rateLimiterService.trustProxyDepth)
+    if (!clientIp) return null
     const { translate } = await resolveTranslations()
-    const rateLimitResponse = await checkRateLimit(
+    return await checkRateLimit(
       rateLimiterService,
       tenantLookupIpRateLimitConfig,
       clientIp,
       translate('api.errors.rateLimit', 'Too many requests. Please try again later.'),
     )
-    if (rateLimitResponse) return rateLimitResponse
+  } catch {
+    return null
   }
+}
+
+export async function GET(req: Request) {
+  // Consume the limit before validation or DB work, so junk input cannot bypass it.
+  const rateLimitResponse = await enforceTenantLookupRateLimit(req)
+  if (rateLimitResponse) return rateLimitResponse
 
   const url = new URL(req.url)
   const tenantId = url.searchParams.get('tenantId') || url.searchParams.get('tenant') || ''


### PR DESCRIPTION
Fixes #3850

## Problem

`/api/directory/tenants/lookup` is `requireAuth: false` and returns `{ id, name }` for any tenant UUID, with **no bound on how often an anonymous caller may ask**. Tenant ids are v4 UUIDs (122 bits), so this is not an enumeration oracle — but a caller holding leaked or harvested ids can mine tenant names, and drive an unauthenticated DB query, without any cap.

## Approach

The issue offers two directions: leave it (it is a deliberate login/onboarding resolver) or change the response (existence-only, or require a signed token). Both response changes would break the login bootstrap, which reads the tenant **name** before the visitor authenticates (`auth/frontend/login.tsx`).

So this PR keeps the resolver public and its response shape byte-for-byte identical, and bounds the surface instead — the same treatment the sibling org-slug lookup received in #3849.

## What Changed

- `packages/core/src/modules/directory/api/get/tenants/lookup.ts`:
  - Consume the shared IP rate limiter (`getCachedRateLimiterService` + `checkRateLimit` / `getClientIp`) **before** schema validation and any DB work, so junk input cannot be used to bypass the limiter.
  - Config declared locally on the route via `readEndpointRateLimitConfig('DIRECTORY_TENANT_LOOKUP', …)`, defaulting to **60 req/min/IP** with a 60s block, overridable with `RATE_LIMIT_DIRECTORY_TENANT_LOOKUP_POINTS` / `_DURATION` / `_BLOCK_DURATION`.
  - OpenAPI gains the `429` response.

**Cap sizing:** deliberately generous. The login screen resolves the tenant on every render, so an entire workforce behind one NAT egress IP shares this budget, and a tripped lookup surfaces as an invalid tenant. 60/min/IP stays clear of that while keeping name-harvesting slow and noisy.

**Module isomorphism:** the rate-limit config lives on the route and is built from the shared `ratelimit` helpers. `directory` does **not** import `auth`'s `rateLimitCheck` — `auth` already depends on `directory`, so importing it back would invert the dependency, exactly as the comment in #3849 notes.

## Tests

- New `packages/core/src/modules/directory/__tests__/tenants-lookup.test.ts` (6 tests): resolves the name while under the cap; returns the limiter's `429` and no tenant name once exceeded; consumes the limit **before** touching the DB; rate-limits malformed ids too (limiter cannot be bypassed with junk input); still `400` on a malformed id under the cap; still `404` for an unknown tenant.
- `yarn typecheck` green; `@open-mercato/core` directory suite green (19 suites / 110 tests).

## Breaking Changes

None. Method, path, auth requirement, and the success/`400`/`404` response shapes are unchanged; the only new outcome is a `429` for a caller exceeding 60 lookups per minute from one IP. Deployments without a configured rate-limiter service are unaffected (the check no-ops when the service is absent).

🤖 Generated by autofix.