### PR TITLE
refactor(shared): adopt the standardized 404 helpers across customers and sales (#2364)

### DIFF
--- a/packages/core/src/modules/customers/api/companies/[id]/people/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/people/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -116,7 +116,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       decryptionScope,
     )
     if (!company) {
-      throw new CrudHttpError(404, { error: translate('customers.errors.company_not_found', 'Company not found') })
+      throw notFound(translate('customers.errors.company_not_found', 'Company not found'))
     }
 
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: company.organizationId })) {

--- a/packages/core/src/modules/customers/api/deals/[id]/companies/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/companies/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -98,7 +98,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       decryptionScope,
     )
     if (!deal) {
-      throw new CrudHttpError(404, { error: translate('customers.errors.deal_not_found', 'Deal not found') })
+      throw notFound(translate('customers.errors.deal_not_found', 'Deal not found'))
     }
 
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {

--- a/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -98,7 +98,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       decryptionScope,
     )
     if (!deal) {
-      throw new CrudHttpError(404, { error: translate('customers.errors.deal_not_found', 'Deal not found') })
+      throw notFound(translate('customers.errors.deal_not_found', 'Deal not found'))
     }
 
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {

--- a/packages/core/src/modules/customers/api/dictionaries/[kind]/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/[kind]/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
 import type { CommandExecuteResult } from '@open-mercato/shared/lib/commands/types'
@@ -86,7 +86,7 @@ export async function PATCH(req: Request, ctx: { params?: { kind?: string; id?: 
     } catch (err) {
       if (isCrudHttpError(err)) {
         if (err.status === 404) {
-          throw new CrudHttpError(404, { error: routeContext.translate('customers.errors.lookup_failed', 'Dictionary entry not found') })
+          throw notFound(routeContext.translate('customers.errors.lookup_failed', 'Dictionary entry not found'))
         }
         if (err.status === 409) {
           if ((err.body as Record<string, unknown> | undefined)?.code === 'role_type_in_use') {
@@ -123,7 +123,7 @@ export async function PATCH(req: Request, ctx: { params?: { kind?: string; id?: 
       },
     )
     if (!entry) {
-      throw new CrudHttpError(404, { error: routeContext.translate('customers.errors.lookup_failed', 'Dictionary entry not found') })
+      throw notFound(routeContext.translate('customers.errors.lookup_failed', 'Dictionary entry not found'))
     }
 
     if (result.changed) {
@@ -218,7 +218,7 @@ export async function DELETE(req: Request, ctx: { params?: { kind?: string; id?:
       })) as CommandExecuteResult<{ entryId: string }>
     } catch (err) {
       if (isCrudHttpError(err) && err.status === 404) {
-        throw new CrudHttpError(404, { error: routeContext.translate('customers.errors.lookup_failed', 'Dictionary entry not found') })
+        throw notFound(routeContext.translate('customers.errors.lookup_failed', 'Dictionary entry not found'))
       }
       if (isCrudHttpError(err) && err.status === 409 && (err.body as Record<string, unknown> | undefined)?.code === 'role_type_in_use') {
         const usageCount = Number((err.body as Record<string, unknown> | undefined)?.usageCount ?? 0)

--- a/packages/core/src/modules/customers/api/entity-roles-factory.ts
+++ b/packages/core/src/modules/customers/api/entity-roles-factory.ts
@@ -4,7 +4,7 @@ import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { validateCrudMutationGuard, runCrudMutationGuardAfterSuccess } from '@open-mercato/shared/lib/crud/mutation-guard'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
@@ -130,7 +130,7 @@ async function resolveEntityRouteScope(
     { tenantId: auth.tenantId, organizationId: scope?.selectedId ?? auth.orgId ?? null },
   )
   if (!entity || entity.tenantId !== auth.tenantId) {
-    throw new CrudHttpError(404, { error: translate('customers.errors.customer_not_found', 'Customer not found') })
+    throw notFound(translate('customers.errors.customer_not_found', 'Customer not found'))
   }
   ensureRouteOrganizationAccess(entity.organizationId, scope, auth, translate)
   return {
@@ -162,7 +162,7 @@ async function resolveRoleRouteScope(
     role.entityType !== entityType ||
     role.entityId !== entityId
   ) {
-    throw new CrudHttpError(404, { error: translate('customers.errors.role_not_found', 'Role not found') })
+    throw notFound(translate('customers.errors.role_not_found', 'Role not found'))
   }
   ensureRouteOrganizationAccess(role.organizationId, scope, auth, translate)
   return {

--- a/packages/core/src/modules/customers/api/labels/assign/route.ts
+++ b/packages/core/src/modules/customers/api/labels/assign/route.ts
@@ -4,7 +4,7 @@ import { labelAssignCommandSchema, labelAssignmentSchema, type LabelAssignComman
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -80,7 +80,7 @@ export async function POST(req: Request) {
       { tenantId: auth.tenantId, organizationId },
     )
     if (!targetEntity) {
-      throw new CrudHttpError(404, { error: translate('customers.errors.entity_not_found', 'Entity not found') })
+      throw notFound(translate('customers.errors.entity_not_found', 'Entity not found'))
     }
     const entityKind = targetEntity.kind === 'person' || targetEntity.kind === 'company' ? targetEntity.kind : null
     const resourceKind = resolveResourceKind(entityKind)

--- a/packages/core/src/modules/customers/api/labels/unassign/route.ts
+++ b/packages/core/src/modules/customers/api/labels/unassign/route.ts
@@ -4,7 +4,7 @@ import { labelUnassignCommandSchema, labelAssignmentSchema, type LabelUnassignCo
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -80,7 +80,7 @@ export async function POST(req: Request) {
       { tenantId: auth.tenantId, organizationId },
     )
     if (!targetEntity) {
-      throw new CrudHttpError(404, { error: translate('customers.errors.entity_not_found', 'Entity not found') })
+      throw notFound(translate('customers.errors.entity_not_found', 'Entity not found'))
     }
     const entityKind = targetEntity.kind === 'person' || targetEntity.kind === 'company' ? targetEntity.kind : null
     const resourceKind = resolveResourceKind(entityKind)

--- a/packages/core/src/modules/customers/api/people/[id]/companies/[linkId]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/[linkId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import {
   runCrudMutationGuardAfterSuccess,
   validateCrudMutationGuard,
@@ -147,9 +147,7 @@ export async function PATCH(req: Request, ctx: { params?: { id?: string; linkId?
       selectedOrganizationId,
     )
     if (!resolvedLinkId) {
-      throw new CrudHttpError(404, {
-        error: translate('customers.errors.person_company_link_not_found', 'Person-company link not found'),
-      })
+      throw notFound(translate('customers.errors.person_company_link_not_found', 'Person-company link not found'))
     }
 
     const commandInput = personCompanyLinkUpdateSchema.parse({
@@ -265,9 +263,7 @@ export async function DELETE(req: Request, ctx: { params?: { id?: string; linkId
       selectedOrganizationId,
     )
     if (!resolvedLinkId) {
-      throw new CrudHttpError(404, {
-        error: translate('customers.errors.person_company_link_not_found', 'Person-company link not found'),
-      })
+      throw notFound(translate('customers.errors.person_company_link_not_found', 'Person-company link not found'))
     }
 
     const commandInput = personCompanyLinkDeleteSchema.parse({

--- a/packages/core/src/modules/customers/api/people/[id]/companies/context.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/context.ts
@@ -1,5 +1,5 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import {
@@ -35,7 +35,7 @@ export async function loadPersonContext(req: Request, personId: string) {
   )
 
   if (!person) {
-    throw new CrudHttpError(404, { error: translate('customers.errors.person_not_found', 'Person not found') })
+    throw notFound(translate('customers.errors.person_not_found', 'Person not found'))
   }
 
   if (!isOrganizationReadAccessAllowed({ scope, auth: authenticatedAuth, organizationId: person.organizationId })) {
@@ -53,7 +53,7 @@ export async function loadPersonContext(req: Request, personId: string) {
     },
   )
   if (!profile) {
-    throw new CrudHttpError(404, { error: translate('customers.errors.person_profile_not_found', 'Person profile not found') })
+    throw notFound(translate('customers.errors.person_profile_not_found', 'Person profile not found'))
   }
 
   return {

--- a/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
@@ -174,7 +174,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
     const decryptionScope = { tenantId: auth.tenantId, organizationId: auth.orgId ?? null }
     const person = await findOneWithDecryption(em, CustomerEntity, { id, kind: 'person', tenantId: auth.tenantId, deletedAt: null }, {}, decryptionScope)
     if (!person) {
-      throw new CrudHttpError(404, { error: translate('customers.errors.person_not_found', 'Person not found') })
+      throw notFound(translate('customers.errors.person_not_found', 'Person not found'))
     }
 
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: person.organizationId })) {

--- a/packages/core/src/modules/customers/api/todos/route.ts
+++ b/packages/core/src/modules/customers/api/todos/route.ts
@@ -7,7 +7,7 @@ import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import {
@@ -218,7 +218,7 @@ async function resolveCanonicalTodoTargetId(
 
   const legacyLink = await findLegacyTodoLink(em, target, tenantId)
   if (!legacyLink) {
-    if (!target.todoId) throw new CrudHttpError(404, { error: 'Todo not found' })
+    if (!target.todoId) throw notFound('Todo not found')
     return target.todoId
   }
 

--- a/packages/core/src/modules/customers/commands/addresses.ts
+++ b/packages/core/src/modules/customers/commands/addresses.ts
@@ -14,7 +14,7 @@ import {
   resolveParentResourceKind,
 } from './shared'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { CrudIndexerConfig, CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
 import { E } from '#generated/entities.ids.generated'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
@@ -288,7 +288,7 @@ const updateAddressCommand: CommandHandler<AddressUpdateInput, { addressId: stri
     const parsed = addressUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const address = await em.findOne(CustomerAddress, { id: parsed.id })
-    if (!address) throw new CrudHttpError(404, { error: 'Address not found' })
+    if (!address) throw notFound('Address not found')
     ensureTenantScope(ctx, address.tenantId)
     ensureOrganizationScope(ctx, address.organizationId)
 
@@ -477,7 +477,7 @@ const deleteAddressCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const id = requireId(input, 'Address id required')
       const em = (ctx.container.resolve('em') as EntityManager).fork()
       const address = await em.findOne(CustomerAddress, { id })
-      if (!address) throw new CrudHttpError(404, { error: 'Address not found' })
+      if (!address) throw notFound('Address not found')
       ensureTenantScope(ctx, address.tenantId)
       ensureOrganizationScope(ctx, address.organizationId)
       em.remove(address)

--- a/packages/core/src/modules/customers/commands/comments.ts
+++ b/packages/core/src/modules/customers/commands/comments.ts
@@ -15,7 +15,7 @@ import {
   resolveParentResourceKind,
 } from './shared'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { CrudIndexerConfig, CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
 import { E } from '#generated/entities.ids.generated'
 import { makeCreateRedo } from '@open-mercato/shared/lib/commands/redo'
@@ -196,7 +196,7 @@ const updateCommentCommand: CommandHandler<CommentUpdateInput, { commentId: stri
     const parsed = commentUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const comment = await em.findOne(CustomerComment, { id: parsed.id })
-    if (!comment) throw new CrudHttpError(404, { error: 'Comment not found' })
+    if (!comment) throw notFound('Comment not found')
     ensureTenantScope(ctx, comment.tenantId)
     ensureOrganizationScope(ctx, comment.organizationId)
 
@@ -332,7 +332,7 @@ const deleteCommentCommand: CommandHandler<{ body?: Record<string, unknown>; que
       const id = requireId(input, 'Comment id required')
       const em = (ctx.container.resolve('em') as EntityManager).fork()
       const comment = await em.findOne(CustomerComment, { id })
-      if (!comment) throw new CrudHttpError(404, { error: 'Comment not found' })
+      if (!comment) throw notFound('Comment not found')
       ensureTenantScope(ctx, comment.tenantId)
       ensureOrganizationScope(ctx, comment.organizationId)
       em.remove(comment)

--- a/packages/core/src/modules/customers/commands/companies.ts
+++ b/packages/core/src/modules/customers/commands/companies.ts
@@ -11,7 +11,7 @@ import {
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import {
   CustomerAddress,
   CustomerComment,
@@ -738,7 +738,7 @@ const updateCompanyCommand: CommandHandler<CompanyUpdateInput, { entityId: strin
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
     const profile = await em.findOne(CustomerCompanyProfile, { entity: record })
-    if (!profile) throw new CrudHttpError(404, { error: 'Company profile not found' })
+    if (!profile) throw notFound('Company profile not found')
 
     await withAtomicFlush(em, [
       () => {

--- a/packages/core/src/modules/customers/commands/deals.ts
+++ b/packages/core/src/modules/customers/commands/deals.ts
@@ -40,7 +40,7 @@ import {
   buildCustomFieldResetMap,
   type CustomFieldChangeSet,
 } from '@open-mercato/shared/lib/commands/customFieldSnapshots'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { CrudIndexerConfig, CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
 import { E } from '#generated/entities.ids.generated'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -625,7 +625,7 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const deal = await findOneWithDecryption(em, CustomerDeal, { id: parsed.id, deletedAt: null })
     const record = deal ?? null
-    if (!record) throw new CrudHttpError(404, { error: 'Deal not found' })
+    if (!record) throw notFound('Deal not found')
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
 
@@ -936,7 +936,7 @@ const deleteDealCommand: CommandHandler<{ body?: Record<string, unknown>; query?
       const em = (ctx.container.resolve('em') as EntityManager).fork()
       const deal = await findOneWithDecryption(em, CustomerDeal, { id, deletedAt: null })
       const record = deal ?? null
-      if (!record) throw new CrudHttpError(404, { error: 'Deal not found' })
+      if (!record) throw notFound('Deal not found')
       ensureTenantScope(ctx, record.tenantId)
       ensureOrganizationScope(ctx, record.organizationId)
       await deleteDealStageTransitions(em, record)

--- a/packages/core/src/modules/customers/commands/dictionaries.ts
+++ b/packages/core/src/modules/customers/commands/dictionaries.ts
@@ -1,7 +1,7 @@
 import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/commands'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { buildChanges } from '@open-mercato/shared/lib/commands/helpers'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { invalidateDictionaryCache } from '../api/dictionaries/cache'
@@ -425,7 +425,7 @@ const updateDictionaryEntryCommand: CommandHandler<CustomerDictionaryEntryUpdate
       },
     )
     if (!entry || entry.organizationId !== parsed.organizationId || entry.tenantId !== parsed.tenantId || entry.kind !== parsed.kind) {
-      throw new CrudHttpError(404, { error: 'Dictionary entry not found' })
+      throw notFound('Dictionary entry not found')
     }
 
     let changed = false
@@ -611,7 +611,7 @@ const deleteDictionaryEntryCommand: CommandHandler<CustomerDictionaryEntryDelete
       },
     )
     if (!entry || entry.organizationId !== parsed.organizationId || entry.tenantId !== parsed.tenantId || entry.kind !== parsed.kind) {
-      throw new CrudHttpError(404, { error: 'Dictionary entry not found' })
+      throw notFound('Dictionary entry not found')
     }
     if (entry.kind === 'person_company_role') {
       const usage = await loadRoleTypeUsage(em, {

--- a/packages/core/src/modules/customers/commands/entity-roles.ts
+++ b/packages/core/src/modules/customers/commands/entity-roles.ts
@@ -2,7 +2,7 @@ import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { CommandHandler } from '@open-mercato/shared/lib/commands'
 import type { CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
 import { emitCrudSideEffects, emitCrudUndoSideEffects } from '@open-mercato/shared/lib/commands/helpers'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
@@ -345,7 +345,7 @@ const updateEntityRoleCommand: CommandHandler<EntityRoleUpdateInput, { roleId: s
       { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
     )
     if (!role) {
-      throw new CrudHttpError(404, { error: 'Role not found' })
+      throw notFound('Role not found')
     }
 
     role.userId = parsed.userId
@@ -448,7 +448,7 @@ const deleteEntityRoleCommand: CommandHandler<EntityRoleDeleteInput, { roleId: s
       { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
     )
     if (!role) {
-      throw new CrudHttpError(404, { error: 'Role not found' })
+      throw notFound('Role not found')
     }
 
     role.deletedAt = new Date()

--- a/packages/core/src/modules/customers/commands/interactions.ts
+++ b/packages/core/src/modules/customers/commands/interactions.ts
@@ -38,7 +38,7 @@ import {
   loadCustomFieldSnapshot,
   buildCustomFieldResetMap,
 } from '@open-mercato/shared/lib/commands/customFieldSnapshots'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { enforceRecordGoneIsConflict, enforceCommandOptimisticLockWithGuards } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { CrudIndexerConfig, CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
@@ -642,7 +642,7 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
       const interaction = await findOneWithDecryption(trx, CustomerInteraction, { id: parsed.id, deletedAt: null })
       if (!interaction) {
         enforceRecordGoneIsConflict({ resourceKind: 'customers.interaction', resourceId: parsed.id, request: ctx.request ?? null })
-        throw new CrudHttpError(404, { error: 'Interaction not found' })
+        throw notFound('Interaction not found')
       }
       ensureTenantScope(ctx, interaction.tenantId)
       ensureOrganizationScope(ctx, interaction.organizationId)
@@ -684,7 +684,7 @@ const updateInteractionCommand: CommandHandler<InteractionUpdateInput, { interac
             userFeatures: undefined,
           })
         ) {
-          throw new CrudHttpError(404, { error: 'Email not found' })
+          throw notFound('Email not found')
         }
       }
 
@@ -915,7 +915,7 @@ const completeInteractionCommand: CommandHandler<InteractionCompleteInput, { int
       const interaction = await findOneWithDecryption(trx, CustomerInteraction, { id: parsed.id, deletedAt: null })
       if (!interaction) {
         enforceRecordGoneIsConflict({ resourceKind: 'customers.interaction', resourceId: parsed.id, request: ctx.request ?? null })
-        throw new CrudHttpError(404, { error: 'Interaction not found' })
+        throw notFound('Interaction not found')
       }
       ensureTenantScope(ctx, interaction.tenantId)
       ensureOrganizationScope(ctx, interaction.organizationId)
@@ -1055,7 +1055,7 @@ const cancelInteractionCommand: CommandHandler<InteractionCancelInput, { interac
       const interaction = await findOneWithDecryption(trx, CustomerInteraction, { id: parsed.id, deletedAt: null })
       if (!interaction) {
         enforceRecordGoneIsConflict({ resourceKind: 'customers.interaction', resourceId: parsed.id, request: ctx.request ?? null })
-        throw new CrudHttpError(404, { error: 'Interaction not found' })
+        throw notFound('Interaction not found')
       }
       ensureTenantScope(ctx, interaction.tenantId)
       ensureOrganizationScope(ctx, interaction.organizationId)
@@ -1193,7 +1193,7 @@ const deleteInteractionCommand: CommandHandler<{ body?: Record<string, unknown>;
         const interaction = await findOneWithDecryption(trx, CustomerInteraction, { id, deletedAt: null })
         if (!interaction) {
           enforceRecordGoneIsConflict({ resourceKind: 'customers.interaction', resourceId: id, request: ctx.request ?? null })
-          throw new CrudHttpError(404, { error: 'Interaction not found' })
+          throw notFound('Interaction not found')
         }
         ensureTenantScope(ctx, interaction.tenantId)
         ensureOrganizationScope(ctx, interaction.organizationId)

--- a/packages/core/src/modules/customers/commands/labels.ts
+++ b/packages/core/src/modules/customers/commands/labels.ts
@@ -2,7 +2,7 @@ import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { CommandHandler } from '@open-mercato/shared/lib/commands'
 import type { CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
 import { emitCrudSideEffects, emitCrudUndoSideEffects } from '@open-mercato/shared/lib/commands/helpers'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
@@ -287,7 +287,7 @@ const assignLabelCommand: CommandHandler<LabelAssignCommandInput, { assignmentId
       { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
     )
     if (!label) {
-      throw new CrudHttpError(404, { error: 'Label not found' })
+      throw notFound('Label not found')
     }
 
     const entity = await findOneWithDecryption(
@@ -298,7 +298,7 @@ const assignLabelCommand: CommandHandler<LabelAssignCommandInput, { assignmentId
       { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
     )
     if (!entity) {
-      throw new CrudHttpError(404, { error: 'Entity not found' })
+      throw notFound('Entity not found')
     }
 
     const existing = await findOneWithDecryption(
@@ -441,7 +441,7 @@ const assignLabelCommand: CommandHandler<LabelAssignCommandInput, { assignmentId
       { tenantId: after.tenantId, organizationId: after.organizationId },
     )
     if (!label) {
-      throw new CrudHttpError(404, { error: 'Label not found' })
+      throw notFound('Label not found')
     }
     const entity = await findOneWithDecryption(
       em,
@@ -451,7 +451,7 @@ const assignLabelCommand: CommandHandler<LabelAssignCommandInput, { assignmentId
       { tenantId: after.tenantId, organizationId: after.organizationId },
     )
     if (!entity) {
-      throw new CrudHttpError(404, { error: 'Entity not found' })
+      throw notFound('Entity not found')
     }
 
     let assignment = await findOneWithDecryption(
@@ -570,7 +570,7 @@ const unassignLabelCommand: CommandHandler<LabelUnassignCommandInput, { assignme
       { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
     )
     if (!label) {
-      throw new CrudHttpError(404, { error: 'Label not found' })
+      throw notFound('Label not found')
     }
 
     const entity = await findOneWithDecryption(
@@ -581,7 +581,7 @@ const unassignLabelCommand: CommandHandler<LabelUnassignCommandInput, { assignme
       { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
     )
     if (!entity) {
-      throw new CrudHttpError(404, { error: 'Entity not found' })
+      throw notFound('Entity not found')
     }
 
     const existing = await findOneWithDecryption(

--- a/packages/core/src/modules/customers/commands/people.ts
+++ b/packages/core/src/modules/customers/commands/people.ts
@@ -46,7 +46,7 @@ import {
 } from './shared'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
 import { resolveRedoSnapshot } from '@open-mercato/shared/lib/commands/redo'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import {
   loadCustomFieldSnapshot,
@@ -851,7 +851,7 @@ const createPersonCommand: CommandHandler<PersonCreateInput, { entityId: string;
         undefined,
         { tenantId: after.entity.tenantId, organizationId: after.entity.organizationId },
       )
-      if (!existingProfile) throw new CrudHttpError(404, { error: 'Person profile not found' })
+      if (!existingProfile) throw notFound('Person profile not found')
       profile = existingProfile
       const survivingEntity = entity
       await withAtomicFlush(em, [
@@ -927,7 +927,7 @@ const updatePersonCommand: CommandHandler<PersonUpdateInput, { entityId: string 
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
     const profile = await em.findOne(CustomerPersonProfile, { entity: record })
-    if (!profile) throw new CrudHttpError(404, { error: 'Person profile not found' })
+    if (!profile) throw notFound('Person profile not found')
 
     if (parsed.displayName !== undefined) {
       const nextDisplayName = parsed.displayName.trim()

--- a/packages/core/src/modules/customers/commands/personCompanyLinks.ts
+++ b/packages/core/src/modules/customers/commands/personCompanyLinks.ts
@@ -2,7 +2,7 @@ import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { CommandHandler } from '@open-mercato/shared/lib/commands'
 import type { CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
 import { emitCrudSideEffects, emitCrudUndoSideEffects } from '@open-mercato/shared/lib/commands/helpers'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
@@ -126,7 +126,7 @@ async function requirePersonEntity(
     { tenantId, organizationId },
   )
   if (!person) {
-    throw new CrudHttpError(404, { error: 'Person not found' })
+    throw notFound('Person not found')
   }
   return person
 }
@@ -145,7 +145,7 @@ async function requireCompanyEntity(
     { tenantId, organizationId },
   )
   if (!company) {
-    throw new CrudHttpError(404, { error: 'Company not found' })
+    throw notFound('Company not found')
   }
   return company
 }
@@ -162,7 +162,7 @@ async function requirePersonProfile(
     { tenantId: person.tenantId, organizationId: person.organizationId },
   )
   if (!profile) {
-    throw new CrudHttpError(404, { error: 'Person profile not found' })
+    throw notFound('Person profile not found')
   }
   return profile
 }
@@ -433,7 +433,7 @@ const updatePersonCompanyLinkCommand: CommandHandler<PersonCompanyLinkUpdateInpu
       { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
     )
     if (!link) {
-      throw new CrudHttpError(404, { error: 'Company link not found' })
+      throw notFound('Company link not found')
     }
 
     const personId = typeof link.person === 'string' ? link.person : link.person.id
@@ -606,7 +606,7 @@ const deletePersonCompanyLinkCommand: CommandHandler<PersonCompanyLinkDeleteInpu
       { tenantId: parsed.tenantId, organizationId: parsed.organizationId },
     )
     if (!link) {
-      throw new CrudHttpError(404, { error: 'Company link not found' })
+      throw notFound('Company link not found')
     }
 
     const personId = typeof link.person === 'string' ? link.person : link.person.id

--- a/packages/core/src/modules/customers/commands/pipeline-stages.ts
+++ b/packages/core/src/modules/customers/commands/pipeline-stages.ts
@@ -14,7 +14,7 @@ import {
   type PipelineStageReorderInput,
 } from '../data/validators'
 import { ensureOrganizationScope, ensureTenantScope, ensureDictionaryEntry } from './shared'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
 import {
   enforceCommandOptimisticLockWithGuards,
@@ -112,7 +112,7 @@ const updatePipelineStageCommand: CommandHandler<PipelineStageUpdateInput, void>
     })
     if (!stage) {
       enforceRecordGoneIsConflict({ resourceKind: 'customers.pipelineStage', resourceId: parsed.id, request: ctx.request ?? null })
-      throw new CrudHttpError(404, { error: 'Pipeline stage not found' })
+      throw notFound('Pipeline stage not found')
     }
 
     ensureTenantScope(ctx, stage.tenantId)
@@ -164,7 +164,7 @@ const deletePipelineStageCommand: CommandHandler<PipelineStageDeleteInput, void>
     })
     if (!stage) {
       enforceRecordGoneIsConflict({ resourceKind: 'customers.pipelineStage', resourceId: parsed.id, request: ctx.request ?? null })
-      throw new CrudHttpError(404, { error: 'Pipeline stage not found' })
+      throw notFound('Pipeline stage not found')
     }
 
     ensureTenantScope(ctx, stage.tenantId)

--- a/packages/core/src/modules/customers/commands/pipelines.ts
+++ b/packages/core/src/modules/customers/commands/pipelines.ts
@@ -11,7 +11,7 @@ import {
   type PipelineDeleteInput,
 } from '../data/validators'
 import { ensureOrganizationScope, ensureTenantScope } from './shared'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import {
   enforceCommandOptimisticLockWithGuards,
   enforceRecordGoneIsConflict,
@@ -62,7 +62,7 @@ const updatePipelineCommand: CommandHandler<PipelineUpdateInput, void> = {
     const pipeline = await em.findOne(CustomerPipeline, { id: parsed.id })
     if (!pipeline) {
       enforceRecordGoneIsConflict({ resourceKind: 'customers.pipeline', resourceId: parsed.id, request: ctx.request ?? null })
-      throw new CrudHttpError(404, { error: 'Pipeline not found' })
+      throw notFound('Pipeline not found')
     }
 
     ensureTenantScope(ctx, pipeline.tenantId)
@@ -102,7 +102,7 @@ const deletePipelineCommand: CommandHandler<PipelineDeleteInput, void> = {
     const pipeline = await em.findOne(CustomerPipeline, { id: parsed.id })
     if (!pipeline) {
       enforceRecordGoneIsConflict({ resourceKind: 'customers.pipeline', resourceId: parsed.id, request: ctx.request ?? null })
-      throw new CrudHttpError(404, { error: 'Pipeline not found' })
+      throw notFound('Pipeline not found')
     }
 
     ensureTenantScope(ctx, pipeline.tenantId)

--- a/packages/core/src/modules/customers/commands/shared.ts
+++ b/packages/core/src/modules/customers/commands/shared.ts
@@ -1,6 +1,6 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CustomerDeal, CustomerEntity, CustomerTag, CustomerTagAssignment, CustomerDictionaryEntry, type CustomerEntityKind } from '../data/entities'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { ensureOrganizationScope, ensureSameScope } from '@open-mercato/shared/lib/commands/scope'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -47,7 +47,7 @@ export async function requireCustomerEntity(
     tenantId: scope.tenantId,
     organizationId: scope.organizationId,
   })
-  if (!entity) throw new CrudHttpError(404, { error: message })
+  if (!entity) throw notFound(message)
   if (kind && entity.kind !== kind) {
     throw new CrudHttpError(400, { error: 'Invalid entity type' })
   }
@@ -80,7 +80,7 @@ export async function requireTimelineParentEntity(
   if (deal) {
     throw new CrudHttpError(422, { error: 'entityId must reference a person or company, not a deal' })
   }
-  throw new CrudHttpError(404, { error: 'Customer not found' })
+  throw notFound('Customer not found')
 }
 
 export async function syncEntityTags(

--- a/packages/core/src/modules/customers/commands/tags.ts
+++ b/packages/core/src/modules/customers/commands/tags.ts
@@ -21,7 +21,7 @@ import {
   loadEntityTagIds,
 } from './shared'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { emitCustomersEvent } from '../events'
@@ -172,7 +172,7 @@ const updateTagCommand: CommandHandler<TagUpdateInput, { tagId: string }> = {
     const parsed = tagUpdateSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const tag = await em.findOne(CustomerTag, { id: parsed.id })
-    if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
+    if (!tag) throw notFound('Tag not found')
     ensureTenantScope(ctx, tag.tenantId)
     ensureOrganizationScope(ctx, tag.organizationId)
 
@@ -290,7 +290,7 @@ const deleteTagCommand: CommandHandler<{ body?: Record<string, unknown>; query?:
     const id = requireId(input, 'Tag id required')
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const tag = await em.findOne(CustomerTag, { id })
-    if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
+    if (!tag) throw notFound('Tag not found')
     ensureTenantScope(ctx, tag.tenantId)
     ensureOrganizationScope(ctx, tag.organizationId)
     await withAtomicFlush(em, [
@@ -386,7 +386,7 @@ const assignTagCommand: CommandHandler<TagAssignmentInput, { assignmentId: strin
 
     const em = (ctx.container.resolve('em') as EntityManager).fork()
   const tag = await em.findOne(CustomerTag, { id: parsed.tagId, tenantId: parsed.tenantId, organizationId: parsed.organizationId })
-  if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
+  if (!tag) throw notFound('Tag not found')
   const entity = await requireCustomerEntity(em, parsed.entityId, { tenantId: parsed.tenantId, organizationId: parsed.organizationId }, undefined, 'Customer not found')
   ensureSameScope(entity, parsed.organizationId, parsed.tenantId)
   const tagIds = await loadEntityTagIds(em, entity)
@@ -477,7 +477,7 @@ const assignTagCommand: CommandHandler<TagAssignmentInput, { assignmentId: strin
     const assignmentId = logEntry?.resourceId ?? null
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const tag = await em.findOne(CustomerTag, { id: before.tagId })
-    if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
+    if (!tag) throw notFound('Tag not found')
     const entity = await requireCustomerEntity(em, before.entityId, { tenantId: before.tenantId, organizationId: before.organizationId }, undefined, 'Customer not found')
     ensureSameScope(entity, before.organizationId, before.tenantId)
 
@@ -537,7 +537,7 @@ const unassignTagCommand: CommandHandler<TagAssignmentInput, { assignmentId: str
       tenantId: parsed.tenantId,
       organizationId: parsed.organizationId,
     })
-    if (!existing) throw new CrudHttpError(404, { error: 'Tag assignment not found' })
+    if (!existing) throw notFound('Tag assignment not found')
     await em.remove(existing).flush()
 
     const de = (ctx.container.resolve('dataEngine') as DataEngine)
@@ -591,7 +591,7 @@ const unassignTagCommand: CommandHandler<TagAssignmentInput, { assignmentId: str
     const tag = await em.findOne(CustomerTag, { id: before.tagId })
     const entity = await requireCustomerEntity(em, before.entityId, { tenantId: before.tenantId, organizationId: before.organizationId }, undefined, 'Customer not found')
     ensureSameScope(entity, before.organizationId, before.tenantId)
-    if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
+    if (!tag) throw notFound('Tag not found')
     const existing = await em.findOne(CustomerTagAssignment, {
       tag,
       entity,

--- a/packages/core/src/modules/customers/commands/todos.ts
+++ b/packages/core/src/modules/customers/commands/todos.ts
@@ -16,7 +16,7 @@ import {
   resolveParentResourceKind,
 } from './shared'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { notFound } from '@open-mercato/shared/lib/crud/errors'
 import {
   CUSTOMER_INTERACTION_TASK_SOURCE,
   CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
@@ -290,7 +290,7 @@ async function resolveTodoTarget(
   const em = (ctx.container.resolve('em') as EntityManager).fork()
   const legacyLink = await em.findOne(CustomerTodoLink, { id: linkId }, { populate: ['entity'] })
   if (!legacyLink) {
-    throw new CrudHttpError(404, { error: 'Todo link not found' })
+    throw notFound('Todo link not found')
   }
 
   const bridgedSnapshot = await loadInteractionSnapshot(legacyLink.todoId, ctx)
@@ -333,7 +333,7 @@ const unlinkTodoCommand: CommandHandler<
     const target = await resolveTodoTarget(parsed.linkId, ctx)
     if (!target.canonicalExists) {
       if (!target.legacyLink) {
-        throw new CrudHttpError(404, { error: 'Todo link not found' })
+        throw notFound('Todo link not found')
       }
       const canonicalCreate = getRequiredHandler<
         InteractionCreateInput & { customValues?: Record<string, unknown> },

--- a/packages/core/src/modules/customers/lib/personCompanies.ts
+++ b/packages/core/src/modules/customers/lib/personCompanies.ts
@@ -1,5 +1,5 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import {
   CustomerEntity,
@@ -48,7 +48,7 @@ async function requireCompany(
 ): Promise<CustomerEntity> {
   const company = await findOneWithDecryption(em, CustomerEntity, { id: companyId, kind: 'company', deletedAt: null }, {}, { tenantId, organizationId })
   if (!company) {
-    throw new CrudHttpError(404, { error: 'Company not found' })
+    throw notFound('Company not found')
   }
   if (company.organizationId !== organizationId || company.tenantId !== tenantId) {
     throw new CrudHttpError(403, { error: 'Cannot link company outside current scope' })
@@ -260,7 +260,7 @@ export async function updatePersonCompanyLink(
   }
 
   if (!link) {
-    throw new CrudHttpError(404, { error: 'Company link not found' })
+    throw notFound('Company link not found')
   }
 
   if (patch.isPrimary === true) {
@@ -301,7 +301,7 @@ export async function removePersonCompanyLink(
       profile.company = null
       return
     }
-    throw new CrudHttpError(404, { error: 'Company link not found' })
+    throw notFound('Company link not found')
   }
 
   const removedCompanyId = typeof link.company === 'string' ? link.company : link.company.id

--- a/packages/core/src/modules/sales/api/notes/route.ts
+++ b/packages/core/src/modules/sales/api/notes/route.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { makeCrudRoute, type CrudCtx } from '@open-mercato/shared/lib/crud/factory'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
@@ -97,9 +97,7 @@ async function loadNoteForPermission(
   })
 
   if (!note) {
-    throw new CrudHttpError(404, {
-      error: translate('sales.documents.detail.error', 'Document not found or inaccessible.'),
-    })
+    throw notFound(translate('sales.documents.detail.error', 'Document not found or inaccessible.'))
   }
 
   return note

--- a/packages/core/src/modules/sales/api/quotes/accept/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/accept/route.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { CommandBus, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { LockMode } from '@mikro-orm/core'
@@ -93,7 +93,7 @@ export async function POST(req: Request) {
         )
       const quote = (await findQuoteByToken(hashedToken)) ?? (await findQuoteByToken(token))
       if (!quote) {
-        throw new CrudHttpError(404, { error: translate('sales.quotes.accept.notFound', 'Quote not found.') })
+        throw notFound(translate('sales.quotes.accept.notFound', 'Quote not found.'))
       }
 
       const now = new Date()

--- a/packages/core/src/modules/sales/api/quotes/public/[token]/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/public/[token]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createRequestContainer } from "@open-mercato/shared/lib/di/container";
 import { resolveTranslations } from "@open-mercato/shared/lib/i18n/server";
-import { CrudHttpError, isCrudHttpError } from "@open-mercato/shared/lib/crud/errors";
+import { isCrudHttpError, notFound } from "@open-mercato/shared/lib/crud/errors";
 import type { OpenApiRouteDoc } from "@open-mercato/shared/lib/openapi";
 import type { EntityManager } from "@mikro-orm/postgresql";
 import { findOneWithDecryption, findWithDecryption } from "@open-mercato/shared/lib/encryption/find";
@@ -43,16 +43,12 @@ export async function GET(req: Request, ctx: { params: { token: string } }) {
       }));
     const { translate } = await resolveTranslations();
     if (!quote) {
-      throw new CrudHttpError(404, {
-        error: translate("sales.quotes.public.notFound", "Quote not found."),
-      });
+      throw notFound(translate("sales.quotes.public.notFound", "Quote not found."));
     }
 
     const auth = await getAuthFromRequest(req);
     if (auth?.tenantId && quote.tenantId !== auth.tenantId) {
-      throw new CrudHttpError(404, {
-        error: translate("sales.quotes.public.notFound", "Quote not found."),
-      });
+      throw notFound(translate("sales.quotes.public.notFound", "Quote not found."));
     }
 
     const now = new Date();

--- a/packages/core/src/modules/sales/api/quotes/send/route.ts
+++ b/packages/core/src/modules/sales/api/quotes/send/route.ts
@@ -5,7 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { resolveTranslations, detectLocale } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
   bridgeLegacyGuard,
@@ -151,7 +151,7 @@ export async function POST(req: Request) {
     const tenantScope = ctx.auth?.tenantId ? { tenantId: ctx.auth.tenantId } : undefined
     const quote = await findOneWithDecryption(em, SalesQuote, { id: input.quoteId, deletedAt: null }, {}, tenantScope)
     if (!quote) {
-      throw new CrudHttpError(404, { error: translate('sales.documents.detail.error', 'Document not found or inaccessible.') })
+      throw notFound(translate('sales.documents.detail.error', 'Document not found or inaccessible.'))
     }
     if (quote.tenantId !== ctx.auth?.tenantId || quote.organizationId !== ctx.selectedOrganizationId) {
       throw new CrudHttpError(403, { error: translate('sales.documents.errors.forbidden', 'Forbidden') })

--- a/packages/core/src/modules/sales/api/returns/[id]/route.ts
+++ b/packages/core/src/modules/sales/api/returns/[id]/route.ts
@@ -6,7 +6,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
-import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SalesReturn, SalesReturnLine } from '../../../data/entities'
 import { createLogger } from '@open-mercato/shared/lib/logger'
@@ -56,7 +56,7 @@ export async function GET(req: Request, ctx: { params: { id: string } }) {
       { tenantId: auth.tenantId, organizationId },
     )
     if (!header || !header.order) {
-      throw new CrudHttpError(404, { error: translate('sales.returns.notFound', 'Return not found.') })
+      throw notFound(translate('sales.returns.notFound', 'Return not found.'))
     }
 
     const lines = await findWithDecryption(

--- a/packages/core/src/modules/sales/commands/configuration.ts
+++ b/packages/core/src/modules/sales/commands/configuration.ts
@@ -9,7 +9,7 @@ import {
   emitCrudUndoSideEffects,
 } from '@open-mercato/shared/lib/commands/helpers'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { notFound } from '@open-mercato/shared/lib/crud/errors'
 import { loadCustomFieldSnapshot, buildCustomFieldResetMap } from '@open-mercato/shared/lib/commands/customFieldSnapshots'
 import { makeCreateRedo } from '@open-mercato/shared/lib/commands/redo'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -751,7 +751,7 @@ const updateChannelCommand: CommandHandler<ChannelUpdateInput, { channelId: stri
     const { parsed, custom } = parseWithCustomFields(channelUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await findOneWithDecryption(em, SalesChannel, { id: parsed.id, deletedAt: null }, {}, { tenantId: parsed.tenantId, organizationId: parsed.organizationId })
-    if (!record) throw new CrudHttpError(404, { error: 'Channel not found' })
+    if (!record) throw notFound('Channel not found')
     const dataEngine = ctx.container.resolve('dataEngine') as DataEngine
     const scope = resolveScopeFromUpdate(record, parsed, ctx)
 
@@ -899,7 +899,7 @@ const deleteChannelCommand: CommandHandler<
     const id = requireId(input, 'Channel id is required')
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await findOneWithDecryption(em, SalesChannel, { id }, {})
-    if (!record) throw new CrudHttpError(404, { error: 'Channel not found' })
+    if (!record) throw notFound('Channel not found')
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
     em.remove(record)
@@ -1097,7 +1097,7 @@ const updateDeliveryWindowCommand: CommandHandler<
     const { parsed, custom } = parseWithCustomFields(deliveryWindowUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await em.findOne(SalesDeliveryWindow, { id: parsed.id, deletedAt: null })
-    if (!record) throw new CrudHttpError(404, { error: 'Delivery window not found' })
+    if (!record) throw notFound('Delivery window not found')
     const scope = resolveScopeFromUpdate(record, parsed, ctx)
     record.organizationId = scope.organizationId
     record.tenantId = scope.tenantId
@@ -1201,7 +1201,7 @@ const deleteDeliveryWindowCommand: CommandHandler<
     const id = requireId(input, 'Delivery window id is required')
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await em.findOne(SalesDeliveryWindow, { id })
-    if (!record) throw new CrudHttpError(404, { error: 'Delivery window not found' })
+    if (!record) throw notFound('Delivery window not found')
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
     em.remove(record)
@@ -1377,7 +1377,7 @@ const updateShippingMethodCommand: CommandHandler<
     const { parsed, custom } = parseWithCustomFields(shippingMethodUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await em.findOne(SalesShippingMethod, { id: parsed.id, deletedAt: null })
-    if (!record) throw new CrudHttpError(404, { error: 'Shipping method not found' })
+    if (!record) throw notFound('Shipping method not found')
     const scope = resolveScopeFromUpdate(record, parsed, ctx)
     record.organizationId = scope.organizationId
     record.tenantId = scope.tenantId
@@ -1501,7 +1501,7 @@ const deleteShippingMethodCommand: CommandHandler<
     const id = requireId(input, 'Shipping method id is required')
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await em.findOne(SalesShippingMethod, { id })
-    if (!record) throw new CrudHttpError(404, { error: 'Shipping method not found' })
+    if (!record) throw notFound('Shipping method not found')
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
     em.remove(record)
@@ -1672,7 +1672,7 @@ const updatePaymentMethodCommand: CommandHandler<
     const { parsed, custom } = parseWithCustomFields(paymentMethodUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await em.findOne(SalesPaymentMethod, { id: parsed.id, deletedAt: null })
-    if (!record) throw new CrudHttpError(404, { error: 'Payment method not found' })
+    if (!record) throw notFound('Payment method not found')
     const scope = resolveScopeFromUpdate(record, parsed, ctx)
     record.organizationId = scope.organizationId
     record.tenantId = scope.tenantId
@@ -1785,7 +1785,7 @@ const deletePaymentMethodCommand: CommandHandler<
     const id = requireId(input, 'Payment method id is required')
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await em.findOne(SalesPaymentMethod, { id })
-    if (!record) throw new CrudHttpError(404, { error: 'Payment method not found' })
+    if (!record) throw notFound('Payment method not found')
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
     em.remove(record)
@@ -1971,7 +1971,7 @@ const updateTaxRateCommand: CommandHandler<TaxRateUpdateInput, { taxRateId: stri
     const { parsed, custom } = parseWithCustomFields(taxRateUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await em.findOne(SalesTaxRate, { id: parsed.id, deletedAt: null })
-    if (!record) throw new CrudHttpError(404, { error: 'Tax rate not found' })
+    if (!record) throw notFound('Tax rate not found')
     const scope = resolveScopeFromUpdate(record, parsed, ctx)
     record.organizationId = scope.organizationId
     record.tenantId = scope.tenantId
@@ -2102,7 +2102,7 @@ const deleteTaxRateCommand: CommandHandler<
     const id = requireId(input, 'Tax rate id is required')
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const record = await em.findOne(SalesTaxRate, { id })
-    if (!record) throw new CrudHttpError(404, { error: 'Tax rate not found' })
+    if (!record) throw notFound('Tax rate not found')
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
     const snapshot = await loadTaxRateSnapshot((ctx.container.resolve('em') as EntityManager), id)

--- a/packages/core/src/modules/sales/commands/documentAddresses.ts
+++ b/packages/core/src/modules/sales/commands/documentAddresses.ts
@@ -4,7 +4,7 @@ import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/c
 import { emitCrudSideEffects } from '@open-mercato/shared/lib/commands/helpers'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import {
   documentAddressCreateSchema,
   documentAddressDeleteSchema,
@@ -106,7 +106,7 @@ function applyDocumentAddressSnapshot(em: EntityManager, entity: SalesDocumentAd
 
 function assertDocumentAddressParent(entity: SalesDocumentAddress, input: { documentId: string; documentKind: 'order' | 'quote' }): void {
   if (entity.documentId !== input.documentId || entity.documentKind !== input.documentKind) {
-    throw new CrudHttpError(404, { error: 'sales.document.address.not_found' })
+    throw notFound('sales.document.address.not_found')
   }
 }
 
@@ -145,7 +145,7 @@ async function requireDocument(
   const repo = kind === 'order' ? SalesOrder : SalesQuote
   const doc = await findOneWithDecryption(em, repo, { id, organizationId, tenantId }, {}, { tenantId, organizationId })
   if (!doc) {
-    throw new CrudHttpError(404, { error: 'sales.document.not_found' })
+    throw notFound('sales.document.not_found')
   }
   return doc
 }

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -15,7 +15,7 @@ import { LockMode } from "@mikro-orm/core";
 import type { EntityManager } from "@mikro-orm/postgresql";
 import type { EventBus } from "@open-mercato/events";
 import type { DataEngine } from "@open-mercato/shared/lib/data/engine";
-import { CrudHttpError } from "@open-mercato/shared/lib/crud/errors";
+import { CrudHttpError, notFound } from "@open-mercato/shared/lib/crud/errors";
 import {
   deriveResourceFromCommandId,
   invalidateCrudCache,
@@ -4854,7 +4854,7 @@ const deleteQuoteCommand: CommandHandler<
     const em = (ctx.container.resolve("em") as EntityManager).fork();
     const quote = await findOneWithDecryption(em, SalesQuote, { id });
     if (!quote)
-      throw new CrudHttpError(404, { error: "Sales quote not found" });
+      throw notFound("Sales quote not found");
     ensureQuoteScope(ctx, quote.organizationId, quote.tenantId);
     const [addresses, notes, tags, adjustments, lines] = await Promise.all([
       findWithDecryption(
@@ -4984,7 +4984,7 @@ const updateQuoteCommand: CommandHandler<
       deletedAt: null,
     });
     if (!quote)
-      throw new CrudHttpError(404, { error: "Sales quote not found" });
+      throw notFound("Sales quote not found");
     ensureQuoteScope(ctx, quote.organizationId, quote.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, quote, SALES_RESOURCE_KIND_QUOTE);
     const shouldInvalidateSentToken = (quote.status ?? null) === "sent";
@@ -5216,7 +5216,7 @@ const updateOrderCommand: CommandHandler<
       deletedAt: null,
     });
     if (!order)
-      throw new CrudHttpError(404, { error: "Sales order not found" });
+      throw notFound("Sales order not found");
     ensureOrderScope(ctx, order.organizationId, order.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, order, SALES_RESOURCE_KIND_ORDER);
     const previousStatus = normalizeStatusValue(order.status);
@@ -5861,7 +5861,7 @@ const deleteOrderCommand: CommandHandler<
     const em = (ctx.container.resolve("em") as EntityManager).fork();
     const order = await findOneWithDecryption(em, SalesOrder, { id });
     if (!order)
-      throw new CrudHttpError(404, { error: "Sales order not found" });
+      throw notFound("Sales order not found");
     ensureOrderScope(ctx, order.organizationId, order.tenantId);
     const shipments = await em.find(SalesShipment, { order: order.id });
     const shipmentIds = shipments.map((entry) => entry.id);
@@ -6055,22 +6055,18 @@ const convertQuoteToOrderCommand: CommandHandler<
       );
       const { translate } = await resolveTranslations();
       if (!quote)
-        throw new CrudHttpError(404, {
-          error: translate(
+        throw notFound(translate(
             "sales.documents.detail.error",
             "Document not found or inaccessible.",
-          ),
-        });
+          ));
       ensureQuoteScope(ctx, quote.organizationId, quote.tenantId);
       await enforceSalesDocumentOptimisticLock(ctx, quote, SALES_RESOURCE_KIND_QUOTE);
       const snapshot = await loadQuoteSnapshot(em, payload.quoteId);
       if (!snapshot)
-        throw new CrudHttpError(404, {
-          error: translate(
+        throw notFound(translate(
             "sales.documents.detail.error",
             "Document not found or inaccessible.",
-          ),
-        });
+          ));
       const orderId = payload.orderId ?? quote.id;
       const existingOrder = await findOneWithDecryption(em, SalesOrder, {
         id: orderId,
@@ -6613,7 +6609,7 @@ const orderLineUpsertCommand: CommandHandler<
       deletedAt: null,
     });
     if (!order)
-      throw new CrudHttpError(404, { error: "Sales order not found" });
+      throw notFound("Sales order not found");
     ensureOrderScope(ctx, order.organizationId, order.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, order, SALES_RESOURCE_KIND_ORDER);
 
@@ -6930,12 +6926,10 @@ const orderLineDeleteCommand: CommandHandler<
       deletedAt: null,
     });
     if (!order)
-      throw new CrudHttpError(404, {
-        error: translate(
+      throw notFound(translate(
           "sales.documents.detail.error",
           "Document not found or inaccessible.",
-        ),
-      });
+        ));
     ensureOrderScope(ctx, order.organizationId, order.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, order, SALES_RESOURCE_KIND_ORDER);
     const shipmentCount = await em.count(SalesShipmentItem, {
@@ -6962,12 +6956,10 @@ const orderLineDeleteCommand: CommandHandler<
     );
     const filtered = existingLines.filter((line) => line.id !== parsed.id);
     if (filtered.length === existingLines.length) {
-      throw new CrudHttpError(404, {
-        error: translate(
+      throw notFound(translate(
           "sales.documents.detail.error",
           "Document not found or inaccessible.",
-        ),
-      });
+        ));
     }
     const sourceInputs = filtered.map((line, index) => ({
       ...mapOrderLineEntityToSnapshot(line),
@@ -7106,7 +7098,7 @@ const quoteLineUpsertCommand: CommandHandler<
       deletedAt: null,
     });
     if (!quote)
-      throw new CrudHttpError(404, { error: "Sales quote not found" });
+      throw notFound("Sales quote not found");
     ensureQuoteScope(ctx, quote.organizationId, quote.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, quote, SALES_RESOURCE_KIND_QUOTE);
     const [existingLines, adjustments] = await Promise.all([
@@ -7418,7 +7410,7 @@ const quoteLineDeleteCommand: CommandHandler<
       deletedAt: null,
     });
     if (!quote)
-      throw new CrudHttpError(404, { error: "Sales quote not found" });
+      throw notFound("Sales quote not found");
     ensureQuoteScope(ctx, quote.organizationId, quote.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, quote, SALES_RESOURCE_KIND_QUOTE);
     const existingLines = await em.find(
@@ -7433,7 +7425,7 @@ const quoteLineDeleteCommand: CommandHandler<
     );
     const filtered = existingLines.filter((line) => line.id !== parsed.id);
     if (filtered.length === existingLines.length) {
-      throw new CrudHttpError(404, { error: "Quote line not found" });
+      throw notFound("Quote line not found");
     }
     const sourceInputs = filtered.map((line, index) => ({
       ...mapQuoteLineEntityToSnapshot(line),
@@ -7572,7 +7564,7 @@ const orderAdjustmentUpsertCommand: CommandHandler<
       deletedAt: null,
     });
     if (!order)
-      throw new CrudHttpError(404, { error: "Sales order not found" });
+      throw notFound("Sales order not found");
     ensureOrderScope(ctx, order.organizationId, order.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, order, SALES_RESOURCE_KIND_ORDER);
     if (parsed.scope === "line") {
@@ -7866,7 +7858,7 @@ const orderAdjustmentDeleteCommand: CommandHandler<
       deletedAt: null,
     });
     if (!order)
-      throw new CrudHttpError(404, { error: "Sales order not found" });
+      throw notFound("Sales order not found");
     ensureOrderScope(ctx, order.organizationId, order.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, order, SALES_RESOURCE_KIND_ORDER);
 
@@ -7880,7 +7872,7 @@ const orderAdjustmentDeleteCommand: CommandHandler<
     ]);
     const filtered = adjustments.filter((adj) => adj.id !== parsed.id);
     if (filtered.length === adjustments.length) {
-      throw new CrudHttpError(404, { error: "Adjustment not found" });
+      throw notFound("Adjustment not found");
     }
     const lineSnapshots = existingLines.map(mapOrderLineEntityToSnapshot);
     const calcLines = lineSnapshots.map((line, index) =>
@@ -8031,7 +8023,7 @@ const quoteAdjustmentUpsertCommand: CommandHandler<
       deletedAt: null,
     });
     if (!quote)
-      throw new CrudHttpError(404, { error: "Sales quote not found" });
+      throw notFound("Sales quote not found");
     ensureQuoteScope(ctx, quote.organizationId, quote.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, quote, SALES_RESOURCE_KIND_QUOTE);
     if (parsed.scope === "line") {
@@ -8323,7 +8315,7 @@ const quoteAdjustmentDeleteCommand: CommandHandler<
       deletedAt: null,
     });
     if (!quote)
-      throw new CrudHttpError(404, { error: "Sales quote not found" });
+      throw notFound("Sales quote not found");
     ensureQuoteScope(ctx, quote.organizationId, quote.tenantId);
     await enforceSalesDocumentOptimisticLock(ctx, quote, SALES_RESOURCE_KIND_QUOTE);
 
@@ -8337,7 +8329,7 @@ const quoteAdjustmentDeleteCommand: CommandHandler<
     ]);
     const filtered = adjustments.filter((adj) => adj.id !== parsed.id);
     if (filtered.length === adjustments.length) {
-      throw new CrudHttpError(404, { error: "Adjustment not found" });
+      throw notFound("Adjustment not found");
     }
     const lineSnapshots = existingLines.map(mapQuoteLineEntityToSnapshot);
     const calcLines = lineSnapshots.map((line, index) =>

--- a/packages/core/src/modules/sales/commands/notes.ts
+++ b/packages/core/src/modules/sales/commands/notes.ts
@@ -7,7 +7,7 @@ import {
 } from '@open-mercato/shared/lib/commands/helpers'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { notFound } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { CrudEventsConfig } from '@open-mercato/shared/lib/crud/types'
 import { E } from '#generated/entities.ids.generated'
@@ -96,7 +96,7 @@ async function requireContext(
   if (contextType === 'order') {
     const order = await findOneWithDecryption(em, SalesOrder, { id: contextId }, {}, { tenantId, organizationId })
     if (!order) {
-      throw new CrudHttpError(404, { error: 'sales.notes.context_not_found' })
+      throw notFound('sales.notes.context_not_found')
     }
     if (organizationId && tenantId) {
       ensureSameScope(order, organizationId, tenantId)
@@ -111,7 +111,7 @@ async function requireContext(
   if (contextType === 'quote') {
     const quote = await findOneWithDecryption(em, SalesQuote, { id: contextId }, {}, { tenantId, organizationId })
     if (!quote) {
-      throw new CrudHttpError(404, { error: 'sales.notes.context_not_found' })
+      throw notFound('sales.notes.context_not_found')
     }
     if (organizationId && tenantId) {
       ensureSameScope(quote, organizationId, tenantId)
@@ -132,7 +132,7 @@ async function requireContext(
     { tenantId, organizationId },
   ) as (SalesInvoice | SalesCreditMemo) | null
   if (!entity) {
-    throw new CrudHttpError(404, { error: 'sales.notes.context_not_found' })
+    throw notFound('sales.notes.context_not_found')
   }
   if (organizationId && tenantId) {
     ensureSameScope(entity, organizationId, tenantId)
@@ -256,7 +256,7 @@ const createNoteCommand: CommandHandler<NoteCreateInput, { noteId: string; autho
     beforeRestore: async ({ em, snapshot }) => {
       const context = await requireContext(em, snapshot.contextType, snapshot.contextId).catch(() => null)
       if (!context) {
-        throw new CrudHttpError(404, { error: 'sales.notes.context_not_found' })
+        throw notFound('sales.notes.context_not_found')
       }
       return {
         order: snapshot.orderId ? context.order ?? null : null,
@@ -279,7 +279,7 @@ const updateNoteCommand: CommandHandler<NoteUpdateInput, { noteId: string }> = {
     const parsed = noteUpdateSchema.parse(rawInput ?? {})
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const note = await findOneWithDecryption(em, SalesNote, { id: parsed.id }, {})
-    if (!note) throw new CrudHttpError(404, { error: 'sales.notes.not_found' })
+    if (!note) throw notFound('sales.notes.not_found')
     ensureTenantScope(ctx, note.tenantId)
     ensureOrganizationScope(ctx, note.organizationId)
 
@@ -413,7 +413,7 @@ const deleteNoteCommand: CommandHandler<{ body?: Record<string, unknown>; query?
       const id = requireId(input, 'Note id required')
       const em = (ctx.container.resolve('em') as EntityManager).fork()
       const note = await findOneWithDecryption(em, SalesNote, { id }, {})
-      if (!note) throw new CrudHttpError(404, { error: 'sales.notes.not_found' })
+      if (!note) throw notFound('sales.notes.not_found')
       ensureTenantScope(ctx, note.tenantId)
       ensureOrganizationScope(ctx, note.organizationId)
       em.remove(note)

--- a/packages/core/src/modules/sales/commands/payments.ts
+++ b/packages/core/src/modules/sales/commands/payments.ts
@@ -3,7 +3,7 @@
 import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/commands'
 import { LockMode } from '@mikro-orm/core'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fields'
 import { setRecordCustomFields } from '@open-mercato/core/modules/entities/lib/helpers'
@@ -346,7 +346,7 @@ const createPaymentCommand: CommandHandler<
       )
       ensureSameScope(order, input.organizationId, input.tenantId)
       if (order.deletedAt) {
-        throw new CrudHttpError(404, { error: 'sales.payments.order_not_found' })
+        throw notFound('sales.payments.order_not_found')
       }
       // Guard the parent order's aggregate version (Gap A): a payment mutation
       // recalculates the order totals, so a stale parent must 409 before we touch it.

--- a/packages/core/src/modules/sales/commands/returns.ts
+++ b/packages/core/src/modules/sales/commands/returns.ts
@@ -3,7 +3,7 @@ import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/c
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
 import { LockMode } from '@mikro-orm/core'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { invalidateCrudCache } from '@open-mercato/shared/lib/crud/cache'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { emitCrudSideEffects } from '@open-mercato/shared/lib/commands/helpers'
@@ -456,7 +456,7 @@ async function restoreReturnEffects(
           { tenantId: snapshot.tenantId, organizationId: snapshot.organizationId },
         )
         if (!order) {
-          throw new CrudHttpError(404, { error: 'sales.returns.orderMissing' })
+          throw notFound('sales.returns.orderMissing')
         }
         ensureSameScope(order, snapshot.organizationId, snapshot.tenantId)
 
@@ -620,7 +620,7 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
         { tenantId: input.tenantId, organizationId: input.organizationId },
       )
       if (!order) {
-        throw new CrudHttpError(404, { error: translate('sales.returns.orderMissing', 'Order not found.') })
+        throw notFound(translate('sales.returns.orderMissing', 'Order not found.'))
       }
       ensureSameScope(order, input.organizationId, input.tenantId)
       await enforceSalesDocumentOptimisticLock(ctx, order, SALES_RESOURCE_KIND_ORDER)
@@ -642,7 +642,7 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
       requested.forEach(({ orderLineId, quantity }) => {
         const line = lineMap.get(orderLineId)
         if (!line) {
-          throw new CrudHttpError(404, { error: translate('sales.returns.lineMissing', 'Order line not found.') })
+          throw notFound(translate('sales.returns.lineMissing', 'Order line not found.'))
         }
         const available = computeAvailableReturnQuantity({
           quantity: toNumeric(line.quantity),
@@ -846,7 +846,7 @@ const createReturnCommand: CommandHandler<ReturnCreateInput, { returnId: string 
       { tenantId: after.tenantId, organizationId: after.organizationId },
     )
     if (!header) {
-      throw new CrudHttpError(404, { error: 'sales.returns.orderMissing' })
+      throw notFound('sales.returns.orderMissing')
     }
 
     await invalidateOrderCache(ctx.container, {
@@ -911,7 +911,7 @@ const updateReturnCommand: CommandHandler<ReturnUpdateInput, { returnId: string 
         { tenantId: input.tenantId, organizationId: input.organizationId },
       )
       if (!entity || !entity.order) {
-        throw new CrudHttpError(404, { error: translate('sales.returns.notFound', 'Return not found.') })
+        throw notFound(translate('sales.returns.notFound', 'Return not found.'))
       }
       ensureSameScope(entity, input.organizationId, input.tenantId)
       const orderId = typeof entity.order === 'string' ? entity.order : entity.order.id
@@ -1031,7 +1031,7 @@ const deleteReturnCommand: CommandHandler<ReturnDeleteInput, { returnId: string 
 
     const snapshot = await loadReturnSnapshot(em, input.id)
     if (!snapshot) {
-      throw new CrudHttpError(404, { error: translate('sales.returns.notFound', 'Return not found.') })
+      throw notFound(translate('sales.returns.notFound', 'Return not found.'))
     }
     ensureSameScope(snapshot, input.organizationId, input.tenantId)
     if (input.orderId !== snapshot.orderId) {
@@ -1046,7 +1046,7 @@ const deleteReturnCommand: CommandHandler<ReturnDeleteInput, { returnId: string 
       { tenantId: input.tenantId, organizationId: input.organizationId },
     )
     if (!header) {
-      throw new CrudHttpError(404, { error: translate('sales.returns.notFound', 'Return not found.') })
+      throw notFound(translate('sales.returns.notFound', 'Return not found.'))
     }
     ensureSameScope(header, input.organizationId, input.tenantId)
     // Lock on the return's own version, captured before any mutation.

--- a/packages/core/src/modules/sales/commands/shared.ts
+++ b/packages/core/src/modules/sales/commands/shared.ts
@@ -1,5 +1,5 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { notFound } from '@open-mercato/shared/lib/crud/errors'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import { enforceCommandOptimisticLockWithGuards } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
@@ -138,6 +138,6 @@ export async function requireScopedEntity<T extends { id: string; deletedAt?: Da
   if (scope.organizationId) where.organizationId = scope.organizationId
   if (scope.tenantId) where.tenantId = scope.tenantId
   const entity = await findOneWithDecryption(em, entityClass, where, {}, scope)
-  if (!entity) throw new CrudHttpError(404, { error: message })
+  if (!entity) throw notFound(message)
   return entity
 }

--- a/packages/core/src/modules/sales/commands/shipments.ts
+++ b/packages/core/src/modules/sales/commands/shipments.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto'
 import { registerCommand, type CommandHandler } from '@open-mercato/shared/lib/commands'
 import { LockMode } from '@mikro-orm/core'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fields'
 import { setRecordCustomFields } from '@open-mercato/core/modules/entities/lib/helpers'
@@ -340,7 +340,7 @@ async function loadOrder(
   scope?: { tenantId: string; organizationId: string }
 ): Promise<SalesOrder> {
   const order = await findOneWithDecryption(em, SalesOrder, { id, deletedAt: null }, {}, scope)
-  if (!order) throw new CrudHttpError(404, { error: 'sales.shipments.not_found' })
+  if (!order) throw notFound('sales.shipments.not_found')
   return order
 }
 
@@ -403,7 +403,7 @@ async function validateShipmentItems(params: {
     }
     const line = lineMap.get(lineId)
     if (!line) {
-      throw new CrudHttpError(404, { error: translate('sales.shipments.line_missing', 'Order line not found.') })
+      throw notFound(translate('sales.shipments.line_missing', 'Order line not found.'))
     }
     const lineTotal = toNumber(line.quantity)
     const alreadyShipped = shippedTotals.get(lineId) ?? 0
@@ -675,7 +675,7 @@ const updateShipmentCommand: CommandHandler<ShipmentUpdateInput, { shipmentId: s
         { tenantId: input.tenantId, organizationId: input.organizationId },
       )
       if (!shipmentEntity || !shipmentEntity.order) {
-        throw new CrudHttpError(404, { error: 'sales.shipments.not_found' })
+        throw notFound('sales.shipments.not_found')
       }
       ensureSameScope(shipmentEntity, input.organizationId, input.tenantId)
       const order = shipmentEntity.order as SalesOrder
@@ -970,7 +970,7 @@ const deleteShipmentCommand: CommandHandler<
         { tenantId: payload.tenantId, organizationId: payload.organizationId },
       )
       if (!shipmentEntity || !shipmentEntity.order) {
-        throw new CrudHttpError(404, { error: translate('sales.shipments.not_found', 'Shipment not found') })
+        throw notFound(translate('sales.shipments.not_found', 'Shipment not found'))
       }
       try {
         ensureSameScope(shipmentEntity, payload.organizationId, payload.tenantId)

--- a/packages/core/src/modules/sales/commands/statuses.ts
+++ b/packages/core/src/modules/sales/commands/statuses.ts
@@ -1,6 +1,6 @@
 import { DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
 import { registerDictionaryEntryCommands } from '@open-mercato/core/modules/dictionaries/commands/factory'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import {
   ensureSalesDictionary,
   getSalesDictionaryDefinition,
@@ -70,7 +70,7 @@ function registerStatusDictionaryCommands(kind: SalesDictionaryKind): void {
     resolveEntry: async ({ em, ctx, id }) => {
       const entry = await findOneWithDecryption(em, DictionaryEntry, id, { populate: ['dictionary'] })
       if (!entry) {
-        throw new CrudHttpError(404, { error: 'Dictionary entry not found' })
+        throw notFound('Dictionary entry not found')
       }
       if (entry.dictionary.key !== definition.key) {
         throw new CrudHttpError(400, { error: 'Entry does not belong to this dictionary.' })

--- a/packages/core/src/modules/sales/commands/tags.ts
+++ b/packages/core/src/modules/sales/commands/tags.ts
@@ -3,7 +3,7 @@
 import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { CommandHandler } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { CrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { SalesDocumentTag, SalesDocumentTagAssignment } from '../data/entities'
 import { ensureTenantScope } from './shared'
 import {
@@ -44,7 +44,7 @@ const updateTagCommand: CommandHandler<SalesTagUpdateInput, { tagId: string }> =
     const parsed = salesTagUpdateSchema.parse(rawInput ?? {})
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const tag = await em.findOne(SalesDocumentTag, { id: parsed.id })
-    if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
+    if (!tag) throw notFound('Tag not found')
     ensureTenantScope(ctx, parsed.tenantId ?? tag.tenantId)
     if (parsed.slug && parsed.slug !== tag.slug) {
       const conflict = await em.findOne(SalesDocumentTag, {
@@ -74,7 +74,7 @@ const deleteTagCommand: CommandHandler<{ id?: string }, { tagId: string }> = {
     if (!id) throw new CrudHttpError(400, { error: 'Tag id is required' })
     const em = (ctx.container.resolve('em') as EntityManager).fork()
     const tag = await em.findOne(SalesDocumentTag, { id })
-    if (!tag) throw new CrudHttpError(404, { error: 'Tag not found' })
+    if (!tag) throw notFound('Tag not found')
     ensureTenantScope(ctx, tag.tenantId)
     await em.nativeDelete(SalesDocumentTagAssignment, { tag: tag.id })
     em.remove(tag)

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -150,6 +150,30 @@ import { hasFeature, hasAllFeatures } from '@open-mercato/shared/security/featur
 - Use `hasAllFeatures(granted, required)` for arrays such as `features`, `requireFeatures`, or handler guard lists.
 - MUST NOT gate raw feature arrays with `includes(...)`, `Set.has(...)`, or ad hoc `every(...includes(...))` checks in shared registries or runners; wildcard grants like `module.*` and `*` are part of the RBAC contract.
 
+### CRUD HTTP Errors — MUST use the shared helpers instead of hand-rolling `CrudHttpError`
+
+`@open-mercato/shared/lib/crud/errors` owns the standardized error shapes. Use the helper, not a raw `new CrudHttpError(...)`:
+
+```typescript
+import { assertFound, notFound, badRequest, forbidden, conflict } from '@open-mercato/shared/lib/crud/errors'
+
+const deal = assertFound(await em.findOne(Deal, { id }), translate('customers.errors.deal_not_found', 'Deal not found'))
+```
+
+| Status | Helper |
+|--------|--------|
+| 400 | `badRequest(message)` |
+| 403 | `forbidden(message?)` |
+| 404 | `notFound(message?)` — or `assertFound(value, message)` when guarding a lookup |
+| 409 | `conflict(message)` |
+
+MUST rules:
+- MUST NOT hand-roll `throw new CrudHttpError(404, { error: msg })`. Pick the helper that fits the call site:
+  - **Inline lookup** → `const deal = assertFound(await em.findOne(Deal, { id }), msg)`. It throws the standardized 404 and returns the value narrowed to `T`, so there is no nullable intermediate binding.
+  - **Guard statement** (multi-line lookup, or a compound condition such as `if (!entity || entity.tenantId !== auth.tenantId)`) → `throw notFound(msg)`. TypeScript already narrows the value after the throw, so this keeps tenant-scoping conditions explicit without losing type safety.
+- `message` is passed through verbatim and is never derived from an entity name — keep routing 404 copy through `translate(...)` so it stays translatable.
+- `assertFound` treats every falsy value as missing. Use it for entity/object lookups only, never to guard numbers or strings where `0`/`''` are valid results.
+
 ### CRUD Multi-ID Filtering
 
 - Use `parseIdsParam()` and `mergeIdFilter()` from `@open-mercato/shared/lib/crud/ids` for factory-level `ids` query support.

--- a/packages/shared/src/lib/crud/__tests__/errors.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/errors.test.ts
@@ -1,4 +1,4 @@
-import { CrudHttpError, isCrudHttpError } from '../errors'
+import { CrudHttpError, isCrudHttpError, assertFound, notFound } from '../errors'
 
 describe('CrudHttpError', () => {
   it('builds from string body', () => {
@@ -32,5 +32,51 @@ describe('CrudHttpError', () => {
   it('cause defaults to undefined when options omitted', () => {
     const err = new CrudHttpError(400, 'x')
     expect(err.cause).toBeUndefined()
+  })
+})
+
+describe('notFound', () => {
+  it('builds the standardized 404 body', () => {
+    const err = notFound('Deal not found')
+    expect(err.status).toBe(404)
+    expect(err.body).toEqual({ error: 'Deal not found' })
+    expect(isCrudHttpError(err)).toBe(true)
+  })
+
+  it('falls back to a generic message', () => {
+    expect(notFound().body).toEqual({ error: 'Not found' })
+  })
+})
+
+describe('assertFound', () => {
+  it('returns the value when present', () => {
+    const deal = { id: 'deal-1' }
+    expect(assertFound(deal, 'Deal not found')).toBe(deal)
+  })
+
+  it('narrows away null and undefined', () => {
+    const lookup = (): { id: string } | null => ({ id: 'deal-1' })
+    const deal: { id: string } = assertFound(lookup(), 'Deal not found')
+    expect(deal.id).toBe('deal-1')
+  })
+
+  it.each([[null], [undefined]])('throws the standardized 404 for %p', (missing) => {
+    expect(() => assertFound(missing, 'Deal not found')).toThrow(CrudHttpError)
+    try {
+      assertFound(missing, 'Deal not found')
+    } catch (err) {
+      expect(isCrudHttpError(err)).toBe(true)
+      expect((err as CrudHttpError).status).toBe(404)
+      expect((err as CrudHttpError).body).toEqual({ error: 'Deal not found' })
+    }
+  })
+
+  it('passes the message through verbatim so translated copy survives', () => {
+    const translated = 'Umowa nie została znaleziona'
+    try {
+      assertFound(null, translated)
+    } catch (err) {
+      expect((err as CrudHttpError).body).toEqual({ error: translated })
+    }
   })
 })

--- a/packages/shared/src/lib/crud/errors.ts
+++ b/packages/shared/src/lib/crud/errors.ts
@@ -36,6 +36,16 @@ export function forbidden(message = 'Forbidden'): CrudHttpError {
   return new CrudHttpError(403, { error: message })
 }
 
+/**
+ * Builds the standardized 404 (`{ error: message }`) — use it instead of hand-rolling
+ * `new CrudHttpError(404, { error: message })`. Reach for this in guard statements, where
+ * the lookup spans several lines or the condition is compound
+ * (`if (!entity || entity.tenantId !== auth.tenantId) throw notFound(msg)`); TypeScript
+ * still narrows the value after the throw. For a plain inline lookup, `assertFound` is terser.
+ *
+ * Pass an already-translated message; this helper never derives one, so 404 copy
+ * stays routed through i18n.
+ */
 export function notFound(message = 'Not found'): CrudHttpError {
   return new CrudHttpError(404, { error: message })
 }
@@ -69,6 +79,19 @@ export function isUniqueViolation(err: unknown, constraintName?: string): boolea
   return false
 }
 
+/**
+ * The canonical "entity must exist" guard for API routes and commands: throws the
+ * standardized 404 when the lookup came back empty, and returns the value narrowed
+ * to `T` so callers drop the `| null` without a cast.
+ *
+ *   const deal = assertFound(await em.findOne(Deal, { id }), translate('customers.errors.deal_not_found', 'Deal not found'))
+ *
+ * Use this instead of hand-rolling `if (!entity) throw new CrudHttpError(404, ...)`.
+ * `message` is required and passed through verbatim, so it must already be translated.
+ *
+ * Treats every falsy value as missing, so it suits entity/object lookups — do not use
+ * it to guard numbers or strings, where `0` and `''` are legitimate results.
+ */
 export function assertFound<T>(value: T | null | undefined, message: string): T {
   if (!value) throw notFound(message)
   return value


### PR DESCRIPTION
Fixes #2364

## Problem

`if (!entity) throw new CrudHttpError(404, { error: '…not found' })` was hand-rolled across 40+ API routes and command handlers in `customers` and `sales`, re-deriving the standardized 404 body at every call site and leaving each lookup with a nullable intermediate binding.

## Approach (differs from the issue's proposal — read this first)

The issue proposed a **new** `requireEntity(entity, entityType, ctx?)` helper that derives the message from the entity type. Two reasons not to add it:

1. **The helpers already exist.** `@open-mercato/shared/lib/crud/errors` has exported `notFound(message)` and `assertFound(value, message)` all along — they were simply never adopted. Adding a third 404 helper would have created a redundant contract surface rather than removing one.
2. **Deriving the message from an entity type would un-translate the copy.** 404 messages are passed through `translate(...)` at the call site today; a helper that builds `"<EntityType> not found"` internally would bypass i18n.

So this PR adds **no new API**: it documents the existing pair and adopts it everywhere.

## What Changed

- `packages/shared/src/lib/crud/errors.ts`: JSDoc on `notFound` and `assertFound` explaining which to reach for. **No behavior change, no signature change.**
- `packages/shared/AGENTS.md`: new "CRUD HTTP Errors" section with the status→helper table and MUST rules, so new code does not reintroduce the hand-rolled form.
- **42 files** in `customers` and `sales` (API routes, command handlers, lib helpers) converted:
  - **Inline lookup** → `const deal = assertFound(await em.findOne(Deal, { id }), msg)` — throws the standardized 404 and returns the value narrowed to `T`.
  - **Guard statement** (multi-line lookup, or a compound condition like `if (!entity || entity.tenantId !== ctx.tenantId)`) → `throw notFound(msg)`. TypeScript still narrows after the throw, so tenant-scoping conditions stay explicit and visible.

Every message is passed through verbatim — no 404 copy was reworded, derived, or moved out of `translate(...)`.

## Tests

- `packages/shared/src/lib/crud/__tests__/errors.test.ts`: coverage for both helpers — the standardized 404 body, the default message, the value passthrough, `null`/`undefined` narrowing, and that the message survives verbatim so translated copy is not mangled.
- `yarn typecheck` green (the type narrowing is what proves the mechanical conversion is faithful).
- `@open-mercato/shared`: 23 suites / 285 tests green. `@open-mercato/core`: 986 of 987 suites green (7557 tests).
- The one failing suite, `customers/components/__tests__/DealsKpiStrip.test.tsx`, is **pre-existing and unrelated** — it reproduces identically on a pristine `develop` with zero changes applied (this dev machine's Polish locale formats currency as `1234,50 USD`, so the test's `1K` lookup misses). Same known failure documented in #4172.

## Breaking Changes

None. Purely mechanical: identical `404` status and identical `{ error: message }` body at every converted call site. No exported signature changed and no helper was added or removed — `CrudHttpError` remains exported and usable for the non-404 cases.

🤖 Generated by autofix.