### PR TITLE
fix(ui): mobile layout — clamp Export dropdown & demo overlays, scrollable calendar tabs

### DIFF
--- a/apps/mercato/src/components/DemoFeedbackWidget.tsx
+++ b/apps/mercato/src/components/DemoFeedbackWidget.tsx
@@ -231,7 +231,7 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
     <button
       type="button"
       onClick={() => { setOpen(true); if (submitState === 'sent') resetForm() }}
-      className="om-demo-feedback-floating fixed bottom-6 right-6 z-banner flex items-center gap-2 rounded-full px-5 py-3 text-sm font-semibold text-black shadow-xl transition-all hover:scale-105 hover:shadow-2xl active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 animate-[subtle-bounce_2s_ease-in-out_infinite]"
+      className="om-demo-feedback-floating fixed bottom-6 right-6 z-banner flex max-w-[calc(100vw-3rem)] items-center gap-2 rounded-full px-5 py-3 text-sm font-semibold text-black shadow-xl transition-all hover:scale-105 hover:shadow-2xl active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 animate-[subtle-bounce_2s_ease-in-out_infinite]"
       style={{
         backgroundImage: 'linear-gradient(135deg, var(--brand-lime, #B4F372) 0%, #EEFB63 50%, var(--brand-violet, #BC9AFF) 100%)',
       }}

--- a/apps/mercato/src/components/GlobalNoticeBars.tsx
+++ b/apps/mercato/src/components/GlobalNoticeBars.tsx
@@ -57,7 +57,7 @@ export function GlobalNoticeBars({ demoModeEnabled }: { demoModeEnabled: boolean
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-4 z-banner flex flex-col items-center gap-3 px-4">
       {showDemoNotice ? (
-        <div className="pointer-events-auto w-full max-w-4xl rounded-lg border border-status-warning-border bg-status-warning-bg/90 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-status-warning-bg/80">
+        <div className="pointer-events-auto w-full max-w-[calc(100vw-2rem)] sm:max-w-4xl rounded-lg border border-status-warning-border bg-status-warning-bg/90 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-status-warning-bg/80">
           <div className="flex items-start gap-3">
             <div className="flex-1 text-sm text-status-warning-text space-y-1">
               <p className="font-medium">{t('notices.demo.title', 'Demo Environment')}</p>
@@ -100,7 +100,7 @@ export function GlobalNoticeBars({ demoModeEnabled }: { demoModeEnabled: boolean
       ) : null}
 
       {showCookieNotice ? (
-        <div className="pointer-events-auto w-full max-w-4xl rounded-lg border border-border bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <div className="pointer-events-auto w-full max-w-[calc(100vw-2rem)] sm:max-w-4xl rounded-lg border border-border bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="text-sm text-muted-foreground">
               {t('notices.cookies.description', 'We use essential cookies to remember your preferences. Learn how we handle data in our')}{' '}

--- a/packages/core/src/modules/customers/components/calendar/CalendarTabs.tsx
+++ b/packages/core/src/modules/customers/components/calendar/CalendarTabs.tsx
@@ -24,7 +24,7 @@ export function CalendarTabs({ tab, counts, view, onTabChange, onViewChange }: C
       variant="underline"
     >
       <div className="flex flex-wrap items-stretch justify-between gap-x-3 gap-y-2">
-        <div className="min-w-0 max-w-full overflow-x-auto">
+        <div className="min-w-0 max-w-full overflow-x-auto scrollbar-hide [mask-image:linear-gradient(to_right,black_calc(100%-1.5rem),transparent)] sm:[mask-image:none]">
           <TabsList className="shrink-0">
             <TabsTrigger value="all" leading={<LayoutGrid className="size-4" />}>
               {t('customers.calendar.tabs.all', 'All Scheduled')}

--- a/packages/create-app/template/src/components/DemoFeedbackWidget.tsx
+++ b/packages/create-app/template/src/components/DemoFeedbackWidget.tsx
@@ -231,7 +231,7 @@ export function DemoFeedbackWidget({ demoModeEnabled }: { demoModeEnabled: boole
     <button
       type="button"
       onClick={() => { setOpen(true); if (submitState === 'sent') resetForm() }}
-      className="om-demo-feedback-floating fixed bottom-6 right-6 z-banner flex items-center gap-2 rounded-full px-5 py-3 text-sm font-semibold text-black shadow-xl transition-all hover:scale-105 hover:shadow-2xl active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 animate-[subtle-bounce_2s_ease-in-out_infinite]"
+      className="om-demo-feedback-floating fixed bottom-6 right-6 z-banner flex max-w-[calc(100vw-3rem)] items-center gap-2 rounded-full px-5 py-3 text-sm font-semibold text-black shadow-xl transition-all hover:scale-105 hover:shadow-2xl active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 animate-[subtle-bounce_2s_ease-in-out_infinite]"
       style={{
         backgroundImage: 'linear-gradient(135deg, var(--brand-lime, #B4F372) 0%, #EEFB63 50%, var(--brand-violet, #BC9AFF) 100%)',
       }}

--- a/packages/create-app/template/src/components/GlobalNoticeBars.tsx
+++ b/packages/create-app/template/src/components/GlobalNoticeBars.tsx
@@ -57,7 +57,7 @@ export function GlobalNoticeBars({ demoModeEnabled }: { demoModeEnabled: boolean
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-4 z-banner flex flex-col items-center gap-3 px-4">
       {showDemoNotice ? (
-        <div className="pointer-events-auto w-full max-w-4xl rounded-lg border border-status-warning-border bg-status-warning-bg/90 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-status-warning-bg/80">
+        <div className="pointer-events-auto w-full max-w-[calc(100vw-2rem)] sm:max-w-4xl rounded-lg border border-status-warning-border bg-status-warning-bg/90 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-status-warning-bg/80">
           <div className="flex items-start gap-3">
             <div className="flex-1 text-sm text-status-warning-text space-y-1">
               <p className="font-medium">{t('notices.demo.title', 'Demo Environment')}</p>
@@ -100,7 +100,7 @@ export function GlobalNoticeBars({ demoModeEnabled }: { demoModeEnabled: boolean
       ) : null}
 
       {showCookieNotice ? (
-        <div className="pointer-events-auto w-full max-w-4xl rounded-lg border border-border bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <div className="pointer-events-auto w-full max-w-[calc(100vw-2rem)] sm:max-w-4xl rounded-lg border border-border bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/80">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="text-sm text-muted-foreground">
               {t('notices.cookies.description', 'We use essential cookies to remember your preferences. Learn how we handle data in our')}{' '}

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -36,6 +36,7 @@ import { apiCall, withScopedApiRequestHeaders } from './utils/apiCall'
 import { buildOptimisticLockHeader } from './utils/optimisticLock'
 import { useGuardedMutation } from './injection/useGuardedMutation'
 import { raiseCrudError } from './utils/serverErrors'
+import { computeMenuViewportShiftX } from './utils/viewport'
 import { PerspectiveSidebar } from './PerspectiveSidebar'
 import { Popover, PopoverTrigger, PopoverContent } from '../primitives/popover'
 import { formatWithPublicDateFormat, normalizeDateFormatPattern } from '../primitives/date-format'
@@ -690,8 +691,32 @@ function ExportMenu({ config, sections }: { config: DataTableExportConfig; secti
   const disabled = Boolean(config.disabled)
   const hasSections = sections.length > 0
   const [open, setOpen] = React.useState(false)
+  const [menuOffsetX, setMenuOffsetX] = React.useState(0)
   const buttonRef = React.useRef<HTMLButtonElement>(null)
   const menuRef = React.useRef<HTMLDivElement>(null)
+
+  // Keep the menu inside the viewport on narrow screens: the trigger can sit
+  // near the left edge, and a `right-0` menu would otherwise render off-screen.
+  // Measure the untransformed rect and shift it back on-screen, re-measuring on
+  // resize/orientation change while the menu stays open.
+  React.useLayoutEffect(() => {
+    if (!open) {
+      setMenuOffsetX(0)
+      return
+    }
+    const measure = () => {
+      const el = menuRef.current
+      if (!el || typeof window === 'undefined') return
+      const previousTransform = el.style.transform
+      el.style.transform = 'none'
+      const rect = el.getBoundingClientRect()
+      el.style.transform = previousTransform
+      setMenuOffsetX(computeMenuViewportShiftX(rect, window.innerWidth))
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [open])
 
   React.useEffect(() => {
     if (!open || !hasSections) return
@@ -773,7 +798,8 @@ function ExportMenu({ config, sections }: { config: DataTableExportConfig; secti
         <div
           ref={menuRef}
           role="menu"
-          className="absolute right-0 mt-2 w-60 rounded-md border bg-background py-2 shadow z-dropdown"
+          className="absolute right-0 mt-2 w-60 max-w-[calc(100vw-1rem)] rounded-md border bg-background py-2 shadow z-dropdown"
+          style={menuOffsetX ? { transform: `translateX(${menuOffsetX}px)` } : undefined}
         >
           {sections.map((section, idx) => (
             <div key={section.key} className={idx > 0 ? 'mt-2 border-t pt-3' : ''}>

--- a/packages/ui/src/backend/utils/__tests__/viewport.test.ts
+++ b/packages/ui/src/backend/utils/__tests__/viewport.test.ts
@@ -1,0 +1,26 @@
+import { computeMenuViewportShiftX } from '../viewport'
+
+describe('computeMenuViewportShiftX', () => {
+  const viewport = 390
+
+  it('returns 0 when the overlay already fits within the viewport', () => {
+    expect(computeMenuViewportShiftX({ left: 100, right: 340 }, viewport)).toBe(0)
+  })
+
+  it('shifts right when the overlay bleeds off the left edge', () => {
+    // Export dropdown reproduction: left:-38 on a narrow phone.
+    expect(computeMenuViewportShiftX({ left: -38, right: 202 }, viewport)).toBe(46)
+  })
+
+  it('shifts left (negative) when the overlay bleeds off the right edge', () => {
+    expect(computeMenuViewportShiftX({ left: 200, right: 440 }, viewport)).toBe(-58)
+  })
+
+  it('respects a custom margin', () => {
+    expect(computeMenuViewportShiftX({ left: 2, right: 200 }, viewport, 16)).toBe(14)
+  })
+
+  it('leaves overlays flush to the margin untouched', () => {
+    expect(computeMenuViewportShiftX({ left: 8, right: 382 }, viewport)).toBe(0)
+  })
+})

--- a/packages/ui/src/backend/utils/viewport.ts
+++ b/packages/ui/src/backend/utils/viewport.ts
@@ -1,0 +1,18 @@
+// Horizontal shift (px) needed to keep an overlay fully inside the viewport.
+// Positive shifts right (overlay bleeds off the left edge), negative shifts left
+// (bleeds off the right edge), 0 when it already fits. Keeps a small margin.
+//
+// The two branches are mutually exclusive for any overlay narrower than the
+// viewport (minus the margins): clearing the left edge cannot then push the
+// right edge off-screen. Callers that could exceed the viewport width MUST cap
+// the overlay (e.g. `max-w-[calc(100vw-1rem)]`) — for a genuinely too-wide
+// overlay this falls back to left-aligning it, which is the sane default.
+export function computeMenuViewportShiftX(
+  rect: { left: number; right: number },
+  viewportWidth: number,
+  margin = 8,
+): number {
+  if (rect.left < margin) return Math.ceil(margin - rect.left)
+  if (rect.right > viewportWidth - margin) return Math.floor(viewportWidth - margin - rect.right)
+  return 0
+}


### PR DESCRIPTION
Mobile (narrow-viewport) polish reported from the demo.

## Changes
- **Export dropdown (shared `DataTable`)** — could render off the left edge when its trigger sits near the left on a phone. Now clamped back into the viewport via a small pure helper (`utils/viewport.ts`, unit-tested), applied on open **and** on resize/orientation change, plus a `max-w` cap so it never exceeds the viewport.
- **Calendar filter tabs** — scroll cleanly on mobile with a right-edge fade affordance (scrollbar hidden) instead of looking cut off. Desktop unchanged (`sm:` resets the mask).
- **Demo notice bars + floating demo feedback button** — clamp to the viewport width so they no longer bleed off-screen on phones. Mirrored into the `create-app` template to keep parity.

The app-shell layout is intentionally **left untouched** — no shell-level `overflow-x` clamp, because `overflow-x: clip` on a `sticky` ancestor breaks `position: sticky` on iOS Safari. Overflow is fixed at each source instead.

## Note for maintainers
A **redeploy of `develop` to the demo is a good idea** — several of the rougher mobile states seen on the demo (e.g. overlapping calendar tabs) are already resolved on `develop` and just need the demo to catch up.

## Validation
- UI unit: **1636/1636** (incl. new `computeMenuViewportShiftX` viewport-clamp tests)
- Integration (ephemeral): **TC-CAL 13/13** — calendar tabs, filtering, customization modal, editor all green
- Typecheck: **21/21** packages · Lint: clean
- Manual QA at a true 375px viewport: filter tabs scroll + fade, Export dropdown on-screen, demo cards clamped, sticky header intact