### PR TITLE
perf: reduce standalone build peak RSS with lazy provider SDKs

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "build": "yarn build:packages && yarn generate && yarn build:packages && yarn build:app",
     "build:app": "turbo run build --filter=@open-mercato/app",
     "build:packages": "turbo run build --filter='./packages/*'",
+    "build:standalone:profile": "node ./scripts/profile-standalone-build-rss.mjs",
+    "build:standalone:profile:report": "node ./scripts/profile-standalone-build-rss.mjs --report",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "test": "cross-env NODE_OPTIONS=--max-old-space-size=768 turbo run test --concurrency=2",

--- a/packages/gateway-stripe/src/modules/gateway_stripe/__tests__/stripe-sdk-lazy-import.test.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/__tests__/stripe-sdk-lazy-import.test.ts
@@ -1,0 +1,27 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+describe('gateway-stripe server SDK loading', () => {
+  function collectTypeScriptFiles(directory: string): string[] {
+    return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+      const entryPath = path.join(directory, entry.name)
+      if (entry.isDirectory()) return collectTypeScriptFiles(entryPath)
+      return entry.isFile() && entry.name.endsWith('.ts') ? [entryPath] : []
+    })
+  }
+
+  it('does not statically import the Stripe server SDK', () => {
+    const runtimeImport = /^\s*import\s+(?!type\b)(?:[^'"]+\sfrom\s+)?['"]stripe['"]/m
+    const serverFiles = collectTypeScriptFiles(path.resolve(__dirname, '../lib'))
+
+    for (const filePath of serverFiles) {
+      const source = fs.readFileSync(filePath, 'utf8')
+      expect(source).not.toMatch(runtimeImport)
+    }
+  })
+
+  it('loads the Stripe server SDK dynamically from the centralized client helper', () => {
+    const source = fs.readFileSync(path.resolve(__dirname, '../lib/client.ts'), 'utf8')
+    expect(source).toMatch(/import\(['"]stripe['"]\)/)
+  })
+})

--- a/packages/gateway-stripe/src/modules/gateway_stripe/__tests__/stripe-sdk.test.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/__tests__/stripe-sdk.test.ts
@@ -1,0 +1,123 @@
+const mockRetrieveCurrent = jest.fn()
+const mockConstructEvent = jest.fn()
+const mockStripeConstructor = jest.fn().mockImplementation(() => ({
+  accounts: { retrieveCurrent: mockRetrieveCurrent },
+  webhooks: { constructEvent: mockConstructEvent },
+}))
+
+jest.mock('stripe', () => ({
+  __esModule: true,
+  default: mockStripeConstructor,
+}))
+
+import { resolveStripeClient } from '../lib/client'
+import { stripeHealthCheck } from '../lib/health'
+import { verifyStripeWebhook } from '../lib/webhook-handler'
+
+describe('gateway-stripe server SDK behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockStripeConstructor.mockImplementation(() => ({
+      accounts: { retrieveCurrent: mockRetrieveCurrent },
+      webhooks: { constructEvent: mockConstructEvent },
+    }))
+  })
+
+  it('rejects missing credentials before constructing a Stripe client', async () => {
+    await expect(resolveStripeClient({}, '2025-02-24.acacia')).rejects.toThrow(
+      'Stripe secret key is required',
+    )
+    expect(mockStripeConstructor).not.toHaveBeenCalled()
+  })
+
+  it('preserves the configured API version, retry count, and timeout', async () => {
+    await resolveStripeClient({ secretKey: 'sk_test_123' }, '2025-02-24.acacia')
+
+    expect(mockStripeConstructor).toHaveBeenCalledWith('sk_test_123', {
+      apiVersion: '2025-02-24.acacia',
+      maxNetworkRetries: 2,
+      timeout: 10_000,
+    })
+  })
+
+  it('returns the existing healthy account result shape', async () => {
+    mockRetrieveCurrent.mockResolvedValue({
+      id: 'acct_123',
+      business_type: 'company',
+      charges_enabled: true,
+      payouts_enabled: false,
+      country: 'PL',
+    })
+
+    const result = await stripeHealthCheck.check({ secretKey: 'sk_test_123' })
+
+    expect(result).toEqual({
+      status: 'healthy',
+      message: 'Connected to Stripe account acct_123',
+      details: {
+        accountId: 'acct_123',
+        businessType: 'company',
+        chargesEnabled: true,
+        payoutsEnabled: false,
+        country: 'PL',
+      },
+      checkedAt: expect.any(Date),
+    })
+  })
+
+  it('keeps health-check SDK failures in the unhealthy result', async () => {
+    mockRetrieveCurrent.mockRejectedValue(new Error('connection refused'))
+
+    await expect(stripeHealthCheck.check({ secretKey: 'sk_test_123' })).resolves.toEqual({
+      status: 'unhealthy',
+      message: 'Stripe connection failed: connection refused',
+      details: { error: 'connection refused' },
+      checkedAt: expect.any(Date),
+    })
+  })
+
+  it('constructs and maps a verified webhook event unchanged', async () => {
+    mockConstructEvent.mockReturnValue({
+      id: 'evt_123',
+      type: 'payment_intent.succeeded',
+      created: 1_735_689_600,
+      data: { object: { id: 'pi_123', status: 'succeeded' } },
+    })
+
+    const result = await verifyStripeWebhook({
+      rawBody: Buffer.from('{"id":"evt_123"}'),
+      headers: { 'stripe-signature': 'sig_123' },
+      credentials: {
+        secretKey: 'sk_test_123',
+        webhookSecret: 'whsec_123',
+      },
+    })
+
+    expect(mockConstructEvent).toHaveBeenCalledWith(
+      '{"id":"evt_123"}',
+      'sig_123',
+      'whsec_123',
+    )
+    expect(result).toEqual({
+      eventType: 'payment_intent.succeeded',
+      eventId: 'evt_123',
+      data: { id: 'pi_123', status: 'succeeded' },
+      idempotencyKey: 'evt_123',
+      timestamp: new Date(1_735_689_600_000),
+    })
+  })
+
+  it('preserves client construction before the missing-signature check', async () => {
+    await expect(verifyStripeWebhook({
+      rawBody: '{}',
+      headers: {},
+      credentials: {
+        secretKey: 'sk_test_123',
+        webhookSecret: 'whsec_123',
+      },
+    })).rejects.toThrow('Missing stripe-signature header')
+
+    expect(mockStripeConstructor).toHaveBeenCalledWith('sk_test_123')
+    expect(mockConstructEvent).not.toHaveBeenCalled()
+  })
+})

--- a/packages/gateway-stripe/src/modules/gateway_stripe/lib/adapters/v2023-10-16.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/lib/adapters/v2023-10-16.ts
@@ -29,7 +29,7 @@ export const stripeAdapterV20231016: GatewayAdapter = {
   providerKey: 'stripe',
 
   async createSession(input: CreateSessionInput): Promise<CreateSessionResult> {
-    const stripe = resolveStripeClient(input.credentials, '2023-10-16')
+    const stripe = await resolveStripeClient(input.credentials, '2023-10-16')
     const rendererKey = resolveStripeRendererKey(input.presentation)
     const rendererSettings = normalizeStripePaymentElementSettings(input.presentation?.rendererSettings)
 
@@ -72,7 +72,7 @@ export const stripeAdapterV20231016: GatewayAdapter = {
   },
 
   async capture(input: CaptureInput): Promise<CaptureResult> {
-    const stripe = resolveStripeClient(input.credentials, '2023-10-16')
+    const stripe = await resolveStripeClient(input.credentials, '2023-10-16')
     const paymentIntent = input.amount
       ? await stripe.paymentIntents.retrieve(input.sessionId)
       : null
@@ -89,7 +89,7 @@ export const stripeAdapterV20231016: GatewayAdapter = {
   },
 
   async refund(input: RefundInput): Promise<RefundResult> {
-    const stripe = resolveStripeClient(input.credentials, '2023-10-16')
+    const stripe = await resolveStripeClient(input.credentials, '2023-10-16')
     const paymentIntent = input.amount
       ? await stripe.paymentIntents.retrieve(input.sessionId)
       : null
@@ -108,13 +108,13 @@ export const stripeAdapterV20231016: GatewayAdapter = {
   },
 
   async cancel(input: CancelInput): Promise<CancelResult> {
-    const stripe = resolveStripeClient(input.credentials, '2023-10-16')
+    const stripe = await resolveStripeClient(input.credentials, '2023-10-16')
     const cancelled = await stripe.paymentIntents.cancel(input.sessionId)
     return { status: mapStripeStatus(cancelled.status) }
   },
 
   async getStatus(input: GetStatusInput): Promise<GatewayPaymentStatus> {
-    const stripe = resolveStripeClient(input.credentials, '2023-10-16')
+    const stripe = await resolveStripeClient(input.credentials, '2023-10-16')
     const pi = await stripe.paymentIntents.retrieve(input.sessionId)
     return {
       status: mapStripeStatus(pi.status),

--- a/packages/gateway-stripe/src/modules/gateway_stripe/lib/adapters/v2024-12-18.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/lib/adapters/v2024-12-18.ts
@@ -31,7 +31,7 @@ export const stripeAdapterV20241218: GatewayAdapter = {
   providerKey: 'stripe',
 
   async createSession(input: CreateSessionInput): Promise<CreateSessionResult> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
     const rendererKey = resolveStripeRendererKey(input.presentation)
     const rendererSettings = normalizeStripePaymentElementSettings(input.presentation?.rendererSettings)
 
@@ -74,7 +74,7 @@ export const stripeAdapterV20241218: GatewayAdapter = {
   },
 
   async capture(input: CaptureInput): Promise<CaptureResult> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
     const paymentIntent = input.amount
       ? await stripe.paymentIntents.retrieve(input.sessionId)
       : null
@@ -95,7 +95,7 @@ export const stripeAdapterV20241218: GatewayAdapter = {
   },
 
   async refund(input: RefundInput): Promise<RefundResult> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
     const paymentIntent = input.amount
       ? await stripe.paymentIntents.retrieve(input.sessionId)
       : null
@@ -119,7 +119,7 @@ export const stripeAdapterV20241218: GatewayAdapter = {
   },
 
   async cancel(input: CancelInput): Promise<CancelResult> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
 
     const cancelled = await stripe.paymentIntents.cancel(input.sessionId, {
       cancellation_reason: 'requested_by_customer',
@@ -131,7 +131,7 @@ export const stripeAdapterV20241218: GatewayAdapter = {
   },
 
   async getStatus(input: GetStatusInput): Promise<GatewayPaymentStatus> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
 
     const pi = await stripe.paymentIntents.retrieve(input.sessionId)
     return {

--- a/packages/gateway-stripe/src/modules/gateway_stripe/lib/adapters/v2025-02-24.acacia.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/lib/adapters/v2025-02-24.acacia.ts
@@ -31,7 +31,7 @@ export const stripeAdapterV20250224Acacia: GatewayAdapter = {
   providerKey: 'stripe',
 
   async createSession(input: CreateSessionInput): Promise<CreateSessionResult> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
     const rendererKey = resolveStripeRendererKey(input.presentation)
     const rendererSettings = normalizeStripePaymentElementSettings(input.presentation?.rendererSettings)
 
@@ -74,7 +74,7 @@ export const stripeAdapterV20250224Acacia: GatewayAdapter = {
   },
 
   async capture(input: CaptureInput): Promise<CaptureResult> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
     const paymentIntent = input.amount
       ? await stripe.paymentIntents.retrieve(input.sessionId)
       : null
@@ -93,7 +93,7 @@ export const stripeAdapterV20250224Acacia: GatewayAdapter = {
   },
 
   async refund(input: RefundInput): Promise<RefundResult> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
     const paymentIntent = input.amount
       ? await stripe.paymentIntents.retrieve(input.sessionId)
       : null
@@ -115,7 +115,7 @@ export const stripeAdapterV20250224Acacia: GatewayAdapter = {
   },
 
   async cancel(input: CancelInput): Promise<CancelResult> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
 
     const cancelled = await stripe.paymentIntents.cancel(input.sessionId, {
       cancellation_reason: 'requested_by_customer',
@@ -127,7 +127,7 @@ export const stripeAdapterV20250224Acacia: GatewayAdapter = {
   },
 
   async getStatus(input: GetStatusInput): Promise<GatewayPaymentStatus> {
-    const stripe = resolveStripeClient(input.credentials, STRIPE_API_VERSION)
+    const stripe = await resolveStripeClient(input.credentials, STRIPE_API_VERSION)
 
     const pi = await stripe.paymentIntents.retrieve(input.sessionId)
     return {

--- a/packages/gateway-stripe/src/modules/gateway_stripe/lib/client.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/lib/client.ts
@@ -1,16 +1,34 @@
-import Stripe from 'stripe'
+import type Stripe from 'stripe'
 
 type StripeConfig = NonNullable<ConstructorParameters<typeof Stripe>[1]>
+type StripeConstructor = typeof Stripe
 
-export function resolveStripeClient(
+let stripeSdkPromise: Promise<StripeConstructor> | null = null
+
+export async function loadStripeSdk(): Promise<StripeConstructor> {
+  const pending = stripeSdkPromise ?? import('stripe').then((module) => module.default)
+  stripeSdkPromise = pending
+
+  try {
+    return await pending
+  } catch (error) {
+    if (stripeSdkPromise === pending) {
+      stripeSdkPromise = null
+    }
+    throw error
+  }
+}
+
+export async function resolveStripeClient(
   credentials: Record<string, unknown>,
   apiVersion: string,
-): Stripe {
+): Promise<Stripe> {
   const secretKey = credentials.secretKey as string
   if (!secretKey) {
     throw new Error('Stripe secret key is required')
   }
 
+  const Stripe = await loadStripeSdk()
   return new Stripe(secretKey, {
     apiVersion: apiVersion as StripeConfig['apiVersion'],
     maxNetworkRetries: 2,

--- a/packages/gateway-stripe/src/modules/gateway_stripe/lib/health.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/lib/health.ts
@@ -1,4 +1,4 @@
-import Stripe from 'stripe'
+import { loadStripeSdk } from './client'
 
 export interface HealthCheckResult {
   status: 'healthy' | 'unhealthy'
@@ -10,6 +10,7 @@ export interface HealthCheckResult {
 export const stripeHealthCheck = {
   async check(credentials: Record<string, unknown>): Promise<HealthCheckResult> {
     try {
+      const Stripe = await loadStripeSdk()
       const stripe = new Stripe(credentials.secretKey as string)
       const account = await stripe.accounts.retrieveCurrent()
 

--- a/packages/gateway-stripe/src/modules/gateway_stripe/lib/webhook-handler.ts
+++ b/packages/gateway-stripe/src/modules/gateway_stripe/lib/webhook-handler.ts
@@ -1,5 +1,5 @@
-import Stripe from 'stripe'
 import type { VerifyWebhookInput, WebhookEvent } from '@open-mercato/shared/modules/payment_gateways/types'
+import { loadStripeSdk } from './client'
 
 export function readStripeSessionIdHint(payload: Record<string, unknown> | null): string | null {
   if (!payload) return null
@@ -24,6 +24,7 @@ export function readStripeSessionIdHint(payload: Record<string, unknown> | null)
 }
 
 export async function verifyStripeWebhook(input: VerifyWebhookInput): Promise<WebhookEvent> {
+  const Stripe = await loadStripeSdk()
   const stripe = new Stripe(input.credentials.secretKey as string)
 
   const signature = input.headers['stripe-signature'] as string

--- a/packages/search/src/__tests__/embedding-lazy-import.test.ts
+++ b/packages/search/src/__tests__/embedding-lazy-import.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+describe('embedding provider loading', () => {
+  it('keeps provider SDKs out of static runtime imports', () => {
+    const source = fs.readFileSync(
+      path.resolve(process.cwd(), 'src/vector/services/embedding.ts'),
+      'utf8',
+    )
+    const providers = [
+      '@ai-sdk/openai',
+      '@ai-sdk/google',
+      '@ai-sdk/mistral',
+      '@ai-sdk/cohere',
+      '@ai-sdk/amazon-bedrock',
+      'ai-sdk-ollama',
+    ]
+
+    for (const provider of providers) {
+      expect(source).not.toMatch(new RegExp(`import\\s+(?!type\\s)[^\\n]+from\\s+['\"]${provider}['\"]`))
+      expect(source).toContain(`await import('${provider}')`)
+    }
+  })
+})

--- a/packages/search/src/__tests__/embedding.test.ts
+++ b/packages/search/src/__tests__/embedding.test.ts
@@ -2,15 +2,45 @@ jest.mock('ai', () => ({
   embed: jest.fn(),
 }))
 
+jest.mock('@ai-sdk/openai', () => ({
+  createOpenAI: jest.fn(() => ({ embedding: jest.fn(() => ({})) })),
+}))
+
+jest.mock('@ai-sdk/google', () => ({
+  createGoogleGenerativeAI: jest.fn(() => ({ textEmbeddingModel: jest.fn(() => ({})) })),
+}))
+
+jest.mock('@ai-sdk/mistral', () => ({
+  createMistral: jest.fn(() => ({ textEmbeddingModel: jest.fn(() => ({})) })),
+}))
+
+jest.mock('@ai-sdk/cohere', () => ({
+  createCohere: jest.fn(() => ({ textEmbeddingModel: jest.fn(() => ({})) })),
+}))
+
+jest.mock('@ai-sdk/amazon-bedrock', () => ({
+  createAmazonBedrock: jest.fn(() => ({ embedding: jest.fn(() => ({})) })),
+}))
+
 jest.mock('ai-sdk-ollama', () => ({
   createOllama: jest.fn(() => ({ embedding: jest.fn(() => ({})) })),
 }))
 
 import { embed } from 'ai'
+import { createOpenAI } from '@ai-sdk/openai'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createMistral } from '@ai-sdk/mistral'
+import { createCohere } from '@ai-sdk/cohere'
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock'
 import { createOllama } from 'ai-sdk-ollama'
 import { EmbeddingService } from '../vector/services/embedding'
 
 const mockedEmbed = jest.mocked(embed)
+const mockedCreateOpenAI = jest.mocked(createOpenAI)
+const mockedCreateGoogle = jest.mocked(createGoogleGenerativeAI)
+const mockedCreateMistral = jest.mocked(createMistral)
+const mockedCreateCohere = jest.mocked(createCohere)
+const mockedCreateBedrock = jest.mocked(createAmazonBedrock)
 const mockedCreateOllama = jest.mocked(createOllama)
 
 describe('EmbeddingService', () => {
@@ -25,6 +55,70 @@ describe('EmbeddingService', () => {
 
   afterAll(() => {
     process.env = originalEnv
+  })
+
+  it('loads only the selected provider and reuses its client', async () => {
+    const providerCases = [
+      {
+        providerId: 'openai' as const,
+        env: { OPENAI_API_KEY: 'openai-key' },
+        factory: mockedCreateOpenAI,
+      },
+      {
+        providerId: 'google' as const,
+        env: { GOOGLE_GENERATIVE_AI_API_KEY: 'google-key' },
+        factory: mockedCreateGoogle,
+      },
+      {
+        providerId: 'mistral' as const,
+        env: { MISTRAL_API_KEY: 'mistral-key' },
+        factory: mockedCreateMistral,
+      },
+      {
+        providerId: 'cohere' as const,
+        env: { COHERE_API_KEY: 'cohere-key' },
+        factory: mockedCreateCohere,
+      },
+      {
+        providerId: 'bedrock' as const,
+        env: {
+          AWS_ACCESS_KEY_ID: 'access-key',
+          AWS_SECRET_ACCESS_KEY: 'secret-key',
+          AWS_REGION: 'eu-central-1',
+        },
+        factory: mockedCreateBedrock,
+      },
+      {
+        providerId: 'ollama' as const,
+        env: { OLLAMA_BASE_URL: 'http://localhost:11434' },
+        factory: mockedCreateOllama,
+      },
+    ]
+    const factories = providerCases.map((entry) => entry.factory)
+
+    for (const providerCase of providerCases) {
+      jest.clearAllMocks()
+      process.env = { ...originalEnv, ...providerCase.env, NODE_ENV: 'test' }
+      mockedEmbed.mockResolvedValue({ embedding: [0.1] } as Awaited<ReturnType<typeof embed>>)
+
+      const service = new EmbeddingService({
+        config: {
+          providerId: providerCase.providerId,
+          model: 'test-model',
+          dimension: 128,
+          updatedAt: new Date().toISOString(),
+        },
+      })
+
+      expect(factories.every((factory) => factory.mock.calls.length === 0)).toBe(true)
+      await expect(service.createEmbedding('first')).resolves.toEqual([0.1])
+      await expect(service.createEmbedding('second')).resolves.toEqual([0.1])
+
+      expect(providerCase.factory).toHaveBeenCalledTimes(1)
+      for (const factory of factories) {
+        if (factory !== providerCase.factory) expect(factory).not.toHaveBeenCalled()
+      }
+    }
   })
 
   it('times out stalled embedding requests', async () => {

--- a/packages/search/src/vector/services/embedding.ts
+++ b/packages/search/src/vector/services/embedding.ts
@@ -1,17 +1,17 @@
 import { embed } from 'ai'
 import type { EmbeddingModel } from 'ai'
-import { createOpenAI } from '@ai-sdk/openai'
+import type { createOpenAI } from '@ai-sdk/openai'
 
 // Local type definition to avoid @ai-sdk/provider version conflicts
 // Matches SharedV3ProviderOptions = Record<string, JSONObject>
 type JSONValue = string | number | boolean | null | JSONValue[] | { [key: string]: JSONValue }
 type JSONObject = { [key: string]: JSONValue }
 type ProviderOptions = Record<string, JSONObject>
-import { createGoogleGenerativeAI } from '@ai-sdk/google'
-import { createMistral } from '@ai-sdk/mistral'
-import { createCohere } from '@ai-sdk/cohere'
-import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock'
-import { createOllama } from 'ai-sdk-ollama'
+import type { createGoogleGenerativeAI } from '@ai-sdk/google'
+import type { createMistral } from '@ai-sdk/mistral'
+import type { createCohere } from '@ai-sdk/cohere'
+import type { createAmazonBedrock } from '@ai-sdk/amazon-bedrock'
+import type { createOllama } from 'ai-sdk-ollama'
 import type { EmbeddingProviderId, EmbeddingProviderConfig } from '../types'
 import { EMBEDDING_PROVIDERS, DEFAULT_EMBEDDING_CONFIG } from '../types'
 import {
@@ -56,7 +56,7 @@ function timeoutError(providerId: EmbeddingProviderId, timeoutMs: number): Error
 
 export class EmbeddingService {
   private config: EmbeddingProviderConfig
-  private clientCache: Map<EmbeddingProviderId, ProviderClient> = new Map()
+  private clientCache: Map<EmbeddingProviderId, Promise<ProviderClient>> = new Map()
 
   constructor(private readonly opts: EmbeddingServiceOptions = {}) {
     if (opts.config) {
@@ -116,12 +116,30 @@ export class EmbeddingService {
     }
   }
 
-  private getClient(providerId: EmbeddingProviderId): ProviderClient {
+  private getClient(
+    providerId: EmbeddingProviderId,
+    config: EmbeddingProviderConfig,
+  ): Promise<ProviderClient> {
     const cached = this.clientCache.get(providerId)
     if (cached) {
       return cached
     }
 
+    let pending: Promise<ProviderClient>
+    pending = this.createClient(providerId, config).catch((error: unknown) => {
+      if (this.clientCache.get(providerId) === pending) {
+        this.clientCache.delete(providerId)
+      }
+      throw error
+    })
+    this.clientCache.set(providerId, pending)
+    return pending
+  }
+
+  private async createClient(
+    providerId: EmbeddingProviderId,
+    config: EmbeddingProviderConfig,
+  ): Promise<ProviderClient> {
     let client: ProviderClient
     switch (providerId) {
       case 'openai': {
@@ -129,6 +147,7 @@ export class EmbeddingService {
         if (!apiKey) {
           throw new Error('[vector.embedding] Missing OPENAI_API_KEY environment variable')
         }
+        const { createOpenAI } = await import('@ai-sdk/openai')
         client = createOpenAI({ apiKey })
         break
       }
@@ -137,6 +156,7 @@ export class EmbeddingService {
         if (!apiKey) {
           throw new Error('[vector.embedding] Missing GOOGLE_GENERATIVE_AI_API_KEY environment variable')
         }
+        const { createGoogleGenerativeAI } = await import('@ai-sdk/google')
         client = createGoogleGenerativeAI({ apiKey })
         break
       }
@@ -145,6 +165,7 @@ export class EmbeddingService {
         if (!apiKey) {
           throw new Error('[vector.embedding] Missing MISTRAL_API_KEY environment variable')
         }
+        const { createMistral } = await import('@ai-sdk/mistral')
         client = createMistral({ apiKey })
         break
       }
@@ -153,6 +174,7 @@ export class EmbeddingService {
         if (!apiKey) {
           throw new Error('[vector.embedding] Missing COHERE_API_KEY environment variable')
         }
+        const { createCohere } = await import('@ai-sdk/cohere')
         client = createCohere({ apiKey })
         break
       }
@@ -162,6 +184,7 @@ export class EmbeddingService {
         if (!accessKeyId || !secretAccessKey) {
           throw new Error('[vector.embedding] Missing AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY environment variables')
         }
+        const { createAmazonBedrock } = await import('@ai-sdk/amazon-bedrock')
         client = createAmazonBedrock({
           accessKeyId,
           secretAccessKey,
@@ -170,7 +193,7 @@ export class EmbeddingService {
         break
       }
       case 'ollama': {
-        const baseURL = this.config.baseUrl ?? process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434'
+        const baseURL = config.baseUrl ?? process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434'
         try {
           assertSafeOllamaBaseUrl(baseURL)
         } catch (err) {
@@ -181,6 +204,7 @@ export class EmbeddingService {
           }
           throw err
         }
+        const { createOllama } = await import('ai-sdk-ollama')
         client = createOllama({ baseURL, fetch: safeOllamaFetch })
         break
       }
@@ -188,13 +212,12 @@ export class EmbeddingService {
         throw new Error(`[vector.embedding] Unknown provider: ${providerId}`)
     }
 
-    this.clientCache.set(providerId, client)
     return client
   }
 
-  private getEmbeddingModel() {
-    const client = this.getClient(this.config.providerId)
-    const { providerId, model, outputDimensionality } = this.config
+  private async getEmbeddingModel(config: EmbeddingProviderConfig) {
+    const client = await this.getClient(config.providerId, config)
+    const { providerId, model } = config
 
     switch (providerId) {
       case 'openai':
@@ -214,8 +237,8 @@ export class EmbeddingService {
     }
   }
 
-  private getProviderOptions(): ProviderOptions | undefined {
-    const { providerId, outputDimensionality, model } = this.config
+  private getProviderOptions(config: EmbeddingProviderConfig): ProviderOptions | undefined {
+    const { providerId, outputDimensionality, model } = config
 
     if (!outputDimensionality) {
       if (providerId === 'cohere') {
@@ -242,6 +265,7 @@ export class EmbeddingService {
   }
 
   async createEmbedding(input: string | string[]): Promise<number[]> {
+    const config = { ...this.config }
     const merged = Array.isArray(input)
       ? input.map((part) => String(part ?? '')).filter((part) => part.length > 0).join('\n\n')
       : String(input ?? '')
@@ -249,13 +273,13 @@ export class EmbeddingService {
       throw new Error('[vector.embedding] Refusing to embed empty payload')
     }
 
-    if (!this.available) {
-      const providerInfo = EMBEDDING_PROVIDERS[this.config.providerId]
+    if (!this.isProviderConfigured(config.providerId)) {
+      const providerInfo = EMBEDDING_PROVIDERS[config.providerId]
       throw new Error(`[vector.embedding] Provider ${providerInfo.name} is not configured. Set ${providerInfo.envKeyRequired} environment variable.`)
     }
 
-    const model = this.getEmbeddingModel() as EmbeddingModel
-    const providerOptions = this.getProviderOptions()
+    const model = await this.getEmbeddingModel(config) as EmbeddingModel
+    const providerOptions = this.getProviderOptions(config)
     const timeoutMs = resolveEmbeddingTimeoutMs()
 
     const abortController = new AbortController()
@@ -276,7 +300,7 @@ export class EmbeddingService {
               // this awaits — promptly, instead of lingering until the platform's
               // default network timeout and pinning pool capacity under a storm.
               abortController.abort()
-              reject(timeoutError(this.config.providerId, timeoutMs))
+              reject(timeoutError(config.providerId, timeoutMs))
             },
             timeoutMs,
           )

--- a/scripts/__tests__/profile-standalone-build-rss.test.mjs
+++ b/scripts/__tests__/profile-standalone-build-rss.test.mjs
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  parseStandaloneBuildProfileArgs,
+  renderStandaloneBuildReportTable,
+} from '../profile-standalone-build-rss.mjs'
+
+test('parses standalone build profiler inputs', () => {
+  assert.deepEqual(
+    parseStandaloneBuildProfileArgs([
+      '--app-dir', '/tmp/standalone-app',
+      '--label', 'baseline',
+      '--interval', '500',
+      '--out-dir', '/tmp/reports',
+    ]),
+    {
+      appDir: '/tmp/standalone-app',
+      label: 'baseline',
+      intervalMs: 500,
+      outDir: '/tmp/reports',
+      report: false,
+      help: false,
+    },
+  )
+})
+
+test('renders peak RSS and build-time deltas', () => {
+  const markdown = renderStandaloneBuildReportTable([
+    {
+      label: 'baseline',
+      startedAt: '2026-07-15T10:00:00.000Z',
+      durationMs: 120_000,
+      exitCode: 0,
+      nodeOptions: '--max-old-space-size=8192',
+      coldBuild: true,
+      summary: { peakTotalMb: 4096, meanTotalMb: 3000, sampleCount: 20 },
+    },
+    {
+      label: 'lazy-imports',
+      startedAt: '2026-07-15T11:00:00.000Z',
+      durationMs: 90_000,
+      exitCode: 0,
+      nodeOptions: '--max-old-space-size=8192',
+      coldBuild: true,
+      summary: { peakTotalMb: 3072, meanTotalMb: 2500, sampleCount: 18 },
+    },
+  ])
+
+  assert.match(markdown, /-1024 MB \(-25%\)/)
+  assert.match(markdown, /-30s/)
+})
+
+test('reports median deltas for repeated cold runs', () => {
+  const report = (label, startedAt, peakTotalMb, durationMs) => ({
+    label,
+    startedAt,
+    durationMs,
+    exitCode: 0,
+    nodeOptions: '--max-old-space-size=8192',
+    summary: { peakTotalMb, meanTotalMb: peakTotalMb, sampleCount: 10 },
+  })
+  const markdown = renderStandaloneBuildReportTable([
+    report('baseline-1', '2026-07-15T10:00:00.000Z', 9000, 90_000),
+    report('baseline-2', '2026-07-15T10:02:00.000Z', 7700, 88_000),
+    report('baseline-3', '2026-07-15T10:04:00.000Z', 7750, 89_000),
+    report('candidate-1', '2026-07-15T11:00:00.000Z', 7000, 85_000),
+    report('candidate-2', '2026-07-15T11:02:00.000Z', 7100, 84_000),
+    report('candidate-3', '2026-07-15T11:04:00.000Z', 7050, 86_000),
+  ])
+
+  assert.match(markdown, /`baseline` \| 3 \| 7750 \| 89s/)
+  assert.match(markdown, /`candidate` \| 3 \| 7050 \| 85s/)
+  assert.match(markdown, /-700 MB \(-9\.03%\)/)
+})

--- a/scripts/profile-standalone-build-rss.mjs
+++ b/scripts/profile-standalone-build-rss.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawn, spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import { pathToFileURL } from 'node:url'
+
+import { sampleProcessTreeMemory, summarizeMemorySamples } from './dev-memory-sampler.mjs'
+
+const DEFAULT_INTERVAL_MS = 250
+const DEFAULT_OUT_DIR = path.join('.mercato', 'standalone-build-rss')
+
+export function parseStandaloneBuildProfileArgs(argv) {
+  const args = {
+    appDir: null,
+    label: null,
+    intervalMs: DEFAULT_INTERVAL_MS,
+    outDir: DEFAULT_OUT_DIR,
+    report: false,
+    help: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index]
+    switch (token) {
+      case '--app-dir':
+        args.appDir = argv[++index] ?? null
+        break
+      case '--label':
+        args.label = argv[++index] ?? null
+        break
+      case '--interval': {
+        const parsed = Number(argv[++index])
+        if (Number.isFinite(parsed) && parsed > 0) args.intervalMs = parsed
+        break
+      }
+      case '--out-dir':
+        args.outDir = argv[++index] ?? DEFAULT_OUT_DIR
+        break
+      case '--report':
+        args.report = true
+        break
+      case '-h':
+      case '--help':
+        args.help = true
+        break
+      default:
+        if (!token.startsWith('--') && !args.label) args.label = token
+        break
+    }
+  }
+
+  return args
+}
+
+function formatMb(value) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : '?'
+}
+
+function formatDuration(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '?'
+  return `${Math.round(value / 100) / 10}s`
+}
+
+function median(values) {
+  const sorted = values.filter((value) => Number.isFinite(value)).slice().sort((left, right) => left - right)
+  if (sorted.length === 0) return null
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle]
+}
+
+function groupRunMedians(reports) {
+  const grouped = new Map()
+  for (const report of reports) {
+    const groupLabel = String(report.label).replace(/-\d+$/, '')
+    const entries = grouped.get(groupLabel) ?? []
+    entries.push(report)
+    grouped.set(groupLabel, entries)
+  }
+
+  return Array.from(grouped.entries())
+    .filter(([, entries]) => entries.length > 1)
+    .map(([label, entries]) => ({
+      label,
+      runs: entries.length,
+      startedAt: entries.map((entry) => entry.startedAt).sort()[0],
+      peakTotalMb: median(entries.map((entry) => entry.summary?.peakTotalMb)),
+      durationMs: median(entries.map((entry) => entry.durationMs)),
+    }))
+    .sort((left, right) => Date.parse(left.startedAt ?? '') - Date.parse(right.startedAt ?? ''))
+}
+
+export function renderStandaloneBuildReportTable(reports) {
+  if (reports.length === 0) return '_No reports found._'
+
+  const sorted = reports.slice().sort((left, right) => {
+    const leftTime = Date.parse(left.startedAt ?? '')
+    const rightTime = Date.parse(right.startedAt ?? '')
+    if (Number.isFinite(leftTime) && Number.isFinite(rightTime) && leftTime !== rightTime) {
+      return leftTime - rightTime
+    }
+    return String(left.label).localeCompare(String(right.label))
+  })
+
+  const lines = [
+    '| Label | Peak RSS (MB) | Mean RSS (MB) | Build time | Exit | Samples | Node options |',
+    '|-------|---------------|---------------|------------|------|---------|--------------|',
+  ]
+
+  for (const report of sorted) {
+    lines.push(
+      `| \`${report.label}\` | ${formatMb(report.summary?.peakTotalMb)} | ${formatMb(report.summary?.meanTotalMb)} | ${formatDuration(report.durationMs)} | ${report.exitCode ?? '?'} | ${report.summary?.sampleCount ?? '?'} | \`${report.nodeOptions || '(unset)'}\` |`,
+    )
+  }
+
+  const medians = groupRunMedians(sorted)
+  if (medians.length > 0) {
+    lines.push('')
+    lines.push('### Run medians')
+    lines.push('')
+    lines.push('| Group | Runs | Median peak RSS (MB) | Median build time |')
+    lines.push('|-------|------|----------------------|-------------------|')
+    for (const entry of medians) {
+      lines.push(`| \`${entry.label}\` | ${entry.runs} | ${formatMb(entry.peakTotalMb)} | ${formatDuration(entry.durationMs)} |`)
+    }
+  }
+
+  if (medians.length >= 2 || (medians.length === 0 && sorted.length >= 2)) {
+    const baseline = medians.length >= 2 ? medians[0] : sorted[0]
+    const candidate = medians.length >= 2 ? medians[medians.length - 1] : sorted[sorted.length - 1]
+    const baselinePeak = baseline.peakTotalMb ?? baseline.summary?.peakTotalMb
+    const candidatePeak = candidate.peakTotalMb ?? candidate.summary?.peakTotalMb
+    const baselineDuration = baseline.durationMs
+    const candidateDuration = candidate.durationMs
+    if (typeof baselinePeak === 'number' && typeof candidatePeak === 'number') {
+      const deltaMb = Math.round((candidatePeak - baselinePeak) * 100) / 100
+      const deltaPercent = baselinePeak === 0
+        ? null
+        : Math.round((deltaMb / baselinePeak) * 10_000) / 100
+      lines.push('')
+      lines.push(
+        `**Peak RSS delta:** \`${candidate.label}\` − \`${baseline.label}\` = **${deltaMb >= 0 ? '+' : ''}${deltaMb} MB${deltaPercent == null ? '' : ` (${deltaPercent >= 0 ? '+' : ''}${deltaPercent}%)`}**.`,
+      )
+    }
+    if (typeof baselineDuration === 'number' && typeof candidateDuration === 'number') {
+      const deltaMs = candidateDuration - baselineDuration
+      lines.push(
+        `**Build-time delta:** \`${candidate.label}\` − \`${baseline.label}\` = **${deltaMs >= 0 ? '+' : ''}${formatDuration(deltaMs)}**.`,
+      )
+    }
+  }
+
+  return lines.join('\n')
+}
+
+function readReports(outDir) {
+  if (!fs.existsSync(outDir)) return []
+  return fs.readdirSync(outDir)
+    .filter((file) => file.endsWith('.json'))
+    .flatMap((file) => {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(path.join(outDir, file), 'utf8'))
+        return parsed && typeof parsed.label === 'string' ? [parsed] : []
+      } catch {
+        return []
+      }
+    })
+}
+
+function safeLabel(label) {
+  return label.replace(/[^a-zA-Z0-9._-]+/g, '-')
+}
+
+function hashFile(filePath) {
+  if (!fs.existsSync(filePath)) return null
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
+
+function readCommandVersion(command, args, cwd) {
+  const result = spawnSync(command, args, { cwd, encoding: 'utf8' })
+  return result.status === 0 ? result.stdout.trim() : null
+}
+
+function resolveEffectiveNodeOptions(buildScript) {
+  const scriptMatch = buildScript.match(/(?:^|\s)NODE_OPTIONS=([^\s]+)/)
+  return scriptMatch?.[1] ?? process.env.NODE_OPTIONS ?? ''
+}
+
+function collectProvenance(resolvedAppDir, packageJson, buildScript) {
+  const modulesPath = path.join(resolvedAppDir, 'src', 'modules.ts')
+  const lockPath = path.join(resolvedAppDir, 'yarn.lock')
+  let repoSha = null
+  try {
+    repoSha = execFileSync('git', ['rev-parse', 'HEAD'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim()
+  } catch {}
+
+  return {
+    repoSha,
+    platform: process.platform,
+    arch: process.arch,
+    nodeVersion: process.version,
+    yarnVersion: readCommandVersion('yarn', ['--version'], resolvedAppDir),
+    nextVersion: packageJson.dependencies?.next ?? packageJson.devDependencies?.next ?? null,
+    packageJsonHash: hashFile(path.join(resolvedAppDir, 'package.json')),
+    lockfileHash: hashFile(lockPath),
+    modulesHash: hashFile(modulesPath),
+    buildScript,
+  }
+}
+
+async function profileStandaloneBuild({ appDir, label, intervalMs, outDir, log }) {
+  const resolvedAppDir = path.resolve(appDir)
+  const packageJsonPath = path.join(resolvedAppDir, 'package.json')
+  if (!fs.existsSync(packageJsonPath)) {
+    throw new Error(`Standalone app package.json not found: ${packageJsonPath}`)
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+  const buildScript = packageJson.scripts?.build
+  if (typeof buildScript !== 'string' || buildScript.trim().length === 0) {
+    throw new Error(`Standalone app has no build script: ${packageJsonPath}`)
+  }
+
+  const nextOutputDir = path.join(resolvedAppDir, '.mercato', 'next')
+  fs.rmSync(nextOutputDir, { recursive: true, force: true })
+  log(`[standalone-build-profile] removed cold-build output: ${nextOutputDir}`)
+
+  const startedAt = new Date().toISOString()
+  const startedAtMs = Date.now()
+  const samples = []
+  const child = spawn('yarn', ['build'], {
+    cwd: resolvedAppDir,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  if (!child.pid) throw new Error('Failed to spawn standalone `yarn build`')
+
+  child.stdout.pipe(process.stdout)
+  child.stderr.pipe(process.stderr)
+  log(`[standalone-build-profile] tracking pid=${child.pid} every ${intervalMs}ms`)
+
+  const exitResult = new Promise((resolve) => {
+    child.once('exit', (exitCode, signal) => resolve({ exitCode, signal }))
+  })
+  let finished = false
+  let result = null
+  exitResult.then((value) => {
+    result = value
+    finished = true
+  })
+
+  while (!finished) {
+    const sample = await sampleProcessTreeMemory(child.pid, { includeCgroup: false })
+    if (sample) samples.push(sample)
+    await Promise.race([delay(intervalMs), exitResult])
+  }
+
+  const durationMs = Date.now() - startedAtMs
+  const report = {
+    label,
+    appDir: resolvedAppDir,
+    command: 'yarn build',
+    rootPid: child.pid,
+    nodeOptions: resolveEffectiveNodeOptions(buildScript),
+    coldBuild: true,
+    provenance: collectProvenance(resolvedAppDir, packageJson, buildScript),
+    intervalMs,
+    durationMs,
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    exitCode: result?.exitCode ?? null,
+    signal: result?.signal ?? null,
+    samples,
+    summary: summarizeMemorySamples(samples),
+  }
+
+  fs.mkdirSync(outDir, { recursive: true })
+  const outPath = path.join(outDir, `${safeLabel(label)}.json`)
+  fs.writeFileSync(outPath, `${JSON.stringify(report, null, 2)}\n`)
+  log(`[standalone-build-profile] report: ${outPath}`)
+  log(`[standalone-build-profile] peak RSS: ${report.summary.peakTotalMb} MB`)
+  log(`[standalone-build-profile] build time: ${formatDuration(durationMs)}`)
+
+  if (report.exitCode !== 0) {
+    throw new Error(`Standalone build failed with exit code ${report.exitCode ?? 'unknown'}${report.signal ? ` (${report.signal})` : ''}`)
+  }
+
+  return report
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  yarn build:standalone:profile --app-dir <generated-app> --label <name>
+  yarn build:standalone:profile:report
+
+Options:
+  --app-dir <dir>       Generated standalone app containing package.json.
+  --label <name>        Report label and filename.
+  --interval <ms>       RSS sampling interval. Default: ${DEFAULT_INTERVAL_MS}.
+  --out-dir <dir>       Report directory. Default: ${DEFAULT_OUT_DIR}.
+  --report              Render all reports in the output directory as Markdown.
+  -h, --help            Show this help.
+`)
+}
+
+async function main() {
+  const args = parseStandaloneBuildProfileArgs(process.argv.slice(2))
+  if (args.help) {
+    printHelp()
+    return
+  }
+  if (process.platform === 'win32') {
+    throw new Error('Standalone build RSS profiling requires Darwin or Linux `ps` output')
+  }
+  if (args.report) {
+    process.stdout.write(`${renderStandaloneBuildReportTable(readReports(args.outDir))}\n`)
+    return
+  }
+  if (!args.appDir) throw new Error('Missing --app-dir <generated-app>')
+  const label = args.label ?? `standalone-${new Date().toISOString().replace(/[:.]/g, '-')}`
+  await profileStandaloneBuild({
+    appDir: args.appDir,
+    label,
+    intervalMs: args.intervalMs,
+    outDir: args.outDir,
+    log: (message) => process.stderr.write(`${message}\n`),
+  })
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary

Reduces full standalone app build peak RSS by lazy-loading optional Search embedding provider SDKs and the Stripe server SDK. Adds a repeatable whole-process-tree RSS profiler so future standalone build-memory changes can be measured consistently.

The root cause was eager runtime imports pulling every configured embedding provider and Stripe into the standalone Next.js/TypeScript graph even though only one Search provider is selected at runtime and Stripe is only used when Stripe work runs.

## Changes

- add `yarn build:standalone:profile` and `yarn build:standalone:profile:report`
  - samples the complete build process tree every 250 ms on Darwin/Linux
  - removes `.mercato/next` before each run
  - records raw samples, peak/mean RSS, duration, heap options, app hashes, and toolchain provenance
  - reports repeated-run medians and before/after deltas
- lazy-load OpenAI, Google, Mistral, Cohere, Bedrock, and Ollama embedding providers after Search provider selection
- cache concurrent Search provider initialization and retry after a rejected provider import
- lazy-load the Stripe SDK through a shared retryable loader used by adapters, health checks, and webhook verification
- preserve existing Stripe API versions, retry/timeout options, validation order, and result shapes
- add focused provider-selection, import-boundary, Stripe behavior, and profiler report tests

AI Assistant was evaluated but intentionally left unchanged: its provider imports also flow through `llm-bootstrap`, `chat-config`, `agent-runtime`, and the root barrel. A useful split would require a broader async `LlmProvider.createModel` contract change, so a superficial `ai-sdk.ts` split would add churn without reducing the measured graph.

## Measurement

Runner: local macOS arm64, Node 24.16.0, Yarn 4.12.0, Next.js 16.2.9. Each side used a fresh classic + Enterprise standalone app with 448 generated API paths, an effective `--max-old-space-size=8192`, a cold `.mercato/next`, and 250 ms whole-process-tree RSS sampling.

| Group | Runs | Peak RSS (MB) | Median peak (MB) | Build time | Median time |
|---|---:|---|---:|---|---:|
| Baseline | 3 | 8942.03, 7645.82, 7704.76 | 7704.76 | 88.3s, 89.0s, 88.6s | 88.6s |
| Candidate | 3 | 8036.07, 7216.62, 6827.45 | 7216.62 | 87.6s, 88.9s, 93.8s | 88.9s |

Median peak RSS changed by **-488.14 MB (-6.34%)**. Median build time changed by **+0.3s**.

The 8192 MB heap cap from #3508 remains unchanged as the requested guardrail.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (internal build-performance/import-loading change; issue #3509 is the design record)

**Spec file path:** N/A

## Testing

Runner: local (`corepack yarn`; no running Docker app selected by the validation probe).

- `corepack yarn test:scripts` — 318 passed
- `corepack yarn workspace @open-mercato/search test --runInBand` — 254 passed
- `corepack yarn workspace @open-mercato/search typecheck`
- `corepack yarn workspace @open-mercato/search build`
- `corepack yarn workspace @open-mercato/gateway-stripe test --runInBand` — 26 passed
- `corepack yarn workspace @open-mercato/gateway-stripe typecheck`
- `corepack yarn workspace @open-mercato/gateway-stripe build`
- `corepack yarn test:create-app:integration --cleanup -- --grep TC-APP-001` — 2 passed against a freshly published/scaffolded standalone app
- three cold baseline builds and three cold candidate builds using `build:standalone:profile`
- production candidate start: `/login` and `/api/healthz` returned HTTP 200
- manual in-app browser QA: production login rendered its email, password, and sign-in controls with no console errors; screenshot evidence attached separately

No new integration spec was added because provider behavior is covered by focused unit tests and the existing `TC-APP-001` standalone harness covers the generated app build/start path.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No documentation/locales/generator output required.)
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (existing `TC-APP-001` exercised; no new test required for an internal import boundary).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (N/A; minor internal performance change).
- [ ] Priority set: suggested `priority-medium` (matches #3509; external contributor cannot apply upstream labels).
- [ ] Risk set: suggested `risk-medium` (matches #3509; external contributor cannot apply upstream labels).
- [ ] QA routing set: suggested `skip-qa` because behavior is unchanged and production/manual QA evidence is included.

### Design System Compliance

N/A — no UI files or visual behavior changed.

## Linked issues

Fixes #3509
