### PR TITLE
fix(data-sync): resume stalled backfills without letting two workers share a run

### DIFF
--- a/packages/cli/src/lib/generators/module-registry.ts
+++ b/packages/cli/src/lib/generators/module-registry.ts
@@ -224,6 +224,7 @@ type SerializableWorkerMetadata = {
   id?: string
   queue?: string
   concurrency?: number
+  maxStalledCount?: number
 }
 
 type PageMetadataManifestLoadResult = {
@@ -1553,6 +1554,7 @@ function normalizeWorkerMetadata(raw: unknown): SerializableWorkerMetadata | nul
   if (typeof source.id === 'string' && source.id.length > 0) normalized.id = source.id
   if (typeof source.queue === 'string' && source.queue.length > 0) normalized.queue = source.queue
   if (typeof source.concurrency === 'number') normalized.concurrency = source.concurrency
+  if (typeof source.maxStalledCount === 'number') normalized.maxStalledCount = source.maxStalledCount
   return Object.keys(normalized).length > 0 ? normalized : null
 }
 
@@ -2055,7 +2057,7 @@ function processWorkers(discovered: DiscoveredWorker[]): string[] {
   for (const { id, importPath, metadata } of discovered) {
     const workerId = metadata.id ?? id
     workers.push(
-      `{ id: ${toLiteral(workerId)}, queue: ${toLiteral(metadata.queue)}, concurrency: ${toLiteral(metadata.concurrency ?? 1)}, handler: createLazyModuleWorker(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)}) }`
+      `{ id: ${toLiteral(workerId)}, queue: ${toLiteral(metadata.queue)}, concurrency: ${toLiteral(metadata.concurrency ?? 1)}${metadata.maxStalledCount === undefined ? '' : `, maxStalledCount: ${toLiteral(metadata.maxStalledCount)}`}, handler: createLazyModuleWorker(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)}) }`
     )
   }
   return workers
@@ -2730,6 +2732,7 @@ function processWorkersAst(discovered: DiscoveredWorker[]): WriterFunction[] {
         { name: 'id', value: workerId },
         { name: 'queue', value: metadata.queue },
         { name: 'concurrency', value: metadata.concurrency ?? 1 },
+        ...(metadata.maxStalledCount === undefined ? [] : [{ name: 'maxStalledCount', value: metadata.maxStalledCount }]),
         {
           name: 'handler',
           value: callExpression(identifier('createLazyModuleWorker'), [

--- a/packages/cli/src/lib/generators/module-registry.ts
+++ b/packages/cli/src/lib/generators/module-registry.ts
@@ -224,6 +224,7 @@ type SerializableWorkerMetadata = {
   id?: string
   queue?: string
   concurrency?: number
+  lockDuration?: number
   maxStalledCount?: number
 }
 
@@ -1554,6 +1555,7 @@ function normalizeWorkerMetadata(raw: unknown): SerializableWorkerMetadata | nul
   if (typeof source.id === 'string' && source.id.length > 0) normalized.id = source.id
   if (typeof source.queue === 'string' && source.queue.length > 0) normalized.queue = source.queue
   if (typeof source.concurrency === 'number') normalized.concurrency = source.concurrency
+  if (typeof source.lockDuration === 'number') normalized.lockDuration = source.lockDuration
   if (typeof source.maxStalledCount === 'number') normalized.maxStalledCount = source.maxStalledCount
   return Object.keys(normalized).length > 0 ? normalized : null
 }
@@ -2057,7 +2059,7 @@ function processWorkers(discovered: DiscoveredWorker[]): string[] {
   for (const { id, importPath, metadata } of discovered) {
     const workerId = metadata.id ?? id
     workers.push(
-      `{ id: ${toLiteral(workerId)}, queue: ${toLiteral(metadata.queue)}, concurrency: ${toLiteral(metadata.concurrency ?? 1)}${metadata.maxStalledCount === undefined ? '' : `, maxStalledCount: ${toLiteral(metadata.maxStalledCount)}`}, handler: createLazyModuleWorker(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)}) }`
+      `{ id: ${toLiteral(workerId)}, queue: ${toLiteral(metadata.queue)}, concurrency: ${toLiteral(metadata.concurrency ?? 1)}${metadata.lockDuration === undefined ? '' : `, lockDuration: ${toLiteral(metadata.lockDuration)}`}${metadata.maxStalledCount === undefined ? '' : `, maxStalledCount: ${toLiteral(metadata.maxStalledCount)}`}, handler: createLazyModuleWorker(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)}) }`
     )
   }
   return workers
@@ -2732,6 +2734,7 @@ function processWorkersAst(discovered: DiscoveredWorker[]): WriterFunction[] {
         { name: 'id', value: workerId },
         { name: 'queue', value: metadata.queue },
         { name: 'concurrency', value: metadata.concurrency ?? 1 },
+        ...(metadata.lockDuration === undefined ? [] : [{ name: 'lockDuration', value: metadata.lockDuration }]),
         ...(metadata.maxStalledCount === undefined ? [] : [{ name: 'maxStalledCount', value: metadata.maxStalledCount }]),
         {
           name: 'handler',

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -1650,6 +1650,7 @@ export async function run(argv = process.argv) {
                 concurrencyOverride ??
                 Math.max(...queueWorkers.map((w) => w.concurrency), 1)
               const maxStalledCount = Math.max(...queueWorkers.map((w) => w.maxStalledCount ?? 1), 1)
+              const lockDuration = Math.max(...queueWorkers.map((w) => w.lockDuration ?? 0), 0) || undefined
 
               console.log(`[worker] Starting "${queue}" with ${queueWorkers.length} handler(s), concurrency: ${concurrency}`)
 
@@ -1658,6 +1659,7 @@ export async function run(argv = process.argv) {
                 queueName: queue,
                 connection: queueRedisUrl ? { url: queueRedisUrl } : undefined,
                 concurrency,
+                lockDuration,
                 maxStalledCount,
                 background: true,
                 handler: createPerJobWorkerHandler(queueWorkers, createRequestContainer),
@@ -1703,6 +1705,7 @@ export async function run(argv = process.argv) {
               const budgetPlan = await resolveWorkerBudgetPlan([{ queue: queueName!, concurrency: requested }])
               const concurrency = budgetPlan.entries[0]?.effective ?? requested
               const maxStalledCount = Math.max(...queueWorkers.map((w) => w.maxStalledCount ?? 1), 1)
+              const lockDuration = Math.max(...queueWorkers.map((w) => w.lockDuration ?? 0), 0) || undefined
 
               console.log(`[worker] Found ${queueWorkers.length} worker(s) for queue "${queueName}"`)
 
@@ -1711,6 +1714,7 @@ export async function run(argv = process.argv) {
                 queueName: queueName!,
                 connection: queueRedisUrl ? { url: queueRedisUrl } : undefined,
                 concurrency,
+                lockDuration,
                 maxStalledCount,
                 handler: createPerJobWorkerHandler(queueWorkers, createRequestContainer),
               })

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -1649,6 +1649,7 @@ export async function run(argv = process.argv) {
                 effectiveByQueue.get(queue) ??
                 concurrencyOverride ??
                 Math.max(...queueWorkers.map((w) => w.concurrency), 1)
+              const maxStalledCount = Math.max(...queueWorkers.map((w) => w.maxStalledCount ?? 1), 1)
 
               console.log(`[worker] Starting "${queue}" with ${queueWorkers.length} handler(s), concurrency: ${concurrency}`)
 
@@ -1657,6 +1658,7 @@ export async function run(argv = process.argv) {
                 queueName: queue,
                 connection: queueRedisUrl ? { url: queueRedisUrl } : undefined,
                 concurrency,
+                maxStalledCount,
                 background: true,
                 handler: createPerJobWorkerHandler(queueWorkers, createRequestContainer),
               })
@@ -1700,6 +1702,7 @@ export async function run(argv = process.argv) {
               // never check out more pooled connections than the worker pool holds.
               const budgetPlan = await resolveWorkerBudgetPlan([{ queue: queueName!, concurrency: requested }])
               const concurrency = budgetPlan.entries[0]?.effective ?? requested
+              const maxStalledCount = Math.max(...queueWorkers.map((w) => w.maxStalledCount ?? 1), 1)
 
               console.log(`[worker] Found ${queueWorkers.length} worker(s) for queue "${queueName}"`)
 
@@ -1708,6 +1711,7 @@ export async function run(argv = process.argv) {
                 queueName: queueName!,
                 connection: queueRedisUrl ? { url: queueRedisUrl } : undefined,
                 concurrency,
+                maxStalledCount,
                 handler: createPerJobWorkerHandler(queueWorkers, createRequestContainer),
               })
             } else {

--- a/packages/core/src/modules/data_sync/lib/__tests__/queue.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/queue.test.ts
@@ -1,0 +1,30 @@
+const mockCreateModuleQueue = jest.fn()
+
+jest.mock('@open-mercato/queue', () => ({
+  createModuleQueue: (...args: unknown[]) => mockCreateModuleQueue(...args),
+}))
+
+import { getSyncQueue } from '../queue'
+
+describe('data sync queue configuration', () => {
+  beforeEach(() => {
+    mockCreateModuleQueue.mockReset()
+    mockCreateModuleQueue.mockReturnValue({})
+  })
+
+  it('allows import and export jobs to survive repeated BullMQ stalled-job recovery', () => {
+    getSyncQueue('data-sync-import')
+    getSyncQueue('data-sync-export')
+
+    expect(mockCreateModuleQueue).toHaveBeenCalledWith('data-sync-import', {
+      concurrency: 5,
+      attempts: 3,
+      maxStalledCount: 10,
+    })
+    expect(mockCreateModuleQueue).toHaveBeenCalledWith('data-sync-export', {
+      concurrency: 5,
+      attempts: 3,
+      maxStalledCount: 10,
+    })
+  })
+})

--- a/packages/core/src/modules/data_sync/lib/__tests__/queue.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/queue.test.ts
@@ -5,6 +5,14 @@ jest.mock('@open-mercato/queue', () => ({
 }))
 
 import { getSyncQueue } from '../queue'
+import {
+  DATA_SYNC_EXPORT_QUEUE,
+  DATA_SYNC_IMPORT_QUEUE,
+  DATA_SYNC_LOCK_DURATION_MS,
+  DATA_SYNC_RESUMABLE_QUEUES,
+} from '../queue-policy'
+import { metadata as importWorkerMetadata } from '../../workers/sync-import'
+import { metadata as exportWorkerMetadata } from '../../workers/sync-export'
 
 describe('data sync queue configuration', () => {
   beforeEach(() => {
@@ -12,19 +20,35 @@ describe('data sync queue configuration', () => {
     mockCreateModuleQueue.mockReturnValue({})
   })
 
-  it('allows import and export jobs to survive repeated BullMQ stalled-job recovery', () => {
-    getSyncQueue('data-sync-import')
-    getSyncQueue('data-sync-export')
+  it('holds the job lock past a slow batch and survives repeated BullMQ stalled-job recovery', () => {
+    getSyncQueue(DATA_SYNC_IMPORT_QUEUE)
+    getSyncQueue(DATA_SYNC_EXPORT_QUEUE)
 
     expect(mockCreateModuleQueue).toHaveBeenCalledWith('data-sync-import', {
       concurrency: 5,
       attempts: 3,
+      lockDuration: DATA_SYNC_LOCK_DURATION_MS,
       maxStalledCount: 10,
     })
     expect(mockCreateModuleQueue).toHaveBeenCalledWith('data-sync-export', {
       concurrency: 5,
       attempts: 3,
+      lockDuration: DATA_SYNC_LOCK_DURATION_MS,
       maxStalledCount: 10,
     })
+  })
+
+  it('leaves queues outside the resumable set on their defaults', () => {
+    getSyncQueue('data-sync-something-else')
+
+    expect(mockCreateModuleQueue).toHaveBeenCalledWith('data-sync-something-else', { concurrency: 5 })
+  })
+
+  it('keeps the worker queue names and the retry policy on the same constants', () => {
+    expect([importWorkerMetadata.queue, exportWorkerMetadata.queue].sort()).toEqual(
+      [...DATA_SYNC_RESUMABLE_QUEUES].sort(),
+    )
+    expect(importWorkerMetadata.lockDuration).toBe(DATA_SYNC_LOCK_DURATION_MS)
+    expect(exportWorkerMetadata.lockDuration).toBe(DATA_SYNC_LOCK_DURATION_MS)
   })
 })

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-export-failures.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-export-failures.test.ts
@@ -135,7 +135,7 @@ describe('data sync engine export item failures', () => {
       organizationId: 'org-1',
       tenantId: 'tenant-1',
       userId: 'user-1',
-    }, null)
+    }, 0)
     expect((integrationLogService as any).write).toHaveBeenCalledWith(expect.objectContaining({
       integrationId: 'sync_magento',
       runId: 'run-1',

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-export-failures.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-export-failures.test.ts
@@ -135,7 +135,7 @@ describe('data sync engine export item failures', () => {
       organizationId: 'org-1',
       tenantId: 'tenant-1',
       userId: 'user-1',
-    })
+    }, null)
     expect((integrationLogService as any).write).toHaveBeenCalledWith(expect.objectContaining({
       integrationId: 'sync_magento',
       runId: 'run-1',

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-import-failures.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-import-failures.test.ts
@@ -146,7 +146,7 @@ describe('data sync engine import item failures', () => {
       organizationId: 'org-1',
       tenantId: 'tenant-1',
       userId: 'user-1',
-    }, null)
+    }, 0)
     expect((integrationLogService as any).write).toHaveBeenCalledWith(expect.objectContaining({
       integrationId: 'sync_akeneo',
       runId: 'run-1',

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-import-failures.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-import-failures.test.ts
@@ -146,7 +146,7 @@ describe('data sync engine import item failures', () => {
       organizationId: 'org-1',
       tenantId: 'tenant-1',
       userId: 'user-1',
-    })
+    }, null)
     expect((integrationLogService as any).write).toHaveBeenCalledWith(expect.objectContaining({
       integrationId: 'sync_akeneo',
       runId: 'run-1',

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-run-id.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-run-id.test.ts
@@ -367,4 +367,77 @@ describe('data sync engine forwards run context to adapters', () => {
     expect(progressService.markCancelled).not.toHaveBeenCalled()
     expect(streamImport).not.toHaveBeenCalled()
   })
+
+  it('resumes a running import from its committed cursor without duplicating an uncommitted batch', async () => {
+    const persistedRecords = new Map([['product-2', { name: 'already written before restart' }]])
+    const adapterUpsert = jest.fn((externalId: string, data: Record<string, unknown>) => {
+      persistedRecords.set(externalId, data)
+    })
+    const streamImport = jest.fn(async function* () {
+      adapterUpsert('product-2', { name: 'replayed after stalled-job recovery' })
+      yield {
+        items: [{ externalId: 'product-2', action: 'update', data: { name: 'replayed after stalled-job recovery' } }],
+        cursor: 'checkpoint-2',
+        hasMore: false,
+        batchIndex: 3,
+      }
+    })
+    const adapter: DataSyncAdapter = {
+      providerKey: 'excel',
+      direction: 'import',
+      supportedEntities: ['catalog.product'],
+      getMapping: jest.fn(async () => ({
+        entityType: 'catalog.product',
+        matchStrategy: 'externalId',
+        fields: [],
+      })),
+      streamImport,
+    }
+    const resumedRun = {
+      id: 'run-import-resume',
+      integrationId: 'sync_excel',
+      entityType: 'catalog.product',
+      direction: 'import' as const,
+      status: 'running' as const,
+      cursor: 'checkpoint-1',
+      progressJobId: null,
+    }
+    const syncRunService = {
+      getRun: jest.fn(async () => resumedRun),
+      markStatus: jest
+        .fn()
+        .mockResolvedValueOnce(resumedRun)
+        .mockResolvedValueOnce({ ...resumedRun, status: 'completed' }),
+      commitBatchProgress: jest.fn(async () => resumedRun),
+    } as unknown as SyncRunService
+
+    mockGetDataSyncAdapter.mockReturnValue(adapter)
+    const engine = createSyncEngine({
+      em: {} as EntityManager,
+      syncRunService,
+      integrationCredentialsService: {
+        resolve: jest.fn(async () => ({ uploadId: 'upload-1' })),
+      } as unknown as CredentialsService,
+      integrationLogService: {
+        write: jest.fn(async () => undefined),
+      } as unknown as IntegrationLogService,
+      integrationStateService: {
+        upsert: jest.fn(async () => undefined),
+      } as any,
+      progressService: createProgressService(),
+    })
+
+    await engine.runImport('run-import-resume', 100, createScope())
+
+    expect(streamImport).toHaveBeenCalledWith(expect.objectContaining({ cursor: 'checkpoint-1' }))
+    expect(adapterUpsert).toHaveBeenCalledTimes(1)
+    expect(persistedRecords.size).toBe(1)
+    expect(persistedRecords.get('product-2')).toEqual({ name: 'replayed after stalled-job recovery' })
+    expect((syncRunService as any).commitBatchProgress).toHaveBeenCalledWith(
+      'run-import-resume',
+      expect.objectContaining({ updatedCount: 1, batchesCompleted: 1 }),
+      'checkpoint-2',
+      createScope(),
+    )
+  })
 })

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-run-id.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-run-id.test.ts
@@ -27,7 +27,7 @@ jest.mock('../../../query_index/lib/coverage', () => ({
 }))
 
 import { createSyncEngine } from '../sync-engine'
-import { SyncRunCursorConflictError } from '../sync-run-service'
+import { SyncRunOwnershipConflictError } from '../sync-run-service'
 
 function createScope() {
   return {
@@ -401,6 +401,7 @@ describe('data sync engine forwards run context to adapters', () => {
       direction: 'import' as const,
       status: 'running' as const,
       cursor: 'checkpoint-1',
+      batchesCompleted: 4,
       progressJobId: null,
     }
     const syncRunService = {
@@ -439,7 +440,7 @@ describe('data sync engine forwards run context to adapters', () => {
       expect.objectContaining({ updatedCount: 1, batchesCompleted: 1 }),
       'checkpoint-2',
       createScope(),
-      'checkpoint-1',
+      4,
     )
   })
 })
@@ -490,7 +491,7 @@ describe('data sync engine fences cursor commits against a concurrent delivery',
     })
   }
 
-  it('chains each commit to the cursor it last committed, so a stale delivery cannot skip a window', async () => {
+  it('chains each commit to the batch count it last committed, so a stale delivery cannot skip a window', async () => {
     const run = {
       id: 'run-chain',
       integrationId: 'sync_excel',
@@ -498,6 +499,7 @@ describe('data sync engine fences cursor commits against a concurrent delivery',
       direction: 'import' as const,
       status: 'pending' as const,
       cursor: null,
+      batchesCompleted: 0,
       progressJobId: null,
     }
     const commitBatchProgress = jest.fn(async () => run)
@@ -517,12 +519,42 @@ describe('data sync engine fences cursor commits against a concurrent delivery',
     await buildEngine(syncRunService).runImport('run-chain', 100, createScope())
 
     expect(commitBatchProgress.mock.calls.map((call) => [call[2], call[4]])).toEqual([
-      ['c1', null],
-      ['c2', 'c1'],
+      ['c1', 0],
+      ['c2', 1],
     ])
   })
 
-  it('yields the run instead of failing it when the cursor was advanced by another worker', async () => {
+  it('chains on the batch count even when the adapter repeats a cursor between batches', async () => {
+    const run = {
+      id: 'run-repeat',
+      integrationId: 'sync_excel',
+      entityType: 'catalog.product',
+      direction: 'import' as const,
+      status: 'pending' as const,
+      cursor: null,
+      batchesCompleted: 0,
+      progressJobId: null,
+    }
+    const commitBatchProgress = jest.fn(async () => run)
+    const syncRunService = {
+      getRun: jest.fn(async () => run),
+      markStatus: jest.fn(async () => ({ ...run, status: 'running' })),
+      commitBatchProgress,
+    } as unknown as SyncRunService
+
+    mockGetDataSyncAdapter.mockReturnValue(
+      createImportAdapter([
+        { cursor: 'same', batchIndex: 1 },
+        { cursor: 'same', batchIndex: 2 },
+      ]),
+    )
+
+    await buildEngine(syncRunService).runImport('run-repeat', 100, createScope())
+
+    expect(commitBatchProgress.mock.calls.map((call) => call[4])).toEqual([0, 1])
+  })
+
+  it('yields the run instead of failing it when another worker already advanced it', async () => {
     const run = {
       id: 'run-conflict',
       integrationId: 'sync_excel',
@@ -530,6 +562,7 @@ describe('data sync engine fences cursor commits against a concurrent delivery',
       direction: 'import' as const,
       status: 'running' as const,
       cursor: 'checkpoint-1',
+      batchesCompleted: 1,
       progressJobId: null,
     }
     const markStatus = jest.fn(async () => ({ ...run, status: 'running' }))
@@ -537,7 +570,7 @@ describe('data sync engine fences cursor commits against a concurrent delivery',
       getRun: jest.fn(async () => run),
       markStatus,
       commitBatchProgress: jest.fn(async () => {
-        throw new SyncRunCursorConflictError('run-conflict', 'checkpoint-1', 'checkpoint-2')
+        throw new SyncRunOwnershipConflictError('run-conflict', 1)
       }),
     } as unknown as SyncRunService
 
@@ -548,5 +581,88 @@ describe('data sync engine fences cursor commits against a concurrent delivery',
     const requestedStatuses = markStatus.mock.calls.map((call) => call[1])
     expect(requestedStatuses).not.toContain('failed')
     expect(requestedStatuses).not.toContain('completed')
+  })
+
+  it('does not report a failure for a run another delivery already completed', async () => {
+    const run = {
+      id: 'run-displaced',
+      integrationId: 'sync_excel',
+      entityType: 'catalog.product',
+      direction: 'import' as const,
+      status: 'running' as const,
+      cursor: 'checkpoint-5',
+      batchesCompleted: 5,
+      progressJobId: 'job-displaced',
+    }
+    // The winning delivery finalized the run while this one was still streaming,
+    // so `markStatus` refuses `completed -> failed` and returns the row as it
+    // stands. Nothing downstream may fire off that refusal.
+    const markStatus = jest.fn(async (_runId: string, status: string) => (
+      status === 'running'
+        ? { ...run, status: 'running' }
+        : { ...run, status: 'completed' }
+    ))
+    const progressService = createProgressService()
+    const integrationLogService = {
+      write: jest.fn(async () => undefined),
+    } as unknown as IntegrationLogService
+    const syncRunService = {
+      getRun: jest.fn(async () => run),
+      markStatus,
+      commitBatchProgress: jest.fn(async () => run),
+    } as unknown as SyncRunService
+
+    mockGetDataSyncAdapter.mockReturnValue({
+      ...createImportAdapter([]),
+      streamImport: jest.fn(async function* () {
+        throw new Error('upstream timed out after the run was taken over')
+      }),
+    })
+
+    const engine = createSyncEngine({
+      em: {} as EntityManager,
+      syncRunService,
+      integrationCredentialsService: {
+        resolve: jest.fn(async () => ({ uploadId: 'upload-1' })),
+      } as unknown as CredentialsService,
+      integrationLogService,
+      integrationStateService: {
+        upsert: jest.fn(async () => undefined),
+      } as any,
+      progressService,
+    })
+
+    await engine.runImport('run-displaced', 100, createScope())
+
+    expect(markStatus).toHaveBeenCalledWith('run-displaced', 'failed', createScope(), expect.any(String))
+    expect(progressService.failJob).not.toHaveBeenCalled()
+    expect(mockEmitDataSyncEvent.mock.calls.map((call) => call[0])).not.toContain('data_sync.run.failed')
+  })
+
+  it('marks a resumed run as such so consumers can tell a restart from a start', async () => {
+    const run = {
+      id: 'run-resumed-event',
+      integrationId: 'sync_excel',
+      entityType: 'catalog.product',
+      direction: 'import' as const,
+      status: 'running' as const,
+      cursor: 'checkpoint-1',
+      batchesCompleted: 1,
+      progressJobId: null,
+    }
+    const syncRunService = {
+      getRun: jest.fn(async () => run),
+      markStatus: jest.fn(async (_runId: string, status: string) => ({ ...run, status })),
+      commitBatchProgress: jest.fn(async () => run),
+    } as unknown as SyncRunService
+
+    mockGetDataSyncAdapter.mockReturnValue(createImportAdapter([]))
+
+    await buildEngine(syncRunService).runImport('run-resumed-event', 100, createScope())
+
+    expect(mockEmitDataSyncEvent).toHaveBeenCalledWith(
+      'data_sync.run.started',
+      expect.objectContaining({ resumed: true }),
+    )
   })
 })

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-run-id.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-engine-run-id.test.ts
@@ -27,6 +27,7 @@ jest.mock('../../../query_index/lib/coverage', () => ({
 }))
 
 import { createSyncEngine } from '../sync-engine'
+import { SyncRunCursorConflictError } from '../sync-run-service'
 
 function createScope() {
   return {
@@ -438,6 +439,114 @@ describe('data sync engine forwards run context to adapters', () => {
       expect.objectContaining({ updatedCount: 1, batchesCompleted: 1 }),
       'checkpoint-2',
       createScope(),
+      'checkpoint-1',
     )
+  })
+})
+
+describe('data sync engine fences cursor commits against a concurrent delivery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetIntegration.mockReturnValue({ providerKey: 'excel' })
+  })
+
+  function createImportAdapter(batches: Array<{ cursor: string; batchIndex: number }>): DataSyncAdapter {
+    return {
+      providerKey: 'excel',
+      direction: 'import',
+      supportedEntities: ['catalog.product'],
+      getMapping: jest.fn(async () => ({
+        entityType: 'catalog.product',
+        matchStrategy: 'externalId',
+        fields: [],
+      })),
+      streamImport: jest.fn(async function* () {
+        for (const batch of batches) {
+          yield {
+            items: [{ externalId: `product-${batch.batchIndex}`, action: 'create', data: {} }],
+            cursor: batch.cursor,
+            hasMore: batch.batchIndex < batches.length,
+            batchIndex: batch.batchIndex,
+          }
+        }
+      }),
+    }
+  }
+
+  function buildEngine(syncRunService: SyncRunService) {
+    return createSyncEngine({
+      em: {} as EntityManager,
+      syncRunService,
+      integrationCredentialsService: {
+        resolve: jest.fn(async () => ({ uploadId: 'upload-1' })),
+      } as unknown as CredentialsService,
+      integrationLogService: {
+        write: jest.fn(async () => undefined),
+      } as unknown as IntegrationLogService,
+      integrationStateService: {
+        upsert: jest.fn(async () => undefined),
+      } as any,
+      progressService: createProgressService(),
+    })
+  }
+
+  it('chains each commit to the cursor it last committed, so a stale delivery cannot skip a window', async () => {
+    const run = {
+      id: 'run-chain',
+      integrationId: 'sync_excel',
+      entityType: 'catalog.product',
+      direction: 'import' as const,
+      status: 'pending' as const,
+      cursor: null,
+      progressJobId: null,
+    }
+    const commitBatchProgress = jest.fn(async () => run)
+    const syncRunService = {
+      getRun: jest.fn(async () => run),
+      markStatus: jest.fn(async () => ({ ...run, status: 'running' })),
+      commitBatchProgress,
+    } as unknown as SyncRunService
+
+    mockGetDataSyncAdapter.mockReturnValue(
+      createImportAdapter([
+        { cursor: 'c1', batchIndex: 1 },
+        { cursor: 'c2', batchIndex: 2 },
+      ]),
+    )
+
+    await buildEngine(syncRunService).runImport('run-chain', 100, createScope())
+
+    expect(commitBatchProgress.mock.calls.map((call) => [call[2], call[4]])).toEqual([
+      ['c1', null],
+      ['c2', 'c1'],
+    ])
+  })
+
+  it('yields the run instead of failing it when the cursor was advanced by another worker', async () => {
+    const run = {
+      id: 'run-conflict',
+      integrationId: 'sync_excel',
+      entityType: 'catalog.product',
+      direction: 'import' as const,
+      status: 'running' as const,
+      cursor: 'checkpoint-1',
+      progressJobId: null,
+    }
+    const markStatus = jest.fn(async () => ({ ...run, status: 'running' }))
+    const syncRunService = {
+      getRun: jest.fn(async () => run),
+      markStatus,
+      commitBatchProgress: jest.fn(async () => {
+        throw new SyncRunCursorConflictError('run-conflict', 'checkpoint-1', 'checkpoint-2')
+      }),
+    } as unknown as SyncRunService
+
+    mockGetDataSyncAdapter.mockReturnValue(createImportAdapter([{ cursor: 'checkpoint-2', batchIndex: 1 }]))
+
+    await buildEngine(syncRunService).runImport('run-conflict', 100, createScope())
+
+    const requestedStatuses = markStatus.mock.calls.map((call) => call[1])
+    expect(requestedStatuses).not.toContain('failed')
+    expect(requestedStatuses).not.toContain('completed')
   })
 })

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-run-service.transactions.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-run-service.transactions.test.ts
@@ -18,6 +18,8 @@ function buildFakeEm() {
     commit: jest.fn().mockResolvedValue(undefined),
     rollback: jest.fn().mockResolvedValue(undefined),
     flush: jest.fn().mockResolvedValue(undefined),
+    nativeUpdate: jest.fn().mockResolvedValue(1),
+    refresh: jest.fn().mockResolvedValue(undefined),
     create: jest.fn((_entity: unknown, data: Record<string, unknown>) => ({ ...data })),
   }
 }
@@ -149,5 +151,33 @@ describe('SyncRunService.updateCursor — UoW-safe cursor write (issue #2341)', 
     expect(em.flush).toHaveBeenCalledTimes(1)
     expect(run.cursor).toBe('advanced-cursor')
     expect(cursorRow.cursor).toBe('advanced-cursor')
+  })
+})
+
+describe('SyncRunService.markStatus — stalled-job recovery', () => {
+  beforeEach(() => {
+    ;(findOneWithDecryption as jest.Mock).mockReset()
+  })
+
+  it('idempotently reclaims a running run without admitting terminal statuses', async () => {
+    const em = buildFakeEm()
+    const run = buildRun({ status: 'running' })
+    mockLookups(run, null)
+
+    const service = createSyncRunService(em as any)
+    const result = await service.markStatus('run-1', 'running', SCOPE)
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      SyncRun,
+      expect.objectContaining({
+        id: 'run-1',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        status: { $in: ['pending', 'running'] },
+      }),
+      expect.objectContaining({ status: 'running' }),
+    )
+    expect(em.refresh).toHaveBeenCalledWith(run)
+    expect(result).toBe(run)
   })
 })

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-run-service.transactions.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-run-service.transactions.test.ts
@@ -2,7 +2,7 @@
 
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SyncCursor, SyncRun } from '../../data/entities'
-import { createSyncRunService, SyncRunCursorConflictError } from '../sync-run-service'
+import { createSyncRunService, SyncRunOwnershipConflictError } from '../sync-run-service'
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findOneWithDecryption: jest.fn(),
@@ -132,18 +132,18 @@ describe('SyncRunService.commitBatchProgress — atomic counter + cursor (issue 
   })
 })
 
-describe('SyncRunService.commitBatchProgress — cursor fencing against a concurrent delivery', () => {
+describe('SyncRunService.commitBatchProgress — ownership fencing against a concurrent delivery', () => {
   beforeEach(() => {
     ;(findOneWithDecryption as jest.Mock).mockReset()
   })
 
-  it('advances the cursor only from the value the caller streamed from', async () => {
+  it('guards on the batch count the caller streamed from and on the run still being running', async () => {
     const em = buildFakeEm()
     const run = buildRun()
     mockLookups(run, { cursor: 'old-cursor' })
 
     const service = createSyncRunService(em as any)
-    await service.commitBatchProgress('run-1', { createdCount: 1, batchesCompleted: 1 }, 'new-cursor', SCOPE, 'old-cursor')
+    await service.commitBatchProgress('run-1', { createdCount: 1, batchesCompleted: 1 }, 'new-cursor', SCOPE, 2)
 
     expect(em.nativeUpdate).toHaveBeenCalledWith(
       SyncRun,
@@ -152,38 +152,41 @@ describe('SyncRunService.commitBatchProgress — cursor fencing against a concur
         organizationId: 'org-1',
         tenantId: 'tenant-1',
         deletedAt: null,
-        cursor: 'old-cursor',
+        status: 'running',
+        batchesCompleted: 2,
       }),
-      expect.objectContaining({ cursor: 'new-cursor' }),
+      expect.objectContaining({ updatedAt: expect.any(Date) }),
     )
     expect(em.commit).toHaveBeenCalledTimes(1)
+    expect(run.cursor).toBe('new-cursor')
   })
 
-  it('fences a null starting cursor so only the first delivery can leave the initial position', async () => {
+  it('fences the first commit of a run that has completed no batches yet', async () => {
     const em = buildFakeEm()
-    const run = buildRun({ cursor: null })
+    const run = buildRun({ cursor: null, batchesCompleted: 0 })
     mockLookups(run, null)
 
     const service = createSyncRunService(em as any)
-    await service.commitBatchProgress('run-1', { batchesCompleted: 1 }, 'first-cursor', SCOPE, null)
+    await service.commitBatchProgress('run-1', { batchesCompleted: 1 }, 'first-cursor', SCOPE, 0)
 
     expect(em.nativeUpdate).toHaveBeenCalledWith(
       SyncRun,
-      expect.objectContaining({ cursor: null }),
-      expect.objectContaining({ cursor: 'first-cursor' }),
+      expect.objectContaining({ batchesCompleted: 0, status: 'running' }),
+      expect.anything(),
     )
+    expect(run.cursor).toBe('first-cursor')
   })
 
-  it('rejects the commit and rolls back when another worker already moved the cursor', async () => {
+  it('rejects the commit and rolls back when another delivery already advanced the run', async () => {
     const em = buildFakeEm()
     em.nativeUpdate.mockResolvedValueOnce(0)
     const run = buildRun()
-    mockLookups(run, { cursor: 'moved-by-other-worker' })
+    mockLookups(run, { cursor: 'old-cursor' })
 
     const service = createSyncRunService(em as any)
     await expect(
-      service.commitBatchProgress('run-1', { createdCount: 1, batchesCompleted: 1 }, 'new-cursor', SCOPE, 'old-cursor'),
-    ).rejects.toBeInstanceOf(SyncRunCursorConflictError)
+      service.commitBatchProgress('run-1', { createdCount: 1, batchesCompleted: 1 }, 'new-cursor', SCOPE, 2),
+    ).rejects.toBeInstanceOf(SyncRunOwnershipConflictError)
 
     expect(em.rollback).toHaveBeenCalledTimes(1)
     expect(em.commit).not.toHaveBeenCalled()
@@ -192,7 +195,35 @@ describe('SyncRunService.commitBatchProgress — cursor fencing against a concur
     expect(run.cursor).toBe('old-cursor')
   })
 
-  it('leaves the cursor unguarded when no expectation is supplied, preserving the legacy write', async () => {
+  it('fences a repeated cursor, which the value-based guard could not', async () => {
+    const em = buildFakeEm()
+    em.nativeUpdate.mockResolvedValueOnce(0)
+    const run = buildRun()
+    mockLookups(run, { cursor: 'repeated-cursor' })
+
+    const service = createSyncRunService(em as any)
+    await expect(
+      service.commitBatchProgress('run-1', { batchesCompleted: 1 }, 'repeated-cursor', SCOPE, 2),
+    ).rejects.toBeInstanceOf(SyncRunOwnershipConflictError)
+
+    expect(em.rollback).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses a fenced commit that would not advance the batch count, since it could not fence anything', async () => {
+    const em = buildFakeEm()
+    const run = buildRun()
+    mockLookups(run, { cursor: 'old-cursor' })
+
+    const service = createSyncRunService(em as any)
+    await expect(
+      service.commitBatchProgress('run-1', { createdCount: 1 }, 'new-cursor', SCOPE, 2),
+    ).rejects.toThrow(/must advance batchesCompleted/)
+
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(em.commit).not.toHaveBeenCalled()
+  })
+
+  it('leaves the write unguarded when no expectation is supplied, preserving the legacy behaviour', async () => {
     const em = buildFakeEm()
     const run = buildRun()
     mockLookups(run, { cursor: 'old-cursor' })

--- a/packages/core/src/modules/data_sync/lib/__tests__/sync-run-service.transactions.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/sync-run-service.transactions.test.ts
@@ -2,7 +2,7 @@
 
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SyncCursor, SyncRun } from '../../data/entities'
-import { createSyncRunService } from '../sync-run-service'
+import { createSyncRunService, SyncRunCursorConflictError } from '../sync-run-service'
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findOneWithDecryption: jest.fn(),
@@ -129,6 +129,79 @@ describe('SyncRunService.commitBatchProgress — atomic counter + cursor (issue 
 
     expect(result).toBeNull()
     expect(em.begin).not.toHaveBeenCalled()
+  })
+})
+
+describe('SyncRunService.commitBatchProgress — cursor fencing against a concurrent delivery', () => {
+  beforeEach(() => {
+    ;(findOneWithDecryption as jest.Mock).mockReset()
+  })
+
+  it('advances the cursor only from the value the caller streamed from', async () => {
+    const em = buildFakeEm()
+    const run = buildRun()
+    mockLookups(run, { cursor: 'old-cursor' })
+
+    const service = createSyncRunService(em as any)
+    await service.commitBatchProgress('run-1', { createdCount: 1, batchesCompleted: 1 }, 'new-cursor', SCOPE, 'old-cursor')
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      SyncRun,
+      expect.objectContaining({
+        id: 'run-1',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        deletedAt: null,
+        cursor: 'old-cursor',
+      }),
+      expect.objectContaining({ cursor: 'new-cursor' }),
+    )
+    expect(em.commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('fences a null starting cursor so only the first delivery can leave the initial position', async () => {
+    const em = buildFakeEm()
+    const run = buildRun({ cursor: null })
+    mockLookups(run, null)
+
+    const service = createSyncRunService(em as any)
+    await service.commitBatchProgress('run-1', { batchesCompleted: 1 }, 'first-cursor', SCOPE, null)
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      SyncRun,
+      expect.objectContaining({ cursor: null }),
+      expect.objectContaining({ cursor: 'first-cursor' }),
+    )
+  })
+
+  it('rejects the commit and rolls back when another worker already moved the cursor', async () => {
+    const em = buildFakeEm()
+    em.nativeUpdate.mockResolvedValueOnce(0)
+    const run = buildRun()
+    mockLookups(run, { cursor: 'moved-by-other-worker' })
+
+    const service = createSyncRunService(em as any)
+    await expect(
+      service.commitBatchProgress('run-1', { createdCount: 1, batchesCompleted: 1 }, 'new-cursor', SCOPE, 'old-cursor'),
+    ).rejects.toBeInstanceOf(SyncRunCursorConflictError)
+
+    expect(em.rollback).toHaveBeenCalledTimes(1)
+    expect(em.commit).not.toHaveBeenCalled()
+    expect(run.createdCount).toBe(5)
+    expect(run.batchesCompleted).toBe(2)
+    expect(run.cursor).toBe('old-cursor')
+  })
+
+  it('leaves the cursor unguarded when no expectation is supplied, preserving the legacy write', async () => {
+    const em = buildFakeEm()
+    const run = buildRun()
+    mockLookups(run, { cursor: 'old-cursor' })
+
+    const service = createSyncRunService(em as any)
+    await service.commitBatchProgress('run-1', { createdCount: 1, batchesCompleted: 1 }, 'new-cursor', SCOPE)
+
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(run.cursor).toBe('new-cursor')
   })
 })
 

--- a/packages/core/src/modules/data_sync/lib/adapter.ts
+++ b/packages/core/src/modules/data_sync/lib/adapter.ts
@@ -104,6 +104,24 @@ export interface DataSyncAdapter {
   readonly runMode?: 'generic' | 'provider'
   readonly operationalTelemetry?: boolean
 
+  /**
+   * Batch work MUST be replay-safe.
+   *
+   * Sync jobs are delivered at least once: BullMQ redelivers a job whose lock
+   * was not renewed, and the engine resumes the run from its last committed
+   * cursor. A batch the generator already yielded can therefore be produced and
+   * executed again, and the engine only fences its own commit — anything the
+   * generator itself did before yielding has already happened.
+   *
+   * Upserts keyed by `externalId` satisfy this. Per-record side effects that are
+   * not idempotent (sending mail, posting to a third party, incrementing a
+   * remote counter) do not, and will run twice on a resume. Make them
+   * conditional on state the adapter can re-read, or move them behind an event
+   * the engine emits after the commit.
+   *
+   * `cursor` is a resume position, not an identity: repeating it between batches
+   * is allowed.
+   */
   streamImport?(input: StreamImportInput): AsyncIterable<ImportBatch>
   streamExport?(input: StreamExportInput): AsyncIterable<ExportBatch>
   getInitialCursor?(input: { entityType: string; scope: TenantScope }): Promise<string | null>

--- a/packages/core/src/modules/data_sync/lib/queue-policy.ts
+++ b/packages/core/src/modules/data_sync/lib/queue-policy.ts
@@ -1,0 +1,2 @@
+export const DATA_SYNC_QUEUE_ATTEMPTS = 3
+export const DATA_SYNC_MAX_STALLED_COUNT = 10

--- a/packages/core/src/modules/data_sync/lib/queue-policy.ts
+++ b/packages/core/src/modules/data_sync/lib/queue-policy.ts
@@ -20,9 +20,9 @@ export const DATA_SYNC_QUEUE_ATTEMPTS = 3
  * stalls more than this many times, and at the default of 1 a single stall
  * during a long backfill discards the run permanently. 10 buys enough
  * redeliveries to survive a rolling restart. Raising it is only safe because a
- * duplicate delivery can no longer corrupt the run: the cursor compare-and-swap
- * in `commitBatchProgress` lets exactly one worker advance a run, and every
- * other delivery aborts on its first commit. A job that genuinely poisons its
+ * duplicate delivery can no longer corrupt the run: the ownership
+ * compare-and-swap in `commitBatchProgress` lets exactly one worker advance a
+ * run, and every other delivery aborts on its first commit. A job that poisons its
  * worker still dies — after 10 stalls, with the run left `running` and its
  * cursor unmoved, which is the state the admin runs list surfaces.
  */

--- a/packages/core/src/modules/data_sync/lib/queue-policy.ts
+++ b/packages/core/src/modules/data_sync/lib/queue-policy.ts
@@ -1,2 +1,30 @@
+/**
+ * Queue names whose jobs resume an existing SyncRun instead of starting a fresh
+ * one. The workers import these to declare their `metadata.queue`, so a rename
+ * cannot silently drop the retry policy.
+ */
+export const DATA_SYNC_IMPORT_QUEUE = 'data-sync-import'
+export const DATA_SYNC_EXPORT_QUEUE = 'data-sync-export'
+
+export const DATA_SYNC_RESUMABLE_QUEUES: readonly string[] = [DATA_SYNC_IMPORT_QUEUE, DATA_SYNC_EXPORT_QUEUE]
+
 export const DATA_SYNC_QUEUE_ATTEMPTS = 3
+
+/**
+ * A backfill batch can hold the processor well past BullMQ's 30s default lock,
+ * so these jobs stall on slow upstreams even when the worker is perfectly
+ * healthy. `DATA_SYNC_LOCK_DURATION_MS` is the primary defence — it stops most
+ * of those false stalls at the source rather than reacting to them.
+ *
+ * `DATA_SYNC_MAX_STALLED_COUNT` covers what is left. BullMQ fails a job once it
+ * stalls more than this many times, and at the default of 1 a single stall
+ * during a long backfill discards the run permanently. 10 buys enough
+ * redeliveries to survive a rolling restart. Raising it is only safe because a
+ * duplicate delivery can no longer corrupt the run: the cursor compare-and-swap
+ * in `commitBatchProgress` lets exactly one worker advance a run, and every
+ * other delivery aborts on its first commit. A job that genuinely poisons its
+ * worker still dies — after 10 stalls, with the run left `running` and its
+ * cursor unmoved, which is the state the admin runs list surfaces.
+ */
+export const DATA_SYNC_LOCK_DURATION_MS = 120_000
 export const DATA_SYNC_MAX_STALLED_COUNT = 10

--- a/packages/core/src/modules/data_sync/lib/queue.ts
+++ b/packages/core/src/modules/data_sync/lib/queue.ts
@@ -1,13 +1,25 @@
 import { createModuleQueue, type Queue } from '@open-mercato/queue'
+import { DATA_SYNC_QUEUE_ATTEMPTS, DATA_SYNC_MAX_STALLED_COUNT } from './queue-policy'
 
 const queues = new Map<string, Queue<Record<string, unknown>>>()
+
+const resumableQueueNames = new Set(['data-sync-import', 'data-sync-export'])
 
 export function getSyncQueue(queueName: string): Queue<Record<string, unknown>> {
   const existing = queues.get(queueName)
   if (existing) return existing
 
   const concurrency = Math.max(1, Number.parseInt(process.env.DATA_SYNC_QUEUE_CONCURRENCY ?? '5', 10) || 5)
-  const created = createModuleQueue<Record<string, unknown>>(queueName, { concurrency })
+  const created = createModuleQueue<Record<string, unknown>>(
+    queueName,
+    resumableQueueNames.has(queueName)
+      ? {
+        concurrency,
+        attempts: DATA_SYNC_QUEUE_ATTEMPTS,
+        maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
+      }
+      : { concurrency },
+  )
 
   queues.set(queueName, created)
   return created

--- a/packages/core/src/modules/data_sync/lib/queue.ts
+++ b/packages/core/src/modules/data_sync/lib/queue.ts
@@ -1,9 +1,14 @@
 import { createModuleQueue, type Queue } from '@open-mercato/queue'
-import { DATA_SYNC_QUEUE_ATTEMPTS, DATA_SYNC_MAX_STALLED_COUNT } from './queue-policy'
+import {
+  DATA_SYNC_LOCK_DURATION_MS,
+  DATA_SYNC_MAX_STALLED_COUNT,
+  DATA_SYNC_QUEUE_ATTEMPTS,
+  DATA_SYNC_RESUMABLE_QUEUES,
+} from './queue-policy'
 
 const queues = new Map<string, Queue<Record<string, unknown>>>()
 
-const resumableQueueNames = new Set(['data-sync-import', 'data-sync-export'])
+const resumableQueueNames = new Set<string>(DATA_SYNC_RESUMABLE_QUEUES)
 
 export function getSyncQueue(queueName: string): Queue<Record<string, unknown>> {
   const existing = queues.get(queueName)
@@ -16,6 +21,7 @@ export function getSyncQueue(queueName: string): Queue<Record<string, unknown>> 
       ? {
         concurrency,
         attempts: DATA_SYNC_QUEUE_ATTEMPTS,
+        lockDuration: DATA_SYNC_LOCK_DURATION_MS,
         maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
       }
       : { concurrency },

--- a/packages/core/src/modules/data_sync/lib/start-run.ts
+++ b/packages/core/src/modules/data_sync/lib/start-run.ts
@@ -1,6 +1,7 @@
 import type { ProgressService } from '../../progress/lib/progressService'
 import type { SyncRunService } from './sync-run-service'
 import { getSyncQueue } from './queue'
+import { DATA_SYNC_EXPORT_QUEUE, DATA_SYNC_IMPORT_QUEUE } from './queue-policy'
 
 export type DataSyncStartScope = {
   organizationId: string
@@ -71,7 +72,7 @@ export async function startDataSyncRun(params: {
     },
   )
 
-  const queueName = input.direction === 'import' ? 'data-sync-import' : 'data-sync-export'
+  const queueName = input.direction === 'import' ? DATA_SYNC_IMPORT_QUEUE : DATA_SYNC_EXPORT_QUEUE
   const queue = getSyncQueue(queueName)
   await queue.enqueue({
     runId: run.id,

--- a/packages/core/src/modules/data_sync/lib/sync-engine.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-engine.ts
@@ -9,7 +9,7 @@ import { emitDataSyncEvent } from '../events'
 import type { DataSyncAdapter, DataMapping, ExportBatch, ImportBatch } from './adapter'
 import { getDataSyncAdapter } from './adapter-registry'
 import type { SyncRunService } from './sync-run-service'
-import { SyncRunCursorConflictError } from './sync-run-service'
+import { SyncRunOwnershipConflictError } from './sync-run-service'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('data_sync').child({ component: 'sync-engine' })
@@ -237,6 +237,21 @@ export function createSyncEngine(deps: EngineDeps) {
       return
     }
 
+    if (run.status !== status) {
+      // `markStatus` refuses a terminal -> different-terminal transition and
+      // returns the row unchanged, so the run is already finished under another
+      // delivery of this job. Everything below — the progress job, the
+      // operational log and the lifecycle event — would describe the wrong
+      // outcome, and `data_sync.run.failed` is dispatched to tenant webhooks.
+      // A displaced worker stays silent instead.
+      logger.warn('Skipping finalization of a sync run another worker already finalized', {
+        runId,
+        requestedStatus: status,
+        actualStatus: run.status,
+      })
+      return
+    }
+
     if (run.progressJobId) {
       if (status === 'completed') {
         await progressService.completeJob(
@@ -409,6 +424,10 @@ export function createSyncEngine(deps: EngineDeps) {
         throw new Error(`Integration ${run.integrationId} is missing credentials`)
       }
 
+      // A run already `running` means a stalled job was redelivered, so this is
+      // a resume rather than a first start. Consumers see one `started` event per
+      // delivery either way; the flag is what lets them tell the two apart.
+      const resumed = run.status === 'running'
       const activeRun = await syncRunService.markStatus(run.id, 'running', scope)
       if (!activeRun || activeRun.status !== 'running') {
         return
@@ -418,6 +437,7 @@ export function createSyncEngine(deps: EngineDeps) {
         integrationId: run.integrationId,
         entityType: run.entityType,
         direction: run.direction,
+        resumed,
         tenantId: scope.tenantId,
         organizationId: scope.organizationId,
       })
@@ -453,7 +473,7 @@ export function createSyncEngine(deps: EngineDeps) {
       const mapping = await resolveMapping(adapter, run.entityType, scope)
       let processedCount = 0
       let totalCount: number | null = null
-      let committedCursor: string | null = run.cursor ?? null
+      let committedBatches = activeRun.batchesCompleted ?? 0
 
       try {
         for await (const batch of adapter.streamImport({
@@ -483,9 +503,9 @@ export function createSyncEngine(deps: EngineDeps) {
             },
             batch.cursor,
             scope,
-            committedCursor,
+            committedBatches,
           )
-          committedCursor = batch.cursor
+          committedBatches += 1
 
           await updateProgress(run.progressJobId, processedCount, totalCount, scope)
           await refreshCoverageSnapshots(batch.refreshCoverageEntityTypes, scope)
@@ -511,10 +531,10 @@ export function createSyncEngine(deps: EngineDeps) {
           })
         }
       } catch (error) {
-        if (error instanceof SyncRunCursorConflictError) {
-          logger.warn('Yielding import run to a concurrent worker that already advanced the cursor', {
+        if (error instanceof SyncRunOwnershipConflictError) {
+          logger.warn('Yielding import run to a concurrent worker that already advanced it', {
             runId: run.id,
-            expectedCursor: error.expectedCursor,
+            expectedBatchesCompleted: error.expectedBatchesCompleted,
           })
           return
         }
@@ -564,6 +584,10 @@ export function createSyncEngine(deps: EngineDeps) {
         throw new Error(`Integration ${run.integrationId} is missing credentials`)
       }
 
+      // A run already `running` means a stalled job was redelivered, so this is
+      // a resume rather than a first start. Consumers see one `started` event per
+      // delivery either way; the flag is what lets them tell the two apart.
+      const resumed = run.status === 'running'
       const activeRun = await syncRunService.markStatus(run.id, 'running', scope)
       if (!activeRun || activeRun.status !== 'running') {
         return
@@ -573,6 +597,7 @@ export function createSyncEngine(deps: EngineDeps) {
         integrationId: run.integrationId,
         entityType: run.entityType,
         direction: run.direction,
+        resumed,
         tenantId: scope.tenantId,
         organizationId: scope.organizationId,
       })
@@ -607,7 +632,7 @@ export function createSyncEngine(deps: EngineDeps) {
 
       const mapping = await resolveMapping(adapter, run.entityType, scope)
       let processedCount = 0
-      let committedCursor: string | null = run.cursor ?? null
+      let committedBatches = activeRun.batchesCompleted ?? 0
 
       try {
         for await (const batch of adapter.streamExport({
@@ -638,9 +663,9 @@ export function createSyncEngine(deps: EngineDeps) {
             },
             batch.cursor,
             scope,
-            committedCursor,
+            committedBatches,
           )
-          committedCursor = batch.cursor
+          committedBatches += 1
           await updateProgress(run.progressJobId, processedCount, null, scope)
           await logExportItemFailures(run.id, run.integrationId, batch.results, scope)
 
@@ -661,10 +686,10 @@ export function createSyncEngine(deps: EngineDeps) {
           })
         }
       } catch (error) {
-        if (error instanceof SyncRunCursorConflictError) {
-          logger.warn('Yielding export run to a concurrent worker that already advanced the cursor', {
+        if (error instanceof SyncRunOwnershipConflictError) {
+          logger.warn('Yielding export run to a concurrent worker that already advanced it', {
             runId: run.id,
-            expectedCursor: error.expectedCursor,
+            expectedBatchesCompleted: error.expectedBatchesCompleted,
           })
           return
         }

--- a/packages/core/src/modules/data_sync/lib/sync-engine.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-engine.ts
@@ -9,6 +9,7 @@ import { emitDataSyncEvent } from '../events'
 import type { DataSyncAdapter, DataMapping, ExportBatch, ImportBatch } from './adapter'
 import { getDataSyncAdapter } from './adapter-registry'
 import type { SyncRunService } from './sync-run-service'
+import { SyncRunCursorConflictError } from './sync-run-service'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('data_sync').child({ component: 'sync-engine' })
@@ -452,6 +453,7 @@ export function createSyncEngine(deps: EngineDeps) {
       const mapping = await resolveMapping(adapter, run.entityType, scope)
       let processedCount = 0
       let totalCount: number | null = null
+      let committedCursor: string | null = run.cursor ?? null
 
       try {
         for await (const batch of adapter.streamImport({
@@ -481,7 +483,9 @@ export function createSyncEngine(deps: EngineDeps) {
             },
             batch.cursor,
             scope,
+            committedCursor,
           )
+          committedCursor = batch.cursor
 
           await updateProgress(run.progressJobId, processedCount, totalCount, scope)
           await refreshCoverageSnapshots(batch.refreshCoverageEntityTypes, scope)
@@ -507,6 +511,13 @@ export function createSyncEngine(deps: EngineDeps) {
           })
         }
       } catch (error) {
+        if (error instanceof SyncRunCursorConflictError) {
+          logger.warn('Yielding import run to a concurrent worker that already advanced the cursor', {
+            runId: run.id,
+            expectedCursor: error.expectedCursor,
+          })
+          return
+        }
         const message = error instanceof Error ? error.message : 'Sync import failed'
         await integrationLogService.write(
           {
@@ -596,6 +607,7 @@ export function createSyncEngine(deps: EngineDeps) {
 
       const mapping = await resolveMapping(adapter, run.entityType, scope)
       let processedCount = 0
+      let committedCursor: string | null = run.cursor ?? null
 
       try {
         for await (const batch of adapter.streamExport({
@@ -626,7 +638,9 @@ export function createSyncEngine(deps: EngineDeps) {
             },
             batch.cursor,
             scope,
+            committedCursor,
           )
+          committedCursor = batch.cursor
           await updateProgress(run.progressJobId, processedCount, null, scope)
           await logExportItemFailures(run.id, run.integrationId, batch.results, scope)
 
@@ -647,6 +661,13 @@ export function createSyncEngine(deps: EngineDeps) {
           })
         }
       } catch (error) {
+        if (error instanceof SyncRunCursorConflictError) {
+          logger.warn('Yielding export run to a concurrent worker that already advanced the cursor', {
+            runId: run.id,
+            expectedCursor: error.expectedCursor,
+          })
+          return
+        }
         const message = error instanceof Error ? error.message : 'Sync export failed'
         await integrationLogService.write(
           {

--- a/packages/core/src/modules/data_sync/lib/sync-run-service.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-run-service.ts
@@ -150,7 +150,11 @@ export function createSyncRunService(em: EntityManager) {
             organizationId: scope.organizationId,
             tenantId: scope.tenantId,
             deletedAt: null,
-            status: 'pending',
+            // A BullMQ stalled-job redelivery finds the run in `running` after
+            // the previous worker was hard-killed. Treat that transition as an
+            // idempotent claim while still excluding terminal states so a
+            // cancelled or completed run cannot be revived.
+            status: { $in: ['pending', 'running'] },
           },
           {
             status,

--- a/packages/core/src/modules/data_sync/lib/sync-run-service.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-run-service.ts
@@ -27,8 +27,9 @@ type SyncScope = {
 }
 
 /**
- * Raised when a batch commit loses the cursor compare-and-swap, meaning another
- * delivery of the same job advanced the run while this worker was streaming.
+ * Raised when a batch commit loses the ownership compare-and-swap, meaning
+ * another delivery of the same job advanced the run while this worker was
+ * streaming.
  *
  * BullMQ guarantees at-least-once delivery: a job whose lock is not renewed is
  * redelivered under the SAME job id, whether the previous worker died or is only
@@ -36,14 +37,13 @@ type SyncScope = {
  * — on the write that matters — instead of at claim time. The loser aborts and
  * leaves the run to the worker that is still making progress.
  */
-export class SyncRunCursorConflictError extends Error {
+export class SyncRunOwnershipConflictError extends Error {
   constructor(
     readonly runId: string,
-    readonly expectedCursor: string | null,
-    readonly attemptedCursor: string,
+    readonly expectedBatchesCompleted: number,
   ) {
-    super(`[internal] Sync run ${runId} cursor moved from ${expectedCursor ?? 'null'} under a concurrent worker`)
-    this.name = 'SyncRunCursorConflictError'
+    super(`[internal] Sync run ${runId} advanced past batch ${expectedBatchesCompleted} under a concurrent worker`)
+    this.name = 'SyncRunOwnershipConflictError'
   }
 }
 
@@ -203,6 +203,12 @@ export function createSyncRunService(em: EntityManager) {
       return row
     },
 
+    /**
+     * @deprecated Use {@link commitBatchProgress}, which writes counters and
+     * cursor in one transaction behind the ownership fence. This method updates
+     * counters unfenced, so two deliveries of the same job can lose each other's
+     * increments. Kept for external callers only.
+     */
     async updateCounts(
       runId: string,
       delta: Partial<Pick<SyncRun, 'createdCount' | 'updatedCount' | 'skippedCount' | 'failedCount' | 'batchesCompleted'>>,
@@ -220,6 +226,11 @@ export function createSyncRunService(em: EntityManager) {
       return row
     },
 
+    /**
+     * @deprecated Use {@link commitBatchProgress}. This method advances the
+     * cursor without the ownership fence, so a stale delivery can move the
+     * cursor of a run another worker owns. Kept for external callers only.
+     */
     async updateCursor(runId: string, cursor: string, scope: SyncScope): Promise<void> {
       const run = await this.getRun(runId, scope)
       if (!run) return
@@ -229,34 +240,61 @@ export function createSyncRunService(em: EntityManager) {
       ], { transaction: true })
     },
 
+    /**
+     * Commits one batch's counters and cursor in a single transaction.
+     *
+     * Passing `expectedBatchesCompleted` fences the write: the run must still be
+     * `running` and still sit on that batch count, or another delivery of the
+     * same BullMQ job owns the run and this commit throws
+     * `SyncRunOwnershipConflictError` and rolls back. Omitting it keeps the
+     * legacy unguarded write for callers outside the engine.
+     *
+     * The fence token is `batchesCompleted` rather than `cursor` because it
+     * advances by construction on every commit. A cursor is a free-form adapter
+     * string that an adapter may legitimately repeat between batches — the
+     * Akeneo products adapter does, between its final page and the
+     * reconciliation batch that follows it — and a repeated token fences
+     * nothing.
+     *
+     * The guard's `UPDATE` also holds the row lock for the rest of the
+     * transaction, so a competing commit blocks here and then re-reads the
+     * advanced count instead of interleaving with this one. That is what lets
+     * the counters below stay a plain read-modify-write against the snapshot
+     * read above: a commit that wins the fence has proven that nothing else
+     * landed since it read.
+     */
     async commitBatchProgress(
       runId: string,
       delta: Partial<Pick<SyncRun, 'createdCount' | 'updatedCount' | 'skippedCount' | 'failedCount' | 'batchesCompleted'>>,
       cursor: string,
       scope: SyncScope,
-      expectedCursor?: string | null,
+      expectedBatchesCompleted?: number,
     ): Promise<SyncRun | null> {
       const run = await this.getRun(runId, scope)
       if (!run) return null
       const cursorRow = await resolveCursorRow(run, scope)
-      const claimCursorAdvance = async () => {
-        const advanced = await em.nativeUpdate(
+      const claimRunOwnership = async () => {
+        if ((delta.batchesCompleted ?? 0) < 1) {
+          throw new Error(`[internal] A fenced commit for sync run ${runId} must advance batchesCompleted`)
+        }
+        const owned = await em.nativeUpdate(
           SyncRun,
           {
             id: runId,
             organizationId: scope.organizationId,
             tenantId: scope.tenantId,
             deletedAt: null,
-            cursor: expectedCursor,
+            status: 'running',
+            batchesCompleted: expectedBatchesCompleted,
           },
-          { cursor, updatedAt: new Date() },
+          { updatedAt: new Date() },
         )
-        if (advanced === 0) {
-          throw new SyncRunCursorConflictError(runId, expectedCursor ?? null, cursor)
+        if (owned === 0) {
+          throw new SyncRunOwnershipConflictError(runId, expectedBatchesCompleted ?? 0)
         }
       }
       await withAtomicFlush(em, [
-        ...(expectedCursor === undefined ? [] : [claimCursorAdvance]),
+        ...(expectedBatchesCompleted === undefined ? [] : [claimRunOwnership]),
         () => {
           run.createdCount += delta.createdCount ?? 0
           run.updatedCount += delta.updatedCount ?? 0

--- a/packages/core/src/modules/data_sync/lib/sync-run-service.ts
+++ b/packages/core/src/modules/data_sync/lib/sync-run-service.ts
@@ -26,6 +26,27 @@ type SyncScope = {
   tenantId: string
 }
 
+/**
+ * Raised when a batch commit loses the cursor compare-and-swap, meaning another
+ * delivery of the same job advanced the run while this worker was streaming.
+ *
+ * BullMQ guarantees at-least-once delivery: a job whose lock is not renewed is
+ * redelivered under the SAME job id, whether the previous worker died or is only
+ * blocked. No identity token can tell those apart, so ownership is enforced here
+ * — on the write that matters — instead of at claim time. The loser aborts and
+ * leaves the run to the worker that is still making progress.
+ */
+export class SyncRunCursorConflictError extends Error {
+  constructor(
+    readonly runId: string,
+    readonly expectedCursor: string | null,
+    readonly attemptedCursor: string,
+  ) {
+    super(`[internal] Sync run ${runId} cursor moved from ${expectedCursor ?? 'null'} under a concurrent worker`)
+    this.name = 'SyncRunCursorConflictError'
+  }
+}
+
 export function createSyncRunService(em: EntityManager) {
   async function resolveCursorRow(run: SyncRun, scope: SyncScope): Promise<SyncCursor | null> {
     return findOneWithDecryption(
@@ -213,11 +234,29 @@ export function createSyncRunService(em: EntityManager) {
       delta: Partial<Pick<SyncRun, 'createdCount' | 'updatedCount' | 'skippedCount' | 'failedCount' | 'batchesCompleted'>>,
       cursor: string,
       scope: SyncScope,
+      expectedCursor?: string | null,
     ): Promise<SyncRun | null> {
       const run = await this.getRun(runId, scope)
       if (!run) return null
       const cursorRow = await resolveCursorRow(run, scope)
+      const claimCursorAdvance = async () => {
+        const advanced = await em.nativeUpdate(
+          SyncRun,
+          {
+            id: runId,
+            organizationId: scope.organizationId,
+            tenantId: scope.tenantId,
+            deletedAt: null,
+            cursor: expectedCursor,
+          },
+          { cursor, updatedAt: new Date() },
+        )
+        if (advanced === 0) {
+          throw new SyncRunCursorConflictError(runId, expectedCursor ?? null, cursor)
+        }
+      }
       await withAtomicFlush(em, [
+        ...(expectedCursor === undefined ? [] : [claimCursorAdvance]),
         () => {
           run.createdCount += delta.createdCount ?? 0
           run.updatedCount += delta.updatedCount ?? 0

--- a/packages/core/src/modules/data_sync/workers/sync-export.ts
+++ b/packages/core/src/modules/data_sync/workers/sync-export.ts
@@ -2,6 +2,7 @@ import type { JobContext, QueuedJob, WorkerMeta } from '@open-mercato/queue'
 import type { ProgressService } from '../../progress/lib/progressService'
 import type { SyncEngine } from '../lib/sync-engine'
 import type { SyncRunService } from '../lib/sync-run-service'
+import { DATA_SYNC_MAX_STALLED_COUNT } from '../lib/queue-policy'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('data_sync').child({ component: 'sync-export' })
@@ -20,6 +21,7 @@ export const metadata: WorkerMeta = {
   queue: 'data-sync-export',
   id: 'data-sync:export',
   concurrency: 5,
+  maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
 }
 
 type HandlerContext = JobContext & {

--- a/packages/core/src/modules/data_sync/workers/sync-export.ts
+++ b/packages/core/src/modules/data_sync/workers/sync-export.ts
@@ -2,7 +2,11 @@ import type { JobContext, QueuedJob, WorkerMeta } from '@open-mercato/queue'
 import type { ProgressService } from '../../progress/lib/progressService'
 import type { SyncEngine } from '../lib/sync-engine'
 import type { SyncRunService } from '../lib/sync-run-service'
-import { DATA_SYNC_MAX_STALLED_COUNT } from '../lib/queue-policy'
+import {
+  DATA_SYNC_EXPORT_QUEUE,
+  DATA_SYNC_LOCK_DURATION_MS,
+  DATA_SYNC_MAX_STALLED_COUNT,
+} from '../lib/queue-policy'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('data_sync').child({ component: 'sync-export' })
@@ -18,9 +22,10 @@ type SyncJobPayload = {
 }
 
 export const metadata: WorkerMeta = {
-  queue: 'data-sync-export',
+  queue: DATA_SYNC_EXPORT_QUEUE,
   id: 'data-sync:export',
   concurrency: 5,
+  lockDuration: DATA_SYNC_LOCK_DURATION_MS,
   maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
 }
 

--- a/packages/core/src/modules/data_sync/workers/sync-import.ts
+++ b/packages/core/src/modules/data_sync/workers/sync-import.ts
@@ -2,6 +2,7 @@ import type { JobContext, QueuedJob, WorkerMeta } from '@open-mercato/queue'
 import type { ProgressService } from '../../progress/lib/progressService'
 import type { SyncEngine } from '../lib/sync-engine'
 import type { SyncRunService } from '../lib/sync-run-service'
+import { DATA_SYNC_MAX_STALLED_COUNT } from '../lib/queue-policy'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('data_sync').child({ component: 'sync-import' })
@@ -20,6 +21,7 @@ export const metadata: WorkerMeta = {
   queue: 'data-sync-import',
   id: 'data-sync:import',
   concurrency: 5,
+  maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
 }
 
 type HandlerContext = JobContext & {

--- a/packages/core/src/modules/data_sync/workers/sync-import.ts
+++ b/packages/core/src/modules/data_sync/workers/sync-import.ts
@@ -2,7 +2,11 @@ import type { JobContext, QueuedJob, WorkerMeta } from '@open-mercato/queue'
 import type { ProgressService } from '../../progress/lib/progressService'
 import type { SyncEngine } from '../lib/sync-engine'
 import type { SyncRunService } from '../lib/sync-run-service'
-import { DATA_SYNC_MAX_STALLED_COUNT } from '../lib/queue-policy'
+import {
+  DATA_SYNC_IMPORT_QUEUE,
+  DATA_SYNC_LOCK_DURATION_MS,
+  DATA_SYNC_MAX_STALLED_COUNT,
+} from '../lib/queue-policy'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('data_sync').child({ component: 'sync-import' })
@@ -18,9 +22,10 @@ type SyncJobPayload = {
 }
 
 export const metadata: WorkerMeta = {
-  queue: 'data-sync-import',
+  queue: DATA_SYNC_IMPORT_QUEUE,
   id: 'data-sync:import',
   concurrency: 5,
+  lockDuration: DATA_SYNC_LOCK_DURATION_MS,
   maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
 }
 

--- a/packages/queue/src/__tests__/async.strategy.test.ts
+++ b/packages/queue/src/__tests__/async.strategy.test.ts
@@ -114,6 +114,27 @@ describe('Queue - async strategy', () => {
     await queue.close()
   })
 
+  it('threads queue retry and stalled-job options to BullMQ', async () => {
+    const queue = createQueue<{ value: number }>('test-queue', 'async', {
+      attempts: 5,
+      maxStalledCount: 10,
+    })
+
+    await queue.enqueue({ value: 42 })
+    await queue.process(async () => {})
+
+    expect(queueAdd).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ payload: { value: 42 } }),
+      expect.objectContaining({ attempts: 5 }),
+    )
+    expect(workerCtor).toHaveBeenCalledWith(
+      'test-queue',
+      expect.any(Function),
+      expect.objectContaining({ maxStalledCount: 10 }),
+    )
+  })
+
   it('removeQueuedJobsByScope removes only queued jobs matching tenant scope', async () => {
     const removeMatching = jest.fn(async () => {})
     const removeAutoIndex = jest.fn(async () => {})

--- a/packages/queue/src/__tests__/async.strategy.test.ts
+++ b/packages/queue/src/__tests__/async.strategy.test.ts
@@ -114,9 +114,10 @@ describe('Queue - async strategy', () => {
     await queue.close()
   })
 
-  it('threads queue retry and stalled-job options to BullMQ', async () => {
+  it('threads queue retry, lock-duration and stalled-job options to BullMQ', async () => {
     const queue = createQueue<{ value: number }>('test-queue', 'async', {
       attempts: 5,
+      lockDuration: 120_000,
       maxStalledCount: 10,
     })
 
@@ -131,8 +132,18 @@ describe('Queue - async strategy', () => {
     expect(workerCtor).toHaveBeenCalledWith(
       'test-queue',
       expect.any(Function),
-      expect.objectContaining({ maxStalledCount: 10 }),
+      expect.objectContaining({ lockDuration: 120_000, maxStalledCount: 10 }),
     )
+  })
+
+  it('leaves BullMQ on its own lock and stall defaults when the options are unset', async () => {
+    const queue = createQueue<{ value: number }>('test-queue', 'async', {})
+
+    await queue.process(async () => {})
+
+    const workerOptions = workerCtor.mock.calls[0]?.[2] as Record<string, unknown>
+    expect(workerOptions).not.toHaveProperty('lockDuration')
+    expect(workerOptions).not.toHaveProperty('maxStalledCount')
   })
 
   it('removeQueuedJobsByScope removes only queued jobs matching tenant scope', async () => {

--- a/packages/queue/src/factory.ts
+++ b/packages/queue/src/factory.ts
@@ -82,13 +82,15 @@ export function resolveQueueStrategy(): QueueStrategyType {
  */
 export function createModuleQueue<T = unknown>(
   name: string,
-  options?: { concurrency?: number },
+  options?: Pick<AsyncQueueOptions, 'attempts' | 'concurrency' | 'maxStalledCount'>,
 ): Queue<T> {
   const strategy = resolveQueueStrategy()
   if (strategy === 'async') {
     return createAsyncQueue<T>(name, {
       connection: { url: getRedisUrlOrThrow('QUEUE') },
       concurrency: options?.concurrency,
+      attempts: options?.attempts,
+      maxStalledCount: options?.maxStalledCount,
     })
   }
   return createLocalQueue<T>(name, { concurrency: options?.concurrency })

--- a/packages/queue/src/factory.ts
+++ b/packages/queue/src/factory.ts
@@ -82,7 +82,7 @@ export function resolveQueueStrategy(): QueueStrategyType {
  */
 export function createModuleQueue<T = unknown>(
   name: string,
-  options?: Pick<AsyncQueueOptions, 'attempts' | 'concurrency' | 'maxStalledCount'>,
+  options?: Pick<AsyncQueueOptions, 'attempts' | 'concurrency' | 'lockDuration' | 'maxStalledCount'>,
 ): Queue<T> {
   const strategy = resolveQueueStrategy()
   if (strategy === 'async') {
@@ -90,6 +90,7 @@ export function createModuleQueue<T = unknown>(
       connection: { url: getRedisUrlOrThrow('QUEUE') },
       concurrency: options?.concurrency,
       attempts: options?.attempts,
+      lockDuration: options?.lockDuration,
       maxStalledCount: options?.maxStalledCount,
     })
   }

--- a/packages/queue/src/strategies/async.ts
+++ b/packages/queue/src/strategies/async.ts
@@ -47,7 +47,7 @@ interface BullMQModule {
   Worker: new <T>(
     name: string,
     processor: (job: { id?: string; data: T; attemptsMade: number }) => Promise<void>,
-    opts: { connection: ConnectionOptions; concurrency: number }
+    opts: { connection: ConnectionOptions; concurrency: number; maxStalledCount?: number }
   ) => BullWorkerInterface
 }
 
@@ -111,6 +111,8 @@ export function createAsyncQueue<T = unknown>(
 ): Queue<T> {
   const connection = resolveConnection(options?.connection)
   const concurrency = options?.concurrency ?? 1
+  const attempts = options?.attempts ?? 3
+  const maxStalledCount = options?.maxStalledCount
   const logger = packageLogger.child({ queue: name })
 
   let bullQueue: BullQueueInterface<QueuedJob<T>> | null = null
@@ -158,7 +160,7 @@ export function createAsyncQueue<T = unknown>(
       delay: options?.delayMs && options.delayMs > 0 ? options.delayMs : undefined,
       removeOnComplete: true,
       removeOnFail: 1000,
-      attempts: 3,
+      attempts,
       backoff: { type: 'exponential', delay: 1000 },
     })
 
@@ -182,6 +184,7 @@ export function createAsyncQueue<T = unknown>(
       {
         connection,
         concurrency,
+        ...(maxStalledCount !== undefined ? { maxStalledCount } : {}),
       }
     )
 

--- a/packages/queue/src/strategies/async.ts
+++ b/packages/queue/src/strategies/async.ts
@@ -47,7 +47,7 @@ interface BullMQModule {
   Worker: new <T>(
     name: string,
     processor: (job: { id?: string; data: T; attemptsMade: number }) => Promise<void>,
-    opts: { connection: ConnectionOptions; concurrency: number; maxStalledCount?: number }
+    opts: { connection: ConnectionOptions; concurrency: number; lockDuration?: number; maxStalledCount?: number }
   ) => BullWorkerInterface
 }
 
@@ -112,6 +112,7 @@ export function createAsyncQueue<T = unknown>(
   const connection = resolveConnection(options?.connection)
   const concurrency = options?.concurrency ?? 1
   const attempts = options?.attempts ?? 3
+  const lockDuration = options?.lockDuration
   const maxStalledCount = options?.maxStalledCount
   const logger = packageLogger.child({ queue: name })
 
@@ -184,6 +185,7 @@ export function createAsyncQueue<T = unknown>(
       {
         connection,
         concurrency,
+        ...(lockDuration !== undefined ? { lockDuration } : {}),
         ...(maxStalledCount !== undefined ? { maxStalledCount } : {}),
       }
     )
@@ -198,6 +200,16 @@ export function createAsyncQueue<T = unknown>(
       const jobWithId = job as { id?: string } | undefined
       const error = err as Error
       logger.error('Job failed', { jobId: jobWithId?.id, err: error })
+    })
+
+    // A stalled job is redelivered under the same id while the previous worker
+    // may still be running it, so this is the signal that a handler is about to
+    // be executed twice. BullMQ's docs require surfacing it: without this line
+    // duplicate processing is invisible.
+    bullWorker.on('stalled', (jobId) => {
+      logger.warn('Job stalled and will be redelivered — the handler may run concurrently with a previous delivery', {
+        jobId: typeof jobId === 'string' ? jobId : null,
+      })
     })
 
     bullWorker.on('error', (err) => {

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -91,6 +91,10 @@ export type AsyncQueueOptions = {
   connection?: RedisConnectionOptions
   /** Number of concurrent job processors. Defaults to 1 */
   concurrency?: number
+  /** Number of attempts for newly enqueued jobs. Defaults to 3. */
+  attempts?: number
+  /** Number of stalled-job recoveries BullMQ permits before failing a job. Defaults to 1. */
+  maxStalledCount?: number
 }
 
 /**
@@ -250,6 +254,8 @@ export type WorkerMeta = {
   id?: string
   /** Worker concurrency (default: 1) */
   concurrency?: number
+  /** Number of stalled-job recoveries BullMQ permits before failing a job. */
+  maxStalledCount?: number
 }
 
 /**
@@ -265,4 +271,6 @@ export type WorkerDescriptor<T = unknown> = {
   handler: JobHandler<T>
   /** Concurrency level */
   concurrency: number
+  /** Number of stalled-job recoveries BullMQ permits before failing a job. */
+  maxStalledCount?: number
 }

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -93,6 +93,8 @@ export type AsyncQueueOptions = {
   concurrency?: number
   /** Number of attempts for newly enqueued jobs. Defaults to 3. */
   attempts?: number
+  /** How long a job lock is held before the job counts as stalled, in ms. Defaults to 30000. */
+  lockDuration?: number
   /** Number of stalled-job recoveries BullMQ permits before failing a job. Defaults to 1. */
   maxStalledCount?: number
 }
@@ -254,6 +256,8 @@ export type WorkerMeta = {
   id?: string
   /** Worker concurrency (default: 1) */
   concurrency?: number
+  /** How long a job lock is held before the job counts as stalled, in ms. */
+  lockDuration?: number
   /** Number of stalled-job recoveries BullMQ permits before failing a job. */
   maxStalledCount?: number
 }
@@ -271,6 +275,8 @@ export type WorkerDescriptor<T = unknown> = {
   handler: JobHandler<T>
   /** Concurrency level */
   concurrency: number
+  /** How long a job lock is held before the job counts as stalled, in ms. */
+  lockDuration?: number
   /** Number of stalled-job recoveries BullMQ permits before failing a job. */
   maxStalledCount?: number
 }

--- a/packages/queue/src/worker/runner.ts
+++ b/packages/queue/src/worker/runner.ts
@@ -16,6 +16,8 @@ export type WorkerRunnerOptions<T = unknown> = {
   connection?: AsyncQueueOptions['connection']
   /** Number of concurrent jobs to process */
   concurrency?: number
+  /** Number of stalled-job recoveries BullMQ permits before failing a job. */
+  maxStalledCount?: number
   /** Whether to set up graceful shutdown handlers */
   gracefulShutdown?: boolean
   /** If true, don't block - return immediately after starting processing (for multi-queue mode) */
@@ -130,6 +132,7 @@ export async function runWorker<T = unknown>(
     handler,
     connection,
     concurrency = 1,
+    maxStalledCount,
     gracefulShutdown = true,
     background = false,
     strategy: strategyOption,
@@ -144,6 +147,7 @@ export async function runWorker<T = unknown>(
   const queue = createQueue<T>(queueName, strategy, {
     connection,
     concurrency,
+    maxStalledCount,
   })
 
   // Set up graceful shutdown

--- a/packages/queue/src/worker/runner.ts
+++ b/packages/queue/src/worker/runner.ts
@@ -16,6 +16,8 @@ export type WorkerRunnerOptions<T = unknown> = {
   connection?: AsyncQueueOptions['connection']
   /** Number of concurrent jobs to process */
   concurrency?: number
+  /** How long a job lock is held before the job counts as stalled, in ms. */
+  lockDuration?: number
   /** Number of stalled-job recoveries BullMQ permits before failing a job. */
   maxStalledCount?: number
   /** Whether to set up graceful shutdown handlers */
@@ -132,6 +134,7 @@ export async function runWorker<T = unknown>(
     handler,
     connection,
     concurrency = 1,
+    lockDuration,
     maxStalledCount,
     gracefulShutdown = true,
     background = false,
@@ -147,6 +150,7 @@ export async function runWorker<T = unknown>(
   const queue = createQueue<T>(queueName, strategy, {
     connection,
     concurrency,
+    lockDuration,
     maxStalledCount,
   })
 

--- a/packages/shared/src/modules/registry.ts
+++ b/packages/shared/src/modules/registry.ts
@@ -194,6 +194,7 @@ export type ModuleWorker = {
   moduleId?: string
   queue: string
   concurrency: number
+  maxStalledCount?: number
   handler: ModuleWorkerHandler
 }
 

--- a/packages/shared/src/modules/registry.ts
+++ b/packages/shared/src/modules/registry.ts
@@ -194,6 +194,7 @@ export type ModuleWorker = {
   moduleId?: string
   queue: string
   concurrency: number
+  lockDuration?: number
   maxStalledCount?: number
   handler: ModuleWorkerHandler
 }


### PR DESCRIPTION
## Summary

Resume stalled data-sync backfills after a worker restart, without letting a redelivered job corrupt a run that another worker is still processing.

Previously, when a BullMQ import/export job stalled (e.g. the worker was killed mid-run), the replacement job could not re-enter the existing `running` SyncRun, so the backfill was stuck forever.

## Why the claim predicate alone is not enough

Making the claim accept `running` (not just `pending`) is what enables the resume, but it also removes the guard that kept two workers off one run. BullMQ is **at-least-once**: `moveStalledJobsToWait` pushes the job back to `wait` under the **same job id**, and it fires whenever the lock is not renewed — including when the worker is alive but blocked (event-loop starvation, GC pause, slow upstream, Redis partition). BullMQ's own docs say such a job "will be double processed".

That means no identity token can restore exclusivity at claim time: `jobId` and `attemptsMade` are byte-identical between "previous worker died" and "previous worker is wedged" (the stalled script increments only `stc`). Distinguishing them needs liveness evidence, not identity.

## What this does instead

Ownership moves to the write that actually matters. `commitBatchProgress` guards its write on the run still being `running` and still sitting on the batch count the caller streamed from, inside the transaction that already writes the counters and cursor:

```sql
UPDATE sync_runs SET updated_at = now()
WHERE id = :run AND status = 'running' AND batches_completed = :expected
```

- Stalled redelivery of a **dead** worker: the count is unmoved, the guard succeeds, the run resumes from its committed position.
- Duplicate delivery alongside a **live** worker: the loser matches 0 rows, its transaction rolls back, and it yields the run instead of failing it.

That `UPDATE` also holds the row lock for the rest of the transaction, so a competing commit blocks and then re-reads the advanced count rather than interleaving. So the cursor cannot move backwards or skip a window and counters cannot double-count, regardless of how many times BullMQ redelivers. No new column, no migration, no lease timeout to tune.

**Why `batches_completed` and not the cursor.** A cursor is a free-form adapter string, and an adapter may legitimately emit the same one for consecutive batches — the Akeneo products adapter does, between its final page and the reconciliation batch that follows it, where `serializeCursor` produces byte-identical output. A repeated token fences nothing, so a value-based guard would silently no-op at exactly that step. `batches_completed` advances by construction on every commit, so no adapter can opt out of the guarantee the widened claim predicate rests on; a fenced commit that would not advance it is rejected outright rather than passing unguarded.

## Lifecycle writes are fenced too

The data fence is not enough on its own, because `finalizeRun` sits outside it. `markStatus` refuses a terminal → different-terminal transition but returns the row **unchanged**, and `finalizeRun` only compared against the status it had asked for. So a worker displaced mid-stream whose upstream then threw would fail a progress job the winner already completed, write an `error` log, flip the integration to `unhealthy`, and emit `data_sync.run.failed` for a run that succeeded — and since that event has no `excludeFromTriggers` and the webhooks subscriber dispatches on `*`, a tenant's endpoint was told the sync failed when it completed. `finalizeRun` now honours the refusal and stays silent. The same guard already existed on the crash path in `workers/sync-import.ts`; it now applies to the happy-path finalizer too.

## Leaning on BullMQ where it helps

- **`lockDuration`** is now set for the data-sync queues (120s). It was never configured anywhere in `packages/queue`, so everything ran on the 30s default — a batch that holds the processor longer than that stalls *spuriously*. This attacks the root cause; `maxStalledCount` only reacts to it.
- **The `stalled` worker event is now logged.** Only `completed`/`failed`/`error` were wired, so double-processing was invisible. BullMQ's docs explicitly require surfacing this.
- **`maxStalledCount: 10` is documented**, including why it is safe to raise: a duplicate delivery can no longer corrupt the run. Resumable queue names are derived from shared constants that the workers and the enqueue site both import, so a rename cannot silently drop the policy.

## Changes

- Ownership compare-and-swap in `commitBatchProgress` (`status` + `batches_completed`) + `SyncRunOwnershipConflictError`; the engine threads the last committed batch count through both the import and export loops and yields on conflict.
- `finalizeRun` bails when `markStatus` reports a terminal status other than the one requested, so a displaced worker emits nothing.
- Allow a stalled job to re-enter its existing `running` SyncRun.
- Configure the data-sync queues for 3 attempts, a 120s lock, and 10 stalled-job recoveries.
- Thread `lockDuration` / `maxStalledCount` through `AsyncQueueOptions` → `WorkerMeta` → `WorkerDescriptor` → runner → CLI → generator. Existing queues keep every previous default.
- `data_sync.run.started` carries `resumed` so consumers can tell a restart from a start; `updateCounts`/`updateCursor` are marked `@deprecated` as the remaining unfenced writers; the adapter contract documents that batch work must be replay-safe.

## Scope of the guarantee

Worth stating precisely, since an earlier revision of this description overclaimed it: the fence protects the engine's **own** writes — cursor, counters, run status and lifecycle events. It does not protect work the adapter performed *inside* `streamImport` before yielding. A losing delivery has already executed one full batch of upserts by the time its commit is rejected. Idempotent upserts keyed on `externalId` make that harmless, which is the pre-existing argument, but a custom adapter that sends mail or posts to a third party per record would do it twice. That requirement is now written into the adapter contract in `lib/adapter.ts` rather than assumed.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (bug fix to existing data-sync/queue behavior)

## Testing

- `SyncRunService`: the guard is issued against the streamed-from batch count and `status: 'running'`; the first commit of a run with no completed batches is fenced; a conflicting commit rolls back with counters and cursor untouched; a **repeated cursor** is still fenced (the case the value-based guard could not catch); a fenced commit that would not advance the count is refused; omitting the expectation preserves the legacy unguarded write.
- Engine: commits chain `0 → 1 → 2` so a stale delivery cannot skip a window, including when the adapter repeats a cursor between batches; a conflict yields the run without marking it `failed` or `completed`; a run another delivery already completed does **not** emit `data_sync.run.failed` when this delivery's adapter throws; a resumed run emits `started` with `resumed: true`.
- Queue: `lockDuration`/`maxStalledCount` reach the BullMQ `Worker`; both are absent when unset so BullMQ keeps its own defaults; worker queue names stay pinned to the policy constants.
- Manual before/after compiled-engine harness: `origin/develop` leaves the run `running` and never calls `streamImport`; this branch reclaims the run, passes the saved cursor, idempotently replays an upsert, commits the next batch, and completes.
- Manual Redis/BullMQ hard-kill exercise: a claimed job was SIGKILLed and a replacement worker redelivered it with the saved run ID and cursor.
- Full repo gate, local runner: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn lint` (0 errors), `yarn test`, `yarn build:app`. `@open-mercato/core` 1040 suites / 7982 tests and `@open-mercato/queue` 56 tests all pass. Two suites (`packages/shared`, `packages/ui`) intermittently report a jest worker that fails to exit gracefully under full parallelism; both pass in isolation and on a re-run, and they are in packages this PR does not touch.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (unit + manual queue recovery coverage; no new API/UI surface).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (N/A — bug fix).
