### PR TITLE
refactor(auth): decompose users list route into a query module (#276)

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/userListQuery.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/userListQuery.test.ts
@@ -1,0 +1,138 @@
+/** @jest-environment node */
+
+import type { EntityManager } from '@mikro-orm/postgresql'
+import {
+  queryUserList,
+  type ResolvedUserListScope,
+} from '@open-mercato/core/modules/auth/api/users/userListQuery'
+
+const mockFindWithDecryption = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+const mockEm = {
+  find: jest.fn(),
+  findAndCount: jest.fn(),
+  getKysely: jest.fn(),
+}
+
+const tenantId = '123e4567-e89b-12d3-a456-426614174001'
+const organizationId = '223e4567-e89b-12d3-a456-426614174001'
+const roleId = '323e4567-e89b-12d3-a456-426614174001'
+
+function baseScope(overrides: Partial<ResolvedUserListScope> = {}): ResolvedUserListScope {
+  return {
+    baseFilters: [{ deletedAt: null }, { tenantId }],
+    effectiveTenantId: tenantId,
+    effectiveSelectedOrganizationId: null,
+    scopeOrganizationId: organizationId,
+    ...overrides,
+  }
+}
+
+describe('queryUserList', () => {
+  beforeEach(() => {
+    mockEm.find.mockReset().mockResolvedValue([])
+    mockEm.findAndCount.mockReset().mockResolvedValue([[], 0])
+    mockEm.getKysely.mockReset()
+    mockFindWithDecryption.mockReset().mockResolvedValue([])
+    mockLoadCustomFieldValues.mockReset().mockResolvedValue({})
+  })
+
+  test('short-circuits to roleFilterEmpty when a role filter matches no users', async () => {
+    mockEm.find.mockResolvedValueOnce([]) // UserRole lookup yields no links
+
+    const result = await queryUserList(mockEm as unknown as EntityManager, {
+      query: { page: 1, pageSize: 50, roleIds: [roleId] },
+      isSuperAdmin: false,
+      scope: baseScope(),
+      authTenantId: tenantId,
+    })
+
+    expect(result).toEqual({ kind: 'roleFilterEmpty' })
+    expect(mockEm.findAndCount).not.toHaveBeenCalled()
+  })
+
+  test('narrows the query to matched user ids for a role filter', async () => {
+    const matchedUserId = '523e4567-e89b-12d3-a456-426614174001'
+    mockEm.find.mockResolvedValueOnce([{ user: { id: matchedUserId }, role: { id: roleId } }])
+    mockEm.findAndCount.mockResolvedValueOnce([
+      [{ id: matchedUserId, email: 'role@example.com', tenantId, organizationId }],
+      1,
+    ])
+
+    const result = await queryUserList(mockEm as unknown as EntityManager, {
+      query: { page: 1, pageSize: 50, roleIds: [roleId] },
+      isSuperAdmin: false,
+      scope: baseScope(),
+      authTenantId: tenantId,
+    })
+
+    const where = mockEm.findAndCount.mock.calls[0][1] as { $and: Array<Record<string, unknown>> }
+    expect(where.$and).toEqual(expect.arrayContaining([{ id: { $in: [matchedUserId] } }]))
+    expect(result.kind).toBe('ok')
+    if (result.kind === 'ok') {
+      expect(result.total).toBe(1)
+      expect(result.items[0]).toMatchObject({ id: matchedUserId, email: 'role@example.com' })
+    }
+  })
+
+  test('maps rows into list items with role names and org/tenant names', async () => {
+    const userId = '523e4567-e89b-12d3-a456-426614174050'
+    mockEm.findAndCount.mockResolvedValueOnce([
+      [{ id: userId, email: 'user@example.com', name: 'User', tenantId, organizationId }],
+      1,
+    ])
+    mockFindWithDecryption.mockResolvedValueOnce([{ user: { id: userId }, role: { id: roleId, name: 'admin' } }])
+    mockEm.find
+      .mockResolvedValueOnce([{ id: organizationId, name: 'Acme' }]) // organization name map
+      .mockResolvedValueOnce([{ id: tenantId, name: 'Tenant A' }]) // tenant name map
+
+    const result = await queryUserList(mockEm as unknown as EntityManager, {
+      query: { page: 1, pageSize: 50 },
+      isSuperAdmin: false,
+      scope: baseScope(),
+      authTenantId: tenantId,
+    })
+
+    expect(result.kind).toBe('ok')
+    if (result.kind === 'ok') {
+      expect(result.items[0]).toMatchObject({
+        id: userId,
+        roles: ['admin'],
+        roleIds: [roleId],
+        organizationName: 'Acme',
+        tenantName: 'Tenant A',
+      })
+      expect(result.items[0]).not.toHaveProperty('hasPassword')
+    }
+  })
+
+  test('exposes hasPassword only on id-scoped lookups', async () => {
+    const userId = '523e4567-e89b-12d3-a456-426614174051'
+    mockEm.findAndCount.mockResolvedValueOnce([
+      [{ id: userId, email: 'user@example.com', tenantId, organizationId, passwordHash: '$2a$10$hash' }],
+      1,
+    ])
+
+    const result = await queryUserList(mockEm as unknown as EntityManager, {
+      query: { id: userId, page: 1, pageSize: 1 },
+      isSuperAdmin: false,
+      scope: baseScope(),
+      authTenantId: tenantId,
+    })
+
+    expect(result.kind).toBe('ok')
+    if (result.kind === 'ok') {
+      expect(result.items[0]).toMatchObject({ id: userId, hasPassword: true })
+    }
+  })
+})

--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -6,11 +5,14 @@ import { logCrudAccess, makeCrudRoute } from '@open-mercato/shared/lib/crud/fact
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import { User, Role, UserRole } from '@open-mercato/core/modules/auth/data/entities'
+import { User } from '@open-mercato/core/modules/auth/data/entities'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
-import { Organization, Tenant } from '@open-mercato/core/modules/directory/data/entities'
-import { E } from '#generated/entities.ids.generated'
-import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fields'
+import {
+  queryUserList,
+  type ResolvedUserListScope,
+  type UserFilter,
+} from './userListQuery'
+import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { userCrudEvents, userCrudIndexer } from '@open-mercato/core/modules/auth/commands/users'
 import {
@@ -19,12 +21,8 @@ import {
   assertActorCanModifySuperAdminUserTarget,
   listSuperAdminUserIds,
 } from '@open-mercato/core/modules/auth/lib/grantChecks'
-import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { buildPasswordSchema } from '@open-mercato/shared/lib/auth/passwordPolicy'
-import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
-import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
-import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
-import { sql } from 'kysely'
 import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
 import {
   getSelectedTenantFromRequest,
@@ -100,7 +98,9 @@ const okResponseSchema = z.object({ ok: z.literal(true) })
 const errorResponseSchema = z.object({ error: z.string() })
 
 type CrudInput = Record<string, unknown>
-type UserListFilter = Record<string, unknown>
+type ListQuery = z.infer<typeof querySchema>
+type RequestContainer = Awaited<ReturnType<typeof createRequestContainer>>
+type RequestAuth = NonNullable<Awaited<ReturnType<typeof getAuthFromRequest>>>
 
 const routeMetadata = {
   GET: { requireAuth: true, requireFeatures: ['auth.users.list'] },
@@ -170,9 +170,52 @@ const crud = makeCrudRoute<CrudInput, CrudInput, Record<string, unknown>>({
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth) return NextResponse.json({ items: [], total: 0, totalPages: 1 })
+  if (!auth) return emptyUserListResponse()
+  const query = parseUsersListQuery(req)
+  if (!query) return emptyUserListResponse()
+
+  const container = await createRequestContainer()
+  const em = container.resolve('em') as EntityManager
+  const isSuperAdmin = await resolveListerIsSuperAdmin(container, auth)
+
+  const scopeResult = await resolveUsersListScope({ req, container, em, auth, isSuperAdmin })
+  if (!scopeResult.ok) return scopeResult.response
+  const { scope } = scopeResult
+
+  const result = await queryUserList(em, {
+    query,
+    isSuperAdmin,
+    scope,
+    authTenantId: auth.tenantId ?? null,
+  })
+  if (result.kind === 'roleFilterEmpty') return emptyUserListResponse()
+  if (result.kind === 'searchEmpty') return emptyUserListResponse({ isSuperAdmin })
+
+  const totalPages = Math.max(1, Math.ceil(result.total / query.pageSize))
+  await logCrudAccess({
+    container,
+    auth,
+    request: req,
+    items: result.items,
+    idField: 'id',
+    resourceKind: 'auth.user',
+    organizationId: scope.effectiveSelectedOrganizationId,
+    tenantId: scope.effectiveTenantId ?? auth.tenantId ?? null,
+    query,
+    accessType: query.id ? 'read:item' : undefined,
+  })
+  return NextResponse.json({ items: result.items, total: result.total, totalPages, isSuperAdmin })
+}
+
+function emptyUserListResponse(fields?: { isSuperAdmin: boolean }): NextResponse {
+  return NextResponse.json({ items: [], total: 0, totalPages: 1, ...(fields ?? {}) })
+}
+
+function parseUsersListQuery(req: Request): ListQuery | null {
   const url = new URL(req.url)
-  const rawRoleIds = url.searchParams.getAll('roleId').filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+  const rawRoleIds = url.searchParams
+    .getAll('roleId')
+    .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
   const parsed = querySchema.safeParse({
     id: url.searchParams.get('id') || undefined,
     page: url.searchParams.get('page') || undefined,
@@ -182,34 +225,49 @@ export async function GET(req: Request) {
     organizationId: url.searchParams.get('organizationId') || undefined,
     roleIds: rawRoleIds.length ? rawRoleIds : undefined,
   })
-  if (!parsed.success) return NextResponse.json({ items: [], total: 0, totalPages: 1 })
-  const container = await createRequestContainer()
-  const em = (container.resolve('em') as EntityManager)
+  return parsed.success ? parsed.data : null
+}
+
+async function resolveListerIsSuperAdmin(container: RequestContainer, auth: RequestAuth): Promise<boolean> {
   let isSuperAdmin = auth.isSuperAdmin === true
-  try {
-    if (auth.sub) {
-      const rbacService = container.resolve('rbacService') as any
-      const acl = await rbacService.loadAcl(auth.sub, { tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null })
+  if (auth.sub) {
+    try {
+      const rbacService = container.resolve('rbacService') as RbacService
+      const acl = await rbacService.loadAcl(auth.sub, {
+        tenantId: auth.tenantId ?? null,
+        organizationId: auth.orgId ?? null,
+      })
       isSuperAdmin = isSuperAdmin || !!acl?.isSuperAdmin
+    } catch (err) {
+      logger.error('Failed to resolve rbac', { err })
     }
-  } catch (err) {
-    logger.error('Failed to resolve rbac', { err })
   }
-  const { id, page, pageSize, search, name, organizationId, roleIds } = parsed.data
-  const filters: any[] = [{ deletedAt: null }]
+  return isSuperAdmin
+}
+
+async function resolveUsersListScope(args: {
+  req: Request
+  container: RequestContainer
+  em: EntityManager
+  auth: RequestAuth
+  isSuperAdmin: boolean
+}): Promise<{ ok: true; scope: ResolvedUserListScope } | { ok: false; response: NextResponse }> {
+  const { req, container, em, auth, isSuperAdmin } = args
+  const baseFilters: UserFilter[] = [{ deletedAt: null }]
   const actorTenantId = auth.tenantId ? String(auth.tenantId) : null
   let effectiveTenantId: string | null = null
   let effectiveOrganizationIds: string[] | null = null
   let effectiveSelectedOrganizationId: string | null = null
   let usesSelectedTenantScope = false
+
   if (!isSuperAdmin) {
     if (!actorTenantId) {
-      return NextResponse.json({ items: [], total: 0, totalPages: 1, isSuperAdmin })
+      return { ok: false, response: emptyUserListResponse({ isSuperAdmin }) }
     }
     effectiveTenantId = actorTenantId
     const superAdminUserIds = await listSuperAdminUserIds(em, actorTenantId)
     if (superAdminUserIds.size) {
-      filters.push({ id: { $nin: Array.from(superAdminUserIds) as any } })
+      baseFilters.push({ id: { $nin: Array.from(superAdminUserIds) } } as UserFilter)
     }
   } else {
     const selectedTenantId = getSelectedTenantFromRequest(req)
@@ -221,247 +279,37 @@ export async function GET(req: Request) {
         tenantId: selectedTenantId.trim(),
       })
       if (!scope.tenantId) {
-        return NextResponse.json({ items: [], total: 0, totalPages: 1, isSuperAdmin })
+        return { ok: false, response: emptyUserListResponse({ isSuperAdmin }) }
       }
       effectiveTenantId = scope.tenantId
       effectiveSelectedOrganizationId = scope.selectedId
       usesSelectedTenantScope = true
       if (Array.isArray(scope.filterIds)) {
         if (scope.filterIds.length === 0) {
-          return NextResponse.json({ items: [], total: 0, totalPages: 1, isSuperAdmin })
+          return { ok: false, response: emptyUserListResponse({ isSuperAdmin }) }
         }
         effectiveOrganizationIds = scope.filterIds
       }
     }
   }
-  if (effectiveTenantId) {
-    filters.push({ tenantId: effectiveTenantId })
-  }
+
+  if (effectiveTenantId) baseFilters.push({ tenantId: effectiveTenantId })
   if (effectiveOrganizationIds) {
-    filters.push({ organizationId: { $in: effectiveOrganizationIds as any } })
+    baseFilters.push({ organizationId: { $in: effectiveOrganizationIds } } as UserFilter)
   }
   const scopeOrganizationId = usesSelectedTenantScope
     ? effectiveSelectedOrganizationId
     : auth.orgId ?? null
-  if (organizationId) filters.push({ organizationId })
-  const trimmedName = typeof name === 'string' ? name.trim() : ''
-  if (trimmedName) {
-    const searchPattern = `%${escapeLikePattern(trimmedName)}%`
-    const displayNameFilters: UserListFilter[] = [{ name: { $ilike: searchPattern } }]
-    const nameTokenScope: string | null | undefined = isSuperAdmin ? (effectiveTenantId ?? undefined) : auth.tenantId ?? null
-    const matchedDisplayNameIds = await findUserIdsBySearchTokens(em, E.auth.user, trimmedName, nameTokenScope, 'name')
-    if (matchedDisplayNameIds && matchedDisplayNameIds.length) {
-      displayNameFilters.push({ id: { $in: matchedDisplayNameIds } })
-    }
-    filters.push(displayNameFilters.length > 1 ? { $or: displayNameFilters } : displayNameFilters[0])
-  }
-  let idFilter: Set<string> | null = id ? new Set([id]) : null
-  if (Array.isArray(roleIds) && roleIds.length > 0) {
-    const uniqueRoleIds = Array.from(new Set(roleIds))
-    const linksForRoles = await em.find(UserRole, { role: { $in: uniqueRoleIds as any } } as any)
-    const roleUserIds = new Set<string>()
-    for (const link of linksForRoles) {
-      const uid = String((link as any).user?.id || (link as any).user || '')
-      if (uid) roleUserIds.add(uid)
-    }
-    if (roleUserIds.size === 0) return NextResponse.json({ items: [], total: 0, totalPages: 1 })
-    if (idFilter) {
-      for (const uid of Array.from(idFilter)) {
-        if (!roleUserIds.has(uid)) idFilter.delete(uid)
-      }
-    } else {
-      idFilter = roleUserIds
-    }
-    if (!idFilter || idFilter.size === 0) return NextResponse.json({ items: [], total: 0, totalPages: 1 })
-  }
-  const trimmedSearch = typeof search === 'string' ? search.trim() : ''
-  if (trimmedSearch) {
-    // Email is encrypted at rest, so plaintext search must go through search_tokens.
-    const tenantScope: string | null | undefined = isSuperAdmin ? (effectiveTenantId ?? undefined) : auth.tenantId ?? null
-    const searchFilters: any[] = []
 
-    const matchedIds = await findUserIdsBySearchTokens(em, E.auth.user, trimmedSearch, tenantScope)
-    if (matchedIds && matchedIds.length) {
-      searchFilters.push({ id: { $in: matchedIds as any } })
-    }
-
-    const searchPattern = `%${escapeLikePattern(trimmedSearch)}%`
-    const organizationSearchFilters: any[] = [
-      { deletedAt: null },
-      { name: { $ilike: searchPattern } },
-    ]
-    if (tenantScope) {
-      organizationSearchFilters.push({ tenant: tenantScope })
-    }
-    const matchingOrganizations = await em.find(
-      Organization,
-      organizationSearchFilters.length > 1 ? { $and: organizationSearchFilters } : organizationSearchFilters[0],
-    )
-    const matchingOrganizationIds = matchingOrganizations
-      .map((org) => (org?.id ? String(org.id) : null))
-      .filter((orgId): orgId is string => typeof orgId === 'string' && orgId.length > 0)
-    if (matchingOrganizationIds.length) {
-      searchFilters.push({ organizationId: { $in: matchingOrganizationIds as any } })
-    }
-
-    const roleSearchFilters: any[] = [
-      { deletedAt: null },
-      { name: { $ilike: searchPattern } },
-    ]
-    if (tenantScope) {
-      roleSearchFilters.push({ $or: [{ tenantId: tenantScope }, { tenantId: null }] })
-    }
-    const matchingRoles = await em.find(
-      Role,
-      roleSearchFilters.length > 1 ? { $and: roleSearchFilters } : roleSearchFilters[0],
-    )
-    const matchingRoleIds = matchingRoles
-      .map((role) => (role?.id ? String(role.id) : null))
-      .filter((roleId): roleId is string => typeof roleId === 'string' && roleId.length > 0)
-    if (matchingRoleIds.length) {
-      const roleSearchLinks = await em.find(
-        UserRole,
-        { role: { $in: matchingRoleIds as any } } as any,
-      )
-      const matchingRoleUserIds = Array.from(new Set(
-        roleSearchLinks
-          .map((link) => {
-            const userRef = (link as any).user
-            const userId = userRef?.id ?? userRef
-            return userId ? String(userId) : null
-          })
-          .filter((userId): userId is string => typeof userId === 'string' && userId.length > 0),
-      ))
-      if (matchingRoleUserIds.length) {
-        searchFilters.push({ id: { $in: matchingRoleUserIds as any } })
-      }
-    }
-
-    if (!searchFilters.length) {
-      return NextResponse.json({ items: [], total: 0, totalPages: 1, isSuperAdmin })
-    }
-
-    filters.push(searchFilters.length > 1 ? { $or: searchFilters } : searchFilters[0])
+  return {
+    ok: true,
+    scope: {
+      baseFilters,
+      effectiveTenantId,
+      effectiveSelectedOrganizationId,
+      scopeOrganizationId,
+    },
   }
-  if (idFilter && idFilter.size) {
-    filters.push({ id: { $in: Array.from(idFilter) as any } })
-  } else if (id) {
-    filters.push({ id })
-  }
-  const where = filters.length > 1 ? { $and: filters } : filters[0]
-  const [rows, count] = await em.findAndCount(User, where, { limit: pageSize, offset: (page - 1) * pageSize })
-  const userIds = rows.map((u: any) => u.id)
-  const links = userIds.length
-    ? await findWithDecryption(
-        em,
-        UserRole,
-        { user: { $in: userIds as any } } as any,
-        { populate: ['role'] },
-        {
-          tenantId: effectiveTenantId ?? auth.tenantId ?? null,
-          organizationId: scopeOrganizationId,
-        },
-      )
-    : []
-  const roleMap: Record<string, string[]> = {}
-  const roleIdMap: Record<string, string[]> = {}
-  for (const l of links) {
-    const uid = String((l as any).user?.id || (l as any).user)
-    const rname = String((l as any).role?.name || '')
-    const rid = String((l as any).role?.id ?? '')
-    if (!roleMap[uid]) roleMap[uid] = []
-    if (!roleIdMap[uid]) roleIdMap[uid] = []
-    if (rname) roleMap[uid].push(rname)
-    if (rid) roleIdMap[uid].push(rid)
-  }
-  const orgIds = rows
-    .map((u: any) => (u.organizationId ? String(u.organizationId) : null))
-    .filter((id): id is string => !!id)
-  const uniqueOrgIds = Array.from(new Set(orgIds))
-  let orgMap: Record<string, string> = {}
-  if (uniqueOrgIds.length) {
-    const organizations = await em.find(
-      Organization,
-      { id: { $in: uniqueOrgIds as any }, deletedAt: null },
-    )
-    orgMap = organizations.reduce<Record<string, string>>((acc, org) => {
-      const orgId = org?.id ? String(org.id) : null
-      if (!orgId) return acc
-      const rawName = (org as any)?.name
-      const orgName = typeof rawName === 'string' && rawName.length > 0 ? rawName : orgId
-      acc[orgId] = orgName
-      return acc
-    }, {})
-  }
-  const tenantIds = rows
-    .map((u: any) => (u.tenantId ? String(u.tenantId) : null))
-    .filter((id): id is string => !!id)
-  const uniqueTenantIds = Array.from(new Set(tenantIds))
-  let tenantMap: Record<string, string> = {}
-  if (uniqueTenantIds.length) {
-    const tenants = await em.find(
-      Tenant,
-      { id: { $in: uniqueTenantIds as any }, deletedAt: null },
-    )
-    tenantMap = tenants.reduce<Record<string, string>>((acc, tenant) => {
-      const tenantId = tenant?.id ? String(tenant.id) : null
-      if (!tenantId) return acc
-      const rawName = (tenant as any)?.name
-      const tenantName = typeof rawName === 'string' && rawName.length > 0 ? rawName : tenantId
-      acc[tenantId] = tenantName
-      return acc
-    }, {})
-  }
-  const tenantByUser: Record<string, string | null> = {}
-  const organizationByUser: Record<string, string | null> = {}
-  for (const u of rows) {
-    const uid = String(u.id)
-    tenantByUser[uid] = u.tenantId ? String(u.tenantId) : null
-    organizationByUser[uid] = u.organizationId ? String(u.organizationId) : null
-  }
-  const cfByUser = userIds.length
-    ? await loadCustomFieldValues({
-        em,
-        entityId: E.auth.user,
-        recordIds: userIds.map(String),
-        tenantIdByRecord: tenantByUser,
-        organizationIdByRecord: organizationByUser,
-        tenantFallbacks: effectiveTenantId ? [effectiveTenantId] : auth.tenantId ? [auth.tenantId] : [],
-      })
-    : {}
-
-  const items = rows.map((u: any) => {
-    const uid = String(u.id)
-    const orgId = u.organizationId ? String(u.organizationId) : null
-    return {
-      id: uid,
-      email: String(u.email),
-      name: u.name ? String(u.name) : null,
-      organizationId: orgId,
-      organizationName: orgId ? orgMap[orgId] ?? orgId : null,
-      tenantId: u.tenantId ? String(u.tenantId) : null,
-      tenantName: u.tenantId ? tenantMap[String(u.tenantId)] ?? String(u.tenantId) : null,
-      roles: roleMap[uid] || [],
-      roleIds: roleIdMap[uid] || [],
-      ...(id ? { hasPassword: !!u.passwordHash } : {}),
-      updatedAt: u.updatedAt instanceof Date ? u.updatedAt.toISOString() : null,
-      ...(cfByUser[uid] || {}),
-    }
-  })
-  const totalPages = Math.max(1, Math.ceil(count / pageSize))
-  await logCrudAccess({
-    container,
-    auth,
-    request: req,
-    items,
-    idField: 'id',
-    resourceKind: 'auth.user',
-    organizationId: effectiveSelectedOrganizationId,
-    tenantId: effectiveTenantId ?? auth.tenantId ?? null,
-    query: parsed.data,
-    accessType: id ? 'read:item' : undefined,
-  })
-  return NextResponse.json({ items, total: count, totalPages, isSuperAdmin })
 }
 
 export const POST = async (req: Request) => {
@@ -488,68 +336,35 @@ export const DELETE = async (req: Request) => {
   return crud.DELETE(req)
 }
 
-async function findUserIdsBySearchTokens(
-  em: EntityManager,
-  entityType: string,
-  search: string,
-  tenantScope: string | null | undefined,
-  field?: string,
-): Promise<string[] | null> {
-  const trimmed = search.trim()
-  if (!trimmed) return null
-  const searchConfig = resolveSearchConfig()
-  if (!searchConfig.enabled) return []
-  const { hashes } = tokenizeText(trimmed, searchConfig)
-  if (!hashes.length) return []
+type ActorRbacContext = {
+  actorUserId: string
+  tenantId: string | null
+  organizationId: string | null
+  em: EntityManager
+  rbacService: RbacService
+}
 
-  const db = (em as any).getKysely() as any
-  let query = db
-    .selectFrom('search_tokens')
-    .select('entity_id')
-    .where('entity_type', '=', entityType)
-    .where('token_hash', 'in', hashes)
-    .groupBy('entity_id')
-    .having(sql<boolean>`count(distinct token_hash) >= ${hashes.length}`)
-  if (field) {
-    query = query.where('field', '=', field)
+async function resolveActorRbacContext(req: Request): Promise<ActorRbacContext> {
+  const auth = await getAuthFromRequest(req)
+  if (!auth?.sub) throw new CrudHttpError(401, { error: 'Unauthorized' })
+  const container = await createRequestContainer()
+  return {
+    actorUserId: auth.sub,
+    tenantId: auth.tenantId ?? null,
+    organizationId: auth.orgId ?? null,
+    em: container.resolve('em') as EntityManager,
+    rbacService: container.resolve('rbacService') as RbacService,
   }
-  if (tenantScope !== undefined) {
-    query = query.where(sql<boolean>`tenant_id is not distinct from ${tenantScope}`)
-  }
-  const rows = (await query.execute()) as Array<{ entity_id?: unknown }>
-  return rows
-    .map((row) => (typeof row.entity_id === 'string' ? row.entity_id : null))
-    .filter((id): id is string => typeof id === 'string' && id.length > 0)
 }
 
 async function assertCanModifySuperAdminTarget(req: Request, targetUserId: string) {
-  const auth = await getAuthFromRequest(req)
-  if (!auth?.sub) throw new CrudHttpError(401, { error: 'Unauthorized' })
-  const container = await createRequestContainer()
-  const em = container.resolve('em') as EntityManager
-  await assertActorCanModifySuperAdminUserTarget({
-    em,
-    rbacService: container.resolve('rbacService') as RbacService,
-    actorUserId: auth.sub,
-    tenantId: auth.tenantId ?? null,
-    organizationId: auth.orgId ?? null,
-    targetUserId,
-  })
+  const actor = await resolveActorRbacContext(req)
+  await assertActorCanModifySuperAdminUserTarget({ ...actor, targetUserId })
 }
 
 async function assertCanAccessUserTarget(req: Request, targetUserId: string) {
-  const auth = await getAuthFromRequest(req)
-  if (!auth?.sub) throw new CrudHttpError(401, { error: 'Unauthorized' })
-  const container = await createRequestContainer()
-  const em = container.resolve('em') as EntityManager
-  await assertActorCanAccessUserTarget({
-    em,
-    rbacService: container.resolve('rbacService') as RbacService,
-    actorUserId: auth.sub,
-    tenantId: auth.tenantId ?? null,
-    organizationId: auth.orgId ?? null,
-    targetUserId,
-  })
+  const actor = await resolveActorRbacContext(req)
+  await assertActorCanAccessUserTarget({ ...actor, targetUserId })
 }
 
 function resolveDeleteTargetId(parsed: unknown, raw: unknown): string | null {
@@ -566,19 +381,9 @@ function readId(record: Record<string, unknown> | null | undefined): string | nu
 
 async function assertCanAssignRoles(req: Request, roles: unknown, payload: Record<string, unknown>) {
   if (!Array.isArray(roles)) return
-  const auth = await getAuthFromRequest(req)
-  if (!auth?.sub) throw new CrudHttpError(401, { error: 'Unauthorized' })
-  const container = await createRequestContainer()
-  const em = container.resolve('em') as EntityManager
-  const tenantId = await resolveTargetTenantIdForRoleGrant(em, payload, auth.tenantId ?? null)
-  await assertActorCanGrantRoleTokens({
-    em,
-    rbacService: container.resolve('rbacService') as RbacService,
-    actorUserId: auth.sub,
-    tenantId,
-    organizationId: auth.orgId ?? null,
-    roleTokens: roles,
-  })
+  const actor = await resolveActorRbacContext(req)
+  const tenantId = await resolveTargetTenantIdForRoleGrant(actor.em, payload, actor.tenantId)
+  await assertActorCanGrantRoleTokens({ ...actor, tenantId, roleTokens: roles })
 }
 
 async function resolveTargetTenantIdForRoleGrant(

--- a/packages/core/src/modules/auth/api/users/userListQuery.ts
+++ b/packages/core/src/modules/auth/api/users/userListQuery.ts
@@ -1,0 +1,379 @@
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
+import type { EntityName } from '@mikro-orm/core'
+import { User, Role, UserRole } from '@open-mercato/core/modules/auth/data/entities'
+import { Organization, Tenant } from '@open-mercato/core/modules/directory/data/entities'
+import { E } from '#generated/entities.ids.generated'
+import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fields'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
+import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
+import { sql } from 'kysely'
+
+export type UserFilter = FilterQuery<User>
+
+export type UserListQuery = {
+  id?: string
+  page: number
+  pageSize: number
+  search?: string
+  name?: string
+  organizationId?: string
+  roleIds?: string[]
+}
+
+// Request-bound scope resolved by the route controller and handed to queryUserList,
+// which stays HTTP-agnostic (no Request, no container, no auth object).
+export type ResolvedUserListScope = {
+  baseFilters: UserFilter[]
+  effectiveTenantId: string | null
+  effectiveSelectedOrganizationId: string | null
+  scopeOrganizationId: string | null
+}
+
+export type UserListQueryParams = {
+  query: UserListQuery
+  isSuperAdmin: boolean
+  scope: ResolvedUserListScope
+  authTenantId: string | null
+}
+
+export type UserListQueryResult =
+  | { kind: 'roleFilterEmpty' }
+  | { kind: 'searchEmpty' }
+  | { kind: 'ok'; items: Array<Record<string, unknown>>; total: number }
+
+// Answers the "list users" query: build the filter, fetch one page, project the rows.
+export async function queryUserList(em: EntityManager, params: UserListQueryParams): Promise<UserListQueryResult> {
+  const filter = await buildUserListFilters(em, params)
+  if (filter.kind !== 'ok') return filter
+
+  const { id, page, pageSize } = params.query
+  const [rows, count] = await em.findAndCount(User, filter.where, { limit: pageSize, offset: (page - 1) * pageSize })
+
+  const items = await mapUserListItems(em, {
+    rows,
+    includeHasPassword: Boolean(id),
+    effectiveTenantId: params.scope.effectiveTenantId,
+    scopeOrganizationId: params.scope.scopeOrganizationId,
+    authTenantId: params.authTenantId,
+  })
+  return { kind: 'ok', items, total: count }
+}
+
+type BuildFiltersResult =
+  | { kind: 'ok'; where: UserFilter }
+  | { kind: 'roleFilterEmpty' }
+  | { kind: 'searchEmpty' }
+
+// Translates the parsed list query + resolved scope into a MikroORM `where`,
+// or signals an empty result when a role/search filter matches nothing.
+async function buildUserListFilters(em: EntityManager, params: UserListQueryParams): Promise<BuildFiltersResult> {
+  const { query, isSuperAdmin, scope, authTenantId } = params
+  const { id, search, name, organizationId, roleIds } = query
+  const filters: UserFilter[] = [...scope.baseFilters]
+  if (organizationId) filters.push({ organizationId })
+
+  const trimmedName = typeof name === 'string' ? name.trim() : ''
+  if (trimmedName) {
+    const nameTokenScope = isSuperAdmin ? (scope.effectiveTenantId ?? undefined) : authTenantId ?? null
+    filters.push(await buildDisplayNameFilter(em, trimmedName, nameTokenScope))
+  }
+
+  let idFilter: Set<string> | null = id ? new Set([id]) : null
+  if (Array.isArray(roleIds) && roleIds.length > 0) {
+    const roleFilter = await resolveRoleIdFilter(em, roleIds, idFilter)
+    if (!roleFilter.ok) return { kind: 'roleFilterEmpty' }
+    idFilter = roleFilter.idFilter
+  }
+
+  const trimmedSearch = typeof search === 'string' ? search.trim() : ''
+  if (trimmedSearch) {
+    const tenantScope = isSuperAdmin ? (scope.effectiveTenantId ?? undefined) : authTenantId ?? null
+    const searchFilters = await collectSearchFilters(em, trimmedSearch, tenantScope)
+    if (!searchFilters.length) return { kind: 'searchEmpty' }
+    filters.push(searchFilters.length > 1 ? { $or: searchFilters } : searchFilters[0])
+  }
+
+  if (idFilter && idFilter.size) {
+    filters.push({ id: { $in: Array.from(idFilter) } } as UserFilter)
+  } else if (id) {
+    filters.push({ id })
+  }
+
+  return { kind: 'ok', where: filters.length > 1 ? { $and: filters } : filters[0] }
+}
+
+async function buildDisplayNameFilter(
+  em: EntityManager,
+  name: string,
+  tenantScope: string | null | undefined,
+): Promise<UserFilter> {
+  const searchPattern = `%${escapeLikePattern(name)}%`
+  const displayNameFilters: UserFilter[] = [{ name: { $ilike: searchPattern } } as UserFilter]
+  const matchedIds = await findUserIdsBySearchTokens(em, E.auth.user, name, tenantScope, 'name')
+  if (matchedIds && matchedIds.length) {
+    displayNameFilters.push({ id: { $in: matchedIds } } as UserFilter)
+  }
+  return displayNameFilters.length > 1 ? { $or: displayNameFilters } : displayNameFilters[0]
+}
+
+async function resolveRoleIdFilter(
+  em: EntityManager,
+  roleIds: string[],
+  idFilter: Set<string> | null,
+): Promise<{ ok: true; idFilter: Set<string> } | { ok: false }> {
+  const uniqueRoleIds = Array.from(new Set(roleIds))
+  const linksForRoles = await em.find(
+    UserRole,
+    { role: { $in: uniqueRoleIds } } as unknown as FilterQuery<UserRole>,
+  )
+  const roleUserIds = new Set<string>()
+  for (const link of linksForRoles) {
+    const uid = resolveRefId((link as UserRole).user)
+    if (uid) roleUserIds.add(uid)
+  }
+  if (roleUserIds.size === 0) return { ok: false }
+  let nextFilter = idFilter
+  if (nextFilter) {
+    for (const uid of Array.from(nextFilter)) {
+      if (!roleUserIds.has(uid)) nextFilter.delete(uid)
+    }
+  } else {
+    nextFilter = roleUserIds
+  }
+  if (!nextFilter || nextFilter.size === 0) return { ok: false }
+  return { ok: true, idFilter: nextFilter }
+}
+
+async function collectSearchFilters(
+  em: EntityManager,
+  search: string,
+  tenantScope: string | null | undefined,
+): Promise<UserFilter[]> {
+  // Email is encrypted at rest, so plaintext search must go through search_tokens.
+  const searchFilters: UserFilter[] = []
+
+  const matchedIds = await findUserIdsBySearchTokens(em, E.auth.user, search, tenantScope)
+  if (matchedIds && matchedIds.length) {
+    searchFilters.push({ id: { $in: matchedIds } } as UserFilter)
+  }
+
+  const searchPattern = `%${escapeLikePattern(search)}%`
+  const organizationSearchFilters: FilterQuery<Organization>[] = [
+    { deletedAt: null },
+    { name: { $ilike: searchPattern } } as FilterQuery<Organization>,
+  ]
+  if (tenantScope) {
+    organizationSearchFilters.push({ tenant: tenantScope } as FilterQuery<Organization>)
+  }
+  const matchingOrganizations = await em.find(
+    Organization,
+    organizationSearchFilters.length > 1 ? { $and: organizationSearchFilters } : organizationSearchFilters[0],
+  )
+  const matchingOrganizationIds = matchingOrganizations
+    .map((org) => (org?.id ? String(org.id) : null))
+    .filter((orgId): orgId is string => typeof orgId === 'string' && orgId.length > 0)
+  if (matchingOrganizationIds.length) {
+    searchFilters.push({ organizationId: { $in: matchingOrganizationIds } } as UserFilter)
+  }
+
+  const roleSearchFilters: FilterQuery<Role>[] = [
+    { deletedAt: null },
+    { name: { $ilike: searchPattern } } as FilterQuery<Role>,
+  ]
+  if (tenantScope) {
+    roleSearchFilters.push({ $or: [{ tenantId: tenantScope }, { tenantId: null }] } as FilterQuery<Role>)
+  }
+  const matchingRoles = await em.find(
+    Role,
+    roleSearchFilters.length > 1 ? { $and: roleSearchFilters } : roleSearchFilters[0],
+  )
+  const matchingRoleIds = matchingRoles
+    .map((role) => (role?.id ? String(role.id) : null))
+    .filter((roleId): roleId is string => typeof roleId === 'string' && roleId.length > 0)
+  if (matchingRoleIds.length) {
+    const roleSearchLinks = await em.find(
+      UserRole,
+      { role: { $in: matchingRoleIds } } as unknown as FilterQuery<UserRole>,
+    )
+    const matchingRoleUserIds = Array.from(new Set(
+      roleSearchLinks
+        .map((link) => resolveRefId((link as UserRole).user))
+        .filter((userId): userId is string => typeof userId === 'string' && userId.length > 0),
+    ))
+    if (matchingRoleUserIds.length) {
+      searchFilters.push({ id: { $in: matchingRoleUserIds } } as UserFilter)
+    }
+  }
+
+  return searchFilters
+}
+
+// Minimal structural view of the Kysely query builder used for search-token lookups.
+// The builder is not exposed on the MikroORM EntityManager type surface.
+type SearchTokenQueryBuilder = {
+  selectFrom: (table: string) => SearchTokenQueryBuilder
+  select: (column: string) => SearchTokenQueryBuilder
+  where: (...args: unknown[]) => SearchTokenQueryBuilder
+  groupBy: (column: string) => SearchTokenQueryBuilder
+  having: (expression: unknown) => SearchTokenQueryBuilder
+  execute: () => Promise<Array<{ entity_id?: unknown }>>
+}
+
+async function findUserIdsBySearchTokens(
+  em: EntityManager,
+  entityType: string,
+  search: string,
+  tenantScope: string | null | undefined,
+  field?: string,
+): Promise<string[] | null> {
+  const trimmed = search.trim()
+  if (!trimmed) return null
+  const searchConfig = resolveSearchConfig()
+  if (!searchConfig.enabled) return []
+  const { hashes } = tokenizeText(trimmed, searchConfig)
+  if (!hashes.length) return []
+
+  const db = (em as unknown as { getKysely: () => SearchTokenQueryBuilder }).getKysely()
+  let query = db
+    .selectFrom('search_tokens')
+    .select('entity_id')
+    .where('entity_type', '=', entityType)
+    .where('token_hash', 'in', hashes)
+    .groupBy('entity_id')
+    .having(sql<boolean>`count(distinct token_hash) >= ${hashes.length}`)
+  if (field) {
+    query = query.where('field', '=', field)
+  }
+  if (tenantScope !== undefined) {
+    query = query.where(sql<boolean>`tenant_id is not distinct from ${tenantScope}`)
+  }
+  const rows = await query.execute()
+  return rows
+    .map((row) => (typeof row.entity_id === 'string' ? row.entity_id : null))
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+// Projects fetched user rows into API list items, resolving role names,
+// organization/tenant names, and custom fields.
+async function mapUserListItems(
+  em: EntityManager,
+  args: {
+    rows: User[]
+    includeHasPassword: boolean
+    effectiveTenantId: string | null
+    scopeOrganizationId: string | null
+    authTenantId: string | null
+  },
+): Promise<Array<Record<string, unknown>>> {
+  const { rows, includeHasPassword, effectiveTenantId, scopeOrganizationId, authTenantId } = args
+  const userIds = rows.map((user) => user.id)
+  const links = userIds.length
+    ? await findWithDecryption(
+        em,
+        UserRole,
+        { user: { $in: userIds } } as unknown as FilterQuery<UserRole>,
+        { populate: ['role'] },
+        {
+          tenantId: effectiveTenantId ?? authTenantId ?? null,
+          organizationId: scopeOrganizationId,
+        },
+      )
+    : []
+  const roleMap: Record<string, string[]> = {}
+  const roleIdMap: Record<string, string[]> = {}
+  for (const link of links) {
+    const uid = resolveRefId((link as UserRole).user)
+    if (!uid) continue
+    const roleName = readStringField((link as UserRole).role, 'name')
+    const roleId = readStringField((link as UserRole).role, 'id')
+    if (!roleMap[uid]) roleMap[uid] = []
+    if (!roleIdMap[uid]) roleIdMap[uid] = []
+    if (roleName) roleMap[uid].push(roleName)
+    if (roleId) roleIdMap[uid].push(roleId)
+  }
+
+  const orgMap = await buildEntityNameMap(em, Organization, collectIds(rows, (user) => user.organizationId))
+  const tenantMap = await buildEntityNameMap(em, Tenant, collectIds(rows, (user) => user.tenantId))
+
+  const tenantByUser: Record<string, string | null> = {}
+  const organizationByUser: Record<string, string | null> = {}
+  for (const user of rows) {
+    const uid = String(user.id)
+    tenantByUser[uid] = user.tenantId ? String(user.tenantId) : null
+    organizationByUser[uid] = user.organizationId ? String(user.organizationId) : null
+  }
+  const customFieldsByUser = userIds.length
+    ? await loadCustomFieldValues({
+        em,
+        entityId: E.auth.user,
+        recordIds: userIds.map(String),
+        tenantIdByRecord: tenantByUser,
+        organizationIdByRecord: organizationByUser,
+        tenantFallbacks: effectiveTenantId ? [effectiveTenantId] : authTenantId ? [authTenantId] : [],
+      })
+    : {}
+
+  return rows.map((user) => {
+    const uid = String(user.id)
+    const orgId = user.organizationId ? String(user.organizationId) : null
+    return {
+      id: uid,
+      email: String(user.email),
+      name: user.name ? String(user.name) : null,
+      organizationId: orgId,
+      organizationName: orgId ? orgMap[orgId] ?? orgId : null,
+      tenantId: user.tenantId ? String(user.tenantId) : null,
+      tenantName: user.tenantId ? tenantMap[String(user.tenantId)] ?? String(user.tenantId) : null,
+      roles: roleMap[uid] || [],
+      roleIds: roleIdMap[uid] || [],
+      ...(includeHasPassword ? { hasPassword: !!user.passwordHash } : {}),
+      updatedAt: user.updatedAt instanceof Date ? user.updatedAt.toISOString() : null,
+      ...(customFieldsByUser[uid] || {}),
+    }
+  })
+}
+
+async function buildEntityNameMap<T extends { id: string }>(
+  em: EntityManager,
+  entity: EntityName<T>,
+  ids: string[],
+): Promise<Record<string, string>> {
+  const uniqueIds = Array.from(new Set(ids))
+  if (!uniqueIds.length) return {}
+  const records = await em.find(entity, { id: { $in: uniqueIds }, deletedAt: null } as FilterQuery<T>)
+  return records.reduce<Record<string, string>>((acc, record) => {
+    const recordId = record?.id ? String(record.id) : null
+    if (!recordId) return acc
+    const name = readStringField(record, 'name')
+    acc[recordId] = name.length > 0 ? name : recordId
+    return acc
+  }, {})
+}
+
+function collectIds(rows: User[], select: (user: User) => string | null | undefined): string[] {
+  return rows
+    .map((user) => {
+      const value = select(user)
+      return value ? String(value) : null
+    })
+    .filter((id): id is string => !!id)
+}
+
+function resolveRefId(ref: unknown): string | null {
+  if (ref && typeof ref === 'object') {
+    const id = (ref as { id?: unknown }).id
+    if (id != null && String(id).length > 0) return String(id)
+  }
+  if (typeof ref === 'string' && ref.length > 0) return ref
+  return null
+}
+
+function readStringField(source: unknown, field: string): string {
+  if (source && typeof source === 'object') {
+    const value = (source as Record<string, unknown>)[field]
+    if (value != null) return String(value)
+  }
+  return ''
+}


### PR DESCRIPTION
## Summary

Refactors `packages/core/src/modules/auth/api/users/route.ts` to address the
maintainability concerns raised in #276 (SRP / DRY / SoC / type-safety /
testability of the `GET /api/auth/users` handler). This is a
**behavior-preserving** refactor — no change to the API contract,
request/response shapes, or query semantics.

Closes #276.

## What changed

The monolithic ~250-line `GET` handler is split into a thin controller plus a
colocated, HTTP-agnostic query module:

- **`api/users/route.ts` (controller)** — owns HTTP concerns: parses the query,
  resolves identity/scope (`parseUsersListQuery`, `resolveListerIsSuperAdmin`,
  `resolveUsersListScope`), delegates the read, logs access, builds the response.
- **`api/users/userListQuery.ts` (new)** — owns the read, decomposed by single
  responsibility:
  - `buildUserListFilters` — translate query + resolved scope into a MikroORM
    `where` (or an empty-result signal),
  - `mapUserListItems` — project fetched rows into API list items (roles,
    org/tenant names, custom fields),
  - `queryUserList` — coordinate the pipeline (build → fetch → map).

Additional cleanups:
- Removed **all** `any` casts; filters typed via `FilterQuery<User>`, rows via
  entity types.
- Deduplicated the repeated write-path authorization boilerplate into
  `resolveActorRbacContext` (POST/PUT/DELETE).
- Added unit tests for the query module (`userListQuery.test.ts`).

## Why this shape

- The extracted logic lives in a **colocated module** (single consumer),
  matching the project's existing pattern for hand-rolled endpoint helpers
  (e.g. `sales/api/documents/factory.ts`) rather than a DI-registered service —
  no new DI key / contract surface.
- Deliberately **out of scope** (avoiding over-engineering, per "Simplicity
  First"): a DI `UserQueryService`, caching, rate-limiting, and
  strategy-pattern-pluggable filters from the original proposal. These would
  change architecture/contracts for no current benefit.

## Behavior preservation & testing

- All existing `users.route` tests pass **unchanged** — they are white-box and
  pin the exact `em` / decryption call sequence.
- New `userListQuery` unit tests exercise the query module in isolation.
- Full **auth suite green: 471 tests**. Lint clean. Typecheck clean w.r.t. this
  change.

## Backward compatibility

No contract surface touched — same API route, request/response schema, DI keys,
and query semantics. `userListQuery.ts` is an internal colocated module.

## Known follow-ups (pre-existing, not addressed here)

Left out to keep this a clean behavior-preserving refactor:
1. **Empty-response `isSuperAdmin` inconsistency** — some empty list responses
   include `isSuperAdmin` and some omit it. Unifying the shape is a small
   **contract change** and belongs in a separate, deliberate PR.
2. **Redundant auth resolution on write paths** — PUT resolves the actor context
   3× per request; DELETE double-checks (wrapper + command `mapInput`,
   intentional belt-and-suspenders). A resolve-once refactor has behavior-timing
   subtleties (lazy 401) and is a pre-existing micro-optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
