### PR TITLE
fix(sales): keep order linked to saved address on re-save (#4169)

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-031-edit-select-prefill.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-031-edit-select-prefill.spec.ts
@@ -350,8 +350,7 @@ test.describe('TC-SALES-031: Sales edit dialogs prefill saved async selects', ()
         .getByText('Shipping address', { exact: true })
         .locator('xpath=ancestor::div[contains(@class,"rounded")]')
         .first()
-      await expect(shippingPanel.getByRole('switch', { name: 'Define new address' })).toBeChecked()
-      await shippingPanel.getByRole('switch', { name: 'Define new address' }).click()
+      await expect(shippingPanel.getByRole('switch', { name: 'Define new address' })).not.toBeChecked()
       await expect(shippingPanel.getByRole('combobox').filter({ hasText: selectedAddress.name }).first()).toBeVisible()
     } finally {
       if (token) {

--- a/packages/core/src/modules/sales/components/documents/AddressesSection.tsx
+++ b/packages/core/src/modules/sales/components/documents/AddressesSection.tsx
@@ -200,9 +200,13 @@ export function SalesDocumentAddressesSection({
   const [addressesLoading, setAddressesLoading] = React.useState(false)
   const [addressesError, setAddressesError] = React.useState<string | null>(null)
   const [addressFormat, setAddressFormat] = React.useState<AddressFormatStrategy>('line_first')
-  const [useCustomShipping, setUseCustomShipping] = React.useState<boolean>(!!shippingAddressSnapshot)
+  const [useCustomShipping, setUseCustomShipping] = React.useState<boolean>(
+    !!shippingAddressSnapshot && !shippingAddressId
+  )
   const [useCustomBilling, setUseCustomBilling] = React.useState<boolean>(
-    billingAddressSnapshot ? true : !!shippingAddressSnapshot
+    billingAddressSnapshot && !billingAddressId
+      ? true
+      : !!shippingAddressSnapshot && !shippingAddressId
   )
   const [sameAsShipping, setSameAsShipping] = React.useState<boolean>(() => {
     if (shippingAddressSnapshot || billingAddressSnapshot) {
@@ -366,8 +370,8 @@ export function SalesDocumentAddressesSection({
   }, [documentId, kind, resolveAddressSummary, t])
 
   React.useEffect(() => {
-    const shippingCustom = !!shippingAddressSnapshot
-    const billingCustom = !!billingAddressSnapshot
+    const shippingCustom = !!shippingAddressSnapshot && !shippingAddressId
+    const billingCustom = !!billingAddressSnapshot && !billingAddressId
     const nextSame = shippingAddressSnapshot || billingAddressSnapshot
       ? deepEqual(shippingAddressSnapshot, billingAddressSnapshot)
       : !billingAddressId || billingAddressId === shippingAddressId

--- a/packages/core/src/modules/sales/components/documents/__tests__/AddressesSection.test.tsx
+++ b/packages/core/src/modules/sales/components/documents/__tests__/AddressesSection.test.tsx
@@ -179,4 +179,58 @@ describe('SalesDocumentAddressesSection', () => {
       shippingAddressSnapshot: resolvedSnapshot,
     }))
   })
+
+  it('keeps a saved address linked after reload and a second save (no silent detach)', async () => {
+    const savedSnapshot = {
+      id: 'customer-address-1',
+      addressLine1: '12 Market Street',
+      city: 'London',
+      postalCode: 'SW1A 1AA',
+      country: 'GB',
+    }
+    mockApiCallOrThrow.mockResolvedValue({
+      ok: true,
+      result: {
+        shippingAddressId: 'customer-address-1',
+        billingAddressId: 'customer-address-1',
+        shippingAddressSnapshot: savedSnapshot,
+        billingAddressSnapshot: savedSnapshot,
+      },
+    })
+    const onUpdated = jest.fn()
+
+    // Reopening the tab passes both the linked address id and the server-denormalized
+    // snapshot — the state after the first correct save. Custom mode must stay off.
+    render(
+      <SalesDocumentAddressesSection
+        documentId="order-1"
+        kind="order"
+        customerId="customer-1"
+        shippingAddressId="customer-address-1"
+        billingAddressId="customer-address-1"
+        shippingAddressSnapshot={savedSnapshot}
+        billingAddressSnapshot={savedSnapshot}
+        onUpdated={onUpdated}
+      />,
+    )
+
+    const combobox = await screen.findByRole('combobox')
+    await waitFor(() => expect(combobox).toHaveValue('customer-address-1'))
+    expect(screen.getByLabelText('Define new address')).not.toBeChecked()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update addresses' }))
+
+    await waitFor(() => expect(mockApiCallOrThrow).toHaveBeenCalledTimes(1))
+    const [, request] = mockApiCallOrThrow.mock.calls[0]
+    const payload = JSON.parse(request.body)
+    expect(payload).toMatchObject({
+      id: 'order-1',
+      shippingAddressId: 'customer-address-1',
+      billingAddressId: 'customer-address-1',
+    })
+    expect(payload.shippingAddressId).not.toBeNull()
+    expect(payload.billingAddressId).not.toBeNull()
+    expect(payload).not.toHaveProperty('shippingAddressSnapshot')
+    expect(payload).not.toHaveProperty('billingAddressSnapshot')
+  })
 })


### PR DESCRIPTION
Fixes #4169

## Problem
On a sales order's **Addresses** tab, after selecting a saved customer address as the shipping address and clicking **Update addresses**, reopening the tab (or reloading the page) showed the **Define new address** switch turned on, with the address as editable fields instead of the saved address selected in the dropdown. Clicking **Update addresses** again — without changing anything — then silently detached the order's shipping and billing address from the customer's saved address record (the FK was set to `null` and only a disconnected copy remained), with no visible change on screen and no error.

## Root Cause
`AddressesSection` derived its "Define new address" (custom) mode purely from the presence of an address snapshot (`useCustomShipping = !!shippingAddressSnapshot`). But a saved-address link legitimately carries **both** a `shippingAddressId` and a snapshot: the order update command denormalizes a snapshot from the linked address whenever an id is saved without an explicit snapshot (`sales/commands/documents.ts:1128-1138` — intentional; shipments/history read it). So after the first (correct) save + reload, the tab re-rendered with id **and** snapshot both set, flipped the switch on, and the submit path (`shippingId = useCustomShipping ? null : …`; `payload.shippingAddressId = shippingSnapshot ? null : shippingId`) then sent `null`, detaching the FK.

## What Changed
- Gate custom mode on "snapshot present **and** no linked id" in the two `useState` initializers (`useCustomShipping` / `useCustomBilling`) and the reset `useEffect` in `AddressesSection.tsx`. A linked saved address now keeps the dropdown selected and the switch off, so re-saving keeps sending the address id; a genuinely custom address (snapshot present, id `null`) still enters custom mode correctly.
- Frontend-only change; no backend, API, or contract change.

## Tests
- Added regression test `keeps a saved address linked after reload and a second save (no silent detach)` in `AddressesSection.test.tsx`: renders the post-reload state (linked id + matching snapshot), asserts the **Define new address** switch is unchecked, and asserts the second-save PUT payload keeps `shippingAddressId`/`billingAddressId` and omits detaching snapshots. Confirmed it fails without the fix and passes with it.
- Full validation gate ran in order and passed: `build:packages`, `generate` (no unrelated churn), `build:packages`, `i18n:check-sync`, `i18n:check-usage` (advisory), `typecheck`, `build:app`. `yarn test`: the only failures are two pre-existing **machine-locale** number/currency-formatting artifacts (`ui/format.test.ts`, `customers/DealsKpiStrip.test.tsx`) unrelated to this change — both pass under `LANG=en_US.UTF-8`; the touched sales AddressesSection tests and the rest of core/ui are green.

## Breaking Changes
None.

🤖 Generated by autofix.
