### PR TITLE
fix(sales): block adding new items to a fulfilled order (#4088)

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/documents.line-fulfilled-guard.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/documents.line-fulfilled-guard.test.ts
@@ -1,0 +1,211 @@
+/** @jest-environment node */
+
+/**
+ * Add-line fulfilled-order guard (issue #4088).
+ *
+ * A brand-new item must not be silently appended to an order whose lifecycle
+ * is already complete ("Fulfilled") — doing so reopens a balance on a
+ * transaction that was already settled. The upsert command now rejects (409)
+ * an add when the order's status or fulfillment status is `fulfilled`. Editing
+ * an existing line stays allowed (that path is guarded separately by #3993),
+ * and adds to non-fulfilled orders keep their previous behavior.
+ */
+
+import { createContainer, asValue, InjectionMode } from 'awilix'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { SalesOrder, SalesShipment, SalesShipmentItem } from '../../data/entities'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string, fallback?: string) => fallback ?? key,
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/cache', () => ({
+  invalidateCrudCache: jest.fn(),
+}))
+
+const ORG_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TENANT_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const ORDER_ID = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+const LINE_ID = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+
+const UNIT_PRICE_NET = 100
+const UNIT_PRICE_GROSS = 123
+const TAX_RATE = 23
+const ORDERED_QUANTITY = 4
+
+function setWorld(options: {
+  status?: string | null
+  fulfillmentStatus?: string | null
+}) {
+  const order = {
+    id: ORDER_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    deletedAt: null,
+    currencyCode: 'USD',
+    status: options.status ?? null,
+    fulfillmentStatus: options.fulfillmentStatus ?? null,
+    updatedAt: new Date('2026-07-08T09:21:29.000Z'),
+  }
+  const orderLine = {
+    id: LINE_ID,
+    lineNumber: 1,
+    kind: 'product',
+    productId: null,
+    productVariantId: null,
+    name: 'Existing line',
+    quantity: String(ORDERED_QUANTITY),
+    quantityUnit: null,
+    normalizedQuantity: String(ORDERED_QUANTITY),
+    normalizedUnit: null,
+    uomSnapshot: null,
+    currencyCode: 'USD',
+    unitPriceNet: String(UNIT_PRICE_NET),
+    unitPriceGross: String(UNIT_PRICE_GROSS),
+    discountAmount: '0',
+    discountPercent: '0',
+    taxRate: String(TAX_RATE),
+    taxAmount: null,
+    totalNetAmount: '400',
+    totalGrossAmount: '492',
+    updatedAt: new Date(),
+  }
+  ;(globalThis as any).__lineFulfilledWorld = { order, orderLine }
+  return { order, orderLine }
+}
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async (_em: unknown, entityClass: unknown) => {
+    const world = (globalThis as any).__lineFulfilledWorld
+    if (entityClass === SalesOrder) return world.order
+    return null
+  }),
+  findWithDecryption: jest.fn(async (_em: unknown, entityClass: unknown) => {
+    if (entityClass === SalesShipment) return []
+    if (entityClass === SalesShipmentItem) return []
+    return []
+  }),
+}))
+
+function makeEm() {
+  const world = () => (globalThis as any).__lineFulfilledWorld
+  const em: any = {
+    fork: function () {
+      return this
+    },
+    transactional: async (cb: (tx: unknown) => Promise<unknown>) => cb(em),
+    find: jest.fn(async (entityClass: unknown) => {
+      const entityName = (entityClass as { name?: string })?.name ?? ''
+      if (entityName === 'SalesOrderLine') return [world().orderLine]
+      return []
+    }),
+    findOne: jest.fn(async () => null),
+    count: jest.fn(async () => 0),
+    create: jest.fn((_entity: unknown, data: unknown) => data),
+    persist: jest.fn(),
+    remove: jest.fn(),
+    flush: jest.fn(async () => {}),
+    getReference: jest.fn((_entity: unknown, id: string) => ({ id })),
+    getConnection: () => ({ execute: jest.fn(async () => [{ value: 1 }]) }),
+  }
+  return em
+}
+
+function makeCtx(em: unknown) {
+  const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+  container.register({
+    em: asValue(em),
+    dataEngine: asValue({ markOrmEntityChange: jest.fn() }),
+    salesCalculationService: asValue({
+      calculateDocumentTotals: jest.fn(async () => ({ totals: {}, lines: [{}] })),
+    }),
+  })
+  return {
+    container,
+    auth: { tenantId: TENANT_ID, orgId: ORG_ID, sub: 'user-1' },
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: null,
+    request: new Request('https://example.test/api/sales/order-lines', { method: 'POST' }),
+  }
+}
+
+function lineBody(overrides: Record<string, unknown> = {}) {
+  return {
+    body: {
+      orderId: ORDER_ID,
+      organizationId: ORG_ID,
+      tenantId: TENANT_ID,
+      currencyCode: 'USD',
+      kind: 'product',
+      quantity: 2,
+      unitPriceNet: UNIT_PRICE_NET,
+      unitPriceGross: UNIT_PRICE_GROSS,
+      taxRate: TAX_RATE,
+      ...overrides,
+    },
+  }
+}
+
+async function runUpsert(input: ReturnType<typeof lineBody>) {
+  const handler = commandRegistry.get('sales.orders.lines.upsert')!
+  const em = makeEm()
+  let caught: unknown
+  try {
+    await handler.execute(input as never, makeCtx(em) as never)
+  } catch (err) {
+    caught = err
+  }
+  return { caught, em }
+}
+
+function isFulfilledConflict(caught: unknown): boolean {
+  return (
+    isCrudHttpError(caught) &&
+    (caught as CrudHttpError).status === 409 &&
+    String((caught as CrudHttpError).body?.error ?? '').includes('fulfilled order')
+  )
+}
+
+describe('sales.orders.lines.upsert fulfilled-order guard (issue #4088)', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../documents')
+  })
+
+  afterEach(() => {
+    delete (globalThis as any).__lineFulfilledWorld
+  })
+
+  it('rejects adding a new item to an order whose status is fulfilled', async () => {
+    setWorld({ status: 'fulfilled' })
+    const { caught, em } = await runUpsert(lineBody())
+    expect(isFulfilledConflict(caught)).toBe(true)
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('rejects adding a new item when only the fulfillment status is fulfilled', async () => {
+    setWorld({ status: 'confirmed', fulfillmentStatus: 'fulfilled' })
+    const { caught, em } = await runUpsert(lineBody())
+    expect(isFulfilledConflict(caught)).toBe(true)
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+
+  it('allows adding a new item to a non-fulfilled order', async () => {
+    setWorld({ status: 'draft' })
+    const { caught } = await runUpsert(lineBody())
+    expect(isFulfilledConflict(caught)).toBe(false)
+  })
+
+  it('allows editing an existing line on a fulfilled order', async () => {
+    setWorld({ status: 'fulfilled' })
+    const { caught } = await runUpsert(lineBody({ id: LINE_ID, quantity: ORDERED_QUANTITY }))
+    expect(isCrudHttpError(caught) && (caught as CrudHttpError).status === 409).toBe(false)
+  })
+})

--- a/packages/core/src/modules/sales/commands/__tests__/documents.line-fulfilled-guard.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/documents.line-fulfilled-guard.test.ts
@@ -100,6 +100,9 @@ function makeEm() {
       return this
     },
     transactional: async (cb: (tx: unknown) => Promise<unknown>) => cb(em),
+    begin: jest.fn(async () => {}),
+    commit: jest.fn(async () => {}),
+    rollback: jest.fn(async () => {}),
     find: jest.fn(async (entityClass: unknown) => {
       const entityName = (entityClass as { name?: string })?.name ?? ''
       if (entityName === 'SalesOrderLine') return [world().orderLine]
@@ -117,13 +120,35 @@ function makeEm() {
   return em
 }
 
+type LineSnapshotLike = {
+  quantity?: number | string | null
+  unitPriceNet?: number | string | null
+  unitPriceGross?: number | string | null
+}
+
+function calculateLineResult(line: LineSnapshotLike) {
+  const quantity = Number(line.quantity ?? 0)
+  const netAmount = quantity * Number(line.unitPriceNet ?? 0)
+  const grossAmount = quantity * Number(line.unitPriceGross ?? 0)
+  return {
+    line,
+    netAmount,
+    grossAmount,
+    taxAmount: grossAmount - netAmount,
+    discountAmount: 0,
+  }
+}
+
 function makeCtx(em: unknown) {
   const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
   container.register({
     em: asValue(em),
     dataEngine: asValue({ markOrmEntityChange: jest.fn() }),
     salesCalculationService: asValue({
-      calculateDocumentTotals: jest.fn(async () => ({ totals: {}, lines: [{}] })),
+      calculateDocumentTotals: jest.fn(async (input: { lines: LineSnapshotLike[] }) => ({
+        totals: {},
+        lines: input.lines.map(calculateLineResult),
+      })),
     }),
   })
   return {
@@ -157,12 +182,13 @@ async function runUpsert(input: ReturnType<typeof lineBody>) {
   const handler = commandRegistry.get('sales.orders.lines.upsert')!
   const em = makeEm()
   let caught: unknown
+  let result: { orderId?: string; lineId?: string } | undefined
   try {
-    await handler.execute(input as never, makeCtx(em) as never)
+    result = (await handler.execute(input as never, makeCtx(em) as never)) as typeof result
   } catch (err) {
     caught = err
   }
-  return { caught, em }
+  return { caught, result, em }
 }
 
 function isFulfilledConflict(caught: unknown): boolean {
@@ -199,13 +225,22 @@ describe('sales.orders.lines.upsert fulfilled-order guard (issue #4088)', () => 
 
   it('allows adding a new item to a non-fulfilled order', async () => {
     setWorld({ status: 'draft' })
-    const { caught } = await runUpsert(lineBody())
-    expect(isFulfilledConflict(caught)).toBe(false)
+    const { caught, result, em } = await runUpsert(lineBody())
+    expect(caught).toBeUndefined()
+    expect(result?.orderId).toBe(ORDER_ID)
+    expect(typeof result?.lineId).toBe('string')
+    expect(result?.lineId).not.toBe(LINE_ID)
+    expect(em.flush).toHaveBeenCalled()
   })
 
   it('allows editing an existing line on a fulfilled order', async () => {
     setWorld({ status: 'fulfilled' })
-    const { caught } = await runUpsert(lineBody({ id: LINE_ID, quantity: ORDERED_QUANTITY }))
-    expect(isCrudHttpError(caught) && (caught as CrudHttpError).status === 409).toBe(false)
+    const { caught, result, em } = await runUpsert(
+      lineBody({ id: LINE_ID, quantity: ORDERED_QUANTITY }),
+    )
+    expect(caught).toBeUndefined()
+    expect(result?.orderId).toBe(ORDER_ID)
+    expect(result?.lineId).toBe(LINE_ID)
+    expect(em.flush).toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -6585,6 +6585,32 @@ async function assertShippedOrderLineEditable(
   }
 }
 
+const FULFILLED_ORDER_STATUS = "fulfilled";
+
+const isFulfilledOrder = (order: SalesOrder): boolean => {
+  const normalize = (value: string | null | undefined): string =>
+    (value ?? "").trim().toLowerCase();
+  return (
+    normalize(order.status) === FULFILLED_ORDER_STATUS ||
+    normalize(order.fulfillmentStatus) === FULFILLED_ORDER_STATUS
+  );
+};
+
+async function assertOrderAcceptsNewLine(
+  order: SalesOrder,
+  existingSnapshot: SalesLineSnapshot | null,
+): Promise<void> {
+  if (existingSnapshot) return;
+  if (!isFulfilledOrder(order)) return;
+  const { translate } = await resolveTranslations();
+  throw new CrudHttpError(409, {
+    error: translate(
+      "sales.documents.items.errorAddToFulfilled",
+      "You cannot add a new item to a fulfilled order. Change the order status first.",
+    ),
+  });
+}
+
 const orderLineUpsertCommand: CommandHandler<
   { body?: Record<string, unknown>; query?: Record<string, unknown> },
   { orderId: string; lineId: string }
@@ -6629,6 +6655,7 @@ const orderLineUpsertCommand: CommandHandler<
     const existingSnapshot = parsed.id
       ? (lineSnapshots.find((line) => line.id === parsed.id) ?? null)
       : null;
+    await assertOrderAcceptsNewLine(order, existingSnapshot);
     await assertShippedOrderLineEditable(em, order, existingSnapshot, parsed);
     const priceMode =
       parsed.priceMode === "gross"

--- a/packages/core/src/modules/sales/i18n/de.json
+++ b/packages/core/src/modules/sales/i18n/de.json
@@ -947,6 +947,7 @@
   "sales.documents.items.deletedCatalogReference.title": "Dieses Katalogprodukt wurde gelöscht",
   "sales.documents.items.editTitle": "Position bearbeiten",
   "sales.documents.items.empty": "Noch keine Positionen.",
+  "sales.documents.items.errorAddToFulfilled": "Zu einem erfüllten Auftrag kann keine neue Position hinzugefügt werden. Ändere zuerst den Auftragsstatus.",
   "sales.documents.items.errorCurrency": "Währung ist erforderlich.",
   "sales.documents.items.errorDelete": "Position konnte nicht gelöscht werden.",
   "sales.documents.items.errorDeleteShipped": "Positionen mit versandten Artikeln können nicht gelöscht werden.",

--- a/packages/core/src/modules/sales/i18n/en.json
+++ b/packages/core/src/modules/sales/i18n/en.json
@@ -947,6 +947,7 @@
   "sales.documents.items.deletedCatalogReference.title": "This catalog item was deleted",
   "sales.documents.items.editTitle": "Edit line",
   "sales.documents.items.empty": "No items yet.",
+  "sales.documents.items.errorAddToFulfilled": "You cannot add a new item to a fulfilled order. Change the order status first.",
   "sales.documents.items.errorCurrency": "Currency is required.",
   "sales.documents.items.errorDelete": "Failed to delete line.",
   "sales.documents.items.errorDeleteShipped": "You cannot delete a line that has shipped items.",

--- a/packages/core/src/modules/sales/i18n/es.json
+++ b/packages/core/src/modules/sales/i18n/es.json
@@ -947,6 +947,7 @@
   "sales.documents.items.deletedCatalogReference.title": "Este artículo del catálogo fue eliminado",
   "sales.documents.items.editTitle": "Editar línea",
   "sales.documents.items.empty": "Aún no hay artículos.",
+  "sales.documents.items.errorAddToFulfilled": "No puedes añadir un nuevo artículo a un pedido ya completado. Cambia primero el estado del pedido.",
   "sales.documents.items.errorCurrency": "La moneda es obligatoria.",
   "sales.documents.items.errorDelete": "No se pudo eliminar la línea.",
   "sales.documents.items.errorDeleteShipped": "No puedes eliminar una línea que ya tiene envíos.",

--- a/packages/core/src/modules/sales/i18n/pl.json
+++ b/packages/core/src/modules/sales/i18n/pl.json
@@ -947,6 +947,7 @@
   "sales.documents.items.deletedCatalogReference.title": "Ten produkt katalogowy został usunięty",
   "sales.documents.items.editTitle": "Edytuj pozycję",
   "sales.documents.items.empty": "Brak pozycji.",
+  "sales.documents.items.errorAddToFulfilled": "Nie można dodać nowej pozycji do zrealizowanego zamówienia. Najpierw zmień status zamówienia.",
   "sales.documents.items.errorCurrency": "Waluta jest wymagana.",
   "sales.documents.items.errorDelete": "Nie udało się usunąć pozycji.",
   "sales.documents.items.errorDeleteShipped": "Nie można usunąć pozycji, która ma wysłane sztuki.",


### PR DESCRIPTION
Fixes #4088

## Problem
On an order that is already marked **Fulfilled**, shipped/delivered, and fully paid (outstanding balance 0), adding a brand-new item via "Dodaj pozycję" succeeded with no warning, confirmation, or block. The new line's price was added to the grand total immediately, reopening an outstanding balance on a transaction that was already settled — even though nothing was shipped or paid for that new item.

## Root Cause
Order lines are created and edited through the single `sales.orders.lines.upsert` command (`packages/core/src/modules/sales/commands/documents.ts`), which backs `POST /api/sales/order-lines` and internal callers. Its only lifecycle guard, `assertShippedOrderLineEditable`, returns early when `existingSnapshot` is `null` — which is exactly the "add a new line" case — so there was no status/fulfillment check when appending a new item. The sibling fix #3993 only covers edits to already-shipped lines.

## What Changed
- Added `assertOrderAcceptsNewLine(order, existingSnapshot)` and called it just before `assertShippedOrderLineEditable` in `orderLineUpsertCommand`.
- When a **new** line is added (`existingSnapshot === null`) to an order whose `status` or `fulfillmentStatus` normalizes to `fulfilled`, it throws `CrudHttpError(409, { error })`. Editing existing lines is untouched (still guarded by #3993).
- The 409 surfaces cleanly in the `LineItemDialog` — it isn't an optimistic-lock body, so `surfaceRecordConflict` passes it through to `CrudForm` as a visible error message.
- Added the `sales.documents.items.errorAddToFulfilled` message in en/de/es/pl.
- Escape hatch: move the order status off `fulfilled` first, then add the item.

## Tests
- New `packages/core/src/modules/sales/commands/__tests__/documents.line-fulfilled-guard.test.ts` (4 cases): rejects add when `status=fulfilled`; rejects add when only `fulfillmentStatus=fulfilled`; allows add on a `draft` order; allows editing an existing line on a fulfilled order (guard is add-only). Verified **red without the guard** (the two reject cases fail), **green with it**.
- Full validation gate ran in order and passed: `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`. The whole `@open-mercato/core` suite is green for this change (7574/7575). The two failing tests in the local run — `customers/DealsKpiStrip.test.tsx` and `@open-mercato/ui` `format.test.ts` — are **pre-existing and locale-specific** (byte-identical to `origin/develop`; caused by a Polish default locale in `Intl.NumberFormat`), unrelated to this sales-only diff.

- **Review follow-up (`9da9eac5d`)**: the two allow-path cases originally asserted only that the caught error was not the new 409, so an unrelated exception passed them — and both were in fact failing with `TypeError: em.begin is not a function`. They now assert the command actually succeeds (no error, expected `orderId`/`lineId`, `flush` called), with the `EntityManager` and `salesCalculationService` mocks completed so the command can run to completion. Re-verified by mutation: removing the guard fails the two reject cases, widening it to also block edits fails the edit allow-path, unmodified passes 4/4.

## Breaking Changes
None. Additive rejection on an existing route, mirroring the merged #3993 guard's 409 pattern and error-body shape; no exported API, response field, event, DB schema, or CLI surface changed.

🤖 Generated by autofix.

