### PR TITLE
fix(sales): include custom/operator-defined order adjustments in the grand total (#4052)

### DIFF
--- a/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
@@ -369,6 +369,82 @@ describe('calculateDocumentTotals', () => {
     expect(positiveResult.totals.discountTotalAmount).toBeCloseTo(20, 4)
   })
 
+  it('folds custom / operator-defined adjustment kinds into the grand total so it never diverges from its itemization (issue #4052)', async () => {
+    const lines: SalesLineSnapshot[] = [
+      {
+        kind: 'product',
+        quantity: 1,
+        currencyCode: 'USD',
+        unitPriceNet: 100,
+        taxRate: 0,
+      },
+    ]
+
+    const positiveResult = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines,
+      adjustments: [
+        {
+          scope: 'order',
+          kind: 'custom',
+          label: 'Handling fee',
+          amountNet: 15,
+          amountGross: 15,
+          currencyCode: 'USD',
+        },
+      ],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    // A positive custom amount adds to the total (operator-controlled sign).
+    expect(positiveResult.totals.grandTotalNetAmount).toBeCloseTo(115, 4)
+    expect(positiveResult.totals.grandTotalGrossAmount).toBeCloseTo(115, 4)
+
+    const partialCreditResult = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines,
+      adjustments: [
+        {
+          scope: 'order',
+          kind: 'custom',
+          label: 'Goodwill credit',
+          amountNet: -30,
+          amountGross: -30,
+          currencyCode: 'USD',
+        },
+      ],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    // A negative custom amount reduces the total instead of being silently dropped.
+    expect(partialCreditResult.totals.grandTotalNetAmount).toBeCloseTo(70, 4)
+    expect(partialCreditResult.totals.grandTotalGrossAmount).toBeCloseTo(70, 4)
+
+    const overCreditResult = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines,
+      adjustments: [
+        {
+          scope: 'order',
+          kind: 'custom',
+          label: 'Large credit',
+          amountNet: -150,
+          amountGross: -150,
+          currencyCode: 'USD',
+        },
+      ],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    // A credit larger than the order total is reflected faithfully (the grand
+    // total equals subtotal + adjustment) rather than leaving the headline
+    // unchanged while the adjustment shows in the breakdown.
+    expect(overCreditResult.totals.grandTotalNetAmount).toBeCloseTo(-50, 4)
+    expect(overCreditResult.totals.grandTotalGrossAmount).toBeCloseTo(-50, 4)
+    // Amount due can never go negative.
+    expect(overCreditResult.totals.outstandingAmount).toBeCloseTo(0, 4)
+  })
+
   it('derives line tax from the net/gross delta when the rate is missing but gross embeds tax (issue #2457)', async () => {
     const lines: SalesLineSnapshot[] = [
       {

--- a/packages/core/src/modules/sales/lib/calculations.ts
+++ b/packages/core/src/modules/sales/lib/calculations.ts
@@ -208,6 +208,21 @@ function buildBaseDocumentResult(params: {
         }
         break
       default:
+        // `return` (credit) adjustments are handled by the dedicated loop below;
+        // skip them here so an order-scoped return is not counted twice.
+        if (adj.kind === 'return') break
+        // Custom / operator-defined kinds carry an operator-controlled sign
+        // (positive adds, negative credits). Fold the raw signed amount into the
+        // grand total so a persisted adjustment can never be silently dropped
+        // from the headline total while still appearing in the itemized
+        // breakdown (#4052). No abs()/clamp here: unlike the sign-constrained
+        // kinds above, custom kinds are intentionally unconstrained
+        // (see enforceAdjustmentSign).
+        subtotalNet += net
+        subtotalGross += gross
+        if (taxPortion) {
+          taxTotal += taxPortion
+        }
         break
     }
   }


### PR DESCRIPTION
Fixes #4052

## Problem
Order (and quote) adjustments of a `custom` — or any operator-defined — kind were persisted and shown correctly in the order's itemized totals breakdown, but the top-line grand total (`Razem (netto)` / `Razem (brutto)` / `Do zapłaty`) was never recalculated to include them, even after a full page reload. The headline total silently diverged from its own itemization.

## Root Cause
In the sales calculation engine `buildBaseDocumentResult` (`packages/core/src/modules/sales/lib/calculations.ts`), the per-adjustment `switch` only folded `discount`/`tax`/`shipping`/`surcharge` into the subtotals (plus a dedicated `return` loop). Every other kind fell into `default: break`. Since `adjustmentKindSchema` accepts an arbitrary kind string (and the code documents `custom`/unknown kinds as "unconstrained / operator-controlled"), a `custom` adjustment's `amountNet`/`amountGross` never reached `subtotalNet`/`subtotalGross`, so `grandTotalNet`/`grandTotalGross` omitted it entirely.

## What Changed
- Replaced the `default: break` branch so any non-return kind folds its raw **signed** `net`/`gross` (and any tax portion) into the subtotals — restoring the invariant that the grand total always equals subtotal + tax + shipping + all adjustment line items.
- Added an explicit `if (adj.kind === 'return') break` in that branch so an order-scoped `return` stays handled solely by the dedicated return loop below (no double-count).
- No `abs()`/clamp is applied to custom kinds: they are intentionally unconstrained (per `enforceAdjustmentSign`), so a positive amount adds and a negative amount credits the total faithfully. `outstandingAmount` remains `Math.max(..., 0)`-clamped, so the amount due never goes negative.
- Fix lives in the shared calculation engine, so both order-adjustments and quote-adjustments are corrected at once.

## Tests
- Added `calculations.test.ts` regression test "folds custom / operator-defined adjustment kinds into the grand total ... (issue #4052)": a positive custom fee (`+15` → `115`), a partial credit (`-30` → `70`), and an over-credit (`-150` → `-50`, with `outstandingAmount` `0`). Verified it **fails without** the fix and **passes with** it.
- Full validation gate run locally (Runner: local): `build:packages` ✓, `generate` ✓, `build:packages` ✓, `i18n:check-sync` ✓, `i18n:check-usage` ✓, `typecheck` ✓, `build:app` ✓. `yarn test` all sales/core suites pass except two **pre-existing** failures that reproduce identically on clean `origin/develop` with this change stashed and are unrelated to it: `packages/ui` `format.test.ts` (host Polish-locale number formatting; passes in CI's en-US locale) and `packages/core` `customers/DealsKpiStrip.test.tsx` (testing-library `waitFor` timeout).

## Breaking Changes
None. No exported signature, HTTP route, response shape, event ID, DI key, ACL feature, or DB schema changed. This corrects wrong totals math — any consumer that relied on custom adjustments being excluded from the grand total was relying on a defect the itemized breakdown already contradicted.

🤖 Generated by autofix.
