### PR TITLE
security(customer_accounts): validate company ownership on admin invite (#3838)

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-events.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-events.test.ts
@@ -44,10 +44,11 @@ jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () =>
 }))
 
 const mockFindWithDecryption = jest.fn(async () => [] as unknown[])
+const mockFindOneWithDecryption = jest.fn(async () => null as unknown)
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
-  findOneWithDecryption: jest.fn(async () => null),
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
 }))
 
 jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
@@ -100,6 +101,7 @@ describe('customer invitation endpoints — invitation-created event', () => {
     })
     mockEmit.mockResolvedValue(undefined)
     mockFindWithDecryption.mockResolvedValue([{ id: roleId, name: 'Buyer', customerAssignable: true }])
+    mockFindOneWithDecryption.mockResolvedValue(null)
   })
 
   it('admin route emits the invitation-created event once with staff context and no raw token', async () => {
@@ -163,6 +165,42 @@ describe('customer invitation endpoints — invitation-created event', () => {
     expect(res.status).toBe(403)
     expect(mockCreateInvitation).not.toHaveBeenCalled()
     expect(invitedEvents()).toHaveLength(0)
+  })
+
+  it('admin route rejects a customerEntityId the caller does not own without inviting', async () => {
+    mockFindOneWithDecryption.mockResolvedValue(null)
+    const foreignCompanyId = '66666666-6666-4666-8666-666666666666'
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/admin/users-invite', {
+        email: 'buyer@example.com',
+        roleIds: [roleId],
+        customerEntityId: foreignCompanyId,
+      }),
+    )
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ ok: false, error: 'Company not found' })
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+    expect(invitedEvents()).toHaveLength(0)
+  })
+
+  it('admin route invites when the customerEntityId is an owned company', async () => {
+    const ownedCompanyId = '77777777-7777-4777-8777-777777777777'
+    mockFindOneWithDecryption.mockResolvedValue({ id: ownedCompanyId, kind: 'company' })
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(
+      makeInviteRequest('/api/customer_accounts/admin/users-invite', {
+        email: 'buyer@example.com',
+        roleIds: [roleId],
+        customerEntityId: ownedCompanyId,
+      }),
+    )
+
+    expect(res.status).toBe(201)
+    expect(mockCreateInvitation).toHaveBeenCalledTimes(1)
+    expect((mockCreateInvitation.mock.calls[0][2] as any)?.customerEntityId).toBe(ownedCompanyId)
+    expect(invitedEvents()).toHaveLength(1)
   })
 
   it('admin route does NOT emit when validation fails', async () => {

--- a/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
@@ -3,8 +3,10 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc, OpenApiMethodDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import type { EntityManager } from '@mikro-orm/postgresql'
 import { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { CustomerInvitationService } from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
+import { isOwnedCompanyEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { inviteUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
@@ -49,6 +51,20 @@ export async function POST(req: Request) {
   const parsed = inviteUserSchema.safeParse(body)
   if (!parsed.success) {
     return NextResponse.json({ ok: false, error: 'Validation failed', details: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  // Reject a customerEntityId the caller does not own. Without this check the
+  // invitation persists a foreign company FK that cross-links the accepted
+  // CustomerUser into another org/company's portal context (#3838, mirrors #2693).
+  if (parsed.data.customerEntityId) {
+    const em = container.resolve('em') as EntityManager
+    const owned = await isOwnedCompanyEntity(em, parsed.data.customerEntityId, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+    if (!owned) {
+      return NextResponse.json({ ok: false, error: 'Company not found' }, { status: 400 })
+    }
   }
 
   const customerInvitationService = container.resolve('customerInvitationService') as CustomerInvitationService


### PR DESCRIPTION
## Summary

The admin customer-invite route accepted a client-supplied `customerEntityId` and passed it straight into `createInvitation` with **no** company-ownership check — unlike its sibling admin routes (user-create and user-update), which were hardened under #2693 to reject a `customerEntityId` the caller's tenant/org does not own.

This was a live IDOR-via-FK: a staff user with `customer_accounts.invite` could submit a company UUID from another organization in the same tenant. On acceptance, `acceptInvitation` copies `invitation.customerEntityId` onto the new `CustomerUser`, cross-linking the account into that foreign company's portal context (which then gates portal company-user listing, invites, and role assignment). Blast radius is same-tenant cross-org — exactly the class the sibling routes were fixed for.

This PR closes the gap by validating company ownership on the invite route, mirroring the existing helper and behavior used by the sibling routes.

## Changes

- `packages/core/src/modules/customer_accounts/api/admin/users-invite.ts`: when `customerEntityId` is provided, validate it with `isOwnedCompanyEntity(em, customerEntityId, { tenantId, organizationId })` before calling `createInvitation`, returning `400 { ok: false, error: 'Company not found' }` when the company is not owned by the caller's tenant/org. Reuses the existing helper for parity with `api/admin/users.ts` and `api/admin/users/[id].ts`.
- `packages/core/src/modules/customer_accounts/api/__tests__/users-invite-events.test.ts`: added coverage for (1) rejecting a non-owned `customerEntityId` (400, no invitation created, no event emitted) and (2) inviting successfully when the `customerEntityId` is an owned company.

The sibling portal invite route (`api/portal/users-invite.ts`) was reviewed and is unaffected — it uses the server-derived `auth.customerEntityId`, never a client-supplied value.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

Single-module authorization hardening that mirrors the already-specced #2693 pattern; no contract-surface or behavior change for legitimate callers.

## Testing

Runner: local

- `yarn workspace @open-mercato/core test -- users-invite-events` → 10 passed (incl. 2 new ownership cases)
- `yarn workspace @open-mercato/core typecheck` → exit 0

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it. (N/A — no user-facing strings or generated files touched; error string reuses the sibling routes' existing `'Company not found'`.)
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (covered by unit tests at the route boundary; the sibling #2693 hardening followed the same approach).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (N/A — minor change).
- [x] Priority set: `priority-medium`.
- [x] Risk set: `risk-medium`.
- [x] QA routing set: `skip-qa` — server-side authorization fix, no customer-facing UI change; behavior is unchanged for legitimate callers and covered by unit tests.

### Design System Compliance
- [x] No UI changes in this PR (backend authorization only) — DS items N/A.

## Linked issues

Fixes #3838
