### PR TITLE
security(entities): opt-in per-entity ACL for custom-entity records (#3857)

### DIFF
--- a/.ai/specs/2026-07-16-custom-entity-record-acl-per-entity.md
+++ b/.ai/specs/2026-07-16-custom-entity-record-acl-per-entity.md
@@ -1,0 +1,427 @@
+# SPEC — Per-Entity ACL for Custom Entity Records (Opt-In Restriction)
+
+**Scope:** OSS
+**Status:** Draft
+**Tracking issue:** [#3857](https://github.com/open-mercato/open-mercato/issues/3857)
+**Related guides:** `packages/core/src/modules/entities/AGENTS.md`, `packages/core/src/modules/auth/AGENTS.md`, `packages/shared/AGENTS.md`, `BACKWARD_COMPATIBILITY.md`
+
+---
+
+## TLDR
+
+`assertEntityAclForRequest` returns early for custom entities
+(`packages/core/src/modules/entities/lib/entityAcl.ts:91`), so the ONLY
+authorization on the custom-entity records API is the coarse route-level
+feature `entities.records.view` / `entities.records.manage`. A user granted
+that one feature can call `GET/POST/PUT/DELETE /api/entities/records` with any
+`entityId` in their tenant and read/modify/delete those records. Sensitive
+custom entities (salaries, board minutes) cannot be compartmentalized from
+ordinary ones. This is an **intra-tenant horizontal-privilege** issue;
+cross-tenant access remains blocked by existing tenant/org scoping.
+
+This spec adds **opt-in per-entity access control** for custom-entity records:
+
+- A custom entity can be flagged `access_restricted`. Default is `false`, so
+  **every existing entity and grant keeps working unchanged** (zero BC break).
+- A restricted entity additionally requires a **synthesized** per-entity
+  feature `entities.records.<entityId>.view` / `.manage`, enforced inside
+  `assertEntityAclForRequest` instead of the current short-circuit.
+- The feature catalog (`/api/auth/features`) is extended to surface those
+  synthesized features so admins can grant them in the Role/User ACL editor.
+- An optional tenant-level policy
+  (`entities.newEntitiesRestrictedByDefault`, default OFF) lets a tenant make
+  new custom entities restricted-by-default without forcing that posture on
+  anyone else.
+
+The composition is a **prerequisite model**: a restricted entity requires the
+coarse feature (route guard, unchanged) **plus** the per-entity feature. This
+solves the filed problem (hide sensitive entities from ordinary holders)
+without relaxing the route-level guard contract. Stronger "scope a user to
+*only* one entity" is called out as a future extension, explicitly out of
+scope here.
+
+---
+
+## Overview
+
+Custom entities are a self-service EAV feature: tenants define their own data
+models (`custom_entities` rows plus module-declared `ce.ts` entities) and their
+records are served by a single shared engine at `/api/entities/records`. In
+practice most custom entities are ordinary (vendors, assets, projects) and a
+minority are sensitive (salaries, board minutes).
+
+Today all custom-entity records share one pair of features. The records route
+enforces those at the metadata layer
+(`packages/core/src/modules/entities/api/records.ts:98-102`):
+
+```ts
+export const metadata = {
+  GET:    { requireAuth: true, requireFeatures: ['entities.records.view'] },
+  POST:   { requireAuth: true, requireFeatures: ['entities.records.manage'] },
+  PUT:    { requireAuth: true, requireFeatures: ['entities.records.manage'] },
+  DELETE: { requireAuth: true, requireFeatures: ['entities.records.manage'] },
+}
+```
+
+Each verb then calls `assertEntityAclForRequest`, which is the intended
+per-entity gate — but it returns immediately for custom entities:
+
+```ts
+// packages/core/src/modules/entities/lib/entityAcl.ts:90
+export async function assertEntityAclForRequest(args: AssertEntityAclArgs): Promise<void> {
+  if (args.isCustomEntity) return
+  // ... system-entity requirement lookup + wildcard-aware feature check
+}
+```
+
+`ENTITY_ACL_REQUIREMENTS` only maps *system* entity ids
+(`directory:*`, `customers:*`, `catalog:*`, `sales:*`, `auth:*`). There is no
+per-entity requirement, and no place to declare one, for custom entities.
+
+This spec introduces the missing per-entity gate as an **opt-in** so the fix is
+additive and low-risk, matching the issue's own guidance ("confirm against
+product intent … likely requires a new per-entity ACL scheme").
+
+## Problem Statement
+
+- `assertEntityAclForRequest` short-circuits for custom entities
+  (`entityAcl.ts:91`), so all four record verbs
+  (`records.ts:177`, `:401`, `:475`, `:574`) fall back to the coarse
+  route-level feature as the sole authorization.
+- The coarse feature is entity-agnostic: `entities.records.view` grants read on
+  **every** custom entity in the caller's tenant/org scope;
+  `entities.records.manage` grants write/delete on every one.
+- Sensitive custom entities cannot be compartmentalized from ordinary ones.
+- The `CustomEntity` model (`entities/data/entities.ts`) carries no ACL
+  metadata (`entityId`, `label`, org/tenant scope only), and the feature
+  catalog `/api/auth/features` is built statically from each module's `acl.ts`
+  — so custom entities contribute no grantable features today.
+
+Non-goals / already-correct behavior (must be preserved):
+
+- Cross-tenant isolation: record queries resolve `resolveOrganizationScope`
+  and are tenant/org-scoped. This spec does not touch that.
+- System (ORM table-backed) entity ids remain rejected by the records route
+  (`systemEntityRecordsRejection`).
+
+## Proposed Solution
+
+### Access model
+
+1. **Restriction flag.** Add `access_restricted` (nullable boolean, default
+   `false`/null) to `custom_entities`. Module-declared (`ce.ts`) custom
+   entities may declare the same flag in their definition; the runtime resolves
+   an effective boolean for any custom `entityId`.
+
+2. **Synthesized per-entity features.** For a restricted entity, two logical
+   features exist, keyed on the immutable `entityId`:
+
+   ```
+   entities.records.<entityId>.view
+   entities.records.<entityId>.manage
+   ```
+
+   Example: `entities.records.hr:salaries.view`. These are dynamic (never in
+   `acl.ts`). `entities.records.<id>.manage` declares
+   `dependsOn: ['entities.records.<id>.view', 'entities.records.manage']`;
+   `entities.records.<id>.view` declares
+   `dependsOn: ['entities.records.view']`.
+
+3. **Enforcement.** `assertEntityAclForRequest` stops short-circuiting on
+   `isCustomEntity`. For a custom entity it branches on the effective
+   restricted flag:
+   - **Not restricted** → allow. The route-level `requireFeatures` guard
+     already enforced the coarse feature. **Byte-for-byte today's behavior.**
+   - **Restricted** → additionally require the per-entity feature via the
+     shared wildcard-aware matcher
+     `hasAllFeatures(acl.features, ['entities.records.<entityId>.<action>'])`.
+     Super admin returns early (unchanged).
+
+4. **Prerequisite composition.** A restricted entity needs the coarse feature
+   (prerequisite, still enforced by the route metadata) **plus** the per-entity
+   feature. Consequence: a role granted a restricted entity also sees all
+   *non-restricted* entities. That is acceptable for v1 and solves the filed
+   issue. Scoping a principal to *only* one entity (dropping the coarse
+   prerequisite) would require the route guard to accept "coarse OR
+   per-entity", which `requireFeatures` (AND-only) cannot express — deferred as
+   a future extension (see § Out of Scope).
+
+### Why the wildcard matcher makes this fall out cleanly
+
+`matchFeature(required, granted)`
+(`packages/shared/src/lib/auth/featureMatch.ts`) treats `*` as global,
+`prefix.*` as recursive (`required.startsWith(prefix + '.')`), and everything
+else as exact string match. Against a synthesized
+`entities.records.<entityId>.<action>`:
+
+| Granted to the role | Access to a restricted entity | Why |
+|---|---|---|
+| `entities.records.view` / `.manage` (coarse only) | **No** | exact match only; string differs |
+| `entities.records.<entityId>.view` (per-entity) | **Yes** | exact match |
+| `entities.records.*` | Yes | recursive prefix |
+| `entities.*` | Yes | recursive prefix |
+| `*` / super admin | Yes | global grant / early return |
+
+This is precisely the desired outcome: ordinary coarse-feature holders lose
+visibility of restricted entities, while explicit per-entity holders and broad
+wildcard/admin grants retain it — with no change to existing admin grants.
+
+### Feature catalog surface
+
+Extend `GET /api/auth/features`
+(`packages/core/src/modules/auth/api/features.ts`) to append synthesized
+per-entity feature items for the **calling tenant's** restricted custom
+entities, after the static module features. Each item:
+
+- `id`: `entities.records.<entityId>.<action>`
+- `title`: e.g. `View records: <label>` / `Manage records: <label>`
+- `module`: `entities`
+- `dependsOn`: as in § Access model
+
+The endpoint already runs with auth context; it becomes tenant-aware for the
+synthesized tail only (static module features remain global and unchanged).
+The Role/User ACL editor (`auth/components/AclEditor.tsx`, fed by
+`/api/auth/features`) then renders them under the Entities group with no
+component change. Granted strings persist in `RoleAcl.featuresJson` /
+`UserAcl.featuresJson` exactly like any other feature — **no ACL schema
+change**.
+
+### Optional tenant default-restricted policy
+
+Add a tenant-scoped `module_config` for the `entities` module:
+`newEntitiesRestrictedByDefault` (boolean, default `false`), read via
+`ModuleConfigService` with tenant scope. When `true`, creating a new custom
+entity initializes `access_restricted = true`. This gives deny-by-default to
+tenants that want it, using the same mechanism, without changing the global
+default.
+
+### Definition UI
+
+Add a "Restrict record access" toggle to the custom-entity definition editor
+(`entities/backend/entities/user/[entityId]/page.tsx` and the create flow),
+bound to `access_restricted`, with an inline help note explaining that
+restricted entities require an explicit per-entity grant. All strings via
+`useT()` / locale files.
+
+## Architecture
+
+### Enforcement flow (records API, per verb)
+
+```
+Request → route metadata requireFeatures (coarse: view/manage)      [unchanged]
+        → classifyRecordsEntity(em, entityId)                        [existing]
+             system  → systemEntityRecordsRejection                  [unchanged]
+             custom  → resolve access_restricted for entityId        [NEW]
+                       assertEntityAclForRequest({ ..., entityMeta }) [MODIFIED]
+                          isCustom && !restricted → allow             [== today]
+                          isCustom &&  restricted → require
+                              entities.records.<entityId>.<action>    [NEW]
+             system-mapped (non-custom) → existing requirement path   [unchanged]
+```
+
+`classifyRecordsEntity` (`records.ts:53`) already resolves the `custom_entities`
+registration for user-created entities; extend it (or a sibling resolver) to
+also return the effective `access_restricted` flag so each verb passes
+`{ isCustomEntity, isRestricted }` into `assertEntityAclForRequest` without a
+second DB round-trip. Module-declared (`ce.ts`) custom entities resolve the flag
+from their declaration; the default remains `false`.
+
+### Components touched
+
+| Component | Change |
+|---|---|
+| `entities/data/entities.ts` (`CustomEntity`) | add `access_restricted` column |
+| `entities/migrations/*` + `.snapshot-open-mercato.json` | scoped migration for the new column |
+| `entities/lib/entityAcl.ts` | replace `if (isCustomEntity) return` with restricted-branch enforcement; accept `isRestricted` in args |
+| `entities/api/records.ts` | resolve restricted flag; pass it into all four `assertEntityAclForRequest` calls |
+| `entities/lib/*` (new helper) | derive per-entity feature id from `entityId` + action; resolve effective restricted flag (DB row / `ce.ts` declaration) |
+| `auth/api/features.ts` | append synthesized per-entity features for the tenant's restricted entities |
+| `entities/backend/entities/user/[entityId]/page.tsx` + create flow | "Restrict record access" toggle |
+| `entities` module config | `newEntitiesRestrictedByDefault` tenant policy (read on create) |
+| `entities/i18n/*` | new strings (toggle label, help, feature titles) |
+
+No new module, no new DI key, no new event id, no new API route. The only new
+ACL *feature-id shape* is dynamic and additive.
+
+## Data Models
+
+`custom_entities` (add one column):
+
+| Column | Type | Notes |
+|---|---|---|
+| `access_restricted` | `boolean` not null default `false` | `false` → unrestricted (current behavior). `true` → requires per-entity feature. Postgres backfills existing rows to `false` |
+
+MikroORM property — mirrors the existing `show_in_sidebar` / `is_active`
+boolean pattern on this entity (`custom_entities` already carries `updated_at`,
+line 155):
+
+```ts
+@Property({ name: 'access_restricted', type: 'boolean', default: false })
+accessRestricted: boolean = false
+```
+
+No changes to `role_acls` / `user_acls` schema — synthesized feature strings use
+the existing `features_json` array.
+
+Module config (tenant-scoped, via `module_configs`, no schema change):
+`entities.newEntitiesRestrictedByDefault: boolean` (default `false`).
+
+## API Contracts
+
+- `GET /api/entities/records` — unchanged request/response shape. Behavior
+  change: a restricted `entityId` now returns `403 { error: 'Forbidden' }`
+  (via `CrudHttpError(403)` from `assertEntityAclForRequest`) unless the caller
+  holds the per-entity `.view` feature (or a satisfying wildcard / super admin).
+- `POST` / `PUT` / `DELETE /api/entities/records` — unchanged shapes; restricted
+  `entityId` requires the per-entity `.manage` feature.
+- `GET /api/auth/features` — response schema unchanged (`items[]` of
+  `{ id, title, module, dependsOn? }`); additionally includes synthesized
+  per-entity feature items for the tenant's restricted entities. Existing
+  consumers that ignore unknown ids are unaffected.
+- Custom-entity definition create/update endpoints — accept and persist
+  `access_restricted`; default derived from the tenant policy on create.
+
+## Backward Compatibility
+
+Contract surfaces touched (per `BACKWARD_COMPATIBILITY.md`): DB schema
+(additive column), ACL features (additive, dynamic), API behavior (records
+authorization).
+
+- **Default is unrestricted.** With `access_restricted` defaulting to
+  `false`/null and the tenant policy defaulting OFF, every existing custom
+  entity and every existing grant behaves exactly as before. No ACL migration,
+  no bridge, no lockout risk — this is the core reason opt-in was chosen over a
+  secure-by-default per-entity-always model.
+- **Additive features.** `/api/auth/features` only *adds* items; the schema is
+  unchanged. No existing feature id is removed or renamed.
+- **New behavior only manifests when an admin opts an entity in.** At that
+  point, holders who previously relied on the coarse feature for that specific
+  entity must be granted the per-entity feature. This is the intended
+  compartmentalization, not a regression — but it MUST be documented so admins
+  understand that flipping the flag narrows access. Add an `UPGRADE_NOTES.md`
+  entry describing the flag, the synthesized feature ids, and the tenant policy.
+- No deprecation protocol needed (nothing removed); this is additive under the
+  ADDITIVE-ONLY classification.
+
+## Risks & Impact Review
+
+| Risk | Failure scenario | Severity | Mitigation | Residual |
+|---|---|---|---|---|
+| Legitimate lockout after flagging | Admin flips `access_restricted` on an in-use entity; existing users lose access until per-entity feature is granted | Medium | Toggle help text warns; `UPGRADE_NOTES.md`; admin (super/`entities.*`) retains access; flag is per-entity and reversible | Low — intended semantics, self-service reversible |
+| Enforcement gap on one verb | A verb keeps short-circuiting and a restricted entity stays open on that path | High if it slips | Single shared `assertEntityAclForRequest` change covers all four call sites; add a test asserting each verb 403s a restricted entity without the grant | Low |
+| Feature-catalog staleness / drift | Synthesized feature id derived inconsistently between catalog and enforcement, so a granted feature never matches | Medium | Derive the feature id from one shared helper used by BOTH `features.ts` and `entityAcl.ts`; unit-test the derivation | Low |
+| entityId → feature-id shape | `entityId` contains a `:` (e.g. `hr:salaries`); malformed segmentation could break wildcard/exact matching | Low | `matchFeature` is `.`-segmented and does exact-string compare for non-wildcards; `:` stays inside one segment. Entity ids never contain `.`. Covered by a matcher test | Low |
+| Performance | Extra per-request restricted-flag lookup | Low | Fold the flag into the existing `classifyRecordsEntity` resolution (no extra round-trip); flag is a tiny boolean | Negligible |
+| Tenant-awareness of `/api/auth/features` | Endpoint gains a tenant-scoped tail; a bug could leak another tenant's entity labels | Medium | Scope the synthesized query by the caller's tenant/org exactly like record queries; test cross-tenant isolation of the catalog tail | Low |
+
+## Testing & Integration Coverage
+
+Unit:
+- `entityAcl.test.ts`: custom + unrestricted → allowed (regression of current
+  behavior); custom + restricted without per-entity feature → 403; with
+  per-entity feature → allowed; with `entities.records.*` / `entities.*` / super
+  admin → allowed.
+- feature-id derivation helper: stable, deterministic, round-trips through
+  `matchFeature` for representative `entityId`s (including one with `:`).
+- `features.test.ts`: restricted entities contribute synthesized items; catalog
+  tail is tenant-scoped (no cross-tenant leakage); unrestricted entities
+  contribute nothing.
+
+Integration (all four record verbs — required per root AGENTS "integration
+coverage for all affected API paths"):
+- Fixtures create two custom entities (one restricted, one not) and roles with
+  (a) coarse-only and (b) coarse + per-entity grants; assert
+  `GET/POST/PUT/DELETE /api/entities/records`:
+  - coarse-only role: full access to the unrestricted entity; `403` on the
+    restricted entity for every verb.
+  - coarse + per-entity role: full access to both.
+  - cross-tenant caller: `403`/scoped-empty as today (no regression).
+- UI smoke: record list/detail/edit forms for an unrestricted entity are
+  unchanged; a restricted entity is hidden/denied for a coarse-only user.
+- Self-contained: create fixtures in setup (prefer API), clean up in teardown;
+  no reliance on seeded/demo data.
+
+## Out of Scope (future extensions)
+
+- **Standalone per-entity scoping** (grant a principal access to *only* one
+  restricted entity without the coarse prerequisite). Requires the records
+  route to accept "coarse OR per-entity", i.e. moving the umbrella check out of
+  `requireFeatures` into the handler. Deferred.
+- **Per-record / ownership-level ACL** (row-level security). Not addressed.
+- **Retrofitting system (ORM-backed) entities** — they already have concrete
+  requirements in `ENTITY_ACL_REQUIREMENTS`.
+- **Other read surfaces that touch `custom_entities_storage`** (search indexer,
+  AI tools, direct Query Engine callers) do **not** yet honor `access_restricted`.
+  They enforce their own feature gates, and this spec closes the records API
+  (the surface named in #3857). Propagating the per-entity restriction to those
+  surfaces is a tracked follow-up — until then, a restricted custom entity's
+  records may still be reachable via search/AI if the caller holds those
+  surfaces' own features. Flagged during the consensus code review.
+
+## Implementation Phases
+
+1. **Schema + flag resolution.** Add `access_restricted` column + migration +
+   snapshot; add the shared helpers (effective-restricted resolver + feature-id
+   deriver). Unit-test the deriver.
+2. **Enforcement.** Rework `assertEntityAclForRequest` (restricted branch);
+   thread `isRestricted` from `records.ts` for all four verbs. Unit + verb tests.
+3. **Feature catalog.** Extend `/api/auth/features` with the tenant-scoped
+   synthesized tail. Tests incl. cross-tenant isolation.
+4. **Definition UI + tenant policy.** Toggle in create/edit; wire
+   `newEntitiesRestrictedByDefault`; i18n strings.
+5. **Docs.** `UPGRADE_NOTES.md`, entities module AGENTS note, integration tests.
+
+## Final Compliance Report
+
+Runner: local (no running app container found via the docker-compose probe).
+
+- [x] `assertEntityAclForRequest` no longer short-circuits custom entities;
+      all four verbs (`records.ts` GET/POST/PUT/DELETE) thread `isRestricted`
+      and enforce the restricted branch.
+- [x] Default posture verified unchanged — unrestricted custom entity does not
+      consult the ACL (regression test in `entityAcl.test.ts` + superadmin GET
+      passes in `records.crud.test.ts`).
+- [x] Feature-id derivation lives in one shared pure helper
+      (`lib/recordFeatures.ts`) used by both enforcement and the catalog;
+      matcher tests (incl. `entityId` with `:`) pass.
+- [x] `/api/auth/features` synthesized tail is tenant-scoped and fails safe;
+      cross-tenant/omit-tenant behavior covered in
+      `restrictedEntityFeatures.test.ts` + `features.test.ts`.
+- [x] Migration `Migration20260716120000` + snapshot reviewed — additive
+      `access_restricted` column only, no unrelated drift (legacy no-dash
+      snapshot left untouched; active snapshot is `.snapshot-open-mercato`).
+- [x] `UPGRADE_NOTES.md` documents the flag, synthesized feature ids, and the
+      tenant policy (under 0.6.5 → 0.6.6).
+- [x] Route-level tests cover GET/POST/PUT/DELETE for a restricted entity:
+      coarse-only → 403 (no write), per-entity grant → allowed, superadmin →
+      allowed. (Route tests exercise the ACL wiring end-to-end with mocked DI;
+      a live Playwright fixture pass remains for the QA gate.)
+- [x] Validation gate (local): `yarn generate`, `yarn build:packages`,
+      `yarn typecheck` (21/21), `yarn lint` (0 errors), `yarn test` for
+      entities+auth (680/680) all green.
+
+## Changelog
+
+- 2026-07-16: Initial draft. Opt-in `access_restricted` flag + synthesized
+  per-entity `entities.records.<entityId>.view/.manage` features + optional
+  tenant `newEntitiesRestrictedByDefault` policy; prerequisite composition;
+  standalone-only scoping deferred.
+- 2026-07-16: Consensus code review (PAL, gpt-5.2 adversarial). Fixed a
+  self-introduced regression — `classifyRecordsEntity` resolved the
+  `access_restricted` security flag from an UNSCOPED `findOne({ entityId })`, so
+  a colliding entityId in another tenant could flip the flag; now resolved with
+  tenant+org overlay precedence (`findScopedCustomEntity`), classification
+  preserved via an unscoped fallback (regression test added). Also: aligned the
+  feature-catalog precedence to treat the declared (ce.ts) registry as
+  authoritative for its ids (matches records enforcement); memoize the declared
+  cache even when empty; documented that other read surfaces (search/AI/query
+  engine) don't yet honor the flag (§ Out of Scope). Earlier in the session also
+  fixed a partial-update un-restrict (zod default made the fallback dead).
+- 2026-07-16: Implemented all five phases. Added `custom_entities.access_restricted`
+  column (migration `Migration20260716120000` + snapshot), pure
+  `lib/recordFeatures.ts` deriver, restricted-branch enforcement in
+  `entityAcl.ts` threaded through all four `records.ts` verbs, tenant-scoped
+  synthesized catalog tail in `/api/auth/features` (`lib/restrictedEntityFeatures.ts`),
+  create/edit toggles, `GET/PUT /api/entities/entity-settings` tenant policy,
+  i18n (en/de/es/pl), unit + route tests, and `UPGRADE_NOTES.md`. Local
+  validation gate green (typecheck/lint/tests).

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -24,6 +24,19 @@ most of the patterns listed below in a user's codebase.
 
 ## 0.6.5 → 0.6.6 (unreleased)
 
+### Opt-in per-entity ACL for custom-entity records (#3857)
+
+Follow-up to the #2612 records-API hardening, which deliberately left custom/EAV entities on the coarse `entities.records.view` / `entities.records.manage` path. Those two features were **entity-agnostic**: any holder could read/modify/delete records of *every* custom entity in their tenant, so sensitive custom entities (salaries, board minutes) could not be compartmentalized from ordinary ones (intra-tenant horizontal privilege; cross-tenant was already blocked).
+
+Custom entities can now be flagged **`access_restricted`**. The change is **additive and default-off**, so existing entities and grants behave exactly as before — no migration, no lockout:
+
+- **Unrestricted (default):** unchanged — the coarse route feature is the whole authorization.
+- **Restricted:** `assertEntityAclForRequest` additionally requires a **synthesized per-entity feature** `entities.records.<entityId>.view` / `entities.records.<entityId>.manage` (e.g. `entities.records.hr:salaries.view`). The coarse feature alone no longer grants it; `entities.records.*`, `entities.*`, and super-admin still do (normal wildcard semantics).
+
+Grant the per-entity features in the Role/User ACL editor — `GET /api/auth/features` now appends them for the calling tenant's restricted entities. New DB column `custom_entities.access_restricted` (`boolean not null default false`, migration `Migration20260716120000`). Toggle it per entity on the custom-entity create/edit page, or declare `accessRestricted: true` in a module's `ce.ts` `CustomEntitySpec`. An optional tenant policy `entities.newEntitiesRestrictedByDefault` (module config, default off; read/set via `GET/PUT /api/entities/entity-settings`) makes new entities restricted-by-default for tenants that want deny-by-default.
+
+*Action for downstream:* none to keep current behavior. **If you flag an in-use entity as restricted, existing coarse-feature holders lose access to it** until granted the per-entity feature — this is the intended compartmentalization. If you ship a sensitive custom entity via `ce.ts`, set `accessRestricted: true` and grant the per-entity features to the roles that should see it. See [`.ai/specs/2026-07-16-custom-entity-record-acl-per-entity.md`](.ai/specs/2026-07-16-custom-entity-record-acl-per-entity.md).
+
 ### Shared `om-*` pipeline skills now come from open-mercato/skills
 
 The generalized agent-pipeline skills (`om-code-review`, `om-auto-create-pr`, `om-auto-review-pr`, `om-merge-buddy`, `om-spec-writing`, the `-loop` variants, `om-prepare-issue`, and 15 more — see the `external` block in [`.ai/skills/tiers.json`](.ai/skills/tiers.json)) were removed from `.ai/skills/` and are now installed from the shared [open-mercato/skills](https://github.com/open-mercato/skills) collection. `yarn install-skills` runs `npx -y skills add open-mercato/skills --skill '*'` after the local tier symlinks, placing the skills under `.agents/skills/` (gitignored), then `npx -y skills update --project` so re-running the installer refreshes the external skills to their latest published versions (the lockfile is gitignored, so `add` seeds and `update` keeps them current).

--- a/packages/core/src/modules/auth/api/__tests__/features.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/features.test.ts
@@ -9,11 +9,23 @@ jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
   getModules: jest.fn(),
 }))
 
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/lib/restrictedEntityFeatures', () => ({
+  synthesizeRestrictedEntityFeatures: jest.fn(),
+}))
+
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { getModules } from '@open-mercato/shared/lib/i18n/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { synthesizeRestrictedEntityFeatures } from '@open-mercato/core/modules/entities/lib/restrictedEntityFeatures'
 
 const mockGetAuth = getAuthFromRequest as jest.Mock
 const mockGetModules = getModules as jest.Mock
+const mockCreateContainer = createRequestContainer as jest.Mock
+const mockSynthesize = synthesizeRestrictedEntityFeatures as jest.Mock
 
 function makeReq() {
   return new Request('http://localhost/api/auth/features')
@@ -23,6 +35,8 @@ describe('GET /api/auth/features', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockGetAuth.mockResolvedValue({ sub: 'u1', tenantId: 't1', orgId: 'o1' })
+    mockCreateContainer.mockResolvedValue({ resolve: () => ({}) })
+    mockSynthesize.mockResolvedValue([])
   })
 
   it('returns 401 when not authenticated', async () => {
@@ -117,5 +131,43 @@ describe('GET /api/auth/features', () => {
     const res = await GET(makeReq())
     const body = await res.json()
     expect(body.items).toEqual([{ id: 'shared.thing', title: 'First', module: 'a' }])
+  })
+
+  it('appends synthesized per-entity features for restricted custom entities', async () => {
+    mockGetModules.mockReturnValue([
+      {
+        id: 'entities',
+        info: { title: 'Entities' },
+        features: [{ id: 'entities.records.view', title: 'View records', module: 'entities' }],
+      },
+    ])
+    mockSynthesize.mockResolvedValue([
+      {
+        id: 'entities.records.hr:salaries.view',
+        title: 'View records: Salaries',
+        module: 'entities',
+        dependsOn: ['entities.records.view'],
+      },
+    ])
+    const res = await GET(makeReq())
+    const body = await res.json()
+    expect(mockSynthesize).toHaveBeenCalledWith(expect.anything(), 't1')
+    expect(body.items).toContainEqual({
+      id: 'entities.records.hr:salaries.view',
+      title: 'View records: Salaries',
+      module: 'entities',
+      dependsOn: ['entities.records.view'],
+    })
+  })
+
+  it('still returns the static catalog when synthesis throws', async () => {
+    mockGetModules.mockReturnValue([
+      { id: 'auth', info: { title: 'Auth' }, features: [{ id: 'auth.users.list', title: 'List users', module: 'auth' }] },
+    ])
+    mockSynthesize.mockRejectedValue(new Error('db down'))
+    const res = await GET(makeReq())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([{ id: 'auth.users.list', title: 'List users', module: 'auth' }])
   })
 })

--- a/packages/core/src/modules/auth/api/features.ts
+++ b/packages/core/src/modules/auth/api/features.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { getModules } from '@open-mercato/shared/lib/i18n/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { synthesizeRestrictedEntityFeatures } from '@open-mercato/core/modules/entities/lib/restrictedEntityFeatures'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['auth.acl.manage'] },
@@ -44,6 +46,21 @@ export async function GET(req: Request) {
       return base
     })
   )
+  // Append synthesized per-entity features for the tenant's restricted custom
+  // entities so they can be granted in the ACL editor. Tenant-scoped; never
+  // throws (falls back to the static catalog on any failure).
+  try {
+    const { resolve } = await createRequestContainer()
+    const em = resolve('em') as any
+    const synthesized = await synthesizeRestrictedEntityFeatures(em, auth.tenantId ?? null)
+    for (const item of synthesized) {
+      const deps = normalizeDependsOn(item.dependsOn)
+      const base: FeatureItem = { id: item.id, title: item.title, module: item.module }
+      if (deps) base.dependsOn = deps
+      items.push(base)
+    }
+  } catch {}
+
   // Deduplicate by id (keep first occurrence)
   const byId = new Map<string, FeatureItem>()
   for (const it of items) if (!byId.has(it.id)) byId.set(it.id, it)

--- a/packages/core/src/modules/entities/api/__tests__/records.crud.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/records.crud.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-import { POST, PUT, DELETE } from '@open-mercato/core/modules/entities/api/records'
+import { GET, POST, PUT, DELETE } from '@open-mercato/core/modules/entities/api/records'
 import { UNKNOWN_CUSTOM_FIELD_ERROR } from '@open-mercato/shared/modules/entities/validation'
 
 let mockRecordUpdatedAt: string | null = null
@@ -42,6 +42,10 @@ const mockDataEngine = {
   deleteCustomEntityRecord: jest.fn(async () => undefined),
 }
 
+const mockQueryEngine = {
+  query: jest.fn(async () => ({ items: [], total: 0 })),
+}
+
 const mockRbac = {
   resolveVisibleOrganizations: jest.fn(async () => ['org']),
   loadAcl: jest.fn(async () => ({ isSuperAdmin: true, features: [], organizations: null })),
@@ -52,6 +56,7 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
     resolve: (k: string) => {
       if (k === 'em') return mockEm
       if (k === 'rbacService') return mockRbac
+      if (k === 'queryEngine') return mockQueryEngine
       return mockDataEngine
     },
   }),
@@ -307,6 +312,121 @@ describe('Records API CRUD operations', () => {
       const res = await DELETE(req)
       expect(res.status).toBe(200)
       expect(mockDataEngine.deleteCustomEntityRecord).toHaveBeenCalled()
+    })
+  })
+
+  // Per-entity ACL enforcement for a custom entity flagged access_restricted.
+  // classifyRecordsEntity resolves the flag from the CustomEntity row; the four
+  // verbs must all deny a coarse-only holder and allow a per-entity holder (#3857).
+  describe('restricted custom entity records require the per-entity feature', () => {
+    const RESTRICTED_ENTITY = 'hr:salaries'
+    const RECORD_ID = '123e4567-e89b-12d3-a456-426614174000'
+
+    beforeEach(() => {
+      // classifyRecordsEntity → CustomEntity lookup returns a restricted row.
+      mockEm.findOne.mockResolvedValue({ accessRestricted: true })
+    })
+
+    afterEach(() => {
+      // Restore the shared defaults so other blocks keep the superadmin path.
+      mockEm.findOne.mockResolvedValue(null)
+      mockRbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [], organizations: null })
+    })
+
+    function grant(features: string[]) {
+      mockRbac.loadAcl.mockResolvedValue({ isSuperAdmin: false, features, organizations: null })
+    }
+
+    it('GET denies a coarse-only viewer with 403', async () => {
+      grant(['entities.records.view'])
+      const req = new Request(`http://x/api/entities/records?entityId=${RESTRICTED_ENTITY}`, { method: 'GET' })
+      const res = await GET(req)
+      expect(res.status).toBe(403)
+    })
+
+    it('POST denies a coarse-only manager with 403 and does not write', async () => {
+      grant(['entities.records.manage'])
+      const req = new Request('http://x/api/entities/records', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ entityId: RESTRICTED_ENTITY, values: { amount: 1000 } }),
+      })
+      const res = await POST(req)
+      expect(res.status).toBe(403)
+      expect(mockDataEngine.createCustomEntityRecord).not.toHaveBeenCalled()
+    })
+
+    it('POST allows a holder of the per-entity manage feature', async () => {
+      grant(['entities.records.manage', 'entities.records.hr:salaries.manage'])
+      mockCustomFieldDefsLookup(['amount'])
+      const req = new Request('http://x/api/entities/records', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ entityId: RESTRICTED_ENTITY, values: { amount: 1000 } }),
+      })
+      const res = await POST(req)
+      expect(res.status).toBe(200)
+      expect(mockDataEngine.createCustomEntityRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ entityId: RESTRICTED_ENTITY }),
+      )
+    })
+
+    it('PUT denies a coarse-only manager with 403', async () => {
+      grant(['entities.records.manage'])
+      const req = new Request('http://x/api/entities/records', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ entityId: RESTRICTED_ENTITY, recordId: RECORD_ID, values: { amount: 5 } }),
+      })
+      const res = await PUT(req)
+      expect(res.status).toBe(403)
+      expect(mockDataEngine.updateCustomEntityRecord).not.toHaveBeenCalled()
+    })
+
+    it('DELETE denies a coarse-only manager with 403', async () => {
+      grant(['entities.records.manage'])
+      const req = new Request(
+        `http://x/api/entities/records?entityId=${RESTRICTED_ENTITY}&recordId=${RECORD_ID}`,
+        { method: 'DELETE' },
+      )
+      const res = await DELETE(req)
+      expect(res.status).toBe(403)
+      expect(mockDataEngine.deleteCustomEntityRecord).not.toHaveBeenCalled()
+    })
+
+    it('DELETE allows a holder of the per-entity manage feature', async () => {
+      grant(['entities.records.manage', 'entities.records.hr:salaries.manage'])
+      const req = new Request(
+        `http://x/api/entities/records?entityId=${RESTRICTED_ENTITY}&recordId=${RECORD_ID}`,
+        { method: 'DELETE' },
+      )
+      const res = await DELETE(req)
+      expect(res.status).toBe(200)
+      expect(mockDataEngine.deleteCustomEntityRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ entityId: RESTRICTED_ENTITY, recordId: RECORD_ID, soft: true }),
+      )
+    })
+
+    it('GET allows a superadmin regardless of the restriction', async () => {
+      mockRbac.loadAcl.mockResolvedValue({ isSuperAdmin: true, features: [], organizations: null })
+      const req = new Request(`http://x/api/entities/records?entityId=${RESTRICTED_ENTITY}`, { method: 'GET' })
+      const res = await GET(req)
+      expect(res.status).toBe(200)
+    })
+
+    it('resolves the restricted flag from a TENANT-SCOPED lookup (not a bare entityId match)', async () => {
+      // Regression guard for the cross-tenant entityId-collision bypass: the
+      // CustomEntity lookup that decides `access_restricted` must be scoped to the
+      // caller's tenant, never `{ entityId }` alone.
+      grant(['entities.records.view'])
+      const req = new Request(`http://x/api/entities/records?entityId=${RESTRICTED_ENTITY}`, { method: 'GET' })
+      await GET(req)
+      const customEntityLookups = mockEm.findOne.mock.calls.filter(
+        ([, where]) => where && typeof where === 'object' && (where as any).entityId === RESTRICTED_ENTITY,
+      )
+      expect(customEntityLookups.length).toBeGreaterThan(0)
+      // Every restriction-deciding lookup carries a tenant scope.
+      expect(customEntityLookups[0][1]).toEqual(expect.objectContaining({ tenantId: 't1' }))
     })
   })
 })

--- a/packages/core/src/modules/entities/api/entities.ts
+++ b/packages/core/src/modules/entities/api/entities.ts
@@ -68,6 +68,7 @@ export async function GET(req: Request) {
       labelField: (c as any).labelField ?? undefined,
       defaultEditor: (c as any).defaultEditor ?? undefined,
       showInSidebar: (c as any).showInSidebar ?? false,
+      accessRestricted: (c as any).accessRestricted ?? false,
       updatedAt: c.updatedAt instanceof Date ? c.updatedAt.toISOString() : (c.updatedAt ?? undefined),
     }))
 
@@ -113,6 +114,10 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 })
   }
   const input = parsed.data
+  // Distinguish "caller did not send the field" (apply tenant default-restricted
+  // policy on create) from "caller explicitly chose false".
+  const accessRestrictedExplicit = body != null && typeof body === 'object'
+    && Object.prototype.hasOwnProperty.call(body, 'accessRestricted')
 
   const container = await createRequestContainer()
   const { resolve } = container
@@ -157,6 +162,7 @@ export async function POST(req: Request) {
   })
   if (guard.blockedResponse) return guard.blockedResponse
 
+  const isCreate = !ent
   if (!ent) ent = em.create(CustomEntity, { ...where, createdAt: new Date() })
   ent.label = input.label
   ent.description = input.description ?? null
@@ -164,6 +170,27 @@ export async function POST(req: Request) {
   ent.labelField = input.labelField ?? ent.labelField ?? null
   ent.defaultEditor = input.defaultEditor ?? ent.defaultEditor ?? null
   ent.showInSidebar = input.showInSidebar ?? ent.showInSidebar ?? false
+  // Never silently flip a security control on a partial upsert. `access_restricted`
+  // changes ONLY when the caller explicitly sends the field. On create without it,
+  // fall back to the tenant default-restricted policy; on update without it, keep
+  // the entity's current value (a metadata-only update must not un-restrict).
+  if (accessRestrictedExplicit) {
+    ent.accessRestricted = input.accessRestricted === true
+  } else if (isCreate) {
+    let policyDefault = false
+    try {
+      const moduleConfigService = resolve('moduleConfigService') as {
+        getValue: (m: string, n: string, o?: { defaultValue?: unknown; scope?: { tenantId?: string | null } }) => Promise<unknown>
+      }
+      policyDefault = (await moduleConfigService.getValue('entities', 'newEntitiesRestrictedByDefault', {
+        defaultValue: false,
+        scope: { tenantId: auth.tenantId ?? null },
+      })) === true
+    } catch {}
+    ent.accessRestricted = policyDefault
+  } else {
+    ent.accessRestricted = ent.accessRestricted ?? false
+  }
   ent.updatedAt = new Date()
   em.persist(ent)
   await em.flush()
@@ -229,6 +256,7 @@ const entitySummarySchema = z.object({
   labelField: z.string().optional(),
   defaultEditor: z.string().optional(),
   showInSidebar: z.boolean().optional(),
+  accessRestricted: z.boolean().optional(),
   updatedAt: z.string().optional(),
   count: z.number(),
 })

--- a/packages/core/src/modules/entities/api/entity-settings.ts
+++ b/packages/core/src/modules/entities/api/entity-settings.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+
+// Tenant-scoped policy: when true, new custom entities are created with
+// `access_restricted = true` unless the create request explicitly sets the flag.
+const CONFIG_MODULE = 'entities'
+const NEW_ENTITIES_RESTRICTED_KEY = 'newEntitiesRestrictedByDefault'
+
+export const metadata = {
+  GET: { requireAuth: true, requireFeatures: ['entities.definitions.view'] },
+  PUT: { requireAuth: true, requireFeatures: ['entities.definitions.manage'] },
+}
+
+type ModuleConfigServiceLike = {
+  getValue: (
+    moduleId: string,
+    name: string,
+    options?: { defaultValue?: unknown; scope?: { tenantId?: string | null } },
+  ) => Promise<unknown>
+  setValue: (
+    moduleId: string,
+    name: string,
+    value: unknown,
+    scope?: { tenantId?: string | null },
+  ) => Promise<unknown>
+}
+
+async function readPolicy(tenantId: string | null): Promise<boolean> {
+  try {
+    const { resolve } = await createRequestContainer()
+    const moduleConfigService = resolve('moduleConfigService') as ModuleConfigServiceLike
+    const value = await moduleConfigService.getValue(CONFIG_MODULE, NEW_ENTITIES_RESTRICTED_KEY, {
+      defaultValue: false,
+      scope: { tenantId },
+    })
+    return value === true
+  } catch {
+    return false
+  }
+}
+
+export async function GET(req: Request) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth || !auth.tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  const newEntitiesRestrictedByDefault = await readPolicy(auth.tenantId ?? null)
+  return NextResponse.json({ newEntitiesRestrictedByDefault })
+}
+
+const putBodySchema = z.object({
+  newEntitiesRestrictedByDefault: z.boolean(),
+})
+
+export async function PUT(req: Request) {
+  const auth = await getAuthFromRequest(req)
+  if (!auth || !auth.tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  let body: unknown
+  try { body = await req.json() } catch { return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 }) }
+  const parsed = putBodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Validation failed', details: parsed.error.flatten() }, { status: 400 })
+  }
+  const { resolve } = await createRequestContainer()
+  const moduleConfigService = resolve('moduleConfigService') as ModuleConfigServiceLike
+  await moduleConfigService.setValue(
+    CONFIG_MODULE,
+    NEW_ENTITIES_RESTRICTED_KEY,
+    parsed.data.newEntitiesRestrictedByDefault,
+    { tenantId: auth.tenantId ?? null },
+  )
+  return NextResponse.json({ ok: true, newEntitiesRestrictedByDefault: parsed.data.newEntitiesRestrictedByDefault })
+}
+
+const settingsResponseSchema = z.object({
+  newEntitiesRestrictedByDefault: z.boolean(),
+})
+
+export const openApi: OpenApiRouteDoc = {
+  tag: 'Entities',
+  summary: 'Custom entity workspace settings',
+  methods: {
+    GET: {
+      summary: 'Get custom entity settings',
+      description: 'Returns the tenant-scoped default-restricted policy for new custom entities.',
+      responses: [
+        { status: 200, description: 'Current settings', schema: settingsResponseSchema },
+        { status: 401, description: 'Missing authentication', schema: z.object({ error: z.string() }) },
+      ],
+    },
+    PUT: {
+      summary: 'Update custom entity settings',
+      description: 'Sets the tenant-scoped default-restricted policy for new custom entities.',
+      requestBody: { schema: putBodySchema },
+      responses: [
+        { status: 200, description: 'Updated settings', schema: z.object({ ok: z.boolean(), newEntitiesRestrictedByDefault: z.boolean() }) },
+        { status: 400, description: 'Invalid payload', schema: z.object({ error: z.string() }) },
+        { status: 401, description: 'Missing authentication', schema: z.object({ error: z.string() }) },
+      ],
+    },
+  },
+}

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -20,28 +20,62 @@ import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('entities').child({ component: 'records' })
 
-let declaredCustomEntityIds: Set<string> | null = null
-function isDeclaredCustomEntity(entityId: string): boolean {
-  if (declaredCustomEntityIds === null) {
+let declaredCustomEntityRestricted: Map<string, boolean> | null = null
+function loadDeclaredCustomEntities(): Map<string, boolean> {
+  if (declaredCustomEntityRestricted === null) {
     try {
-      const mods = getModules() as Array<{ customEntities?: Array<{ id?: string }> }>
-      if (Array.isArray(mods) && mods.length) {
-        const ids = new Set<string>()
-        for (const mod of mods) {
-          for (const spec of mod?.customEntities ?? []) {
-            if (spec?.id) ids.add(spec.id)
-          }
+      const mods = getModules() as Array<{ customEntities?: Array<{ id?: string; accessRestricted?: boolean }> }>
+      const map = new Map<string, boolean>()
+      for (const mod of mods ?? []) {
+        for (const spec of mod?.customEntities ?? []) {
+          if (spec?.id) map.set(spec.id, spec.accessRestricted === true)
         }
-        declaredCustomEntityIds = ids
       }
+      // Cache even when empty so we don't rebuild on every request (and fall back
+      // to the DB lookup unnecessarily). Only a thrown getModules() leaves it null
+      // so a genuinely-uninitialized registry is retried.
+      declaredCustomEntityRestricted = map
     } catch {}
   }
-  return declaredCustomEntityIds?.has(entityId) ?? false
+  return declaredCustomEntityRestricted ?? new Map<string, boolean>()
+}
+function isDeclaredCustomEntity(entityId: string): boolean {
+  return loadDeclaredCustomEntities().has(entityId)
+}
+
+type RecordsEntityScope = { tenantId: string | null; organizationId: string | null }
+
+// Resolve the CustomEntity registration that applies to THIS caller, most-specific
+// first (org+tenant → tenant-global → instance-global), mirroring the overlay
+// precedence used by the entity-definitions list. Scoping matters because the
+// row's `access_restricted` flag is a security control: an unscoped lookup could
+// read another tenant's row for a colliding entityId (e.g. `user:vendors`) and
+// mis-decide the restriction. Returns null when the caller's scope has no row.
+async function findScopedCustomEntity(em: any, CustomEntity: any, entityId: string, scope: RecordsEntityScope) {
+  const { tenantId, organizationId } = scope
+  const candidates: Array<Record<string, unknown>> = [
+    { entityId, organizationId, tenantId },
+    { entityId, organizationId: null, tenantId },
+    { entityId, organizationId: null, tenantId: null },
+  ]
+  const seen = new Set<string>()
+  for (const where of candidates) {
+    const key = JSON.stringify(where)
+    if (seen.has(key)) continue
+    seen.add(key)
+    const row = await em.findOne(CustomEntity as any, where)
+    if (row) return row
+  }
+  return null
 }
 
 const CUSTOM_ENTITY_RECORD_RESOURCE_KIND = 'entities.record'
 
 type RecordsEntityKind = 'system' | 'custom' | 'unknown'
+
+// `restricted` is meaningful only when `kind === 'custom'`; it drives the
+// per-entity ACL gate in `assertEntityAclForRequest`.
+type RecordsEntityClassification = { kind: RecordsEntityKind; restricted: boolean }
 
 // This surface manages doc-storage records, which exist for CUSTOM entities only.
 // Module-declared ids backed by a registered ORM table are system entities — their
@@ -50,18 +84,25 @@ type RecordsEntityKind = 'system' | 'custom' | 'unknown'
 // previous fallback that classified an entity by the mere presence of
 // `custom_entities_storage` rows is gone: within the allowed set, declaration (ce.ts)
 // or an active `custom_entities` registration is authoritative.
-async function classifyRecordsEntity(em: any, entityId: string): Promise<RecordsEntityKind> {
-  if (isOrmBackedSystemEntityId(em, entityId)) return 'system'
-  if (isDeclaredCustomEntity(entityId)) return 'custom'
+async function classifyRecordsEntity(em: any, entityId: string, scope: RecordsEntityScope): Promise<RecordsEntityClassification> {
+  if (isOrmBackedSystemEntityId(em, entityId)) return { kind: 'system', restricted: false }
+  const declared = loadDeclaredCustomEntities()
+  if (declared.has(entityId)) return { kind: 'custom', restricted: declared.get(entityId) === true }
   try {
     const { CustomEntity } = await import('../data/entities')
-    // Any registration row — active or soft-deleted — proves the id is a custom
-    // entity. Records persist beyond the definition's soft delete (TC-ENTITIES-006)
-    // and must stay readable/deletable, e.g. for the restore flow and cleanup.
-    const found = await em.findOne(CustomEntity as any, { entityId })
-    if (found) return 'custom'
+    // Restriction is decided from the row that applies to THIS caller's scope so
+    // a colliding entityId in another tenant can't flip the flag.
+    const scoped = await findScopedCustomEntity(em, CustomEntity, entityId, scope)
+    if (scoped) return { kind: 'custom', restricted: (scoped as any).accessRestricted === true }
+    // No in-scope registration: preserve the historical custom-vs-unknown
+    // classification (any registration row — active or soft-deleted — proves the
+    // id is custom; records persist beyond soft delete, TC-ENTITIES-006). A row
+    // outside the caller's scope never marks the entity restricted for them, and
+    // the record query is itself tenant/org-scoped, so this cannot leak data.
+    const anyRow = await em.findOne(CustomEntity as any, { entityId })
+    if (anyRow) return { kind: 'custom', restricted: false }
   } catch {}
-  return 'unknown'
+  return { kind: 'unknown', restricted: false }
 }
 
 function systemEntityRecordsRejection(entityId: string) {
@@ -171,10 +212,10 @@ export async function GET(req: Request) {
     // registered in `custom_entities`, so classification checks the declared registry plus
     // active registrations. System (table-backed) ids are rejected above; for the allowed
     // set `isCustomEntity` drives mapRow's cf_ stripping so the edit form reads back values.
-    const entityKind = await classifyRecordsEntity(em, entityId)
+    const { kind: entityKind, restricted: isRestricted } = await classifyRecordsEntity(em, entityId, { tenantId: auth.tenantId ?? null, organizationId: scope.selectedId ?? auth.orgId ?? null })
     if (entityKind === 'system') return systemEntityRecordsRejection(entityId)
     const isCustomEntity = entityKind === 'custom'
-    await assertEntityAclForRequest({ auth, entityId, action: 'view', isCustomEntity, rbac })
+    await assertEntityAclForRequest({ auth, entityId, action: 'view', isCustomEntity, isRestricted, rbac })
     if (organizationIds && organizationIds.length === 0) {
       return NextResponse.json({ items: [], total: 0, page, pageSize, totalPages: 0 })
     }
@@ -395,10 +436,10 @@ export async function POST(req: Request) {
     const scope = await resolveOrganizationScope({ em, rbac, auth, selectedId: getSelectedOrganizationFromRequest(req) })
     const targetOrgId = scope.selectedId ?? auth.orgId
     if (!targetOrgId) return NextResponse.json({ error: 'Organization context is required' }, { status: 400 })
-    const entityKind = await classifyRecordsEntity(em, entityId)
+    const { kind: entityKind, restricted: isRestricted } = await classifyRecordsEntity(em, entityId, { tenantId: auth.tenantId ?? null, organizationId: scope.selectedId ?? auth.orgId ?? null })
     if (entityKind === 'system') return systemEntityRecordsRejection(entityId)
     const isCustomEntity = entityKind === 'custom'
-    await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, rbac })
+    await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, isRestricted, rbac })
     // Strip reserved record/system columns the edit form echoes back from the loaded record
     // (`id`, plus `updated_at`/`updatedAt` used for optimistic locking). They are not custom
     // fields; without this they validate as cf_id / cf_updated_at / cf_updatedAt and are
@@ -469,10 +510,10 @@ export async function PUT(req: Request) {
     const scope = await resolveOrganizationScope({ em, rbac, auth, selectedId: getSelectedOrganizationFromRequest(req) })
     const targetOrgId = scope.selectedId ?? auth.orgId
     if (!targetOrgId) return NextResponse.json({ error: 'Organization context is required' }, { status: 400 })
-    const entityKind = await classifyRecordsEntity(em, entityId)
+    const { kind: entityKind, restricted: isRestricted } = await classifyRecordsEntity(em, entityId, { tenantId: auth.tenantId ?? null, organizationId: scope.selectedId ?? auth.orgId ?? null })
     if (entityKind === 'system') return systemEntityRecordsRejection(entityId)
     const isCustomEntity = entityKind === 'custom'
-    await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, rbac })
+    await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, isRestricted, rbac })
     // Strip reserved record/system columns the edit form echoes back from the loaded record
     // (`id`, plus `updated_at`/`updatedAt` used for optimistic locking). They are not custom
     // fields; without this they validate as cf_id / cf_updated_at / cf_updatedAt and are
@@ -568,10 +609,10 @@ export async function DELETE(req: Request) {
     const scope = await resolveOrganizationScope({ em, rbac, auth, selectedId: getSelectedOrganizationFromRequest(req) })
     const targetOrgId = scope.selectedId ?? auth.orgId
     if (!targetOrgId) return NextResponse.json({ error: 'Organization context is required' }, { status: 400 })
-    const entityKind = await classifyRecordsEntity(em, entityId)
+    const { kind: entityKind, restricted: isRestricted } = await classifyRecordsEntity(em, entityId, { tenantId: auth.tenantId ?? null, organizationId: scope.selectedId ?? auth.orgId ?? null })
     if (entityKind === 'system') return systemEntityRecordsRejection(entityId)
     const isCustomEntity = entityKind === 'custom'
-    await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, rbac })
+    await assertEntityAclForRequest({ auth, entityId, action: 'manage', isCustomEntity, isRestricted, rbac })
 
     try {
       const currentUpdatedAt = await readCustomEntityRecordUpdatedAt(em, {

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/page.tsx
@@ -53,7 +53,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
   const [label, setLabel] = useState('')
   const [entitySource, setEntitySource] = useState<EntitySource>('custom')
   const [entityFormLoading, setEntityFormLoading] = useState(true)
-  const [entityInitial, setEntityInitial] = useState<{ label?: string; description?: string; labelField?: string; defaultEditor?: string; showInSidebar?: boolean; updatedAt?: string }>({})
+  const [entityInitial, setEntityInitial] = useState<{ label?: string; description?: string; labelField?: string; defaultEditor?: string; showInSidebar?: boolean; accessRestricted?: boolean; updatedAt?: string }>({})
   const [defs, setDefs] = useState<Def[]>([])
   const [defsVersion, setDefsVersion] = useState<string | null>(null)
   const [orderDirty, setOrderDirty] = useState(false)
@@ -180,6 +180,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
           const defaultEditorValue =
             typeof record?.defaultEditor === 'string' ? record.defaultEditor : ''
           const showInSidebarValue = record?.showInSidebar === true
+          const accessRestrictedValue = record?.accessRestricted === true
           const updatedAtValue =
             typeof record?.updatedAt === 'string' && record.updatedAt.length > 0 ? record.updatedAt : undefined
           setLabel(labelValue)
@@ -190,6 +191,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
             labelField: labelFieldValue,
             defaultEditor: defaultEditorValue,
             showInSidebar: showInSidebarValue,
+            accessRestricted: accessRestrictedValue,
             updatedAt: updatedAtValue,
           })
           setEntityFormLoading(false)
@@ -419,6 +421,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       defaultEditor: z.union([z.enum(['markdown','simpleMarkdown','htmlRichText']).optional(), z.literal('')]).optional(),
       // Include showInSidebar so CrudForm doesn't strip it on submit
       showInSidebar: z.boolean().optional(),
+      accessRestricted: z.boolean().optional(),
     }) as z.ZodType<Record<string, unknown>>
 
   const metadataFieldsReadOnly = entitySource === 'code'
@@ -438,6 +441,12 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
       ],
     } as any,
     ...(entitySource === 'custom' ? [{ id: 'showInSidebar', label: t('entities.userEntities.form.showInSidebar.label', 'Show in sidebar'), type: 'checkbox' }] : []),
+    ...(entitySource === 'custom' ? [{
+      id: 'accessRestricted',
+      label: t('entities.userEntities.form.accessRestricted.label', 'Restrict record access'),
+      type: 'checkbox',
+      description: t('entities.userEntities.form.accessRestricted.help', 'Require an explicit per-entity permission to view or manage this entity’s records. Leave off to allow anyone with the general records permission.'),
+    }] : []),
   ]
   const renderFieldDefinitions = React.useCallback(() => (
       <FieldDefinitionsEditor
@@ -496,7 +505,7 @@ export default function EditDefinitionsPage({ params }: { params?: { entityId?: 
   const definitionsGroup: CrudFormGroup = { id: 'definitions', title: t('entities.userEntities.edit.groups.definitions', 'Field Definitions'), column: 1, component: renderFieldDefinitions }
 
   const groups: CrudFormGroup[] = [
-    { id: 'settings', title: t('entities.userEntities.edit.groups.settings', 'Entity Settings'), column: 1, fields: entitySource === 'custom' ? ['label','description','defaultEditor','showInSidebar'] : ['label','description','defaultEditor'] },
+    { id: 'settings', title: t('entities.userEntities.edit.groups.settings', 'Entity Settings'), column: 1, fields: entitySource === 'custom' ? ['label','description','defaultEditor','showInSidebar','accessRestricted'] : ['label','description','defaultEditor'] },
     definitionsGroup,
   ]
 
@@ -673,7 +682,7 @@ export function buildEntityMetadataPayload(
   const partial = entitySource === 'custom'
     ? upsertCustomEntitySchema
         .pick({ label: true, description: true, labelField: true as any, defaultEditor: true as any })
-        .extend({ showInSidebar: z.boolean().optional() }) as unknown as z.ZodTypeAny
+        .extend({ showInSidebar: z.boolean().optional(), accessRestricted: z.boolean().optional() }) as unknown as z.ZodTypeAny
     : upsertCustomEntitySchema
         .pick({ label: true, description: true, defaultEditor: true as any }) as unknown as z.ZodTypeAny
   const normalized = {

--- a/packages/core/src/modules/entities/backend/entities/user/create/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/create/page.tsx
@@ -9,6 +9,7 @@ import { upsertCustomEntitySchema } from '@open-mercato/core/modules/entities/da
 import { useRouter } from 'next/navigation'
 import { pushWithFlash } from '@open-mercato/ui/backend/utils/flash'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { LoadingMessage } from '@open-mercato/ui/backend/detail'
 
 const schema = upsertCustomEntitySchema
 
@@ -17,6 +18,21 @@ import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 export default function CreateEntityPage() {
   const t = useT()
   const router = useRouter()
+  // Pre-fill the restriction toggle from the tenant default-restricted policy so
+  // the form reflects the workspace posture; null while loading.
+  const [defaultRestricted, setDefaultRestricted] = React.useState<boolean | null>(null)
+  React.useEffect(() => {
+    let active = true
+    ;(async () => {
+      const data = await readApiResultOrThrow<{ newEntitiesRestrictedByDefault?: boolean }>(
+        '/api/entities/entity-settings',
+        undefined,
+        { errorMessage: '[internal] Failed to load entity settings', fallback: { newEntitiesRestrictedByDefault: false } },
+      ).catch(() => ({ newEntitiesRestrictedByDefault: false }))
+      if (active) setDefaultRestricted(data?.newEntitiesRestrictedByDefault === true)
+    })()
+    return () => { active = false }
+  }, [])
   const fields = React.useMemo<CrudField[]>(() => ([
     {
       id: 'entityId',
@@ -39,7 +55,23 @@ export default function CreateEntityPage() {
       ],
     } as unknown as CrudField,
     { id: 'showInSidebar', label: t('entities.userEntities.form.showInSidebar.label', 'Show in sidebar'), type: 'checkbox' } as CrudField,
+    {
+      id: 'accessRestricted',
+      label: t('entities.userEntities.form.accessRestricted.label', 'Restrict record access'),
+      type: 'checkbox',
+      description: t('entities.userEntities.form.accessRestricted.help', 'Require an explicit per-entity permission to view or manage this entity’s records. Leave off to allow anyone with the general records permission.'),
+    } as CrudField,
   ]), [t])
+
+  if (defaultRestricted === null) {
+    return (
+      <Page>
+        <PageBody>
+          <LoadingMessage label={t('entities.userEntities.form.loading', 'Loading…')} />
+        </PageBody>
+      </Page>
+    )
+  }
 
   return (
     <Page>
@@ -49,7 +81,7 @@ export default function CreateEntityPage() {
           backHref="/backend/entities/user"
           schema={schema}
           fields={fields}
-          initialValues={{ entityId: 'user:your_entity', label: '', showInSidebar: false }}
+          initialValues={{ entityId: 'user:your_entity', label: '', showInSidebar: false, accessRestricted: defaultRestricted }}
           submitLabel={t('entities.userEntities.form.submit', 'Create')}
           cancelHref="/backend/entities/user"
           onSubmit={async (vals) => {

--- a/packages/core/src/modules/entities/data/entities.ts
+++ b/packages/core/src/modules/entities/data/entities.ts
@@ -136,6 +136,12 @@ export class CustomEntity {
   @Property({ name: 'show_in_sidebar', type: 'boolean', default: false })
   showInSidebar: boolean = false
 
+  // When true, records require an explicit per-entity ACL grant
+  // (entities.records.<entity_id>.view/.manage) beyond the coarse
+  // entities.records.* feature. Defaults to unrestricted for backward compat.
+  @Property({ name: 'access_restricted', type: 'boolean', default: false })
+  accessRestricted: boolean = false
+
   // Note: Per-field UI preferences (list visibility, filter visibility, form editability)
   // are stored in CustomFieldDef.configJson, not at entity level.
 

--- a/packages/core/src/modules/entities/i18n/de.json
+++ b/packages/core/src/modules/entities/i18n/de.json
@@ -231,6 +231,8 @@
   "entities.userEntities.form.entityId.placeholder": "module_name:entity_id",
   "entities.userEntities.form.label.label": "Bezeichnung",
   "entities.userEntities.form.showInSidebar.label": "In der Seitenleiste anzeigen",
+  "entities.userEntities.form.accessRestricted.label": "Datensatzzugriff einschränken",
+  "entities.userEntities.form.accessRestricted.help": "Erfordert eine explizite entitätsspezifische Berechtigung zum Anzeigen oder Verwalten der Datensätze dieser Entität. Deaktiviert lassen, um allen Benutzern mit der allgemeinen Datensatzberechtigung Zugriff zu gewähren.",
   "entities.userEntities.form.submit": "Erstellen",
   "entities.userEntities.form.title": "Entität erstellen",
   "entities.userEntities.records.errors.deleteFailed": "Datensatz konnte nicht gelöscht werden",
@@ -241,5 +243,6 @@
   "entities.userEntities.records.form.editTitle": "Datensatz bearbeiten",
   "entities.userEntities.records.form.submitCreate": "Erstellen",
   "entities.userEntities.records.form.submitSave": "Speichern",
-  "entities.userEntities.records.loading": "Datensatz wird geladen..."
+  "entities.userEntities.records.loading": "Datensatz wird geladen...",
+  "entities.userEntities.form.loading": "Wird geladen…"
 }

--- a/packages/core/src/modules/entities/i18n/de.json
+++ b/packages/core/src/modules/entities/i18n/de.json
@@ -221,6 +221,8 @@
   "entities.userEntities.errors.entityIdRequired": "Entitäts-ID ist erforderlich",
   "entities.userEntities.errors.loadFailed": "Entitäten konnten nicht geladen werden",
   "entities.userEntities.flash.created": "Entität erstellt",
+  "entities.userEntities.form.accessRestricted.help": "Erfordert eine explizite entitätsspezifische Berechtigung zum Anzeigen oder Verwalten der Datensätze dieser Entität. Deaktiviert lassen, um allen Benutzern mit der allgemeinen Datensatzberechtigung Zugriff zu gewähren.",
+  "entities.userEntities.form.accessRestricted.label": "Datensatzzugriff einschränken",
   "entities.userEntities.form.defaultEditor.label": "Standardeditor (mehrzeilig)",
   "entities.userEntities.form.defaultEditor.options.default": "Standard (Markdown)",
   "entities.userEntities.form.defaultEditor.options.htmlRichText": "HTML-Rich-Text",
@@ -230,9 +232,8 @@
   "entities.userEntities.form.entityId.label": "Entitäts-ID",
   "entities.userEntities.form.entityId.placeholder": "module_name:entity_id",
   "entities.userEntities.form.label.label": "Bezeichnung",
+  "entities.userEntities.form.loading": "Wird geladen…",
   "entities.userEntities.form.showInSidebar.label": "In der Seitenleiste anzeigen",
-  "entities.userEntities.form.accessRestricted.label": "Datensatzzugriff einschränken",
-  "entities.userEntities.form.accessRestricted.help": "Erfordert eine explizite entitätsspezifische Berechtigung zum Anzeigen oder Verwalten der Datensätze dieser Entität. Deaktiviert lassen, um allen Benutzern mit der allgemeinen Datensatzberechtigung Zugriff zu gewähren.",
   "entities.userEntities.form.submit": "Erstellen",
   "entities.userEntities.form.title": "Entität erstellen",
   "entities.userEntities.records.errors.deleteFailed": "Datensatz konnte nicht gelöscht werden",
@@ -243,6 +244,5 @@
   "entities.userEntities.records.form.editTitle": "Datensatz bearbeiten",
   "entities.userEntities.records.form.submitCreate": "Erstellen",
   "entities.userEntities.records.form.submitSave": "Speichern",
-  "entities.userEntities.records.loading": "Datensatz wird geladen...",
-  "entities.userEntities.form.loading": "Wird geladen…"
+  "entities.userEntities.records.loading": "Datensatz wird geladen..."
 }

--- a/packages/core/src/modules/entities/i18n/en.json
+++ b/packages/core/src/modules/entities/i18n/en.json
@@ -221,6 +221,8 @@
   "entities.userEntities.errors.entityIdRequired": "Entity ID is required",
   "entities.userEntities.errors.loadFailed": "Failed to load entities",
   "entities.userEntities.flash.created": "Entity created",
+  "entities.userEntities.form.accessRestricted.help": "Require an explicit per-entity permission to view or manage this entity’s records. Leave off to allow anyone with the general records permission.",
+  "entities.userEntities.form.accessRestricted.label": "Restrict record access",
   "entities.userEntities.form.defaultEditor.label": "Default Editor (multiline)",
   "entities.userEntities.form.defaultEditor.options.default": "Default (Markdown)",
   "entities.userEntities.form.defaultEditor.options.htmlRichText": "HTML Rich Text",
@@ -230,9 +232,8 @@
   "entities.userEntities.form.entityId.label": "Entity ID",
   "entities.userEntities.form.entityId.placeholder": "module_name:entity_id",
   "entities.userEntities.form.label.label": "Label",
+  "entities.userEntities.form.loading": "Loading…",
   "entities.userEntities.form.showInSidebar.label": "Show in sidebar",
-  "entities.userEntities.form.accessRestricted.label": "Restrict record access",
-  "entities.userEntities.form.accessRestricted.help": "Require an explicit per-entity permission to view or manage this entity’s records. Leave off to allow anyone with the general records permission.",
   "entities.userEntities.form.submit": "Create",
   "entities.userEntities.form.title": "Create Entity",
   "entities.userEntities.records.errors.deleteFailed": "Failed to delete record",
@@ -243,6 +244,5 @@
   "entities.userEntities.records.form.editTitle": "Edit record",
   "entities.userEntities.records.form.submitCreate": "Create",
   "entities.userEntities.records.form.submitSave": "Save",
-  "entities.userEntities.records.loading": "Loading record...",
-  "entities.userEntities.form.loading": "Loading…"
+  "entities.userEntities.records.loading": "Loading record..."
 }

--- a/packages/core/src/modules/entities/i18n/en.json
+++ b/packages/core/src/modules/entities/i18n/en.json
@@ -231,6 +231,8 @@
   "entities.userEntities.form.entityId.placeholder": "module_name:entity_id",
   "entities.userEntities.form.label.label": "Label",
   "entities.userEntities.form.showInSidebar.label": "Show in sidebar",
+  "entities.userEntities.form.accessRestricted.label": "Restrict record access",
+  "entities.userEntities.form.accessRestricted.help": "Require an explicit per-entity permission to view or manage this entity’s records. Leave off to allow anyone with the general records permission.",
   "entities.userEntities.form.submit": "Create",
   "entities.userEntities.form.title": "Create Entity",
   "entities.userEntities.records.errors.deleteFailed": "Failed to delete record",
@@ -241,5 +243,6 @@
   "entities.userEntities.records.form.editTitle": "Edit record",
   "entities.userEntities.records.form.submitCreate": "Create",
   "entities.userEntities.records.form.submitSave": "Save",
-  "entities.userEntities.records.loading": "Loading record..."
+  "entities.userEntities.records.loading": "Loading record...",
+  "entities.userEntities.form.loading": "Loading…"
 }

--- a/packages/core/src/modules/entities/i18n/es.json
+++ b/packages/core/src/modules/entities/i18n/es.json
@@ -221,6 +221,8 @@
   "entities.userEntities.errors.entityIdRequired": "El ID de la entidad es obligatorio",
   "entities.userEntities.errors.loadFailed": "No se pudieron cargar las entidades",
   "entities.userEntities.flash.created": "Entidad creada",
+  "entities.userEntities.form.accessRestricted.help": "Requiere un permiso explícito por entidad para ver o gestionar los registros de esta entidad. Déjalo desactivado para permitir el acceso a cualquiera con el permiso general de registros.",
+  "entities.userEntities.form.accessRestricted.label": "Restringir acceso a registros",
   "entities.userEntities.form.defaultEditor.label": "Editor predeterminado (multilínea)",
   "entities.userEntities.form.defaultEditor.options.default": "Predeterminado (Markdown)",
   "entities.userEntities.form.defaultEditor.options.htmlRichText": "HTML enriquecido",
@@ -230,9 +232,8 @@
   "entities.userEntities.form.entityId.label": "ID de la entidad",
   "entities.userEntities.form.entityId.placeholder": "nombre_modulo:id_entidad",
   "entities.userEntities.form.label.label": "Etiqueta",
+  "entities.userEntities.form.loading": "Cargando…",
   "entities.userEntities.form.showInSidebar.label": "Mostrar en la barra lateral",
-  "entities.userEntities.form.accessRestricted.label": "Restringir acceso a registros",
-  "entities.userEntities.form.accessRestricted.help": "Requiere un permiso explícito por entidad para ver o gestionar los registros de esta entidad. Déjalo desactivado para permitir el acceso a cualquiera con el permiso general de registros.",
   "entities.userEntities.form.submit": "Crear",
   "entities.userEntities.form.title": "Crear entidad",
   "entities.userEntities.records.errors.deleteFailed": "No se pudo eliminar el registro",
@@ -243,6 +244,5 @@
   "entities.userEntities.records.form.editTitle": "Editar registro",
   "entities.userEntities.records.form.submitCreate": "Crear",
   "entities.userEntities.records.form.submitSave": "Guardar",
-  "entities.userEntities.records.loading": "Cargando registro...",
-  "entities.userEntities.form.loading": "Cargando…"
+  "entities.userEntities.records.loading": "Cargando registro..."
 }

--- a/packages/core/src/modules/entities/i18n/es.json
+++ b/packages/core/src/modules/entities/i18n/es.json
@@ -231,6 +231,8 @@
   "entities.userEntities.form.entityId.placeholder": "nombre_modulo:id_entidad",
   "entities.userEntities.form.label.label": "Etiqueta",
   "entities.userEntities.form.showInSidebar.label": "Mostrar en la barra lateral",
+  "entities.userEntities.form.accessRestricted.label": "Restringir acceso a registros",
+  "entities.userEntities.form.accessRestricted.help": "Requiere un permiso explícito por entidad para ver o gestionar los registros de esta entidad. Déjalo desactivado para permitir el acceso a cualquiera con el permiso general de registros.",
   "entities.userEntities.form.submit": "Crear",
   "entities.userEntities.form.title": "Crear entidad",
   "entities.userEntities.records.errors.deleteFailed": "No se pudo eliminar el registro",
@@ -241,5 +243,6 @@
   "entities.userEntities.records.form.editTitle": "Editar registro",
   "entities.userEntities.records.form.submitCreate": "Crear",
   "entities.userEntities.records.form.submitSave": "Guardar",
-  "entities.userEntities.records.loading": "Cargando registro..."
+  "entities.userEntities.records.loading": "Cargando registro...",
+  "entities.userEntities.form.loading": "Cargando…"
 }

--- a/packages/core/src/modules/entities/i18n/pl.json
+++ b/packages/core/src/modules/entities/i18n/pl.json
@@ -221,6 +221,8 @@
   "entities.userEntities.errors.entityIdRequired": "Identyfikator encji jest wymagany",
   "entities.userEntities.errors.loadFailed": "Nie udało się wczytać encji",
   "entities.userEntities.flash.created": "Encja została utworzona",
+  "entities.userEntities.form.accessRestricted.help": "Wymaga jawnego uprawnienia dla tej encji, aby przeglądać lub zarządzać jej rekordami. Pozostaw wyłączone, aby zezwolić na dostęp każdemu z ogólnym uprawnieniem do rekordów.",
+  "entities.userEntities.form.accessRestricted.label": "Ogranicz dostęp do rekordów",
   "entities.userEntities.form.defaultEditor.label": "Domyślny edytor (wiele linii)",
   "entities.userEntities.form.defaultEditor.options.default": "Domyślne (Markdown)",
   "entities.userEntities.form.defaultEditor.options.htmlRichText": "HTML Rich Text",
@@ -230,9 +232,8 @@
   "entities.userEntities.form.entityId.label": "Identyfikator encji",
   "entities.userEntities.form.entityId.placeholder": "module_name:entity_id",
   "entities.userEntities.form.label.label": "Etykieta",
+  "entities.userEntities.form.loading": "Ładowanie…",
   "entities.userEntities.form.showInSidebar.label": "Pokaż w panelu bocznym",
-  "entities.userEntities.form.accessRestricted.label": "Ogranicz dostęp do rekordów",
-  "entities.userEntities.form.accessRestricted.help": "Wymaga jawnego uprawnienia dla tej encji, aby przeglądać lub zarządzać jej rekordami. Pozostaw wyłączone, aby zezwolić na dostęp każdemu z ogólnym uprawnieniem do rekordów.",
   "entities.userEntities.form.submit": "Utwórz",
   "entities.userEntities.form.title": "Utwórz encję",
   "entities.userEntities.records.errors.deleteFailed": "Nie udało się usunąć rekordu",
@@ -243,6 +244,5 @@
   "entities.userEntities.records.form.editTitle": "Edytuj rekord",
   "entities.userEntities.records.form.submitCreate": "Utwórz",
   "entities.userEntities.records.form.submitSave": "Zapisz",
-  "entities.userEntities.records.loading": "Wczytywanie rekordu...",
-  "entities.userEntities.form.loading": "Ładowanie…"
+  "entities.userEntities.records.loading": "Wczytywanie rekordu..."
 }

--- a/packages/core/src/modules/entities/i18n/pl.json
+++ b/packages/core/src/modules/entities/i18n/pl.json
@@ -231,6 +231,8 @@
   "entities.userEntities.form.entityId.placeholder": "module_name:entity_id",
   "entities.userEntities.form.label.label": "Etykieta",
   "entities.userEntities.form.showInSidebar.label": "Pokaż w panelu bocznym",
+  "entities.userEntities.form.accessRestricted.label": "Ogranicz dostęp do rekordów",
+  "entities.userEntities.form.accessRestricted.help": "Wymaga jawnego uprawnienia dla tej encji, aby przeglądać lub zarządzać jej rekordami. Pozostaw wyłączone, aby zezwolić na dostęp każdemu z ogólnym uprawnieniem do rekordów.",
   "entities.userEntities.form.submit": "Utwórz",
   "entities.userEntities.form.title": "Utwórz encję",
   "entities.userEntities.records.errors.deleteFailed": "Nie udało się usunąć rekordu",
@@ -241,5 +243,6 @@
   "entities.userEntities.records.form.editTitle": "Edytuj rekord",
   "entities.userEntities.records.form.submitCreate": "Utwórz",
   "entities.userEntities.records.form.submitSave": "Zapisz",
-  "entities.userEntities.records.loading": "Wczytywanie rekordu..."
+  "entities.userEntities.records.loading": "Wczytywanie rekordu...",
+  "entities.userEntities.form.loading": "Ładowanie…"
 }

--- a/packages/core/src/modules/entities/lib/__tests__/entityAcl.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/entityAcl.test.ts
@@ -158,7 +158,7 @@ describe('assertEntityAclForRequest', () => {
     ).resolves.toBeUndefined()
   })
 
-  test('always passes for a custom entity without consulting the ACL', async () => {
+  test('an unrestricted custom entity passes without consulting the ACL', async () => {
     const rbac = makeRbac({ isSuperAdmin: false, features: [], organizations: null })
 
     await expect(
@@ -167,9 +167,85 @@ describe('assertEntityAclForRequest', () => {
         entityId: 'custom:thing',
         action: 'manage',
         isCustomEntity: true,
+        isRestricted: false,
         rbac: rbac as never,
       }),
     ).resolves.toBeUndefined()
     expect(rbac.loadAcl).not.toHaveBeenCalled()
+  })
+
+  test('a restricted custom entity is denied when the per-entity feature is missing', async () => {
+    const rbac = makeRbac({ isSuperAdmin: false, features: ['entities.records.view', 'entities.records.manage'], organizations: null })
+
+    await expect(
+      assertEntityAclForRequest({
+        auth: baseAuth,
+        entityId: 'hr:salaries',
+        action: 'view',
+        isCustomEntity: true,
+        isRestricted: true,
+        rbac: rbac as never,
+      }),
+    ).rejects.toMatchObject({ status: 403 })
+  })
+
+  test('a restricted custom entity is allowed with the exact per-entity feature', async () => {
+    const rbac = makeRbac({ isSuperAdmin: false, features: ['entities.records.manage', 'entities.records.hr:salaries.manage'], organizations: null })
+
+    await expect(
+      assertEntityAclForRequest({
+        auth: baseAuth,
+        entityId: 'hr:salaries',
+        action: 'manage',
+        isCustomEntity: true,
+        isRestricted: true,
+        rbac: rbac as never,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  test('a restricted custom entity is satisfied by the entities.records.* wildcard', async () => {
+    const rbac = makeRbac({ isSuperAdmin: false, features: ['entities.records.*'], organizations: null })
+
+    await expect(
+      assertEntityAclForRequest({
+        auth: baseAuth,
+        entityId: 'hr:salaries',
+        action: 'view',
+        isCustomEntity: true,
+        isRestricted: true,
+        rbac: rbac as never,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  test('a restricted custom entity is allowed for a superadmin', async () => {
+    const rbac = makeRbac({ isSuperAdmin: true, features: ['*'], organizations: null })
+
+    await expect(
+      assertEntityAclForRequest({
+        auth: baseAuth,
+        entityId: 'hr:salaries',
+        action: 'manage',
+        isCustomEntity: true,
+        isRestricted: true,
+        rbac: rbac as never,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  test('granting one restricted entity does not grant another', async () => {
+    const rbac = makeRbac({ isSuperAdmin: false, features: ['entities.records.view', 'entities.records.user:vendors.view'], organizations: null })
+
+    await expect(
+      assertEntityAclForRequest({
+        auth: baseAuth,
+        entityId: 'hr:salaries',
+        action: 'view',
+        isCustomEntity: true,
+        isRestricted: true,
+        rbac: rbac as never,
+      }),
+    ).rejects.toMatchObject({ status: 403 })
   })
 })

--- a/packages/core/src/modules/entities/lib/__tests__/recordFeatures.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/recordFeatures.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment node */
+
+import {
+  coarseRecordFeature,
+  deriveCustomEntityRecordFeature,
+  synthesizedRecordFeatures,
+  RECORDS_VIEW_FEATURE,
+  RECORDS_MANAGE_FEATURE,
+} from '@open-mercato/core/modules/entities/lib/recordFeatures'
+import { matchFeature, hasAllFeatures } from '@open-mercato/shared/security/features'
+
+describe('recordFeatures deriver', () => {
+  test('coarse features are the entity-agnostic route features', () => {
+    expect(coarseRecordFeature('view')).toBe('entities.records.view')
+    expect(coarseRecordFeature('manage')).toBe('entities.records.manage')
+  })
+
+  test('derives a stable per-entity feature keyed on entityId', () => {
+    expect(deriveCustomEntityRecordFeature('hr:salaries', 'view')).toBe('entities.records.hr:salaries.view')
+    expect(deriveCustomEntityRecordFeature('hr:salaries', 'manage')).toBe('entities.records.hr:salaries.manage')
+    expect(deriveCustomEntityRecordFeature('user:vendors', 'view')).toBe('entities.records.user:vendors.view')
+  })
+
+  test('coarse grant does NOT satisfy a per-entity feature (compartmentalization)', () => {
+    const required = deriveCustomEntityRecordFeature('hr:salaries', 'view')
+    expect(matchFeature(required, RECORDS_VIEW_FEATURE)).toBe(false)
+    expect(hasAllFeatures([RECORDS_VIEW_FEATURE], [required])).toBe(false)
+  })
+
+  test('the exact per-entity grant satisfies the requirement', () => {
+    const required = deriveCustomEntityRecordFeature('hr:salaries', 'manage')
+    expect(hasAllFeatures([required], [required])).toBe(true)
+  })
+
+  test('records and module wildcards satisfy per-entity features; global too', () => {
+    const required = deriveCustomEntityRecordFeature('hr:salaries', 'view')
+    expect(matchFeature(required, 'entities.records.*')).toBe(true)
+    expect(matchFeature(required, 'entities.*')).toBe(true)
+    expect(matchFeature(required, '*')).toBe(true)
+  })
+
+  test('an entityId with a colon stays a single segment (no cross-entity leakage)', () => {
+    const salaries = deriveCustomEntityRecordFeature('hr:salaries', 'view')
+    const vendors = deriveCustomEntityRecordFeature('user:vendors', 'view')
+    // Granting one entity must not satisfy another.
+    expect(hasAllFeatures([vendors], [salaries])).toBe(false)
+    // A wildcard scoped to a different concrete entity path must not match.
+    expect(matchFeature(salaries, 'entities.records.user:vendors.*')).toBe(false)
+  })
+
+  test('synthesized features carry coarse prerequisites in dependsOn', () => {
+    const [view, manage] = synthesizedRecordFeatures('hr:salaries')
+    expect(view).toEqual({
+      id: 'entities.records.hr:salaries.view',
+      action: 'view',
+      dependsOn: [RECORDS_VIEW_FEATURE],
+    })
+    expect(manage).toEqual({
+      id: 'entities.records.hr:salaries.manage',
+      action: 'manage',
+      dependsOn: ['entities.records.hr:salaries.view', RECORDS_MANAGE_FEATURE],
+    })
+  })
+})

--- a/packages/core/src/modules/entities/lib/__tests__/restrictedEntityFeatures.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/restrictedEntityFeatures.test.ts
@@ -1,0 +1,88 @@
+/** @jest-environment node */
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  getModules: jest.fn(),
+}))
+
+import { synthesizeRestrictedEntityFeatures } from '@open-mercato/core/modules/entities/lib/restrictedEntityFeatures'
+import { getModules } from '@open-mercato/shared/lib/i18n/server'
+
+const mockGetModules = getModules as jest.Mock
+
+// Minimal kysely stub: records the where() calls and returns the seeded rows.
+function makeEm(rows: Array<{ entity_id: string; label?: string }>) {
+  const calls: Array<[string, string, unknown]> = []
+  const builder: any = {
+    select: () => builder,
+    where: (col: unknown, op?: unknown, val?: unknown) => {
+      if (typeof col === 'string') calls.push([col, String(op), val])
+      // support the eb(...)/eb.or(...) callback form used for tenant scope
+      if (typeof col === 'function') {
+        const eb: any = (...args: unknown[]) => { calls.push(['eb', String(args[0]), args[2]]); return eb }
+        eb.or = () => builder
+        eb.and = () => builder
+        ;(col as (eb: unknown) => unknown)(eb)
+      }
+      return builder
+    },
+    execute: async () => rows,
+  }
+  const kysely = { selectFrom: () => builder }
+  return { em: { getKysely: () => kysely }, calls }
+}
+
+describe('synthesizeRestrictedEntityFeatures', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetModules.mockReturnValue([])
+  })
+
+  it('returns nothing without a tenant', async () => {
+    const { em } = makeEm([])
+    expect(await synthesizeRestrictedEntityFeatures(em, null)).toEqual([])
+  })
+
+  it('synthesizes view+manage features for a registered restricted entity', async () => {
+    const { em } = makeEm([{ entity_id: 'hr:salaries', label: 'Salaries' }])
+    const items = await synthesizeRestrictedEntityFeatures(em, 't1')
+    expect(items).toEqual([
+      {
+        id: 'entities.records.hr:salaries.view',
+        title: 'View records: Salaries',
+        module: 'entities',
+        dependsOn: ['entities.records.view'],
+      },
+      {
+        id: 'entities.records.hr:salaries.manage',
+        title: 'Manage records: Salaries',
+        module: 'entities',
+        dependsOn: ['entities.records.hr:salaries.view', 'entities.records.manage'],
+      },
+    ])
+  })
+
+  it('includes module-declared (ce.ts) restricted entities', async () => {
+    mockGetModules.mockReturnValue([
+      { customEntities: [{ id: 'board:minutes', label: 'Board Minutes', accessRestricted: true }, { id: 'crm:vendors', label: 'Vendors' }] },
+    ])
+    const { em } = makeEm([])
+    const items = await synthesizeRestrictedEntityFeatures(em, 't1')
+    const ids = items.map((i) => i.id)
+    expect(ids).toContain('entities.records.board:minutes.view')
+    expect(ids).not.toContain('entities.records.crm:vendors.view') // not flagged
+  })
+
+  it('dedupes when an entity is both declared and registered', async () => {
+    mockGetModules.mockReturnValue([{ customEntities: [{ id: 'hr:salaries', label: 'Salaries', accessRestricted: true }] }])
+    const { em } = makeEm([{ entity_id: 'hr:salaries', label: 'Salaries (registered)' }])
+    const items = await synthesizeRestrictedEntityFeatures(em, 't1')
+    expect(items.filter((i) => i.id === 'entities.records.hr:salaries.view')).toHaveLength(1)
+  })
+
+  it('never throws — returns declared features even if the DB read fails', async () => {
+    mockGetModules.mockReturnValue([{ customEntities: [{ id: 'hr:salaries', label: 'Salaries', accessRestricted: true }] }])
+    const em = { getKysely: () => { throw new Error('db down') } }
+    const items = await synthesizeRestrictedEntityFeatures(em, 't1')
+    expect(items.map((i) => i.id)).toContain('entities.records.hr:salaries.view')
+  })
+})

--- a/packages/core/src/modules/entities/lib/entityAcl.ts
+++ b/packages/core/src/modules/entities/lib/entityAcl.ts
@@ -1,6 +1,7 @@
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { hasAllFeatures } from '@open-mercato/shared/security/features'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import { deriveCustomEntityRecordFeature } from './recordFeatures'
 
 export type EntityAclRequirement = {
   view: string[]
@@ -80,6 +81,10 @@ type AssertEntityAclArgs = {
   entityId: string
   action: 'view' | 'manage'
   isCustomEntity: boolean
+  // Set for a custom entity flagged `access_restricted`. When true, the coarse
+  // route-level entities.records.* feature is no longer sufficient — the caller
+  // must additionally hold the synthesized per-entity feature.
+  isRestricted?: boolean
   rbac: RbacService
 }
 
@@ -87,15 +92,32 @@ function forbiddenEntityAccess(): CrudHttpError {
   return new CrudHttpError(403, { error: 'Forbidden' })
 }
 
-export async function assertEntityAclForRequest(args: AssertEntityAclArgs): Promise<void> {
-  if (args.isCustomEntity) return
-
-  const requirement = resolveEntityAclRequirement(args.entityId)
-
-  const acl = await args.rbac.loadAcl(args.auth.sub ?? '', {
+async function loadActorAcl(args: AssertEntityAclArgs) {
+  return args.rbac.loadAcl(args.auth.sub ?? '', {
     tenantId: args.auth.tenantId ?? null,
     organizationId: args.auth.orgId ?? null,
   })
+}
+
+export async function assertEntityAclForRequest(args: AssertEntityAclArgs): Promise<void> {
+  if (args.isCustomEntity) {
+    // Unrestricted custom entities keep the historical behavior: the coarse
+    // entities.records.view/.manage route guard is the whole authorization.
+    if (!args.isRestricted) return
+
+    const acl = await loadActorAcl(args)
+    if (acl?.isSuperAdmin) return
+
+    const required = deriveCustomEntityRecordFeature(args.entityId, args.action)
+    if (!hasAllFeatures(acl?.features, [required])) {
+      throw forbiddenEntityAccess()
+    }
+    return
+  }
+
+  const requirement = resolveEntityAclRequirement(args.entityId)
+
+  const acl = await loadActorAcl(args)
 
   if (acl?.isSuperAdmin) return
 

--- a/packages/core/src/modules/entities/lib/install-from-ce.ts
+++ b/packages/core/src/modules/entities/lib/install-from-ce.ts
@@ -148,6 +148,7 @@ function buildChecksumPayload(params: {
     labelField: spec?.labelField ?? null,
     defaultEditor: spec?.defaultEditor ?? null,
     showInSidebar: spec?.showInSidebar ?? false,
+    accessRestricted: spec?.accessRestricted ?? false,
     fields: fields.map((f) => normalizeField(f)),
   }
 }
@@ -244,6 +245,7 @@ export async function installCustomEntitiesFromModules(
           organizationId: null,
           tenantId: scope.tenantId,
           showInSidebar: spec?.showInSidebar ?? false,
+          accessRestricted: spec?.accessRestricted ?? false,
           labelField: spec?.labelField ?? null,
           defaultEditor: spec?.defaultEditor ?? null,
           isActive: true,

--- a/packages/core/src/modules/entities/lib/recordFeatures.ts
+++ b/packages/core/src/modules/entities/lib/recordFeatures.ts
@@ -1,0 +1,48 @@
+// Pure, dependency-free helpers describing the ACL features that gate
+// custom-entity records. Kept import-free so both the enforcement path
+// (`entityAcl.ts`) and the feature catalog (`auth/api/features.ts`) can derive
+// the SAME feature id without coupling to each other or to the ORM.
+//
+// Coarse (route-level) features stay entity-agnostic:
+//   entities.records.view   — read any non-restricted custom entity's records
+//   entities.records.manage — write any non-restricted custom entity's records
+//
+// A custom entity flagged `access_restricted` ALSO requires a synthesized
+// per-entity feature keyed on its immutable entityId:
+//   entities.records.<entityId>.view
+//   entities.records.<entityId>.manage
+//
+// entityId always matches `^[a-z0-9_]+:[a-z0-9_]+$` (it contains a `:` and no
+// `.`), so it can never collide with the coarse `view`/`manage` segments and
+// stays a single dotted segment for the wildcard matcher.
+
+export type RecordsAction = 'view' | 'manage'
+
+export const RECORDS_VIEW_FEATURE = 'entities.records.view'
+export const RECORDS_MANAGE_FEATURE = 'entities.records.manage'
+
+export function coarseRecordFeature(action: RecordsAction): string {
+  return action === 'manage' ? RECORDS_MANAGE_FEATURE : RECORDS_VIEW_FEATURE
+}
+
+export function deriveCustomEntityRecordFeature(entityId: string, action: RecordsAction): string {
+  return `entities.records.${entityId}.${action}`
+}
+
+export type SynthesizedRecordFeature = {
+  id: string
+  action: RecordsAction
+  dependsOn: string[]
+}
+
+// The per-entity features an admin can grant for a restricted custom entity.
+// `dependsOn` mirrors the coarse prerequisite composition: the per-entity grant
+// is meaningful only alongside the coarse route-level feature.
+export function synthesizedRecordFeatures(entityId: string): SynthesizedRecordFeature[] {
+  const view = deriveCustomEntityRecordFeature(entityId, 'view')
+  const manage = deriveCustomEntityRecordFeature(entityId, 'manage')
+  return [
+    { id: view, action: 'view', dependsOn: [RECORDS_VIEW_FEATURE] },
+    { id: manage, action: 'manage', dependsOn: [view, RECORDS_MANAGE_FEATURE] },
+  ]
+}

--- a/packages/core/src/modules/entities/lib/register.ts
+++ b/packages/core/src/modules/entities/lib/register.ts
@@ -7,6 +7,7 @@ export type UpsertEntityOptions = {
   organizationId?: string | null
   tenantId?: string | null
   showInSidebar?: boolean
+  accessRestricted?: boolean
   labelField?: string | null
   defaultEditor?: string | null
   isActive?: boolean
@@ -29,6 +30,7 @@ export async function upsertCustomEntity(em: EntityManager, entityId: string, op
     description: opts.description ?? null,
     isActive: opts.isActive ?? true,
     showInSidebar: !!opts.showInSidebar,
+    accessRestricted: !!opts.accessRestricted,
     labelField: opts.labelField ?? null,
     defaultEditor: opts.defaultEditor ?? null,
   }
@@ -40,6 +42,7 @@ export async function upsertCustomEntity(em: EntityManager, entityId: string, op
     ent.description = desired.description
     ent.isActive = desired.isActive
     ent.showInSidebar = desired.showInSidebar
+    ent.accessRestricted = desired.accessRestricted
     ent.labelField = desired.labelField
     ent.defaultEditor = desired.defaultEditor
     ent.updatedAt = new Date()
@@ -51,6 +54,7 @@ export async function upsertCustomEntity(em: EntityManager, entityId: string, op
     if ((ent.description ?? null) !== desired.description) return true
     if ((ent.isActive ?? true) !== desired.isActive) return true
     if ((ent.showInSidebar ?? false) !== desired.showInSidebar) return true
+    if ((ent.accessRestricted ?? false) !== desired.accessRestricted) return true
     if ((ent.labelField ?? null) !== desired.labelField) return true
     if ((ent.defaultEditor ?? null) !== desired.defaultEditor) return true
     if (ent.deletedAt != null) return true

--- a/packages/core/src/modules/entities/lib/restrictedEntityFeatures.ts
+++ b/packages/core/src/modules/entities/lib/restrictedEntityFeatures.ts
@@ -1,0 +1,98 @@
+import { getModules } from '@open-mercato/shared/lib/i18n/server'
+import { synthesizedRecordFeatures } from './recordFeatures'
+
+export type SynthesizedFeatureItem = {
+  id: string
+  title: string
+  module: string
+  dependsOn?: string[]
+}
+
+type RestrictedEntity = { entityId: string; label: string }
+
+type DeclaredEntities = { restricted: RestrictedEntity[]; ids: Set<string> }
+
+// Reads module-declared (ce.ts) custom entities. `restricted` holds those flagged
+// accessRestricted; `ids` holds ALL declared ids so the DB path can defer to the
+// declaration — the declared registry is authoritative for its own ids, matching
+// the records-route enforcement precedence (declared wins over the DB row).
+function declaredEntities(): DeclaredEntities {
+  const restricted: RestrictedEntity[] = []
+  const ids = new Set<string>()
+  try {
+    const mods = getModules() as Array<{
+      customEntities?: Array<{ id?: string; label?: string; accessRestricted?: boolean }>
+    }>
+    for (const mod of mods || []) {
+      for (const spec of mod?.customEntities ?? []) {
+        if (!spec?.id) continue
+        ids.add(spec.id)
+        if (spec.accessRestricted === true) restricted.push({ entityId: spec.id, label: spec.label || spec.id })
+      }
+    }
+  } catch {}
+  return { restricted, ids }
+}
+
+// Reads user-registered custom entities flagged access_restricted for the given
+// tenant scope. Uses the raw table (not the ORM class) to keep this helper cheap
+// and avoid pulling entity metadata into unrelated callers.
+async function registeredRestrictedEntities(em: any, tenantId: string): Promise<RestrictedEntity[]> {
+  try {
+    const db = em.getKysely()
+    const rows = await db
+      .selectFrom('custom_entities' as any)
+      .select(['entity_id' as any, 'label' as any])
+      .where('access_restricted' as any, '=', true)
+      .where('deleted_at' as any, 'is', null as any)
+      .where((eb: any) =>
+        eb.or([
+          eb('tenant_id' as any, '=', tenantId),
+          eb('tenant_id' as any, 'is', null as any),
+        ]),
+      )
+      .execute()
+    return (rows as Array<{ entity_id?: unknown; label?: unknown }>).map((row) => ({
+      entityId: String(row.entity_id ?? ''),
+      label: typeof row.label === 'string' && row.label.length ? row.label : String(row.entity_id ?? ''),
+    })).filter((row) => row.entityId.length > 0)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Feature-catalog contribution for restricted custom entities: two synthesized
+ * per-entity features (view/manage) per restricted entity in the tenant scope,
+ * so admins can grant them in the Role/User ACL editor. Fails safe (returns what
+ * it can) — never throws — so the static feature catalog is unaffected on error.
+ */
+export async function synthesizeRestrictedEntityFeatures(
+  em: any,
+  tenantId: string | null | undefined,
+): Promise<SynthesizedFeatureItem[]> {
+  if (!tenantId) return []
+  const declared = declaredEntities()
+  const byEntityId = new Map<string, RestrictedEntity>()
+  for (const entity of declared.restricted) byEntityId.set(entity.entityId, entity)
+  // DB rows are authoritative only for ids the declared registry does not own, so
+  // the catalog and the records-route enforcement agree on the same source.
+  for (const entity of await registeredRestrictedEntities(em, tenantId)) {
+    if (declared.ids.has(entity.entityId)) continue
+    byEntityId.set(entity.entityId, entity)
+  }
+
+  const items: SynthesizedFeatureItem[] = []
+  for (const { entityId, label } of byEntityId.values()) {
+    for (const feature of synthesizedRecordFeatures(entityId)) {
+      const verb = feature.action === 'manage' ? 'Manage records' : 'View records'
+      items.push({
+        id: feature.id,
+        title: `${verb}: ${label}`,
+        module: 'entities',
+        dependsOn: feature.dependsOn,
+      })
+    }
+  }
+  return items
+}

--- a/packages/core/src/modules/entities/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/entities/migrations/.snapshot-open-mercato.json
@@ -71,6 +71,16 @@
           "default": "false",
           "mappedType": "boolean"
         },
+        "access_restricted": {
+          "name": "access_restricted",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "default": "false",
+          "mappedType": "boolean"
+        },
         "organization_id": {
           "name": "organization_id",
           "type": "uuid",

--- a/packages/core/src/modules/entities/migrations/Migration20260716120000.ts
+++ b/packages/core/src/modules/entities/migrations/Migration20260716120000.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260716120000 extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "custom_entities" add column "access_restricted" boolean not null default false;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "custom_entities" drop column "access_restricted";`);
+  }
+
+}

--- a/packages/shared/src/modules/entities.ts
+++ b/packages/shared/src/modules/entities.ts
@@ -94,6 +94,10 @@ export type CustomEntitySpec = {
   labelField?: string
   defaultEditor?: string
   showInSidebar?: boolean
+  // When true, records of this entity require an explicit per-entity ACL grant
+  // (entities.records.<id>.view/.manage) beyond the coarse entities.records.*
+  // feature. Defaults to unrestricted.
+  accessRestricted?: boolean
   global?: boolean
   fields?: CustomFieldDefinition[]
 }

--- a/packages/shared/src/modules/entities/validators.ts
+++ b/packages/shared/src/modules/entities/validators.ts
@@ -15,6 +15,7 @@ export const upsertCustomEntitySchema = z.object({
   labelField: z.string().min(1).max(100).regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/).optional(),
   defaultEditor: z.enum(['markdown','simpleMarkdown','htmlRichText']).optional(),
   showInSidebar: z.boolean().default(false),
+  accessRestricted: z.boolean().default(false),
   isActive: z.boolean().optional(),
 })
 


### PR DESCRIPTION
Fixes #3857.

## Problem

`assertEntityAclForRequest` short-circuited (`if (isCustomEntity) return`) for custom entities, so the **only** authorization on the custom-entity records API (`GET/POST/PUT/DELETE /api/entities/records`) was the coarse route-level feature `entities.records.view` / `.manage`. Those features are entity-agnostic, so any holder could read/modify/delete records of **every** custom entity in their tenant. Sensitive custom entities (salaries, board minutes) could not be compartmentalized from ordinary ones — an intra-tenant horizontal privilege escalation. (Cross-tenant access was already blocked by tenant/org-scoped queries.)

## Fix (opt-in, default-off, additive — zero BC break)

- **`custom_entities.access_restricted`** — new `boolean not null default false` column (additive migration). Existing entities and grants behave exactly as before.
- **Enforcement** — `assertEntityAclForRequest` no longer short-circuits. For a custom entity: unrestricted → allow (unchanged, coarse route guard already ran); restricted → additionally require the synthesized per-entity feature `entities.records.<entityId>.view/.manage` via the wildcard-aware matcher. Super-admin and `entities.records.*` / `entities.*` still satisfy it. Threaded through all four record verbs.
- **Tenant/org-scoped flag resolution** — the restriction flag is resolved with tenant+org overlay precedence so a colliding `entityId` in another tenant (e.g. `user:vendors`) cannot flip the decision.
- **Feature catalog** — `GET /api/auth/features` appends the synthesized per-entity features for the caller's tenant's restricted entities, so they can be granted in the existing ACL editor. No ACL-schema change.
- **Tenant policy** — `entities.newEntitiesRestrictedByDefault` (module config, default off) sets the create-time default; `access_restricted` mutates only when the caller explicitly sends the field (a metadata-only update never un-restricts). Read/set via `GET/PUT /api/entities/entity-settings`.
- **UI** — "Restrict record access" toggle on the custom-entity create/edit pages; i18n for en/de/es/pl.

Per-entity feature ids are derived by one shared pure helper used by both enforcement and the catalog; the API validator forbids dots in `entityId`, so the wildcard matcher can't be tricked.

## Composition & scope

Prerequisite composition for v1: a restricted entity requires the coarse feature (route guard) **plus** the per-entity feature — this hides sensitive entities from ordinary holders without relaxing the AND-only route-guard contract. Scoping a principal to *only* one entity is deferred. Other read surfaces (search indexer, AI tools, direct Query Engine) do not yet honor `access_restricted` — tracked as a follow-up (they enforce their own feature gates; this PR closes the records API named in the issue).

## Review

A multi-model consensus code review flagged (and this PR fixes) a self-introduced regression: the restriction flag was initially resolved from an unscoped `findOne({ entityId })` — now tenant/org-scoped. Also fixed a partial-update un-restrict (zod `.default(false)` made the fallback dead) and aligned catalog/enforcement precedence.

## Validation

`yarn typecheck` 21/21 · `yarn lint` 0 errors · entities+auth tests **681/681** (new unit coverage for the deriver, the restricted enforcement branch across all four verbs, the tenant-scoping regression guard, and the catalog synthesis incl. cross-tenant isolation). Full spec: `.ai/specs/2026-07-16-custom-entity-record-acl-per-entity.md`; upgrade note in `UPGRADE_NOTES.md`.

## BC / Safety

Default is unrestricted and the tenant policy defaults off, so no migration of existing grants is required and no legitimate holder is locked out. New behavior only manifests when an admin marks an entity restricted; at that point coarse-only holders lose that entity until granted the per-entity feature (the intended compartmentalization) — documented in `UPGRADE_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
