### PR TITLE
fix(shared): restore standalone optimistic locking DI

### DIFF
--- a/.ai/specs/implemented/2026-05-25-oss-optimistic-locking.md
+++ b/.ai/specs/implemented/2026-05-25-oss-optimistic-locking.md
@@ -451,3 +451,7 @@ generalist primitive `enforceCommandOptimisticLock(...)`
   accept/convert race). Payments/shipments stay on their existing row-level
   guard (flat command input keeps the factory `candidateId`). Full coverage
   matrix + remaining deferrals: `.ai/specs/2026-05-28-optimistic-locking-coverage-completion.md`.
+
+## 11. Changelog
+
+- **2026-07-16 — standalone DI safety fix (#4201).** The platform default `crudMutationGuardService` now uses a CLASSIC-compatible named `em` factory parameter, so Awilix no longer attempts to resolve the nonexistent `scopedEm` dependency. Guard resolution failures emit one structured warning per process instead of silently disabling the bridge. Standalone and monorepo app bootstraps now pass `src/di.ts`'s registrar explicitly into the shared bootstrap factory, restoring the documented app-level override hook without relying on a package-internal `@/di` import.

--- a/.ai/specs/implemented/SPEC-036-2026-02-21-application-request-lifecycle-events.md
+++ b/.ai/specs/implemented/SPEC-036-2026-02-21-application-request-lifecycle-events.md
@@ -151,3 +151,4 @@ Runtime payload fields are structured records (`Record<string, unknown>`) with t
 
 ## Changelog
 - **2026-02-21**: Initial backfilled spec for runtime application/request lifecycle events introduced in codebase.
+- **2026-07-16**: Standalone and monorepo `src/bootstrap.ts` now pass the app's `src/di.ts` registrar explicitly to `createBootstrap`, ensuring lifecycle registration runs from published-package apps instead of relying on an unresolved package-internal `@/di` import (#4201).

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -24,6 +24,25 @@ most of the patterns listed below in a user's codebase.
 
 ## 0.6.5 → 0.6.6 (unreleased)
 
+### Standalone apps: optimistic-lock guard restored; `src/di.ts` now requires explicit bootstrap wiring (#4201)
+
+Two related DI defects affected standalone (npm) apps:
+
+1. **The default OSS optimistic-lock guard was silently disabled.** The request container is built in Awilix CLASSIC injection mode, and the guard's factory destructured a renamed parameter (`({ em: scopedEm })`), which CLASSIC cannot resolve. The resolution error was swallowed, so every `makeCrudRoute` PUT/DELETE ignored the `x-om-ext-optimistic-lock-expected-updated-at` header and stale writes returned `200` instead of `409`. *Action for downstream:* none — upgrading `@open-mercato/shared` restores the guard. A failed guard resolution now logs a warning (once per process) instead of failing silently.
+
+2. **`src/di.ts` `register()` never ran in standalone apps.** The `@/di` dynamic import inside the published package does not resolve to the app's `src/di.ts`, so the documented app-level DI override hook was dead. Apps now wire it explicitly from `src/bootstrap.ts`. *Action for downstream:* apps scaffolded before 0.6.6 that want `src/di.ts` to work must add the wiring to their `src/bootstrap.ts` (new scaffolds include it):
+
+```ts
+import { register as registerAppDi } from '@/di'
+
+export const bootstrap = createBootstrap(
+  { /* existing generated data */ },
+  { appDiRegistrar: registerAppDi },
+)
+```
+
+Additionally, two core-module registrations that destructured factory parameters without opting into per-registration PROXY resolution (`catalogPricingService`, `notificationService`) silently received `undefined` dependencies under CLASSIC mode; both now chain `.proxy()`. *Action for downstream:* none, but if your own module's `di.ts` registers `asFunction(({ dep }) => ...)`, chain `.proxy()` (or take plain named parameters) — a guard test (`packages/core/src/__tests__/di-classic-proxy.test.ts`) now enforces this for in-repo modules.
+
 ### Shared `om-*` pipeline skills now come from open-mercato/skills
 
 The generalized agent-pipeline skills (`om-code-review`, `om-auto-create-pr`, `om-auto-review-pr`, `om-merge-buddy`, `om-spec-writing`, the `-loop` variants, `om-prepare-issue`, and 15 more — see the `external` block in [`.ai/skills/tiers.json`](.ai/skills/tiers.json)) were removed from `.ai/skills/` and are now installed from the shared [open-mercato/skills](https://github.com/open-mercato/skills) collection. `yarn install-skills` runs `npx -y skills add open-mercato/skills --skill '*'` after the local tier symlinks, placing the skills under `.agents/skills/` (gitignored), then `npx -y skills update --project` so re-running the installer refreshes the external skills to their latest published versions (the lockfile is gitignored, so `add` seeds and `update` keeps them current).

--- a/apps/docs/docs/framework/ioc/container.mdx
+++ b/apps/docs/docs/framework/ioc/container.mdx
@@ -29,6 +29,31 @@ export function register(container: AppContainer) {
 - In subscribers: the second argument is `{ container, logger, ... }`—resolve services the same way.
 - Avoid importing services directly; resolving them keeps modules overridable.
 
+## App-level overrides
+
+Standalone and monorepo apps can register application-specific services in `src/di.ts`:
+
+```ts title="src/di.ts"
+import { asValue } from 'awilix'
+import type { AppContainer } from '@open-mercato/shared/lib/di/container'
+
+export function register(container: AppContainer) {
+  container.register({ applicationPolicy: asValue({ enabled: true }) })
+}
+```
+
+The scaffolded `src/bootstrap.ts` passes this function explicitly to the shared bootstrap factory:
+
+```ts title="src/bootstrap.ts"
+import { register as registerAppDi } from '@/di'
+
+export const bootstrap = createBootstrap(data, {
+  appDiRegistrar: registerAppDi,
+})
+```
+
+Explicit wiring keeps the app alias in the app's bundler context, so scaffolded apps do not rely on package code resolving `@/di` on their behalf. A package-level dynamic-import fallback remains only for compatibility with older app bootstraps. The registrar runs for each request container after core and module registrars; inline `modules.ts` DI overrides remain the final mutation tier.
+
 ## Best practices
 
 - **Naming** – use descriptive keys (`organizationInvitationService`). Keep module-specific prefixes to avoid collisions.

--- a/apps/mercato/src/__tests__/bootstrap.test.ts
+++ b/apps/mercato/src/__tests__/bootstrap.test.ts
@@ -4,6 +4,7 @@ const registerEventModuleConfigsMock = jest.fn()
 const registerMessageTypesMock = jest.fn()
 const registerMessageObjectTypesMock = jest.fn()
 const runBootstrapRegistrationsMock = jest.fn()
+const appDiRegistrarMock = jest.fn()
 
 describe('app bootstrap', () => {
   beforeEach(() => {
@@ -14,6 +15,7 @@ describe('app bootstrap', () => {
     registerMessageTypesMock.mockClear()
     registerMessageObjectTypesMock.mockClear()
     runBootstrapRegistrationsMock.mockClear()
+    appDiRegistrarMock.mockClear()
   })
 
   it('registers the bootstrap module manifest instead of route-aware registries', async () => {
@@ -51,6 +53,7 @@ describe('app bootstrap', () => {
       runBootstrapRegistrations: runBootstrapRegistrationsMock,
     }))
     jest.doMock('@open-mercato/ai-assistant', () => ({}))
+    jest.doMock('@/di', () => ({ register: appDiRegistrarMock }))
     jest.doMock('@open-mercato/shared/modules/events', () => ({
       registerEventModuleConfigs: registerEventModuleConfigsMock,
     }))
@@ -71,5 +74,6 @@ describe('app bootstrap', () => {
     expect(createBootstrapMock.mock.calls[0][0].modules).toBe(bootstrapModules)
     expect(createBootstrapMock.mock.calls[0][0].modules).not.toBe(fullModules)
     expect(createBootstrapMock.mock.calls[0][0].modules).not.toBe(appModules)
+    expect(createBootstrapMock.mock.calls[0][1]).toEqual({ appDiRegistrar: appDiRegistrarMock })
   })
 })

--- a/apps/mercato/src/bootstrap.ts
+++ b/apps/mercato/src/bootstrap.ts
@@ -11,6 +11,7 @@
 
 // Register app dictionary loader before bootstrap (required for i18n in standalone packages)
 import './lib/i18n/register-dictionary-loader'
+import { register as registerAppDi } from '@/di'
 
 // modules.ts inline overrides (replace/disable any contract a module
 // presents through the unified modules.ts override surface).
@@ -63,24 +64,27 @@ runBootstrapRegistrations()
 import { createBootstrap, isBootstrapped } from '@open-mercato/shared/lib/bootstrap'
 
 // Create bootstrap function with app's generated data
-export const bootstrap = createBootstrap({
-  modules,
-  entities,
-  diRegistrars,
-  entityIds: E,
-  entityFieldsRegistry,
-  dashboardWidgetEntries,
-  injectionWidgetEntries,
-  injectionTables,
-  searchModuleConfigs,
-  analyticsModuleConfigs,
-  enricherEntries,
-  interceptorEntries,
-  componentOverrideEntries,
-  guardEntries,
-  commandInterceptorEntries,
-  commandLoaderEntries,
-  notificationHandlerEntries,
-})
+export const bootstrap = createBootstrap(
+  {
+    modules,
+    entities,
+    diRegistrars,
+    entityIds: E,
+    entityFieldsRegistry,
+    dashboardWidgetEntries,
+    injectionWidgetEntries,
+    injectionTables,
+    searchModuleConfigs,
+    analyticsModuleConfigs,
+    enricherEntries,
+    interceptorEntries,
+    componentOverrideEntries,
+    guardEntries,
+    commandInterceptorEntries,
+    commandLoaderEntries,
+    notificationHandlerEntries,
+  },
+  { appDiRegistrar: registerAppDi },
+)
 
 export { isBootstrapped }

--- a/packages/core/src/__tests__/di-classic-proxy.test.ts
+++ b/packages/core/src/__tests__/di-classic-proxy.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+// The request container is built in Awilix CLASSIC injection mode
+// (packages/shared/src/lib/di/container.ts). CLASSIC resolves dependencies by
+// parsing parameter NAMES, so a factory that destructures its first parameter —
+// asFunction(({ em }) => ...) — receives the positionally-resolved dependency as
+// the object being destructured and every destructured binding comes out
+// undefined (or, for renamed bindings, resolution throws). See issue #4201.
+// Destructuring factories must therefore opt into PROXY resolution per
+// registration by chaining .proxy().
+
+const packagesRoot = path.resolve(__dirname, '..', '..', '..')
+
+function listModuleDiFiles(): string[] {
+  const diFiles: string[] = []
+  for (const packageName of fs.readdirSync(packagesRoot)) {
+    const modulesDir = path.join(packagesRoot, packageName, 'src', 'modules')
+    if (!fs.existsSync(modulesDir) || !fs.statSync(modulesDir).isDirectory()) continue
+    for (const moduleName of fs.readdirSync(modulesDir)) {
+      const diFile = path.join(modulesDir, moduleName, 'di.ts')
+      if (fs.existsSync(diFile)) diFiles.push(diFile)
+    }
+  }
+  return diFiles
+}
+
+function findMatchingParen(source: string, openParenIndex: number): number {
+  let depth = 0
+  for (let index = openParenIndex; index < source.length; index += 1) {
+    const char = source[index]
+    if (char === '(') depth += 1
+    if (char === ')') {
+      depth -= 1
+      if (depth === 0) return index
+    }
+  }
+  return -1
+}
+
+type Violation = { file: string; snippet: string }
+
+function findDestructuringWithoutProxy(file: string): Violation[] {
+  const source = fs.readFileSync(file, 'utf8')
+  const violations: Violation[] = []
+  const destructuredFactory = /asFunction\s*(?=\(\s*(?:async\s*)?\(\s*\{)/g
+  let match: RegExpExecArray | null
+  while ((match = destructuredFactory.exec(source)) !== null) {
+    const openParenIndex = source.indexOf('(', match.index + match[0].length)
+    const closeParenIndex = findMatchingParen(source, openParenIndex)
+    if (closeParenIndex === -1) {
+      violations.push({ file, snippet: source.slice(match.index, match.index + 80) })
+      continue
+    }
+    const modifierChain = source.slice(closeParenIndex + 1).match(/^(?:\s*\.\s*\w+\(\))*/)?.[0] ?? ''
+    if (!/\.\s*proxy\(\)/.test(modifierChain)) {
+      violations.push({ file, snippet: source.slice(match.index, closeParenIndex + 1).slice(0, 120) })
+    }
+  }
+  return violations
+}
+
+describe('module DI registrations vs CLASSIC injection mode', () => {
+  it('every asFunction factory with a destructured parameter chains .proxy()', () => {
+    const diFiles = listModuleDiFiles()
+    expect(diFiles.length).toBeGreaterThan(0)
+
+    const violations = diFiles.flatMap(findDestructuringWithoutProxy)
+    const report = violations
+      .map(({ file, snippet }) => `${path.relative(packagesRoot, file)}: ${snippet.replace(/\s+/g, ' ')}`)
+      .join('\n')
+
+    expect(report).toBe('')
+  })
+})

--- a/packages/core/src/modules/catalog/di.ts
+++ b/packages/core/src/modules/catalog/di.ts
@@ -12,7 +12,9 @@ export function register(container: AppContainer) {
   container.register({
     catalogPricingService: asFunction(({ eventBus }: AppCradle) => {
       return new DefaultCatalogPricingService(eventBus ?? null)
-    }).singleton(),
+    })
+      .singleton()
+      .proxy(),
     CatalogProduct: asValue(CatalogProduct),
     CatalogProductPrice: asValue(CatalogProductPrice),
   })

--- a/packages/core/src/modules/notifications/di.ts
+++ b/packages/core/src/modules/notifications/di.ts
@@ -6,6 +6,6 @@ export function register(container: AppContainer): void {
   container.register({
     notificationService: asFunction(({ em, eventBus, commandBus }) =>
       createNotificationService({ em, eventBus, commandBus })
-    ).scoped(),
+    ).scoped().proxy(),
   })
 }

--- a/packages/create-app/src/lib/template-app-di-wiring.test.ts
+++ b/packages/create-app/src/lib/template-app-di-wiring.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+function readSource(relativeUrl: string): string {
+  return fs.readFileSync(new URL(relativeUrl, import.meta.url), 'utf8')
+}
+
+test('standalone and monorepo bootstraps explicitly wire the app DI registrar', () => {
+  const sources = [
+    readSource('../../template/src/bootstrap.ts'),
+    readSource('../../../../apps/mercato/src/bootstrap.ts'),
+  ]
+
+  for (const source of sources) {
+    assert.match(source, /import \{ register as registerAppDi \} from '@\/di'/)
+    assert.match(source, /appDiRegistrar: registerAppDi/)
+  }
+})

--- a/packages/create-app/template/src/bootstrap.ts
+++ b/packages/create-app/template/src/bootstrap.ts
@@ -11,6 +11,7 @@
 
 // Register app dictionary loader before bootstrap (required for i18n in standalone packages)
 import './lib/i18n/register-dictionary-loader'
+import { register as registerAppDi } from '@/di'
 
 // modules.ts inline overrides (replace/disable any contract a module
 // presents through the unified modules.ts override surface).
@@ -63,24 +64,27 @@ runBootstrapRegistrations()
 import { createBootstrap, isBootstrapped } from '@open-mercato/shared/lib/bootstrap'
 
 // Create bootstrap function with app's generated data
-export const bootstrap = createBootstrap({
-  modules,
-  entities,
-  diRegistrars,
-  entityIds: E,
-  entityFieldsRegistry,
-  dashboardWidgetEntries,
-  injectionWidgetEntries,
-  injectionTables,
-  searchModuleConfigs,
-  analyticsModuleConfigs,
-  enricherEntries,
-  interceptorEntries,
-  componentOverrideEntries,
-  guardEntries,
-  commandInterceptorEntries,
-  commandLoaderEntries,
-  notificationHandlerEntries,
-})
+export const bootstrap = createBootstrap(
+  {
+    modules,
+    entities,
+    diRegistrars,
+    entityIds: E,
+    entityFieldsRegistry,
+    dashboardWidgetEntries,
+    injectionWidgetEntries,
+    injectionTables,
+    searchModuleConfigs,
+    analyticsModuleConfigs,
+    enricherEntries,
+    interceptorEntries,
+    componentOverrideEntries,
+    guardEntries,
+    commandInterceptorEntries,
+    commandLoaderEntries,
+    notificationHandlerEntries,
+  },
+  { appDiRegistrar: registerAppDi },
+)
 
 export { isBootstrapped }

--- a/packages/shared/src/lib/bootstrap/factory.ts
+++ b/packages/shared/src/lib/bootstrap/factory.ts
@@ -1,6 +1,6 @@
 import type { BootstrapData, BootstrapOptions } from './types'
 import { registerOrmEntities } from '../db/mikro'
-import { registerDiRegistrars } from '../di/container'
+import { registerAppDiRegistrar, registerDiRegistrars } from '../di/container'
 import { registerModules } from '../modules/registry'
 import { registerEntityIds } from '../encryption/entityIds'
 import { registerEntityFields } from '../encryption/entityFields'
@@ -33,6 +33,9 @@ let _asyncRegistrationPromise: Promise<void> | null = null
  */
 export function createBootstrap(data: BootstrapData, options: BootstrapOptions = {}) {
   return function bootstrap(): void {
+    if (options.appDiRegistrar) {
+      registerAppDiRegistrar(options.appDiRegistrar)
+    }
     // In development, always re-run registrations to handle HMR
     // (Module state may be reset when Turbopack reloads packages)
     if (_bootstrapped && process.env.NODE_ENV !== 'development') return

--- a/packages/shared/src/lib/bootstrap/types.ts
+++ b/packages/shared/src/lib/bootstrap/types.ts
@@ -1,4 +1,4 @@
-import type { DiRegistrar } from '../di/container'
+import type { AppDiRegistrar, DiRegistrar } from '../di/container'
 import type { EntityIds } from '../encryption/entityIds'
 import type { EntityFieldsRegistry } from '../encryption/entityFields'
 import type { Module, ModuleDashboardWidgetEntry, ModuleInjectionWidgetEntry } from '../../modules/registry'
@@ -69,4 +69,5 @@ export interface BootstrapData {
 export interface BootstrapOptions {
   skipSearchConfigs?: boolean
   onRegistrationComplete?: () => void
+  appDiRegistrar?: AppDiRegistrar
 }

--- a/packages/shared/src/lib/crud/__tests__/route-mutation-guard.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/route-mutation-guard.test.ts
@@ -1,6 +1,6 @@
 import type { AwilixContainer } from 'awilix'
 import { registerMutationGuards } from '../mutation-guard-store'
-import type { MutationGuard } from '../mutation-guard-registry'
+import { bridgeLegacyGuard, type MutationGuard } from '../mutation-guard-registry'
 import { runRouteMutationGuards, toRegistryMutationOperation } from '../route-mutation-guard'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
@@ -16,12 +16,13 @@ jest.mock('@open-mercato/shared/lib/logger', () => {
   return { createLogger: jest.fn(() => mocked) }
 })
 const loggerError = createLogger('shared').error as jest.Mock
-
+const loggerWarn = createLogger('shared').warn as jest.Mock
 
 type Registrations = Record<string, unknown>
 
 function makeContainer(registrations: Registrations = {}): AwilixContainer {
   return {
+    hasRegistration: (name: string) => Object.prototype.hasOwnProperty.call(registrations, name),
     resolve: (name: string) => {
       if (Object.prototype.hasOwnProperty.call(registrations, name)) return registrations[name]
       throw new Error(`[test] no registration for ${name}`)
@@ -271,5 +272,25 @@ describe('runRouteMutationGuards', () => {
     if (result.ok) throw new Error('expected blocked result')
     expect(result.errorStatus).toBe(409)
     expect(result.errorBody).toEqual({ error: 'locked' })
+  })
+
+  it('warns only once when the registered legacy guard cannot be resolved', () => {
+    delete (globalThis as Record<string, unknown>).__openMercatoCrudMutationGuardResolutionWarningEmitted__
+    loggerWarn.mockClear()
+    const resolutionError = new Error('Could not resolve scopedEm')
+    const container = {
+      hasRegistration: () => true,
+      resolve: () => {
+        throw resolutionError
+      },
+    } as unknown as AwilixContainer
+
+    expect(bridgeLegacyGuard(container)).toBeNull()
+    expect(bridgeLegacyGuard(container)).toBeNull()
+    expect(loggerWarn).toHaveBeenCalledTimes(1)
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'CRUD mutation guard service could not be resolved; the legacy guard bridge is disabled',
+      { err: resolutionError },
+    )
   })
 })

--- a/packages/shared/src/lib/crud/mutation-guard-registry.ts
+++ b/packages/shared/src/lib/crud/mutation-guard-registry.ts
@@ -1,5 +1,6 @@
 import type { AwilixContainer } from 'awilix'
 import { hasAllFeatures } from '../../security/features'
+import { resolveCrudMutationGuardService } from './mutation-guard-service'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -125,45 +126,8 @@ export async function runMutationGuards(
 // Legacy guard bridge
 // ---------------------------------------------------------------------------
 
-type LegacyCrudMutationGuardService = {
-  validateMutation: (input: {
-    tenantId: string
-    organizationId?: string | null
-    userId: string
-    resourceKind: string
-    resourceId: string
-    operation: 'create' | 'update' | 'delete' | 'custom'
-    requestMethod: string
-    requestHeaders: Headers
-    mutationPayload?: Record<string, unknown> | null
-  }) => Promise<{ ok: boolean; status?: number; body?: Record<string, unknown>; shouldRunAfterSuccess?: boolean; metadata?: Record<string, unknown> | null } | null>
-  afterMutationSuccess: (input: {
-    tenantId: string
-    organizationId?: string | null
-    userId: string
-    resourceKind: string
-    resourceId: string
-    operation: 'create' | 'update' | 'delete' | 'custom'
-    requestMethod: string
-    requestHeaders: Headers
-    metadata?: Record<string, unknown> | null
-  }) => Promise<void>
-}
-
-function resolveLegacyGuardService(container: AwilixContainer): LegacyCrudMutationGuardService | null {
-  try {
-    const service = container.resolve<LegacyCrudMutationGuardService>('crudMutationGuardService')
-    if (!service) return null
-    if (typeof service.validateMutation !== 'function') return null
-    if (typeof service.afterMutationSuccess !== 'function') return null
-    return service
-  } catch {
-    return null
-  }
-}
-
 export function bridgeLegacyGuard(container: AwilixContainer): MutationGuard | null {
-  const legacyService = resolveLegacyGuardService(container)
+  const legacyService = resolveCrudMutationGuardService(container)
   if (!legacyService) return null
 
   return {

--- a/packages/shared/src/lib/crud/mutation-guard-service.ts
+++ b/packages/shared/src/lib/crud/mutation-guard-service.ts
@@ -1,0 +1,48 @@
+import type { AwilixContainer } from 'awilix'
+import { createLogger } from '../logger'
+import type {
+  CrudMutationGuardAfterSuccessInput,
+  CrudMutationGuardValidateInput,
+  CrudMutationGuardValidationResult,
+} from './mutation-guard'
+
+const logger = createLogger('shared').child({ component: 'crud' })
+const RESOLUTION_WARNING_KEY = '__openMercatoCrudMutationGuardResolutionWarningEmitted__'
+
+export type CrudMutationGuardServiceLike = {
+  validateMutation: (
+    input: CrudMutationGuardValidateInput,
+  ) => Promise<CrudMutationGuardValidationResult | null>
+  afterMutationSuccess: (input: CrudMutationGuardAfterSuccessInput) => Promise<void>
+}
+
+function warnResolutionFailureOnce(error: unknown): void {
+  const globalScope = globalThis as Record<string, unknown>
+  if (globalScope[RESOLUTION_WARNING_KEY] === true) return
+  globalScope[RESOLUTION_WARNING_KEY] = true
+  logger.warn('CRUD mutation guard service could not be resolved; the legacy guard bridge is disabled', {
+    err: error,
+  })
+}
+
+export function resolveCrudMutationGuardService(
+  container: AwilixContainer,
+): CrudMutationGuardServiceLike | null {
+  if (
+    typeof container.hasRegistration === 'function'
+    && !container.hasRegistration('crudMutationGuardService')
+  ) {
+    return null
+  }
+
+  try {
+    const service = container.resolve<CrudMutationGuardServiceLike>('crudMutationGuardService')
+    if (!service) return null
+    if (typeof service.validateMutation !== 'function') return null
+    if (typeof service.afterMutationSuccess !== 'function') return null
+    return service
+  } catch (error) {
+    warnResolutionFailureOnce(error)
+    return null
+  }
+}

--- a/packages/shared/src/lib/crud/mutation-guard.ts
+++ b/packages/shared/src/lib/crud/mutation-guard.ts
@@ -1,5 +1,6 @@
 import type { AwilixContainer } from 'awilix'
 import { createLogger } from '../logger'
+import { resolveCrudMutationGuardService } from './mutation-guard-service'
 
 const logger = createLogger('shared').child({ component: 'crud' })
 
@@ -41,23 +42,6 @@ export type CrudMutationGuardAfterSuccessInput = {
   requestMethod: string
   requestHeaders: Headers
   metadata?: Record<string, unknown> | null
-}
-
-type CrudMutationGuardServiceLike = {
-  validateMutation: (input: CrudMutationGuardValidateInput) => Promise<CrudMutationGuardValidationResult>
-  afterMutationSuccess: (input: CrudMutationGuardAfterSuccessInput) => Promise<void>
-}
-
-function resolveCrudMutationGuardService(container: AwilixContainer): CrudMutationGuardServiceLike | null {
-  try {
-    const service = container.resolve<CrudMutationGuardServiceLike>('crudMutationGuardService')
-    if (!service) return null
-    if (typeof service.validateMutation !== 'function') return null
-    if (typeof service.afterMutationSuccess !== 'function') return null
-    return service
-  } catch {
-    return null
-  }
 }
 
 /**

--- a/packages/shared/src/lib/di/__tests__/bootstrap-cache.test.ts
+++ b/packages/shared/src/lib/di/__tests__/bootstrap-cache.test.ts
@@ -8,6 +8,7 @@
 // `OM_BOOTSTRAP_CACHE` gates the whole behavior; default OFF.
 
 import { asValue } from 'awilix'
+import type { AwilixContainer } from 'awilix'
 
 // Mock the deep ORM/engine imports BEFORE importing container.ts so we can
 // exercise the bootstrap once-guard without pulling in MikroORM decorators.
@@ -64,11 +65,14 @@ jest.mock(
   () => ({
     __esModule: true,
     applyDiOverridesToContainer: () => {},
+    applyModuleOverridesToModules: (modules: unknown[]) => modules,
+    applyComponentOverridesToEntries: (entries: unknown[]) => entries,
   }),
   { virtual: false },
 )
 
 const {
+  registerAppDiRegistrar,
   registerDiRegistrars,
   resetBootstrapCache,
 } = require('@open-mercato/shared/lib/di/container')
@@ -105,6 +109,7 @@ const ORIGINAL_FLAG = process.env.OM_BOOTSTRAP_CACHE
 describe('bootstrap once-guard cache', () => {
   beforeEach(() => {
     resetBootstrapCache()
+    registerAppDiRegistrar(null)
     bootstrapMock.mockClear()
     subscriberRegistered.mockClear()
     registerDiRegistrars([])
@@ -144,6 +149,55 @@ describe('bootstrap once-guard cache', () => {
     await createRequestContainer()
     await createRequestContainer()
     expect(bootstrapMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('resolves the default optimistic-lock guard in CLASSIC injection mode', async () => {
+    const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+    const container = await createRequestContainer()
+
+    expect(container.resolve('crudMutationGuardService')).toEqual(expect.objectContaining({
+      validateMutation: expect.any(Function),
+      afterMutationSuccess: expect.any(Function),
+    }))
+  })
+
+  it('runs the explicitly registered app DI registrar for each request container', async () => {
+    const appDiRegistrar = jest.fn(async (container: AwilixContainer) => {
+      container.register({ appLevelService: asValue('app-level') })
+    })
+    registerAppDiRegistrar(appDiRegistrar)
+
+    const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+    const container = await createRequestContainer()
+
+    expect(appDiRegistrar).toHaveBeenCalledTimes(1)
+    expect(appDiRegistrar).toHaveBeenCalledWith(container)
+    expect(container.resolve('appLevelService')).toBe('app-level')
+  })
+
+  it('preserves the app DI registrar when a CLI-style bootstrap omits the option', async () => {
+    const appDiRegistrar = jest.fn((container: AwilixContainer) => {
+      container.register({ appLevelService: asValue('preserved') })
+    })
+    registerAppDiRegistrar(appDiRegistrar)
+
+    const { createBootstrap, resetBootstrapState } = await import('@open-mercato/shared/lib/bootstrap/factory')
+    resetBootstrapState()
+    createBootstrap({
+      modules: [],
+      entities: [],
+      diRegistrars: [],
+      entityIds: {},
+      dashboardWidgetEntries: [],
+      injectionWidgetEntries: [],
+      injectionTables: [],
+    })()
+
+    const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+    const container = await createRequestContainer()
+
+    expect(appDiRegistrar).toHaveBeenCalledTimes(1)
+    expect(container.resolve('appLevelService')).toBe('preserved')
   })
 
   it('registerDiRegistrars clears the cache so HMR re-runs bootstrap on the next request', async () => {

--- a/packages/shared/src/lib/di/container.ts
+++ b/packages/shared/src/lib/di/container.ts
@@ -17,11 +17,13 @@ type DynamicCradle = Record<string, any>
 
 export type AppContainer = AwilixContainer<DynamicCradle>
 export type DiRegistrar = (container: AppContainer) => void
+export type AppDiRegistrar = (container: AppContainer) => void | Promise<void>
 
 // Registration pattern for publishable packages
 // Use globalThis to survive tsx/esbuild module duplication issue where the same
 // file can be loaded as multiple module instances when mixing dynamic and static imports
 const GLOBAL_KEY = '__openMercatoDiRegistrars__'
+const APP_DI_REGISTRAR_KEY = '__openMercatoAppDiRegistrar__'
 // Phase 5 — process-scoped bootstrap cache. The cache/event-bus/encryption
 // services bootstrap() creates are inherently process-scoped (they hold
 // state across requests). Caching them on globalThis after the first
@@ -126,6 +128,15 @@ export function getDiRegistrars(): DiRegistrar[] {
   return registrars
 }
 
+function getAppDiRegistrar(): AppDiRegistrar | null {
+  const registrar = (globalThis as Record<string, unknown>)[APP_DI_REGISTRAR_KEY]
+  return typeof registrar === 'function' ? registrar as AppDiRegistrar : null
+}
+
+export function registerAppDiRegistrar(registrar: AppDiRegistrar | null): void {
+  ;(globalThis as Record<string, unknown>)[APP_DI_REGISTRAR_KEY] = registrar
+}
+
 /** Test-only helper to drop the process-scoped bootstrap cache. */
 export function resetBootstrapCache(): void {
   (globalThis as any)[BOOTSTRAP_CACHE_KEY] = null
@@ -169,9 +180,9 @@ export async function createRequestContainer(): Promise<AppContainer> {
     // registrations override this default via Awilix replace semantics —
     // see the enterprise `record_locks` module for the canonical override.
     // Spec: .ai/specs/implemented/2026-05-25-oss-optimistic-locking.md
-    crudMutationGuardService: asFunction(({ em: scopedEm }: { em: EntityManager }) =>
+    crudMutationGuardService: asFunction((em: EntityManager) =>
       createOptimisticLockGuardService({
-        getEm: () => scopedEm,
+        getEm: () => em,
         readers: getAllOptimisticLockReaders(),
       }),
     ).scoped(),
@@ -215,18 +226,30 @@ export async function createRequestContainer(): Promise<AppContainer> {
       } catch { /* optional */ }
     }
   }
-  // App-level DI override (last chance)
-  // This import path resolves only in the app context, not in packages
-  try {
-    // @ts-ignore - @/di only exists in app context, not in packages
-    const appDi = await import('@/di') as any
-    if (appDi?.register) {
-      try {
-        const maybe = appDi.register(container)
-        if (maybe && typeof maybe.then === 'function') await maybe
-      } catch {}
+  // App-level DI override. Scaffolded apps register this callback explicitly
+  // from their own bootstrap module so app aliases resolve in app context.
+  const appDiRegistrar = getAppDiRegistrar()
+  if (appDiRegistrar) {
+    try {
+      await appDiRegistrar(container)
+    } catch (error) {
+      logger.error('App-level DI registrar failed', { err: error })
     }
-  } catch {}
+  } else {
+    // Backward-compatible fallback for apps that have not adopted explicit wiring.
+    try {
+      // @ts-ignore - @/di only exists in app context, not in packages
+      const appDi = await import('@/di') as any
+      if (appDi?.register) {
+        try {
+          const maybe = appDi.register(container)
+          if (maybe && typeof maybe.then === 'function') await maybe
+        } catch (error) {
+          logger.error('App-level DI registrar failed', { err: error })
+        }
+      }
+    } catch {}
+  }
   applyDiOverridesToContainer({
     register: (registrations) => container.register(toAwilixRegistrations(registrations)),
     unregister: (key) => container.register({ [key]: asValue(undefined) }),


### PR DESCRIPTION
## Summary

Restore OSS optimistic locking and app-level DI overrides in standalone applications installed from npm packages.

The default `crudMutationGuardService` used a destructured alias (`scopedEm`) in an Awilix CLASSIC factory. CLASSIC injection resolves parameter names, so standalone request containers tried to resolve a nonexistent `scopedEm` registration and the guard bridge silently returned `null`. Separately, package code attempted to import the app-only `@/di` alias, so a scaffolded app's `src/di.ts` hook never ran from the published package context.

Standalone apps now reject stale writes with the structured `409 optimistic_lock_conflict` response, and application DI registrations run for every request container.

## Changes

- make the default optimistic-lock guard factory CLASSIC-compatible by injecting the named `em` registration
- pass the app's `src/di.ts` registrar explicitly through `createBootstrap`
- retain the package-level dynamic import only as a compatibility fallback for older app bootstraps
- centralize legacy guard-service resolution and emit one structured warning per process when a registered guard cannot resolve
- mirror bootstrap wiring into the create-app template and guard monorepo/template parity with a source test
- document the app-level DI hook and update the optimistic-locking and lifecycle spec changelogs

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file paths:**
- `.ai/specs/implemented/2026-05-25-oss-optimistic-locking.md`
- `.ai/specs/implemented/SPEC-036-2026-02-21-application-request-lifecycle-events.md`

## Testing

Runner: local

- `yarn workspace @open-mercato/shared test --runInBand` — 136 suites, 1471 tests passed
- `yarn workspace @open-mercato/shared test --runInBand src/lib/di/__tests__/bootstrap-cache.test.ts src/lib/crud/__tests__/route-mutation-guard.test.ts` — focused regression coverage passed
- `yarn workspace create-mercato-app test --test-name-pattern='app DI registrar'` — 86 create-app tests passed
- `yarn workspace @open-mercato/app test --runInBand src/__tests__/bootstrap.test.ts` — passed
- `yarn typecheck` — 21 workspaces passed
- `yarn lint` — 0 errors; 12 pre-existing warnings
- `yarn build:packages` → `yarn generate` → `yarn build:packages` — passed (21 packages)
- `yarn logger:check-console:ci` — passed
- `yarn test:create-app` — npm/Verdaccio standalone scaffold and generation passed
- `yarn test:create-app:integration -- packages/core/src/modules/customers/__integration__/TC-LOCK-OSS-001.spec.ts` — 2/2 tests passed against a fresh standalone app; stale write returned structured 409
- manual in-app browser QA on a fresh standalone build — explicit `src/di.ts` probe resolved `standalone-app-di-ran`; an out-of-band update followed by a stale form save displayed the `Record changed` conflict banner; browser console had 0 errors; fixture cleaned up

Screenshot evidence will be attached in the PR conversation.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I used the existing standalone integration coverage for the affected API path (`TC-LOCK-OSS-001`).
- [x] I updated the relevant specs with changelog entries.
- [ ] Priority set: suggested `priority-high` because this restores a data-integrity guard.
- [ ] Risk set: suggested `risk-high` because this changes shared DI/bootstrap contract wiring.
- [ ] QA routing set: suggested `needs-qa`; self-QA evidence is attached, but maintainers should apply labels according to repository policy.

### Design System Compliance

- [x] No UI styling or component behavior changed.

## Suggested labels

`bug`, `priority-high`, `risk-high`, `needs-qa`

## Linked issues

Fixes #4201
