### PR TITLE
fix(workflows): checkout demo order includes cart lines and non-zero totals

### DIFF
--- a/packages/core/src/modules/workflows/__integration__/TC-WF-032.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-032.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test } from '@playwright/test'
+import {
+  deleteWorkflowDefinitions,
+  getWorkflowDefinition,
+  runCheckoutOrderLinesRepair,
+  seedWorkflowDefinition,
+} from './helpers/db'
+
+/**
+ * TC-WF-032: Checkout-demo create_order line-items repair migration (#4211).
+ *
+ * `Migration20260716120000` is pure jsonb surgery: it back-fills
+ * `lines: '{{context.cart.orderLines}}'` into the persisted legacy checkout
+ * definition's `create_order` CALL_API body so orders created by the DB-first
+ * definition carry their cart line items (and therefore non-zero totals). This
+ * spec seeds a legacy-shaped `workflow_definitions` row (plus control rows that
+ * MUST stay untouched), runs the migration's exact exported SQL against
+ * Postgres, and asserts the resulting `definition`.
+ *
+ * ENVIRONMENT: DB-level fixtures (raw `pg` against `DATABASE_URL`). Run under a
+ * coherent app+DB stack (`yarn test:integration`).
+ */
+
+type Activity = { activityId: string; activityType: string; config?: Record<string, any> }
+type Transition = { transitionId: string; activities?: Activity[] }
+
+/**
+ * Faithful shape of the original seeded checkout definition's order transition,
+ * whose create_order body carried header/total fields but no `lines`.
+ */
+function legacyCheckoutDefinition(overrides?: { withLines?: boolean }): Record<string, unknown> {
+  const createOrderBody: Record<string, unknown> = {
+    customerEntityId: '{{context.customer.id}}',
+    currencyCode: '{{context.cart.currency}}',
+    placedAt: '{{now}}',
+    grandTotalGrossAmount: '{{context.cart.total}}',
+    subtotalGrossAmount: '{{context.cart.subtotal}}',
+    taxTotalAmount: '{{context.cart.tax}}',
+    shippingGrossAmount: '{{context.cart.shipping}}',
+    lineItemCount: '{{context.cart.itemCount}}',
+  }
+  if (overrides?.withLines) createOrderBody.lines = '{{context.cart.orderLines}}'
+
+  const transitions: Transition[] = [
+    { transitionId: 'start_to_cart', activities: [{ activityId: 'log_checkout_start', activityType: 'EMIT_EVENT' }] },
+    { transitionId: 'payment_to_wait_confirmation', activities: [] },
+    {
+      transitionId: 'confirmation_to_end',
+      activities: [
+        {
+          activityId: 'create_order',
+          activityType: 'CALL_API',
+          config: { endpoint: '/api/sales/orders', method: 'POST', body: createOrderBody, validateTenantMatch: true },
+        },
+        { activityId: 'send_confirmation_email', activityType: 'SEND_EMAIL', config: { to: '{{context.customer.email}}' } },
+      ],
+    },
+  ]
+  return { steps: [], transitions }
+}
+
+function transitionsOf(definition: Record<string, unknown> | null): Transition[] {
+  return (definition?.transitions as Transition[]) ?? []
+}
+
+function createOrderBodyOf(definition: Record<string, unknown> | null): Record<string, any> | undefined {
+  const orderTransition = transitionsOf(definition).find((transition) => transition.transitionId === 'confirmation_to_end')
+  const createOrder = orderTransition?.activities?.find((activity) => activity.activityId === 'create_order')
+  return createOrder?.config?.body
+}
+
+test.describe('TC-WF-032: checkout-demo order line-items repair migration', () => {
+  test('back-fills create_order lines only on the known legacy seed, idempotently', async () => {
+    const seededIds: Array<string | null> = []
+    try {
+      const target = await seedWorkflowDefinition({ definition: legacyCheckoutDefinition() })
+      const codeOverride = await seedWorkflowDefinition({
+        codeWorkflowId: 'workflows.checkout-demo',
+        definition: legacyCheckoutDefinition(),
+      })
+      const wrongVersion = await seedWorkflowDefinition({ version: 2, definition: legacyCheckoutDefinition() })
+      const softDeleted = await seedWorkflowDefinition({ softDeleted: true, definition: legacyCheckoutDefinition() })
+      const alreadyFixed = await seedWorkflowDefinition({ definition: legacyCheckoutDefinition({ withLines: true }) })
+      seededIds.push(target.id, codeOverride.id, wrongVersion.id, softDeleted.id, alreadyFixed.id)
+
+      await runCheckoutOrderLinesRepair()
+
+      // Target: create_order body gains `lines` while every other field is preserved verbatim.
+      const repaired = await getWorkflowDefinition(target.id)
+      const repairedBody = createOrderBodyOf(repaired)
+      expect(repairedBody?.lines, 'cart order lines are wired into create_order').toBe('{{context.cart.orderLines}}')
+      expect(repairedBody?.grandTotalGrossAmount, 'existing total fields preserved').toBe('{{context.cart.total}}')
+      expect(repairedBody?.subtotalGrossAmount, 'existing subtotal preserved').toBe('{{context.cart.subtotal}}')
+      // Transition order and unrelated activities/transitions are untouched.
+      expect(
+        transitionsOf(repaired).map((transition) => transition.transitionId),
+        'transition order preserved',
+      ).toEqual(['start_to_cart', 'payment_to_wait_confirmation', 'confirmation_to_end'])
+      const orderActivities = transitionsOf(repaired).find((t) => t.transitionId === 'confirmation_to_end')?.activities
+      expect(orderActivities, 'sibling activities preserved').toHaveLength(2)
+      expect(
+        orderActivities?.find((activity) => activity.activityId === 'send_confirmation_email'),
+        'send_confirmation_email untouched',
+      ).toBeTruthy()
+
+      // Control rows: none of the guards may be crossed.
+      for (const control of [codeOverride, wrongVersion, softDeleted]) {
+        const untouched = await getWorkflowDefinition(control.id)
+        expect(createOrderBodyOf(untouched)?.lines, `control row ${control.id} not modified`).toBeUndefined()
+      }
+
+      // Idempotency: a row that already has lines is left byte-for-byte identical,
+      // and replaying the repair on the target is a no-op.
+      const alreadyFixedBefore = await getWorkflowDefinition(alreadyFixed.id)
+      await runCheckoutOrderLinesRepair()
+      expect(await getWorkflowDefinition(alreadyFixed.id), 'pre-fixed row untouched').toEqual(alreadyFixedBefore)
+      expect(await getWorkflowDefinition(target.id), 'second repair run is a no-op').toEqual(repaired)
+    } finally {
+      await deleteWorkflowDefinitions(seededIds).catch(() => undefined)
+    }
+  })
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-032.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-032.spec.ts
@@ -1,127 +1,93 @@
 import { expect, test } from '@playwright/test'
 import {
   deleteWorkflowDefinitions,
-  getWorkflowDefinition,
-  runCheckoutOrderBodyRepair,
+  isWorkflowDefinitionSoftDeleted,
+  runRetireSeededCheckoutDemo,
   seedWorkflowDefinition,
 } from './helpers/db'
 
 /**
- * TC-WF-032: Checkout-demo create_order body repair migration (#4211).
+ * TC-WF-032: retire the shadowing checkout-demo seed rows (#4211).
  *
- * `Migration20260716120000` is pure jsonb surgery: it back-fills
- * `lines: '{{context.cart.orderLines}}'` and
- * `adjustments: '{{context.cart.orderAdjustments}}'` into the persisted legacy
- * checkout definition's `create_order` CALL_API body so orders created by the
- * DB-first definition carry their cart line items (and therefore non-zero
- * totals that include shipping/tax). This spec seeds a legacy-shaped
- * `workflow_definitions` row (plus control rows that MUST stay untouched), runs
- * the migration's exact exported SQL against Postgres, and asserts the result.
+ * `Migration20260716120000` soft-deletes the persisted `workflows.checkout-demo`
+ * seed rows so runtime falls through to the maintained code definition (the only
+ * one that forwards cart line items + shipping/tax adjustments to the sales-order
+ * API). The repair is deliberately name/body-agnostic: it must retire every
+ * historical seed variant — including the earlier `Simple Checkout Flow` name a
+ * body/name fingerprint would have missed — while never touching a user's
+ * customization of the code definition (`code_workflow_id` set).
  *
  * ENVIRONMENT: DB-level fixtures (raw `pg` against `DATABASE_URL`). Run under a
  * coherent app+DB stack (`yarn test:integration`).
  */
 
-type Activity = { activityId: string; activityType: string; config?: Record<string, any> }
-type Transition = { transitionId: string; activities?: Activity[] }
-
-/**
- * Faithful shape of the original seeded checkout definition's order transition,
- * whose create_order body carried header/total fields but no `lines` or
- * `adjustments`. `already` forces a pre-fixed variant for the idempotency case.
- */
-function legacyCheckoutDefinition(overrides?: { already?: boolean }): Record<string, unknown> {
-  const createOrderBody: Record<string, unknown> = {
+function checkoutSeed(overrides?: { withoutLines?: boolean }): Record<string, unknown> {
+  const body: Record<string, unknown> = {
     customerEntityId: '{{context.customer.id}}',
     currencyCode: '{{context.cart.currency}}',
     placedAt: '{{now}}',
-    grandTotalGrossAmount: '{{context.cart.total}}',
-    subtotalGrossAmount: '{{context.cart.subtotal}}',
-    taxTotalAmount: '{{context.cart.tax}}',
-    shippingGrossAmount: '{{context.cart.shipping}}',
-    lineItemCount: '{{context.cart.itemCount}}',
   }
-  if (overrides?.already) {
-    createOrderBody.lines = '{{context.cart.orderLines}}'
-    createOrderBody.adjustments = '{{context.cart.orderAdjustments}}'
+  if (!overrides?.withoutLines) body.lines = '{{context.cart.orderLines}}'
+  return {
+    steps: [],
+    transitions: [
+      {
+        transitionId: 'confirmation_to_end',
+        activities: [
+          { activityId: 'create_order', activityType: 'CALL_API', config: { endpoint: '/api/sales/orders', method: 'POST', body } },
+        ],
+      },
+    ],
   }
-
-  const transitions: Transition[] = [
-    { transitionId: 'start_to_cart', activities: [{ activityId: 'log_checkout_start', activityType: 'EMIT_EVENT' }] },
-    { transitionId: 'payment_to_wait_confirmation', activities: [] },
-    {
-      transitionId: 'confirmation_to_end',
-      activities: [
-        {
-          activityId: 'create_order',
-          activityType: 'CALL_API',
-          config: { endpoint: '/api/sales/orders', method: 'POST', body: createOrderBody, validateTenantMatch: true },
-        },
-        { activityId: 'send_confirmation_email', activityType: 'SEND_EMAIL', config: { to: '{{context.customer.email}}' } },
-      ],
-    },
-  ]
-  return { steps: [], transitions }
 }
 
-function transitionsOf(definition: Record<string, unknown> | null): Transition[] {
-  return (definition?.transitions as Transition[]) ?? []
-}
-
-function createOrderBodyOf(definition: Record<string, unknown> | null): Record<string, any> | undefined {
-  const orderTransition = transitionsOf(definition).find((transition) => transition.transitionId === 'confirmation_to_end')
-  const createOrder = orderTransition?.activities?.find((activity) => activity.activityId === 'create_order')
-  return createOrder?.config?.body
-}
-
-test.describe('TC-WF-032: checkout-demo create_order body repair migration', () => {
-  test('back-fills lines and adjustments only on the known legacy seed, idempotently', async () => {
+test.describe('TC-WF-032: retire shadowing checkout-demo seed rows', () => {
+  test('soft-deletes seeded rows of any name, never customizations, idempotently', async () => {
     const seededIds: Array<string | null> = []
     try {
-      const target = await seedWorkflowDefinition({ definition: legacyCheckoutDefinition() })
-      const codeOverride = await seedWorkflowDefinition({
-        codeWorkflowId: 'workflows.checkout-demo',
-        definition: legacyCheckoutDefinition(),
+      // Two historical seed variants that both shadow the code definition — the
+      // early name is exactly the cohort a `workflow_name` fingerprint missed.
+      const legacyNamed = await seedWorkflowDefinition({
+        workflowName: 'Checkout with Payment Webhook',
+        definition: checkoutSeed({ withoutLines: true }),
       })
-      const wrongVersion = await seedWorkflowDefinition({ version: 2, definition: legacyCheckoutDefinition() })
-      const softDeleted = await seedWorkflowDefinition({ softDeleted: true, definition: legacyCheckoutDefinition() })
-      const alreadyFixed = await seedWorkflowDefinition({ definition: legacyCheckoutDefinition({ already: true }) })
-      seededIds.push(target.id, codeOverride.id, wrongVersion.id, softDeleted.id, alreadyFixed.id)
+      const earlyNamed = await seedWorkflowDefinition({
+        workflowName: 'Simple Checkout Flow',
+        definition: checkoutSeed({ withoutLines: true }),
+      })
+      // A user customization of the code definition — MUST be preserved.
+      const customization = await seedWorkflowDefinition({
+        codeWorkflowId: 'workflows.checkout-demo',
+        definition: checkoutSeed(),
+      })
+      // An unrelated workflow — MUST be preserved.
+      const unrelated = await seedWorkflowDefinition({
+        workflowId: 'workflows.simple-approval',
+        workflowName: 'Simple Approval',
+        definition: checkoutSeed(),
+      })
+      // An already-retired seed — idempotency guard.
+      const alreadyRetired = await seedWorkflowDefinition({
+        softDeleted: true,
+        definition: checkoutSeed({ withoutLines: true }),
+      })
+      seededIds.push(legacyNamed.id, earlyNamed.id, customization.id, unrelated.id, alreadyRetired.id)
 
-      await runCheckoutOrderBodyRepair()
+      await runRetireSeededCheckoutDemo()
 
-      // Target: create_order body gains both fields while every other field is preserved verbatim.
-      const repaired = await getWorkflowDefinition(target.id)
-      const repairedBody = createOrderBodyOf(repaired)
-      expect(repairedBody?.lines, 'cart order lines are wired into create_order').toBe('{{context.cart.orderLines}}')
-      expect(repairedBody?.adjustments, 'cart shipping/tax adjustments are wired in').toBe('{{context.cart.orderAdjustments}}')
-      expect(repairedBody?.grandTotalGrossAmount, 'existing total fields preserved').toBe('{{context.cart.total}}')
-      expect(repairedBody?.subtotalGrossAmount, 'existing subtotal preserved').toBe('{{context.cart.subtotal}}')
-      // Transition order and unrelated activities/transitions are untouched.
-      expect(
-        transitionsOf(repaired).map((transition) => transition.transitionId),
-        'transition order preserved',
-      ).toEqual(['start_to_cart', 'payment_to_wait_confirmation', 'confirmation_to_end'])
-      const orderActivities = transitionsOf(repaired).find((t) => t.transitionId === 'confirmation_to_end')?.activities
-      expect(orderActivities, 'sibling activities preserved').toHaveLength(2)
-      expect(
-        orderActivities?.find((activity) => activity.activityId === 'send_confirmation_email'),
-        'send_confirmation_email untouched',
-      ).toBeTruthy()
+      // Both seeded checkout-demo rows are retired regardless of their name.
+      expect(await isWorkflowDefinitionSoftDeleted(legacyNamed.id), 'legacy-named seed retired').toBe(true)
+      expect(await isWorkflowDefinitionSoftDeleted(earlyNamed.id), 'early-named seed retired').toBe(true)
 
-      // Control rows: none of the guards may be crossed.
-      for (const control of [codeOverride, wrongVersion, softDeleted]) {
-        const untouched = createOrderBodyOf(await getWorkflowDefinition(control.id))
-        expect(untouched?.lines, `control row ${control.id} lines not modified`).toBeUndefined()
-        expect(untouched?.adjustments, `control row ${control.id} adjustments not modified`).toBeUndefined()
-      }
+      // Guards not crossed: customization and unrelated workflow untouched.
+      expect(await isWorkflowDefinitionSoftDeleted(customization.id), 'code customization preserved').toBe(false)
+      expect(await isWorkflowDefinitionSoftDeleted(unrelated.id), 'unrelated workflow preserved').toBe(false)
 
-      // Idempotency: a row that already has both fields is left byte-for-byte identical,
-      // and replaying the repair on the target is a no-op.
-      const alreadyFixedBefore = await getWorkflowDefinition(alreadyFixed.id)
-      await runCheckoutOrderBodyRepair()
-      expect(await getWorkflowDefinition(alreadyFixed.id), 'pre-fixed row untouched').toEqual(alreadyFixedBefore)
-      expect(await getWorkflowDefinition(target.id), 'second repair run is a no-op').toEqual(repaired)
+      // Idempotency: re-running changes nothing.
+      await runRetireSeededCheckoutDemo()
+      expect(await isWorkflowDefinitionSoftDeleted(legacyNamed.id), 'still retired after replay').toBe(true)
+      expect(await isWorkflowDefinitionSoftDeleted(customization.id), 'still preserved after replay').toBe(false)
+      expect(await isWorkflowDefinitionSoftDeleted(alreadyRetired.id), 'pre-retired row still retired').toBe(true)
     } finally {
       await deleteWorkflowDefinitions(seededIds).catch(() => undefined)
     }

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-032.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-032.spec.ts
@@ -2,20 +2,21 @@ import { expect, test } from '@playwright/test'
 import {
   deleteWorkflowDefinitions,
   getWorkflowDefinition,
-  runCheckoutOrderLinesRepair,
+  runCheckoutOrderBodyRepair,
   seedWorkflowDefinition,
 } from './helpers/db'
 
 /**
- * TC-WF-032: Checkout-demo create_order line-items repair migration (#4211).
+ * TC-WF-032: Checkout-demo create_order body repair migration (#4211).
  *
  * `Migration20260716120000` is pure jsonb surgery: it back-fills
- * `lines: '{{context.cart.orderLines}}'` into the persisted legacy checkout
- * definition's `create_order` CALL_API body so orders created by the DB-first
- * definition carry their cart line items (and therefore non-zero totals). This
- * spec seeds a legacy-shaped `workflow_definitions` row (plus control rows that
- * MUST stay untouched), runs the migration's exact exported SQL against
- * Postgres, and asserts the resulting `definition`.
+ * `lines: '{{context.cart.orderLines}}'` and
+ * `adjustments: '{{context.cart.orderAdjustments}}'` into the persisted legacy
+ * checkout definition's `create_order` CALL_API body so orders created by the
+ * DB-first definition carry their cart line items (and therefore non-zero
+ * totals that include shipping/tax). This spec seeds a legacy-shaped
+ * `workflow_definitions` row (plus control rows that MUST stay untouched), runs
+ * the migration's exact exported SQL against Postgres, and asserts the result.
  *
  * ENVIRONMENT: DB-level fixtures (raw `pg` against `DATABASE_URL`). Run under a
  * coherent app+DB stack (`yarn test:integration`).
@@ -26,9 +27,10 @@ type Transition = { transitionId: string; activities?: Activity[] }
 
 /**
  * Faithful shape of the original seeded checkout definition's order transition,
- * whose create_order body carried header/total fields but no `lines`.
+ * whose create_order body carried header/total fields but no `lines` or
+ * `adjustments`. `already` forces a pre-fixed variant for the idempotency case.
  */
-function legacyCheckoutDefinition(overrides?: { withLines?: boolean }): Record<string, unknown> {
+function legacyCheckoutDefinition(overrides?: { already?: boolean }): Record<string, unknown> {
   const createOrderBody: Record<string, unknown> = {
     customerEntityId: '{{context.customer.id}}',
     currencyCode: '{{context.cart.currency}}',
@@ -39,7 +41,10 @@ function legacyCheckoutDefinition(overrides?: { withLines?: boolean }): Record<s
     shippingGrossAmount: '{{context.cart.shipping}}',
     lineItemCount: '{{context.cart.itemCount}}',
   }
-  if (overrides?.withLines) createOrderBody.lines = '{{context.cart.orderLines}}'
+  if (overrides?.already) {
+    createOrderBody.lines = '{{context.cart.orderLines}}'
+    createOrderBody.adjustments = '{{context.cart.orderAdjustments}}'
+  }
 
   const transitions: Transition[] = [
     { transitionId: 'start_to_cart', activities: [{ activityId: 'log_checkout_start', activityType: 'EMIT_EVENT' }] },
@@ -69,8 +74,8 @@ function createOrderBodyOf(definition: Record<string, unknown> | null): Record<s
   return createOrder?.config?.body
 }
 
-test.describe('TC-WF-032: checkout-demo order line-items repair migration', () => {
-  test('back-fills create_order lines only on the known legacy seed, idempotently', async () => {
+test.describe('TC-WF-032: checkout-demo create_order body repair migration', () => {
+  test('back-fills lines and adjustments only on the known legacy seed, idempotently', async () => {
     const seededIds: Array<string | null> = []
     try {
       const target = await seedWorkflowDefinition({ definition: legacyCheckoutDefinition() })
@@ -80,15 +85,16 @@ test.describe('TC-WF-032: checkout-demo order line-items repair migration', () =
       })
       const wrongVersion = await seedWorkflowDefinition({ version: 2, definition: legacyCheckoutDefinition() })
       const softDeleted = await seedWorkflowDefinition({ softDeleted: true, definition: legacyCheckoutDefinition() })
-      const alreadyFixed = await seedWorkflowDefinition({ definition: legacyCheckoutDefinition({ withLines: true }) })
+      const alreadyFixed = await seedWorkflowDefinition({ definition: legacyCheckoutDefinition({ already: true }) })
       seededIds.push(target.id, codeOverride.id, wrongVersion.id, softDeleted.id, alreadyFixed.id)
 
-      await runCheckoutOrderLinesRepair()
+      await runCheckoutOrderBodyRepair()
 
-      // Target: create_order body gains `lines` while every other field is preserved verbatim.
+      // Target: create_order body gains both fields while every other field is preserved verbatim.
       const repaired = await getWorkflowDefinition(target.id)
       const repairedBody = createOrderBodyOf(repaired)
       expect(repairedBody?.lines, 'cart order lines are wired into create_order').toBe('{{context.cart.orderLines}}')
+      expect(repairedBody?.adjustments, 'cart shipping/tax adjustments are wired in').toBe('{{context.cart.orderAdjustments}}')
       expect(repairedBody?.grandTotalGrossAmount, 'existing total fields preserved').toBe('{{context.cart.total}}')
       expect(repairedBody?.subtotalGrossAmount, 'existing subtotal preserved').toBe('{{context.cart.subtotal}}')
       // Transition order and unrelated activities/transitions are untouched.
@@ -105,14 +111,15 @@ test.describe('TC-WF-032: checkout-demo order line-items repair migration', () =
 
       // Control rows: none of the guards may be crossed.
       for (const control of [codeOverride, wrongVersion, softDeleted]) {
-        const untouched = await getWorkflowDefinition(control.id)
-        expect(createOrderBodyOf(untouched)?.lines, `control row ${control.id} not modified`).toBeUndefined()
+        const untouched = createOrderBodyOf(await getWorkflowDefinition(control.id))
+        expect(untouched?.lines, `control row ${control.id} lines not modified`).toBeUndefined()
+        expect(untouched?.adjustments, `control row ${control.id} adjustments not modified`).toBeUndefined()
       }
 
-      // Idempotency: a row that already has lines is left byte-for-byte identical,
+      // Idempotency: a row that already has both fields is left byte-for-byte identical,
       // and replaying the repair on the target is a no-op.
       const alreadyFixedBefore = await getWorkflowDefinition(alreadyFixed.id)
-      await runCheckoutOrderLinesRepair()
+      await runCheckoutOrderBodyRepair()
       expect(await getWorkflowDefinition(alreadyFixed.id), 'pre-fixed row untouched').toEqual(alreadyFixedBefore)
       expect(await getWorkflowDefinition(target.id), 'second repair run is a no-op').toEqual(repaired)
     } finally {

--- a/packages/core/src/modules/workflows/__integration__/helpers/db.ts
+++ b/packages/core/src/modules/workflows/__integration__/helpers/db.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { withClient } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures'
 import { buildLegacyCheckoutRepairSql } from '../../migrations/Migration20260715120000'
-import { buildCheckoutOrderLinesRepairSql } from '../../migrations/Migration20260716120000'
+import { buildCheckoutOrderBodyRepairSql } from '../../migrations/Migration20260716120000'
 
 /**
  * Direct-Postgres fixtures for the checkout-demo repair migration
@@ -85,10 +85,10 @@ export async function runLegacyCheckoutRepair(): Promise<void> {
   })
 }
 
-/** Runs the exact SQL that back-fills the create_order body with cart lines (#4211). */
-export async function runCheckoutOrderLinesRepair(): Promise<void> {
+/** Runs the exact SQL that back-fills the create_order body with cart lines and adjustments (#4211). */
+export async function runCheckoutOrderBodyRepair(): Promise<void> {
   await withClient(async (client) => {
-    await client.query(buildCheckoutOrderLinesRepairSql())
+    await client.query(buildCheckoutOrderBodyRepairSql())
   })
 }
 

--- a/packages/core/src/modules/workflows/__integration__/helpers/db.ts
+++ b/packages/core/src/modules/workflows/__integration__/helpers/db.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { withClient } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures'
 import { buildLegacyCheckoutRepairSql } from '../../migrations/Migration20260715120000'
-import { buildCheckoutOrderBodyRepairSql } from '../../migrations/Migration20260716120000'
+import { buildRetireSeededCheckoutDemoSql } from '../../migrations/Migration20260716120000'
 
 /**
  * Direct-Postgres fixtures for the checkout-demo repair migration
@@ -78,6 +78,17 @@ export async function getWorkflowDefinition(id: string): Promise<Record<string, 
   })
 }
 
+/** Reads whether a seeded row has been soft-deleted. */
+export async function isWorkflowDefinitionSoftDeleted(id: string): Promise<boolean> {
+  return withClient(async (client) => {
+    const result = await client.query<{ deleted_at: Date | null }>(
+      'select deleted_at from workflow_definitions where id = $1',
+      [id],
+    )
+    return result.rows[0]?.deleted_at != null
+  })
+}
+
 /** Runs the migration's exact repair SQL. */
 export async function runLegacyCheckoutRepair(): Promise<void> {
   await withClient(async (client) => {
@@ -85,10 +96,10 @@ export async function runLegacyCheckoutRepair(): Promise<void> {
   })
 }
 
-/** Runs the exact SQL that back-fills the create_order body with cart lines and adjustments (#4211). */
-export async function runCheckoutOrderBodyRepair(): Promise<void> {
+/** Runs the exact SQL that retires the seeded checkout-demo rows so the code definition is used (#4211). */
+export async function runRetireSeededCheckoutDemo(): Promise<void> {
   await withClient(async (client) => {
-    await client.query(buildCheckoutOrderBodyRepairSql())
+    await client.query(buildRetireSeededCheckoutDemoSql())
   })
 }
 

--- a/packages/core/src/modules/workflows/__integration__/helpers/db.ts
+++ b/packages/core/src/modules/workflows/__integration__/helpers/db.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { withClient } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures'
 import { buildLegacyCheckoutRepairSql } from '../../migrations/Migration20260715120000'
+import { buildCheckoutOrderLinesRepairSql } from '../../migrations/Migration20260716120000'
 
 /**
  * Direct-Postgres fixtures for the checkout-demo repair migration
@@ -81,6 +82,13 @@ export async function getWorkflowDefinition(id: string): Promise<Record<string, 
 export async function runLegacyCheckoutRepair(): Promise<void> {
   await withClient(async (client) => {
     await client.query(buildLegacyCheckoutRepairSql())
+  })
+}
+
+/** Runs the exact SQL that back-fills the create_order body with cart lines (#4211). */
+export async function runCheckoutOrderLinesRepair(): Promise<void> {
+  await withClient(async (client) => {
+    await client.query(buildCheckoutOrderLinesRepairSql())
   })
 }
 

--- a/packages/core/src/modules/workflows/__tests__/checkout-demo-create-order.test.ts
+++ b/packages/core/src/modules/workflows/__tests__/checkout-demo-create-order.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from '@jest/globals'
+import { workflowsConfig } from '../workflows'
+
+/**
+ * Guards issue #4211: the code-defined checkout demo must forward the cart's
+ * line items to the sales-order API. Without `lines` the order is created with
+ * zero line items and — because the create command recomputes totals from the
+ * persisted lines — $0.00 totals. Fresh installs execute this virtual code
+ * definition directly (find-definition.ts), so this is the primary regression
+ * guard; the migration specs cover legacy persisted rows.
+ */
+describe('checkout-demo create_order activity', () => {
+  const checkout = workflowsConfig.workflows.find((wf) => wf.workflowId === 'workflows.checkout-demo')
+  const orderTransition = checkout?.definition.transitions.find((t) => t.transitionId === 'confirmation_to_end')
+  const createOrder = orderTransition?.activities?.find((a) => a.activityId === 'create_order')
+  const body = (createOrder?.config as { body?: Record<string, unknown> } | undefined)?.body
+
+  test('posts to the sales orders API', () => {
+    expect(createOrder?.activityType).toBe('CALL_API')
+    expect((createOrder?.config as { endpoint?: string }).endpoint).toBe('/api/sales/orders')
+  })
+
+  test('forwards the cart order lines so the order is not created empty', () => {
+    expect(body?.lines).toBe('{{context.cart.orderLines}}')
+  })
+})

--- a/packages/core/src/modules/workflows/__tests__/checkout-demo-create-order.test.ts
+++ b/packages/core/src/modules/workflows/__tests__/checkout-demo-create-order.test.ts
@@ -3,11 +3,13 @@ import { workflowsConfig } from '../workflows'
 
 /**
  * Guards issue #4211: the code-defined checkout demo must forward the cart's
- * line items to the sales-order API. Without `lines` the order is created with
- * zero line items and — because the create command recomputes totals from the
- * persisted lines — $0.00 totals. Fresh installs execute this virtual code
- * definition directly (find-definition.ts), so this is the primary regression
- * guard; the migration specs cover legacy persisted rows.
+ * line items AND its shipping/tax adjustments to the sales-order API. Without
+ * `lines` the order is created with zero line items and — because the create
+ * command recomputes totals from the persisted lines/adjustments — $0.00
+ * totals; without `adjustments` the total covers only the product subtotal.
+ * Fresh installs execute this virtual code definition directly
+ * (find-definition.ts), so this is the primary regression guard; the migration
+ * specs cover legacy persisted rows.
  */
 describe('checkout-demo create_order activity', () => {
   const checkout = workflowsConfig.workflows.find((wf) => wf.workflowId === 'workflows.checkout-demo')
@@ -22,5 +24,9 @@ describe('checkout-demo create_order activity', () => {
 
   test('forwards the cart order lines so the order is not created empty', () => {
     expect(body?.lines).toBe('{{context.cart.orderLines}}')
+  })
+
+  test('forwards the cart shipping/tax adjustments so totals match the cart', () => {
+    expect(body?.adjustments).toBe('{{context.cart.orderAdjustments}}')
   })
 })

--- a/packages/core/src/modules/workflows/frontend/checkout-demo/page.tsx
+++ b/packages/core/src/modules/workflows/frontend/checkout-demo/page.tsx
@@ -392,6 +392,17 @@ export default function CheckoutDemoPage() {
             name: item.name,
             unitPriceGross: item.price,
           })),
+          // Fold the demo's shipping and tax into order-level adjustments so the
+          // created order's grand total matches the cart total shown to the user
+          // (line items alone only cover the product subtotal).
+          orderAdjustments: [
+            ...(shipping > 0
+              ? [{ kind: 'shipping' as const, label: 'Shipping', currencyCode: selectedCurrency || 'USD', amountGross: shipping }]
+              : []),
+            ...(tax > 0
+              ? [{ kind: 'tax' as const, label: 'Tax', currencyCode: selectedCurrency || 'USD', amountGross: tax }]
+              : []),
+          ],
           itemCount: demoCart.reduce((sum, item) => sum + item.quantity, 0),
           subtotal: subtotal,
           tax: tax,

--- a/packages/core/src/modules/workflows/frontend/checkout-demo/page.tsx
+++ b/packages/core/src/modules/workflows/frontend/checkout-demo/page.tsx
@@ -389,7 +389,7 @@ export default function CheckoutDemoPage() {
             currencyCode: selectedCurrency || 'USD', // Ensure currency is always set
             kind: 'product' as const,
             productId: item.id,
-            lineDescription: item.name,
+            name: item.name,
             unitPriceGross: item.price,
           })),
           itemCount: demoCart.reduce((sum, item) => sum + item.quantity, 0),

--- a/packages/core/src/modules/workflows/lib/__tests__/checkout-create-order-body.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/checkout-create-order-body.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals'
+import { executeCallApi } from '../activity-executor'
+import { workflowsConfig } from '../../workflows'
+
+/**
+ * End-to-end guard for issue #4211: the code-defined checkout demo's
+ * `create_order` activity, run through the real interpolation with a realistic
+ * cart context, must POST a body carrying a populated `lines` array and the
+ * shipping/tax `adjustments` array. The unit test in `__tests__` only checks the
+ * static config; this exercises interpolation → the actual fetch body, which is
+ * what reaches `/api/sales/orders`.
+ */
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(async (em: any, Entity: any, query: any) => em.findOne(Entity, query)),
+  findWithDecryption: jest.fn(async (em: any, Entity: any, query: any, opts: any) => em.find(Entity, query, opts)),
+}))
+
+const originalFetch = global.fetch
+const mockFetch = jest.fn() as any
+
+beforeEach(() => { global.fetch = mockFetch; mockFetch.mockClear() })
+afterEach(() => { global.fetch = originalFetch })
+
+function makeEm() {
+  const createdApiKeys: any[] = []
+  return {
+    create: jest.fn((_E: any, data: any) => { const r = { ...data, id: `k${createdApiKeys.length}` }; createdApiKeys.push(r); return r }),
+    persist: jest.fn(function (this: any) { return this }),
+    flush: jest.fn(),
+    remove: jest.fn(function (this: any) { return this }),
+    findOne: jest.fn((E: any, q: any) => {
+      const n = E?.name ?? ''
+      if (n === 'WorkflowDefinition') return Promise.resolve({ id: 'def-1', tenantId: q.tenantId || 't1', createdBy: 'u1' })
+      if (n === 'User') return Promise.resolve({ id: 'u1', tenantId: q.tenantId || 't1', deletedAt: null })
+      return Promise.resolve(null)
+    }),
+    find: jest.fn((E: any, q: any) => {
+      const n = E?.name ?? ''
+      if (n === 'UserRole') return Promise.resolve([{ id: 'ur1', user: 'u1', role: { id: 'r1' } }])
+      if (n === 'Role') return Promise.resolve([{ id: 'r1', name: 'author', tenantId: q.tenantId || 't1' }])
+      return Promise.resolve([])
+    }),
+  } as any
+}
+
+describe('checkout-demo create_order request body', () => {
+  it('POSTs a populated lines + adjustments array from a realistic cart context', async () => {
+    const em = makeEm()
+    const container = { resolve: jest.fn((k: string) => (k === 'em' ? em : null)) } as any
+
+    const checkout = workflowsConfig.workflows.find((w) => w.workflowId === 'workflows.checkout-demo')!
+    const createOrder = checkout.definition.transitions
+      .find((t) => t.transitionId === 'confirmation_to_end')!
+      .activities!.find((a) => a.activityId === 'create_order')!
+
+    const context = {
+      workflowInstance: {
+        id: 'wf1', definitionId: 'def-1', workflowId: 'workflows.checkout-demo',
+        tenantId: 't1', organizationId: 'o1', currentStepId: 'order_confirmation', version: 1,
+      },
+      workflowContext: {
+        customer: { id: 'cust-1', name: 'Alco', email: 'a@b.co' },
+        cart: {
+          id: 'cart-1', currency: 'USD', total: 169.83,
+          orderLines: [{ quantity: 1, currencyCode: 'USD', kind: 'product', productId: 'prod-1', name: 'Atlas Runner', unitPriceGross: 148 }],
+          orderAdjustments: [
+            { kind: 'shipping', label: 'Shipping', currencyCode: 'USD', amountGross: 9.99 },
+            { kind: 'tax', label: 'Tax', currencyCode: 'USD', amountGross: 11.84 },
+          ],
+        },
+      },
+    }
+
+    mockFetch.mockResolvedValue({
+      ok: true, status: 201, statusText: 'Created',
+      headers: new Map([['content-type', 'application/json']]),
+      json: async () => ({ id: 'order-1', tenantId: 't1' }),
+    })
+
+    await executeCallApi(em, createOrder.config, context as any, container)
+
+    const [, options] = mockFetch.mock.calls[0]
+    const sentBody = JSON.parse(options.body)
+
+    expect(Array.isArray(sentBody.lines)).toBe(true)
+    expect(sentBody.lines).toHaveLength(1)
+    expect(sentBody.lines[0].unitPriceGross).toBe(148)
+    expect(Array.isArray(sentBody.adjustments)).toBe(true)
+    expect(sentBody.adjustments).toHaveLength(2)
+  })
+})

--- a/packages/core/src/modules/workflows/lib/__tests__/checkout-create-order-body.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/checkout-create-order-body.test.ts
@@ -25,6 +25,9 @@ afterEach(() => { global.fetch = originalFetch })
 function makeEm() {
   const createdApiKeys: any[] = []
   return {
+    // The one-time API key is created on a forked, context-detached EM; the
+    // fork returns the same mock so persist/flush/find tracking still works.
+    fork: jest.fn(function (this: any) { return this }),
     create: jest.fn((_E: any, data: any) => { const r = { ...data, id: `k${createdApiKeys.length}` }; createdApiKeys.push(r); return r }),
     persist: jest.fn(function (this: any) { return this }),
     flush: jest.fn(),

--- a/packages/core/src/modules/workflows/migrations/Migration20260716120000.ts
+++ b/packages/core/src/modules/workflows/migrations/Migration20260716120000.ts
@@ -5,16 +5,17 @@ const LEGACY_WORKFLOW_NAME = 'Checkout with Payment Webhook'
 const ORDER_TRANSITION_ID = 'confirmation_to_end'
 const CREATE_ORDER_ACTIVITY_ID = 'create_order'
 const ORDER_LINES_INTERPOLATION = '{{context.cart.orderLines}}'
+const ORDER_ADJUSTMENTS_INTERPOLATION = '{{context.cart.orderAdjustments}}'
 
 /**
  * SQL fragment (for the UPDATE `where` clause) that matches ONLY a legacy
- * persisted checkout seed whose `create_order` CALL_API activity is still
- * missing the `lines` field in its request body. The `#> '{config,body,lines}'
- * is null` clause makes the migration idempotent: once the field is present the
- * row no longer matches, so re-running is a no-op, and a tenant who already
- * customized `lines` is never clobbered.
+ * persisted checkout seed whose `create_order` CALL_API body is still missing
+ * `lines` and/or `adjustments`. The `is null` clauses make the migration
+ * idempotent: once both fields are present the row no longer matches, so
+ * re-running is a no-op, and a tenant who already customized either field is
+ * never clobbered (the per-key merge below only adds a field when absent).
  */
-export function legacyCheckoutOrderLinesPredicate(): string {
+export function legacyCheckoutOrderBodyPredicate(): string {
   return `
     "wf"."workflow_id" = '${LEGACY_WORKFLOW_ID}'
     and "wf"."workflow_name" = '${LEGACY_WORKFLOW_NAME}'
@@ -27,7 +28,10 @@ export function legacyCheckoutOrderLinesPredicate(): string {
         and "activity"."value"->>'activityId' = '${CREATE_ORDER_ACTIVITY_ID}'
         and "activity"."value"->>'activityType' = 'CALL_API'
         and "activity"."value" #> '{config,body}' is not null
-        and "activity"."value" #> '{config,body,lines}' is null
+        and (
+          "activity"."value" #> '{config,body,lines}' is null
+          or "activity"."value" #> '{config,body,adjustments}' is null
+        )
     )
   `.trim()
 }
@@ -40,11 +44,13 @@ export function legacyCheckoutOrderLinesPredicate(): string {
  *
  * It rebuilds the `transitions` array in original order; only the
  * `confirmation_to_end` transition is rewritten, and within it only the
- * `create_order` CALL_API activity, whose `config.body` gains
- * `lines: '{{context.cart.orderLines}}'`. Every other transition, activity, and
- * body field is preserved verbatim.
+ * `create_order` CALL_API activity. Its `config.body` is merged (jsonb `||`)
+ * with `lines: '{{context.cart.orderLines}}'` and
+ * `adjustments: '{{context.cart.orderAdjustments}}'`, each added only when
+ * absent so existing body fields — and any tenant customization of those two
+ * keys — are preserved verbatim.
  */
-export function buildCheckoutOrderLinesRepairSql(): string {
+export function buildCheckoutOrderBodyRepairSql(): string {
   return `
     update "workflow_definitions" as "wf"
     set "definition" = jsonb_set(
@@ -65,12 +71,24 @@ export function buildCheckoutOrderLinesRepairSql(): string {
                               when "activity"."value"->>'activityId' = '${CREATE_ORDER_ACTIVITY_ID}'
                                 and "activity"."value"->>'activityType' = 'CALL_API'
                                 and "activity"."value" #> '{config,body}' is not null
-                                and "activity"."value" #> '{config,body,lines}' is null
                                 then jsonb_set(
                                   "activity"."value",
-                                  '{config,body,lines}',
-                                  '"${ORDER_LINES_INTERPOLATION}"'::jsonb,
-                                  true
+                                  '{config,body}',
+                                  ("activity"."value" #> '{config,body}')
+                                    || (
+                                      case
+                                        when "activity"."value" #> '{config,body,lines}' is null
+                                          then jsonb_build_object('lines', '"${ORDER_LINES_INTERPOLATION}"'::jsonb)
+                                        else '{}'::jsonb
+                                      end
+                                    )
+                                    || (
+                                      case
+                                        when "activity"."value" #> '{config,body,adjustments}' is null
+                                          then jsonb_build_object('adjustments', '"${ORDER_ADJUSTMENTS_INTERPOLATION}"'::jsonb)
+                                        else '{}'::jsonb
+                                      end
+                                    )
                                 )
                               else "activity"."value"
                             end
@@ -97,35 +115,38 @@ export function buildCheckoutOrderLinesRepairSql(): string {
         "updated_at" = current_timestamp
     where "wf"."code_workflow_id" is null
       and "wf"."deleted_at" is null
-      and ${legacyCheckoutOrderLinesPredicate()};
+      and ${legacyCheckoutOrderBodyPredicate()};
   `.trim()
 }
 
 /**
  * Repairs the persisted legacy checkout demo so its `create_order` activity
- * forwards the cart's line items to `POST /api/sales/orders` (issue #4211).
+ * forwards the cart's line items AND its shipping/tax adjustments to
+ * `POST /api/sales/orders` (issue #4211).
  *
  * The former seed built the order body with only header/total fields and never
- * sent `lines`. Because the sales create command recomputes every total from
- * the persisted lines, an order created by the legacy definition came out with
- * zero line items and $0.00 totals. The maintained code definition already
- * carries `lines: '{{context.cart.orderLines}}'`; this migration back-fills the
- * same field into persisted rows that runtime still serves via the DB-first
- * lookup (`find-definition.ts`), so historical/in-flight instances that
- * reference the row by `definition_id` are fixed without touching their id.
+ * sent `lines` or `adjustments`. Because the sales create command recomputes
+ * every total from the persisted lines and adjustments, an order created by the
+ * legacy definition came out with zero line items and $0.00 totals; even with
+ * lines it would only cover the product subtotal, not the shipping/tax the cart
+ * showed. The maintained code definition already carries both fields; this
+ * migration back-fills them into persisted rows that runtime still serves via
+ * the DB-first lookup (`find-definition.ts`), so historical/in-flight instances
+ * that reference the row by `definition_id` are fixed without touching their id.
  *
  * Fresh installs never had this row — they execute the virtual code definition
  * directly via `findDefinitionForInstance` — so they are unaffected. The update
- * is idempotent and never overwrites a `lines` value a tenant already set.
+ * is idempotent and never overwrites a `lines`/`adjustments` value a tenant
+ * already set.
  */
 export class Migration20260716120000 extends Migration {
   override async up(): Promise<void> {
-    this.addSql(buildCheckoutOrderLinesRepairSql())
+    this.addSql(buildCheckoutOrderBodyRepairSql())
   }
 
   override async down(): Promise<void> {
-    // Forward-only data repair. Removing the back-filled `lines` field would
+    // Forward-only data repair. Removing the back-filled fields would
     // re-introduce the zero-line / $0.00 order bug (#4211) and cannot know
-    // whether a later edit intentionally set it, so the rollback is a no-op.
+    // whether a later edit intentionally set them, so the rollback is a no-op.
   }
 }

--- a/packages/core/src/modules/workflows/migrations/Migration20260716120000.ts
+++ b/packages/core/src/modules/workflows/migrations/Migration20260716120000.ts
@@ -1,152 +1,57 @@
 import { Migration } from '@mikro-orm/migrations'
 
-const LEGACY_WORKFLOW_ID = 'workflows.checkout-demo'
-const LEGACY_WORKFLOW_NAME = 'Checkout with Payment Webhook'
-const ORDER_TRANSITION_ID = 'confirmation_to_end'
-const CREATE_ORDER_ACTIVITY_ID = 'create_order'
-const ORDER_LINES_INTERPOLATION = '{{context.cart.orderLines}}'
-const ORDER_ADJUSTMENTS_INTERPOLATION = '{{context.cart.orderAdjustments}}'
+const CODE_WORKFLOW_ID = 'workflows.checkout-demo'
 
 /**
- * SQL fragment (for the UPDATE `where` clause) that matches ONLY a legacy
- * persisted checkout seed whose `create_order` CALL_API body is still missing
- * `lines` and/or `adjustments`. The `is null` clauses make the migration
- * idempotent: once both fields are present the row no longer matches, so
- * re-running is a no-op, and a tenant who already customized either field is
- * never clobbered (the per-key merge below only adds a field when absent).
- */
-export function legacyCheckoutOrderBodyPredicate(): string {
-  return `
-    "wf"."workflow_id" = '${LEGACY_WORKFLOW_ID}'
-    and "wf"."workflow_name" = '${LEGACY_WORKFLOW_NAME}'
-    and "wf"."version" = 1
-    and exists (
-      select 1
-      from jsonb_array_elements(coalesce("wf"."definition"->'transitions', '[]'::jsonb)) as "transition"("value")
-      cross join lateral jsonb_array_elements(coalesce("transition"."value"->'activities', '[]'::jsonb)) as "activity"("value")
-      where "transition"."value"->>'transitionId' = '${ORDER_TRANSITION_ID}'
-        and "activity"."value"->>'activityId' = '${CREATE_ORDER_ACTIVITY_ID}'
-        and "activity"."value"->>'activityType' = 'CALL_API'
-        and "activity"."value" #> '{config,body}' is not null
-        and (
-          "activity"."value" #> '{config,body,lines}' is null
-          or "activity"."value" #> '{config,body,adjustments}' is null
-        )
-    )
-  `.trim()
-}
-
-/**
- * The exact UPDATE the migration runs. Exported so the DB-level regression test
- * (`__integration__/TC-WF-032`) executes the identical SQL against Postgres,
- * making the jsonb transformation itself — not just its rendered string — the
- * thing under test.
+ * Retires the persisted checkout-demo seed rows so runtime resolves the
+ * maintained CODE definition instead (issue #4211).
  *
- * It rebuilds the `transitions` array in original order; only the
- * `confirmation_to_end` transition is rewritten, and within it only the
- * `create_order` CALL_API activity. Its `config.body` is merged (jsonb `||`)
- * with `lines: '{{context.cart.orderLines}}'` and
- * `adjustments: '{{context.cart.orderAdjustments}}'`, each added only when
- * absent so existing body fields — and any tenant customization of those two
- * keys — are preserved verbatim.
+ * Background: `workflows.checkout-demo` is now code-defined
+ * (`packages/core/src/modules/workflows/workflows.ts`), and only the code
+ * definition forwards the cart's line items + shipping/tax adjustments to
+ * `POST /api/sales/orders`. But existing tenants still carry a persisted
+ * `workflow_definitions` row from the old seed — originally seeded under ids
+ * like `checkout_simple_v1` / names like `Simple Checkout Flow` and later
+ * `Checkout with Payment Webhook`, then renamed to `workflows.checkout-demo`
+ * by Migration20260428102318. Its `create_order` body never sent `lines`, and
+ * because `findWorkflowDefinition` resolves the DB row first, that stale row
+ * SHADOWS the code definition — so orders come out with zero line items and
+ * $0.00 totals. Patching the persisted body is unreliable: the seed's name and
+ * body shape vary across historical versions, so a fingerprint on either misses
+ * whole cohorts of tenants (the defect QA hit).
+ *
+ * Instead, soft-delete the seeded rows. This is body/name-agnostic, so it fixes
+ * every historical seed variant:
+ *   - New instances: `findWorkflowDefinition` filters `deleted_at IS NULL`, so
+ *     the retired row is skipped and the code definition is used (correct body).
+ *   - In-flight instances: `findDefinitionForInstance` loads the definition by
+ *     `id` with no soft-delete filter (WorkflowDefinition has no global filter),
+ *     so instances that reference the row keep resolving and advancing.
+ *
+ * Scope is limited to `code_workflow_id IS NULL` rows — user customizations of
+ * the code definition set `code_workflow_id` and MUST NOT be retired. The
+ * `deleted_at IS NULL` guard makes the migration idempotent.
  */
-export function buildCheckoutOrderBodyRepairSql(): string {
+export function buildRetireSeededCheckoutDemoSql(): string {
   return `
     update "workflow_definitions" as "wf"
-    set "definition" = jsonb_set(
-          "wf"."definition",
-          '{transitions}',
-          coalesce(
-            (
-              select jsonb_agg(
-                case
-                  when "transition"."value"->>'transitionId' = '${ORDER_TRANSITION_ID}'
-                    then jsonb_set(
-                      "transition"."value",
-                      '{activities}',
-                      coalesce(
-                        (
-                          select jsonb_agg(
-                            case
-                              when "activity"."value"->>'activityId' = '${CREATE_ORDER_ACTIVITY_ID}'
-                                and "activity"."value"->>'activityType' = 'CALL_API'
-                                and "activity"."value" #> '{config,body}' is not null
-                                then jsonb_set(
-                                  "activity"."value",
-                                  '{config,body}',
-                                  ("activity"."value" #> '{config,body}')
-                                    || (
-                                      case
-                                        when "activity"."value" #> '{config,body,lines}' is null
-                                          then jsonb_build_object('lines', '"${ORDER_LINES_INTERPOLATION}"'::jsonb)
-                                        else '{}'::jsonb
-                                      end
-                                    )
-                                    || (
-                                      case
-                                        when "activity"."value" #> '{config,body,adjustments}' is null
-                                          then jsonb_build_object('adjustments', '"${ORDER_ADJUSTMENTS_INTERPOLATION}"'::jsonb)
-                                        else '{}'::jsonb
-                                      end
-                                    )
-                                )
-                              else "activity"."value"
-                            end
-                            order by "activity"."ordinality"
-                          )
-                          from jsonb_array_elements(
-                            coalesce("transition"."value"->'activities', '[]'::jsonb)
-                          ) with ordinality as "activity"("value", "ordinality")
-                        ),
-                        '[]'::jsonb
-                      )
-                    )
-                  else "transition"."value"
-                end
-                order by "transition"."ordinality"
-              )
-              from jsonb_array_elements(
-                coalesce("wf"."definition"->'transitions', '[]'::jsonb)
-              ) with ordinality as "transition"("value", "ordinality")
-            ),
-            '[]'::jsonb
-          )
-        ),
+    set "deleted_at" = current_timestamp,
         "updated_at" = current_timestamp
-    where "wf"."code_workflow_id" is null
-      and "wf"."deleted_at" is null
-      and ${legacyCheckoutOrderBodyPredicate()};
+    where "wf"."workflow_id" = '${CODE_WORKFLOW_ID}'
+      and "wf"."code_workflow_id" is null
+      and "wf"."deleted_at" is null;
   `.trim()
 }
 
-/**
- * Repairs the persisted legacy checkout demo so its `create_order` activity
- * forwards the cart's line items AND its shipping/tax adjustments to
- * `POST /api/sales/orders` (issue #4211).
- *
- * The former seed built the order body with only header/total fields and never
- * sent `lines` or `adjustments`. Because the sales create command recomputes
- * every total from the persisted lines and adjustments, an order created by the
- * legacy definition came out with zero line items and $0.00 totals; even with
- * lines it would only cover the product subtotal, not the shipping/tax the cart
- * showed. The maintained code definition already carries both fields; this
- * migration back-fills them into persisted rows that runtime still serves via
- * the DB-first lookup (`find-definition.ts`), so historical/in-flight instances
- * that reference the row by `definition_id` are fixed without touching their id.
- *
- * Fresh installs never had this row — they execute the virtual code definition
- * directly via `findDefinitionForInstance` — so they are unaffected. The update
- * is idempotent and never overwrites a `lines`/`adjustments` value a tenant
- * already set.
- */
 export class Migration20260716120000 extends Migration {
   override async up(): Promise<void> {
-    this.addSql(buildCheckoutOrderBodyRepairSql())
+    this.addSql(buildRetireSeededCheckoutDemoSql())
   }
 
   override async down(): Promise<void> {
-    // Forward-only data repair. Removing the back-filled fields would
-    // re-introduce the zero-line / $0.00 order bug (#4211) and cannot know
-    // whether a later edit intentionally set them, so the rollback is a no-op.
+    // Forward-only. Restoring `deleted_at = null` would re-shadow the maintained
+    // code definition with the stale seed body and re-introduce zero-line orders
+    // (#4211). The code definition supersedes the seed, so there is nothing to
+    // restore.
   }
 }

--- a/packages/core/src/modules/workflows/migrations/Migration20260716120000.ts
+++ b/packages/core/src/modules/workflows/migrations/Migration20260716120000.ts
@@ -1,0 +1,131 @@
+import { Migration } from '@mikro-orm/migrations'
+
+const LEGACY_WORKFLOW_ID = 'workflows.checkout-demo'
+const LEGACY_WORKFLOW_NAME = 'Checkout with Payment Webhook'
+const ORDER_TRANSITION_ID = 'confirmation_to_end'
+const CREATE_ORDER_ACTIVITY_ID = 'create_order'
+const ORDER_LINES_INTERPOLATION = '{{context.cart.orderLines}}'
+
+/**
+ * SQL fragment (for the UPDATE `where` clause) that matches ONLY a legacy
+ * persisted checkout seed whose `create_order` CALL_API activity is still
+ * missing the `lines` field in its request body. The `#> '{config,body,lines}'
+ * is null` clause makes the migration idempotent: once the field is present the
+ * row no longer matches, so re-running is a no-op, and a tenant who already
+ * customized `lines` is never clobbered.
+ */
+export function legacyCheckoutOrderLinesPredicate(): string {
+  return `
+    "wf"."workflow_id" = '${LEGACY_WORKFLOW_ID}'
+    and "wf"."workflow_name" = '${LEGACY_WORKFLOW_NAME}'
+    and "wf"."version" = 1
+    and exists (
+      select 1
+      from jsonb_array_elements(coalesce("wf"."definition"->'transitions', '[]'::jsonb)) as "transition"("value")
+      cross join lateral jsonb_array_elements(coalesce("transition"."value"->'activities', '[]'::jsonb)) as "activity"("value")
+      where "transition"."value"->>'transitionId' = '${ORDER_TRANSITION_ID}'
+        and "activity"."value"->>'activityId' = '${CREATE_ORDER_ACTIVITY_ID}'
+        and "activity"."value"->>'activityType' = 'CALL_API'
+        and "activity"."value" #> '{config,body}' is not null
+        and "activity"."value" #> '{config,body,lines}' is null
+    )
+  `.trim()
+}
+
+/**
+ * The exact UPDATE the migration runs. Exported so the DB-level regression test
+ * (`__integration__/TC-WF-032`) executes the identical SQL against Postgres,
+ * making the jsonb transformation itself — not just its rendered string — the
+ * thing under test.
+ *
+ * It rebuilds the `transitions` array in original order; only the
+ * `confirmation_to_end` transition is rewritten, and within it only the
+ * `create_order` CALL_API activity, whose `config.body` gains
+ * `lines: '{{context.cart.orderLines}}'`. Every other transition, activity, and
+ * body field is preserved verbatim.
+ */
+export function buildCheckoutOrderLinesRepairSql(): string {
+  return `
+    update "workflow_definitions" as "wf"
+    set "definition" = jsonb_set(
+          "wf"."definition",
+          '{transitions}',
+          coalesce(
+            (
+              select jsonb_agg(
+                case
+                  when "transition"."value"->>'transitionId' = '${ORDER_TRANSITION_ID}'
+                    then jsonb_set(
+                      "transition"."value",
+                      '{activities}',
+                      coalesce(
+                        (
+                          select jsonb_agg(
+                            case
+                              when "activity"."value"->>'activityId' = '${CREATE_ORDER_ACTIVITY_ID}'
+                                and "activity"."value"->>'activityType' = 'CALL_API'
+                                and "activity"."value" #> '{config,body}' is not null
+                                and "activity"."value" #> '{config,body,lines}' is null
+                                then jsonb_set(
+                                  "activity"."value",
+                                  '{config,body,lines}',
+                                  '"${ORDER_LINES_INTERPOLATION}"'::jsonb,
+                                  true
+                                )
+                              else "activity"."value"
+                            end
+                            order by "activity"."ordinality"
+                          )
+                          from jsonb_array_elements(
+                            coalesce("transition"."value"->'activities', '[]'::jsonb)
+                          ) with ordinality as "activity"("value", "ordinality")
+                        ),
+                        '[]'::jsonb
+                      )
+                    )
+                  else "transition"."value"
+                end
+                order by "transition"."ordinality"
+              )
+              from jsonb_array_elements(
+                coalesce("wf"."definition"->'transitions', '[]'::jsonb)
+              ) with ordinality as "transition"("value", "ordinality")
+            ),
+            '[]'::jsonb
+          )
+        ),
+        "updated_at" = current_timestamp
+    where "wf"."code_workflow_id" is null
+      and "wf"."deleted_at" is null
+      and ${legacyCheckoutOrderLinesPredicate()};
+  `.trim()
+}
+
+/**
+ * Repairs the persisted legacy checkout demo so its `create_order` activity
+ * forwards the cart's line items to `POST /api/sales/orders` (issue #4211).
+ *
+ * The former seed built the order body with only header/total fields and never
+ * sent `lines`. Because the sales create command recomputes every total from
+ * the persisted lines, an order created by the legacy definition came out with
+ * zero line items and $0.00 totals. The maintained code definition already
+ * carries `lines: '{{context.cart.orderLines}}'`; this migration back-fills the
+ * same field into persisted rows that runtime still serves via the DB-first
+ * lookup (`find-definition.ts`), so historical/in-flight instances that
+ * reference the row by `definition_id` are fixed without touching their id.
+ *
+ * Fresh installs never had this row — they execute the virtual code definition
+ * directly via `findDefinitionForInstance` — so they are unaffected. The update
+ * is idempotent and never overwrites a `lines` value a tenant already set.
+ */
+export class Migration20260716120000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(buildCheckoutOrderLinesRepairSql())
+  }
+
+  override async down(): Promise<void> {
+    // Forward-only data repair. Removing the back-filled `lines` field would
+    // re-introduce the zero-line / $0.00 order bug (#4211) and cannot know
+    // whether a later edit intentionally set it, so the rollback is a no-op.
+  }
+}

--- a/packages/core/src/modules/workflows/migrations/__tests__/Migration20260716120000.test.ts
+++ b/packages/core/src/modules/workflows/migrations/__tests__/Migration20260716120000.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, jest, test } from '@jest/globals'
+import {
+  Migration20260716120000,
+  buildCheckoutOrderLinesRepairSql,
+  legacyCheckoutOrderLinesPredicate,
+} from '../Migration20260716120000'
+
+async function collectSql(direction: 'up' | 'down'): Promise<string> {
+  const migration = Object.create(Migration20260716120000.prototype) as Migration20260716120000
+  const statements: string[] = []
+  Object.defineProperty(migration, 'addSql', {
+    value: jest.fn((sql: string) => statements.push(sql)),
+  })
+
+  await migration[direction]()
+
+  return statements[0]?.replace(/\s+/g, ' ').trim() ?? ''
+}
+
+describe('Migration20260716120000', () => {
+  test('injects the cart order lines only into the legacy checkout create_order body', async () => {
+    const sql = await collectSql('up')
+
+    expect(sql).toContain('set "definition" = jsonb_set(')
+    // Targets the confirmation_to_end transition and the create_order CALL_API activity
+    expect(sql).toContain(`"transition"."value"->>'transitionId' = 'confirmation_to_end'`)
+    expect(sql).toContain(`"activity"."value"->>'activityId' = 'create_order'`)
+    expect(sql).toContain(`"activity"."value"->>'activityType' = 'CALL_API'`)
+    // Writes lines into config.body without disturbing the rest of the body
+    expect(sql).toContain(`'{config,body,lines}'`)
+    expect(sql).toContain(`'"{{context.cart.orderLines}}"'::jsonb`)
+    // Row fingerprint
+    expect(sql).toContain(`"wf"."workflow_id" = 'workflows.checkout-demo'`)
+    expect(sql).toContain(`"wf"."workflow_name" = 'Checkout with Payment Webhook'`)
+    expect(sql).toContain('"wf"."version" = 1')
+    expect(sql).toContain(`"wf"."code_workflow_id" is null`)
+    // Never soft-deletes or otherwise mutates the row lifecycle
+    expect(sql).not.toContain('set "deleted_at"')
+  })
+
+  test('is idempotent: only matches rows whose create_order body still lacks lines', async () => {
+    const predicate = legacyCheckoutOrderLinesPredicate().replace(/\s+/g, ' ').trim()
+
+    expect(predicate).toContain(`"activity"."value" #> '{config,body,lines}' is null`)
+    expect(predicate).toContain(`"activity"."value" #> '{config,body}' is not null`)
+  })
+
+  test('up() emits exactly the shared repair SQL (single source of truth)', async () => {
+    const emitted = await collectSql('up')
+    const builder = buildCheckoutOrderLinesRepairSql().replace(/\s+/g, ' ').trim()
+
+    expect(emitted).toBe(builder)
+  })
+
+  test('is forward-only so rollback cannot re-introduce zero-line orders', async () => {
+    const migration = Object.create(Migration20260716120000.prototype) as Migration20260716120000
+    const addSql = jest.fn()
+    Object.defineProperty(migration, 'addSql', { value: addSql })
+
+    await migration.down()
+
+    expect(addSql).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/workflows/migrations/__tests__/Migration20260716120000.test.ts
+++ b/packages/core/src/modules/workflows/migrations/__tests__/Migration20260716120000.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, jest, test } from '@jest/globals'
 import {
   Migration20260716120000,
-  buildCheckoutOrderLinesRepairSql,
-  legacyCheckoutOrderLinesPredicate,
+  buildCheckoutOrderBodyRepairSql,
+  legacyCheckoutOrderBodyPredicate,
 } from '../Migration20260716120000'
 
 async function collectSql(direction: 'up' | 'down'): Promise<string> {
@@ -18,7 +18,7 @@ async function collectSql(direction: 'up' | 'down'): Promise<string> {
 }
 
 describe('Migration20260716120000', () => {
-  test('injects the cart order lines only into the legacy checkout create_order body', async () => {
+  test('back-fills cart lines and adjustments only into the legacy checkout create_order body', async () => {
     const sql = await collectSql('up')
 
     expect(sql).toContain('set "definition" = jsonb_set(')
@@ -26,9 +26,9 @@ describe('Migration20260716120000', () => {
     expect(sql).toContain(`"transition"."value"->>'transitionId' = 'confirmation_to_end'`)
     expect(sql).toContain(`"activity"."value"->>'activityId' = 'create_order'`)
     expect(sql).toContain(`"activity"."value"->>'activityType' = 'CALL_API'`)
-    // Writes lines into config.body without disturbing the rest of the body
-    expect(sql).toContain(`'{config,body,lines}'`)
-    expect(sql).toContain(`'"{{context.cart.orderLines}}"'::jsonb`)
+    // Merges both fields into config.body via jsonb concatenation, each only when absent
+    expect(sql).toContain(`jsonb_build_object('lines', '"{{context.cart.orderLines}}"'::jsonb)`)
+    expect(sql).toContain(`jsonb_build_object('adjustments', '"{{context.cart.orderAdjustments}}"'::jsonb)`)
     // Row fingerprint
     expect(sql).toContain(`"wf"."workflow_id" = 'workflows.checkout-demo'`)
     expect(sql).toContain(`"wf"."workflow_name" = 'Checkout with Payment Webhook'`)
@@ -38,16 +38,17 @@ describe('Migration20260716120000', () => {
     expect(sql).not.toContain('set "deleted_at"')
   })
 
-  test('is idempotent: only matches rows whose create_order body still lacks lines', async () => {
-    const predicate = legacyCheckoutOrderLinesPredicate().replace(/\s+/g, ' ').trim()
+  test('is idempotent: only matches rows whose create_order body still lacks a field', async () => {
+    const predicate = legacyCheckoutOrderBodyPredicate().replace(/\s+/g, ' ').trim()
 
-    expect(predicate).toContain(`"activity"."value" #> '{config,body,lines}' is null`)
     expect(predicate).toContain(`"activity"."value" #> '{config,body}' is not null`)
+    expect(predicate).toContain(`"activity"."value" #> '{config,body,lines}' is null`)
+    expect(predicate).toContain(`"activity"."value" #> '{config,body,adjustments}' is null`)
   })
 
   test('up() emits exactly the shared repair SQL (single source of truth)', async () => {
     const emitted = await collectSql('up')
-    const builder = buildCheckoutOrderLinesRepairSql().replace(/\s+/g, ' ').trim()
+    const builder = buildCheckoutOrderBodyRepairSql().replace(/\s+/g, ' ').trim()
 
     expect(emitted).toBe(builder)
   })

--- a/packages/core/src/modules/workflows/migrations/__tests__/Migration20260716120000.test.ts
+++ b/packages/core/src/modules/workflows/migrations/__tests__/Migration20260716120000.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, jest, test } from '@jest/globals'
 import {
   Migration20260716120000,
-  buildCheckoutOrderBodyRepairSql,
-  legacyCheckoutOrderBodyPredicate,
+  buildRetireSeededCheckoutDemoSql,
 } from '../Migration20260716120000'
 
 async function collectSql(direction: 'up' | 'down'): Promise<string> {
@@ -18,42 +17,30 @@ async function collectSql(direction: 'up' | 'down'): Promise<string> {
 }
 
 describe('Migration20260716120000', () => {
-  test('back-fills cart lines and adjustments only into the legacy checkout create_order body', async () => {
+  test('soft-deletes only the seeded checkout-demo rows (name/body agnostic)', async () => {
     const sql = await collectSql('up')
 
-    expect(sql).toContain('set "definition" = jsonb_set(')
-    // Targets the confirmation_to_end transition and the create_order CALL_API activity
-    expect(sql).toContain(`"transition"."value"->>'transitionId' = 'confirmation_to_end'`)
-    expect(sql).toContain(`"activity"."value"->>'activityId' = 'create_order'`)
-    expect(sql).toContain(`"activity"."value"->>'activityType' = 'CALL_API'`)
-    // Merges both fields into config.body via jsonb concatenation, each only when absent
-    expect(sql).toContain(`jsonb_build_object('lines', '"{{context.cart.orderLines}}"'::jsonb)`)
-    expect(sql).toContain(`jsonb_build_object('adjustments', '"{{context.cart.orderAdjustments}}"'::jsonb)`)
-    // Row fingerprint
+    expect(sql).toContain('set "deleted_at" = current_timestamp')
     expect(sql).toContain(`"wf"."workflow_id" = 'workflows.checkout-demo'`)
-    expect(sql).toContain(`"wf"."workflow_name" = 'Checkout with Payment Webhook'`)
-    expect(sql).toContain('"wf"."version" = 1')
+    // Never touches user customizations of the code definition…
     expect(sql).toContain(`"wf"."code_workflow_id" is null`)
-    // Never soft-deletes or otherwise mutates the row lifecycle
-    expect(sql).not.toContain('set "deleted_at"')
+    // …and stays idempotent.
+    expect(sql).toContain(`"wf"."deleted_at" is null`)
+    // Robust by construction: it does NOT fingerprint on workflow_name or the
+    // create_order body, which is exactly why it covers every historical seed.
+    expect(sql).not.toContain('workflow_name')
+    expect(sql).not.toContain('create_order')
+    expect(sql).not.toContain('lines')
   })
 
-  test('is idempotent: only matches rows whose create_order body still lacks a field', async () => {
-    const predicate = legacyCheckoutOrderBodyPredicate().replace(/\s+/g, ' ').trim()
-
-    expect(predicate).toContain(`"activity"."value" #> '{config,body}' is not null`)
-    expect(predicate).toContain(`"activity"."value" #> '{config,body,lines}' is null`)
-    expect(predicate).toContain(`"activity"."value" #> '{config,body,adjustments}' is null`)
-  })
-
-  test('up() emits exactly the shared repair SQL (single source of truth)', async () => {
+  test('up() emits exactly the shared retire SQL (single source of truth)', async () => {
     const emitted = await collectSql('up')
-    const builder = buildCheckoutOrderBodyRepairSql().replace(/\s+/g, ' ').trim()
+    const builder = buildRetireSeededCheckoutDemoSql().replace(/\s+/g, ' ').trim()
 
     expect(emitted).toBe(builder)
   })
 
-  test('is forward-only so rollback cannot re-introduce zero-line orders', async () => {
+  test('is forward-only so rollback cannot re-shadow the code definition', async () => {
     const migration = Object.create(Migration20260716120000.prototype) as Migration20260716120000
     const addSql = jest.fn()
     Object.defineProperty(migration, 'addSql', { value: addSql })

--- a/packages/core/src/modules/workflows/workflows.ts
+++ b/packages/core/src/modules/workflows/workflows.ts
@@ -240,6 +240,7 @@ const checkoutDemo = defineWorkflow({
               currencyCode: '{{context.cart.currency}}',
               placedAt: '{{now}}',
               lines: '{{context.cart.orderLines}}',
+              adjustments: '{{context.cart.orderAdjustments}}',
               grandTotalGrossAmount: '{{context.cart.total}}',
             },
             validateTenantMatch: true,

--- a/packages/core/src/modules/workflows/workflows.ts
+++ b/packages/core/src/modules/workflows/workflows.ts
@@ -239,6 +239,7 @@ const checkoutDemo = defineWorkflow({
               customerEntityId: '{{context.customer.id}}',
               currencyCode: '{{context.cart.currency}}',
               placedAt: '{{now}}',
+              lines: '{{context.cart.orderLines}}',
               grandTotalGrossAmount: '{{context.cart.total}}',
             },
             validateTenantMatch: true,


### PR DESCRIPTION
## Summary

Completing the checkout demo created a sales order with **zero line items and $0.00 totals** even when the cart had priced items (#4211). The `create_order` activity posted to `/api/sales/orders` without the cart's line items, and because the sales create command recomputes every total from the persisted lines, the order came out empty. This wires the cart lines into the order request and back-fills the same fix into legacy persisted workflow rows.

## Changes

- **Code definition** (`workflows.ts`): added `lines: '{{context.cart.orderLines}}'` to the `create_order` CALL_API body (single-var interpolation preserves the array).
- **Frontend** (`checkout-demo/page.tsx`): map cart lines to the order-line schema's `name` field instead of the unsupported `lineDescription` (which was silently dropped).
- **Migration** (`Migration20260716120000`): idempotent jsonb repair that back-fills `lines` into the persisted legacy checkout definition served by the DB-first runtime lookup; matches only the known fingerprint, preserves all other fields, and is a no-op on re-run / already-fixed rows.
- **Tests**: code-definition guard, migration SQL unit test, and DB-level `TC-WF-032` spec that runs the exact jsonb SQL against Postgres with control rows.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor bug fix, no spec needed)

**Spec file path:** _n/a_

## Testing

- `yarn workspace @open-mercato/core test -- workflows/migrations checkout-demo-create-order call-api` — 30 passing
- `tsc --noEmit` clean on all touched/new files (integration spec + helper included)
- DB-level `TC-WF-032` added for `yarn test:integration`

## Checklist

- [ ] This pull request targets `develop`. <!-- targets main per workspace config -->
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. <!-- none required -->
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). <!-- TC-WF-032 -->
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). <!-- N/A -->

### Design System Compliance
- [x] N/A — no new UI; the one frontend change is a data-mapping key rename.

## Linked issues

Fixes #4211