### PR TITLE
perf(cli): stop hashing generator inputs while idle

### DIFF
--- a/packages/cli/src/lib/__tests__/generate-watch-events.test.ts
+++ b/packages/cli/src/lib/__tests__/generate-watch-events.test.ts
@@ -1,0 +1,112 @@
+import path from 'node:path'
+import {
+  createGenerateWatchChangeSignal,
+  type GenerateWatchTarget,
+} from '../generate-watch-events'
+
+type RegisteredWatcher = {
+  target: GenerateWatchTarget
+  onChange: () => void
+  onError: () => void
+  close: jest.Mock
+}
+
+function createWatchHarness(initialTargets: GenerateWatchTarget[]) {
+  let targets = initialTargets
+  const registered: RegisteredWatcher[] = []
+  const watchDirectory = jest.fn((
+    target: GenerateWatchTarget,
+    onChange: () => void,
+    onError: () => void,
+  ) => {
+    const watcher = { target, onChange, onError, close: jest.fn() }
+    registered.push(watcher)
+    return watcher
+  })
+  const signal = createGenerateWatchChangeSignal({
+    getWatchTargets: () => targets,
+    watchDirectory,
+  })
+
+  return {
+    signal,
+    registered,
+    watchDirectory,
+    setTargets: (nextTargets: GenerateWatchTarget[]) => { targets = nextTargets },
+  }
+}
+
+describe('createGenerateWatchChangeSignal', () => {
+  it('deduplicates targets and increments its version on filesystem events', async () => {
+    const target = { directory: './modules', recursive: true }
+    const { signal, registered, watchDirectory } = createWatchHarness([target, target])
+
+    await signal.refresh()
+    expect(watchDirectory).toHaveBeenCalledTimes(1)
+    expect(registered[0].target.directory).toBe(path.resolve('./modules'))
+    expect(signal.currentVersion()).toBe(0)
+
+    registered[0].onChange()
+    registered[0].onChange()
+    expect(signal.currentVersion()).toBe(2)
+    expect(signal.usesPollingFallback()).toBe(false)
+  })
+
+  it('refreshes changed watch roots without recreating stable watchers', async () => {
+    const first = { directory: './modules-a', recursive: true }
+    const second = { directory: './modules-b', recursive: true }
+    const harness = createWatchHarness([first])
+
+    await harness.signal.refresh()
+    harness.setTargets([first, second])
+    await harness.signal.refresh()
+    expect(harness.watchDirectory).toHaveBeenCalledTimes(2)
+    expect(harness.registered[0].close).not.toHaveBeenCalled()
+
+    harness.setTargets([second])
+    await harness.signal.refresh()
+    expect(harness.registered[0].close).toHaveBeenCalledTimes(1)
+    expect(harness.registered[1].close).not.toHaveBeenCalled()
+  })
+
+  it('falls back to checksum polling when watcher setup fails', async () => {
+    const firstClose = jest.fn()
+    const watchDirectory = jest.fn()
+      .mockReturnValueOnce({ close: firstClose })
+      .mockImplementationOnce(() => { throw new Error('watch unavailable') })
+    const signal = createGenerateWatchChangeSignal({
+      getWatchTargets: () => [
+        { directory: './modules-a', recursive: true },
+        { directory: './modules-b', recursive: true },
+      ],
+      watchDirectory,
+    })
+
+    await signal.refresh()
+    expect(signal.usesPollingFallback()).toBe(true)
+    expect(signal.currentVersion()).toBe(1)
+    expect(firstClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to checksum polling when an active watcher errors', async () => {
+    const { signal, registered } = createWatchHarness([
+      { directory: './modules', recursive: true },
+    ])
+
+    await signal.refresh()
+    registered[0].onError()
+    expect(signal.usesPollingFallback()).toBe(true)
+    expect(registered[0].close).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes filesystem watchers exactly once', async () => {
+    const { signal, registered } = createWatchHarness([
+      { directory: './modules', recursive: true },
+    ])
+
+    await signal.refresh()
+    await signal.close()
+    await signal.close()
+    expect(registered[0].close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/cli/src/lib/__tests__/generate-watch-structure.test.ts
+++ b/packages/cli/src/lib/__tests__/generate-watch-structure.test.ts
@@ -77,4 +77,24 @@ describe('calculateGenerateWatchStructureChecksum', () => {
 
     expect(currentChecksum()).not.toBe(before)
   })
+
+  it('changes when a discovered worker is added and removed', () => {
+    const before = currentChecksum()
+    const workerPath = path.join(pkgModule, 'workers', 'sync-customers.ts')
+
+    write(workerPath, 'export default async function syncCustomers() {}\n')
+    const afterAdd = currentChecksum()
+    expect(afterAdd).not.toBe(before)
+
+    fs.rmSync(workerPath)
+    expect(currentChecksum()).toBe(before)
+  })
+
+  it('changes when the module registry configuration changes', () => {
+    const before = currentChecksum()
+
+    write(path.join(appDir, 'src', 'modules.ts'), 'export const enabledModules = ["customers"]\n')
+
+    expect(currentChecksum()).not.toBe(before)
+  })
 })

--- a/packages/cli/src/lib/__tests__/in-process-generate-watcher.test.ts
+++ b/packages/cli/src/lib/__tests__/in-process-generate-watcher.test.ts
@@ -1,11 +1,29 @@
-import { startInProcessGenerateWatcher } from '../in-process-generate-watcher'
+import {
+  startInProcessGenerateWatcher,
+  type GenerateWatcherChangeSignal,
+} from '../in-process-generate-watcher'
 
 const silentLogger = { log: jest.fn(), error: jest.fn() }
 
 async function flushAsync(times = 5): Promise<void> {
   for (let i = 0; i < times; i++) {
-    // eslint-disable-next-line no-await-in-loop
     await Promise.resolve()
+  }
+}
+
+function createFakeChangeSignal() {
+  let version = 0
+  let fallback = false
+  const signal: GenerateWatcherChangeSignal = {
+    currentVersion: () => version,
+    refresh: jest.fn(async () => undefined),
+    usesPollingFallback: () => fallback,
+    close: jest.fn(async () => undefined),
+  }
+  return {
+    signal,
+    markChanged: () => { version += 1 },
+    usePollingFallback: () => { fallback = true },
   }
 }
 
@@ -95,6 +113,179 @@ describe('startInProcessGenerateWatcher', () => {
 
     await handle.close()
     await handle.done
+  })
+
+  it('does not recompute the full checksum during event-gated idle polls', async () => {
+    const runGenerators = jest.fn(async () => undefined)
+    const computeStructureChecksum = jest.fn(async () => 'stable')
+    const { signal } = createFakeChangeSignal()
+    const handle = startInProcessGenerateWatcher({
+      pollMs: 1000,
+      skipInitial: true,
+      quiet: true,
+      logger: silentLogger,
+      changeSignal: signal,
+      computeStructureChecksum,
+      runGenerators,
+    })
+
+    await flushAsync(8)
+    expect(computeStructureChecksum).toHaveBeenCalledTimes(1)
+
+    for (let poll = 0; poll < 20; poll += 1) {
+      jest.advanceTimersByTime(1000)
+      await flushAsync(8)
+    }
+
+    expect(computeStructureChecksum).toHaveBeenCalledTimes(1)
+    expect(runGenerators).not.toHaveBeenCalled()
+    await handle.close()
+  })
+
+  it('coalesces filesystem event bursts into one checksum and regeneration', async () => {
+    let currentChecksum = 'before'
+    const runGenerators = jest.fn(async () => undefined)
+    const computeStructureChecksum = jest.fn(async () => currentChecksum)
+    const { signal, markChanged } = createFakeChangeSignal()
+    const handle = startInProcessGenerateWatcher({
+      pollMs: 1000,
+      skipInitial: true,
+      quiet: true,
+      logger: silentLogger,
+      changeSignal: signal,
+      computeStructureChecksum,
+      runGenerators,
+    })
+
+    await flushAsync(8)
+    currentChecksum = 'after'
+    markChanged()
+    markChanged()
+    markChanged()
+    jest.advanceTimersByTime(1000)
+    await flushAsync(12)
+
+    expect(computeStructureChecksum).toHaveBeenCalledTimes(2)
+    expect(runGenerators).toHaveBeenCalledTimes(1)
+    expect(runGenerators).toHaveBeenCalledWith('structure change')
+    await handle.close()
+  })
+
+  it('validates an unrelated filesystem event without regenerating', async () => {
+    const runGenerators = jest.fn(async () => undefined)
+    const computeStructureChecksum = jest.fn(async () => 'stable')
+    const { signal, markChanged } = createFakeChangeSignal()
+    const handle = startInProcessGenerateWatcher({
+      pollMs: 1000,
+      skipInitial: true,
+      quiet: true,
+      logger: silentLogger,
+      changeSignal: signal,
+      computeStructureChecksum,
+      runGenerators,
+    })
+
+    await flushAsync(8)
+    markChanged()
+    jest.advanceTimersByTime(1000)
+    await flushAsync(12)
+
+    expect(computeStructureChecksum).toHaveBeenCalledTimes(2)
+    expect(runGenerators).not.toHaveBeenCalled()
+    await handle.close()
+  })
+
+  it('retries a dirty checksum after a transient checksum failure', async () => {
+    const runGenerators = jest.fn(async () => undefined)
+    const computeStructureChecksum = jest.fn()
+      .mockResolvedValueOnce('before')
+      .mockRejectedValueOnce(new Error('temporary read failure'))
+      .mockResolvedValue('after')
+    const { signal, markChanged } = createFakeChangeSignal()
+    const handle = startInProcessGenerateWatcher({
+      pollMs: 1000,
+      skipInitial: true,
+      quiet: true,
+      logger: silentLogger,
+      changeSignal: signal,
+      computeStructureChecksum,
+      runGenerators,
+    })
+
+    await flushAsync(8)
+    markChanged()
+    jest.advanceTimersByTime(1000)
+    await flushAsync(8)
+    expect(runGenerators).not.toHaveBeenCalled()
+
+    jest.advanceTimersByTime(1000)
+    await flushAsync(12)
+    expect(computeStructureChecksum).toHaveBeenCalledTimes(3)
+    expect(runGenerators).toHaveBeenCalledTimes(1)
+    await handle.close()
+  })
+
+  it('keeps an event that arrives while a checksum is in flight dirty for the next poll', async () => {
+    let releaseChecksum: ((value: string) => void) | null = null
+    const runGenerators = jest.fn(async () => undefined)
+    const computeStructureChecksum = jest.fn()
+      .mockResolvedValueOnce('before')
+      .mockImplementationOnce(() => new Promise<string>((resolve) => {
+        releaseChecksum = resolve
+      }))
+      .mockResolvedValue('after')
+    const { signal, markChanged } = createFakeChangeSignal()
+    const handle = startInProcessGenerateWatcher({
+      pollMs: 1000,
+      skipInitial: true,
+      quiet: true,
+      logger: silentLogger,
+      changeSignal: signal,
+      computeStructureChecksum,
+      runGenerators,
+    })
+
+    await flushAsync(8)
+    markChanged()
+    jest.advanceTimersByTime(1000)
+    await flushAsync(8)
+    expect(computeStructureChecksum).toHaveBeenCalledTimes(2)
+
+    markChanged()
+    releaseChecksum?.('after')
+    await flushAsync(12)
+    expect(runGenerators).toHaveBeenCalledTimes(1)
+
+    jest.advanceTimersByTime(1000)
+    await flushAsync(12)
+    expect(computeStructureChecksum).toHaveBeenCalledTimes(3)
+    await handle.close()
+  })
+
+  it('falls back to full checksum polling when filesystem watching is unavailable', async () => {
+    const runGenerators = jest.fn(async () => undefined)
+    const computeStructureChecksum = jest.fn(async () => 'stable')
+    const { signal, usePollingFallback } = createFakeChangeSignal()
+    usePollingFallback()
+    const handle = startInProcessGenerateWatcher({
+      pollMs: 1000,
+      skipInitial: true,
+      quiet: true,
+      logger: silentLogger,
+      changeSignal: signal,
+      computeStructureChecksum,
+      runGenerators,
+    })
+
+    await flushAsync(8)
+    jest.advanceTimersByTime(1000)
+    await flushAsync(8)
+    jest.advanceTimersByTime(1000)
+    await flushAsync(8)
+
+    expect(computeStructureChecksum).toHaveBeenCalledTimes(3)
+    await handle.close()
+    expect(signal.close).toHaveBeenCalledTimes(1)
   })
 
   it('does not start a new poll while a regeneration is in flight', async () => {

--- a/packages/cli/src/lib/generate-watch-events.ts
+++ b/packages/cli/src/lib/generate-watch-events.ts
@@ -1,0 +1,125 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import type { GenerateWatcherChangeSignal } from './in-process-generate-watcher'
+
+export type GenerateWatchTarget = {
+  directory: string
+  recursive: boolean
+  fileName?: string
+}
+
+type WatchHandle = {
+  close(): void
+}
+
+type WatchDirectory = (
+  target: GenerateWatchTarget,
+  onChange: (fileName?: string) => void,
+  onError: () => void,
+) => WatchHandle
+
+export type GenerateWatchChangeSignalOptions = {
+  getWatchTargets: () => Promise<GenerateWatchTarget[]> | GenerateWatchTarget[]
+  watchDirectory?: WatchDirectory
+}
+
+function targetKey(target: GenerateWatchTarget): string {
+  return JSON.stringify([
+    path.resolve(target.directory),
+    target.recursive,
+    target.fileName ?? '',
+  ])
+}
+
+const defaultWatchDirectory: WatchDirectory = (target, onChange, onError) => {
+  const watcher = fs.watch(
+    target.directory,
+    { recursive: target.recursive },
+    (_eventType, fileName) => {
+      const normalizedName = String(fileName ?? '')
+      if (target.fileName && normalizedName && normalizedName !== target.fileName) return
+      onChange(normalizedName || undefined)
+    },
+  )
+  watcher.on('error', onError)
+  return watcher
+}
+
+export function createGenerateWatchChangeSignal(
+  options: GenerateWatchChangeSignalOptions,
+): GenerateWatcherChangeSignal {
+  const watchDirectory = options.watchDirectory ?? defaultWatchDirectory
+  const watchers = new Map<string, WatchHandle>()
+  let version = 0
+  let pollingFallback = false
+  let closed = false
+
+  const closeWatchers = () => {
+    for (const watcher of watchers.values()) {
+      try { watcher.close() } catch {}
+    }
+    watchers.clear()
+  }
+
+  const enterPollingFallback = () => {
+    if (pollingFallback) return
+    pollingFallback = true
+    version += 1
+    closeWatchers()
+  }
+
+  return {
+    currentVersion: () => version,
+    usesPollingFallback: () => pollingFallback,
+    refresh: async () => {
+      if (closed || pollingFallback) return
+
+      let targets: GenerateWatchTarget[]
+      try {
+        targets = await options.getWatchTargets()
+      } catch {
+        enterPollingFallback()
+        return
+      }
+
+      const normalizedTargets = new Map<string, GenerateWatchTarget>()
+      for (const target of targets) {
+        const normalized: GenerateWatchTarget = {
+          ...target,
+          directory: path.resolve(target.directory),
+        }
+        normalizedTargets.set(targetKey(normalized), normalized)
+      }
+
+      for (const [key, watcher] of watchers) {
+        if (normalizedTargets.has(key)) continue
+        try { watcher.close() } catch {}
+        watchers.delete(key)
+      }
+
+      for (const [key, target] of normalizedTargets) {
+        if (watchers.has(key)) continue
+        try {
+          const watcher = watchDirectory(
+            target,
+            () => { version += 1 },
+            enterPollingFallback,
+          )
+          if (closed || pollingFallback) {
+            try { watcher.close() } catch {}
+            continue
+          }
+          watchers.set(key, watcher)
+        } catch {
+          enterPollingFallback()
+          return
+        }
+      }
+    },
+    close: () => {
+      if (closed) return
+      closed = true
+      closeWatchers()
+    },
+  }
+}

--- a/packages/cli/src/lib/in-process-generate-watcher.ts
+++ b/packages/cli/src/lib/in-process-generate-watcher.ts
@@ -1,15 +1,16 @@
 /**
  * In-process generate watcher.
  *
- * Polls a structural-fingerprint function on a configurable interval and
- * invokes the supplied generator callback whenever the fingerprint changes.
+ * Coalesces filesystem events on a configurable interval, then verifies them
+ * with the existing structural fingerprint before invoking the generator.
+ * If filesystem watching is unavailable, it falls back to fingerprint polling.
  * The polling loop is identical to the legacy standalone watcher; the only
  * difference is that it now runs inside whatever process calls it
  * (typically `mercato server dev`), so the dev runtime no longer needs a
  * sidecar `mercato generate watch` Node process.
  *
- * Contract preserved 1:1 with the prior standalone watcher:
- *   - Default poll interval 1000 ms (minimum 250 ms).
+ * Contract preserved from the prior standalone watcher:
+ *   - Default debounce/fallback poll interval 1000 ms (minimum 250 ms).
  *   - One initial generator run unless `skipInitial` is true.
  *   - Concurrent regeneration requests are coalesced (running + pending).
  *   - Generator errors are logged but never crash the watcher.
@@ -18,12 +19,25 @@
 
 export type GenerateWatcherLogger = Pick<Console, 'log' | 'error'>
 
+export type GenerateWatcherChangeSignal = {
+  /** Monotonic event generation. Changes indicate that a checksum may be stale. */
+  currentVersion(): number
+  /** Refresh filesystem subscriptions after module configuration changes. */
+  refresh(): Promise<void> | void
+  /** When true, preserve the legacy full-checksum-on-every-poll behavior. */
+  usesPollingFallback(): boolean
+  /** Close filesystem subscriptions. Idempotent. */
+  close(): Promise<void> | void
+}
+
 export type GenerateWatcherOptions = {
   /**
    * Function that returns the current structural fingerprint of the module
    * tree. The watcher re-runs `runGenerators` whenever this value changes.
    */
   computeStructureChecksum: () => Promise<string> | string
+  /** Optional event signal that avoids full checksum work during idle polls. */
+  changeSignal?: GenerateWatcherChangeSignal
   /**
    * Function that performs the actual regeneration work. Called once on
    * startup (unless `skipInitial`) and again whenever the checksum changes.
@@ -69,13 +83,14 @@ export function startInProcessGenerateWatcher(
   const quiet = options.quiet === true
   const pollMs = resolvePollMs(options.pollMs)
   const skipInitial = options.skipInitial === true
-  const { computeStructureChecksum, runGenerators } = options
+  const { changeSignal, computeStructureChecksum, runGenerators } = options
 
   let stopping = false
   let pollTimer: ReturnType<typeof setTimeout> | null = null
   let running = false
   let pendingReason: string | null = null
   let previousChecksum = ''
+  let observedChangeVersion = -1
   let doneResolve: (() => void) | null = null
   const done = new Promise<void>((resolve) => {
     doneResolve = resolve
@@ -114,7 +129,17 @@ export function startInProcessGenerateWatcher(
       void (async () => {
         if (stopping) return
         try {
+          const changeVersion = changeSignal?.currentVersion() ?? 0
+          if (
+            changeSignal
+            && !changeSignal.usesPollingFallback()
+            && changeVersion === observedChangeVersion
+          ) {
+            return
+          }
           const nextChecksum = await computeStructureChecksum()
+          observedChangeVersion = changeVersion
+          await changeSignal?.refresh()
           if (nextChecksum !== previousChecksum) {
             previousChecksum = nextChecksum
             await runOnce('structure change')
@@ -132,15 +157,18 @@ export function startInProcessGenerateWatcher(
 
   void (async () => {
     try {
+      await changeSignal?.refresh()
+      const initialChangeVersion = changeSignal?.currentVersion() ?? 0
       if (!skipInitial) {
         await runOnce('initial')
       }
       previousChecksum = await computeStructureChecksum()
+      observedChangeVersion = initialChangeVersion
       if (!quiet) {
         if (skipInitial) {
           logger.log('[generate:watch] Skipping initial regeneration and watching the current generated state.')
         }
-        logger.log(`[generate:watch] Watching structural module files every ${pollMs}ms (in-process).`)
+        logger.log(`[generate:watch] Watching structural module files with a ${pollMs}ms debounce (in-process).`)
       }
       scheduleNext()
     } catch (error) {
@@ -162,6 +190,7 @@ export function startInProcessGenerateWatcher(
       clearTimeout(pollTimer)
       pollTimer = null
     }
+    await changeSignal?.close()
     if (doneResolve) {
       doneResolve()
       doneResolve = null

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -774,24 +774,59 @@ async function runGeneratorSuite(quiet: boolean): Promise<void> {
 }
 
 /**
- * Builds the structural-fingerprint function used by the in-process generate
- * watcher. Walks the same module roots the legacy `mercato generate watch`
- * CLI command tracked, so the polling semantics are byte-for-byte identical.
+ * Builds the event-gated structural fingerprint runtime used by generate
+ * watchers. Filesystem events mark the tree dirty; the existing full content
+ * checksum remains the final authority and the fallback when watching fails.
  */
-function createGenerateWatchChecksumFn(): () => Promise<string> {
-  return async () => {
-    const { createResolver } = await import('./lib/resolver')
-    const { calculateGenerateWatchStructureChecksum } = await import('./lib/generate-watch-structure')
+async function createGenerateWatchRuntime() {
+  const [
+    { createResolver },
+    { calculateGenerateWatchStructureChecksum },
+    { createGenerateWatchChangeSignal },
+    { resolveStandaloneSourceMirrorBase },
+  ] = await Promise.all([
+    import('./lib/resolver'),
+    import('./lib/generate-watch-structure'),
+    import('./lib/generate-watch-events'),
+    import('./lib/generators/scanner'),
+  ])
+
+  const collectWatchState = () => {
     const resolver = createResolver()
     const moduleRoots = []
     for (const entry of resolver.loadEnabledModules()) {
       const roots = resolver.getModulePaths(entry)
       moduleRoots.push({ appBase: roots.appBase, pkgBase: roots.pkgBase })
     }
-    return calculateGenerateWatchStructureChecksum({
-      modulesFile: path.join(resolver.getAppDir(), 'src', 'modules.ts'),
+    return {
+      modulesFile: resolver.getModulesConfigPath(),
       moduleRoots,
-    })
+    }
+  }
+
+  return {
+    computeStructureChecksum: async () => {
+      return calculateGenerateWatchStructureChecksum(collectWatchState())
+    },
+    changeSignal: createGenerateWatchChangeSignal({
+      getWatchTargets: () => {
+        const state = collectWatchState()
+        const targets: Array<{ directory: string; recursive: boolean; fileName?: string }> = [{
+          directory: path.dirname(state.modulesFile),
+          recursive: false,
+          fileName: path.basename(state.modulesFile),
+        }]
+        for (const roots of state.moduleRoots) {
+          targets.push({ directory: path.dirname(roots.appBase), recursive: true })
+          targets.push({ directory: path.dirname(roots.pkgBase), recursive: true })
+          const sourceMirror = resolveStandaloneSourceMirrorBase(roots.pkgBase)
+          if (sourceMirror) {
+            targets.push({ directory: path.dirname(sourceMirror), recursive: true })
+          }
+        }
+        return targets
+      },
+    }),
   }
 }
 
@@ -1791,11 +1826,12 @@ export async function run(argv = process.argv) {
           const parsedInterval = intervalArg ? Number.parseInt(intervalArg.split('=')[1] ?? '', 10) : NaN
           const intervalMs = Number.isFinite(parsedInterval) && parsedInterval >= 250 ? parsedInterval : 1000
 
+          const generateWatchRuntime = await createGenerateWatchRuntime()
           const watcher = startInProcessGenerateWatcher({
             pollMs: intervalMs,
             skipInitial,
             quiet,
-            computeStructureChecksum: createGenerateWatchChecksumFn(),
+            ...generateWatchRuntime,
             runGenerators: async () => {
               await runGeneratorSuite(true)
               await runPostGenerateStructuralCachePurge(true)
@@ -2238,6 +2274,7 @@ export async function run(argv = process.argv) {
                 // (measured against the legacy sidecar). Opt back into the
                 // sidecar with `OM_DEV_GENERATE_WATCH_MODE=legacy` if needed.
                 console.log('[server] In-process generate watcher enabled — structural changes will regenerate without a sidecar process.')
+                const generateWatchRuntime = await createGenerateWatchRuntime()
                 activeGenerateWatcher = startInProcessGenerateWatcher({
                   // `--skip-initial` equivalent: `yarn dev` always runs an
                   // initial `mercato generate` before reaching the server
@@ -2246,7 +2283,7 @@ export async function run(argv = process.argv) {
                   // twice in a row.
                   skipInitial: true,
                   quiet: false,
-                  computeStructureChecksum: createGenerateWatchChecksumFn(),
+                  ...generateWatchRuntime,
                   runGenerators: async () => {
                     await runGeneratorSuite(true)
                     await runPostGenerateStructuralCachePurge(true)


### PR DESCRIPTION
## Summary

- gate the existing full generation checksum behind recursive filesystem change signals
- preserve the checksum as the final correctness authority and fall back to legacy polling if filesystem watching cannot be established or later errors
- refresh watched roots after module configuration changes and close all filesystem watchers during shutdown
- keep the existing interval as the debounce and fallback polling interval

## Why

The idle generation watcher previously traversed and content-hashed the module tree every second. On the current 50-module checkout, one warm pass measured about 75 ms and performed roughly 18,339 existence checks, 1,522 directory reads, 1,608 stats, 1,608 file reads, and 8.76 MB of file hashing.

With this change, the initial baseline checksum still runs once, but 20 idle debounce windows run zero additional full checksums. A burst of structural filesystem events coalesces into one checksum and one regeneration.
