### PR TITLE
perf(cli): avoid invalidation after no-op generation

### DIFF
--- a/.ai/specs/2026-05-28-compile-and-route-warmup-speedup.md
+++ b/.ai/specs/2026-05-28-compile-and-route-warmup-speedup.md
@@ -430,6 +430,9 @@ The 30–50% target is carried by Workstream A (build/generate/typecheck) plus t
 
 ## Changelog
 
+### 2026-07-16
+- Implemented the focused A2/B1 no-op invalidation slice: entity-ID auxiliary outputs now use exact content-gated writes, generator results are aggregated across all one-shot and watcher paths, and the broad structural cache/barrel purge runs only when at least one generated output changed. The explicit `mercato configs cache structural` recovery command is unchanged. A real-checkout repeat-generation check preserved the size and mtime of all 890 app/package generated files. A1, A3, A4, A5, B2, and B3 remain separate follow-ups.
+
 ### 2026-05-28
 - Initial specification. Targets a further 30–50% on compilation (build/generate/typecheck pipeline) and dev route warmup, building on the implemented April 2, 2026 cold-start work without duplicating it. Grounded in static source analysis; measured columns gated on Phase 1.
 - Revised per maintainer review: Workstream B no longer broadens the dev warmup. The default warmup stays the existing three requests (`GET /login`, `POST /api/auth/login`, `GET /backend`); the broaden-warmup lever and the bounded-parallel batch (and `OM_DEV_WARMUP_CONCURRENCY`) are dropped. `OM_DEV_WARMUP_ROUTES` is retained as an opt-in (default unset) override only. Workstream B is now scoped to the no-op-restart Turbopack cache and the lever sweep.

--- a/packages/cli/src/__tests__/mercato.test.ts
+++ b/packages/cli/src/__tests__/mercato.test.ts
@@ -547,7 +547,11 @@ describe('generate post-step structural cache purge', () => {
   it('runs structural cache purge after successful generation when configs cache CLI is available', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
     const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
-    const generateEntityIds = jest.fn().mockResolvedValue(undefined)
+    const generateEntityIds = jest.fn().mockResolvedValue({
+      filesWritten: ['/tmp/test-app/.mercato/generated/entities.ids.generated.ts'],
+      filesUnchanged: [],
+      errors: [],
+    })
     const generateModuleRegistry = jest.fn().mockResolvedValue(undefined)
     const generateModuleRegistryApp = jest.fn().mockResolvedValue(undefined)
     const generateModuleRegistryCli = jest.fn().mockResolvedValue(undefined)
@@ -594,10 +598,57 @@ describe('generate post-step structural cache purge', () => {
     consoleLogSpy.mockRestore()
   })
 
+  it('skips structural invalidation when every generated output is unchanged', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+    const unchangedResult = {
+      filesWritten: [],
+      filesUnchanged: ['/tmp/test-app/.mercato/generated/unchanged.generated.ts'],
+      errors: [],
+    }
+    const generators = {
+      generateEntityIds: jest.fn().mockResolvedValue(unchangedResult),
+      generateModuleRegistry: jest.fn().mockResolvedValue(unchangedResult),
+      generateModuleRegistryApp: jest.fn().mockResolvedValue(unchangedResult),
+      generateModuleRegistryCli: jest.fn().mockResolvedValue(unchangedResult),
+      generateModuleEntities: jest.fn().mockResolvedValue(unchangedResult),
+      generateModuleDi: jest.fn().mockResolvedValue(unchangedResult),
+      generateModulePackageSources: jest.fn().mockResolvedValue(unchangedResult),
+      generateOpenApi: jest.fn().mockResolvedValue(unchangedResult),
+    }
+    const bootstrapFromAppRoot = jest.fn()
+
+    jest.doMock('../lib/generators', () => generators)
+    jest.doMock('../lib/resolver', () => ({
+      createResolver: () => ({
+        getAppDir: () => '/tmp/test-app',
+      }),
+    }))
+    jest.doMock('@open-mercato/shared/lib/bootstrap/dynamicLoader', () => ({
+      bootstrapFromAppRoot,
+    }))
+
+    const mercato = await import('../mercato')
+    const exitCode = await mercato.run(['node', 'mercato', 'generate'])
+
+    expect(exitCode).toBe(0)
+    expect(bootstrapFromAppRoot).not.toHaveBeenCalled()
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '[generate] Generated outputs unchanged; skipping structural cache purge.',
+    )
+
+    consoleErrorSpy.mockRestore()
+    consoleLogSpy.mockRestore()
+  })
+
   it('keeps generation successful when the post-generate cache purge bootstrap fails', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
     const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
-    const generateEntityIds = jest.fn().mockResolvedValue(undefined)
+    const generateEntityIds = jest.fn().mockResolvedValue({
+      filesWritten: ['/tmp/test-app/.mercato/generated/entities.ids.generated.ts'],
+      filesUnchanged: [],
+      errors: [],
+    })
     const generateModuleRegistry = jest.fn().mockResolvedValue(undefined)
     const generateModuleRegistryApp = jest.fn().mockResolvedValue(undefined)
     const generateModuleRegistryCli = jest.fn().mockResolvedValue(undefined)

--- a/packages/cli/src/lib/generators/__tests__/entity-ids.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/entity-ids.test.ts
@@ -30,7 +30,10 @@ function createMockResolver(tmpRoot: string, enabled: ModuleEntry[]): PackageRes
       appBase: `@/modules/${entry.id}`,
       pkgBase: `@open-mercato/core/modules/${entry.id}`,
     }),
-    getPackageOutputDir: () => outputDir,
+    getPackageOutputDir: (packageName: string) =>
+      packageName === '@app'
+        ? outputDir
+        : path.join(tmpRoot, 'packages', 'core', 'generated'),
     getPackageRoot: () => path.join(tmpRoot, 'packages', 'core'),
   }
 }
@@ -75,6 +78,82 @@ afterEach(() => {
 })
 
 describe('generateEntityIds', () => {
+  it('does not rewrite generated entity outputs when inputs are unchanged', async () => {
+    const moduleEntry: ModuleEntry = { id: 'orders', from: '@open-mercato/core' }
+    const entitiesFile = path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'orders', 'data', 'entities.ts')
+    fs.mkdirSync(path.dirname(entitiesFile), { recursive: true })
+    fs.writeFileSync(entitiesFile, 'export class SalesOrder { id!: string\n totalGross!: number\n}\n')
+    const resolver = createMockResolver(tmpDir, [moduleEntry])
+
+    const first = await generateEntityIds({ resolver, quiet: true })
+    expect(first.filesWritten.length).toBeGreaterThan(0)
+
+    const appOutput = resolver.getOutputDir()
+    const packageOutput = resolver.getPackageOutputDir('@open-mercato/core')
+    const generatedFiles = [
+      path.join(appOutput, 'entities.ids.generated.ts'),
+      path.join(appOutput, 'entity-fields-registry.ts'),
+      path.join(appOutput, 'entities', 'sales_order', 'index.ts'),
+      path.join(packageOutput, 'entities.ids.generated.ts'),
+      path.join(packageOutput, 'entity-fields-registry.ts'),
+      path.join(packageOutput, 'entities', 'sales_order', 'index.ts'),
+    ]
+    const pinnedTime = new Date('2026-01-01T00:00:00.000Z')
+    for (const filePath of generatedFiles) {
+      fs.utimesSync(filePath, pinnedTime, pinnedTime)
+    }
+
+    const second = await generateEntityIds({ resolver, quiet: true })
+
+    expect(second.filesWritten).toEqual([])
+    for (const filePath of generatedFiles) {
+      expect(fs.statSync(filePath).mtimeMs).toBe(pinnedTime.getTime())
+    }
+  })
+
+  it('reports field-only generated changes without rewriting the entity id map', async () => {
+    const moduleEntry: ModuleEntry = { id: 'orders', from: '@open-mercato/core' }
+    const entitiesFile = path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'orders', 'data', 'entities.ts')
+    fs.mkdirSync(path.dirname(entitiesFile), { recursive: true })
+    fs.writeFileSync(entitiesFile, 'export class SalesOrder { id!: string\n}\n')
+    const resolver = createMockResolver(tmpDir, [moduleEntry])
+    await generateEntityIds({ resolver, quiet: true })
+    const rootIds = path.join(resolver.getOutputDir(), 'entities.ids.generated.ts')
+    const pinnedTime = new Date('2026-01-01T00:00:00.000Z')
+    fs.utimesSync(rootIds, pinnedTime, pinnedTime)
+
+    fs.writeFileSync(entitiesFile, 'export class SalesOrder { id!: string\n status!: string\n}\n')
+    const result = await generateEntityIds({ resolver, quiet: true })
+
+    expect(result.filesWritten).not.toContain(rootIds)
+    expect(fs.statSync(rootIds).mtimeMs).toBe(pinnedTime.getTime())
+    expect(result.filesWritten).toContain(
+      path.join(resolver.getOutputDir(), 'entities', 'sales_order', 'index.ts'),
+    )
+    expect(result.filesWritten).toContain(
+      path.join(resolver.getOutputDir(), 'entity-fields-registry.ts'),
+    )
+  })
+
+  it('keeps deletion changes visible while removing stale entity field output', async () => {
+    const moduleEntry: ModuleEntry = { id: 'orders', from: '@open-mercato/core' }
+    const entitiesFile = path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'orders', 'data', 'entities.ts')
+    fs.mkdirSync(path.dirname(entitiesFile), { recursive: true })
+    fs.writeFileSync(entitiesFile, 'export class SalesOrder { id!: string }\nexport class SalesLine { id!: string }\n')
+    const resolver = createMockResolver(tmpDir, [moduleEntry])
+    await generateEntityIds({ resolver, quiet: true })
+    const staleDirectory = path.join(resolver.getOutputDir(), 'entities', 'sales_line')
+    expect(fs.existsSync(staleDirectory)).toBe(true)
+
+    fs.writeFileSync(entitiesFile, 'export class SalesOrder { id!: string }\n')
+    const result = await generateEntityIds({ resolver, quiet: true })
+
+    expect(fs.existsSync(staleDirectory)).toBe(false)
+    expect(result.filesWritten).toContain(
+      path.join(resolver.getOutputDir(), 'entities.ids.generated.ts'),
+    )
+  })
+
   it('writes an inline entity fields registry without generated entity imports', async () => {
     const moduleEntry: ModuleEntry = { id: 'orders', from: '@open-mercato/core' }
     const entitiesFile = path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'orders', 'data', 'entities.ts')

--- a/packages/cli/src/lib/generators/__tests__/entity-ids.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/entity-ids.test.ts
@@ -154,6 +154,24 @@ describe('generateEntityIds', () => {
     )
   })
 
+  it('reports stale entity directory cleanup when every generated file is unchanged', async () => {
+    const moduleEntry: ModuleEntry = { id: 'orders', from: '@open-mercato/core' }
+    const entitiesFile = path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'orders', 'data', 'entities.ts')
+    fs.mkdirSync(path.dirname(entitiesFile), { recursive: true })
+    fs.writeFileSync(entitiesFile, 'export class SalesOrder { id!: string }\n')
+    const resolver = createMockResolver(tmpDir, [moduleEntry])
+    await generateEntityIds({ resolver, quiet: true })
+
+    const staleDirectory = path.join(resolver.getOutputDir(), 'entities', 'sales_line')
+    fs.mkdirSync(staleDirectory, { recursive: true })
+    fs.writeFileSync(path.join(staleDirectory, 'index.ts'), 'export const id = "id"\n')
+
+    const result = await generateEntityIds({ resolver, quiet: true })
+
+    expect(fs.existsSync(staleDirectory)).toBe(false)
+    expect(result.filesWritten).toEqual([staleDirectory])
+  })
+
   it('writes an inline entity fields registry without generated entity imports', async () => {
     const moduleEntry: ModuleEntry = { id: 'orders', from: '@open-mercato/core' }
     const entitiesFile = path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'orders', 'data', 'entities.ts')

--- a/packages/cli/src/lib/generators/entity-ids.ts
+++ b/packages/cli/src/lib/generators/entity-ids.ts
@@ -13,6 +13,7 @@ import {
   toSnake,
   rimrafDir,
   logGenerationResult,
+  writeIfChanged,
   type GeneratorResult,
   createGeneratorResult,
 } from '../utils'
@@ -240,7 +241,23 @@ function parseEntityFieldsFromFile(filePath: string, exportedClassNames: string[
   return result
 }
 
-function writePerEntityFieldFiles(outRoot: string, fieldsByEntity: EntityFieldMap): void {
+function writeTrackedFile(
+  filePath: string,
+  content: string,
+  result: GeneratorResult,
+): void {
+  if (writeIfChanged(filePath, content)) {
+    result.filesWritten.push(filePath)
+  } else {
+    result.filesUnchanged.push(filePath)
+  }
+}
+
+function writePerEntityFieldFiles(
+  outRoot: string,
+  fieldsByEntity: EntityFieldMap,
+  result: GeneratorResult,
+): void {
   fs.mkdirSync(outRoot, { recursive: true })
   const desiredEntities = new Set(Object.keys(fieldsByEntity))
   for (const [entity, fields] of Object.entries(fieldsByEntity)) {
@@ -259,7 +276,7 @@ function writePerEntityFieldFiles(outRoot: string, fieldsByEntity: EntityFieldMa
         ],
       })
     }
-    fs.writeFileSync(path.join(entDir, 'index.ts'), getSourceText(sourceFile))
+    writeTrackedFile(path.join(entDir, 'index.ts'), getSourceText(sourceFile), result)
   }
 
   const existingEntries = fs.existsSync(outRoot) ? fs.readdirSync(outRoot, { withFileTypes: true }) : []
@@ -270,7 +287,11 @@ function writePerEntityFieldFiles(outRoot: string, fieldsByEntity: EntityFieldMa
   }
 }
 
-function writeEntityFieldsRegistry(generatedRoot: string, fieldsByEntity: EntityFieldMap): void {
+function writeEntityFieldsRegistry(
+  generatedRoot: string,
+  fieldsByEntity: EntityFieldMap,
+  result: GeneratorResult,
+): void {
   const entities = Object.keys(fieldsByEntity).sort((a, b) => a.localeCompare(b))
   const registry: Record<string, Record<string, string>> = {}
   for (const entity of entities) {
@@ -302,8 +323,7 @@ function writeEntityFieldsRegistry(generatedRoot: string, fieldsByEntity: Entity
     statements: [returnStatement(elementAccess(identifier('entityFieldsRegistry'), identifier('slug')))],
   })
   const outPath = path.join(generatedRoot, 'entity-fields-registry.ts')
-  ensureDir(outPath)
-  fs.writeFileSync(outPath, getSourceText(sourceFile))
+  writeTrackedFile(outPath, getSourceText(sourceFile), result)
 }
 
 export async function generateEntityIds(options: EntityIdsOptions): Promise<GeneratorResult> {
@@ -472,9 +492,7 @@ export async function generateEntityIds(options: EntityIdsOptions): Promise<Gene
       type: 'typeof E',
     })
     const src = getSourceText(groupSourceFile)
-    ensureDir(out)
-    fs.writeFileSync(out, src)
-    result.filesWritten.push(out)
+    writeTrackedFile(out, src, result)
 
     const fieldsRoot = path.join(pkgOutputDir, 'entities')
     const fieldsByModule = fieldsByGroup[g] || {}
@@ -485,10 +503,10 @@ export async function generateEntityIds(options: EntityIdsOptions): Promise<Gene
         combined[entity] = Array.from(new Set([...(combined[entity] || []), ...fields]))
       }
     }
-    writePerEntityFieldFiles(fieldsRoot, combined)
+    writePerEntityFieldFiles(fieldsRoot, combined, result)
 
     // Generate static entity fields registry for Turbopack compatibility
-    writeEntityFieldsRegistry(pkgOutputDir, combined)
+    writeEntityFieldsRegistry(pkgOutputDir, combined, result)
   }
 
   // Write combined entity fields to root generated/ folder
@@ -500,8 +518,8 @@ export async function generateEntityIds(options: EntityIdsOptions): Promise<Gene
       }
     }
   }
-  writePerEntityFieldFiles(path.join(outputDir, 'entities'), combinedAll)
-  writeEntityFieldsRegistry(outputDir, combinedAll)
+  writePerEntityFieldFiles(path.join(outputDir, 'entities'), combinedAll, result)
+  writeEntityFieldsRegistry(outputDir, combinedAll, result)
 
   return result
 }

--- a/packages/cli/src/lib/generators/entity-ids.ts
+++ b/packages/cli/src/lib/generators/entity-ids.ts
@@ -283,7 +283,9 @@ function writePerEntityFieldFiles(
   for (const entry of existingEntries) {
     if (!entry.isDirectory()) continue
     if (desiredEntities.has(entry.name)) continue
-    rimrafDir(path.join(outRoot, entry.name))
+    const staleDirectory = path.join(outRoot, entry.name)
+    rimrafDir(staleDirectory)
+    result.filesWritten.push(staleDirectory)
   }
 }
 

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -750,7 +750,7 @@ async function runPostGenerateStructuralCachePurge(quiet: boolean): Promise<void
  * so the watcher embedded in the server lifecycle can reuse the same closure
  * without re-importing the closure-scoped version inside `buildBaseModules`.
  */
-async function runGeneratorSuite(quiet: boolean): Promise<void> {
+async function runGeneratorSuite(quiet: boolean): Promise<boolean> {
   const { createResolver } = await import('./lib/resolver')
   const {
     generateEntityIds,
@@ -763,14 +763,28 @@ async function runGeneratorSuite(quiet: boolean): Promise<void> {
     generateOpenApi,
   } = await import('./lib/generators')
   const resolver = createResolver()
-  await generateEntityIds({ resolver, quiet })
-  await generateModuleRegistry({ resolver, quiet })
-  await generateModuleRegistryApp({ resolver, quiet })
-  await generateModuleRegistryCli({ resolver, quiet })
-  await generateModuleEntities({ resolver, quiet })
-  await generateModuleDi({ resolver, quiet })
-  await generateModulePackageSources({ resolver, quiet })
-  await generateOpenApi({ resolver, quiet })
+  const results = [
+    await generateEntityIds({ resolver, quiet }),
+    await generateModuleRegistry({ resolver, quiet }),
+    await generateModuleRegistryApp({ resolver, quiet }),
+    await generateModuleRegistryCli({ resolver, quiet }),
+    await generateModuleEntities({ resolver, quiet }),
+    await generateModuleDi({ resolver, quiet }),
+    await generateModulePackageSources({ resolver, quiet }),
+    await generateOpenApi({ resolver, quiet }),
+  ]
+  return results.some((result) => (result?.filesWritten.length ?? 0) > 0)
+}
+
+async function runGeneratorSuiteWithStructuralInvalidation(quiet: boolean): Promise<void> {
+  const generatedFilesChanged = await runGeneratorSuite(quiet)
+  if (!generatedFilesChanged) {
+    if (!quiet) {
+      console.log('[generate] Generated outputs unchanged; skipping structural cache purge.')
+    }
+    return
+  }
+  await runPostGenerateStructuralCachePurge(quiet)
 }
 
 /**
@@ -1777,8 +1791,7 @@ export async function run(argv = process.argv) {
           const quiet = args.includes('--quiet') || args.includes('-q')
 
           console.log('Running all generators...')
-          await runGeneratorSuite(quiet)
-          await runPostGenerateStructuralCachePurge(quiet)
+          await runGeneratorSuiteWithStructuralInvalidation(quiet)
           console.log('All generators completed.')
         },
       },
@@ -1797,8 +1810,7 @@ export async function run(argv = process.argv) {
             quiet,
             computeStructureChecksum: createGenerateWatchChecksumFn(),
             runGenerators: async () => {
-              await runGeneratorSuite(true)
-              await runPostGenerateStructuralCachePurge(true)
+              await runGeneratorSuiteWithStructuralInvalidation(true)
             },
           })
 
@@ -2248,8 +2260,7 @@ export async function run(argv = process.argv) {
                   quiet: false,
                   computeStructureChecksum: createGenerateWatchChecksumFn(),
                   runGenerators: async () => {
-                    await runGeneratorSuite(true)
-                    await runPostGenerateStructuralCachePurge(true)
+                    await runGeneratorSuiteWithStructuralInvalidation(true)
                   },
                 })
               } else {


### PR DESCRIPTION
## Summary

- make entity-ID package, registry, and per-entity auxiliary outputs content-stable instead of rewriting identical bytes
- aggregate `GeneratorResult.filesWritten` across the full suite
- run the broad structural cache/barrel purge only when at least one generated output changed
- route one-shot generation, standalone generation watch, and the embedded dev watcher through the same conditional invalidation helper
- leave the explicit `mercato configs cache structural` recovery command unchanged

## Why

A clean repeated generation previously caused about 421 direct entity-ID auxiliary rewrites. The unconditional post-step then touched roughly 87 top-level generated TypeScript/checksum files and evicted navigation caches across every tenant: approximately 508 invalidating writes despite byte-identical generated state.

After this change, a real-checkout repeat generation preserved the size and mtime of all 890 generated files across the app and package output trees, logged the unchanged path, and did not bootstrap or execute structural cache invalidation.

Real output changes still trigger the existing broad structural purge exactly once. Field-only entity changes remain reported even when the consolidated entity ID map is unchanged, and entity deletion still removes stale generated directories while surfacing a changed output.
