### PR TITLE
fix(auth): stop session refresh minting "null" tenant/org scope claims

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/session.refresh.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/session.refresh.test.ts
@@ -2,6 +2,7 @@
 import { GET, POST } from '@open-mercato/core/modules/auth/api/session/refresh'
 
 const refreshFromSessionToken = jest.fn()
+const signJwt = jest.fn(() => 'jwt-token')
 const originalAppUrl = process.env.APP_URL
 
 jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
@@ -19,7 +20,7 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 }))
 
 jest.mock('@open-mercato/shared/lib/auth/jwt', () => ({
-  signJwt: () => 'jwt-token',
+  signJwt: (...args: unknown[]) => signJwt(...(args as [])),
 }))
 
 jest.mock('@open-mercato/core/modules/auth/lib/rateLimitCheck', () => ({
@@ -97,6 +98,56 @@ describe('/api/auth/session/refresh', () => {
     expect(response.status).toBe(307)
     expect(response.headers.get('location')).toBe('https://demo.openmercato.com/backend')
     expect(refreshFromSessionToken).toHaveBeenCalledWith('refresh-token')
+  })
+
+  it('GET mints scope claims as null, never the string "null", when the user has no tenant or organization', async () => {
+    refreshFromSessionToken.mockResolvedValue({
+      user: { id: 'user-1', tenantId: null, organizationId: null, email: 'admin@acme.com' },
+      roles: ['admin'],
+    })
+
+    await GET(new Request('https://demo.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend', {
+      headers: { cookie: 'session_token=refresh-token' },
+    }))
+
+    expect(signJwt).toHaveBeenCalledTimes(1)
+    expect(signJwt.mock.calls[0][0]).toMatchObject({ tenantId: null, orgId: null })
+  })
+
+  it('POST mints scope claims as null, never the string "null", when the user has no tenant or organization', async () => {
+    refreshFromSessionToken.mockResolvedValue({
+      user: { id: 'user-1', tenantId: null, organizationId: null, email: 'admin@acme.com' },
+      roles: ['admin'],
+    })
+
+    await POST(new Request('http://localhost/api/auth/session/refresh', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refreshToken: 'refresh-token' }),
+    }))
+
+    expect(signJwt).toHaveBeenCalledTimes(1)
+    expect(signJwt.mock.calls[0][0]).toMatchObject({ tenantId: null, orgId: null })
+  })
+
+  it('keeps forwarding concrete tenant and organization ids as strings', async () => {
+    refreshFromSessionToken.mockResolvedValue({
+      user: { id: 'user-1', tenantId: 'tenant-1', organizationId: 'org-1', email: 'admin@acme.com' },
+      roles: ['admin'],
+      session: { id: 'session-1' },
+    })
+
+    await GET(new Request('https://demo.openmercato.com/api/auth/session/refresh?redirect=%2Fbackend', {
+      headers: { cookie: 'session_token=refresh-token' },
+    }))
+
+    expect(signJwt.mock.calls[0][0]).toMatchObject({
+      sub: 'user-1',
+      sid: 'session-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      roles: ['admin'],
+    })
   })
 
   it('POST clears cookies when refresh token is invalid', async () => {

--- a/packages/core/src/modules/auth/api/session/refresh.ts
+++ b/packages/core/src/modules/auth/api/session/refresh.ts
@@ -25,6 +25,23 @@ function parseCookie(req: Request, name: string): string | null {
   return m ? decodeURIComponent(m[1]) : null
 }
 
+type RefreshedSession = NonNullable<Awaited<ReturnType<AuthService['refreshFromSessionToken']>>>
+
+// Scope claims must stay absent rather than stringified when the user has no tenant/org:
+// `String(null)` yields the literal "null", which is not a UUID, so session-integrity
+// resolution rejects the token it just minted and the caller is stuck in a refresh loop.
+// Mirrors how `api/login.ts` builds the same claims.
+function buildStaffJwtClaims({ user, roles, session }: RefreshedSession) {
+  return {
+    sub: String(user.id),
+    sid: session ? String(session.id) : undefined,
+    tenantId: user.tenantId ? String(user.tenantId) : null,
+    orgId: user.organizationId ? String(user.organizationId) : null,
+    email: user.email,
+    roles,
+  }
+}
+
 function clearStaffAuthCookies(response: NextResponse) {
   response.cookies.set('auth_token', '', {
     httpOnly: true,
@@ -61,8 +78,7 @@ export async function GET(req: Request) {
       buildSafeRedirectResponse(req, '/login?redirect=' + encodeURIComponent(redirectTo))
     )
   }
-  const { user, roles, session } = ctx
-  const jwt = signJwt({ sub: String(user.id), sid: session ? String(session.id) : undefined, tenantId: String(user.tenantId), orgId: String(user.organizationId), email: user.email, roles })
+  const jwt = signJwt(buildStaffJwtClaims(ctx))
   const res = buildSafeRedirectResponse(req, redirectTo)
   res.cookies.set('auth_token', jwt, { httpOnly: true, path: '/', sameSite: 'lax', secure: process.env.NODE_ENV === 'production', maxAge: 60 * 60 * 8 })
   return res
@@ -112,15 +128,7 @@ export async function POST(req: Request) {
     )
   }
 
-  const { user, roles, session } = ctx
-  const jwt = signJwt({
-    sub: String(user.id),
-    sid: session ? String(session.id) : undefined,
-    tenantId: String(user.tenantId),
-    orgId: String(user.organizationId),
-    email: user.email,
-    roles,
-  })
+  const jwt = signJwt(buildStaffJwtClaims(ctx))
 
   const res = NextResponse.json({
     ok: true,


### PR DESCRIPTION
## Problem

`/api/auth/session/refresh` mints a JWT that the very next request refuses, permanently locking out any user who has no tenant or organization.

Both the GET (browser) and POST (API/mobile) paths built their scope claims with a bare `String(...)`:

```ts
tenantId: String(user.tenantId),
orgId: String(user.organizationId),
```

When `user.organizationId` is `null`, `String(null)` produces the **literal string `"null"`**. That is not a UUID, so `normalizeScopeId` in `sessionIntegrity.ts` classifies it as `INVALID_SCOPE`:

```ts
return UUID_RE.test(trimmed) ? trimmed : INVALID_SCOPE
```

and `resolveCanonicalStaffAuthContext` bails out:

```ts
if (subjectId === INVALID_SCOPE || actorTenantId === INVALID_SCOPE || actorOrganizationId === INVALID_SCOPE) {
  return null
}
```

A null auth context resolves to `status: 'invalid'` → 401.

## Why it is a lockout rather than a bad request

The 401 feeds straight back into the thing that produced it:

1. A protected page (or `apiFetch` on a 401) redirects to `/api/auth/session/refresh`.
2. Refresh finds the session perfectly valid and mints another poisoned token.
3. The next request is rejected again.
4. Go to 1.

The user sees an endless reload claiming their session expired. **Logging in again does not help** — `api/login.ts` already builds the same claims null-safely:

```ts
orgId: user.organizationId ? String(user.organizationId) : null,
```

So the account works right up until its first token refresh, then breaks for good.

## Scope

Every other call site in the repo already uses the null-safe form (`login.ts`, `reset.ts`, `reset/confirm.ts`, `commands/users.ts`, `lib/userEmail.ts`, …). These two were the **only** outliers, and they drifted precisely because the claim object was duplicated across GET and POST.

## Fix

- Build the claims null-safely, matching `api/login.ts`.
- Extract `buildStaffJwtClaims` so GET and POST share one definition and cannot diverge again — the duplication is what allowed the bug in the first place.

No behaviour change for users who have a tenant and organization: concrete ids are still forwarded as strings.

## Testing

Added to `packages/core/src/modules/auth/api/__tests__/session.refresh.test.ts` (the `signJwt` mock now captures its arguments so the claims can be asserted):

- GET mints `tenantId: null` / `orgId: null` rather than `"null"`.
- POST mints `tenantId: null` / `orgId: null` rather than `"null"`.
- Concrete tenant/org/session ids are still forwarded unchanged (regression guard for the happy path).

Verified these are real regression tests — **2 fail against the unpatched route, 11/11 pass with the fix.**

- Auth module suites: **477/477 pass** across 61 suites (`--testPathPatterns="modules/auth"`).
- `yarn typecheck`: **21/21 successful.**
- `yarn lint`: no findings for the touched files.

Runner: local.

## Notes

No spec added — per `AGENTS.md` (§ Workflow Orchestration) specs are skipped for small fixes; this is a null-safety fix confined to one route.

Found while debugging a separate all-organizations 401 loop (#4222); the two are independent defects in different routes.

Suggested labels: `bug`, `priority-high` (auth/session fix per the inference rule), `risk-medium`, `needs-qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwkRCFK9Epsnb3bk55bjZv
