### PR TITLE
fix(integrations): stop the 401 session-refresh loop on "all organizations"

### DIFF
--- a/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
@@ -21,6 +21,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
+import { resolveIntegrationsOrganizationId } from '../../../lib/organization-scope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -44,7 +45,8 @@ function resolveParams(ctx: { params?: Promise<{ id?: string }> | { id?: string 
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveIntegrationsOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -61,7 +63,7 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
 
   const container = await createRequestContainer()
   const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId: organizationId, tenantId: auth.tenantId }
 
   let values: Record<string, unknown> | null
   let updatedAt: Date | null
@@ -89,7 +91,8 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveIntegrationsOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -115,7 +118,7 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
     container,
     {
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub ?? '',
     resourceKind: 'integrations.integration',
     resourceId: integration.id,
@@ -141,7 +144,7 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
   }
 
   const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId: organizationId, tenantId: auth.tenantId }
   const schema = credentialsService.getSchema(integration.id)
 
   try {
@@ -190,13 +193,13 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
   await emitIntegrationsEvent('integrations.credentials.updated', {
     integrationId: integration.id,
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub,
   })
 
   await runIntegrationMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
       tenantId: auth.tenantId,
-      organizationId: auth.orgId,
+      organizationId,
       userId: auth.sub ?? '',
       resourceKind: 'integrations.integration',
       resourceId: integration.id,

--- a/packages/core/src/modules/integrations/api/[id]/health/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/health/route.ts
@@ -9,6 +9,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
+import { resolveIntegrationsOrganizationId } from '../../../lib/organization-scope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -23,7 +24,8 @@ export const openApi = {
 
 export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveIntegrationsOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -46,7 +48,7 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
     container,
     {
       tenantId: auth.tenantId,
-      organizationId: auth.orgId,
+      organizationId,
       userId: auth.sub ?? '',
       resourceKind: 'integrations.integration',
       resourceId: integration.id,
@@ -65,12 +67,12 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
 
   const result = await healthService.runHealthCheck(
     integration.id,
-    { organizationId: auth.orgId as string, tenantId: auth.tenantId },
+    { organizationId: organizationId, tenantId: auth.tenantId },
   )
 
   await runIntegrationMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub ?? '',
     resourceKind: 'integrations.integration',
     resourceId: integration.id,

--- a/packages/core/src/modules/integrations/api/[id]/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/route.ts
@@ -12,6 +12,7 @@ import {
   integrationApiRoutePaths,
   runIntegrationsReadBeforeInterceptors,
 } from '../umes-read'
+import { resolveIntegrationsOrganizationId } from '../../lib/organization-scope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -26,7 +27,8 @@ export const openApi = {
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveIntegrationsOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -57,7 +59,7 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
   const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
   const stateService = container.resolve('integrationStateService') as IntegrationStateService
   const logService = container.resolve('integrationLogService') as IntegrationLogService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId: organizationId, tenantId: auth.tenantId }
 
   const [credentials, credentialsUpdatedAt, state, analyticsMap] = await Promise.all([
     credentialsService.resolve(integration.id, scope).catch((err) => {

--- a/packages/core/src/modules/integrations/api/[id]/state/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/state/route.ts
@@ -13,6 +13,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
+import { resolveIntegrationsOrganizationId } from '../../../lib/organization-scope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -27,7 +28,8 @@ export const openApi = {
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveIntegrationsOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -56,7 +58,7 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
     container,
     {
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub ?? '',
     resourceKind: 'integrations.integration',
     resourceId: integration.id,
@@ -82,7 +84,7 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
   }
 
   const stateService = container.resolve('integrationStateService') as IntegrationStateService
-  const stateScope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const stateScope = { organizationId: organizationId, tenantId: auth.tenantId }
 
   try {
     const current = await stateService.resolveState(integration.id, stateScope)
@@ -113,13 +115,13 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
     isEnabled: state.isEnabled,
     reauthRequired: state.reauthRequired,
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub,
   })
 
   await runIntegrationMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
       tenantId: auth.tenantId,
-      organizationId: auth.orgId,
+      organizationId,
       userId: auth.sub ?? '',
       resourceKind: 'integrations.integration',
       resourceId: integration.id,

--- a/packages/core/src/modules/integrations/api/[id]/version/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/version/route.ts
@@ -14,6 +14,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
+import { resolveIntegrationsOrganizationId } from '../../../lib/organization-scope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -28,7 +29,8 @@ export const openApi = {
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveIntegrationsOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -73,7 +75,7 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
     container,
     {
       tenantId: auth.tenantId,
-      organizationId: auth.orgId,
+      organizationId,
       userId: auth.sub ?? '',
       resourceKind: 'integrations.integration',
       resourceId: integration.id,
@@ -102,7 +104,7 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
   }
 
   const stateService = container.resolve('integrationStateService') as IntegrationStateService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId: organizationId, tenantId: auth.tenantId }
 
   const currentState = await stateService.resolveState(integration.id, scope)
   try {
@@ -127,13 +129,13 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
     previousVersion: before ?? defaultVersion,
     apiVersion: payloadData.apiVersion,
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub,
   })
 
   await runIntegrationMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub ?? '',
     resourceKind: 'integrations.integration',
     resourceId: integration.id,

--- a/packages/core/src/modules/integrations/api/logs/route.ts
+++ b/packages/core/src/modules/integrations/api/logs/route.ts
@@ -8,6 +8,7 @@ import {
   integrationApiRoutePaths,
   runIntegrationsReadBeforeInterceptors,
 } from '../umes-read'
+import { resolveIntegrationsOrganizationId } from '../../lib/organization-scope'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['integrations.manage'] },
@@ -20,7 +21,8 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveIntegrationsOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -52,7 +54,7 @@ export async function GET(req: Request) {
   const logService = container.resolve('integrationLogService') as IntegrationLogService
 
   const { items, total } = await logService.query(parsed.data, {
-    organizationId: auth.orgId as string,
+    organizationId: organizationId,
     tenantId: auth.tenantId,
   })
 

--- a/packages/core/src/modules/integrations/api/route.ts
+++ b/packages/core/src/modules/integrations/api/route.ts
@@ -14,6 +14,7 @@ import {
   integrationApiRoutePaths,
   runIntegrationsReadBeforeInterceptors,
 } from './umes-read'
+import { resolveIntegrationsOrganizationId } from '../lib/organization-scope'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['integrations.view'] },
@@ -46,7 +47,8 @@ function matchesSearchQuery(
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveIntegrationsOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -71,7 +73,7 @@ export async function GET(req: Request) {
   const stateService = container.resolve('integrationStateService') as IntegrationStateService
   const logService = container.resolve('integrationLogService') as IntegrationLogService
 
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId as string }
+  const scope = { organizationId: organizationId, tenantId: auth.tenantId as string }
   const searchNeedle = query.q?.trim().toLowerCase() ?? ''
 
   type ListRow = {

--- a/packages/core/src/modules/integrations/api/umes-read.ts
+++ b/packages/core/src/modules/integrations/api/umes-read.ts
@@ -4,6 +4,7 @@ import type { AwilixContainer } from 'awilix'
 import { runApiInterceptorsAfter, runApiInterceptorsBefore, type RunInterceptorsBeforeResult } from '@open-mercato/shared/lib/crud/interceptor-runner'
 import { applyResponseEnrichers, applyResponseEnricherToRecord } from '@open-mercato/shared/lib/crud/enricher-runner'
 import type { ApiInterceptorMethod, InterceptorRequest } from '@open-mercato/shared/lib/crud/api-interceptor'
+import { resolveIntegrationsOrganizationId } from '../lib/organization-scope'
 
 export const integrationApiRoutePaths = {
   list: 'integrations',
@@ -66,7 +67,7 @@ function mergeAdditiveBody(
 
 function getEnricherContext(input: ReadRouteContext) {
   return {
-    organizationId: input.auth.orgId as string,
+    organizationId: resolveIntegrationsOrganizationId(input.auth) as string,
     tenantId: input.auth.tenantId as string,
     userId: input.auth.sub ?? '',
     em: input.container.resolve('em') as EntityManager,

--- a/packages/core/src/modules/integrations/lib/__tests__/organization-scope.test.ts
+++ b/packages/core/src/modules/integrations/lib/__tests__/organization-scope.test.ts
@@ -1,0 +1,34 @@
+/** @jest-environment node */
+
+import { resolveIntegrationsOrganizationId } from '../organization-scope'
+
+const accountOrgId = '22222222-2222-4222-8222-222222222222'
+const selectedOrgId = '33333333-3333-4333-8333-333333333333'
+
+describe('integrations organization scope', () => {
+  it('uses the selected organization when one is set', () => {
+    expect(
+      resolveIntegrationsOrganizationId({ orgId: selectedOrgId, actorOrgId: accountOrgId }),
+    ).toBe(selectedOrgId)
+  })
+
+  // `orgId: null` + `actorOrgId` set is exactly the shape `applySuperAdminScope` produces for an
+  // all-organizations selection. Answering 401 for it sent `apiFetch` into a refresh loop.
+  it('falls back to the actor organization for an all-organizations selection', () => {
+    expect(
+      resolveIntegrationsOrganizationId({ orgId: null, actorOrgId: accountOrgId }),
+    ).toBe(accountOrgId)
+  })
+
+  it('returns null when the caller has no organization at all', () => {
+    expect(resolveIntegrationsOrganizationId({ orgId: null })).toBeNull()
+    expect(resolveIntegrationsOrganizationId({ orgId: null, actorOrgId: null })).toBeNull()
+    expect(resolveIntegrationsOrganizationId(null)).toBeNull()
+  })
+
+  it('ignores blank and non-string values rather than scoping to them', () => {
+    expect(resolveIntegrationsOrganizationId({ orgId: '   ', actorOrgId: accountOrgId })).toBe(accountOrgId)
+    expect(resolveIntegrationsOrganizationId({ orgId: null, actorOrgId: '  ' })).toBeNull()
+    expect(resolveIntegrationsOrganizationId({ orgId: null, actorOrgId: 42 })).toBeNull()
+  })
+})

--- a/packages/core/src/modules/integrations/lib/organization-scope.ts
+++ b/packages/core/src/modules/integrations/lib/organization-scope.ts
@@ -1,0 +1,27 @@
+type OrganizationScopedAuth = {
+  orgId?: string | null
+  actorOrgId?: unknown
+} | null | undefined
+
+/**
+ * Resolves the organization an integrations request is scoped to.
+ *
+ * Integrations are configured per organization — `integration_credentials` and
+ * `integration_states` both require a non-null `organization_id` — so there is no
+ * meaningful "all organizations" view of this module. When an operator selects that
+ * option the super-admin cookie override clears `auth.orgId` and preserves the actor's
+ * own organization in `actorOrgId`; fall back to it so the module keeps showing the
+ * operator's own configuration instead of failing.
+ *
+ * Answering 401 for that case is not merely wrong but self-perpetuating: `apiFetch`
+ * reads 401 as an expired session and redirects through `/api/auth/session/refresh`,
+ * which succeeds and returns to the same page, reloading forever.
+ */
+export function resolveIntegrationsOrganizationId(auth: OrganizationScopedAuth): string | null {
+  if (!auth) return null
+  const selected = auth.orgId
+  if (typeof selected === 'string' && selected.trim().length > 0) return selected
+  const actorOrgId = auth.actorOrgId
+  if (typeof actorOrgId === 'string' && actorOrgId.trim().length > 0) return actorOrgId
+  return null
+}


### PR DESCRIPTION
## Problem

`/backend/integrations` reloads forever claiming the session expired, whenever the operator has **"all organizations"** selected.

Every integrations API route rejects a null `auth.orgId` as unauthenticated:

```ts
if (!auth?.tenantId || !auth.orgId) {
  return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
}
```

But a null `orgId` is exactly how an all-organizations selection reaches these routes — `applySuperAdminScope` clears it when the `om_selected_org` cookie holds the `__all__` token, stashing the actor's real organization in `actorOrgId`.

The 401 is self-perpetuating rather than merely wrong:

1. The page requests `/api/integrations`.
2. The route answers 401.
3. `apiFetch` treats any 401 as an expired session → `redirectToSessionRefresh()`.
4. `/api/auth/session/refresh` finds the session perfectly valid, mints a fresh token, redirects back.
5. Go to 1.

## Reproduction

Same server, same token — the only variable is the cookie:

```
om_selected_org=<concrete org uuid>   →  /api/integrations       →  200
om_selected_org=__all__               →  /api/integrations       →  401
om_selected_org=__all__               →  /api/integrations/logs  →  401
```

## Why the fix differs from the deals routes

[#4222](https://github.com/open-mercato/open-mercato/pull/4222) fixed the same class of bug in `deals/summary` + `deals/aggregate` by **widening** to every organization in the tenant. That is not available here:

```
integration_credentials.organization_id  NOT NULL
integration_states.organization_id       NOT NULL
```

An integration is always configured for exactly one organization — credentials and enablement state are per-org — so there is no coherent "all organizations" view to render. Which org's Gmail credentials would the list show?

So this route resolves the scope through `resolveIntegrationsOrganizationId`, which falls back to the actor's **own** organization: precisely what the operator would see by picking it in the switcher. A caller that genuinely has no organization still gets 401.

`umes-read.ts` built its enricher context from the same raw `auth.orgId` (`organizationId: input.auth.orgId as string`), which would have passed a null through masquerading as a `string`; it uses the resolver now too.

## Design note for maintainers

The fallback is the conservative choice — it keeps the module working without changing its data model — but it does mean an operator on "all organizations" silently sees one org's integrations. The alternative, tenant-wide integrations that apply to every organization at once, is a real gap but needs a schema change (nullable `organization_id` meaning tenant-wide, or fan-out rows per org) and a spec. Raised separately as an issue rather than smuggled into a bug fix. Happy to follow whichever direction you prefer here.

## Testing

- New unit tests: `packages/core/src/modules/integrations/lib/__tests__/organization-scope.test.ts` — selected org wins; all-organizations falls back to the actor org; no-organization still resolves to null; blank/non-string values are ignored rather than scoped to.
- Integrations module suites: **83/83 pass** across 16 suites.
- `yarn typecheck`: **21/21 successful.**
- `yarn lint`: no findings for the touched files.
- Deployed to a live instance and confirmed against the reproduction above: `/api/integrations` and `/api/integrations/logs` both return 200 with `om_selected_org=__all__`, and the reload loop is gone.

Runner: local.

## Notes

No spec added — per `AGENTS.md` (§ Workflow Orchestration) specs are skipped for small fixes; this is a scope-resolution fix confined to one module.

Third in a series of independent 401-loop defects found in one debugging session: [#4222](https://github.com/open-mercato/open-mercato/pull/4222) (deals, all-organizations) and [#4223](https://github.com/open-mercato/open-mercato/pull/4223) (session refresh minting `"null"` scope claims). The same `!auth.orgId → 401` guard also exists in `data_sync`, `payment_gateways`, `shipping_carriers`, and `catalog/bulk-delete` — not touched here, since each needs the same per-module judgement about what an all-organizations selection should mean.

Suggested labels: `bug`, `priority-medium`, `risk-medium`, `needs-qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwkRCFK9Epsnb3bk55bjZv
