### PR TITLE
fix(checkout): localize pay-page session-start failure and add field a11y semantics (#4212)

### DIFF
--- a/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/route.ts
+++ b/packages/checkout/src/modules/checkout/api/pay/[slug]/submit/route.ts
@@ -524,7 +524,7 @@ export async function POST(req: Request, { params }: { params: Promise<{ slug: s
           providerKey: link.gatewayProviderKey,
           err: error,
         })
-        throw new CrudHttpError(502, { error: 'Unable to start the payment session' })
+        throw new CrudHttpError(502, { error: 'checkout.payPage.errors.sessionStart' })
       }
       const refreshedTransaction = await findOneWithDecryption(em, CheckoutTransaction, {
         id: transaction.id,

--- a/packages/checkout/src/modules/checkout/components/PayPage.tsx
+++ b/packages/checkout/src/modules/checkout/components/PayPage.tsx
@@ -803,6 +803,8 @@ export function PayPageCustomerForm({
           const value = customerData[field.key]
           const containerClass = field.kind === 'multiline' ? 'space-y-2 sm:col-span-2' : 'space-y-2'
           const semanticType = getCheckoutCustomerFieldSemanticType(field)
+          const fieldId = `checkout-customer-${field.key}`
+          const fieldErrorId = `${fieldId}-error`
 
           return (
             <div key={field.key} className={containerClass}>
@@ -820,6 +822,9 @@ export function PayPageCustomerForm({
                   <Checkbox
                     checked={value === true}
                     disabled={inputsLocked}
+                    aria-required={field.required ? true : undefined}
+                    aria-invalid={fieldError ? true : undefined}
+                    aria-describedby={fieldError ? fieldErrorId : undefined}
                     onCheckedChange={(checked) => onFieldChange(field.key, checked === true)}
                   />
                   <span className="space-y-1">
@@ -836,17 +841,21 @@ export function PayPageCustomerForm({
                 </label>
               ) : (
                 <>
-                  <label className="text-sm font-medium">
+                  <label htmlFor={fieldId} className="text-sm font-medium">
                     {field.label}
                     {field.required ? ' *' : ''}
                   </label>
                   {field.kind === 'multiline' ? (
                     <Textarea
+                      id={fieldId}
                       className={READABLE_INPUT_CLASSNAME}
                       value={typeof value === 'string' ? value : ''}
                       disabled={inputsLocked}
                       onChange={(event) => onFieldChange(field.key, event.target.value)}
                       placeholder={field.placeholder ?? undefined}
+                      aria-required={field.required ? true : undefined}
+                      aria-invalid={fieldError ? true : undefined}
+                      aria-describedby={fieldError ? fieldErrorId : undefined}
                       style={buildReadableInputStyle(themeTokens, Boolean(fieldError), inputsLocked)}
                     />
                   ) : field.kind === 'select' || field.kind === 'radio' ? (
@@ -858,8 +867,11 @@ export function PayPageCustomerForm({
                       }}
                     >
                       <SelectTrigger
+                        id={fieldId}
                         className={`rounded-xl ${READABLE_INPUT_CLASSNAME}`}
+                        aria-required={field.required ? true : undefined}
                         aria-invalid={Boolean(fieldError)}
+                        aria-describedby={fieldError ? fieldErrorId : undefined}
                         style={buildReadableInputStyle(themeTokens, Boolean(fieldError), inputsLocked)}
                       >
                         <SelectValue placeholder={t('checkout.payPage.fields.selectPlaceholder', 'Select...')} />
@@ -875,6 +887,7 @@ export function PayPageCustomerForm({
                     </Select>
                   ) : (
                     <Input
+                      id={fieldId}
                       className={READABLE_INPUT_CLASSNAME}
                       type={semanticType === 'email' ? 'email' : semanticType === 'phone' ? 'tel' : 'text'}
                       value={typeof value === 'string' ? value : ''}
@@ -882,13 +895,16 @@ export function PayPageCustomerForm({
                       onChange={(event) => onFieldChange(field.key, event.target.value)}
                       placeholder={field.placeholder ?? undefined}
                       autoComplete={semanticType === 'email' ? 'email' : semanticType === 'phone' ? 'tel' : undefined}
+                      aria-required={field.required ? true : undefined}
+                      aria-invalid={fieldError ? true : undefined}
+                      aria-describedby={fieldError ? fieldErrorId : undefined}
                       style={buildReadableInputStyle(themeTokens, Boolean(fieldError), inputsLocked)}
                     />
                   )}
                 </>
               )}
               {fieldError ? (
-                <p className="text-sm" style={buildValidationMessageStyle(themeTokens)}>
+                <p id={fieldErrorId} className="text-sm" style={buildValidationMessageStyle(themeTokens)}>
                   {translateValidationMessage(fieldError, fieldPath)}
                 </p>
               ) : null}

--- a/packages/checkout/src/modules/checkout/i18n/de.json
+++ b/packages/checkout/src/modules/checkout/i18n/de.json
@@ -326,6 +326,7 @@
   "checkout.payPage.errors.loadMessage": "Diese Zahlungsseite konnte nicht geladen werden. Bitte versuche es erneut.",
   "checkout.payPage.errors.loadTitle": "Zahlungslink konnte nicht geladen werden",
   "checkout.payPage.errors.password": "Das Passwort konnte nicht verifiziert werden. Bitte versuche es erneut.",
+  "checkout.payPage.errors.sessionStart": "Die Zahlungssitzung konnte nicht gestartet werden. Bitte versuche es erneut.",
   "checkout.payPage.errors.submit": "Die Zahlung konnte nicht gestartet werden. Bitte versuche es erneut.",
   "checkout.payPage.fields.booleanFalse": "Nein",
   "checkout.payPage.fields.booleanTrue": "Ja",

--- a/packages/checkout/src/modules/checkout/i18n/en.json
+++ b/packages/checkout/src/modules/checkout/i18n/en.json
@@ -326,6 +326,7 @@
   "checkout.payPage.errors.loadMessage": "We couldn't load this payment page. Please try again.",
   "checkout.payPage.errors.loadTitle": "Unable to load payment link",
   "checkout.payPage.errors.password": "Unable to verify password. Please try again.",
+  "checkout.payPage.errors.sessionStart": "Unable to start the payment session. Please try again.",
   "checkout.payPage.errors.submit": "Unable to start the payment. Please try again.",
   "checkout.payPage.fields.booleanFalse": "No",
   "checkout.payPage.fields.booleanTrue": "Yes",

--- a/packages/checkout/src/modules/checkout/i18n/es.json
+++ b/packages/checkout/src/modules/checkout/i18n/es.json
@@ -326,6 +326,7 @@
   "checkout.payPage.errors.loadMessage": "No pudimos cargar esta pagina de pago. Intentalo de nuevo.",
   "checkout.payPage.errors.loadTitle": "No se pudo cargar el enlace de pago",
   "checkout.payPage.errors.password": "No se pudo verificar la contrasena. Intentalo de nuevo.",
+  "checkout.payPage.errors.sessionStart": "No se pudo iniciar la sesión de pago. Inténtalo de nuevo.",
   "checkout.payPage.errors.submit": "No se pudo iniciar el pago. Intentalo de nuevo.",
   "checkout.payPage.fields.booleanFalse": "No",
   "checkout.payPage.fields.booleanTrue": "Si",

--- a/packages/checkout/src/modules/checkout/i18n/pl.json
+++ b/packages/checkout/src/modules/checkout/i18n/pl.json
@@ -326,6 +326,7 @@
   "checkout.payPage.errors.loadMessage": "Nie udało się załadować tej strony płatności. Spróbuj ponownie.",
   "checkout.payPage.errors.loadTitle": "Nie udało się załadować linku płatności",
   "checkout.payPage.errors.password": "Nie udało się zweryfikować hasła. Spróbuj ponownie.",
+  "checkout.payPage.errors.sessionStart": "Nie udało się uruchomić sesji płatności. Spróbuj ponownie.",
   "checkout.payPage.errors.submit": "Nie udało się rozpocząć płatności. Spróbuj ponownie.",
   "checkout.payPage.fields.booleanFalse": "Nie",
   "checkout.payPage.fields.booleanTrue": "Tak",


### PR DESCRIPTION
Fixes #4212

## O1 — Payment-failure message is now localized

The submit route (`api/pay/[slug]/submit/route.ts`) returned a raw English `'Unable to start the payment session'` that `PayPage` rendered verbatim on non-English locales. The route now returns the `checkout.payPage.errors.sessionStart` i18n key — the same key-through-the-wire pattern the route already uses for validation errors (`checkout.payPage.validation.fixErrors`), which `translateValidationMessage` resolves client-side. Translations added for all four locales (en/pl/de/es).

Deliberately NOT converted: `'This payment link is not currently accepting payments'` — the integration test `TC-CHKT-030` string-matches it, and it is shared with `commands/transactions.ts`; converting it is a separate, wider change.

## O2 — Pay-page customer fields expose accessible names and required state

For every customer-detail field (input, textarea, select, checkbox):
- visible label is programmatically associated via `htmlFor`/`id`,
- required fields expose `aria-required="true"`,
- errored controls expose `aria-invalid`,
- the validation message paragraph gets an `id` and is linked via `aria-describedby` (only when rendered).

## Validation

Runner: local
- `yarn workspace @open-mercato/checkout test` — 76 tests pass
- `yarn workspace @open-mercato/checkout typecheck` + `@open-mercato/core typecheck` — clean
- `eslint` on touched files — only pre-existing warnings outside changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)