### PR TITLE
security(api_keys): fail closed on empty organization allowlist at key creation (#4168)

### DIFF
--- a/packages/core/src/modules/api_keys/api/__tests__/keys.route.test.ts
+++ b/packages/core/src/modules/api_keys/api/__tests__/keys.route.test.ts
@@ -297,6 +297,86 @@ describe('API Keys route', () => {
     expect(mockDataEngine.createOrmEntity).not.toHaveBeenCalled()
   })
 
+  it('denies creation when the resolved organization allowlist is empty', async () => {
+    mockResolveScope.mockResolvedValueOnce({ selectedId: null, filterIds: [], allowedIds: [] })
+    const res = await postHandler(
+      new Request('http://localhost/api/api_keys/keys', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Deny-all key',
+          organizationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        }),
+      }),
+    )
+    expect(res.status).toBe(403)
+    const payload = await res.json()
+    expect(payload.error).toBe('Organization out of scope')
+    expect(mockDataEngine.createOrmEntity).not.toHaveBeenCalled()
+  })
+
+  it('denies tenant-wide creation for an organization-restricted principal', async () => {
+    mockResolveScope.mockResolvedValueOnce({
+      selectedId: null,
+      filterIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+      allowedIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+    })
+    const res = await postHandler(
+      new Request('http://localhost/api/api_keys/keys', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name: 'Tenant-wide key' }),
+      }),
+    )
+    expect(res.status).toBe(403)
+    const payload = await res.json()
+    expect(payload.error).toBe('Organization out of scope')
+    expect(mockDataEngine.createOrmEntity).not.toHaveBeenCalled()
+  })
+
+  it('preserves unrestricted (null allowlist) creation for a non-superadmin', async () => {
+    mockResolveScope.mockResolvedValueOnce({ selectedId: null, filterIds: null, allowedIds: null })
+    const res = await postHandler(
+      new Request('http://localhost/api/api_keys/keys', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Unrestricted key',
+          organizationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        }),
+      }),
+    )
+    expect(res.status).toBe(201)
+    expect(mockDataEngine.createOrmEntity).toHaveBeenCalledTimes(1)
+    const createArgs = mockDataEngine.createOrmEntity.mock.calls[0][0]
+    expect(createArgs.data).toMatchObject({ organizationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb' })
+  })
+
+  it('allows a superadmin to create across organizations despite an empty allowlist', async () => {
+    const superAdminAuth = {
+      sub: 'user-1',
+      tenantId: '123e4567-e89b-12d3-a456-426614174000',
+      orgId: null,
+      isSuperAdmin: true,
+    }
+    mockGetAuthFromCookies.mockResolvedValueOnce(superAdminAuth)
+    mockGetAuthFromRequest.mockResolvedValueOnce(superAdminAuth)
+    mockRbac.loadAcl.mockResolvedValue({ isSuperAdmin: true })
+    mockResolveScope.mockResolvedValueOnce({ selectedId: null, filterIds: [], allowedIds: [] })
+    const res = await postHandler(
+      new Request('http://localhost/api/api_keys/keys', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Superadmin key',
+          organizationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        }),
+      }),
+    )
+    expect(res.status).toBe(201)
+    expect(mockDataEngine.createOrmEntity).toHaveBeenCalledTimes(1)
+  })
+
   it('denies deletion when the resolved organization allowlist is empty', async () => {
     const record = {
       id: '11111111-1111-4111-8111-111111111111',

--- a/packages/core/src/modules/api_keys/api/keys/route.ts
+++ b/packages/core/src/modules/api_keys/api/keys/route.ts
@@ -299,10 +299,15 @@ const crud = makeCrudRoute<
 
       const allowedIds = ctx.organizationScope?.allowedIds ?? null
       const organizationId = input.organizationId ?? ctx.selectedOrganizationId ?? auth.orgId ?? null
-      if (organizationId && Array.isArray(allowedIds) && allowedIds.length > 0) {
-        if (!allowedIds.includes(organizationId)) {
-          throw json({ error: translate('api_keys.errors.organizationOutOfScope', 'Organization out of scope') }, { status: 403 })
-        }
+      const isSuperAdmin = await resolveIsSuperAdmin(scopedCtx)
+      if (
+        !isOrganizationAccessAllowed({
+          isSuperAdmin,
+          allowedOrganizationIds: allowedIds,
+          targetOrganizationId: organizationId,
+        })
+      ) {
+        throw json({ error: translate('api_keys.errors.organizationOutOfScope', 'Organization out of scope') }, { status: 403 })
       }
       scopedCtx.__apiKeyOrganizationId = organizationId ?? null
 


### PR DESCRIPTION
Fixes #4168

## Problem

`POST /api/api_keys/keys` treated `organizationScope.allowedIds = []` as if no restriction existed: the `beforeCreate` guard was gated on `allowedIds.length > 0`, so a deny-all principal with `api_keys.create` could create a key scoped to **any** organization in their tenant (HTTP 201). This is the create-verb twin of the deletion fail-open fixed by #4033/#4051.

## Fix

`beforeCreate` now routes the decision through the shared fail-closed predicate `isOrganizationAccessAllowed` (`packages/shared/src/lib/auth/organizationAccess.ts`) — the same predicate `beforeDelete` adopted in #4051:

- superadmin → allowed,
- `allowedIds === null` (truly unrestricted) → allowed,
- restricted scope → the target organization must be a member of the allowlist; empty allowlist denies everything.

Parity note: this also denies an **organization-restricted** principal creating a **tenant-wide** (org-null) key — previously allowed by the length-gated check. That matches the deletion semantics (`restricted + no target org → deny`, per the predicate's decision table) and the deny-all expectation in the issue. Legitimate same-org creation, `null` (unrestricted) scopes, and superadmin behavior are unchanged.

## Acceptance criteria coverage

- [x] `allowedIds: []` denies creation for every organization-bound target (403, no row persisted)
- [x] Allowed organization succeeds; foreign organization still fails for non-empty scopes (pre-existing test kept green)
- [x] Superadmin and `allowedIds === null` behavior remain correct (new regression tests)
- [x] Route tests assert `createOrmEntity` is not called on rejection

## Validation

Runner: local
- `yarn workspace @open-mercato/core test --testPathPatterns 'api_keys'` — 31 tests pass (4 new)
- `yarn workspace @open-mercato/core typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)