### PR TITLE
fix(attachments): keep org reconcile healing when one entity group is unregistrable (#4145)

### DIFF
--- a/packages/core/src/modules/attachments/lib/__tests__/reconcileOrganization.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/reconcileOrganization.test.ts
@@ -28,6 +28,7 @@ function buildEm(scanRows: ScanRow[]) {
     flush: jest.fn(async () => {
       for (const ref of references) flushed.push({ id: ref.id, organizationId: ref.organizationId })
     }),
+    transactional: jest.fn(async (callback: () => Promise<unknown>) => callback()),
   }
   return { em, flushed }
 }
@@ -138,6 +139,41 @@ describe('reconcileAttachmentOrganizations', () => {
     expect(report.unresolved).toBe(1)
     expect(report.updated).toBe(0)
     expect(flushed).toEqual([])
+  })
+
+  it('still heals other groups when one entity group is unregistrable (#4145)', async () => {
+    const { em, flushed } = buildEm([
+      { id: 'att-bogus', entity_id: 'some:bogus_entity', record_id: 'x-1', organization_id: 'home-org' },
+      { id: 'att-good', entity_id: 'catalog:product', record_id: 'p-1', organization_id: 'home-org' },
+    ])
+    const queryEngine = buildQueryEngine({ 'catalog:product': { 'p-1': 'selected-org' } })
+
+    const report = await reconcileAttachmentOrganizations({
+      em: em as any,
+      queryEngine: queryEngine as any,
+      tenantId: 't1',
+    })
+
+    expect(report.unresolved).toBe(1)
+    expect(report.updated).toBe(1)
+    expect(report.byEntity['some:bogus_entity']).toEqual({ scanned: 1, updated: 0, unresolved: 1 })
+    expect(flushed).toEqual([{ id: 'att-good', organizationId: 'selected-org' }])
+  })
+
+  it('scopes every parent-resolution query to a nested transaction savepoint (#4145)', async () => {
+    const { em } = buildEm([
+      { id: 'att-1', entity_id: 'catalog:product', record_id: 'p-1', organization_id: 'org-a' },
+    ])
+    const queryEngine = buildQueryEngine({ 'catalog:product': { 'p-1': 'org-a' } })
+
+    await reconcileAttachmentOrganizations({
+      em: em as any,
+      queryEngine: queryEngine as any,
+      tenantId: 't1',
+    })
+
+    expect(em.transactional).toHaveBeenCalledTimes(1)
+    expect(queryEngine.query).toHaveBeenCalledTimes(1)
   })
 
   it('reconciles a mixed batch and reports per-entity stats', async () => {

--- a/packages/core/src/modules/attachments/lib/reconcileOrganization.ts
+++ b/packages/core/src/modules/attachments/lib/reconcileOrganization.ts
@@ -132,13 +132,22 @@ export async function reconcileAttachmentOrganizations(opts: {
     for (let index = 0; index < recordIds.length; index += batchSize) {
       const chunk = recordIds.slice(index, index + batchSize)
       try {
-        const result = await queryEngine.query(entityId as any, {
-          fields: ['id', 'organization_id'],
-          filters: { id: chunk.length === 1 ? { $eq: chunk[0] } : { $in: chunk } },
-          tenantId,
-          withDeleted: true,
-          page: { pageSize: Math.max(chunk.length, 1) },
-        })
+        // An unregistrable entity id makes the Query Engine emit SQL against a
+        // non-existent relation, and a failed statement aborts the surrounding
+        // Postgres transaction the caller runs this reconcile in — poisoning
+        // the whole backfill (#4145). Running each resolution query inside a
+        // nested transaction scopes the failure to a savepoint, so the catch
+        // below can mark just this group unresolved while every other group
+        // and the final flush keep working.
+        const result = await em.transactional(async () =>
+          queryEngine.query(entityId as any, {
+            fields: ['id', 'organization_id'],
+            filters: { id: chunk.length === 1 ? { $eq: chunk[0] } : { $in: chunk } },
+            tenantId,
+            withDeleted: true,
+            page: { pageSize: Math.max(chunk.length, 1) },
+          }),
+        )
         for (const item of result.items ?? []) {
           const record = item as Record<string, unknown>
           const recordId = record.id != null ? String(record.id) : null


### PR DESCRIPTION
Fixes #4145

## Problem

The `attachments.reconcile-organization` upgrade action runs inside a single `em.transactional`. When a tenant has even one attachment whose `entity_id` is not resolvable by the Query Engine, the resolution query emits SQL against a non-existent relation and Postgres **aborts the surrounding transaction**. The per-group `try/catch` catches the JS error and counts the group `unresolved` (as the documented conservative contract intends), but cannot un-abort the transaction — so the pending-updates `flush()` and the `UpgradeActionRun` insert fail with `current transaction is aborted`, the route returns 500, **nothing is healed**, and the action stays pending on every retry.

## Fix

`reconcileAttachmentOrganizations` now runs each parent-resolution query inside a nested `em.transactional(...)`. Inside an open transaction MikroORM scopes that to a **savepoint**, so a failed statement rolls back only the savepoint: the offending entity group is counted `unresolved` per the existing contract, while every other group resolves, the misfiled rows flush, and the `UpgradeActionRun` record commits. Outside a transaction the wrapper degrades to a short read-only transaction — no behavior change.

This matches the reconcile's documented contract: *"conservative — when the parent org cannot be resolved (unregistered entity id, …) the row is counted as `unresolved` and left as-is"* — which the QA in the issue proved was violated end-to-end.

## Tests

- New: an unregistrable group + a genuinely misfiled valid group → the valid row heals, the bogus group counts `unresolved`, per-entity stats pinned (the exact #4145 QA scenario).
- New: parent-resolution queries are pinned to run through the nested-transaction wrapper.
- Existing 6 reconcile tests stay green (mock `em` gained a pass-through `transactional`).

## Validation

Runner: local
- `yarn workspace @open-mercato/core test --testPathPatterns 'reconcileOrganization'` — 8 tests pass
- `yarn workspace @open-mercato/core typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)