### PR TITLE
security(ent_security): fail closed when MFA enforcement cannot verify compliance (#3853)

### DIFF
--- a/packages/enterprise/src/modules/security/lib/__tests__/enforcement-redirect.test.ts
+++ b/packages/enterprise/src/modules/security/lib/__tests__/enforcement-redirect.test.ts
@@ -58,9 +58,72 @@ describe('resolveMfaEnrollmentRedirect', () => {
     expect(redirect).toBeNull()
   })
 
-  test('returns null when enforcement service is unavailable', async () => {
+  test('fails closed to enrollment when the enforcement service is unavailable (#3853)', async () => {
     const redirect = await resolveMfaEnrollmentRedirect(
       buildArgs({
+        container: {
+          resolve: () => null,
+        },
+      }),
+    )
+    expect(redirect).toBe(
+      '/backend/profile/security/mfa?redirect=%2Fbackend%2Fcustomers%2Fpeople&reason=mfa_enrollment_required',
+    )
+  })
+
+  test('fails closed to enrollment when service resolution throws (#3853)', async () => {
+    const redirect = await resolveMfaEnrollmentRedirect(
+      buildArgs({
+        container: {
+          resolve: () => {
+            throw new Error('DI failure')
+          },
+        },
+      }),
+    )
+    expect(redirect).toContain('reason=mfa_enrollment_required')
+  })
+
+  test('fails closed to enrollment when the compliance check throws (#3853)', async () => {
+    const redirect = await resolveMfaEnrollmentRedirect(
+      buildArgs({
+        container: {
+          resolve: () => ({
+            checkUserCompliance: async () => {
+              throw new Error('transient db error')
+            },
+          }),
+        },
+      }),
+    )
+    expect(redirect).toBe(
+      '/backend/profile/security/mfa?redirect=%2Fbackend%2Fcustomers%2Fpeople&reason=mfa_enrollment_required',
+    )
+  })
+
+  test('keeps the enrollment page reachable during the fail-closed state', async () => {
+    const redirect = await resolveMfaEnrollmentRedirect(
+      buildArgs({
+        pathname: '/backend/profile/security/mfa',
+        container: {
+          resolve: () => {
+            throw new Error('DI failure')
+          },
+        },
+      }),
+    )
+    expect(redirect).toBeNull()
+  })
+
+  test('does not fail closed for a tenant-less principal', async () => {
+    const redirect = await resolveMfaEnrollmentRedirect(
+      buildArgs({
+        auth: {
+          sub: 'user-1',
+          tenantId: null,
+          orgId: null,
+          roles: ['superadmin'],
+        } as ResolveArgs['auth'],
         container: {
           resolve: () => null,
         },

--- a/packages/enterprise/src/modules/security/lib/enforcement-redirect.ts
+++ b/packages/enterprise/src/modules/security/lib/enforcement-redirect.ts
@@ -1,6 +1,9 @@
 import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import { isEnforcementDeadlineOverdue } from '../services/MfaEnforcementService'
 import { readSecurityModuleConfig } from './security-config'
+
+const logger = createLogger('ent_security').child({ component: 'enforcement-redirect' })
 
 const MFA_ENROLLMENT_PATH = '/backend/profile/security/mfa'
 
@@ -52,6 +55,17 @@ function resolveEnforcementService(
   }
 }
 
+function buildEnrollmentRedirect(pathname: string, options: { overdue?: boolean } = {}): string {
+  const searchParams = new URLSearchParams({
+    redirect: pathname,
+    reason: 'mfa_enrollment_required',
+  })
+  if (options.overdue) {
+    searchParams.set('overdue', '1')
+  }
+  return `${MFA_ENROLLMENT_PATH}?${searchParams.toString()}`
+}
+
 export async function resolveMfaEnrollmentRedirect(args: {
   auth: AuthContext
   pathname: string
@@ -63,8 +77,23 @@ export async function resolveMfaEnrollmentRedirect(args: {
   if (isExemptPath(pathname)) return null
   if (readSecurityModuleConfig().mfa.emergencyBypass) return null
 
+  // resolveMfaEnrollmentRedirect is the only gate forcing enforcement-covered
+  // users to enroll, so an unavailable enforcement service or a thrown
+  // compliance check must fail CLOSED for authenticated tenant-scoped users
+  // (#3853). The exempt-path check above keeps the enrollment page itself
+  // reachable while the fail-closed state lasts; tenant-less principals have
+  // no tenant enforcement policy to violate, so they pass through.
+  const hasTenantScope = typeof auth.tenantId === 'string' && auth.tenantId.length > 0
+
   const enforcementService = resolveEnforcementService(container)
-  if (!enforcementService) return null
+  if (!enforcementService) {
+    if (!hasTenantScope) return null
+    logger.error('MFA enforcement service unavailable — failing closed to enrollment', {
+      userId: auth.sub,
+      pathname,
+    })
+    return buildEnrollmentRedirect(pathname)
+  }
 
   try {
     const compliance = await enforcementService.checkUserCompliance(auth.sub)
@@ -73,16 +102,15 @@ export async function resolveMfaEnrollmentRedirect(args: {
     const deadlineState = resolveDeadlineRedirectState(compliance.deadline)
     if (!deadlineState.shouldRedirect) return null
 
-    const searchParams = new URLSearchParams({
-      redirect: pathname,
-      reason: 'mfa_enrollment_required',
+    return buildEnrollmentRedirect(pathname, { overdue: deadlineState.overdue })
+  } catch (error) {
+    if (!hasTenantScope) return null
+    logger.error('MFA compliance check failed — failing closed to enrollment', {
+      userId: auth.sub,
+      pathname,
+      err: error,
     })
-    if (deadlineState.overdue) {
-      searchParams.set('overdue', '1')
-    }
-    return `${MFA_ENROLLMENT_PATH}?${searchParams.toString()}`
-  } catch {
-    return null
+    return buildEnrollmentRedirect(pathname)
   }
 }
 


### PR DESCRIPTION
Fixes #3853

## Problem

`resolveMfaEnrollmentRedirect()` is the sole enforcement gate that forces enforcement-covered users to enroll MFA, and it failed **open** in two ways:

1. `container.resolve('mfaEnforcementService')` throwing (or returning a non-service) → `resolveEnforcementService` returned `null` → no redirect.
2. `checkUserCompliance(auth.sub)` throwing (e.g. `findUserById` raising 404, or a transient DB error) → the outer `catch { return null }` swallowed it → no redirect.

In both cases a non-compliant user under an active enforcement policy retained full access with no MFA and no trace of the failure.

## Fix

Both failure modes now fail **closed** for authenticated principals with a resolvable tenant: the middleware redirects to the enrollment page with the standard `reason=mfa_enrollment_required` (so the existing enrollment notice renders), and the underlying failure is logged via the structured logger for operator diagnosis.

Safety rails from the issue's BC notes:
- The `isExemptPath('/backend/profile/security')` carve-out is evaluated **before** the fail-closed branches, so the enrollment/security page itself stays reachable while the fail-closed state lasts — users can complete enrollment and are not locked out (pinned by a test).
- Tenant-less principals (no tenant enforcement policy to violate, e.g. global superadmin contexts) still pass through (pinned by a test).
- `auth.mfa_pending` and the emergency-bypass config checks are unchanged.

## Tests

Updated the test that pinned the old fail-open behavior and added four: service-unavailable → redirect, DI-throw → redirect, compliance-throw → redirect, exempt-path reachability during fail-closed, tenant-less pass-through. Security module suite: 258 tests green.

## Validation

Runner: local
- `yarn workspace @open-mercato/enterprise test --testPathPatterns 'security'` — 31 suites / 258 tests pass
- `yarn workspace @open-mercato/enterprise typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)