### PR TITLE
fix(scheduler): carry payload parity fix into 0.6.7

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -22,7 +22,7 @@ most of the patterns listed below in a user's codebase.
 
 ---
 
-## 0.6.5 → 0.6.6 (unreleased)
+## 0.6.6 → 0.6.7 (unreleased)
 
 ### Scheduler queue targets now deliver one flat payload contract in both execution modes (#4221)
 
@@ -35,6 +35,8 @@ The local scheduler used to wrap a scheduled queue target's configured `targetPa
 Scheduler-owned `tenantId`/`organizationId`/`_idempotencyKey` are applied after the spread, so they always win over conflicting `targetPayload` fields. Scheduler execution metadata (`scheduleId`, `scheduleName`, `scopeType`, `triggeredAt`) is no longer injected into the application payload. The async worker's idempotency key is now derived from the retry-stable execute-schedule job id instead of `Date.now()`, so BullMQ retries of one logical firing reuse the same `_idempotencyKey`.
 
 **Action for downstream:** workers written to the documented flat contract need no change and now also work under the local scheduler. A worker that relied on the undocumented local envelope (reading `job.payload.payload.*` or `scheduleId`/`scheduleName`/`triggeredAt` from the payload) must switch to the flat fields; include any identifiers it needs in `targetPayload` when registering the schedule.
+
+## 0.6.5 → 0.6.6 (unreleased)
 
 ### Shared `om-*` pipeline skills now come from open-mercato/skills
 

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -24,6 +24,18 @@ most of the patterns listed below in a user's codebase.
 
 ## 0.6.5 → 0.6.6 (unreleased)
 
+### Scheduler queue targets now deliver one flat payload contract in both execution modes (#4221)
+
+The local scheduler used to wrap a scheduled queue target's configured `targetPayload` in an undocumented envelope (`{ scheduleId, scheduleName, scopeType, tenantId, organizationId, payload: { …targetPayload }, triggeredAt }`), while the asynchronous execute-schedule worker already spread `targetPayload` onto the worker payload root. Both paths now build their payload through one scheduler-owned helper (`packages/scheduler/src/modules/scheduler/lib/queueTargetPayload.ts`) and deliver the documented flat contract:
+
+```ts
+{ ...targetPayload, tenantId, organizationId, _idempotencyKey }
+```
+
+Scheduler-owned `tenantId`/`organizationId`/`_idempotencyKey` are applied after the spread, so they always win over conflicting `targetPayload` fields. Scheduler execution metadata (`scheduleId`, `scheduleName`, `scopeType`, `triggeredAt`) is no longer injected into the application payload. The async worker's idempotency key is now derived from the retry-stable execute-schedule job id instead of `Date.now()`, so BullMQ retries of one logical firing reuse the same `_idempotencyKey`.
+
+**Action for downstream:** workers written to the documented flat contract need no change and now also work under the local scheduler. A worker that relied on the undocumented local envelope (reading `job.payload.payload.*` or `scheduleId`/`scheduleName`/`triggeredAt` from the payload) must switch to the flat fields; include any identifiers it needs in `targetPayload` when registering the schedule.
+
 ### Shared `om-*` pipeline skills now come from open-mercato/skills
 
 The generalized agent-pipeline skills (`om-code-review`, `om-auto-create-pr`, `om-auto-review-pr`, `om-merge-buddy`, `om-spec-writing`, the `-loop` variants, `om-prepare-issue`, and 15 more — see the `external` block in [`.ai/skills/tiers.json`](.ai/skills/tiers.json)) were removed from `.ai/skills/` and are now installed from the shared [open-mercato/skills](https://github.com/open-mercato/skills) collection. `yarn install-skills` runs `npx -y skills add open-mercato/skills --skill '*'` after the local tier symlinks, placing the skills under `.agents/skills/` (gitignored), then `npx -y skills update --project` so re-running the installer refreshes the external skills to their latest published versions (the lockfile is gitignored, so `add` seeds and `update` keeps them current).

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/queueTargetPayload.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/queueTargetPayload.test.ts
@@ -1,0 +1,85 @@
+import { buildQueueTargetPayload, buildSchedulerIdempotencyKey } from '../queueTargetPayload'
+
+describe('buildQueueTargetPayload', () => {
+  it('spreads targetPayload fields onto the payload root', () => {
+    const payload = buildQueueTargetPayload({
+      targetPayload: { connectionId: 'connection-id', scope: 'organization' },
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      idempotencyKey: 'scheduler-s1-key',
+    })
+    expect(payload).toEqual({
+      connectionId: 'connection-id',
+      scope: 'organization',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      _idempotencyKey: 'scheduler-s1-key',
+    })
+  })
+
+  it('lets scheduler-owned scope and idempotency fields win over colliding targetPayload fields', () => {
+    const payload = buildQueueTargetPayload({
+      targetPayload: {
+        tenantId: 'spoofed-tenant',
+        organizationId: 'spoofed-org',
+        _idempotencyKey: 'spoofed-key',
+      },
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      idempotencyKey: 'scheduler-s1-key',
+    })
+    expect(payload.tenantId).toBe('tenant-1')
+    expect(payload.organizationId).toBe('org-1')
+    expect(payload._idempotencyKey).toBe('scheduler-s1-key')
+  })
+
+  it('handles empty and non-object targetPayload values', () => {
+    for (const targetPayload of [null, undefined, {}, 'text', 42, ['array']]) {
+      const payload = buildQueueTargetPayload({
+        targetPayload,
+        tenantId: null,
+        organizationId: null,
+        idempotencyKey: 'scheduler-s1-key',
+      })
+      expect(payload).toEqual({
+        tenantId: null,
+        organizationId: null,
+        _idempotencyKey: 'scheduler-s1-key',
+      })
+    }
+  })
+
+  it('preserves a literal application field named payload on the root', () => {
+    const payload = buildQueueTargetPayload({
+      targetPayload: { payload: { nested: true }, other: 1 },
+      tenantId: 'tenant-1',
+      organizationId: null,
+      idempotencyKey: 'scheduler-s1-key',
+    })
+    expect(payload.payload).toEqual({ nested: true })
+    expect(payload.other).toBe(1)
+  })
+
+  it('does not mutate the configured targetPayload', () => {
+    const configured = { connectionId: 'connection-id' }
+    buildQueueTargetPayload({
+      targetPayload: configured,
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      idempotencyKey: 'scheduler-s1-key',
+    })
+    expect(configured).toEqual({ connectionId: 'connection-id' })
+  })
+})
+
+describe('buildSchedulerIdempotencyKey', () => {
+  it('is deterministic for one logical execution key', () => {
+    expect(buildSchedulerIdempotencyKey('s1', 'job-1')).toBe('scheduler-s1-job-1')
+    expect(buildSchedulerIdempotencyKey('s1', 'job-1')).toBe(buildSchedulerIdempotencyKey('s1', 'job-1'))
+  })
+
+  it('differs across schedules and executions', () => {
+    expect(buildSchedulerIdempotencyKey('s1', 'job-1')).not.toBe(buildSchedulerIdempotencyKey('s2', 'job-1'))
+    expect(buildSchedulerIdempotencyKey('s1', 'job-1')).not.toBe(buildSchedulerIdempotencyKey('s1', 'job-2'))
+  })
+})

--- a/packages/scheduler/src/modules/scheduler/lib/queueTargetPayload.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/queueTargetPayload.ts
@@ -1,0 +1,37 @@
+export type QueueTargetPayloadInput = {
+  targetPayload: unknown
+  tenantId: string | null | undefined
+  organizationId: string | null | undefined
+  idempotencyKey: string
+}
+
+/**
+ * Single source of truth for the payload a scheduled queue target receives.
+ * Both the local scheduler and the asynchronous execute-schedule worker MUST
+ * build their enqueue payload here so workers see one flat contract:
+ * the configured targetPayload fields on the root, with scheduler-owned
+ * tenantId/organizationId/_idempotencyKey applied last so they always win
+ * over conflicting targetPayload fields.
+ */
+export function buildQueueTargetPayload(input: QueueTargetPayloadInput): Record<string, unknown> {
+  const base =
+    input.targetPayload && typeof input.targetPayload === 'object' && !Array.isArray(input.targetPayload)
+      ? { ...(input.targetPayload as Record<string, unknown>) }
+      : {}
+  return {
+    ...base,
+    tenantId: input.tenantId ?? null,
+    organizationId: input.organizationId ?? null,
+    _idempotencyKey: input.idempotencyKey,
+  }
+}
+
+/**
+ * One logical scheduled firing must keep one idempotency key across worker
+ * retries, so downstream consumers can deduplicate. Pass a retry-stable
+ * execution key: the execute-schedule job id in async mode, or the firing
+ * timestamp in local mode (which runs each firing exactly once).
+ */
+export function buildSchedulerIdempotencyKey(scheduleId: string, executionKey: string | number): string {
+  return `scheduler-${scheduleId}-${executionKey}`
+}

--- a/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
+++ b/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
@@ -271,9 +271,9 @@ describe('LocalSchedulerService', () => {
 
       expect(mockQueue.enqueue).toHaveBeenCalledWith(
         expect.objectContaining({
-          scheduleId: 'test-1',
-          scheduleName: 'Test Schedule',
-          scopeType: 'system',
+          tenantId: null,
+          organizationId: null,
+          _idempotencyKey: expect.stringMatching(/^scheduler-test-1-/),
         })
       )
     })
@@ -548,9 +548,9 @@ describe('LocalSchedulerService', () => {
       )
     })
 
-    it('should pass payload to queue job', async () => {
+    it('should deliver the flat targetPayload contract to the queue job', async () => {
       const schedule = createSchedule({
-        targetPayload: { foo: 'bar', baz: 123 },
+        targetPayload: { foo: 'bar', baz: 123, tenantId: 'spoofed-tenant' },
       })
 
       mockForkedEm.find.mockResolvedValue([schedule])
@@ -565,9 +565,17 @@ describe('LocalSchedulerService', () => {
 
       expect(mockQueue.enqueue).toHaveBeenCalledWith(
         expect.objectContaining({
-          payload: { foo: 'bar', baz: 123 },
+          foo: 'bar',
+          baz: 123,
+          tenantId: schedule.tenantId,
+          organizationId: schedule.organizationId,
+          _idempotencyKey: expect.stringMatching(new RegExp(`^scheduler-${schedule.id}-`)),
         })
       )
+      const enqueued = mockQueue.enqueue.mock.calls[0][0] as Record<string, unknown>
+      expect(enqueued).not.toHaveProperty('payload')
+      expect(enqueued).not.toHaveProperty('scheduleId')
+      expect(enqueued).not.toHaveProperty('scheduleName')
     })
 
     it('should pass scope to command input', async () => {

--- a/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
@@ -8,6 +8,7 @@ import { recalculateNextRun } from '../lib/nextRunCalculator'
 import { emitSchedulerEvent } from '../events.js'
 import { getGlobalEventBus } from '@open-mercato/shared/modules/events'
 import { buildScheduledCommandContext } from '../lib/commandContext.js'
+import { buildQueueTargetPayload, buildSchedulerIdempotencyKey } from '../lib/queueTargetPayload.js'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('scheduler').child({ component: 'local' })
@@ -251,16 +252,17 @@ export class LocalSchedulerService {
     }
 
     const queue = this.queueFactory(schedule.targetQueue)
-    
-    await queue.enqueue({
-      scheduleId: schedule.id,
-      scheduleName: schedule.name,
-      scopeType: schedule.scopeType,
+
+    // Deliver the same flat contract as the asynchronous execute-schedule
+    // worker: targetPayload fields on the root, scheduler-owned scope and
+    // idempotency fields applied last. Local mode runs each firing exactly
+    // once, so the firing timestamp is a valid logical execution key.
+    await queue.enqueue(buildQueueTargetPayload({
+      targetPayload: schedule.targetPayload,
       tenantId: schedule.tenantId,
       organizationId: schedule.organizationId,
-      payload: schedule.targetPayload || {},
-      triggeredAt: new Date(),
-    })
+      idempotencyKey: buildSchedulerIdempotencyKey(schedule.id, Date.now()),
+    }))
 
     logger.info('Enqueued job to target queue', { scheduleId: schedule.id, targetQueue: schedule.targetQueue })
   }

--- a/packages/scheduler/src/modules/scheduler/workers/__tests__/execute-schedule.worker.test.ts
+++ b/packages/scheduler/src/modules/scheduler/workers/__tests__/execute-schedule.worker.test.ts
@@ -1,5 +1,6 @@
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { ensureTenantScope } from '@open-mercato/shared/lib/commands/scope'
+import { createQueue } from '@open-mercato/queue'
 import { ScheduledJob } from '../../data/entities'
 import executeScheduleWorker from '../execute-schedule.worker'
 
@@ -14,6 +15,10 @@ jest.mock('@open-mercato/shared/lib/commands', () => ({
 jest.mock('@open-mercato/queue', () => ({
   createQueue: jest.fn(),
 }), { virtual: true })
+
+jest.mock('@open-mercato/shared/lib/redis/connection', () => ({
+  getRedisUrlOrThrow: jest.fn(() => 'redis://localhost:6379'),
+}))
 
 jest.mock('../../events', () => ({
   emitSchedulerEvent: jest.fn(async () => undefined),
@@ -98,5 +103,78 @@ describe('executeScheduleWorker command scope', () => {
     ).rejects.toBeInstanceOf(CrudHttpError)
 
     expect(em.flush).not.toHaveBeenCalled()
+  })
+})
+
+describe('executeScheduleWorker queue target payload contract', () => {
+  const enqueue = jest.fn(async () => 'target-job-1')
+  const close = jest.fn(async () => undefined)
+
+  function buildQueueSchedule(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
+    return buildCommandSchedule({
+      targetType: 'queue',
+      targetQueue: 'example',
+      targetCommand: null,
+      targetPayload: { connectionId: 'connection-id', scope: 'organization' },
+      ...overrides,
+    })
+  }
+
+  function runWorker(schedule: ScheduledJob, jobId = 'worker-job-1', attemptNumber = 1) {
+    const { context } = buildWorkerContext(schedule)
+    return executeScheduleWorker(
+      {
+        id: 'queued-job-1',
+        queue: 'scheduler-execution',
+        payload: {
+          scheduleId,
+          tenantId: schedule.tenantId,
+          organizationId: schedule.organizationId,
+          scopeType: schedule.scopeType,
+        },
+        attempts: 0,
+        createdAt: Date.now(),
+      },
+      { ...context, jobId, attemptNumber },
+    )
+  }
+
+  beforeEach(() => {
+    enqueue.mockClear()
+    close.mockClear()
+    ;(createQueue as jest.Mock).mockReturnValue({ enqueue, close })
+  })
+
+  it('delivers the flat targetPayload contract with scheduler-owned fields applied last', async () => {
+    const schedule = buildQueueSchedule({
+      targetPayload: {
+        connectionId: 'connection-id',
+        scope: 'organization',
+        tenantId: 'spoofed-tenant',
+        payload: { nested: true },
+      },
+    })
+
+    await runWorker(schedule)
+
+    expect(enqueue).toHaveBeenCalledWith({
+      connectionId: 'connection-id',
+      scope: 'organization',
+      payload: { nested: true },
+      tenantId: 'tenant-a',
+      organizationId: 'org-a',
+      _idempotencyKey: `scheduler-${scheduleId}-worker-job-1`,
+    })
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps one idempotency key across retries of the same logical firing', async () => {
+    await runWorker(buildQueueSchedule(), 'worker-job-1', 1)
+    await runWorker(buildQueueSchedule(), 'worker-job-1', 2)
+
+    const firstKey = (enqueue.mock.calls[0][0] as Record<string, unknown>)._idempotencyKey
+    const secondKey = (enqueue.mock.calls[1][0] as Record<string, unknown>)._idempotencyKey
+    expect(firstKey).toBe(`scheduler-${scheduleId}-worker-job-1`)
+    expect(secondKey).toBe(firstKey)
   })
 })

--- a/packages/scheduler/src/modules/scheduler/workers/execute-schedule.worker.ts
+++ b/packages/scheduler/src/modules/scheduler/workers/execute-schedule.worker.ts
@@ -7,6 +7,7 @@ import { CommandBus } from '@open-mercato/shared/lib/commands'
 import type { AppContainer } from '@open-mercato/shared/lib/di/container'
 import { emitSchedulerEvent } from '../events.js'
 import { buildScheduledCommandContext } from '../lib/commandContext.js'
+import { buildQueueTargetPayload, buildSchedulerIdempotencyKey } from '../lib/queueTargetPayload.js'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('scheduler').child({ component: 'worker' })
@@ -168,20 +169,17 @@ export default async function executeScheduleWorker(
     
     let targetJobId: string | undefined
     try {
-      // Generate a deterministic idempotency key so that if BullMQ retries
-      // this worker after a crash between enqueue and DB flush, downstream
-      // workers can deduplicate using this key.
-      const executionTimestamp = Date.now()
-      const idempotencyKey = `scheduler-${schedule.id}-${executionTimestamp}`
+      // The execute-schedule job id is stable across BullMQ retries, so if
+      // this worker crashes between enqueue and DB flush the retried attempt
+      // reuses the same idempotency key and downstream workers can dedupe.
+      const idempotencyKey = buildSchedulerIdempotencyKey(schedule.id, ctx.jobId ?? Date.now())
 
-      const queuePayload = {
-        ...((schedule.targetPayload as Record<string, unknown>) || {}),
+      targetJobId = await targetQueue.enqueue(buildQueueTargetPayload({
+        targetPayload: schedule.targetPayload,
         tenantId: schedule.tenantId,
         organizationId: schedule.organizationId,
-        _idempotencyKey: idempotencyKey,
-      }
-
-      targetJobId = await targetQueue.enqueue(queuePayload)
+        idempotencyKey,
+      }))
     } finally {
       // Always close the queue instance to free Redis connections
       await targetQueue.close()


### PR DESCRIPTION
Supersedes #4252

Credit: original implementation by @wojciechszyjka. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the original branch.

## Included work
- Original scheduler payload-contract changes from #4252
- Moved the breaking-change guidance to the `0.6.6 → 0.6.7` upgrade window requested during re-review

## Validation
- `yarn workspace @open-mercato/scheduler test --runInBand` (17 suites, 336 tests passed)
- `yarn build:packages`
- `yarn generate`
- `yarn workspace @open-mercato/scheduler typecheck`

The carried-forward diff was re-reviewed after the autofix and is intended to be merge-ready pending CI and manual QA.
