### PR TITLE
fix(attachments): carry reconcile healing fix past audit gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "undici@npm:^7.19.0": "7.28.0",
     "undici@npm:^8.3.0": "8.5.0",
     "undici@npm:^8.4.1": "8.5.0",
+    "websocket-driver": "0.7.5",
     "nodemailer": "9.0.1",
     "brace-expansion": "5.0.5",
     "handlebars": "4.7.9",

--- a/packages/core/src/modules/attachments/lib/__tests__/reconcileOrganization.test.ts
+++ b/packages/core/src/modules/attachments/lib/__tests__/reconcileOrganization.test.ts
@@ -28,6 +28,7 @@ function buildEm(scanRows: ScanRow[]) {
     flush: jest.fn(async () => {
       for (const ref of references) flushed.push({ id: ref.id, organizationId: ref.organizationId })
     }),
+    transactional: jest.fn(async (callback: () => Promise<unknown>) => callback()),
   }
   return { em, flushed }
 }
@@ -138,6 +139,41 @@ describe('reconcileAttachmentOrganizations', () => {
     expect(report.unresolved).toBe(1)
     expect(report.updated).toBe(0)
     expect(flushed).toEqual([])
+  })
+
+  it('still heals other groups when one entity group is unregistrable (#4145)', async () => {
+    const { em, flushed } = buildEm([
+      { id: 'att-bogus', entity_id: 'some:bogus_entity', record_id: 'x-1', organization_id: 'home-org' },
+      { id: 'att-good', entity_id: 'catalog:product', record_id: 'p-1', organization_id: 'home-org' },
+    ])
+    const queryEngine = buildQueryEngine({ 'catalog:product': { 'p-1': 'selected-org' } })
+
+    const report = await reconcileAttachmentOrganizations({
+      em: em as any,
+      queryEngine: queryEngine as any,
+      tenantId: 't1',
+    })
+
+    expect(report.unresolved).toBe(1)
+    expect(report.updated).toBe(1)
+    expect(report.byEntity['some:bogus_entity']).toEqual({ scanned: 1, updated: 0, unresolved: 1 })
+    expect(flushed).toEqual([{ id: 'att-good', organizationId: 'selected-org' }])
+  })
+
+  it('scopes every parent-resolution query to a nested transaction savepoint (#4145)', async () => {
+    const { em } = buildEm([
+      { id: 'att-1', entity_id: 'catalog:product', record_id: 'p-1', organization_id: 'org-a' },
+    ])
+    const queryEngine = buildQueryEngine({ 'catalog:product': { 'p-1': 'org-a' } })
+
+    await reconcileAttachmentOrganizations({
+      em: em as any,
+      queryEngine: queryEngine as any,
+      tenantId: 't1',
+    })
+
+    expect(em.transactional).toHaveBeenCalledTimes(1)
+    expect(queryEngine.query).toHaveBeenCalledTimes(1)
   })
 
   it('reconciles a mixed batch and reports per-entity stats', async () => {

--- a/packages/core/src/modules/attachments/lib/reconcileOrganization.ts
+++ b/packages/core/src/modules/attachments/lib/reconcileOrganization.ts
@@ -132,13 +132,22 @@ export async function reconcileAttachmentOrganizations(opts: {
     for (let index = 0; index < recordIds.length; index += batchSize) {
       const chunk = recordIds.slice(index, index + batchSize)
       try {
-        const result = await queryEngine.query(entityId as any, {
-          fields: ['id', 'organization_id'],
-          filters: { id: chunk.length === 1 ? { $eq: chunk[0] } : { $in: chunk } },
-          tenantId,
-          withDeleted: true,
-          page: { pageSize: Math.max(chunk.length, 1) },
-        })
+        // An unregistrable entity id makes the Query Engine emit SQL against a
+        // non-existent relation, and a failed statement aborts the surrounding
+        // Postgres transaction the caller runs this reconcile in — poisoning
+        // the whole backfill (#4145). Running each resolution query inside a
+        // nested transaction scopes the failure to a savepoint, so the catch
+        // below can mark just this group unresolved while every other group
+        // and the final flush keep working.
+        const result = await em.transactional(async () =>
+          queryEngine.query(entityId as any, {
+            fields: ['id', 'organization_id'],
+            filters: { id: chunk.length === 1 ? { $eq: chunk[0] } : { $in: chunk } },
+            tenantId,
+            withDeleted: true,
+            page: { pageSize: Math.max(chunk.length, 1) },
+          }),
+        )
         for (const item of result.items ?? []) {
           const record = item as Record<string, unknown>
           const recordId = record.id != null ? String(record.id) : null

--- a/yarn.lock
+++ b/yarn.lock
@@ -30562,14 +30562,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+"websocket-driver@npm:0.7.5":
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 10/17197d265d5812b96c728e70fd6fe7d067471e121669768fe0c7100c939d997ddfc807d371a728556e24fc7238aa9d58e630ea4ff5fd4cfbb40f3d0a240ef32d
+  checksum: 10/0671fef8c79ba1b1b2fa6b7d95cb034d059410e7c4cfd7ef42063a254e12ca2917806c3a5026206b33abf25a5d44a651c547b8f74d9ec94c9fe4df6fa1bc63f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Supersedes #4253

Credit: original implementation by @wojciechszyjka. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the original branch.

## Included work
- Original attachment reconciliation savepoint fix and regression tests from #4253
- Root `websocket-driver@0.7.5` resolution that clears the critical dependency-audit advisory blocking the PR

## Validation
- `yarn npm audit --all --recursive --severity high` (no audit suggestions)
- attachment reconcile regression test (1 suite, 8 tests passed)
- `yarn build:packages`
- `yarn generate`
- `yarn workspace @open-mercato/core typecheck`

The carried-forward diff was re-reviewed after the autofix and is intended to be merge-ready pending CI.
