### PR TITLE
fix(workflows): resume code-defined workflow instances after async activities (#4257)

### DIFF
--- a/.ai/specs/implemented/2026-04-14-code-based-workflow-definitions.md
+++ b/.ai/specs/implemented/2026-04-14-code-based-workflow-definitions.md
@@ -307,6 +307,8 @@ The `source` concept is derived at query time, not stored:
 
 No changes needed. The instance stores `definitionId`, `workflowId`, and `version` as before. The executor continues to fetch the latest definition on every step/resume — code-based definitions are resolved from the in-memory registry using the same live-read pattern.
 
+**Runtime resolution for started instances.** An instance started from an unpersisted code definition stores the deterministic `codeWorkflowUuid(workflowId)` as its `definitionId`. Runtime handlers (executor loop, step, transition, task, signal, timer) resolve the backing definition via `findDefinitionForInstance()` in `lib/find-definition.ts`: database row by id first, then a code-registry fallback gated on `codeWorkflowUuid(instance.workflowId) === instance.definitionId`. The UUID-equality gate guarantees the fallback never substitutes the code payload for a hard-deleted *persisted* row (those have their own random UUIDs), and a disabled code definition still resolves so in-flight instances can finish — matching persisted-definition semantics, where disabling blocks new starts but not running instances. Without this fallback, a virtual code workflow could start but never advance (`DEFINITION_NOT_FOUND` on the first transition).
+
 ### CodeWorkflowDefinition (new shared type, not a DB entity)
 
 ```typescript
@@ -677,3 +679,7 @@ None.
 - Removed the cross-organization customize block: any organization within the tenant can now revive a soft-deleted override row, matching the tenant-scoped unique constraint semantics. The previous 409 response (and corresponding OpenAPI entry) was dropped from `/customize` and the `code:*` PUT path.
 - Corrected the `Migration20260428102318` `down()` ordering so `workflow_definitions` is renamed before `workflow_instances` joins back through `definition_id`, eliminating a transient mismatch during rollback.
 - Switched override insert/delete paths from `persistAndFlush`/`removeAndFlush` to explicit `persist`+`flush` / `remove`+`flush` for consistency with surrounding code.
+
+### 2026-07-17
+
+- Forward-ported the fresh-install runtime fix from `main` (06d290bed, PR #4193) for issue #4257: added `findDefinitionForInstance()` / `resolveCodeDefinitionForInstance()` to `lib/find-definition.ts` and switched every runtime `definition_id` lookup (executor loop and resume-after-activities, step, transition, task, signal, and timer handlers) to it. Instances started from an unpersisted virtual code definition — whose `definitionId` is the deterministic `codeWorkflowUuid` — can now advance past async activities instead of the activity worker failing with `DEFINITION_NOT_FOUND` and leaving the instance in `WAITING_FOR_ACTIVITIES` forever. The `main`-only data-repair migration (`Migration20260715120000`) and its integration specs were not ported; they cover legacy upgraded tenants on the release line.

--- a/packages/core/src/modules/workflows/lib/__tests__/find-definition.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/find-definition.test.ts
@@ -5,7 +5,12 @@
 import { describe, test, expect, beforeEach, jest } from '@jest/globals'
 import { EntityManager } from '@mikro-orm/core'
 import { WorkflowDefinition } from '../../data/entities'
-import { codeWorkflowUuid, findWorkflowDefinition } from '../find-definition'
+import {
+  codeWorkflowUuid,
+  findWorkflowDefinition,
+  findDefinitionForInstance,
+  resolveCodeDefinitionForInstance,
+} from '../find-definition'
 import { registerCodeWorkflows, clearCodeWorkflowRegistry } from '../code-registry'
 import type { CodeWorkflowDefinition } from '@open-mercato/shared/modules/workflows'
 
@@ -186,5 +191,118 @@ describe('findWorkflowDefinition()', () => {
       WorkflowDefinition,
       expect.objectContaining({ version: 2 }),
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// resolveCodeDefinitionForInstance
+// ---------------------------------------------------------------------------
+
+describe('resolveCodeDefinitionForInstance()', () => {
+  const virtualInstance = {
+    definitionId: codeWorkflowUuid('test.workflow'),
+    workflowId: 'test.workflow',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+  }
+
+  beforeEach(() => {
+    clearCodeWorkflowRegistry()
+  })
+
+  test('resolves the virtual definition for an instance started from a code definition', () => {
+    registerCodeWorkflows([makeCodeDef()])
+
+    const result = resolveCodeDefinitionForInstance(virtualInstance)
+
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe(virtualInstance.definitionId)
+    expect(result?.workflowId).toBe('test.workflow')
+    expect(result?.codeWorkflowId).toBe('test.workflow')
+    expect(result?.tenantId).toBe('tenant-1')
+    expect(result?.organizationId).toBe('org-1')
+  })
+
+  test('returns null when the definitionId is not the deterministic code UUID', () => {
+    registerCodeWorkflows([makeCodeDef()])
+
+    const result = resolveCodeDefinitionForInstance({
+      ...virtualInstance,
+      definitionId: 'db-uuid-1111-2222-3333-444444444444',
+    })
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null when the workflowId is not registered as a code workflow', () => {
+    const result = resolveCodeDefinitionForInstance(virtualInstance)
+
+    expect(result).toBeNull()
+  })
+
+  test('still resolves a disabled code definition so in-flight instances can finish', () => {
+    registerCodeWorkflows([makeCodeDef({ enabled: false })])
+
+    const result = resolveCodeDefinitionForInstance(virtualInstance)
+
+    expect(result).not.toBeNull()
+    expect(result?.enabled).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// findDefinitionForInstance
+// ---------------------------------------------------------------------------
+
+describe('findDefinitionForInstance()', () => {
+  let mockEm: jest.Mocked<Pick<EntityManager, 'findOne'>>
+
+  const virtualInstance = {
+    definitionId: codeWorkflowUuid('test.workflow'),
+    workflowId: 'test.workflow',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+  }
+
+  beforeEach(() => {
+    clearCodeWorkflowRegistry()
+    mockEm = { findOne: jest.fn() } as any
+  })
+
+  test('returns the persisted definition when the definitionId exists in the DB', async () => {
+    const dbDef = makeDbDef()
+    mockEm.findOne.mockResolvedValue(dbDef as any)
+    registerCodeWorkflows([makeCodeDef()])
+
+    const result = await findDefinitionForInstance(mockEm as any, {
+      ...virtualInstance,
+      definitionId: dbDef.id,
+    })
+
+    expect(result).toBe(dbDef)
+    expect(mockEm.findOne).toHaveBeenCalledWith(WorkflowDefinition, { id: dbDef.id })
+  })
+
+  test('falls back to the code registry when the DB misses and the UUID matches', async () => {
+    mockEm.findOne.mockResolvedValue(null)
+    registerCodeWorkflows([makeCodeDef()])
+
+    const result = await findDefinitionForInstance(mockEm as any, virtualInstance)
+
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe(virtualInstance.definitionId)
+    expect(result?.workflowId).toBe('test.workflow')
+  })
+
+  test('returns null when the DB misses and the definitionId belonged to a deleted persisted row', async () => {
+    mockEm.findOne.mockResolvedValue(null)
+    registerCodeWorkflows([makeCodeDef()])
+
+    const result = await findDefinitionForInstance(mockEm as any, {
+      ...virtualInstance,
+      definitionId: 'db-uuid-1111-2222-3333-444444444444',
+    })
+
+    expect(result).toBeNull()
   })
 })

--- a/packages/core/src/modules/workflows/lib/find-definition.ts
+++ b/packages/core/src/modules/workflows/lib/find-definition.ts
@@ -80,9 +80,17 @@ export async function findWorkflowDefinition(
   // so disabled code workflows aren't silently executable.
   if (version === undefined && !codeDef.enabled) return null
 
+  return buildVirtualCodeDefinition(codeDef, tenantId, organizationId)
+}
+
+function buildVirtualCodeDefinition(
+  codeDef: NonNullable<ReturnType<typeof getCodeWorkflow>>,
+  tenantId: string,
+  organizationId: string,
+): WorkflowDefinition {
   // Construct a virtual WorkflowDefinition object (not persisted)
   const virtual = new WorkflowDefinition()
-  virtual.id = codeWorkflowUuid(workflowId)
+  virtual.id = codeWorkflowUuid(codeDef.workflowId)
   virtual.workflowId = codeDef.workflowId
   virtual.workflowName = codeDef.workflowName
   virtual.description = codeDef.description ?? null
@@ -97,4 +105,48 @@ export async function findWorkflowDefinition(
   virtual.updatedAt = new Date(0)
 
   return virtual
+}
+
+/**
+ * Resolve a virtual code definition for an already-started instance whose
+ * `definitionId` does not exist in the database.
+ *
+ * Instances started from a virtual code definition persist the deterministic
+ * `codeWorkflowUuid(workflowId)` as their `definitionId`. Runtime handlers
+ * (step/transition/signal/timer/task) load definitions by that id, so without
+ * this fallback an unpersisted code workflow starts but can never advance.
+ *
+ * The UUID equality gate ensures the fallback never substitutes the code
+ * definition for a hard-deleted persisted row: those rows have their own
+ * random UUIDs that can never match the deterministic code UUID.
+ */
+export function resolveCodeDefinitionForInstance(instance: {
+  definitionId: string
+  workflowId: string
+  tenantId: string
+  organizationId: string
+}): WorkflowDefinition | null {
+  const codeDef = getCodeWorkflow(instance.workflowId)
+  if (!codeDef) return null
+  if (codeWorkflowUuid(instance.workflowId) !== instance.definitionId) return null
+  return buildVirtualCodeDefinition(codeDef, instance.tenantId, instance.organizationId)
+}
+
+/**
+ * Find the definition backing a workflow instance: database row by id first,
+ * falling back to the in-memory code registry for instances started from an
+ * unpersisted code definition.
+ */
+export async function findDefinitionForInstance(
+  em: EntityManager,
+  instance: {
+    definitionId: string
+    workflowId: string
+    tenantId: string
+    organizationId: string
+  },
+): Promise<WorkflowDefinition | null> {
+  const dbDef = await em.findOne(WorkflowDefinition, { id: instance.definitionId })
+  if (dbDef) return dbDef
+  return resolveCodeDefinitionForInstance(instance)
 }

--- a/packages/core/src/modules/workflows/lib/signal-handler.ts
+++ b/packages/core/src/modules/workflows/lib/signal-handler.ts
@@ -13,6 +13,7 @@ import type * as eventLoggerModule from './event-logger'
 import type * as stepHandlerModule from './step-handler'
 import type * as transitionHandlerModule from './transition-handler'
 import type * as workflowExecutorModule from './workflow-executor'
+import { resolveCodeDefinitionForInstance } from './find-definition'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('workflows')
@@ -95,13 +96,13 @@ export async function sendSignal(
   // Branch-scoped signal: a FORKED instance routes the signal to the branch
   // paused at a matching WAIT_FOR_SIGNAL step.
   if (instance.status === 'FORKED') {
-    const branchDefinition = await findOneWithDecryption(
+    const branchDefinition = (await findOneWithDecryption(
       em as PostgreSqlEntityManager,
       WorkflowDefinition,
       { id: instance.definitionId, tenantId: instance.tenantId, organizationId: instance.organizationId, deletedAt: null },
       undefined,
       { tenantId: instance.tenantId, organizationId: instance.organizationId },
-    )
+    )) ?? resolveCodeDefinitionForInstance(instance)
     if (!branchDefinition) {
       throw new SignalError('Workflow definition not found', 'DEFINITION_NOT_FOUND', { definitionId: instance.definitionId })
     }
@@ -173,7 +174,7 @@ export async function sendSignal(
   }
 
   // Load workflow definition with tenant/org scope to check current step
-  const definition = await findOneWithDecryption(
+  const definition = (await findOneWithDecryption(
     em as PostgreSqlEntityManager,
     WorkflowDefinition,
     {
@@ -184,7 +185,7 @@ export async function sendSignal(
     },
     undefined,
     { tenantId: instance.tenantId, organizationId: instance.organizationId },
-  )
+  )) ?? resolveCodeDefinitionForInstance(instance)
   if (!definition) {
     throw new SignalError(
       'Workflow definition not found',

--- a/packages/core/src/modules/workflows/lib/step-handler.ts
+++ b/packages/core/src/modules/workflows/lib/step-handler.ts
@@ -13,7 +13,6 @@ import { EntityManager } from '@mikro-orm/core'
 import {
   WorkflowInstance,
   WorkflowBranchInstance,
-  WorkflowDefinition,
   StepInstance,
   UserTask,
   WorkflowEvent,
@@ -22,6 +21,7 @@ import {
 } from '../data/entities'
 import { parseDuration } from './duration'
 import { logWorkflowEvent } from './event-logger'
+import { findDefinitionForInstance } from './find-definition'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('workflows')
@@ -76,9 +76,7 @@ export async function enterStep(
   branch?: WorkflowBranchInstance | null
 ): Promise<StepInstance> {
   // Load workflow definition to get step details
-  const definition = await em.findOne(WorkflowDefinition, {
-    id: instance.definitionId,
-  })
+  const definition = await findDefinitionForInstance(em, instance)
 
   if (!definition) {
     throw new StepExecutionError(
@@ -213,9 +211,7 @@ export async function executeStep(
     const stepInstance = await enterStep(em, instance, stepId, context, branch)
 
     // Load workflow definition to get step configuration
-    const definition = await em.findOne(WorkflowDefinition, {
-      id: instance.definitionId,
-    })
+    const definition = await findDefinitionForInstance(em, instance)
 
     if (!definition) {
       throw new StepExecutionError(
@@ -359,7 +355,7 @@ async function executeStepByType(
           { stepType, stepId: stepDef.stepId }
         )
       }
-      const definition = await em.findOne(WorkflowDefinition, { id: instance.definitionId })
+      const definition = await findDefinitionForInstance(em, instance)
       if (!definition) {
         throw new StepExecutionError(
           `Workflow definition not found: ${instance.definitionId}`,

--- a/packages/core/src/modules/workflows/lib/task-handler.ts
+++ b/packages/core/src/modules/workflows/lib/task-handler.ts
@@ -17,9 +17,9 @@ import {
   WorkflowInstance,
   WorkflowEvent,
   StepInstance,
-  WorkflowDefinition,
 } from '../data/entities'
 import { executeWorkflow } from './workflow-executor'
+import { findDefinitionForInstance } from './find-definition'
 import * as stepHandler from './step-handler'
 import * as transitionHandler from './transition-handler'
 import { createLogger } from '@open-mercato/shared/lib/logger'
@@ -191,9 +191,7 @@ export async function completeUserTask(
   const currentStepId = instance.currentStepId
 
   // Load workflow definition to find transitions
-  const definition = await em.findOne(WorkflowDefinition, {
-    id: instance.definitionId,
-  })
+  const definition = await findDefinitionForInstance(em, instance)
 
   if (!definition) {
     throw new UserTaskError(

--- a/packages/core/src/modules/workflows/lib/timer-handler.ts
+++ b/packages/core/src/modules/workflows/lib/timer-handler.ts
@@ -14,6 +14,7 @@ import type * as eventLoggerModule from './event-logger'
 import type * as stepHandlerModule from './step-handler'
 import type * as transitionHandlerModule from './transition-handler'
 import type * as workflowExecutorModule from './workflow-executor'
+import { resolveCodeDefinitionForInstance } from './find-definition'
 
 export interface FireTimerOptions {
   instanceId: string
@@ -110,7 +111,7 @@ export async function fireTimer(
     )
   }
 
-  const definition = await findOneWithDecryption(
+  const definition = (await findOneWithDecryption(
     em as PostgreSqlEntityManager,
     WorkflowDefinition,
     {
@@ -121,7 +122,7 @@ export async function fireTimer(
     },
     undefined,
     { tenantId: instance.tenantId, organizationId: instance.organizationId },
-  )
+  )) ?? resolveCodeDefinitionForInstance(instance)
   if (!definition) {
     throw new TimerError(
       'Workflow definition not found',

--- a/packages/core/src/modules/workflows/lib/transition-handler.ts
+++ b/packages/core/src/modules/workflows/lib/transition-handler.ts
@@ -15,7 +15,6 @@ import type { AwilixContainer } from 'awilix'
 import type { EventBus } from '@open-mercato/events'
 import {
   WorkflowInstance,
-  WorkflowDefinition,
   WorkflowEvent,
 } from '../data/entities'
 import * as ruleEvaluator from '../../business_rules/lib/rule-evaluator'
@@ -23,6 +22,7 @@ import * as ruleEngine from '../../business_rules/lib/rule-engine'
 import * as activityExecutor from './activity-executor'
 import type { ActivityDefinition } from './activity-executor'
 import * as stepHandler from './step-handler'
+import { findDefinitionForInstance } from './find-definition'
 import {
   type ExecutionToken,
   rootToken,
@@ -116,9 +116,7 @@ export async function evaluateTransition(
 
   try {
     // Load workflow definition
-    const definition = await em.findOne(WorkflowDefinition, {
-      id: instance.definitionId,
-    })
+    const definition = await findDefinitionForInstance(em, instance)
 
     if (!definition) {
       return {
@@ -227,9 +225,7 @@ export async function findValidTransitions(
 ): Promise<TransitionEvaluationResult[]> {
   try {
     // Load workflow definition
-    const definition = await em.findOne(WorkflowDefinition, {
-      id: instance.definitionId,
-    })
+    const definition = await findDefinitionForInstance(em, instance)
 
     if (!definition) {
       return []
@@ -752,9 +748,7 @@ async function evaluatePreConditions(
 ): Promise<ruleEngine.RuleEngineResult> {
   try {
     // Load workflow definition to get workflow ID
-    const definition = await em.findOne(WorkflowDefinition, {
-      id: instance.definitionId,
-    })
+    const definition = await findDefinitionForInstance(em, instance)
 
     if (!definition) {
       return {
@@ -881,9 +875,7 @@ async function evaluatePostConditions(
 ): Promise<ruleEngine.RuleEngineResult> {
   try {
     // Load workflow definition to get workflow ID
-    const definition = await em.findOne(WorkflowDefinition, {
-      id: instance.definitionId,
-    })
+    const definition = await findDefinitionForInstance(em, instance)
 
     if (!definition) {
       return {

--- a/packages/core/src/modules/workflows/lib/workflow-executor.ts
+++ b/packages/core/src/modules/workflows/lib/workflow-executor.ts
@@ -19,7 +19,7 @@ import {
   type WorkflowInstanceStatus,
 } from '../data/entities'
 import { compensateWorkflow } from './compensation-handler'
-import { findWorkflowDefinition } from './find-definition'
+import { findWorkflowDefinition, findDefinitionForInstance } from './find-definition'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('workflows')
@@ -278,9 +278,7 @@ export async function executeWorkflow(
         )
       }
 
-      const definition = await trx.findOne(WorkflowDefinition, {
-        id: instance.definitionId,
-      })
+      const definition = await findDefinitionForInstance(trx, instance)
 
       if (!definition) {
         throw new WorkflowExecutionError(
@@ -614,7 +612,7 @@ export async function completeWorkflow(
 
   // Trigger compensation if workflow failed and has compensatable activities (Phase 8.2)
   if (status === 'FAILED') {
-    const definition = await em.findOne(WorkflowDefinition, { id: instance.definitionId })
+    const definition = await findDefinitionForInstance(em, instance)
 
     if (definition && checkIfCompensationNeeded(definition)) {
       try {
@@ -836,9 +834,14 @@ export async function resumeWorkflowAfterActivities(
       fromStepId: instance.currentStepId,
     })
 
-    const definition = await trx.findOneOrFail(WorkflowDefinition, {
-      id: instance.definitionId,
-    })
+    const definition = await findDefinitionForInstance(trx, instance)
+    if (!definition) {
+      throw new WorkflowExecutionError(
+        `Workflow definition not found: ${instance.definitionId}`,
+        'DEFINITION_NOT_FOUND',
+        { definitionId: instance.definitionId }
+      )
+    }
 
     const step = definition.definition.steps.find(s => s.stepId === pendingTransition.toStepId)
 


### PR DESCRIPTION
## Summary

Fixes #4257.

The checkout demo (and any workflow that exists only as a code definition, i.e. every fresh install) starts fine but can never advance past an async activity: the `workflow-activities` worker resumes the instance, looks the definition up by `instance.definitionId` **in the database only**, finds nothing (code-defined instances persist the deterministic `codeWorkflowUuid` which has no DB row), and fails with `WorkflowExecutionError: Workflow definition not found: <uuid>`. The instance is left in `WAITING_FOR_ACTIVITIES` forever while the order itself was already created — exactly what #4257 reports.

## Root cause & fix

This was already fixed on `main` by 06d290bed (merged via #4193, targeting `main` for the v0.6.6 hotfix line) — but **never forward-ported to `develop`**, so develop still has the DB-only lookups. #4257 was reproduced on a develop-based branch (`issue-4211`), which is consistent with that gap.

This PR is a faithful forward-port of the runtime half of 06d290bed:

- `lib/find-definition.ts`: adds `resolveCodeDefinitionForInstance()` + `findDefinitionForInstance()` (DB row by id first, then code-registry fallback gated on `codeWorkflowUuid(instance.workflowId) === instance.definitionId`).
- Switches every runtime `definition_id` lookup to it: `workflow-executor.ts` (execution loop, resume-after-activities/compensation path), `step-handler.ts`, `transition-handler.ts`, `signal-handler.ts`, `timer-handler.ts`, `task-handler.ts`.
- Ports the accompanying unit tests (`find-definition.test.ts`) and the spec-doc updates.

All 8 engine/test files were **byte-identical** between pre-hotfix `main` and current `develop`, so the port applies 1:1 with no adaptation.

**Deliberately not ported:** `Migration20260715120000` and `__integration__/TC-WF-030/031` + helpers — they repair the *legacy upgraded-tenant* seed shadowing on the release line and depend on main-only files that don't exist on develop. The runtime fallback here is the root-cause half relevant to develop.

## Validation

- `yarn workspace @open-mercato/core test --testPathPatterns 'workflows'` → **37 suites / 609 tests passed** (includes the ported `find-definition` coverage: byId DB-precedence, UUID-equality gate, deleted-row non-substitution, disabled-definition semantics).
- `yarn workspace @open-mercato/core typecheck` → clean.
- Runner: local.

## Labels (no triage rights — please apply)

Suggest: `bug`, `priority-high` (breaks the checkout demo / first-run experience on every fresh install), `risk-medium` (engine lookup paths, but byte-identical to code already shipped and exercised on `main`/v0.6.6), `needs-qa` (user-facing demo flow — happy to self-QA with evidence like on #4226/#4227/#4254/#4255 if QA has no capacity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)