### PR TITLE
fix(workflows): register code workflows in CLI/worker bootstrap (#4257)

### DIFF
--- a/packages/core/src/modules/workflows/lib/code-registry.ts
+++ b/packages/core/src/modules/workflows/lib/code-registry.ts
@@ -1,24 +1,33 @@
 /**
- * In-Memory Code Workflow Registry
+ * Code Workflow Registry (validating bridge)
  *
- * Stores code-based workflow definitions populated at bootstrap from
- * the generated workflows.generated.ts. Definitions live purely in memory —
- * no DB row is created until a user customizes the definition.
+ * The registry store itself lives in `@open-mercato/shared` so all bootstrap
+ * contexts (Next.js app, CLI, `mercato workers`) share one process-wide map —
+ * see `@open-mercato/shared/modules/workflows/code-registry`. This module
+ * keeps the workflows engine's import path stable and adds Zod validation on
+ * top of the raw registration used by the shared bootstrap factory.
  */
 
 import type { CodeWorkflowDefinition } from '@open-mercato/shared/modules/workflows'
+import { registerCodeWorkflowEntries } from '@open-mercato/shared/modules/workflows/code-registry'
 import { workflowDefinitionDataSchema } from '../data/validators'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('workflows')
 
-const codeWorkflowRegistry = new Map<string, CodeWorkflowDefinition>()
+export {
+  getCodeWorkflow,
+  getAllCodeWorkflows,
+  isCodeWorkflow,
+  clearCodeWorkflowRegistry,
+} from '@open-mercato/shared/modules/workflows/code-registry'
 
 /**
  * Register code-based workflow definitions at bootstrap time.
  * Validates each definition against the Zod schema and warns on failures.
  */
 export function registerCodeWorkflows(workflows: CodeWorkflowDefinition[]): void {
+  const valid: CodeWorkflowDefinition[] = []
   for (const wf of workflows) {
     const validation = workflowDefinitionDataSchema.safeParse(wf.definition)
     if (!validation.success) {
@@ -28,39 +37,7 @@ export function registerCodeWorkflows(workflows: CodeWorkflowDefinition[]): void
       })
       continue
     }
-
-    if (codeWorkflowRegistry.has(wf.workflowId)) {
-      logger.warn('Duplicate code workflow ID — overwriting', { workflowId: wf.workflowId, moduleId: wf.moduleId })
-    }
-
-    codeWorkflowRegistry.set(wf.workflowId, wf)
+    valid.push(wf)
   }
-}
-
-/**
- * Get a single code workflow definition by workflowId.
- */
-export function getCodeWorkflow(workflowId: string): CodeWorkflowDefinition | undefined {
-  return codeWorkflowRegistry.get(workflowId)
-}
-
-/**
- * Get all registered code workflow definitions.
- */
-export function getAllCodeWorkflows(): CodeWorkflowDefinition[] {
-  return Array.from(codeWorkflowRegistry.values())
-}
-
-/**
- * Check if a workflowId is a code-based definition.
- */
-export function isCodeWorkflow(workflowId: string): boolean {
-  return codeWorkflowRegistry.has(workflowId)
-}
-
-/**
- * Clear the registry (for testing).
- */
-export function clearCodeWorkflowRegistry(): void {
-  codeWorkflowRegistry.clear()
+  registerCodeWorkflowEntries(valid)
 }

--- a/packages/shared/src/lib/bootstrap/dynamicLoader.ts
+++ b/packages/shared/src/lib/bootstrap/dynamicLoader.ts
@@ -155,12 +155,14 @@ export async function loadBootstrapData(appRoot?: string): Promise<BootstrapData
     diModule,
     searchModule,
     commandLoadersModule,
+    workflowsModule,
   ] = await Promise.all([
     compileAndImport(path.join(generatedDir, 'modules.cli.generated.ts')),
     compileAndImport(path.join(generatedDir, 'entities.generated.ts')),
     compileAndImport(path.join(generatedDir, 'di.generated.ts')),
     compileAndImport(path.join(generatedDir, 'search.generated.ts')).catch(() => ({ searchModuleConfigs: [] })),
     compileAndImport(path.join(generatedDir, 'command-loaders.generated.ts')).catch(() => ({ commandLoaderEntries: [] })),
+    compileAndImport(path.join(generatedDir, 'workflows.generated.ts')).catch(() => ({ allCodeWorkflows: [] })),
   ])
 
   return {
@@ -171,6 +173,8 @@ export async function loadBootstrapData(appRoot?: string): Promise<BootstrapData
     // Search configs are needed by workers for indexing
     searchModuleConfigs: (searchModule.searchModuleConfigs ?? []) as BootstrapData['searchModuleConfigs'],
     commandLoaderEntries: (commandLoadersModule.commandLoaderEntries ?? []) as BootstrapData['commandLoaderEntries'],
+    // Code workflow definitions are needed by workers to resume code-defined instances
+    codeWorkflows: (workflowsModule.allCodeWorkflows ?? []) as BootstrapData['codeWorkflows'],
     // Empty UI-related data - not needed for CLI
     dashboardWidgetEntries: [],
     injectionWidgetEntries: [],

--- a/packages/shared/src/lib/bootstrap/factory.ts
+++ b/packages/shared/src/lib/bootstrap/factory.ts
@@ -6,6 +6,7 @@ import { registerEntityIds } from '../encryption/entityIds'
 import { registerEntityFields } from '../encryption/entityFields'
 import { registerSearchModuleConfigs } from '../../modules/search'
 import { registerAnalyticsModuleConfigs } from '../../modules/analytics'
+import { registerCodeWorkflowEntries } from '../../modules/workflows/code-registry'
 import { registerResponseEnrichers } from '../crud/enricher-registry'
 import { registerApiInterceptors } from '../crud/interceptor-registry'
 import { registerComponentOverrides } from '../../modules/widgets/component-registry'
@@ -70,6 +71,11 @@ export function createBootstrap(data: BootstrapData, options: BootstrapOptions =
     // === 6. Analytics module configs (for dashboard widgets and analytics API) ===
     if (data.analyticsModuleConfigs) {
       registerAnalyticsModuleConfigs(data.analyticsModuleConfigs)
+    }
+
+    // === 6a. Code workflow definitions (so CLI/worker processes resolve them like the app runtime) ===
+    if (data.codeWorkflows?.length) {
+      registerCodeWorkflowEntries(data.codeWorkflows)
     }
 
     // === 6b. Response enrichers (for CRUD response enrichment) ===

--- a/packages/shared/src/lib/bootstrap/types.ts
+++ b/packages/shared/src/lib/bootstrap/types.ts
@@ -64,6 +64,7 @@ export interface BootstrapData {
   commandInterceptorEntries?: CommandInterceptorBootstrapEntry[]
   commandLoaderEntries?: CommandLoaderBootstrapEntry[]
   notificationHandlerEntries?: NotificationHandlerBootstrapEntry[]
+  codeWorkflows?: import('../../modules/workflows/types').CodeWorkflowDefinition[]
 }
 
 export interface BootstrapOptions {

--- a/packages/shared/src/modules/workflows/code-registry.ts
+++ b/packages/shared/src/modules/workflows/code-registry.ts
@@ -1,0 +1,54 @@
+/**
+ * In-Memory Code Workflow Registry (shared)
+ *
+ * Single process-wide store for code-based workflow definitions. Lives in
+ * `@open-mercato/shared` so every runtime that bootstraps from generated data
+ * (Next.js app via `bootstrap.ts`, CLI commands, and the `mercato workers`
+ * process via `bootstrapFromAppRoot`) populates the same registry the
+ * workflows engine reads through `@open-mercato/core`'s `code-registry`
+ * bridge. Definitions live purely in memory — no DB row is created until a
+ * user customizes the definition.
+ */
+
+import { createLogger } from '../../lib/logger'
+import type { CodeWorkflowDefinition } from './types'
+
+const logger = createLogger('workflows')
+
+const codeWorkflowRegistry = new Map<string, CodeWorkflowDefinition>()
+
+/**
+ * Register code workflow definitions without schema validation.
+ *
+ * Bootstrap paths that cannot depend on the workflows module's Zod validators
+ * (shared bootstrap factory, CLI/workers) register through this entry point;
+ * the validating wrapper lives in
+ * `@open-mercato/core/modules/workflows/lib/code-registry`.
+ */
+export function registerCodeWorkflowEntries(workflows: CodeWorkflowDefinition[]): void {
+  for (const wf of workflows) {
+    if (codeWorkflowRegistry.has(wf.workflowId)) {
+      const existing = codeWorkflowRegistry.get(wf.workflowId)
+      if (existing !== wf && existing?.moduleId !== wf.moduleId) {
+        logger.warn('Duplicate code workflow ID — overwriting', { workflowId: wf.workflowId, moduleId: wf.moduleId })
+      }
+    }
+    codeWorkflowRegistry.set(wf.workflowId, wf)
+  }
+}
+
+export function getCodeWorkflow(workflowId: string): CodeWorkflowDefinition | undefined {
+  return codeWorkflowRegistry.get(workflowId)
+}
+
+export function getAllCodeWorkflows(): CodeWorkflowDefinition[] {
+  return Array.from(codeWorkflowRegistry.values())
+}
+
+export function isCodeWorkflow(workflowId: string): boolean {
+  return codeWorkflowRegistry.has(workflowId)
+}
+
+export function clearCodeWorkflowRegistry(): void {
+  codeWorkflowRegistry.clear()
+}


### PR DESCRIPTION
## Summary

Companion to #4262; together they fully fix #4257. **This half also affects current `main`** (reproduced on `c31422a47`), so it likely wants a carry-forward to the release line after review.

The in-memory code-workflow registry is populated only by the Next.js app's `bootstrap.ts` (`registerCodeWorkflows(allCodeWorkflows)`). The separate `mercato workers` process — and every other CLI context — bootstraps via `bootstrapFromAppRoot()`, which never loads `workflows.generated.ts`, so those processes run with an **empty registry**. Result: an instance started from an unpersisted code-defined workflow (the checkout demo on any fresh install) starts and advances fine in the web process, but the moment an **async activity** completes, the activity worker's `resumeWorkflowAfterActivities()` → `findDefinitionForInstance()` → code-registry fallback finds nothing and fails with `Workflow definition not found: <codeWorkflowUuid>`; the instance stays `WAITING_FOR_ACTIVITIES` forever. This is the exact log signature reported in #4257, and I reproduced it on **both** `develop` (with #4262 applied) and **current `main`** in the two-process `yarn dev` runtime.

## Fix

Follows the existing search-module-configs pattern:

- Registry store moved to `@open-mercato/shared/modules/workflows/code-registry` (plain map + `registerCodeWorkflowEntries`).
- `@open-mercato/core/modules/workflows/lib/code-registry` keeps its **stable import path and full export surface** as a bridge: `registerCodeWorkflows` still Zod-validates then delegates; `getCodeWorkflow`/`getAllCodeWorkflows`/`isCodeWorkflow`/`clearCodeWorkflowRegistry` re-export from shared. No caller changes anywhere (app `bootstrap.ts`, create-app template, engine, tests all untouched).
- `bootstrapFromAppRoot()` now loads `workflows.generated.ts` (fail-open `{ allCodeWorkflows: [] }` fallback, like `search.generated.ts`) and exposes optional `BootstrapData.codeWorkflows`.
- The bootstrap factory registers them (`registerCodeWorkflowEntries`) — so workers, `mercato` CLI commands, and any dynamic-loader consumer share one process-wide registry.

## Validation

- `yarn workspace @open-mercato/core test --testPathPatterns 'code-registry|find-definition'` → 21 tests green; `yarn workspace @open-mercato/shared test --testPathPatterns 'bootstrap|workflows'` → 42 green; both packages typecheck clean. Runner: local.
- **Live E2E** (fresh `mercato_qa` DB, `yarn dev` two-process runtime, develop + #4262 + this PR): checkout demo runs start → cart validation → customer-info user task → payment webhook signal → `create_order` CALL_API → async `send_confirmation_email` → worker resume → **“Order Confirmed!”, workflow COMPLETED**:

![Order Confirmed](https://raw.githubusercontent.com/wojciechszyjka/open-mercato-mk/qa-evidence-2026-07-17/4262-combined-outcome.png)

Same scenario **without** this PR (develop + #4262 only): stuck `WAITING_FOR_ACTIVITIES` with `ERROR [workflows:activity-worker] Failed to resume workflow instance … Workflow definition not found` — and identically on current `main`.

Evidence scripts + screenshots: [`qa-evidence-2026-07-17`](https://github.com/wojciechszyjka/open-mercato-mk/tree/qa-evidence-2026-07-17).

## Labels (no triage rights — please apply)

Suggest: `bug`, `priority-high`, `risk-medium` (additive bootstrap wiring; stable import paths preserved; store relocation is behavior-neutral for the web app), `needs-qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)