### PR TITLE
fix(docker): unblock app image build + harden corporate-TLS cert handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ COPY packages/shared/package.json ./packages/shared/
 COPY packages/storage-s3/package.json ./packages/storage-s3/
 COPY packages/sync-akeneo/package.json ./packages/sync-akeneo/
 COPY packages/ui/package.json ./packages/ui/
+COPY packages/web-search/package.json ./packages/web-search/
 COPY packages/webhooks/package.json ./packages/webhooks/
 COPY scripts/official-modules-setup.mjs ./scripts/
 COPY scripts/lib/official-modules.mjs ./scripts/lib/
@@ -142,6 +143,7 @@ COPY packages/shared/package.json ./packages/shared/
 COPY packages/storage-s3/package.json ./packages/storage-s3/
 COPY packages/sync-akeneo/package.json ./packages/sync-akeneo/
 COPY packages/ui/package.json ./packages/ui/
+COPY packages/web-search/package.json ./packages/web-search/
 COPY packages/webhooks/package.json ./packages/webhooks/
 COPY scripts/official-modules-setup.mjs ./scripts/
 COPY scripts/lib/official-modules.mjs ./scripts/lib/
@@ -283,6 +285,7 @@ COPY --from=builder /app/packages/shared/package.json ./packages/shared/
 COPY --from=builder /app/packages/storage-s3/package.json ./packages/storage-s3/
 COPY --from=builder /app/packages/sync-akeneo/package.json ./packages/sync-akeneo/
 COPY --from=builder /app/packages/ui/package.json ./packages/ui/
+COPY --from=builder /app/packages/web-search/package.json ./packages/web-search/
 COPY --from=builder /app/packages/webhooks/package.json ./packages/webhooks/
 
 # Install only production dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,12 @@ WORKDIR /app
 # The certs land in /usr/local/share/ca-certificates so a later
 # update-ca-certificates keeps them, AND get appended to the live bundle so the
 # very first apk fetch below already trusts the proxy.
-# cert[s] is a glob + .dockerignore an always-present anchor: the COPY then
+# cert[s] is a glob + docker/README.md an always-present anchor: the COPY then
 # succeeds even when docker/certs/ is missing from a partial checkout.
-COPY .dockerignore docker/cert[s] /tmp/om-certs/
+# The anchor MUST live inside docker/: BuildKit only transfers the paths a
+# COPY names, so anchoring outside it leaves the whole docker/ directory out
+# of the filtered context and the unmatched glob fails on `lstat /docker`.
+COPY docker/README.md docker/cert[s] /tmp/om-certs/
 RUN set -eu; \
     mkdir -p /usr/local/share/ca-certificates; \
     for cert in /tmp/om-certs/*.crt /tmp/om-certs/*.pem; do \
@@ -100,9 +103,12 @@ ENV NODE_ENV=development     NEXT_TELEMETRY_DISABLED=1     TURBO_CACHE_DIR=/app/
 WORKDIR /app
 
 # Corporate proxy CA trust - see the builder stage comment / docker/certs/README.md.
-# cert[s] is a glob + .dockerignore an always-present anchor: the COPY then
+# cert[s] is a glob + docker/README.md an always-present anchor: the COPY then
 # succeeds even when docker/certs/ is missing from a partial checkout.
-COPY .dockerignore docker/cert[s] /tmp/om-certs/
+# The anchor MUST live inside docker/: BuildKit only transfers the paths a
+# COPY names, so anchoring outside it leaves the whole docker/ directory out
+# of the filtered context and the unmatched glob fails on `lstat /docker`.
+COPY docker/README.md docker/cert[s] /tmp/om-certs/
 RUN set -eu; \
     mkdir -p /usr/local/share/ca-certificates; \
     for cert in /tmp/om-certs/*.crt /tmp/om-certs/*.pem; do \
@@ -175,9 +181,12 @@ WORKDIR /app
 # Corporate proxy CA trust - see the builder stage comment / docker/certs/README.md.
 # Baked into the runtime stage too: the entrypoint's fallback `yarn install`
 # and any in-container downloads hit the same intercepting proxy.
-# cert[s] is a glob + .dockerignore an always-present anchor: the COPY then
+# cert[s] is a glob + docker/README.md an always-present anchor: the COPY then
 # succeeds even when docker/certs/ is missing from a partial checkout.
-COPY .dockerignore docker/cert[s] /tmp/om-certs/
+# The anchor MUST live inside docker/: BuildKit only transfers the paths a
+# COPY names, so anchoring outside it leaves the whole docker/ directory out
+# of the filtered context and the unmatched glob fails on `lstat /docker`.
+COPY docker/README.md docker/cert[s] /tmp/om-certs/
 RUN set -eu; \
     mkdir -p /usr/local/share/ca-certificates; \
     for cert in /tmp/om-certs/*.crt /tmp/om-certs/*.pem; do \
@@ -238,9 +247,12 @@ ENV NODE_ENV=production \
 WORKDIR /app
 
 # Corporate proxy CA trust - see the builder stage comment / docker/certs/README.md.
-# cert[s] is a glob + .dockerignore an always-present anchor: the COPY then
+# cert[s] is a glob + docker/README.md an always-present anchor: the COPY then
 # succeeds even when docker/certs/ is missing from a partial checkout.
-COPY .dockerignore docker/cert[s] /tmp/om-certs/
+# The anchor MUST live inside docker/: BuildKit only transfers the paths a
+# COPY names, so anchoring outside it leaves the whole docker/ directory out
+# of the filtered context and the unmatched glob fails on `lstat /docker`.
+COPY docker/README.md docker/cert[s] /tmp/om-certs/
 RUN set -eu; \
     mkdir -p /usr/local/share/ca-certificates; \
     for cert in /tmp/om-certs/*.crt /tmp/om-certs/*.pem; do \

--- a/docker/opencode/Dockerfile
+++ b/docker/opencode/Dockerfile
@@ -30,8 +30,16 @@ RUN set -eu; \
 # transiently on shared/corporate networks (rate limits, proxies), and
 # `curl | bash` masks download failures as a later `cp` error - so download the
 # installer to a file and retry the install up to 3 times.
+# A blocking proxy answers with an HTML page and HTTP 200, which curl -f cannot
+# reject; feeding that to bash yields `syntax error near unexpected token
+# 'newline'` and the retry loop just repeats it. Check the bytes and fail fast
+# with the real reason instead.
 RUN set -eu; \
     curl -fsSL --retry 3 --retry-delay 5 https://opencode.ai/install -o /tmp/opencode-install.sh; \
+    if head -c 512 /tmp/opencode-install.sh | grep -qi '<!doctype\|<html'; then \
+        echo "https://opencode.ai/install returned an HTML page instead of a script - a proxy is blocking it. Retrying cannot help; ask IT to allow opencode.ai." >&2; \
+        exit 1; \
+    fi; \
     attempt=1; \
     until bash /tmp/opencode-install.sh --version "$OPENCODE_VERSION"; do \
         if [ "$attempt" -ge 3 ]; then echo "OpenCode install failed after $attempt attempts" >&2; exit 1; fi; \


### PR DESCRIPTION
Two follow-ups to the corporate-TLS support in ee74f2ec7, plus the build blocker that sits in front of it. Base is `feat/agent-orchestrator-mvp`.

## 1. `web-search` manifest copy — the actual blocker

`packages/web-search` was added as a workspace in f86c15b89 without its Dockerfile manifest COPY, so **every app image build fails** during yarn resolution:

```
YN0001: │ Error: @open-mercato/web-search@workspace:*: Workspace not found
ERROR: process "/bin/sh -c yarn install --immutable" did not complete successfully: exit code: 1
```

This is unrelated to TLS, but it blocks the dev image the Windows launcher builds — so the proxy work cannot be exercised until it lands. `scripts/__tests__/dockerfile-runtime-copy.test.mjs` already asserted this and was failing on the branch (322/323); it is green again.

## 2. The anchored glob did not survive a missing certs dir

`COPY .dockerignore docker/cert[s] …` was intended to keep builds working when `docker/certs/` is absent. It does not: BuildKit only transfers the paths a COPY names, so with the glob matching nothing, `docker/` never enters the filtered context and the build fails with `lstat /docker: no such file or directory` — the exact case the anchor was meant to cover.

Anchoring on a file **inside** `docker/` fixes it. `docker/opencode/Dockerfile` is unaffected — its glob is top-level, so there is no parent to resolve. A comment records why, since this reads like a pointless indirection otherwise.

## 3. Proxy block pages are no longer piped into bash

`curl -f` cannot reject an HTML block page served with HTTP 200. bash then reports ``syntax error near unexpected token `newline' `` — as seen on the reporting machine — and the retry loop repeats it twice more before failing with a message pointing nowhere near the cause. The bytes are now checked and the build fails fast with the real reason.

## Verification

Against real image builds, not static checks:

| Check | Result |
|---|---|
| `yarn install --immutable` with the manifest fix | resolution → fetch → link → OK (previously failed in 0.13s) |
| Anchor, `docker/certs` present | builds |
| Anchor, `docker/certs` removed entirely | builds (previously `lstat /docker`) |
| Anchor, CA present | still picked up |
| HTML guard vs real block-page bytes | fires, fails fast |
| HTML guard vs the genuine installer | no false positive; pinned `opencode 1.1.21` still produced |
| `yarn test:scripts` | 315/315 |

Also confirmed while reviewing ee74f2ec7 (unchanged by this PR): the CA mechanism itself works — a throwaway root CA is trusted by both curl and node in the app image, `.pem` and `.crt` both work in the opencode image, the interception detector fires on the real `curl: (60)` and correctly ignores the cascade `not found` noise, and the `Tee-Object` capture makes the retry path live rather than dead code.

## Not addressed

The production `runner` stage also trusts the corporate CA (all four stages do). It is inert in CI, where `docker/certs/` is empty, but an image built on a corporate machine would bake in an interception CA. Left as a deliberate decision for the branch owner rather than changed here.

**Still needs a run on the corporate Windows machine.** Detection only executes on Windows behind a real proxy; it cannot be exercised from macOS/Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
