### PR TITLE
fix(dev-env): container-egress triage + Alpine mirror & cert-store fallbacks for corporate builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,12 @@ RUN set -eu; \
     rm -rf /tmp/om-certs
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
+# Corporate networks that category-block dl-cdn.alpinelinux.org can point apk
+# at an internal mirror (e.g. Artifactory alpine remote): set ALPINE_MIRROR in
+# the repo-root .env; empty (the default) leaves the official CDN in place.
+ARG ALPINE_MIRROR=""
+RUN [ -z "$ALPINE_MIRROR" ] || sed -i "s|https://dl-cdn.alpinelinux.org|$ALPINE_MIRROR|g" /etc/apk/repositories
+
 # Install system deps required by optional native modules (Alpine uses apk)
 RUN apk add --no-cache python3 make g++ ca-certificates openssl
 
@@ -121,6 +127,10 @@ RUN set -eu; \
     rm -rf /tmp/om-certs
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
+# Optional internal Alpine mirror - see the builder stage comment.
+ARG ALPINE_MIRROR=""
+RUN [ -z "$ALPINE_MIRROR" ] || sed -i "s|https://dl-cdn.alpinelinux.org|$ALPINE_MIRROR|g" /etc/apk/repositories
+
 RUN apk add --no-cache python3 make g++ ca-certificates openssl
 RUN corepack enable
 
@@ -199,6 +209,10 @@ RUN set -eu; \
     rm -rf /tmp/om-certs
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
 
+# Optional internal Alpine mirror - see the builder stage comment.
+ARG ALPINE_MIRROR=""
+RUN [ -z "$ALPINE_MIRROR" ] || sed -i "s|https://dl-cdn.alpinelinux.org|$ALPINE_MIRROR|g" /etc/apk/repositories
+
 # Build toolchain kept: the entrypoint's fallback `yarn install` (stale
 # lockfile vs prebuilt image) still compiles native modules.
 RUN apk add --no-cache python3 make g++ ca-certificates openssl
@@ -264,6 +278,10 @@ RUN set -eu; \
     done; \
     rm -rf /tmp/om-certs
 ENV NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt
+
+# Optional internal Alpine mirror - see the builder stage comment.
+ARG ALPINE_MIRROR=""
+RUN [ -z "$ALPINE_MIRROR" ] || sed -i "s|https://dl-cdn.alpinelinux.org|$ALPINE_MIRROR|g" /etc/apk/repositories
 
 # Install only production system dependencies (Alpine uses apk)
 # sudo: allows non-root user to chown the Railway-mounted volume at startup

--- a/docker-compose.fullapp.dev.yml
+++ b/docker-compose.fullapp.dev.yml
@@ -198,6 +198,10 @@ services:
     build:
       context: .
       target: dev
+      args:
+        # Optional internal Alpine mirror for proxy-blocked corporate networks
+        # (empty = official CDN; see the Dockerfile builder stage comment).
+        - ALPINE_MIRROR=${ALPINE_MIRROR:-}
     image: open-mercato/app:${DEPLOY_ENV:-local}-dev
     # Without a restart policy the app stays down after a daemon/host reboot
     # while mcp and opencode (restart: unless-stopped) wait on it forever.

--- a/docker-compose.fullapp.yml
+++ b/docker-compose.fullapp.yml
@@ -119,6 +119,9 @@ services:
       context: .
       args:
         - CONTAINER_PORT=${CONTAINER_PORT:-3000}
+        # Optional internal Alpine mirror for proxy-blocked corporate networks
+        # (empty = official CDN; see the Dockerfile builder stage comment).
+        - ALPINE_MIRROR=${ALPINE_MIRROR:-}
     image: open-mercato/app:${DEPLOY_ENV:-local}
     # Without a restart policy the app stays down after a daemon/host reboot
     # while mcp and opencode (restart: unless-stopped) wait on it forever.

--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -12,12 +12,37 @@ directory (apk, node, yarn — via the system bundle and `NODE_EXTRA_CA_CERTS`),
 and the Windows launcher (`scripts/windows/start-dev.ps1`) mirrors these files
 into `docker/opencode/certs/` so the opencode image build trusts them too.
 
-The Windows launcher also detects this failure automatically and exports the
-proxy's root certificate here as `corporate-proxy-root.crt` before retrying.
+The Windows launcher also detects this failure automatically: it captures the
+root certificate from a live connection (probing `dl-cdn.alpinelinux.org`,
+`registry-1.docker.io`, then `github.com`) and saves it here as
+`corporate-proxy-root.crt`; if the capture is blocked (CONNECT-only proxies),
+it falls back to exporting known TLS-inspection vendor roots (Zscaler,
+Netskope, Palo Alto, …) from the Windows certificate store as
+`interception-root-*.crt`, then retries the build.
 
 To export the certificate manually on Windows: open `https://example.com` in
 Edge/Chrome, inspect the certificate chain, export the **topmost (root)**
-certificate as Base-64 encoded X.509, and save it in this directory.
+certificate as Base-64 encoded X.509, and save it in this directory. Or from
+PowerShell (replace the vendor/company pattern):
+
+```powershell
+$roots = Get-ChildItem Cert:\LocalMachine\Root, Cert:\CurrentUser\Root |
+  Where-Object { $_.Subject -match 'Zscaler|Netskope|MyCompany' }
+foreach ($c in $roots) {
+  $pem = "-----BEGIN CERTIFICATE-----`n" +
+    ([Convert]::ToBase64String($c.Export('Cert')) -replace '(.{64})', "`$1`n").TrimEnd("`n") +
+    "`n-----END CERTIFICATE-----`n"
+  [IO.File]::WriteAllText("docker\certs\$($c.Thumbprint).crt", $pem)
+}
+```
+
+If the proxy does not just intercept but **blocks** `dl-cdn.alpinelinux.org`
+outright (block page instead of packages), certificates cannot help. Either ask
+IT to allow the host (plus `registry-1.docker.io`, `registry.yarnpkg.com`,
+`opencode.ai`, `github.com`), or set `ALPINE_MIRROR=<internal alpine mirror
+base URL>` in the repo-root `.env` to build against your company's Artifactory/
+Nexus alpine remote. `scripts\windows\check-windows.bat` audits all of these
+hosts read-only before you start.
 
 Everything in this directory except this README is gitignored — never commit
 a certificate.

--- a/scripts/windows/preflight-windows.ps1
+++ b/scripts/windows/preflight-windows.ps1
@@ -223,7 +223,13 @@ function Test-Network {
         @{ Host = "github.com"; Url = "https://github.com/open-mercato/open-mercato"; Why = "repo clone" },
         @{ Host = "api.github.com"; Url = "https://api.github.com"; Why = "installer version lookups" },
         @{ Host = "desktop.docker.com"; Url = "https://desktop.docker.com"; Why = "Docker Desktop download" },
-        @{ Host = "wslstorestorage.blob.core.windows.net"; Url = "https://wslstorestorage.blob.core.windows.net"; Why = "WSL2 kernel download" }
+        @{ Host = "wslstorestorage.blob.core.windows.net"; Url = "https://wslstorestorage.blob.core.windows.net"; Why = "WSL2 kernel download" },
+        # Hosts the IMAGE BUILDS download from (via the container runtime's VM,
+        # but a Windows-side block almost always means a VM-side block too).
+        @{ Host = "dl-cdn.alpinelinux.org"; Url = "https://dl-cdn.alpinelinux.org/alpine/latest-stable/main/x86_64/APKINDEX.tar.gz"; Why = "Alpine packages in app image builds (apk add)" },
+        @{ Host = "registry-1.docker.io"; Url = "https://registry-1.docker.io/v2/"; Why = "Docker Hub base image pulls" },
+        @{ Host = "registry.yarnpkg.com"; Url = "https://registry.yarnpkg.com"; Why = "yarn install inside image builds" },
+        @{ Host = "opencode.ai"; Url = "https://opencode.ai/install"; Why = "OpenCode install in image build" }
     )
     foreach ($target in $targets) {
         try {
@@ -237,6 +243,17 @@ function Test-Network {
                 Add-Finding WARN "Reach" ("{0}: TLS/cert error - a TLS-intercepting proxy (Zscaler/Netskope) is likely. Image builds will need your corporate root CA in docker\certs\. ({1})" -f $target.Host, $target.Why)
             } elseif ($msg -match "407") {
                 Add-Finding FAIL "Reach" ("{0}: proxy authentication required (407). Set HTTPS_PROXY with credentials. ({1})" -f $target.Host, $target.Why) -Hard
+            } elseif ($_.Exception.Response) {
+                $statusCode = 0
+                try { $statusCode = [int]$_.Exception.Response.StatusCode } catch {}
+                if ($statusCode -eq 401 -or $statusCode -eq 404 -or $statusCode -eq 405) {
+                    # Origin-style answers: registry-1.docker.io returns 401 by
+                    # design and some CDNs reject HEAD - the host is reachable.
+                    Add-Finding PASS "Reach" ("{0} reachable - answered HTTP {1}, which is fine for this probe ({2})." -f $target.Host, $statusCode, $target.Why)
+                } else {
+                    # 403 and friends are how category-blocking proxies answer.
+                    Add-Finding WARN "Reach" ("{0}: answered HTTP {1} - if that is a proxy block page, image builds will fail on this host. Ask IT to allow it. ({2})" -f $target.Host, $statusCode, $target.Why)
+                }
             } else {
                 $shortMsg = ($msg -replace "\s+", " ").Trim()
                 if ($shortMsg.Length -gt 80) { $shortMsg = $shortMsg.Substring(0, 80) }

--- a/scripts/windows/start-dev.ps1
+++ b/scripts/windows/start-dev.ps1
@@ -1175,7 +1175,24 @@ function Sync-CorporateCerts {
 function Test-TlsInterceptionSignature {
     param([string]$Text)
     if (-not $Text) { return $false }
-    return ($Text -match "certificate not trusted|certificate verify failed|unable to get local issuer certificate|self.signed certificate|SSL certificate problem|tls: failed to verify")
+    return ($Text -match "certificate not trusted|certificate verify failed|certificate verification failed|unable to get local issuer certificate|self.signed certificate|SSL certificate problem|tls: failed to verify|x509: certificate signed by unknown authority")
+}
+
+function Test-NetworkFailureSignature {
+    # Matches build downloads failing in bulk without a clear TLS wording:
+    # apk aborting on unfetchable package indexes, DNS errors, timeouts, or the
+    # proxy's blunt "Permission denied". These need the container-egress triage
+    # to tell WHY (DNS vs TLS interception vs proxy category-block).
+    param([string]$Text)
+    if (-not $Text) { return $false }
+    return ($Text -match "apk add[^`r`n]*did not complete successfully|unable to select packages|bad address|temporary error \(try again later\)|Could not resolve host|network is unreachable|i/o timeout|TLS handshake timeout|dl-cdn\.alpinelinux\.org[^`r`n]*Permission denied")
+}
+
+function ConvertTo-PemCertificate {
+    param([Parameter(Mandatory = $true)][System.Security.Cryptography.X509Certificates.X509Certificate2]$Certificate)
+    $base64 = [Convert]::ToBase64String($Certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
+    $wrapped = ($base64 -replace "(.{64})", "`$1`n").TrimEnd("`n")
+    return "-----BEGIN CERTIFICATE-----`n$wrapped`n-----END CERTIFICATE-----`n"
 }
 
 function Export-ObservedTlsRootCa {
@@ -1198,15 +1215,34 @@ function Export-ObservedTlsRootCa {
         [void]$chain.Build($leaf)
         if ($chain.ChainElements.Count -lt 1) { return $null }
         $root = $chain.ChainElements[$chain.ChainElements.Count - 1].Certificate
-        $base64 = [Convert]::ToBase64String($root.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert))
-        $wrapped = ($base64 -replace "(.{64})", "`$1`n").TrimEnd("`n")
-        return "-----BEGIN CERTIFICATE-----`n$wrapped`n-----END CERTIFICATE-----`n"
+        return (ConvertTo-PemCertificate -Certificate $root)
     } catch {
         return $null
     } finally {
         if ($sslStream) { $sslStream.Dispose() }
         if ($tcpClient) { $tcpClient.Dispose() }
     }
+}
+
+function Export-KnownInterceptionRootsFromStore {
+    # CONNECT-only proxies block the raw-socket chain capture below, but IT
+    # always installs the interception root into the Windows certificate
+    # store. Export every root from a known TLS-inspection vendor so the
+    # image builds can trust whichever one re-signs their traffic.
+    param([Parameter(Mandatory = $true)][string]$TargetDir)
+    $vendorPattern = "Zscaler|Netskope|Blue ?Coat|Palo Alto|Forcepoint|Fortinet|FortiGate|Cisco Umbrella|Skyhigh|McAfee|Sophos|WatchGuard|iboss|Menlo Security"
+    $roots = @()
+    foreach ($storePath in @("Cert:\LocalMachine\Root", "Cert:\CurrentUser\Root")) {
+        $roots += @(Get-ChildItem -Path $storePath -ErrorAction SilentlyContinue | Where-Object { $_.Subject -match $vendorPattern })
+    }
+    $exported = 0
+    foreach ($cert in ($roots | Sort-Object -Property Thumbprint -Unique)) {
+        $fileName = "interception-root-{0}.crt" -f $cert.Thumbprint.Substring(0, 8).ToLower()
+        [System.IO.File]::WriteAllText((Join-Path $TargetDir $fileName), (ConvertTo-PemCertificate -Certificate $cert))
+        Write-Ok ("Exported interception root from the Windows store: {0} -> docker\certs\{1}" -f $cert.Subject, $fileName)
+        $exported++
+    }
+    return ($exported -gt 0)
 }
 
 function Repair-TlsInterception {
@@ -1219,17 +1255,63 @@ function Repair-TlsInterception {
     if ($script:TlsRepairAttempted) { return $false }
     $script:TlsRepairAttempted = $true
     Write-Info "The failure looks like a TLS-intercepting proxy (corporate network). Capturing its root certificate so the image builds can trust it..."
-    $pem = Export-ObservedTlsRootCa -ProbeHost "dl-cdn.alpinelinux.org"
-    if (-not $pem) {
+    $certsDir = Join-Path $script:RepoRoot "docker\certs"
+    New-Item -Path $certsDir -ItemType Directory -Force | Out-Null
+    # Probe the host the failing download talks to first - SNI-based proxy
+    # rules can intercept one host and pass another through untouched.
+    $pem = $null
+    foreach ($probeHost in @("dl-cdn.alpinelinux.org", "registry-1.docker.io", "github.com")) {
+        $pem = Export-ObservedTlsRootCa -ProbeHost $probeHost
+        if ($pem) { break }
+    }
+    if ($pem) {
+        [System.IO.File]::WriteAllText((Join-Path $certsDir "corporate-proxy-root.crt"), $pem)
+        Write-Ok "Proxy root certificate exported to docker\certs\corporate-proxy-root.crt"
+    } elseif (-not (Export-KnownInterceptionRootsFromStore -TargetDir $certsDir)) {
         Write-Warn "Could not capture the proxy's root certificate automatically. Export your company's root CA as a Base-64 X.509 (PEM) file into docker\certs\ (see docker\certs\README.md), then re-run start-windows.bat -Rebuild."
         return $false
     }
-    $certsDir = Join-Path $script:RepoRoot "docker\certs"
-    New-Item -Path $certsDir -ItemType Directory -Force | Out-Null
-    [System.IO.File]::WriteAllText((Join-Path $certsDir "corporate-proxy-root.crt"), $pem)
     Sync-CorporateCerts
-    Write-Ok "Proxy root certificate exported to docker\certs\corporate-proxy-root.crt"
     return $true
+}
+
+function Invoke-BuildNetworkTriage {
+    # A build download step failed without a clear TLS wording. Probe the
+    # network FROM INSIDE a container - the exact path the image build uses -
+    # and classify the failure: DNS dead, TLS interception, proxy block page,
+    # or actually fine. Returns $true when a TLS repair was applied and a
+    # compose retry makes sense; every other outcome prints targeted guidance.
+    $probeImage = "node:24-alpine"
+    if ((Invoke-NativeQuiet "docker" @("image", "inspect", $probeImage)) -ne 0) {
+        Write-Warn "The build is failing before its base image ($probeImage) is even available locally - the Docker engine itself cannot pull images on this network. If pulls fail with an x509/certificate error, the engine needs your corporate root CA; run scripts\windows\check-windows.bat for the full egress picture and docker\certs\README.md for the cert steps."
+        return $false
+    }
+    Write-Info "Diagnosing network access from inside a container (the same path image builds use)..."
+    # Single-quoted on purpose: everything in here is busybox sh, not PowerShell.
+    $probeScript = 'if ! nslookup dl-cdn.alpinelinux.org >/dev/null 2>&1; then echo OM_TRIAGE=DNS_FAIL; exit 0; fi; ' +
+        'out=$(wget -T 20 -O /tmp/apkindex https://dl-cdn.alpinelinux.org/alpine/latest-stable/main/x86_64/APKINDEX.tar.gz 2>&1); ' +
+        'if [ $? -ne 0 ]; then echo "$out"; if echo "$out" | grep -qiE "certificate|trust|verif"; then echo OM_TRIAGE=TLS_FAIL; else echo OM_TRIAGE=FETCH_FAIL; fi; exit 0; fi; ' +
+        'magic=$(head -c 2 /tmp/apkindex | od -An -tx1 | tr -d " \n"); ' +
+        'if [ "$magic" = "1f8b" ]; then echo OM_TRIAGE=OK; else echo OM_TRIAGE=BLOCK_PAGE; fi'
+    $probeOutput = Invoke-NativeCapture "docker" @("run", "--rm", $probeImage, "sh", "-c", $probeScript)
+    if ($probeOutput -match "OM_TRIAGE=DNS_FAIL") {
+        Write-Warn "Containers cannot resolve DNS (dl-cdn.alpinelinux.org does not resolve inside the VM). This is the classic corporate-VPN + WSL2 DNS breakage: quit the container runtime (Rancher: 'rdctl shutdown'; Docker Desktop: Quit), run 'wsl --shutdown', reconnect the VPN, then re-run the launcher. If it persists, ask IT about VPN DNS for WSL2."
+        return $false
+    }
+    if ($probeOutput -match "OM_TRIAGE=TLS_FAIL") {
+        Write-Info "Containers reach the network but do not trust its TLS - a TLS-intercepting proxy."
+        return (Repair-TlsInterception)
+    }
+    if ($probeOutput -match "OM_TRIAGE=BLOCK_PAGE") {
+        Write-Warn "Your proxy answers dl-cdn.alpinelinux.org with a block page, so Alpine packages in image builds cannot download. Ask IT to allow dl-cdn.alpinelinux.org (plus registry-1.docker.io, registry.yarnpkg.com, opencode.ai, github.com), or point the build at an internal Alpine mirror: set ALPINE_MIRROR=<mirror base URL> in the repo-root .env and re-run with -Rebuild."
+        return $false
+    }
+    if ($probeOutput -match "OM_TRIAGE=OK") {
+        Write-Info "Container network to dl-cdn.alpinelinux.org works - the build failure is not basic egress. The failing step's own output above has the real error."
+        return $false
+    }
+    Write-Warn ("Container network probe was inconclusive. Probe output: {0}" -f (($probeOutput -replace "\s+", " ").Trim()))
+    return $false
 }
 
 # ---------------------------------------------------------------------------
@@ -1710,12 +1792,20 @@ function Start-Stack {
         Write-Info "Starting services (the FIRST run builds images and can take 10+ minutes; later runs are much faster)..."
     }
     $exitCode = Invoke-Compose $composeArgs
-    if ($exitCode -ne 0 -and (Test-TlsInterceptionSignature $script:LastComposeOutput) -and (Repair-TlsInterception)) {
-        Write-Info "Retrying docker compose up with the exported proxy certificate..."
-        $exitCode = Invoke-Compose $composeArgs
+    if ($exitCode -ne 0) {
+        $shouldRetry = $false
+        if (Test-TlsInterceptionSignature $script:LastComposeOutput) {
+            $shouldRetry = Repair-TlsInterception
+        } elseif (Test-NetworkFailureSignature $script:LastComposeOutput) {
+            $shouldRetry = Invoke-BuildNetworkTriage
+        }
+        if ($shouldRetry) {
+            Write-Info "Retrying docker compose up with the exported proxy certificate..."
+            $exitCode = Invoke-Compose $composeArgs
+        }
     }
     if ($exitCode -ne 0) {
-        Write-Fail "docker compose up failed (exit $exitCode). The output above shows the failing step; first-run image builds download from the internet, so corporate proxies/TLS inspection or transient network errors can break them (a TLS-intercepting proxy's root CA can be trusted via docker\certs\ - see docker\certs\README.md) - re-running start-windows.bat resumes from the failed step. Inspect further with: docker compose -f $script:ComposeFile logs --tail 100"
+        Write-Fail "docker compose up failed (exit $exitCode). The output above shows the failing step; first-run image builds download from the internet, so corporate proxies/TLS inspection or transient network errors can break them (a TLS-intercepting proxy's root CA can be trusted via docker\certs\ - see docker\certs\README.md; scripts\windows\check-windows.bat audits the whole machine read-only) - re-running start-windows.bat resumes from the failed step. Inspect further with: docker compose -f $script:ComposeFile logs --tail 100"
     }
     Write-Ok "Containers started"
 }


### PR DESCRIPTION
## Problem

On the corporate Windows machine (Rancher/Docker on WSL2, TLS-intercepting proxy), the app image build still dies at

```
RUN apk add --no-cache python3 make g++ ca-certificates openssl
... did not complete successfully: exit code: 5
```

even with #4264–#4266 in place. apk's exit code is the number of unfetchable packages — all 5 failed, i.e. the build container cannot fetch the Alpine package index at all. The launcher's TLS auto-repair never fired because (a) several real apk/x509 failure wordings weren't in its signature list, (b) the root-CA capture probed a single host over a raw socket (blocked by CONNECT-only proxies) with no fallback, and (c) a proxy that *category-blocks* dl-cdn.alpinelinux.org can't be fixed with certificates at all.

## Changes

- **`scripts/windows/start-dev.ps1`**
  - Broadened `Test-TlsInterceptionSignature` (apk/OpenSSL/x509 wordings).
  - New `Test-NetworkFailureSignature` + `Invoke-BuildNetworkTriage`: when a build fails network-shaped without a clear TLS wording, run one probe **inside a container** (the exact network path builds use) and name the cause — VM DNS breakage (VPN+WSL2 guidance), TLS interception (auto-repair + retry), proxy block page (IT-allowlist / ALPINE_MIRROR guidance), or "egress is fine, look at the step's own error".
  - `Repair-TlsInterception` now probes three hosts (dl-cdn → registry-1.docker.io → github.com) and, when raw-socket capture fails, exports known TLS-inspection vendor roots (Zscaler, Netskope, Palo Alto, Fortinet, …) straight from the Windows certificate store into `docker\certs\`.
- **`Dockerfile` + both fullapp compose files**: `ALPINE_MIRROR` build arg in every Alpine stage rewrites `/etc/apk/repositories` to an internal mirror (Artifactory/Nexus alpine remote) — set it in the repo-root `.env`; empty default is a byte-for-byte no-op.
- **`scripts/windows/preflight-windows.ps1`**: reachability targets now include the hosts image builds download from (`dl-cdn.alpinelinux.org`, `registry-1.docker.io`, `registry.yarnpkg.com`, `opencode.ai`); HTTP error answers are classified (401/404/405 = reachable by design, 403-style = likely block page) instead of all reading as "not reachable".
- **`docker/certs/README.md`**: manual cert-store export one-liner, the new automatic fallbacks, and the ALPINE_MIRROR escape hatch.

## Verification

- PowerShell parser clean on both edited scripts (pwsh 7.4.6).
- 8/8 signature classification cases pass, including the exact observed failure line.
- Triage probe script executed end-to-end in `node:24-alpine` → `OM_TRIAGE=OK` on a healthy network.
- `ALPINE_MIRROR` exercised through a real `docker build` with and without the arg (empty = repositories untouched; set = both repo lines rewritten).
- `docker compose config` clean for both fullapp files; `node --test scripts/__tests__/dockerfile-runtime-copy.test.mjs` passes.

## Manual test checklist (corporate 22H2 machine)

1. `git fetch` this branch, then `scripts\windows\check-windows.bat` → section 4 should now probe dl-cdn/registry/yarn/opencode and name any block.
2. `scripts\windows\start-windows-rancher.bat` (or `-docker`) → on the apk failure the launcher should print the triage verdict and, for TLS interception, drop `docker\certs\*.crt` and retry on its own.
3. If IT blocks dl-cdn outright: set `ALPINE_MIRROR=<internal mirror>` in the repo-root `.env`, re-run with `-Rebuild`.

Maintainer: please add labels (`bug`, `review`, `priority-high`, `risk-medium`, `skip-qa` suggested) — fork account has no label permissions.