### PR TITLE
fix(ui): scope DataTable unsaved column widths to the auth session (#4185)

### DIFF
--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -14,6 +14,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { translateWithFallback } from '@open-mercato/shared/lib/i18n/translate'
 import { clearAllOperations } from '@open-mercato/ui/backend/operations/store'
 import { notifyAuthIdentityChange } from '@open-mercato/ui/backend/AuthSessionGuard'
+import { clearAllPerspectiveState } from '@open-mercato/ui/backend/DataTable'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
 import { X } from 'lucide-react'
 import { Alert, AlertDescription } from '@open-mercato/ui/primitives/alert'
@@ -260,6 +261,7 @@ export default function LoginPage() {
       const res = await fetch('/api/auth/login', { method: 'POST', body: form })
       if (res.redirected) {
         clearAllOperations()
+        clearAllPerspectiveState()
         notifyAuthIdentityChange()
         // NextResponse.redirect from API
         router.replace(res.url)
@@ -314,6 +316,7 @@ export default function LoginPage() {
       const data = await res.json().catch(() => null) as LoginResponseEventDetail
       emitLoginResponseEvent(data)
       clearAllOperations()
+      clearAllPerspectiveState()
       notifyAuthIdentityChange()
       if (data && typeof data.redirect === 'string' && data.redirect.length > 0) {
         router.replace(data.redirect)

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-087.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-087.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+import { login, DEFAULT_CREDENTIALS } from '@open-mercato/core/modules/core/__integration__/helpers/auth';
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api';
+import { deleteEntityIfExists, readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures';
+
+/**
+ * TC-CRM-087: unsaved DataTable column widths must not carry over to a different
+ * account signing in on the same browser tab (#4185).
+ *
+ * The live/unsaved column widths are persisted in a browser-local perspective
+ * snapshot keyed only by tableId, so before the fix they were shared by every
+ * account that logged in on the same browser profile — one account's resize
+ * leaked to whoever logged in next (a different tenant in the report). The fix
+ * purges every perspective snapshot when a new identity signs in through the
+ * login form, so a fresh login always starts from the default, auto-computed
+ * widths.
+ *
+ * Self-contained: creates two companies so the grid has rows, drives the real
+ * DataTable on `/backend/customers/companies`, exercises the real login form for
+ * the account switch, and deletes the fixtures in teardown.
+ */
+test.describe('TC-CRM-087: unsaved column widths cleared on login', () => {
+  test('a different account logging in through the form sees default widths, not the previous account\'s resize', async ({ page, request }) => {
+    test.slow();
+
+    let token: string | null = null;
+    const companyIds: string[] = [];
+    const prefix = `QA TC-CRM-087 ${Date.now()}`;
+
+    const handleColumnWidth = (handle: import('@playwright/test').Locator) =>
+      handle.evaluate((el) => Math.round((el.closest('th') as HTMLElement).getBoundingClientRect().width));
+
+    const waitForTableReady = async () => {
+      await page.getByText('Loading table', { exact: false })
+        .waitFor({ state: 'hidden', timeout: 10_000 }).catch(() => {});
+      await page.locator('tbody tr').first().waitFor({ state: 'visible', timeout: 10_000 });
+    };
+
+    // Second data-column resize handle — avoids the (potentially sticky) first column.
+    const handleAt = () => page.locator('thead [role="separator"][aria-orientation="vertical"]').nth(1);
+
+    try {
+      token = await getAuthToken(request);
+      for (let i = 0; i < 2; i++) {
+        const createResponse = await apiRequest(request, 'POST', '/api/customers/companies', {
+          token,
+          data: { displayName: `${prefix} Co${i}` },
+        });
+        expect(createResponse.ok()).toBeTruthy();
+        const body = (await readJsonSafe<{ id?: unknown }>(createResponse)) ?? {};
+        const id = typeof body.id === 'string' ? body.id : null;
+        expect(id).toBeTruthy();
+        companyIds.push(id!);
+      }
+
+      // -- 1) admin widens a column; the width persists across a reload -----------
+      await login(page, 'admin');
+      await page.goto('/backend/customers/companies', { waitUntil: 'domcontentloaded' });
+      await waitForTableReady();
+
+      const handle = handleAt();
+      await expect(handle).toBeAttached();
+      const defaultWidth = await handleColumnWidth(handle);
+
+      const box = await handle.boundingBox();
+      expect(box).not.toBeNull();
+      const cx = box!.x + box!.width / 2;
+      const cy = box!.y + box!.height / 2;
+      await page.mouse.move(cx, cy);
+      await page.mouse.down();
+      await page.mouse.move(cx + 130, cy, { steps: 10 });
+      await page.mouse.up();
+
+      const widened = await handleColumnWidth(handle);
+      expect(widened, 'dragging the handle should widen the column').toBeGreaterThan(defaultWidth + 80);
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await waitForTableReady();
+      expect(
+        await handleColumnWidth(handleAt()),
+        'the resized width should survive a reload for the account that set it',
+      ).toBeGreaterThan(defaultWidth + 80);
+
+      // -- 2) log out, then sign in as a DIFFERENT account through the real form --
+      // The login helper uses an API fast-path that bypasses the form; the fix
+      // fires in the login form's submit handler, so the account switch must go
+      // through the actual form to exercise it.
+      await page.request.post('/api/auth/logout').catch(() => {});
+      await page.goto('/login', { waitUntil: 'domcontentloaded' });
+      await page.waitForSelector('form[data-auth-ready="1"]', { state: 'visible', timeout: 10_000 }).catch(() => {});
+
+      const employee = DEFAULT_CREDENTIALS.employee;
+      await page.getByLabel('Email').fill(employee.email);
+      const passwordInput = page.getByLabel('Password', { exact: true }).first();
+      await passwordInput.fill(employee.password);
+      await passwordInput.press('Enter');
+      await page.waitForURL(/\/backend(?:\/.*)?$/, { timeout: 15_000 });
+
+      // -- 3) the employee gets the default width — no carry-over ----------------
+      await page.goto('/backend/customers/companies', { waitUntil: 'domcontentloaded' });
+      await waitForTableReady();
+      expect(
+        await handleColumnWidth(handleAt()),
+        'a different account must not inherit the previous account\'s unsaved column width',
+      ).toBeLessThan(defaultWidth + 60);
+    } finally {
+      for (const id of companyIds) {
+        await deleteEntityIfExists(request, token, '/api/customers/companies', id);
+      }
+    }
+  });
+});

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -550,6 +550,43 @@ export function writePerspectiveSnapshot(tableId: string, snapshot: PerspectiveS
   writeVersionedPreference(key, PERSPECTIVE_SNAPSHOT_VERSION, snapshot)
 }
 
+/**
+ * Purge every browser-local DataTable perspective snapshot and active-view cookie
+ * across all tables in this origin. Snapshots persist the unsaved/live table state
+ * (column widths, order, visibility) keyed only by `tableId`, so they are shared by
+ * every account that signs in on the same browser profile. Call this at the auth
+ * identity boundary (login) so one user's unsaved layout never carries over to a
+ * different user — including a different tenant — reusing the same browser tab (#4185).
+ */
+export function clearAllPerspectiveState(): void {
+  if (typeof window !== 'undefined') {
+    try {
+      const storage = window.localStorage
+      const staleKeys: string[] = []
+      for (let index = 0; index < storage.length; index += 1) {
+        const key = storage.key(index)
+        if (key && key.startsWith(`${PERSPECTIVE_STORAGE_PREFIX}:`)) staleKeys.push(key)
+      }
+      for (const key of staleKeys) storage.removeItem(key)
+    } catch {
+      // private mode / quota errors are non-fatal
+    }
+  }
+  if (typeof document !== 'undefined') {
+    try {
+      const cookies = document.cookie ? document.cookie.split(';') : []
+      for (const cookie of cookies) {
+        const name = cookie.split('=')[0]?.trim()
+        if (name && name.startsWith(`${PERSPECTIVE_COOKIE_PREFIX}:`)) {
+          document.cookie = `${name}=; Path=/; Max-Age=0; SameSite=Lax`
+        }
+      }
+    } catch {
+      // ignore — cookie access can throw in sandboxed contexts
+    }
+  }
+}
+
 export function sanitizePerspectiveSettings(source?: PerspectiveSettings | null): PerspectiveSettings | null {
   if (!source || typeof source !== 'object') return null
   const forbidden = new Set(['__proto__', 'prototype', 'constructor'])

--- a/packages/ui/src/backend/__tests__/DataTable.perspectiveStorage.test.ts
+++ b/packages/ui/src/backend/__tests__/DataTable.perspectiveStorage.test.ts
@@ -1,7 +1,8 @@
 /** @jest-environment jsdom */
-import { readPerspectiveSnapshot, writePerspectiveSnapshot } from '../DataTable'
+import { clearAllPerspectiveState, readPerspectiveSnapshot, writePerspectiveSnapshot } from '../DataTable'
 
 const PREFIX = 'om_table_perspective_snapshot'
+const COOKIE_PREFIX = 'om_table_perspective'
 
 describe('DataTable perspective snapshot storage (versioned envelope)', () => {
   beforeEach(() => {
@@ -50,5 +51,65 @@ describe('DataTable perspective snapshot storage (versioned envelope)', () => {
     writePerspectiveSnapshot('tbl5', { perspectiveId: null, settings: { columnOrder: ['z'] }, updatedAt: 1 })
     writePerspectiveSnapshot('tbl5', null)
     expect(localStorage.getItem(`${PREFIX}:tbl5`)).toBeNull()
+  })
+})
+
+describe('clearAllPerspectiveState (tenant-isolation at the auth identity boundary, #4185)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    for (const cookie of document.cookie ? document.cookie.split(';') : []) {
+      const name = cookie.split('=')[0]?.trim()
+      if (name) document.cookie = `${name}=; Path=/; Max-Age=0`
+    }
+  })
+
+  it('removes every perspective snapshot across all tables', () => {
+    writePerspectiveSnapshot('customers-companies', {
+      perspectiveId: null,
+      settings: { columnSizing: { name: 210, status: 60 } },
+      updatedAt: 1,
+    })
+    writePerspectiveSnapshot('customers-people', {
+      perspectiveId: null,
+      settings: { columnSizing: { name: 300 } },
+      updatedAt: 2,
+    })
+
+    clearAllPerspectiveState()
+
+    expect(localStorage.getItem(`${PREFIX}:customers-companies`)).toBeNull()
+    expect(localStorage.getItem(`${PREFIX}:customers-people`)).toBeNull()
+    expect(readPerspectiveSnapshot('customers-companies')).toBeNull()
+    expect(readPerspectiveSnapshot('customers-people')).toBeNull()
+  })
+
+  it('leaves unrelated localStorage keys untouched', () => {
+    writePerspectiveSnapshot('customers-companies', {
+      perspectiveId: null,
+      settings: { columnSizing: { name: 210 } },
+      updatedAt: 1,
+    })
+    localStorage.setItem('om_login_tenant', 'acme')
+    localStorage.setItem('om:auth:identity', '123')
+
+    clearAllPerspectiveState()
+
+    expect(localStorage.getItem(`${PREFIX}:customers-companies`)).toBeNull()
+    expect(localStorage.getItem('om_login_tenant')).toBe('acme')
+    expect(localStorage.getItem('om:auth:identity')).toBe('123')
+  })
+
+  it('expires the active-view perspective cookies', () => {
+    document.cookie = `${COOKIE_PREFIX}:customers-companies=view-1; Path=/`
+    expect(document.cookie).toContain(`${COOKIE_PREFIX}:customers-companies=view-1`)
+
+    clearAllPerspectiveState()
+
+    expect(document.cookie).not.toContain(`${COOKIE_PREFIX}:customers-companies`)
+  })
+
+  it('is a no-op when nothing is stored', () => {
+    expect(() => clearAllPerspectiveState()).not.toThrow()
+    expect(localStorage.length).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

Fixes #4185 — unsaved DataTable column widths carried over to a different account (a different tenant in the report) reusing the same browser tab.

**Root cause.** The live/unsaved perspective snapshot (column widths, order, visibility) is persisted to `localStorage` under `om_table_perspective_snapshot:<tableId>` and the active view to the `om_table_perspective:<tableId>` cookie — keyed **only by `tableId`, with no user/tenant scope** (`packages/ui/src/backend/DataTable.tsx`). `localStorage`/cookies are shared by every session in a browser profile, so after logout → login as a different account in the same tab, the new account's DataTable reads the previous account's snapshot. The incognito negative control passes because a fresh profile starts with empty storage. Saved (named) perspectives are unaffected because those live server-side per user.

**Fix.** Add `clearAllPerspectiveState()` to `DataTable` and call it from the login form's submit handler (both success branches, next to the existing `clearAllOperations()` / `notifyAuthIdentityChange()`). Every credential login purges the stale per-user table snapshots + active-view cookies before entering the backend. Because `localStorage` is shared across tabs and every login runs the purge, this closes the same-tab, cross-tab, and redirect-straight-to-a-list variants. It does **not** run on a plain refresh, so an account's own unsaved widths still survive a reload (the documented behavior).

## Changes

- `packages/ui/src/backend/DataTable.tsx` — new exported `clearAllPerspectiveState()` (removes all `om_table_perspective_snapshot:*` keys + expires `om_table_perspective:*` cookies; guarded, no-throw). Additive export — no existing signature changed.
- `packages/core/src/modules/auth/frontend/login.tsx` — call it on successful login (redirect + JSON-200 branches).

## Tests

- **Unit** (`DataTable.perspectiveStorage.test.ts`): `clearAllPerspectiveState` removes every snapshot across tables, expires the active-view cookies, leaves unrelated `localStorage` keys intact, and no-ops when empty.
- **Integration** (`TC-CRM-087.spec.ts`): admin widens a column and it persists across a reload; then after logout + a **real login-form** sign-in as a different account, the companies grid shows default widths — no carry-over. (Drives the actual form because the integration `login()` helper's API fast-path bypasses the form where the fix lives.)

## Validation

Runner: local. `yarn build:packages`, `yarn generate`, `yarn typecheck` (21/21), `yarn i18n:check-sync`, `yarn lint` (0 errors) all green. UI DataTable suites (38) and core login suites (55) pass. Full `yarn test` / `yarn build:app` / the integration run are left to CI.

## Notes for QA

- Repro from the issue: log in, widen a list column (do not save a view), log out, log in as a different account in the same tab, open the same list → expect default widths.
- An account's own unsaved widths must still survive a plain page refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
