### PR TITLE
fix(create-app): pin scaffolded app to yarn 4.17.1 for TS 7 install

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,8 +233,7 @@
     "ws@npm:^7.3.1": "7.5.11",
     "ws@npm:^8.17.1": "8.21.0",
     "ws@npm:^8.18.0": "8.21.0",
-    "ws@npm:~8.18.3": "8.21.0",
-    "websocket-driver": "0.7.5"
+    "ws@npm:~8.18.3": "8.21.0"
   },
   "dependenciesMeta": {
     "@datadog/pprof": {

--- a/packages/create-app/template/Dockerfile
+++ b/packages/create-app/template/Dockerfile
@@ -7,7 +7,7 @@ ARG OPEN_MERCATO_DOCKER_REGISTRY_HOST=host.docker.internal
 WORKDIR /app
 
 RUN apk add --no-cache python3 make g++ ca-certificates openssl
-RUN corepack enable && corepack prepare yarn@4.12.0 --activate
+RUN corepack enable
 
 COPY package.json yarn.lock .yarnrc.yml ./
 RUN if grep -Eq 'http://(localhost|127\\.0\\.0\\.1):' .yarnrc.yml; then \
@@ -36,7 +36,7 @@ ARG OPEN_MERCATO_DOCKER_REGISTRY_HOST=host.docker.internal
 WORKDIR /app
 
 RUN apk add --no-cache python3 make g++ ca-certificates openssl
-RUN corepack enable && corepack prepare yarn@4.12.0 --activate
+RUN corepack enable
 
 COPY package.json yarn.lock .yarnrc.yml ./
 RUN if grep -Eq 'http://(localhost|127\\.0\\.0\\.1):' .yarnrc.yml; then \
@@ -74,7 +74,7 @@ ENV NODE_ENV=production \
 WORKDIR /app
 
 RUN apk add --no-cache ca-certificates openssl
-RUN corepack enable && corepack prepare yarn@4.12.0 --activate
+RUN corepack enable
 
 COPY package.json yarn.lock .yarnrc.yml ./
 RUN if grep -Eq 'http://(localhost|127\\.0\\.0\\.1):' .yarnrc.yml; then \

--- a/packages/create-app/template/package.json.template
+++ b/packages/create-app/template/package.json.template
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "packageManager": "yarn@4.12.0+sha512.f45ab632439a67f8bc759bf32ead036a1f413287b9042726b7cc4818b7b49e14e9423ba49b18f9e06ea4941c1ad062385b1d8760a8d5091a1a31e5f6219afca8",
+  "packageManager": "yarn@4.17.1+sha512.ccbfabf7d7b6b32075088be9386fb9a2e00bb6887ef07fa56effabc890a56d53da1ccc4128d62db245fcbd3961b236d75335bdf7d5320ed6eafb7588b7ad4697",
   "scripts": {
     "setup": "node ./scripts/setup.mjs",
     "setup:classic": "node ./scripts/setup.mjs --classic",


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

The TypeScript 7.0.2 native compiler (adopted in #4199) ships no `lib/_tsc.js`, but yarn 4.12.0's builtin `compat/typescript` patch expects it — so the **Standalone App Integration Tests** job on `develop` failed at `yarn install` with `ENOENT ... typescript/lib/_tsc.js`, since scaffolded apps pull `typescript@7.0.2` transitively via `@open-mercato/cli`. #4199 bumped the monorepo to yarn 4.17.1 (whose compat plugin handles TS 7) but never mirrored the bump into the create-app template. This pins the scaffolded app to yarn 4.17.1 and makes the Dockerfile derive the version from `packageManager` instead of hardcoding it.

## Changes

- `packages/create-app/template/package.json.template`: `packageManager` → `yarn@4.17.1` (mirrors the monorepo root).
- `packages/create-app/template/Dockerfile`: replace `corepack prepare yarn@4.12.0 --activate` with plain `corepack enable` in all three stages, so `packageManager` is the single source of truth (those lines run before `package.json` is copied and can't read it anyway; `yarn install`/`yarn workspaces focus` provision the pinned version on demand).
- `package.json`: remove a duplicate `"websocket-driver": "0.7.5"` key in `resolutions` (two independent security fixes each added it on different lines, merging into a duplicate JSON key; behavior unchanged).

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- Verified against CI run 29649602522: the failing `yarn install` used yarn 4.12.0's TS patch (`hash=5786d5`); the monorepo's passing job uses 4.17.1 (`hash=3bafbf`).
- Confirmed `package.json.template` still parses with placeholders stripped and `packageManager` resolves to `yarn@4.17.1`.
- Full validation runs on the standalone integration job that this fix unblocks.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes.

### Design System Compliance
- [x] N/A — build tooling only, no UI changes.

## Linked issues

N/A
