### PR TITLE
fix(ci): retry standalone install through npm quarantine window

### DIFF
--- a/.github/workflows/npm-snapshot-preview.yml
+++ b/.github/workflows/npm-snapshot-preview.yml
@@ -272,24 +272,32 @@ jobs:
           EOF
           )
 
-          echo "Waiting for Open Mercato packages @ ${VERSION} on npm..."
+          # `npm view … version` only proves the version's METADATA is public.
+          # npm briefly QUARANTINES a freshly published version's tarball for a
+          # security scan while its metadata is already visible, so the old probe
+          # passed instantly and the downstream `yarn install` then failed with
+          # YN0016 "… are quarantined". Probe the actual tarball with `npm pack`
+          # so we wait for install-readiness, not mere visibility.
+          PROBE_DIR="$(mktemp -d)"
+          echo "Waiting for Open Mercato packages @ ${VERSION} to be installable on npm..."
           for pkg in "${PACKAGES[@]}"; do
             echo "Checking ${pkg}@${VERSION}..."
             ok=false
-            for i in $(seq 1 30); do
-              if npm view "${pkg}@${VERSION}" version 2>/dev/null; then
-                echo "  ${pkg} available after attempt ${i}"
+            for i in $(seq 1 40); do
+              if npm pack "${pkg}@${VERSION}" --pack-destination "$PROBE_DIR" >/dev/null 2>&1; then
+                echo "  ${pkg} installable after attempt ${i}"
                 ok=true
                 break
               fi
-              echo "  Attempt ${i}/30: waiting 10s..."
-              sleep 10
+              echo "  Attempt ${i}/40: metadata may be visible but tarball not installable yet (quarantine); waiting 15s..."
+              sleep 15
             done
             if [ "$ok" != "true" ]; then
-              echo "Package ${pkg}@${VERSION} not available after 5 minutes"
+              echo "Package ${pkg}@${VERSION} not installable after 10 minutes (still quarantined?)"
               exit 1
             fi
           done
+          rm -rf "$PROBE_DIR"
 
       - name: Scaffold standalone app
         run: npx "create-mercato-app@${{ needs.snapshot.outputs.snapshot_version }}" /tmp/standalone-app --skip-agentic-setup --registry https://registry.npmjs.org

--- a/.github/workflows/npm-snapshot-preview.yml
+++ b/.github/workflows/npm-snapshot-preview.yml
@@ -272,35 +272,35 @@ jobs:
           EOF
           )
 
-          # `npm view … version` only proves the version's METADATA is public.
-          # npm briefly QUARANTINES a freshly published version's tarball for a
-          # security scan while its metadata is already visible, so the old probe
-          # passed instantly and the downstream `yarn install` then failed with
-          # YN0016 "… are quarantined". Probe the actual tarball with `npm pack`
-          # so we wait for install-readiness, not mere visibility.
-          PROBE_DIR="$(mktemp -d)"
-          echo "Waiting for Open Mercato packages @ ${VERSION} to be installable on npm..."
+          # Wait for the published version's METADATA to propagate. This does NOT
+          # cover npm's post-publish tarball QUARANTINE (metadata goes public
+          # first while the tarball stays quarantined for a security scan) — that
+          # is handled by retrying the real scaffold/install steps below via
+          # scripts/ci/npm-retry-on-quarantine.sh.
+          echo "Waiting for Open Mercato packages @ ${VERSION} on npm..."
           for pkg in "${PACKAGES[@]}"; do
             echo "Checking ${pkg}@${VERSION}..."
             ok=false
-            for i in $(seq 1 40); do
-              if npm pack "${pkg}@${VERSION}" --pack-destination "$PROBE_DIR" >/dev/null 2>&1; then
-                echo "  ${pkg} installable after attempt ${i}"
+            for i in $(seq 1 30); do
+              if npm view "${pkg}@${VERSION}" version 2>/dev/null; then
+                echo "  ${pkg} available after attempt ${i}"
                 ok=true
                 break
               fi
-              echo "  Attempt ${i}/40: metadata may be visible but tarball not installable yet (quarantine); waiting 15s..."
-              sleep 15
+              echo "  Attempt ${i}/30: waiting 10s..."
+              sleep 10
             done
             if [ "$ok" != "true" ]; then
-              echo "Package ${pkg}@${VERSION} not installable after 10 minutes (still quarantined?)"
+              echo "Package ${pkg}@${VERSION} not available after 5 minutes"
               exit 1
             fi
           done
-          rm -rf "$PROBE_DIR"
 
       - name: Scaffold standalone app
-        run: npx "create-mercato-app@${{ needs.snapshot.outputs.snapshot_version }}" /tmp/standalone-app --skip-agentic-setup --registry https://registry.npmjs.org
+        # Retry through npm's post-publish quarantine window (see the script).
+        run: |
+          bash "$GITHUB_WORKSPACE/scripts/ci/npm-retry-on-quarantine.sh" \
+            npx "create-mercato-app@${{ needs.snapshot.outputs.snapshot_version }}" /tmp/standalone-app --skip-agentic-setup --registry https://registry.npmjs.org
 
       - name: Configure standalone app environment
         working-directory: /tmp/standalone-app
@@ -339,14 +339,16 @@ jobs:
         env:
           YARN_ENABLE_HARDENED_MODE: '0'
           YARN_ENABLE_IMMUTABLE_INSTALLS: '0'
-        run: yarn install
+        # Retry through npm's post-publish quarantine window (see the script).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/npm-retry-on-quarantine.sh" yarn install
 
       - name: Install standalone enterprise package
         working-directory: /tmp/standalone-app
         env:
           YARN_ENABLE_HARDENED_MODE: '0'
           YARN_ENABLE_IMMUTABLE_INSTALLS: '0'
-        run: yarn add "@open-mercato/enterprise@${{ needs.snapshot.outputs.snapshot_version }}"
+        # Retry through npm's post-publish quarantine window (see the script).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/npm-retry-on-quarantine.sh" yarn add "@open-mercato/enterprise@${{ needs.snapshot.outputs.snapshot_version }}"
 
       - name: Generate standalone app modules
         working-directory: /tmp/standalone-app

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -188,24 +188,32 @@ jobs:
           EOF
           )
 
-          echo "Waiting for Open Mercato packages @ ${VERSION} on npm..."
+          # `npm view … version` only proves the version's METADATA is public.
+          # npm briefly QUARANTINES a freshly published version's tarball for a
+          # security scan while its metadata is already visible, so the old probe
+          # passed instantly and the downstream `yarn install` then failed with
+          # YN0016 "… are quarantined". Probe the actual tarball with `npm pack`
+          # so we wait for install-readiness, not mere visibility.
+          PROBE_DIR="$(mktemp -d)"
+          echo "Waiting for Open Mercato packages @ ${VERSION} to be installable on npm..."
           for pkg in "${PACKAGES[@]}"; do
             echo "Checking ${pkg}@${VERSION}..."
             ok=false
-            for i in $(seq 1 30); do
-              if npm view "${pkg}@${VERSION}" version 2>/dev/null; then
-                echo "  ${pkg} available after attempt ${i}"
+            for i in $(seq 1 40); do
+              if npm pack "${pkg}@${VERSION}" --pack-destination "$PROBE_DIR" >/dev/null 2>&1; then
+                echo "  ${pkg} installable after attempt ${i}"
                 ok=true
                 break
               fi
-              echo "  Attempt ${i}/30: waiting 10s..."
-              sleep 10
+              echo "  Attempt ${i}/40: metadata may be visible but tarball not installable yet (quarantine); waiting 15s..."
+              sleep 15
             done
             if [ "$ok" != "true" ]; then
-              echo "Package ${pkg}@${VERSION} not available after 5 minutes"
+              echo "Package ${pkg}@${VERSION} not installable after 10 minutes (still quarantined?)"
               exit 1
             fi
           done
+          rm -rf "$PROBE_DIR"
 
       # --- Scaffold & build standalone app ---
       - name: Scaffold standalone app

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -188,36 +188,36 @@ jobs:
           EOF
           )
 
-          # `npm view … version` only proves the version's METADATA is public.
-          # npm briefly QUARANTINES a freshly published version's tarball for a
-          # security scan while its metadata is already visible, so the old probe
-          # passed instantly and the downstream `yarn install` then failed with
-          # YN0016 "… are quarantined". Probe the actual tarball with `npm pack`
-          # so we wait for install-readiness, not mere visibility.
-          PROBE_DIR="$(mktemp -d)"
-          echo "Waiting for Open Mercato packages @ ${VERSION} to be installable on npm..."
+          # Wait for the published version's METADATA to propagate. This does NOT
+          # cover npm's post-publish tarball QUARANTINE (metadata goes public
+          # first while the tarball stays quarantined for a security scan) — that
+          # is handled by retrying the real scaffold/install steps below via
+          # scripts/ci/npm-retry-on-quarantine.sh.
+          echo "Waiting for Open Mercato packages @ ${VERSION} on npm..."
           for pkg in "${PACKAGES[@]}"; do
             echo "Checking ${pkg}@${VERSION}..."
             ok=false
-            for i in $(seq 1 40); do
-              if npm pack "${pkg}@${VERSION}" --pack-destination "$PROBE_DIR" >/dev/null 2>&1; then
-                echo "  ${pkg} installable after attempt ${i}"
+            for i in $(seq 1 30); do
+              if npm view "${pkg}@${VERSION}" version 2>/dev/null; then
+                echo "  ${pkg} available after attempt ${i}"
                 ok=true
                 break
               fi
-              echo "  Attempt ${i}/40: metadata may be visible but tarball not installable yet (quarantine); waiting 15s..."
-              sleep 15
+              echo "  Attempt ${i}/30: waiting 10s..."
+              sleep 10
             done
             if [ "$ok" != "true" ]; then
-              echo "Package ${pkg}@${VERSION} not installable after 10 minutes (still quarantined?)"
+              echo "Package ${pkg}@${VERSION} not available after 5 minutes"
               exit 1
             fi
           done
-          rm -rf "$PROBE_DIR"
 
       # --- Scaffold & build standalone app ---
       - name: Scaffold standalone app
-        run: npx "create-mercato-app@${{ needs.snapshot.outputs.snapshot_version }}" /tmp/standalone-app --skip-agentic-setup --registry https://registry.npmjs.org
+        # Retry through npm's post-publish quarantine window (see the script).
+        run: |
+          bash "$GITHUB_WORKSPACE/scripts/ci/npm-retry-on-quarantine.sh" \
+            npx "create-mercato-app@${{ needs.snapshot.outputs.snapshot_version }}" /tmp/standalone-app --skip-agentic-setup --registry https://registry.npmjs.org
 
       - name: Configure standalone app environment
         working-directory: /tmp/standalone-app
@@ -270,14 +270,16 @@ jobs:
         env:
           YARN_ENABLE_HARDENED_MODE: '0'
           YARN_ENABLE_IMMUTABLE_INSTALLS: '0'
-        run: yarn install
+        # Retry through npm's post-publish quarantine window (see the script).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/npm-retry-on-quarantine.sh" yarn install
 
       - name: Install standalone enterprise package
         working-directory: /tmp/standalone-app
         env:
           YARN_ENABLE_HARDENED_MODE: '0'
           YARN_ENABLE_IMMUTABLE_INSTALLS: '0'
-        run: yarn add "@open-mercato/enterprise@${{ needs.snapshot.outputs.snapshot_version }}"
+        # Retry through npm's post-publish quarantine window (see the script).
+        run: bash "$GITHUB_WORKSPACE/scripts/ci/npm-retry-on-quarantine.sh" yarn add "@open-mercato/enterprise@${{ needs.snapshot.outputs.snapshot_version }}"
 
       - name: Generate standalone app modules
         working-directory: /tmp/standalone-app

--- a/scripts/ci/npm-retry-on-quarantine.sh
+++ b/scripts/ci/npm-retry-on-quarantine.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Retry a command that installs freshly published npm packages, tolerating
+# npm's post-publish security QUARANTINE window.
+#
+# npm quarantines a newly published version's tarball for a security scan while
+# its metadata is already public. A scaffold/install that runs immediately after
+# the snapshot publish therefore fails with `YN0016 … are quarantined` (yarn) or
+# a 403 quarantine error (npm) even though `npm view <pkg> version` succeeds.
+# The quarantine clears on its own after a while, so retry the *actual* install
+# operation (the thing yarn/npm does) rather than a proxy probe — `npm pack`
+# hits the CDN tarball and can report ready while yarn's manifest check still
+# sees quarantine. Only the quarantine signal is retried; any other failure
+# exits immediately so real errors surface fast.
+#
+# Usage: npm-retry-on-quarantine.sh <command> [args...]
+# Tunables (env): QUARANTINE_MAX_ATTEMPTS (default 20), QUARANTINE_RETRY_SLEEP (default 60s)
+set -uo pipefail
+
+MAX_ATTEMPTS="${QUARANTINE_MAX_ATTEMPTS:-20}"
+SLEEP_SECONDS="${QUARANTINE_RETRY_SLEEP:-60}"
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::npm-retry-on-quarantine.sh requires a command to run" >&2
+  exit 2
+fi
+
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+attempt=1
+while :; do
+  "$@" 2>&1 | tee "$log"
+  code="${PIPESTATUS[0]}"
+
+  if [ "$code" -eq 0 ]; then
+    exit 0
+  fi
+
+  if ! grep -qiE 'quarantin' "$log"; then
+    echo "::error::\`$*\` failed (exit ${code}) for a non-quarantine reason; not retrying." >&2
+    exit "$code"
+  fi
+
+  if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+    echo "::error::\`$*\` still hitting npm quarantine after ${MAX_ATTEMPTS} attempts (~$((MAX_ATTEMPTS * SLEEP_SECONDS / 60)) min); giving up." >&2
+    exit "$code"
+  fi
+
+  echo "npm quarantine detected — attempt ${attempt}/${MAX_ATTEMPTS} failed; retrying in ${SLEEP_SECONDS}s..."
+  attempt=$((attempt + 1))
+  sleep "$SLEEP_SECONDS"
+done


### PR DESCRIPTION
## Summary

The develop snapshot's **Standalone App Integration Tests** job fails when a freshly published snapshot is still inside npm's **quarantine window**: npm quarantines a new version's tarball for a security scan while its metadata is already public, so the scaffolded app's `yarn install` fails with `YN0016 … are quarantined` (e.g. CI run 29655311753). Measured behavior: the tarball stayed quarantined to yarn for **>15 minutes** after publish, and `npm pack` (npm CLI hitting the CDN tarball) can report "ready" while yarn's manifest-level quarantine check still fails — so a proxy probe is not trustworthy. This retries the **actual** install operations through the quarantine window instead.

## Changes

- `scripts/ci/npm-retry-on-quarantine.sh` (new): runs a command and retries **only** on the quarantine signal (up to ~20 min, `QUARANTINE_MAX_ATTEMPTS`/`QUARANTINE_RETRY_SLEEP` tunable), failing fast on any other error so real failures surface immediately.
- `.github/workflows/snapshot.yml` and `.github/workflows/npm-snapshot-preview.yml`: wrap the three npm-fetching steps — scaffold (`npx create-mercato-app`), `yarn install`, and the enterprise `yarn add` — in that script. The metadata-propagation wait is left as the cheap `npm view` check (it only covers metadata visibility; a comment now says so).

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (CI reliability fix, no spec needed)

## Testing

- Unit-tested the wrapper locally: success passes through (exit 0); a non-quarantine failure exits immediately with the original code (no retry); a quarantine-signalled failure retries to the cap then exits non-zero.
- `bash -n` on the script and Ruby `YAML.load` on both workflows pass; parsed the wrapped `run:` blocks to confirm they resolve to the intended commands.
- Root cause verified against run 29655311753: attempt 1 failed ~5 min post-publish and my re-run (attempt 2) still failed ~15 min post-publish, both `YN0016 … are quarantined`; the version became installable later once npm cleared the quarantine — confirming the failure is the post-publish quarantine window, not the package contents or the yarn 4.17.1 bump (#4280) that unblocked TypeScript 7.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (CI-workflow-only change; the standalone integration job itself is the coverage).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label.
- [x] QA routing set: `skip-qa` (CI-only, non-customer-facing).

### Design System Compliance
- [x] N/A — CI workflow only, no UI.
