### PR TITLE
fix(query-index): resolve global entity scope from metadata

### DIFF
--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/HANDOFF.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/HANDOFF.md
@@ -3,7 +3,8 @@
 ## Current state
 
 - Branch: `fix/query-index-global-entity-scope` from `origin/develop`.
-- Resume at: Step 4.1 — create the blocked draft PR, then rerun the full managed integration suite once stale sibling worktrees are removed or excluded from discovery.
+- Draft PR: https://github.com/open-mercato/open-mercato/pull/4285.
+- Resume at: rerun the full managed integration suite once stale sibling worktrees are removed or excluded from discovery, then update the draft PR.
 - Unrelated working-tree file preserved: `.ai/reports/ds-health-2026-07-02.txt`.
 
 ## Decisions already made
@@ -20,3 +21,4 @@
 - Review: independent final review found no actionable findings.
 - Blocked external gate: `yarn test:integration:ephemeral` fails during global discovery because stale `.worktrees` are not excluded. It errors before feature tests run with missing stale `dist` imports and duplicate `@playwright/test` loads.
 - Template parity: `yarn template:sync` reports 25 pre-existing unrelated template drifts; no template surface was changed in this work.
+- GitHub handoff: the branch is in the configured writable fork and the draft PR is open. The upstream API token can create/comment but cannot assign or mutate labels, so a maintainer must apply the intended `bug`, `priority-high`, `risk-high`, and `blocked` labels (and release any claim state once the integration gate is resolved).

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/HANDOFF.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/HANDOFF.md
@@ -4,7 +4,8 @@
 
 - Branch: `fix/query-index-global-entity-scope` from `origin/develop`.
 - Draft PR: https://github.com/open-mercato/open-mercato/pull/4285.
-- Resume at: rerun the full managed integration suite once stale sibling worktrees are removed or excluded from discovery, then update the draft PR.
+- Latest pushed fix: `9ca4d60cb fix(feature-toggles): list global indexes`.
+- Resume at: inspect the required CI checks for the latest commit. Keep the PR as a draft until `ephemeral-integration` passes and a maintainer can review it.
 - Unrelated working-tree file preserved: `.ai/reports/ds-health-2026-07-02.txt`.
 
 ## Decisions already made
@@ -18,6 +19,8 @@
 
 - Passed: focused core Jest suites (36 tests), full `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`, and `git diff --check` (Runner: local).
 - Passed: isolated `TC-FT-001` against a managed ephemeral app and database; it verified the global null/null projection after create/update and physical removal after delete.
+- Passed after the CI failure investigation: shared query-engine regression (`20` tests), root `yarn typecheck`, and all `22` managed feature-toggle integration tests, including `TC-FT-008` filtering/pagination and `TC-FT-001` projection lifecycle.
+- Local test-note: the managed feature-toggle run used temporary `.worktrees` discovery ignores because sibling worktrees otherwise load a second Playwright copy; those local-only edits were reverted and are not part of the PR.
 - Review: independent final review found no actionable findings.
 - Blocked external gate: `yarn test:integration:ephemeral` fails during global discovery because stale `.worktrees` are not excluded. It errors before feature tests run with missing stale `dist` imports and duplicate `@playwright/test` loads.
 - Template parity: `yarn template:sync` reports 25 pre-existing unrelated template drifts; no template surface was changed in this work.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/HANDOFF.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/HANDOFF.md
@@ -3,7 +3,7 @@
 ## Current state
 
 - Branch: `fix/query-index-global-entity-scope` from `origin/develop`.
-- Resume at: Step 0.1 — land the copied source spec, readiness report, and loop plan.
+- Resume at: Step 4.1 — create the blocked draft PR, then rerun the full managed integration suite once stale sibling worktrees are removed or excluded from discovery.
 - Unrelated working-tree file preserved: `.ai/reports/ds-health-2026-07-02.txt`.
 
 ## Decisions already made
@@ -11,3 +11,12 @@
 - The supplied core-spec invocation is treated as explicit authorization for the specified core fix.
 - The global projection delete assertion will follow existing `markDeleted()` semantics: the projection is physically removed, not soft-deleted.
 - No UI is touched, so the design-system pass is not applicable.
+- MikroORM v7 returns `em.getMetadata().getAll()` as a `Map`; the strict metadata resolver now supports it, covered by a regression test.
+
+## Validation
+
+- Passed: focused core Jest suites (36 tests), full `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`, and `git diff --check` (Runner: local).
+- Passed: isolated `TC-FT-001` against a managed ephemeral app and database; it verified the global null/null projection after create/update and physical removal after delete.
+- Review: independent final review found no actionable findings.
+- Blocked external gate: `yarn test:integration:ephemeral` fails during global discovery because stale `.worktrees` are not excluded. It errors before feature tests run with missing stale `dist` imports and duplicate `@playwright/test` loads.
+- Template parity: `yarn template:sync` reports 25 pre-existing unrelated template drifts; no template surface was changed in this work.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/HANDOFF.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/HANDOFF.md
@@ -1,0 +1,13 @@
+# Handoff — query-index-global-entity-scope
+
+## Current state
+
+- Branch: `fix/query-index-global-entity-scope` from `origin/develop`.
+- Resume at: Step 0.1 — land the copied source spec, readiness report, and loop plan.
+- Unrelated working-tree file preserved: `.ai/reports/ds-health-2026-07-02.txt`.
+
+## Decisions already made
+
+- The supplied core-spec invocation is treated as explicit authorization for the specified core fix.
+- The global projection delete assertion will follow existing `markDeleted()` semantics: the projection is physically removed, not soft-deleted.
+- No UI is touched, so the design-system pass is not applicable.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/NOTIFY.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/NOTIFY.md
@@ -4,3 +4,4 @@
 - 2026-07-18: Landed strict registered entity-ID and ORM-metadata scope resolution, global feature-toggle producer correction, and focused unit/integration regression coverage in `b57d4c804`.
 - 2026-07-18: Fixed the discovered MikroORM v7 metadata-Map compatibility gap and confirmed `TC-FT-001` end-to-end against a managed ephemeral app.
 - 2026-07-18: Full local validation and independent review passed. The repository-wide managed integration suite is blocked before test execution by stale sibling worktree discovery; this will be called out on the draft PR.
+- 2026-07-18: Opened draft PR #4285. The upstream GitHub API token is read-only, so label/assignee automation requires a maintainer handoff.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/NOTIFY.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/NOTIFY.md
@@ -1,3 +1,6 @@
 # Notifications — query-index-global-entity-scope
 
 - 2026-07-18: Run initialized from the supplied implementation-ready specification.
+- 2026-07-18: Landed strict registered entity-ID and ORM-metadata scope resolution, global feature-toggle producer correction, and focused unit/integration regression coverage in `b57d4c804`.
+- 2026-07-18: Fixed the discovered MikroORM v7 metadata-Map compatibility gap and confirmed `TC-FT-001` end-to-end against a managed ephemeral app.
+- 2026-07-18: Full local validation and independent review passed. The repository-wide managed integration suite is blocked before test execution by stale sibling worktree discovery; this will be called out on the draft PR.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/NOTIFY.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/NOTIFY.md
@@ -1,0 +1,3 @@
+# Notifications — query-index-global-entity-scope
+
+- 2026-07-18: Run initialized from the supplied implementation-ready specification.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/NOTIFY.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/NOTIFY.md
@@ -5,3 +5,4 @@
 - 2026-07-18: Fixed the discovered MikroORM v7 metadata-Map compatibility gap and confirmed `TC-FT-001` end-to-end against a managed ephemeral app.
 - 2026-07-18: Full local validation and independent review passed. The repository-wide managed integration suite is blocked before test execution by stale sibling worktree discovery; this will be called out on the draft PR.
 - 2026-07-18: Opened draft PR #4285. The upstream GitHub API token is read-only, so label/assignee automation requires a maintainer handoff.
+- 2026-07-22: Reproduced the CI `TC-FT-008` failure, fixed global-list query scope plus the documented direct-query search-token behavior in `9ca4d60cb`, and pushed it to PR #4285. Shared query regression, typecheck, and all 22 feature-toggle integration tests pass; draft remains pending required CI.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/PLAN.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/PLAN.md
@@ -1,0 +1,68 @@
+# Auto Create PR Loop Plan — query-index-global-entity-scope
+
+**Date:** 2026-07-18
+**Slug:** `query-index-global-entity-scope`
+**Branch:** `fix/query-index-global-entity-scope`
+**Mode:** Spec-implementation run
+**Source spec:** `.ai/specs/2026-07-18-query-index-global-entity-scope.md`
+
+## Tasks
+
+> Authoritative status table. `Status` is `todo` or `done`. A completed step records the commit that landed it; the first non-done step is the resume point.
+
+| Phase | Step | Title | Status | Commit |
+|---|---|---|---|---|
+| 0 | 0.1 | Land source specification and pre-implementation analysis | todo | — |
+| 1 | 1.1 | Make global feature-toggle index identifiers explicit | todo | — |
+| 2 | 2.1 | Resolve registered source metadata and strict scope state | todo | — |
+| 2 | 2.2 | Apply metadata-aware scope handling to upsert and delete coverage | todo | — |
+| 3 | 3.1 | Extend focused unit and feature-toggle integration coverage | todo | — |
+| 4 | 4.1 | Run validation, review, and create the pull request | todo | — |
+
+## Goal
+
+Correct query-index scope handling for registered global ORM entities without weakening tenant-scoped source-row authority.
+
+## Scope
+
+- Copy the supplied source spec and record its readiness analysis.
+- Emit explicit null/null index scope for global feature-toggle commands.
+- Resolve scope columns only from registered MikroORM metadata; fail closed for missing metadata.
+- Avoid source scope reads for global entities and omit absent scope predicates from delete coverage.
+- Cover global, tenant-only, mismatched, missing-source, and unknown-entity paths with focused tests; assert the feature-toggle API lifecycle persists a global projection.
+
+## Scope correction
+
+`markDeleted()` physically removes `entity_indexes` rows. The supplied spec's delete integration assertion is therefore corrected to require no remaining projection row, preserving established index deletion behavior rather than expanding this bug fix into a storage-semantics change.
+
+## Non-goals
+
+- No schema, migration, API, event-ID, ACL, UI, cache-policy, or reindex-contract changes.
+- No fallback table guessing for unregistered entity IDs.
+- No change to the all-tenant reindex opt-in contract.
+
+## Validation plan
+
+- Focused core Jest suites for query-index scope/subscribers and global feature-toggle commands.
+- Managed ephemeral integration run filtered to `TC-FT-001`.
+- Full configured validation gate using one selected runner, then `git diff --check` and template parity review.
+- No DS review is needed because no UI file changes.
+
+## File manifest
+
+| File | Action | Purpose |
+|---|---|---|
+| `.ai/specs/2026-07-18-query-index-global-entity-scope.md` | Add/update | Versioned source specification and implementation status. |
+| `.ai/specs/analysis/ANALYSIS-2026-07-18-query-index-global-entity-scope.md` | Add | Mandatory readiness and compatibility audit. |
+| `packages/core/src/modules/query_index/lib/subscriber-scope.ts` | Modify | Strict metadata descriptor and scope-state resolver. |
+| `packages/core/src/modules/query_index/subscribers/upsert_one.ts` | Modify | Resolve scope without swallowed metadata/SQL errors. |
+| `packages/core/src/modules/query_index/subscribers/delete_one.ts` | Modify | Use conditional metadata-backed coverage predicates. |
+| `packages/core/src/modules/query_index/__tests__/*scope*.test.ts` | Modify/add | Scope resolver and global-upsert regressions. |
+| `packages/core/src/modules/query_index/__tests__/delete-one-coverage.test.ts` | Modify | Global delete coverage predicate regression. |
+| `packages/core/src/modules/feature_toggles/commands/global.ts` | Modify | Constant global command identifiers. |
+| `packages/core/src/modules/feature_toggles/commands/__tests__/global.test.ts` | Modify | Actor scope cannot leak into index identifiers. |
+| `packages/core/src/modules/feature_toggles/__integration__/TC-FT-001.spec.ts` | Modify | API lifecycle projection-scope regression. |
+
+## Backward compatibility
+
+Existing event IDs and payload fields, APIs, entities, schema, DI keys, generated registries, and reindex contract remain unchanged. For valid tenant-scoped records, source-row scope remains authoritative; only the corrected feature-toggle values and strict handling of invalid/unregistered index inputs change.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/PLAN.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/PLAN.md
@@ -18,7 +18,8 @@
 | 2 | 2.2 | Apply metadata-aware scope handling to upsert and delete coverage | done | b57d4c804 |
 | 3 | 3.1 | Extend focused unit and feature-toggle integration coverage | done | b57d4c804 |
 | 3 | 3.2 | Run the managed feature-toggle integration scenario | done | pending commit |
-| 4 | 4.1 | Run validation, review, and create the blocked draft pull request | todo | — |
+| 4 | 4.1 | Await required CI and maintainer review on the draft pull request | todo | — |
+| 4 | 4.2 | Correct global list query scope and revalidate feature toggles | done | 9ca4d60cb |
 
 ## Goal
 
@@ -53,6 +54,7 @@ Correct query-index scope handling for registered global ORM entities without we
 
 - The isolated managed `TC-FT-001` scenario passed after exercising create, update, and delete projection state.
 - The repository-wide managed Playwright command remains blocked before execution by stale sibling `.worktrees` that its discovery does not ignore; those worktrees load incompatible `@playwright/test` copies and stale `dist/` imports. This is outside the feature diff and must be cleared or excluded before rerunning the full suite.
+- The CI-reported `TC-FT-008` failure is fixed in `9ca4d60cb`: global-list reads retain required query context but opt out of automatic tenant/org and scope-bound search-token filtering. The focused shared regression, `yarn typecheck`, and all 22 feature-toggle integration tests pass against a fresh ephemeral app.
 - Draft PR: https://github.com/open-mercato/open-mercato/pull/4285. Required upstream labels could not be applied because the GitHub API token has read-only upstream permission.
 
 ## File manifest

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/PLAN.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/PLAN.md
@@ -18,7 +18,7 @@
 | 2 | 2.2 | Apply metadata-aware scope handling to upsert and delete coverage | done | b57d4c804 |
 | 3 | 3.1 | Extend focused unit and feature-toggle integration coverage | done | b57d4c804 |
 | 3 | 3.2 | Run the managed feature-toggle integration scenario | done | pending commit |
-| 4 | 4.1 | Run validation, review, and create the pull request | todo | — |
+| 4 | 4.1 | Run validation, review, and create the blocked draft pull request | todo | — |
 
 ## Goal
 
@@ -53,6 +53,7 @@ Correct query-index scope handling for registered global ORM entities without we
 
 - The isolated managed `TC-FT-001` scenario passed after exercising create, update, and delete projection state.
 - The repository-wide managed Playwright command remains blocked before execution by stale sibling `.worktrees` that its discovery does not ignore; those worktrees load incompatible `@playwright/test` copies and stale `dist/` imports. This is outside the feature diff and must be cleared or excluded before rerunning the full suite.
+- Draft PR: https://github.com/open-mercato/open-mercato/pull/4285. Required upstream labels could not be applied because the GitHub API token has read-only upstream permission.
 
 ## File manifest
 

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/PLAN.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/PLAN.md
@@ -12,11 +12,12 @@
 
 | Phase | Step | Title | Status | Commit |
 |---|---|---|---|---|
-| 0 | 0.1 | Land source specification and pre-implementation analysis | todo | — |
-| 1 | 1.1 | Make global feature-toggle index identifiers explicit | todo | — |
-| 2 | 2.1 | Resolve registered source metadata and strict scope state | todo | — |
-| 2 | 2.2 | Apply metadata-aware scope handling to upsert and delete coverage | todo | — |
-| 3 | 3.1 | Extend focused unit and feature-toggle integration coverage | todo | — |
+| 0 | 0.1 | Land source specification and pre-implementation analysis | done | 5df9fb7c4 |
+| 1 | 1.1 | Make global feature-toggle index identifiers explicit | done | b57d4c804 |
+| 2 | 2.1 | Resolve registered source metadata and strict scope state | done | b57d4c804 |
+| 2 | 2.2 | Apply metadata-aware scope handling to upsert and delete coverage | done | b57d4c804 |
+| 3 | 3.1 | Extend focused unit and feature-toggle integration coverage | done | b57d4c804 |
+| 3 | 3.2 | Run the managed feature-toggle integration scenario | done | pending commit |
 | 4 | 4.1 | Run validation, review, and create the pull request | todo | — |
 
 ## Goal
@@ -47,6 +48,11 @@ Correct query-index scope handling for registered global ORM entities without we
 - Managed ephemeral integration run filtered to `TC-FT-001`.
 - Full configured validation gate using one selected runner, then `git diff --check` and template parity review.
 - No DS review is needed because no UI file changes.
+
+## Gate result
+
+- The isolated managed `TC-FT-001` scenario passed after exercising create, update, and delete projection state.
+- The repository-wide managed Playwright command remains blocked before execution by stale sibling `.worktrees` that its discovery does not ignore; those worktrees load incompatible `@playwright/test` copies and stale `dist/` imports. This is outside the feature diff and must be cleared or excluded before rerunning the full suite.
 
 ## File manifest
 

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/step-3.2-checks.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/step-3.2-checks.md
@@ -1,0 +1,13 @@
+# Step 3.2 checks — managed feature-toggle integration
+
+Runner: managed ephemeral Docker environment (local host launcher).
+
+## Passed
+
+- Isolated `TC-FT-001` Playwright scenario: 1 passed.
+  - The app and database were created by `yarn test:integration:ephemeral:start`.
+  - The scenario verified the feature-toggle `entity_indexes` projection has explicit `organization_id = null` and `tenant_id = null` after create and update, and is absent after delete.
+
+## Repository-wide suite blocker
+
+`yarn test:integration:ephemeral` initializes and builds successfully, but Playwright then fails before test execution. Discovery includes stale sibling `.worktrees` that are not in the configured ignore list, producing missing stale `dist` imports and duplicate `@playwright/test` loads. This is independent of the feature test and its source files.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/step-4.1-checks.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/step-4.1-checks.md
@@ -1,0 +1,21 @@
+# Step 4.1 checks — validation and review
+
+Runner: local.
+
+## Passed
+
+- `yarn build:packages`
+- `yarn generate`
+- `yarn build:packages` (post-generation)
+- `yarn i18n:check-sync`
+- `yarn i18n:check-usage` (advisory unused-key report only)
+- `yarn typecheck`
+- `yarn test` (23 packages successful)
+- `yarn build:app`
+- `git diff --check`
+- Independent final code review: no actionable findings.
+
+## Non-code gate notes
+
+- `yarn template:sync` reports 25 unrelated existing template drifts; this change does not touch any mirrored application/template surface.
+- The full managed integration suite is blocked before feature test collection by stale sibling worktree discovery. The isolated managed feature scenario passed and the draft PR must retain the `blocked` label until the global runner issue is resolved.

--- a/.ai/runs/2026-07-18-query-index-global-entity-scope/step-4.1-checks.md
+++ b/.ai/runs/2026-07-18-query-index-global-entity-scope/step-4.1-checks.md
@@ -19,3 +19,9 @@ Runner: local.
 
 - `yarn template:sync` reports 25 unrelated existing template drifts; this change does not touch any mirrored application/template surface.
 - The full managed integration suite is blocked before feature test collection by stale sibling worktree discovery. The isolated managed feature scenario passed and the draft PR must retain the `blocked` label until the global runner issue is resolved.
+
+## Pull request handoff
+
+- Draft PR: https://github.com/open-mercato/open-mercato/pull/4285
+- Branch was pushed to the configured writable fork over SSH because upstream is read-only for this account.
+- The upstream API token cannot apply labels or assignees. A maintainer must apply `bug`, `priority-high`, `risk-high`, and `blocked` before review routing.

--- a/.ai/specs/2026-07-18-query-index-global-entity-scope.md
+++ b/.ai/specs/2026-07-18-query-index-global-entity-scope.md
@@ -1,0 +1,418 @@
+# Query-index scope resolution for global entities
+
+**Date**: 2026-07-18
+**Status**: Proposed — ready for implementation
+
+## TLDR
+
+**Key points:**
+
+- `query_index.upsert_one` and `query_index.delete_one` currently select `organization_id` and `tenant_id` from every source table. That is invalid for legitimate global entities such as `feature_toggles.feature_toggle`, whose mapped table has neither column.
+- Make the existing scope-verification path metadata-aware. It will read only columns declared by the resolved MikroORM entity, skip the source read for a global entity, and keep source-row authority and mismatch rejection for tenant-scoped entities.
+- Correct the global feature-toggle command producer so every query-index event declares the global scope explicitly as `organizationId: null` and `tenantId: null`.
+
+**Scope:**
+
+- Resolve a registered source entity and its physical scope columns from MikroORM metadata; never infer a table or column from an unregistered `entityType`.
+- Cover the upsert path and the delete path, including delete coverage's second source-table probe.
+- Add focused unit coverage and extend the existing global feature-toggle API integration test to prove that the resulting `entity_indexes` row has global scope.
+
+**MVP:**
+
+- The complete deliverable is the producer, metadata-aware subscriber, delete-coverage, and regression-test set described here. No follow-on phase is planned; later entities gain support automatically through their registered metadata.
+
+**Out of scope:**
+
+- Database schema or migration changes, reindex/backfill work, public API/OpenAPI changes, new UI, cache policy changes, and changes to the all-tenant reindex contract.
+- Treating an unknown/unregistered entity as global. That would turn a metadata/wiring fault into an unchecked event payload.
+
+## Overview
+
+The query-index subscriber is a shared projection consumer. A CRUD mutation emits an existing `query_index.upsert_one` or `query_index.delete_one` event; the subscriber derives the authoritative index scope before touching `entity_indexes`, search tokens, coverage, or search side effects.
+
+`FeatureToggle` is intentionally instance-global: it declares neither `organizationId` nor `tenantId`. Its global command currently carries the authenticated actor's tenant ID into the generic CRUD side-effect helper, which is actor context rather than ownership context. The new invariant is therefore explicit: a source entity with neither mapped scope property emits and indexes only `{ organizationId: null, tenantId: null }`.
+
+> **Market reference:** MikroORM exposes runtime entity metadata, including `properties`, mapped `tableName`, and each property's `fieldNames`; that is the application-authoritative mapping for a code-first ORM ([EntityMetadata](https://mikro-orm.io/api/next/core/class/EntityMetadata), [EntityProperty](https://mikro-orm.io/api/core/interface/EntityProperty)). PostgreSQL's `information_schema.columns` can also reveal table columns, but it is a privilege-filtered database catalogue view ([PostgreSQL documentation](https://www.postgresql.org/docs/17/infoschema-columns.html)). We deliberately do not add a per-event catalogue query or cache: the ORM has already resolved the mapping at bootstrap, and its metadata gives the correct physical column name even if a naming strategy changes.
+
+## Problem statement
+
+`loadQueryIndexRowScope()` resolves a table with `resolveEntityTableName()` and unconditionally projects `organization_id` and `tenant_id`.
+
+For `feature_toggles.feature_toggle`, PostgreSQL rejects that projection because the `feature_toggles` table has neither column. Both subscribers currently convert any load error into `null`, so the event can continue only because its payload supplies a scope. This creates three defects:
+
+1. Every indexed global feature-toggle mutation attempts an invalid SQL read.
+2. A failed source-scope read is indistinguishable from a legitimately deleted/missing source row, weakening the trusted-row boundary added by `fix(query-index): enforce trusted tenant scope in subscribers`.
+3. `delete_one` independently probes `deleted_at` with unconditional `organization_id` and `tenant_id` predicates for coverage accounting, so correcting only `loadQueryIndexRowScope()` leaves the delete path invalid.
+
+The producer adds a fourth issue. `featureToggleIdentifiers()` currently sends `ctx.auth?.tenantId`, even though the source entity is global. An actor's selected tenant must not decide the scope of a global projection row.
+
+## Goals and non-goals
+
+| Goal | Decision |
+|---|---|
+| Preserve tenant isolation | A present source-row scope remains authoritative; a supplied non-null or null value that differs from it is rejected. |
+| Support all three source shapes | Handle both columns, only one scope column, and neither scope column. |
+| Keep global events explicit | A metadata-declared global entity requires both payload keys and each must be exactly `null`. |
+| Fail safely on wiring faults | An unregistered entity or unusable scope metadata throws a `QueryIndexScopeError`; it is recorded by the existing subscriber error path and the originating domain write remains best-effort. |
+| Avoid schema probing | No `information_schema` lookup, migration, cache, or new DI service. |
+| Preserve contracts | Event IDs and payload fields remain unchanged. Only the values emitted for a global feature toggle become correct. |
+
+## User stories / use cases
+
+- **A super administrator** creates, edits, restores, or soft-deletes a global feature toggle, so its index projection is stored once at global scope and no invalid-column query is attempted.
+- **A tenant-scoped module** emits an index event, so the subscriber still derives omitted scope from the source row and rejects an event whose supplied scope differs from that row.
+- **An operator** encounters a bad or unregistered index `entityType`, so the indexer reports a deterministic wiring error instead of silently trusting event scope or guessing a database table.
+
+## Proposed solution
+
+### Design decisions
+
+| Decision | Rationale |
+|---|---|
+| Resolve registered table metadata, not `resolveEntityTableName()` fallback | The fallback pluralizes unregistered IDs. Index scope is security-sensitive and must not query an attacker- or typo-chosen table. `resolveRegisteredEntityTableName()` already provides the strict table-resolution primitive. |
+| Read `properties.organizationId?.fieldNames[0]` and `properties.tenantId?.fieldNames[0]` | The property presence describes whether a scope dimension exists; `fieldNames` supplies the mapped physical identifier. A missing property is a true absent dimension, not a nullable value. |
+| Carry a discriminated source-scope result | `global`, `row`, and `missing` are materially different states. Reusing `null` for all three would let a global entity or a metadata error bypass the correct validation rule. |
+| Remove `loadQueryIndexRowScope(...).catch(() => null)` | A missing row is a normal, explicit result. A metadata or SQL failure must reach the existing outer error handler rather than be mistaken for a deleted row. |
+| Make `FeatureToggle` identifiers constant-global | The source entity owns its scope, not the current actor. This fixes all create/update/delete/undo/redo call sites through one helper. |
+| Reuse source metadata in delete coverage | The delete coverage probe must conditionally add only the scope predicates declared by the source entity; global rows get no scope predicate. |
+
+### Alternatives considered
+
+| Alternative | Rejected because |
+|---|---|
+| Catch missing-column SQL errors and continue from payload | It hides genuine source-read failures and leaves an error on every global mutation. |
+| Query `information_schema.columns` on each event | It adds database round trips and a cache/invalidation problem for data already known to MikroORM. |
+| Maintain a hard-coded allowlist of global entity IDs | Every new global entity would require a central update and could drift from its entity declaration. |
+| Normalize any non-null global payload silently | It masks a producer bug and permits an event contract violation to recur. A global event must explicitly carry two null keys. |
+| Remove query indexing from global feature toggles | It changes existing behavior instead of making the generic indexer correctly support an entity shape it already receives. |
+
+## Architecture
+
+```text
+FeatureToggle command
+  └─ featureToggleIdentifiers() -> { organizationId: null, tenantId: null }
+       └─ DataEngine emits existing query_index.upsert_one / delete_one
+            └─ Query-index subscriber
+                 ├─ resolve registered entity + mapped scope columns
+                 ├─ global: require explicit null/null, no source scope SELECT
+                 ├─ scoped: read only declared scope columns; validate payload against row
+                 └─ write/soft-delete entity_indexes at resolved scope
+```
+
+### 1. Resolve source metadata once per subscriber invocation
+
+Add an internal helper in `packages/core/src/modules/query_index/lib/subscriber-scope.ts` that returns a typed descriptor:
+
+```ts
+type QueryIndexSourceMetadata = {
+  table: string
+  organizationColumn: string | null
+  tenantColumn: string | null
+}
+```
+
+It MUST:
+
+1. Resolve `entityType` with `resolveRegisteredEntityTableName(em, entityType)`.
+2. Find the matching MikroORM metadata entry by the resolved table name.
+3. Read `organizationId` and `tenantId` only from that metadata entry's properties. When present, require exactly one mapped `fieldNames` entry and use that physical column name.
+4. Throw `QueryIndexScopeError` if the table is not registered, metadata cannot be matched, or an expected scope property has no single physical field name.
+
+This descriptor is local to `query_index`; it does not introduce a new shared public API or DI service.
+
+### 2. Represent source-scope state explicitly
+
+Replace the nullable-only internal hand-off with a discriminated result such as:
+
+```ts
+type QueryIndexSourceScope =
+  | { kind: 'global' }
+  | { kind: 'missing' }
+  | { kind: 'row'; scope: QueryIndexScope }
+```
+
+`loadQueryIndexRowScope()` receives the resolved descriptor and behaves as follows:
+
+| Source metadata | Database read | Result |
+|---|---|---|
+| Neither scope property | None | `{ kind: 'global' }` |
+| One or two scope properties, row exists | Select only those mapped columns by primary key | `{ kind: 'row', scope }`; an absent dimension is `null` |
+| One or two scope properties, row absent | Same narrow lookup | `{ kind: 'missing' }` |
+
+All dynamic table and column identifiers originate exclusively in trusted ORM metadata. Query values, including `recordId`, remain Kysely parameters.
+
+### 3. Resolve and validate the index record scope
+
+`resolveQueryIndexRecordScope()` consumes payload-key presence, payload values, and `QueryIndexSourceScope`:
+
+| Source state | Required behavior |
+|---|---|
+| `global` | Both keys MUST be present and both values MUST be `null`; otherwise throw `QueryIndexScopeError`. Return global null/null scope. |
+| `row` | Preserve current behavior: every supplied dimension must equal the row dimension; fill omitted dimensions from the row. |
+| `missing` | Preserve current delete-safe behavior: both payload keys are required because there is no row left to verify; normalize their values exactly as today. |
+
+The `upsert_one` and `delete_one` subscribers must call the helper without an error-swallowing catch. Their existing outer `try/catch` continues to record failures through `recordIndexerError()` and rethrow. The originating `DataEngine` already logs a failed index event without failing the completed domain mutation, so this is fail-closed for the projection but not a user-visible write failure.
+
+### 4. Delete coverage probe
+
+After `markDeleted()`, `delete_one` currently probes the source row to calculate coverage delta. Reuse `QueryIndexSourceMetadata.table` instead of the permissive resolver and add predicates only when the corresponding mapped column exists:
+
+- always: `id = recordId`;
+- when `organizationColumn` exists: compare it with resolved `organizationId`, including `IS NULL` semantics;
+- when `tenantColumn` exists: use existing null-safe equality against resolved `tenantId`.
+
+For `FeatureToggle`, the coverage probe therefore selects `deleted_at` by ID with no organization or tenant predicate. The existing fallback remains unchanged when the `deleted_at` probe itself cannot run; this spec changes only the invalid scope-column assumptions.
+
+### 5. Correct the global producer
+
+Change `featureToggleIdentifiers()` in `packages/core/src/modules/feature_toggles/commands/global.ts` to return a constant scope:
+
+```ts
+{ id: toggle.id, organizationId: null, tenantId: null }
+```
+
+Remove its dependency on `ctx.auth`. Every call site already uses this one helper, including create, update, delete, undo, and redo. No command ID, event ID, request schema, or authorization rule changes.
+
+## Data models
+
+No entity or column changes are introduced.
+
+| Existing model | Change |
+|---|---|
+| `feature_toggles` / `FeatureToggle` | Remains intentionally global with no `organization_id` or `tenant_id`. |
+| `entity_indexes` / `EntityIndexRow` | Receives the existing nullable `organization_id` and `tenant_id` values as null/null for global toggles. |
+| MikroORM metadata | Read-only runtime input to choose a safe projection and predicate; never persisted. |
+
+There are no new PII fields, encryption maps, relationships, foreign keys, lifecycle columns, or transactions.
+
+## Commands and events
+
+No new commands or events are introduced.
+
+| Existing surface | Compatibility decision |
+|---|---|
+| `feature_toggles.global.create`, `.update`, `.delete` | Keep IDs, input schemas, authorization, undo/redo behavior, and cache invalidation. Correct the index side-effect identifiers to global null/null. |
+| `query_index.upsert_one` | Keep event ID and payload shape. For a global `FeatureToggle`, existing scope fields are now explicitly null. |
+| `query_index.delete_one` | Same compatibility rule; delete uses the validated global scope for index soft deletion and coverage. |
+| `query_index.reindex` | Unchanged. In particular, `resolveQueryIndexReindexScope()` and its `allowAllTenants` requirement are not modified. |
+
+The only mutation remains the source feature-toggle command and its existing index side effect. There is no new command graph, event subscription, external call, or undo contract. The projection remains rebuildable from the source entity; command undo/redo continue to emit the appropriate existing index event.
+
+## API contracts and UI/UX
+
+No HTTP route, request/response schema, OpenAPI document, page, component, client boundary, translation, or design-system surface changes.
+
+The existing `GET/POST/PUT/DELETE /api/feature_toggles/global` routes retain their contracts. Their command implementation produces a corrected internal index scope only. Consequently, `CrudForm`, `DataTable`, `apiCall`, `useGuardedMutation`, i18n, and the Frontend Architecture Contract are not applicable.
+
+## Performance, cache, and scale
+
+| Concern | Design |
+|---|---|
+| Global mutation | Removes one failing source scope query entirely. |
+| Tenant-scoped mutation | Keeps one primary-key point lookup, but narrows its projection to one or two actual columns. |
+| Delete coverage | Retains its one source-row point lookup; it removes nonexistent predicates for global/partial-scope tables. |
+| Metadata lookup | In-memory ORM metadata only; no database catalogue read, cache, or invalidation path. |
+| Indexes | Existing source primary keys support all lookups. No new index is necessary. |
+| N+1 / bulk | Each event handles one record as before. Existing bulk/reindex batching is unchanged. |
+| Cache | No read cache or cache key is introduced; no invalidation changes are needed. |
+
+## Migration and backward compatibility
+
+- No migration, backfill, generated-file change, configuration change, or deployment ordering constraint is required.
+- The existing event IDs and fields remain stable. The corrected null/null values for global feature-toggle events are a bug fix: they now match the ownership model declared by `FeatureToggle`.
+- Tenant-scoped event behavior remains backward compatible: omitted scope still derives from a source row, and a deleted source row still requires an explicit full payload scope.
+- An unregistered `entityType` changes from best-effort table guessing to a logged index failure. This is intentional security hardening; valid CRUD indexers are registered through generated entity metadata.
+- Rollback is code-only. Reverting the change restores prior behavior; it does not need data reversal. A pre-existing wrongly scoped global index row will be corrected by the next create/update/redo/reindex path, with no schema work.
+
+## Implementation plan
+
+### Phase 1 — Establish the global producer contract
+
+1. Modify `featureToggleIdentifiers()` to emit null/null without reading the command actor. Update `commands/__tests__/global.test.ts` so a super-admin context with a real tenant ID still passes null/null identifiers to `markOrmEntityChange`. **Verification:** existing global command tests pass, and the assertion proves actor scope cannot leak into a global index event.
+2. Extend `TC-FT-001.spec.ts`'s self-cleaning create → update → delete flow. After create and update, read the existing `entity_indexes` projection through `withClient()` and assert `organization_id IS NULL` and `tenant_id IS NULL`; after delete, assert the projection row is removed. `markDeleted()` already physically removes projection rows, so this preserves the existing delete contract. **Verification:** the API flow succeeds and the persisted active projection is global at every lifecycle point.
+
+### Phase 2 — Make query-index scope resolution metadata-aware
+
+3. Add the internal registered-source metadata descriptor and discriminated `global`/`row`/`missing` source-scope result in `lib/subscriber-scope.ts`. Replace permissive table fallback with `resolveRegisteredEntityTableName()`, project only declared mapped scope columns, and reject unknown metadata. **Verification:** unit tests cover both, tenant-only, global, missing-row, and unknown-metadata cases.
+4. Update `resolveQueryIndexRecordScope()` to enforce explicit null/null for a metadata-declared global entity while retaining existing row authority and missing-row compatibility. Remove the `.catch(() => null)` from both subscribers. **Verification:** mismatch and missing-row regression tests remain green; global wrong/non-null payloads are rejected.
+5. Reuse the source descriptor in `subscribers/delete_one.ts` so its coverage probe conditionally applies scope predicates. **Verification:** a global delete makes no scope predicate/read, while a tenant-scoped delete retains both predicates.
+
+### Phase 3 — Prove the event paths and validate
+
+6. Add subscriber-level unit tests for global upsert and delete. Assert global upsert calls `upsertIndexRow` with null/null and never creates a scope SELECT; assert global delete's coverage probe uses only the ID predicate and writes/marks the global index row. **Verification:** these tests fail against the old unconditional-column implementation.
+7. Run the focused Jest suites, the affected integration scenario, and type checking with the repository's selected runner. **Verification:** no generated files change and the diff has no whitespace errors.
+
+### File manifest
+
+| File | Action | Purpose |
+|---|---|---|
+| `packages/core/src/modules/query_index/lib/subscriber-scope.ts` | Modify | Resolve registered metadata, model source-scope state, and enforce its validation rules. |
+| `packages/core/src/modules/query_index/subscribers/upsert_one.ts` | Modify | Use the strict metadata/scope result and stop swallowing scope-load failures. |
+| `packages/core/src/modules/query_index/subscribers/delete_one.ts` | Modify | Use the strict result and build the coverage probe from declared source columns. |
+| `packages/core/src/modules/query_index/__tests__/subscriber-scope.test.ts` | Modify | Cover metadata shapes and resolver invariants. |
+| `packages/core/src/modules/query_index/__tests__/delete-one-coverage.test.ts` or a focused sibling | Modify/Create | Prove global delete omits scope predicates while scoped behavior remains intact. |
+| `packages/core/src/modules/query_index/__tests__/upsert-one-global-scope.test.ts` | Create | Prove global upsert uses null/null without a source scope SELECT. |
+| `packages/core/src/modules/feature_toggles/commands/global.ts` | Modify | Emit global identifiers through the existing shared helper path. |
+| `packages/core/src/modules/feature_toggles/commands/__tests__/global.test.ts` | Modify | Assert global command side effects are independent of actor tenant scope. |
+| `packages/core/src/modules/feature_toggles/__integration__/TC-FT-001.spec.ts` | Modify | Assert index projection scope through the existing self-cleaning API lifecycle test. |
+
+## Testing strategy
+
+### Unit tests
+
+| ID | Coverage | Expected result |
+|---|---|---|
+| `TC-QI-SCOPE-001` | Registered entity with both scope columns | A primary-key lookup selects both mapped fields; omitted payload scope derives from the row; mismatches reject. |
+| `TC-QI-SCOPE-002` | Registered tenant-only entity | The lookup selects only `tenant_id`; the absent organization dimension is null and a non-null payload organization is rejected. |
+| `TC-QI-SCOPE-003` | `FeatureToggle` global entity | No Kysely scope query is made; only explicit `organizationId: null, tenantId: null` resolves. |
+| `TC-QI-SCOPE-004` | Missing source row | Existing full explicit payload behavior remains valid for delete timing. |
+| `TC-QI-SCOPE-005` | Unknown or unmatched metadata | A `QueryIndexScopeError` is raised; no pluralized table fallback is used. |
+| `TC-QI-UPSERT-001` | Global upsert subscriber | Calls `upsertIndexRow` with null/null and does not record a missing-column source-read error. |
+| `TC-QI-DELETE-001` | Global delete subscriber | Coverage source probe includes only ID (no organization/tenant predicate); global `markDeleted` scope is null/null. |
+| `TC-FT-SCOPE-001` | Create/update/delete and undo/redo command paths | Every `markOrmEntityChange` identifier set is null/null even when the actor has a tenant ID. |
+
+### Integration coverage
+
+Extend `packages/core/src/modules/feature_toggles/__integration__/TC-FT-001.spec.ts`; do not add a separate fixture family.
+
+1. Log in as the existing super-admin fixture and create a uniquely named global feature toggle through `POST /api/feature_toggles/global`.
+2. Read `entity_indexes` with the existing exported `withClient()` test helper and assert the one `feature_toggles:feature_toggle` projection has null organization and tenant fields.
+3. Update through the existing API and assert the same global scope again.
+4. Delete through the existing API, assert the projection has no remaining row, then use the test's current `finally` cleanup path.
+
+The test creates data through the API, reuses its existing `finally` cleanup, and reads only its own generated record ID. It needs no seeded feature toggle, no migration, no external service, or UI path because this is an internal index-side-effect correction with no customer-facing UI change.
+
+### Validation commands
+
+Choose the runner once using the root `AGENTS.md` rule. Expected minimal gate sequence:
+
+```bash
+# Local runner
+yarn workspace @open-mercato/core test --runInBand --runTestsByPath \
+  src/modules/query_index/__tests__/subscriber-scope.test.ts \
+  src/modules/query_index/__tests__/delete-one-coverage.test.ts \
+  src/modules/query_index/__tests__/upsert-one-global-scope.test.ts \
+  src/modules/feature_toggles/commands/__tests__/global.test.ts
+
+OM_INTEGRATION_MODULES=feature_toggles npx playwright test --config .ai/qa/tests/playwright.config.ts TC-FT-001
+yarn workspace @open-mercato/core typecheck
+git diff --check
+```
+
+In Docker mode, replace each `yarn …` gate with `node scripts/docker-exec.mjs …`; invoke the Playwright command in the environment selected by the integration-test runner. No `yarn generate` is required because no auto-discovered module file is added or changed.
+
+## Risks and impact review
+
+#### Incorrectly treating an unknown entity as global
+
+- **Scenario**: An index event contains a typo or unregistered `entityType`; a permissive fallback infers a table or treats the absence of metadata as global and accepts its payload scope.
+- **Severity**: High
+- **Affected area**: Query-index tenant isolation and projection integrity.
+- **Mitigation**: Resolve only registered metadata and throw `QueryIndexScopeError` when it cannot be found. Do not convert this error to `missing`.
+- **Residual risk**: The originating domain write can complete without its index projection because index side effects are intentionally best-effort. The existing indexer-error logging makes the fault detectable and a later reindex can repair it.
+
+#### Cross-tenant or duplicate global projection
+
+- **Scenario**: The actor's selected tenant is emitted for a global feature toggle, yielding a tenant-scoped index row for instance-global data.
+- **Severity**: High
+- **Affected area**: `entity_indexes`, coverage, and downstream search/index events.
+- **Mitigation**: The global producer emits null/null; the metadata-declared global resolver requires exactly null/null; integration coverage observes the persisted projection after all three API mutations.
+- **Residual risk**: Legacy rows may retain an old non-null tenant until the record changes or is reindexed. No schema or API data is exposed through this correction, and the next lifecycle event corrects the row.
+
+#### Delete path still queries missing columns
+
+- **Scenario**: Scope loading is fixed but delete coverage retains unconditional organization/tenant predicates, causing an invalid-column read during every global delete.
+- **Severity**: Medium
+- **Affected area**: `query_index.delete_one` coverage accounting.
+- **Mitigation**: Reuse the resolved source descriptor to construct predicates only for declared scope fields; add a subscriber-level global-delete regression test.
+- **Residual risk**: The independent `deleted_at` probe may still use its established fallback for entities that do not support soft delete. That existing fallback remains conservative (`baseDelta = -1`).
+
+#### Metadata shape or naming-strategy regression
+
+- **Scenario**: A future entity maps a scope property unusually, yielding no or multiple physical `fieldNames`.
+- **Severity**: Medium
+- **Affected area**: Index event processing for that entity.
+- **Mitigation**: Validate a single mapped column in the descriptor and fail with a diagnosable `QueryIndexScopeError`; tests cover mapped column selection rather than hard-coded names.
+- **Residual risk**: Such an entity will not be indexed until its mapping is corrected, which is safer than reading an arbitrary physical column.
+
+#### Event storm or latency regression
+
+- **Scenario**: Metadata resolution adds work to every write-heavy index event.
+- **Severity**: Low
+- **Affected area**: CRUD latency and event throughput.
+- **Mitigation**: Use already-loaded runtime metadata, remove the global-table scope query, retain one primary-key lookup only for scoped records, and add no database catalogue query or cache.
+- **Residual risk**: Existing per-record query-index work remains; bulk/reindex batching and coverage throttling are unchanged.
+
+## Final compliance report — 2026-07-18
+
+### AGENTS.md files reviewed
+
+- `AGENTS.md` (root)
+- `packages/core/AGENTS.md`
+- `packages/shared/AGENTS.md`
+- `packages/search/AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `.ai/qa/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance matrix
+
+| Rule source | Rule | Status | Notes |
+|---|---|---|---|
+| Root `AGENTS.md` | Preserve behavior unless a spec requests change; keep changes minimal and integrated at real call sites | Compliant | Corrects two real event paths and the single global producer helper; no unrelated refactor. |
+| Root `AGENTS.md` | Never expose cross-tenant data or skip tenant/organization scoping | Compliant | Source row remains authoritative; global entities explicitly resolve only null/null; unknown metadata fails closed. |
+| `BACKWARD_COMPATIBILITY.md` | Do not remove/rename event IDs or payload fields | Compliant | `query_index.*` IDs and fields are unchanged; global value correction is intentional. |
+| `packages/core/AGENTS.md` | Event subscribers use module subscriber conventions | Compliant | Modifies existing non-persistent subscribers only; no new cross-module import or event. |
+| `packages/core/AGENTS.md` | Cross-module side effects use events | Compliant | Retains existing DataEngine → query-index event boundary; no direct module coupling. |
+| `packages/shared/AGENTS.md` | Shared has no domain logic; avoid new broad public contracts | Compliant | The metadata helper remains inside `query_index`; it reuses the existing strict shared table resolver. |
+| `packages/search/AGENTS.md` | Search/index changes define scope and index strategy | Compliant | Projection scope is explicit; no search schema, index, or reindex strategy change. |
+| `.ai/qa/AGENTS.md` | Integration tests are self-contained and clean up fixtures | Compliant | Extends existing API-created, `finally`-cleaned `TC-FT-001`; DB read is limited to its own record. |
+| Root/API and UI rules | `makeCrudRoute`, OpenAPI, CrudForm/DataTable, `apiCall`, i18n, DS tokens | N/A | No route, UI, client, or user-visible string change. |
+| Root/data rules | New entities require tenancy, optimistic locking, migrations, and encryption review | N/A | No entity or sensitive data is added or changed. |
+| Frontend Architecture Contract | Required for app/UI/client-boundary work | N/A | No frontend file or UI behavior changes. |
+
+### Internal consistency check
+
+| Check | Status | Notes |
+|---|---|---|
+| Data models match event scope | Pass | `FeatureToggle` has no scope fields; projection scope becomes null/null. |
+| Event contract matches producer and subscriber | Pass | Existing fields retained; producer, source metadata, and resolver agree on global semantics. |
+| Risks cover all mutation paths | Pass | Create/update/delete plus undo/redo share one corrected identifier helper; delete coverage is explicit. |
+| Cache and scale behavior | Pass | No cache added; source reads remain primary-key point lookups. |
+| API/UI compatibility | Pass | No public endpoint or UI contract changes. |
+
+### Non-compliant items
+
+None.
+
+### Verdict
+
+**Approved — ready for implementation.**
+
+## Review record
+
+### Author review — 2026-07-18
+
+- **Security**: Passed — strict registered metadata resolution, row mismatch rejection, and explicit global null scope.
+- **Performance**: Passed — removes global scope reads and adds no database catalogue query.
+- **Cache**: N/A — no cache behavior changes.
+- **Commands**: Passed — existing command IDs, undo/redo, and event IDs stay intact.
+- **Risks**: Passed — scope, delete coverage, metadata drift, and operational detection documented.
+- **Verdict**: Approved.
+
+### Independent scope-cohesion review — 2026-07-18
+
+- **Reviewer**: Fresh-context agent, given only this spec path.
+- **Result**: **KEEP** — source producer, generic metadata-aware scope resolver, and delete-coverage predicate repair are one atomic capability. Each half alone would either retain invalid source-column probes or cause existing global feature-toggle events to fail.
+- **Boundary check**: The strict unregistered-entity rule is a necessary security property of the same resolver, not an independently deployable feature. No schema, reindex, API, or UI scope has been added.
+- **Follow-up applied**: Added an explicit MVP/no-future-phase statement.
+
+## Changelog
+
+### 2026-07-18
+
+- Expanded the skeleton into an implementation-ready specification.
+- Resolved Q1: global feature-toggle events must emit explicit null/null scope rather than normalize actor tenant scope inside `query_index`.
+- Added metadata-driven scope resolution, strict unknown-entity handling, delete-coverage repair, unit/integration coverage, compatibility, risk, and compliance requirements.
+- Recorded an independent scope-cohesion **KEEP** review and explicit MVP boundary.
+- Corrected the integration delete expectation to match the established physical removal of `entity_indexes` rows by `markDeleted()`; this avoids an unrelated projection-storage semantics change.

--- a/.ai/specs/2026-07-18-query-index-global-entity-scope.md
+++ b/.ai/specs/2026-07-18-query-index-global-entity-scope.md
@@ -204,6 +204,8 @@ No HTTP route, request/response schema, OpenAPI document, page, component, clien
 
 The existing `GET/POST/PUT/DELETE /api/feature_toggles/global` routes retain their contracts. Their command implementation produces a corrected internal index scope only. Consequently, `CrudForm`, `DataTable`, `apiCall`, `useGuardedMutation`, i18n, and the Frontend Architecture Contract are not applicable.
 
+The global list route keeps the authenticated tenant value only to satisfy the query engine's required request context, but sets `omitAutomaticTenantOrgScope: true`: `FeatureToggle` has no tenant or organization column, and its query-index row is explicitly null/null. In that documented direct-query mode, `BasicQueryEngine` must bypass scope-bound `search_tokens` filtering and apply the endpoint's existing SQL filters directly; otherwise a correct global projection is hidden by the actor's tenant filter.
+
 ## Performance, cache, and scale
 
 | Concern | Design |
@@ -255,6 +257,9 @@ The existing `GET/POST/PUT/DELETE /api/feature_toggles/global` routes retain the
 | `packages/core/src/modules/feature_toggles/commands/global.ts` | Modify | Emit global identifiers through the existing shared helper path. |
 | `packages/core/src/modules/feature_toggles/commands/__tests__/global.test.ts` | Modify | Assert global command side effects are independent of actor tenant scope. |
 | `packages/core/src/modules/feature_toggles/__integration__/TC-FT-001.spec.ts` | Modify | Assert index projection scope through the existing self-cleaning API lifecycle test. |
+| `packages/core/src/modules/feature_toggles/api/global/route.ts` | Modify | List global toggles without automatic tenant/org filtering while retaining required query context. |
+| `packages/shared/src/lib/query/engine.ts` | Modify | Skip scope-bound token filtering for the documented direct-query scope mode. |
+| `packages/shared/src/lib/query/__tests__/engine.test.ts` | Modify | Prove direct-query mode applies the original SQL filter rather than a tenant-scoped token filter. |
 
 ## Testing strategy
 
@@ -270,6 +275,7 @@ The existing `GET/POST/PUT/DELETE /api/feature_toggles/global` routes retain the
 | `TC-QI-UPSERT-001` | Global upsert subscriber | Calls `upsertIndexRow` with null/null and does not record a missing-column source-read error. |
 | `TC-QI-DELETE-001` | Global delete subscriber | Coverage source probe includes only ID (no organization/tenant predicate); global `markDeleted` scope is null/null. |
 | `TC-FT-SCOPE-001` | Create/update/delete and undo/redo command paths | Every `markOrmEntityChange` identifier set is null/null even when the actor has a tenant ID. |
+| `TC-QI-LIST-SCOPE-001` | Direct global-list query | `omitAutomaticTenantOrgScope` bypasses scope-bound search tokens and retains the endpoint's SQL `ilike` filter. |
 
 ### Integration coverage
 
@@ -281,6 +287,8 @@ Extend `packages/core/src/modules/feature_toggles/__integration__/TC-FT-001.spec
 4. Delete through the existing API, assert the projection has no remaining row, then use the test's current `finally` cleanup path.
 
 The test creates data through the API, reuses its existing `finally` cleanup, and reads only its own generated record ID. It needs no seeded feature toggle, no migration, no external service, or UI path because this is an internal index-side-effect correction with no customer-facing UI change.
+
+Run the existing `TC-FT-008` list/pagination scenario as well: it creates three global toggles and proves identifier, search, category, type, name, sort, and pagination filters can retrieve the null/null indexed records.
 
 ### Validation commands
 
@@ -296,6 +304,8 @@ yarn workspace @open-mercato/core test --runInBand --runTestsByPath \
 
 OM_INTEGRATION_MODULES=feature_toggles npx playwright test --config .ai/qa/tests/playwright.config.ts TC-FT-001
 yarn workspace @open-mercato/core typecheck
+yarn workspace @open-mercato/shared test --runInBand --runTestsByPath src/lib/query/__tests__/engine.test.ts
+yarn test:integration:ephemeral feature_toggles
 git diff --check
 ```
 
@@ -318,6 +328,14 @@ In Docker mode, replace each `yarn …` gate with `node scripts/docker-exec.mjs 
 - **Affected area**: `entity_indexes`, coverage, and downstream search/index events.
 - **Mitigation**: The global producer emits null/null; the metadata-declared global resolver requires exactly null/null; integration coverage observes the persisted projection after all three API mutations.
 - **Residual risk**: Legacy rows may retain an old non-null tenant until the record changes or is reindexed. No schema or API data is exposed through this correction, and the next lifecycle event corrects the row.
+
+#### Correct global projection is hidden by a scoped list filter
+
+- **Scenario**: The producer and index projection are corrected to null/null, but `GET /api/feature_toggles/global` routes `ilike` filters through `search_tokens` scoped to the request tenant, returning an empty result.
+- **Severity**: High
+- **Affected area**: Global feature-toggle list, filtering, and pagination.
+- **Mitigation**: The route opts into the existing direct-query scope mode; `BasicQueryEngine` disables scope-bound token filtering in that mode and unit plus feature-toggle integration coverage verifies the direct SQL filters.
+- **Residual risk**: Direct-query mode is reserved for globally visible routes; tenant-scoped callers retain automatic scope and token filtering.
 
 #### Delete path still queries missing columns
 
@@ -418,10 +436,15 @@ None.
 - Corrected the integration delete expectation to match the established physical removal of `entity_indexes` rows by `markDeleted()`; this avoids an unrelated projection-storage semantics change.
 - Required exact generated entity-ID membership before resolving MikroORM metadata, because table resolution alone can match a class-name collision under another module prefix.
 
+### 2026-07-22
+
+- Fixed the global feature-toggle list after its projection scope became null/null: retained the query context but opted the route into documented global direct-query scope, and made that mode bypass scope-bound search-token filters.
+- Added query-engine regression coverage and ran the complete self-cleaning feature-toggle integration suite.
+
 ## Implementation Status
 
 | Phase | Status | Date | Notes |
 |---|---|---|---|
 | Phase 1 — Establish the global producer contract | Done | 2026-07-18 | All feature-toggle lifecycle side effects now emit explicit null/null identifiers; unit and integration assertions were added. |
 | Phase 2 — Make query-index scope resolution metadata-aware | Done | 2026-07-18 | Registered entity-ID and metadata resolution distinguish global, row, and missing scope state; delete coverage uses declared predicates only. |
-| Phase 3 — Prove event paths and validate | Blocked | 2026-07-18 | Focused Jest suites, full local validation, and the managed `TC-FT-001` scenario pass. The repository-wide managed suite is blocked before test execution by stale sibling `.worktrees` that discovery does not ignore. |
+| Phase 3 — Prove event paths and validate | In review | 2026-07-22 | The shared query regression and all 22 managed feature-toggle integration tests pass. The full repository integration suite remains pending CI because local stale `.worktrees` interfere with Playwright discovery. |

--- a/.ai/specs/2026-07-18-query-index-global-entity-scope.md
+++ b/.ai/specs/2026-07-18-query-index-global-entity-scope.md
@@ -8,7 +8,7 @@
 **Key points:**
 
 - `query_index.upsert_one` and `query_index.delete_one` currently select `organization_id` and `tenant_id` from every source table. That is invalid for legitimate global entities such as `feature_toggles.feature_toggle`, whose mapped table has neither column.
-- Make the existing scope-verification path metadata-aware. It will read only columns declared by the resolved MikroORM entity, skip the source read for a global entity, and keep source-row authority and mismatch rejection for tenant-scoped entities.
+- Make the existing scope-verification path metadata-aware. It will require the generated entity-ID registry and resolved MikroORM metadata, read only declared scope columns, skip the source read for a global entity, and keep source-row authority and mismatch rejection for tenant-scoped entities.
 - Correct the global feature-toggle command producer so every query-index event declares the global scope explicitly as `organizationId: null` and `tenantId: null`.
 
 **Scope:**
@@ -69,7 +69,7 @@ The producer adds a fourth issue. `featureToggleIdentifiers()` currently sends `
 
 | Decision | Rationale |
 |---|---|
-| Resolve registered table metadata, not `resolveEntityTableName()` fallback | The fallback pluralizes unregistered IDs. Index scope is security-sensitive and must not query an attacker- or typo-chosen table. `resolveRegisteredEntityTableName()` already provides the strict table-resolution primitive. |
+| Require generated entity-ID membership plus registered table metadata, not `resolveEntityTableName()` fallback | The fallback pluralizes unregistered IDs, and `resolveRegisteredEntityTableName()` alone can match a different module prefix that shares an entity segment. Index scope is security-sensitive and must not query an attacker- or typo-chosen table. |
 | Read `properties.organizationId?.fieldNames[0]` and `properties.tenantId?.fieldNames[0]` | The property presence describes whether a scope dimension exists; `fieldNames` supplies the mapped physical identifier. A missing property is a true absent dimension, not a nullable value. |
 | Carry a discriminated source-scope result | `global`, `row`, and `missing` are materially different states. Reusing `null` for all three would let a global entity or a metadata error bypass the correct validation rule. |
 | Remove `loadQueryIndexRowScope(...).catch(() => null)` | A missing row is a normal, explicit result. A metadata or SQL failure must reach the existing outer error handler rather than be mistaken for a deleted row. |
@@ -113,10 +113,10 @@ type QueryIndexSourceMetadata = {
 
 It MUST:
 
-1. Resolve `entityType` with `resolveRegisteredEntityTableName(em, entityType)`.
+1. Require `entityType` to be an exact member of the generated entity-ID registry, then resolve it with `resolveRegisteredEntityTableName(em, entityType)`.
 2. Find the matching MikroORM metadata entry by the resolved table name.
 3. Read `organizationId` and `tenantId` only from that metadata entry's properties. When present, require exactly one mapped `fieldNames` entry and use that physical column name.
-4. Throw `QueryIndexScopeError` if the table is not registered, metadata cannot be matched, or an expected scope property has no single physical field name.
+4. Throw `QueryIndexScopeError` if the ID is not registered, the table is not registered, metadata cannot be matched, or an expected scope property has no single physical field name.
 
 This descriptor is local to `query_index`; it does not introduce a new shared public API or DI service.
 
@@ -266,7 +266,7 @@ The existing `GET/POST/PUT/DELETE /api/feature_toggles/global` routes retain the
 | `TC-QI-SCOPE-002` | Registered tenant-only entity | The lookup selects only `tenant_id`; the absent organization dimension is null and a non-null payload organization is rejected. |
 | `TC-QI-SCOPE-003` | `FeatureToggle` global entity | No Kysely scope query is made; only explicit `organizationId: null, tenantId: null` resolves. |
 | `TC-QI-SCOPE-004` | Missing source row | Existing full explicit payload behavior remains valid for delete timing. |
-| `TC-QI-SCOPE-005` | Unknown or unmatched metadata | A `QueryIndexScopeError` is raised; no pluralized table fallback is used. |
+| `TC-QI-SCOPE-005` | Unknown, prefix-colliding, or unmatched metadata | A `QueryIndexScopeError` is raised; no pluralized-table or class-name collision fallback is used. |
 | `TC-QI-UPSERT-001` | Global upsert subscriber | Calls `upsertIndexRow` with null/null and does not record a missing-column source-read error. |
 | `TC-QI-DELETE-001` | Global delete subscriber | Coverage source probe includes only ID (no organization/tenant predicate); global `markDeleted` scope is null/null. |
 | `TC-FT-SCOPE-001` | Create/update/delete and undo/redo command paths | Every `markOrmEntityChange` identifier set is null/null even when the actor has a tenant ID. |
@@ -416,3 +416,12 @@ None.
 - Added metadata-driven scope resolution, strict unknown-entity handling, delete-coverage repair, unit/integration coverage, compatibility, risk, and compliance requirements.
 - Recorded an independent scope-cohesion **KEEP** review and explicit MVP boundary.
 - Corrected the integration delete expectation to match the established physical removal of `entity_indexes` rows by `markDeleted()`; this avoids an unrelated projection-storage semantics change.
+- Required exact generated entity-ID membership before resolving MikroORM metadata, because table resolution alone can match a class-name collision under another module prefix.
+
+## Implementation Status
+
+| Phase | Status | Date | Notes |
+|---|---|---|---|
+| Phase 1 — Establish the global producer contract | Done | 2026-07-18 | All feature-toggle lifecycle side effects now emit explicit null/null identifiers; unit and integration assertions were added. |
+| Phase 2 — Make query-index scope resolution metadata-aware | Done | 2026-07-18 | Registered entity-ID and metadata resolution distinguish global, row, and missing scope state; delete coverage uses declared predicates only. |
+| Phase 3 — Prove event paths and validate | In Progress | 2026-07-18 | Focused Jest suites pass; managed integration and repository validation gates remain. |

--- a/.ai/specs/2026-07-18-query-index-global-entity-scope.md
+++ b/.ai/specs/2026-07-18-query-index-global-entity-scope.md
@@ -424,4 +424,4 @@ None.
 |---|---|---|---|
 | Phase 1 — Establish the global producer contract | Done | 2026-07-18 | All feature-toggle lifecycle side effects now emit explicit null/null identifiers; unit and integration assertions were added. |
 | Phase 2 — Make query-index scope resolution metadata-aware | Done | 2026-07-18 | Registered entity-ID and metadata resolution distinguish global, row, and missing scope state; delete coverage uses declared predicates only. |
-| Phase 3 — Prove event paths and validate | In Progress | 2026-07-18 | Focused Jest suites pass; managed integration and repository validation gates remain. |
+| Phase 3 — Prove event paths and validate | Blocked | 2026-07-18 | Focused Jest suites, full local validation, and the managed `TC-FT-001` scenario pass. The repository-wide managed suite is blocked before test execution by stale sibling `.worktrees` that discovery does not ignore. |

--- a/.ai/specs/analysis/ANALYSIS-2026-07-18-query-index-global-entity-scope.md
+++ b/.ai/specs/analysis/ANALYSIS-2026-07-18-query-index-global-entity-scope.md
@@ -1,0 +1,113 @@
+# Pre-Implementation Analysis: Query-index scope resolution for global entities
+
+## Executive Summary
+
+The specification is ready to implement as a focused core hardening change. It preserves every published event, API, schema, and generated-file contract while closing an unsafe permissive table-resolution path and correcting a global producer that leaks actor scope. One test assertion conflicts with the established physical-delete behavior of `entity_indexes`; the implementation should preserve that behavior and assert the projection row is absent after delete.
+
+## Backward Compatibility
+
+### Violations Found
+
+| # | Surface | Issue | Severity | Proposed Fix |
+|---|---|---|---|---|
+| 1 | Internal integration expectation | The source spec expects a soft-deleted projection after feature-toggle delete, but `markDeleted()` physically removes `entity_indexes` rows. | Warning | Keep current deletion semantics; assert no matching projection row after DELETE and record the correction in the copied spec. |
+
+### 13-surface audit
+
+| Surface | Result |
+|---|---|
+| Auto-discovery conventions | No files or exports are renamed; existing subscriber paths remain unchanged. |
+| Public types and interfaces | The descriptor and source-scope union remain internal to `query_index`. |
+| Function signatures | No public function signature changes. |
+| Import paths | No moved public import path. |
+| Event IDs and payloads | `query_index.upsert_one` and `delete_one` IDs and fields remain unchanged; feature-toggle values become correct null/null scope. |
+| Widget injection spots | Not applicable; no UI changes. |
+| API URLs and schemas | Unchanged. |
+| Database schema | Unchanged. |
+| DI names | Unchanged. |
+| ACL features | Unchanged. |
+| Notification type IDs | Unchanged. |
+| CLI commands | Unchanged. |
+| Generated contracts | No generated file is edited; no discovery convention changes. |
+
+## Spec Completeness
+
+### Missing Sections
+
+| Section | Impact | Recommendation |
+|---|---|---|
+| None | The source includes scope, architecture, data, compatibility, risk, implementation, unit, and integration coverage sections. | No addition required. |
+
+### Incomplete Sections
+
+| Section | Gap | Recommendation |
+|---|---|---|
+| Integration coverage | Delete expects a soft-deleted projection despite established physical deletion. | Assert the projection is absent after DELETE; keep the create/update null-scope assertions. |
+| Integration metadata | The feature-toggle integration folder currently declares only `feature_toggles`, while the new DB assertion depends on query indexing. | Add `query_index` to the existing module dependencies if module-gated runs permit it. |
+
+## AGENTS.md Compliance
+
+### Violations
+
+| Rule | Location | Fix |
+|---|---|---|
+| Preserve tenant/organization scoping and never trust an arbitrary table | Existing `loadQueryIndexRowScope()` uses permissive `resolveEntityTableName()` and both subscribers convert any error to missing-row scope. | Resolve only registered metadata, distinguish global/row/missing results, and let metadata or SQL failures reach the existing error recorder. |
+| Persistent/index side effects must preserve contracts | Feature-toggle command helper derives index scope from the actor. | Use a context-free global identifier helper returning null/null on every lifecycle path. |
+| Integration tests are self-cleaning and module-local | Extended `TC-FT-001` reads the shared projection table. | Query only the generated toggle ID; retain API cleanup and remove any residual exact projection row in `finally`. |
+
+## Risk Assessment
+
+### High Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Treating unknown metadata as global | A malformed entity ID could bypass scope verification or query an inferred table. | Require registered table metadata and throw `QueryIndexScopeError`; cover unknown metadata. |
+| Actor scope leaks into global projection | Global data may be stored as tenant-scoped, creating incorrect coverage and token side effects. | Constant global identifiers plus strict explicit-null global payload validation. |
+
+### Medium Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Delete coverage retains invalid predicates | Global deletes continue issuing invalid-column SQL. | Reuse the resolved descriptor and conditionally add only declared scope predicates. |
+| Metadata mapping drift | An unusual property mapping could select an invalid column. | Require exactly one mapped `fieldNames` entry for each declared scope property and fail closed. |
+
+### Low Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| In-memory metadata lookup per event | Small event-path overhead. | Use already-loaded ORM metadata; global entities remove the current source query. |
+
+## Gap Analysis
+
+### Critical Gaps (Block Implementation)
+
+- None.
+
+### Important Gaps (Should Address)
+
+- Preserve physical projection deletion in the integration test rather than changing `markDeleted()` outside the declared scope.
+- Assert a present global payload is literal `null`, not an omitted or `undefined` value normalized by `??`.
+
+### Nice-to-Have Gaps
+
+- None; the existing feature-toggle lifecycle test is the correct fixture family.
+
+## Remediation Plan
+
+### Before Implementation (Must Do)
+
+1. Land the source spec and this analysis, including the physical-delete correction.
+2. Create loop artifacts with a resumable task table.
+
+### During Implementation (Add to Spec)
+
+1. Record that all source table and column identifiers derive exclusively from registered MikroORM metadata.
+2. Add unit and integration evidence for global, partial-scope, missing-row, mismatch, and unknown-entity behavior.
+
+### Post-Implementation (Follow Up)
+
+1. Run the configured validation gate and review the actual diff against the full checklist.
+
+## Recommendation
+
+Ready to implement. The physical-delete test correction is a non-breaking clarification that preserves current projection storage semantics.

--- a/packages/core/src/modules/feature_toggles/__integration__/TC-FT-001.spec.ts
+++ b/packages/core/src/modules/feature_toggles/__integration__/TC-FT-001.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures'
 import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
 import { readJsonSafe } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
 import {
@@ -6,11 +7,48 @@ import {
   deleteFeatureToggleIfExists,
 } from '@open-mercato/core/modules/core/__integration__/helpers/featureTogglesFixtures'
 
+const FEATURE_TOGGLE_ENTITY_TYPE = 'feature_toggles:feature_toggle'
+
+type FeatureToggleIndexRow = {
+  organization_id: string | null
+  tenant_id: string | null
+  deleted_at: Date | null
+}
+
+async function readFeatureToggleIndexRows(toggleId: string): Promise<FeatureToggleIndexRow[]> {
+  return withClient(async (client) => {
+    const result = await client.query<FeatureToggleIndexRow>(
+      `select organization_id, tenant_id, deleted_at
+       from entity_indexes
+       where entity_type = $1 and entity_id = $2`,
+      [FEATURE_TOGGLE_ENTITY_TYPE, toggleId],
+    )
+    return result.rows
+  })
+}
+
+async function expectGlobalFeatureToggleProjection(toggleId: string): Promise<void> {
+  const rows = await readFeatureToggleIndexRows(toggleId)
+  expect(rows).toHaveLength(1)
+  expect(rows[0]).toMatchObject({ organization_id: null, tenant_id: null, deleted_at: null })
+}
+
+async function deleteFeatureToggleProjectionIfExists(toggleId: string | null): Promise<void> {
+  if (!toggleId) return
+  await withClient(async (client) => {
+    await client.query(
+      'delete from entity_indexes where entity_type = $1 and entity_id = $2',
+      [FEATURE_TOGGLE_ENTITY_TYPE, toggleId],
+    )
+  })
+}
+
 test.describe('TC-FT-001: Global feature toggle CRUD APIs', () => {
   test('should create, update, list, and delete a global feature toggle', async ({ request }) => {
     const token = await getAuthToken(request, 'superadmin')
     const identifier = `qa_toggle_${Date.now()}`
     let toggleId: string | null = null
+    let indexedToggleId: string | null = null
 
     try {
       toggleId = await createFeatureToggleFixture(request, token, {
@@ -21,6 +59,8 @@ test.describe('TC-FT-001: Global feature toggle CRUD APIs', () => {
         type: 'boolean',
         defaultValue: true,
       })
+      indexedToggleId = toggleId
+      await expectGlobalFeatureToggleProjection(toggleId)
 
       const listResponse = await apiRequest(request, 'GET', '/api/feature_toggles/global?page=1&pageSize=100', { token })
       expect(listResponse.status()).toBe(200)
@@ -38,6 +78,7 @@ test.describe('TC-FT-001: Global feature toggle CRUD APIs', () => {
         },
       })
       expect(updateResponse.status()).toBe(200)
+      await expectGlobalFeatureToggleProjection(toggleId)
 
       const verifyResponse = await apiRequest(
         request,
@@ -58,6 +99,7 @@ test.describe('TC-FT-001: Global feature toggle CRUD APIs', () => {
         { token },
       )
       expect(deleteResponse.status()).toBe(200)
+      expect(await readFeatureToggleIndexRows(toggleId)).toHaveLength(0)
       const deletedToggleId = toggleId
       toggleId = null
 
@@ -70,6 +112,7 @@ test.describe('TC-FT-001: Global feature toggle CRUD APIs', () => {
       expect(afterDeleteResponse.status()).toBe(404)
     } finally {
       await deleteFeatureToggleIfExists(request, token, toggleId)
+      await deleteFeatureToggleProjectionIfExists(indexedToggleId).catch(() => undefined)
     }
   })
 })

--- a/packages/core/src/modules/feature_toggles/__integration__/meta.ts
+++ b/packages/core/src/modules/feature_toggles/__integration__/meta.ts
@@ -1,3 +1,3 @@
 export const integrationMeta = {
-  dependsOnModules: ['feature_toggles'],
+  dependsOnModules: ['feature_toggles', 'query_index'],
 }

--- a/packages/core/src/modules/feature_toggles/api/global/route.ts
+++ b/packages/core/src/modules/feature_toggles/api/global/route.ts
@@ -103,13 +103,19 @@ const crud = makeCrudRoute({
     entity: FeatureToggle,
     idField: 'id',
     orgField: null,
-    tenantField: "tenantId",
+    // The query engine requires the caller's tenant context even when the
+    // underlying entity is global; the list below explicitly disables its
+    // automatic tenant predicate.
+    tenantField: 'tenantId',
     softDeleteField: 'deletedAt'
   },
   indexer: { entityType: E.feature_toggles.feature_toggle },
   list: {
     schema: listQuerySchema,
     entityId: E.feature_toggles.feature_toggle,
+    // FeatureToggle rows and their query-index projections are global
+    // (null/null scope), so filtering them by the actor's tenant hides them.
+    omitAutomaticTenantOrgScope: true,
     fields: listFields,
     sortFieldMap: {
       id: 'id',

--- a/packages/core/src/modules/feature_toggles/commands/__tests__/global.test.ts
+++ b/packages/core/src/modules/feature_toggles/commands/__tests__/global.test.ts
@@ -64,7 +64,7 @@ describe('feature_toggles.global commands', () => {
 
             const ctx: any = {
                 container,
-                auth: { isSuperAdmin: true },
+                auth: { isSuperAdmin: true, tenantId: 'actor-tenant-id' },
             }
 
             const input = {
@@ -92,6 +92,7 @@ describe('feature_toggles.global commands', () => {
             expect(dataEngine.markOrmEntityChange).toHaveBeenCalledWith(expect.objectContaining({
                 action: 'created',
                 entity: expect.objectContaining({ id: 'new-toggle-id' }),
+                identifiers: expect.objectContaining({ id: 'new-toggle-id', organizationId: null, tenantId: null }),
                 indexer: expect.objectContaining({ entityType: 'feature_toggles:feature_toggle' }),
             }))
         })
@@ -177,6 +178,7 @@ describe('feature_toggles.global commands', () => {
             expect(dataEngine.markOrmEntityChange).toHaveBeenCalledWith(expect.objectContaining({
                 action: 'created',
                 entity: expect.objectContaining({ id: 'seeded-toggle-id' }),
+                identifiers: expect.objectContaining({ id: 'seeded-toggle-id', organizationId: null, tenantId: null }),
                 indexer: expect.objectContaining({ entityType: 'feature_toggles:feature_toggle' }),
             }))
         })
@@ -217,7 +219,7 @@ describe('feature_toggles.global commands', () => {
                 }),
             }
 
-            const ctx: any = { container, auth: { isSuperAdmin: true } }
+            const ctx: any = { container, auth: { isSuperAdmin: true, tenantId: 'actor-tenant-id' } }
             const logEntry = { resourceId: toggleId }
 
             await createCommand.undo({ logEntry, ctx })
@@ -229,6 +231,7 @@ describe('feature_toggles.global commands', () => {
             expect(dataEngine.markOrmEntityChange).toHaveBeenCalledWith(expect.objectContaining({
                 action: 'deleted',
                 entity: existingToggle,
+                identifiers: expect.objectContaining({ id: toggleId, organizationId: null, tenantId: null }),
                 indexer: expect.objectContaining({ entityType: 'feature_toggles:feature_toggle' }),
             }))
         })
@@ -275,7 +278,7 @@ describe('feature_toggles.global commands', () => {
             expect(dataEngine.markOrmEntityChange).toHaveBeenCalledWith(expect.objectContaining({
                 action: 'created',
                 entity: expect.objectContaining({ id: 'toggle-id', identifier: 'qa.redo' }),
-                identifiers: expect.objectContaining({ id: 'toggle-id', organizationId: null, tenantId: 'tenant-1' }),
+                identifiers: expect.objectContaining({ id: 'toggle-id', organizationId: null, tenantId: null }),
                 indexer: expect.objectContaining({ entityType: 'feature_toggles:feature_toggle' }),
             }))
             expect(invalidateIsEnabledCacheByIdentifierTag).toHaveBeenCalledWith('qa.redo')
@@ -317,7 +320,7 @@ describe('feature_toggles.global commands', () => {
                 }),
             }
 
-            const ctx: any = { container, auth: { isSuperAdmin: true } }
+            const ctx: any = { container, auth: { isSuperAdmin: true, tenantId: 'actor-tenant-id' } }
 
             const input = {
                 id: '123e4567-e89b-12d3-a456-426614174000',
@@ -335,9 +338,64 @@ describe('feature_toggles.global commands', () => {
             expect(dataEngine.markOrmEntityChange).toHaveBeenCalledWith(expect.objectContaining({
                 action: 'updated',
                 entity: existingToggle,
+                identifiers: expect.objectContaining({ id: existingToggle.id, organizationId: null, tenantId: null }),
                 indexer: expect.objectContaining({ entityType: 'feature_toggles:feature_toggle' }),
             }))
             expect(invalidateIsEnabledCacheByIdentifierTag).toHaveBeenCalledWith('test_feature')
+        })
+
+        it('keeps update undo side effects global for a super-admin with a selected tenant', async () => {
+            let updateCommand: any
+            jest.isolateModules(() => {
+                require('../global')
+                updateCommand = registerCommand.mock.calls.find(([cmd]) => cmd.id === 'feature_toggles.global.update')?.[0]
+            })
+
+            const existingToggle = {
+                id: '123e4567-e89b-12d3-a456-426614174000',
+                identifier: 'test_feature',
+            }
+            const em = {
+                fork: jest.fn().mockReturnThis(),
+                findOne: jest.fn().mockResolvedValue(existingToggle),
+                flush: jest.fn().mockResolvedValue(undefined),
+            }
+            const dataEngine = { markOrmEntityChange: jest.fn() }
+            const container = {
+                resolve: jest.fn((token: string) => {
+                    if (token === 'em') return em
+                    if (token === 'dataEngine') return dataEngine
+                    if (token === 'featureTogglesService') return { invalidateIsEnabledCacheByIdentifierTag }
+                    return undefined
+                }),
+            }
+            const ctx: any = { container, auth: { isSuperAdmin: true, tenantId: 'actor-tenant-id' } }
+
+            await updateCommand.undo({
+                logEntry: {
+                    payload: {
+                        undo: {
+                            before: {
+                                id: existingToggle.id,
+                                identifier: existingToggle.identifier,
+                                name: 'Test Feature',
+                                description: null,
+                                category: null,
+                                type: 'boolean',
+                                defaultValue: true,
+                            },
+                        },
+                    },
+                },
+                ctx,
+            })
+
+            expect(dataEngine.markOrmEntityChange).toHaveBeenCalledWith(expect.objectContaining({
+                action: 'updated',
+                entity: existingToggle,
+                identifiers: expect.objectContaining({ id: existingToggle.id, organizationId: null, tenantId: null }),
+                indexer: expect.objectContaining({ entityType: 'feature_toggles:feature_toggle' }),
+            }))
         })
 
         it('throws error when toggle not found', async () => {
@@ -359,7 +417,7 @@ describe('feature_toggles.global commands', () => {
                 }),
             }
 
-            const ctx: any = { container, auth: { isSuperAdmin: true } }
+            const ctx: any = { container, auth: { isSuperAdmin: true, tenantId: 'actor-tenant-id' } }
 
             await expect(updateCommand.execute({ id: '123e4567-e89b-12d3-a456-426614174000' }, ctx)).rejects.toThrow('Toggle not found')
         })
@@ -428,6 +486,7 @@ describe('feature_toggles.global commands', () => {
             expect(dataEngine.markOrmEntityChange).toHaveBeenCalledWith(expect.objectContaining({
                 action: 'deleted',
                 entity: existingToggle,
+                identifiers: expect.objectContaining({ id: existingToggle.id, organizationId: null, tenantId: null }),
                 indexer: expect.objectContaining({ entityType: 'feature_toggles:feature_toggle' }),
             }))
             expect(invalidateIsEnabledCacheByIdentifierTag).toHaveBeenCalledWith('test_feature')
@@ -468,6 +527,11 @@ describe('feature_toggles.global commands', () => {
             expect(em.create).toHaveBeenCalledTimes(2)
             expect(em.persist).toHaveBeenCalledTimes(2)
             expect(em.flush).toHaveBeenCalled()
+            expect(dataEngine.markOrmEntityChange).toHaveBeenLastCalledWith(expect.objectContaining({
+                action: 'updated',
+                identifiers: expect.objectContaining({ id: existingToggle.id, organizationId: null, tenantId: null }),
+                indexer: expect.objectContaining({ entityType: 'feature_toggles:feature_toggle' }),
+            }))
         })
 
         it('throws error when toggle not found', async () => {

--- a/packages/core/src/modules/feature_toggles/commands/global.ts
+++ b/packages/core/src/modules/feature_toggles/commands/global.ts
@@ -52,14 +52,11 @@ const featureToggleCrudIndexer = { entityType: E.feature_toggles.feature_toggle 
 
 const FEATURE_TOGGLE_LOCK_RESOURCE_KIND = 'feature_toggles.feature_toggle'
 
-function featureToggleIdentifiers(
-  toggle: FeatureToggle | ToggleSnapshot,
-  ctx: { auth?: { tenantId?: string | null } | null },
-) {
+function featureToggleIdentifiers(toggle: FeatureToggle | ToggleSnapshot) {
   return {
     id: toggle.id,
     organizationId: null,
-    tenantId: ctx.auth?.tenantId ?? null,
+    tenantId: null,
   }
 }
 
@@ -113,7 +110,7 @@ const createToggleCommand: CommandHandler<ToggleCreateInput, { toggleId: string 
       dataEngine,
       action: 'created',
       entity: toggle,
-      identifiers: featureToggleIdentifiers(toggle, ctx),
+      identifiers: featureToggleIdentifiers(toggle),
       syncOrigin: ctx.syncOrigin,
       indexer: featureToggleCrudIndexer,
     })
@@ -157,7 +154,7 @@ const createToggleCommand: CommandHandler<ToggleCreateInput, { toggleId: string 
         dataEngine,
         action: 'deleted',
         entity: toggle,
-        identifiers: featureToggleIdentifiers(toggle, ctx),
+        identifiers: featureToggleIdentifiers(toggle),
         syncOrigin: ctx.syncOrigin,
         indexer: featureToggleCrudIndexer,
       })
@@ -196,7 +193,7 @@ const createToggleCommand: CommandHandler<ToggleCreateInput, { toggleId: string 
       dataEngine,
       action: 'created',
       entity: toggle,
-      identifiers: featureToggleIdentifiers(toggle, ctx),
+      identifiers: featureToggleIdentifiers(toggle),
       syncOrigin: ctx.syncOrigin,
       indexer: featureToggleCrudIndexer,
     })
@@ -245,7 +242,7 @@ const updateToggleCommand: CommandHandler<ToggleUpdateInput, { toggleId: string 
       dataEngine,
       action: 'updated',
       entity: toggle,
-      identifiers: featureToggleIdentifiers(toggle, ctx),
+      identifiers: featureToggleIdentifiers(toggle),
       syncOrigin: ctx.syncOrigin,
       indexer: featureToggleCrudIndexer,
     })
@@ -328,7 +325,7 @@ const updateToggleCommand: CommandHandler<ToggleUpdateInput, { toggleId: string 
       dataEngine,
       action: 'updated',
       entity: toggle,
-      identifiers: featureToggleIdentifiers(toggle, ctx),
+      identifiers: featureToggleIdentifiers(toggle),
       syncOrigin: ctx.syncOrigin,
       indexer: featureToggleCrudIndexer,
     })
@@ -369,7 +366,7 @@ const deleteToggleCommand: CommandHandler<{ body?: Record<string, unknown>; quer
       dataEngine,
       action: 'deleted',
       entity: toggle,
-      identifiers: featureToggleIdentifiers(toggle, ctx),
+      identifiers: featureToggleIdentifiers(toggle),
       syncOrigin: ctx.syncOrigin,
       indexer: featureToggleCrudIndexer,
     })
@@ -443,7 +440,7 @@ const deleteToggleCommand: CommandHandler<{ body?: Record<string, unknown>; quer
       dataEngine,
       action: 'updated',
       entity: toggle,
-      identifiers: featureToggleIdentifiers(toggle, ctx),
+      identifiers: featureToggleIdentifiers(toggle),
       syncOrigin: ctx.syncOrigin,
       indexer: featureToggleCrudIndexer,
     })

--- a/packages/core/src/modules/query_index/__tests__/delete-one-coverage.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/delete-one-coverage.test.ts
@@ -2,7 +2,12 @@ const mockMarkDeleted = jest.fn(async () => ({ wasActive: true }))
 const mockApplyCoverageAdjustments = jest.fn(async () => undefined)
 const mockCreateCoverageAdjustments = jest.fn(() => [])
 const mockRecordIndexerError = jest.fn(async () => undefined)
-const mockLoadQueryIndexRowScope = jest.fn(async () => null)
+const mockLoadQueryIndexRowScope = jest.fn(async () => ({ kind: 'missing' as const }))
+const mockResolveQueryIndexSourceMetadata = jest.fn(() => ({
+  table: 'entity_indexes',
+  organizationColumn: 'organization_id',
+  tenantColumn: 'tenant_id',
+}))
 const mockResolveQueryIndexRecordScope = jest.fn((input: any) => ({
   organizationId: input.payloadOrganizationId ?? null,
   tenantId: input.payloadTenantId ?? null,
@@ -19,6 +24,7 @@ jest.mock('../lib/coverage', () => ({
 
 jest.mock('../lib/subscriber-scope', () => ({
   loadQueryIndexRowScope: (...args: unknown[]) => mockLoadQueryIndexRowScope(...(args as [])),
+  resolveQueryIndexSourceMetadata: (...args: unknown[]) => mockResolveQueryIndexSourceMetadata(...(args as [])),
   resolveQueryIndexRecordScope: (...args: unknown[]) => mockResolveQueryIndexRecordScope(...(args as [any])),
 }))
 
@@ -26,17 +32,13 @@ jest.mock('@open-mercato/shared/lib/indexers/error-log', () => ({
   recordIndexerError: (...args: unknown[]) => mockRecordIndexerError(...(args as [])),
 }))
 
-jest.mock('@open-mercato/shared/lib/query/engine', () => ({
-  resolveEntityTableName: () => 'entity_indexes',
-}))
-
 import handleDeleteOne from '../subscribers/delete_one'
 
-function createContext() {
+function createContext(getKysely: () => unknown = () => { throw new Error('no kysely in test') }) {
   const emitEvent = jest.fn(async () => undefined)
   const eventBus = { emitEvent }
-  // `getKysely` throws so the base-delta probe short-circuits to -1 (baseCheckSucceeded=false).
-  const em = { getKysely: () => { throw new Error('no kysely in test') } }
+  // The default `getKysely` throws so the base-delta probe short-circuits to -1 (baseCheckSucceeded=false).
+  const em = { getKysely }
   const sourceEm = { fork: jest.fn(() => em) }
   const ctx = {
     resolve: jest.fn((name: string) => {
@@ -62,6 +64,12 @@ describe('query_index delete_one coverage refresh throttling', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(Date, 'now').mockReturnValue(NOW)
+    mockLoadQueryIndexRowScope.mockResolvedValue({ kind: 'missing' })
+    mockResolveQueryIndexSourceMetadata.mockReturnValue({
+      table: 'entity_indexes',
+      organizationColumn: 'organization_id',
+      tenantColumn: 'tenant_id',
+    })
   })
 
   afterEach(() => {
@@ -112,5 +120,42 @@ describe('query_index delete_one coverage refresh throttling', () => {
     const calls = coverageRefreshCalls(emitEvent)
     expect(calls).toHaveLength(2)
     expect(calls[0][1]).toMatchObject({ delayMs: 250 })
+  })
+
+  it('uses only the ID predicate for a global entity coverage probe', async () => {
+    const executeTakeFirst = jest.fn(async () => ({ deleted_at: new Date() }))
+    const baseQuery: { where: jest.Mock; executeTakeFirst: typeof executeTakeFirst } = {
+      where: jest.fn(),
+      executeTakeFirst,
+    }
+    baseQuery.where.mockReturnValue(baseQuery)
+    const select = jest.fn(() => baseQuery)
+    const selectFrom = jest.fn(() => ({ select }))
+    const { ctx } = createContext(() => ({ selectFrom }))
+    mockResolveQueryIndexSourceMetadata.mockReturnValue({
+      table: 'feature_toggles',
+      organizationColumn: null,
+      tenantColumn: null,
+    })
+    mockLoadQueryIndexRowScope.mockResolvedValue({ kind: 'global' })
+    mockResolveQueryIndexRecordScope.mockReturnValue({ organizationId: null, tenantId: null })
+
+    await handleDeleteOne({
+      entityType: 'feature_toggles:feature_toggle',
+      recordId: 'toggle-1',
+      organizationId: null,
+      tenantId: null,
+      suppressCoverage: true,
+    }, ctx)
+
+    expect(mockMarkDeleted).toHaveBeenCalledWith(expect.anything(), {
+      entityType: 'feature_toggles:feature_toggle',
+      recordId: 'toggle-1',
+      organizationId: null,
+      tenantId: null,
+    })
+    expect(selectFrom).toHaveBeenCalledWith('feature_toggles')
+    expect(baseQuery.where).toHaveBeenCalledTimes(1)
+    expect(baseQuery.where).toHaveBeenCalledWith('id', '=', 'toggle-1')
   })
 })

--- a/packages/core/src/modules/query_index/__tests__/subscriber-scope.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/subscriber-scope.test.ts
@@ -1,8 +1,135 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { registerEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
 import {
+  loadQueryIndexRowScope,
   QueryIndexScopeError,
   resolveQueryIndexRecordScope,
   resolveQueryIndexReindexScope,
+  resolveQueryIndexSourceMetadata,
 } from '../lib/subscriber-scope'
+
+type MetadataShape = {
+  className: string
+  tableName: string
+  properties: Record<string, { fieldNames: string[] }>
+}
+
+function createMetadata(input: Omit<MetadataShape, 'properties'> & { organizationColumn?: string; tenantColumn?: string }): MetadataShape {
+  const properties: MetadataShape['properties'] = {}
+  if (input.organizationColumn) properties.organizationId = { fieldNames: [input.organizationColumn] }
+  if (input.tenantColumn) properties.tenantId = { fieldNames: [input.tenantColumn] }
+  return { className: input.className, tableName: input.tableName, properties }
+}
+
+function createEm(metadata: MetadataShape, row?: Record<string, string | null>) {
+  const executeTakeFirst = jest.fn().mockResolvedValue(row)
+  const where = jest.fn(() => ({ executeTakeFirst }))
+  const select = jest.fn(() => ({ where }))
+  const selectFrom = jest.fn(() => ({ select }))
+  const getKysely = jest.fn(() => ({ selectFrom }))
+  const em = {
+    getKysely,
+    getMetadata: () => ({
+      find: (className: string) => className === metadata.className ? metadata : undefined,
+      getAll: () => [metadata],
+    }),
+  } as unknown as EntityManager
+  return { em, getKysely, selectFrom, select, where }
+}
+
+beforeEach(() => {
+  registerEntityIds({
+    feature_toggles: { feature_toggle: 'feature_toggles:feature_toggle' },
+    customer_accounts: { customer_user: 'customer_accounts:customer_user' },
+    customers: { customer_person: 'customers:customer_person' },
+  })
+})
+
+afterEach(() => {
+  registerEntityIds({})
+})
+
+describe('resolveQueryIndexSourceMetadata', () => {
+  it('uses registered metadata and mapped scope columns', async () => {
+    const metadata = createMetadata({
+      className: 'CustomerPerson',
+      tableName: 'customer_people',
+      organizationColumn: 'org_scope',
+      tenantColumn: 'tenant_scope',
+    })
+    const { em, select } = createEm(metadata, { org_scope: 'org-1', tenant_scope: 'tenant-1' })
+    const source = resolveQueryIndexSourceMetadata(em, 'customers:customer_person')
+
+    expect(source).toEqual({
+      table: 'customer_people',
+      organizationColumn: 'org_scope',
+      tenantColumn: 'tenant_scope',
+    })
+    await expect(loadQueryIndexRowScope(em, source, 'record-1')).resolves.toEqual({
+      kind: 'row',
+      scope: { organizationId: 'org-1', tenantId: 'tenant-1' },
+    })
+    expect(select).toHaveBeenCalledWith(['org_scope', 'tenant_scope'])
+  })
+
+  it('supports a tenant-only entity without reading an organization column', async () => {
+    const metadata = createMetadata({
+      className: 'CustomerUser',
+      tableName: 'customer_users',
+      tenantColumn: 'tenant_id',
+    })
+    const { em, select } = createEm(metadata, { tenant_id: 'tenant-1' })
+    const source = resolveQueryIndexSourceMetadata(em, 'customer_accounts:customer_user')
+
+    await expect(loadQueryIndexRowScope(em, source, 'record-1')).resolves.toEqual({
+      kind: 'row',
+      scope: { organizationId: null, tenantId: 'tenant-1' },
+    })
+    expect(select).toHaveBeenCalledWith(['tenant_id'])
+  })
+
+  it('returns global scope without creating a Kysely query', async () => {
+    const metadata = createMetadata({ className: 'FeatureToggle', tableName: 'feature_toggles' })
+    const { em, getKysely } = createEm(metadata)
+    const source = resolveQueryIndexSourceMetadata(em, 'feature_toggles:feature_toggle')
+
+    await expect(loadQueryIndexRowScope(em, source, 'record-1')).resolves.toEqual({ kind: 'global' })
+    expect(getKysely).not.toHaveBeenCalled()
+  })
+
+  it('distinguishes a missing scoped source row from a global entity', async () => {
+    const metadata = createMetadata({
+      className: 'CustomerPerson',
+      tableName: 'customer_people',
+      organizationColumn: 'organization_id',
+      tenantColumn: 'tenant_id',
+    })
+    const { em } = createEm(metadata)
+    const source = resolveQueryIndexSourceMetadata(em, 'customers:customer_person')
+
+    await expect(loadQueryIndexRowScope(em, source, 'missing-record')).resolves.toEqual({ kind: 'missing' })
+  })
+
+  it('rejects an entity ID that only collides with registered class metadata', () => {
+    const metadata = createMetadata({ className: 'FeatureToggle', tableName: 'feature_toggles' })
+    const { em, getKysely } = createEm(metadata)
+
+    expect(() => resolveQueryIndexSourceMetadata(em, 'other:feature_toggle')).toThrow(QueryIndexScopeError)
+    expect(getKysely).not.toHaveBeenCalled()
+  })
+
+  it('rejects a registered entity when its resolved table has no metadata entry', () => {
+    const resolvedMetadata = createMetadata({ className: 'FeatureToggle', tableName: 'feature_toggles' })
+    const em = {
+      getMetadata: () => ({
+        find: () => resolvedMetadata,
+        getAll: () => [],
+      }),
+    } as unknown as EntityManager
+
+    expect(() => resolveQueryIndexSourceMetadata(em, 'feature_toggles:feature_toggle')).toThrow(QueryIndexScopeError)
+  })
+})
 
 describe('resolveQueryIndexRecordScope', () => {
   it('fills missing payload scope from the source row', () => {
@@ -12,107 +139,84 @@ describe('resolveQueryIndexRecordScope', () => {
         payloadOrganizationId: 'org-1',
         hasPayloadTenantId: false,
         hasPayloadOrganizationId: true,
-        rowScope: {
-          tenantId: 'tenant-1',
-          organizationId: 'org-1',
-        },
+        sourceScope: { kind: 'row', scope: { tenantId: 'tenant-1', organizationId: 'org-1' } },
       })
-    ).toEqual({
-      tenantId: 'tenant-1',
-      organizationId: 'org-1',
-    })
+    ).toEqual({ tenantId: 'tenant-1', organizationId: 'org-1' })
   })
 
-  it('rejects tenant mismatches between payload and source row', () => {
-    expect(() =>
-      resolveQueryIndexRecordScope({
-        payloadTenantId: 'tenant-b',
-        payloadOrganizationId: 'org-1',
-        hasPayloadTenantId: true,
-        hasPayloadOrganizationId: true,
-        rowScope: {
-          tenantId: 'tenant-a',
-          organizationId: 'org-1',
-        },
-      })
-    ).toThrow(QueryIndexScopeError)
+  it('rejects scope mismatches between payload and source row', () => {
+    expect(() => resolveQueryIndexRecordScope({
+      payloadTenantId: 'tenant-b',
+      payloadOrganizationId: 'org-1',
+      hasPayloadTenantId: true,
+      hasPayloadOrganizationId: true,
+      sourceScope: { kind: 'row', scope: { tenantId: 'tenant-a', organizationId: 'org-1' } },
+    })).toThrow(QueryIndexScopeError)
   })
 
   it('rejects organization mismatches between payload and source row', () => {
-    expect(() =>
-      resolveQueryIndexRecordScope({
-        payloadTenantId: 'tenant-1',
-        payloadOrganizationId: 'org-b',
-        hasPayloadTenantId: true,
-        hasPayloadOrganizationId: true,
-        rowScope: {
-          tenantId: 'tenant-1',
-          organizationId: 'org-a',
-        },
-      })
-    ).toThrow(QueryIndexScopeError)
+    expect(() => resolveQueryIndexRecordScope({
+      payloadTenantId: 'tenant-1',
+      payloadOrganizationId: 'org-b',
+      hasPayloadTenantId: true,
+      hasPayloadOrganizationId: true,
+      sourceScope: { kind: 'row', scope: { tenantId: 'tenant-1', organizationId: 'org-a' } },
+    })).toThrow(QueryIndexScopeError)
   })
 
-  it('rejects partial payload scope when the source row scope cannot be resolved', () => {
-    expect(() =>
-      resolveQueryIndexRecordScope({
-        payloadTenantId: undefined,
-        payloadOrganizationId: 'org-1',
-        hasPayloadTenantId: false,
-        hasPayloadOrganizationId: true,
-        rowScope: null,
-      })
-    ).toThrow('missing tenantId/organizationId')
+  it('rejects partial payload scope when the source row is missing', () => {
+    expect(() => resolveQueryIndexRecordScope({
+      payloadTenantId: undefined,
+      payloadOrganizationId: 'org-1',
+      hasPayloadTenantId: false,
+      hasPayloadOrganizationId: true,
+      sourceScope: { kind: 'missing' },
+    })).toThrow('missing tenantId/organizationId')
   })
 
-  it('allows explicit full scope when the source row no longer exists', () => {
-    expect(
-      resolveQueryIndexRecordScope({
-        payloadTenantId: 'tenant-1',
-        payloadOrganizationId: 'org-1',
-        hasPayloadTenantId: true,
-        hasPayloadOrganizationId: true,
-        rowScope: null,
-      })
-    ).toEqual({
-      tenantId: 'tenant-1',
-      organizationId: 'org-1',
-    })
+  it('allows explicit full scope when the source row is missing', () => {
+    expect(resolveQueryIndexRecordScope({
+      payloadTenantId: 'tenant-1',
+      payloadOrganizationId: 'org-1',
+      hasPayloadTenantId: true,
+      hasPayloadOrganizationId: true,
+      sourceScope: { kind: 'missing' },
+    })).toEqual({ tenantId: 'tenant-1', organizationId: 'org-1' })
+  })
+
+  it.each([
+    { payloadTenantId: undefined, payloadOrganizationId: null, hasPayloadTenantId: false, hasPayloadOrganizationId: true },
+    { payloadTenantId: null, payloadOrganizationId: undefined, hasPayloadTenantId: true, hasPayloadOrganizationId: true },
+    { payloadTenantId: 'tenant-1', payloadOrganizationId: null, hasPayloadTenantId: true, hasPayloadOrganizationId: true },
+  ])('rejects invalid global payload %#', (payload) => {
+    expect(() => resolveQueryIndexRecordScope({ ...payload, sourceScope: { kind: 'global' } })).toThrow(QueryIndexScopeError)
+  })
+
+  it('accepts only explicit null/null global scope', () => {
+    expect(resolveQueryIndexRecordScope({
+      payloadTenantId: null,
+      payloadOrganizationId: null,
+      hasPayloadTenantId: true,
+      hasPayloadOrganizationId: true,
+      sourceScope: { kind: 'global' },
+    })).toEqual({ tenantId: null, organizationId: null })
   })
 })
 
 describe('resolveQueryIndexReindexScope', () => {
   it('rejects implicit all-tenant reindex payloads', () => {
-    expect(() =>
-      resolveQueryIndexReindexScope({
-        tenantId: undefined,
-        organizationId: undefined,
-      })
-    ).toThrow('all-tenant reindex must opt in')
+    expect(() => resolveQueryIndexReindexScope({ tenantId: undefined, organizationId: undefined })).toThrow('all-tenant reindex must opt in')
   })
 
   it('allows explicit all-tenant reindex payloads', () => {
-    expect(
-      resolveQueryIndexReindexScope({
-        tenantId: undefined,
-        organizationId: undefined,
-        allowAllTenants: true,
-      })
-    ).toEqual({
+    expect(resolveQueryIndexReindexScope({
       tenantId: undefined,
       organizationId: undefined,
-    })
+      allowAllTenants: true,
+    })).toEqual({ tenantId: undefined, organizationId: undefined })
   })
 
   it('preserves explicit global scope', () => {
-    expect(
-      resolveQueryIndexReindexScope({
-        tenantId: null,
-        organizationId: null,
-      })
-    ).toEqual({
-      tenantId: null,
-      organizationId: null,
-    })
+    expect(resolveQueryIndexReindexScope({ tenantId: null, organizationId: null })).toEqual({ tenantId: null, organizationId: null })
   })
 })

--- a/packages/core/src/modules/query_index/__tests__/subscriber-scope.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/subscriber-scope.test.ts
@@ -21,7 +21,11 @@ function createMetadata(input: Omit<MetadataShape, 'properties'> & { organizatio
   return { className: input.className, tableName: input.tableName, properties }
 }
 
-function createEm(metadata: MetadataShape, row?: Record<string, string | null>) {
+function createEm(
+  metadata: MetadataShape,
+  row?: Record<string, string | null>,
+  metadataCollection: MetadataShape[] | Map<string, MetadataShape> = [metadata],
+) {
   const executeTakeFirst = jest.fn().mockResolvedValue(row)
   const where = jest.fn(() => ({ executeTakeFirst }))
   const select = jest.fn(() => ({ where }))
@@ -31,7 +35,7 @@ function createEm(metadata: MetadataShape, row?: Record<string, string | null>) 
     getKysely,
     getMetadata: () => ({
       find: (className: string) => className === metadata.className ? metadata : undefined,
-      getAll: () => [metadata],
+      getAll: () => metadataCollection,
     }),
   } as unknown as EntityManager
   return { em, getKysely, selectFrom, select, where }
@@ -95,6 +99,17 @@ describe('resolveQueryIndexSourceMetadata', () => {
 
     await expect(loadQueryIndexRowScope(em, source, 'record-1')).resolves.toEqual({ kind: 'global' })
     expect(getKysely).not.toHaveBeenCalled()
+  })
+
+  it('reads MikroORM v7 Map metadata for a global entity', async () => {
+    const metadata = createMetadata({ className: 'FeatureToggle', tableName: 'feature_toggles' })
+    const { em } = createEm(metadata, undefined, new Map([[metadata.className, metadata]]))
+
+    expect(resolveQueryIndexSourceMetadata(em, 'feature_toggles:feature_toggle')).toEqual({
+      table: 'feature_toggles',
+      organizationColumn: null,
+      tenantColumn: null,
+    })
   })
 
   it('distinguishes a missing scoped source row from a global entity', async () => {

--- a/packages/core/src/modules/query_index/__tests__/upsert-one-global-scope.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/upsert-one-global-scope.test.ts
@@ -1,0 +1,74 @@
+const mockUpsertIndexRow = jest.fn(async () => ({
+  doc: { id: 'toggle-1' },
+  created: true,
+  revived: false,
+}))
+const mockReindexSearchTokensForRecord = jest.fn(async () => undefined)
+const mockRecordIndexerError = jest.fn(async () => undefined)
+const mockResolveQueryIndexSourceMetadata = jest.fn(() => ({
+  table: 'feature_toggles',
+  organizationColumn: null,
+  tenantColumn: null,
+}))
+const mockLoadQueryIndexRowScope = jest.fn(async () => ({ kind: 'global' as const }))
+const mockResolveQueryIndexRecordScope = jest.fn(() => ({ organizationId: null, tenantId: null }))
+
+jest.mock('../lib/indexer', () => ({
+  upsertIndexRow: (...args: unknown[]) => mockUpsertIndexRow(...args),
+  reindexSearchTokensForRecord: (...args: unknown[]) => mockReindexSearchTokensForRecord(...args),
+}))
+
+jest.mock('../lib/subscriber-scope', () => ({
+  resolveQueryIndexSourceMetadata: (...args: unknown[]) => mockResolveQueryIndexSourceMetadata(...args),
+  loadQueryIndexRowScope: (...args: unknown[]) => mockLoadQueryIndexRowScope(...args),
+  resolveQueryIndexRecordScope: (...args: unknown[]) => mockResolveQueryIndexRecordScope(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/indexers/error-log', () => ({
+  recordIndexerError: (...args: unknown[]) => mockRecordIndexerError(...args),
+}))
+
+import handleUpsertOne from '../subscribers/upsert_one'
+
+function flushFireAndForget() {
+  return new Promise<void>((resolve) => setImmediate(resolve))
+}
+
+describe('query_index upsert_one global scope', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('writes an explicit global projection without a source scope query', async () => {
+    const em = { getKysely: jest.fn() }
+    const sourceEm = { fork: jest.fn(() => em) }
+    const emitEvent = jest.fn(async () => undefined)
+    const ctx = {
+      resolve: jest.fn((name: string) => {
+        if (name === 'em') return sourceEm
+        if (name === 'eventBus') return { emitEvent }
+        throw new Error(`Unexpected token: ${name}`)
+      }),
+    }
+
+    await handleUpsertOne({
+      entityType: 'feature_toggles:feature_toggle',
+      recordId: 'toggle-1',
+      organizationId: null,
+      tenantId: null,
+      suppressCoverage: true,
+    }, ctx)
+    await flushFireAndForget()
+
+    expect(mockResolveQueryIndexSourceMetadata).toHaveBeenCalledWith(em, 'feature_toggles:feature_toggle')
+    expect(mockLoadQueryIndexRowScope).toHaveBeenCalledWith(em, expect.anything(), 'toggle-1')
+    expect(em.getKysely).not.toHaveBeenCalled()
+    expect(mockUpsertIndexRow).toHaveBeenCalledWith(em, expect.objectContaining({
+      entityType: 'feature_toggles:feature_toggle',
+      recordId: 'toggle-1',
+      organizationId: null,
+      tenantId: null,
+    }))
+    expect(mockRecordIndexerError).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/query_index/lib/subscriber-scope.ts
+++ b/packages/core/src/modules/query_index/lib/subscriber-scope.ts
@@ -1,10 +1,22 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
+import { getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
+import { resolveRegisteredEntityTableName } from '@open-mercato/shared/lib/query/engine'
 
 export type QueryIndexScope = {
   tenantId: string | null
   organizationId: string | null
 }
+
+export type QueryIndexSourceMetadata = {
+  table: string
+  organizationColumn: string | null
+  tenantColumn: string | null
+}
+
+export type QueryIndexSourceScope =
+  | { kind: 'global' }
+  | { kind: 'missing' }
+  | { kind: 'row'; scope: QueryIndexScope }
 
 export class QueryIndexScopeError extends Error {
   constructor(message: string) {
@@ -18,7 +30,7 @@ type ResolveRecordScopeInput = {
   payloadOrganizationId: string | null | undefined
   hasPayloadTenantId: boolean
   hasPayloadOrganizationId: boolean
-  rowScope: QueryIndexScope | null
+  sourceScope: QueryIndexSourceScope
 }
 
 type ResolveReindexScopeInput = {
@@ -27,26 +39,62 @@ type ResolveReindexScopeInput = {
   allowAllTenants?: boolean
 }
 
-export async function loadQueryIndexRowScope(
+export function resolveQueryIndexSourceMetadata(
   em: EntityManager,
   entityType: string,
-  recordId: string
-): Promise<QueryIndexScope | null> {
-  const db = em.getKysely<any>()
-  const table = resolveEntityTableName(em, entityType)
-  const row = await db
-    .selectFrom(table as any)
-    .select(['organization_id' as any, 'tenant_id' as any])
-    .where('id' as any, '=', recordId)
-    .executeTakeFirst() as { organization_id: string | null; tenant_id: string | null } | undefined
+): QueryIndexSourceMetadata {
+  const registeredEntityIds = Object.values(getEntityIds(false)).flatMap((moduleEntities) => Object.values(moduleEntities ?? {}))
+  if (!registeredEntityIds.includes(entityType)) {
+    throw new QueryIndexScopeError(`Query index entity type is not registered: ${entityType}`)
+  }
 
-  if (!row) {
-    return null
+  const table = resolveRegisteredEntityTableName(em, entityType as never)
+  if (!table) {
+    throw new QueryIndexScopeError(`Query index entity type has no registered ORM table: ${entityType}`)
+  }
+
+  const registry = em.getMetadata?.()
+  const allMetadataRaw = typeof registry?.getAll === 'function' ? registry.getAll() : null
+  const allMetadata = Array.isArray(allMetadataRaw) ? allMetadataRaw : Object.values(allMetadataRaw ?? {})
+  const metadata = allMetadata.find((candidate) => String(candidate?.tableName ?? '') === table)
+  if (!metadata) {
+    throw new QueryIndexScopeError(`Query index entity metadata was not found for table: ${table}`)
   }
 
   return {
-    organizationId: row.organization_id ?? null,
-    tenantId: row.tenant_id ?? null,
+    table,
+    organizationColumn: resolveScopeColumn(metadata, 'organizationId', table),
+    tenantColumn: resolveScopeColumn(metadata, 'tenantId', table),
+  }
+}
+
+export async function loadQueryIndexRowScope(
+  em: EntityManager,
+  source: QueryIndexSourceMetadata,
+  recordId: string,
+): Promise<QueryIndexSourceScope> {
+  if (!source.organizationColumn && !source.tenantColumn) {
+    return { kind: 'global' }
+  }
+
+  const db = em.getKysely<any>()
+  const columns = [source.organizationColumn, source.tenantColumn].filter((column): column is string => column !== null)
+  const row = await db
+    .selectFrom(source.table as any)
+    .select(columns as any)
+    .where('id' as any, '=', recordId)
+    .executeTakeFirst() as Record<string, string | null | undefined> | undefined
+
+  if (!row) {
+    return { kind: 'missing' }
+  }
+
+  return {
+    kind: 'row',
+    scope: {
+      organizationId: source.organizationColumn ? row[source.organizationColumn] ?? null : null,
+      tenantId: source.tenantColumn ? row[source.tenantColumn] ?? null : null,
+    },
   }
 }
 
@@ -56,10 +104,23 @@ export function resolveQueryIndexRecordScope(input: ResolveRecordScopeInput): Qu
     payloadOrganizationId,
     hasPayloadTenantId,
     hasPayloadOrganizationId,
-    rowScope,
+    sourceScope,
   } = input
 
-  if (!rowScope) {
+  if (sourceScope.kind === 'global') {
+    if (!hasPayloadTenantId || !hasPayloadOrganizationId || payloadTenantId !== null || payloadOrganizationId !== null) {
+      throw new QueryIndexScopeError(
+        'Query index event for a global entity must explicitly provide tenantId and organizationId as null'
+      )
+    }
+
+    return {
+      tenantId: null,
+      organizationId: null,
+    }
+  }
+
+  if (sourceScope.kind === 'missing') {
     if (!hasPayloadTenantId || !hasPayloadOrganizationId) {
       throw new QueryIndexScopeError(
         'Query index event is missing tenantId/organizationId and source row scope could not be resolved'
@@ -71,6 +132,8 @@ export function resolveQueryIndexRecordScope(input: ResolveRecordScopeInput): Qu
       organizationId: payloadOrganizationId ?? null,
     }
   }
+
+  const rowScope = sourceScope.scope
 
   if (hasPayloadTenantId && !isSameScopeValue(payloadTenantId, rowScope.tenantId)) {
     throw new QueryIndexScopeError(
@@ -108,4 +171,16 @@ export function resolveQueryIndexReindexScope(input: ResolveReindexScopeInput): 
 
 function isSameScopeValue(left: string | null | undefined, right: string | null): boolean {
   return (left ?? null) === right
+}
+
+function resolveScopeColumn(metadata: { properties?: Record<string, { fieldNames?: unknown }> }, property: string, table: string): string | null {
+  const scopeProperty = metadata.properties?.[property]
+  if (!scopeProperty) return null
+  const fieldNames = scopeProperty.fieldNames
+  if (!Array.isArray(fieldNames) || fieldNames.length !== 1 || typeof fieldNames[0] !== 'string' || !fieldNames[0]) {
+    throw new QueryIndexScopeError(
+      `Query index ${property} metadata must map exactly one physical column for table: ${table}`
+    )
+  }
+  return fieldNames[0]
 }

--- a/packages/core/src/modules/query_index/lib/subscriber-scope.ts
+++ b/packages/core/src/modules/query_index/lib/subscriber-scope.ts
@@ -18,6 +18,11 @@ export type QueryIndexSourceScope =
   | { kind: 'missing' }
   | { kind: 'row'; scope: QueryIndexScope }
 
+type QueryIndexEntityMetadata = {
+  tableName?: unknown
+  properties?: Record<string, { fieldNames?: unknown }>
+}
+
 export class QueryIndexScopeError extends Error {
   constructor(message: string) {
     super(message)
@@ -55,8 +60,12 @@ export function resolveQueryIndexSourceMetadata(
 
   const registry = em.getMetadata?.()
   const allMetadataRaw = typeof registry?.getAll === 'function' ? registry.getAll() : null
-  const allMetadata = Array.isArray(allMetadataRaw) ? allMetadataRaw : Object.values(allMetadataRaw ?? {})
-  const metadata = allMetadata.find((candidate) => String(candidate?.tableName ?? '') === table)
+  const allMetadata: QueryIndexEntityMetadata[] = Array.isArray(allMetadataRaw)
+    ? allMetadataRaw as QueryIndexEntityMetadata[]
+    : allMetadataRaw instanceof Map
+      ? Array.from(allMetadataRaw.values()) as QueryIndexEntityMetadata[]
+      : Object.values(allMetadataRaw ?? {}) as QueryIndexEntityMetadata[]
+  const metadata = allMetadata.find((candidate) => String(candidate.tableName ?? '') === table)
   if (!metadata) {
     throw new QueryIndexScopeError(`Query index entity metadata was not found for table: ${table}`)
   }
@@ -173,7 +182,7 @@ function isSameScopeValue(left: string | null | undefined, right: string | null)
   return (left ?? null) === right
 }
 
-function resolveScopeColumn(metadata: { properties?: Record<string, { fieldNames?: unknown }> }, property: string, table: string): string | null {
+function resolveScopeColumn(metadata: QueryIndexEntityMetadata, property: string, table: string): string | null {
   const scopeProperty = metadata.properties?.[property]
   if (!scopeProperty) return null
   const fieldNames = scopeProperty.fieldNames

--- a/packages/core/src/modules/query_index/subscribers/delete_one.ts
+++ b/packages/core/src/modules/query_index/subscribers/delete_one.ts
@@ -1,9 +1,12 @@
 import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
-import { resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
 import { sql } from 'kysely'
 import { markDeleted } from '../lib/indexer'
 import { applyCoverageAdjustments, createCoverageAdjustments } from '../lib/coverage'
-import { loadQueryIndexRowScope, resolveQueryIndexRecordScope } from '../lib/subscriber-scope'
+import {
+  loadQueryIndexRowScope,
+  resolveQueryIndexRecordScope,
+  resolveQueryIndexSourceMetadata,
+} from '../lib/subscriber-scope'
 
 export const metadata = { event: 'query_index.delete_one', persistent: false }
 
@@ -40,13 +43,14 @@ export default async function handle(payload: any, ctx: { resolve: <T=any>(name:
   try {
     const hasPayloadOrganizationId = Object.prototype.hasOwnProperty.call(payload ?? {}, 'organizationId')
     const hasPayloadTenantId = Object.prototype.hasOwnProperty.call(payload ?? {}, 'tenantId')
-    const rowScope = await loadQueryIndexRowScope(em, entityType, recordId).catch(() => null)
+    const source = resolveQueryIndexSourceMetadata(em, entityType)
+    const sourceScope = await loadQueryIndexRowScope(em, source, recordId)
     const resolvedScope = resolveQueryIndexRecordScope({
       payloadOrganizationId: payload?.organizationId,
       payloadTenantId: payload?.tenantId,
       hasPayloadOrganizationId,
       hasPayloadTenantId,
-      rowScope,
+      sourceScope,
     })
     organizationId = resolvedScope.organizationId
     tenantId = resolvedScope.tenantId
@@ -57,14 +61,21 @@ export default async function handle(payload: any, ctx: { resolve: <T=any>(name:
     let baseCheckSucceeded = false
     try {
       const db = (em as any).getKysely()
-      const table = resolveEntityTableName(em, entityType)
-      const row = await db
-        .selectFrom(table as any)
+      let baseQuery = db
+        .selectFrom(source.table as any)
         .select(['deleted_at' as any])
         .where('id' as any, '=', recordId)
-        .where('organization_id' as any, organizationId === null ? 'is' : '=', organizationId as any)
-        .where(sql`tenant_id is not distinct from ${tenantId}`)
-        .executeTakeFirst() as { deleted_at: Date | null } | undefined
+      if (source.organizationColumn) {
+        baseQuery = baseQuery.where(
+          source.organizationColumn as any,
+          organizationId === null ? 'is' : '=',
+          organizationId as any,
+        )
+      }
+      if (source.tenantColumn) {
+        baseQuery = baseQuery.where(sql`${sql.ref(source.tenantColumn)} is not distinct from ${tenantId}`)
+      }
+      const row = await baseQuery.executeTakeFirst() as { deleted_at: Date | null } | undefined
       const baseMissing = !row
       const baseDeleted = baseMissing || (row && row.deleted_at != null)
       baseCheckSucceeded = true

--- a/packages/core/src/modules/query_index/subscribers/upsert_one.ts
+++ b/packages/core/src/modules/query_index/subscribers/upsert_one.ts
@@ -1,7 +1,11 @@
 import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
 import { upsertIndexRow, reindexSearchTokensForRecord } from '../lib/indexer'
 import { applyCoverageAdjustments, createCoverageAdjustments } from '../lib/coverage'
-import { loadQueryIndexRowScope, resolveQueryIndexRecordScope } from '../lib/subscriber-scope'
+import {
+  loadQueryIndexRowScope,
+  resolveQueryIndexRecordScope,
+  resolveQueryIndexSourceMetadata,
+} from '../lib/subscriber-scope'
 
 export const metadata = { event: 'query_index.upsert_one', persistent: false }
 
@@ -25,13 +29,14 @@ export default async function handle(payload: any, ctx: { resolve: <T=any>(name:
   try {
     const hasPayloadOrganizationId = Object.prototype.hasOwnProperty.call(payload ?? {}, 'organizationId')
     const hasPayloadTenantId = Object.prototype.hasOwnProperty.call(payload ?? {}, 'tenantId')
-    const rowScope = await loadQueryIndexRowScope(em, entityType, recordId).catch(() => null)
+    const source = resolveQueryIndexSourceMetadata(em, entityType)
+    const sourceScope = await loadQueryIndexRowScope(em, source, recordId)
     const resolvedScope = resolveQueryIndexRecordScope({
       payloadOrganizationId: payload?.organizationId,
       payloadTenantId: payload?.tenantId,
       hasPayloadOrganizationId,
       hasPayloadTenantId,
-      rowScope,
+      sourceScope,
     })
     organizationId = resolvedScope.organizationId
     tenantId = resolvedScope.tenantId

--- a/packages/shared/src/lib/query/__tests__/engine.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.test.ts
@@ -477,6 +477,36 @@ describe('BasicQueryEngine (Kysely)', () => {
     )
   })
 
+  test('bypasses search-token filtering when automatic scope is explicitly disabled', async () => {
+    const fakeDb = createFakeKysely({
+      todos: [],
+      'information_schema.tables': [
+        { table_name: 'search_tokens' },
+      ],
+      'information_schema.columns': [
+        { table_name: 'todos', column_name: 'search_text' },
+      ],
+    })
+    const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
+    const hasSearchTokensSpy = jest.spyOn(engine as any, 'hasSearchTokens').mockResolvedValue(true)
+    const applySearchTokensSpy = jest.spyOn(engine as any, 'applySearchTokens')
+
+    await engine.query('example:todo', {
+      tenantId: 't1',
+      fields: ['id'],
+      omitAutomaticTenantOrgScope: true,
+      filters: {
+        search_text: { $ilike: '%avision%' },
+      },
+      page: { page: 1, pageSize: 10 },
+    })
+
+    expect(hasSearchTokensSpy).not.toHaveBeenCalled()
+    expect(applySearchTokensSpy).not.toHaveBeenCalled()
+    const baseCall = fakeDb._calls.find((builder: any) => builder._ops.table === 'todos')
+    expect(baseCall?._ops.wheres).toContainEqual(['todos.search_text', 'ilike', '%avision%'])
+  })
+
   test('join filters use whereExists with configured alias', async () => {
     const fakeDb = createFakeKysely({
       customer_entities: [],

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -293,7 +293,11 @@ export class BasicQueryEngine implements QueryEngine {
     const { baseFilters, joinFilters } = partitionFilters(table, normalizedFilters, joinMap)
     const cfFilters = normalizedFilters.filter((filter) => String(filter.field).startsWith('cf:'))
     const searchConfig = resolveSearchConfig()
-    const searchEnabled = searchConfig.enabled && await this.tableExists('search_tokens')
+    // Callers that opt out of automatic tenant/org scoping own the full
+    // visibility predicate. Search-token filtering has its own tenant/org
+    // guards, so it must be disabled on this direct-query path as documented
+    // by QueryOptions.omitAutomaticTenantOrgScope.
+    const searchEnabled = !skipAutoScope && searchConfig.enabled && await this.tableExists('search_tokens')
     const hasSearchTokens = searchEnabled
       ? await this.hasSearchTokens(String(entity), opts.tenantId ?? null, orgScope)
       : false


### PR DESCRIPTION
## Summary

- Resolve query-index source scope exclusively from registered MikroORM metadata, including global entities and tenant-only mappings.
- Emit explicit null organization and tenant identifiers for all global feature-toggle lifecycle writes.
- Verify the feature-toggle CRUD projection remains global and is physically removed on delete.

## Validation

- Passed: focused Jest suites, package build, generation, i18n checks, typecheck, full unit suite, app build, and independent code review.
- Passed: managed ephemeral TC-FT-001 scenario.
- Blocked: full managed Playwright discovery loads unrelated stale sibling worktrees before test execution.
- Template parity reports existing unrelated drift; no template surface changed.

## Risk

High risk because this hardens shared query-index tenant scope. Existing tenant-scoped source-row authority and public contracts are unchanged.

Source spec: .ai/specs/2026-07-18-query-index-global-entity-scope.md
Run record: .ai/runs/2026-07-18-query-index-global-entity-scope/PLAN.md