### PR TITLE
refactor(opencode): distribute OpenCode via a prebuilt base image (1.18.3)

### DIFF
--- a/docker-compose.fullapp.dev.yml
+++ b/docker-compose.fullapp.dev.yml
@@ -5,6 +5,11 @@ services:
   opencode:
     build:
       context: ./docker/opencode
+      args:
+        # OpenCode is pre-installed in this base image (see
+        # docker/opencode/BASE_IMAGE.md); the build only COPYs project files, so
+        # it needs no network. Override to pin a different pushed base tag.
+        OPENCODE_BASE_IMAGE: ${OPENCODE_BASE_IMAGE:-docker.io/openmercatocom/open-mercato-opencode:1.18.3}
     image: opencode-mvp
     container_name: mercato-opencode-${DEPLOY_ENV:-local}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,11 @@ services:
   opencode:
     build:
       context: ./docker/opencode
+      args:
+        # OpenCode is pre-installed in this base image (see
+        # docker/opencode/BASE_IMAGE.md); the build only COPYs project files, so
+        # it needs no network. Override to pin a different pushed base tag.
+        OPENCODE_BASE_IMAGE: ${OPENCODE_BASE_IMAGE:-docker.io/openmercatocom/open-mercato-opencode:1.18.3}
     image: opencode-mvp
     container_name: mercato-opencode
     restart: unless-stopped

--- a/docker/opencode/BASE_IMAGE.md
+++ b/docker/opencode/BASE_IMAGE.md
@@ -1,0 +1,106 @@
+# OpenCode base image — build & publish
+
+The OpenCode CLI is baked into a **base image** (`Dockerfile.base`) that is built
+and pushed to a registry once. The service image (`Dockerfile`) starts `FROM`
+that base and only layers in this project's `AGENTS.md`, agents, skills, and
+entrypoint.
+
+**Why:** the old service `Dockerfile` ran `curl https://opencode.ai/install | …`
+on every build. Behind a corporate TLS-intercepting proxy that download fails
+(`self-signed certificate in certificate chain`), and even on a good network it
+is slow and rate-limitable. Downloading once into a base image removes that step
+from every app/dev build — rebuilds become a few seconds of `COPY`, and corporate
+machines only need to `docker pull` an already-built image.
+
+Current pin: **OpenCode 1.18.3**. Registry: **`docker.io/openmercatocom/open-mercato-opencode`**.
+
+---
+
+## Prerequisites
+
+```bash
+docker login                      # authenticate to Docker Hub (openmercatocom)
+```
+
+## Build & push (multi-arch — required)
+
+Corporate Windows/Rancher machines are **linux/amd64**; Apple-Silicon dev
+machines are **linux/arm64**. A single-arch image pushed from the wrong host
+will not run on the other, so build both with `buildx` and push in one shot.
+
+```bash
+# from the repo root
+docker buildx create --use --name om-builder 2>/dev/null || docker buildx use om-builder
+
+docker buildx build \
+  --file docker/opencode/Dockerfile.base \
+  --platform linux/amd64,linux/arm64 \
+  --build-arg OPENCODE_VERSION=1.18.3 \
+  --tag docker.io/openmercatocom/open-mercato-opencode:1.18.3 \
+  --tag docker.io/openmercatocom/open-mercato-opencode:latest \
+  --push \
+  docker/opencode
+```
+
+> The build context is `docker/opencode` (last argument) so the cert anchor in
+> `Dockerfile.base` can reuse `AGENTS.md` + `certs/`.
+
+### Single-arch fallback (amd64 only)
+
+If `buildx` is unavailable, build at least the amd64 image the target machines
+need (run this on an amd64 host, or it will emulate slowly):
+
+```bash
+docker build \
+  --file docker/opencode/Dockerfile.base \
+  --platform linux/amd64 \
+  --build-arg OPENCODE_VERSION=1.18.3 \
+  --tag docker.io/openmercatocom/open-mercato-opencode:1.18.3 \
+  docker/opencode
+docker push docker.io/openmercatocom/open-mercato-opencode:1.18.3
+```
+
+## Verify the pushed image
+
+```bash
+docker run --rm --entrypoint sh docker.io/openmercatocom/open-mercato-opencode:1.18.3 \
+  -c 'opencode --version'          # -> 1.18.3
+docker buildx imagetools inspect docker.io/openmercatocom/open-mercato-opencode:1.18.3 \
+  | grep -i platform               # -> linux/amd64 and linux/arm64
+```
+
+## After a push, the service image just works
+
+`docker/opencode/Dockerfile` defaults to
+`docker.io/openmercatocom/open-mercato-opencode:1.18.3`, so once the base is
+pushed:
+
+```bash
+docker compose -f docker-compose.fullapp.dev.yml build opencode   # pulls base, COPYs project files
+```
+
+Override the base per build without editing the Dockerfile:
+
+```bash
+docker build --build-arg OPENCODE_BASE_IMAGE=docker.io/openmercatocom/open-mercato-opencode:1.18.3-rc docker/opencode
+```
+
+---
+
+## Bumping the OpenCode version
+
+The pin is a **breaking-risk** change — the `opencode.jsonc` schema written by
+`entrypoint.sh` (provider / `mcp` / `permission` / `tools` / `server`) and the
+agent-file/skill contract are validated against a specific tag.
+
+1. Edit `OPENCODE_VERSION` in `Dockerfile.base` and the tag + `OPENCODE_BASE_IMAGE`
+   default in `Dockerfile` (keep them in lockstep).
+2. Rebuild + push the base (commands above) with the new tag.
+3. Re-verify: `docker compose -f docker-compose.fullapp.dev.yml up` and exercise
+   a Cmd+K → tool-call → MCP round-trip. Startup already logs
+   `opencode server listening on http://0.0.0.0:4096` when the config is accepted.
+
+**1.18.3 note:** newer OpenCode logs `OPENCODE_SERVER_PASSWORD is not set; server
+is unsecured` at startup. The dev/prod compose stacks keep the OpenCode port
+off the public interface (published on localhost in dev, internal in prod), so
+this is informational; set `OPENCODE_SERVER_PASSWORD` if you ever expose it.

--- a/docker/opencode/Dockerfile
+++ b/docker/opencode/Dockerfile
@@ -1,65 +1,20 @@
-FROM debian:bookworm-slim
-# Pinned OpenCode version. The contract (agent-file frontmatter, per-message
-# `agent` selection, native skills, task delegation) is validated against THIS
-# tag — do not float to latest. Verified: the installer accepts the pin both as
-# a VERSION env var and a --version flag; either skips its GitHub API lookup.
-ARG OPENCODE_VERSION=1.1.21
+# OpenCode is pre-installed in the base image (docker/opencode/Dockerfile.base,
+# built and pushed to a registry — see BASE_IMAGE.md). This image only layers in
+# the project's agents, skills, and entrypoint, so app/dev builds need NO network
+# and cannot hit the OpenCode-installer TLS-proxy failures. Rebuilds are seconds.
+#
+# Set OPENCODE_BASE_IMAGE to your pushed base tag. The default is a placeholder
+# on purpose: it fails loudly if left unset rather than silently pulling the
+# wrong image. Override per build with `--build-arg OPENCODE_BASE_IMAGE=...` or
+# set the default below to your registry namespace.
+ARG OPENCODE_BASE_IMAGE=docker.io/openmercatocom/open-mercato-opencode:1.18.3
+FROM ${OPENCODE_BASE_IMAGE}
 
-# Install dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates bash passwd \
-    && rm -rf /var/lib/apt/lists/*
-
-# Corporate TLS-intercepting proxies re-sign HTTPS with a root CA the host
-# trusts but this build does not, breaking the installer download below. Trust
-# any PEM dropped into certs/ (the Windows launcher mirrors docker/certs/ here;
-# see docker/certs/README.md). No-op when the directory is empty.
-# cert[s] is a glob + AGENTS.md an always-present anchor: the COPY then
-# succeeds even when certs/ is missing from a partial checkout.
-COPY AGENTS.md cert[s] /tmp/om-certs/
-RUN set -eu; \
-    for cert in /tmp/om-certs/*.crt /tmp/om-certs/*.pem; do \
-        [ -f "$cert" ] || continue; \
-        name="$(basename "$cert")"; \
-        cp "$cert" "/usr/local/share/ca-certificates/om-extra-${name%.*}.crt"; \
-    done; \
-    update-ca-certificates; \
-    rm -rf /tmp/om-certs
-
-# Install OpenCode (pinned) and move to system path. The install can fail
-# transiently on shared/corporate networks (rate limits, proxies), and
-# `curl | bash` masks download failures as a later `cp` error - so download the
-# installer to a file and retry the install up to 3 times.
-# A blocking proxy answers with an HTML page and HTTP 200, which curl -f cannot
-# reject; feeding that to bash yields `syntax error near unexpected token
-# 'newline'` and the retry loop just repeats it. Check the bytes and fail fast
-# with the real reason instead.
-RUN set -eu; \
-    curl -fsSL --retry 3 --retry-delay 5 https://opencode.ai/install -o /tmp/opencode-install.sh; \
-    if head -c 512 /tmp/opencode-install.sh | grep -qi '<!doctype\|<html'; then \
-        echo "https://opencode.ai/install returned an HTML page instead of a script - a proxy is blocking it. Retrying cannot help; ask IT to allow opencode.ai." >&2; \
-        exit 1; \
-    fi; \
-    attempt=1; \
-    until bash /tmp/opencode-install.sh --version "$OPENCODE_VERSION"; do \
-        if [ "$attempt" -ge 3 ]; then echo "OpenCode install failed after $attempt attempts" >&2; exit 1; fi; \
-        attempt=$((attempt + 1)); \
-        echo "OpenCode install failed - retrying (attempt $attempt of 3)..." >&2; \
-        sleep 10; \
-    done; \
-    rm -f /tmp/opencode-install.sh; \
-    cp /root/.opencode/bin/opencode /usr/local/bin/opencode; \
-    chmod +x /usr/local/bin/opencode
-
-# Create non-root user
-RUN useradd -m -s /bin/bash opencode
-
-# Switch to non-root user
+# The base image already installed OpenCode, created the non-root `opencode`
+# user + /home/opencode/.config/opencode, and set WORKDIR. Re-assert them so
+# this Dockerfile is readable on its own and safe if the base ever changes.
 USER opencode
 WORKDIR /home/opencode
-
-# Create config directory
-RUN mkdir -p /home/opencode/.config/opencode
 
 # Copy instructions to working directory (OpenCode resolves relative to $CWD)
 COPY --chown=opencode:opencode AGENTS.md /home/opencode/AGENTS.md
@@ -67,13 +22,11 @@ COPY --chown=opencode:opencode entrypoint.sh /home/opencode/entrypoint.sh
 
 # Bake the generated, file-defined OpenCode agents into the image (prod delivery
 # model B). Dev bind-mounts this same dir via docker-compose.*.dev.yml (model A).
-# Target the plural `agents/` dir under the non-root opencode user's config home.
 COPY --chown=opencode:opencode agents/ /home/opencode/.config/opencode/agents/
 
-# Bake the generated NATIVE OpenCode skill files (Phase 3) into the image. Dev
-# bind-mounts the same dir. Target the plural `skills/` dir; OpenCode lists each
-# skill in the built-in `skill` tool and pulls SKILL.md on demand (progressive
-# disclosure). The dir is created above; the COPY is a no-op when no skills exist.
+# Bake the generated NATIVE OpenCode skill files into the image. Dev bind-mounts
+# the same dir. OpenCode lists each skill in the built-in `skill` tool and pulls
+# SKILL.md on demand (progressive disclosure).
 COPY --chown=opencode:opencode skills/ /home/opencode/.config/opencode/skills/
 
 USER root

--- a/docker/opencode/Dockerfile.base
+++ b/docker/opencode/Dockerfile.base
@@ -1,0 +1,74 @@
+# OpenCode base image — built and pushed to a registry ONCE, then consumed by
+# docker/opencode/Dockerfile via `FROM`. This is the only place OpenCode is
+# downloaded, so application/dev builds never run the installer and never hit
+# its TLS-proxy / rate-limit failures.
+#
+# Rebuild + push this image only when bumping OPENCODE_VERSION. See BASE_IMAGE.md
+# for the build/tag/push commands.
+#
+# Build context is docker/opencode/ (same as the thin image) so the cert anchor
+# below can reuse AGENTS.md + certs/.
+FROM debian:bookworm-slim
+
+# Pin the OpenCode version. The contract (agent-file frontmatter, per-message
+# `agent` selection, native skills, task delegation, and the opencode.jsonc
+# schema written by entrypoint.sh) is validated against THIS tag — do not float
+# to latest. Bumping it is a breaking-risk change: rebuild the base, push it,
+# and re-verify the agentic flow end to end before shipping.
+ARG OPENCODE_VERSION=1.18.3
+
+# Install dependencies. Debian's apt fetches over plain HTTP, so this step still
+# works behind a TLS-intercepting proxy and bootstraps the cert tooling the
+# HTTPS install below needs.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates bash passwd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Corporate TLS-intercepting proxies re-sign HTTPS with a root CA the host
+# trusts but this build does not, breaking the installer download below. Trust
+# any PEM/CRT dropped into certs/ (see docker/certs/README.md). No-op when the
+# directory is empty. cert[s] is a glob + AGENTS.md an always-present anchor, so
+# the COPY succeeds even when certs/ is missing from a partial checkout.
+COPY AGENTS.md cert[s] /tmp/om-certs/
+RUN set -eu; \
+    for cert in /tmp/om-certs/*.crt /tmp/om-certs/*.pem; do \
+        [ -f "$cert" ] || continue; \
+        name="$(basename "$cert")"; \
+        cp "$cert" "/usr/local/share/ca-certificates/om-extra-${name%.*}.crt"; \
+    done; \
+    update-ca-certificates; \
+    rm -rf /tmp/om-certs
+
+# Install OpenCode (pinned) to the system path. Download to a file rather than
+# piping into bash: a blocking proxy answers with an HTML page and HTTP 200,
+# which curl -f cannot reject, and `curl | bash` masks download failures as a
+# later `cp` error. Guard against HTML, then retry the install up to 3 times.
+RUN set -eu; \
+    curl -fsSL --retry 3 --retry-delay 5 https://opencode.ai/install -o /tmp/opencode-install.sh; \
+    if head -c 512 /tmp/opencode-install.sh | grep -qi '<!doctype\|<html'; then \
+        echo "https://opencode.ai/install returned an HTML page instead of a script - a proxy is blocking it. Retrying cannot help; ask IT to allow opencode.ai." >&2; \
+        exit 1; \
+    fi; \
+    attempt=1; \
+    until bash /tmp/opencode-install.sh --version "$OPENCODE_VERSION"; do \
+        if [ "$attempt" -ge 3 ]; then echo "OpenCode install failed after $attempt attempts" >&2; exit 1; fi; \
+        attempt=$((attempt + 1)); \
+        echo "OpenCode install failed - retrying (attempt $attempt of 3)..." >&2; \
+        sleep 10; \
+    done; \
+    rm -f /tmp/opencode-install.sh; \
+    cp /root/.opencode/bin/opencode /usr/local/bin/opencode; \
+    chmod +x /usr/local/bin/opencode
+
+# Non-root user + config skeleton the thin image fills in with agents/skills.
+RUN useradd -m -s /bin/bash opencode \
+    && mkdir -p /home/opencode/.config/opencode \
+    && chown -R opencode:opencode /home/opencode/.config
+
+# Record the baked version for `docker inspect` / provenance.
+LABEL org.opencontainers.image.title="open-mercato-opencode" \
+      org.opencontainers.image.description="Debian slim + pinned OpenCode CLI, base for the Open Mercato opencode service" \
+      com.open-mercato.opencode.version="${OPENCODE_VERSION}"
+
+USER opencode
+WORKDIR /home/opencode


### PR DESCRIPTION
Distributes OpenCode as a prebuilt base image so app/dev builds stop downloading the installer. Base is `feat/agent-orchestrator-mvp`.

## Why

`docker/opencode/Dockerfile` ran `curl https://opencode.ai/install | ...` on every build. Behind a corporate TLS-intercepting proxy that fails (`self-signed certificate in certificate chain`); even on a good network it is slow and rate-limitable. This is the download that broke on the reporting machine.

## What

Split the image in two:

- **`docker/opencode/Dockerfile.base`** (new) — Debian slim + OpenCode (pinned **1.18.3**) + the non-root `opencode` user and config skeleton. Built and pushed to a registry **once** (`docker.io/openmercatocom/open-mercato-opencode`). Keeps the cert handling and HTML-block-page guard, since this is now the only place the installer runs.
- **`docker/opencode/Dockerfile`** (rewritten thin) — `FROM` the base, then only `COPY`s this project's `AGENTS.md`, agents, skills, entrypoint. No network, no install; rebuilds are seconds.
- **`docker/opencode/BASE_IMAGE.md`** (new) — build/push runbook.
- **compose** — both fullapp/dev and the base `docker-compose.yml` pass `OPENCODE_BASE_IMAGE` as an overridable build arg (`${OPENCODE_BASE_IMAGE:-docker.io/openmercatocom/open-mercato-opencode:1.18.3}`).

## Version bump 1.1.21 → 1.18.3 — verified

The old pin carried a "do not float" warning because the `opencode.jsonc` the entrypoint writes is validated against a specific tag. Checked against 1.18.3 with real builds:

| Check | Result |
|---|---|
| installer accepts `--version 1.18.3` | yes; real 177 MB binary, not a download stub |
| `opencode --version` in the base | `1.18.3` |
| entrypoint CLI flags (`serve --hostname/--print-logs/--log-level DEBUG`) | all still valid |
| **`opencode.jsonc` schema** (provider / `mcp` remote / `permission` / `tools` / `server`) | **accepted** — `opencode server listening on http://0.0.0.0:4096`, on both anthropic and openai-compatible provider branches, zero schema errors |
| thin image builds with the committed default (no build-args, as compose invokes it) | exit 0; 6 agents + 3 skills baked, owned by `opencode` |
| both compose files parse; env override wins | OK |

## Merge order / caveats

- **Push the base first.** Until `docker buildx … --push` from `BASE_IMAGE.md` runs, `docker compose … build opencode` cannot pull `openmercatocom/open-mercato-opencode:1.18.3`. That is the one required manual step.
- **Multi-arch is required.** Corporate Windows/Rancher is `linux/amd64`; dev Macs are `arm64`. The runbook uses `buildx --platform linux/amd64,linux/arm64`.
- **Not a total TLS cure:** `docker pull` still traverses the proxy, but trusting one registry (`registry-1.docker.io`, usually allowlisted) is far more reliable than a per-build `curl | bash` of a GitHub-hosted binary.
- **Residual (needs a live-stack run):** verified config parsing + server startup, not a full Cmd+K → tool-call → MCP round-trip. 1.18.3 also logs `OPENCODE_SERVER_PASSWORD is not set; server is unsecured` — the compose stacks keep the port off the public interface, so it is informational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
