### PR TITLE
feat(entities): resolve relation column display labels on the generic records list

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/definitions.api.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/definitions.api.test.ts
@@ -148,6 +148,51 @@ describe('entities/definitions API', () => {
     expect(notes?.defaultValue).toBeUndefined()
   })
 
+  it('exposes relatedEntityId for relation-kind fields only', async () => {
+    mockEm.find
+      .mockResolvedValueOnce([
+        {
+          key: 'goods',
+          kind: 'relation',
+          entityId: 'custom:stock_in',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+          updatedAt: new Date(),
+          configJson: { label: 'Goods', relatedEntityId: 'custom:goods' },
+        },
+        {
+          key: 'broken_relation',
+          kind: 'relation',
+          entityId: 'custom:stock_in',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+          updatedAt: new Date(),
+          configJson: { label: 'Broken' }, // relation without a target
+        },
+        {
+          key: 'notes',
+          kind: 'text',
+          entityId: 'custom:stock_in',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+          updatedAt: new Date(),
+          // non-relation kinds must not leak the field even if config carries it
+          configJson: { label: 'Notes', relatedEntityId: 'custom:goods' },
+        },
+      ])
+      .mockResolvedValueOnce([]) // tombstones
+
+    const response = await GET(
+      new Request('http://x/api/entities/definitions?entityId=custom:stock_in'),
+    )
+
+    expect(response.status).toBe(200)
+    const items = (await response.json()).items as Array<Record<string, unknown>>
+    expect(items.find((i) => i.key === 'goods')?.relatedEntityId).toBe('custom:goods')
+    expect(items.find((i) => i.key === 'broken_relation')?.relatedEntityId).toBeUndefined()
+    expect(items.find((i) => i.key === 'notes')?.relatedEntityId).toBeUndefined()
+  })
+
   it('hides inherited definitions that have a scoped tombstone', async () => {
     mockEm.find
       .mockResolvedValueOnce([

--- a/packages/core/src/modules/entities/api/definitions.ts
+++ b/packages/core/src/modules/entities/api/definitions.ts
@@ -393,6 +393,11 @@ export async function GET(req: Request) {
         label: d.configJson?.label || d.key,
         description: d.configJson?.description || undefined,
         multi: Boolean(d.configJson?.multi),
+        // Relation target (README: relation fields carry `relatedEntityId` in config).
+        // Exposed so list/detail UIs can resolve display labels instead of raw record ids.
+        relatedEntityId: d.kind === 'relation' && typeof d.configJson?.relatedEntityId === 'string'
+          ? d.configJson.relatedEntityId
+          : undefined,
         options: (() => {
           if (d.kind === 'currency') return undefined
           const normalizedOptions = normalizeCustomFieldOptions(d.configJson?.options)

--- a/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
+++ b/packages/core/src/modules/entities/backend/entities/user/[entityId]/records/page.tsx
@@ -170,16 +170,96 @@ function RecordsPageInner({ params }: { params: { entityId?: string } }) {
     return () => { cancelled = true }
   }, [entityId, page, pageSize, sorting, filterValues, scopeVersion, search, searchableFields])
 
+  // Resolve display labels for relation columns. Relation cells store raw related-record
+  // ids; rendering them verbatim is unreadable (GOAL Phase 2A gap). One batched fetch per
+  // related entity (never per row): ids -> related records -> labelField/name/title.
+  const relationDefs = React.useMemo(
+    () => (filterCustomFieldDefs(cfDefs, 'list') as any[]).filter(
+      (d: any) => d.kind === 'relation' && typeof d.relatedEntityId === 'string' && d.relatedEntityId,
+    ),
+    [cfDefs],
+  )
+  const [relationLabels, setRelationLabels] = React.useState<Record<string, string>>({})
+  React.useEffect(() => {
+    if (!relationDefs.length || !rawData.length) return
+    let cancelled = false
+    const run = async () => {
+      const wanted = new Map<string, Set<string>>()
+      for (const def of relationDefs) {
+        const target = def.relatedEntityId as string
+        const set = wanted.get(target) ?? new Set<string>()
+        for (const row of rawData) {
+          const v = (row as any)?.[def.key]
+          for (const id of Array.isArray(v) ? v : [v]) {
+            if (typeof id === 'string' && id && relationLabels[id] === undefined) set.add(id)
+          }
+        }
+        if (set.size) wanted.set(target, set)
+      }
+      if (!wanted.size) return
+      // labelField per related entity (single definitions fetch covers all targets)
+      let labelFieldByEntity = new Map<string, string>()
+      try {
+        const defsRes = await readApiResultOrThrow<{ items?: Array<{ entityId: string; labelField?: string }> }>(
+          '/api/entities/entities',
+          undefined,
+          { errorMessage: 'Failed to load entity definitions', fallback: { items: [] } },
+        )
+        labelFieldByEntity = new Map((defsRes.items ?? []).map((e) => [e.entityId, e.labelField || '']))
+      } catch {
+        // label resolution is progressive enhancement — fall back to generic fields below
+      }
+      const next: Record<string, string> = {}
+      await Promise.all(Array.from(wanted.entries()).map(async ([target, ids]) => {
+        try {
+          const params = new URLSearchParams()
+          params.set('entityId', target)
+          params.set('id', Array.from(ids).join(','))
+          params.set('pageSize', String(Math.min(ids.size, 200)))
+          const res = await readApiResultOrThrow<{ items?: Array<Record<string, unknown>> }>(
+            `/api/entities/records?${params.toString()}`,
+            undefined,
+            { errorMessage: 'Failed to load related records', fallback: { items: [] } },
+          )
+          const labelField = labelFieldByEntity.get(target) || ''
+          for (const item of res.items ?? []) {
+            const id = typeof item.id === 'string' ? item.id : null
+            if (!id) continue
+            const label = [labelField ? item[labelField] : null, item.name, item.title, item.label]
+              .find((v) => typeof v === 'string' && (v as string).trim().length > 0) as string | undefined
+            if (label) next[id] = label
+          }
+        } catch {
+          // leave unresolved ids as-is (cell falls back to the raw value)
+        }
+      }))
+      if (!cancelled && Object.keys(next).length) setRelationLabels((prev) => ({ ...prev, ...next }))
+    }
+    void run()
+    return () => { cancelled = true }
+    // relationLabels intentionally read (skip already-resolved ids) but not a retrigger source
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [relationDefs, rawData])
+
   // Build columns from custom field definitions only (no data round-trip)
   React.useEffect(() => {
     const visibleDefs = filterCustomFieldDefs(cfDefs, 'list') as any
     const maxVisible = 10
+    const relationKeys = new Set(relationDefs.map((d: any) => d.key))
     const cols: ColumnDef<any>[] = visibleDefs.map((d: any, idx: number) => ({
       accessorKey: d.key,
       header: d.label || d.key,
       meta: { priority: idx < 4 ? 1 : idx < 6 ? 2 : idx < 8 ? 3 : idx < maxVisible ? 4 : 5 },
       cell: ({ getValue }: { getValue: () => unknown }) => {
         const v = getValue() as any
+        if (relationKeys.has(d.key)) {
+          const resolved = (Array.isArray(v) ? v : [v])
+            .filter((id: unknown) => typeof id === 'string' && id)
+            .map((id: string) => relationLabels[id] ?? id)
+            .join(', ')
+          // title keeps the raw id(s) so operators can still copy them
+          return <span className="truncate max-w-[24ch] inline-block align-top" title={normalizeCell(v)}>{resolved || normalizeCell(v)}</span>
+        }
         return <span className="truncate max-w-[24ch] inline-block align-top" title={normalizeCell(v)}>{normalizeCell(v)}</span>
       },
     }))
@@ -187,7 +267,7 @@ function RecordsPageInner({ params }: { params: { entityId?: string } }) {
     const hasIdCol = cols.some((c) => (c as any).accessorKey === 'id' || (c as any).id === 'id')
     if (!hasIdCol) cols.unshift({ accessorKey: 'id', header: 'ID', meta: { hidden: true, priority: 6 } } as any)
     setColumns(cols)
-  }, [cfDefs])
+  }, [cfDefs, relationDefs, relationLabels])
 
   // Search is server-side (see fetch effect); render the fetched page as-is so
   // pagination totals and exports stay consistent with the active search (#3229).

--- a/packages/ui/src/backend/utils/customFieldDefs.ts
+++ b/packages/ui/src/backend/utils/customFieldDefs.ts
@@ -37,6 +37,8 @@ export type CustomFieldDefDto = {
   dictionaryId?: string
   dictionaryInlineCreate?: boolean
   defaultValue?: string | number | boolean | null
+  // relation kind: target entity id (e.g. `custom:goods`) for display-label resolution
+  relatedEntityId?: string
 }
 
 export type CustomFieldsetGroupDto = {


### PR DESCRIPTION
## Problem

Relation custom fields store raw related-record ids. The generic records list (`/backend/entities/user/[entityId]/records`) renders those ids verbatim, which is unreadable for operators (documented gap: GOAL Phase 2A).

## Fix

- The definitions API now exposes `relatedEntityId` for relation-kind fields (per the module README, relation config carries `relatedEntityId`); non-relation kinds never leak the field even if present in config. `CustomFieldDefDto` gains the optional field.
- The records list resolves display labels with **one batched fetch per related entity** (collected ids → `/api/entities/records?id=a,b,c`), preferring the related entity's `labelField`, then `name`/`title`/`label`, falling back to the raw id. Cell titles keep the raw ids so operators can still copy them.
- Resolution is progressive enhancement: any fetch failure leaves cells on the previous raw-id behaviour.

## Validation

- New test case in `definitions.api.test.ts`: `relatedEntityId` exposed for relation kind only (3 assertions incl. non-leak for other kinds).
- `yarn workspace @open-mercato/core test entities`: 255 passed.
- `build:packages` + `generate` + `turbo run typecheck --filter=@open-mercato/core --filter=@open-mercato/ui`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
