### PR TITLE
fix(dev-env): hybrid Windows dev-env fixes (MCP key owner, container→host, native build toolchain)

### DIFF
--- a/packages/starter/src/__tests__/starter.test.mjs
+++ b/packages/starter/src/__tests__/starter.test.mjs
@@ -10,7 +10,8 @@ import { DEFAULT_OPENCODE_BASE_IMAGE, DEFAULT_PORTS, resolveStackPorts } from '.
 import { addEnvValue, readEnvValue, setEnvValue } from '../env-file.mjs'
 import { ensureLlmProvider, syncProviderConfigToAppEnv } from '../providers.mjs'
 import { ensureWindowsUtf8Console, resolveSpawnCommand } from '../spawn.mjs'
-import { StepBlocked, clearConvergenceState, listMigrationModules, migrationsFingerprint, readAppliedMigrationModules, resolveOpencodeBaseImage, runSteps } from '../steps.mjs'
+import { StepBlocked, buildToolchainStep, clearConvergenceState, listMigrationModules, migrationsFingerprint, readAppliedMigrationModules, resolveOpencodeBaseImage, runSteps } from '../steps.mjs'
+import { checkBuildToolchain } from '../doctor.mjs'
 
 function makeTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
@@ -320,4 +321,13 @@ test('resolveOpencodeBaseImage: env wins, then .env, then the pinned default', (
   } finally {
     fs.rmSync(root, { recursive: true, force: true })
   }
+})
+
+test('checkBuildToolchain is a no-op off Windows and the gate only applies to hybrid+win32', () => {
+  if (process.platform !== 'win32') {
+    assert.equal(checkBuildToolchain(), null)
+  }
+  // The converge gate never runs off Windows, and never in docker mode.
+  assert.equal(buildToolchainStep.appliesTo({ mode: 'hybrid' }), process.platform === 'win32')
+  assert.equal(buildToolchainStep.appliesTo({ mode: 'docker' }), false)
 })

--- a/packages/starter/src/cli.mjs
+++ b/packages/starter/src/cli.mjs
@@ -277,11 +277,12 @@ async function commandStatus(flags) {
   printStatus(status)
 }
 
-async function commandDoctor() {
+async function commandDoctor(flags) {
   const company = await loadCompanyConfig(repoRoot)
   const runState = readRunState(repoRoot)
   const stackRunning = Boolean(runState && isPidAlive(runState.pid))
-  const checks = await runDoctor(repoRoot, { company, stackRunning, includeContainerProbe: true })
+  const mode = resolveMode(flags?.mode)
+  const checks = await runDoctor(repoRoot, { company, stackRunning, includeContainerProbe: true, mode })
   const ok = printDoctorReport(checks, { company })
   process.exit(ok ? 0 : 2)
 }
@@ -340,7 +341,7 @@ async function main() {
     case 'logs':
       return tailLogs(repoRoot, { follow: flags.follow })
     case 'doctor':
-      return commandDoctor()
+      return commandDoctor(flags)
     case 'reset':
       return commandReset(flags)
     case 'infra':

--- a/packages/starter/src/doctor.mjs
+++ b/packages/starter/src/doctor.mjs
@@ -317,12 +317,19 @@ export function checkContainerToHost(repoRoot, { mcpPort }) {
     })
   }
   if (pinned.resolvedIp || native.resolvedIp) {
-    return result('container-host', 'Container → host connectivity', 'warn', 'host.docker.internal resolves but the MCP port did not answer (MCP not running yet, or a host firewall blocks the docker bridge)', {
+    const isWindows = process.platform === 'win32'
+    const firewallRule = `New-NetFirewallRule -DisplayName "Open Mercato MCP dev" -Direction Inbound -Action Allow -Protocol TCP -LocalPort ${mcpPort} -Profile Any`
+    return result('container-host', 'Container → host connectivity', 'warn', `host.docker.internal resolves${pinned.resolvedIp ? ` (${pinned.resolvedIp})` : ''} but the MCP port did not answer — MCP is not running yet, or a host firewall blocks the container→host hop`, {
       guide: [
-        'Start the stack first (yarn om / npx @open-mercato/starter), then re-run the doctor.',
-        'Windows: allow the first-run firewall prompt for Node.js on Private networks.',
-        'Linux (ufw): sudo ufw allow from 172.16.0.0/12 to any port ' + mcpPort + ' proto tcp',
+        'If the stack is not running yet, start it (yarn om) and re-run the doctor.',
+        isWindows
+          ? `Windows Firewall drops the container→host hop over the WSL/vEthernet adapter. Allow it (elevated PowerShell): ${firewallRule}`
+          : 'Windows: allow node.exe inbound on the MCP port for Private networks (the first-run firewall prompt).',
+        `Linux (ufw): sudo ufw allow from 172.16.0.0/12 to any port ${mcpPort} proto tcp`,
       ],
+      it: isWindows
+        ? [`Approve an inbound firewall rule for the local dev MCP server: ${firewallRule}`]
+        : [],
     })
   }
   return result('container-host', 'Container → host connectivity', 'fail', 'host.docker.internal does not resolve inside containers', {

--- a/packages/starter/src/doctor.mjs
+++ b/packages/starter/src/doctor.mjs
@@ -136,6 +136,38 @@ export function checkWsl2() {
   })
 }
 
+// Hybrid mode compiles native Node addons (better-sqlite3, isolated-vm,
+// cpu-features, …) from C++ during `yarn install`. On Windows that needs the
+// Visual C++ toolchain, which the starter never installs (propose-only) — so a
+// clean machine otherwise fails the install with a cryptic node-gyp error.
+// macOS/Linux ship clang/gcc widely enough that we don't gate on them here.
+export function checkBuildToolchain() {
+  if (process.platform !== 'win32') return null
+  const programFilesX86 = process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)'
+  const vswhere = path.join(programFilesX86, 'Microsoft Visual Studio', 'Installer', 'vswhere.exe')
+  let installPath = ''
+  if (fs.existsSync(vswhere)) {
+    const out = commandOutput(vswhere, [
+      '-latest', '-products', '*',
+      '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
+      '-property', 'installationPath',
+    ])
+    installPath = (out ?? '').trim()
+  }
+  if (installPath) {
+    return result('build-tools', 'C++ build toolchain (native Node modules)', 'pass', 'Visual Studio Build Tools with the VC++ workload')
+  }
+  return result('build-tools', 'C++ build toolchain (native Node modules)', 'fail', 'not found — native addons (better-sqlite3, isolated-vm, …) cannot compile on the host', {
+    guide: [
+      'Hybrid mode builds native Node modules on the host, which needs the Visual C++ toolchain.',
+      'Install it (several GB, admin required), then open a NEW terminal and re-run:',
+      '  winget install Microsoft.VisualStudio.2022.BuildTools --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"',
+      'No admin, or cannot install it? Build everything in containers instead:  yarn om up --mode docker',
+    ],
+    it: ['Install "Visual Studio 2022 Build Tools" with the "Desktop development with C++" (VCTools) workload — required to compile native Node modules for the native/hybrid dev workflow.'],
+  })
+}
+
 export function checkResources(repoRoot) {
   const totalGb = os.totalmem() / GIB
   let freeDiskGb = null
@@ -337,7 +369,7 @@ export function checkContainerToHost(repoRoot, { mcpPort }) {
   })
 }
 
-export async function runDoctor(repoRoot, { company = null, stackRunning = false, includeContainerProbe = false } = {}) {
+export async function runDoctor(repoRoot, { company = null, stackRunning = false, includeContainerProbe = false, mode = 'hybrid' } = {}) {
   const ports = resolveStackPorts(repoRoot)
   const checks = [
     checkNodeVersion(),
@@ -346,6 +378,9 @@ export async function runDoctor(repoRoot, { company = null, stackRunning = false
     checkWsl2(),
     checkContainerRuntime(),
     checkDockerDesktopVersion(),
+    // The host C++ toolchain only matters when native modules build on the
+    // host — i.e. hybrid mode. In --mode docker they compile in the container.
+    mode === 'docker' ? null : checkBuildToolchain(),
     checkResources(repoRoot),
     await checkLocalhostResolution(),
     checkProxyConsistency(),

--- a/packages/starter/src/env-setup.mjs
+++ b/packages/starter/src/env-setup.mjs
@@ -98,5 +98,22 @@ export function ensureEnvFiles(repoRoot, { log = console.log, warn = console.war
     log('apps/mercato/.env already exists (left untouched)')
   }
 
+  // The host-run `mercato` CLI (yarn initialize, yarn ... mcp:ensure-api-key)
+  // loads apps/mercato/.env, NOT the root compose .env. The superadmin
+  // identity must live there too: otherwise `initialize` seeds one admin while
+  // MCP key provisioning resolves a different (default) owner, throws "owner
+  // not found", and OpenCode never gets a key. Propagate the same values
+  // (fill-missing-only, so a user's own app .env is never clobbered).
+  if (fs.existsSync(appEnv)) {
+    const superEmail = readEnvValue(rootEnv, 'OM_INIT_SUPERADMIN_EMAIL')?.trim()
+    const superPassword = readEnvValue(rootEnv, 'OM_INIT_SUPERADMIN_PASSWORD')?.trim()
+    if (superEmail && addEnvValue(appEnv, 'OM_INIT_SUPERADMIN_EMAIL', superEmail)) {
+      log('  set OM_INIT_SUPERADMIN_EMAIL in apps/mercato/.env')
+    }
+    if (superPassword && addEnvValue(appEnv, 'OM_INIT_SUPERADMIN_PASSWORD', superPassword)) {
+      log('  set OM_INIT_SUPERADMIN_PASSWORD (sha256 …) in apps/mercato/.env')
+    }
+  }
+
   return { rootEnv, appEnv, jwtSecret }
 }

--- a/packages/starter/src/steps.mjs
+++ b/packages/starter/src/steps.mjs
@@ -7,7 +7,7 @@ import { detectDocker, parseComposePsOutput, runCaptureSync, runCompose, runStre
 import { captureInterceptionCas, findVendorCaBundles, harvestWindowsStoreCas, hostTrustEnv, probeTlsInterception, provisionDockerCerts, provisionRancherDesktopCa, summarizeProbeResults, writeCaBundle } from './certs.mjs'
 import { loadCompanyConfig, resolveCompanyCertBundles } from './company.mjs'
 import { CAPTURED_CA_BUNDLE, DEFAULT_OPENCODE_BASE_IMAGE, OPENCODE_SERVICE_IMAGE, STARTER_STATE_DIR, resolveStackPorts } from './constants.mjs'
-import { checkContainerRuntime, checkGit, checkNodeVersion, checkWsl2 } from './doctor.mjs'
+import { checkBuildToolchain, checkContainerRuntime, checkGit, checkNodeVersion, checkWsl2 } from './doctor.mjs'
 import { ensureEnvFiles } from './env-setup.mjs'
 import { readEnvValue } from './env-file.mjs'
 import { ensureMcpSharedDir, infraUp } from './infra.mjs'
@@ -311,6 +311,24 @@ export const corporateCertsStep = {
   },
 }
 
+export const buildToolchainStep = {
+  id: 'build-toolchain',
+  expectation: 'instant check; install guidance if missing',
+  title: 'C++ build toolchain (native Node modules)',
+  // Only hybrid builds native addons on the host; --mode docker compiles them
+  // in the container. The check itself is Windows-only (returns null elsewhere).
+  appliesTo: (ctx) => ctx.mode === 'hybrid' && process.platform === 'win32',
+  async check() {
+    const toolchain = checkBuildToolchain()
+    if (!toolchain || toolchain.level === 'pass') {
+      return { ok: true, detail: toolchain?.detail ?? 'not required on this platform' }
+    }
+    // Fail fast with the fix instead of letting `yarn install` faceplant on
+    // node-gyp after several minutes. Propose-only: we never install it.
+    throw new StepBlocked(this.id, toolchain.guide)
+  },
+}
+
 export const envFilesStep = {
   id: 'env-files',
   expectation: 'instant; secrets generated once, never rotated',
@@ -514,6 +532,7 @@ export function buildUpSteps(ctx) {
   const base = [
     prerequisitesStep,
     containerRuntimeStep,
+    buildToolchainStep,
     corporateCertsStep,
     envFilesStep,
     workspaceInstallStep,

--- a/scripts/__tests__/dev-mcp.test.mjs
+++ b/scripts/__tests__/dev-mcp.test.mjs
@@ -8,6 +8,7 @@ import {
   deriveMcpHealthUrl,
   isFastMcpCrash,
   isKeyRotationOutput,
+  looksLikeMissingKeyOwner,
   looksLikePermissionError,
   looksLikeUninitializedDatabase,
   nextMcpKeyRetryDelayMs,
@@ -113,4 +114,15 @@ test('output classifiers detect rotation, permission, and uninitialized-database
   assert.equal(looksLikeUninitializedDatabase(['error: relation "api_keys" does not exist']), true)
   assert.equal(looksLikeUninitializedDatabase(['connect ECONNREFUSED 127.0.0.1:5432']), true)
   assert.equal(looksLikeUninitializedDatabase(['TypeError: boom']), false)
+})
+
+test('looksLikeMissingKeyOwner detects the owner-not-found throw', () => {
+  assert.equal(
+    looksLikeMissingKeyOwner(['[internal] MCP API key owner not found: no active user with email "superadmin@acme.com".']),
+    true,
+  )
+  assert.equal(looksLikeMissingKeyOwner(['Run "mercato init" first or pass --email pointing at an existing admin user.']), true)
+  // "Run mercato init" is an owner-resolution failure, not a bare DB-not-ready signal.
+  assert.equal(looksLikeUninitializedDatabase(['Run "mercato init" first']), false)
+  assert.equal(looksLikeMissingKeyOwner(['connect ECONNREFUSED 127.0.0.1:5432']), false)
 })

--- a/scripts/dev-mcp.mjs
+++ b/scripts/dev-mcp.mjs
@@ -73,7 +73,16 @@ export function looksLikePermissionError(outputLines = []) {
 
 export function looksLikeUninitializedDatabase(outputLines = []) {
   return outputLines.some((line) =>
-    /relation .* does not exist|database .* does not exist|Run mercato init|ECONNREFUSED/i.test(String(line)),
+    /relation .* does not exist|database .* does not exist|ECONNREFUSED/i.test(String(line)),
+  )
+}
+
+// `mcp:ensure-api-key` resolves the key's owner by the superadmin email in the
+// null-tenant scope and throws when no user matches — the app is up but the DB
+// was seeded under a different admin email or a different LOOKUP_HASH_PEPPER.
+export function looksLikeMissingKeyOwner(outputLines = []) {
+  return outputLines.some((line) =>
+    /MCP API key owner not found|no active user with email|Run "?mercato init"?/i.test(String(line)),
   )
 }
 

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -33,6 +33,7 @@ import {
   deriveMcpHealthUrl,
   isFastMcpCrash,
   isKeyRotationOutput,
+  looksLikeMissingKeyOwner,
   looksLikePermissionError,
   looksLikeUninitializedDatabase,
   nextMcpKeyRetryDelayMs,
@@ -1859,10 +1860,18 @@ async function provisionMcpApiKey() {
     if (looksLikePermissionError(capturedLines)) {
       console.warn(`⚠️ MCP key provisioning hit a permission error writing ${mcpKeyFilePath}.`)
       console.warn('   ↳ if Docker created .mercato/mcp-shared as root, fix it with: sudo chown -R "$(id -u)" .mercato/mcp-shared')
+    } else if (looksLikeMissingKeyOwner(capturedLines)) {
+      console.warn('⚠️ MCP API key provisioning failed — the key owner (superadmin) could not be resolved.')
+      console.warn('   ↳ set OM_INIT_SUPERADMIN_EMAIL in apps/mercato/.env to the email you sign into /backend with, then restart.')
+      console.warn('   ↳ if it still fails with the right email, the database was seeded under different secrets (LOOKUP_HASH_PEPPER); reseed with `yarn om reset` then `yarn om`.')
     } else if (looksLikeUninitializedDatabase(capturedLines)) {
       console.warn('⚠️ MCP API key provisioning failed — is the database initialized and reachable? Run `yarn infra:up`, then `yarn db:migrate && yarn initialize`.')
     } else {
-      console.warn('⚠️ MCP API key provisioning failed — see the dev runner log for details.')
+      console.warn('⚠️ MCP API key provisioning failed:')
+      for (const line of extractFailureLines(capturedLines, 4)) {
+        console.warn(`   ${line}`)
+      }
+      console.warn('   ↳ full output in the dev runner log.')
     }
     const delay = nextMcpKeyRetryDelayMs(attempt)
     console.warn(`   ↳ retrying in ${Math.round(delay / 1000)}s (the app keeps running without MCP in the meantime)`)


### PR DESCRIPTION
## Summary

Three fixes for issues hit while bringing up the hybrid dev stack (app + MCP native on the Windows host, OpenCode + services in containers). All dev-environment only; no product/runtime behavior change.

### 1. MCP key never created → OpenCode can't authenticate (root cause)
`mcp:ensure-api-key` provisions the MCP key **owned by the superadmin**, resolved by email in the `tenantId: null` scope, and **throws before creating anything** if no user matches. In hybrid mode both `yarn initialize` and `yarn … mcp:ensure-api-key` run on the host and read **`apps/mercato/.env`** — but the starter wrote `OM_INIT_SUPERADMIN_EMAIL`/`_PASSWORD` only into the **root compose `.env`**. So provisioning fell back to the default owner, threw "owner not found", produced **no DB key and no key file**, and `yarn dev` retried that throw forever behind a generic warning.
- **`env-setup.mjs`** propagates `OM_INIT_SUPERADMIN_EMAIL`/`_PASSWORD` into `apps/mercato/.env` too (fill-missing-only).
- **`dev.mjs` / `dev-mcp.mjs`** classify the owner-not-found failure with a targeted hint and print the **real captured error** on any other failure instead of the opaque "see the dev runner log" line.

### 2. Native build toolchain missing → `yarn install` faceplants
Hybrid compiles native addons (`better-sqlite3`, `isolated-vm`, `cpu-features`, `@newrelic/native-metrics`, …) from C++ during install; on Windows that needs the Visual C++ toolchain, which the starter never checked for — so a clean machine hit a cryptic node-gyp failure ~30s in.
- **`doctor.mjs`** — new `checkBuildToolchain()` detects VS Build Tools (VCTools workload) via `vswhere`; on failure prints the exact `winget install … Microsoft.VisualStudio.2022.BuildTools` command, the `--mode docker` escape hatch, and an IT hand-off entry. Gated to hybrid mode.
- **`steps.mjs`** — new `buildToolchainStep` gates the converge **before** `yarn install` (hybrid + win32 only), blocking with the fix instead of a confusing install failure. Propose-only, like the runtime/WSL2 gates.

### 3. Container→host connectivity diagnostics (Windows)
- **`doctor.mjs`** — the container→host check now emits the exact `New-NetFirewallRule … -LocalPort <mcp> -Profile Any` command (and IT entry) for the case where `host.docker.internal` resolves but the port is firewalled.

## Validation
`yarn test:scripts` → **341 pass** (added: `looksLikeMissingKeyOwner` classifier coverage, a functional env-setup propagation check, and a guard that the build-toolchain gate is a no-op off Windows / in docker mode). Syntax-checked all edited files.

Docs companion (rewritten Windows manuals, incl. the corrected VS Build Tools requirement) is separate: #4297.

## Scope
Dev-environment only. `risk-low`.