### PR TITLE
fix(starter): build-toolchain gate warns instead of blocking a converged workspace

### DIFF
--- a/packages/starter/src/__tests__/starter.test.mjs
+++ b/packages/starter/src/__tests__/starter.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -330,4 +331,29 @@ test('checkBuildToolchain is a no-op off Windows and the gate only applies to hy
   // The converge gate never runs off Windows, and never in docker mode.
   assert.equal(buildToolchainStep.appliesTo({ mode: 'hybrid' }), process.platform === 'win32')
   assert.equal(buildToolchainStep.appliesTo({ mode: 'docker' }), false)
+})
+
+test('buildToolchainStep warns instead of blocking when the workspace install already converged', async () => {
+  const repo = makeFakeRepo()
+  const missingToolchain = () => ({ level: 'fail', guide: ['install VC++'] })
+  const ctx = { repoRoot: repo, log: () => {}, checkBuildToolchainImpl: missingToolchain }
+
+  // No node_modules, no install marker: an install is pending — hard block.
+  await assert.rejects(() => buildToolchainStep.check(ctx), (error) => error instanceof StepBlocked)
+
+  // Converged workspace (node_modules + matching install.hash): warn, no block.
+  fs.mkdirSync(path.join(repo, 'node_modules'), { recursive: true })
+  fs.mkdirSync(path.join(repo, '.mercato', 'starter'), { recursive: true })
+  const currentHash = crypto.createHash('sha256')
+    .update('yarn.lock').update(Buffer.alloc(0))
+    .update('package.json').update(Buffer.alloc(0))
+    .digest('hex')
+  fs.writeFileSync(path.join(repo, '.mercato', 'starter', 'install.hash'), `${currentHash}\n`)
+  const outcome = await buildToolchainStep.check(ctx)
+  assert.equal(outcome.ok, true)
+  assert.match(outcome.detail, /already converged/)
+
+  // A pending lockfile change re-arms the hard block.
+  fs.writeFileSync(path.join(repo, 'yarn.lock'), 'changed\n')
+  await assert.rejects(() => buildToolchainStep.check(ctx), (error) => error instanceof StepBlocked)
 })

--- a/packages/starter/src/steps.mjs
+++ b/packages/starter/src/steps.mjs
@@ -318,10 +318,22 @@ export const buildToolchainStep = {
   // Only hybrid builds native addons on the host; --mode docker compiles them
   // in the container. The check itself is Windows-only (returns null elsewhere).
   appliesTo: (ctx) => ctx.mode === 'hybrid' && process.platform === 'win32',
-  async check() {
-    const toolchain = checkBuildToolchain()
+  async check(ctx) {
+    const toolchain = (ctx.checkBuildToolchainImpl ?? checkBuildToolchain)()
     if (!toolchain || toolchain.level === 'pass') {
       return { ok: true, detail: toolchain?.detail ?? 'not required on this platform' }
+    }
+    // The toolchain only matters when `yarn install` is about to (re)build
+    // native addons. Prebuilt binaries cover most modules, so a workspace
+    // that already converged runs fine without VC++ — blocking it would
+    // regress a working environment. Warn and move on; the hard gate stays
+    // for runs where an install is actually pending.
+    const installConverged = fs.existsSync(path.join(ctx.repoRoot, 'node_modules'))
+      && readState(ctx.repoRoot, 'install.hash') === hashFiles(ctx.repoRoot, ['yarn.lock', 'package.json'])
+    if (installConverged) {
+      ctx.log('   ⚠️ VC++ build toolchain not found — dependencies are already installed, so this is not blocking now.')
+      ctx.log('   ↳ the next dependency change may need it:  winget install Microsoft.VisualStudio.2022.BuildTools --override "--wait --quiet --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"')
+      return { ok: true, detail: 'toolchain missing, but the workspace install already converged (prebuilt binaries)' }
     }
     // Fail fast with the fix instead of letting `yarn install` faceplant on
     // node-gyp after several minutes. Propose-only: we never install it.


### PR DESCRIPTION
Follow-up to #4304: the C++ build-toolchain gate blocked machines that need nothing.

## Problem

After #4304 merged, `up` on a Windows machine without VS Build Tools stops at:

```
── Step 3/10 C++ build toolchain (native Node modules)
   XX blocked — this starter proposes, it does not install system components
```

…even when `yarn install` had **already converged** and the whole stack was running. Prebuilt binaries cover the native modules the dev stack actually loads, so the toolchain is only genuinely required when an install is about to compile something. Observed live: a machine with no `vswhere.exe` at all had a green, working stack — and the gate bricked its next `up`.

## Fix

`buildToolchainStep.check` now hard-blocks only when an install is actually pending — `node_modules` missing, or the recorded `install.hash` no longer matching `yarn.lock`/`package.json` (the exact convergence signal `workspaceInstallStep` uses). A converged workspace gets a warning with the winget one-liner for the day a dependency change does need the compiler; a later lockfile change re-arms the hard block. The check takes an injectable toolchain probe so all three transitions (block → warn → re-armed block) are unit-tested on any platform.

## Verification

Runner: local

- Starter suite 23/23.
- Live on the affected machine (no vswhere, converged install): check returns ok with the warning lines, converge proceeds.

Labels rationale: `bug` + `review`; `priority-medium` (blocks `up` for affected Windows users); `risk-low` (single step's check logic, dev-environment only, tested); `skip-qa` (dev tooling, verification evidence above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
