### PR TITLE
fix(opencode): azure provider via @ai-sdk/openai so reasoning models get max_completion_tokens

### DIFF
--- a/docker/opencode/entrypoint.sh
+++ b/docker/opencode/entrypoint.sh
@@ -174,7 +174,20 @@ case "$PROVIDER" in
     fi
     PROVIDER_CONFIG="\"openrouter\": { \"models\": { \"$MODEL_ID\": {} }$OPENROUTER_OPTIONS }"
     ;;
-  azure | deepinfra | groq | together | fireworks | litellm | ollama | lm-studio)
+  azure)
+    # Azure's /openai/v1 surface is OpenAI-compatible, but reasoning-family
+    # deployments (gpt-5*, o*) reject `max_tokens` (wanting
+    # `max_completion_tokens`) and `temperature`. Only the dedicated
+    # @ai-sdk/openai provider performs that parameter mapping — it detects
+    # reasoning models from the model id prefix, so deployments should be
+    # named after their model family (e.g. "gpt-5-something").
+    AZURE_OPTIONS="\"apiKey\": \"$(json_escape "$PROVIDER_KEY")\""
+    if [ -n "$PROVIDER_BASE_URL" ]; then
+      AZURE_OPTIONS="$AZURE_OPTIONS, \"baseURL\": \"$(json_escape "$PROVIDER_BASE_URL")\""
+    fi
+    PROVIDER_CONFIG="\"azure\": { \"npm\": \"@ai-sdk/openai\", \"options\": { $AZURE_OPTIONS }, \"models\": { \"$MODEL_ID\": {} } }"
+    ;;
+  deepinfra | groq | together | fireworks | litellm | ollama | lm-studio)
     # Treat as an OpenAI-compatible endpoint (@ai-sdk/openai-compatible). The
     # key/baseURL are passed explicitly so OpenCode does not need a built-in
     # provider definition for the id.


### PR DESCRIPTION
## Problem

OpenCode agent runs against an Azure reasoning-family deployment (gpt-5*, o*) fail with:

```
Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
```

The entrypoint wires the `azure` provider through the generic `@ai-sdk/openai-compatible` package, which always sends `max_tokens`. Azure's `/openai/v1` surface rejects that for reasoning models (and would reject `temperature` next), so every agent run dies inside the OpenCode container.

## Fix

Split `azure` out of the OpenAI-compatible case in `docker/opencode/entrypoint.sh` and wire it through the dedicated `@ai-sdk/openai` provider, which performs the reasoning-model parameter mapping (`max_completion_tokens`, stripped sampling params) based on the model id prefix. Endpoint URL, API key, and the declared models map are unchanged; non-reasoning deployments keep working (the remap only applies to reasoning-prefixed ids). Deployments should be named after their model family (e.g. `gpt-5-...`) for the detection to kick in — noted in the entrypoint comment.

Other OpenAI-compatible providers (deepinfra / groq / together / fireworks / litellm / ollama / lm-studio) stay on `@ai-sdk/openai-compatible`.

## Verification

Runner: local

- `bash -n` on the entrypoint.
- Live on the affected stack (azure `gpt-5.5-hackathon` deployment): thin image rebuilt, container boots, generated config shows the `@ai-sdk/openai` provider block, server accepts it and listens.

Labels rationale: `bug` + `review`; `priority-medium` (breaks all OpenCode agent runs on Azure reasoning deployments); `risk-low` (single provider case in the dev-stack entrypoint, other providers untouched); `skip-qa` (dev-environment container config, verification evidence above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
