### PR TITLE
fix(create-app): include currencies and communication_channels in CRM…

### DIFF
--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -41,10 +41,10 @@ test('resolvePreset: empty returns 10-module list', () => {
   assert.ok(result.filesToRemove.includes('src/modules/example_customers_sync'))
 })
 
-test('resolvePreset: crm returns 14-module list extending empty (includes ai_assistant)', () => {
+test('resolvePreset: crm returns 16-module list extending empty (includes currencies + communication_channels + ai_assistant)', () => {
   const result = resolvePreset('crm')
   assert.equal(result.isClassic, false)
-  assert.equal(result.modules.length, 14)
+  assert.equal(result.modules.length, 16)
   const ids = result.modules.map((m) => m.id)
   assert.ok(ids.includes('auth'))
   assert.ok(ids.includes('directory'))
@@ -59,6 +59,10 @@ test('resolvePreset: crm returns 14-module list extending empty (includes ai_ass
   assert.ok(ids.includes('notifications'))
   assert.ok(ids.includes('dashboards'))
   assert.ok(ids.includes('events'))
+  // currencies backs deals KPI/aggregate base-currency + FX lookups
+  assert.ok(ids.includes('currencies'))
+  // communication_channels backs CRM email + /backend/profile/communication-channels
+  assert.ok(ids.includes('communication_channels'))
   // ai_assistant must be included so customers AI widgets can register
   // (issue #1849 — CRM mode must enable AI assistant module)
   assert.ok(ids.includes('ai_assistant'))
@@ -102,9 +106,11 @@ test('generateModulesTs: produces valid content for crm modules', () => {
   assert.ok(content.includes("id: 'customers'"))
   assert.ok(content.includes("id: 'feature_toggles'"))
   assert.ok(content.includes("id: 'dictionaries'"))
+  assert.ok(content.includes("id: 'currencies'"))
   assert.ok(content.includes("id: 'notifications'"))
   assert.ok(content.includes("id: 'dashboards'"))
   assert.ok(content.includes("id: 'events'"))
+  assert.ok(content.includes("id: 'communication_channels'"))
   // ai_assistant must register from its own package
   assert.ok(content.includes("id: 'ai_assistant'"))
   assert.ok(content.includes("from: '@open-mercato/ai-assistant'"))
@@ -159,7 +165,7 @@ test('applyStarterPreset: empty writes 10-module modules.ts and removes example 
   }
 })
 
-test('applyStarterPreset: crm writes 14-module modules.ts and removes example dirs', () => {
+test('applyStarterPreset: crm writes 16-module modules.ts and removes example dirs', () => {
   const dir = makeTempDir()
   try {
     applyStarterPreset('crm', dir)
@@ -168,9 +174,11 @@ test('applyStarterPreset: crm writes 14-module modules.ts and removes example di
     assert.ok(content.includes("id: 'customers'"))
     assert.ok(content.includes("id: 'dictionaries'"))
     assert.ok(content.includes("id: 'feature_toggles'"))
+    assert.ok(content.includes("id: 'currencies'"))
     assert.ok(content.includes("id: 'notifications'"))
     assert.ok(content.includes("id: 'dashboards'"))
     assert.ok(content.includes("id: 'events'"))
+    assert.ok(content.includes("id: 'communication_channels'"))
     // ai_assistant must register so customers AI widgets work in the CRM preset
     // (regression coverage for issue #1849)
     assert.ok(content.includes("id: 'ai_assistant'"))

--- a/packages/create-app/src/lib/ready-apps.test.ts
+++ b/packages/create-app/src/lib/ready-apps.test.ts
@@ -298,6 +298,8 @@ test('CLI bare scaffold applies explicit crm preset without prompting', () => {
     assert.match(modulesTs, /id: 'customers'/)
     assert.match(modulesTs, /id: 'dictionaries'/)
     assert.match(modulesTs, /id: 'feature_toggles'/)
+    assert.match(modulesTs, /id: 'currencies'/)
+    assert.match(modulesTs, /id: 'communication_channels'/)
     assert.doesNotMatch(modulesTs, /id: 'example'/)
     assert.equal(existsSync(join(targetDir, 'src', 'modules', 'example')), false)
     assert.equal(existsSync(join(targetDir, '.mercato', 'starter-preset.json')), true)

--- a/packages/create-app/src/lib/starter-presets.ts
+++ b/packages/create-app/src/lib/starter-presets.ts
@@ -65,6 +65,8 @@ export const STARTER_PRESETS: Record<string, StarterPreset> = {
         { id: 'customers', from: CORE },
         { id: 'dictionaries', from: CORE },
         { id: 'feature_toggles', from: CORE },
+        { id: 'currencies', from: CORE },
+        { id: 'communication_channels', from: CORE },
         { id: 'ai_assistant', from: AI_ASSISTANT },
       ],
     },


### PR DESCRIPTION
## Summary
- Add `currencies` to the CRM starter preset so deals KPI/aggregate endpoints have the `currencies` table after migrate (fixes `relation "currencies" does not exist` on `/backend/customers/deals` metrics).
- Add `communication_channels` to the CRM starter preset so CRM email threads and `/backend/profile/communication-channels` are available in CRM scaffolds.
- Update create-app preset unit/CLI assertions for the expanded CRM module baseline.

## Why
CRM preset standalone apps enabled `customers` without the modules those CRM surfaces depend on. Deals metrics hard-query `currencies`, and CRM messaging/profile flows expect `communication_channels`.