### PR TITLE
docs(workflows): specify secure durable user tasks

### DIFF
--- a/.ai/specs/2026-07-15-contextual-workflow-task-actions.md
+++ b/.ai/specs/2026-07-15-contextual-workflow-task-actions.md
@@ -1,0 +1,479 @@
+# Contextual Workflow Task Actions
+
+## TLDR
+
+**Key points:**
+
+- Keep the existing workflow task APIs, workflow-instance metadata, event triggers, task pages, and widget injection.
+- Add a provenance-checked task-source binding that public workflow-start callers cannot activate by supplying metadata.
+- Keep raw source identifiers server-side until the source-owning module authorizes the current actor.
+- Ship `customers.deal` as the reference adapter: a compact task CTA on deal detail and authorized deal context on task detail.
+- Reuse the secure task capabilities and durable completion response defined by the companion user-task specifications.
+
+**Scope:** trusted event-produced source binding, one focused server-side source-query contract, two customers-owned adapter routes/widgets, and fieldless inline completion.
+
+**Primary risks:** forged business context creating a confused-deputy action, source-record identifier disclosure, cross-module authorization bypass, and an optional widget breaking its host page.
+
+## Overview
+
+Users should be able to act on `Initial contact` or another human task while viewing the business record that caused it, without first understanding workflow administration. Open Mercato already has the required task lifecycle and widget surfaces. The missing contract is a trustworthy, authorization-safe association between a task and its source record.
+
+Existing `WorkflowInstance.metadata.entityType/entityId` values are useful opaque metadata but are accepted by the public start API and therefore are not proof of provenance. This specification preserves those fields unchanged and introduces a separate task-source shape whose trusted form requires server-only provenance. Source modules then own the routes and widgets that disclose their records.
+
+Authorization and server capabilities come from [`2026-07-15-secure-workflow-user-task-access-and-personal-inbox.md`](2026-07-15-secure-workflow-user-task-access-and-personal-inbox.md). Inline completion and its pending/applied response come from [`2026-07-15-durable-workflow-user-task-continuation.md`](2026-07-15-durable-workflow-user-task-continuation.md). This specification does not duplicate either contract.
+
+## Current Baseline and Delta
+
+Baseline reviewed: `open-mercato/open-mercato` `develop` at `28649ddec6dd26c15244f4b4264117c8e645a368` on 2026-07-21.
+
+| Existing capability | Keep | Missing delta |
+| --- | --- | --- |
+| `WorkflowInstance.metadata.entityType/entityId` | Preserve as opaque legacy/general metadata | Never treat caller-supplied values as trusted task context |
+| Public workflow start with arbitrary metadata | Preserve unchanged | Caller-provided `taskSource` remains opaque and never satisfies trusted provenance |
+| Event-trigger service derives entity ID/type from trusted event context | Preserve | Pass an explicit server-only source option and persist provenance |
+| `UserTask.workflowInstanceId` | Preserve | Focused scoped lookup by a trusted source binding |
+| `detail:customers.deal:header` | Preserve frozen spot | Customers-owned task CTA widget |
+| Task detail page | Preserve route and form | Add one frozen context injection spot that passes task identity only |
+| Task claim/complete APIs | Preserve | Consume companion capabilities and durable response |
+| Specialized order-approval widget | Preserve unchanged | Do not generalize its workflow-specific assumptions |
+
+[PR #4019](https://github.com/open-mercato/open-mercato/pull/4019) owns visual-editor persistence, [PR #4085](https://github.com/open-mercato/open-mercato/pull/4085) owns user-task form normalization, and [PR #4291](https://github.com/open-mercato/open-mercato/pull/4291) owns role selection in the editor. Implementation must re-check their live replacements/merge state. None currently provides trusted task-source provenance, source-authorized contextual routes, a generic deal CTA, or task-detail business context.
+
+## Problem Statement
+
+The current business flow has two UX failures and two trust-boundary traps:
+
+- an operator must leave a deal, find workflow tasks, and interpret technical instance context;
+- task detail emphasizes workflow identifiers instead of the deal/company/person context;
+- caller-supplied metadata can claim an unrelated deal and mislead an otherwise authorized assignee;
+- returning raw source IDs from the generic task API would disclose customer associations before customers ACL approves them.
+
+The specialized order widget cannot become the generic solution because it is coupled to one workflow ID, sales status values, metadata names, and a particular decision form.
+
+## Goals
+
+1. Let an authorized task worker discover and act on a relevant task from an authorized source record.
+2. Prove source association through server-authored provenance rather than caller metadata or naming inference.
+3. Keep source IDs server-side until the source module authorizes record access.
+4. Keep workflows independent of customers and free of cross-module ORM relationships.
+5. Provide a reusable server-side lookup contract and one complete `customers.deal` reference adapter.
+6. Degrade to no widget when the peer module, trusted binding, record, or permission is absent.
+7. Preserve existing task and workflow-start URLs and arbitrary metadata behavior.
+
+## Non-Goals
+
+- Automatic source inference from workflow IDs, task names, context keys, URLs, or event-name string parsing.
+- Treating existing raw `metadata.entityType/entityId` as trusted context.
+- Allowing public/manual workflow starts to set trusted source bindings in this phase.
+- A universal entity router, client-visible source registry, or cross-module ORM relation.
+- Generic rendering of arbitrary source schemas.
+- Inline rendering of task forms inside source pages.
+- Refactoring the specialized order-approval widget.
+- Replacing the personal inbox or task detail form.
+- A database migration or backfill.
+
+## Proposed Solution
+
+### Design Decisions
+
+| Decision | Rationale |
+| --- | --- |
+| Trusted binding combines a structured metadata value with server provenance invariants | Reuses scoped instance storage without treating mere persistence as authority |
+| Public start keeps arbitrary metadata unchanged but cannot set server provenance | Preserves compatibility while preventing callers with `workflows.instances.create` from activating contextual UI |
+| Server event-trigger context is the first trusted producer | Existing module commands emit scoped entity events; the trigger already starts the instance server-side |
+| Raw source pair is available only through a server-side DI contract | Source adapters can query without declassifying IDs through the generic task API |
+| Source module owns contextual HTTP routes | Its ACL and record scoping run before any source details reach the browser |
+| Workflows owns the task-detail injection spot | Future optional source modules receive a stable host without workflow importing them |
+| Customers owns both reference widgets and routes | Optional consumer owns integration glue and disappears cleanly |
+| Inline Complete is limited to canonically fieldless tasks | Convenience never bypasses form validation |
+
+### Alternatives Considered
+
+| Alternative | Why rejected |
+| --- | --- |
+| Expose raw `metadata.entityType/entityId` in task responses | Public start can forge it, and task-only access does not imply source-record access |
+| Add generic public source filters to `/api/workflows/tasks` | Enables record-ID association probing before the source module authorizes disclosure |
+| Infer source from workflow/task/event names | Names are mutable and not an authorization contract |
+| Let workflows load customer entities | Creates forbidden ownership and ORM/ACL coupling |
+| Put all adapters in a workflows registry | Adds framework surface when a focused server query plus source-owned routes is sufficient |
+| Copy customer summaries onto `UserTask` | Duplicates PII, becomes stale, and requires migration/backfill |
+
+## User Stories
+
+- As a deal owner, I see that a workflow task is waiting while I view a deal I may access.
+- As an eligible role member, I can claim that task from the deal and then complete it when no input is required.
+- As an assignee with an input form, I follow a direct link to the full task form.
+- As a task worker who may read the deal, I see deal/company/person context and an Open deal link.
+- As a task worker without customers permission, I can still perform my task but receive no deal ID or context.
+- As a module author, I can add a source-owned route/widget that calls the same server-side trusted-source query contract.
+
+## Architecture
+
+### Ownership and Dependency Direction
+
+```text
+trusted module event
+  -> workflows event-trigger service
+  -> server-only trustedTaskSource option
+  -> WorkflowInstance.metadata.taskSource
+
+workflows
+  |- workflowTaskSourceQuery DI service (server only)
+  |- task API remains source-ID-free
+  `- task detail host: detail:workflows.user_task:context
+
+customers (optional consumer)
+  |- deal-scoped contextual routes check customers ACL/record scope
+  |- resolves workflowTaskSourceQuery with tryResolve
+  |- deal task CTA -> detail:customers.deal:header
+  `- task deal context -> detail:workflows.user_task:context
+```
+
+Workflows has no import, ORM relation, or hard `requires` edge to customers. Customers uses a documented optional DI key through `tryResolve`; absence returns an empty/not-applicable response and never breaks deal or task detail.
+
+The new DI key is justified because browser-visible source filters would cross the customers authorization boundary. It has two current call sites in the reference adapter and replaces, rather than supplements, a public raw-ID API.
+
+### Trusted Source Binding
+
+```ts
+type TrustedWorkflowTaskSource = {
+  version: 1
+  entityType: string
+  entityId: string
+  provenance: {
+    kind: 'module_event'
+    eventId: string
+    triggerId: string
+  }
+}
+```
+
+The persisted location is `WorkflowInstance.metadata.taskSource`. Both strings are trimmed and bounded to 100/255 characters before persistence. A binding is trusted only when its provenance trigger ID matches the server-authored `metadata.initiatedBy = trigger:{id}` value and its event/entity declaration matches the generated module event catalog.
+
+The public start schema continues accepting arbitrary metadata unchanged. Its route still overwrites `initiatedBy` with the authenticated caller and never maps client input into the server-only `trustedTaskSource` executor option. Therefore a caller may persist a lookalike `taskSource` value for backward-compatible opaque metadata use, but it cannot satisfy the trusted provenance invariant or appear in contextual lookup.
+
+The first producer is the existing event-trigger service. It may pass `trustedTaskSource` only when the consumed event is present in the generated module event catalog, carries trusted tenant/organization scope, declares an entity, and provides the entity ID through the event contract. The producer copies the catalog identity; it does not infer type by parsing an event name. For the reference adapter, catalog-declared customers deal events produce `entityType='customers.deal'`.
+
+Raw legacy `metadata.entityType/entityId` remains untouched for backward compatibility and specialized features, but the new contextual service ignores it.
+
+### Server-Side Source Query Contract
+
+The workflows module registers one optional DI service:
+
+```ts
+type WorkflowTaskSourceQuery = {
+  listForSource(input: {
+    actor: UserTaskActor
+    source: { entityType: string; entityId: string }
+    statuses: Array<'PENDING' | 'IN_PROGRESS'>
+    limit: number
+    order: 'createdAt:asc'
+  }): Promise<{ items: AuthorizedUserTaskProjection[]; total: number }>
+
+  resolveForTask(input: {
+    actor: UserTaskActor
+    taskId: string
+  }): Promise<TrustedWorkflowTaskSource | null>
+}
+```
+
+Both methods reuse the secure-access companion's human actor, tenant/organization scope, personal predicate, and server-derived capabilities. `listForSource` matches only a provenance-valid binding through a parameterized same-module `EXISTS` query before count/order/limit. `resolveForTask` first proves task visibility, then loads and validates its instance binding. Neither method is directly callable over HTTP and neither authorizes the source record; that remains the source route's responsibility.
+
+### Customers Reference Routes
+
+#### Deal task list
+
+`GET /api/customers/deals/{id}/workflow-tasks`
+
+1. Require a human session and customers deal-read feature.
+2. Load the deal with exact tenant/organization scope; missing/invisible is `404`.
+3. Resolve `workflowTaskSourceQuery` with `tryResolve`; absent returns `{ data: [], total: 0 }`.
+4. Query `customers.deal/{id}`, active statuses, fixed `createdAt:asc`, and limit `10`.
+5. Return task ID/name/status/due date/form summary and companion capabilities, never a source ID.
+
+#### Task deal context
+
+`GET /api/customers/workflow-task-context/{taskId}`
+
+1. Require a human session and customers deal-read feature.
+2. Ask `resolveForTask` for a personally visible task's trusted source.
+3. Continue only for `entityType === 'customers.deal'`.
+4. Load the deal in exact tenant/organization scope using customers-owned services.
+5. Return authorized deal title, optional company/person summaries already allowed by customers ACL, and the canonical deal href.
+
+All missing, wrong-type, inaccessible, and foreign-scope outcomes return the same `404`; the response never reveals whether a hidden source binding exists.
+
+### Widget Contracts
+
+The deal CTA maps a customers-owned widget to the frozen existing `detail:customers.deal:header` spot. It calls only the customers deal-task route. The oldest actionable task is primary; additional count links to `/backend/tasks?myTasks=true`.
+
+Workflows adds the frozen spot:
+
+```text
+detail:workflows.user_task:context
+```
+
+Its public context contains the authorized task ID and route-local retry callback only, never source type/ID. The customers-owned widget calls its task-context route and renders `null` for `404`/absent-module/not-applicable outcomes.
+
+### Action Rules
+
+- `canClaim=true`: render Claim. After success, refetch; complete may become available.
+- `canComplete=true` and the canonical normalized form has no user-editable fields: render confirmed Complete inline.
+- `canComplete=true` and input is required: render Open task linking to `/backend/tasks/{id}`.
+- `canRetryContinuation=true`: render the durable companion's non-destructive Retry continuation action.
+- no capability: show status only when the task is otherwise personally visible.
+
+All mutations use the existing workflows claim/complete APIs through `useGuardedMutation`; the server recomputes authorization. Inline completion submits `{ formData: {} }`, never invents comments, and consumes `continuation.status` from the durable companion.
+
+## Data Models
+
+No entity or migration is added.
+
+| Existing data | Contract |
+| --- | --- |
+| `WorkflowInstance.metadata.taskSource` | New binding shape trusted only with matching server provenance |
+| `WorkflowInstance.metadata.entityType/entityId` | Preserved opaque metadata; not trusted by this feature |
+| `UserTask.workflowInstanceId` | Same-module scalar link used by the server query |
+
+No customer names, company/person snapshots, or source labels are stored on workflow entities.
+
+## API Contracts
+
+### Existing workflows task API
+
+No source query parameter or source record field is added. Task projections consume only the capability additions owned by the secure-access companion. Claim/complete routes and bodies remain unchanged; completion response additions are owned by the durable companion.
+
+### Public workflow start
+
+General metadata remains open as today. The internal executor's `trustedTaskSource` option is not part of the HTTP schema, and OpenAPI does not claim caller metadata can create contextual source identity.
+
+### Customers contextual responses
+
+Both new GET routes export OpenAPI schemas. The deal-task list returns a bounded task projection without source identifiers. Task-context returns only customers-authorized display fields and href. Errors use structured `400/401/403/404`; foreign/invisible/not-applicable source outcomes collapse to `404`.
+
+## UI/UX
+
+### Deal CTA
+
+Render one compact operational row/banner rather than a nested card stack:
+
+- task name and waiting/claimed state;
+- optional due/overdue state using semantic tokens and `StatusBadge`;
+- one primary CTA: Claim, Complete task, Retry continuation, or Open task;
+- View all tasks when more than one relevant task exists.
+
+Use `Spinner`/`LoadingMessage` for initial loading, `Alert` only for an actionable recoverable error, and `null` for a normal empty/peer-absent case. Confirmation uses `useConfirmDialog`.
+
+### Task Context
+
+The task detail widget renders a small `SectionHeader` context section with linked deal title, permitted company/person summaries, and Open deal. It never renders raw workflow instance or source IDs as primary context. Missing, deleted, inaccessible, untrusted, or non-deal sources produce no contextual widget; the task form remains usable.
+
+## Frontend Architecture Contract
+
+| Surface | Server boundary | Client island | Data source | Guardrail |
+| --- | --- | --- | --- | --- |
+| deal detail | existing customers route host | customers task CTA widget | customers deal-task route | optional widget, one query |
+| task detail | existing workflows route host | customers context widget | customers task-context route | task ID only in injection context |
+
+No new page-root client component or provider is introduced. Widget files use `apiCall`, React Query, shared UI primitives, localized strings, route-local guarded mutations, and existing injection-table discovery. Runtime network budget is one contextual GET per mounted widget plus requested mutations; absent peer modules do not trigger retry loops.
+
+## Internationalization
+
+Add deal-task and task-context strings to customers dictionaries for every supported locale. Reserved-key and structured API errors use server translation conventions. Task action/status strings owned by workflows remain in workflows dictionaries. No source, task, or record labels are hard-coded.
+
+## Migration and Backward Compatibility
+
+- No schema migration or backfill.
+- Existing workflow/task routes, bodies, IDs, metadata, and specialized widgets remain.
+- Existing raw `metadata.entityType/entityId` is not rewritten and does not gain new UI meaning.
+- Existing instances without a trusted `metadata.taskSource` binding render no contextual widgets.
+- Public start keeps arbitrary metadata unchanged; lookalike caller values remain opaque and fail trusted-provenance checks.
+- Disabling customers leaves workflows tasks functional; disabling workflows leaves deal detail functional with no task widget.
+- The new DI key and task-detail spot become frozen public extension contracts after merge.
+
+## Performance and Cache
+
+- Contextual responses are not server-cached because they are actor-sensitive and task state changes rapidly.
+- Deal-task query applies tenant/org, trusted binding, personal task predicate, status, ascending creation order, and limit before projection.
+- It uses one parameterized `EXISTS` query plus count, never an unbounded instance-ID list or cross-module join.
+- Task-context uses one scoped task/instance lookup and one customers-owned deal read.
+- React Query keys include deal/task IDs; workflow task events and successful mutations invalidate them.
+- Implementation captures query plans at 10,000 scoped active tasks/instances; p95 target is below 250 ms per contextual GET.
+- If current indexes cannot meet the target, implementation stops for a separately approved additive index proposal.
+
+## Implementation Plan
+
+### Phase 1: Trusted Binding and Server Query
+
+1. Add the server-only executor option and provenance validator without narrowing public metadata.
+2. Persist catalog-validated event-trigger provenance and ignore raw legacy source metadata.
+3. Add the focused `workflowTaskSourceQuery` DI contract/service with scoped source/task lookup.
+4. Add spoofing, provenance, scope, optional-service, query-count, and performance tests.
+
+### Phase 2: Customers Reference Adapter
+
+1. Add customers-owned deal-task and task-context routes with customers ACL and scoped record reads.
+2. Add deal CTA and task-context widget modules and map both frozen spots.
+3. Use companion capabilities and canonical form normalization for Claim/Complete/Retry/Open decisions.
+4. Add all locale strings and loading/error/empty/absent-module behavior.
+
+### Phase 3: Integration and UI Proof
+
+1. Add self-contained customers deal event -> workflow -> user-task fixtures.
+2. Exercise fieldless and input-required tasks, continuation pending/applied, and correct CTA routing.
+3. Prove public metadata spoofing, API-key actors, unauthorized source readers, deleted deals, foreign scope, and missing modules fail closed.
+4. Verify desktop/narrow layouts, hydration, keyboard confirmation, and network budgets.
+
+## Expected File Manifest
+
+| Path | Action | Purpose |
+| --- | --- | --- |
+| `packages/shared/src/modules/workflows/task-source.ts` / `index.ts` | Create/Modify | Frozen structural DI contract, exports, and contract tests shared by optional modules |
+| `packages/core/src/modules/workflows/lib/workflow-task-source.ts` | Create | Trusted binding validation and scoped query service |
+| `packages/core/src/modules/workflows/di.ts` | Modify | Register `workflowTaskSourceQuery` |
+| `packages/core/src/modules/workflows/lib/workflow-executor.ts` | Modify | Server-only trusted source option/persistence |
+| `packages/core/src/modules/workflows/lib/event-trigger-service.ts` | Modify | Catalog-backed module-event provenance |
+| `packages/core/src/modules/workflows/api/instances/route.ts` / OpenAPI validators | Modify/Test | Preserve caller metadata while proving it cannot set trusted provenance |
+| `packages/core/src/modules/workflows/backend/tasks/[id]/page.tsx` | Modify | Task-ID-only context InjectionSpot |
+| `packages/core/src/modules/customers/api/deals/[id]/workflow-tasks/route.ts` | Create | Deal-authorized task list |
+| `packages/core/src/modules/customers/api/workflow-task-context/[taskId]/route.ts` | Create | Task + source-authorized context |
+| `packages/core/src/modules/customers/widgets/injection/workflow-deal-task-actions/**` | Create | Deal CTA adapter |
+| `packages/core/src/modules/customers/widgets/injection/workflow-deal-task-context/**` | Create | Task-detail deal context adapter |
+| `packages/core/src/modules/customers/widgets/injection-table.ts` | Modify | Map adapter widgets |
+| customers/workflows locale files | Modify | Adapter copy |
+| workflows/customers integration tests | Create/Modify | Security, API, optionality, UI, performance proof |
+
+## Testing Strategy
+
+| Area | Required coverage |
+| --- | --- |
+| Provenance | catalog-declared deal event creates trusted binding; public/raw metadata cannot |
+| Public start | arbitrary/lookalike metadata remains accepted but cannot activate contextual lookup |
+| Server query | trusted pair only, personal task predicate, ascending order, bounded count |
+| Source disclosure | task-only actor without customers read receives no source ID/context |
+| Authorization | wrong task actor and wrong source reader collapse to `404`; manager inspection grants no action |
+| Principal type | API key with matching features/role cannot use contextual or task mutations |
+| Scope | same IDs in foreign tenant/organization never match |
+| Deal CTA | empty, claimable, directly completable fieldless, claimed, input form, retry pending |
+| Task context | authorized deal/company/person summary; deleted/hidden/untrusted source renders nothing |
+| Optional modules | either module disabled leaves the host route/page functional |
+| UI | loading/error/retry, desktop/narrow, keyboard confirmation, locale sync |
+| Performance | constant query count and representative query plan/runtime trace |
+
+Fixtures create a deal through customers APIs, emit a real scoped customers deal event through the supported command/event path, start the workflow via its event trigger, and clean up in `finally`. A separate adversarial fixture starts a workflow through the public API with forged raw/lookalike metadata and proves it never creates contextual UI.
+
+## Risks and Impact Review
+
+### Forged Source Association
+
+- **Scenario:** a caller starts a workflow with `customers.deal` metadata for an unrelated deal so another operator completes a real task under false context.
+- **Severity:** Critical.
+- **Affected area:** human decisions and downstream workflow effects.
+- **Mitigation:** public start cannot set the server-only executor option or trigger-authored `initiatedBy`; contextual lookup requires both plus catalog-backed event provenance; raw/lookalike metadata is ignored.
+- **Residual risk:** trusted module code or an incorrectly declared event contract can still bind the wrong record and requires normal code review/tests.
+
+### Source Identifier Disclosure
+
+- **Scenario:** a task-only actor learns customer record IDs/associations before customers ACL approves them.
+- **Severity:** High.
+- **Affected area:** customer metadata confidentiality and object enumeration.
+- **Mitigation:** generic task API/injection context contains no source ID; source-owned routes check customers feature and scoped record before responding; hidden outcomes share `404`.
+- **Residual risk:** authorized source readers can see associations by design.
+
+### Cross-Module Authorization Bypass
+
+- **Scenario:** a widget or route loads customer data directly from workflow metadata without customers policy.
+- **Severity:** Critical.
+- **Affected area:** deal/company/person data.
+- **Mitigation:** customers owns both HTTP routes and record reads; workflows exposes server-only task/source lookup, not customer data; no cross-module ORM.
+- **Residual risk:** future adapters must repeat this source-owned authorization pattern; frozen contract and module-decoupling tests protect it.
+
+### Form Validation Bypass
+
+- **Scenario:** a widget incorrectly labels a task fieldless and completes with `{}`.
+- **Severity:** High.
+- **Affected area:** workflow decision data.
+- **Mitigation:** one canonical merged form-schema normalizer; conservative Open task fallback; server validation and authorization rerun.
+- **Residual risk:** novel schema constructs may reduce convenience by routing to detail.
+
+### Optional Integration Failure
+
+- **Scenario:** a peer route/service is absent, slow, or errors and breaks deal/task detail.
+- **Severity:** Medium.
+- **Affected area:** host-page availability.
+- **Mitigation:** `tryResolve`, isolated query/error boundaries, bounded requests, null/empty normal absence, no retry loop.
+- **Residual risk:** transient failures may hide context until a user retry; the underlying task/record remains usable.
+
+### Source Query Degradation
+
+- **Scenario:** JSON metadata lookup scans large scoped instance/task sets.
+- **Severity:** Medium.
+- **Affected area:** deal/task page latency.
+- **Mitigation:** bounded parameterized query, count/order before projection, representative plan/runtime gate.
+- **Residual risk:** large tenants may require a later separately approved additive index.
+
+## Final Compliance Report
+
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `.ai/qa/AGENTS.md`
+- `packages/core/AGENTS.md`
+- `packages/core/src/modules/workflows/AGENTS.md`
+- `packages/core/src/modules/auth/AGENTS.md`
+- `packages/shared/AGENTS.md`
+- `packages/ui/AGENTS.md`
+- `packages/ui/src/backend/AGENTS.md`
+- `packages/events/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+
+| Rule source | Rule | Status | Notes |
+| --- | --- | --- | --- |
+| root/core | No cross-module ORM relationships | Compliant | Source query is workflows-owned; customers owns source reads |
+| core | Optional consumer owns integration glue | Compliant | Customers owns both routes/widgets and uses `tryResolve` |
+| workflows | Scope all task queries | Compliant | Human actor + tenant/org + personal policy precede source predicate |
+| companion specs | Reuse access and completion contracts | Compliant | Widgets consume capabilities/status; no duplicate auth/resume logic |
+| auth/security | Do not cross privilege boundaries with opaque IDs | Compliant | Source IDs remain server-side until customers authorizes the record |
+| core | Stable DI/widget/API contracts | Compliant | One justified DI key, one frozen task spot, additive customers routes |
+| UI/backend | `apiCall`, guarded mutations, shared states | Compliant | Reference widgets use canonical helpers |
+| shared | i18n and bounded input | Compliant | Localized strings and bounded trusted binding |
+| QA | Self-contained integration coverage | Compliant | Public fixtures, adversarial starts, and cleanup specified |
+| backward compatibility | Preserve existing routes/IDs/metadata | Compliant | Raw metadata remains but gains no unsafe new meaning |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+| --- | --- | --- |
+| Data model matches trust contract | Pass | Contextual lookup accepts only a binding with explicit producer provenance |
+| API contracts match UI | Pass | Browser calls source-owned routes; no raw generic source API |
+| Risks cover all writes | Pass | Claim/complete owned by companions; inline path covered |
+| Commands defined for mutations | Pass | Widgets invoke existing guarded task APIs |
+| Cache/performance covers reads | Pass | No actor-sensitive cache; bounded query and network budgets |
+
+### Non-Compliant Items
+
+None identified.
+
+### Verdict
+
+Implementation is ready for upstream review only together with both companion user-task specifications. Coding remains blocked until the merged-spec and public feature-claim admission gates are satisfied.
+
+## Changelog
+
+### 2026-07-21
+
+- Refreshed the delta against current `develop` and active workflow PRs.
+- Replaced caller-trusted source metadata/public raw-ID filters with provenance-checked binding and source-authorized routes.
+- Added explicit API-key, spoofing, identifier-disclosure, and confused-deputy protections.
+- Kept the three-spec split: access, durable continuation, and contextual actions remain independently owned.
+
+### 2026-07-16
+
+- Expanded the approved skeleton into a complete source, adapter, UI, compatibility, test, and risk design.
+
+### 2026-07-15
+
+- Initial skeleton.

--- a/.ai/specs/2026-07-15-durable-workflow-user-task-continuation.md
+++ b/.ai/specs/2026-07-15-durable-workflow-user-task-continuation.md
@@ -1,0 +1,412 @@
+# Durable Workflow User-Task Continuation
+
+## TLDR
+
+**Key points:**
+
+- Keep `USER_TASK` completion and the existing complete endpoint, but separate the durable database acknowledgement from post-completion workflow execution.
+- Commit the completed task, root/branch context, exited step, and an immutable continuation intent atomically.
+- Make repeated completion delivery idempotently re-drive the same continuation, with one database winner and explicit at-least-once semantics for external activities.
+
+**Scope:** root and parallel-branch user tasks, completion races, crash recovery, persistent retry, replay-safe responses, and operational reconciliation.
+
+**Primary risk:** the current handler flushes `COMPLETED` before later lookups and transition execution. A failure can therefore leave a completed task attached to a paused workflow, while a blind retry is rejected as already completed.
+
+## Overview
+
+The current `completeUserTask()` performs several independently flushed phases: mark the task completed, load and update the workflow instance, exit the step, execute a transition, and continue the executor. A process failure or thrown transition can split those phases permanently.
+
+This specification defines a durable handoff without inventing a new workflow step or claiming exactly-once external side effects. The database becomes authoritative for whether a user completion was accepted and whether its continuation was applied. Normal execution attempts continuation immediately; persistent delivery and replay repair failures. A repeated identical completion is a recovery operation, not a second business mutation.
+
+Access and assignment checks come from [`2026-07-15-secure-workflow-user-task-access-and-personal-inbox.md`](2026-07-15-secure-workflow-user-task-access-and-personal-inbox.md). This specification begins only after that policy authorizes the actor.
+
+## Current Baseline and Delta
+
+Baseline reviewed: `open-mercato/open-mercato` `develop` at `28649ddec6dd26c15244f4b4264117c8e645a368` on 2026-07-21.
+
+| Current behavior | Keep | Required delta |
+| --- | --- | --- |
+| `POST /api/workflows/tasks/{id}/complete` | URL/body and task form validation | Idempotent recovery response and continuation status |
+| Root task context merge | Form data remains merged into root context | Commit with task/step/intent in one transaction |
+| Parallel task branch resume | Branch namespace and branch-only progression | Commit branch completion intent atomically and resume only that branch |
+| `WorkflowEvent` audit log | Existing table and event history | Use immutable requested/applied events as the recovery journal |
+| Workflow execution lock | Existing instance/branch pessimistic serialization | Reuse for a single continuation winner |
+| Persistent event/queue runtime | Existing retry infrastructure | Declare a focused completion event/subscriber |
+| Instance retry API | Existing failed-instance behavior | Also reconcile pending user-task continuation when explicitly retried |
+
+No merged upstream change currently provides this continuation journal or replay path. PRs #4019, #4085, and #4291 do not overlap it.
+
+## Problem Statement
+
+The current completion sequence can produce these externally visible states:
+
+1. task is `COMPLETED`, but workflow/branch context was not updated;
+2. context and task are updated, but the step is still active;
+3. step is exited, but no outgoing transition was applied;
+4. a transition side effect ran, the transaction rolled back, and retry may run it again;
+5. a second HTTP request sees only “already completed” and cannot repair any of the above.
+
+Task completion and workflow execution cannot share a long transaction safely because synchronous activities may call external systems. Conversely, a database commit followed by an unrecorded in-memory continuation call creates an unrecoverable crash window.
+
+## Goals
+
+1. Atomically persist accepted user input and a durable continuation intent.
+2. Keep the task-completion transaction short and free of arbitrary transition activities.
+3. Serialize root/branch continuation so only one database transition is applied.
+4. Make identical completion replay a safe recovery mechanism.
+5. Resume both root and parallel-branch tasks.
+6. Expose pending/applied status without changing existing route/body contracts.
+7. State external side-effect guarantees honestly as at-least-once.
+
+## Non-Goals
+
+- Exactly-once HTTP, email, webhook, or third-party activity execution.
+- A platform-wide transactional outbox.
+- Changing queue strategy, retry defaults, or worker concurrency.
+- Reworking all workflow executor transaction boundaries.
+- User-task assignment, visibility, navigation, or contextual widgets.
+- Manual transition selection, task release/unclaim, compensation redesign, or timer/signal continuation.
+- A database migration in this first version.
+
+## Proposed Solution
+
+### Design Decisions
+
+| Decision | Rationale |
+| --- | --- |
+| `WorkflowEvent` records requested/applied continuation | Existing scoped durable storage avoids a new table and migration |
+| Accepted task completion and requested event share one transaction | No completed task can exist without a recoverable handoff record |
+| Transition activities run after that transaction | User-task row locks are not held across external work |
+| Existing instance/branch execution lock is the single-winner boundary | Reuses current workflow serialization |
+| Same-actor, same-input replay repairs pending continuation | Closes the commit/response/enqueue crash window without a new endpoint |
+| Same original actor with different input returns `409`; any different actor is rejected as `404` before replay classification | Prevents accepted-data rewrites without creating a task-existence oracle |
+| Persistent completion event is a retry accelerator, not the source of truth | Database/message enqueue is not atomic today |
+| Instance retry and a scoped reconcile command can re-drive pending intents | Gives operators a deterministic recovery path when no client retries |
+
+### Alternatives Considered
+
+| Alternative | Why rejected |
+| --- | --- |
+| Keep current flushes and add `try/catch` | Does not repair process termination or committed partial state |
+| Execute the full workflow inside the completion transaction | Holds locks while arbitrary activities run |
+| Add a continuation table/outbox | A platform outbox does not exist; a one-off dispatcher would add more machinery than the scoped journal |
+| Treat event-bus enqueue as atomic with task commit | The queue is outside the task database transaction |
+| Return conflict for every repeated complete request | Prevents recovery after an acknowledged database commit |
+| Promise exactly-once activities | Existing executor/activity contracts are retryable and external effects cannot be atomically committed with Postgres |
+
+## Architecture
+
+```text
+authorized complete route
+  -> short scoped completion transaction
+       task + context + step exit + requested WorkflowEvent
+  -> resumeUserTaskContinuation
+       existing root/branch execution lock
+       recorded transition + applied WorkflowEvent in one transaction
+  -> existing workflow execution loop
+
+HTTP replay / persistent subscriber / instance retry / scoped CLI
+  -> the same resumeUserTaskContinuation entry point
+```
+
+The workflows module owns the completion command, requested/applied journal events, resume function, persistent subscriber, and reconciliation entry points. The secure-access companion owns actor admission and replay visibility; this specification never creates an alternate authorization path. Existing workflow executor, transition, parallel-branch, event, and queue primitives remain the only execution mechanisms.
+
+No public DI key, cross-module dependency, new worker framework, or second workflow cursor is introduced. The task/instance/branch locks and `WorkflowEvent` journal form the durability boundary; event delivery and explicit retries are accelerators that converge on the same idempotent command.
+
+## State and Invariants
+
+### Durable Events
+
+The workflow audit log adds two internal event types:
+
+```ts
+type UserTaskContinuationRequested = {
+  taskId: string
+  stepInstanceId: string
+  branchInstanceId?: string | null
+  fromStepId: string
+  transitionId: string
+  toStepId: string
+  completedBy: string
+  inputDigest: string
+}
+
+type UserTaskContinuationApplied = {
+  taskId: string
+  transitionId: string
+  toStepId: string
+}
+```
+
+`inputDigest` is a deterministic server-side digest of canonicalized validated form data plus comments. It is used only to compare retries and does not replace stored form data. It must not contain secrets or be exposed as an authentication credential.
+
+The correctness invariants are:
+
+1. A task first enters `COMPLETED` in the same transaction as `USER_TASK_COMPLETED` and, when an outgoing transition is selected, `USER_TASK_CONTINUATION_REQUESTED`.
+2. One task has one accepted input digest and at most one effective requested transition.
+3. `USER_TASK_CONTINUATION_APPLIED` is written in the same database transaction that moves the root/branch token away from the user-task step.
+4. A token already moved away from the recorded step is an idempotent applied/no-op outcome, never a reason to run the transition again.
+5. A completed task with requested but not applied continuation remains recoverable through replay/reconciliation.
+
+The implementation may enforce uniqueness through the existing task lock plus event lookup; it does not require a new database constraint in this phase. Concurrency tests must prove the invariant rather than assuming event order.
+
+### Transition Selection
+
+After form data is merged into a transaction-local context, the completion command evaluates the version-pinned workflow definition and selects the same first valid automatic transition semantics used today. The chosen transition ID/from/to is persisted in the requested event so retry does not reselect against later mutable state.
+
+- If a valid automatic transition exists, create the continuation intent.
+- If automatic transitions exist but none is valid, return `409 USER_TASK_NO_VALID_TRANSITION` and roll back the task completion. The task remains actionable so corrected input/definition handling can recover instead of producing a completed-but-stuck task.
+- If the definition intentionally has no automatic outgoing transition, preserve current task-complete/no-progression behavior and return `continuation.status = 'not_required'`; no requested event is written.
+
+The no-outgoing-transition case is explicit legacy behavior, not a durable progression guarantee.
+
+## Completion Transaction
+
+The authorized complete command performs:
+
+1. Validate and canonicalize form data before opening the transaction.
+2. Resolve the scoped task identity, then acquire the existing root instance or branch execution lock and the task/step locks in one documented order shared with affected resume paths.
+3. Re-read task, actor eligibility, workflow/branch cursor, and active step under lock.
+4. For a first completion:
+   - merge form data into root context or branch namespace;
+   - set task completion fields;
+   - exit the active step with the existing output shape;
+   - append `USER_TASK_COMPLETED`;
+   - select/persist `USER_TASK_CONTINUATION_REQUESTED` when required.
+5. Commit without executing transition activities or emitting an external event.
+6. After commit, call the continuation service once and emit `workflows.task.completed` as a persistent event; either order is safe because both are idempotent accelerators.
+
+The implementation must audit lock order against `executeWorkflow`, parallel resume, signals, and async-activity resume. It must not introduce a new inverse lock order.
+
+## Continuation Application
+
+`resumeUserTaskContinuation(taskId, scope)`:
+
+1. Load the scoped task and requested event.
+2. Acquire the same root/branch execution lock.
+3. If an applied event exists, return `applied`.
+4. If the token no longer points at the recorded source step and the recorded transition is present in workflow history, record/return `applied` without executing again.
+5. Verify the task is completed, definition version and transition IDs match, and the step was exited by this task.
+6. Execute the recorded transition through the existing transition/executor primitives.
+7. Write `USER_TASK_CONTINUATION_APPLIED` in the same database transaction that advances the root/branch cursor.
+8. After that commit, continue the normal workflow loop from the new cursor.
+
+For a parallel task, only the recorded branch namespace/cursor is resumed. Sibling branches and the root context retain existing join semantics.
+
+The short completion transaction is always separate from transition execution. The existing executor may still run synchronous activities inside its own transaction; therefore a crash after an external effect but before its database commit can repeat that activity. Existing activity idempotency requirements remain mandatory, and this feature does not claim otherwise.
+
+## Replay and Recovery Contract
+
+### Repeated Complete Request
+
+When the route sees an already-completed task, the secure-access policy first admits only the original completing actor with the complete feature. This admission applies to pending, applied, and not-required outcomes so a lost-response retry remains idempotent; only the pending outcome is advertised as an interactive retry capability. The durable command then performs a scoped locked read:
+
+- same `completedBy` and same canonical input digest: do not mutate the task; call continuation resume and return current state;
+- same original actor but different input digest: return `409 TASK_ALREADY_COMPLETED`;
+- any different actor is rejected as `404` by the secure-access boundary before replay classification, preserving task non-enumerability;
+- applied continuation: return the same successful projection;
+- pending continuation: attempt resume and return pending/applied result.
+
+Thus a client retry after a lost HTTP response repairs the continuation without duplicating the user completion. The access specification owns completed-task detail visibility and the server-derived `canRetryContinuation` capability; this specification owns digest comparison and resume behavior.
+
+### Persistent Event
+
+Declare `workflows.task.completed` with trusted tenant/organization scope and a minimal `{ taskId }` payload. Its persistent subscriber calls the same resume function. Redelivery after application is a no-op.
+
+The event is emitted after the database commit. Enqueue failure does not erase or roll back the accepted task; the requested event remains the source of truth.
+
+### Explicit Reconciliation
+
+Two existing operational entry points gain focused repair behavior:
+
+- an authorized instance retry first checks for requested-without-applied user-task continuation for that instance and re-drives it before applying failed-instance retry semantics;
+- a workflows CLI command accepts tenant/organization and optional instance/task filters, scans a bounded page of requested-without-applied events, and invokes the same resume function.
+
+The command is finite and operator-invoked; this specification does not add a polling loop. It reports scanned/applied/already-applied/failed counts without form data or comments.
+
+## API Contracts
+
+### Complete Response
+
+The existing response remains successful after the task commit and adds:
+
+```ts
+{
+  data: UserTask,
+  continuation: {
+    status: 'applied' | 'pending' | 'not_required'
+    retryable: boolean
+  }
+}
+```
+
+- `applied`: token left the user-task step.
+- `pending`: completion is durable but continuation attempt failed or has not finished; repeating the same request is safe.
+- `not_required`: no automatic outgoing transition exists.
+
+Existing clients may ignore the additive field. The route does not return a generic `500` after a durable task commit merely because post-commit continuation failed. Structured logs/metrics capture the failure, and the response marks it pending.
+
+Errors before commit retain `400/401/403/404/409` semantics. Same-actor different-input replay returns `409`; a different actor receives the access specification's indistinguishable `404`.
+
+## UI/UX
+
+- On `applied`, remove the task from the active inbox and show the existing success message.
+- On `pending`, show a non-destructive “Task completed; workflow is continuing” state and retain a Retry continuation action that repeats the same complete request payload.
+- Disable repeat submission while one request is in flight.
+- Contextual widgets and task detail consume the same continuation status; neither invents a separate resume endpoint.
+- A task whose continuation is pending is no longer actionable as a task, but its detail remains available to the completing user and managers under the access specification.
+
+All new strings use workflows locale keys and semantic status components.
+
+## Data Models
+
+No new entity or column is planned. Existing records are used as follows:
+
+| Record | Durable role |
+| --- | --- |
+| `UserTask` | accepted input, completing actor, immutable completed lifecycle |
+| `WorkflowEvent` | requested/applied continuation journal and audit |
+| `WorkflowInstance` | root cursor, context, and execution lock |
+| `WorkflowBranchInstance` | branch cursor, namespace, and execution lock |
+| `StepInstance` | proof that the user-task step exited |
+
+If implementation evidence proves event lookup cannot meet bounded recovery targets without a schema change, work stops for a separately reviewed additive index proposal.
+
+## Observability and Performance
+
+- Structured logs include task/instance/branch IDs, transition ID, outcome, and attempt source, but never form data/comments.
+- Metrics: requested count, applied count, pending age, replay count, reconciliation failure count.
+- Normal completion adds bounded event lookups and one post-commit continuation attempt.
+- Reconciliation is paginated, tenant/organization scoped, oldest pending first, and bounded by an explicit limit.
+- Target: p95 database-only completion acknowledgement below 250 ms excluding post-commit workflow activity time.
+- The API must not hold task locks while external activities run.
+
+## Migration and Backward Compatibility
+
+- No schema migration, route rename, body change, or existing workflow event removal.
+- Response fields are additive.
+- Repeated identical completion changes from conflict/not-found to idempotent success; this is an intentional reliability correction.
+- Repeated completion with different input remains a conflict.
+- Existing completed tasks without requested events are not automatically replayed; only tasks completed after this contract, or explicitly repaired through a separately reviewed backfill, participate.
+- External activities retain at-least-once behavior.
+
+## Implementation Plan
+
+### Phase 1: Atomic Completion Intent
+
+1. Refactor complete into one scoped transaction with deterministic lock order.
+2. Persist task/context/step plus requested event atomically.
+3. Add input digest and replay classification helpers.
+
+### Phase 2: Idempotent Resume
+
+1. Add the root/branch continuation resume function using existing execution locks.
+2. Persist applied event with cursor advancement.
+3. Declare the persistent completion event/subscriber.
+
+### Phase 3: Recovery and UX
+
+1. Make identical complete replay re-drive pending continuation.
+2. Add instance-retry reconciliation and bounded CLI repair.
+3. Expose continuation status and pending/retry UI.
+4. Add crash-window, redelivery, branch, and headed UI coverage.
+
+## Expected File Manifest
+
+| Path | Action |
+| --- | --- |
+| `packages/core/src/modules/workflows/lib/task-handler.ts` | Refactor completion transaction/replay |
+| `packages/core/src/modules/workflows/lib/user-task-continuation.ts` | Add focused resume/reconcile logic |
+| `packages/core/src/modules/workflows/lib/transition-handler.ts` / `parallel-handler.ts` | Narrow integration with recorded transition and branch cursor |
+| `packages/core/src/modules/workflows/api/tasks/[id]/complete/route.ts` | Add replay and continuation response |
+| `packages/core/src/modules/workflows/events.ts` | Declare completion event |
+| `packages/core/src/modules/workflows/subscribers/user-task-completed.ts` | Persistent idempotent resume |
+| workflows CLI command surface | Add bounded scoped reconcile command |
+| task detail/inbox and locales | Add pending/applied UX |
+| workflows unit/integration tests | Add atomicity, crash, replay, branch, redelivery proof |
+
+## Testing Strategy
+
+| Area | Required proof |
+| --- | --- |
+| Atomicity | injected failure before commit leaves task/context/step/events unchanged |
+| Commit/response crash | task+request committed, client retry applies continuation once |
+| Emit failure | accepted task remains pending and explicit replay repairs it |
+| Complete race | two requests accept one input; one mutation/event; other idempotent or `409` by digest |
+| Resume race | HTTP attempt and persistent subscriber produce one applied transition |
+| Root progression | form data, exited step, transition, next step, applied event |
+| Parallel progression | only target branch advances; sibling/join behavior retained |
+| Redelivery | repeated persistent job is a no-op after applied |
+| No valid transition | rollback with `409`; task remains actionable |
+| No outgoing transition | explicit `not_required` legacy behavior |
+| External effect | test documents possible at-least-once execution; idempotent handler fixture tolerates replay |
+| Reconcile | tenant/org filters, bounded page, metrics, no sensitive logs |
+| UI | applied and pending states on desktop/narrow; retry repeats identical payload |
+
+## Risks and Impact Review
+
+### Completed Task, Paused Workflow
+
+- **Scenario:** the process stops after task commit but before continuation execution or queue enqueue.
+- **Severity:** High.
+- **Affected area:** workflow liveness.
+- **Mitigation:** requested event is committed with the task; identical HTTP replay, persistent subscriber, instance retry, and CLI reconciliation call the same idempotent resume.
+- **Residual risk:** without a client retry, event enqueue, instance retry, or operator reconciliation, recovery latency is unbounded; a platform outbox is explicitly outside this scope.
+
+### Duplicate Database Progression
+
+- **Scenario:** HTTP and worker attempts race.
+- **Severity:** High.
+- **Affected area:** cursor, context, audit history.
+- **Mitigation:** existing execution lock, source-step verification, requested/applied event checks, concurrency integration test.
+- **Residual risk:** future resume paths must preserve the same lock order.
+
+### Duplicate External Activity
+
+- **Scenario:** external side effect succeeds but executor transaction rolls back before applied state commits.
+- **Severity:** High.
+- **Affected area:** third-party systems.
+- **Mitigation:** explicit at-least-once contract and existing activity idempotency requirements; never label the feature exactly-once.
+- **Residual risk:** non-idempotent legacy activities can duplicate and require provider-side keys or compensation.
+
+### Lock Deadlock or Latency
+
+- **Scenario:** complete acquires task/instance/branch locks in an order opposite another resume path.
+- **Severity:** High.
+- **Affected area:** workflow throughput.
+- **Mitigation:** lock-order inventory before coding, one documented order, short completion transaction, race/deadlock tests.
+- **Residual risk:** unrelated future executor changes can reintroduce inversion.
+
+### Sensitive Replay Logging
+
+- **Scenario:** form data/comments or their canonical representation are logged during reconciliation.
+- **Severity:** High.
+- **Affected area:** privacy and secrets.
+- **Mitigation:** logs contain identifiers/outcomes only; digest is non-reversible and not logged unless necessary at truncated safe form.
+- **Residual risk:** task data remains subject to its existing database protection policy.
+
+## Final Compliance Report
+
+| Requirement | Planned compliance |
+| --- | --- |
+| Scope and locks | Tenant/org predicates and existing instance/branch serialization |
+| Transaction safety | Task/context/step/request committed together; external execution after commit |
+| Queue guidance | Idempotent persistent subscriber; no new strategy/default/polling loop |
+| Backward compatibility | Existing route/body/event history retained; additive response/internal events |
+| Sensitive data | No form/comment payload in logs or event-bus payload |
+| Simplicity | Reuse `WorkflowEvent` and current retry/executor paths; no new table/public framework |
+| Integration coverage | Root, branch, races, crash windows, redelivery, reconciliation explicitly required |
+
+Implementation remains blocked until this specification is merged and the public feature-claim admission gate is satisfied.
+
+## Changelog
+
+### 2026-07-21
+
+- Split durable completion/continuation from the access and inbox specification.
+- Grounded the design in the current multi-flush handler, existing workflow event log, root/branch execution locks, persistent event runtime, and instance retry path.
+- Defined identical-request replay, requested/applied journal events, explicit reconciliation, and honest at-least-once external side-effect semantics.
+
+### 2026-07-15
+
+- Initial scope approved as part of the workflow user-task improvement design.

--- a/.ai/specs/2026-07-15-secure-workflow-user-task-access-and-personal-inbox.md
+++ b/.ai/specs/2026-07-15-secure-workflow-user-task-access-and-personal-inbox.md
@@ -1,0 +1,511 @@
+# Secure Workflow User-Task Access and Personal Inbox
+
+## TLDR
+
+**Key points:**
+
+- Keep the existing `USER_TASK`, `/backend/tasks`, task APIs, `UserTask` entity/fields, ACL IDs, and widget infrastructure while adding an explicit upgrade bridge for legacy direct-assignment values.
+- Add one server-authoritative human-session actor policy for personal visibility, claim, complete, and replay decisions.
+- Make the existing task page discoverable as a top-level personal inbox for operators while preserving a separate permission-gated administrative `User Tasks` destination for workflow managers.
+
+**Scope:**
+
+- Correct `myTasks` filtering and manager-only broad inspection.
+- Enforce tenant, organization, assignment, role, and claimant checks on list, detail, claim, and complete.
+- Make claim single-winner and hand authorized completion to the companion durable-continuation contract.
+- Emit direct-assignment notifications with the canonical `/backend/tasks/{id}` link.
+
+**Primary risks:** task disclosure across users or organizations, unauthorized execution, claim races, and navigation that either exposes workflow administration to operators or hides it from managers.
+
+## Overview
+
+Open Mercato already pauses a root workflow instance or parallel branch when a `USER_TASK` is entered. The current task page and API are therefore the right foundation; a new workflow step type is unnecessary.
+
+The missing boundary is authorization. Feature grants answer whether an actor may use task functionality, while assignment answers whether the actor may see or execute a particular task. Both checks are required. A workflow manager may inspect all tasks but does not gain execution authority solely from `workflows.manage`.
+
+This specification is intentionally delta-first. Durable post-completion progression is defined separately in [`2026-07-15-durable-workflow-user-task-continuation.md`](2026-07-15-durable-workflow-user-task-continuation.md), and business-record placement is defined in [`2026-07-15-contextual-workflow-task-actions.md`](2026-07-15-contextual-workflow-task-actions.md).
+
+## Current Baseline and Delta
+
+Baseline reviewed: `open-mercato/open-mercato` `develop` at `28649ddec6dd26c15244f4b4264117c8e645a368` on 2026-07-21.
+
+| Existing capability | Keep | Missing delta |
+| --- | --- | --- |
+| `USER_TASK` pauses root/branch execution | Yes | None |
+| `/backend/tasks` and `/backend/tasks/{id}` | Yes | Personal navigation, access-aware actions, shared states |
+| `GET /api/workflows/tasks` with `myTasks` query support | Yes | UI must send the flag; predicate must exclude peer-claimed tasks |
+| Task detail, claim, and complete APIs | Yes | Shared actor policy, scoped locked writes, structured authorization errors |
+| `assignedTo` UUID, email, and non-email legacy values | Field/config shapes remain readable | Canonical creation, pre-runtime audit, and explicit repair guidance |
+| `workflows.view_tasks` and `workflows.tasks.*` | Every ID remains | Explicit compatibility bridge and coherent page/API grants |
+| `workflows.task.assigned` notification type/subscriber | Type ID remains | Declare and emit event; fix `/backend/workflows/tasks/{id}` deep link |
+| Workflow task integration coverage | Existing happy paths remain | Adversarial actor, scope, race, navigation, and notification coverage |
+
+Concurrent work must be rechecked before implementation. [PR #4019](https://github.com/open-mercato/open-mercato/pull/4019) owns visual-editor persistence, [PR #4085](https://github.com/open-mercato/open-mercato/pull/4085) owns user-task form normalization, and [PR #4291](https://github.com/open-mercato/open-mercato/pull/4291) owns role selection in the editor. None currently implements this access or navigation contract.
+
+## Problem Statement
+
+The current implementation has independent checks that do not form an authorization boundary:
+
+- the page initializes its `My Tasks` filter but omits `myTasks=true` from API requests;
+- the list role predicate still includes a role task after another member claims it;
+- claim does not verify that the caller belongs to an assigned role and starts with an unscoped read;
+- completion does not prove that the caller is the direct assignee or claimant;
+- saved definitions and pending tasks contain a mix of canonical IDs, emails, and non-email aliases, so secure canonicalization cannot ship without a compatibility inventory/repair path;
+- route-level scope checks are followed by unscoped handler lookups;
+- claim is read-then-write without a database single-winner boundary;
+- the legacy page feature and current API feature protect different surfaces;
+- the administrative navigation entry cannot be globally removed merely because a personal entry exists;
+- notification infrastructure exists, but task creation does not emit its event and stored links target a non-existent route.
+
+## Goals
+
+1. Give operational users a personal task queue without requiring workflow-administration navigation.
+2. Enforce one human task actor policy across list, detail, claim, complete, replay, contextual widgets, and notification recipients.
+3. Scope every read and write by tenant and selected organization.
+4. Make role-task claim a single-winner operation.
+5. Keep manager inspection distinct from assignment-based execution.
+6. Preserve the current routes, entities, task configuration, ACL identifiers, and notification type.
+7. Preserve an administrative `User Tasks` destination for authorized workflow managers.
+8. Inventory and safely bridge every existing direct-assignment shape before canonical-only execution becomes active.
+
+## Non-Goals
+
+- A new workflow step type or a change to `USER_TASK` pause semantics.
+- General release, unclaim, reassignment, delegation, draft form data, or SLA escalation; the narrowly scoped compatibility repair command is the only reassignment in scope.
+- Role-queue notification fan-out.
+- A dynamic navigation badge.
+- Business-record widgets; the contextual-actions specification owns them.
+- Post-completion retry mechanics; the durable-continuation specification owns them.
+- A database migration.
+- Machine completion through API keys; that requires a separate task type, permission, and machine-principal audit contract.
+
+## Proposed Solution
+
+### Design Decisions
+
+| Decision | Rationale |
+| --- | --- |
+| One module-local actor/policy helper owns visibility and capabilities | Prevents route and widget rules from drifting without adding a public service abstraction |
+| Direct assignments do not require claim | The assigned user is already the sole worker |
+| Role queues require claim before complete | Establishes one owner and removes the task from peers |
+| `workflows.manage` grants broad inspection only | Administration must not silently authorize business execution |
+| Existing page and API read IDs remain distinct and bridged | Preserves frozen contracts while keeping current routes usable |
+| Two explicit menu items represent two different jobs | Personal execution and administrative inspection are intentionally separate |
+| `navHidden` is only a generator control, never the navigation policy | Prevents a repeat of globally hiding the manager destination |
+| Assignment notifications target direct users only | Avoids noisy and expensive role fan-out |
+| API-key principals cannot become human task actors | Preserves the human-in-the-loop boundary and canonical human audit identity |
+| Runtime email equality never authorizes execution | Email is mutable and recyclable; direct work must bind to an immutable user ID |
+| Upgrade audit classifies UUID, email, and non-email aliases before rollout | Security hardening must not silently break saved definitions or strand pending tasks |
+
+### Alternatives Considered
+
+| Alternative | Why rejected |
+| --- | --- |
+| Add a new wait/approval step | `USER_TASK` already provides the pause |
+| Let the client decide `canClaim`/`canComplete` | Client checks are bypassable |
+| Let managers execute every task | Conflates inspection with assignment |
+| Replace frozen ACL IDs with one new permission | Breaks existing roles and integrations |
+| Keep the generated admin entry visible to all task operators | Task execution dependencies would recreate the Workflows administration group |
+| Set `navHidden` and keep only My Tasks | Hides the administrative destination from workflow managers |
+| Notify every member of a candidate role | Produces notification storms; the inbox remains the role queue |
+
+## User Stories
+
+- As an operator, I can open My Tasks from the top-level navigation.
+- As a direct assignee, I can complete my task without claiming it.
+- As an eligible role member, I can claim a task and become its only executor.
+- As another role member, I stop seeing a task after a peer claims it.
+- As a workflow manager, I can inspect all tasks through the Workflows group without gaining execution authority.
+- As an existing administrator, I retain the administrative `User Tasks` destination.
+
+## Architecture
+
+### Components
+
+| Component | Responsibility |
+| --- | --- |
+| `lib/user-task-access.ts` | Actor shape, personal predicate, broad-inspection check, `canClaim`/`canComplete`/`canRetryContinuation` |
+| `lib/task-handler.ts` or focused task command module | Scoped locked claim and authorized handoff to completion |
+| task API routes | Parse input, resolve actor/features, call shared policy/commands, expose OpenAPI |
+| task pages | Personal inbox/detail UX driven by server capabilities |
+| task navigation widget | Top-level personal item and grouped administrative item |
+| task event/subscriber | Direct-assignment notification and client invalidation if broadcast is enabled |
+| workflows assignment audit/repair CLI | Dry-run inventory, explicit pending-task mapping, and actionable definition remediation |
+
+No new cross-module ORM relationship, global authorization primitive, or public DI key is introduced.
+
+### Actor Contract
+
+```ts
+type UserTaskActor = {
+  principalKind: 'human-session'
+  userId: string
+  roles: string[]
+  features: string[]
+  tenantId: string
+  organizationId: string
+}
+```
+
+The actor is constructed from authenticated server state and the selected organization. Feature checks use the shared wildcard-aware matcher. The resolver rejects `auth.isApiKey` and every other non-interactive principal with `403`; it never substitutes an API key's backing `userId` or treats API-key roles as human candidate-role membership. `userId` is the canonical session user ID.
+
+When a new task has a direct assignment, task creation resolves the configured reference to exactly one active human in tenant/organization scope and persists the canonical user ID. A canonical user ID or email may be accepted as definition configuration input for that creation-time resolution, but email is never compared to the current actor at read or mutation time. Missing, inactive, foreign-scope, ambiguous, and non-email legacy aliases fail task creation with `USER_TASK_ASSIGNEE_UNRESOLVED` instead of persisting a non-canonical assignment.
+
+### Assignment Compatibility Classification
+
+Before canonical-only execution is enabled, `corepack yarn mercato workflows audit-user-task-assignees` runs dry by default and scans the selected tenant/organization's active definition versions plus `PENDING`/`IN_PROGRESS` tasks. It classifies every direct value:
+
+| Stored/configured shape | Future definition behavior | Existing task behavior |
+| --- | --- | --- |
+| canonical active scoped user ID | accepted and persisted unchanged | remains actionable |
+| email in a definition | resolved once at new task creation; canonical ID stored | never authorized by runtime equality |
+| email in an existing task | not auto-bound because address history/recycling is unknowable | pending fails closed until explicit task-ID-to-user-ID repair; an in-progress task with a canonical `claimedBy` keeps its claimant |
+| non-email legacy alias such as a username/label | cannot be guessed as user or role | pending fails closed until definition update/task repair; an in-progress task with a canonical `claimedBy` keeps its claimant |
+| missing/inactive/foreign/ambiguous reference | definition validation error | fail closed and report |
+
+The report names definition/version/task IDs, classification, and remediation without logging decrypted emails in normal output. `--apply-task-map <user-owned-json>` accepts exact task-ID-to-canonical-user-ID mappings, requires tenant/organization flags, verifies the target user is active/in scope, locks an unclaimed pending task, rewrites only `assignedTo`, and appends a user-task assignment-repaired audit event. It never guesses from current email ownership, never edits completed/claimed tasks, and never rewrites versioned definitions. Definitions are corrected through their existing editor/API by selecting a canonical user ID or intentional `assignedToRoles` value.
+
+Implementation updates repository-owned examples, seeds, and integration fixtures that currently use aliases such as `approver` or `admin`. `UPGRADE_NOTES.md` requires a dry run and zero unresolved active definitions before deployment; unresolved production definitions fail validation/preflight before entering `USER_TASK`, not silently after creating a stranded row.
+
+### Personal Visibility and Capabilities
+
+Every predicate begins with exact tenant and organization scope.
+
+| Task | Personal visibility | `canClaim` | `canComplete` | `canRetryContinuation` |
+| --- | --- | --- | --- | --- |
+| `PENDING`, canonical direct user ID matches | Yes | No | Yes when complete feature is granted | No |
+| `PENDING`, unclaimed role queue overlaps actor roles | Yes | Yes when claim feature is granted | No | No |
+| `IN_PROGRESS`, `claimedBy` equals actor | Yes | No | Yes when complete feature is granted | No |
+| Role task claimed by another actor | No | No | No | No |
+| `COMPLETED`, `completedBy` equals actor and continuation is pending | Yes in detail/history, not in the default actionable inbox | No | No | Yes when complete feature is granted |
+| `COMPLETED`, `completedBy` equals actor and continuation is applied/not required | Only in explicit history view | No | No | No |
+| `PENDING`, legacy email-only assignment | Manager inspection only | No | No | No |
+| `PENDING`, non-email legacy alias | Manager inspection only | No | No | No |
+| Any foreign assignment or scope | No | No | No | No |
+
+Capabilities are computed server-side for list/detail responses and recomputed under the mutation lock. They are presentation hints, not authorization tokens.
+
+### Broad Inspection
+
+- `myTasks=true` applies the personal predicate.
+- `myTasks=false` or an omitted flag requests a broad organization-scoped list and requires wildcard-aware `workflows.manage`.
+- Direct detail access requires personal visibility or `workflows.manage`.
+- Manager inspection does not change `canClaim` or `canComplete`.
+- Foreign-scope, missing, and non-visible task IDs return the same `404` response.
+
+### ACL and Navigation Compatibility
+
+All existing feature IDs remain. The implementation aligns them as follows:
+
+- the generated task page retains `requireFeatures: ['workflows.view_tasks']`;
+- task APIs retain their current `workflows.tasks.view/claim/complete` feature IDs;
+- `workflows.tasks.view` depends on the legacy `workflows.view_tasks` feature as a one-way compatibility bridge;
+- the legacy `workflows.view_tasks` feature no longer depends on the broad `workflows.view` feature, because a personal task worker must not gain workflow-definition navigation merely to execute assigned work;
+- the default employee role receives `workflows.view_tasks`, `workflows.tasks.view`, `workflows.tasks.claim`, and `workflows.tasks.complete` so the personal inbox works on new tenants;
+- administrators keep `workflows.*`;
+- existing tenants receive the same grants through the standard idempotent ACL sync during implementation rollout.
+
+Navigation contains two explicit contributions to `menu:sidebar:main`:
+
+1. `workflows-my-tasks` → `/backend/tasks`, gated by `workflows.tasks.view`, with no group, labelled My Tasks;
+2. `workflows-user-tasks-admin` → `/backend/tasks`, grouped under Workflows, gated by all of `workflows.manage`, `workflows.view_tasks`, and `workflows.tasks.view`, labelled User Tasks.
+
+The task route may be `navHidden: true` only to suppress automatic route generation. That change and both explicit menu contributions are one atomic implementation unit. Shipping `navHidden` without the grouped manager item is a navigation regression and fails this specification. An operational employee sees exactly one task destination; a workflow manager may see both because they represent personal work and administrative inspection.
+
+## Mutations
+
+### Claim
+
+1. Resolve actor and require `workflows.tasks.claim`.
+2. In one transaction, fetch the task with `PESSIMISTIC_WRITE` using task ID, tenant ID, organization ID, `PENDING`, and no direct assignee.
+3. Re-evaluate role overlap under the lock.
+4. Set `claimedBy`, `claimedAt`, `status=IN_PROGRESS`, and `updatedAt`.
+5. Append the existing `USER_TASK_STARTED` workflow audit event in the same transaction.
+6. Commit before any optional broadcast/notification side effect.
+
+Concurrent eligible claimers produce one success and one `409`. No undo is added; release/unclaim requires a separate lifecycle design.
+
+### Complete Authorization Handoff
+
+The complete route resolves the same actor, requires `workflows.tasks.complete`, validates the form through the canonical user-task form normalizer, and re-evaluates one of these conditions under the durable completion lock:
+
+- pending direct assignment matches the actor; or
+- in-progress role task has `claimedBy === actor.userId`.
+
+For an already-completed task, the access layer exposes a separate replay branch only when `completedBy === actor.userId` and the actor still has `workflows.tasks.complete`. It does not set `canComplete=true` and cannot change accepted input. `canRetryContinuation` is true only while continuation is pending, but an identical transport retry may still reach this replay branch after continuation was applied or was not required so the route can return the same success. The durable-continuation specification owns same-input comparison and the idempotent result; a different actor remains indistinguishable from a missing task.
+
+Only an authorized first completion or replay may invoke the transaction and continuation contract in the durable-continuation specification. A manager who is neither assignee, claimant, nor the original completing actor receives `404`, not an execution override.
+
+Custom claim/complete routes run mutation guards before the command and after-success callbacks only after a successful commit.
+
+## Events and Notifications
+
+The existing notification type ID `workflows.task.assigned` remains. The workflows event registry declares the matching event, and task creation emits it after the task commit only when a canonical direct user ID was persisted.
+
+Trusted tenant, organization, and recipient scope is supplied in event options/context, not taken from arbitrary payload fields. The subscriber:
+
+- resolves one canonical direct recipient;
+- creates at most one notification per task/type/recipient under the notification module's idempotency contract;
+- uses `/backend/tasks/{taskId}` for both action and link;
+- does nothing for role-only queues or non-canonical legacy assignments;
+- logs delivery failure without rolling back task creation.
+
+## Data Models
+
+No schema change is required.
+
+| Existing field | Contract |
+| --- | --- |
+| `UserTask.assignedTo` | Canonical user ID for new direct assignments; legacy email/alias values remain manager-readable but never authorize personal execution |
+| `UserTask.assignedToRoles` | Existing role identifiers emitted by workflow configuration |
+| `claimedBy` / `completedBy` | Canonical user IDs |
+| tenant/organization columns | Mandatory predicates for every task query/write |
+
+No new PII is stored. Task APIs do not return decrypted auth fields or raw feature grants.
+
+## API Contracts
+
+All current URLs and methods remain, and every route keeps an `openApi` export.
+
+### `GET /api/workflows/tasks`
+
+- Parse and clamp `limit` to `1..100`; preserve `offset`.
+- `myTasks=true` defaults to active `PENDING,IN_PROGRESS` states when status is omitted.
+- `myTasks=false`/omitted is manager-only broad inspection.
+- Existing filters remain.
+- Add `canClaim`, `canComplete`, and `canRetryContinuation` to each task projection.
+- Errors: `400` invalid query/scope, `401` unauthenticated, `403` missing coarse feature or broad-inspection grant.
+
+### `GET /api/workflows/tasks/{id}`
+
+Return the current task projection plus `canClaim`/`canComplete`/`canRetryContinuation`. Personal visibility or manager inspection is required; invisible and foreign-scope IDs return `404`.
+
+### `POST /api/workflows/tasks/{id}/claim`
+
+No body. Return the updated projection. Errors: `400`, `401`, `403` missing claim feature, `404` invisible/ineligible task, `409` stale lifecycle or lost race.
+
+### `POST /api/workflows/tasks/{id}/complete`
+
+The existing `{ formData, comments? }` body remains. Access and error semantics follow the authorization handoff above; durable response/idempotency semantics are defined by the continuation specification.
+
+## UI/UX
+
+### Personal Inbox
+
+- The page initializes and sends `myTasks=true` on initial load, filter changes, and pagination.
+- Clearing filters restores personal active-task mode rather than broad mode.
+- The All Tasks option is present only for wildcard-aware `workflows.manage`.
+- Claim/Complete/Retry controls come only from server `canClaim`/`canComplete`/`canRetryContinuation`.
+- Reuse the existing DataTable and task detail form; replace touched bespoke status/loading/error markup with shared semantic components.
+- Every write uses `useGuardedMutation`; reads use `apiCall`/`apiCallOrThrow`.
+- All visible strings use workflows locale keys for every supported locale.
+
+### Navigation Acceptance Matrix
+
+| Actor grants | Top-level My Tasks | Workflows → User Tasks | Administrative group introduced by task-only rights |
+| --- | --- | --- | --- |
+| operational defaults | Yes | No | No |
+| workflow manager with all three admin-item grants | Yes | Yes | N/A |
+| `workflows.*` | Yes | Yes | N/A |
+| no task read grant | No | No | No |
+
+Desktop and narrow headed tests must assert stable item IDs and route destinations, not localized text alone.
+
+## Frontend Architecture Contract
+
+| Surface | Server boundary | Client island | Guardrail |
+| --- | --- | --- | --- |
+| `/backend/tasks` | generated backend route metadata | existing DataTable page | no new provider; split touched file if it remains over 300 LOC |
+| `/backend/tasks/{id}` | generated backend route metadata | existing form/actions | reuse canonical form normalizer |
+| sidebar | existing AppShell/menu injection | existing injected-menu consumer | static items only; stable IDs and wildcard-aware features |
+
+No new page-root client component, global provider, editor/graph dependency, or navigation data endpoint is introduced. `yarn check:client-boundaries` and hydration smoke tests remain required for implementation.
+
+## Internationalization
+
+Add or update keys for top-level My Tasks, administrative User Tasks, personal/history filters, access-aware actions, empty states, and structured errors in every supported workflows locale. Existing notification type keys remain stable.
+
+## Migration and Backward Compatibility
+
+- No database schema migration or automatic identity backfill.
+- No route, entity, notification type, or ACL ID is removed or renamed.
+- The legacy task-view feature's dependency on broad workflow view is relaxed, not replaced by a new ID; existing grants keep working while task-only roles stop inheriting workflow-definition navigation through ACL dependency repair.
+- Response capability fields are additive.
+- Existing broad callers without `workflows.manage` begin receiving `403`; this intentional security hardening must appear in release notes.
+- Existing canonical `assignedTo` IDs remain actionable. Legacy email/alias tasks become manager-readable but fail closed for personal access/execution until an explicit scoped task mapping is applied.
+- Active definition versions are inventoried before rollout. Canonical IDs remain unchanged; emails resolve only for future task creation; non-email aliases must be replaced explicitly with a canonical user or `assignedToRoles` configuration.
+- The compatibility CLI is dry-run by default, never infers historical identity, never changes versioned definitions, and applies only exact operator-provided pending-task mappings under lock with an audit event.
+- `UPGRADE_NOTES.md` documents classification, command examples, repository example changes, rollout order, and rollback (restore the previous application version; repair writes remain canonical and safe).
+- New default employee grants require `yarn mercato auth sync-role-acls` for existing tenants during implementation rollout.
+- Structural navigation cache refresh is required only if implementation changes discovered page/widget metadata; it is not a substitute for ACL sync.
+
+## Performance and Cache
+
+- Personal task reads are not server-cached.
+- List queries apply tenant, organization, active status, then assignment/claim predicates before ordering and pagination.
+- Actor identity/features are resolved once per request, not per row.
+- Query count remains one paginated read plus one count.
+- Implementation evidence includes representative direct-assignee and role-queue query plans at 10,000 scoped active tasks; p95 target is below 250 ms.
+- If the existing indexes cannot meet the target, implementation stops for a separately reviewed additive-index design rather than weakening authorization.
+
+## Implementation Plan
+
+### Phase 1: Actor Policy and Secure Reads
+
+1. Add the module-local actor/access helper and focused unit tests.
+2. Add canonical assignment resolution plus the dry-run audit/explicit task-map repair command.
+3. Update repository aliases and publish the required upgrade notes/preflight.
+4. Apply the policy to list/detail projections and broad-inspection gating.
+5. Send `myTasks=true` from the UI and hide broad mode from non-managers.
+
+### Phase 2: ACL, Navigation, and Claim
+
+1. Add the dependency/default-grant bridge and required ACL sync instructions.
+2. Deliver `navHidden` suppression and both explicit navigation entries together.
+3. Make claim scoped, locked, role-authorized, and single-winner.
+
+### Phase 3: Completion Handoff and Notifications
+
+1. Apply the access helper to complete before the durable continuation command.
+2. Declare/emit direct assignment events and correct notification links.
+3. Add self-contained API and headed UI coverage.
+
+## Expected File Manifest
+
+| Path | Action |
+| --- | --- |
+| `packages/core/src/modules/workflows/lib/user-task-access.ts` | Create focused internal policy helper |
+| `packages/core/src/modules/workflows/lib/task-handler.ts` | Modify scoped claim and authorized completion handoff |
+| workflows task-creation/definition validation paths | Modify canonical direct-assignee resolution and structured preflight error |
+| `packages/core/src/modules/workflows/cli.ts` and focused command | Modify/Add dry-run assignment audit and explicit task-map repair |
+| `packages/core/src/modules/workflows/workflows.ts` and affected fixtures/examples | Modify remove repository-owned non-canonical aliases |
+| `packages/core/src/modules/workflows/api/tasks/**` | Modify parsing, access, projections, OpenAPI |
+| `packages/core/src/modules/workflows/acl.ts` / `setup.ts` | Modify compatibility dependency/default grants |
+| `packages/core/src/modules/workflows/backend/tasks/**` | Modify personal inbox/detail UX and metadata |
+| `packages/core/src/modules/workflows/widgets/injection/**` | Add two static navigation items |
+| `packages/core/src/modules/workflows/events.ts` / `subscribers/**` | Declare/emit notification event and fix subscriber |
+| `packages/core/src/modules/workflows/notifications.ts` | Fix canonical deep link |
+| `packages/core/src/modules/workflows/i18n/*.json` | Update copy |
+| workflow unit/integration tests | Add actor, race, navigation, notification coverage |
+| `UPGRADE_NOTES.md` | Modify direct-assignment inventory, repair, rollout, and rollback guidance |
+
+## Testing Strategy
+
+Fixtures create users, roles, workflow definitions, instances, and tasks through public APIs where practical and clean up in `finally`.
+
+| Area | Required proof |
+| --- | --- |
+| Identity | canonical ID succeeds; definition email resolves only at creation; legacy/recycled email and non-email task aliases fail closed |
+| Upgrade compatibility | audit classifies UUID/email/alias definitions and tasks; dry run writes nothing; explicit map repairs one locked pending task/audit; claimed/completed/foreign mappings rejected; existing canonical claimant can finish |
+| Definition preflight | repository examples migrated; unresolved active alias reported before runtime; canonical user and role queue paths remain valid |
+| Principal type | human session succeeds; API key with matching role/features receives `403` and writes no audit/task state |
+| Personal list/detail | direct, candidate role, claimant, peer disappearance, completed history, original completer can view/retry pending continuation |
+| Features | legacy/current read bridge, claim/complete independently, manager inspect without execute, wildcards |
+| Scope | foreign tenant/organization absent on list and `404` on detail/mutations |
+| Claim race | two eligible users, one success, one `409`, one audit event |
+| Navigation | operator exactly one item; manager grouped item; wildcard admin; no global-hide regression |
+| Notification | one direct recipient, valid `/backend/tasks/{id}` link, no role fan-out |
+| UI | personal query actually contains `myTasks=true`; desktop/narrow loading, empty, error, claim, complete |
+| Optional integration | contextual widgets consume capabilities but cannot bypass mutations |
+
+## Risks and Impact Review
+
+### Cross-Scope Disclosure
+
+- **Scenario:** a handler repeats an unscoped lookup after a scoped route check.
+- **Severity:** Critical.
+- **Affected area:** task/form/workflow data.
+- **Mitigation:** one actor scope flows to every query and locked write; foreign/missing IDs share `404`; adversarial API tests.
+- **Residual risk:** future bypass routes must import the same helper; route inventory tests remain necessary.
+
+### Unauthorized Claim or Completion
+
+- **Scenario:** an actor has a coarse feature but is not the assignee, claimant, or candidate-role member.
+- **Severity:** Critical.
+- **Affected area:** workflow decisions and downstream business state.
+- **Mitigation:** assignment policy is recomputed under lock; manager inspection is not an override.
+- **Residual risk:** role identifier semantics must stay aligned with auth/editor output.
+
+### Claim Race
+
+- **Scenario:** two role members claim the same pending task.
+- **Severity:** High.
+- **Affected area:** ownership and subsequent completion.
+- **Mitigation:** scoped pessimistic lock and single transaction.
+- **Residual risk:** losing client must handle `409` and refetch.
+
+### Navigation Regression
+
+- **Scenario:** automatic route navigation is hidden and no manager replacement is registered, or task grants recreate the admin group for operators.
+- **Severity:** High.
+- **Affected area:** task discoverability and least-privilege UX.
+- **Mitigation:** two stable injected entries, all-of manager gate, atomic metadata/widget delivery, role-separated tests.
+- **Residual risk:** custom sidebar preferences can still reorder/hide items by design.
+
+### Mutable or Recycled Email Assignment
+
+- **Scenario:** a pending legacy task is authorized by comparing its email with a changed, deleted, or recycled account address.
+- **Severity:** High.
+- **Affected area:** visibility and notification recipient.
+- **Mitigation:** new tasks persist canonical user IDs at creation; runtime email equality never grants visibility or execution; all legacy email-only tasks fail closed.
+- **Residual risk:** historical tasks require explicit administrator correction or workflow restart.
+
+### Legacy Alias Upgrade Regression
+
+- **Scenario:** an existing definition or pending task contains `assignedTo='admin'`, `approver`, or another non-email label and canonical-only execution activates without warning.
+- **Severity:** High.
+- **Affected area:** workflow availability and pending human work.
+- **Mitigation:** exhaustive pre-runtime audit, repository fixture migration, zero-unresolved rollout gate, structured definition validation, and exact scoped task-map repair with audit.
+- **Residual risk:** an operator can map an alias to the wrong human; dry-run review, exact task IDs, active-user validation, and audit evidence make that decision explicit rather than inferred.
+
+### Machine Principal Executes Human Task
+
+- **Scenario:** an API key inherits employee task features and a candidate role, then claims or completes a human task.
+- **Severity:** Critical.
+- **Affected area:** human approval boundary and audit attribution.
+- **Mitigation:** actor resolution rejects API keys/non-interactive principals before personal predicates or mutations; no backing-user substitution.
+- **Residual risk:** future machine-completable work requires a separate explicit contract and audit identity.
+
+### Notification Failure
+
+- **Scenario:** persistent delivery or notification service is unavailable.
+- **Severity:** Low.
+- **Affected area:** awareness only.
+- **Mitigation:** task commits first; inbox is source of truth; subscriber retry/idempotency.
+- **Residual risk:** notification can arrive late.
+
+## Final Compliance Report
+
+| Requirement | Planned compliance |
+| --- | --- |
+| Tenant/organization isolation | Mandatory in all reads and locks |
+| Wildcard-aware RBAC | Shared feature matcher only |
+| Human principal boundary | API keys/non-interactive principals rejected; canonical session user IDs only |
+| Assignment backward compatibility | UUID/email/alias inventory, explicit repair, preflight, examples, and upgrade notes required |
+| Frozen route/ACL/notification contracts | Existing identifiers retained |
+| Operator/manager navigation separation | Task-only grants do not imply broad workflow view; explicit stable menu items preserve both destinations |
+| Cross-module independence | Auth used through scoped helpers; no ORM relation |
+| Mutation guards and command boundary | Required for claim/complete |
+| UI helpers, i18n, accessibility | Existing DataTable/forms plus shared states and localized copy |
+| Self-contained integration coverage | Fixtures and cleanup explicitly required |
+| Scope simplicity | One internal access helper; no global auth or navigation framework change |
+
+Implementation remains blocked until this specification is merged and the public feature-claim admission gate is satisfied.
+
+## Changelog
+
+### 2026-07-21
+
+- Refreshed the delta against current `develop` and concurrent PRs.
+- Split durable continuation into its own specification.
+- Corrected the navigation contract: `navHidden` alone is explicitly non-compliant, operators retain top-level My Tasks, and workflow managers retain a grouped User Tasks destination.
+- Simplified the architecture to one module-local access helper and existing task handlers rather than a new public DI service.
+- Added an exhaustive UUID/email/non-email assignment upgrade bridge and required `UPGRADE_NOTES.md` guidance.
+
+### 2026-07-16
+
+- Expanded the approved skeleton into a complete access, inbox, and notification design.
+
+### 2026-07-15
+
+- Initial skeleton.

--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -104,6 +104,9 @@ Specs awaiting implementation or partially complete. Focus here for actionable w
 | [Package Previews](2026-06-22-label-based-package-previews.md) | 2026-06-22 | Label-Based Package Previews | Label-triggered pkg.pr.new previews with npm canary snapshots moved behind a separate opt-in label |
 | [Bulk-Import Side-Effect Suppression](2026-07-08-bulk-import-side-effect-suppression.md) | 2026-07-08 | Bulk-Import Side-Effect Suppression | Opt-in `ctx.bulkImport` flag lets a backfill defer per-record reindex/events/notifications (rebuilt in one batched pass); concurrency-safe via parameter threading, no shared engine state |
 | [Scoped Staff Member Directory](2026-07-15-staff-member-directory.md) | 2026-07-15 | Scoped Staff Member Directory | Narrow optional-module DI contract for resolving active, tenant- and organization-scoped staff scheduling references from trusted user IDs |
+| [Secure Workflow User-Task Access and Personal Inbox](2026-07-15-secure-workflow-user-task-access-and-personal-inbox.md) | 2026-07-15 | Secure Workflow User-Task Access and Personal Inbox | Scoped personal task visibility, assignment-safe claim/complete, separate operator and manager navigation, and direct-assignment notifications |
+| [Durable Workflow User-Task Continuation](2026-07-15-durable-workflow-user-task-continuation.md) | 2026-07-15 | Durable Workflow User-Task Continuation | Atomic completion intent, replay-safe root/branch continuation, persistent retry, and explicit reconciliation with at-least-once activity semantics |
+| [Contextual Workflow Task Actions](2026-07-15-contextual-workflow-task-actions.md) | 2026-07-15 | Contextual Workflow Task Actions | Provenance-checked task source context, source-owned authorization routes, stable widget seams, and a `customers.deal` reference adapter |
 
 ### Implemented Specifications
 


### PR DESCRIPTION
## Summary

Define three independent, delta-first contracts for workflow user tasks:

- secure human-task access, personal inbox navigation, and manager inspection;
- durable completion-to-continuation handoff and replay/reconciliation;
- provenance-checked contextual task actions with a `customers.deal` reference adapter.

The specs preserve the existing `USER_TASK`, routes, task APIs, ACL identifiers, workflow event storage, metadata, and widget infrastructure where safe. They explicitly keep a top-level personal inbox for operators and a separate permission-gated administrative task destination for workflow managers.

## Changes

- add the secure workflow user-task access and personal inbox specification;
- add the durable workflow user-task continuation specification;
- add the contextual workflow task actions specification;
- add the three pending specs to `.ai/specs/README.md`;
- document compatibility, security, migration, integration-test, and admission gates without adding runtime code.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [x] No (created new specs)
- [ ] N/A (minor change, no spec needed)

**Spec file paths:**

- `.ai/specs/2026-07-15-secure-workflow-user-task-access-and-personal-inbox.md`
- `.ai/specs/2026-07-15-durable-workflow-user-task-continuation.md`
- `.ai/specs/2026-07-15-contextual-workflow-task-actions.md`

## Testing

- `git diff --cached --check`
- required-section and local Markdown link validation for all three specs
- public-artifact scan for credentials and non-upstream context
- independent scope-cohesion review
- independent authorization/security review
- Open Mercato contribution review against the current `develop` policy floor

No runtime tests were run because this PR contains specifications only. Each spec defines the self-contained unit, integration, performance, and headed UI coverage required in a later admitted implementation.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Documentation only; no locale/generator output changes.)
- [ ] I added or adjusted tests that cover the change. (No runtime code; required implementation tests are specified.)
- [ ] I added or updated integration tests in `.ai/qa/tests/` (Not required for a spec-only PR; all future integration paths are specified.)
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry.
- [ ] Priority set: maintainer label requested: `priority-low` (documentation-only).
- [ ] Risk set: maintainer label requested: `risk-low` (specification-only, no runtime behavior).
- [ ] QA routing set: maintainer label requested: `skip-qa` for this documentation-only change.

### Design System Compliance

Not applicable to this specification-only PR; no UI implementation is included. The contextual UI spec nevertheless requires shared components, semantic tokens, accessibility, loading/empty/error states, and narrow-viewport proof for the admitted implementation.

## Linked issues

No public implementation claim is opened by this PR. Per the contribution policy, a feature/claim issue will be created only after the required specification is merged and will remain subject to Core approval before implementation.
