### PR TITLE
chore(docker): restore root docker-compose duplicates for deployment backwards compatibility

### DIFF
--- a/docker-compose.fullapp.dev.yml
+++ b/docker-compose.fullapp.dev.yml
@@ -1,0 +1,505 @@
+# Backwards-compatibility duplicate of starters/docker/compose.fullapp.dev.yml — the canonical file
+# lives there; edit that one. scripts/__tests__/root-compose-backcompat.test.mjs
+# enforces byte equality with the source.
+
+# Full stack with app in dev mode: mounted source + yarn dev (watch).
+# Usage: docker compose --project-directory . -f starters/docker/compose.fullapp.dev.yml up --build
+
+services:
+  opencode:
+    build:
+      context: ./docker/opencode
+      args:
+        # OpenCode is pre-installed in this published base image (see
+        # docker/opencode/BASE_IMAGE.md); the local build only COPYs project
+        # files, so it needs no proxy-hostile network — the FROM pull goes
+        # through the container engine's trust (OS certificate store).
+        # Override to pin a different pushed base tag.
+        OPENCODE_BASE_IMAGE: ${OPENCODE_BASE_IMAGE:-docker.io/openmercatocom/open-mercato-opencode:1.18.3}
+    image: opencode-mvp
+    container_name: mercato-opencode-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    environment:
+      # Unified AI provider/model selection. OM_AI_* wins; OPENCODE_* stays
+      # as a BC fallback resolved by the opencode entrypoint script.
+      OM_AI_PROVIDER: ${OM_AI_PROVIDER:-openai}
+      OM_AI_MODEL: ${OM_AI_MODEL:-gpt-5-mini}
+      OPENCODE_PROVIDER: ${OPENCODE_PROVIDER:-}
+      OPENCODE_MODEL: ${OPENCODE_MODEL:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENROUTER_BASE_URL: ${OPENROUTER_BASE_URL:-}
+      # Additional OM AI providers (Windows setup / .env). Forwarded so a
+      # provider chosen in the configurator actually reaches this container.
+      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZURE_OPENAI_BASE_URL: ${AZURE_OPENAI_BASE_URL:-}
+      DEEPINFRA_API_KEY: ${DEEPINFRA_API_KEY:-}
+      DEEPINFRA_BASE_URL: ${DEEPINFRA_BASE_URL:-}
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+      GROQ_BASE_URL: ${GROQ_BASE_URL:-}
+      TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
+      TOGETHER_BASE_URL: ${TOGETHER_BASE_URL:-}
+      FIREWORKS_API_KEY: ${FIREWORKS_API_KEY:-}
+      FIREWORKS_BASE_URL: ${FIREWORKS_BASE_URL:-}
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-}
+      LITELLM_BASE_URL: ${LITELLM_BASE_URL:-}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+      LM_STUDIO_API_KEY: ${LM_STUDIO_API_KEY:-}
+      LM_STUDIO_BASE_URL: ${LM_STUDIO_BASE_URL:-}
+      # In-network MCP wiring. MCP_SERVER_API_KEY (env) wins when set; the
+      # file fallback reads the key the mcp service provisioned into the
+      # shared volume after waiting for the MCP /health endpoint.
+      OPENCODE_MCP_URL: ${OPENCODE_MCP_URL:-http://mcp:3001/mcp}
+      MCP_SERVER_API_KEY: ${MCP_SERVER_API_KEY:-}
+      MCP_SERVER_API_KEY_FILE: /run/mcp-shared/mcp-api-key
+    volumes:
+      - mcp_shared:/run/mcp-shared:ro
+      # File-defined agents (delivery model A — dev bind-mount). The generator
+      # emits these from `agents/<id>/` dirs; OpenCode loads them on new sessions
+      # (no guaranteed hot-reload — restart this service after `yarn generate`).
+      - ./docker/opencode/agents:/home/opencode/.config/opencode/agents:ro
+      # Native OpenCode skills (Phase 3). Generated from `agents/<id>/skills/`;
+      # loaded on new sessions (restart this service after `yarn generate`).
+      - ./docker/opencode/skills:/home/opencode/.config/opencode/skills:ro
+      # Corporate CA bundle for pulled images (entrypoint exports
+      # SSL_CERT_FILE/NODE_EXTRA_CA_CERTS when certs are present).
+      - ./docker/opencode/certs:/run/om-certs:ro
+    ports:
+      - "${OPENCODE_PORT:-4096}:4096"
+    depends_on:
+      mcp:
+        condition: service_started
+    # Visibility only (compose ps / smoke tests): the entrypoint owns the
+    # wait-for-MCP-and-key sequencing.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "--max-time", "5", "http://127.0.0.1:4096/global/health"]
+      interval: 30s
+      timeout: 6s
+      retries: 20
+      start_period: 900s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - mercato-network-fullapp
+
+  mcp:
+    # No build block on purpose: compose builds this exact tag via the app
+    # service before creating containers, so declaring the build here would
+    # only solve the multi-hundred-MB build context a second time.
+    image: open-mercato/app:${DEPLOY_ENV:-local}-dev
+    container_name: mercato-mcp-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    user: "0"
+    command: ["/bin/sh", "/app/docker/scripts/mcp-entrypoint.sh"]
+    volumes:
+      - .:/app
+      - app_node_modules:/app/node_modules
+      - mcp_shared:/run/mcp-shared
+      # Same dist volumes as the app service so the MCP process sees the
+      # container-built package output instead of any host dist/ artifacts.
+      # KEEP IN SYNC with the app service's pkg_*_dist list and the top-level
+      # volumes block — a package missing here resolves stale host artifacts
+      # only inside this container.
+      - pkg_core_dist:/app/packages/core/dist
+      - pkg_shared_dist:/app/packages/shared/dist
+      - pkg_ui_dist:/app/packages/ui/dist
+      - pkg_cli_dist:/app/packages/cli/dist
+      - pkg_cache_dist:/app/packages/cache/dist
+      - pkg_content_dist:/app/packages/content/dist
+      - pkg_checkout_dist:/app/packages/checkout/dist
+      - pkg_events_dist:/app/packages/events/dist
+      - pkg_onboarding_dist:/app/packages/onboarding/dist
+      - pkg_queue_dist:/app/packages/queue/dist
+      - pkg_search_dist:/app/packages/search/dist
+      - pkg_scheduler_dist:/app/packages/scheduler/dist
+      - pkg_ai_assistant_dist:/app/packages/ai-assistant/dist
+      - pkg_create_app_dist:/app/packages/create-app/dist
+    ports:
+      - "${MCP_PORT:-3001}:3001"
+    environment:
+      NODE_ENV: development
+      NODE_OPTIONS: ${MCP_NODE_OPTIONS:---max-old-space-size=2048}
+      DEPLOY_ENV: ${DEPLOY_ENV:-local}
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@mercato-postgres-${DEPLOY_ENV:-local}:5432/${POSTGRES_DB:-open-mercato}
+      REDIS_URL: redis://mercato-redis-${DEPLOY_ENV:-local}:6379
+      QUEUE_REDIS_URL: redis://mercato-redis-${DEPLOY_ENV:-local}:6379
+      CACHE_REDIS_URL: redis://mercato-redis-${DEPLOY_ENV:-local}:6379
+      CACHE_STRATEGY: redis
+      AUTO_SPAWN_WORKERS: "false"
+      AUTO_SPAWN_SCHEDULER: "false"
+      MEILISEARCH_HOST: http://mercato-meilisearch-${DEPLOY_ENV:-local}:7700
+      MEILISEARCH_API_KEY: ${MEILISEARCH_MASTER_KEY:-meilisearch-dev-key}
+      JWT_SECRET: ${JWT_SECRET:-JWT}
+      # Code Mode api.request() must call back into the app over service DNS.
+      # NEXT_PUBLIC_* are pinned because the CLI dotenv-loads the bind-mounted
+      # apps/mercato/.env for vars missing from the container env — a host
+      # .env pointing at localhost:3000 would otherwise hijack the base URL.
+      APP_URL: http://app:3000
+      NEXT_PUBLIC_APP_URL: http://app:3000
+      NEXT_PUBLIC_API_BASE_URL: ""
+      # Session-token (tier 2) decryption requires the app's encryption config.
+      TENANT_DATA_ENCRYPTION: ${TENANT_DATA_ENCRYPTION:-true}
+      TENANT_DATA_ENCRYPTION_DEBUG: ${TENANT_DATA_ENCRYPTION_DEBUG:-false}
+      TENANT_DATA_ENCRYPTION_FALLBACK_KEY: ${TENANT_DATA_ENCRYPTION_FALLBACK_KEY:-dev-tenant-encryption-fallback-key-32chars}
+      TENANT_DATA_ENCRYPTION_KEY: ${TENANT_DATA_ENCRYPTION_KEY:-}
+      OM_INIT_SUPERADMIN_EMAIL: ${OM_INIT_SUPERADMIN_EMAIL:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+      MCP_PORT: "3001"
+      MCP_SERVER_API_KEY_FILE: /run/mcp-shared/mcp-api-key
+      MCP_WAIT_FOR_APP_TIMEOUT: ${MCP_WAIT_FOR_APP_TIMEOUT:-1800}
+      MCP_DEBUG: ${MCP_DEBUG:-false}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      meilisearch:
+        condition: service_healthy
+      app:
+        condition: service_started
+    # Visibility only (compose ps / smoke tests): startup ordering is owned by
+    # the entrypoint wait loops, not by this healthcheck.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3001/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 20
+      start_period: 900s
+    networks:
+      - mercato-network-fullapp
+
+  # Traefik (TLS termination, on-demand ACME, custom-domain ForwardAuth gate)
+  # is now an opt-in overlay so this base file works behind an external reverse
+  # proxy (Dokploy, Caddy, nginx, Cloudflare Tunnel, etc.) without conflict.
+  # To run the bundled Traefik in dev, layer the prod-default overlay plus the
+  # dev overlay (the dev overlay flips ACME to LE staging so iteration does
+  # not burn LE production rate limits):
+  #   docker compose --project-directory . -f starters/docker/compose.fullapp.dev.yml \
+  #     -f starters/docker/compose.fullapp.traefik.yml \
+  #     -f starters/docker/compose.fullapp.traefik.dev.yml up --build
+
+  # One-shot: raise the shared WSL2/Linux kernel's inotify limits before the
+  # app starts watching. Turbopack watches the whole repo via inotify and does
+  # NOT honor the polling env vars above, so the defaults overflow with
+  # "System limit for number of file watchers reached". All Docker Desktop /
+  # WSL2 containers share one kernel, so this single privileged container
+  # raises the limit for the app too. Each `|| true` keeps a read-only or
+  # already-higher value from failing the run. If your Docker policy forbids
+  # privileged containers, remove this service and the app's dependency on it,
+  # then raise the limits on the host/WSL2 kernel yourself.
+  file-watch-limits:
+    image: busybox:1.37
+    container_name: mercato-file-watch-limits-${DEPLOY_ENV:-local}
+    privileged: true
+    restart: "no"
+    network_mode: none
+    command:
+      - sh
+      - -c
+      - |
+        sysctl -w fs.inotify.max_user_watches=16777216 || true
+        sysctl -w fs.inotify.max_user_instances=8192 || true
+        sysctl -w fs.inotify.max_queued_events=1048576 || true
+        echo "[file-watch-limits] inotify limits now:"
+        sysctl fs.inotify.max_user_watches fs.inotify.max_user_instances fs.inotify.max_queued_events || true
+
+  app:
+    build:
+      context: .
+      target: dev
+      args:
+        # Optional internal Alpine mirror for proxy-blocked corporate networks
+        # (empty = official CDN; see the Dockerfile builder stage comment).
+        - ALPINE_MIRROR=${ALPINE_MIRROR:-}
+    image: open-mercato/app:${DEPLOY_ENV:-local}-dev
+    # Without a restart policy the app stays down after a daemon/host reboot
+    # while mcp and opencode (restart: unless-stopped) wait on it forever.
+    restart: unless-stopped
+    user: "0"
+    command: ["/bin/sh", "/app/docker/scripts/dev-entrypoint.sh"]
+    # Traefik labels live in compose.fullapp.traefik.yml — opt-in only.
+    volumes:
+      - .:/app
+      - app_node_modules:/app/node_modules
+      - app_next:/app/apps/mercato/.next
+      - init_marker:/tmp/init-marker
+      - attachments_storage:/app/apps/mercato/storage
+      # Exclude package dist dirs so container builds own output (avoids host dist overwriting .js imports).
+      # KEEP IN SYNC with the mcp service's pkg_*_dist list and the top-level volumes block.
+      - pkg_core_dist:/app/packages/core/dist
+      - pkg_shared_dist:/app/packages/shared/dist
+      - pkg_ui_dist:/app/packages/ui/dist
+      - pkg_cli_dist:/app/packages/cli/dist
+      - pkg_cache_dist:/app/packages/cache/dist
+      - pkg_content_dist:/app/packages/content/dist
+      - pkg_checkout_dist:/app/packages/checkout/dist
+      - pkg_events_dist:/app/packages/events/dist
+      - pkg_onboarding_dist:/app/packages/onboarding/dist
+      - pkg_queue_dist:/app/packages/queue/dist
+      - pkg_search_dist:/app/packages/search/dist
+      - pkg_scheduler_dist:/app/packages/scheduler/dist
+      - pkg_ai_assistant_dist:/app/packages/ai-assistant/dist
+      - pkg_create_app_dist:/app/packages/create-app/dist
+      - mcp_shared:/run/mcp-shared:ro
+    ports:
+      - "${APP_PORT:-3000}:3000"
+      - "${OM_DEV_SPLASH_PORT:-4000}:${OM_DEV_SPLASH_PORT:-4000}"
+    environment:
+      CHOKIDAR_USEPOLLING: ${CHOKIDAR_USEPOLLING:-true}
+      WATCHPACK_POLLING: ${WATCHPACK_POLLING:-true}
+      OM_DEV_SPLASH_PORT: ${OM_DEV_SPLASH_PORT:-4000}
+      # Bind on all interfaces INSIDE the container: the dev server (next dev)
+      # and the splash both default to loopback (127.0.0.1), which Docker's
+      # published-port forwarding cannot reach, so the browser gets connection
+      # refused even though the port is mapped.
+      HOSTNAME: 0.0.0.0
+      OM_DEV_SPLASH_BIND: ${OM_DEV_SPLASH_BIND:-0.0.0.0}
+      REDIS_URL: redis://mercato-redis-${DEPLOY_ENV:-local}:6379
+      QUEUE_REDIS_URL: redis://mercato-redis-${DEPLOY_ENV:-local}:6379
+      TENANT_DATA_ENCRYPTION: ${TENANT_DATA_ENCRYPTION:-true}
+      TENANT_DATA_ENCRYPTION_DEBUG: ${TENANT_DATA_ENCRYPTION_DEBUG:-false}
+      TENANT_DATA_ENCRYPTION_FALLBACK_KEY: ${TENANT_DATA_ENCRYPTION_FALLBACK_KEY:-dev-tenant-encryption-fallback-key-32chars}
+      NODE_ENV: development
+      NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072}
+      DEPLOY_ENV: ${DEPLOY_ENV:-local}
+      PORT: 3000
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@mercato-postgres-${DEPLOY_ENV:-local}:5432/${POSTGRES_DB:-open-mercato}
+      JWT_SECRET: ${JWT_SECRET:-JWT}
+      APP_URL: ${APP_URL:-http://localhost:3000}
+      # Additional trusted app/dev origins for the Open Mercato origin allowlist (resolveAllowedDevOrigins)
+      APP_ALLOWED_ORIGINS: ${APP_ALLOWED_ORIGINS:-}
+      CACHE_REDIS_URL: redis://mercato-redis-${DEPLOY_ENV:-local}:6379
+      CACHE_STRATEGY: redis
+      ENABLE_CRUD_API_CACHE: ${ENABLE_CRUD_API_CACHE:-true}
+      OM_AI_PROVIDER: ${OM_AI_PROVIDER:-openai}
+      OM_AI_MODEL: ${OM_AI_MODEL:-gpt-5-mini}
+      OPENCODE_PROVIDER: ${OPENCODE_PROVIDER:-}
+      OPENCODE_MODEL: ${OPENCODE_MODEL:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENROUTER_BASE_URL: ${OPENROUTER_BASE_URL:-}
+      # Additional OM AI providers (Windows setup / .env), for the unified
+      # in-process AI framework (playground / <AiChat>).
+      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZURE_OPENAI_BASE_URL: ${AZURE_OPENAI_BASE_URL:-}
+      DEEPINFRA_API_KEY: ${DEEPINFRA_API_KEY:-}
+      DEEPINFRA_BASE_URL: ${DEEPINFRA_BASE_URL:-}
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+      GROQ_BASE_URL: ${GROQ_BASE_URL:-}
+      TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
+      TOGETHER_BASE_URL: ${TOGETHER_BASE_URL:-}
+      FIREWORKS_API_KEY: ${FIREWORKS_API_KEY:-}
+      FIREWORKS_BASE_URL: ${FIREWORKS_BASE_URL:-}
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-}
+      LITELLM_BASE_URL: ${LITELLM_BASE_URL:-}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+      LM_STUDIO_API_KEY: ${LM_STUDIO_API_KEY:-}
+      LM_STUDIO_BASE_URL: ${LM_STUDIO_BASE_URL:-}
+      MEILISEARCH_HOST: http://mercato-meilisearch-${DEPLOY_ENV:-local}:7700
+      MEILISEARCH_API_KEY: ${MEILISEARCH_MASTER_KEY:-meilisearch-dev-key}
+      NEXT_PUBLIC_UPGRADE_ACTIONS_ENABLED: ${NEXT_PUBLIC_UPGRADE_ACTIONS_ENABLED:-true}
+      UPGRADE_ACTIONS_ENABLED: ${UPGRADE_ACTIONS_ENABLED:-true}
+      SELF_SERVICE_ONBOARDING_ENABLED: ${SELF_SERVICE_ONBOARDING_ENABLED:-true}
+      DEMO_MODE: ${DEMO_MODE:-true}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      EMAIL_FROM: ${EMAIL_FROM:-}
+      NEW_RELIC_APP_NAME: ${NEW_RELIC_APP_NAME:-}
+      NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY:-}
+      TENANT_DATA_ENCRYPTION_KEY: ${TENANT_DATA_ENCRYPTION_KEY:-}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
+      OM_INIT_SUPERADMIN_EMAIL: ${OM_INIT_SUPERADMIN_EMAIL:-}
+      OM_INIT_SUPERADMIN_PASSWORD: ${OM_INIT_SUPERADMIN_PASSWORD:-password}
+      SSO_DEV_SEED: ${SSO_DEV_SEED:-true}
+      # Service DNS, not the container_name: survives DEPLOY_ENV != local.
+      SSO_DEV_ISSUER: ${SSO_DEV_ISSUER:-http://keycloak:8080/realms/open-mercato}
+      SSO_DEV_CLIENT_ID: ${SSO_DEV_CLIENT_ID:-open-mercato-app}
+      SSO_DEV_CLIENT_SECRET: ${SSO_DEV_CLIENT_SECRET:-}
+      SSO_DEV_ALLOWED_DOMAINS: ${SSO_DEV_ALLOWED_DOMAINS:-example.com}
+      # Custom-domain routing (Phase 1–3 of portal-custom-domain spec).
+      DOMAIN_CHECK_SECRET: ${DOMAIN_CHECK_SECRET:-}
+      DOMAIN_RESOLVE_SECRET: ${DOMAIN_RESOLVE_SECRET:-}
+      INTERNAL_APP_ORIGIN: ${INTERNAL_APP_ORIGIN:-http://app:3000}
+      PLATFORM_DOMAINS: ${PLATFORM_DOMAINS:-localhost,openmercato.com}
+      PLATFORM_PORTAL_BASE_URL: ${PLATFORM_PORTAL_BASE_URL:-https://openmercato.com}
+      CUSTOMER_DOMAIN_ORIGIN_HEADER: ${CUSTOMER_DOMAIN_ORIGIN_HEADER:-X-Open-Mercato-Origin}
+      # AI assistant wiring (service DNS; NEXT_PUBLIC_APP_URL stays a
+      # browser-resolvable URL and must NOT point at service DNS).
+      OPENCODE_URL: ${OPENCODE_URL:-http://opencode:4096}
+      MCP_URL: ${MCP_URL:-http://mcp:3001}
+      MCP_SERVER_API_KEY_FILE: /run/mcp-shared/mcp-api-key
+    depends_on:
+      file-watch-limits:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      meilisearch:
+        condition: service_healthy
+    # Visibility only (compose ps / smoke tests); dependents use their own
+    # entrypoint waits, so tuning this does not change startup ordering.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3000"]
+      interval: 30s
+      timeout: 10s
+      retries: 40
+      start_period: 900s
+    networks:
+      - mercato-network-fullapp
+
+  postgres:
+    image: pgvector/pgvector:pg17-trixie
+    container_name: mercato-postgres-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-open-mercato}
+    # ports not exposed - only accessible within docker network
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network-fullapp
+
+  redis:
+    image: redis:7-alpine
+    container_name: mercato-redis-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    # ports not exposed - only accessible within docker network
+    volumes:
+      - ./docker/redis/redis.conf:/usr/local/etc/redis/redis.conf
+      - redis_data:/data
+    command: redis-server /usr/local/etc/redis/redis.conf --maxmemory ${REDIS_MAXMEMORY:-512mb}
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network-fullapp
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.1
+    container_name: mercato-keycloak-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    command: start-dev
+    environment:
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+    ports:
+      - "${KEYCLOAK_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080; echo -e 'GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3; cat <&3 | grep -q '200'"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    networks:
+      - mercato-network-fullapp
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.11
+    container_name: mercato-meilisearch-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    environment:
+      MEILI_ENV: development
+      MEILI_MASTER_KEY: ${MEILISEARCH_MASTER_KEY:-meilisearch-dev-key}
+      MEILI_NO_ANALYTICS: "true"
+    # ports not exposed - only accessible within docker network
+    volumes:
+      - meilisearch_data:/meili_data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7700/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network-fullapp
+
+  localstack:
+    image: localstack/localstack:latest
+    container_name: mercato-localstack-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    profiles:
+      - storage-s3
+    ports:
+      - "${LOCALSTACK_PORT:-4566}:4566"
+    environment:
+      SERVICES: s3
+      AWS_DEFAULT_REGION: us-east-1
+      LOCALSTACK_HOST: localhost
+    volumes:
+      - localstack_data:/var/lib/localstack
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:4566/_localstack/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - mercato-network-fullapp
+
+volumes:
+  postgres_data:
+    name: mercato-postgres-data-${DEPLOY_ENV:-local}
+  redis_data:
+    name: mercato-redis-data-${DEPLOY_ENV:-local}
+  meilisearch_data:
+    name: mercato-meilisearch-data-${DEPLOY_ENV:-local}
+  localstack_data:
+    name: mercato-localstack-data-${DEPLOY_ENV:-local}
+  init_marker:
+    name: mercato-init-marker-${DEPLOY_ENV:-local}
+  mcp_shared:
+    name: mercato-mcp-shared-${DEPLOY_ENV:-local}
+  attachments_storage:
+    name: mercato-attachments-storage-${DEPLOY_ENV:-local}
+  app_node_modules:
+    name: mercato-app-node-modules-${DEPLOY_ENV:-local}
+  app_next:
+    name: mercato-app-next-${DEPLOY_ENV:-local}
+  pkg_core_dist:
+    name: mercato-pkg-core-dist-${DEPLOY_ENV:-local}
+  pkg_shared_dist:
+    name: mercato-pkg-shared-dist-${DEPLOY_ENV:-local}
+  pkg_ui_dist:
+    name: mercato-pkg-ui-dist-${DEPLOY_ENV:-local}
+  pkg_cli_dist:
+    name: mercato-pkg-cli-dist-${DEPLOY_ENV:-local}
+  pkg_cache_dist:
+    name: mercato-pkg-cache-dist-${DEPLOY_ENV:-local}
+  pkg_content_dist:
+    name: mercato-pkg-content-dist-${DEPLOY_ENV:-local}
+  pkg_checkout_dist:
+    name: mercato-pkg-checkout-dist-${DEPLOY_ENV:-local}
+  pkg_events_dist:
+    name: mercato-pkg-events-dist-${DEPLOY_ENV:-local}
+  pkg_onboarding_dist:
+    name: mercato-pkg-onboarding-dist-${DEPLOY_ENV:-local}
+  pkg_queue_dist:
+    name: mercato-pkg-queue-dist-${DEPLOY_ENV:-local}
+  pkg_search_dist:
+    name: mercato-pkg-search-dist-${DEPLOY_ENV:-local}
+  pkg_scheduler_dist:
+    name: mercato-pkg-scheduler-dist-${DEPLOY_ENV:-local}
+  pkg_ai_assistant_dist:
+    name: mercato-pkg-ai-assistant-dist-${DEPLOY_ENV:-local}
+  pkg_create_app_dist:
+    name: mercato-pkg-create-app-dist-${DEPLOY_ENV:-local}
+
+networks:
+  mercato-network-fullapp:
+    name: mercato-network-${DEPLOY_ENV:-local}
+    driver: bridge

--- a/docker-compose.fullapp.traefik.dev.yml
+++ b/docker-compose.fullapp.traefik.dev.yml
@@ -1,0 +1,22 @@
+# Backwards-compatibility duplicate of starters/docker/compose.fullapp.traefik.dev.yml — the canonical file
+# lives there; edit that one. scripts/__tests__/root-compose-backcompat.test.mjs
+# enforces byte equality with the source.
+
+# Dev-only overlay for the bundled Traefik. Applied on top of the prod-default
+# Traefik overlay (`starters/docker/compose.fullapp.traefik.yml`) to flip the ACME
+# directory to Let's Encrypt **staging** so iteration does not burn the LE
+# production rate limits (50 certs / registered-domain / week; 5 failed
+# validations / host / hour).
+#
+# Usage (dev with bundled Traefik):
+#   docker compose --project-directory . -f starters/docker/compose.fullapp.dev.yml \
+#     -f starters/docker/compose.fullapp.traefik.yml \
+#     -f starters/docker/compose.fullapp.traefik.dev.yml up --build
+#
+# To opt back into LE production from a dev compose set, drop this file from
+# the `-f` chain or export `TRAEFIK_CA_SERVER` explicitly before running.
+
+services:
+  traefik:
+    environment:
+      TRAEFIK_CA_SERVER: ${TRAEFIK_CA_SERVER:-https://acme-staging-v02.api.letsencrypt.org/directory}

--- a/docker-compose.fullapp.traefik.yml
+++ b/docker-compose.fullapp.traefik.yml
@@ -1,0 +1,103 @@
+# Backwards-compatibility duplicate of starters/docker/compose.fullapp.traefik.yml — the canonical file
+# lives there; edit that one. scripts/__tests__/root-compose-backcompat.test.mjs
+# enforces byte equality with the source.
+
+# Optional Traefik overlay for the Open Mercato fullapp stack.
+#
+# Use this overlay when you want the bundled Traefik to terminate TLS,
+# auto-issue Let's Encrypt certificates, and run the custom-domain
+# ForwardAuth gate (Phase 3 of `.ai/specs/implemented/2026-04-08-portal-custom-domain-routing.md`).
+#
+# Skip this overlay when an external reverse proxy already terminates TLS
+# (Dokploy, Caddy, nginx, Cloudflare Tunnel, etc.) — point that proxy at
+# the app container's port and replicate the two routers + ForwardAuth
+# middleware in its own config. See docker/traefik/README.md.
+#
+# This overlay defaults `TRAEFIK_CA_SERVER` to the LE **production** directory
+# so the prod invocation issues real certificates. Dev workflows layer the
+# dev-only `starters/docker/compose.fullapp.traefik.dev.yml` overlay on top to flip the
+# default to LE staging (untrusted certs, much higher rate limits) for safe
+# iteration.
+#
+# Usage:
+#   # Production:
+#   docker compose --project-directory . -f starters/docker/compose.fullapp.yml \
+#     -f starters/docker/compose.fullapp.traefik.yml up -d
+#
+#   # Dev (staging ACME via the dev overlay; drop the third file to use prod):
+#   docker compose --project-directory . -f starters/docker/compose.fullapp.dev.yml \
+#     -f starters/docker/compose.fullapp.traefik.yml \
+#     -f starters/docker/compose.fullapp.traefik.dev.yml up --build
+
+services:
+  traefik:
+    image: traefik:v3.2
+    container_name: mercato-traefik-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    command:
+      - "--configFile=/etc/traefik/traefik.yml"
+    ports:
+      - "${TRAEFIK_HTTP_PORT:-80}:80"
+      - "${TRAEFIK_HTTPS_PORT:-443}:443"
+      # Dashboard is NOT published by default. The Traefik dashboard exposes
+      # routers/services/cert metadata to anyone who can reach the published
+      # port. Set TRAEFIK_DASHBOARD_PORT to publish it (operator opt-in) and
+      # restrict access via firewall/VPN; otherwise keep it private.
+      # - "${TRAEFIK_DASHBOARD_PORT}:8080"
+    volumes:
+      - ./docker/traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - traefik_acme:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      ACME_EMAIL: ${ACME_EMAIL:-admin@example.com}
+      TRAEFIK_LOG_LEVEL: ${TRAEFIK_LOG_LEVEL:-INFO}
+      TRAEFIK_CA_SERVER: ${TRAEFIK_CA_SERVER:-https://acme-v02.api.letsencrypt.org/directory}
+      TRAEFIK_DOCKER_NETWORK: mercato-network-${DEPLOY_ENV:-local}
+    depends_on:
+      app:
+        condition: service_healthy
+    networks:
+      - mercato-network-fullapp
+
+  app:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=mercato-network-${DEPLOY_ENV:-local}"
+      # Platform router — known operator hostnames bypass the domain-check
+      # middleware. Configure PLATFORM_PRIMARY_HOST in the deployment env.
+      - "traefik.http.routers.platform.rule=Host(`${PLATFORM_PRIMARY_HOST:-openmercato.com}`)"
+      - "traefik.http.routers.platform.priority=100"
+      - "traefik.http.routers.platform.entrypoints=websecure"
+      - "traefik.http.routers.platform.tls=true"
+      - "traefik.http.routers.platform.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.platform.service=app-upstream"
+      # Catch-all router for custom customer domains. Goes through the
+      # inject-secret + domain-check middlewares so unmapped hostnames are
+      # rejected at the edge.
+      - "traefik.http.routers.customer.rule=HostRegexp(`{any:.+}`)"
+      - "traefik.http.routers.customer.priority=1"
+      - "traefik.http.routers.customer.entrypoints=websecure"
+      - "traefik.http.routers.customer.tls=true"
+      - "traefik.http.routers.customer.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.customer.service=app-upstream"
+      - "traefik.http.routers.customer.middlewares=inject-domain-check-secret,domain-check"
+      # Inject the shared secret onto the request so ForwardAuth can forward
+      # it to the app. The header is also delivered to the upstream app, but
+      # the app ignores X-Domain-Check-Secret outside the domain-check route.
+      # `:?` makes compose fail fast when the secret is unset — a bare
+      # interpolation would silently inject an empty header and neuter the
+      # custom-domain gate.
+      - "traefik.http.middlewares.inject-domain-check-secret.headers.customrequestheaders.X-Domain-Check-Secret=${DOMAIN_CHECK_SECRET:?DOMAIN_CHECK_SECRET must be set when the traefik overlay is used}"
+      # Verification endpoint — Traefik forwards X-Forwarded-Host (the
+      # original Host) which the app's domain-check route accepts.
+      - "traefik.http.middlewares.domain-check.forwardauth.address=http://app:${CONTAINER_PORT:-3000}/api/customer_accounts/domain-check"
+      - "traefik.http.middlewares.domain-check.forwardauth.authrequestheaders=X-Domain-Check-Secret,X-Forwarded-Host,X-Forwarded-Proto,X-Forwarded-Uri"
+      - "traefik.http.middlewares.domain-check.forwardauth.authresponseheaders=X-Open-Mercato-Origin"
+      - "traefik.http.middlewares.domain-check.forwardauth.trustforwardheader=false"
+      # Service definition: route to the app on its container port.
+      - "traefik.http.services.app-upstream.loadbalancer.server.port=${CONTAINER_PORT:-3000}"
+      - "traefik.http.services.app-upstream.loadbalancer.passhostheader=true"
+
+volumes:
+  traefik_acme:
+    name: mercato-traefik-acme-${DEPLOY_ENV:-local}

--- a/docker-compose.fullapp.yml
+++ b/docker-compose.fullapp.yml
@@ -1,0 +1,370 @@
+# Backwards-compatibility duplicate of starters/docker/compose.fullapp.yml — the canonical file
+# lives there; edit that one. scripts/__tests__/root-compose-backcompat.test.mjs
+# enforces byte equality with the source.
+
+
+
+services:
+  opencode:
+    build:
+      context: ./docker/opencode
+      args:
+        # OpenCode is pre-installed in this published base image (see
+        # docker/opencode/BASE_IMAGE.md); the local build only COPYs project
+        # files, so it needs no proxy-hostile network — the FROM pull goes
+        # through the container engine's trust (OS certificate store).
+        # Override to pin a different pushed base tag.
+        OPENCODE_BASE_IMAGE: ${OPENCODE_BASE_IMAGE:-docker.io/openmercatocom/open-mercato-opencode:1.18.3}
+    image: opencode-mvp
+    container_name: mercato-opencode-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    environment:
+      # Unified AI provider/model selection. OM_AI_* wins; OPENCODE_* stays
+      # as a BC fallback resolved by the opencode entrypoint script.
+      OM_AI_PROVIDER: ${OM_AI_PROVIDER:-openai}
+      OM_AI_MODEL: ${OM_AI_MODEL:-gpt-5-mini}
+      OPENCODE_PROVIDER: ${OPENCODE_PROVIDER:-}
+      OPENCODE_MODEL: ${OPENCODE_MODEL:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENROUTER_BASE_URL: ${OPENROUTER_BASE_URL:-}
+      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZURE_OPENAI_BASE_URL: ${AZURE_OPENAI_BASE_URL:-}
+      DEEPINFRA_API_KEY: ${DEEPINFRA_API_KEY:-}
+      DEEPINFRA_BASE_URL: ${DEEPINFRA_BASE_URL:-}
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+      GROQ_BASE_URL: ${GROQ_BASE_URL:-}
+      TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
+      TOGETHER_BASE_URL: ${TOGETHER_BASE_URL:-}
+      FIREWORKS_API_KEY: ${FIREWORKS_API_KEY:-}
+      FIREWORKS_BASE_URL: ${FIREWORKS_BASE_URL:-}
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-}
+      LITELLM_BASE_URL: ${LITELLM_BASE_URL:-}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+      LM_STUDIO_API_KEY: ${LM_STUDIO_API_KEY:-}
+      LM_STUDIO_BASE_URL: ${LM_STUDIO_BASE_URL:-}
+      # In-network MCP wiring. MCP_SERVER_API_KEY (env) wins when set; the
+      # file fallback reads the key the mcp service provisioned into the
+      # shared volume after waiting for the MCP /health endpoint.
+      OPENCODE_MCP_URL: ${OPENCODE_MCP_URL:-http://mcp:3001/mcp}
+      MCP_SERVER_API_KEY: ${MCP_SERVER_API_KEY:-}
+      MCP_SERVER_API_KEY_FILE: /run/mcp-shared/mcp-api-key
+    volumes:
+      - mcp_shared:/run/mcp-shared:ro
+      # Corporate CA bundle for pulled images (entrypoint exports
+      # SSL_CERT_FILE/NODE_EXTRA_CA_CERTS when certs are present).
+      - ./docker/opencode/certs:/run/om-certs:ro
+    depends_on:
+      mcp:
+        condition: service_started
+    # Visibility only (compose ps / smoke tests): the entrypoint owns the
+    # wait-for-MCP-and-key sequencing.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "--max-time", "5", "http://127.0.0.1:4096/global/health"]
+      interval: 30s
+      timeout: 6s
+      retries: 20
+      start_period: 900s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - mercato-network-fullapp
+
+  mcp:
+    image: open-mercato/app:${DEPLOY_ENV:-local}
+    container_name: mercato-mcp-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    user: "0"
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        if [ ! -f /app/docker/scripts/mcp-entrypoint.sh ]; then
+          echo "ERROR: mcp-entrypoint.sh not found. Please rebuild the container: docker compose build --no-cache app"
+          exit 1
+        fi
+        sh /app/docker/scripts/mcp-entrypoint.sh
+    volumes:
+      - mcp_shared:/run/mcp-shared
+    environment:
+      NODE_ENV: development
+      NODE_OPTIONS: ${MCP_NODE_OPTIONS:---max-old-space-size=2048}
+      DEPLOY_ENV: ${DEPLOY_ENV:-local}
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@mercato-postgres-${DEPLOY_ENV:-local}:5432/${POSTGRES_DB:-open-mercato}
+      CACHE_REDIS_URL: redis://mercato-redis-${DEPLOY_ENV:-local}:6379
+      CACHE_STRATEGY: redis
+      AUTO_SPAWN_WORKERS: "false"
+      AUTO_SPAWN_SCHEDULER: "false"
+      MEILISEARCH_HOST: http://mercato-meilisearch-${DEPLOY_ENV:-local}:7700
+      MEILISEARCH_API_KEY: ${MEILISEARCH_MASTER_KEY:-meilisearch-dev-key}
+      JWT_SECRET: ${JWT_SECRET:-JWT}
+      # Code Mode api.request() must call back into the app over service DNS.
+      # NEXT_PUBLIC_* are pinned so a stray .env cannot hijack the base URL.
+      APP_URL: http://app:${CONTAINER_PORT:-3000}
+      NEXT_PUBLIC_APP_URL: http://app:${CONTAINER_PORT:-3000}
+      NEXT_PUBLIC_API_BASE_URL: ""
+      # Session-token (tier 2) decryption requires the app's encryption config.
+      TENANT_DATA_ENCRYPTION: ${TENANT_DATA_ENCRYPTION:-true}
+      TENANT_DATA_ENCRYPTION_DEBUG: ${TENANT_DATA_ENCRYPTION_DEBUG:-false}
+      TENANT_DATA_ENCRYPTION_FALLBACK_KEY: ${TENANT_DATA_ENCRYPTION_FALLBACK_KEY:-dev-tenant-encryption-fallback-key-32chars}
+      TENANT_DATA_ENCRYPTION_KEY: ${TENANT_DATA_ENCRYPTION_KEY:-}
+      OM_INIT_SUPERADMIN_EMAIL: ${OM_INIT_SUPERADMIN_EMAIL:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+      MCP_PORT: "3001"
+      MCP_SERVER_API_KEY_FILE: /run/mcp-shared/mcp-api-key
+      MCP_WAIT_FOR_APP_TIMEOUT: ${MCP_WAIT_FOR_APP_TIMEOUT:-1800}
+      MCP_DEBUG: ${MCP_DEBUG:-false}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      meilisearch:
+        condition: service_healthy
+      app:
+        condition: service_healthy
+    # Visibility only (compose ps / smoke tests): startup ordering is owned by
+    # the entrypoint wait loops, not by this healthcheck.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:3001/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 20
+      start_period: 900s
+    networks:
+      - mercato-network-fullapp
+
+  # Traefik (TLS termination, on-demand ACME, custom-domain ForwardAuth gate)
+  # is now an opt-in overlay so this base file works behind an external reverse
+  # proxy (Dokploy, Caddy, nginx, Cloudflare Tunnel, etc.) without conflict.
+  # To run the bundled Traefik, add `-f starters/docker/compose.fullapp.traefik.yml`.
+
+  app:
+    build:
+      context: .
+      args:
+        - CONTAINER_PORT=${CONTAINER_PORT:-3000}
+        # Optional internal Alpine mirror for proxy-blocked corporate networks
+        # (empty = official CDN; see the Dockerfile builder stage comment).
+        - ALPINE_MIRROR=${ALPINE_MIRROR:-}
+    image: open-mercato/app:${DEPLOY_ENV:-local}
+    # Without a restart policy the app stays down after a daemon/host reboot
+    # while mcp and opencode (restart: unless-stopped) wait on it forever.
+    restart: unless-stopped
+    user: "0"
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        if [ ! -f /app/docker/scripts/init-or-migrate.sh ]; then
+          echo "ERROR: init-or-migrate.sh not found. Please rebuild the container: docker compose build --no-cache app"
+          exit 1
+        fi
+        INIT_COMMAND='yarn mercato init' sh /app/docker/scripts/init-or-migrate.sh
+        yarn start
+    volumes:
+      - init_marker:/tmp/init-marker
+      - attachments_storage:/app/apps/mercato/storage
+      - mcp_shared:/run/mcp-shared:ro
+    working_dir: /app/apps/mercato
+    ports:
+      - "${APP_PORT:-3000}:${CONTAINER_PORT:-3000}"
+    # Traefik labels are declared in compose.fullapp.traefik.yml so
+    # external reverse proxies (Dokploy, etc.) that also watch the Docker
+    # socket don't accidentally pick them up.
+    environment:
+      TENANT_DATA_ENCRYPTION: ${TENANT_DATA_ENCRYPTION:-true}
+      TENANT_DATA_ENCRYPTION_DEBUG: ${TENANT_DATA_ENCRYPTION_DEBUG:-false}
+      TENANT_DATA_ENCRYPTION_FALLBACK_KEY: ${TENANT_DATA_ENCRYPTION_FALLBACK_KEY:-dev-tenant-encryption-fallback-key-32chars}
+      NODE_ENV: development
+      # Prevents V8 from growing toward total host RAM before GC kicks in.
+      # Override in .env to tune for your host: --max-old-space-size=6144 suits 16 GB+ servers.
+      NODE_OPTIONS: ${NODE_OPTIONS:---max-old-space-size=3072}
+      DEPLOY_ENV: ${DEPLOY_ENV:-local}
+      PORT: ${CONTAINER_PORT:-3000}
+      # Bind on all interfaces so Docker's published-port forwarding can reach
+      # the server; next start otherwise honors the container's HOSTNAME and
+      # binds an address unreachable from the host.
+      HOSTNAME: 0.0.0.0
+      DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@mercato-postgres-${DEPLOY_ENV:-local}:5432/${POSTGRES_DB:-open-mercato}
+      JWT_SECRET: ${JWT_SECRET:-JWT}
+      APP_URL: ${APP_URL:-http://localhost:3000}
+      # Additional trusted app/dev origins for the Open Mercato origin allowlist (resolveAllowedDevOrigins)
+      APP_ALLOWED_ORIGINS: ${APP_ALLOWED_ORIGINS:-}
+      CACHE_REDIS_URL: redis://mercato-redis-${DEPLOY_ENV:-local}:6379
+      CACHE_STRATEGY: redis
+      ENABLE_CRUD_API_CACHE: ${ENABLE_CRUD_API_CACHE:-true}
+      OM_AI_PROVIDER: ${OM_AI_PROVIDER:-openai}
+      OM_AI_MODEL: ${OM_AI_MODEL:-gpt-5-mini}
+      OPENCODE_PROVIDER: ${OPENCODE_PROVIDER:-}
+      OPENCODE_MODEL: ${OPENCODE_MODEL:-}
+      # Point OpenCode clients at the sibling opencode service (the code default
+      # http://localhost:4096 is unreachable from inside the app container).
+      OPENCODE_URL: ${OPENCODE_URL:-http://opencode:4096}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENROUTER_BASE_URL: ${OPENROUTER_BASE_URL:-}
+      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZURE_OPENAI_BASE_URL: ${AZURE_OPENAI_BASE_URL:-}
+      DEEPINFRA_API_KEY: ${DEEPINFRA_API_KEY:-}
+      DEEPINFRA_BASE_URL: ${DEEPINFRA_BASE_URL:-}
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+      GROQ_BASE_URL: ${GROQ_BASE_URL:-}
+      TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
+      TOGETHER_BASE_URL: ${TOGETHER_BASE_URL:-}
+      FIREWORKS_API_KEY: ${FIREWORKS_API_KEY:-}
+      FIREWORKS_BASE_URL: ${FIREWORKS_BASE_URL:-}
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-}
+      LITELLM_BASE_URL: ${LITELLM_BASE_URL:-}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+      LM_STUDIO_API_KEY: ${LM_STUDIO_API_KEY:-}
+      LM_STUDIO_BASE_URL: ${LM_STUDIO_BASE_URL:-}
+      MEILISEARCH_HOST: http://mercato-meilisearch-${DEPLOY_ENV:-local}:7700
+      MEILISEARCH_API_KEY: ${MEILISEARCH_MASTER_KEY:-meilisearch-dev-key}
+      NEXT_PUBLIC_UPGRADE_ACTIONS_ENABLED: ${NEXT_PUBLIC_UPGRADE_ACTIONS_ENABLED:-true}
+      UPGRADE_ACTIONS_ENABLED: ${UPGRADE_ACTIONS_ENABLED:-true}
+      SELF_SERVICE_ONBOARDING_ENABLED: ${SELF_SERVICE_ONBOARDING_ENABLED:-true}
+      DEMO_MODE: ${DEMO_MODE:-true}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      EMAIL_FROM: ${EMAIL_FROM:-}
+      NEW_RELIC_APP_NAME: ${NEW_RELIC_APP_NAME:-}
+      NEW_RELIC_LICENSE_KEY: ${NEW_RELIC_LICENSE_KEY:-}
+      TENANT_DATA_ENCRYPTION_KEY: ${TENANT_DATA_ENCRYPTION_KEY:-}
+      ADMIN_EMAIL: ${ADMIN_EMAIL:-admin@example.com}
+      OM_INIT_SUPERADMIN_EMAIL: ${OM_INIT_SUPERADMIN_EMAIL:-}
+      OM_INIT_SUPERADMIN_PASSWORD: ${OM_INIT_SUPERADMIN_PASSWORD:-password}
+      SSO_FORCE_ROLE_ON_LOGIN: employee
+      # Custom-domain routing (Phase 1–3 of portal-custom-domain spec).
+      DOMAIN_CHECK_SECRET: ${DOMAIN_CHECK_SECRET:-}
+      DOMAIN_RESOLVE_SECRET: ${DOMAIN_RESOLVE_SECRET:-}
+      INTERNAL_APP_ORIGIN: ${INTERNAL_APP_ORIGIN:-http://app:${CONTAINER_PORT:-3000}}
+      PLATFORM_DOMAINS: ${PLATFORM_DOMAINS:-localhost,${PLATFORM_PRIMARY_HOST:-openmercato.com}}
+      PLATFORM_PORTAL_BASE_URL: ${PLATFORM_PORTAL_BASE_URL:-https://${PLATFORM_PRIMARY_HOST:-openmercato.com}}
+      CUSTOMER_DOMAIN_ORIGIN_HEADER: ${CUSTOMER_DOMAIN_ORIGIN_HEADER:-X-Open-Mercato-Origin}
+      # MCP wiring (OPENCODE_URL is declared above with the AI provider block;
+      # NEXT_PUBLIC_APP_URL stays a browser-resolvable URL, never service DNS).
+      MCP_URL: ${MCP_URL:-http://mcp:3001}
+      MCP_SERVER_API_KEY_FILE: /run/mcp-shared/mcp-api-key
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      meilisearch:
+        condition: service_healthy
+    # Gates mcp (and the traefik overlay) on the app actually serving HTTP.
+    # The generous start_period covers first-boot init-or-migrate + seed.
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://127.0.0.1:${CONTAINER_PORT:-3000}"]
+      interval: 30s
+      timeout: 10s
+      retries: 40
+      start_period: 900s
+    networks:
+      - mercato-network-fullapp
+
+  postgres:
+    image: pgvector/pgvector:pg17-trixie
+    container_name: mercato-postgres-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-open-mercato}
+    # ports not exposed - only accessible within docker network
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network-fullapp
+
+  redis:
+    image: redis:7-alpine
+    container_name: mercato-redis-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    # ports not exposed - only accessible within docker network
+    volumes:
+      - ./docker/redis/redis.conf:/usr/local/etc/redis/redis.conf
+      - redis_data:/data
+    command: redis-server /usr/local/etc/redis/redis.conf --maxmemory ${REDIS_MAXMEMORY:-512mb}
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network-fullapp
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.11
+    container_name: mercato-meilisearch-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    environment:
+      MEILI_ENV: development
+      MEILI_MASTER_KEY: ${MEILISEARCH_MASTER_KEY:-meilisearch-dev-key}
+      MEILI_NO_ANALYTICS: "true"
+    # ports not exposed - only accessible within docker network
+    volumes:
+      - meilisearch_data:/meili_data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7700/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network-fullapp
+
+  localstack:
+    image: localstack/localstack:latest
+    container_name: mercato-localstack-${DEPLOY_ENV:-local}
+    restart: unless-stopped
+    profiles:
+      - storage-s3
+    ports:
+      - "${LOCALSTACK_PORT:-4566}:4566"
+    environment:
+      SERVICES: s3
+      AWS_DEFAULT_REGION: us-east-1
+      LOCALSTACK_HOST: localhost
+    volumes:
+      - localstack_data:/var/lib/localstack
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:4566/_localstack/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - mercato-network-fullapp
+
+volumes:
+  postgres_data:
+    name: mercato-postgres-data-${DEPLOY_ENV:-local}
+  redis_data:
+    name: mercato-redis-data-${DEPLOY_ENV:-local}
+  meilisearch_data:
+    name: mercato-meilisearch-data-${DEPLOY_ENV:-local}
+  localstack_data:
+    name: mercato-localstack-data-${DEPLOY_ENV:-local}
+  init_marker:
+    name: mercato-init-marker-${DEPLOY_ENV:-local}
+  attachments_storage:
+    name: mercato-attachments-storage-${DEPLOY_ENV:-local}
+  mcp_shared:
+    name: mercato-mcp-shared-${DEPLOY_ENV:-local}
+
+networks:
+  mercato-network-fullapp:
+    name: mercato-network-${DEPLOY_ENV:-local}
+    driver: bridge

--- a/docker-compose.preview.yaml
+++ b/docker-compose.preview.yaml
@@ -1,0 +1,21 @@
+# Backwards-compatibility duplicate of starters/docker/compose.preview.yml — the canonical file
+# lives there; edit that one. scripts/__tests__/root-compose-backcompat.test.mjs
+# enforces byte equality with the source.
+
+services:
+  preview-app:
+    build:
+      context: .
+      dockerfile: ./docker/preview/Dockerfile
+    image: open-mercato/preview:local
+    restart: "no"
+    ports:
+      - "5000:5001"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      DOCKER_HOST: unix:///var/run/docker.sock
+      TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE: /var/run/docker.sock
+      TESTCONTAINERS_HOST_OVERRIDE: host.docker.internal
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,246 @@
+# Backwards-compatibility duplicate of starters/docker/compose.infra.yml — the canonical file
+# lives there; edit that one. scripts/__tests__/root-compose-backcompat.test.mjs
+# enforces byte equality with the source.
+
+# Hybrid dev infra: OpenCode + backing services in containers, the app and the
+# MCP server natively on the host (`yarn dev` runs both). Always invoke with
+# the project directory anchored at the repo root so .env interpolation and
+# relative paths resolve there:
+#   docker compose --project-directory . -f starters/docker/compose.infra.yml up -d
+# or simply: yarn infra:up
+
+services:
+  opencode:
+    build:
+      context: ./docker/opencode
+      args:
+        # OpenCode is pre-installed in this published base image (see
+        # docker/opencode/BASE_IMAGE.md); the local build only COPYs project
+        # files (agents, skills, entrypoint), so it needs no proxy-hostile
+        # network — the FROM pull goes through the container engine's trust,
+        # which honors the OS certificate store on Docker/Rancher Desktop.
+        # The starter pre-pulls this tag (yarn om) and prints a mirror hint
+        # when the registry is blocked. Override to pin a different base tag.
+        OPENCODE_BASE_IMAGE: ${OPENCODE_BASE_IMAGE:-docker.io/openmercatocom/open-mercato-opencode:1.18.3}
+    image: opencode-mvp
+    container_name: mercato-opencode
+    restart: unless-stopped
+    environment:
+      # Unified AI provider/model selection. New deployments set OM_AI_*;
+      # the legacy OPENCODE_* variables stay forwarded as a BC fallback so
+      # the entrypoint picks them up when OM_AI_* is empty.
+      OM_AI_PROVIDER: ${OM_AI_PROVIDER:-openai}
+      OM_AI_MODEL: ${OM_AI_MODEL:-gpt-5-mini}
+      # Legacy provider selection (anthropic, openai, google) — BC only.
+      OPENCODE_PROVIDER: ${OPENCODE_PROVIDER:-}
+      OPENCODE_MODEL: ${OPENCODE_MODEL:-}
+      # Provider API keys (set the one matching OM_AI_PROVIDER)
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${GOOGLE_GENERATIVE_AI_API_KEY:-}
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      OPENROUTER_BASE_URL: ${OPENROUTER_BASE_URL:-}
+      AZURE_OPENAI_API_KEY: ${AZURE_OPENAI_API_KEY:-}
+      AZURE_OPENAI_BASE_URL: ${AZURE_OPENAI_BASE_URL:-}
+      DEEPINFRA_API_KEY: ${DEEPINFRA_API_KEY:-}
+      DEEPINFRA_BASE_URL: ${DEEPINFRA_BASE_URL:-}
+      GROQ_API_KEY: ${GROQ_API_KEY:-}
+      GROQ_BASE_URL: ${GROQ_BASE_URL:-}
+      TOGETHER_API_KEY: ${TOGETHER_API_KEY:-}
+      TOGETHER_BASE_URL: ${TOGETHER_BASE_URL:-}
+      FIREWORKS_API_KEY: ${FIREWORKS_API_KEY:-}
+      FIREWORKS_BASE_URL: ${FIREWORKS_BASE_URL:-}
+      LITELLM_API_KEY: ${LITELLM_API_KEY:-}
+      LITELLM_BASE_URL: ${LITELLM_BASE_URL:-}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-}
+      LM_STUDIO_API_KEY: ${LM_STUDIO_API_KEY:-}
+      LM_STUDIO_BASE_URL: ${LM_STUDIO_BASE_URL:-}
+      # MCP wiring: the MCP server runs on the HOST (`yarn dev` starts it).
+      # host.docker.internal resolves natively on Docker Desktop (Win/mac) and
+      # via the host-gateway extra_hosts mapping below on native Linux.
+      # MCP_SERVER_API_KEY (env) wins when set; the file fallback reads the
+      # key `yarn dev` provisions into .mercato/mcp-shared on the host.
+      OPENCODE_MCP_URL: ${OPENCODE_MCP_URL:-http://host.docker.internal:3001/mcp}
+      MCP_SERVER_API_KEY: ${MCP_SERVER_API_KEY:-}
+      MCP_SERVER_API_KEY_FILE: /run/mcp-shared/mcp-api-key
+      OPENCODE_MCP_KEY_WAIT_SECONDS: ${OPENCODE_MCP_KEY_WAIT_SECONDS:-1800}
+      # File plane (#12): kill-switch. When true the entrypoint exposes the built-in
+      # read/write/edit tools so file-agents can produce artifacts (default off).
+      OM_OPENCODE_FILES_ENABLED: ${OM_OPENCODE_FILES_ENABLED:-false}
+    ports:
+      - "${OPENCODE_PORT:-4096}:4096"
+    volumes:
+      # Host-provisioned MCP API key (see scripts/dev-mcp.mjs). Relative to the
+      # repo root because every invocation passes --project-directory.
+      - ${OM_MCP_SHARED_DIR:-./.mercato/mcp-shared}:/run/mcp-shared:ro
+      # File-defined agents (delivery model A — dev bind-mount). Generated from
+      # `agents/<id>/` dirs; OpenCode picks them up on new sessions (no guaranteed
+      # hot-reload — restart this service after `yarn generate`).
+      - ./docker/opencode/agents:/home/opencode/.config/opencode/agents:ro
+      # Native OpenCode skills (Phase 3). Generated from `agents/<id>/skills/`;
+      # loaded on new sessions (restart this service after `yarn generate`).
+      - ./docker/opencode/skills:/home/opencode/.config/opencode/skills:ro
+      # Corporate CA bundle for pulled images: the entrypoint exports
+      # SSL_CERT_FILE/NODE_EXTRA_CA_CERTS from any certs found here (baked-in
+      # certs only exist in locally built images). No-op when empty.
+      - ./docker/opencode/certs:/run/om-certs:ro
+      # File plane (#12): shared writable sandbox. The OM host process writes/reads
+      # the host source (OM_OPENCODE_WORKSPACE_ROOT); the agent sees it at the
+      # container path (OM_OPENCODE_WORKSPACE_ROOT_CONTAINER, /home/opencode/work).
+      - ${OM_OPENCODE_WORKSPACE_ROOT:-./.mercato/opencode-work}:/home/opencode/work:rw
+    extra_hosts:
+      # host-gateway is right on native Linux and Docker Desktop. On Rancher
+      # Desktop (WSL2) it can resolve to the WSL distro instead of the Windows
+      # host — the doctor detects that and tells you to set OM_HOST_GATEWAY in
+      # .env to the IP that reaches the host (or to the literal value the
+      # engine resolves natively).
+      - "host.docker.internal:${OM_HOST_GATEWAY:-host-gateway}"
+    networks:
+      - mercato-network
+
+  postgres:
+    image: pgvector/pgvector:pg17-trixie
+    container_name: mercato-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-open-mercato}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network
+
+  redis:
+    image: redis:7-alpine
+    container_name: mercato-redis
+    restart: unless-stopped
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - ./docker/redis/redis.conf:/usr/local/etc/redis/redis.conf
+      - redis_data:/data
+    command: redis-server /usr/local/etc/redis/redis.conf --maxmemory ${REDIS_MAXMEMORY:-512mb}
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.11
+    container_name: mercato-meilisearch
+    restart: unless-stopped
+    environment:
+      MEILI_ENV: development
+      MEILI_MASTER_KEY: ${MEILISEARCH_MASTER_KEY:-meilisearch-dev-key}
+      MEILI_NO_ANALYTICS: "true"
+    ports:
+      - "${MEILISEARCH_PORT:-7700}:7700"
+    volumes:
+      - meilisearch_data:/meili_data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7700/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.1
+    container_name: mercato-keycloak
+    restart: unless-stopped
+    # SSO development against a local IdP — opt in with `--profile sso`.
+    profiles:
+      - sso
+    command: start-dev
+    environment:
+      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+    ports:
+      - "${KEYCLOAK_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080; echo -e 'GET /health/ready HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3; cat <&3 | grep -q '200'"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    networks:
+      - mercato-network
+
+  localstack:
+    image: localstack/localstack:latest
+    container_name: mercato-localstack
+    restart: unless-stopped
+    profiles:
+      - storage-s3
+    ports:
+      - "${LOCALSTACK_PORT:-4566}:4566"
+    environment:
+      SERVICES: s3
+      AWS_DEFAULT_REGION: us-east-1
+      LOCALSTACK_HOST: localhost
+    volumes:
+      - localstack_data:/var/lib/localstack
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:4566/_localstack/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - mercato-network
+
+  verdaccio:
+    image: verdaccio/verdaccio:6
+    container_name: mercato-verdaccio
+    restart: unless-stopped
+    # Only needed for standalone-app/package publishing workflows — opt in with
+    # `--profile registry` (it is not part of the default dev loop).
+    profiles:
+      - registry
+    environment:
+      VERDACCIO_PORT: 4873
+      VERDACCIO_PUBLIC_URL: http://localhost:4873
+    ports:
+      - "${VERDACCIO_PORT:-4873}:4873"
+    volumes:
+      - verdaccio_storage:/verdaccio/storage
+      - verdaccio_plugins:/verdaccio/plugins
+      - ./config/verdaccio/config.yaml:/verdaccio/conf/config.yaml:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4873/-/ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mercato-network
+
+volumes:
+  postgres_data:
+    name: mercato-postgres-data
+  redis_data:
+    name: mercato-redis-data
+  meilisearch_data:
+    name: mercato-meilisearch-data
+  localstack_data:
+    name: mercato-localstack-data
+  verdaccio_storage:
+    name: mercato-verdaccio-storage
+  verdaccio_plugins:
+    name: mercato-verdaccio-plugins
+
+networks:
+  mercato-network:
+    name: mercato-network
+    driver: bridge

--- a/scripts/__tests__/root-compose-backcompat.test.mjs
+++ b/scripts/__tests__/root-compose-backcompat.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+// Root duplicates exist only so pre-starters/docker deployments keep working;
+// the starters/docker file is canonical. Remove this map (and the root files)
+// when the backwards-compatibility window closes.
+const ROOT_DUPLICATES = {
+  'docker-compose.yml': 'starters/docker/compose.infra.yml',
+  'docker-compose.fullapp.yml': 'starters/docker/compose.fullapp.yml',
+  'docker-compose.fullapp.dev.yml': 'starters/docker/compose.fullapp.dev.yml',
+  'docker-compose.fullapp.traefik.yml': 'starters/docker/compose.fullapp.traefik.yml',
+  'docker-compose.fullapp.traefik.dev.yml': 'starters/docker/compose.fullapp.traefik.dev.yml',
+  'docker-compose.preview.yaml': 'starters/docker/compose.preview.yml',
+}
+
+function expectedHeader(canonical) {
+  return (
+    `# Backwards-compatibility duplicate of ${canonical} — the canonical file\n` +
+    '# lives there; edit that one. scripts/__tests__/root-compose-backcompat.test.mjs\n' +
+    '# enforces byte equality with the source.\n\n'
+  )
+}
+
+for (const [rootName, canonical] of Object.entries(ROOT_DUPLICATES)) {
+  test(`root ${rootName} stays in sync with ${canonical}`, () => {
+    const rootPath = path.resolve(ROOT, rootName)
+    assert.ok(fs.existsSync(rootPath), `${rootName} is missing at the repo root`)
+    const rootContent = fs.readFileSync(rootPath, 'utf8')
+    const canonicalContent = fs.readFileSync(path.resolve(ROOT, canonical), 'utf8')
+    assert.strictEqual(
+      rootContent,
+      expectedHeader(canonical) + canonicalContent,
+      `${rootName} diverged from ${canonical} — after editing the canonical file, regenerate the root duplicate (copy the file and keep its 4-line header)`
+    )
+  })
+}

--- a/starters/docker/README.md
+++ b/starters/docker/README.md
@@ -23,6 +23,10 @@ Compose files for every containerized way to run Open Mercato, plus the hardened
 
 Optional profiles on `compose.infra.yml`: `--profile storage-s3` (localstack), `--profile registry` (verdaccio for standalone-app/package workflows).
 
+## Root duplicates (temporary backwards compatibility)
+
+Deployments that predate this directory invoke the compose files by their old repo-root names (`docker-compose.yml`, `docker-compose.fullapp*.yml`, `docker-compose.preview.yaml`). Those names exist again at the repo root as byte-identical duplicates of the files here (plus a header pointing back). The files in this directory stay canonical — edit them, then copy the change into the root duplicate; `scripts/__tests__/root-compose-backcompat.test.mjs` fails CI on any drift. The duplicates (and the test) go away once existing deployments migrate to the `starters/docker/` paths.
+
 ## Windows launcher (`windows/`)
 
 One-command fully containerized stack for clean or locked-down Windows machines — installs Git/WSL2/a container runtime, handles reboots, corporate proxies and TLS interception, generates `.env` secrets, and waits for health:


### PR DESCRIPTION
Deployments that predate starters/docker/ still call the compose files by their old repo-root names, so this restores docker-compose.yml, docker-compose.fullapp*.yml and docker-compose.preview.yaml as exact copies of the starters/docker files, each with a short header pointing at the canonical one. The canonical files already use root-anchored relative paths (they run with --project-directory .), so the old `docker compose -f docker-compose.fullapp.yml up` invocation from the repo root works unchanged — same .env, same build contexts, same project name.

A small test (scripts/__tests__/root-compose-backcompat.test.mjs) fails CI when a root copy drifts from its starters/docker source, and the starters/docker README now says which copy to edit. This is meant to be temporary: delete the duplicates and the test once deployments migrate to the starters/docker paths.

`docker compose config -q` parses all six root files including the traefik overlay chain; yarn test:scripts passes (362).