### PR TITLE
feat(workflows): type inline transition conditions

### DIFF
--- a/.ai/specs/implemented/2026-04-14-code-based-workflow-definitions.md
+++ b/.ai/specs/implemented/2026-04-14-code-based-workflow-definitions.md
@@ -4,12 +4,15 @@
 
 **Key Points:**
 - Introduce a `defineWorkflow()` TypeScript builder API that provides compile-time type safety for step IDs, transition references, and activity definitions — turning runtime `STEP_NOT_FOUND` errors into TS compiler errors.
+- Expose the runtime-supported inline transition `condition` through the shared canonical condition-expression contract and preserve it through validation and graph conversion.
 - Code-based workflow definitions live purely in memory (populated at bootstrap from a generated registry). No DB row is created until a user customizes the definition.
 - Add a `workflows.ts` auto-discovery convention at module root, following the established `events.ts` / `search.ts` pattern.
 
 **Scope:**
 - `packages/shared/src/modules/workflows/` — builder API and types
+- `packages/shared/src/modules/conditions.ts` — canonical condition operators and expression types
 - `packages/cli/src/lib/generators/extensions/` — generator extension for `workflows.ts` discovery
+- `packages/core/src/modules/business_rules/` — canonical contract consumption and runtime validation
 - `packages/core/src/modules/workflows/` — in-memory registry, executor integration, API merge logic
 - `packages/core/src/modules/workflows/data/` — `code_workflow_id` column for override tracking
 
@@ -18,6 +21,7 @@
 - Activity function registry with compile-time function reference checking (Phase 4 / future spec)
 - Deploy-time command infrastructure (prerequisite for any future boot-time DB sync approach)
 - Variable interpolation type safety (`{{context.foo}}` remains stringly-typed)
+- A visual condition-builder UI for inline transition expressions
 
 **Concerns:**
 - Executor currently reads definitions exclusively from DB; the read path must be extended to check the in-memory registry as a fallback.
@@ -50,6 +54,8 @@ This spec introduces a TypeScript-first workflow definition experience: develope
 
 5. **No source tracking:** There is no way to distinguish a definition created by the visual editor from one seeded by code. This makes it impossible to know whether a definition can be safely overwritten or should be preserved as a user customization.
 
+6. **Inline conditions missing from the code contract:** The transition runtime evaluates `transition.condition`, but the public code-workflow types, builder, and workflow validator omit that field. Conditional routing therefore cannot be expressed through the supported typed builder, and definition/graph conversion can silently discard it.
+
 ## Proposed Solution
 
 ### Design Decisions
@@ -64,6 +70,9 @@ This spec introduces a TypeScript-first workflow definition experience: develope
 | No definition snapshot (matches existing behavior) | The executor always reads the latest definition on every step/resume. Code-based definitions follow the same pattern — code changes on redeploy affect running instances immediately, just like DB edits today. This preserves the ability to hot-fix running workflows. |
 | Output matches existing `WorkflowDefinitionData` | No new JSONB schema. The executor, validators, and visual editor all work unchanged. |
 | Generic type parameter for step IDs | TypeScript const inference captures step IDs as a literal union. Transitions constrain `fromStepId`/`toStepId` to this union. |
+| Workflows declares its existing business-rules dependency | Workflow setup, persisted start/pre/post conditions, the editor, and transition evaluation already use `business_rules`. Declaring `requires: ['business_rules']` makes invalid module configurations fail during generation instead of later during setup or execution. |
+| One shared condition-expression contract | `@open-mercato/shared/modules/conditions` owns the comparison/logical operator tuples, Zod schemas, and derived recursive JSON-safe types. Workflow types use the JSON-safe contract directly. Business-rules schemas, validation, and UI options reuse its canonical operators, while existing evaluator/component type exports retain their historically broad `value: any` contract through a compatibility adapter derived from the shared shape. Hardened runtime expression validation remains in `business_rules`. |
+| Inline conditions reuse business-rules validation | Code transitions use the canonical business-rules condition-expression validator. Validation limits field paths to 200 characters, groups to 50 rules, and semantic nesting to five levels. |
 
 ### Alternatives Considered
 
@@ -157,11 +166,38 @@ interface TransitionDefinition<TStepId extends string> {
   fromStepId: TStepId    // ← constrained to step ID union
   toStepId: TStepId      // ← constrained to step ID union
   trigger: TransitionTrigger
+  condition?: ConditionExpression
   // ... remaining fields match existing schema
 }
 ```
 
 The `const` modifier on `TSteps` tells TypeScript to infer literal types for the `stepId` values. `ExtractStepIds` extracts the union of all step IDs from the tuple. Transitions then constrain `fromStepId`/`toStepId` to this union.
+
+**Inline transition conditions:** The runtime already evaluates an optional recursive condition before selecting a transition. The shared code-workflow contract re-exports the generic contract from `@open-mercato/shared/modules/conditions` without introducing a second expression language:
+
+```typescript
+type ConditionExpression = SimpleCondition | GroupCondition
+
+interface SimpleCondition {
+  field: string
+  operator: '=' | '==' | '!=' | '>' | '>=' | '<' | '<='
+    | 'IN' | 'NOT_IN' | 'CONTAINS' | 'NOT_CONTAINS'
+    | 'STARTS_WITH' | 'ENDS_WITH' | 'MATCHES' | 'IS_EMPTY' | 'IS_NOT_EMPTY'
+  value: JsonValue
+  valueField?: string
+}
+
+interface GroupCondition {
+  operator: 'AND' | 'OR' | 'NOT'
+  rules: ConditionExpression[]
+}
+```
+
+`defineWorkflow()` preserves `condition` unchanged, while `workflowTransitionSchema` composes the canonical `business_rules` condition-expression validator with the shared JSON-safe schema. The business-rules stage applies expression safety and semantic validation before the shared stage rejects `null` and non-JSON values and exposes the shared `ConditionExpression` output type. Field paths are limited to 200 characters, groups to 50 rules, and semantic nesting to five levels. The visual-editor graph conversion carries the property in both directions so viewing or customizing a code definition does not drop its routing logic. A visual condition-builder UI remains out of scope.
+
+`CONDITION_COMPARISON_OPERATORS` and `CONDITION_LOGICAL_OPERATORS` are the single runtime source for accepted operators. Shared Zod schemas consume those tuples, and all canonical operator and recursive expression types are derived with `z.infer`. Code-workflow condition values use the JSON-safe schema because definitions can cross API and JSONB boundaries. The business-rules validators re-export the shared operator schemas and use the canonical tuples for validation membership; UI options map over them. Existing business-rules component/evaluator import paths preserve their broader `value: any` types through a compatibility adapter so downstream TypeScript consumers are not narrowed. Evaluator switch cases remain explicit because they implement operator behavior rather than define which operators exist.
+
+The workflows module declares `requires: ['business_rules']`. This formalizes an existing hard dependency: workflow setup seeds `BusinessRule` entities, start/pre/post conditions execute persisted rules, transition conditions use the rule evaluator, and the editor queries the business-rules API. The shared workflow builder remains independent of `@open-mercato/core`; only the core workflows module imports the business-rules runtime validator.
 
 **Workflow ID convention:** Prefix with module name using dot notation: `module.workflow-name` (e.g., `sales.order-approval`, `workflows.demo-checkout`). This follows the same namespacing convention as event IDs (`module.entity.action`) and ACL features (`module.action`). Unlike those systems, the workflows generator extension validates uniqueness at `yarn generate` time — duplicate `workflowId` across modules is a hard error. This is cheap to add since we're building a new generator extension.
 
@@ -463,6 +499,9 @@ The data repair is forward-only: the obsolete external activity payloads cannot 
 - **Existing API consumers:** New fields (`source`, `codeModuleId`, `isCodeBased`) are additive. No fields removed.
 - **Existing seeds:** Seeded definitions remain `source='user'` in the DB. `Migration20260715120000` is a narrow payload repair for the exact legacy checkout seed; it preserves the row while aligning its side-effecting transitions with the maintained demo definition.
 - **Auto-discovery:** `workflows.ts` is a new optional convention. Modules without it are unaffected.
+- **Inline transition conditions:** `condition` is optional. Existing code and persisted definitions that omit it are unchanged; definitions that use it now retain the same expression through builder, registry validation, and graph conversion.
+- **Business-rules public types:** Existing `SimpleCondition`, `GroupCondition`, and `ConditionExpression` exports keep their historically broad value contract. The JSON-only type is additive and applies to the new code-workflow condition property; no downstream business-rules consumer must migrate.
+- **Module configuration:** Workflows now declares its existing `business_rules` requirement. Configurations that enable workflows without business rules fail early during module generation; that combination already failed during workflow default seeding or rule-backed execution.
 - **Contract surface classification:** `workflows.ts` export convention is STABLE (new, additive). `defineWorkflow()` function signature is STABLE.
 
 ### Breaking Changes
@@ -482,6 +521,7 @@ None. This is fully additive.
 7. Create example `packages/core/src/modules/workflows/workflows.ts` — migrate existing example JSON to builder API
 8. Unit tests for builder (type safety, Zod validation, error messages)
 9. Run `yarn generate` and verify output
+10. Follow-up: declare the existing business-rules module dependency, centralize the condition-expression contract in shared, add typed inline transition conditions using the business-rules validator, and preserve them through builder output, registry validation, and graph conversion
 
 ### Phase 2: Executor + API Integration
 
@@ -515,6 +555,14 @@ Deferred to a separate spec. Covers:
 |------|--------|-------|---------|
 | `packages/shared/src/modules/workflows/builder.ts` | Create | 1 | `defineWorkflow()` builder with type inference |
 | `packages/shared/src/modules/workflows/types.ts` | Create | 1 | Shared types for code workflow definitions |
+| `packages/shared/src/modules/conditions.ts` | Create | 1 | Canonical condition operator tuples and recursive expression types |
+| `packages/shared/src/modules/__tests__/conditions.test.ts` | Create | 1 | Shared contract coverage for operators, recursion, and JSON-safe values |
+| `packages/core/src/modules/business_rules/data/validators.ts` | Modify | 1 | Derive operator schemas from the shared canonical tuples |
+| `packages/core/src/modules/business_rules/components/utils/conditionValidation.ts` | Modify | 1 | Reuse canonical operators for validation/UI options and preserve legacy condition types |
+| `packages/core/src/modules/business_rules/lib/expression-evaluator.ts` | Modify | 1 | Reuse canonical operators/shape while preserving the public `value: any` compatibility contract |
+| `packages/core/src/modules/workflows/index.ts` | Modify | 1 | Declare the existing hard dependency on `business_rules` |
+| `packages/core/src/modules/workflows/data/validators.ts` | Modify | 1 | Validate recursive inline transition conditions |
+| `packages/core/src/modules/workflows/lib/graph-utils.ts` | Modify | 1 | Preserve inline conditions across definition/graph conversion |
 | `packages/cli/src/lib/generators/extensions/workflows.ts` | Create | 1 | Generator extension for `workflows.ts` discovery |
 | `packages/cli/src/lib/generators/extensions/index.ts` | Modify | 1 | Register workflows extension |
 | `packages/core/src/modules/workflows/lib/code-registry.ts` | Create | 1 | In-memory code definition registry |
@@ -532,6 +580,14 @@ Deferred to a separate spec. Covers:
   - Builder produces valid `WorkflowDefinitionData` (passes Zod validation)
   - Builder rejects invalid configs (missing START step, orphan transitions) at runtime
   - Type tests: verify that invalid step ID references produce TS errors (using `ts-expect-error`)
+  - Builder preserves omitted, simple, and grouped inline conditions
+  - Shared condition schemas accept recursive JSON-safe expressions and reject invalid operators, `Date`, function, and `bigint` values
+  - Business-rules Zod schemas and UI options expose every canonical shared operator in contract order
+  - Existing business-rules condition type exports retain their broad value compatibility contract
+  - Validator accepts evaluator-compatible JSON conditions and rejects invalid operators, empty groups, non-JSON values, and nesting beyond five levels
+  - Workflow metadata declares `business_rules` as a required module
+  - Code registry rejects invalid conditions, and graph conversion round-trips valid conditions without loss
+- **No new app/browser fixture:** Runtime transition-condition evaluation is already covered by `transition-handler.test.ts`. This follow-up changes the typed builder, validation, registry, and graph plumbing rather than executor behavior, so focused unit and contract coverage is sufficient for the reduced upstream scope.
 - **Integration tests (Phase 2):**
   - Start a workflow from a code-based definition
   - Verify instance stores `definitionSnapshot`
@@ -550,6 +606,10 @@ Deferred to a separate spec. Covers:
 - **Instance definition drift:** If a code definition changes between deploys (e.g., step removed, transition renamed) and an instance is mid-flight, the instance could reference steps/transitions that no longer exist.
   - Mitigation: This is the same behavior as editing a DB definition today — the executor always reads the latest version. Developers must treat code definition changes the same as DB edits: avoid removing steps/transitions that running instances may be on. This is an existing operational concern, not a new one introduced by this spec.
   - Residual: No new risk. Matches existing behavior exactly.
+
+- **Condition behavior drifts from the shared contract:** A future operator could be added without corresponding evaluator or UI behavior.
+  - Mitigation: The shared operator tuples derive the public types, business-rules Zod schemas, validation membership, and UI option order. Evaluator behavior remains explicitly typed, while focused tests assert schema and UI parity with every canonical operator.
+  - Residual: New operators still require an intentional evaluator case and translated UI label, both checked by TypeScript and focused coverage.
 
 - **Override orphaning:** If a code definition is removed from code but a `code_override` DB row exists, the override references a non-existent base.
   - Mitigation: The override is still a valid definition (it stores the full JSONB). It continues working. The "Reset to code version" action would fail gracefully (code version not found).
@@ -666,6 +726,10 @@ None.
 
 **Fully compliant** — ready for implementation. Post-implementation fixes through 2026-04-28 (dedicated `/customize` endpoint, soft-deleted override revival, embedded triggers in PUT, dotted `workflowId` regex, mutation-guard wiring on reset, list `find`/`count` split, legacy seed-ID rename migration, removal of cross-organization customize block) were re-reviewed against the same compliance matrix with no regressions.
 
+### Inline Condition Addendum — 2026-07-21
+
+The typed inline-condition follow-up introduces one optional transition property and a canonical shared condition-expression contract, changes no entity or endpoint contract, adds no dependency from shared to core, and preserves the runtime's existing expression semantics. Business-rules validation, schemas, and UI options consume the shared operator tuples; their existing evaluator/component type exports retain the broad value contract through a compatibility adapter. The core workflows module now declares its pre-existing hard dependency on `business_rules` and composes that module's semantic validator with the shared JSON-safe schema. Unsupported workflows-only configurations fail at generation time instead of later during setup or execution. Focused builder, business-rules contract, validator, registry, metadata, and graph round-trip tests pass together with shared/core type-checking and production builds.
+
 ## Changelog
 
 ### 2026-04-14
@@ -715,3 +779,7 @@ None.
 ### 2026-07-16
 
 - Fixed issue #4202: once the #4179 repairs let the checkout demo reach `confirmation_to_end`, its `create_order` `CALL_API` activity failed with `401 Unauthorized`. `executeCallApi` minted the one-time API key on the container EM, but the activity runs inside `workflowExecutor.executeWorkflow()`'s `em.transactional(...)`; with `useContext: true` the request EM's writes are redirected into the still-open transaction, so the outbound self-authenticated `fetch` (a separate pooled connection) could not see the uncommitted key. The key is now created on a context-detached fork (`em.fork({ clear: true, freshEventManager: true, useContext: false })`, matching the `query_index`/`webhooks` isolated-EM convention) so it auto-commits on its own connection and is visible to the internal request. Distinct from #4179 (a legacy `CALL_WEBHOOK`); this is the internal `CALL_API` auth path. Covered by a `call-api.test.ts` regression asserting the key EM is forked with `useContext: false`.
+
+### 2026-07-21
+
+- Added typed inline transition conditions to the shared code-workflow contract and `defineWorkflow()` builder, centralized condition operators and recursive JSON-safe expression types in `@open-mercato/shared/modules/conditions`, migrated business-rules schemas/validation/UI options to the canonical operators while preserving legacy public value types, composed business-rules semantic validation with the shared JSON-safe schema, declared the workflows module's existing `business_rules` dependency, and preserved conditions through visual-editor graph conversion. Added focused builder, business-rules compatibility, validator, metadata, registry, and round-trip coverage. No persistence, endpoint, customization, or runtime execution behavior changed.

--- a/packages/core/src/modules/business_rules/components/utils/__tests__/conditionValidation.test.ts
+++ b/packages/core/src/modules/business_rules/components/utils/__tests__/conditionValidation.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from '@jest/globals'
+import {
+  CONDITION_COMPARISON_OPERATORS,
+  CONDITION_LOGICAL_OPERATORS,
+} from '@open-mercato/shared/modules/conditions'
+import type { SimpleCondition as EvaluatorSimpleCondition } from '../../../lib/expression-evaluator'
+import {
+  getComparisonOperators,
+  getLogicalOperators,
+  type SimpleCondition as ValidationSimpleCondition,
+} from '../conditionValidation'
+
+describe('condition validation operator options', () => {
+  const translate = (key: string) => key
+
+  test('uses every canonical comparison operator in contract order', () => {
+    expect(getComparisonOperators(translate).map(({ value }) => value)).toEqual([
+      ...CONDITION_COMPARISON_OPERATORS,
+    ])
+  })
+
+  test('uses every canonical logical operator in contract order', () => {
+    expect(getLogicalOperators(translate).map(({ value }) => value)).toEqual([
+      ...CONDITION_LOGICAL_OPERATORS,
+    ])
+  })
+
+  test('keeps existing business-rules condition value types broad', () => {
+    const evaluatorCondition: EvaluatorSimpleCondition = {
+      field: 'invoice.createdAt',
+      operator: '=',
+      value: new Date(),
+    }
+    const validationCondition: ValidationSimpleCondition = {
+      field: 'invoice.callback',
+      operator: '=',
+      value: () => true,
+    }
+    const bigintCondition: ValidationSimpleCondition = {
+      field: 'invoice.sequence',
+      operator: '=',
+      value: BigInt(1),
+    }
+
+    expect(evaluatorCondition.value).toBeInstanceOf(Date)
+    expect(typeof validationCondition.value).toBe('function')
+    expect(typeof bigintCondition.value).toBe('bigint')
+  })
+})

--- a/packages/core/src/modules/business_rules/components/utils/conditionValidation.ts
+++ b/packages/core/src/modules/business_rules/components/utils/conditionValidation.ts
@@ -1,4 +1,18 @@
-import type { ComparisonOperator, LogicalOperator } from '../../data/validators'
+import {
+  CONDITION_COMPARISON_OPERATORS,
+  CONDITION_LOGICAL_OPERATORS,
+  type ConditionComparisonOperator as ComparisonOperator,
+  type ConditionLogicalOperator as LogicalOperator,
+} from '@open-mercato/shared/modules/conditions'
+import type {
+  ConditionExpression as LegacyConditionExpression,
+  GroupCondition as LegacyGroupCondition,
+  SimpleCondition as LegacySimpleCondition,
+} from '../../lib/expression-evaluator'
+
+export type SimpleCondition = LegacySimpleCondition
+export type GroupCondition = LegacyGroupCondition
+export type ConditionExpression = LegacyConditionExpression
 
 export type TranslatorFn = (key: string, params?: Record<string, any>) => string
 
@@ -7,46 +21,30 @@ export type ValidationResult = {
   errors: string[]
 }
 
-/**
- * Valid comparison operators
- */
-const VALID_COMPARISON_OPERATORS: ComparisonOperator[] = [
-  '=',
-  '==',
-  '!=',
-  '>',
-  '>=',
-  '<',
-  '<=',
-  'IN',
-  'NOT_IN',
-  'CONTAINS',
-  'NOT_CONTAINS',
-  'STARTS_WITH',
-  'ENDS_WITH',
-  'MATCHES',
-  'IS_EMPTY',
-  'IS_NOT_EMPTY',
-]
+const COMPARISON_OPERATOR_LABEL_KEYS = {
+  '=': 'business_rules.validation.operators.equals',
+  '==': 'business_rules.validation.operators.equalsStrict',
+  '!=': 'business_rules.validation.operators.notEquals',
+  '>': 'business_rules.validation.operators.greaterThan',
+  '>=': 'business_rules.validation.operators.greaterThanOrEqual',
+  '<': 'business_rules.validation.operators.lessThan',
+  '<=': 'business_rules.validation.operators.lessThanOrEqual',
+  IN: 'business_rules.validation.operators.in',
+  NOT_IN: 'business_rules.validation.operators.notIn',
+  CONTAINS: 'business_rules.validation.operators.contains',
+  NOT_CONTAINS: 'business_rules.validation.operators.notContains',
+  STARTS_WITH: 'business_rules.validation.operators.startsWith',
+  ENDS_WITH: 'business_rules.validation.operators.endsWith',
+  MATCHES: 'business_rules.validation.operators.matches',
+  IS_EMPTY: 'business_rules.validation.operators.isEmpty',
+  IS_NOT_EMPTY: 'business_rules.validation.operators.isNotEmpty',
+} satisfies Record<ComparisonOperator, string>
 
-/**
- * Valid logical operators
- */
-const VALID_LOGICAL_OPERATORS: LogicalOperator[] = ['AND', 'OR', 'NOT']
-
-export type SimpleCondition = {
-  field: string
-  operator: ComparisonOperator
-  value: any
-  valueField?: string
-}
-
-export type GroupCondition = {
-  operator: LogicalOperator
-  rules: ConditionExpression[]
-}
-
-export type ConditionExpression = SimpleCondition | GroupCondition
+const LOGICAL_OPERATOR_LABEL_KEYS = {
+  AND: 'business_rules.validation.logical.and',
+  OR: 'business_rules.validation.logical.or',
+  NOT: 'business_rules.validation.logical.not',
+} satisfies Record<LogicalOperator, string>
 
 /**
  * Check if expression is a group condition
@@ -80,8 +78,8 @@ export function validateConditionExpression(expr: any, depth = 0, maxDepth = 5, 
 
   if (isGroupCondition(expr)) {
     // Validate group condition
-    if (!VALID_LOGICAL_OPERATORS.includes(expr.operator)) {
-      errors.push(translate('business_rules.validation.condition.invalidLogicalOperator', { operator: expr.operator, validOperators: VALID_LOGICAL_OPERATORS.join(', ') }))
+    if (!CONDITION_LOGICAL_OPERATORS.includes(expr.operator)) {
+      errors.push(translate('business_rules.validation.condition.invalidLogicalOperator', { operator: expr.operator, validOperators: CONDITION_LOGICAL_OPERATORS.join(', ') }))
     }
 
     if (!Array.isArray(expr.rules) || expr.rules.length === 0) {
@@ -105,8 +103,8 @@ export function validateConditionExpression(expr: any, depth = 0, maxDepth = 5, 
 
     if (!expr.operator) {
       errors.push(translate('business_rules.validation.condition.operatorRequired'))
-    } else if (!VALID_COMPARISON_OPERATORS.includes(expr.operator)) {
-      errors.push(translate('business_rules.validation.condition.invalidComparisonOperator', { operator: expr.operator, validOperators: VALID_COMPARISON_OPERATORS.join(', ') }))
+    } else if (!CONDITION_COMPARISON_OPERATORS.includes(expr.operator)) {
+      errors.push(translate('business_rules.validation.condition.invalidComparisonOperator', { operator: expr.operator, validOperators: CONDITION_COMPARISON_OPERATORS.join(', ') }))
     }
 
     if (expr.value === undefined && !expr.valueField) {
@@ -139,33 +137,18 @@ export function isValidFieldPath(path: string): boolean {
  * Get available comparison operators
  */
 export function getComparisonOperators(t: TranslatorFn): { value: ComparisonOperator; label: string }[] {
-  return [
-    { value: '=', label: t('business_rules.validation.operators.equals') },
-    { value: '==', label: t('business_rules.validation.operators.equalsStrict') },
-    { value: '!=', label: t('business_rules.validation.operators.notEquals') },
-    { value: '>', label: t('business_rules.validation.operators.greaterThan') },
-    { value: '>=', label: t('business_rules.validation.operators.greaterThanOrEqual') },
-    { value: '<', label: t('business_rules.validation.operators.lessThan') },
-    { value: '<=', label: t('business_rules.validation.operators.lessThanOrEqual') },
-    { value: 'IN', label: t('business_rules.validation.operators.in') },
-    { value: 'NOT_IN', label: t('business_rules.validation.operators.notIn') },
-    { value: 'CONTAINS', label: t('business_rules.validation.operators.contains') },
-    { value: 'NOT_CONTAINS', label: t('business_rules.validation.operators.notContains') },
-    { value: 'STARTS_WITH', label: t('business_rules.validation.operators.startsWith') },
-    { value: 'ENDS_WITH', label: t('business_rules.validation.operators.endsWith') },
-    { value: 'MATCHES', label: t('business_rules.validation.operators.matches') },
-    { value: 'IS_EMPTY', label: t('business_rules.validation.operators.isEmpty') },
-    { value: 'IS_NOT_EMPTY', label: t('business_rules.validation.operators.isNotEmpty') },
-  ]
+  return CONDITION_COMPARISON_OPERATORS.map((value) => ({
+    value,
+    label: t(COMPARISON_OPERATOR_LABEL_KEYS[value]),
+  }))
 }
 
 /**
  * Get logical operators
  */
 export function getLogicalOperators(t: TranslatorFn): { value: LogicalOperator; label: string }[] {
-  return [
-    { value: 'AND', label: t('business_rules.validation.logical.and') },
-    { value: 'OR', label: t('business_rules.validation.logical.or') },
-    { value: 'NOT', label: t('business_rules.validation.logical.not') },
-  ]
+  return CONDITION_LOGICAL_OPERATORS.map((value) => ({
+    value,
+    label: t(LOGICAL_OPERATOR_LABEL_KEYS[value]),
+  }))
 }

--- a/packages/core/src/modules/business_rules/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/business_rules/data/__tests__/validators.test.ts
@@ -1,11 +1,16 @@
 import { describe, test, expect } from '@jest/globals'
 import {
+  CONDITION_COMPARISON_OPERATORS,
+  CONDITION_LOGICAL_OPERATORS,
+} from '@open-mercato/shared/modules/conditions'
+import {
   createBusinessRuleSchema,
   createLocalizedBusinessRuleSchema,
   createLocalizedUpdateBusinessRuleSchema,
   updateBusinessRuleSchema,
   ruleTypeSchema,
   comparisonOperatorSchema,
+  logicalOperatorSchema,
   executionResultSchema,
   createRuleExecutionLogSchema,
   ruleExecutionLogFilterSchema,
@@ -37,15 +42,24 @@ describe('Business Rules Validators', () => {
   })
 
   describe('comparisonOperatorSchema', () => {
-    test('should accept valid comparison operators', () => {
-      expect(comparisonOperatorSchema.parse('=')).toBe('=')
-      expect(comparisonOperatorSchema.parse('>')).toBe('>')
-      expect(comparisonOperatorSchema.parse('IN')).toBe('IN')
-      expect(comparisonOperatorSchema.parse('CONTAINS')).toBe('CONTAINS')
+    test('should accept every canonical comparison operator', () => {
+      expect(comparisonOperatorSchema.options).toEqual([...CONDITION_COMPARISON_OPERATORS])
+      for (const operator of CONDITION_COMPARISON_OPERATORS) {
+        expect(comparisonOperatorSchema.parse(operator)).toBe(operator)
+      }
     })
 
     test('should reject invalid operators', () => {
       expect(() => comparisonOperatorSchema.parse('INVALID')).toThrow()
+    })
+  })
+
+  describe('logicalOperatorSchema', () => {
+    test('should accept every canonical logical operator', () => {
+      expect(logicalOperatorSchema.options).toEqual([...CONDITION_LOGICAL_OPERATORS])
+      for (const operator of CONDITION_LOGICAL_OPERATORS) {
+        expect(logicalOperatorSchema.parse(operator)).toBe(operator)
+      }
     })
   })
 

--- a/packages/core/src/modules/business_rules/data/validators.ts
+++ b/packages/core/src/modules/business_rules/data/validators.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod'
 import {
+  conditionComparisonOperatorSchema,
+  conditionLogicalOperatorSchema,
+} from '@open-mercato/shared/modules/conditions'
+import {
   validateConditionExpressionForApi,
   validateActionsForApi,
   isSafeExpression,
@@ -21,28 +25,11 @@ export const conditionTypeSchema = z.enum(['EXPRESSION', 'GROUP'])
 export type ConditionType = z.infer<typeof conditionTypeSchema>
 
 // Logical Operators
-export const logicalOperatorSchema = z.enum(['AND', 'OR', 'NOT'])
+export const logicalOperatorSchema = conditionLogicalOperatorSchema
 export type LogicalOperator = z.infer<typeof logicalOperatorSchema>
 
 // Comparison Operators
-export const comparisonOperatorSchema = z.enum([
-  '=',
-  '==',
-  '!=',
-  '>',
-  '>=',
-  '<',
-  '<=',
-  'IN',
-  'NOT_IN',
-  'CONTAINS',
-  'NOT_CONTAINS',
-  'STARTS_WITH',
-  'ENDS_WITH',
-  'MATCHES',
-  'IS_EMPTY',
-  'IS_NOT_EMPTY',
-])
+export const comparisonOperatorSchema = conditionComparisonOperatorSchema
 export type ComparisonOperator = z.infer<typeof comparisonOperatorSchema>
 
 // Data Types

--- a/packages/core/src/modules/business_rules/lib/expression-evaluator.ts
+++ b/packages/core/src/modules/business_rules/lib/expression-evaluator.ts
@@ -1,4 +1,8 @@
-import type { ComparisonOperator, LogicalOperator } from '../data/validators'
+import type {
+  ConditionComparisonOperator as ComparisonOperator,
+  GroupCondition as SharedGroupCondition,
+  SimpleCondition as SharedSimpleCondition,
+} from '@open-mercato/shared/modules/conditions'
 import { testLinearRegex } from '@open-mercato/shared/lib/regex/linear'
 import { getNestedValue, resolveSpecialValue } from './value-resolver'
 import { createLogger } from '@open-mercato/shared/lib/logger'
@@ -6,21 +10,19 @@ import { createLogger } from '@open-mercato/shared/lib/logger'
 const logger = createLogger('business_rules').child({ component: 'expression-evaluator' })
 
 /**
- * Type definitions for condition expressions
+ * Compatibility types for the existing business-rules evaluator contract.
+ * Business rules historically accepted arbitrary runtime values, while the
+ * shared workflow condition contract is intentionally JSON-safe.
  */
-export type ConditionExpression = SimpleCondition | GroupCondition
-
-export interface SimpleCondition {
-  field: string
-  operator: ComparisonOperator
+export interface SimpleCondition extends Omit<SharedSimpleCondition, 'value'> {
   value: any
-  valueField?: string // For field-to-field comparison
 }
 
-export interface GroupCondition {
-  operator: LogicalOperator // 'AND' | 'OR' | 'NOT'
+export interface GroupCondition extends Omit<SharedGroupCondition, 'rules'> {
   rules: ConditionExpression[]
 }
+
+export type ConditionExpression = SimpleCondition | GroupCondition
 
 export interface EvaluationContext {
   user?: {
@@ -135,8 +137,10 @@ function evaluateGroupCondition(
       }
       break
 
-    default:
-      throw new Error(`Unknown logical operator: ${operator}`)
+    default: {
+      const unsupportedOperator: never = operator
+      throw new Error(`Unknown logical operator: ${unsupportedOperator}`)
+    }
   }
 
   logger.debug('Group condition evaluated', { operator, passed: result })
@@ -220,8 +224,10 @@ function applyOperator(left: any, operator: ComparisonOperator, right: any): boo
     case 'IS_NOT_EMPTY':
       return !isEmpty(left)
 
-    default:
-      throw new Error(`Unknown operator: ${operator}`)
+    default: {
+      const unsupportedOperator: never = operator
+      throw new Error(`Unknown operator: ${unsupportedOperator}`)
+    }
   }
 }
 

--- a/packages/core/src/modules/workflows/__tests__/metadata.test.ts
+++ b/packages/core/src/modules/workflows/__tests__/metadata.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from '@jest/globals'
+import { metadata } from '../index'
+
+describe('workflows module metadata', () => {
+  test('declares the business rules dependency', () => {
+    expect(metadata.requires).toContain('business_rules')
+  })
+})

--- a/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
@@ -303,6 +303,60 @@ describe('Workflows Validators', () => {
       expect(result.preConditions?.[0].ruleId).toBe('check-inventory')
     })
 
+    test('should validate simple and grouped inline conditions', () => {
+      const simple = workflowTransitionSchema.parse({
+        ...validTransition,
+        condition: { field: 'invoice.action', operator: '=', value: 'approve' },
+      })
+      const grouped = workflowTransitionSchema.parse({
+        ...validTransition,
+        condition: {
+          operator: 'AND',
+          rules: [
+            { field: 'invoice.total', operator: '>=', value: 1000 },
+            { field: 'invoice.currency', operator: '=', value: 'EUR' },
+          ],
+        },
+      })
+
+      expect(simple.condition).toEqual({ field: 'invoice.action', operator: '=', value: 'approve' })
+      expect(grouped.condition).toEqual({
+        operator: 'AND',
+        rules: [
+          { field: 'invoice.total', operator: '>=', value: 1000 },
+          { field: 'invoice.currency', operator: '=', value: 'EUR' },
+        ],
+      })
+    })
+
+    test('should reject invalid inline condition shapes', () => {
+      expect(() => workflowTransitionSchema.parse({
+        ...validTransition,
+        condition: { field: 'invoice.action', operator: 'equals', value: 'approve' },
+      })).toThrow()
+
+      expect(() => workflowTransitionSchema.parse({
+        ...validTransition,
+        condition: { operator: 'AND', rules: [] },
+      })).toThrow()
+
+      expect(() => workflowTransitionSchema.parse({
+        ...validTransition,
+        condition: null,
+      })).toThrow()
+    })
+
+    test.each([
+      ['Date', new Date()],
+      ['function', () => true],
+      ['bigint', BigInt(1)],
+    ])('should reject non-JSON %s inline condition values', (_label, value) => {
+      expect(() => workflowTransitionSchema.parse({
+        ...validTransition,
+        condition: { field: 'invoice.value', operator: '=', value },
+      })).toThrow()
+    })
+
     test('should validate transition with activities', () => {
       const withActivities = {
         ...validTransition,
@@ -483,6 +537,23 @@ describe('Workflows Validators', () => {
       expect(result.enabled).toBe(true)
       expect(result.definition.steps).toHaveLength(2)
       expect(result.definition.transitions).toHaveLength(1)
+    })
+
+    test('should reject inline conditions nested deeper than five groups', () => {
+      let condition: unknown = { field: 'invoice.action', operator: '=', value: 'approve' }
+      for (let depth = 0; depth < 7; depth += 1) {
+        condition = { operator: 'NOT', rules: [condition] }
+      }
+
+      const deeplyNested = {
+        ...validDefinition,
+        definition: {
+          ...validDefinition.definition,
+          transitions: [{ ...validDefinition.definition.transitions[0], condition }],
+        },
+      }
+
+      expect(() => createWorkflowDefinitionSchema.parse(deeplyNested)).toThrow()
     })
 
     test('should apply default values', () => {

--- a/packages/core/src/modules/workflows/data/validators.ts
+++ b/packages/core/src/modules/workflows/data/validators.ts
@@ -1,4 +1,11 @@
 import { z } from 'zod'
+import {
+  conditionExpressionSchema as sharedConditionExpressionSchema,
+  type ConditionExpression,
+} from '@open-mercato/shared/modules/conditions'
+import {
+  conditionExpressionSchema as businessRulesConditionExpressionSchema,
+} from '../../business_rules/data/validators'
 import { parseDuration } from '../lib/duration'
 
 /**
@@ -341,6 +348,9 @@ export const transitionConditionSchema = z.object({
   required: z.boolean().default(true),
 })
 
+export const workflowConditionExpressionSchema: z.ZodType<ConditionExpression> =
+  businessRulesConditionExpressionSchema.pipe(sharedConditionExpressionSchema)
+
 // Transition definition
 export const workflowTransitionSchema = z.object({
   transitionId: z.string().min(1).max(100).regex(/^[a-z0-9_-]+$/, 'Transition ID must contain only lowercase letters, numbers, hyphens, and underscores'),
@@ -348,6 +358,7 @@ export const workflowTransitionSchema = z.object({
   toStepId: z.string().min(1).max(100),
   transitionName: z.string().max(255).optional(),
   trigger: transitionTriggerSchema,
+  condition: workflowConditionExpressionSchema.optional(),
   preConditions: z.array(transitionConditionSchema).optional(),
   postConditions: z.array(transitionConditionSchema).optional(),
   activities: z.array(activityDefinitionSchema).optional(), // Activities to execute during transition

--- a/packages/core/src/modules/workflows/index.ts
+++ b/packages/core/src/modules/workflows/index.ts
@@ -14,4 +14,5 @@ export const metadata: ModuleInfo = {
   version: '1.0.0',
   author: 'Open Mercato',
   ejectable: true,
+  requires: ['business_rules'],
 }

--- a/packages/core/src/modules/workflows/lib/__tests__/code-registry.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/code-registry.test.ts
@@ -125,6 +125,23 @@ describe('Code Workflow Registry', () => {
       expect(getCodeWorkflow('my-workflow')).toEqual(second)
     })
 
+    test('rejects workflows with invalid inline transition conditions', () => {
+      const invalidCondition = makeWorkflow('invalid-condition')
+      Object.assign(invalidCondition.definition.transitions[0], { condition: {
+        field: 'invoice.action',
+        operator: 'equals',
+        value: 'approve',
+      } })
+
+      registerCodeWorkflows([invalidCondition])
+
+      expect(getCodeWorkflow('invalid-condition')).toBeUndefined()
+      expect(mockLoggerInstance.warn).toHaveBeenCalledWith(
+        'Code workflow failed validation',
+        expect.objectContaining({ workflowId: 'invalid-condition' }),
+      )
+    })
+
     test('handles empty array without errors', () => {
       expect(() => registerCodeWorkflows([])).not.toThrow()
       expect(getAllCodeWorkflows()).toHaveLength(0)

--- a/packages/core/src/modules/workflows/lib/__tests__/graph-utils.condition.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/graph-utils.condition.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from '@jest/globals'
+import { definitionToGraph, graphToDefinition } from '../graph-utils'
+
+describe('workflow graph inline conditions', () => {
+  test('preserves inline conditions through definition and graph conversion', () => {
+    const condition = {
+      operator: 'AND',
+      rules: [
+        { field: 'invoice.total', operator: '>=', value: 1000 },
+        { field: 'invoice.currency', operator: '=', value: 'EUR' },
+      ],
+    }
+    const definition = {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [
+        {
+          transitionId: 'to-end',
+          fromStepId: 'start',
+          toStepId: 'end',
+          trigger: 'auto',
+          condition,
+        },
+      ],
+    }
+
+    const graph = definitionToGraph(definition)
+    expect(graph.edges[0].data?.condition).toEqual(condition)
+
+    const roundTripped = graphToDefinition(graph.nodes, graph.edges)
+    expect(roundTripped.transitions[0].condition).toEqual(condition)
+  })
+})

--- a/packages/core/src/modules/workflows/lib/graph-utils.ts
+++ b/packages/core/src/modules/workflows/lib/graph-utils.ts
@@ -131,6 +131,10 @@ export function graphToDefinition(
       transition.continueOnActivityFailure = edgeData.continueOnActivityFailure
     }
 
+    if (edgeData?.condition !== undefined) {
+      transition.condition = edgeData.condition
+    }
+
     // Add conditions if present
     if (edgeData?.preConditions && edgeData.preConditions.length > 0) {
       transition.preConditions = edgeData.preConditions
@@ -322,6 +326,7 @@ export function definitionToGraph(
         continueOnActivityFailure: (transition as any).continueOnActivityFailure !== undefined
           ? (transition as any).continueOnActivityFailure
           : false,
+        condition: transition.condition,
         preConditions: transition.preConditions || [],
         postConditions: transition.postConditions || [],
         activities: transition.activities || [],

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -62,6 +62,7 @@ When you need shared type definitions, import from these:
 | Need | Import from |
 |------|-------------|
 | Dashboard widget types | `@open-mercato/shared/modules/dashboard/widgets` |
+| Condition-expression operators, schemas, and types | `@open-mercato/shared/modules/conditions` |
 | DSL helpers (`defineLink`, `entityId`, `cf.*`) | `@open-mercato/shared/modules/dsl` |
 | Event declarations (`createModuleEvents`) | `@open-mercato/shared/modules/events` |
 | Search config types (`SearchModuleConfig`) | `@open-mercato/shared/modules/search` |

--- a/packages/shared/src/modules/__tests__/conditions.test.ts
+++ b/packages/shared/src/modules/__tests__/conditions.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from '@jest/globals'
+import {
+  CONDITION_COMPARISON_OPERATORS,
+  CONDITION_LOGICAL_OPERATORS,
+  conditionComparisonOperatorSchema,
+  conditionExpressionSchema,
+  conditionLogicalOperatorSchema,
+} from '../conditions'
+
+describe('condition contract', () => {
+  test('derives operator schemas from the canonical tuples', () => {
+    expect(conditionComparisonOperatorSchema.options).toEqual([
+      ...CONDITION_COMPARISON_OPERATORS,
+    ])
+    expect(conditionLogicalOperatorSchema.options).toEqual([
+      ...CONDITION_LOGICAL_OPERATORS,
+    ])
+  })
+
+  test('parses recursive conditions with JSON values', () => {
+    const condition = {
+      operator: 'AND',
+      rules: [
+        { field: 'invoice.total', operator: '>=', value: 1000 },
+        {
+          operator: 'OR',
+          rules: [
+            { field: 'invoice.currency', operator: '=', value: 'EUR' },
+            { field: 'invoice.tags', operator: 'CONTAINS', value: ['priority'] },
+          ],
+        },
+      ],
+    }
+
+    expect(conditionExpressionSchema.parse(condition)).toEqual(condition)
+  })
+
+  test('rejects invalid operators and non-JSON values', () => {
+    expect(() => conditionExpressionSchema.parse({
+      field: 'invoice.status',
+      operator: 'equals',
+      value: 'approved',
+    })).toThrow()
+
+    expect(() => conditionExpressionSchema.parse({
+      field: 'invoice.createdAt',
+      operator: '=',
+      value: new Date(),
+    })).toThrow()
+
+    expect(() => conditionExpressionSchema.parse({
+      field: 'invoice.callback',
+      operator: '=',
+      value: () => true,
+    })).toThrow()
+
+    expect(() => conditionExpressionSchema.parse({
+      field: 'invoice.sequence',
+      operator: '=',
+      value: BigInt(1),
+    })).toThrow()
+  })
+})

--- a/packages/shared/src/modules/conditions.ts
+++ b/packages/shared/src/modules/conditions.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+
+export const CONDITION_COMPARISON_OPERATORS = [
+  '=',
+  '==',
+  '!=',
+  '>',
+  '>=',
+  '<',
+  '<=',
+  'IN',
+  'NOT_IN',
+  'CONTAINS',
+  'NOT_CONTAINS',
+  'STARTS_WITH',
+  'ENDS_WITH',
+  'MATCHES',
+  'IS_EMPTY',
+  'IS_NOT_EMPTY',
+] as const
+
+export const CONDITION_LOGICAL_OPERATORS = ['AND', 'OR', 'NOT'] as const
+
+export const conditionComparisonOperatorSchema = z.enum(CONDITION_COMPARISON_OPERATORS)
+export const conditionLogicalOperatorSchema = z.enum(CONDITION_LOGICAL_OPERATORS)
+
+export const simpleConditionSchema = z.object({
+  field: z.string(),
+  operator: conditionComparisonOperatorSchema,
+  value: z.json(),
+  valueField: z.string().optional(),
+})
+
+export const groupConditionSchema = z.object({
+  operator: conditionLogicalOperatorSchema,
+  get rules() {
+    return z.array(conditionExpressionSchema)
+  },
+})
+
+export const conditionExpressionSchema = z.union([simpleConditionSchema, groupConditionSchema])
+
+export type ConditionComparisonOperator = z.infer<typeof conditionComparisonOperatorSchema>
+export type ConditionLogicalOperator = z.infer<typeof conditionLogicalOperatorSchema>
+export type SimpleCondition = z.infer<typeof simpleConditionSchema>
+export type GroupCondition = z.infer<typeof groupConditionSchema>
+export type ConditionExpression = z.infer<typeof conditionExpressionSchema>

--- a/packages/shared/src/modules/workflows/__tests__/builder.test.ts
+++ b/packages/shared/src/modules/workflows/__tests__/builder.test.ts
@@ -264,11 +264,59 @@ describe('defineWorkflow()', () => {
 
     const transition = workflow.definition.transitions[0]
     expect(transition).not.toHaveProperty('transitionName')
+    expect(transition).not.toHaveProperty('condition')
     expect(transition).not.toHaveProperty('preConditions')
     expect(transition).not.toHaveProperty('postConditions')
     expect(transition).not.toHaveProperty('activities')
     expect(transition).not.toHaveProperty('continueOnActivityFailure')
     expect(transition).not.toHaveProperty('priority')
+  })
+
+  test('preserves simple and grouped inline transition conditions', () => {
+    const workflow = defineWorkflow({
+      workflowId: 'test.conditional-workflow',
+      workflowName: 'Conditional Workflow',
+      steps: minimalSteps,
+      transitions: [
+        {
+          transitionId: 'simple-condition',
+          fromStepId: 'start',
+          toStepId: 'end',
+          trigger: 'auto',
+          condition: {
+            field: 'invoice.action',
+            operator: '=',
+            value: 'approve',
+          },
+        },
+        {
+          transitionId: 'grouped-condition',
+          fromStepId: 'start',
+          toStepId: 'end',
+          trigger: 'auto',
+          condition: {
+            operator: 'AND',
+            rules: [
+              { field: 'invoice.total', operator: '>=', value: 1000 },
+              { field: 'invoice.currency', operator: '=', value: 'EUR' },
+            ],
+          },
+        },
+      ],
+    })
+
+    expect(workflow.definition.transitions[0].condition).toEqual({
+      field: 'invoice.action',
+      operator: '=',
+      value: 'approve',
+    })
+    expect(workflow.definition.transitions[1].condition).toEqual({
+      operator: 'AND',
+      rules: [
+        { field: 'invoice.total', operator: '>=', value: 1000 },
+        { field: 'invoice.currency', operator: '=', value: 'EUR' },
+      ],
+    })
   })
 
   test('works correctly with as const steps (key type safety feature)', () => {

--- a/packages/shared/src/modules/workflows/builder.ts
+++ b/packages/shared/src/modules/workflows/builder.ts
@@ -71,6 +71,7 @@ interface TransitionInput<TStepId extends string> {
   toStepId: TStepId
   transitionName?: string
   trigger: TransitionTrigger
+  condition?: CodeTransitionDefinition['condition']
   preConditions?: CodeTransitionDefinition['preConditions']
   postConditions?: CodeTransitionDefinition['postConditions']
   activities?: CodeActivityDefinition[]
@@ -120,6 +121,7 @@ export function defineWorkflow<const TSteps extends readonly StepInput<string>[]
     toStepId: t.toStepId,
     trigger: t.trigger,
     ...(t.transitionName !== undefined && { transitionName: t.transitionName }),
+    ...(t.condition !== undefined && { condition: t.condition }),
     ...(t.preConditions !== undefined && { preConditions: t.preConditions }),
     ...(t.postConditions !== undefined && { postConditions: t.postConditions }),
     ...(t.activities !== undefined && { activities: t.activities }),

--- a/packages/shared/src/modules/workflows/index.ts
+++ b/packages/shared/src/modules/workflows/index.ts
@@ -7,6 +7,11 @@ export type {
   CodeActivityDefinition,
   WorkflowStepType,
   TransitionTrigger,
+  ConditionComparisonOperator,
+  ConditionLogicalOperator,
+  SimpleCondition,
+  GroupCondition,
+  ConditionExpression,
   ActivityType,
   WorkflowsModuleConfig,
 } from './types'

--- a/packages/shared/src/modules/workflows/types.ts
+++ b/packages/shared/src/modules/workflows/types.ts
@@ -6,6 +6,16 @@
  * generic type safety for step ID references in transitions.
  */
 
+import type { ConditionExpression } from '../conditions'
+
+export type {
+  ConditionComparisonOperator,
+  ConditionLogicalOperator,
+  SimpleCondition,
+  GroupCondition,
+  ConditionExpression,
+} from '../conditions'
+
 // ============================================================================
 // Step Types
 // ============================================================================
@@ -111,6 +121,7 @@ export interface CodeTransitionDefinition<TStepId extends string = string> {
   toStepId: TStepId
   transitionName?: string
   trigger: TransitionTrigger
+  condition?: ConditionExpression
   preConditions?: Array<{
     ruleId: string
     required?: boolean


### PR DESCRIPTION
## Summary

Add typed, JSON-safe inline transition conditions to code-defined workflows while preserving the existing business-rules public type contract.

## Changes

- Add a shared canonical condition schema and operator definitions.
- Expose `transition.condition` through workflow types and `defineWorkflow()`.
- Compose business-rules semantic validation with JSON-safe workflow validation.
- Preserve conditions through registry and graph conversion.
- Declare the workflows dependency on `business_rules`.
- Update tests and the existing workflow specification.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**

`.ai/specs/implemented/2026-04-14-code-based-workflow-definitions.md`

## Testing

- Shared focused tests: 28 passed.
- Core focused tests: 156 passed.
- Shared and core typechecks passed.
- `yarn build:packages`
- `yarn generate`
- `yarn build:app`

No new integration fixture is required because runtime transition-condition evaluation is already covered by `transition-handler.test.ts`; this change affects types, validation, registry, and graph plumbing.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes, otherwise `needs-qa`.

### Design System Compliance

N/A — this PR contains no UI changes.

## Linked issues

N/A