### PR TITLE
build(deps): port engine.io 6.6.9 update to develop

### DIFF
--- a/.ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md
+++ b/.ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md
@@ -46,14 +46,16 @@ The attempted cherry-pick exposed a lockfile conflict because `develop` already 
 
 ## Progress
 
+PR: #4351
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Port the dependency update
 
-- [ ] 1.1 Apply PR #4347's dependency commit onto `develop`
-- [ ] 1.2 Verify the port contains only intended lockfile changes
+- [x] 1.1 Apply PR #4347's dependency commit onto `develop` — no-op: superseded by `3140fbb3d`; documented in `b716acb68`
+- [x] 1.2 Verify the port contains only intended lockfile changes — `b716acb68`
 
 ### Phase 2: Validate and publish
 
-- [ ] 2.1 Run targeted checks and the configured validation gate
+- [x] 2.1 Run targeted checks and the configured validation gate — docs/no-change path; immutable install and lock assertions passed
 - [ ] 2.2 Review, finalize the replacement PR, and close PR #4347

--- a/.ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md
+++ b/.ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md
@@ -1,0 +1,55 @@
+# Port engine.io 6.6.9 to develop
+
+## Overview
+
+Port the dependency lockfile update from PR #4347 onto the configured `develop` base branch, validate the resulting dependency graph, open a replacement PR, and close the original `main`-targeted PR after the replacement is available.
+
+## Goal
+
+Land the `engine.io` 6.6.5 → 6.6.9 update (including its patched `ws` dependency) on `develop` without carrying unrelated `main`/`develop` divergence.
+
+## Scope
+
+- Base the replacement branch on `origin/develop`.
+- Port only commit `db77937e7a393d655d062ad3e2cf38a90636be8e` from PR #4347.
+- Verify the lockfile resolves `engine.io` 6.6.9 and the updated `ws` dependency.
+- Run the repository validation gate, review the diff, and open a ready replacement PR.
+- Close PR #4347 with a link to the replacement PR.
+
+## Non-goals
+
+- Do not merge the replacement PR.
+- Do not modify package manifests or unrelated dependency versions.
+- Do not carry unrelated changes caused by the source PR targeting `main`.
+
+## Implementation Plan
+
+### Phase 1: Port the dependency update
+
+1. Apply the source PR's single dependency commit to a branch based on `develop`.
+2. Confirm the resulting diff is limited to the intended lockfile resolution changes.
+
+### Phase 2: Validate and publish
+
+1. Run targeted dependency checks and the configured validation gate.
+2. Complete backward-compatibility and automated review, finalize the replacement PR, and close PR #4347.
+
+## Risks
+
+- The source PR targets `main`, whose history differs substantially from `develop`; cherry-picking only its single commit avoids importing unrelated branch divergence.
+- Transitive dependency resolution may differ on `develop`; the lockfile diff and install validation must be inspected before publication.
+- Closing PR #4347 is deferred until the replacement PR exists so the security update remains traceable.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Port the dependency update
+
+- [ ] 1.1 Apply PR #4347's dependency commit onto `develop`
+- [ ] 1.2 Verify the port contains only intended lockfile changes
+
+### Phase 2: Validate and publish
+
+- [ ] 2.1 Run targeted checks and the configured validation gate
+- [ ] 2.2 Review, finalize the replacement PR, and close PR #4347

--- a/.ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md
+++ b/.ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md
@@ -58,4 +58,4 @@ PR: #4351
 ### Phase 2: Validate and publish
 
 - [x] 2.1 Run targeted checks and the configured validation gate — docs/no-change path; immutable install and lock assertions passed
-- [ ] 2.2 Review, finalize the replacement PR, and close PR #4347
+- [x] 2.2 Review, finalize the replacement PR, and close PR #4347 — no-action review complete; PR #4347 closed

--- a/.ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md
+++ b/.ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md
@@ -40,6 +40,10 @@ Land the `engine.io` 6.6.5 → 6.6.9 update (including its patched `ws` dependen
 - Transitive dependency resolution may differ on `develop`; the lockfile diff and install validation must be inspected before publication.
 - Closing PR #4347 is deferred until the replacement PR exists so the security update remains traceable.
 
+## Outcome
+
+The attempted cherry-pick exposed a lockfile conflict because `develop` already contains the complete dependency remediation in commit `3140fbb3d` (`fix(deps): patch high-severity audit advisories in transitive deps`). After aborting the cherry-pick, the working `yarn.lock` matched `origin/develop` byte-for-byte. No dependency change is required; PR #4351 exists only as the workflow audit trail and should be closed without merge after recording verification.
+
 ## Progress
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md
Status: in-progress

## Goal
- Port PR #4347's `engine.io` 6.6.9 security-related dependency update onto `develop` and close the original `main`-targeted PR.

## What Changed
- Added a resumable execution plan; implementation and validation are in progress.

## Tests
- Pending.

## Backward Compatibility
- Pending review; the intended change is lockfile-only.

## Progress
See [Progress section in the plan](.ai/runs/2026-07-22-port-engine-io-6-6-9-to-develop.md#progress).

Source PR: #4347
