### PR TITLE
fix(sales): hide compose-message action on order/quote pages when messages module is disabled

### DIFF
--- a/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
+++ b/packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx
@@ -27,6 +27,8 @@ import { ArrowRightLeft, Building2, CreditCard, Mail, Pencil, Plus, Send, Store,
 import { FormHeader, type ActionItem } from '@open-mercato/ui/backend/forms'
 import { VersionHistoryAction } from '@open-mercato/ui/backend/version-history'
 import { SendObjectMessageDialog } from '@open-mercato/ui/backend/messages'
+import { useBackendChrome } from '@open-mercato/ui/backend/BackendChromeProvider'
+import { hasFeature } from '@open-mercato/shared/security/features'
 import Link from 'next/link'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { apiCall, apiCallOrThrow, readApiResultOrThrow, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
@@ -3994,6 +3996,9 @@ export default function SalesDocumentDetailPage({
     []
   )
 
+  const { payload: backendChromePayload, isReady: backendChromeReady } = useBackendChrome()
+  const canComposeMessages = backendChromeReady && hasFeature(backendChromePayload?.grantedFeatures, 'messages.compose')
+
   const tabInjectionSpotId = React.useMemo(() => `sales.document.detail.${kind}:tabs`, [kind])
   const { widgets: injectedTabWidgets } = useInjectionWidgets(tabInjectionSpotId, {
     context: detailInjectionContext,
@@ -4575,25 +4580,27 @@ export default function SalesDocumentDetailPage({
           backLabel={t('sales.documents.detail.back', 'Back to documents')}
           utilityActions={record ? (
             <>
-              <SendObjectMessageDialog
-                object={{
-                  entityModule: 'sales',
-                  entityType: kind,
-                  entityId: record.id,
-                  sourceEntityType: kind === 'order' ? 'sales.order' : 'sales.quote',
-                  sourceEntityId: record.id,
-                  previewData: {
-                    title: number,
-                    status: statusDisplay?.label ?? record?.status ?? undefined,
-                    metadata: Object.keys(messagePreviewMetadata).length > 0 ? messagePreviewMetadata : undefined,
-                  },
-                }}
-                viewHref={`/backend/sales/${kind === 'order' ? 'orders' : 'quotes'}/${record.id}`}
-                defaultValues={{
-                  sourceEntityType: kind === 'order' ? 'sales.order' : 'sales.quote',
-                  sourceEntityId: record.id,
-                }}
-              />
+              {canComposeMessages ? (
+                <SendObjectMessageDialog
+                  object={{
+                    entityModule: 'sales',
+                    entityType: kind,
+                    entityId: record.id,
+                    sourceEntityType: kind === 'order' ? 'sales.order' : 'sales.quote',
+                    sourceEntityId: record.id,
+                    previewData: {
+                      title: number,
+                      status: statusDisplay?.label ?? record?.status ?? undefined,
+                      metadata: Object.keys(messagePreviewMetadata).length > 0 ? messagePreviewMetadata : undefined,
+                    },
+                  }}
+                  viewHref={`/backend/sales/${kind === 'order' ? 'orders' : 'quotes'}/${record.id}`}
+                  defaultValues={{
+                    sourceEntityType: kind === 'order' ? 'sales.order' : 'sales.quote',
+                    sourceEntityId: record.id,
+                  }}
+                />
+              ) : null}
               <VersionHistoryAction
                 config={{
                   resourceKind: kind === 'order' ? 'sales.order' : 'sales.quote',


### PR DESCRIPTION
## What & why

The order and quote detail pages (shared `SalesDocumentDetailPage`) rendered the **Compose message** action (`SendObjectMessageDialog`) unconditionally. When the `messages` module is disabled, the server already strips `messages.*` from the backend-chrome granted features (`filterGrantsByEnabledModules`), but the action still rendered and would fail on use.

This gates the dialog on the module-filtered `messages.compose` grant via `useBackendChrome()` + `hasFeature()`, mirroring the existing `ProgressTopBar` / `UpgradeActionBanner` pattern. It hides the action both when the `messages` module is disabled and when the user lacks compose permission.

## Change

`packages/core/src/modules/sales/backend/sales/documents/[id]/page.tsx`:
- add `const { payload, isReady } = useBackendChrome()` + `canComposeMessages = isReady && hasFeature(payload?.grantedFeatures, 'messages.compose')`
- wrap `<SendObjectMessageDialog />` in `{canComposeMessages ? … : null}`

Covers both orders and quotes since they share this component.

## Verification (local, real app)

Booted the app against a local Postgres (`mercato init`, seeded demo orders), logged in as superadmin, and drove the order detail page in a headless browser:

- **messages enabled** (default): compose (paper-plane) action present next to History + Delete — `composeButtonCount = 1`, no console errors.
- **messages disabled** (commented out in `apps/mercato/src/modules.ts`, regenerated + restarted): compose action gone; only History + Delete remain — `composeButtonCount = 0`, page renders cleanly, no console errors.

This also confirms superadmin's `*` grant is correctly narrowed: `filterGrantsByEnabledModules` expands `*` to `<id>.*` only for enabled modules.

`yarn workspace @open-mercato/core typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
