### PR TITLE
security(auth): enforce nulled ACL feature overrides as a runtime deny-list

### DIFF
--- a/.ai/specs/2026-07-22-nulled-acl-feature-deny-list.md
+++ b/.ai/specs/2026-07-22-nulled-acl-feature-deny-list.md
@@ -55,21 +55,53 @@ super admins):
     grant list (wildcards pass through; consumers matching against a concrete
     required id go through `userHasAllFeatures` / feature-check for
     authoritative answers).
+- `CustomerRbacService` (core customer_accounts, portal RBAC):
+  - `userHasAllFeatures()` denies removed required features **before** the
+    portal-admin branch, mirroring the backend super-admin handling. (Portal
+    RBAC still has no module-level grant filtering — that pre-existing gap is
+    orthogonal to this spec.)
 
-### Known limitation
+### Residual gaps and why they are out of scope
 
-Pure grant-side matching surfaces (client-side `hasFeature` against
-`BackendChromePayload.grantedFeatures`, guard lists evaluated with the shared
-`hasAllFeatures` against a raw grant array) can still show UI affordances when
-a wildcard grant covers a removed feature — a deny cannot be expressed in
-grant strings alone, and `security/features.ts` must stay isomorphic/pure.
-Server-side enforcement (`userHasAllFeatures`, `/api/auth/feature-check`,
-page/API guards, `tenantHasFeature`) is authoritative, so such affordances
-fail closed with a 403. Shipping a denied-feature list to the client chrome is
-a possible follow-up if the cosmetic gap matters.
+The deny-list lives at the RBAC chokepoints. Two classes of call sites match
+raw grant arrays directly and therefore still let a wildcard grant satisfy a
+removed feature. They were triaged deliberately:
 
-Portal RBAC (`CustomerRbacService`) does not yet apply module-level or
-removed-feature filtering; extending the deny-list there is a follow-up.
+1. **Client-side UI affordances (cosmetic).** Client code matches concrete
+   feature ids against `BackendChromePayload.grantedFeatures` (e.g.
+   `useInjectedMenuItems`, header chrome buttons, per-component `hasFeature`
+   checks). A wildcard grant in the payload can still show an affordance for a
+   removed feature; a deny cannot be expressed in grant strings alone, and
+   `security/features.ts` must stay isomorphic/pure (the module registry and
+   override store are server-populated). Every mutating action behind such an
+   affordance hits a server guard that routes through `userHasAllFeatures`, so
+   these fail closed with a 403. Follow-up if the cosmetic gap matters: add an
+   additive `removedFeatures` field to `BackendChromePayload` and subtract it
+   in the client-side check helpers.
+
+2. **Server-side in-handler fine-grained checks (real but bounded).** Roughly
+   a dozen handlers perform secondary checks like
+   `hasFeature(acl.features, 'dashboards.configure')` against the raw ACL
+   (dashboards routes, `messages/lib/routeHelpers`, `entities/lib/entityAcl`,
+   `communication_channels/lib/access-control`,
+   `customers/lib/visibilityFilter`, `inbox_ops`/`search` AI tools,
+   `workflows/lib/activity-executor`, `ai-assistant/lib/auth`). The route-level
+   `requireFeatures` guard (which routes through `RbacService`) already denies
+   removed features, but when a route requires a broader feature and the
+   handler checks a removed one inline, a wildcard grant still passes.
+   Follow-up: a server-side `hasFeatureRespectingRemovals(granted, required)`
+   helper and a per-site migration of **authorization** checks only.
+
+3. **Why the shared matcher must NOT be made deny-aware globally.** The same
+   `hasFeature`/`hasAllFeatures` helpers also gate **activation** of
+   interceptors (`command-interceptor-runner`, `interceptor-runner`), mutation
+   guards (`mutation-guard-registry`), response enrichers, component
+   overrides, and notification recipients. At those sites `features` means
+   "this component applies when the user holds the feature" — globally denying
+   removed ids would silently *deactivate* security-enforcing components,
+   failing open instead of closed. The deny must therefore stay at
+   authorization chokepoints and be migrated per-site (gap 2), never baked
+   into the pure matcher.
 
 ## Migration & Backward Compatibility
 
@@ -95,6 +127,8 @@ removed-feature filtering; extending the deny-list there is a follow-up.
 - `packages/core/src/modules/auth/services/__tests__/rbacService.test.ts` —
   wildcard-grant denial, stale-explicit-grant denial, super-admin denial,
   `tenantHasFeature` denial, `getGrantedFeatures` filtering.
+- `packages/core/src/modules/customer_accounts/services/__tests__/customerRbacService.test.ts` —
+  portal wildcard-grant denial and portal-admin denial.
 
 Integration coverage: enforcement is fully covered at the unit level against
 the real override store; no HTTP-level flow changes (guards already route
@@ -104,3 +138,7 @@ through `userHasAllFeatures`).
 
 - 2026-07-22: Implemented deny-list enforcement for nulled ACL feature
   overrides across `enabledModulesRegistry` and `RbacService`.
+- 2026-07-22: Extended the deny-list to portal `CustomerRbacService` and
+  replaced the "Known limitation" note with a triage of the residual
+  grant-side gaps (client cosmetic, in-handler fine-grained checks) and the
+  fail-open rationale for keeping the shared matcher deny-unaware.

--- a/.ai/specs/2026-07-22-nulled-acl-feature-deny-list.md
+++ b/.ai/specs/2026-07-22-nulled-acl-feature-deny-list.md
@@ -1,0 +1,106 @@
+# Nulled ACL Feature Overrides Act as a Runtime Deny-List
+
+- Date: 2026-07-22
+- Status: Implemented
+- Scope: OSS — `@open-mercato/shared` (enabled-modules registry, module overrides), `@open-mercato/core` (auth `RbacService`)
+- Related: `.ai/specs/implemented/2026-05-04-modules-ts-unified-overrides.md` (umbrella overrides spec), `.ai/specs/implemented/2026-04-30-ai-overrides-and-module-disable.md`
+
+## Problem
+
+`entry.overrides.acl.features: { '<feature-id>': null }` (and the programmatic
+`applyAclFeatureOverrides`) removes a feature from the module registry's ACL
+catalog. Before this change, that removal only affected **catalog surfaces**:
+the role-management UI checkboxes, `setup.ts` / `sync-role-acls` seeding, and
+docs. Runtime enforcement never consulted the registry for feature existence:
+
+1. `hasAllFeatures(granted, required)` is a pure string match between the
+   required feature id and the caller's grant strings. A removed feature id
+   hardcoded at a call site (e.g. `sales.documents.number.edit` in the sales
+   routes) was still satisfied by a wildcard grant such as `sales.*`.
+2. Grants come from the database (`role_acls.features_json`), not the
+   registry. `filterGrantsByEnabledModules()` filters at **module**
+   granularity only, and `getOwningModuleId()` falls back to the feature-id
+   prefix for ids unknown to the registry — so both wildcard grants and stale
+   explicit grants for a removed feature survived filtering.
+3. The super-admin branch of `RbacService.userHasAllFeatures` passed whenever
+   the required feature's **owning module** was enabled — the prefix fallback
+   again resolved a removed feature to its enabled module.
+
+Net effect: nulling a feature read as "this feature does not exist in this
+app", but every enforcement path disagreed. The override silently did not
+deny anything.
+
+## Decision
+
+Treat feature ids overridden to `null` as a **deny-list at enforcement time**,
+mirroring the existing disabled-modules handling (which already denies even
+super admins):
+
+- `@open-mercato/shared/security/enabledModulesRegistry` gains:
+  - `getRemovedAclFeatureIds(): ReadonlySet<string>` — composed from
+    `composeAclFeatureOverrides()` entries whose value is `null` (modules-tier
+    and programmatic-tier, with the existing programmatic-over-modules
+    precedence; a non-null replacement override is NOT removed).
+  - `isAclFeatureRemoved(featureId): boolean` — membership check.
+  - `filterGrantsByEnabledModules()` now drops **explicit** grants whose id is
+    a removed feature, including when the module registry is unavailable
+    (tests/CLI). Wildcard grants are left in place — the required-side check
+    below is the authoritative gate.
+- `RbacService` (core auth):
+  - `userHasAllFeatures()` returns `false` when any required feature is
+    removed — checked **before** the super-admin branch, so super admins are
+    denied too.
+  - `tenantHasFeature()` returns `false` for a removed feature.
+  - `getGrantedFeatures()` filters explicit removed ids out of the returned
+    grant list (wildcards pass through; consumers matching against a concrete
+    required id go through `userHasAllFeatures` / feature-check for
+    authoritative answers).
+
+### Known limitation
+
+Pure grant-side matching surfaces (client-side `hasFeature` against
+`BackendChromePayload.grantedFeatures`, guard lists evaluated with the shared
+`hasAllFeatures` against a raw grant array) can still show UI affordances when
+a wildcard grant covers a removed feature — a deny cannot be expressed in
+grant strings alone, and `security/features.ts` must stay isomorphic/pure.
+Server-side enforcement (`userHasAllFeatures`, `/api/auth/feature-check`,
+page/API guards, `tenantHasFeature`) is authoritative, so such affordances
+fail closed with a 403. Shipping a denied-feature list to the client chrome is
+a possible follow-up if the cosmetic gap matters.
+
+Portal RBAC (`CustomerRbacService`) does not yet apply module-level or
+removed-feature filtering; extending the deny-list there is a follow-up.
+
+## Migration & Backward Compatibility
+
+- No contract surface is removed or renamed; `enabledModulesRegistry` gains
+  two additive exports.
+- Behavior change (intended, fail-closed): downstream apps that null an ACL
+  feature now actually deny it at runtime for all users, including super
+  admins and holders of wildcard or stale explicit grants. Apps that nulled a
+  feature merely to hide the role-management checkbox while still relying on
+  wildcard grants to permit the action must replace the `null` override with a
+  replacement entry (e.g. `{ id: '<feature-id>' }`) or remove the override.
+- A stale `null` override targeting a feature id no module declares still
+  denies that id (and bootstrap logs the existing stale-override warning) —
+  consistent with "this feature does not exist here".
+- No DB migration: stale explicit grants persisted in `role_acls` /
+  `user_acls` become inert instead of being rewritten.
+
+## Test Coverage
+
+- `packages/shared/src/security/__tests__/enabledModulesRegistry.test.ts` —
+  removed-id reporting, replacement-override non-removal, explicit-grant
+  filtering with and without a populated module registry.
+- `packages/core/src/modules/auth/services/__tests__/rbacService.test.ts` —
+  wildcard-grant denial, stale-explicit-grant denial, super-admin denial,
+  `tenantHasFeature` denial, `getGrantedFeatures` filtering.
+
+Integration coverage: enforcement is fully covered at the unit level against
+the real override store; no HTTP-level flow changes (guards already route
+through `userHasAllFeatures`).
+
+## Changelog
+
+- 2026-07-22: Implemented deny-list enforcement for nulled ACL feature
+  overrides across `enabledModulesRegistry` and `RbacService`.

--- a/apps/docs/docs/framework/modules/overrides.mdx
+++ b/apps/docs/docs/framework/modules/overrides.mdx
@@ -238,7 +238,8 @@ overrides: {
 Nulling an ACL feature is a **runtime deny-list**, not just catalog cleanup. Beyond
 hiding the feature from role-management checkboxes and default-role seeding, a
 removed feature is denied by `RbacService.userHasAllFeatures` /
-`tenantHasFeature` for every caller — including super admins, wildcard grants
+`tenantHasFeature` and the portal `CustomerRbacService.userHasAllFeatures`
+for every caller — including super admins, portal admins, wildcard grants
 (`catalog.*`, `*`), and stale explicit grants persisted in existing role/user
 ACLs — mirroring how disabled modules are enforced. To hide a feature from the
 role UI without denying it, replace it instead of nulling it.

--- a/apps/docs/docs/framework/modules/overrides.mdx
+++ b/apps/docs/docs/framework/modules/overrides.mdx
@@ -235,6 +235,14 @@ overrides: {
 }
 ```
 
+Nulling an ACL feature is a **runtime deny-list**, not just catalog cleanup. Beyond
+hiding the feature from role-management checkboxes and default-role seeding, a
+removed feature is denied by `RbacService.userHasAllFeatures` /
+`tenantHasFeature` for every caller — including super admins, wildcard grants
+(`catalog.*`, `*`), and stale explicit grants persisted in existing role/user
+ACLs — mirroring how disabled modules are enforced. To hide a feature from the
+role UI without denying it, replace it instead of nulling it.
+
 ## Programmatic Overrides
 
 Use programmatic helpers for env-driven boot decisions and tests:

--- a/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
+++ b/packages/core/src/modules/auth/services/__tests__/rbacService.test.ts
@@ -4,6 +4,7 @@ import { ApiKey } from '@open-mercato/core/modules/api_keys/data/entities'
 import { createMemoryStrategy } from '@open-mercato/cache'
 import type { CacheStrategy } from '@open-mercato/cache'
 import * as enabledModulesRegistry from '@open-mercato/shared/security/enabledModulesRegistry'
+import { applyAclFeatureOverrides, resetModuleContractOverridesForTests } from '@open-mercato/shared/modules/overrides'
 import { buildOrgScopeUserCacheTag, buildOrgScopeTenantCacheTag } from '@open-mercato/core/modules/directory/utils/organizationScope'
 
 // Minimal mock of MikroORM EntityManager surface used by RbacService
@@ -450,6 +451,72 @@ describe('RbacService', () => {
 
       const ok = await service.userHasAllFeatures(baseUser.id!, ['entities.records.view'], { tenantId: null, organizationId: 'org-unknown' })
       expect(ok).toBe(true)
+    })
+  })
+
+  describe('removed ACL features (null overrides)', () => {
+    afterEach(() => {
+      resetModuleContractOverridesForTests()
+    })
+
+    const mockUserAcl = (uacl: Partial<UserAcl>) => {
+      em.findOne.mockImplementation(async (entity: any, where: any) => {
+        if (entity === User && where?.id === baseUser.id) return baseUser
+        if (entity === UserAcl && where?.user === baseUser.id && where?.tenantId === baseUser.tenantId) return uacl
+        return null
+      })
+    }
+
+    it('denies a removed feature even when a module wildcard grant matches it', async () => {
+      applyAclFeatureOverrides({ 'sales.documents.number.edit': null })
+      mockUserAcl({ isSuperAdmin: false, featuresJson: ['sales.*'], organizationsJson: null })
+
+      const removedAllowed = await service.userHasAllFeatures(baseUser.id!, ['sales.documents.number.edit'], { tenantId: null, organizationId: null })
+      const siblingAllowed = await service.userHasAllFeatures(baseUser.id!, ['sales.documents.view'], { tenantId: null, organizationId: null })
+
+      expect(removedAllowed).toBe(false)
+      expect(siblingAllowed).toBe(true)
+    })
+
+    it('denies a removed feature for an explicit stale grant persisted in the ACL', async () => {
+      applyAclFeatureOverrides({ 'sales.documents.number.edit': null })
+      mockUserAcl({ isSuperAdmin: false, featuresJson: ['sales.documents.number.edit'], organizationsJson: null })
+
+      const ok = await service.userHasAllFeatures(baseUser.id!, ['sales.documents.number.edit'], { tenantId: null, organizationId: null })
+      expect(ok).toBe(false)
+    })
+
+    it('denies a removed feature for super admins, mirroring disabled-module handling', async () => {
+      applyAclFeatureOverrides({ 'sales.documents.number.edit': null })
+      mockUserAcl({ isSuperAdmin: true, featuresJson: [] })
+
+      const ok = await service.userHasAllFeatures(baseUser.id!, ['sales.documents.number.edit'], { tenantId: null, organizationId: null })
+      expect(ok).toBe(false)
+    })
+
+    it('denies a removed feature in tenant-scope checks despite wildcard role grants', async () => {
+      applyAclFeatureOverrides({ 'sales.documents.number.edit': null })
+      const roleAcls: Array<Partial<RoleAcl>> = [
+        { tenantId: 'tenant-1', isSuperAdmin: false, featuresJson: ['sales.*'], organizationsJson: null },
+      ]
+      em.find.mockImplementation(async (entity: any, where: any) => {
+        if (entity === RoleAcl && where?.tenantId === 'tenant-1') return roleAcls
+        return []
+      })
+
+      const removedAllowed = await service.tenantHasFeature('tenant-1', 'sales.documents.number.edit')
+      const siblingAllowed = await service.tenantHasFeature('tenant-1', 'sales.documents.view')
+
+      expect(removedAllowed).toBe(false)
+      expect(siblingAllowed).toBe(true)
+    })
+
+    it('filters explicit removed grants out of getGrantedFeatures while keeping other grants', async () => {
+      applyAclFeatureOverrides({ 'sales.documents.number.edit': null })
+      mockUserAcl({ isSuperAdmin: false, featuresJson: ['sales.documents.number.edit', 'sales.*'], organizationsJson: null })
+
+      const grants = await service.getGrantedFeatures(baseUser.id!, { tenantId: null, organizationId: null })
+      expect(grants).toEqual(['sales.*'])
     })
   })
 

--- a/packages/core/src/modules/auth/services/rbacService.ts
+++ b/packages/core/src/modules/auth/services/rbacService.ts
@@ -6,7 +6,7 @@ import { ApiKey } from '@open-mercato/core/modules/api_keys/data/entities'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { buildOrgScopeUserCacheTag, buildOrgScopeTenantCacheTag } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { matchFeature as sharedMatchFeature, hasAllFeatures as sharedHasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
-import { filterGrantsByEnabledModules, getOwningModuleId, getEnabledModuleIds } from '@open-mercato/shared/security/enabledModulesRegistry'
+import { filterGrantsByEnabledModules, getOwningModuleId, getEnabledModuleIds, getRemovedAclFeatureIds, isAclFeatureRemoved } from '@open-mercato/shared/security/enabledModulesRegistry'
 
 interface AclData {
   isSuperAdmin: boolean
@@ -385,7 +385,10 @@ export class RbacService {
     scope: { tenantId: string | null; organizationId: string | null },
   ): Promise<string[]> {
     const acl = await this.loadAcl(userId, scope)
-    return Array.isArray(acl.features) ? acl.features : []
+    const features = Array.isArray(acl.features) ? acl.features : []
+    const removed = getRemovedAclFeatureIds()
+    if (!removed.size) return features
+    return features.filter((feature) => !removed.has(feature))
   }
 
   /**
@@ -400,6 +403,7 @@ export class RbacService {
     opts?: { organizationId?: string | null },
   ): Promise<boolean> {
     if (!tenantId || !feature) return false
+    if (isAclFeatureRemoved(feature)) return false
 
     const enabledIds = getEnabledModuleIds()
     if (enabledIds.length && !enabledIds.includes(getOwningModuleId(feature))) return false
@@ -427,10 +431,12 @@ export class RbacService {
    *
    * Authorization logic:
    * 1. No features required → always returns true
-   * 2. User is super admin → always returns true
-   * 3. Organization restriction check: If the user's ACL has a restricted organization list
+   * 2. Removed feature check: If any required feature was removed via a `null` ACL
+   *    override → returns false (applies to super admins too, mirroring disabled modules)
+   * 3. User is super admin → returns true when every required feature's owning module is enabled
+   * 4. Organization restriction check: If the user's ACL has a restricted organization list
    *    and the requested organization is not in that list → returns false
-   * 4. Feature matching: User must have all required features (supports wildcards)
+   * 5. Feature matching: User must have all required features (supports wildcards)
    *
    * @param userId - The ID of the user
    * @param required - Array of feature strings to check (e.g., ['users.view', 'users.edit'])
@@ -456,6 +462,8 @@ export class RbacService {
    */
   async userHasAllFeatures(userId: string, required: string[], scope: { tenantId: string | null; organizationId: string | null }): Promise<boolean> {
     if (!required.length) return true
+    const removed = getRemovedAclFeatureIds()
+    if (removed.size && required.some((feature) => removed.has(feature))) return false
     const acl = await this.loadAcl(userId, scope)
     if (acl.isSuperAdmin) {
       const enabledIds = getEnabledModuleIds()

--- a/packages/core/src/modules/customer_accounts/services/__tests__/customerRbacService.test.ts
+++ b/packages/core/src/modules/customer_accounts/services/__tests__/customerRbacService.test.ts
@@ -1,5 +1,6 @@
 import { CustomerRoleAcl, CustomerUserAcl, CustomerUserRole } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { CustomerRbacService } from '@open-mercato/core/modules/customer_accounts/services/customerRbacService'
+import { applyAclFeatureOverrides, resetModuleContractOverridesForTests } from '@open-mercato/shared/modules/overrides'
 
 type MockEm = {
   findOne: jest.Mock
@@ -58,5 +59,41 @@ describe('CustomerRbacService organization scope', () => {
       { populate: ['role'] },
     )
     expect(acl).toEqual({ isPortalAdmin: false, features: ['portal.orders.view'] })
+  })
+})
+
+describe('CustomerRbacService removed ACL features (null overrides)', () => {
+  afterEach(() => {
+    resetModuleContractOverridesForTests()
+  })
+
+  const mockUserAcl = (em: MockEm, userId: string, tenantId: string, acl: Record<string, unknown>) => {
+    em.findOne.mockImplementation(async (entity: unknown, where: Record<string, any>) => (
+      entity === CustomerUserAcl && where?.user === userId && where?.tenantId === tenantId ? acl : null
+    ))
+  }
+
+  it('denies a removed feature even when a wildcard grant matches it', async () => {
+    applyAclFeatureOverrides({ 'portal.orders.reorder': null })
+    const em = createMockEm()
+    mockUserAcl(em, 'customer-user-1', 'tenant-1', { isPortalAdmin: false, featuresJson: ['portal.*'] })
+
+    const service = new CustomerRbacService(em as any)
+    const scope = { tenantId: 'tenant-1', organizationId: 'org-a' }
+
+    expect(await service.userHasAllFeatures('customer-user-1', ['portal.orders.reorder'], scope)).toBe(false)
+    expect(await service.userHasAllFeatures('customer-user-1', ['portal.orders.view'], scope)).toBe(true)
+  })
+
+  it('denies a removed feature for portal admins, mirroring super-admin handling', async () => {
+    applyAclFeatureOverrides({ 'portal.orders.reorder': null })
+    const em = createMockEm()
+    mockUserAcl(em, 'customer-user-1', 'tenant-1', { isPortalAdmin: true, featuresJson: [] })
+
+    const service = new CustomerRbacService(em as any)
+    const scope = { tenantId: 'tenant-1', organizationId: 'org-a' }
+
+    expect(await service.userHasAllFeatures('customer-user-1', ['portal.orders.reorder'], scope)).toBe(false)
+    expect(await service.userHasAllFeatures('customer-user-1', ['portal.orders.view'], scope)).toBe(true)
   })
 })

--- a/packages/core/src/modules/customer_accounts/services/customerRbacService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerRbacService.ts
@@ -6,6 +6,7 @@ import {
   CustomerUserRole,
 } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { hasAllFeatures } from '@open-mercato/shared/lib/auth/featureMatch'
+import { getRemovedAclFeatureIds } from '@open-mercato/shared/security/enabledModulesRegistry'
 
 interface CustomerAclData {
   isPortalAdmin: boolean
@@ -128,6 +129,8 @@ export class CustomerRbacService {
     scope: { tenantId: string; organizationId: string },
   ): Promise<boolean> {
     if (!required.length) return true
+    const removed = getRemovedAclFeatureIds()
+    if (removed.size && required.some((feature) => removed.has(feature))) return false
     const acl = await this.loadAcl(userId, scope)
     if (acl.isPortalAdmin) return true
     return hasAllFeatures(required, acl.features)

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -223,6 +223,7 @@ Downstream apps replace or disable any contract a module presents through a sing
 
 MUST rules:
 - `entry.overrides` is the ONLY canonical override surface — never patch upstream module source.
+- ACL features overridden to `null` are a runtime deny-list, not just catalog removal: `getRemovedAclFeatureIds()` / `isAclFeatureRemoved()` (`@open-mercato/shared/security/enabledModulesRegistry`) feed `RbacService`, which denies removed features even for super admins, wildcard grants, and stale persisted grants (see `.ai/specs/2026-07-22-nulled-acl-feature-deny-list.md`).
 - API-route override keys are `'METHOD /api/path'` (method case-insensitive, path leading slash optional). Trailing slashes are stripped.
 - Page-route override keys are `'/backend/path'` or `'/frontend/path'`.
 - `null` disables the matching method; `{ handler, metadata? }` replaces it. Disabling every method on an entry drops the entry.

--- a/packages/shared/src/security/__tests__/enabledModulesRegistry.test.ts
+++ b/packages/shared/src/security/__tests__/enabledModulesRegistry.test.ts
@@ -1,9 +1,15 @@
 import type { Module } from '../../modules/registry'
 import { getModules } from '../../lib/modules/registry'
 import {
+  applyAclFeatureOverrides,
+  resetModuleContractOverridesForTests,
+} from '../../modules/overrides'
+import {
   filterGrantsByEnabledModules,
   getEnabledModuleIds,
   getOwningModuleId,
+  getRemovedAclFeatureIds,
+  isAclFeatureRemoved,
 } from '../enabledModulesRegistry'
 
 jest.mock('../../lib/modules/registry', () => ({
@@ -119,5 +125,51 @@ describe('enabledModulesRegistry', () => {
     })
 
     expect(filterGrantsByEnabledModules(['*', 'search.global'])).toEqual(['*', 'search.global'])
+  })
+
+  describe('removed ACL features (null overrides)', () => {
+    afterEach(() => {
+      resetModuleContractOverridesForTests()
+    })
+
+    it('reports feature ids overridden to null as removed', () => {
+      applyAclFeatureOverrides({ 'sales.documents.number.edit': null })
+
+      expect(isAclFeatureRemoved('sales.documents.number.edit')).toBe(true)
+      expect(isAclFeatureRemoved('sales.documents.view')).toBe(false)
+      expect(getRemovedAclFeatureIds()).toEqual(new Set(['sales.documents.number.edit']))
+    })
+
+    it('does not report a feature as removed when the override replaces it with a value', () => {
+      applyAclFeatureOverrides({ 'sales.documents.number.edit': { id: 'sales.documents.number.edit' } })
+
+      expect(isAclFeatureRemoved('sales.documents.number.edit')).toBe(false)
+      expect(getRemovedAclFeatureIds().size).toBe(0)
+    })
+
+    it('drops explicit grants for removed features while keeping module wildcards', () => {
+      mockGetModules.mockReturnValue([
+        {
+          id: 'sales',
+          features: [{ id: 'sales.documents.view', title: 'View documents' }],
+        } as Module,
+      ])
+      applyAclFeatureOverrides({ 'sales.documents.number.edit': null })
+
+      expect(
+        filterGrantsByEnabledModules(['sales.*', 'sales.documents.number.edit', 'sales.documents.view']),
+      ).toEqual(['sales.*', 'sales.documents.view'])
+    })
+
+    it('drops explicit grants for removed features even when the module registry is unavailable', () => {
+      mockGetModules.mockImplementation(() => {
+        throw new Error('registry not initialized')
+      })
+      applyAclFeatureOverrides({ 'sales.documents.number.edit': null })
+
+      expect(
+        filterGrantsByEnabledModules(['sales.documents.number.edit', 'sales.documents.view']),
+      ).toEqual(['sales.documents.view'])
+    })
   })
 })

--- a/packages/shared/src/security/enabledModulesRegistry.ts
+++ b/packages/shared/src/security/enabledModulesRegistry.ts
@@ -24,6 +24,7 @@
  */
 
 import { getModules } from '../lib/modules/registry'
+import { composeAclFeatureOverrides } from '../modules/overrides'
 import type { Module } from '../modules/registry'
 
 type FeatureRegistry = {
@@ -93,21 +94,54 @@ export function getEnabledModuleIds(): string[] {
   return registry ? [...registry.enabledModuleIds] : []
 }
 
+const EMPTY_REMOVED_FEATURES: ReadonlySet<string> = new Set()
+
+/**
+ * Feature ids removed from the ACL contract via a `null` override
+ * (`entry.overrides.acl.features` or `applyAclFeatureOverrides`).
+ *
+ * Removal is a deny-list, not just catalog cleanup. Nulling a feature reads
+ * as "this feature does not exist in this app", so enforcement must agree:
+ * wildcard grants (`sales.*`, `*`), stale explicit grants persisted in
+ * `role_acls`/`user_acls`, and super-admin access all stop satisfying a
+ * removed feature — mirroring how disabled modules are handled.
+ */
+export function getRemovedAclFeatureIds(): ReadonlySet<string> {
+  const overrides = composeAclFeatureOverrides()
+  const keys = Object.keys(overrides)
+  if (!keys.length) return EMPTY_REMOVED_FEATURES
+  const removed = new Set<string>()
+  for (const key of keys) {
+    if (overrides[key] === null) removed.add(key)
+  }
+  return removed.size ? removed : EMPTY_REMOVED_FEATURES
+}
+
+export function isAclFeatureRemoved(featureId: string): boolean {
+  return getRemovedAclFeatureIds().has(featureId)
+}
+
 /**
  * Filters a raw granted-features list down to the grants whose owning
  * module is currently enabled. Expands `*` (superadmin) into one wildcard
  * per enabled module so the result is still safe to feed into a pure
  * `matchFeature` check, plus one wildcard per off-convention feature
  * prefix (e.g. `analytics.*`) whose declared owning module is enabled.
- * If the module registry is not populated (tests, CLI), returns the input
- * unchanged — preserves legacy behavior.
+ * Explicit grants matching a feature removed via a `null` ACL override are
+ * always dropped (see `getRemovedAclFeatureIds`), even when the module
+ * registry is not populated (tests, CLI) — otherwise the input is returned
+ * unchanged in that case, preserving legacy behavior.
  */
 export function filterGrantsByEnabledModules(granted: readonly string[]): string[] {
+  const removed = getRemovedAclFeatureIds()
   const registry = getRegistry()
-  if (!registry) return [...granted]
+  if (!registry) {
+    return removed.size ? granted.filter((grant) => !removed.has(grant)) : [...granted]
+  }
   const { enabledModuleIds, enabledModuleSet, prefixToModule } = registry
   const result: string[] = []
   for (const grant of granted) {
+    if (removed.has(grant)) continue
     if (grant === '*') {
       for (const id of enabledModuleIds) result.push(`${id}.*`)
       for (const [prefix, owningModule] of prefixToModule) {


### PR DESCRIPTION
## Problem

`entry.overrides.acl.features: { '<feature-id>': null }` (and programmatic `applyAclFeatureOverrides`) reads like "this feature does not exist in this app" — but it only removed the feature from **catalog surfaces** (role-management UI checkboxes, `setup.ts`/`sync-role-acls` seeding, docs). Runtime enforcement never consulted the registry for feature existence:

1. `hasAllFeatures(granted, required)` is a pure string match; a removed feature id hardcoded at a call site (e.g. `sales.documents.number.edit`) was still satisfied by a wildcard grant such as `sales.*`.
2. Grants come from the DB (`role_acls.features_json`), not the registry. `filterGrantsByEnabledModules()` filters at module granularity, and `getOwningModuleId()` falls back to the id prefix for registry-unknown ids — so wildcard grants **and** stale explicit grants for a removed feature both survived.
3. The super-admin branch of `userHasAllFeatures` passes when the required feature's owning module is enabled — the prefix fallback resolved a removed feature to its (enabled) module, so super admins sailed through too.

Net effect: nulling a feature denied nothing at runtime.

## Fix

Treat null'd feature ids as a **deny-list at enforcement time**, mirroring the existing disabled-modules handling (which already denies super admins):

- `@open-mercato/shared/security/enabledModulesRegistry`
  - New `getRemovedAclFeatureIds()` / `isAclFeatureRemoved()` composed from `null` ACL overrides (modules-tier + programmatic; a non-null replacement override is **not** removed).
  - `filterGrantsByEnabledModules()` drops explicit grants matching a removed id, including when the module registry is unavailable (tests/CLI).
- `RbacService` (core auth)
  - `userHasAllFeatures()` denies when any required feature is removed — checked **before** the super-admin branch.
  - `tenantHasFeature()` denies a removed feature.
  - `getGrantedFeatures()` filters explicit removed ids out of the returned grants.

Spec: `.ai/specs/2026-07-22-nulled-acl-feature-deny-list.md` — includes the known limitation (pure grant-side matching surfaces like client-side `hasFeature` against chrome grants can still show affordances under a wildcard grant; server-side enforcement is authoritative and fails closed) and the follow-up to extend the deny-list to portal `CustomerRbacService`.

## Migration & Backward Compatibility

- Additive exports only; no contract surface removed or renamed.
- Intended fail-closed behavior change: apps that nulled a feature merely to hide the role-UI checkbox while still relying on wildcard grants must switch the `null` override to a replacement entry (e.g. `{ id: '<feature-id>' }`).
- Stale explicit grants persisted in `role_acls`/`user_acls` become inert; no DB migration.

## Validation

Runner: local

- `yarn workspace @open-mercato/shared test` — 136 suites / 1484 tests pass (includes 4 new deny-list tests)
- `yarn workspace @open-mercato/core test` — 7679 tests pass (includes 5 new RbacService deny-list tests; 11 suites need `yarn generate` artifacts in a fresh checkout, green after)
- `yarn typecheck` — pass
- `eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
