### PR TITLE
fix(shared,webhooks): stop pg idle-client error crashing daemons; fix webhook worker payload

### DIFF
--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -152,6 +152,18 @@ export async function getOrm() {
       options: connectionOptions,
       ssl: sslConfig,
       onPoolCreated: (pool: any) => {
+        // node-postgres re-emits errors from IDLE pooled clients on the pool's
+        // 'error' event. Postgres terminates idle sessions on its own (admin
+        // termination, network drop, and — most relevantly for long-running
+        // daemons like the scheduler — `idle_in_transaction_session_timeout`,
+        // which defaults to 120s above). Without a listener here, such a
+        // termination surfaces as an unhandled 'error' event and crashes the
+        // whole process (e.g. "Scheduler polling engine exited unexpectedly
+        // with exit code 1"). Swallow it: the pool discards the dead client and
+        // opens a fresh connection on the next acquire.
+        pool.on('error', (err: unknown) => {
+          logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
+        })
         if (process.env.OM_DB_POOL_DEBUG === '1' || process.env.OM_INTEGRATION_TEST === 'true') {
           logger.info('pg pool created with options', {
             max: pool.options?.max,

--- a/packages/webhooks/src/modules/webhooks/workers/__tests__/webhook-delivery.test.ts
+++ b/packages/webhooks/src/modules/webhooks/workers/__tests__/webhook-delivery.test.ts
@@ -27,7 +27,7 @@ describe('webhooks delivery worker', () => {
     const em = { fork: jest.fn().mockReturnThis() } as unknown as EntityManager
     mockProcessWebhookDeliveryJob.mockResolvedValue(null)
 
-    await handler({ data: jobData }, makeCtx(em))
+    await handler({ payload: jobData }, makeCtx(em))
 
     expect(mockProcessWebhookDeliveryJob).toHaveBeenCalledWith(em, jobData)
   })
@@ -37,6 +37,6 @@ describe('webhooks delivery worker', () => {
     const cause = new Error('DB connection lost')
     mockProcessWebhookDeliveryJob.mockRejectedValue(cause)
 
-    await expect(handler({ data: jobData }, makeCtx(em))).rejects.toThrow('DB connection lost')
+    await expect(handler({ payload: jobData }, makeCtx(em))).rejects.toThrow('DB connection lost')
   })
 })

--- a/packages/webhooks/src/modules/webhooks/workers/webhook-delivery.ts
+++ b/packages/webhooks/src/modules/webhooks/workers/webhook-delivery.ts
@@ -11,16 +11,16 @@ export const metadata = {
 }
 
 export default async function handler(
-  job: { data: WebhookDeliveryJob },
+  job: { payload: WebhookDeliveryJob },
   ctx: { resolve: <T = unknown>(name: string) => T },
 ) {
   const em = (ctx.resolve('em') as EntityManager).fork()
   try {
-    await processWebhookDeliveryJob(em, job.data)
+    await processWebhookDeliveryJob(em, job.payload)
   } catch (error) {
     logger.error('Job processing failed', {
-      deliveryId: job.data.deliveryId,
-      tenantId: job.data.tenantId,
+      deliveryId: job.payload?.deliveryId,
+      tenantId: job.payload?.tenantId,
       err: error,
     })
     throw error


### PR DESCRIPTION
## Summary

Two independent reliability fixes, both surfaced by a single scheduler crash log (process exit 1 + webhook deliveries dead-lettering).

### 1. `shared/db` — pg idle-client error crashed long-running daemons
The MikroORM `pg.Pool` created in `getOrm()` never registered a `pool.on('error')` listener. node-postgres re-emits errors from **idle pooled clients** on the pool's `error` event. When Postgres reaps an idle-in-transaction connection — the default `idle_in_transaction_session_timeout` is `120_000` ms, FATAL `25P03` — the unhandled `'error'` event crashed the **entire process**:

```
throw er; // Unhandled 'error' event
error: terminating connection due to idle-in-transaction timeout
...
💥 Failed: [server] Scheduler polling engine exited unexpectedly with exit code 1.
```

**Fix:** attach a swallowing `pool.on('error')` handler in the existing `onPoolCreated` hook (which MikroORM v7's `PostgreSqlConnection` invokes with the real `pg.Pool`). The pool discards the dead client and reconnects on next acquire. Protects **web, worker, and scheduler** processes — not just the scheduler.

### 2. `webhooks` — delivery worker read the wrong job field
`workers/webhook-delivery.ts` read `job.data`, but the queue worker contract passes `QueuedJob<T>` with a `.payload` field (confirmed in `packages/queue/src/types.ts` + both strategies; the sibling notifications worker and this package's own local inline processor already use `.payload`). So `job.data` was always `undefined`:

- `processWebhookDeliveryJob(em, undefined)` threw, then
- the `catch` block's `job.data.deliveryId` threw again → `Cannot read properties of undefined (reading 'deliveryId')`, masking the real error and **dead-lettering every delivery** after 3 attempts.

**Fix:** use `job.payload` (with optional chaining in the catch). Corrected the unit test that had encoded the wrong `{ data }` shape and was hiding the bug.

## Scope verification
Repo-wide sweep of all workers / `queue.process` handlers confirms `webhook-delivery.ts` was the **only** worker reading the nonexistent `job.data`.

## Testing
Runner: local.
- `shared/src/lib/db` — 22/22 pass
- `webhooks` — 104/104 tests pass (worker log now correctly emits `deliveryId`/`tenantId`)

> Two `webhooks` API suites fail to *load* only due to a pre-existing `re2js` dependency-resolution gap in the isolated worktree (unrelated to this change; passes in a normal installed checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
