### PR TITLE
fix(shared,webhooks): stop pg idle-client error crashing daemons; fix webhook worker payload (develop)

### DIFF
--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -152,6 +152,18 @@ export async function getOrm() {
       options: connectionOptions,
       ssl: sslConfig,
       onPoolCreated: (pool: any) => {
+        // node-postgres re-emits errors from IDLE pooled clients on the pool's
+        // 'error' event. Postgres terminates idle sessions on its own (admin
+        // termination, network drop, and — most relevantly for long-running
+        // daemons like the scheduler — `idle_in_transaction_session_timeout`,
+        // which defaults to 120s above). Without a listener here, such a
+        // termination surfaces as an unhandled 'error' event and crashes the
+        // whole process (e.g. "Scheduler polling engine exited unexpectedly
+        // with exit code 1"). Swallow it: the pool discards the dead client and
+        // opens a fresh connection on the next acquire.
+        pool.on('error', (err: unknown) => {
+          logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
+        })
         if (process.env.OM_DB_POOL_DEBUG === '1' || process.env.OM_INTEGRATION_TEST === 'true') {
           logger.info('pg pool created with options', {
             max: pool.options?.max,

--- a/packages/webhooks/src/modules/webhooks/workers/__tests__/webhook-delivery.test.ts
+++ b/packages/webhooks/src/modules/webhooks/workers/__tests__/webhook-delivery.test.ts
@@ -27,7 +27,7 @@ describe('webhooks delivery worker', () => {
     const em = { fork: jest.fn().mockReturnThis() } as unknown as EntityManager
     mockProcessWebhookDeliveryJob.mockResolvedValue(null)
 
-    await handler({ data: jobData }, makeCtx(em))
+    await handler({ payload: jobData }, makeCtx(em))
 
     expect(mockProcessWebhookDeliveryJob).toHaveBeenCalledWith(em, jobData)
   })
@@ -37,6 +37,6 @@ describe('webhooks delivery worker', () => {
     const cause = new Error('DB connection lost')
     mockProcessWebhookDeliveryJob.mockRejectedValue(cause)
 
-    await expect(handler({ data: jobData }, makeCtx(em))).rejects.toThrow('DB connection lost')
+    await expect(handler({ payload: jobData }, makeCtx(em))).rejects.toThrow('DB connection lost')
   })
 })

--- a/packages/webhooks/src/modules/webhooks/workers/webhook-delivery.ts
+++ b/packages/webhooks/src/modules/webhooks/workers/webhook-delivery.ts
@@ -11,16 +11,16 @@ export const metadata = {
 }
 
 export default async function handler(
-  job: { data: WebhookDeliveryJob },
+  job: { payload: WebhookDeliveryJob },
   ctx: { resolve: <T = unknown>(name: string) => T },
 ) {
   const em = (ctx.resolve('em') as EntityManager).fork()
   try {
-    await processWebhookDeliveryJob(em, job.data)
+    await processWebhookDeliveryJob(em, job.payload)
   } catch (error) {
     logger.error('Job processing failed', {
-      deliveryId: job.data.deliveryId,
-      tenantId: job.data.tenantId,
+      deliveryId: job.payload?.deliveryId,
+      tenantId: job.payload?.tenantId,
       err: error,
     })
     throw error


### PR DESCRIPTION
## Summary

Ports the two reliability fixes from #4359 (against `main`) onto `develop`, where both bugs are still present.

### 1. `shared/db` — pg idle-client error crashed long-running daemons
The MikroORM `pg.Pool` never registered a `pool.on('error')` listener. node-postgres re-emits errors from idle pooled clients on the pool's `error` event; when Postgres reaps an idle-in-transaction connection (default `idle_in_transaction_session_timeout=120s`, FATAL `25P03`) the unhandled `'error'` event crashed the whole process (`Scheduler polling engine exited unexpectedly with exit code 1`). Fix attaches a swallowing handler in the existing `onPoolCreated` hook. Protects web, worker, and scheduler processes.

### 2. `webhooks` — delivery worker read the wrong job field
`workers/webhook-delivery.ts` read `job.data`, but the queue worker contract passes `QueuedJob<T>` with `.payload`. `job.data` was always `undefined`, so the worker threw and the catch's `job.data.deliveryId` threw again (`Cannot read properties of undefined (reading 'deliveryId')`), dead-lettering every delivery. Fix uses `job.payload` (+ optional chaining) and corrects the test that had encoded the wrong `{ data }` shape.

## Testing
Verified on the `main`-based branch: `shared/db` 22/22 and `webhooks` 104/104 tests pass. This branch is a clean cherry-pick (identical file changes).

Companion PR against `main`: #4359

🤖 Generated with [Claude Code](https://claude.com/claude-code)
