### PR TITLE
fix(scheduler,shared): stop idle-in-transaction reaps crashing the scheduler daemon

### DIFF
--- a/.ai/runs/2026-08-04-pr-4364-review-followups.md
+++ b/.ai/runs/2026-08-04-pr-4364-review-followups.md
@@ -1,0 +1,67 @@
+# PR #4364 — review follow-ups (om-auto-fix-pr)
+
+**Subject PR:** open-mercato/open-mercato#4364 — `fix(scheduler,shared): stop idle-in-transaction reaps crashing the scheduler daemon`
+**Driver:** `om-auto-fix-pr 4364`
+**Follow-up issue:** #4934 (lease-based claim)
+
+## 🎯 Goal
+
+Drive #4364 to merge-ready by resolving the two `changes-requested` reviews on it
+(@wojciechszyjka 2026-07-26, @patzick 2026-08-03) without touching the crash fix
+itself. The PR author's branch lives in the upstream repository and this account
+has read-only access to it, so the work is delivered as a small PR **targeting
+that branch** instead of pushed onto it.
+
+## 📋 Progress
+
+- [x] Claim #4364 (comment only — assignee and `in-progress` label return HTTP 403 for a read-only account)
+- [x] Merge the current `main` into the PR head so review and validation judge the real merge result
+- [x] Major finding — restore an honest guarantee: startup warning + documentation for the lost cross-process exclusion
+- [x] Minor finding — class docstring and the three scheduler docs pages no longer claim advisory-lock single-instance safety
+- [x] Minor finding — `heldKeys` records the one-instance-per-process invariant it relies on
+- [x] Nit — client-level pg error message made state-neutral (an idle reap logs through both handlers)
+- [x] Nit — the never-removed client-level listener documented as a deliberate last-resort sink
+- [x] Test gaps — startup warning, different keys do not block each other, key released when the claim transaction itself rejects
+- [x] Validation gate (local runner): all eight configured commands green
+- [x] Follow-up issue for the deferred lease implementation (#4934)
+- [x] Open the delivery PR against `dokploy-runtime-error-fix`
+- [ ] Author merges the delivery PR; #4364 re-reviewed and labels normalized by a maintainer
+
+## Decisions
+
+**Major finding — option 2, not option 1.** @patzick offered two resolutions: a
+lease-based claim that advances `next_run_at` inside the claim transaction
+(behavior-preserving, restores real cross-process exclusion), or a startup
+warning plus documentation with the lease tracked as a follow-up — explicitly
+stating "I would accept that as a resolution". This run took the second route
+because #4364 is a `priority-high` production hotfix for a crash-loop: changing
+when the scheduler advances `next_run_at` alters the claim/retry path of every
+schedule and deserves its own PR and its own review, not a rider on a hotfix.
+The deferred half is tracked in #4934 with the reviewer's exact proposal quoted.
+
+**Docs beyond the review's ask.** The review named
+`apps/docs/docs/framework/scheduler/overview.mdx`. Two further pages made the
+same now-false promise — `user-guide/scheduler.mdx` ("Uses PostgreSQL advisory
+locks for safety") and `cli/scheduler.mdx` ("Lock Strategy: PostgreSQL advisory
+locks") — so both were corrected in the same pass rather than left to contradict
+the code.
+
+**Delivery shape.** The base-first step was performed as a *validation* step
+only: `main` was merged into a scratch branch and the whole gate ran against that
+merged state, so the fixes are proven against the current base. The delivery PR
+itself is the two fix commits cherry-picked onto the untouched PR head, so its
+diff is nine files instead of the ~1100 a merge commit would have dragged in.
+Updating #4364 against `main` is one "Update branch" click for the author and
+does not need to ride along here. An earlier delivery PR that did carry the merge
+commit was closed for exactly this reason.
+
+## Validation
+
+Local runner (no compose `app` container running). Every command in
+`.ai/agentic.config.json` → `validation.commands`, in order, against the merged
+state: `yarn build:packages`, `yarn generate`, `yarn build:packages`,
+`yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`,
+`yarn build:app` — all green. `yarn test` ran 23/23 turbo tasks; the scheduler
+and shared suites relevant to this change are 37 and 12 tests respectively.
+`i18n:check-usage` reports 2 missing keys and 3819 unused keys as advisory
+pre-existing findings unrelated to this diff (it touches no locale files).

--- a/apps/docs/docs/cli/scheduler.mdx
+++ b/apps/docs/docs/cli/scheduler.mdx
@@ -223,7 +223,7 @@ Starting scheduler in LOCAL mode...
 
 Configuration:
 - Poll Interval: 30000ms
-- Lock Strategy: PostgreSQL advisory locks
+- Lock Strategy: in-process (single instance only)
 - Execution: Direct (queue/command)
 
 Database connected

--- a/apps/docs/docs/framework/scheduler/overview.mdx
+++ b/apps/docs/docs/framework/scheduler/overview.mdx
@@ -64,7 +64,8 @@ import {
 ```typescript
 class LocalSchedulerService {
   // Polls database every 30s (configurable via SCHEDULER_POLL_INTERVAL_MS)
-  // Uses PostgreSQL advisory locks for single-instance safety
+  // Prevents duplicate execution in-process; the PostgreSQL advisory lock
+  // only serialises the claim, not the run
   // Enqueues to target queues or executes commands directly
   async start(): Promise<void>
   async stop(): Promise<void>
@@ -80,6 +81,23 @@ class LocalSchedulerService {
 - ~30 second timing accuracy
 - Single instance only
 - No execution history UI
+
+:::warning Run exactly one process with `QUEUE_STRATEGY=local`
+
+The local strategy provides **no cross-process protection**. Duplicate prevention is
+in-process only: the PostgreSQL advisory lock is released as soon as the short claim
+transaction commits (holding it across the whole run would pin a connection
+idle-in-transaction and get it reaped), and `nextRunAt` is advanced only after the
+target has run. A second process polling the same database therefore sees the schedule
+as still due and executes it too — the same job is enqueued twice, or the same command
+runs twice.
+
+Two entry points start this engine: `mercato scheduler start` and
+`mercato worker --with-scheduler`. Running both, or overlapping containers during a
+rolling redeploy, double-fires every schedule due in that window. Use
+`QUEUE_STRATEGY=async` when more than one instance may run.
+
+:::
 
 #### Async Strategy (`QUEUE_STRATEGY=async`)
 

--- a/apps/docs/docs/user-guide/scheduler.mdx
+++ b/apps/docs/docs/user-guide/scheduler.mdx
@@ -105,7 +105,7 @@ The scheduler supports two execution strategies:
 **Environment:** `QUEUE_STRATEGY=local` (default)
 
 - Polls the database every 30 seconds for due schedules
-- Uses PostgreSQL advisory locks for safety
+- Prevents duplicate execution within the process only — run exactly one scheduler process, or a second one will execute the same due schedule
 - No Redis required
 - Best for development and single-instance deployments
 

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
@@ -87,5 +87,76 @@ describe('LocalLockStrategy', () => {
       await expect(strategy.runWithLock('test-key', fn)).rejects.toThrow(fnError)
       expect(fn).toHaveBeenCalledTimes(1)
     })
+
+    it('should run fn outside the claim transaction', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      let transactionOpen = false
+      transactionalImpl.mockImplementation(async (cb: any) => {
+        transactionOpen = true
+        const result = await cb(mockForkedEm)
+        transactionOpen = false
+        return result
+      })
+
+      let openDuringFn: boolean | null = null
+      const fn = jest.fn(async () => {
+        openDuringFn = transactionOpen
+        return 'ok'
+      })
+
+      const result = await strategy.runWithLock('test-key', fn)
+
+      expect(result).toEqual({ acquired: true, result: 'ok' })
+      expect(openDuringFn).toBe(false)
+    })
+
+    it('should reject a concurrent run for the same key without touching the database', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      let releaseFirst: () => void = () => {}
+      const firstDone = new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      })
+      const firstRun = strategy.runWithLock('test-key', async () => {
+        await firstDone
+        return 'first'
+      })
+      await Promise.resolve()
+
+      const secondFn = jest.fn(async () => 'second')
+      const secondRun = await strategy.runWithLock('test-key', secondFn)
+
+      expect(secondRun).toEqual({ acquired: false })
+      expect(secondFn).not.toHaveBeenCalled()
+      expect(mockConnection.execute).toHaveBeenCalledTimes(1)
+
+      releaseFirst()
+      await expect(firstRun).resolves.toEqual({ acquired: true, result: 'first' })
+    })
+
+    it('should release the key after fn completes or throws', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      await expect(
+        strategy.runWithLock('test-key', async () => {
+          throw new Error('Callback failed')
+        }),
+      ).rejects.toThrow('Callback failed')
+
+      const fn = jest.fn(async () => 'ok')
+      await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should release the key when the claim is not acquired', async () => {
+      ;(mockConnection.execute as any).mockResolvedValueOnce([{ acquired: false }])
+      ;(mockConnection.execute as any).mockResolvedValueOnce([{ acquired: true }])
+
+      await expect(strategy.runWithLock('test-key', async () => 'ok')).resolves.toEqual({ acquired: false })
+
+      const fn = jest.fn(async () => 'ok')
+      await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
+    })
   })
 })

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
@@ -158,5 +158,40 @@ describe('LocalLockStrategy', () => {
       const fn = jest.fn(async () => 'ok')
       await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
     })
+
+    it('should release the key when the claim transaction itself rejects', async () => {
+      ;(mockConnection.execute as any).mockRejectedValueOnce(new Error('Database connection failed'))
+      ;(mockConnection.execute as any).mockResolvedValueOnce([{ acquired: true }])
+
+      await expect(strategy.runWithLock('test-key', async () => 'ok')).resolves.toEqual({ acquired: false })
+
+      const fn = jest.fn(async () => 'ok')
+      await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not let a held key block a different key', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      let releaseFirst: () => void = () => {}
+      const firstDone = new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      })
+      const firstRun = strategy.runWithLock('key-a', async () => {
+        await firstDone
+        return 'first'
+      })
+      await Promise.resolve()
+
+      const secondFn = jest.fn(async () => 'second')
+      await expect(strategy.runWithLock('key-b', secondFn)).resolves.toEqual({
+        acquired: true,
+        result: 'second',
+      })
+      expect(secondFn).toHaveBeenCalledTimes(1)
+
+      releaseFirst()
+      await expect(firstRun).resolves.toEqual({ acquired: true, result: 'first' })
+    })
   })
 })

--- a/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
@@ -7,41 +7,60 @@ const logger = createLogger('scheduler').child({ component: 'local' })
  * PostgreSQL advisory lock strategy for single-instance or local development
  */
 export class LocalLockStrategy {
+  private heldKeys = new Set<string>()
+
   constructor(private em: () => EntityManager) {}
 
   /**
-   * Execute a function under a PostgreSQL advisory lock.
+   * Execute a function under a mutual-exclusion lock.
    *
-   * IMPORTANT: Uses transaction-scoped advisory locks (`pg_try_advisory_xact_lock`)
-   * to avoid connection pool/session mismatch issues. The lock is automatically
-   * released when the transaction ends.
+   * In-process exclusion for the whole duration of `fn` comes from `heldKeys`
+   * (this strategy is single-instance by contract). The transaction-scoped
+   * advisory lock (`pg_try_advisory_xact_lock`) only guards the claim itself
+   * against a concurrently claiming process and is released when the short
+   * claim transaction commits, BEFORE `fn` runs.
+   *
+   * IMPORTANT: `fn` must NOT run inside that transaction. Holding the
+   * transaction open across `fn` leaves the connection idle-in-transaction
+   * while `fn` awaits non-DB work; the pool's default
+   * `idle_in_transaction_session_timeout` (120s) then makes Postgres kill the
+   * connection (FATAL 25P03), which crashes the scheduler process.
    */
   async runWithLock<T>(key: string, fn: () => Promise<T>): Promise<{ acquired: boolean; result?: T }> {
-    const em = this.em().fork()
-    const hash = this.hashString(key)
-    let lockAcquired = false
+    if (this.heldKeys.has(key)) {
+      return { acquired: false }
+    }
+    // Reserve synchronously before the async claim so a concurrent in-process
+    // caller cannot slip in between our claim transaction committing (which
+    // releases the advisory xact lock) and the start of `fn`.
+    this.heldKeys.add(key)
 
     try {
-      return await em.transactional(async (txEm) => {
-        const result = await txEm.getConnection().execute<{ acquired: boolean }[]>(
-          `SELECT pg_try_advisory_xact_lock(?) as acquired`,
-          [hash],
-        )
+      const em = this.em().fork()
+      const hash = this.hashString(key)
+      let claimed = false
 
-        const acquired = result[0]?.acquired === true
-        if (!acquired) return { acquired: false }
-        lockAcquired = true
-
-        const fnResult = await fn()
-        return { acquired: true, result: fnResult }
-      })
-    } catch (error) {
-      if (lockAcquired) {
-        throw error
+      try {
+        claimed = await em.transactional(async (txEm) => {
+          const result = await txEm.getConnection().execute<{ acquired: boolean }[]>(
+            `SELECT pg_try_advisory_xact_lock(?) as acquired`,
+            [hash],
+          )
+          return result[0]?.acquired === true
+        })
+      } catch (error) {
+        logger.error('Failed to acquire lock', { lockKey: key, err: error })
+        return { acquired: false }
       }
 
-      logger.error('Failed to acquire lock', { lockKey: key, err: error })
-      return { acquired: false }
+      if (!claimed) {
+        return { acquired: false }
+      }
+
+      const fnResult = await fn()
+      return { acquired: true, result: fnResult }
+    } finally {
+      this.heldKeys.delete(key)
     }
   }
 

--- a/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
@@ -4,9 +4,24 @@ import { createLogger } from '@open-mercato/shared/lib/logger'
 const logger = createLogger('scheduler').child({ component: 'local' })
 
 /**
- * PostgreSQL advisory lock strategy for single-instance or local development
+ * Mutual-exclusion strategy for single-instance or local development.
+ *
+ * Exclusion for the duration of the guarded run is IN-PROCESS (`heldKeys`).
+ * The PostgreSQL advisory lock only serialises concurrent *claims* — it is
+ * transaction-scoped and released as soon as the short claim transaction
+ * commits, before the guarded function runs. It therefore does NOT protect
+ * against two processes executing the same key concurrently; that matches the
+ * documented single-instance contract of the local scheduler strategy, and
+ * `LocalSchedulerService.start()` warns about it at startup.
  */
 export class LocalLockStrategy {
+  // Process-local by construction, so it only guards a single strategy
+  // instance. Invariant relied upon: exactly one LocalLockStrategy exists per
+  // process, because the only construction site is LocalSchedulerService
+  // (an Awilix singleton) and only the CLI entry points start the polling
+  // engine. A caller that resolves a second container would silently get an
+  // independent guard — see the single-instance warning in
+  // LocalSchedulerService.start().
   private heldKeys = new Set<string>()
 
   constructor(private em: () => EntityManager) {}

--- a/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
+++ b/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
@@ -113,6 +113,16 @@ describe('LocalSchedulerService', () => {
       expect(loggerInfo).toHaveBeenCalledWith('Polling engine started')
     })
 
+    it('should warn that the local strategy has no cross-process protection', async () => {
+      mockForkedEm.find.mockResolvedValue([])
+
+      await service.start()
+
+      expect(loggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('no cross-process protection'),
+      )
+    })
+
     it('should run initial poll immediately', async () => {
       mockForkedEm.find.mockResolvedValue([])
 

--- a/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
@@ -28,14 +28,19 @@ export interface LocalSchedulerConfig {
  * 
  * Features:
  * - PostgreSQL polling (configurable interval, default 30s)
- * - PostgreSQL advisory locks for duplicate prevention
+ * - In-process duplicate prevention across overlapping poll ticks
  * - Supports both queue and command targets
  * - Emits the same events as async strategy
  * - Updates nextRunAt after execution
- * 
+ *
  * Limitations:
  * - Polling delay (up to configured interval)
- * - Single instance only (no distributed locking across instances)
+ * - Single instance only (no distributed locking across instances). Duplicate
+ *   prevention is in-process only: the advisory lock serialises the claim, not
+ *   the execution, and nextRunAt is advanced only after the target has run, so
+ *   two processes polling the same database will both execute a due schedule.
+ *   Run exactly one process with QUEUE_STRATEGY=local, or use the async
+ *   strategy, which locks across instances.
  * - Higher database load than async strategy
  * 
  * Set QUEUE_STRATEGY=local to use this service.
@@ -65,6 +70,9 @@ export class LocalSchedulerService {
 
     this.isRunning = true
     logger.info('Starting polling engine', { pollIntervalMs: this.config.pollIntervalMs })
+    logger.warn(
+      'Local scheduler strategy provides no cross-process protection: duplicate prevention is in-process only, so a second process polling the same database will execute the same due schedule. Run exactly one process with QUEUE_STRATEGY=local, or use the async strategy for distributed locking.',
+    )
 
     // Run initial poll immediately
     await this.poll()

--- a/packages/shared/src/lib/db/__tests__/mikro.test.ts
+++ b/packages/shared/src/lib/db/__tests__/mikro.test.ts
@@ -24,6 +24,31 @@ describe('ORM entity registry', () => {
   })
 })
 
+describe('attachPoolErrorHandlers', () => {
+  it('swallows errors from idle pooled clients (pool-level emit)', async () => {
+    const { EventEmitter } = await import('node:events')
+    const { attachPoolErrorHandlers } = await import('../mikro')
+    const pool = new EventEmitter()
+
+    attachPoolErrorHandlers(pool as any)
+
+    expect(() => pool.emit('error', new Error('terminating connection due to idle-in-transaction timeout'))).not.toThrow()
+  })
+
+  it('swallows errors from checked-out clients (client-level emit)', async () => {
+    const { EventEmitter } = await import('node:events')
+    const { attachPoolErrorHandlers } = await import('../mikro')
+    const pool = new EventEmitter()
+    const client = new EventEmitter()
+
+    attachPoolErrorHandlers(pool as any)
+    pool.emit('connect', client)
+
+    expect(client.listenerCount('error')).toBe(1)
+    expect(() => client.emit('error', new Error('terminating connection due to idle-in-transaction timeout'))).not.toThrow()
+  })
+})
+
 describe('resolvePoolConfig', () => {
   const baseEnv = (extra: Record<string, string | undefined> = {}): NodeJS.ProcessEnv =>
     ({ ...extra }) as NodeJS.ProcessEnv

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -79,6 +79,35 @@ export function resolvePoolConfig(env: NodeJS.ProcessEnv = process.env): Resolve
   }
 }
 
+type PoolLike = {
+  on(event: 'error', listener: (err: unknown) => void): unknown
+  on(event: 'connect', listener: (client: { on(event: 'error', listener: (err: unknown) => void): unknown }) => void): unknown
+  options?: Record<string, unknown>
+}
+
+// Postgres can terminate a connection at any moment (admin termination, network
+// drop, and — most relevantly for long-running daemons — the
+// `idle_in_transaction_session_timeout` configured above, FATAL 25P03). Where
+// node-postgres surfaces that depends on the client's state:
+// - IDLE (checked into the pool): pg-pool re-emits on the pool's 'error' event.
+// - CHECKED OUT (e.g. a connection pinned by an open transaction while the app
+//   awaits non-DB work): pg-pool removes its idle listener, so the FATAL emits
+//   on the Client itself.
+// Either way an unlistened 'error' event crashes the whole process ("Scheduler
+// polling engine exited unexpectedly with exit code 1"). Swallow both: the pool
+// discards the dead client, and any in-flight transaction still fails normally
+// on its next query/commit against the dead connection.
+export function attachPoolErrorHandlers(pool: PoolLike): void {
+  pool.on('error', (err: unknown) => {
+    logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
+  })
+  pool.on('connect', (client) => {
+    client.on('error', (err: unknown) => {
+      logger.warn('Checked-out pg client error (connection reaped/terminated)', { err })
+    })
+  })
+}
+
 export async function getOrm() {
   if (ormInstance) {
     return ormInstance
@@ -151,19 +180,8 @@ export async function getOrm() {
       lock_timeout: lockTimeoutMs,
       options: connectionOptions,
       ssl: sslConfig,
-      onPoolCreated: (pool: any) => {
-        // node-postgres re-emits errors from IDLE pooled clients on the pool's
-        // 'error' event. Postgres terminates idle sessions on its own (admin
-        // termination, network drop, and — most relevantly for long-running
-        // daemons like the scheduler — `idle_in_transaction_session_timeout`,
-        // which defaults to 120s above). Without a listener here, such a
-        // termination surfaces as an unhandled 'error' event and crashes the
-        // whole process (e.g. "Scheduler polling engine exited unexpectedly
-        // with exit code 1"). Swallow it: the pool discards the dead client and
-        // opens a fresh connection on the next acquire.
-        pool.on('error', (err: unknown) => {
-          logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
-        })
+      onPoolCreated: (pool: PoolLike) => {
+        attachPoolErrorHandlers(pool)
         if (process.env.OM_DB_POOL_DEBUG === '1' || process.env.OM_INTEGRATION_TEST === 'true') {
           logger.info('pg pool created with options', {
             max: pool.options?.max,

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -97,13 +97,20 @@ type PoolLike = {
 // polling engine exited unexpectedly with exit code 1"). Swallow both: the pool
 // discards the dead client, and any in-flight transaction still fails normally
 // on its next query/commit against the dead connection.
+// The per-client listener is deliberately attached once on 'connect' and never
+// removed: it is a last-resort sink whose only job is to guarantee the 'error'
+// event always has a listener, in every client state. It is not error handling
+// and must not be "cleaned up" — removing it reintroduces the process crash.
+// A reaped IDLE client therefore logs twice (once here, once via the pool-level
+// handler that pg-pool's own idle listener re-emits); the pool-level line is the
+// one that identifies the client as idle.
 export function attachPoolErrorHandlers(pool: PoolLike): void {
   pool.on('error', (err: unknown) => {
     logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
   })
   pool.on('connect', (client) => {
     client.on('error', (err: unknown) => {
-      logger.warn('Checked-out pg client error (connection reaped/terminated)', { err })
+      logger.warn('pg client error (connection reaped/terminated)', { err })
     })
   })
 }


### PR DESCRIPTION
## Problem

Open Mercato deployments on Dokploy crash-loop after some time with:

```
error: terminating connection due to idle-in-transaction timeout   (FATAL 25P03)
Emitted 'error' event on Client instance ...
💥 Failed: [server] Scheduler polling engine exited unexpectedly with exit code 1.
```

Each restart re-finds the due-schedule backlog (100 in the reported log), executes, and crashes again.

## Root cause

1. `LocalLockStrategy.runWithLock` wrapped the **entire schedule execution** in `em.transactional()` just to hold `pg_try_advisory_xact_lock`. While the execution ran (inline event subscribers, RBAC feature check, enqueue), the transaction's connection sat **idle in transaction**.
2. `resolvePoolConfig` deliberately sets `idle_in_transaction_session_timeout=120s` on every connection (production included), so any execution slower than 120s got its connection reaped. The reported log matches exactly: "Executing schedule" at 05:42:25.88, crash 120s later.
3. The reaped client was **checked out** (pinned by the open transaction). pg-pool only routes errors from *idle-in-pool* clients to `pool.on('error')` (the #4359 fix); a checked-out client emits on the `Client` itself → unhandled `'error'` event → process exit. So #4359 could not prevent this crash.

## Fix

- **`packages/scheduler/.../localLockStrategy.ts`** (root cause): the advisory-lock transaction is now a short *claim* only — take the lock, commit, release the connection — and the schedule runs **outside** any transaction. In-process exclusion for the run's duration comes from a held-keys set reserved synchronously before the claim (this strategy is single-instance by contract), so overlapping poll ticks cannot double-execute.
- **`packages/shared/src/lib/db/mikro.ts`** (defense in depth): extracted a testable `attachPoolErrorHandlers(pool)` that keeps the pool-level handler and adds `pool.on('connect', client => client.on('error', …))`, so a reaped **checked-out** connection anywhere (web, worker, scheduler) logs a warning instead of killing the process. The in-flight operation still fails normally on its next query/commit.

## Verification

Unit: new tests cover fn-outside-transaction ordering, in-process concurrent-key rejection, key release on success/throw/unclaimed, and pool/client-level error swallowing. Scheduler 331 tests / shared 1450 tests pass; both packages typecheck; eslint clean. Runner: local.

End-to-end against a real Postgres, driving `mercato scheduler start` with `DB_IDLE_IN_TRANSACTION_TIMEOUT_MS=1` (guarantees the production race on every schedule):

- **Pre-fix build**: crashed in <200ms with the byte-for-byte production signature (`25P03`, `Emitted 'error' event on Client instance`, exit 1) — with the #4359 pool handler present.
- **Fixed build, same 1ms reap window**: survived 4+ poll cycles; reaps surfaced as `WARN [shared:orm] Checked-out pg client error`, failed claims degraded to "Failed to acquire lock → skipping" and retried next poll.
- **Fixed build, default timeouts**: schedules execute cleanly (`Executing → Enqueued → Schedule completed`); `pg_stat_activity` shows the daemon's connection `idle` with **no open transaction** during execution.
- **Probe**: `pg_terminate_backend` on all the daemon's backends mid-run → warning logged, next polls proceed on a fresh connection, no crash.

## Migration & backward compatibility

No contract-surface changes. `attachPoolErrorHandlers` is a new additive export; `runWithLock`'s signature and result shape are unchanged. Cross-process claim exclusion is unchanged at claim time; holding the DB lock for the run's duration is replaced by in-process exclusion, which matches the local strategy's documented single-instance contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)