### PR TITLE
fix(scheduler,shared): stop idle-in-transaction reaps crashing the scheduler daemon (develop)

### DIFF
--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
@@ -87,5 +87,76 @@ describe('LocalLockStrategy', () => {
       await expect(strategy.runWithLock('test-key', fn)).rejects.toThrow(fnError)
       expect(fn).toHaveBeenCalledTimes(1)
     })
+
+    it('should run fn outside the claim transaction', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      let transactionOpen = false
+      transactionalImpl.mockImplementation(async (cb: any) => {
+        transactionOpen = true
+        const result = await cb(mockForkedEm)
+        transactionOpen = false
+        return result
+      })
+
+      let openDuringFn: boolean | null = null
+      const fn = jest.fn(async () => {
+        openDuringFn = transactionOpen
+        return 'ok'
+      })
+
+      const result = await strategy.runWithLock('test-key', fn)
+
+      expect(result).toEqual({ acquired: true, result: 'ok' })
+      expect(openDuringFn).toBe(false)
+    })
+
+    it('should reject a concurrent run for the same key without touching the database', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      let releaseFirst: () => void = () => {}
+      const firstDone = new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      })
+      const firstRun = strategy.runWithLock('test-key', async () => {
+        await firstDone
+        return 'first'
+      })
+      await Promise.resolve()
+
+      const secondFn = jest.fn(async () => 'second')
+      const secondRun = await strategy.runWithLock('test-key', secondFn)
+
+      expect(secondRun).toEqual({ acquired: false })
+      expect(secondFn).not.toHaveBeenCalled()
+      expect(mockConnection.execute).toHaveBeenCalledTimes(1)
+
+      releaseFirst()
+      await expect(firstRun).resolves.toEqual({ acquired: true, result: 'first' })
+    })
+
+    it('should release the key after fn completes or throws', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      await expect(
+        strategy.runWithLock('test-key', async () => {
+          throw new Error('Callback failed')
+        }),
+      ).rejects.toThrow('Callback failed')
+
+      const fn = jest.fn(async () => 'ok')
+      await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should release the key when the claim is not acquired', async () => {
+      ;(mockConnection.execute as any).mockResolvedValueOnce([{ acquired: false }])
+      ;(mockConnection.execute as any).mockResolvedValueOnce([{ acquired: true }])
+
+      await expect(strategy.runWithLock('test-key', async () => 'ok')).resolves.toEqual({ acquired: false })
+
+      const fn = jest.fn(async () => 'ok')
+      await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
+    })
   })
 })

--- a/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
@@ -7,41 +7,60 @@ const logger = createLogger('scheduler').child({ component: 'local' })
  * PostgreSQL advisory lock strategy for single-instance or local development
  */
 export class LocalLockStrategy {
+  private heldKeys = new Set<string>()
+
   constructor(private em: () => EntityManager) {}
 
   /**
-   * Execute a function under a PostgreSQL advisory lock.
+   * Execute a function under a mutual-exclusion lock.
    *
-   * IMPORTANT: Uses transaction-scoped advisory locks (`pg_try_advisory_xact_lock`)
-   * to avoid connection pool/session mismatch issues. The lock is automatically
-   * released when the transaction ends.
+   * In-process exclusion for the whole duration of `fn` comes from `heldKeys`
+   * (this strategy is single-instance by contract). The transaction-scoped
+   * advisory lock (`pg_try_advisory_xact_lock`) only guards the claim itself
+   * against a concurrently claiming process and is released when the short
+   * claim transaction commits, BEFORE `fn` runs.
+   *
+   * IMPORTANT: `fn` must NOT run inside that transaction. Holding the
+   * transaction open across `fn` leaves the connection idle-in-transaction
+   * while `fn` awaits non-DB work; the pool's default
+   * `idle_in_transaction_session_timeout` (120s) then makes Postgres kill the
+   * connection (FATAL 25P03), which crashes the scheduler process.
    */
   async runWithLock<T>(key: string, fn: () => Promise<T>): Promise<{ acquired: boolean; result?: T }> {
-    const em = this.em().fork()
-    const hash = this.hashString(key)
-    let lockAcquired = false
+    if (this.heldKeys.has(key)) {
+      return { acquired: false }
+    }
+    // Reserve synchronously before the async claim so a concurrent in-process
+    // caller cannot slip in between our claim transaction committing (which
+    // releases the advisory xact lock) and the start of `fn`.
+    this.heldKeys.add(key)
 
     try {
-      return await em.transactional(async (txEm) => {
-        const result = await txEm.getConnection().execute<{ acquired: boolean }[]>(
-          `SELECT pg_try_advisory_xact_lock(?) as acquired`,
-          [hash],
-        )
+      const em = this.em().fork()
+      const hash = this.hashString(key)
+      let claimed = false
 
-        const acquired = result[0]?.acquired === true
-        if (!acquired) return { acquired: false }
-        lockAcquired = true
-
-        const fnResult = await fn()
-        return { acquired: true, result: fnResult }
-      })
-    } catch (error) {
-      if (lockAcquired) {
-        throw error
+      try {
+        claimed = await em.transactional(async (txEm) => {
+          const result = await txEm.getConnection().execute<{ acquired: boolean }[]>(
+            `SELECT pg_try_advisory_xact_lock(?) as acquired`,
+            [hash],
+          )
+          return result[0]?.acquired === true
+        })
+      } catch (error) {
+        logger.error('Failed to acquire lock', { lockKey: key, err: error })
+        return { acquired: false }
       }
 
-      logger.error('Failed to acquire lock', { lockKey: key, err: error })
-      return { acquired: false }
+      if (!claimed) {
+        return { acquired: false }
+      }
+
+      const fnResult = await fn()
+      return { acquired: true, result: fnResult }
+    } finally {
+      this.heldKeys.delete(key)
     }
   }
 

--- a/packages/shared/src/lib/db/__tests__/mikro.test.ts
+++ b/packages/shared/src/lib/db/__tests__/mikro.test.ts
@@ -24,6 +24,31 @@ describe('ORM entity registry', () => {
   })
 })
 
+describe('attachPoolErrorHandlers', () => {
+  it('swallows errors from idle pooled clients (pool-level emit)', async () => {
+    const { EventEmitter } = await import('node:events')
+    const { attachPoolErrorHandlers } = await import('../mikro')
+    const pool = new EventEmitter()
+
+    attachPoolErrorHandlers(pool as any)
+
+    expect(() => pool.emit('error', new Error('terminating connection due to idle-in-transaction timeout'))).not.toThrow()
+  })
+
+  it('swallows errors from checked-out clients (client-level emit)', async () => {
+    const { EventEmitter } = await import('node:events')
+    const { attachPoolErrorHandlers } = await import('../mikro')
+    const pool = new EventEmitter()
+    const client = new EventEmitter()
+
+    attachPoolErrorHandlers(pool as any)
+    pool.emit('connect', client)
+
+    expect(client.listenerCount('error')).toBe(1)
+    expect(() => client.emit('error', new Error('terminating connection due to idle-in-transaction timeout'))).not.toThrow()
+  })
+})
+
 describe('resolvePoolConfig', () => {
   const baseEnv = (extra: Record<string, string | undefined> = {}): NodeJS.ProcessEnv =>
     ({ ...extra }) as NodeJS.ProcessEnv

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -79,6 +79,35 @@ export function resolvePoolConfig(env: NodeJS.ProcessEnv = process.env): Resolve
   }
 }
 
+type PoolLike = {
+  on(event: 'error', listener: (err: unknown) => void): unknown
+  on(event: 'connect', listener: (client: { on(event: 'error', listener: (err: unknown) => void): unknown }) => void): unknown
+  options?: Record<string, unknown>
+}
+
+// Postgres can terminate a connection at any moment (admin termination, network
+// drop, and — most relevantly for long-running daemons — the
+// `idle_in_transaction_session_timeout` configured above, FATAL 25P03). Where
+// node-postgres surfaces that depends on the client's state:
+// - IDLE (checked into the pool): pg-pool re-emits on the pool's 'error' event.
+// - CHECKED OUT (e.g. a connection pinned by an open transaction while the app
+//   awaits non-DB work): pg-pool removes its idle listener, so the FATAL emits
+//   on the Client itself.
+// Either way an unlistened 'error' event crashes the whole process ("Scheduler
+// polling engine exited unexpectedly with exit code 1"). Swallow both: the pool
+// discards the dead client, and any in-flight transaction still fails normally
+// on its next query/commit against the dead connection.
+export function attachPoolErrorHandlers(pool: PoolLike): void {
+  pool.on('error', (err: unknown) => {
+    logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
+  })
+  pool.on('connect', (client) => {
+    client.on('error', (err: unknown) => {
+      logger.warn('Checked-out pg client error (connection reaped/terminated)', { err })
+    })
+  })
+}
+
 export async function getOrm() {
   if (ormInstance) {
     return ormInstance
@@ -151,19 +180,8 @@ export async function getOrm() {
       lock_timeout: lockTimeoutMs,
       options: connectionOptions,
       ssl: sslConfig,
-      onPoolCreated: (pool: any) => {
-        // node-postgres re-emits errors from IDLE pooled clients on the pool's
-        // 'error' event. Postgres terminates idle sessions on its own (admin
-        // termination, network drop, and — most relevantly for long-running
-        // daemons like the scheduler — `idle_in_transaction_session_timeout`,
-        // which defaults to 120s above). Without a listener here, such a
-        // termination surfaces as an unhandled 'error' event and crashes the
-        // whole process (e.g. "Scheduler polling engine exited unexpectedly
-        // with exit code 1"). Swallow it: the pool discards the dead client and
-        // opens a fresh connection on the next acquire.
-        pool.on('error', (err: unknown) => {
-          logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
-        })
+      onPoolCreated: (pool: PoolLike) => {
+        attachPoolErrorHandlers(pool)
         if (process.env.OM_DB_POOL_DEBUG === '1' || process.env.OM_INTEGRATION_TEST === 'true') {
           logger.info('pg pool created with options', {
             max: pool.options?.max,


### PR DESCRIPTION
Cherry-pick of #4364 onto `develop` (same commit, applied cleanly; targeted scheduler + shared/db test suites re-run green on this base).

## Problem

Open Mercato deployments on Dokploy crash-loop after some time with:

```
error: terminating connection due to idle-in-transaction timeout   (FATAL 25P03)
Emitted 'error' event on Client instance ...
💥 Failed: [server] Scheduler polling engine exited unexpectedly with exit code 1.
```

Each restart re-finds the due-schedule backlog (100 in the reported log), executes, and crashes again.

## Root cause

1. `LocalLockStrategy.runWithLock` wrapped the **entire schedule execution** in `em.transactional()` just to hold `pg_try_advisory_xact_lock`. While the execution ran (inline event subscribers, RBAC feature check, enqueue), the transaction's connection sat **idle in transaction**.
2. `resolvePoolConfig` deliberately sets `idle_in_transaction_session_timeout=120s` on every connection (production included), so any execution slower than 120s got its connection reaped.
3. The reaped client was **checked out** (pinned by the open transaction). pg-pool only routes errors from *idle-in-pool* clients to `pool.on('error')` (the #4359 fix); a checked-out client emits on the `Client` itself → unhandled `'error'` event → process exit.

## Fix

- **`packages/scheduler/.../localLockStrategy.ts`** (root cause): the advisory-lock transaction is now a short *claim* only — take the lock, commit, release the connection — and the schedule runs **outside** any transaction. In-process exclusion for the run's duration comes from a held-keys set reserved synchronously before the claim (single-instance by contract), so overlapping poll ticks cannot double-execute.
- **`packages/shared/src/lib/db/mikro.ts`** (defense in depth): extracted `attachPoolErrorHandlers(pool)` that keeps the pool-level handler and adds `pool.on('connect', client => client.on('error', …))`, so a reaped **checked-out** connection anywhere (web, worker, scheduler) logs a warning instead of killing the process.

## Verification

See #4364 for the full end-to-end evidence: pre-fix build reproduces the exact production crash under `DB_IDLE_IN_TRANSACTION_TIMEOUT_MS=1`; fixed build survives the same reaps, executes schedules cleanly at default timeouts, shows no idle-in-transaction session during execution, and survives `pg_terminate_backend` on all its backends. On this branch: scheduler lock/service suites (34 tests) and shared db suite (12 tests) pass. Runner: local.

## Migration & backward compatibility

No contract-surface changes. `attachPoolErrorHandlers` is a new additive export; `runWithLock`'s signature and result shape are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)