### PR TITLE
fix(core): handle "All organizations" scope across audited org-scoped endpoints

### DIFF
--- a/packages/core/src/modules/catalog/api/__tests__/categories.route.test.ts
+++ b/packages/core/src/modules/catalog/api/__tests__/categories.route.test.ts
@@ -1,0 +1,90 @@
+/** @jest-environment node */
+
+const mockEm = {
+  find: jest.fn(async () => []),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => (token === 'em' ? mockEm : null),
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn(async () => ({})),
+}))
+
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { GET } from '../categories/route'
+
+function request() {
+  return new Request('http://localhost/api/catalog/categories?view=manage')
+}
+
+describe('catalog categories list — organization scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.find.mockResolvedValue([])
+  })
+
+  it('scopes by tenant only (no org filter) under the "All organizations" scope', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: null,
+      isSuperAdmin: true,
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: 'tenant-1',
+    })
+
+    const response = await GET(request())
+
+    expect(response.status).toBe(200)
+    const where = mockEm.find.mock.calls[0][1]
+    expect(where).toMatchObject({ tenantId: 'tenant-1', deletedAt: null })
+    expect(where).not.toHaveProperty('organizationId')
+  })
+
+  it('narrows to the caller\'s visible organizations when restricted', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-a',
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: 'org-a',
+      filterIds: ['org-a'],
+      allowedIds: ['org-a'],
+      tenantId: 'tenant-1',
+    })
+
+    const response = await GET(request())
+
+    expect(response.status).toBe(200)
+    const where = mockEm.find.mock.calls[0][1]
+    expect(where).toMatchObject({
+      tenantId: 'tenant-1',
+      deletedAt: null,
+      organizationId: { $in: ['org-a'] },
+    })
+  })
+})

--- a/packages/core/src/modules/catalog/api/__tests__/tags.route.test.ts
+++ b/packages/core/src/modules/catalog/api/__tests__/tags.route.test.ts
@@ -1,0 +1,85 @@
+/** @jest-environment node */
+
+const mockEm = {
+  findAndCount: jest.fn(async () => [[], 0]),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => (token === 'em' ? mockEm : null),
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { GET } from '../tags/route'
+
+function request() {
+  return new Request('http://localhost/api/catalog/tags')
+}
+
+describe('catalog tags list — organization scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockEm.findAndCount.mockResolvedValue([[], 0])
+  })
+
+  it('scopes by tenant only (no org filter) under the "All organizations" scope', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: null,
+      isSuperAdmin: true,
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: 'tenant-1',
+    })
+
+    const response = await GET(request())
+
+    expect(response.status).toBe(200)
+    const where = mockEm.findAndCount.mock.calls[0][1]
+    expect(where).toEqual({ tenantId: 'tenant-1' })
+    expect(where).not.toHaveProperty('organizationId')
+  })
+
+  it('narrows to the caller\'s visible organizations when restricted', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-a',
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null,
+      filterIds: ['org-a', 'org-b'],
+      allowedIds: ['org-a', 'org-b'],
+      tenantId: 'tenant-1',
+    })
+
+    const response = await GET(request())
+
+    expect(response.status).toBe(200)
+    const where = mockEm.findAndCount.mock.calls[0][1]
+    expect(where).toMatchObject({
+      tenantId: 'tenant-1',
+      organizationId: { $in: ['org-a', 'org-b'] },
+    })
+  })
+})

--- a/packages/core/src/modules/catalog/api/categories/route.ts
+++ b/packages/core/src/modules/catalog/api/categories/route.ts
@@ -6,6 +6,7 @@ import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fields'
 import { E } from '#generated/entities.ids.generated'
@@ -100,7 +101,7 @@ type ManageCategoryRow = {
   descendantCount: number
   isActive: boolean
   updatedAt: string | null
-  organizationId: string
+  organizationId: string | null
   tenantId: string
 }
 
@@ -159,20 +160,17 @@ export async function GET(req: Request) {
     )
   }
 
-  const allowed = scope?.filterIds ?? scope?.allowedIds ?? (auth.orgId ? [auth.orgId] : null)
-  const preferredOrg = scope?.selectedId ?? auth.orgId ?? null
-  const organizationId = preferredOrg ?? (Array.isArray(allowed) && allowed.length ? allowed[0]! : null)
-
-  if (!organizationId || (Array.isArray(allowed) && allowed.length && !allowed.includes(organizationId))) {
-    return NextResponse.json(
-      { items: [], error: translate('catalog.errors.organization_required', 'Organization context is required.') },
-      { status: 400 }
-    )
-  }
+  // Scope by the caller's visible organizations. Under "All organizations"
+  // (super-admin) `where` is empty, so the tree scopes by tenant only instead
+  // of 400-ing; restricted callers get their `filterIds` `$in` guard.
+  const orgFilter = resolveOrganizationScopeFilter(scope, auth)
+  // Caller's resolved org echoed at the top level; null under "All organizations"
+  // where the tree spans orgs and each row carries its own org instead.
+  const responseOrganizationId = orgFilter.rbacOrganizationId ?? null
 
   const categories = await em.find(
     CatalogProductCategory,
-    { organizationId, tenantId, deletedAt: null },
+    { ...orgFilter.where, tenantId, deletedAt: null },
     { orderBy: { name: 'ASC' } }
   )
   const categoryMap = new Map(categories.map((cat) => [String(cat.id), cat]))
@@ -233,7 +231,7 @@ export async function GET(req: Request) {
   const organizationIdByRecord: Record<string, string | null> = {}
   for (const id of recordIds) {
     tenantIdByRecord[id] = tenantId
-    organizationIdByRecord[id] = organizationId
+    organizationIdByRecord[id] = categoryMap.get(id)?.organizationId ?? null
   }
   const cfValues = recordIds.length
     ? await loadCustomFieldValues({
@@ -264,7 +262,7 @@ export async function GET(req: Request) {
       descendantCount: node.descendantIds.length,
       isActive: node.isActive,
       updatedAt: category?.updatedAt ? new Date(category.updatedAt).toISOString() : null,
-      organizationId,
+      organizationId: category?.organizationId ?? null,
       tenantId,
       ...(cfValues[recordId] ?? {}),
     }
@@ -277,7 +275,7 @@ export async function GET(req: Request) {
     page,
     pageSize,
     totalPages,
-    organizationId,
+    organizationId: responseOrganizationId,
     tenantId,
   })
 }
@@ -300,7 +298,7 @@ const categoryListItemSchema = z.object({
   descendantCount: z.number(),
   isActive: z.boolean(),
   updatedAt: z.string().nullable().optional(),
-  organizationId: z.string().uuid(),
+  organizationId: z.string().uuid().nullable(),
   tenantId: z.string().uuid(),
 })
 

--- a/packages/core/src/modules/catalog/api/tags/route.ts
+++ b/packages/core/src/modules/catalog/api/tags/route.ts
@@ -4,6 +4,7 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CatalogProductTag } from '../../data/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -54,18 +55,13 @@ export async function GET(req: Request) {
     )
   }
 
-  const allowed = scope?.filterIds ?? scope?.allowedIds ?? (auth.orgId ? [auth.orgId] : null)
-  const preferredOrg = scope?.selectedId ?? auth.orgId ?? null
-  const organizationId = preferredOrg ?? (Array.isArray(allowed) && allowed.length ? allowed[0]! : null)
-  if (!organizationId || (Array.isArray(allowed) && allowed.length && !allowed.includes(organizationId))) {
-    return NextResponse.json(
-      { items: [], error: translate('catalog.errors.organization_required', 'Organization context is required.') },
-      { status: 400 }
-    )
-  }
+  // Scope by the caller's visible organizations. Under "All organizations"
+  // (super-admin) `where` is empty, so the list scopes by tenant only instead
+  // of 400-ing; restricted callers get their `filterIds` `$in` guard.
+  const orgFilter = resolveOrganizationScopeFilter(scope, auth)
 
   const where: Record<string, unknown> = {
-    organizationId,
+    ...orgFilter.where,
     tenantId,
   }
   const search = query.search?.trim()

--- a/packages/core/src/modules/customers/api/interactions/[id]/visibility/__tests__/route.authz.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/[id]/visibility/__tests__/route.authz.test.ts
@@ -20,6 +20,7 @@ import { PATCH } from '../route'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 
 const mockAuth = getAuthFromRequest as jest.MockedFunction<typeof getAuthFromRequest>
 const mockContainer = createRequestContainer as jest.MockedFunction<typeof createRequestContainer>
@@ -106,5 +107,24 @@ describe('PATCH visibility — authorization', () => {
 
     const res = await PATCH(mockRequest({ visibility: 'shared' }), routeCtx())
     expect(res.status).toBe(404)
+  })
+
+  it('under "All organizations" loads by tenant+id (no org filter) and attributes the write to the record\'s org', async () => {
+    mockAuth.mockResolvedValue({ sub: 'user-A', tenantId: TENANT_ID, orgId: null, isSuperAdmin: true } as never)
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValueOnce({ selectedId: null, filterIds: null })
+    setupContainer([])
+    mockFindOne.mockResolvedValue({ id: INTERACTION_ID, organizationId: 'org-9', authorUserId: 'user-A', visibility: 'private' } as never)
+
+    const res = await PATCH(mockRequest({ visibility: 'shared' }), routeCtx())
+
+    expect(res.status).toBe(200)
+    // Lookup is tenant-scoped, not filtered by a (null) selected org.
+    const where = mockFindOne.mock.calls[0][2] as Record<string, unknown>
+    expect(where).not.toHaveProperty('organizationId')
+    // The command is scoped to the interaction's real org, not the null selection.
+    expect(commandBus.execute).toHaveBeenCalledWith(
+      'customers.interactions.update',
+      expect.objectContaining({ ctx: expect.objectContaining({ selectedOrganizationId: 'org-9' }) }),
+    )
   })
 })

--- a/packages/core/src/modules/customers/api/interactions/[id]/visibility/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/[id]/visibility/route.ts
@@ -52,9 +52,40 @@ export async function PATCH(req: Request, context: RouteContext): Promise<Respon
   const container = await createRequestContainer()
   const em = (container.resolve('em') as EntityManager).fork()
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
-  const organizationId = scope?.selectedId ?? (auth as { orgId?: string | null }).orgId ?? null
-  const dscope = { tenantId: auth.tenantId as string, organizationId }
   const userId = resolveAuthActorId(auth)
+
+  // Load the interaction by its tenant-unique id (not a hand-rolled selected
+  // org) so this keeps working under the "All organizations" scope. The record's
+  // own organization then becomes the concrete org the guard, command, and audit
+  // event are attributed to.
+  const interaction = (await findOneWithDecryption(
+    em,
+    CustomerInteraction,
+    {
+      id,
+      tenantId: auth.tenantId,
+      deletedAt: null,
+      interactionType: 'email',
+    } as any,
+    undefined,
+    { tenantId: auth.tenantId as string, organizationId: scope?.selectedId ?? (auth as { orgId?: string | null }).orgId ?? null },
+  )) as { id: string; organizationId?: string | null; authorUserId?: string | null; visibility?: string | null } | null
+
+  if (!interaction) {
+    return NextResponse.json({ error: 'Email not found' }, { status: 404 })
+  }
+
+  // Personal mailbox privacy (v1: strict owner-only): ONLY the author may flip
+  // their own email's visibility — no admin bypass. Return 404 (not 403) for
+  // everyone else so we don't leak the row's existence — this also covers
+  // non-authors who cannot see a private email in the first place. This owner
+  // check is stricter than any org gate, so no separate org read guard is needed.
+  const isAuthor = !!interaction.authorUserId && interaction.authorUserId === auth.sub
+  if (!isAuthor) {
+    return NextResponse.json({ error: 'Email not found' }, { status: 404 })
+  }
+
+  const organizationId = interaction.organizationId ?? null
 
   const guardResult = await validateCrudMutationGuard(container, {
     tenantId: auth.tenantId,
@@ -68,33 +99,6 @@ export async function PATCH(req: Request, context: RouteContext): Promise<Respon
   })
   if (guardResult && !guardResult.ok) {
     return NextResponse.json(guardResult.body, { status: guardResult.status })
-  }
-
-  const interaction = (await findOneWithDecryption(
-    em,
-    CustomerInteraction,
-    {
-      id,
-      tenantId: auth.tenantId,
-      organizationId,
-      deletedAt: null,
-      interactionType: 'email',
-    } as any,
-    undefined,
-    dscope,
-  )) as { id: string; authorUserId?: string | null; visibility?: string | null } | null
-
-  if (!interaction) {
-    return NextResponse.json({ error: 'Email not found' }, { status: 404 })
-  }
-
-  // Personal mailbox privacy (v1: strict owner-only): ONLY the author may flip
-  // their own email's visibility — no admin bypass. Return 404 (not 403) for
-  // everyone else so we don't leak the row's existence — this also covers
-  // non-authors who cannot see a private email in the first place.
-  const isAuthor = !!interaction.authorUserId && interaction.authorUserId === auth.sub
-  if (!isAuthor) {
-    return NextResponse.json({ error: 'Email not found' }, { status: 404 })
   }
 
   // No-op: visibility is already at the requested value.

--- a/packages/core/src/modules/customers/api/people/[id]/email-threads/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/email-threads/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+/** @jest-environment node */
+
+const mockEm = {
+  fork: jest.fn(() => mockEm),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => (token === 'em' ? mockEm : null),
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(),
+}))
+
+jest.mock('../../../../../lib/personEmailThreads', () => ({
+  buildPersonEmailThreads: jest.fn(async () => []),
+}))
+
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { buildPersonEmailThreads } from '../../../../../lib/personEmailThreads'
+import { GET } from '../route'
+
+const PERSON_ID = '44444444-4444-4444-8444-444444444444'
+
+function request() {
+  return new Request(`http://localhost/api/customers/people/${PERSON_ID}/email-threads`)
+}
+
+describe('person email-threads — organization scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue({ id: PERSON_ID, organizationId: 'org-x' })
+  })
+
+  it('loads the person by tenant + id under "All organizations" and uses the record\'s own org', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: null,
+      isSuperAdmin: true,
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: 'tenant-1',
+    })
+
+    const response = await GET(request(), { params: { id: PERSON_ID } })
+
+    expect(response.status).toBe(200)
+    const where = (findOneWithDecryption as jest.Mock).mock.calls[0][2]
+    expect(where).toMatchObject({ id: PERSON_ID, kind: 'person', tenantId: 'tenant-1' })
+    expect(where).not.toHaveProperty('organizationId')
+    // Downstream thread query is scoped to the person's real organization.
+    expect(buildPersonEmailThreads).toHaveBeenCalledWith(
+      mockEm,
+      expect.objectContaining({ personId: PERSON_ID, organizationId: 'org-x' }),
+    )
+  })
+
+  it('denies a restricted caller who cannot see the record\'s organization', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-a',
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null,
+      filterIds: ['org-a'],
+      allowedIds: ['org-a'],
+      tenantId: 'tenant-1',
+    })
+
+    const response = await GET(request(), { params: { id: PERSON_ID } })
+
+    expect(response.status).toBe(404)
+    expect(buildPersonEmailThreads).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/people/[id]/email-threads/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/email-threads/route.ts
@@ -5,6 +5,7 @@ import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { CustomerEntity } from '../../../../data/entities'
 import { buildPersonEmailThreads } from '../../../../lib/personEmailThreads'
 
@@ -33,12 +34,12 @@ export async function GET(req: Request, context: RouteContext): Promise<Response
 
   const container = await createRequestContainer()
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
-  const organizationId = scope?.selectedId ?? (auth as { orgId?: string | null }).orgId ?? null
   const em = (container.resolve('em') as EntityManager).fork()
-  const dscope = { tenantId: auth.tenantId as string, organizationId }
 
-  // Verify the Person exists in the caller's tenant/org (ownership check,
-  // same pattern as the [id]/emails compose route).
+  // Verify the Person exists in the caller's tenant, then fail-closed on the
+  // record's own organization — same pattern as the [id] detail route. Loading
+  // by tenant + id (not a hand-rolled selected org) keeps this working under the
+  // "All organizations" scope, where no concrete org is carried.
   const person = await findOneWithDecryption(
     em,
     CustomerEntity,
@@ -46,13 +47,16 @@ export async function GET(req: Request, context: RouteContext): Promise<Response
       id: personId,
       kind: 'person',
       tenantId: auth.tenantId,
-      organizationId,
       deletedAt: null,
     } as never,
     undefined,
-    dscope,
+    { tenantId: auth.tenantId as string, organizationId: scope?.selectedId ?? (auth as { orgId?: string | null }).orgId ?? null },
   )
   if (!person) {
+    return NextResponse.json({ error: 'Person not found' }, { status: 404 })
+  }
+  const organizationId = (person as { organizationId?: string | null }).organizationId ?? null
+  if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId })) {
     return NextResponse.json({ error: 'Person not found' }, { status: 404 })
   }
 

--- a/packages/core/src/modules/customers/api/people/[id]/emails/__tests__/route.orgscope.test.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/emails/__tests__/route.orgscope.test.ts
@@ -1,0 +1,92 @@
+/** @jest-environment node */
+
+const mockEm = { fork: jest.fn(() => mockEm) }
+const mockSendAsUser = jest.fn(async () => ({ ok: true, messageId: 'm1', threadId: 't1' }))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({ getAuthFromRequest: jest.fn() }))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => {
+      if (token === 'em') return mockEm
+      if (token === 'communicationChannelsSendAsUser') return mockSendAsUser
+      return null
+    },
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({ findOneWithDecryption: jest.fn() }))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/mutation-guard', () => ({
+  validateCrudMutationGuard: jest.fn(async () => ({ ok: true, shouldRunAfterSuccess: false })),
+  runCrudMutationGuardAfterSuccess: jest.fn(async () => {}),
+}))
+
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { validateCrudMutationGuard } from '@open-mercato/shared/lib/crud/mutation-guard'
+import { POST } from '../route'
+
+const PERSON_ID = '44444444-4444-4444-8444-444444444444'
+const CHANNEL_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+
+function request() {
+  return new Request(`http://localhost/api/customers/people/${PERSON_ID}/emails`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ userChannelId: CHANNEL_ID, to: ['x@y.io'], subject: 'hi', body: 'hello' }),
+  })
+}
+
+describe('POST person emails — organization scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue({ id: PERSON_ID, organizationId: 'org-9' })
+  })
+
+  it('finds the person by tenant+id under "All organizations" and attributes the send to the record\'s org', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1', tenantId: 'tenant-1', orgId: null, isSuperAdmin: true,
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null, filterIds: null, allowedIds: null, tenantId: 'tenant-1',
+    })
+
+    const response = await POST(request(), { params: { id: PERSON_ID } })
+
+    expect(response.status).toBe(200)
+    const personWhere = (findOneWithDecryption as jest.Mock).mock.calls[0][2]
+    expect(personWhere).toMatchObject({ id: PERSON_ID, kind: 'person', tenantId: 'tenant-1' })
+    expect(personWhere).not.toHaveProperty('organizationId')
+    // Guard + outbound send are attributed to the person's real org, not null.
+    expect(validateCrudMutationGuard).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ organizationId: 'org-9' }),
+    )
+    expect(mockSendAsUser).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ organizationId: 'org-9' }),
+      expect.anything(),
+    )
+  })
+
+  it('denies a restricted caller who cannot see the record\'s organization', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-a',
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null, filterIds: ['org-a'], allowedIds: ['org-a'], tenantId: 'tenant-1',
+    })
+
+    const response = await POST(request(), { params: { id: PERSON_ID } })
+
+    expect(response.status).toBe(404)
+    expect(validateCrudMutationGuard).not.toHaveBeenCalled()
+    expect(mockSendAsUser).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/people/[id]/emails/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/emails/route.ts
@@ -10,6 +10,7 @@ import {
   runCrudMutationGuardAfterSuccess,
 } from '@open-mercato/shared/lib/crud/mutation-guard'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
 import { resolveAuthActorId } from '../../../../lib/interactionRequestContext'
 import { CustomerEntity } from '../../../../data/entities'
 import type { SendAsUserService } from '@open-mercato/core/modules/communication_channels/lib/send-as-user'
@@ -66,7 +67,33 @@ export async function POST(req: Request, context: RouteContext): Promise<Respons
   const container = await createRequestContainer()
   const userId = resolveAuthActorId(auth)
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
-  const organizationId = scope?.selectedId ?? (auth as { orgId?: string | null }).orgId ?? null
+
+  const em = (container.resolve('em') as EntityManager).fork()
+
+  // 1. Verify the Person exists in the caller's tenant, then fail-closed on the
+  //    record's own organization — same pattern as the [id]/route.ts GET handler.
+  //    Loading by tenant + id (not a hand-rolled selected org) keeps this working
+  //    under the "All organizations" scope; the record's own org then becomes the
+  //    concrete org the guard and the outbound message are attributed to.
+  const person = await findOneWithDecryption(
+    em,
+    CustomerEntity,
+    {
+      id: personId,
+      kind: 'person',
+      tenantId: auth.tenantId,
+      deletedAt: null,
+    } as never,
+    undefined,
+    { tenantId: auth.tenantId as string, organizationId: scope?.selectedId ?? (auth as { orgId?: string | null }).orgId ?? null },
+  )
+  if (!person) {
+    return NextResponse.json({ error: 'Person not found' }, { status: 404 })
+  }
+  const organizationId = (person as { organizationId?: string | null }).organizationId ?? null
+  if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId })) {
+    return NextResponse.json({ error: 'Person not found' }, { status: 404 })
+  }
 
   const guardResult = await validateCrudMutationGuard(container, {
     tenantId: auth.tenantId,
@@ -80,29 +107,6 @@ export async function POST(req: Request, context: RouteContext): Promise<Respons
   })
   if (guardResult && !guardResult.ok) {
     return NextResponse.json(guardResult.body, { status: guardResult.status })
-  }
-
-  const em = (container.resolve('em') as EntityManager).fork()
-  const dscope = { tenantId: auth.tenantId as string, organizationId }
-
-  // 1. Verify the Person exists in the caller's tenant.
-  //    Uses CustomerEntity (kind='person') as the canonical ownership check —
-  //    the same pattern as the existing [id]/route.ts GET handler.
-  const person = await findOneWithDecryption(
-    em,
-    CustomerEntity,
-    {
-      id: personId,
-      kind: 'person',
-      tenantId: auth.tenantId,
-      organizationId,
-      deletedAt: null,
-    } as never,
-    undefined,
-    dscope,
-  )
-  if (!person) {
-    return NextResponse.json({ error: 'Person not found' }, { status: 404 })
   }
 
   // 2. Call the hub's send-as-user facade in-process (resolved via DI) so the

--- a/packages/core/src/modules/sales/api/__tests__/document-history.route.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/document-history.route.test.ts
@@ -103,4 +103,35 @@ describe('sales document-history route authorization', () => {
       resourceId: DOCUMENT_ID,
     }))
   })
+
+  it('loads history under the "all organizations" scope by dropping the org filter', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: null,
+      isSuperAdmin: true,
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null,
+      allowedIds: null,
+      filterIds: null,
+    })
+
+    const response = await GET(requestFor('order'))
+
+    expect(response.status).toBe(200)
+    // No concrete org is required — the RBAC check runs tenant-wide (super-admin)
+    // and the log query is scoped by tenant + resource only.
+    expect(mockRbac.userHasAllFeatures).toHaveBeenCalledWith('user-1', ['sales.orders.view'], {
+      tenantId: 'tenant-1',
+      organizationId: null,
+    })
+    expect(mockActionLogService.list).toHaveBeenCalledWith(expect.objectContaining({
+      organizationId: undefined,
+      resourceKind: 'sales.order',
+      resourceId: DOCUMENT_ID,
+    }))
+    const noteFilter = (findWithDecryption as jest.Mock).mock.calls[0][2]
+    expect(noteFilter).not.toHaveProperty('organizationId')
+  })
 })

--- a/packages/core/src/modules/sales/api/__tests__/returns-detail.route.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/returns-detail.route.test.ts
@@ -1,0 +1,100 @@
+/** @jest-environment node */
+
+const mockEm = {
+  fork: jest.fn(() => mockEm),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => (token === 'em' ? mockEm : null),
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(async () => []),
+}))
+
+import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { GET } from '../returns/[id]/route'
+
+const RETURN_ID = '33333333-3333-4333-8333-333333333333'
+
+function request() {
+  return new Request(`http://localhost/api/sales/returns/${RETURN_ID}`)
+}
+
+describe('sales return detail — organization scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(findOneWithDecryption as jest.Mock).mockResolvedValue({
+      id: RETURN_ID,
+      order: { id: 'order-1' },
+      returnNumber: 'R-1',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    })
+  })
+
+  it('loads the return by its tenant-unique id under the "All organizations" scope', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: null,
+      isSuperAdmin: true,
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: null,
+      filterIds: null,
+      allowedIds: null,
+      tenantId: 'tenant-1',
+    })
+
+    const response = await GET(request(), { params: { id: RETURN_ID } })
+
+    expect(response.status).toBe(200)
+    const where = (findOneWithDecryption as jest.Mock).mock.calls[0][2]
+    expect(where).toMatchObject({ id: RETURN_ID, tenantId: 'tenant-1' })
+    expect(where).not.toHaveProperty('organizationId')
+  })
+
+  it('narrows to the caller\'s visible organizations when restricted', async () => {
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-a',
+    })
+    ;(resolveOrganizationScopeForRequest as jest.Mock).mockResolvedValue({
+      selectedId: 'org-a',
+      filterIds: ['org-a'],
+      allowedIds: ['org-a'],
+      tenantId: 'tenant-1',
+    })
+
+    const response = await GET(request(), { params: { id: RETURN_ID } })
+
+    expect(response.status).toBe(200)
+    const where = (findOneWithDecryption as jest.Mock).mock.calls[0][2]
+    expect(where).toMatchObject({
+      id: RETURN_ID,
+      tenantId: 'tenant-1',
+      organizationId: { $in: ['org-a'] },
+    })
+  })
+})

--- a/packages/core/src/modules/sales/api/document-history/route.ts
+++ b/packages/core/src/modules/sales/api/document-history/route.ts
@@ -4,6 +4,7 @@ import { loadAuditLogDisplayMaps } from '@open-mercato/core/modules/audit_logs/a
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { NextResponse } from 'next/server'
@@ -67,12 +68,12 @@ export async function GET(req: Request) {
     }
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
-    const organizationId = scope?.selectedId ?? auth.orgId ?? null
-    if (!organizationId) {
-      throw new CrudHttpError(400, {
-        error: translate('sales.documents.errors.organization_required', 'Organization context is required'),
-      })
-    }
+    // Resolve the organization scope the same way every other scoped read does.
+    // Under "All organizations" (super-admin) `rbacOrganizationId` is null and
+    // `where` is empty, so the read scopes by tenant + resource only instead of
+    // failing — the document's `id` is a tenant-unique UUID, so no cross-org leak.
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
+    const organizationId = orgFilter.rbacOrganizationId
 
     const requiredFeature = query.kind === 'order' ? 'sales.orders.view' : 'sales.quotes.view'
     const rbac = container.resolve('rbacService') as RbacService
@@ -92,7 +93,7 @@ export async function GET(req: Request) {
     const [actionLogList, notes] = await Promise.all([
       actionLogService.list({
         tenantId: auth.tenantId,
-        organizationId,
+        organizationId: organizationId ?? undefined,
         resourceKind,
         resourceId: query.id,
         includeRelated: true,
@@ -107,11 +108,11 @@ export async function GET(req: Request) {
           contextType: query.kind,
           contextId: query.id,
           tenantId: auth.tenantId,
-          organizationId,
+          ...orgFilter.where,
           deletedAt: null,
         },
         { orderBy: { createdAt: 'DESC' } },
-        { tenantId: auth.tenantId, organizationId },
+        { tenantId: auth.tenantId, organizationId: organizationId ?? undefined },
       ),
     ])
     const logs = actionLogList.items as ActionLog[]

--- a/packages/core/src/modules/sales/api/returns/[id]/route.ts
+++ b/packages/core/src/modules/sales/api/returns/[id]/route.ts
@@ -5,6 +5,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
+import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CrudHttpError, isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -40,20 +41,20 @@ export async function GET(req: Request, ctx: { params: { id: string } }) {
     }
 
     const scope = await resolveOrganizationScopeForRequest({ container, auth, request: req })
-    const organizationId = scope?.selectedId ?? auth.orgId ?? null
-    if (!organizationId) {
-      throw new CrudHttpError(400, {
-        error: translate('sales.documents.errors.organization_required', 'Organization context is required'),
-      })
-    }
+    // Scope by the caller's visible organizations. Under "All organizations"
+    // (super-admin) `where` is empty and `rbacOrganizationId` is null, so the
+    // return is fetched by its tenant-unique id instead of 400-ing; restricted
+    // callers keep their `filterIds` `$in` guard.
+    const orgFilter = resolveOrganizationScopeFilter(scope, auth)
+    const decryptionOrganizationId = orgFilter.rbacOrganizationId ?? undefined
 
     const em = (container.resolve('em') as EntityManager).fork()
     const header = await findOneWithDecryption(
       em,
       SalesReturn,
-      { id, deletedAt: null, tenantId: auth.tenantId, organizationId },
+      { id, deletedAt: null, tenantId: auth.tenantId, ...orgFilter.where },
       { populate: ['order'] },
-      { tenantId: auth.tenantId, organizationId },
+      { tenantId: auth.tenantId, organizationId: decryptionOrganizationId },
     )
     if (!header || !header.order) {
       throw notFound(translate('sales.returns.notFound', 'Return not found.'))
@@ -64,7 +65,7 @@ export async function GET(req: Request, ctx: { params: { id: string } }) {
       SalesReturnLine,
       { salesReturn: header.id, deletedAt: null },
       { populate: ['orderLine'] },
-      { tenantId: auth.tenantId, organizationId },
+      { tenantId: auth.tenantId, organizationId: decryptionOrganizationId },
     )
 
     const totals = lines.reduce(


### PR DESCRIPTION
## Problem

Super-admins with the org switcher set to **All organizations** carry no concrete organization on the request. Several endpoints hand-rolled `scope.selectedId ?? auth.orgId` and then hard-required a single org — so they failed even though the target is a tenant-unique record.

Originally reported for the order **History** tab (`GET /api/sales/document-history`), which returned `400 "Organization context is required"`. An audit of ~220 API routes surfaced the same latent pattern in a handful of siblings.

## Fix

Adopt the scope helpers the rest of the codebase already uses:

- **List reads** -> `resolveOrganizationScopeFilter(scope, auth)`: empty org filter (tenant-only) under all-orgs; `{ $in: filterIds }` for restricted callers.
- **By-id detail reads** -> load by `tenant + id`, then fail-closed via `isOrganizationReadAccessAllowed` on the record's own org.
- **Writes** -> derive the concrete org from the loaded record so the mutation guard, command, and outbound message attribute to the right org.

### Endpoints fixed
- `sales/document-history` (read) — the reported bug
- `catalog/tags` list, `catalog/categories` list (reads)
- `sales/returns/[id]` detail (read)
- `customers/people/[id]/email-threads` (read)
- `customers/people/[id]/emails` compose (write)
- `customers/interactions/[id]/visibility` (write)

## Backward-compatibility note

`catalog/categories` list response: `organizationId` (top-level **and** per-row) is now **nullable** — under all-orgs the tree can span organizations, so each row carries its own org and the top-level echoes the caller's resolved org (null in all-orgs). The row type and zod schema were widened accordingly. It becomes `null` solely in the new all-orgs mode.

## Tests

Route-level unit coverage of the org-scoping behavior (all-orgs **and** restricted paths) for every changed endpoint. Each asserts the where-clause drops `organizationId` under all-orgs and that writes attribute to the record's own org, so they fail if the fix is reverted.

## QA — verified on a running app (self-verified)

Booted the app against Postgres with a seeded super-admin whose session carries **no** concrete org, then captured before/after by building old vs fixed into `dist`:

| Endpoint (All organizations) | BEFORE | AFTER |
|---|---|---|
| `sales/document-history` | **400** org-required | **200** |
| `sales/returns/[id]` (real record) | **400** org-required | **200** |
| `catalog/tags` | **400** org-required | **200** |
| `catalog/categories` | **400** org-required | **200** (8 categories) |
| `customers/.../email-threads` | **404** person-not-found | **200** |
| `customers/.../emails` compose | **404** "Person not found" | person found -> **404** "Channel not found" (fake channel; send path unchanged) |
| `customers/.../interactions/[id]/visibility` (real owned row) | **404** email-not-found | **200**, DB flipped `private -> shared` |

Concrete-org control passed in **both** builds, confirming the bug is specific to all-orgs mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
