### PR TITLE
feat(starter): self-healing OpenCode↔MCP connectivity on Windows

### DIFF
--- a/packages/starter/src/__tests__/starter.test.mjs
+++ b/packages/starter/src/__tests__/starter.test.mjs
@@ -13,6 +13,7 @@ import { ensureLlmProvider, syncProviderConfigToAppEnv } from '../providers.mjs'
 import { ensureWindowsUtf8Console, resolveSpawnCommand } from '../spawn.mjs'
 import { StepBlocked, buildToolchainStep, clearConvergenceState, databaseIsInitialized, listMigrationModules, migrationsFingerprint, probePostgresCredentials, readAppliedMigrationModules, resolveOpencodeBaseImage, runSteps } from '../steps.mjs'
 import { ensureEnvFiles } from '../env-setup.mjs'
+import { removeLeftoverComposeResources } from '../infra.mjs'
 import { checkBuildToolchain, defenderExclusionCovers } from '../doctor.mjs'
 
 function makeTempDir(prefix) {
@@ -357,6 +358,48 @@ test('buildToolchainStep warns instead of blocking when the workspace install al
   // A pending lockfile change re-arms the hard block.
   fs.writeFileSync(path.join(repo, 'yarn.lock'), 'changed\n')
   await assert.rejects(() => buildToolchainStep.check(ctx), (error) => error instanceof StepBlocked)
+})
+
+test('removeLeftoverComposeResources sweeps fixed-name containers and volumes down cannot see', () => {
+  const calls = []
+  const runComposeImpl = () => ({
+    status: 0,
+    stdout: JSON.stringify({
+      services: { postgres: { container_name: 'mercato-postgres' } },
+      volumes: { postgres_data: { name: 'mercato-postgres-data' } },
+    }),
+  })
+  const runCaptureImpl = (command, args) => {
+    const key = args.join(' ')
+    calls.push(key)
+    if (key === 'ps -a --format {{.Names}}') return { status: 0, stdout: 'mercato-postgres\nunrelated-container\n' }
+    if (key === 'volume ls --format {{.Name}}') return { status: 0, stdout: 'mercato-postgres-data\nunrelated-volume\n' }
+    return { status: 0, stdout: '' }
+  }
+  const clean = removeLeftoverComposeResources('/repo', { runComposeImpl, runCaptureImpl, log: () => {}, warn: () => {} })
+  assert.equal(clean, true)
+  assert.ok(calls.includes('rm -f mercato-postgres'))
+  assert.ok(calls.includes('volume rm mercato-postgres-data'))
+  assert.ok(!calls.some((key) => key.includes('unrelated')))
+})
+
+test('removeLeftoverComposeResources reports in-use volumes with their holders and returns false', () => {
+  const warnings = []
+  const runComposeImpl = () => ({
+    status: 0,
+    stdout: JSON.stringify({ services: {}, volumes: { postgres_data: { name: 'mercato-postgres-data' } } }),
+  })
+  const runCaptureImpl = (command, args) => {
+    const key = args.join(' ')
+    if (key === 'ps -a --format {{.Names}}') return { status: 0, stdout: '' }
+    if (key === 'volume ls --format {{.Name}}') return { status: 0, stdout: 'mercato-postgres-data\n' }
+    if (key === 'volume rm mercato-postgres-data') return { status: 1, stderr: 'volume is in use' }
+    if (key.startsWith('ps -a --filter')) return { status: 0, stdout: 'old-checkout-postgres\n' }
+    return { status: 0, stdout: '' }
+  }
+  const clean = removeLeftoverComposeResources('/repo', { runComposeImpl, runCaptureImpl, log: () => {}, warn: (line) => warnings.push(line) })
+  assert.equal(clean, false)
+  assert.ok(warnings.some((line) => line.includes('old-checkout-postgres')))
 })
 
 test('defenderExclusionCovers matches the repo or an ancestor, case-insensitively', () => {

--- a/packages/starter/src/__tests__/starter.test.mjs
+++ b/packages/starter/src/__tests__/starter.test.mjs
@@ -14,7 +14,7 @@ import { ensureWindowsUtf8Console, resolveSpawnCommand } from '../spawn.mjs'
 import { StepBlocked, buildToolchainStep, clearConvergenceState, databaseIsInitialized, listMigrationModules, migrationsFingerprint, probePostgresCredentials, readAppliedMigrationModules, resolveOpencodeBaseImage, runSteps } from '../steps.mjs'
 import { ensureEnvFiles } from '../env-setup.mjs'
 import { removeLeftoverComposeResources } from '../infra.mjs'
-import { checkBuildToolchain, defenderExclusionCovers } from '../doctor.mjs'
+import { checkBuildToolchain, defenderExclusionCovers, detectHostGateway, hostIpCandidates } from '../doctor.mjs'
 
 function makeTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
@@ -400,6 +400,40 @@ test('removeLeftoverComposeResources reports in-use volumes with their holders a
   const clean = removeLeftoverComposeResources('/repo', { runComposeImpl, runCaptureImpl, log: () => {}, warn: (line) => warnings.push(line) })
   assert.equal(clean, false)
   assert.ok(warnings.some((line) => line.includes('old-checkout-postgres')))
+})
+
+test('detectHostGateway prefers the default pin, falls back to host IPs, and reports unreachable', () => {
+  const pinOk = detectHostGateway(3001, { probeImpl: () => ({ ran: true, mcpAnswered: true, output: '{"status":"ok"}' }), candidates: [] })
+  assert.deepEqual(pinOk, { status: 'pin-ok' })
+
+  const probes = []
+  const secondCandidateWins = detectHostGateway(3001, {
+    probeImpl: (port, addHost) => {
+      probes.push(addHost)
+      return { ran: true, mcpAnswered: addHost === 'host.docker.internal:172.20.0.1', output: '' }
+    },
+    candidates: ['192.168.1.10', '172.20.0.1'],
+  })
+  assert.deepEqual(secondCandidateWins, { status: 'use-ip', ip: '172.20.0.1' })
+  assert.deepEqual(probes, ['host.docker.internal:host-gateway', 'host.docker.internal:192.168.1.10', 'host.docker.internal:172.20.0.1'])
+
+  const unreachable = detectHostGateway(3001, { probeImpl: () => ({ ran: true, mcpAnswered: false, output: '' }), candidates: ['192.168.1.10'] })
+  assert.deepEqual(unreachable, { status: 'unreachable' })
+
+  const pullBlocked = detectHostGateway(3001, {
+    probeImpl: () => ({ ran: true, mcpAnswered: false, output: 'Unable to find image busybox:1.37 locally' }),
+    candidates: ['192.168.1.10'],
+  })
+  assert.deepEqual(pullBlocked, { status: 'skip' })
+})
+
+test('hostIpCandidates lists external IPv4s with WSL adapters first', () => {
+  const candidates = hostIpCandidates({
+    'Ethernet': [{ family: 'IPv4', internal: false, address: '192.168.1.10' }],
+    'vEthernet (WSL (Hyper-V firewall))': [{ family: 'IPv4', internal: false, address: '172.20.0.1' }],
+    'Loopback Pseudo-Interface 1': [{ family: 'IPv4', internal: true, address: '127.0.0.1' }],
+  })
+  assert.deepEqual(candidates, ['172.20.0.1', '192.168.1.10'])
 })
 
 test('defenderExclusionCovers matches the repo or an ancestor, case-insensitively', () => {

--- a/packages/starter/src/cli.mjs
+++ b/packages/starter/src/cli.mjs
@@ -26,7 +26,7 @@ import { readEnvValue } from './env-file.mjs'
 import { FULLAPP_DEV_COMPOSE_FILE, STARTER_STATE_DIR, resolveStackPorts, stackUrls } from './constants.mjs'
 import { loadCompanyConfig } from './company.mjs'
 import { printDoctorReport, runDoctor } from './doctor.mjs'
-import { infraDown, infraUp, ensureMcpSharedDir } from './infra.mjs'
+import { infraDown, infraUp, ensureMcpSharedDir, removeLeftoverComposeResources } from './infra.mjs'
 import { buildUpSteps, clearConvergenceState, createStepContext, ensureOpencodeImage, runSteps, yarnInvocation } from './steps.mjs'
 import { collectStatus, printStatus, readRunState, isPidAlive, startDetached, stopDetached, tailLogs } from './supervise.mjs'
 import { ensureWindowsUtf8Console } from './spawn.mjs'
@@ -308,7 +308,13 @@ async function commandReset(flags) {
   await stopDetached(repoRoot)
   const docker = detectDocker()
   if (docker.ok) {
-    runCompose(repoRoot, ['down', '--volumes'], { composeFile: mode === 'docker' ? FULLAPP_DEV_COMPOSE_FILE : undefined })
+    const composeFile = mode === 'docker' ? FULLAPP_DEV_COMPOSE_FILE : undefined
+    runCompose(repoRoot, ['down', '--volumes'], { composeFile })
+    // down only sees THIS project's resources; fixed-name containers/volumes
+    // created by another checkout of the repo survive it — sweep by name.
+    if (!removeLeftoverComposeResources(repoRoot, { composeFile })) {
+      console.warn('⚠️ Some volumes could not be removed — the next run would reuse the old data. Fix the items above and re-run reset.')
+    }
   }
   fs.rmSync(path.join(repoRoot, STARTER_STATE_DIR), { recursive: true, force: true })
   if (removeEnvFiles) {

--- a/packages/starter/src/doctor.mjs
+++ b/packages/starter/src/doctor.mjs
@@ -387,6 +387,36 @@ function probeContainerToHost(mcpPort, addHost) {
   }
 }
 
+export function hostIpCandidates(interfaces = os.networkInterfaces()) {
+  const named = Object.entries(interfaces ?? {})
+  // WSL vEthernet adapters first — the usual winner on Rancher Desktop/WSL2.
+  named.sort(([a], [b]) => Number(/wsl/i.test(b)) - Number(/wsl/i.test(a)))
+  const ips = []
+  for (const [, addresses] of named) {
+    for (const address of addresses ?? []) {
+      const family = address?.family
+      if ((family === 'IPv4' || family === 4) && !address.internal) ips.push(address.address)
+    }
+  }
+  return [...new Set(ips)]
+}
+
+// Find a host.docker.internal mapping that actually reaches this machine:
+// the compose default pin first (correct on Docker Desktop and native Linux),
+// then every host IPv4. Callers must ensure something answers on mcpPort.
+export function detectHostGateway(mcpPort, { probeImpl = probeContainerToHost, candidates = hostIpCandidates() } = {}) {
+  const pinned = probeImpl(mcpPort, 'host.docker.internal:host-gateway')
+  if (!pinned.ran || /unable to find image|error response from daemon|cannot connect to the docker daemon/i.test(pinned.output ?? '')) {
+    return { status: 'skip' }
+  }
+  if (pinned.mcpAnswered) return { status: 'pin-ok' }
+  for (const ip of candidates) {
+    const probe = probeImpl(mcpPort, `host.docker.internal:${ip}`)
+    if (probe.mcpAnswered) return { status: 'use-ip', ip }
+  }
+  return { status: 'unreachable' }
+}
+
 export function checkContainerToHost(repoRoot, { mcpPort }) {
   const docker = detectDocker()
   if (!docker.ok) return null

--- a/packages/starter/src/infra.mjs
+++ b/packages/starter/src/infra.mjs
@@ -7,7 +7,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { detectDocker, resolveRepoRoot, runCompose } from './compose.mjs'
+import { detectDocker, resolveRepoRoot, runCompose, runCaptureSync } from './compose.mjs'
 
 export function ensureMcpSharedDir(repoRoot) {
   // Pre-create the bind-mount source so dockerd never creates it root-owned
@@ -33,6 +33,62 @@ export function infraUp(repoRooot, { profiles = [] } = {}) {
 
 export function infraDown(repoRoot, { volumes = false } = {}) {
   return runCompose(repoRoot ?? resolveRepoRoot(), ['down', ...(volumes ? ['--volumes'] : [])]).status ?? 1
+}
+
+export function composeResourceNames(repoRoot, { composeFile, runComposeImpl = runCompose } = {}) {
+  const config = runComposeImpl(repoRoot, ['config', '--format', 'json'], { composeFile, stdio: 'pipe' })
+  if ((config.status ?? 1) !== 0) return { containers: [], volumes: [] }
+  try {
+    const parsed = JSON.parse(String(config.stdout ?? ''))
+    return {
+      containers: Object.values(parsed.services ?? {}).map((service) => service?.container_name).filter(Boolean),
+      volumes: Object.values(parsed.volumes ?? {}).map((volume) => volume?.name).filter(Boolean),
+    }
+  } catch {
+    return { containers: [], volumes: [] }
+  }
+}
+
+// `docker compose down --volumes` only removes resources labeled with the
+// CURRENT project (named after the checkout directory). The fixed
+// container_name/volume names in the compose files mean a second checkout of
+// this repo reuses resources created by the first — down skips those
+// silently, so a reset would leave the old database volume (and its
+// incompatible secrets) alive. Sweep leftovers by their fixed names.
+export function removeLeftoverComposeResources(repoRoot, { composeFile, runComposeImpl = runCompose, runCaptureImpl = runCaptureSync, log = console.log, warn = console.warn } = {}) {
+  const { containers, volumes } = composeResourceNames(repoRoot, { composeFile, runComposeImpl })
+  const listNames = (args) => {
+    const run = runCaptureImpl('docker', args)
+    if (run.error || (run.status ?? 1) !== 0) return new Set()
+    return new Set(String(run.stdout ?? '').split('\n').map((line) => line.trim()).filter(Boolean))
+  }
+
+  const existingContainers = listNames(['ps', '-a', '--format', '{{.Names}}'])
+  for (const name of containers) {
+    if (!existingContainers.has(name)) continue
+    const removed = runCaptureImpl('docker', ['rm', '-f', name])
+    if ((removed.status ?? 1) === 0) log(`   removed leftover container ${name} (created by another checkout)`)
+    else warn(`   could not remove container ${name}: ${String(removed.stderr ?? '').trim()}`)
+  }
+
+  let clean = true
+  const existingVolumes = listNames(['volume', 'ls', '--format', '{{.Name}}'])
+  for (const name of volumes) {
+    if (!existingVolumes.has(name)) continue
+    const removed = runCaptureImpl('docker', ['volume', 'rm', name])
+    if ((removed.status ?? 1) === 0) {
+      log(`   removed leftover volume ${name} (created by another checkout)`)
+      continue
+    }
+    clean = false
+    warn(`   could not remove volume ${name}: ${String(removed.stderr ?? '').trim()}`)
+    const holders = runCaptureImpl('docker', ['ps', '-a', '--filter', `volume=${name}`, '--format', '{{.Names}}'])
+    const holderNames = String(holders.stdout ?? '').split('\n').map((line) => line.trim()).filter(Boolean)
+    if (holderNames.length > 0) {
+      warn(`   still mounted by: ${holderNames.join(', ')} — remove them (docker rm -f ${holderNames.join(' ')}) and re-run reset`)
+    }
+  }
+  return clean
 }
 
 function main() {

--- a/packages/starter/src/steps.mjs
+++ b/packages/starter/src/steps.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
@@ -7,9 +7,9 @@ import { detectDocker, parseComposePsOutput, runCaptureSync, runCompose, runStre
 import { captureInterceptionCas, findVendorCaBundles, harvestWindowsStoreCas, hostTrustEnv, probeTlsInterception, provisionDockerCerts, provisionRancherDesktopCa, summarizeProbeResults, writeCaBundle } from './certs.mjs'
 import { loadCompanyConfig, resolveCompanyCertBundles } from './company.mjs'
 import { CAPTURED_CA_BUNDLE, DEFAULT_OPENCODE_BASE_IMAGE, OPENCODE_SERVICE_IMAGE, STARTER_STATE_DIR, resolveStackPorts } from './constants.mjs'
-import { checkBuildToolchain, checkContainerRuntime, checkGit, checkNodeVersion, checkWsl2 } from './doctor.mjs'
+import { checkBuildToolchain, checkContainerRuntime, checkGit, checkNodeVersion, checkWsl2, detectHostGateway } from './doctor.mjs'
 import { ensureEnvFiles } from './env-setup.mjs'
-import { readEnvValue } from './env-file.mjs'
+import { addEnvValue, readEnvValue } from './env-file.mjs'
 import { ensureMcpSharedDir, infraUp } from './infra.mjs'
 import { ensureLlmProvider } from './providers.mjs'
 import { color, formatDuration, guideBox, statusLine, stepHeader } from './ui.mjs'
@@ -630,6 +630,70 @@ export const databaseStep = {
   },
 }
 
+function startHostProbeListener(port) {
+  const script = `require('node:http').createServer((req, res) => { res.setHeader('content-type', 'application/json'); res.end('{"status":"ok","probe":"open-mercato-starter"}') }).listen(${port}, '0.0.0.0', () => console.log('listening'))`
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ['-e', script], { stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true })
+    // A busy port (the real MCP server from a running dev session) is fine —
+    // the probes then hit whatever already answers there.
+    const timer = setTimeout(() => resolve(child), 2000)
+    child.stdout?.on('data', (chunk) => {
+      if (String(chunk).includes('listening')) {
+        clearTimeout(timer)
+        resolve(child)
+      }
+    })
+    child.on('error', () => {
+      clearTimeout(timer)
+      resolve(null)
+    })
+  })
+}
+
+// Rancher Desktop/WSL2 can resolve host-gateway to the WSL distro instead of
+// the Windows host, silently breaking OpenCode -> host MCP. Probe BEFORE the
+// containers come up and pin a working IP into .env (compose feeds it to
+// extra_hosts; a changed pin makes compose recreate opencode on the next up).
+// A throwaway listener on the MCP port makes the probe exercise the exact
+// firewall path the real server will use.
+export const hostGatewayStep = {
+  id: 'host-gateway',
+  expectation: 'a few seconds of container→host probing (Windows only)',
+  title: 'Container → host networking (OM_HOST_GATEWAY)',
+  appliesTo: (ctx) => process.platform === 'win32' && !ctx.flags.noInfra,
+  async check(ctx) {
+    if (readEnvValue(path.join(ctx.repoRoot, '.env'), 'OM_HOST_GATEWAY')?.trim()) {
+      return { ok: true, detail: 'OM_HOST_GATEWAY already pinned in .env' }
+    }
+    if (readState(ctx.repoRoot, 'host-gateway') === 'pin-ok') {
+      return { ok: true, detail: 'default host-gateway mapping verified earlier' }
+    }
+    return { ok: false, detail: 'probing whether containers can reach this machine' }
+  },
+  async apply(ctx) {
+    const ports = resolveStackPorts(ctx.repoRoot)
+    const listener = await startHostProbeListener(ports.mcp)
+    try {
+      const outcome = detectHostGateway(ports.mcp)
+      if (outcome.status === 'pin-ok') {
+        writeState(ctx.repoRoot, 'host-gateway', 'pin-ok')
+        ctx.log('   default host-gateway mapping reaches this machine')
+      } else if (outcome.status === 'use-ip') {
+        addEnvValue(path.join(ctx.repoRoot, '.env'), 'OM_HOST_GATEWAY', outcome.ip)
+        ctx.log(`   host-gateway does not reach this machine (Rancher Desktop/WSL2) — pinned OM_HOST_GATEWAY=${outcome.ip} in .env`)
+      } else if (outcome.status === 'skip') {
+        ctx.log('   probe container could not run — skipping (run `yarn om doctor` for the full audit)')
+      } else {
+        ctx.log(`   ⚠️ containers cannot reach this machine on port ${ports.mcp} — Windows Firewall likely blocks the WSL adapter`)
+        ctx.log(`   ↳ allow it (elevated PowerShell): New-NetFirewallRule -DisplayName "Open Mercato MCP dev" -Direction Inbound -Action Allow -Protocol TCP -LocalPort ${ports.mcp} -Profile Any`)
+        ctx.log('   ↳ then re-run — OpenCode waits for the MCP server and recovers once the port answers')
+      }
+    } finally {
+      listener?.kill()
+    }
+  },
+}
+
 export function buildUpSteps(ctx) {
   const base = [
     prerequisitesStep,
@@ -640,6 +704,7 @@ export function buildUpSteps(ctx) {
     workspaceInstallStep,
     workspaceBuildStep,
     llmProviderStep,
+    hostGatewayStep,
     infraUpStep,
     databaseStep,
   ]

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,4 +1,5 @@
 import { createServer } from 'node:http'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import spawn from 'cross-spawn'
@@ -1850,8 +1851,9 @@ async function provisionMcpApiKey() {
 
     if (resolveChildExitCode(result) === 0) {
       if (isKeyRotationOutput(capturedLines)) {
-        const rotationHint = 'MCP API key rotated — restart the OpenCode container to pick it up'
-        console.warn(`🔑 ${rotationHint} (docker compose --project-directory . -f starters/docker/compose.infra.yml restart opencode)`)
+        opencodeKeyRefreshNeeded = true
+        const rotationHint = 'MCP API key rotated — OpenCode restarts automatically once the MCP server is up'
+        console.log(`🔑 ${rotationHint}`)
         updateSplashState({ activity: rotationHint })
       }
       return true
@@ -1895,19 +1897,58 @@ async function waitForMcpHealthy() {
   return false
 }
 
-async function checkOpencodeMcpWiring() {
+async function fetchOpencodeMcpStatus() {
   const baseUrl = (process.env.OPENCODE_URL?.trim() || 'http://localhost:4096').replace(/\/+$/, '')
   try {
     const response = await fetch(`${baseUrl}/mcp`, { signal: AbortSignal.timeout(3000) })
-    if (!response.ok) return
+    if (!response.ok) return null
     const body = await response.json().catch(() => null)
     const status = body?.['open-mercato']?.status
-    if (typeof status === 'string' && status !== 'connected') {
-      console.warn('⚠️ OpenCode is running but not connected to the MCP server (it may hold a stale key).')
-      console.warn('   ↳ restart it with: docker compose --project-directory . -f starters/docker/compose.infra.yml restart opencode')
-    }
+    return typeof status === 'string' ? status : null
   } catch {
-    // OpenCode container not running — a legitimate state, stay silent.
+    // OpenCode container not running (or mid-restart) — a legitimate state.
+    return null
+  }
+}
+
+// The OpenCode entrypoint reads the MCP key ONCE at container start. When the
+// key appears or rotates after that (headerless start on a slow first run, a
+// reseeded database), the container holds a stale binding until restarted —
+// do it automatically, once per dev session so a broken hop can't loop it.
+let opencodeKeyRefreshNeeded = false
+let opencodeRestartAttempted = false
+
+function restartOpencodeContainer(reason) {
+  if (opencodeRestartAttempted || shuttingDown) return false
+  opencodeRestartAttempted = true
+  const running = spawnSync('docker', ['ps', '--format', '{{.Names}}'], { encoding: 'utf8' })
+  const names = running.error || running.status !== 0 ? [] : String(running.stdout ?? '').split('\n').map((line) => line.trim())
+  if (!names.includes('mercato-opencode')) return false
+  console.log(`🔄 ${reason} — restarting the OpenCode container to pick up the fresh MCP key...`)
+  updateSplashState({ activity: 'Restarting OpenCode to pick up the fresh MCP key' })
+  const restart = spawnSync('docker', ['restart', 'mercato-opencode'], { encoding: 'utf8', timeout: 120_000 })
+  if (restart.error || restart.status !== 0) {
+    console.warn('⚠️ Could not restart the OpenCode container automatically.')
+    console.warn('   ↳ restart it manually: docker compose --project-directory . -f starters/docker/compose.infra.yml restart opencode')
+    return false
+  }
+  return true
+}
+
+async function checkOpencodeMcpWiring() {
+  const status = await fetchOpencodeMcpStatus()
+  if (status === null || status === 'connected') return
+  if (!restartOpencodeContainer('OpenCode is not connected to the MCP server')) {
+    console.warn('⚠️ OpenCode is running but not connected to the MCP server (it may hold a stale key).')
+    console.warn('   ↳ restart it with: docker compose --project-directory . -f starters/docker/compose.infra.yml restart opencode')
+    return
+  }
+  await sleepUnlessShuttingDown(30_000)
+  const rechecked = await fetchOpencodeMcpStatus()
+  if (rechecked === 'connected') {
+    console.log('🔌 OpenCode reconnected to the MCP server.')
+  } else if (rechecked !== null) {
+    console.warn('⚠️ OpenCode is still not connected after a restart — check `docker logs mercato-opencode` and the container→host hop (yarn om doctor).')
   }
 }
 
@@ -1924,11 +1965,17 @@ async function runMcpLifecycle() {
       if (capturedLines.length > 200) capturedLines.shift()
     })
 
-    void waitForMcpHealthy().then((healthy) => {
+    void waitForMcpHealthy().then(async (healthy) => {
       if (!healthy || shuttingDown) return
       const readyMessage = `MCP server ready on http://localhost:${mcpPort}/mcp`
       console.log(`🔌 ${readyMessage}`)
       updateSplashState({ activity: readyMessage })
+      if (opencodeKeyRefreshNeeded) {
+        opencodeKeyRefreshNeeded = false
+        if (restartOpencodeContainer('MCP API key was rotated')) {
+          await sleepUnlessShuttingDown(30_000)
+        }
+      }
       void checkOpencodeMcpWiring()
     })
 

--- a/starters/docker/compose.infra.yml
+++ b/starters/docker/compose.infra.yml
@@ -88,9 +88,9 @@ services:
     extra_hosts:
       # host-gateway is right on native Linux and Docker Desktop. On Rancher
       # Desktop (WSL2) it can resolve to the WSL distro instead of the Windows
-      # host — the doctor detects that and tells you to set OM_HOST_GATEWAY in
-      # .env to the IP that reaches the host (or to the literal value the
-      # engine resolves natively).
+      # host — on Windows the starter probes this before `up` and pins a
+      # working IP into .env as OM_HOST_GATEWAY automatically (the doctor
+      # detects and explains the same condition).
       - "host.docker.internal:${OM_HOST_GATEWAY:-host-gateway}"
     networks:
       - mercato-network


### PR DESCRIPTION
Follow-up to #4370 — the connectivity half of the Windows dev-env work, verified against an affected Rancher Desktop machine:

- New win32 `host-gateway` step: before the containers come up, probe whether `host.docker.internal:host-gateway` actually reaches the machine (throwaway listener on the MCP port, so the probe exercises the exact firewall path the real server uses), then try every host IPv4 (WSL vEthernet adapters first) and auto-pin the first working one into `.env` as `OM_HOST_GATEWAY` — compose recreates opencode with the fixed pin on the same run. This is the Rancher Desktop/WSL2 case where the pin resolves to the WSL distro and OpenCode sits in "connecting" forever. When nothing answers it prints the `New-NetFirewallRule` guidance instead of failing setup; a blocked probe image skips quietly and defers to the doctor.
- `yarn om reset` now sweeps fixed-name containers/volumes that `compose down --volumes` cannot see: down only removes resources labeled with the current project, so a second checkout of the repo silently kept the first checkout's `mercato-postgres-data` (with its incompatible LOOKUP_HASH_PEPPER-hashed data) alive while reset claimed success. Unremovable volumes are reported with the containers still mounting them.
- `yarn dev` restarts the OpenCode container automatically (once per session) when the MCP key rotates or OpenCode reports a stale/missing binding after the MCP server comes up — the entrypoint reads the key only at container start, and the manual-restart hint was easy to miss.

Starter suite (32) passes; the manual equivalent of the auto-pin flow fixed OpenCode↔MCP end to end on the affected machine.