### PR TITLE
fix(workflows): simple-approval EMIT_EVENT activities use eventName so instances stop failing

### DIFF
--- a/packages/core/src/modules/workflows/__tests__/emit-event-config.test.ts
+++ b/packages/core/src/modules/workflows/__tests__/emit-event-config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from '@jest/globals'
+import { workflowsConfig } from '../workflows'
+
+/**
+ * Guards issue #4322: the EMIT_EVENT activity executor requires a
+ * `config.eventName` field and throws at runtime when it is missing
+ * (`executeEmitEvent` in lib/activity-executor.ts). The simple-approval
+ * example shipped with `config.eventType` instead, so every started
+ * instance failed at its first async activity. This walks all code-defined
+ * workflows shipped by this module and asserts each EMIT_EVENT activity
+ * carries a usable `eventName` (and not the silently ignored `eventType`).
+ */
+describe('code-defined workflows EMIT_EVENT config', () => {
+  const emitEventActivities = workflowsConfig.workflows.flatMap((workflow) =>
+    workflow.definition.transitions.flatMap((transition) =>
+      (transition.activities ?? [])
+        .filter((activity) => activity.activityType === 'EMIT_EVENT')
+        .map((activity) => ({
+          workflowId: workflow.workflowId,
+          transitionId: transition.transitionId,
+          activityId: activity.activityId,
+          config: (activity.config ?? {}) as Record<string, unknown>,
+        })),
+    ),
+  )
+
+  test('module ships EMIT_EVENT activities to guard', () => {
+    expect(emitEventActivities.length).toBeGreaterThan(0)
+  })
+
+  test.each(emitEventActivities.map((entry) => [
+    `${entry.workflowId} / ${entry.transitionId} / ${entry.activityId}`,
+    entry,
+  ] as const))('%s declares eventName required by the executor', (_label, entry) => {
+    expect(typeof entry.config.eventName).toBe('string')
+    expect((entry.config.eventName as string).length).toBeGreaterThan(0)
+    expect(entry.config).not.toHaveProperty('eventType')
+  })
+})

--- a/packages/core/src/modules/workflows/workflows.ts
+++ b/packages/core/src/modules/workflows/workflows.ts
@@ -59,7 +59,7 @@ const simpleApproval = defineWorkflow({
           activityName: 'Emit Approval Requested Event',
           activityType: 'EMIT_EVENT',
           config: {
-            eventType: 'approval.requested',
+            eventName: 'approval.requested',
             payload: { requestId: '{{context.request.id}}', workflowInstanceId: '{{workflow.instanceId}}' },
           },
           async: true,
@@ -98,7 +98,7 @@ const simpleApproval = defineWorkflow({
           activityName: 'Emit Approval Completed Event',
           activityType: 'EMIT_EVENT',
           config: {
-            eventType: 'approval.completed',
+            eventName: 'approval.completed',
             payload: {
               requestId: '{{context.request.id}}',
               approved: '{{task.result.approved}}',


### PR DESCRIPTION
## Summary

Fixes #4322.

The `EMIT_EVENT` activity executor requires `config.eventName` and throws `EMIT_EVENT requires "eventName" field` when it is absent (`executeEmitEvent` in `lib/activity-executor.ts`). The `workflows.simple-approval` example configured both of its `EMIT_EVENT` activities with `eventType` instead, so every started instance went `FAILED` at the `start → approval` transition once async activities actually executed (reproduced during manual QA of PR #4263 — evidence linked in the issue).

## Changes

- Rename `eventType` → `eventName` in both `EMIT_EVENT` activities of `simpleApproval` (`packages/core/src/modules/workflows/workflows.ts`), matching `checkoutDemo` which already uses `eventName`.
- Add a guard test (`__tests__/emit-event-config.test.ts`) that walks all code-defined workflows shipped by the module and asserts every `EMIT_EVENT` activity declares a non-empty `eventName` and does not carry the silently ignored `eventType`.

## Validation

- `yarn workspace @open-mercato/core test --testPathPatterns "workflows/__tests__/(emit-event-config|checkout-demo-create-order)"` — 7/7 passed
- Runner: local

Suggested labels: `bug`, `priority-low`, `risk-low`, `skip-qa` (example/demo definition + test only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)