### PR TITLE
fix(workflows): resolve synthetic code-definition UUID in definitions/[id] GET

### DIFF
--- a/packages/core/src/modules/workflows/api/__tests__/definitions.route.test.ts
+++ b/packages/core/src/modules/workflows/api/__tests__/definitions.route.test.ts
@@ -12,6 +12,9 @@ import {
   DELETE as deleteDefinition,
 } from '../definitions/[id]/route'
 import { WorkflowDefinition, WorkflowInstance } from '../../data/entities'
+import { registerCodeWorkflows, clearCodeWorkflowRegistry } from '../../lib/code-registry'
+import { codeWorkflowUuid } from '../../lib/find-definition'
+import { workflowsConfig } from '../../workflows'
 
 // Mock dependencies
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
@@ -501,6 +504,29 @@ describe('Workflow Definitions API', () => {
       const response = await getDefinition(request, { params: Promise.resolve({ id: 'non-existent' }) })
 
       expect(response.status).toBe(404)
+    })
+
+    test('should resolve the synthetic code-definition UUID stored on instances', async () => {
+      // Instances of unpersisted code workflows carry codeWorkflowUuid(workflowId)
+      // as definitionId; looking that raw UUID up must hit the code registry
+      // instead of returning 404 (issue #4323).
+      mockEm.findOne.mockResolvedValue(null)
+      const codeDef = workflowsConfig.workflows[0]
+      registerCodeWorkflows([codeDef])
+
+      try {
+        const syntheticId = codeWorkflowUuid(codeDef.workflowId)
+        const request = new NextRequest(`http://localhost/api/workflows/definitions/${syntheticId}`)
+        const response = await getDefinition(request, { params: Promise.resolve({ id: syntheticId }) })
+        const data = await response.json()
+
+        expect(response.status).toBe(200)
+        expect(data.data.id).toBe(`code:${codeDef.workflowId}`)
+        expect(data.data.workflowId).toBe(codeDef.workflowId)
+        expect(data.data.isCodeBased).toBe(true)
+      } finally {
+        clearCodeWorkflowRegistry()
+      }
     })
 
     test('should enforce tenant isolation', async () => {

--- a/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/[id]/route.ts
@@ -20,7 +20,8 @@ import {
 } from '../../../data/validators'
 import { serializeWorkflowDefinition, serializeCodeWorkflowDefinition } from '../serialize'
 import { invalidateTriggerCache } from '../../../lib/event-trigger-service'
-import { getCodeWorkflow } from '../../../lib/code-registry'
+import { getCodeWorkflow, getAllCodeWorkflows } from '../../../lib/code-registry'
+import { codeWorkflowUuid } from '../../../lib/find-definition'
 import { createGenericOptimisticLockReader } from '@open-mercato/shared/lib/crud/optimistic-lock'
 import { registerOptimisticLockReaderIfAbsent } from '@open-mercato/shared/lib/crud/optimistic-lock-store'
 import { validateCrudMutationGuard, runCrudMutationGuardAfterSuccess } from '@open-mercato/shared/lib/crud/mutation-guard'
@@ -97,6 +98,18 @@ export async function GET(
     })
 
     if (!definition) {
+      // Instances started from an unpersisted code definition store the
+      // deterministic codeWorkflowUuid(workflowId) as their definitionId
+      // (see lib/find-definition.ts). Resolve that synthetic UUID back to
+      // the code registry so lookups by instance.definitionId succeed.
+      const codeDef = getAllCodeWorkflows().find(
+        (workflow) => codeWorkflowUuid(workflow.workflowId) === params.id
+      )
+      if (codeDef) {
+        return NextResponse.json({
+          data: serializeCodeWorkflowDefinition(codeDef, `code:${codeDef.workflowId}`),
+        })
+      }
       return NextResponse.json(
         { error: 'Workflow definition not found' },
         { status: 404 }


### PR DESCRIPTION
## Summary

Fixes #4323.

Instances started from an unpersisted code workflow persist the deterministic `codeWorkflowUuid(workflowId)` as their `definitionId` (see `lib/find-definition.ts`), but `GET /api/workflows/definitions/[id]` only resolved code definitions for ids in the `code:<workflowId>` form — a raw synthetic UUID fell through to the DB lookup and 404ed. As a result, the instance-detail **Visual Workflow Flow** panel showed *"Workflow definition not found"* for every code-defined workflow (e.g. `workflows.checkout-demo`), including fully `COMPLETED` instances.

## Changes

- `api/definitions/[id]/route.ts` (GET): on a DB miss, map the requested UUID back to the code registry (`getAllCodeWorkflows()` + `codeWorkflowUuid`) and serialize the code definition with the canonical `code:<workflowId>` id, matching the definitions list response. Fixing it server-side repairs every caller of the endpoint, not just the instance page.
- Route test covering the synthetic-UUID lookup (200, canonical `code:` id, `isCodeBased: true`).

No tenant-scoping change: code definitions are global and were already served unscoped via the existing `code:<workflowId>` branch of this endpoint.

## Validation

- `yarn workspace @open-mercato/core test --testPathPatterns "workflows/api/__tests__/definitions"` — 44/44 passed
- `yarn workspace @open-mercato/core build` — built successfully
- Runner: local

Suggested labels: `bug`, `priority-low`, `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)