### PR TITLE
fix(sales): order-approval trigger listens for sales.order.created so it can auto-start

### DIFF
--- a/packages/core/src/modules/sales/__tests__/order-approval-trigger.test.ts
+++ b/packages/core/src/modules/sales/__tests__/order-approval-trigger.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from '@jest/globals'
+import { workflowsConfig } from '../workflows'
+import { eventsConfig } from '../events'
+
+/**
+ * Guards issue #4333: the order-approval workflow's auto-start trigger
+ * listened for 'sales.orders.created' (plural), but the sales module emits
+ * 'sales.order.created' (singular) — the trigger could never fire, so the
+ * approval workflow never auto-started for any order. This pins every
+ * non-wildcard trigger eventPattern in this module's code-defined workflows
+ * to an event the module actually declares (and allows in triggers).
+ */
+describe('sales code-defined workflow triggers', () => {
+  const triggerableEventIds = new Set(
+    eventsConfig.events
+      .filter((event) => !event.excludeFromTriggers)
+      .map((event) => event.id),
+  )
+
+  const triggers = workflowsConfig.workflows.flatMap((workflow) =>
+    (workflow.definition.triggers ?? []).map((trigger) => ({
+      workflowId: workflow.workflowId,
+      triggerId: trigger.triggerId,
+      eventPattern: trigger.eventPattern,
+    })),
+  )
+
+  test('module ships workflow triggers to guard', () => {
+    expect(triggers.length).toBeGreaterThan(0)
+  })
+
+  test.each(triggers.map((entry) => [
+    `${entry.workflowId} / ${entry.triggerId}`,
+    entry,
+  ] as const))('%s listens for a declared, triggerable event', (_label, entry) => {
+    if (entry.eventPattern.includes('*')) return
+    expect(triggerableEventIds).toContain(entry.eventPattern)
+  })
+
+  test('order approval trigger listens for the singular order-created event', () => {
+    const orderApproval = workflowsConfig.workflows.find(
+      (workflow) => workflow.workflowId === 'sales.order-approval',
+    )
+    const trigger = orderApproval?.definition.triggers?.find(
+      (entry) => entry.triggerId === 'order_approval_trigger',
+    )
+    expect(trigger?.eventPattern).toBe('sales.order.created')
+  })
+})

--- a/packages/core/src/modules/sales/workflows.ts
+++ b/packages/core/src/modules/sales/workflows.ts
@@ -174,7 +174,7 @@ const orderApproval = defineWorkflow({
     triggerId: 'order_approval_trigger',
     name: 'Order Approval Trigger',
     description: 'Triggers when a new sales order is created',
-    eventPattern: 'sales.orders.created',
+    eventPattern: 'sales.order.created',
     config: { entityType: 'SalesOrder' },
     enabled: true,
     priority: 0,


### PR DESCRIPTION
## Summary

Fixes #4333.

The `sales.order-approval` workflow's auto-start trigger declared `eventPattern: 'sales.orders.created'` (plural), but the sales module emits `sales.order.created` (singular — consistent with `sales.quote.created`, `sales.invoice.created` and every other CRUD event it declares). The pattern never matched an emitted event, so the approval workflow has never auto-started for any created order; the only way to start it was the manual *Request Approval* path.

## Changes

- `packages/core/src/modules/sales/workflows.ts`: `eventPattern` `sales.orders.created` → `sales.order.created` (one line).
- Guard test (`__tests__/order-approval-trigger.test.ts`): pins every non-wildcard trigger `eventPattern` in this module's code-defined workflows to an event the module actually declares as triggerable (`eventsConfig.events` minus `excludeFromTriggers`), plus an explicit assertion for the order-approval trigger. Prevents this event-name drift from recurring for future triggers.

## Validation

- `yarn workspace @open-mercato/core test --testPathPatterns "sales/__tests__/order-approval-trigger"` — 3/3 passed
- Runner: local

Related: this is the sibling of #4334 (fixed in PR #4341) — same workflow, different defect. Suggested labels: `bug`, `priority-medium`, `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)