### PR TITLE
fix(customers): give ActivityTimeline 'Mark done' the compact sizing its sibling uses

### DIFF
--- a/packages/core/src/modules/customers/components/detail/ActivityTimeline.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivityTimeline.tsx
@@ -135,7 +135,7 @@ function TimelineEntry({
                 size="sm"
                 disabled={markingDone}
                 onClick={handleMarkDone}
-                className="shrink-0"
+                className="h-7 shrink-0 text-xs"
               >
                 <Check className="size-3.5" />
                 {t('customers.activities.actions.markDone', 'Mark done')}


### PR DESCRIPTION
## Summary

Fixes #4375.

The **Mark done** button on `ActivityTimeline` rendered at default `size="sm"` height inside the timeline's tight `text-[10px]/[11px]` row, while the sibling `PlannedActivitiesSection` shrinks its equivalent button with `h-7 text-xs`. One-line change aligning the two (`className="h-7 shrink-0 text-xs"`), exactly as proposed in the issue.

## Validation

- Visual one-liner matching an existing in-file pattern; no behavior change.
- Runner: local

Suggested labels: `bug`, `priority-low`, `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)