### PR TITLE
fix(customers): CustomFieldValuesList honors listVisible and formats values by kind

### DIFF
--- a/packages/core/src/modules/customers/components/detail/CustomFieldValuesList.tsx
+++ b/packages/core/src/modules/customers/components/detail/CustomFieldValuesList.tsx
@@ -30,6 +30,8 @@ type DisplayEntry = {
   value: unknown
   dictionaryMap: DictionaryMap | null
   multi: boolean
+  kind?: string
+  options?: CustomFieldDefDto['options']
 }
 
 type CustomFieldValuesListProps = {
@@ -97,10 +99,23 @@ function renderDictionaryValues(
   )
 }
 
-function renderPrimitiveValues(value: unknown): React.ReactNode {
+function resolveOptionLabel(value: unknown, options: CustomFieldDefDto['options']): unknown {
+  if (!options?.length || typeof value !== 'string') return value
+  const trimmed = value.trim()
+  const match = options.find((option) => option.value === trimmed)
+  return match ? match.label : value
+}
+
+function applyOptionLabels(value: unknown, options: CustomFieldDefDto['options']): unknown {
+  if (!options?.length) return value
+  if (Array.isArray(value)) return value.map((entry) => resolveOptionLabel(entry, options))
+  return resolveOptionLabel(value, options)
+}
+
+function renderPrimitiveValues(value: unknown, kind?: string): React.ReactNode {
   if (Array.isArray(value)) {
     const parts = value
-      .map((entry) => stringifyCustomValue(entry))
+      .map((entry) => stringifyCustomValue(entry, { kind }))
       .map((entry) => entry.trim())
       .filter((entry) => entry.length > 0)
     if (!parts.length) return null
@@ -117,7 +132,7 @@ function renderPrimitiveValues(value: unknown): React.ReactNode {
       </div>
     )
   }
-  const label = stringifyCustomValue(value).trim()
+  const label = stringifyCustomValue(value, { kind }).trim()
   if (!label.length) return null
   return <span className="text-sm text-foreground">{label}</span>
 }
@@ -179,6 +194,12 @@ function buildDisplayEntries(
   definitions.forEach((def, index) => {
     const normalizedKey = normalizeCustomFieldKey(def.key)
     if (!normalizedKey) return
+    // Operational fields marked listVisible:false must not render — neither
+    // here nor as a definition-less "extra" below, so consume the key anyway.
+    if (def.listVisible === false) {
+      consumedKeys.add(normalizedKey)
+      return
+    }
     const entry = combined.get(normalizedKey)
     if (!entry || isEmptyCustomValue(entry.value)) return
     const label = resolveCustomFieldLabel(entry.label ?? def.label, entry.key)
@@ -191,6 +212,8 @@ function buildDisplayEntries(
       value: entry.value,
       dictionaryMap,
       multi: def.multi ?? Array.isArray(entry.value),
+      kind: def.kind,
+      options: def.options,
     })
     consumedKeys.add(normalizedKey)
   })
@@ -242,7 +265,8 @@ export function CustomFieldValuesList({
     <div className={cn('grid gap-3 sm:grid-cols-2', className)}>
       {displayEntries.map((entry, index) => {
         const dictionaryContent = renderDictionaryValues(entry.value, entry.dictionaryMap, entry.multi)
-        const primitiveContent = dictionaryContent ?? renderPrimitiveValues(entry.value)
+        const primitiveContent =
+          dictionaryContent ?? renderPrimitiveValues(applyOptionLabels(entry.value, entry.options), entry.kind)
         const content =
           dictionaryContent ??
           primitiveContent ??

--- a/packages/core/src/modules/customers/components/detail/__tests__/CustomFieldValuesList.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/CustomFieldValuesList.test.tsx
@@ -87,3 +87,68 @@ describe('CustomFieldValuesList', () => {
     expect(screen.queryByText('Test Test')).not.toBeInTheDocument()
   })
 })
+
+/**
+ * Guards issue #4373: honor listVisible:false, format values by definition
+ * kind (no blind date-parsing of plain strings, no literal "false"), and
+ * render select option labels instead of raw slugs.
+ */
+describe('CustomFieldValuesList visibility and formatting (#4373)', () => {
+  const definitions = [
+    { key: 'internal_ref', kind: 'text', label: 'Internal ref', listVisible: false },
+    { key: 'campaign', kind: 'text', label: 'Campaign' },
+    { key: 'signed_at', kind: 'date', label: 'Signed at' },
+    { key: 'vip', kind: 'boolean', label: 'VIP' },
+    {
+      key: 'segment',
+      kind: 'select',
+      label: 'Segment',
+      options: [
+        { value: 'small_biz', label: 'Small business' },
+        { value: 'enterprise', label: 'Enterprise' },
+      ],
+    },
+  ]
+
+  const values = {
+    internal_ref: 'OP-129',
+    campaign: 'Report 2024',
+    signed_at: '2026-01-15T10:00:00.000Z',
+    vip: false,
+    segment: 'small_biz',
+  }
+
+  it('hides listVisible:false fields entirely (no leak into extras)', () => {
+    render(<CustomFieldValuesList values={values} definitions={definitions} />)
+    expect(screen.queryByText('Internal ref')).not.toBeInTheDocument()
+    expect(screen.queryByText('OP-129')).not.toBeInTheDocument()
+  })
+
+  it('leaves non-date strings untouched even when Date can parse them', () => {
+    render(<CustomFieldValuesList values={values} definitions={definitions} />)
+    expect(screen.getByText('Report 2024')).toBeInTheDocument()
+  })
+
+  it('date-formats values only for date-kind fields', () => {
+    render(<CustomFieldValuesList values={values} definitions={definitions} />)
+    const expected = new Date('2026-01-15T10:00:00.000Z').toLocaleString()
+    expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+
+  it('treats boolean false as empty instead of rendering "false"', () => {
+    render(<CustomFieldValuesList values={values} definitions={definitions} />)
+    expect(screen.queryByText('false')).not.toBeInTheDocument()
+    expect(screen.queryByText('VIP')).not.toBeInTheDocument()
+  })
+
+  it('renders select option labels instead of raw slugs', () => {
+    render(<CustomFieldValuesList values={values} definitions={definitions} />)
+    expect(screen.getByText('Small business')).toBeInTheDocument()
+    expect(screen.queryByText('small_biz')).not.toBeInTheDocument()
+  })
+
+  it('still renders definition-less extras', () => {
+    render(<CustomFieldValuesList values={{ loose_note: 'hello there' }} definitions={definitions} />)
+    expect(screen.getByText('hello there')).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/customFieldUtils.ts
+++ b/packages/core/src/modules/customers/components/detail/customFieldUtils.ts
@@ -53,6 +53,7 @@ export function resolveCustomFieldLabel(label: string | null | undefined, key: s
 
 export function isEmptyCustomValue(value: unknown): boolean {
   if (value === null || value === undefined) return true
+  if (value === false) return true
   if (typeof value === 'string') return value.trim().length === 0
   if (Array.isArray(value)) return value.length === 0 || value.every((entry) => isEmptyCustomValue(entry))
   if (typeof value === 'object') {
@@ -65,11 +66,14 @@ export function isEmptyCustomValue(value: unknown): boolean {
   return false
 }
 
-export function stringifyCustomValue(value: unknown): string {
+const DATE_FIELD_KINDS = new Set(['date', 'datetime'])
+const ISO_DATE_PREFIX_RE = /^\d{4}-\d{2}-\d{2}([T ]|$)/
+
+export function stringifyCustomValue(value: unknown, options?: { kind?: string }): string {
   if (value === null || value === undefined) return ''
   if (Array.isArray(value)) {
     const parts = value
-      .map((entry) => stringifyCustomValue(entry))
+      .map((entry) => stringifyCustomValue(entry, options))
       .map((entry) => entry.trim())
       .filter((entry) => entry.length > 0)
     return parts.join(', ')
@@ -81,7 +85,15 @@ export function stringifyCustomValue(value: unknown): string {
   if (typeof value === 'string') {
     const trimmed = value.trim()
     if (!trimmed.length) return ''
-    return formatDateTime(trimmed) ?? trimmed
+    // Date-format strings only when the definition says the field is a date,
+    // or (for definition-less extras) when the value is unambiguously ISO-like.
+    // `new Date(...)` parses far too loosely to run on every string — it used
+    // to mangle plain text such as "Report 2024" into a date.
+    const kind = options?.kind
+    if (kind ? DATE_FIELD_KINDS.has(kind) : ISO_DATE_PREFIX_RE.test(trimmed)) {
+      return formatDateTime(trimmed) ?? trimmed
+    }
+    return trimmed
   }
   if (typeof value === 'number' || typeof value === 'bigint' || typeof value === 'boolean') {
     return String(value)


### PR DESCRIPTION
## Summary

Fixes #4373 — items (a), (b), (c) from the issue's proposed solution.

The profile "Custom fields" card rendered every custom-field definition and formatted values blindly:
- fields marked `listVisible:false` (operational ids) still rendered,
- **every** string went through `formatDateTime` → loose `new Date(...)` parsing, so plain text like `Report 2024` was mangled into a date,
- boolean `false` rendered as the literal text "false",
- `select` fields with inline `options` rendered the raw slug instead of the option label.

## Changes

- `CustomFieldValuesList.tsx` (`buildDisplayEntries`): skip `listVisible:false` definitions **while still consuming their keys**, so a hidden field's value cannot leak back in through the definition-less "extras" path; carry `def.kind` / `def.options` into display entries; map select values to option labels before rendering.
- `customFieldUtils.ts`: `stringifyCustomValue` takes an optional `{ kind }` — strings are date-formatted only for `date`/`datetime` kinds (definition-less extras: only unambiguously ISO-like strings, `^\d{4}-\d{2}-\d{2}`); `isEmptyCustomValue` treats boolean `false` as empty. Both helpers are used only by this card.
- Item (d) from the issue (injection spot around the card) is intentionally **not** included — that is a new extension-surface contract, which per repo rules needs a maintainer decision first.

## Validation

- `yarn workspace @open-mercato/core test --testPathPatterns "CustomFieldValuesList"` — 11/11 passed (5 pre-existing label tests + 6 new covering each fixed behavior)
- Runner: local

Suggested labels: `bug`, `priority-low`, `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)