### PR TITLE
feat(customers): configurable excludeInteractionType on profile activity sections

### DIFF
--- a/packages/core/src/modules/customers/components/detail/ActivitiesSection.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesSection.tsx
@@ -36,6 +36,8 @@ export type ActivitiesSectionProps = {
   runGuardedMutation?: GuardedMutationRunner
   refreshKey?: number
   onEditActivity?: (activity: InteractionSummary) => void
+  /** Interaction type hidden from the timeline by default ('task' unless overridden); pass null to show every type. */
+  excludeInteractionType?: string | null
 }
 
 function toDateOnly(value: string | null | undefined): string {
@@ -109,6 +111,7 @@ export function ActivitiesSection({
   refreshKey = 0,
   onEditActivity,
   runGuardedMutation,
+  excludeInteractionType = 'task',
 }: ActivitiesSectionProps) {
   const t = useT()
   const [filterTypes, setFilterTypes] = React.useState<string[]>([])
@@ -169,17 +172,18 @@ export function ActivitiesSection({
     setLoading(true)
     try {
       // Always fetch canonical interactions (new activities are always created here)
-      const taskFilterActive = filterTypes.includes('task')
+      const excludedFilterActive = excludeInteractionType ? filterTypes.includes(excludeInteractionType) : true
       const canonicalParams = new URLSearchParams({
         entityId,
         limit: '50',
         sortField: 'occurredAt',
         sortDir: 'desc',
       })
-      // Hide tasks from the activity timeline by default — they have their own tab —
-      // but lift the exclusion when the user explicitly toggled the Task chip on
-      // (mirrors `ActivityHistorySection.tsx` after the #1805 fix).
-      if (!taskFilterActive) canonicalParams.set('excludeInteractionType', 'task')
+      // Hide the configured type (tasks by default — they have their own tab)
+      // from the activity timeline, but lift the exclusion when the user
+      // explicitly toggled that type's chip on (mirrors
+      // `ActivityHistorySection.tsx` after the #1805 fix).
+      if (excludeInteractionType && !excludedFilterActive) canonicalParams.set('excludeInteractionType', excludeInteractionType)
       if (dealId) canonicalParams.set('dealId', dealId)
       if (filterTypes.length > 0) canonicalParams.set('type', filterTypes.join(','))
       if (filterDateFrom) canonicalParams.set('from', filterDateFrom)
@@ -261,7 +265,7 @@ export function ActivitiesSection({
     } finally {
       setLoading(false)
     }
-  }, [dealId, entityId, filterDateFrom, filterDateTo, filterTypes, loadedPages, useCanonicalInteractions, refreshKey, t])
+  }, [dealId, entityId, excludeInteractionType, filterDateFrom, filterDateTo, filterTypes, loadedPages, useCanonicalInteractions, refreshKey, t])
 
   React.useEffect(() => {
     setLoadedPages(1)

--- a/packages/core/src/modules/customers/components/detail/ActivityHistorySection.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivityHistorySection.tsx
@@ -30,6 +30,8 @@ type ActivityHistorySectionProps = {
   /** Optional guarded-mutation runner so per-row mutations route through the parent's
    * `useGuardedMutation` and emit retry-last-mutation context. */
   runMutation?: GuardedMutationRunner
+  /** Interaction type hidden from the history by default ('task' unless overridden); pass null to show every type. */
+  excludeInteractionType?: string | null
 }
 
 type InteractionListResponse = {
@@ -170,6 +172,7 @@ export function ActivityHistorySection({
   refreshKey = 0,
   onEditActivity,
   runMutation,
+  excludeInteractionType = 'task',
 }: ActivityHistorySectionProps) {
   const t = useT()
   const [searchInput, setSearchInput] = React.useState('')
@@ -231,14 +234,14 @@ export function ActivityHistorySection({
       let firstPageHasMore = false
       let pagesLoaded = 0
 
-      const taskFilterActive = activeTypes.includes('task')
+      const excludedFilterActive = excludeInteractionType ? activeTypes.includes(excludeInteractionType) : true
       do {
         const params = new URLSearchParams({
           entityId,
           limit: String(pageSize),
           from: rangeStart,
         })
-        if (!taskFilterActive) params.set('excludeInteractionType', 'task')
+        if (excludeInteractionType && !excludedFilterActive) params.set('excludeInteractionType', excludeInteractionType)
         if (activeTypes.length > 0) params.set('type', activeTypes.join(','))
         if (search) params.set('search', search)
         if (sortMode === 'recent') {
@@ -310,7 +313,7 @@ export function ActivityHistorySection({
     } finally {
       if (!isStale()) setLoading(false)
     }
-  }, [activeTypes, dateRange, entityId, loadedPages, search, sortMode, t, useCanonicalInteractions])
+  }, [activeTypes, dateRange, entityId, excludeInteractionType, loadedPages, search, sortMode, t, useCanonicalInteractions])
 
   React.useEffect(() => {
     const controller = new AbortController()

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.excludeType.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesSection.excludeType.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Guards issue #4372: the profile activity timeline hides tasks by default,
+ * but the hidden type must be configurable — `excludeInteractionType` prop
+ * overrides it and `null` disables the exclusion entirely.
+ */
+import * as React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { ActivitiesSection } from '../ActivitiesSection'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+const requestedUrls: string[] = []
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: async (url: string) => {
+    requestedUrls.push(url)
+    return { items: [] }
+  },
+  apiCallOrThrow: async () => ({}),
+}))
+
+function renderSection(excludeInteractionType?: string | null) {
+  return render(
+    <ActivitiesSection
+      entityId="entity-1"
+      useCanonicalInteractions
+      addActionLabel="Add"
+      emptyState={{ title: 'No activities', actionLabel: 'Add' }}
+      {...(excludeInteractionType !== undefined ? { excludeInteractionType } : {})}
+    />,
+  )
+}
+
+async function interactionsRequest(): Promise<URLSearchParams> {
+  await waitFor(() => {
+    expect(requestedUrls.some((url) => url.startsWith('/api/customers/interactions?'))).toBe(true)
+  })
+  const url = requestedUrls.find((entry) => entry.startsWith('/api/customers/interactions?')) as string
+  return new URLSearchParams(url.split('?')[1])
+}
+
+describe('ActivitiesSection excludeInteractionType', () => {
+  beforeEach(() => {
+    requestedUrls.length = 0
+  })
+
+  it('hides tasks by default', async () => {
+    renderSection()
+    const params = await interactionsRequest()
+    expect(params.get('excludeInteractionType')).toBe('task')
+  })
+
+  it('hides the configured type instead when overridden', async () => {
+    renderSection('note')
+    const params = await interactionsRequest()
+    expect(params.get('excludeInteractionType')).toBe('note')
+  })
+
+  it('hides nothing when the prop is null', async () => {
+    renderSection(null)
+    const params = await interactionsRequest()
+    expect(params.get('excludeInteractionType')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #4372.

`ActivitiesSection` and `ActivityHistorySection` hardcode hiding `interactionType='task'` from the profile timeline (`ActivitiesSection.tsx:182`, `ActivityHistorySection.tsx:241`) and expose no prop to change it — a downstream app cannot show tasks (or hide a different type) without forking both sections.

## Changes

- Add an optional `excludeInteractionType?: string | null` prop to both sections: default `'task'` (behavior unchanged for all current callers), any other string hides that type instead, `null` disables the exclusion entirely.
- The existing chip-lift behavior is generalized: toggling the excluded type's filter chip still lifts the exclusion, exactly as it previously did for the Task chip (#1805 behavior preserved).
- **Single-type by design** — the issue floats a plural `excludeInteractionTypes`, but `GET /api/customers/interactions` accepts exactly one `excludeInteractionType` (`route.ts:352`, `!=` comparison), so the prop mirrors the API contract 1:1 instead of promising multi-type exclusion the backend can't serve. Extending the API to a list would be a separate, wider change.

## Validation

- `yarn workspace @open-mercato/core test --testPathPatterns "ActivitiesSection.excludeType"` — 3/3 passed (default hides `task`, override hides the configured type, `null` hides nothing — asserted on the actual request URLs)
- Runner: local

Suggested labels: `feature`, `priority-low`, `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)