### PR TITLE
chore(agents): sync agent-pipeline tracker & browser descriptors

### DIFF
--- a/.ai/agentic.config.json
+++ b/.ai/agentic.config.json
@@ -2,6 +2,9 @@
   "version": 1,
   "baseBranch": "develop",
   "tracker": "github",
+  "browser": {
+    "provider": "playwright"
+  },
   "validation": {
     "commands": [
       "yarn build:packages",

--- a/.ai/browsers/playwright.md
+++ b/.ai/browsers/playwright.md
@@ -1,0 +1,73 @@
+# Browser provider: playwright
+
+This is the compatibility provider for repositories that use Playwright for
+agent-driven browser exploration and evidence capture.
+
+## Operations
+
+### ensure-installed
+
+If the repository already has `@playwright/test` or a `playwright.config.*`, use
+its package runner and config. Otherwise install Playwright as a development
+dependency with the package manager selected by the repository's lockfile, then
+run its browser installer for Chromium with OS dependencies. On Linux, retry the
+dependency install only when root or passwordless elevation is already
+available; do not ask the operator to perform the install.
+
+Write a minimal shared config at `<paths.qa>/playwright.config.ts` when the repo
+has none. It reads `process.env.BASE_URL`; timeouts and retries live in that
+shared config.
+
+Output:
+
+```text
+BROWSER_PROVIDER=playwright
+BROWSER_INSTALLED=0|1
+BROWSER_COMMAND=<repository package-runner command>
+BROWSER_VERSION=<version or unknown>
+BROWSER_NOTES=<empty or concrete blocker>
+```
+
+### doctor
+
+Run the repository package runner's Playwright version command, then launch a
+one-page Chromium smoke test against a local `data:` URL. Return non-zero when
+the browser cannot launch.
+
+### open
+
+Use Playwright's configured Chromium project and a throwaway spec outside the
+repository's discovered test directories. Navigate to the validated `BASE_URL`.
+
+### snapshot
+
+Use the live page's accessibility tree or role/label queries. Record exact
+roles, labels, text, and element states before interacting.
+
+### interact
+
+Use only role/label/text locators observed by **snapshot**. Do not guess CSS
+paths. Re-observe after navigation or material DOM changes.
+
+### assert
+
+Use Playwright web-first assertions in the throwaway spec. Return non-zero on a
+failed condition and preserve the error context artifact.
+
+### screenshot
+
+Call `page.screenshot({ path: SCREENSHOT_PATH, fullPage: true })`, then verify
+the PNG exists and is non-empty.
+
+### close
+
+Close the throwaway page, context, and browser in `finally`. Safe to repeat.
+
+## Rules
+
+- Use the repository's package manager and existing runner configuration; never
+  add a second Playwright installation.
+- Keep throwaway exploration specs under the QA artifacts directory, never in a
+  discovered test directory.
+- Repository-native committed tests remain authoritative and run with the
+  repository's existing command.

--- a/.ai/trackers/github.md
+++ b/.ai/trackers/github.md
@@ -1,8 +1,8 @@
 # Tracker provider: GitHub
 
-This file is the GitHub implementation of the tracker operations contract (see `TEMPLATE.md` for the contract itself). Every skill in the collection performs issue/PR state management through **named tracker operations** — `**get-issue**`, `**comment-pr**`, and so on — and this file defines what each operation means for GitHub, using the `gh` CLI.
+This file is the GitHub implementation of the tracker operations contract (see `TEMPLATE.md` for the contract itself). Skills perform issue/PR state management through **named tracker operations** — `**get-issue**`, `**comment-pr**`, and so on — and this file defines what each operation means for GitHub, using the `gh` CLI.
 
-How it is used at runtime: `om-setup-agent-pipeline` copies this file into the repository at `.ai/trackers/github.md`, and the config's `tracker` field selects it. When a skill says "tracker operation **get-pr**", execute the command documented under that operation heading in the repo's copy. The repo's copy is authoritative: teams extend or override any operation by editing it — add flags, swap a command, append repo-specific conventions — and every skill picks the change up on its next run. An operation not covered by an edit keeps its behavior from this file's text as copied.
+At runtime: `om-setup-agent-pipeline` copies this file into the repository at `.ai/trackers/github.md`, and the config's `tracker` field selects it. When a skill says "tracker operation **get-pr**", execute the command documented under that operation heading in the repo's copy. The repo's copy is authoritative: teams extend or override any operation by editing it, and every skill picks the change up on its next run. An operation not covered by an edit keeps its behavior from this file's text as copied.
 
 ## Prerequisites
 
@@ -130,6 +130,12 @@ gh issue close {issueId} --repo {owner}/{repo} --reason completed --comment "<co
 gh issue comment {issueId} --repo {owner}/{repo} --body "<body>"
 ```
 
+#### update-issue
+`{issueId}`, new title and/or body (use a body-file for multi-line bodies). Edits the issue's own fields; does not touch labels or assignees (those have their own operations).
+```bash
+gh issue edit {issueId} --repo {owner}/{repo} --title "<title>" --body-file <file>
+```
+
 #### assign-issue / unassign-issue
 ```bash
 gh issue edit {issueId} --repo {owner}/{repo} --add-assignee "<login>"
@@ -149,6 +155,12 @@ gh api repos/{owner}/{repo}/issues/comments/{commentId} --jq '{body,user:.user.l
 `{issueId or prNumber}` → conversation comments (PR conversation comments are issue comments on GitHub).
 ```bash
 gh api repos/{owner}/{repo}/issues/{number}/comments --jq '.[] | {id,user:.user.login,body}'
+```
+
+#### update-comment
+`{commentId}`, new body → rewrite an existing conversation comment in place (works for issue and PR conversation comments alike). This is how marker-idempotent comments (label rationale, verification, claim take-overs) are updated on re-runs: find your `🤖 …` marker via **list-issue-comments**, then update that comment instead of posting a new one. Use a body file so multi-line bodies survive.
+```bash
+gh api -X PATCH repos/{owner}/{repo}/issues/comments/{commentId} -F body=@<path>
 ```
 
 ### Pull requests
@@ -179,6 +191,17 @@ Base branch, draft flag, title, body → PR.
 gh pr create --repo {owner}/{repo} --base "$BASE_BRANCH" --draft --title "<title>" --body "<body>"
 PR_URL=$(gh pr view --json url --jq .url)
 PR_NUMBER=$(gh pr view --json number --jq .number)
+```
+
+#### update-pr
+`{prNumber}`, new title and/or new body → the PR's own title/body rewritten in place (not a comment), e.g. reframing a doc-originated spec PR that grew a feature implementation. Pass whichever of `--title` / `--body-file` changed; omit the other. Use a body file so multi-line bodies survive.
+```bash
+gh pr edit {prNumber} --title "<title>"
+gh pr edit {prNumber} --body-file <path-or-process-substitution>
+```
+If `gh pr edit` silently no-ops in this repo (some GitHub setups do), fall back to the REST API:
+```bash
+gh api -X PATCH repos/{owner}/{repo}/pulls/{prNumber} -f title="<title>" -f body="$(cat <path>)"
 ```
 
 #### comment-pr


### PR DESCRIPTION
## 🎯 Goal

Re-sync the installed agent-pipeline artifacts under `.ai/` with the upstream `open-mercato/skills` collection after a skills upgrade, run via the `om-apply-upgrade-notes` skill. **No application code, tests, or CI config is touched** — only pipeline descriptors and their config key.

## 📋 What changed

- **`.ai/trackers/github.md`** — adds three missing tracker operations: `update-issue`, `update-comment`, and `update-pr`. The installed copy carried **no local edits** (it was a strict subset of the shipped descriptor), so it was re-synced whole-file to the authoritative `open-mercato/skills@main` version. `attach-image-evidence` and `mark-pr-ready` were already present and are unchanged.
- **`.ai/browsers/playwright.md`** — installs the shipped Playwright browser-provider descriptor. The `.ai/browsers/` directory did not exist before.
- **`.ai/agentic.config.json`** — adds `browser.provider = "playwright"` as the additive default. This **preserves the existing embedded-Playwright QA behavior** and is deliberately *not* a switch to agent-browser.

## Why

The bundled shipped reference in the local skills install predated three tracker operations that the skills now depend on (`om-auto-manage-issues` → `update-issue`; label-rationale/verification comment idempotency → `update-comment`; doc-originated-PR reframing → `update-pr`), and the QA skills expect an explicit browser-provider descriptor to resolve. Without this sync those operations degrade or skip.

## 🧪 Verification

- `jq` parses the config; `browser.provider` resolves to the newly installed descriptor.
- Every operation named by the installed skills is present in the descriptor.
- Idempotent: a re-run of `om-apply-upgrade-notes` now diffs clean.

## 💥 Breaking changes

None. All changes are additive; the tracker re-sync introduced no local-edit loss (the installed descriptor had none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
