### PR TITLE
fix(attachments): stop assignment inputs losing focus on every keystroke (#4338)

### DIFF
--- a/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
@@ -199,7 +199,7 @@ type AssignmentsEditorProps = {
   disabled?: boolean
 }
 
-function AttachmentAssignmentsEditor({ value, onChange, labels, disabled }: AssignmentsEditorProps) {
+export function AttachmentAssignmentsEditor({ value, onChange, labels, disabled }: AssignmentsEditorProps) {
   const handleChange = React.useCallback(
     (index: number, patch: Partial<AssignmentDraft>) => {
       onChange(value.map((entry, idx) => (idx === index ? { ...entry, ...patch } : entry)))
@@ -229,7 +229,7 @@ function AttachmentAssignmentsEditor({ value, onChange, labels, disabled }: Assi
           <div className="text-xs text-muted-foreground">No assignments yet.</div>
         ) : (
           value.map((entry, index) => (
-            <div key={`${index}-${entry.type}-${entry.id}`} className="rounded border p-3 space-y-2">
+            <div key={index} className="rounded border p-3 space-y-2">
               <div className="grid gap-2 sm:grid-cols-2">
                 <div className="space-y-1">
                   <label className="text-xs font-medium">{labels.type}</label>

--- a/packages/core/src/modules/attachments/components/__tests__/assignmentsEditorFocus.test.tsx
+++ b/packages/core/src/modules/attachments/components/__tests__/assignmentsEditorFocus.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for #4338: the upload dialog's assignment row key must
+ * stay stable while the user types — a value-derived key remounts the row on
+ * every keystroke, dropping focus after each character.
+ */
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { AttachmentAssignmentsEditor } from '../AttachmentLibrary'
+import type { AssignmentDraft } from '@open-mercato/ui/backend/detail'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+const labels = {
+  title: 'Assignments',
+  description: 'Link this attachment to records',
+  type: 'Type',
+  id: 'Record ID',
+  href: 'Link',
+  label: 'Label',
+  add: 'Add assignment',
+  remove: 'Remove',
+}
+
+function EditorHarness({ initial }: { initial: AssignmentDraft[] }) {
+  const [value, setValue] = React.useState<AssignmentDraft[]>(initial)
+  return <AttachmentAssignmentsEditor value={value} onChange={setValue} labels={labels} />
+}
+
+describe('AttachmentAssignmentsEditor (upload dialog)', () => {
+  it('keeps the Type input mounted and focused while typing multiple characters', () => {
+    render(<EditorHarness initial={[{ type: '', id: '', href: '', label: '' }]} />)
+
+    const typeInput = screen.getAllByRole('textbox')[0] as HTMLInputElement
+    typeInput.focus()
+
+    let typed = ''
+    for (const char of 'catalog.product') {
+      typed += char
+      fireEvent.change(typeInput, { target: { value: typed } })
+      expect(screen.getAllByRole('textbox')[0]).toBe(typeInput)
+      expect(document.activeElement).toBe(typeInput)
+    }
+
+    expect(typeInput.value).toBe('catalog.product')
+  })
+
+  it('keeps the Record ID input mounted and focused while typing', () => {
+    render(<EditorHarness initial={[{ type: 'catalog.product', id: '', href: '', label: '' }]} />)
+
+    const idInput = screen.getAllByRole('textbox')[1] as HTMLInputElement
+    idInput.focus()
+
+    fireEvent.change(idInput, { target: { value: 'a' } })
+    fireEvent.change(idInput, { target: { value: 'ab' } })
+
+    expect(screen.getAllByRole('textbox')[1]).toBe(idInput)
+    expect(document.activeElement).toBe(idInput)
+    expect(idInput.value).toBe('ab')
+  })
+})

--- a/packages/ui/src/backend/detail/AttachmentMetadataDialog.tsx
+++ b/packages/ui/src/backend/detail/AttachmentMetadataDialog.tsx
@@ -249,7 +249,7 @@ function AssignmentInputRow({
   )
 }
 
-function AttachmentAssignmentsEditor({
+export function AttachmentAssignmentsEditor({
   value,
   onChange,
   labels,
@@ -290,7 +290,7 @@ function AttachmentAssignmentsEditor({
       <div className="space-y-2">
         {value.length ? value.map((entry, idx) => (
           <AssignmentInputRow
-            key={`${entry.type}-${entry.id}-${idx}`}
+            key={idx}
             value={entry}
             labels={labels}
             disabled={disabled}

--- a/packages/ui/src/backend/detail/__tests__/AttachmentAssignmentsEditor.test.tsx
+++ b/packages/ui/src/backend/detail/__tests__/AttachmentAssignmentsEditor.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for #4338: the assignment row key must stay stable while
+ * the user types — a value-derived key remounts the row on every keystroke,
+ * which throws the input out of focus after each character.
+ */
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+jest.mock('@open-mercato/core/generated-shims/entities.ids.generated', () => ({
+  E: new Proxy({}, {
+    get: (_target, moduleId) => new Proxy({}, {
+      get: (_entity, entityId) => `${String(moduleId)}:${String(entityId)}`,
+    }),
+  }),
+}))
+
+import { AttachmentAssignmentsEditor, type AssignmentDraft } from '../AttachmentMetadataDialog'
+
+const labels = {
+  title: 'Assignments',
+  description: 'Link this attachment to records',
+  type: 'Type',
+  id: 'Record ID',
+  href: 'Link',
+  label: 'Label',
+  add: 'Add assignment',
+  remove: 'Remove assignment',
+}
+
+function EditorHarness({ initial }: { initial: AssignmentDraft[] }) {
+  const [value, setValue] = React.useState<AssignmentDraft[]>(initial)
+  return <AttachmentAssignmentsEditor value={value} onChange={setValue} labels={labels} />
+}
+
+describe('AttachmentAssignmentsEditor (metadata dialog)', () => {
+  it('keeps the Type input mounted and focused while typing multiple characters', () => {
+    render(<EditorHarness initial={[{ type: '', id: '', href: '', label: '' }]} />)
+
+    const typeInput = screen.getByPlaceholderText('catalog.product') as HTMLInputElement
+    typeInput.focus()
+
+    let typed = ''
+    for (const char of 'catalog.product') {
+      typed += char
+      fireEvent.change(typeInput, { target: { value: typed } })
+      expect(screen.getByPlaceholderText('catalog.product')).toBe(typeInput)
+      expect(document.activeElement).toBe(typeInput)
+    }
+
+    expect(typeInput.value).toBe('catalog.product')
+  })
+
+  it('keeps the Record ID input mounted and focused while typing', () => {
+    render(<EditorHarness initial={[{ type: 'catalog.product', id: '', href: '', label: '' }]} />)
+
+    const idInput = screen.getByPlaceholderText('Record ID') as HTMLInputElement
+    idInput.focus()
+
+    fireEvent.change(idInput, { target: { value: 'a' } })
+    fireEvent.change(idInput, { target: { value: 'ab' } })
+
+    expect(screen.getByPlaceholderText('Record ID')).toBe(idInput)
+    expect(document.activeElement).toBe(idInput)
+    expect(idInput.value).toBe('ab')
+  })
+
+  it('still adds and removes assignment rows', () => {
+    render(<EditorHarness initial={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add assignment' }))
+    expect(screen.getByPlaceholderText('catalog.product')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove assignment' }))
+    expect(screen.queryByPlaceholderText('catalog.product')).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #4338.

## Root cause

Both assignment editors keyed their rows by the values being typed:

- `packages/ui/src/backend/detail/AttachmentMetadataDialog.tsx` (Edit metadata dialog): `key={\`${entry.type}-${entry.id}-${idx}\`}`
- `packages/core/src/modules/attachments/components/AttachmentLibrary.tsx` (upload dialog): `key={\`${index}-${entry.type}-${entry.id}\`}`

Every keystroke in "Type" or "Record ID" changed the row's React key, so React unmounted and remounted the whole row — the freshly mounted input has no focus, which is exactly the one-character-per-click behavior reported.

## Fix

Key rows by index only. Draft rows have no natural identity and the list is never reordered — index keys are stable across edits, and add/remove still renders correctly because all inputs are controlled.

## Tests

Both editors are now exported for direct component testing. New regression tests type multiple characters through a stateful harness and assert the input **element identity** and **focus** survive every keystroke — verified to fail against the old value-derived keys (2 failures) and pass with the fix:

- `packages/ui`: `AttachmentAssignmentsEditor.test.tsx` — 3/3
- `packages/core`: `assignmentsEditorFocus.test.tsx` — 2/2

Full suites: `packages/core` attachments 186/186, `packages/ui` backend/detail 28/28.

Label suggestion (no triage rights): `review` + `bug` + `needs-qa` + `priority-medium` + `risk-low` — user-facing dialog fix, two-line production diff plus tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-medium` · `risk-low` · `needs-qa`