### PR TITLE
fix(customers): inline hint instead of error toast when dictionary options need an org context (#4401)

### DIFF
--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -40,6 +40,7 @@ import type {
 } from '@open-mercato/ui/backend/CrudForm'
 import {
   DictionaryEntrySelect,
+  DictionaryOptionsUnavailableError,
   type DictionarySelectLabels,
 } from '@open-mercato/core/modules/dictionaries/components/DictionaryEntrySelect'
 import { RolesSection } from './detail/RolesSection'
@@ -188,14 +189,27 @@ export function DictionarySelectField({
   )
 
   const fetchOptions = React.useCallback(async () => {
-    const data = await ensureCustomerDictionary(queryClient, kind, scopeVersion)
-    return data.entries.map((entry) => ({
-      value: entry.value,
-      label: entry.label,
-      color: entry.color ?? null,
-      icon: entry.icon ?? null,
-    }))
-  }, [kind, queryClient, scopeVersion])
+    try {
+      const data = await ensureCustomerDictionary(queryClient, kind, scopeVersion)
+      return data.entries.map((entry) => ({
+        value: entry.value,
+        label: entry.label,
+        color: entry.color ?? null,
+        icon: entry.icon ?? null,
+      }))
+    } catch (err) {
+      const status = (err as { status?: unknown } | null)?.status
+      if (status === 400) {
+        const serverMessage = err instanceof Error ? err.message.trim() : ''
+        throw new DictionaryOptionsUnavailableError(
+          serverMessage.length
+            ? serverMessage
+            : translate('customers.errors.organization_required', 'Organization context is required'),
+        )
+      }
+      throw err
+    }
+  }, [kind, queryClient, scopeVersion, translate])
 
   const createOption = React.useCallback(
     async (input: { value: string; label?: string; color?: string | null; icon?: string | null }) => {

--- a/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
+++ b/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
@@ -31,6 +31,13 @@ import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('dictionaries').child({ component: 'DictionaryEntrySelect' })
 
+export class DictionaryOptionsUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DictionaryOptionsUnavailableError'
+  }
+}
+
 const DEFAULT_APPEARANCE_LABELS: AppearanceSelectorLabels = {
   colorLabel: 'Color',
   colorHelp: 'Pick a highlight color for this entry.',
@@ -126,17 +133,24 @@ export function DictionaryEntrySelect({
   const [newValue, setNewValue] = React.useState('')
   const [newLabel, setNewLabel] = React.useState('')
   const [formError, setFormError] = React.useState<string | null>(null)
+  const [unavailableMessage, setUnavailableMessage] = React.useState<string | null>(null)
   const appearance = useAppearanceState(null, null)
 
   const loadOptions = React.useCallback(async () => {
     setLoading(true)
+    setUnavailableMessage(null)
     try {
       const items = await fetchOptions()
       setOptions(sortOptions === 'none' ? items : items.slice().sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })))
     } catch (err) {
-      logger.error('Failed to fetch options', { err })
-      flash(labels.errorLoad, 'error')
-      setOptions([])
+      if (err instanceof DictionaryOptionsUnavailableError) {
+        setUnavailableMessage(err.message)
+        setOptions([])
+      } else {
+        logger.error('Failed to fetch options', { err })
+        flash(labels.errorLoad, 'error')
+        setOptions([])
+      }
     } finally {
       setLoading(false)
     }
@@ -276,7 +290,7 @@ export function DictionaryEntrySelect({
     return '⌘/Ctrl + Enter'
   }, [labels.saveShortcutHint])
 
-  const disabled = disabledProp || loading || saving
+  const disabled = disabledProp || loading || saving || unavailableMessage !== null
   const manageLink = manageHref ?? '/backend/config/dictionaries'
   const returnTo = React.useMemo(() => {
     const query = searchParams?.toString() ?? ''
@@ -294,6 +308,9 @@ export function DictionaryEntrySelect({
 
   return (
     <div className="space-y-2">
+      {unavailableMessage ? (
+        <p className="text-xs text-muted-foreground">{unavailableMessage}</p>
+      ) : null}
       <div className="flex items-center gap-2">
         <Select
           key={`dictionary-entry:${value ?? ''}:${optionsKey}`}

--- a/packages/core/src/modules/dictionaries/components/__tests__/DictionaryEntrySelect.test.tsx
+++ b/packages/core/src/modules/dictionaries/components/__tests__/DictionaryEntrySelect.test.tsx
@@ -3,7 +3,12 @@
  */
 import * as React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
-import { DictionaryEntrySelect, type DictionarySelectLabels } from '../DictionaryEntrySelect'
+import {
+  DictionaryEntrySelect,
+  DictionaryOptionsUnavailableError,
+  type DictionarySelectLabels,
+} from '../DictionaryEntrySelect'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
 
 jest.mock('next/navigation', () => ({
   usePathname: () => '/backend/customers',
@@ -86,6 +91,7 @@ function optionLabels() {
 describe('DictionaryEntrySelect', () => {
   beforeEach(() => {
     fetchOptions.mockClear()
+    ;(flash as jest.Mock).mockClear()
   })
 
   it('keeps API order when sortOptions is none', async () => {
@@ -132,5 +138,48 @@ describe('DictionaryEntrySelect', () => {
     )
 
     await waitFor(() => expect(optionLabels()).toEqual(['legacy', 'Alpha', 'Beta']))
+  })
+
+  it('shows an inline hint instead of an error toast when options are unavailable (#4401)', async () => {
+    const unavailableFetch = jest.fn(async () => {
+      throw new DictionaryOptionsUnavailableError('Organization context is required')
+    })
+
+    render(
+      <DictionaryEntrySelect
+        value={undefined}
+        onChange={jest.fn()}
+        fetchOptions={unavailableFetch}
+        labels={labels}
+        allowInlineCreate={false}
+        showManage={false}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText('Organization context is required')).toBeInTheDocument(),
+    )
+    expect(flash).not.toHaveBeenCalled()
+    expect(optionLabels()).toEqual([])
+  })
+
+  it('still flashes the load error for unexpected failures', async () => {
+    const failingFetch = jest.fn(async () => {
+      throw new Error('boom')
+    })
+
+    render(
+      <DictionaryEntrySelect
+        value={undefined}
+        onChange={jest.fn()}
+        fetchOptions={failingFetch}
+        labels={labels}
+        allowInlineCreate={false}
+        showManage={false}
+      />,
+    )
+
+    await waitFor(() => expect(flash).toHaveBeenCalledWith('Load failed', 'error'))
+    expect(screen.queryByText('boom')).toBeNull()
   })
 })


### PR DESCRIPTION
Fixes #4401.

## Problem

Under **All organizations**, opening the deal Create page or any deal Detail page immediately fired a red "Nie udało się załadować opcji" toast — before any user interaction — and left the Status dropdown with zero options and no explanation. The deals List page hits the identical failure silently, so the three pages disagreed.

The 400 itself is a deliberate guard: `/api/customers/dictionaries/[kind]` needs a single organization to compute local-vs-inherited entries. The defect is how the shared select surfaces it.

## Fix

- `DictionaryEntrySelect` (dictionaries module): new exported `DictionaryOptionsUnavailableError`. When `fetchOptions` throws it, the component renders the error's message as a muted inline hint above the (disabled) select — no toast, no logger noise. Any other failure keeps the existing toast behavior.
- `DictionarySelectField` (customers `formConfig.tsx`): maps a 400 from the dictionaries endpoint to `DictionaryOptionsUnavailableError`, passing through the server's already-translated explanation (`customers.errors.organization_required` → "Wymagany jest kontekst organizacji"), with a client-side translated fallback.

Because every dictionary-backed form field (status, source, industry, job title, …) goes through `DictionarySelectField`, this fixes the toast storm on deal/person/company Create and Detail pages in one place, consistently with the silent List page — and the user now sees *why* the dropdown is empty, as the issue's expected-result asks.

Inline-create is disabled in that state too (creating an entry would hit the same org guard).

## Tests

`DictionaryEntrySelect.test.tsx`: two new cases — unavailable error renders the inline hint with **no** `flash` call and an empty option list; unexpected errors still flash `errorLoad`. Suites: dictionaries + customers components **326/326**.

Label suggestion (no triage rights): `review` + `bug` + `needs-qa` + `priority-medium` + `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-low` · `risk-low` · `needs-qa`