### PR TITLE
fix(dashboards): apply overrides.widgets.dashboard to the server-side widget catalog (#4377)

### DIFF
--- a/packages/core/src/modules/dashboards/__tests__/widgets.test.ts
+++ b/packages/core/src/modules/dashboards/__tests__/widgets.test.ts
@@ -48,6 +48,44 @@ describe('dashboard widget discovery', () => {
     expect(fetched?.metadata.title).toBe('Notes')
   })
 
+  it('honors overrides.widgets.dashboard on the server-side catalog (#4377)', async () => {
+    const keptLoader = jest.fn(async () => ({
+      default: {
+        metadata: { id: 'example.dashboard.kept', title: 'Kept' },
+        Widget: () => null,
+      } satisfies DashboardWidgetModule<any>,
+    }))
+    const removedLoader = jest.fn(async () => ({
+      default: {
+        metadata: { id: 'example.dashboard.removed', title: 'Removed' },
+        Widget: () => null,
+      } satisfies DashboardWidgetModule<any>,
+    }))
+
+    const { registerModules } = await import('@open-mercato/shared/lib/i18n/server')
+    registerModules([
+      {
+        id: 'example',
+        dashboardWidgets: [
+          { key: 'example:kept:widget', moduleId: 'example', loader: keptLoader },
+          { key: 'example:removed:widget', moduleId: 'example', loader: removedLoader },
+        ],
+      },
+    ] as any)
+
+    const { applyDashboardWidgetOverrides } = await import('@open-mercato/shared/modules/overrides')
+    applyDashboardWidgetOverrides({ 'example:removed:widget': null })
+
+    const { loadAllWidgets, loadWidgetById, invalidateWidgetCache } = await import('../lib/widgets')
+    invalidateWidgetCache()
+
+    const all = await loadAllWidgets()
+    expect(all.map((widget) => widget.metadata.id)).toEqual(['example.dashboard.kept'])
+    expect(removedLoader).not.toHaveBeenCalled()
+
+    await expect(loadWidgetById('example.dashboard.removed')).resolves.toBeNull()
+  })
+
   it('returns null for unknown widget id', async () => {
     const { registerModules } = await import('@open-mercato/shared/lib/i18n/server')
     registerModules([] as any)

--- a/packages/core/src/modules/dashboards/lib/widgets.ts
+++ b/packages/core/src/modules/dashboards/lib/widgets.ts
@@ -1,5 +1,6 @@
 import type { Module, ModuleDashboardWidgetEntry } from '@open-mercato/shared/modules/registry'
 import type { DashboardWidgetMetadata, DashboardWidgetModule } from '@open-mercato/shared/modules/dashboard/widgets'
+import { applyDashboardWidgetOverridesToEntries } from '@open-mercato/shared/modules/overrides'
 import { getModules } from '@open-mercato/shared/lib/i18n/server'
 
 type LoadedWidgetModule = DashboardWidgetModule<any> & { metadata: DashboardWidgetMetadata }
@@ -20,13 +21,14 @@ async function loadWidgetEntries(): Promise<WidgetEntry[]> {
   if (!widgetEntriesPromise) {
     widgetEntriesPromise = Promise.resolve().then(() => {
       const list = getModules() as Module[]
-      return list.flatMap((mod) => {
-        const entries = mod.dashboardWidgets ?? []
-        return entries.map((entry) => ({
+      const entries = list.flatMap((mod) => {
+        const moduleEntries = mod.dashboardWidgets ?? []
+        return moduleEntries.map((entry) => ({
           ...entry,
           moduleId: mod.id,
         }))
       })
+      return applyDashboardWidgetOverridesToEntries(entries) as WidgetEntry[]
     })
   }
   return widgetEntriesPromise


### PR DESCRIPTION
Fixes #4377.

## Problem

`applyDashboardWidgetOverridesToEntries` was only called from the **client** widget registry (`packages/ui/src/backend/dashboard/widgetRegistry.ts`). The server-side catalog (`packages/core/src/modules/dashboards/lib/widgets.ts`) read `getModules()` directly, so `overrides.widgets.dashboard['x'] = null` never removed a widget from new users' default layout or from the picker — it only produced a broken render when a saved layout still referenced the widget. Downstream apps had to reconcile `DashboardRoleWidgets` as a workaround.

## Fix

`loadWidgetEntries()` now routes the flattened module entries through the same `applyDashboardWidgetOverridesToEntries` helper the client uses. Every server consumer — widgets catalog, layout defaults, role-widget catalogs, users/widgets, CLI — flows through `loadAllWidgets`/`loadWidgetById`, so this single pass makes `null` overrides (and entry replacements) effective everywhere, consistently with the client render path.

## Tests

New regression case in `widgets.test.ts`: registers two widgets, applies `applyDashboardWidgetOverrides({ 'example:removed:widget': null })`, and asserts `loadAllWidgets` excludes it, its loader is **never invoked**, and `loadWidgetById` resolves null. Full dashboards suite 126/126.

Label suggestion (no triage rights): `review` + `bug` + `priority-medium` + `risk-low` + `skip-qa` (server-side behavior with test coverage; no UI change on default configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-medium` · `risk-medium` · `needs-qa`