### PR TITLE
fix(attachments): stable assignment row keys; cell anchors no longer trigger row click

### DIFF
--- a/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
@@ -199,7 +199,7 @@ type AssignmentsEditorProps = {
   disabled?: boolean
 }
 
-function AttachmentAssignmentsEditor({ value, onChange, labels, disabled }: AssignmentsEditorProps) {
+export function AttachmentAssignmentsEditor({ value, onChange, labels, disabled }: AssignmentsEditorProps) {
   const handleChange = React.useCallback(
     (index: number, patch: Partial<AssignmentDraft>) => {
       onChange(value.map((entry, idx) => (idx === index ? { ...entry, ...patch } : entry)))
@@ -229,7 +229,7 @@ function AttachmentAssignmentsEditor({ value, onChange, labels, disabled }: Assi
           <div className="text-xs text-muted-foreground">No assignments yet.</div>
         ) : (
           value.map((entry, index) => (
-            <div key={`${index}-${entry.type}-${entry.id}`} className="rounded border p-3 space-y-2">
+            <div key={index} className="rounded border p-3 space-y-2">
               <div className="grid gap-2 sm:grid-cols-2">
                 <div className="space-y-1">
                   <label className="text-xs font-medium">{labels.type}</label>
@@ -913,9 +913,10 @@ export function AttachmentLibrary() {
                   <a
                     key={`${assignment.type}-${assignment.id}-${assignment.href}`}
                     href={assignment.href}
-                    className="text-sm text-blue-600 underline"
+                    className="text-sm text-primary underline"
                     target="_blank"
                     rel="noreferrer"
+                    onClick={(event) => event.stopPropagation()}
                   >
                     {content}
                   </a>
@@ -961,7 +962,12 @@ export function AttachmentLibrary() {
           const absolute = resolveAbsoluteUrl(downloadPath)
           return (
             <Button variant="ghost" size="icon" asChild>
-              <a href={absolute} download aria-label={t('attachments.library.table.download', 'Download')}>
+              <a
+                href={absolute}
+                download
+                aria-label={t('attachments.library.table.download', 'Download')}
+                onClick={(event) => event.stopPropagation()}
+              >
                 <Download className="h-4 w-4" />
               </a>
             </Button>

--- a/packages/core/src/modules/attachments/components/__tests__/AttachmentAssignmentsEditor.test.tsx
+++ b/packages/core/src/modules/attachments/components/__tests__/AttachmentAssignmentsEditor.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { act, fireEvent, render } from '@testing-library/react'
+import type { AssignmentDraft } from '@open-mercato/ui/backend/detail'
+import { AttachmentAssignmentsEditor } from '../AttachmentLibrary'
+
+const labels = {
+  title: 'Assignments',
+  description: 'Link this attachment to records.',
+  type: 'Type',
+  id: 'Record ID',
+  href: 'Link',
+  label: 'Label',
+  add: 'Add assignment',
+  remove: 'Remove assignment',
+}
+
+function Harness() {
+  const [value, setValue] = React.useState<AssignmentDraft[]>([{ type: '', id: '', href: '', label: '' }])
+  return <AttachmentAssignmentsEditor value={value} onChange={setValue} labels={labels} />
+}
+
+function typeInto(input: HTMLInputElement, text: string) {
+  for (let index = 1; index <= text.length; index += 1) {
+    fireEvent.change(input, { target: { value: text.slice(0, index) } })
+  }
+}
+
+describe('AttachmentAssignmentsEditor (upload dialog) — row identity while typing (#4338)', () => {
+  it('keeps the Type input mounted and focused across keystrokes', () => {
+    const { container } = render(<Harness />)
+
+    const input = container.querySelectorAll('input')[0] as HTMLInputElement
+    act(() => {
+      input.focus()
+    })
+
+    typeInto(input, 'catalog.product')
+
+    expect(container.querySelectorAll('input')[0]).toBe(input)
+    expect(document.activeElement).toBe(input)
+    expect(input.value).toBe('catalog.product')
+  })
+
+  it('keeps the Record ID input mounted and focused across keystrokes', () => {
+    const { container } = render(<Harness />)
+
+    const input = container.querySelectorAll('input')[1] as HTMLInputElement
+    act(() => {
+      input.focus()
+    })
+
+    typeInto(input, 'prod-123')
+
+    expect(container.querySelectorAll('input')[1]).toBe(input)
+    expect(document.activeElement).toBe(input)
+    expect(input.value).toBe('prod-123')
+  })
+})

--- a/packages/ui/jest.config.cjs
+++ b/packages/ui/jest.config.cjs
@@ -9,6 +9,7 @@ module.exports = {
   rootDir: '.',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   moduleNameMapper: {
+    '^#generated/entities\\.ids\\.generated$': '<rootDir>/../core/jest.mocks/entities.ids.generated.js',
     '^@open-mercato/ui/(.*)$': '<rootDir>/src/$1',
     '^@open-mercato/core/(.*)$': '<rootDir>/../core/src/$1',
     '^@open-mercato/shared/(.*)$': '<rootDir>/../shared/src/$1',

--- a/packages/ui/src/backend/detail/AttachmentMetadataDialog.tsx
+++ b/packages/ui/src/backend/detail/AttachmentMetadataDialog.tsx
@@ -249,7 +249,7 @@ function AssignmentInputRow({
   )
 }
 
-function AttachmentAssignmentsEditor({
+export function AttachmentAssignmentsEditor({
   value,
   onChange,
   labels,
@@ -290,7 +290,7 @@ function AttachmentAssignmentsEditor({
       <div className="space-y-2">
         {value.length ? value.map((entry, idx) => (
           <AssignmentInputRow
-            key={`${entry.type}-${entry.id}-${idx}`}
+            key={idx}
             value={entry}
             labels={labels}
             disabled={disabled}

--- a/packages/ui/src/backend/detail/__tests__/AttachmentAssignmentsEditor.test.tsx
+++ b/packages/ui/src/backend/detail/__tests__/AttachmentAssignmentsEditor.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { AttachmentAssignmentsEditor, type AssignmentDraft } from '../AttachmentMetadataDialog'
+
+const labels = {
+  title: 'Assignments',
+  description: 'Link this attachment to records.',
+  type: 'Type',
+  id: 'Record ID',
+  href: 'Link',
+  label: 'Label',
+  add: 'Add assignment',
+  remove: 'Remove assignment',
+}
+
+function Harness() {
+  const [value, setValue] = React.useState<AssignmentDraft[]>([{ type: '', id: '', href: '', label: '' }])
+  return <AttachmentAssignmentsEditor value={value} onChange={setValue} labels={labels} />
+}
+
+function typeInto(input: HTMLInputElement, text: string) {
+  for (let index = 1; index <= text.length; index += 1) {
+    fireEvent.change(input, { target: { value: text.slice(0, index) } })
+  }
+}
+
+describe('AttachmentAssignmentsEditor — row identity while typing (#4338)', () => {
+  it('keeps the Type input mounted and focused across keystrokes', () => {
+    render(<Harness />)
+
+    const input = screen.getByPlaceholderText('catalog.product') as HTMLInputElement
+    act(() => {
+      input.focus()
+    })
+
+    typeInto(input, 'catalog.product')
+
+    expect(screen.getByPlaceholderText('catalog.product')).toBe(input)
+    expect(document.activeElement).toBe(input)
+    expect(input.value).toBe('catalog.product')
+  })
+
+  it('keeps the Record ID input mounted and focused across keystrokes', () => {
+    render(<Harness />)
+
+    const input = screen.getByPlaceholderText('Record ID') as HTMLInputElement
+    act(() => {
+      input.focus()
+    })
+
+    typeInto(input, 'prod-123')
+
+    expect(screen.getByPlaceholderText('Record ID')).toBe(input)
+    expect(document.activeElement).toBe(input)
+    expect(input.value).toBe('prod-123')
+  })
+})


### PR DESCRIPTION
Fixes #4338
Fixes #4342

## What & why

Two closely-related bugs on `/backend/storage/attachments` (#4342 was split out of #4338; same component family, so one PR):

**#4338 — "Type"/"Record ID" fields lose focus after every character.** Both assignment editors (the Edit-metadata dialog's `AttachmentAssignmentsEditor` in `@open-mercato/ui` and the upload dialog's twin in `AttachmentLibrary.tsx`) built the row's React `key` from the very fields being typed into (`entry.type`/`entry.id`). Every keystroke changed the key → React remounted the row → the input lost focus. Rows are now keyed by index — correct here because rows are only appended or removed by index and all inputs are controlled.

**#4342 — Download icon opens the Edit-metadata dialog.** The download anchor did not stop click propagation, so the click bubbled to the table's `onRowClick` (which opens the dialog). Fixed with `stopPropagation`, matching the existing handlers in the same file (the issue's suggested option 1 — `rowClickActionIds` doesn't apply here, it maps row clicks to RowActions ids rather than excluding cells). Per the issue's "check whether any other action cell has the same gap": the assignments-column `target="_blank"` links had the identical bug and are fixed the same way.

## Tests

- New jsdom regression tests for **both** assignment editors pin that the Type/Record ID inputs stay mounted (same DOM node) and focused across a full typed value. **Mutation-verified**: with the old key expressions restored, all 4 tests fail; with the fix they pass.
- To make the ui-package test able to import the metadata dialog, `packages/ui/jest.config.cjs` gains the same `#generated/entities.ids.generated` mock mapping `packages/core` already uses.
- Full `packages/ui` suite: **204 suites / 1647 tests green**; `packages/core` attachments module: **24 suites / 186 tests green**; `tsc --noEmit` clean in both packages; eslint clean on changed files (only pre-existing warnings).
- Runner: local.

## Notes for reviewers

- `AttachmentAssignmentsEditor` is now exported from both files (additive) solely so the regression tests can mount the real components.
- Boy Scout on a touched line: assignments link `text-blue-600` → `text-primary` (DS token).
- Label suggestion (read-permission account, can't self-label): `bug`, `review`, `needs-qa` (user-facing backend UI), `priority-medium`, `risk-low` (isolated UI fix shipping with tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)