### PR TITLE
fix(customer_accounts): render Portal users as a full-width row on company details

### DIFF
--- a/packages/core/src/modules/customer_accounts/widgets/__tests__/injection-table.test.ts
+++ b/packages/core/src/modules/customer_accounts/widgets/__tests__/injection-table.test.ts
@@ -30,6 +30,7 @@ function expectSingleGroupWidget(
   spotId: string,
   widgetId: string,
   groupLabel: string,
+  column: 1 | 2,
 ) {
   const slots = table[spotId]
   expect(Array.isArray(slots)).toBe(true)
@@ -37,7 +38,7 @@ function expectSingleGroupWidget(
   expect(slot).toEqual({
     widgetId,
     kind: 'group',
-    column: 2,
+    column,
     groupLabel,
     priority: 200,
   })
@@ -51,17 +52,22 @@ describe('customer_accounts injection table', () => {
         spotId,
         'customer_accounts.injection.account-status',
         'customer_accounts.widgets.accountStatus',
+        2,
       )
     }
   })
 
-  it('registers the company-users widget on the spots the company detail host requests', () => {
+  // Regression guard for #4400: a column-2 group forces CrudForm into the narrow
+  // 7fr/3fr secondary-column layout on company details. Portal users must stay a
+  // full-width row in the column-1 stack.
+  it('registers the company-users widget in column 1 on the spots the company detail host requests', () => {
     for (const spotId of ['customers.company', 'crud-form:customers.company']) {
       expectSingleGroupWidget(
         injectionTable,
         spotId,
         'customer_accounts.injection.company-users',
         'customer_accounts.widgets.portalUsers',
+        1,
       )
     }
   })

--- a/packages/core/src/modules/customer_accounts/widgets/injection-table.ts
+++ b/packages/core/src/modules/customer_accounts/widgets/injection-table.ts
@@ -8,10 +8,13 @@ const accountStatusWidget = {
   priority: 200,
 } as const
 
+// Column 1 on purpose (#4400): any column-2 group makes CrudForm switch the
+// company detail page to the narrow 7fr/3fr two-column layout, compressing the
+// left-side groups. Portal users belongs in the left stack as a full-width row.
 const companyUsersWidget = {
   widgetId: 'customer_accounts.injection.company-users',
   kind: 'group',
-  column: 2,
+  column: 1,
   groupLabel: 'customer_accounts.widgets.portalUsers',
   priority: 200,
 } as const

--- a/packages/ui/src/backend/__tests__/CrudForm.groupInjectionColumn.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.groupInjectionColumn.test.tsx
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+jest.setTimeout(15000)
+
+// Regression guard for #4400: an injected group widget placed in column 1 must
+// render as a full-width row in the main stack — CrudForm must NOT switch to
+// the narrow 7fr/3fr secondary-column layout unless a widget explicitly asks
+// for column 2. The hook is mocked so the test drives the injected widgets
+// directly, following the CrudForm.fieldInjection.test.tsx pattern.
+let injectedGroupWidgets: unknown[] = []
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {} }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}))
+jest.mock('remark-gfm', () => ({ __esModule: true, default: {} }))
+jest.mock('../injection/InjectionSpot', () => ({
+  __esModule: true,
+  InjectionSpot: () => null,
+  useInjectionWidgets: () => ({ widgets: injectedGroupWidgets, loading: false, error: null }),
+  useInjectionSpotEvents: () => ({ triggerEvent: jest.fn(async () => ({ ok: true, data: {} })) }),
+}))
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  __esModule: true,
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false, error: null }),
+}))
+
+import * as React from 'react'
+import { waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { CrudForm, type CrudField, type CrudFormGroup } from '../CrudForm'
+
+const fields: CrudField[] = [
+  { id: 'name', label: 'Name', type: 'text' },
+]
+
+const groups: CrudFormGroup[] = [
+  { id: 'contact', label: 'Contact', fields: ['name'] },
+]
+
+function makeGroupWidget(column: 1 | 2) {
+  return {
+    widgetId: 'customer_accounts.injection.company-users',
+    placement: { kind: 'group', column, groupLabel: 'Portal users', priority: 200 },
+    module: {
+      metadata: { title: 'Portal users', description: '' },
+      Widget: () => <div data-testid="portal-users-widget">portal users</div>,
+    },
+  }
+}
+
+function renderForm() {
+  return renderWithProviders(
+    React.createElement(CrudForm as never, {
+      title: 'Company',
+      entityId: 'customers:company',
+      fields,
+      groups,
+      onSubmit: () => {},
+    }),
+  )
+}
+
+describe('CrudForm injected group column placement (#4400)', () => {
+  afterEach(() => {
+    injectedGroupWidgets = []
+  })
+
+  it('renders a column-1 group widget as a full-width row without the secondary column', async () => {
+    injectedGroupWidgets = [makeGroupWidget(1)]
+
+    const { container } = renderForm()
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="portal-users-widget"]')).toBeTruthy()
+    })
+
+    expect(container.querySelector('[data-crud-injection-region]')).toBeNull()
+    const twoColumnGrid = Array.from(container.querySelectorAll('div')).find((node) =>
+      node.className.includes('7fr_3fr'),
+    )
+    expect(twoColumnGrid).toBeUndefined()
+  })
+
+  it('still supports an explicit column-2 group widget via the secondary column (sanity)', async () => {
+    injectedGroupWidgets = [makeGroupWidget(2)]
+
+    const { container } = renderForm()
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="portal-users-widget"]')).toBeTruthy()
+    })
+
+    const secondaryRegion = container.querySelector('[data-crud-injection-region]')
+    expect(secondaryRegion).toBeTruthy()
+    expect(secondaryRegion?.querySelector('[data-testid="portal-users-widget"]')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
Fixes #4400

## What & why

The injected **Portal users** group (`companyUsersWidget` in `packages/core/src/modules/customer_accounts/widgets/injection-table.ts`) declared `column: 2`. In `CrudForm`, any column-2 group flips the grouped layout to the narrow `lg:grid-cols-[7fr_3fr]` two-column mode, which compressed the left-side groups on company details and rendered Portal users as a sliver column (regression from #3522, landed via #3976).

Per the issue's implementation plan:
1. `companyUsersWidget` moved to `column: 1` — it now renders as its own full-width row in the left stack. Widget ID and both spot registrations (`customers.company`, `crud-form:customers.company`) unchanged; person-detail `account-status` stays column 2.
2. `injection-table.test.ts` now asserts columns per widget (person → 2, company → 1) with a #4400 regression note.
3. New focused CrudForm layout test (`CrudForm.groupInjectionColumn.test.tsx`): a column-1 injected group renders **without** the secondary column (`[data-crud-injection-region]` absent, no `7fr_3fr` grid) and the widget content lands in the main stack; a column-2 widget still renders via the secondary region (sanity that the mechanism is intact).

## Validation

- `packages/core` customer_accounts widgets: 4 suites / 11 tests green.
- `packages/ui` new layout test: 2/2 green.
- Runner: local.
- Placement-only UI correction — no API/DB/ACL/migration changes, no contract-surface changes (widget/spot IDs untouched).

## QA note

Per the issue this deserves a desktop+mobile visual pass on `/backend/customers/companies/<id>` — suggesting `needs-qa`. Label suggestion (read-permission account): `bug`, `review`, `needs-qa`, `priority-medium`, `risk-low` (mirroring the issue's classification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-low` · `risk-low` · `needs-qa`