### PR TITLE
feat(customers): primary person on deals + sensible default activity target (#4376)

### DIFF
--- a/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
@@ -39,6 +39,7 @@ type DealPersonItem = {
   subtitle: string | null
   kind: 'person'
   linkedAt: string
+  isPrimary: boolean
 }
 
 function matchesSearch(item: DealPersonItem, query: string): boolean {
@@ -124,6 +125,7 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
           subtitle: person.primaryEmail ?? person.primaryPhone ?? null,
           kind: 'person',
           linkedAt: link.createdAt.toISOString(),
+          isPrimary: link.isPrimary === true,
         } satisfies DealPersonItem
       })
       .filter((item): item is DealPersonItem => item !== null)
@@ -169,6 +171,7 @@ export const openApi: OpenApiRouteDoc = {
                 subtitle: z.string().nullable(),
                 kind: z.literal('person'),
                 linkedAt: z.string(),
+                isPrimary: z.boolean(),
               }),
             ),
             total: z.number().int().nonnegative(),

--- a/packages/core/src/modules/customers/api/deals/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/route.ts
@@ -56,6 +56,7 @@ type DealAssociation = {
   label: string
   subtitle: string | null
   kind: 'person' | 'company'
+  isPrimary?: boolean
 }
 
 function normalizePersonAssociation(entity: CustomerEntity): { label: string; subtitle: string | null } {
@@ -602,13 +603,19 @@ export async function GET(request: Request, context: { params?: Record<string, u
             )
           : [],
       ])
+      const primaryPersonIds = new Set(
+        personLinkRows
+          .filter((link) => link.isPrimary === true)
+          .map((link) => (typeof link.person === 'string' ? link.person : link.person?.id))
+          .filter((value): value is string => typeof value === 'string'),
+      )
       const previewPeopleMap = new Map(previewPeople.map((entity) => [entity.id, entity]))
       const previewCompaniesMap = new Map(previewCompanies.map((entity) => [entity.id, entity]))
       const people = linkedPersonIds.slice(0, 3).reduce<DealAssociation[]>((acc, personId) => {
         const entity = previewPeopleMap.get(personId) ?? null
         if (!entity || entity.deletedAt) return acc
         const { label, subtitle } = normalizePersonAssociation(entity)
-        acc.push({ id: entity.id, label, subtitle, kind: 'person' })
+        acc.push({ id: entity.id, label, subtitle, kind: 'person', isPrimary: primaryPersonIds.has(entity.id) })
         return acc
       }, [])
       const companies = linkedCompanyIds.slice(0, 3).reduce<DealAssociation[]>((acc, companyId) => {
@@ -654,7 +661,7 @@ export async function GET(request: Request, context: { params?: Record<string, u
       const entity = link.person as CustomerEntity | null
       if (!entity || entity.deletedAt) return acc
       const { label, subtitle } = normalizePersonAssociation(entity)
-      acc.push({ id: entity.id, label, subtitle, kind: 'person' })
+      acc.push({ id: entity.id, label, subtitle, kind: 'person', isPrimary: link.isPrimary === true })
       return acc
     }, [])
 
@@ -927,6 +934,7 @@ const dealDetailResponseSchema = z.object({
       label: z.string(),
       subtitle: z.string().nullable().optional(),
       kind: z.literal('person'),
+      isPrimary: z.boolean().optional(),
     }),
   ),
   companies: z.array(

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/__tests__/page.test.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/__tests__/page.test.tsx
@@ -506,7 +506,48 @@ describe('DealDetailPage', () => {
     expect(detailRequestCount).toBe(1)
   })
 
-  it('requires an explicit entity selection before quick activity actions bind to a linked customer', async () => {
+  it('defaults the activity target to the primary linked person when one is flagged (#4376)', async () => {
+    readApiResultOrThrowMock.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/customers/deals/deal-123')) {
+        const payload = createDealPayload()
+        payload.people = [
+          {
+            id: 'person-1',
+            label: 'Ada Lovelace',
+            subtitle: 'VP Partnerships',
+            kind: 'person' as const,
+          },
+          {
+            id: 'person-2',
+            label: 'Grace Hopper',
+            subtitle: 'Procurement lead',
+            kind: 'person' as const,
+            isPrimary: true,
+          },
+        ]
+        payload.linkedPersonIds = ['person-1', 'person-2']
+        payload.counts.people = 2
+        return payload
+      }
+      if (url.startsWith('/api/customers/interactions')) {
+        return { items: [] }
+      }
+      throw new Error(`Unexpected URL: ${url}`)
+    })
+
+    renderWithProviders(<DealDetailPage params={{ id: 'deal-123' }} />)
+
+    const selector = await screen.findByLabelText('Choose customer record')
+
+    await waitFor(() => {
+      expect((selector as HTMLSelectElement).value).toBe('person-2')
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('inline-activity-composer')).toHaveTextContent('person:person-2')
+    })
+  })
+
+  it('falls back to the first linked record when no primary is flagged, and honors manual changes (#4376)', async () => {
     readApiResultOrThrowMock.mockImplementation(async (url: string) => {
       if (url.startsWith('/api/customers/deals/deal-1/stats')) {
         return {
@@ -552,8 +593,12 @@ describe('DealDetailPage', () => {
 
     const selector = await screen.findByLabelText('Choose customer record')
 
-    expect(screen.queryByTestId('inline-activity-composer')).not.toBeInTheDocument()
-    expect(screen.getByTestId('planned-activities-section')).toHaveTextContent('schedule-disabled')
+    await waitFor(() => {
+      expect((selector as HTMLSelectElement).value).toBe('person-1')
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('inline-activity-composer')).toHaveTextContent('person:person-1')
+    })
 
     fireEvent.change(selector, { target: { value: 'company-1' } })
 

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/hooks/types.ts
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/hooks/types.ts
@@ -3,6 +3,7 @@ export type DealAssociation = {
   label: string
   subtitle: string | null
   kind: 'person' | 'company'
+  isPrimary?: boolean
 }
 
 export type PersonAssociationApiRecord = {

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/page.tsx
@@ -130,6 +130,7 @@ export default function DealDetailPage({ params }: { params?: { id?: string } })
           id: entry.id,
           label: entry.subtitle ? `${entry.label} · ${entry.subtitle}` : entry.label,
           kind: entry.kind,
+          isPrimary: entry.isPrimary === true,
         }))
       : []),
     [data],
@@ -140,7 +141,8 @@ export default function DealDetailPage({ params }: { params?: { id?: string } })
     setSelectedActivityEntityId((current) => {
       if (activityEntities.length === 1) return activityEntities[0].id
       if (current && activityEntities.some((entry) => entry.id === current)) return current
-      return null
+      const primary = activityEntities.find((entry) => entry.isPrimary)
+      return (primary ?? activityEntities[0])?.id ?? null
     })
   }, [activityEntities])
 

--- a/packages/core/src/modules/customers/commands/deals.ts
+++ b/packages/core/src/modules/customers/commands/deals.ts
@@ -372,9 +372,22 @@ function toNumericString(value: number | null | undefined): string | null {
 async function syncDealPeople(
   em: EntityManager,
   deal: CustomerDeal,
-  personIds: string[] | undefined | null
+  personIds: string[] | undefined | null,
+  primaryPersonEntityId?: string | null
 ): Promise<void> {
-  if (personIds === undefined) return
+  if (personIds === undefined) {
+    if (primaryPersonEntityId === undefined) return
+    const links = await em.find(CustomerDealPersonLink, { deal })
+    for (const link of links) {
+      link.isPrimary = link.person.id === primaryPersonEntityId
+    }
+    return
+  }
+  let effectivePrimaryId = primaryPersonEntityId
+  if (effectivePrimaryId === undefined) {
+    const existingPrimary = await em.findOne(CustomerDealPersonLink, { deal, isPrimary: true })
+    effectivePrimaryId = existingPrimary?.person?.id ?? null
+  }
   await em.nativeDelete(CustomerDealPersonLink, { deal })
   if (!personIds || !personIds.length) return
   const unique = Array.from(new Set(personIds))
@@ -384,6 +397,7 @@ async function syncDealPeople(
     const link = em.create(CustomerDealPersonLink, {
       deal,
       person,
+      isPrimary: personId === effectivePrimaryId,
     })
     em.persist(link)
   }
@@ -479,7 +493,7 @@ const createDealCommand: CommandHandler<DealCreateInput, { dealId: string }> = {
           transitionedByUserId: normalizedTransitionAuthorUserId,
         })
       },
-      () => syncDealPeople(em, deal, parsed.personIds ?? []),
+      () => syncDealPeople(em, deal, parsed.personIds ?? [], parsed.primaryPersonEntityId),
       () => syncDealCompanies(em, deal, parsed.companyIds ?? []),
     ], { transaction: true })
 
@@ -746,7 +760,7 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
             transitionedByUserId: normalizedTransitionAuthorUserId,
           })
         },
-        () => syncDealPeople(em, record, parsed.personIds),
+        () => syncDealPeople(em, record, parsed.personIds, parsed.primaryPersonEntityId),
         () => syncDealCompanies(em, record, parsed.companyIds),
       ],
     })

--- a/packages/core/src/modules/customers/data/entities.ts
+++ b/packages/core/src/modules/customers/data/entities.ts
@@ -441,13 +441,16 @@ export class CustomerDealStageTransition {
 @Index({ name: 'customer_deal_people_person_idx', properties: ['person'] })
 @Unique({ name: 'customer_deal_people_unique', properties: ['deal', 'person'] })
 export class CustomerDealPersonLink {
-  [OptionalProps]?: 'createdAt'
+  [OptionalProps]?: 'isPrimary' | 'createdAt'
 
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
 
   @Property({ name: 'role', type: 'text', nullable: true })
   participantRole?: string | null
+
+  @Property({ name: 'is_primary', type: 'boolean', default: false })
+  isPrimary: boolean = false
 
   @Property({ name: 'created_at', type: Date, onCreate: () => new Date() })
   createdAt: Date = new Date()

--- a/packages/core/src/modules/customers/data/validators.ts
+++ b/packages/core/src/modules/customers/data/validators.ts
@@ -180,6 +180,7 @@ export const dealCreateSchema = scopedSchema.extend({
   lossNotes: z.string().max(4000).optional(),
   companyIds: z.array(uuid()).optional(),
   personIds: z.array(uuid()).optional(),
+  primaryPersonEntityId: uuid().nullable().optional(),
 })
 
 export const dealUpdateSchema = z

--- a/packages/core/src/modules/customers/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/customers/migrations/.snapshot-open-mercato.json
@@ -1685,6 +1685,23 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
         "person_entity_id": {
           "name": "person_entity_id",
           "type": "uuid",

--- a/packages/core/src/modules/customers/migrations/Migration20260723210000_customers.ts
+++ b/packages/core/src/modules/customers/migrations/Migration20260723210000_customers.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260723210000_customers extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(`alter table "customer_deal_people" add "is_primary" boolean not null default false;`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`alter table "customer_deal_people" drop column "is_primary";`);
+  }
+
+}


### PR DESCRIPTION
Fixes #4376.

## What

Two-part fix, exactly as the issue proposes:

**(a) `is_primary` on `customer_deal_people`** — `CustomerDealPersonLink` gains `isPrimary` (boolean, not null, default false; mirrors `CustomerPersonCompanyLink`), with a scoped migration (`Migration20260723210000_customers`) and a matching `.snapshot-open-mercato.json` update.

- `dealCreateSchema`/`dealUpdateSchema` accept an optional `primaryPersonEntityId` (additive, backward compatible).
- `syncDealPeople` flags the matching link; when links are resynced **without** the field it preserves the existing primary (no silent loss on unrelated deal edits); when the field arrives **without** `personIds` it re-flags existing links in place.
- Deal detail API returns `isPrimary` on people associations in **both** resolution branches (lite link-rows and full populate), and `GET /deals/[id]/people` returns it per item. OpenAPI schemas updated additively.

**(b) Default activity target** — the Activities tab no longer parks on "Choose customer record": it defaults to the **primary** linked record, falls back to the **first** one, keeps the existing single-record auto-select, and manual changes still win (also across reloads of the same entity set).

## Tests

- New page test: with `isPrimary` on the second person, the selector auto-binds to it and the composer targets `person:person-2`.
- The prior "requires explicit selection" page test was updated to the new contract (fallback = first record) — it previously passed only by effect-flush timing and would have become a flake.
- Suites: customers **1215/1215**, core guard tests (optimistic-lock exemptions for junction tables, module decoupling) **126/126**.

No UI yet for *setting* the primary flag (API-first, per the issue's scope); a small star-toggle in the linked-people editor can follow up.

Label suggestion (no triage rights): `review` + `feature` + `needs-qa` + `priority-low` + `risk-medium` (DB migration, single module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-medium` · `risk-medium` · `needs-qa`