### PR TITLE
fix(shared): load command interceptors in the CLI/queue-worker bootstrap

### DIFF
--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.commandInterceptors.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.commandInterceptors.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment node
+ *
+ * Regression guard for #4327: the CLI/queue-worker bootstrap path
+ * (loadBootstrapData) must load command-interceptors.generated.ts and expose
+ * `commandInterceptorEntries` in its BootstrapData. The interceptor registry is
+ * per-process, so a worker that omits the field silently no-ops every command
+ * interceptor while the Next.js runtime applies them — split behavior between
+ * web and queued execution of the same command.
+ *
+ * The test authors both the generated .ts sources and fresh compiled .mjs
+ * siblings, so compileAndImport takes its cache path and never invokes esbuild.
+ * The .mjs stubs use module.exports because Jest's CJS runtime handles the
+ * dynamic import() and does not transform .mjs files; the loader consumes the
+ * named exports identically either way.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { loadBootstrapData } from '../dynamicLoader'
+
+const GENERATED_MODULES: Record<string, { ts: string; compiled: string }> = {
+  'entities.ids.generated': { ts: 'export const E = {}', compiled: 'module.exports = { E: {} }' },
+  'modules.cli.generated': { ts: 'export const modules = []', compiled: 'module.exports = { modules: [] }' },
+  'entities.generated': { ts: 'export const entities = []', compiled: 'module.exports = { entities: [] }' },
+  'di.generated': { ts: 'export const diRegistrars = []', compiled: 'module.exports = { diRegistrars: [] }' },
+  'command-interceptors.generated': {
+    ts: 'export const commandInterceptorEntries = []',
+    compiled: `module.exports = { commandInterceptorEntries: [
+      { moduleId: 'example', interceptors: [{ id: 'example.adjust-probability' }] },
+    ] }`,
+  },
+}
+
+function writeGeneratedModule(generatedDir: string, baseName: string, source: { ts: string; compiled: string }) {
+  fs.writeFileSync(path.join(generatedDir, `${baseName}.ts`), source.ts)
+  fs.writeFileSync(path.join(generatedDir, `${baseName}.mjs`), source.compiled)
+  const fresh = new Date(Date.now() + 60_000)
+  fs.utimesSync(path.join(generatedDir, `${baseName}.mjs`), fresh, fresh)
+}
+
+describe('loadBootstrapData — command interceptors reach worker/CLI bootstrap (#4327)', () => {
+  let appRoot: string
+
+  beforeAll(() => {
+    appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-bootstrap-4327-'))
+    const generatedDir = path.join(appRoot, '.mercato', 'generated')
+    fs.mkdirSync(generatedDir, { recursive: true })
+    for (const [baseName, source] of Object.entries(GENERATED_MODULES)) {
+      writeGeneratedModule(generatedDir, baseName, source)
+    }
+  })
+
+  afterAll(() => {
+    fs.rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  it('returns commandInterceptorEntries from command-interceptors.generated', async () => {
+    const data = await loadBootstrapData(appRoot)
+
+    expect(data.commandInterceptorEntries).toEqual([
+      { moduleId: 'example', interceptors: [{ id: 'example.adjust-probability' }] },
+    ])
+  })
+
+  it('falls back to an empty array (not undefined) when the generated file is absent', async () => {
+    const generatedDir = path.join(appRoot, '.mercato', 'generated')
+    fs.rmSync(path.join(generatedDir, 'command-interceptors.generated.ts'))
+    fs.rmSync(path.join(generatedDir, 'command-interceptors.generated.mjs'))
+
+    const data = await loadBootstrapData(appRoot)
+
+    expect(data.commandInterceptorEntries).toEqual([])
+    expect(data.commandLoaderEntries).toEqual([])
+  })
+})

--- a/packages/shared/src/lib/bootstrap/dynamicLoader.ts
+++ b/packages/shared/src/lib/bootstrap/dynamicLoader.ts
@@ -155,6 +155,7 @@ export async function loadBootstrapData(appRoot?: string): Promise<BootstrapData
     diModule,
     searchModule,
     commandLoadersModule,
+    commandInterceptorsModule,
     workflowsModule,
   ] = await Promise.all([
     compileAndImport(path.join(generatedDir, 'modules.cli.generated.ts')),
@@ -162,6 +163,7 @@ export async function loadBootstrapData(appRoot?: string): Promise<BootstrapData
     compileAndImport(path.join(generatedDir, 'di.generated.ts')),
     compileAndImport(path.join(generatedDir, 'search.generated.ts')).catch(() => ({ searchModuleConfigs: [] })),
     compileAndImport(path.join(generatedDir, 'command-loaders.generated.ts')).catch(() => ({ commandLoaderEntries: [] })),
+    compileAndImport(path.join(generatedDir, 'command-interceptors.generated.ts')).catch(() => ({ commandInterceptorEntries: [] })),
     compileAndImport(path.join(generatedDir, 'workflows.generated.ts')).catch(() => ({ allCodeWorkflows: [] })),
   ])
 
@@ -173,6 +175,12 @@ export async function loadBootstrapData(appRoot?: string): Promise<BootstrapData
     // Search configs are needed by workers for indexing
     searchModuleConfigs: (searchModule.searchModuleConfigs ?? []) as BootstrapData['searchModuleConfigs'],
     commandLoaderEntries: (commandLoadersModule.commandLoaderEntries ?? []) as BootstrapData['commandLoaderEntries'],
+    // Command interceptors must apply in worker/CLI processes too — the
+    // interceptor registry is per-process, so relying on the Next.js runtime's
+    // registration silently no-ops every interceptor for queued/CLI commands
+    // (#4327).
+    commandInterceptorEntries: (commandInterceptorsModule.commandInterceptorEntries ??
+      []) as BootstrapData['commandInterceptorEntries'],
     // Code workflow definitions are needed by workers to resume code-defined instances
     codeWorkflows: (workflowsModule.allCodeWorkflows ?? []) as BootstrapData['codeWorkflows'],
     // Empty UI-related data - not needed for CLI


### PR DESCRIPTION
Fixes #4327

## What & why

`loadBootstrapData` (the CLI/queue-worker bootstrap path) never imported `.mercato/generated/command-interceptors.generated.ts`, so its `BootstrapData` carried no `commandInterceptorEntries` and the guard in `createBootstrap` (`factory.ts`) never called `registerCommandInterceptors`. Since the interceptor registry lives per-process (`globalThis` command-interceptor-store), registration done by the Next.js runtime doesn't carry over — every module command interceptor **silently no-oped** for queued/CLI-executed commands while applying correctly on the web request path. Exactly the split behavior the issue reports (interceptor applied on web `update-deal`, ignored by a queued `bulk-update-stage`).

The fix mirrors the existing `command-loaders.generated.ts` load: import `command-interceptors.generated.ts` in the same `Promise.all` (with the same `.catch` → `[]` fallback for apps generated before this file existed) and pass `commandInterceptorEntries` through. `factory.ts` picks it up unchanged — no contract-surface changes (the `BootstrapData` field already existed as optional).

## Tests

- New regression test drives the real `loadBootstrapData` against an authored temp `.mercato/generated/` dir (pre-compiled `.mjs` siblings so `compileAndImport` takes its cache path and esbuild never runs): pins (1) entries from `command-interceptors.generated` reach `BootstrapData`, (2) absent file falls back to `[]`, not `undefined`. **Mutation-verified**: fails without the loader change, passes with it.
- Full `packages/shared` suite: **1482 tests green**; `yarn typecheck` clean.
- Runner: local.

## Labels (suggestion — read-permission account)

`bug`, `review`, `priority-high` (event/command-reliability class: silent behavioral split between web and worker execution of the same command), `risk-low` (additive load with fallback, mirrors existing pattern), `skip-qa` (no UI surface; covered by unit regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-medium` · `risk-medium` · `needs-qa`