### PR TITLE
fix(cli): eject reads module metadata from shipped sources, not dist

### DIFF
--- a/packages/cli/src/lib/__tests__/eject.test.ts
+++ b/packages/cli/src/lib/__tests__/eject.test.ts
@@ -362,4 +362,89 @@ describe('eject', () => {
       )
     })
   })
+
+  // Regression guards for #4272: standalone installs resolve getModulePaths'
+  // pkgBase to node_modules/<pkg>/dist/modules (compiled JS, no index.ts), so
+  // eject reported every module as "not marked as ejectable" and --list came up
+  // (nearly) empty. Ejection must prefer the shipped src/modules TypeScript.
+  describe('standalone installs (#4272)', () => {
+    function createStandaloneResolver(baseDir: string, options: { shipSrc: boolean }): PackageResolver {
+      const appDir = path.join(baseDir, 'app')
+      const modulesTsPath = path.join(appDir, 'src', 'modules.ts')
+      const packageRoot = path.join(baseDir, 'node_modules', '@open-mercato', 'core')
+      const distModuleDir = path.join(packageRoot, 'dist', 'modules', 'customers')
+      const srcModuleDir = path.join(packageRoot, 'src', 'modules', 'customers')
+
+      fs.mkdirSync(path.join(appDir, 'src'), { recursive: true })
+      fs.mkdirSync(distModuleDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(appDir, 'src', 'modules.ts'),
+        "export const enabledModules = [{ id: 'customers', from: '@open-mercato/core' }]\n",
+      )
+      fs.writeFileSync(
+        path.join(distModuleDir, 'index.js'),
+        'var metadata = { title: "Customers", description: "Compiled", ejectable: true };\nexport { metadata };\n',
+      )
+      fs.writeFileSync(path.join(distModuleDir, 'index.js.map'), '{}\n')
+
+      if (options.shipSrc) {
+        fs.mkdirSync(srcModuleDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(srcModuleDir, 'index.ts'),
+          "export const metadata = { title: 'Customers', description: 'Source', ejectable: true }\n",
+        )
+        fs.writeFileSync(path.join(srcModuleDir, 'acl.ts'), 'export const features = []\n')
+      }
+
+      return {
+        getAppDir: () => appDir,
+        getModulesConfigPath: () => modulesTsPath,
+        loadEnabledModules: () => [{ id: 'customers', from: '@open-mercato/core' }],
+        getModulePaths: () => ({
+          appBase: path.join(appDir, 'src', 'modules', 'customers'),
+          pkgBase: distModuleDir,
+        }),
+        getPackageRoot: () => packageRoot,
+      } as unknown as PackageResolver
+    }
+
+    it('lists core modules as ejectable when pkgBase points at dist/modules', () => {
+      const resolver = createStandaloneResolver(tmpDir, { shipSrc: true })
+
+      expect(listEjectableModules(resolver)).toEqual([
+        {
+          id: 'customers',
+          title: 'Customers',
+          description: 'Source',
+          from: '@open-mercato/core',
+        },
+      ])
+    })
+
+    it('ejects the shipped TypeScript sources, not the compiled dist output', () => {
+      const resolver = createStandaloneResolver(tmpDir, { shipSrc: true })
+      const appModuleDir = path.join(tmpDir, 'app', 'src', 'modules', 'customers')
+      const modulesTsPath = path.join(tmpDir, 'app', 'src', 'modules.ts')
+
+      ejectModule(resolver, 'customers')
+
+      expect(fs.existsSync(path.join(appModuleDir, 'index.ts'))).toBe(true)
+      expect(fs.existsSync(path.join(appModuleDir, 'acl.ts'))).toBe(true)
+      expect(fs.existsSync(path.join(appModuleDir, 'index.js'))).toBe(false)
+      expect(fs.readFileSync(modulesTsPath, 'utf8')).toContain("{ id: 'customers', from: '@app' }")
+    })
+
+    it('falls back to compiled index.js metadata for dist-only packages', () => {
+      const resolver = createStandaloneResolver(tmpDir, { shipSrc: false })
+
+      expect(listEjectableModules(resolver)).toEqual([
+        {
+          id: 'customers',
+          title: 'Customers',
+          description: 'Compiled',
+          from: '@open-mercato/core',
+        },
+      ])
+    })
+  })
 })

--- a/packages/cli/src/lib/eject.ts
+++ b/packages/cli/src/lib/eject.ts
@@ -194,12 +194,34 @@ type ResolvedModuleSource = {
   metadata: ModuleMetadata
 }
 
+// Standalone installs resolve getModulePaths' pkgBase to the package's
+// dist/modules tree when it exists (compiled JS, no index.ts), which made every
+// ejectable module read as "not ejectable" and eject copies of compiled output
+// (#4272). Prefer the shipped TypeScript sources under src/modules; fall back
+// to the resolved base for packages that ship dist only.
+function resolveModuleSourceBase(resolver: PackageResolver, entry: ModuleEntry): string {
+  const { pkgBase } = resolver.getModulePaths(entry)
+  const from = entry.from || '@open-mercato/core'
+  if (from === '@app') return pkgBase
+  const sourceBase = path.join(resolver.getPackageRoot(from), 'src', 'modules', entry.id)
+  if (path.resolve(sourceBase) !== path.resolve(pkgBase) && fs.existsSync(sourceBase)) {
+    return sourceBase
+  }
+  return pkgBase
+}
+
+function readModuleMetadata(moduleDir: string): ModuleMetadata {
+  const tsIndex = path.join(moduleDir, 'index.ts')
+  if (fs.existsSync(tsIndex)) return parseModuleMetadata(tsIndex)
+  return parseModuleMetadata(path.join(moduleDir, 'index.js'))
+}
+
 function resolveModuleSource(
   resolver: PackageResolver,
   entry: ModuleEntry,
 ): ResolvedModuleSource {
-  const { pkgBase } = resolver.getModulePaths(entry)
-  const fallbackMetadata = parseModuleMetadata(path.join(pkgBase, 'index.ts'))
+  const pkgBase = resolveModuleSourceBase(resolver, entry)
+  const fallbackMetadata = readModuleMetadata(pkgBase)
   const from = entry.from || '@open-mercato/core'
 
   if (from === '@app' || from === '@open-mercato/core') {


### PR DESCRIPTION
Fixes #4272

## Root cause

In a **standalone (non-monorepo) install**, `resolver.getModulePaths()` resolves `pkgBase` to `node_modules/<pkg>/dist/modules/<id>` whenever a dist tree exists (`resolver.ts` → `pkgDirFor`). `eject` then read metadata from `<pkgBase>/index.ts` — which never exists in compiled output — so `parseModuleMetadata` returned `{}`, `metadata.ejectable` was `undefined`, and every module failed with *"Module x is not marked as ejectable"* even though its source declares `ejectable: true`. The same undefined flag is why `eject --list` showed almost nothing: the only entry that appeared was an official-module package, which resolves through `resolveInstalledOfficialModulePackage` and reads real `src` metadata.

Second-order bug in the same path: had the flag been read, eject would have **copied compiled JS** into `src/modules/` instead of the TypeScript the user is meant to edit.

## Fix

- New `resolveModuleSourceBase()`: prefer `<packageRoot>/src/modules/<id>` when the package ships sources (the normal case — packages publish `src/`), else fall back to the resolved base.
- New `readModuleMetadata()`: try `index.ts`, fall back to `index.js` so a dist-only package still reports its flag correctly instead of silently reading as non-ejectable.
- Monorepo behavior is unchanged (`pkgBase` already points at `src/modules`, so the preference is a no-op there), as is the official-module package path.

## Tests

Three regression tests for a standalone layout (`node_modules/@open-mercato/core` with both `dist/modules` and `src/modules`, resolver's `pkgBase` pointing at dist):
1. `listEjectableModules` finds the module and reports its **source** metadata;
2. `ejectModule` copies `index.ts`/`acl.ts` and **not** `index.js`;
3. a dist-only package still resolves metadata via the `index.js` fallback.

**Mutation-verified**: all three fail without the fix. Full `packages/cli` suite: **64 suites / 1217 tests green**; `yarn typecheck` clean; eslint clean. Runner: local.

## Labels (suggestion — read-permission account)

`bug`, `review`, `priority-medium`, `risk-low`, `skip-qa` (CLI-only, no UI surface; covered by unit regressions). Worth a maintainer sanity check on a real standalone app: `yarn mercato eject --list` should now show all `ejectable: true` core modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-medium` · `risk-low` · `skip-qa`