### PR TITLE
feat(entities): honor declared custom-field priority and declaration order (#4378)

### DIFF
--- a/packages/core/src/modules/entities/lib/__tests__/field-definitions.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/field-definitions.test.ts
@@ -63,6 +63,26 @@ describe('ensureCustomFieldDefinitions (issue #1399)', () => {
     expect(em.flush).toHaveBeenCalledTimes(1)
   })
 
+  it('passes a declared priority through to configJson (#4378)', async () => {
+    const em = createMockEm()
+    const sets = [
+      {
+        entity: 'a:one',
+        fields: [
+          { key: 'tax_id', kind: 'text' as const, priority: 5 },
+          { key: 'notes', kind: 'text' as const },
+        ],
+      },
+    ]
+
+    await ensureCustomFieldDefinitions(em as any, sets, scope)
+
+    const [taxId, notes] = em.persisted as Array<{ key: string; configJson: Record<string, unknown> }>
+    expect(taxId.key).toBe('tax_id')
+    expect(taxId.configJson.priority).toBe(5)
+    expect(notes.configJson.priority).toBeUndefined()
+  })
+
   it('does not query or flush on a dry run', async () => {
     const em = createMockEm()
     const sets = [{ entity: 'a:one', fields: [{ key: 'foo', kind: 'text' as const }] }]

--- a/packages/core/src/modules/entities/lib/__tests__/install-from-ce.resolveFields.test.ts
+++ b/packages/core/src/modules/entities/lib/__tests__/install-from-ce.resolveFields.test.ts
@@ -1,0 +1,54 @@
+import { resolveFields } from '../install-from-ce'
+
+describe('resolveFields (#4378)', () => {
+  it('keeps declaration order instead of sorting alphabetically', () => {
+    const resolved = resolveFields([
+      {
+        entity: 'crm:company',
+        fields: [
+          { key: 'tax_id', kind: 'text' },
+          { key: 'annual_revenue', kind: 'integer' },
+          { key: 'billing_notes', kind: 'text' },
+        ],
+      },
+    ] as never)
+
+    expect(resolved.map((field) => field.key)).toEqual(['tax_id', 'annual_revenue', 'billing_notes'])
+    expect(resolved.map((field) => field.priority)).toEqual([0, 1, 2])
+  })
+
+  it('honors an explicit priority over declaration order', () => {
+    const resolved = resolveFields([
+      {
+        entity: 'crm:company',
+        fields: [
+          { key: 'first_declared', kind: 'text', priority: 30 },
+          { key: 'second_declared', kind: 'text', priority: 10 },
+          { key: 'third_declared', kind: 'text', priority: 20 },
+        ],
+      },
+    ] as never)
+
+    expect(resolved.map((field) => field.key)).toEqual(['second_declared', 'third_declared', 'first_declared'])
+    expect(resolved.map((field) => field.priority)).toEqual([10, 20, 30])
+  })
+
+  it('merges field sets by key while keeping the first declaration position', () => {
+    const resolved = resolveFields([
+      {
+        entity: 'crm:company',
+        fields: [
+          { key: 'tax_id', kind: 'text' },
+          { key: 'notes', kind: 'text' },
+        ],
+      },
+      {
+        entity: 'crm:company',
+        fields: [{ key: 'tax_id', kind: 'text', label: 'Tax identifier' }],
+      },
+    ] as never)
+
+    expect(resolved.map((field) => field.key)).toEqual(['tax_id', 'notes'])
+    expect(resolved[0].label).toBe('Tax identifier')
+  })
+})

--- a/packages/core/src/modules/entities/lib/field-definitions.ts
+++ b/packages/core/src/modules/entities/lib/field-definitions.ts
@@ -36,6 +36,7 @@ const CONFIG_PASSTHROUGH_KEYS: Array<keyof CustomFieldDefinition> = [
   'formEditable',
   'listVisible',
   'indexed',
+  'priority',
   'editor',
   'input',
   'relatedEntityId',

--- a/packages/core/src/modules/entities/lib/install-from-ce.ts
+++ b/packages/core/src/modules/entities/lib/install-from-ce.ts
@@ -49,6 +49,7 @@ const FIELD_DETAIL_KEYS: Array<keyof CustomFieldDefinition> = [
   'formEditable',
   'listVisible',
   'indexed',
+  'priority',
   'editor',
   'input',
   'relatedEntityId',
@@ -108,14 +109,28 @@ function buildAggregatedConfigs(): AggregatedEntityConfig[] {
   return Array.from(map.values())
 }
 
-function resolveFields(fieldSets: CustomFieldSet[]): CustomFieldDefinition[] {
+export function resolveFields(fieldSets: CustomFieldSet[]): CustomFieldDefinition[] {
   const byKey = new Map<string, CustomFieldDefinition>()
+  const declarationOrder = new Map<string, number>()
   for (const set of fieldSets) {
     for (const field of set.fields ?? []) {
+      if (!declarationOrder.has(field.key)) declarationOrder.set(field.key, declarationOrder.size)
       byKey.set(field.key, { ...field })
     }
   }
-  return Array.from(byKey.values()).sort((a, b) => a.key.localeCompare(b.key))
+  // Declaration order is the author's intent, so it drives `priority` (and the
+  // resulting render order) unless a field states its own. Sorting alphabetically
+  // by key here would silently discard that intent (#4378).
+  const resolved = Array.from(byKey.values()).map((field) => (
+    typeof field.priority === 'number'
+      ? field
+      : { ...field, priority: declarationOrder.get(field.key) ?? 0 }
+  ))
+  return resolved.sort((a, b) => {
+    const byPriority = (a.priority ?? 0) - (b.priority ?? 0)
+    if (byPriority !== 0) return byPriority
+    return a.key.localeCompare(b.key)
+  })
 }
 
 function normalizeField(field: CustomFieldDefinition) {

--- a/packages/shared/src/modules/entities.ts
+++ b/packages/shared/src/modules/entities.ts
@@ -51,6 +51,9 @@ export type CustomFieldDefinition = {
   formEditable?: boolean
   indexed?: boolean
   listVisible?: boolean
+  // Display order within a form/card; lower renders first. When omitted, the
+  // installer derives it from the declaration order of the field set.
+  priority?: number
   // Optional UI hints for generated forms/filters
   // Editors for multiline-rich text fields:
   //  - 'markdown' -> UIW Markdown editor


### PR DESCRIPTION
Addresses **part (a)** of #4378 (the passthrough + ordering half). Parts (b)–(d) — injecting a custom field into a *native* form group, reordering/splitting native groups, and declarative `defaultCollapsed` — touch `formConfig.tsx`'s hardcoded native groups and are a larger design change; happy to follow up separately if maintainers agree on the shape.

## Problem

A module could declare custom fields in `ce.ts` but had no say in their render order:

- `CONFIG_PASSTHROUGH_KEYS` (`entities/lib/field-definitions.ts`) did not include `priority`, so a declared value never reached `configJson`;
- `resolveFields` (`entities/lib/install-from-ce.ts`) additionally re-sorted every field **alphabetically by key**, discarding declaration order as well.

Only the admin batch endpoint (`definitions.batch.ts`) could ever write `configJson.priority`, so downstream apps had to reconcile it themselves (exactly the workaround the issue reports).

## Fix

- `priority?: number` added to `CustomFieldDefinition` (additive, optional).
- `priority` added to `CONFIG_PASSTHROUGH_KEYS` (reaches `configJson`) and to `FIELD_DETAIL_KEYS` (so changing it invalidates the install checksum and actually re-installs).
- `resolveFields` derives `priority` from **declaration order** when a field doesn't state one, then sorts by priority with the key as a stable tiebreaker — instead of sorting alphabetically.

The rest of the chain already honored it, so this closes the loop end-to-end: `definitions.ts` sorts by and returns `configJson.priority`, and `CrudForm` sorts custom fields by `priority` when building the card layout.

## Tests

- `field-definitions.test.ts`: a declared `priority` lands in `configJson`; a field without one doesn't get a spurious value.
- New `install-from-ce.resolveFields.test.ts` (3 cases): declaration order is preserved with derived priorities `0,1,2`; an explicit `priority` wins over declaration order; merging field sets by key keeps the first declaration position while later definitions still override the payload.
- Suite: entities **172/172 passing**. One suite in that folder (`edit-entity-submit.test.ts`) fails to *load* on a missing `#generated/entity-fields-registry` — pre-existing in a fresh worktree, verified identical on clean `develop` (stash check), unrelated to this diff.

Label suggestion (no triage rights): `review` + `feature` + `priority-low` + `risk-medium` + `skip-qa` — install-path ordering change covered by tests; affects how declared custom fields sort on first install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-medium` · `risk-medium` · `needs-qa`