### PR TITLE
fix(create-app): make yarn test/lint/install-skills work on a fresh scaffold (#4328)

### DIFF
--- a/packages/create-app/src/lib/template-script-targets.test.ts
+++ b/packages/create-app/src/lib/template-script-targets.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+const TEMPLATE_DIR = new URL('../../template/', import.meta.url)
+const PACKAGE_JSON_TEMPLATE = new URL('package.json.template', TEMPLATE_DIR)
+
+function readScripts(): Record<string, string> {
+  const raw = fs.readFileSync(PACKAGE_JSON_TEMPLATE, 'utf8')
+  const parsed = JSON.parse(raw) as { scripts?: Record<string, string> }
+  return parsed.scripts ?? {}
+}
+
+// #4328: `yarn test`, `yarn lint`, and `yarn install-skills` failed on a clean
+// scaffold because the template's package.json pointed at files it did not ship
+// (and at `next lint`, removed in Next 16). Keep those targets honest.
+test('every file a template script references is shipped by the template', () => {
+  const scripts = readScripts()
+  const referenced: Array<{ script: string; file: string }> = []
+
+  for (const [name, command] of Object.entries(scripts)) {
+    const configMatch = command.match(/--config\s+([^\s]+)/)
+    if (configMatch && !configMatch[1].startsWith('.ai/')) {
+      referenced.push({ script: name, file: configMatch[1] })
+    }
+    const shMatch = command.match(/\b(?:sh|bash|node)\s+(\.\/)?(scripts\/[^\s]+)/)
+    if (shMatch) referenced.push({ script: name, file: shMatch[2] })
+  }
+
+  assert.ok(referenced.length > 0, 'expected the template to reference at least one script file')
+
+  for (const { script, file } of referenced) {
+    assert.ok(
+      fs.existsSync(new URL(file, TEMPLATE_DIR)),
+      `template script "${script}" references ${file}, which the template does not ship`,
+    )
+  }
+})
+
+test('lint does not use `next lint` (removed in Next 16) and a flat config ships', () => {
+  const scripts = readScripts()
+  assert.ok(scripts.lint, 'template must define a lint script')
+  assert.ok(
+    !/\bnext\s+lint\b/.test(scripts.lint),
+    '`next lint` was removed in Next 16 — the template must call the ESLint CLI instead',
+  )
+  assert.ok(
+    fs.existsSync(new URL('eslint.config.mjs', TEMPLATE_DIR)),
+    'template must ship an eslint.config.mjs so `yarn lint` works out of the box',
+  )
+})

--- a/packages/create-app/template/eslint.config.mjs
+++ b/packages/create-app/template/eslint.config.mjs
@@ -1,0 +1,30 @@
+// Flat ESLint config for a standalone Open Mercato app.
+// `next lint` was removed in Next 16, so `yarn lint` runs the ESLint CLI
+// against this config instead.
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+
+const ignores = [
+  'node_modules/**',
+  '.next/**',
+  '.mercato/**',
+  'dist/**',
+  'out/**',
+  'build/**',
+  'next-env.d.ts',
+]
+
+const ruleOverrides = {
+  'react/display-name': 'off',
+  'react-hooks/immutability': 'off',
+  'react-hooks/preserve-manual-memoization': 'off',
+  'react-hooks/purity': 'off',
+  'react-hooks/refs': 'off',
+  'react-hooks/set-state-in-effect': 'off',
+  'react-hooks/static-components': 'off',
+}
+
+export default [
+  ...nextCoreWebVitals,
+  { ignores },
+  { name: 'app/rule-overrides', rules: ruleOverrides },
+]

--- a/packages/create-app/template/jest.config.cjs
+++ b/packages/create-app/template/jest.config.cjs
@@ -1,0 +1,34 @@
+/** @type {import('jest').Config} */
+// Unit-test config for a standalone Open Mercato app.
+// Integration tests run through Playwright (`yarn test:integration:ephemeral`)
+// and are excluded here.
+module.exports = {
+  testEnvironment: 'node',
+  testTimeout: 30000,
+  rootDir: '.',
+  roots: ['<rootDir>/src'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^@/\\.mercato/(.*)$': '<rootDir>/.mercato/$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^#generated/(.*)$': '<rootDir>/.mercato/generated/$1',
+  },
+  transform: {
+    '^.+\\.(t|j)sx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          jsx: 'react-jsx',
+          module: 'commonjs',
+          moduleResolution: 'node',
+          esModuleInterop: true,
+          allowJs: true,
+          isolatedModules: true,
+        },
+        diagnostics: false,
+      },
+    ],
+  },
+  transformIgnorePatterns: ['/node_modules/(?!(@open-mercato)/)'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/.mercato/', '/.ai/qa/'],
+}

--- a/packages/create-app/template/package.json.template
+++ b/packages/create-app/template/package.json.template
@@ -16,7 +16,7 @@
     "dev:reset": "node ./scripts/dev-reset.mjs",
     "build": "yarn generate && cross-env NODE_OPTIONS=--max-old-space-size=8192 next build",
     "start": "mercato server start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.config.cjs",
     "test:integration": "npx playwright test --config .ai/qa/tests/playwright.config.ts",

--- a/packages/create-app/template/scripts/install-skills.sh
+++ b/packages/create-app/template/scripts/install-skills.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Placeholder shipped by the bare scaffold.
+#
+# The real installer lives in the agentic overlay and is copied over this file
+# by `create-mercato-app` (agentic setup) or by `mercato agentic:init`. If you
+# are reading this message, that step has not run for this app yet, so there is
+# nothing to install skills from.
+set -e
+
+cat <<'MESSAGE'
+Agent skills are not set up for this app yet.
+
+`yarn install-skills` installs the shared open-mercato/skills collection, which
+requires the agentic setup files. Run:
+
+    yarn mercato agentic:init
+
+then re-run `yarn install-skills`. (Scaffolding with --skip-agentic-setup or
+--agents none intentionally leaves this app without agent tooling.)
+MESSAGE
+
+exit 1


### PR DESCRIPTION
Fixes #4328 (points 1–3; the TypeScript-preview pin, point 4, is a deliberate maintainer decision and left alone).

## Problem

Three scripts in `template/package.json.template` referenced files the template does not ship, or a command that no longer exists — so a freshly scaffolded app failed on first run:

| Script | Failure |
|---|---|
| `test` | `jest --config jest.config.cjs` — no `jest.config.*` anywhere in the template |
| `lint` | `next lint` — removed in Next 16 (template pins `next 16.2.10`), and no flat config to fall back to |
| `install-skills` | `sh scripts/install-skills.sh` — the script only exists in the agentic overlay, so a scaffold created with `--skip-agentic-setup` / `--agents none` (or an interrupted setup) points at a missing file |

## Fix

- **`jest.config.cjs`** — node environment, `ts-jest` transform (already a template devDependency), the app's `@/` + `@/.mercato/` + `#generated/` aliases mirrored from `tsconfig.json`, `roots: ['<rootDir>/src']`, and Playwright/integration paths excluded so `yarn test` and `yarn test:integration:ephemeral` stay separate.
- **`eslint.config.mjs`** — flat config extending `eslint-config-next/core-web-vitals` (already a template devDependency), with the same rule overrides and ignore list the monorepo root config uses; `lint` now runs `eslint .` like `apps/mercato` does.
- **`scripts/install-skills.sh`** — a stub that explains agentic setup has not run, points at `yarn mercato agentic:init`, and exits non-zero. Both copy pipelines use `copyFileSync`, so the real overlay installer overwrites this file whenever agentic setup runs — no duplicated logic and no drift risk (the per-AGENTS.md concern).

## Tests

New `src/lib/template-script-targets.test.ts`:
- derives the referenced file from each template script (`--config …`, `sh/node scripts/…`) and asserts the template actually ships it — so this class of bug can't come back for a future script either;
- asserts `lint` never regresses to `next lint` and that a flat config ships.

Verified it **fails on the previous template state** (both cases) and passes with the fix. Package suite: 103/107, with the same 4 failures on clean `develop` (build/dist-dependent tests in an unbuilt worktree) — unrelated to this diff.

Label suggestion (no triage rights): `review` + `bug` + `priority-medium` + `risk-low` + `skip-qa` — first-run DX of the scaffold; template-only files plus a guard test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-medium` · `risk-medium` · `skip-qa`