### PR TITLE
fix(workflows): register code-defined workflow triggers with the event engine (#4333)

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/event-trigger-code-workflows.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/event-trigger-code-workflows.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Regression test for #4333: triggers declared by code-defined workflows never
+ * reached the runtime matcher.
+ *
+ * `loadTriggersForTenant` merged only two DB-backed sources (legacy
+ * `workflow_event_triggers` rows and triggers embedded in `workflow_definitions`
+ * JSONB). A code workflow lives purely in the in-memory registry until a user
+ * customizes it, so `sales.order-approval` could never auto-start from
+ * `sales.order.created` — no matter how correct its event pattern was.
+ * Self-QA on PR #4385 confirmed this end-to-end (instance count stayed at 0).
+ */
+
+jest.mock('../workflow-executor', () => ({
+  executeWorkflow: jest.fn(),
+  startWorkflow: jest.fn(),
+}))
+
+const getAllCodeWorkflowsMock = jest.fn()
+jest.mock('../code-registry', () => ({
+  getAllCodeWorkflows: () => getAllCodeWorkflowsMock(),
+}))
+
+const GLOBAL_KEY = '__openMercatoWorkflowTriggerCache__'
+
+function makeCodeWorkflow(overrides: Record<string, unknown> = {}) {
+  return {
+    workflowId: 'sales.order-approval',
+    workflowName: 'Order approval',
+    description: null,
+    version: 1,
+    enabled: true,
+    metadata: null,
+    moduleId: 'sales',
+    definition: {
+      steps: [],
+      transitions: [],
+      triggers: [
+        {
+          triggerId: 'on-order-created',
+          name: 'On order created',
+          eventPattern: 'sales.order.created',
+          priority: 10,
+        },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+/** Minimal EntityManager stub: no legacy triggers, no definitions, no shadow rows. */
+function makeEm(shadowWorkflowIds: string[] = []) {
+  return {
+    find: jest.fn(async (_entity: unknown, where: Record<string, unknown>) => {
+      // loadCodeTriggers' shadow probe filters by workflowId: { $in: [...] }
+      const workflowIdFilter = where?.workflowId as { $in?: string[] } | undefined
+      if (workflowIdFilter?.$in) {
+        return shadowWorkflowIds
+          .filter((id) => workflowIdFilter.$in!.includes(id))
+          .map((workflowId) => ({ workflowId }))
+      }
+      return []
+    }),
+    findOne: jest.fn(async () => null),
+  }
+}
+
+describe('loadTriggersForTenant — code-defined workflow triggers (#4333)', () => {
+  beforeEach(() => {
+    delete (globalThis as never as Record<string, unknown>)[GLOBAL_KEY]
+    getAllCodeWorkflowsMock.mockReset()
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    delete (globalThis as never as Record<string, unknown>)[GLOBAL_KEY]
+  })
+
+  it('exposes a code workflow trigger to the matcher', async () => {
+    getAllCodeWorkflowsMock.mockReturnValue([makeCodeWorkflow()])
+    const { loadTriggersForTenant } = await import('../event-trigger-service')
+
+    const triggers = await loadTriggersForTenant(makeEm() as never, 'tenant-a', 'org-a')
+
+    expect(triggers).toHaveLength(1)
+    expect(triggers[0]).toMatchObject({
+      triggerId: 'on-order-created',
+      eventPattern: 'sales.order.created',
+      workflowId: 'sales.order-approval',
+      workflowVersion: 1,
+      source: 'code',
+      enabled: true,
+      priority: 10,
+    })
+    // Deterministic virtual-definition UUID, so concurrency limits count the
+    // instances these triggers actually start.
+    expect(triggers[0].workflowDefinitionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    )
+  })
+
+  it('lets a customized DB definition shadow the code triggers', async () => {
+    getAllCodeWorkflowsMock.mockReturnValue([makeCodeWorkflow()])
+    const { loadTriggersForTenant } = await import('../event-trigger-service')
+
+    const triggers = await loadTriggersForTenant(
+      makeEm(['sales.order-approval']) as never,
+      'tenant-a',
+      'org-a',
+    )
+
+    expect(triggers).toHaveLength(0)
+  })
+
+  it('skips disabled workflows and disabled triggers', async () => {
+    getAllCodeWorkflowsMock.mockReturnValue([
+      makeCodeWorkflow({ enabled: false }),
+      makeCodeWorkflow({
+        workflowId: 'sales.other',
+        definition: {
+          steps: [],
+          transitions: [],
+          triggers: [
+            {
+              triggerId: 'off',
+              name: 'Disabled trigger',
+              eventPattern: 'sales.order.created',
+              enabled: false,
+            },
+          ],
+        },
+      }),
+    ])
+    const { loadTriggersForTenant } = await import('../event-trigger-service')
+
+    const triggers = await loadTriggersForTenant(makeEm() as never, 'tenant-a', 'org-a')
+
+    expect(triggers).toHaveLength(0)
+  })
+
+  it('does not query the shadow probe when no code workflow declares triggers', async () => {
+    getAllCodeWorkflowsMock.mockReturnValue([
+      makeCodeWorkflow({ definition: { steps: [], transitions: [], triggers: [] } }),
+    ])
+    const { loadTriggersForTenant } = await import('../event-trigger-service')
+    const em = makeEm()
+
+    const triggers = await loadTriggersForTenant(em as never, 'tenant-a', 'org-a')
+
+    expect(triggers).toHaveLength(0)
+    const shadowProbes = em.find.mock.calls.filter(
+      ([, where]) => (where as { workflowId?: unknown })?.workflowId,
+    )
+    expect(shadowProbes).toHaveLength(0)
+  })
+})

--- a/packages/core/src/modules/workflows/lib/event-trigger-service.ts
+++ b/packages/core/src/modules/workflows/lib/event-trigger-service.ts
@@ -22,6 +22,8 @@ import {
   type WorkflowDefinitionTrigger,
 } from '../data/entities'
 import { startWorkflow, executeWorkflow } from './workflow-executor'
+import { getAllCodeWorkflows } from './code-registry'
+import { codeWorkflowUuid } from './find-definition'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('workflows').child({ component: 'event-trigger' })
@@ -59,7 +61,7 @@ export interface UnifiedTrigger {
   workflowDefinitionId: string
   workflowId: string
   workflowVersion: number
-  source: 'legacy' | 'embedded'
+  source: 'legacy' | 'embedded' | 'code'
   tenantId: string
   organizationId: string
 }
@@ -411,6 +413,73 @@ async function loadLegacyTriggers(
 }
 
 /**
+ * Load triggers declared by code-defined workflows (#4333).
+ *
+ * Code workflows live only in the in-memory registry until a user customizes
+ * them, so their `triggers` array never reaches the DB-backed sources above —
+ * which meant a code workflow could never auto-start from an event no matter
+ * how correct its event pattern was.
+ *
+ * A DB definition with the same `workflowId` means the user customized this
+ * workflow; the DB row (and its embedded triggers) then wins, mirroring how
+ * `findWorkflowDefinition` and the definitions list already shadow code
+ * definitions. `workflowDefinitionId` uses the same deterministic UUID the
+ * executor assigns to virtual code definitions, so concurrency limits count
+ * the instances these triggers actually start.
+ */
+async function loadCodeTriggers(
+  em: EntityManager,
+  tenantId: string,
+  organizationId: string
+): Promise<UnifiedTrigger[]> {
+  const codeWorkflows = getAllCodeWorkflows().filter(
+    (workflow) => workflow.enabled && (workflow.definition?.triggers?.length ?? 0) > 0,
+  )
+  if (codeWorkflows.length === 0) return []
+
+  const shadowingRows = await em.find(
+    WorkflowDefinition,
+    {
+      workflowId: { $in: codeWorkflows.map((workflow) => workflow.workflowId) },
+      tenantId,
+      organizationId,
+      deletedAt: null,
+    },
+    { fields: ['workflowId'] as const },
+  )
+  const shadowed = new Set(shadowingRows.map((row) => row.workflowId))
+
+  const triggers: UnifiedTrigger[] = []
+
+  for (const workflow of codeWorkflows) {
+    if (shadowed.has(workflow.workflowId)) continue
+
+    for (const trigger of workflow.definition.triggers ?? []) {
+      if (trigger.enabled === false) continue
+
+      triggers.push({
+        id: `code:${workflow.workflowId}:${trigger.triggerId}`,
+        triggerId: trigger.triggerId,
+        name: trigger.name,
+        description: trigger.description ?? null,
+        eventPattern: trigger.eventPattern,
+        config: (trigger.config ?? null) as WorkflowEventTriggerConfig | null,
+        enabled: true,
+        priority: trigger.priority ?? 0,
+        workflowDefinitionId: codeWorkflowUuid(workflow.workflowId),
+        workflowId: workflow.workflowId,
+        workflowVersion: workflow.version,
+        source: 'code' as const,
+        tenantId,
+        organizationId,
+      })
+    }
+  }
+
+  return triggers
+}
+
+/**
  * Load embedded triggers from workflow definitions.
  * New triggers are embedded directly in the definition JSONB.
  */
@@ -467,7 +536,8 @@ async function loadEmbeddedTriggers(
 
 /**
  * Load all enabled triggers for a tenant/organization with caching.
- * Merges both legacy (entity) triggers and embedded (definition) triggers.
+ * Merges legacy (entity) triggers, embedded (definition) triggers, and
+ * triggers declared by code-defined workflows.
  */
 export async function loadTriggersForTenant(
   em: EntityManager,
@@ -484,14 +554,15 @@ export async function loadTriggersForTenant(
     return cached.triggers
   }
 
-  // Load from both sources
-  const [legacyTriggers, embeddedTriggers] = await Promise.all([
+  // Load from every source
+  const [legacyTriggers, embeddedTriggers, codeTriggers] = await Promise.all([
     loadLegacyTriggers(em, tenantId, organizationId),
     loadEmbeddedTriggers(em, tenantId, organizationId),
+    loadCodeTriggers(em, tenantId, organizationId),
   ])
 
   // Merge and sort by priority (higher first)
-  const allTriggers = [...legacyTriggers, ...embeddedTriggers]
+  const allTriggers = [...legacyTriggers, ...embeddedTriggers, ...codeTriggers]
     .sort((a, b) => b.priority - a.priority)
 
   // Update cache


### PR DESCRIPTION
Completes #4333 end-to-end. Follow-up to **#4385**, which corrected the event *name* — this PR makes the trigger actually reach the engine. Merge order: #4385 first (or either order; they touch different files and don't conflict).

## Why

Self-QA on #4385 (see [that PR's comment](https://github.com/open-mercato/open-mercato/pull/4385)) showed the order-approval workflow **still** never auto-starts with the corrected event name. Verified in code, not inferred:

`loadTriggersForTenant` (`lib/event-trigger-service.ts`) merges exactly two **DB-backed** sources — legacy `workflow_event_triggers` rows and triggers embedded in `workflow_definitions` JSONB. `sales.order-approval` is a **code-defined** workflow: it lives purely in the in-memory registry until a user customizes it, and `getAllCodeWorkflows()` was referenced only by `lib/code-registry.ts` and the definitions LIST route — never by the trigger engine. So a code workflow's `triggers` array never reached the runtime matcher, regardless of which event name it carried.

## Fix

New `loadCodeTriggers` source, merged into `loadTriggersForTenant` alongside the existing two:

- reads `getAllCodeWorkflows()`, keeps enabled workflows that declare triggers, and honors `trigger.enabled === false`;
- **shadowing**: skips any workflow that already has a `workflow_definitions` row for this tenant/org — the customized definition's own embedded triggers win, mirroring how `findWorkflowDefinition` and the definitions list already shadow code definitions. This is what prevents double-firing after a user customizes a code workflow;
- stamps `workflowDefinitionId` with `codeWorkflowUuid(workflowId)` — the same deterministic UUID the executor assigns to virtual code definitions — so `maxConcurrentInstances` counts the instances these triggers actually start;
- skips the shadow query entirely when no code workflow declares a trigger (no extra DB round-trip on the hot event path for installs without code triggers).

No executor change needed: `startWorkflow` already resolves code workflows via `findWorkflowDefinition`'s registry fallback.

**Contract note:** `UnifiedTrigger.source` gains `'code'` (union widening). Checked every consumer — it is only written into instance metadata/labels, never switched on exhaustively.

## Tests

New `event-trigger-code-workflows.test.ts` (4 cases): a code trigger reaches the matcher with the right shape + deterministic UUID; a DB definition shadows it; disabled workflows/triggers are skipped; no shadow probe fires when nothing declares triggers. **Verified failing against the pre-fix service** (the exposure case), passing after. Workflows suite: **634/634**.

Label suggestion (no triage rights): `review` + `bug` + `needs-qa` + `priority-medium` + `risk-medium` — hot event path in the workflows engine; shadowing keeps existing customized workflows unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-high` · `risk-medium` · `needs-qa`