### PR TITLE
fix(workflows): validate activity config at edit time instead of failing at run time

### DIFF
--- a/packages/core/src/__tests__/shipped-workflow-activity-config.test.ts
+++ b/packages/core/src/__tests__/shipped-workflow-activity-config.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment node
+ *
+ * Repo-wide guard for #4232: every activity in a code-defined workflow this
+ * repo ships must satisfy `activityDefinitionSchema`, which now requires the
+ * config keys each executor reads at run time. Generalizes the EMIT_EVENT-only
+ * guard added for #4322 — a shipped example whose activity config the executor
+ * cannot use is a bug we hand to every install.
+ */
+import { activityDefinitionSchema } from '@open-mercato/core/modules/workflows/data/validators'
+import { workflowsConfig as coreWorkflows } from '@open-mercato/core/modules/workflows/workflows'
+import { workflowsConfig as salesWorkflows } from '@open-mercato/core/modules/sales/workflows'
+
+type ShippedActivity = {
+  label: string
+  activity: unknown
+}
+
+function collectActivities(
+  moduleId: string,
+  config: { workflows: Array<{ workflowId: string; definition: Record<string, unknown> }> },
+): ShippedActivity[] {
+  const collected: ShippedActivity[] = []
+  for (const workflow of config.workflows) {
+    const definition = workflow.definition as {
+      steps?: Array<{ stepId?: string; activities?: unknown[] }>
+      transitions?: Array<{ transitionId?: string; activities?: unknown[] }>
+    }
+    for (const step of definition.steps ?? []) {
+      for (const activity of step.activities ?? []) {
+        collected.push({
+          label: `${moduleId} / ${workflow.workflowId} / step ${step.stepId} / ${(activity as { activityId?: string }).activityId}`,
+          activity,
+        })
+      }
+    }
+    for (const transition of definition.transitions ?? []) {
+      for (const activity of transition.activities ?? []) {
+        collected.push({
+          label: `${moduleId} / ${workflow.workflowId} / transition ${transition.transitionId} / ${(activity as { activityId?: string }).activityId}`,
+          activity,
+        })
+      }
+    }
+  }
+  return collected
+}
+
+const shippedActivities = [
+  ...collectActivities('workflows', coreWorkflows as never),
+  ...collectActivities('sales', salesWorkflows as never),
+]
+
+describe('shipped code-defined workflow activities', () => {
+  test('there are shipped activities to guard', () => {
+    expect(shippedActivities.length).toBeGreaterThan(0)
+  })
+
+  test.each(shippedActivities.map((entry) => [entry.label, entry.activity] as const))(
+    '%s has a config its executor can run',
+    (label, activity) => {
+      const result = activityDefinitionSchema.safeParse(activity)
+      const problems = result.success
+        ? ''
+        : result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; ')
+      expect(problems).toBe('')
+    },
+  )
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-002.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-002.spec.ts
@@ -55,7 +55,10 @@ function buildDefinitionPayload(timestamp: number) {
               activityName: 'Emit review requested',
               activityType: 'EMIT_EVENT',
               config: {
-                eventType: 'qa.workflow.review.requested',
+                // eventName, not eventType — the EMIT_EVENT executor reads
+                // eventName and this fixture would have failed at run time
+                // (same defect as #4322).
+                eventName: 'qa.workflow.review.requested',
                 payload: { workflow: '{{workflow.instanceId}}' },
               },
               async: true,

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-017.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-017.spec.ts
@@ -52,7 +52,10 @@ test.describe('TC-WF-017: branch failure cancels siblings and fails the instance
                 activityId: 'boom',
                 activityName: 'Boom',
                 activityType: 'EXECUTE_FUNCTION',
-                config: { functionId: 'qa-nonexistent-function-do-not-register' },
+                // functionName, not functionId — with the wrong key the activity
+                // failed on "requires functionName" rather than on the missing
+                // registration this test is actually about.
+                config: { functionName: 'qa-nonexistent-function-do-not-register' },
               },
             ],
           },

--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
@@ -11,6 +11,7 @@ import { useState, useCallback, useEffect } from 'react'
 import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 import { graphToDefinition, definitionToGraph, validateWorkflowGraph, generateStepId, generateTransitionId, appendWorkflowEdge, ValidationError } from '../../../lib/graph-utils'
 import { performDeleteEdgeFlow, performDeleteNodeFlow } from '../../../lib/visual-editor-delete-flow'
+import { humanizeDefinitionIssuePath } from '../../../lib/format-validation-error'
 import { workflowDefinitionDataSchema } from '../../../data/validators'
 import { Page } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
@@ -357,11 +358,19 @@ export default function VisualEditorPage() {
       triggers: triggers.length > 0 ? triggers : undefined,
     }
 
-    // Run Zod schema validation before saving
+    // Run Zod schema validation before saving. Report every issue, not just the
+    // first: a save rejected for one missing activity field used to look like
+    // "nothing happened" once the operator fixed that field and hit a second
+    // one (#4232). Paths are humanized (steps.2.activities.0.config.endpoint →
+    // step 3 › activity 1 › endpoint) so the message points at the node to open.
     const schemaResult = workflowDefinitionDataSchema.safeParse(definitionData)
     if (!schemaResult.success) {
-      const firstIssue = schemaResult.error.issues[0]
-      flash(`Schema error: ${firstIssue.path.join('.')} - ${firstIssue.message}`, 'error')
+      const issues = schemaResult.error.issues
+      const described = issues
+        .slice(0, 3)
+        .map((issue) => `${humanizeDefinitionIssuePath(issue.path)}: ${issue.message}`)
+      const suffix = issues.length > described.length ? ` (+${issues.length - described.length} more)` : ''
+      flash(`Cannot save — ${described.join('; ')}${suffix}`, 'error')
       return
     }
 

--- a/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
@@ -317,7 +317,10 @@ describe('Workflows Validators', () => {
             activityId: 'update-inventory-1',
             activityName: 'Update Inventory',
             activityType: 'UPDATE_ENTITY',
-            config: { entityType: 'inventory', updates: { count: 10 } },
+            // commandId + input are what executeUpdateEntity actually reads; the
+            // previous entityType/updates shape would have failed at runtime and
+            // is now rejected at validation time (#4232).
+            config: { commandId: 'sales.documents.update', input: { count: 10 } },
           },
         ],
       }
@@ -430,7 +433,10 @@ describe('Workflows Validators', () => {
             activityId: 'send-email-2',
             activityName: 'Send Email',
             activityType: 'SEND_EMAIL' as const,
-            config: { to: 'a@b.c' },
+            // Complete SEND_EMAIL config: the WAIT duration/until rules must not
+            // leak here, while SEND_EMAIL's own to/subject requirement applies
+            // (#4232).
+            config: { to: 'a@b.c', subject: 'Hello' },
           })
         ).not.toThrow()
       })

--- a/packages/core/src/modules/workflows/data/validators.ts
+++ b/packages/core/src/modules/workflows/data/validators.ts
@@ -202,6 +202,20 @@ export const activityRetryPolicySchema = z.object({
   maxIntervalMs: z.number().int().min(0),
 })
 
+/**
+ * Config fields each activity executor requires to run (see
+ * `lib/activity-executor.ts`). WAIT is handled separately below because it
+ * takes "duration" OR "until" rather than a fixed key set.
+ */
+const REQUIRED_ACTIVITY_CONFIG_KEYS: Partial<Record<ActivityType, readonly string[]>> = {
+  SEND_EMAIL: ['to', 'subject'],
+  CALL_API: ['endpoint'],
+  CALL_WEBHOOK: ['url'],
+  UPDATE_ENTITY: ['commandId', 'input'],
+  EMIT_EVENT: ['eventName'],
+  EXECUTE_FUNCTION: ['functionName'],
+}
+
 // Activity definition (embedded in transitions)
 export const activityDefinitionSchema = z.object({
   activityId: z.string().min(1).max(100).regex(/^[a-z0-9_-]+$/, 'Activity ID must contain only lowercase letters, numbers, hyphens, and underscores'),
@@ -216,6 +230,32 @@ export const activityDefinitionSchema = z.object({
     automatic: z.boolean().default(true).optional() // Auto-trigger on failure
   }).optional(), // Compensation configuration (Phase 8.2)
 }).superRefine((activity, ctx) => {
+  // Config keys each activity executor requires at runtime. Without this, an
+  // activity missing e.g. CALL_API's `endpoint` saved cleanly from the visual
+  // editor and only failed once an instance ran it — the "edit silently
+  // disappeared / nothing told me why" report in #4232 (and the class of bug
+  // #4322 was an instance of). Validating here surfaces the exact missing field
+  // at edit time, since both the editor's save path and the API route parse
+  // through this schema.
+  const requiredConfigKeys = REQUIRED_ACTIVITY_CONFIG_KEYS[activity.activityType]
+  if (requiredConfigKeys) {
+    const config = activity.config || {}
+    for (const key of requiredConfigKeys) {
+      const value = config[key]
+      const isEmpty =
+        value == null ||
+        (typeof value === 'string' && value.trim() === '') ||
+        (key === 'input' && typeof value !== 'object')
+      if (isEmpty) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['config', key],
+          message: `${activity.activityType} activity requires "${key}"`,
+        })
+      }
+    }
+  }
+
   if (activity.activityType !== 'WAIT') return
   const config = activity.config || {}
   const hasDuration = config.duration != null && config.duration !== ''

--- a/packages/core/src/modules/workflows/lib/__tests__/activity-config-required.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-config-required.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ *
+ * Guards #4232: activity configs were validated only for WAIT, so an activity
+ * missing a field its executor requires (CALL_API `endpoint`, EMIT_EVENT
+ * `eventName`, …) saved cleanly from the visual editor and only blew up when an
+ * instance ran it — the "my edit silently disappeared and nothing told me why"
+ * report. The schema now rejects them at edit/save time with the exact path.
+ */
+import { activityDefinitionSchema } from '../../data/validators'
+import { humanizeDefinitionIssuePath } from '../format-validation-error'
+
+function activity(activityType: string, config: Record<string, unknown>) {
+  return {
+    activityId: 'act_1',
+    activityName: 'Test activity',
+    activityType,
+    config,
+  }
+}
+
+describe('activityDefinitionSchema — required config per activity type (#4232)', () => {
+  const cases: Array<[string, Record<string, unknown>, string]> = [
+    ['CALL_API', {}, 'endpoint'],
+    ['EMIT_EVENT', {}, 'eventName'],
+    ['CALL_WEBHOOK', {}, 'url'],
+    ['EXECUTE_FUNCTION', {}, 'functionName'],
+    ['SEND_EMAIL', { to: 'a@b.c' }, 'subject'],
+    ['UPDATE_ENTITY', { commandId: 'sales.documents.update' }, 'input'],
+  ]
+
+  it.each(cases)('rejects %s missing %s', (activityType, config, missingKey) => {
+    const result = activityDefinitionSchema.safeParse(activity(activityType, config))
+    expect(result.success).toBe(false)
+    if (result.success) return
+    const issue = result.error.issues.find((candidate) => candidate.path.join('.') === `config.${missingKey}`)
+    expect(issue?.message).toBe(`${activityType} activity requires "${missingKey}"`)
+  })
+
+  it('rejects a blank string as missing (whitespace-only endpoint)', () => {
+    const result = activityDefinitionSchema.safeParse(activity('CALL_API', { endpoint: '   ' }))
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts activities whose required config is present', () => {
+    expect(activityDefinitionSchema.safeParse(activity('CALL_API', { endpoint: '/api/x' })).success).toBe(true)
+    expect(activityDefinitionSchema.safeParse(activity('EMIT_EVENT', { eventName: 'a.b.c' })).success).toBe(true)
+    expect(
+      activityDefinitionSchema.safeParse(
+        activity('UPDATE_ENTITY', { commandId: 'sales.documents.update', input: { id: '1' } }),
+      ).success,
+    ).toBe(true)
+  })
+
+  it('leaves the existing WAIT duration/until rules intact', () => {
+    expect(activityDefinitionSchema.safeParse(activity('WAIT', {})).success).toBe(false)
+    expect(activityDefinitionSchema.safeParse(activity('WAIT', { duration: 'PT5M' })).success).toBe(true)
+  })
+})
+
+describe('humanizeDefinitionIssuePath (#4232)', () => {
+  it('renders collection indexes 1-based with recognizable labels', () => {
+    expect(humanizeDefinitionIssuePath(['steps', 2, 'activities', 0, 'config', 'endpoint'])).toBe(
+      'step 3 › activity 1 › config.endpoint',
+    )
+    expect(humanizeDefinitionIssuePath(['transitions', 0, 'toStepId'])).toBe('transition 1 › toStepId')
+  })
+
+  it('falls back sensibly for short and empty paths', () => {
+    expect(humanizeDefinitionIssuePath(['workflowName'])).toBe('workflowName')
+    expect(humanizeDefinitionIssuePath([])).toBe('definition')
+  })
+})

--- a/packages/core/src/modules/workflows/lib/format-validation-error.ts
+++ b/packages/core/src/modules/workflows/lib/format-validation-error.ts
@@ -8,6 +8,66 @@ type ApiErrorBody = {
   details?: ZodIssueLite[]
 }
 
+// Collection segments in a definition path, mapped to the label an operator
+// recognizes from the editor. Indexes are rendered 1-based.
+const COLLECTION_LABELS: Record<string, string> = {
+  steps: 'step',
+  transitions: 'transition',
+  activities: 'activity',
+  triggers: 'trigger',
+  preConditions: 'pre-condition',
+}
+
+/**
+ * Turn a raw Zod path into something an operator can act on:
+ * `steps.2.activities.0.config.endpoint` → `step 3 › activity 1 › config.endpoint`.
+ *
+ * The raw dotted path reads as internal JSON and gives no hint which node to
+ * open in the visual editor (#4232).
+ */
+export function humanizeDefinitionIssuePath(path: ReadonlyArray<PropertyKey>): string {
+  if (!path.length) return 'definition'
+  const parts: string[] = []
+  let pending: string | null = null
+
+  for (const rawSegment of path) {
+    // Zod types issue paths as PropertyKey; symbols can't appear in JSON data
+    // but narrow defensively rather than casting.
+    const segment = typeof rawSegment === 'symbol' ? rawSegment.toString() : rawSegment
+    if (typeof segment === 'number') {
+      parts.push(pending ? `${pending} ${segment + 1}` : `#${segment + 1}`)
+      pending = null
+      continue
+    }
+    const label = COLLECTION_LABELS[segment]
+    if (label) {
+      if (pending) parts.push(pending)
+      pending = label
+      continue
+    }
+    if (pending) {
+      parts.push(pending)
+      pending = null
+    }
+    parts.push(segment)
+  }
+  if (pending) parts.push(pending)
+
+  const [head, ...rest] = parts
+  if (!rest.length) return head
+  // Keep trailing field names dotted (config.endpoint), collections chevroned.
+  const grouped: string[] = [head]
+  for (const part of rest) {
+    const isIndexed = /\s\d+$/.test(part) || part.startsWith('#')
+    if (!isIndexed && grouped.length > 0 && !/\s\d+$/.test(grouped[grouped.length - 1]) && !grouped[grouped.length - 1].startsWith('#')) {
+      grouped[grouped.length - 1] = `${grouped[grouped.length - 1]}.${part}`
+      continue
+    }
+    grouped.push(part)
+  }
+  return grouped.join(' › ')
+}
+
 /**
  * Format an API validation error body into a user-readable message.
  *


### PR DESCRIPTION
Fixes #4232

## Root cause

The issue describes edits that appear to save and are then gone, "usually a missing required parameter (e.g. in a Call API JSON body) that fails validation quietly". Tracked it to `activityDefinitionSchema`: it validates config **only for WAIT**; every other activity type takes `config: z.record(z.string(), z.any())`. So an activity missing a field its executor requires passes validation, is persisted, and only throws once an instance runs it:

| Activity | Required by executor (`lib/activity-executor.ts`) |
|---|---|
| `CALL_API` | `endpoint` |
| `EMIT_EVENT` | `eventName` |
| `CALL_WEBHOOK` | `url` |
| `UPDATE_ENTITY` | `commandId`, `input` |
| `SEND_EMAIL` | `to`, `subject` |
| `EXECUTE_FUNCTION` | `functionName` |

#4322 (simple-approval using `eventType` where the executor wants `eventName`) was one instance of exactly this class — it shipped in a bundled example precisely because nothing validated it.

## Fix

1. **`activityDefinitionSchema` requires each type's runtime config keys**, reporting the precise path (`config.endpoint`). Both the visual editor's pre-save parse and the definitions API route go through this schema, so the missing field is now named where the user is editing instead of at run time. WAIT keeps its existing duration/until rules.
2. **The visual editor reports up to three issues, not just the first.** Previously, fixing one field and re-saving surfaced the next one as another rejection, which reads as "it still didn't save and I don't know why".
3. **Issue paths are humanized**: `steps.2.activities.0.config.endpoint` → `step 3 › activity 1 › config.endpoint`, so the message points at the node to open. The helper lives next to `formatWorkflowValidationError` (same file) so the non-visual editor can adopt it too.

## Tests

New `activity-config-required.test.ts` (11 tests): each type rejects its missing key with the exact message and path, whitespace-only counts as missing, valid configs pass, WAIT rules unchanged, plus path-humanizing cases.

**Two existing fixtures had to be corrected** — worth a reviewer's eye, since they encoded configs that could never have run:
- `UPDATE_ENTITY` with `{ entityType, updates }` (executor reads `commandId` + `input`);
- a SEND_EMAIL fixture without `subject` in the "WAIT rules don't leak to other types" test — kept its intent with a complete config.

`packages/core` workflows module: **43 suites / 641 tests green**; `tsc --noEmit` clean; eslint clean on changed files. The shipped code workflows (`workflows.ts`) validate under the stricter schema. Runner: local.

## Scope note

The issue asks for "upfront, inline validation with visible error messages at edit time". This lands the validation layer plus clear, path-pointed messages on save. Per-field inline errors *inside* the node/edge dialogs (red text under the offending input as you type) are the natural follow-up and are a bigger UI change to `NodeEditDialog`/`EdgeEditDialog`; happy to do it in a second PR if you want it, but this alone turns a silent drop into a specific, actionable message.

## Labels (suggestion — read-permission account)

`bug`, `review`, `needs-qa` (workflow editor flow), `priority-medium`, `risk-medium` (tightens a validation contract: definitions with previously-unvalidated activity configs will now be rejected on save — that is the point, but it can surface pre-existing bad data in an install; the shipped examples were checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-medium` · `risk-low` · `needs-qa`