### PR TITLE
fix(workflows): keep the activity config JSON field editable while typing

### DIFF
--- a/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
+++ b/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
@@ -46,8 +46,59 @@ const ACTIVITY_TYPES = [
   { value: 'WAIT', label: 'Wait' },
 ]
 
+/**
+ * Per-activity draft of the raw JSON config text (#4234).
+ *
+ * The config textarea used to be controlled directly by
+ * `JSON.stringify(activity.config)`, and its onChange dropped anything that
+ * did not parse. Every intermediate keystroke of a hand edit is invalid JSON,
+ * so the state never advanced and React re-rendered the previous serialized
+ * value — the field read as frozen/non-editable right after a config was
+ * pasted. Keeping the raw text locally lets the user type freely; the parsed
+ * object is propagated whenever the text is valid, and an inline error is shown
+ * while it is not.
+ */
+type ConfigDraft = { text: string; error: string | null }
+
+function serializeConfig(config: Record<string, unknown> | undefined): string {
+  return JSON.stringify(config ?? {}, null, 2)
+}
+
 export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEditorProps) {
   const t = useT()
+  const [configDrafts, setConfigDrafts] = React.useState<Record<number, ConfigDraft>>({})
+
+  const configTextFor = (index: number, activity: Activity): string =>
+    configDrafts[index]?.text ?? serializeConfig(activity.config)
+
+  const handleConfigTextChange = (index: number, text: string) => {
+    let parsed: Record<string, unknown> | null = null
+    let parseError: string | null = null
+    try {
+      const candidate = JSON.parse(text) as unknown
+      if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+        parsed = candidate as Record<string, unknown>
+      } else {
+        parseError = t('workflows.activities.configMustBeObject', 'Config must be a JSON object')
+      }
+    } catch (err) {
+      parseError = err instanceof Error ? err.message : t('workflows.activities.configInvalidJson', 'Invalid JSON')
+    }
+
+    setConfigDrafts((drafts) => ({ ...drafts, [index]: { text, error: parseError } }))
+    if (parsed) updateActivity(index, 'config', parsed)
+  }
+
+  // Drop the raw draft once the field loses focus and its content is valid, so
+  // the textarea goes back to mirroring the canonical (re-formatted) config.
+  const handleConfigBlur = (index: number) => {
+    setConfigDrafts((drafts) => {
+      if (!drafts[index] || drafts[index].error) return drafts
+      const next = { ...drafts }
+      delete next[index]
+      return next
+    })
+  }
 
   const addActivity = () => {
     const newActivity: Activity = {
@@ -318,19 +369,24 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
                 </Label>
                 <Textarea
                   id={`activity-${index}-config`}
-                  value={JSON.stringify(activity.config || {}, null, 2)}
-                  onChange={(e) => {
-                    try {
-                      const parsed = JSON.parse(e.target.value)
-                      updateActivity(index, 'config', parsed)
-                    } catch {
-                      // Invalid JSON, don't update
-                    }
-                  }}
+                  value={configTextFor(index, activity)}
+                  onChange={(e) => handleConfigTextChange(index, e.target.value)}
+                  onBlur={() => handleConfigBlur(index)}
+                  aria-invalid={configDrafts[index]?.error ? true : undefined}
+                  aria-describedby={configDrafts[index]?.error ? `activity-${index}-config-error` : undefined}
                   placeholder='{"key": "value"}'
                   rows={3}
                   className="mt-1 font-mono text-xs"
                 />
+                {configDrafts[index]?.error ? (
+                  <p
+                    id={`activity-${index}-config-error`}
+                    className="mt-1 text-xs text-status-error-text"
+                    role="alert"
+                  >
+                    {configDrafts[index]?.error}
+                  </p>
+                ) : null}
               </div>
               )}
             </div>

--- a/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
+++ b/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
@@ -136,6 +136,18 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
 
   const removeActivity = (index: number) => {
     onChange(value.filter((_, i) => i !== index))
+    // Keep the index-keyed drafts aligned with the re-indexed activities:
+    // drop the removed row's draft and shift every later draft down by one,
+    // otherwise a pending (invalid) draft would render over a different row.
+    setConfigDrafts((drafts) => {
+      const next: Record<number, ConfigDraft> = {}
+      for (const key of Object.keys(drafts)) {
+        const i = Number(key)
+        if (i === index) continue
+        next[i > index ? i - 1 : i] = drafts[i]
+      }
+      return next
+    })
   }
 
   const moveActivity = (index: number, direction: 'up' | 'down') => {
@@ -147,6 +159,18 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
     updated[index] = updated[newIndex]
     updated[newIndex] = temp
     onChange(updated)
+    // Swap the two rows' drafts too, so an in-progress edit follows its activity.
+    setConfigDrafts((drafts) => {
+      if (!(index in drafts) && !(newIndex in drafts)) return drafts
+      const next = { ...drafts }
+      const atIndex = drafts[index]
+      const atNew = drafts[newIndex]
+      if (atNew !== undefined) next[index] = atNew
+      else delete next[index]
+      if (atIndex !== undefined) next[newIndex] = atIndex
+      else delete next[newIndex]
+      return next
+    })
   }
 
   return (

--- a/packages/core/src/modules/workflows/components/__tests__/ActivitiesEditor.configJson.test.tsx
+++ b/packages/core/src/modules/workflows/components/__tests__/ActivitiesEditor.configJson.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Guards #4234: the activity config textarea was controlled by
+ * `JSON.stringify(activity.config)` and its onChange discarded anything that
+ * did not parse. Every intermediate keystroke of a hand edit is invalid JSON,
+ * so state never advanced and React restored the previous text — the field read
+ * as frozen right after a config was pasted, pushing users to the non-visual
+ * editor.
+ */
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallbackOrParams?: unknown) =>
+    typeof fallbackOrParams === 'string' ? fallbackOrParams : key,
+}))
+
+import { ActivitiesEditor } from '../ActivitiesEditor'
+
+type Activity = {
+  activityId: string
+  activityName: string
+  activityType: string
+  config?: Record<string, unknown>
+}
+
+const baseActivity: Activity = {
+  activityId: 'call_api_1',
+  activityName: 'Call API',
+  activityType: 'CALL_API',
+  config: { endpoint: '/api/sales/orders' },
+}
+
+/** Host that owns the activities array, like the real dialogs do. */
+function Harness({ initial = [baseActivity] }: { initial?: Activity[] }) {
+  const [activities, setActivities] = React.useState<Activity[]>(initial)
+  return <ActivitiesEditor value={activities as never} onChange={setActivities as never} />
+}
+
+function configTextarea(): HTMLTextAreaElement {
+  return screen.getByLabelText(/Configuration|workflows\.activities\.config/i) as HTMLTextAreaElement
+}
+
+describe('ActivitiesEditor config JSON field (#4234)', () => {
+  it('accepts a keystroke that leaves the JSON temporarily invalid', () => {
+    render(<Harness />)
+    const textarea = configTextarea()
+
+    // Deleting the closing brace is the first keystroke of any hand edit.
+    const brokenText = textarea.value.slice(0, -1)
+    fireEvent.change(textarea, { target: { value: brokenText } })
+
+    expect(textarea.value).toBe(brokenText)
+  })
+
+  it('surfaces an inline error while the JSON is invalid', () => {
+    render(<Harness />)
+    fireEvent.change(configTextarea(), { target: { value: '{"endpoint": ' } })
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(configTextarea()).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('lets a pasted config be edited afterwards (the reported symptom)', () => {
+    render(<Harness />)
+    const textarea = configTextarea()
+
+    // Paste a doc snippet…
+    fireEvent.change(textarea, {
+      target: { value: '{"endpoint": "/api/sales/orders", "method": "POST"}' },
+    })
+    // …then hand-edit it: the intermediate state is invalid JSON.
+    fireEvent.change(textarea, {
+      target: { value: '{"endpoint": "/api/sales/orders", "method": "POS' },
+    })
+    expect(textarea.value).toBe('{"endpoint": "/api/sales/orders", "method": "POS')
+
+    // Finishing the edit clears the error and keeps the typed text.
+    fireEvent.change(textarea, {
+      target: { value: '{"endpoint": "/api/sales/orders", "method": "PUT"}' },
+    })
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(textarea.value).toBe('{"endpoint": "/api/sales/orders", "method": "PUT"}')
+  })
+
+  it('rejects a valid-JSON non-object (arrays would break config lookups)', () => {
+    render(<Harness />)
+    fireEvent.change(configTextarea(), { target: { value: '["nope"]' } })
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('re-serializes from the canonical config on blur once valid', () => {
+    render(<Harness />)
+    const textarea = configTextarea()
+
+    fireEvent.change(textarea, { target: { value: '{"endpoint":"/x"}' } })
+    fireEvent.blur(textarea)
+
+    // Back to the pretty-printed projection of the parsed config.
+    expect(textarea.value).toBe(JSON.stringify({ endpoint: '/x' }, null, 2))
+  })
+
+  it('keeps the raw text on blur while it is still invalid, so work is not lost', () => {
+    render(<Harness />)
+    const textarea = configTextarea()
+
+    fireEvent.change(textarea, { target: { value: '{"endpoint": ' } })
+    fireEvent.blur(textarea)
+
+    expect(textarea.value).toBe('{"endpoint": ')
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/modules/workflows/components/__tests__/ActivitiesEditor.configJson.test.tsx
+++ b/packages/core/src/modules/workflows/components/__tests__/ActivitiesEditor.configJson.test.tsx
@@ -112,4 +112,47 @@ describe('ActivitiesEditor config JSON field (#4234)', () => {
     expect(textarea.value).toBe('{"endpoint": ')
     expect(screen.getByRole('alert')).toBeInTheDocument()
   })
+
+  // The config drafts are keyed by row index, so removing/moving a row must
+  // re-index the drafts map — otherwise a pending (invalid) draft renders over
+  // a different activity and can be saved onto the wrong config.
+  const secondActivity: Activity = {
+    activityId: 'call_api_2',
+    activityName: 'Call API 2',
+    activityType: 'CALL_API',
+    config: { endpoint: '/api/sales/quotes' },
+  }
+  const allConfigTextareas = () =>
+    screen.getAllByLabelText(/Configuration|workflows\.activities\.config/i) as HTMLTextAreaElement[]
+
+  it('keeps an in-progress invalid config draft with its activity when a row above is removed', () => {
+    render(<Harness initial={[baseActivity, secondActivity]} />)
+
+    // Start an edit on the second row that leaves the JSON invalid (draft at index 1).
+    fireEvent.change(allConfigTextareas()[1], { target: { value: '{"endpoint": ' } })
+    expect(allConfigTextareas()[1].value).toBe('{"endpoint": ')
+
+    // Remove the first row — the second activity becomes index 0.
+    fireEvent.click(screen.getAllByTitle('common.delete')[0])
+
+    const remaining = allConfigTextareas()
+    expect(remaining).toHaveLength(1)
+    // The draft follows its activity to the new index instead of vanishing or
+    // landing on another row.
+    expect(remaining[0].value).toBe('{"endpoint": ')
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('moves an in-progress config draft with its activity when the row is reordered', () => {
+    render(<Harness initial={[baseActivity, secondActivity]} />)
+
+    fireEvent.change(allConfigTextareas()[1], { target: { value: '{"endpoint": ' } })
+    // Move the second row up — it becomes index 0, its draft must move with it.
+    fireEvent.click(screen.getAllByTitle('common.moveUp')[1])
+
+    const after = allConfigTextareas()
+    expect(after[0].value).toBe('{"endpoint": ')
+    // The former first row (now index 1) shows its canonical config, no stale draft.
+    expect(after[1].value).toBe(JSON.stringify({ endpoint: '/api/sales/orders' }, null, 2))
+  })
 })

--- a/packages/core/src/modules/workflows/i18n/de.json
+++ b/packages/core/src/modules/workflows/i18n/de.json
@@ -80,6 +80,8 @@
   "workflows.activities.async": "Asynchron",
   "workflows.activities.compensation": "Kompensation",
   "workflows.activities.config": "Konfiguration",
+  "workflows.activities.configInvalidJson": "Ungültiges JSON",
+  "workflows.activities.configMustBeObject": "Konfiguration muss ein JSON-Objekt sein",
   "workflows.activities.deleteActivity": "Aktivität löschen",
   "workflows.activities.editActivity": "Aktivität bearbeiten",
   "workflows.activities.plural": "Aktivitäten",

--- a/packages/core/src/modules/workflows/i18n/en.json
+++ b/packages/core/src/modules/workflows/i18n/en.json
@@ -80,6 +80,8 @@
   "workflows.activities.async": "Asynchronous",
   "workflows.activities.compensation": "Compensation",
   "workflows.activities.config": "Configuration",
+  "workflows.activities.configInvalidJson": "Invalid JSON",
+  "workflows.activities.configMustBeObject": "Config must be a JSON object",
   "workflows.activities.deleteActivity": "Delete Activity",
   "workflows.activities.editActivity": "Edit Activity",
   "workflows.activities.plural": "Activities",

--- a/packages/core/src/modules/workflows/i18n/es.json
+++ b/packages/core/src/modules/workflows/i18n/es.json
@@ -80,6 +80,8 @@
   "workflows.activities.async": "Asincrona",
   "workflows.activities.compensation": "Compensacion",
   "workflows.activities.config": "Configuracion",
+  "workflows.activities.configInvalidJson": "JSON no válido",
+  "workflows.activities.configMustBeObject": "La configuración debe ser un objeto JSON",
   "workflows.activities.deleteActivity": "Eliminar actividad",
   "workflows.activities.editActivity": "Editar actividad",
   "workflows.activities.plural": "Actividades",

--- a/packages/core/src/modules/workflows/i18n/pl.json
+++ b/packages/core/src/modules/workflows/i18n/pl.json
@@ -80,6 +80,8 @@
   "workflows.activities.async": "Asynchroniczne",
   "workflows.activities.compensation": "Kompensacja",
   "workflows.activities.config": "Konfiguracja",
+  "workflows.activities.configInvalidJson": "Nieprawidłowy JSON",
+  "workflows.activities.configMustBeObject": "Konfiguracja musi być obiektem JSON",
   "workflows.activities.deleteActivity": "Usuń Działanie",
   "workflows.activities.editActivity": "Edytuj Działanie",
   "workflows.activities.plural": "Działania",


### PR DESCRIPTION
Fixes #4234

## Reproduced, not already fixed

The issue was filed as *"may be fixed — verify and close"*. It is **not** fixed on `develop`. Root cause in `ActivitiesEditor.tsx`:

```tsx
<Textarea
  value={JSON.stringify(activity.config || {}, null, 2)}   // controlled by the parsed object
  onChange={(e) => {
    try { updateActivity(index, 'config', JSON.parse(e.target.value)) }
    catch { /* Invalid JSON, don't update */ }
  }}
/>
```

Every intermediate keystroke of a hand edit is momentarily invalid JSON → state never advances → React re-renders the previous serialized value → the keystroke is reverted. Pasting a complete valid snippet works (it parses atomically), but the field is then effectively **read-only**, which is precisely the reported "pasted config JSON locks editing". That also explains why it did not reproduce live in the meeting: the paste itself succeeds; the lock only appears on the next hand edit.

## Fix

Per-activity local draft of the raw text:

- the user types freely; the parsed object is propagated to `onChange` whenever the text is valid;
- an inline error is shown while it is not (`role="alert"`, `aria-invalid`, `aria-describedby`, `text-status-error-text`);
- on **blur** a valid draft is released so the field goes back to mirroring the canonical pretty-printed config; an invalid draft is **kept** so half-finished work isn't silently discarded;
- valid-JSON non-objects (arrays, scalars) are rejected — config lookups assume an object.

New i18n keys (`configInvalidJson`, `configMustBeObject`) added to en/pl/de/es.

## Tests

Six jsdom regression tests: typing through an invalid state, the paste-then-edit scenario from the report, the inline error, non-object rejection, and both blur behaviors. **Mutation-verified**: 5 of 6 fail against the current component.

`packages/core` workflows components: 4 suites / 24 tests green; full workflows module green; `tsc --noEmit` clean; eslint clean; `yarn i18n:check-values` clean. Runner: local.

## Relationship to #4232 / PR #4423

Complementary and independent (this branch is cut from `develop`, no file overlap): #4423 stops invalid activity configs from being *saved* silently, this one stops the config field from being *unusable* in the first place. Together they cover the two halves of "the editor loses my work without telling me".

## Labels (suggestion — read-permission account)

`bug`, `review`, `needs-qa` (workflow editor UI), `priority-medium`, `risk-low` (single component, local state only, no contract change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-low` · `risk-low` · `needs-qa`