### PR TITLE
fix(workflows): make per-activity timeouts actually take effect

### DIFF
--- a/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
+++ b/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
@@ -26,7 +26,11 @@ interface Activity {
     retryDelay?: number
     backoffMultiplier?: number
   }
-  timeout?: number
+  // Milliseconds, matching the executor and the definition schema. This field
+  // used to be written as `timeout` (a number) while the schema typed `timeout`
+  // as an ISO 8601 string, so saving a timeout from this editor failed
+  // validation outright (#4424).
+  timeoutMs?: number
   compensation?: Record<string, any>
 }
 
@@ -211,8 +215,8 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
                   <Input
                     id={`activity-${index}-timeout`}
                     type="number"
-                    value={activity.timeout || ''}
-                    onChange={(e) => updateActivity(index, 'timeout', e.target.value ? parseInt(e.target.value) : undefined)}
+                    value={activity.timeoutMs || ''}
+                    onChange={(e) => updateActivity(index, 'timeoutMs', e.target.value ? parseInt(e.target.value) : undefined)}
                     placeholder="30000"
                     className="mt-1"
                   />

--- a/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
@@ -26,7 +26,11 @@ interface Activity {
     retryDelay?: number
     backoffMultiplier?: number
   }
-  timeout?: number
+  // Milliseconds, matching the executor and the definition schema. This field
+  // used to be written as `timeout` (a number) while the schema typed `timeout`
+  // as an ISO 8601 string, so saving a timeout from this editor failed
+  // validation outright (#4424).
+  timeoutMs?: number
   compensation?: Record<string, any>
 }
 
@@ -461,8 +465,8 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
                             <Input
                               id={`activity-${index}-${activityIndex}-timeout`}
                               type="number"
-                              value={activity.timeout || ''}
-                              onChange={(e) => updateActivity(index, activityIndex, 'timeout', e.target.value ? parseInt(e.target.value) : undefined)}
+                              value={activity.timeoutMs || ''}
+                              onChange={(e) => updateActivity(index, activityIndex, 'timeoutMs', e.target.value ? parseInt(e.target.value) : undefined)}
                               placeholder="30000"
                               className="mt-1 text-xs h-8"
                             />

--- a/packages/core/src/modules/workflows/data/validators.ts
+++ b/packages/core/src/modules/workflows/data/validators.ts
@@ -210,7 +210,18 @@ export const activityDefinitionSchema = z.object({
   config: z.record(z.string(), z.any()),
   async: z.boolean().default(false).optional(), // For Phase 8.3
   retryPolicy: activityRetryPolicySchema.optional(),
-  timeout: z.string().optional(), // ISO 8601 duration
+  /**
+   * Per-activity timeout in milliseconds. This is what the editor writes and
+   * what `executeActivity` reads; it was missing from the schema, so
+   * `z.object()` stripped it on save and UI-configured timeouts silently did
+   * nothing (#4424).
+   */
+  timeoutMs: z.number().int().positive().optional(),
+  /**
+   * @deprecated Use `timeoutMs`. Accepted for definitions already stored with
+   * an ISO 8601 duration string; the executor normalizes it to milliseconds.
+   */
+  timeout: z.string().optional(),
   compensation: z.object({
     activityId: z.string().min(1), // ID of compensation activity
     automatic: z.boolean().default(true).optional() // Auto-trigger on failure

--- a/packages/core/src/modules/workflows/lib/__tests__/activity-timeout.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-timeout.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ *
+ * Guards #4424: a per-activity timeout set in the editor never took effect.
+ * Three layers disagreed on the field name — the editors wrote `timeoutMs`
+ * (number) or `timeout` (number, labelled "ms"), the definition schema accepted
+ * only `timeout` (ISO 8601 string), and the executor read only `timeoutMs`. So
+ * `z.object()` stripped `timeoutMs` on save, a numeric `timeout` failed
+ * validation, and a stored ISO `timeout` was ignored at run time.
+ */
+import { activityDefinitionSchema } from '../../data/validators'
+import { resolveActivityTimeoutMs } from '../activity-executor'
+
+const baseActivity = {
+  activityId: 'call_api_1',
+  activityName: 'Call API',
+  activityType: 'CALL_API' as const,
+  config: { endpoint: '/api/x' },
+}
+
+describe('activity timeout round-trip (#4424)', () => {
+  it('keeps timeoutMs through schema validation instead of stripping it', () => {
+    const result = activityDefinitionSchema.safeParse({ ...baseActivity, timeoutMs: 30000 })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.timeoutMs).toBe(30000)
+  })
+
+  it('rejects a non-positive or fractional timeoutMs', () => {
+    expect(activityDefinitionSchema.safeParse({ ...baseActivity, timeoutMs: 0 }).success).toBe(false)
+    expect(activityDefinitionSchema.safeParse({ ...baseActivity, timeoutMs: -1 }).success).toBe(false)
+    expect(activityDefinitionSchema.safeParse({ ...baseActivity, timeoutMs: 1.5 }).success).toBe(false)
+  })
+
+  it('still accepts the deprecated ISO 8601 timeout string (stored definitions)', () => {
+    const result = activityDefinitionSchema.safeParse({ ...baseActivity, timeout: 'PT30S' })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('resolveActivityTimeoutMs (#4424)', () => {
+  it('prefers timeoutMs', () => {
+    expect(resolveActivityTimeoutMs({ timeoutMs: 30000 })).toBe(30000)
+    expect(resolveActivityTimeoutMs({ timeoutMs: 30000, timeout: 'PT5M' })).toBe(30000)
+  })
+
+  it('normalizes a legacy ISO 8601 timeout to milliseconds', () => {
+    expect(resolveActivityTimeoutMs({ timeout: 'PT30S' })).toBe(30_000)
+    expect(resolveActivityTimeoutMs({ timeout: 'PT5M' })).toBe(300_000)
+    expect(resolveActivityTimeoutMs({ timeout: 'PT1H' })).toBe(3_600_000)
+  })
+
+  it('normalizes the simple duration format the parser also supports', () => {
+    expect(resolveActivityTimeoutMs({ timeout: '30s' })).toBe(30_000)
+    expect(resolveActivityTimeoutMs({ timeout: '5m' })).toBe(300_000)
+  })
+
+  it('returns undefined when no usable timeout is configured', () => {
+    expect(resolveActivityTimeoutMs({})).toBeUndefined()
+    expect(resolveActivityTimeoutMs({ timeout: '' })).toBeUndefined()
+    expect(resolveActivityTimeoutMs({ timeout: '   ' })).toBeUndefined()
+    expect(resolveActivityTimeoutMs({ timeoutMs: 0 })).toBeUndefined()
+  })
+
+  it('ignores a malformed timeout rather than failing the activity', () => {
+    expect(resolveActivityTimeoutMs({ timeout: 'not-a-duration' })).toBeUndefined()
+    expect(resolveActivityTimeoutMs({ timeout: 'PT' })).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -107,7 +107,40 @@ export interface ActivityDefinition {
   async?: boolean // Flag to execute activity asynchronously via queue
   retryPolicy?: RetryPolicy
   timeoutMs?: number
+  /**
+   * @deprecated Use `timeoutMs`. Legacy ISO 8601 duration string accepted by
+   * the definition schema before #4424; normalized by `resolveActivityTimeoutMs`.
+   */
+  timeout?: string
   compensate?: boolean // Flag to execute compensation on failure
+}
+
+/**
+ * Effective timeout for an activity, in milliseconds.
+ *
+ * The editor and this executor both speak `timeoutMs`, but the definition
+ * schema historically accepted only an ISO 8601 `timeout` string — so stored
+ * definitions can carry either. Prefer `timeoutMs`; fall back to parsing
+ * `timeout`, ignoring a malformed value rather than throwing mid-execution
+ * (an unparseable timeout must not fail an activity that would otherwise
+ * succeed). Returns undefined when no usable timeout is configured (#4424).
+ */
+export function resolveActivityTimeoutMs(activity: {
+  timeoutMs?: number
+  timeout?: string
+}): number | undefined {
+  if (typeof activity.timeoutMs === 'number' && activity.timeoutMs > 0) {
+    return activity.timeoutMs
+  }
+  if (typeof activity.timeout === 'string' && activity.timeout.trim().length > 0) {
+    try {
+      const parsed = parseDuration(activity.timeout.trim())
+      if (Number.isFinite(parsed) && parsed > 0) return parsed
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
 }
 
 export interface RetryPolicy {
@@ -332,11 +365,13 @@ export async function executeActivity(
     try {
       const startTime = Date.now()
 
-      // Execute with timeout if specified
-      const result = activity.timeoutMs
+      // Execute with timeout if specified (timeoutMs, or a legacy ISO 8601
+      // `timeout` string normalized to ms — see resolveActivityTimeoutMs).
+      const timeoutMs = resolveActivityTimeoutMs(activity)
+      const result = timeoutMs
         ? await executeWithTimeout(
             () => executeActivityByType(em, container, activity, context),
-            activity.timeoutMs
+            timeoutMs
           )
         : await executeActivityByType(em, container, activity, context)
 


### PR DESCRIPTION
Fixes #4424

## What I found (one layer more than the issue described)

The issue names two field spellings; there are actually **three editors with three conventions**, none of which reached the executor:

| Editor | Writes | Outcome before this PR |
|---|---|---|
| `NodeEditDialog.tsx` | `timeoutMs` (number) | schema has no such key → `z.object()` **strips it** on save |
| `ActivitiesEditor.tsx` | `timeout` (**number**, field labelled "(ms)") | schema types `timeout` as a **string** → the whole save **fails validation** |
| `fields/ActivityArrayEditor.tsx` | `timeout` (ISO 8601 **string**) | validates and persists, but `executeActivity` only read `timeoutMs` → **ignored at run time** |

So every path was broken, and the middle one broke the save itself rather than just the timeout.

## Fix

Reconcile on `timeoutMs` — the name the executor already uses and two of the three editors already mean:

- `activityDefinitionSchema` accepts `timeoutMs: z.number().int().positive().optional()`; `timeout` stays as a **deprecated alias** (JSDoc'd) because stored definitions may already carry a duration string — per `BACKWARD_COMPATIBILITY.md`, no removal in one release.
- New exported `resolveActivityTimeoutMs(activity)`: prefers `timeoutMs`, otherwise normalizes the legacy string via the module's existing `parseDuration` (which handles both `PT30S` and `30s`). A malformed value returns `undefined` rather than throwing — an unparseable timeout must not fail an activity that would otherwise succeed.
- `executeActivity` wraps the call with the resolved value.
- `ActivitiesEditor` now writes `timeoutMs`, matching its own "(ms)" label.

## Tests

Eight tests: schema keeps `timeoutMs` (the round-trip the issue asks for), rejects non-positive/fractional values, still accepts the deprecated string; `resolveActivityTimeoutMs` prefers `timeoutMs`, normalizes both duration formats, and returns `undefined` for empty/malformed/absent. **Mutation-verified**: 7 of 8 fail without the fix.

`packages/core` workflows: 43 suites / 638 tests green; `tsc --noEmit` clean; eslint clean. Runner: local.

## Notes for reviewers

- **Behavior change worth a look**: definitions that stored an ISO `timeout` string were silently un-timed and will now actually be bounded. That's the point of the fix, but it means an activity that used to run unbounded may start timing out — worth a line in the release notes.
- Docs stay consistent with #4422 (which removed the misleading `"timeout": "5m"` snippets); once this lands, activity timeouts can be documented with `timeoutMs`.

## Labels (suggestion — read-permission account)

`bug`, `review`, `needs-qa` (editor round-trip is the user-visible half), `priority-medium`, `risk-medium` (contract surface: schema gains a field and previously-ignored timeouts start being enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cezar-self-triage -->
**Proposed triage** (self-assessed per AGENTS.md; I don't have triage rights to apply the labels): `priority-medium` · `risk-medium` · `needs-qa`