### PR TITLE
fix(workflows): register code-defined workflow triggers with the trigger engine

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/code-triggers.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/code-triggers.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment node
+ *
+ * Guards #4425: triggers declared on a code-defined workflow never reached the
+ * trigger engine, because `loadTriggersForTenant` merged only the two DB-backed
+ * sources. `loadCodeTriggers` projects the in-memory registry's triggers into
+ * UnifiedTriggers so a code-declared trigger auto-starts its workflow without an
+ * operator first customizing the definition into a DB row.
+ */
+jest.mock('../workflow-executor', () => ({
+  executeWorkflow: jest.fn(),
+  startWorkflow: jest.fn(),
+}))
+
+import {
+  registerCodeWorkflowEntries,
+  clearCodeWorkflowRegistry,
+} from '@open-mercato/shared/modules/workflows/code-registry'
+import type { CodeWorkflowDefinition } from '@open-mercato/shared/modules/workflows'
+import { loadCodeTriggers } from '../event-trigger-service'
+import { codeWorkflowUuid } from '../find-definition'
+
+const TENANT = 'tenant-1'
+const ORG = 'org-1'
+
+function codeWorkflow(overrides: Partial<CodeWorkflowDefinition> = {}): CodeWorkflowDefinition {
+  return {
+    workflowId: 'sales.order-approval',
+    workflowName: 'Order Approval',
+    description: null,
+    version: 1,
+    enabled: true,
+    metadata: null,
+    moduleId: 'sales',
+    definition: {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [{ transitionId: 't1', fromStepId: 'start', toStepId: 'end', trigger: 'auto' }],
+      triggers: [
+        {
+          triggerId: 'on-order-created',
+          name: 'On order created',
+          eventPattern: 'sales.order.created',
+          enabled: true,
+          priority: 10,
+          config: null,
+        },
+      ],
+    } as CodeWorkflowDefinition['definition'],
+    ...overrides,
+  }
+}
+
+describe('loadCodeTriggers (#4425)', () => {
+  afterEach(() => clearCodeWorkflowRegistry())
+
+  it('projects a code workflow trigger into a UnifiedTrigger', () => {
+    registerCodeWorkflowEntries([codeWorkflow()])
+
+    const triggers = loadCodeTriggers(TENANT, ORG, new Set())
+
+    expect(triggers).toHaveLength(1)
+    expect(triggers[0]).toMatchObject({
+      triggerId: 'on-order-created',
+      eventPattern: 'sales.order.created',
+      workflowId: 'sales.order-approval',
+      workflowVersion: 1,
+      source: 'code',
+      tenantId: TENANT,
+      organizationId: ORG,
+    })
+    // definitionId must match what startWorkflow persists, so the concurrency
+    // limit counts the right instances.
+    expect(triggers[0].workflowDefinitionId).toBe(codeWorkflowUuid('sales.order-approval'))
+    expect(triggers[0].id).toBe('code:sales.order-approval:on-order-created')
+  })
+
+  it('is suppressed when a DB-backed definition exists for the same workflowId (customize wins)', () => {
+    registerCodeWorkflowEntries([codeWorkflow()])
+
+    const triggers = loadCodeTriggers(TENANT, ORG, new Set(['sales.order-approval']))
+
+    expect(triggers).toHaveLength(0)
+  })
+
+  it('skips disabled code workflows and disabled triggers', () => {
+    registerCodeWorkflowEntries([
+      codeWorkflow({ workflowId: 'wf.disabled-workflow', enabled: false }),
+      codeWorkflow({
+        workflowId: 'wf.disabled-trigger',
+        definition: {
+          steps: [
+            { stepId: 'start', stepName: 'Start', stepType: 'START' },
+            { stepId: 'end', stepName: 'End', stepType: 'END' },
+          ],
+          transitions: [{ transitionId: 't1', fromStepId: 'start', toStepId: 'end', trigger: 'auto' }],
+          triggers: [
+            {
+              triggerId: 'off',
+              name: 'Disabled trigger',
+              eventPattern: 'x.y.z',
+              enabled: false,
+              priority: 0,
+              config: null,
+            },
+          ],
+        } as CodeWorkflowDefinition['definition'],
+      }),
+    ])
+
+    expect(loadCodeTriggers(TENANT, ORG, new Set())).toHaveLength(0)
+  })
+
+  it('ignores code workflows that declare no triggers', () => {
+    registerCodeWorkflowEntries([
+      codeWorkflow({
+        workflowId: 'wf.no-triggers',
+        definition: {
+          steps: [
+            { stepId: 'start', stepName: 'Start', stepType: 'START' },
+            { stepId: 'end', stepName: 'End', stepType: 'END' },
+          ],
+          transitions: [{ transitionId: 't1', fromStepId: 'start', toStepId: 'end', trigger: 'auto' }],
+        } as CodeWorkflowDefinition['definition'],
+      }),
+    ])
+
+    expect(loadCodeTriggers(TENANT, ORG, new Set())).toHaveLength(0)
+  })
+})

--- a/packages/core/src/modules/workflows/lib/event-trigger-service.ts
+++ b/packages/core/src/modules/workflows/lib/event-trigger-service.ts
@@ -22,6 +22,8 @@ import {
   type WorkflowDefinitionTrigger,
 } from '../data/entities'
 import { startWorkflow, executeWorkflow } from './workflow-executor'
+import { getAllCodeWorkflows } from './code-registry'
+import { codeWorkflowUuid } from './find-definition'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('workflows').child({ component: 'event-trigger' })
@@ -59,7 +61,7 @@ export interface UnifiedTrigger {
   workflowDefinitionId: string
   workflowId: string
   workflowVersion: number
-  source: 'legacy' | 'embedded'
+  source: 'legacy' | 'embedded' | 'code'
   tenantId: string
   organizationId: string
 }
@@ -413,12 +415,17 @@ async function loadLegacyTriggers(
 /**
  * Load embedded triggers from workflow definitions.
  * New triggers are embedded directly in the definition JSONB.
+ *
+ * Also returns the set of every enabled DB definition's `workflowId` — even
+ * those with no triggers — so the caller can let a materialized (customized)
+ * definition suppress its code-registry counterpart regardless of whether the
+ * customization kept any triggers (#4425).
  */
 async function loadEmbeddedTriggers(
   em: EntityManager,
   tenantId: string,
   organizationId: string
-): Promise<UnifiedTrigger[]> {
+): Promise<{ triggers: UnifiedTrigger[]; workflowIds: Set<string> }> {
   const postgresEm = em as unknown as PostgreSqlEntityManager
   // Load all enabled definitions that may have triggers
   const definitions = await findWithDecryption(
@@ -435,8 +442,11 @@ async function loadEmbeddedTriggers(
   )
 
   const triggers: UnifiedTrigger[] = []
+  const workflowIds = new Set<string>()
 
   for (const def of definitions) {
+    workflowIds.add(def.workflowId)
+
     const embeddedTriggers = def.definition?.triggers as WorkflowDefinitionTrigger[] | undefined
     if (!embeddedTriggers || embeddedTriggers.length === 0) continue
 
@@ -462,12 +472,70 @@ async function loadEmbeddedTriggers(
     }
   }
 
+  return { triggers, workflowIds }
+}
+
+/**
+ * Project triggers declared on code-defined workflows into UnifiedTriggers.
+ *
+ * Code workflows live only in the in-memory registry, so their `triggers`
+ * arrays never reached the DB-backed loaders — a code-declared trigger was inert
+ * until an operator ran `POST …/code:<id>/customize` to materialize the
+ * definition into a `workflow_definitions` row (#4425). This projects them
+ * directly. It is synchronous (no DB) and scoped to the caller's tenant/org via
+ * the deterministic virtual definition id, matching what `startWorkflow`
+ * persists as the instance's `definitionId` so the concurrency limit counts
+ * correctly.
+ *
+ * `dbBackedWorkflowIds` are workflowIds already contributed by the legacy or
+ * embedded (DB) sources; a code workflow whose id appears there is skipped so a
+ * customized DB override wins and its trigger is not double-registered.
+ */
+export function loadCodeTriggers(
+  tenantId: string,
+  organizationId: string,
+  dbBackedWorkflowIds: Set<string>,
+): UnifiedTrigger[] {
+  const triggers: UnifiedTrigger[] = []
+
+  for (const codeDef of getAllCodeWorkflows()) {
+    if (!codeDef.enabled) continue
+    if (dbBackedWorkflowIds.has(codeDef.workflowId)) continue
+
+    const embeddedTriggers = codeDef.definition?.triggers
+    if (!embeddedTriggers || embeddedTriggers.length === 0) continue
+
+    const definitionId = codeWorkflowUuid(codeDef.workflowId)
+    for (const trigger of embeddedTriggers) {
+      if (!trigger.enabled) continue
+
+      triggers.push({
+        id: `code:${codeDef.workflowId}:${trigger.triggerId}`,
+        triggerId: trigger.triggerId,
+        name: trigger.name,
+        description: trigger.description ?? null,
+        eventPattern: trigger.eventPattern,
+        config: (trigger.config ?? null) as WorkflowEventTriggerConfig | null,
+        enabled: trigger.enabled,
+        priority: trigger.priority,
+        workflowDefinitionId: definitionId,
+        workflowId: codeDef.workflowId,
+        workflowVersion: codeDef.version,
+        source: 'code' as const,
+        tenantId,
+        organizationId,
+      })
+    }
+  }
+
   return triggers
 }
 
 /**
  * Load all enabled triggers for a tenant/organization with caching.
- * Merges both legacy (entity) triggers and embedded (definition) triggers.
+ * Merges legacy (entity), embedded (definition), and code-registry triggers;
+ * a DB-backed source for a given workflowId takes precedence over its code
+ * trigger so `customize` semantics are preserved.
  */
 export async function loadTriggersForTenant(
   em: EntityManager,
@@ -484,14 +552,24 @@ export async function loadTriggersForTenant(
     return cached.triggers
   }
 
-  // Load from both sources
-  const [legacyTriggers, embeddedTriggers] = await Promise.all([
+  // Load from both DB sources
+  const [legacyTriggers, embedded] = await Promise.all([
     loadLegacyTriggers(em, tenantId, organizationId),
     loadEmbeddedTriggers(em, tenantId, organizationId),
   ])
+  const embeddedTriggers = embedded.triggers
+
+  // Project code-registry triggers, letting any DB-backed definition for the
+  // same workflowId win (preserves `customize` override semantics — including
+  // a customization that removed its triggers).
+  const dbBackedWorkflowIds = new Set<string>([
+    ...embedded.workflowIds,
+    ...legacyTriggers.map((t) => t.workflowId),
+  ])
+  const codeTriggers = loadCodeTriggers(tenantId, organizationId, dbBackedWorkflowIds)
 
   // Merge and sort by priority (higher first)
-  const allTriggers = [...legacyTriggers, ...embeddedTriggers]
+  const allTriggers = [...legacyTriggers, ...embeddedTriggers, ...codeTriggers]
     .sort((a, b) => b.priority - a.priority)
 
   // Update cache


### PR DESCRIPTION
Fixes #4425

## Root cause

`defineWorkflow({ ..., triggers: [...] })` lets a code workflow declare event triggers, but they never reached the runtime matcher. `loadTriggersForTenant` merged only two **DB-backed** sources — `workflow_event_triggers` rows and `triggers` embedded in `workflow_definitions` rows — while code workflows live solely in the in-memory registry (`getAllCodeWorkflows()`, referenced only by the LIST endpoint, never by the trigger engine). So a code-declared trigger was **inert until an operator ran `POST …/code:<id>/customize`** to materialize the definition into a DB row.

This is why the #4333 event-name fix (#4385) didn't close it end-to-end: with the corrected `sales.order.created` pattern in place, `sales.order-approval` still produced no instance because its trigger was never registered.

## Fix — the issue's option 1 (merge in the loader)

- New `loadCodeTriggers(tenantId, org, dbBackedWorkflowIds)` projects registry triggers into `UnifiedTrigger`s with `source: 'code'`.
- `workflowDefinitionId` = `codeWorkflowUuid(workflowId)` — the **same** deterministic id `startWorkflow` persists as the instance's `definitionId`, so `checkConcurrencyLimit`'s `maxConcurrentInstances` count is correct.
- **DB override wins**: a code workflow whose `workflowId` is already contributed by a DB definition is skipped, preserving `customize` semantics. Crucially this holds *even when the customization removed all triggers* — `loadEmbeddedTriggers` now also returns the full set of enabled DB `workflowId`s (it already loads those rows, so no extra query), rather than inferring the set from triggers alone.
- Cache/invalidation model is untouched: the existing `invalidateTriggerCache` on definition writes already clears the merged result, so adding a customize override drops the code trigger on the next load.

## Tests

New `code-triggers.test.ts`: projection shape + correct `definitionId`/`id`, DB-override suppression, disabled-workflow / disabled-trigger / no-triggers skips. `packages/core` workflows module green (43 suites / 634 tests); `tsc --noEmit` clean; eslint clean. Runner: local.

The end-to-end browser proof (queue worker running, confirmed order ⇒ `sales.order-approval` instance) needs an ephemeral env I can't stand up here — flagging for QA. The unit coverage locks the registration path that was missing.

## Notes for reviewers

- Behavioral change with a small but real blast radius: `sales.order-approval` (the only code workflow shipping a trigger today) will now **auto-start on `sales.order.created`** on fresh installs without a manual customize step. That's the intended fix, but it changes default runtime behavior — worth a release note, and it pairs naturally with #4385.
- Third-party modules shipping code workflows with triggers get the same fix for free.

## Labels (suggestion — read-permission account)

`bug`, `review`, `needs-qa` (auto-start behavior), `priority-medium`, `risk-medium` (trigger-engine loader + a default workflow starts auto-firing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)