### PR TITLE
fix(shared): malformed ?ids= no longer returns the full list

### DIFF
--- a/packages/shared/src/lib/crud/__tests__/ids.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/ids.test.ts
@@ -1,4 +1,4 @@
-import { MAX_IDS_PER_REQUEST, mergeIdFilter, parseIdsParam } from '@open-mercato/shared/lib/crud/ids'
+import { MAX_IDS_PER_REQUEST, mergeIdFilter, parseIdsParam, isIdsParamProvided } from '@open-mercato/shared/lib/crud/ids'
 
 describe('crud ids helpers', () => {
   const idA = '550e8400-e29b-41d4-a716-446655440001'
@@ -107,6 +107,36 @@ describe('crud ids helpers', () => {
     })
     expect(mergeIdFilter({ id: null } as any, [idA])).toEqual({
       id: { $in: [idA] },
+    })
+  })
+
+  // #4143 Finding 3: `?ids=<garbage>` parsed to [] and silently dropped the
+  // filter, returning the full list — a record-count side channel. A supplied
+  // but fully-invalid ids param must match nothing, like a valid-unknown UUID.
+  it('isIdsParamProvided distinguishes a supplied param from an absent one', () => {
+    expect(isIdsParamProvided('not-a-uuid')).toBe(true)
+    expect(isIdsParamProvided(`${idA}`)).toBe(true)
+    expect(isIdsParamProvided('')).toBe(false)
+    expect(isIdsParamProvided('   ')).toBe(false)
+    expect(isIdsParamProvided(undefined)).toBe(false)
+    expect(isIdsParamProvided(null)).toBe(false)
+  })
+
+  it('mergeIdFilter matches nothing when ids param was provided but all invalid', () => {
+    // Malformed input: parseIdsParam yields [], but the param WAS provided.
+    expect(mergeIdFilter({}, parseIdsParam('not-a-uuid'), { idsParamProvided: true })).toEqual({
+      id: { $in: [] },
+    })
+    // Preserves any existing filters alongside the match-nothing id clause.
+    expect(
+      mergeIdFilter({ tenantId: 't1' } as any, [], { idsParamProvided: true }),
+    ).toEqual({ tenantId: 't1', id: { $in: [] } })
+  })
+
+  it('mergeIdFilter still no-ops on empty ids when the param was absent (BC)', () => {
+    expect(mergeIdFilter({ tenantId: 't1' } as any, [])).toEqual({ tenantId: 't1' })
+    expect(mergeIdFilter({ tenantId: 't1' } as any, [], { idsParamProvided: false })).toEqual({
+      tenantId: 't1',
     })
   })
 })

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -66,7 +66,7 @@ import { applyResponseEnrichers, applyResponseEnricherToRecord, resolveListCache
 import type { EnricherContext } from './response-enricher'
 import type { ApiInterceptorMethod, InterceptorRequest, InterceptorResponse } from './api-interceptor'
 import { runApiInterceptorsAfter, runApiInterceptorsBefore } from './interceptor-runner'
-import { mergeIdFilter, parseIdsParam } from './ids'
+import { mergeIdFilter, parseIdsParam, isIdsParamProvided } from './ids'
 import { mergeAdvancedFilters } from './advanced-filter-integration'
 import { parseExtensionHeaders } from '../umes/extension-headers'
 import { createGenericOptimisticLockReader } from './optimistic-lock'
@@ -1445,6 +1445,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         ...(interceptorRequest.query ?? {}),
       } as Record<string, unknown>
       const parsedIds = parseIdsParam(queryParams.ids)
+      const idsParamProvided = isIdsParamProvided(queryParams.ids)
 
       await opts.hooks?.beforeList?.(validated as any, ctx)
       profiler.mark('before_list_hook')
@@ -1664,7 +1665,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         const filters = exportFullRequested
           ? baseFilters
           : mergeAdvancedFilters(baseFilters as Record<string, unknown>, validated as Record<string, unknown>) as Where<any>
-        const mergedFilters = exportFullRequested ? filters : mergeIdFilter(filters, parsedIds)
+        const mergedFilters = exportFullRequested ? filters : mergeIdFilter(filters, parsedIds, { idsParamProvided })
         const withDeleted = parseBooleanToken((queryParams as any).withDeleted) === true
         profiler.mark('filters_ready', { withDeleted })
         if (
@@ -1951,7 +1952,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         : mergeAdvancedFilters(fallbackBaseFilters as Record<string, unknown>, validated as Record<string, unknown>) as Where<any>
       const mergedFallbackFilters = exportFullRequested
         ? fallbackFilters
-        : mergeIdFilter(fallbackFilters, parsedIds)
+        : mergeIdFilter(fallbackFilters, parsedIds, { idsParamProvided })
       const ormFilters = translateFiltersForOrm(
         mergedFallbackFilters as Record<string, any>,
         em,

--- a/packages/shared/src/lib/crud/ids.ts
+++ b/packages/shared/src/lib/crud/ids.ts
@@ -49,11 +49,32 @@ export function parseIdsParam(raw: unknown, maxIds: number = MAX_IDS_PER_REQUEST
   return parsed.slice(0, safeMax)
 }
 
+/**
+ * Whether an `?ids=` param was supplied at all (a non-empty string), regardless
+ * of whether any value survived UUID validation. Lets a caller tell "no ids
+ * filter requested" apart from "ids filter requested but every value was
+ * malformed" — the latter must match nothing, not fall back to the full list
+ * (#4143 Finding 3).
+ */
+export function isIdsParamProvided(raw: unknown): boolean {
+  return typeof raw === 'string' && raw.trim().length > 0
+}
+
 export function mergeIdFilter<Fields extends Record<string, unknown>>(
   existingFilters: Where<Fields>,
   parsedIds: string[],
+  options?: { idsParamProvided?: boolean },
 ): Where<Fields> {
-  if (parsedIds.length === 0) return existingFilters
+  if (parsedIds.length === 0) {
+    // The `?ids=` param was supplied but nothing survived UUID validation.
+    // Match nothing, mirroring a valid-but-unknown id returning zero rows,
+    // rather than silently dropping the filter and returning the full list
+    // (record-count side channel — #4143 Finding 3).
+    if (options?.idsParamProvided) {
+      return { ...existingFilters, id: { $in: [] } }
+    }
+    return existingFilters
+  }
 
   const existingFilter = (existingFilters as Record<string, unknown>).id
   const existingIds = readExistingIds(existingFilter)


### PR DESCRIPTION
Addresses **Finding 3** of #4143.

## Scope note

#4143 is a QA report against the unmerged invoice PR (#1977). Its **main** findings (1: live vs. frozen customer name; 2: `customerSnapshot` string on `[id]` route; 4: duplicate-invoice race) all live in that PR's `_documentListEnrichers.ts` / sales invoice routes, which **do not exist on `develop`** — they belong in #1977's review, not here. **Finding 3** is different: the reporter explicitly notes it is *"a `packages/shared` CRUD-factory behaviour, not sales-specific — likely a shared follow-up."* That part is on `develop` and is what this PR fixes.

## Bug

`parseIdsParam` strips every non-UUID value, so `GET /api/…?ids=not-a-uuid` parses to `[]` — indistinguishable from `?ids` being absent. `mergeIdFilter` treated `[]` as "no ids filter" and returned the **full** (tenant/org-scoped) list, whereas a valid-but-unknown UUID correctly returns zero rows. Same malformed input, two behaviors — a record-count side channel, and a trap for callers that build `?ids=` from untrusted input.

## Fix

- New `isIdsParamProvided(raw)` — was an `?ids=` value supplied at all (non-empty string), regardless of whether any survived UUID validation.
- `mergeIdFilter` gains an opt-in `{ idsParamProvided }`: when the param was supplied but `parsedIds` is empty, install `id: { : [] }` (match nothing) instead of dropping the filter. **Default off**, so the absent-param path and every other caller are unchanged (BC).
- Both `makeCrudRoute` list call sites (primary + fallback) pass the flag.

`{ id: { : [] } }` is the exact shape `mergeIdFilter` already emits for a disjoint intersection (existing test at `ids.test.ts`), so the ORM translation path is not a new code path.

## Tests

`ids.test.ts`: `isIdsParamProvided` truth table; malformed-but-provided ⇒ match-nothing (with existing filters preserved); absent-param still no-ops (BC). Full `packages/shared` CRUD suite: **21 suites / 266 tests green**; `tsc --noEmit` clean; eslint clean. Runner: local.

## Blast radius

This touches the **shared CRUD list factory**, so it affects every `makeCrudRoute` list endpoint. The behavior change is narrow (only the supplied-but-all-invalid `?ids=` case flips from full-list to empty), and no endpoint that omits `?ids=` is affected. Flagging for reviewer attention given the surface; the ephemeral integration suite exercises many of these routes.

## Labels (suggestion — read-permission account)

`bug`, `review`, `priority-medium`, `risk-medium` (shared contract-adjacent surface; behavior change on malformed input), `skip-qa` (covered by unit tests; no UI change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)