### PR TITLE
fix(workflows): activity configuration — edit-time validation, editable JSON, working timeouts

### DIFF
--- a/apps/docs/docs/user-guide/workflows/activities.mdx
+++ b/apps/docs/docs/user-guide/workflows/activities.mdx
@@ -22,11 +22,15 @@ An activity is a discrete unit of work performed by the workflow engine. While s
 | Activity Type | Purpose | Common Use Cases |
 |---------------|---------|------------------|
 | **SEND_EMAIL** | Send email notifications | Approval requests, status updates, alerts |
-| **CALL_API** | Make HTTP requests to external systems | Payment processing, inventory checks, CRM updates |
+| **CALL_API** | Call this app's own `/api/*` endpoints | Read or update Open Mercato records through the API |
 | **EMIT_EVENT** | Publish domain events | Trigger other workflows, update dashboards, log actions |
-| **UPDATE_ENTITY** | Modify database records | Update order status, mark tasks complete, change flags |
-| **CALL_WEBHOOK** | Generic webhook calls | Integrate with Zapier, Slack, custom services |
-| **EXECUTE_FUNCTION** | Run custom JavaScript/TypeScript code | Custom business logic, complex transformations |
+| **UPDATE_ENTITY** | Modify records through a command | Update order status, mark tasks complete, change flags |
+| **CALL_WEBHOOK** | Call external HTTP endpoints | Integrate with Zapier, Slack, custom services |
+| **EXECUTE_FUNCTION** | Run a registered workflow function | Custom business logic, complex transformations |
+| **WAIT** | Pause the workflow | Cool-off periods, scheduled follow-ups |
+
+> ⚠️ **Calling third-party services**: use **CALL_WEBHOOK**, not CALL_API. `CALL_API` targets this
+> application only — it rejects any endpoint whose host differs from `APP_URL` (SSRF prevention).
 
 ## Configuring Activities
 
@@ -43,80 +47,90 @@ Send email notifications with dynamic content from workflow context.
   "activityType": "SEND_EMAIL",
   "config": {
     "to": "{{context.approverEmail}}",
-    "cc": "{{context.requesterEmail}}",
     "subject": "Approval Required: {{context.requestTitle}}",
     "body": "A new request requires your approval.\n\nRequest: {{context.requestTitle}}\nAmount: ${{context.amount}}\nRequester: {{context.requesterName}}\n\nPlease review and approve or reject this request.",
-    "templateKey": "approval-request"
+    "template": "approval-request",
+    "templateData": {
+      "requestTitle": "{{context.requestTitle}}"
+    }
   }
 }
 ```
 
 **Parameters:**
-- `to`: Recipient email address (supports variables)
-- `cc`, `bcc`: Optional carbon copy recipients
-- `subject`: Email subject line
+- `to`: Recipient email address (required, supports variables)
+- `subject`: Email subject line (required)
 - `body`: Email body (plain text or HTML)
-- `templateKey`: Optional reference to email template
+- `template`: Optional email template name
+- `templateData`: Optional data passed to the template
+
+Only these fields are forwarded to the email service — `cc` / `bcc` are not supported.
 
 ### CALL_API
 
-Make HTTP requests to external APIs for integration with third-party systems.
+Call this application's own `/api/*` endpoints. The engine authenticates the request with a
+one-time API key that it creates and deletes around the call, so no credentials belong in the
+configuration.
 
 **Configuration:**
 
 ```json
 {
-  "activityId": "charge-payment",
-  "activityName": "Charge Payment via Stripe",
+  "activityId": "reserve-stock",
+  "activityName": "Reserve Stock for Order",
   "activityType": "CALL_API",
   "config": {
-    "url": "https://api.stripe.com/v1/charges",
+    "endpoint": "/api/inventory/reservations",
     "method": "POST",
     "headers": {
-      "Authorization": "Bearer {{env.STRIPE_SECRET_KEY}}",
       "Content-Type": "application/json"
     },
     "body": {
-      "amount": "{{context.amountCents}}",
-      "currency": "usd",
-      "source": "{{context.paymentToken}}",
-      "description": "Order {{context.orderId}}"
+      "orderId": "{{context.orderId}}",
+      "quantity": "{{context.quantity}}"
     }
   },
   "async": true,
-  "timeout": "30s",
   "retryPolicy": {
     "maxAttempts": 3,
-    "backoff": "exponential"
+    "initialIntervalMs": 1000,
+    "backoffCoefficient": 2,
+    "maxIntervalMs": 10000
   }
 }
 ```
 
 **Parameters:**
-- `url`: API endpoint (supports variable interpolation)
-- `method`: HTTP method (GET, POST, PUT, DELETE, PATCH)
-- `headers`: Request headers (authentication, content type, etc.)
+- `endpoint`: Path or URL to call (required) — a relative path must start with `/api/`
+- `method`: HTTP method (default `GET`)
+- `headers`: Request headers
 - `body`: Request body (object or string)
+- `validateTenantMatch`: Verify the response belongs to the workflow's tenant (default `true`)
+
+> ⚠️ **Internal endpoints only**: relative paths are resolved against `APP_URL` and must start
+> with `/api/`; an absolute URL must resolve to the same host as `APP_URL`. Anything else fails
+> with an SSRF-prevention error. To reach a third-party service, use **CALL_WEBHOOK**.
 
 **Response Handling:**
 
-API responses are saved to workflow context under `activities.<activityId>.output`:
+When an activity runs asynchronously, its output is merged into the workflow context under
+`<activityId>_result` once the workflow resumes:
 
 ```json
 {
-  "activities": {
-    "charge-payment": {
-      "output": {
-        "id": "ch_123",
-        "status": "succeeded",
-        "amount": 5000
-      }
+  "reserve-stock_result": {
+    "status": 200,
+    "statusText": "OK",
+    "body": {
+      "reservationId": "res_123"
     }
   }
 }
 ```
 
-Access response data in subsequent steps: `{{activities.charge-payment.output.id}}`
+Access response data in subsequent steps: `{{context.reserve-stock_result.body.reservationId}}`.
+Synchronous activities are not written to the context — have them update a record, or run them
+asynchronously when a later step needs the result.
 
 ### EMIT_EVENT
 
@@ -130,7 +144,7 @@ Publish domain events to trigger other workflows or update application state.
   "activityName": "Emit Order Placed Event",
   "activityType": "EMIT_EVENT",
   "config": {
-    "eventType": "order.placed",
+    "eventName": "order.placed",
     "payload": {
       "orderId": "{{context.orderId}}",
       "customerId": "{{context.customerId}}",
@@ -142,12 +156,16 @@ Publish domain events to trigger other workflows or update application state.
 ```
 
 **Parameters:**
-- `eventType`: Event name (convention: `module.action`)
+- `eventName`: Event name (required, convention: `module.entity.action`)
 - `payload`: Event data (any JSON object)
+
+The engine adds a `_workflow` block (instance id, workflow id, tenant, organization) to every
+payload it publishes. A configuration without `eventName` fails the activity with
+`EMIT_EVENT requires "eventName" field`.
 
 ### UPDATE_ENTITY
 
-Update database records directly from the workflow.
+Update records through a command, so the change keeps its audit log, undo support, and side effects.
 
 **Configuration:**
 
@@ -157,11 +175,9 @@ Update database records directly from the workflow.
   "activityName": "Mark Order as Shipped",
   "activityType": "UPDATE_ENTITY",
   "config": {
-    "entityType": "SalesOrder",
-    "entityId": "{{context.orderId}}",
-    "updates": {
-      "status": "SHIPPED",
-      "shippedAt": "{{now}}",
+    "commandId": "sales.orders.update",
+    "input": {
+      "id": "{{context.orderId}}",
       "trackingNumber": "{{context.trackingNumber}}"
     }
   }
@@ -169,9 +185,30 @@ Update database records directly from the workflow.
 ```
 
 **Parameters:**
-- `entityType`: Database entity name
-- `entityId`: Record ID to update
-- `updates`: Fields and values to change
+- `commandId`: Command to execute (required) — must be one of the workflow-safe commands
+- `input`: Object with the command payload (required), including the record `id`
+- `statusDictionary`: Optional dictionary used to resolve `input.statusValue`
+
+To set a status by its label instead of its id, name the dictionary and pass `statusValue`; the
+engine resolves it to `statusEntryId` before running the command:
+
+```json
+{
+  "config": {
+    "commandId": "sales.orders.update",
+    "statusDictionary": "sales.order_status",
+    "input": {
+      "id": "{{context.id}}",
+      "statusValue": "pending_approval"
+    }
+  }
+}
+```
+
+The activity runs as the workflow's user and fails when that user is missing or lacks the
+command's required features. Only commands registered as workflow-safe can be used — the sales
+module ships `sales.orders.update`, and a module adds its own with
+`registerWorkflowSafeCommands()`.
 
 ### CALL_WEBHOOK
 
@@ -194,9 +231,18 @@ Generic webhook calls for integrations with Zapier, Slack, or custom services.
 }
 ```
 
+**Parameters:**
+- `url`: Destination URL (required)
+- `method`: HTTP method (default `POST`)
+- `headers`: Request headers
+- `body`: Request body
+
+Requests to private or loopback addresses are blocked, and redirects are rejected rather than
+followed.
+
 ### EXECUTE_FUNCTION
 
-Run custom JavaScript or TypeScript functions for complex business logic.
+Run a function registered in the DI container under `workflowFunction:<functionName>`.
 
 **Configuration:**
 
@@ -207,7 +253,7 @@ Run custom JavaScript or TypeScript functions for complex business logic.
   "activityType": "EXECUTE_FUNCTION",
   "config": {
     "functionName": "calculateVolumeDiscount",
-    "arguments": {
+    "args": {
       "quantity": "{{context.quantity}}",
       "unitPrice": "{{context.unitPrice}}",
       "customerTier": "{{context.customerTier}}"
@@ -215,6 +261,36 @@ Run custom JavaScript or TypeScript functions for complex business logic.
   }
 }
 ```
+
+**Parameters:**
+- `functionName`: Registered function name (required)
+- `args`: Object passed to the function as its first argument (default `{}`)
+
+### WAIT
+
+Pause the workflow for a relative duration or until an absolute moment.
+
+**Configuration:**
+
+```json
+{
+  "activityId": "cool-off",
+  "activityName": "Wait Before Follow-up",
+  "activityType": "WAIT",
+  "config": {
+    "duration": "PT5M"
+  },
+  "async": true
+}
+```
+
+**Parameters:**
+- `duration`: Relative delay, e.g. `"PT5M"`, `"1h"`, `"30s"`
+- `until`: Absolute ISO 8601 datetime, e.g. `"2026-04-15T10:00:00Z"`
+
+Provide `duration` or `until` — a WAIT activity with neither is rejected when the definition is
+saved. Prefer `"async": true` so the delay is scheduled on the queue instead of blocking the
+worker.
 
 ## Execution Modes
 
@@ -235,12 +311,11 @@ The workflow waits for the activity to complete before continuing.
 
 ### Asynchronous
 
-The workflow continues immediately while the activity runs in the background.
+The workflow continues immediately while the activity runs in the background on the queue.
 
 ```json
 {
-  "async": true,
-  "timeout": "5m"
+  "async": true
 }
 ```
 
@@ -259,21 +334,22 @@ Configure automatic retries for activities that might fail temporarily (network 
 {
   "retryPolicy": {
     "maxAttempts": 3,
-    "backoff": "exponential",
-    "retryableErrors": ["NETWORK_ERROR", "TIMEOUT", "RATE_LIMIT"]
+    "initialIntervalMs": 1000,
+    "backoffCoefficient": 2,
+    "maxIntervalMs": 10000
   }
 }
 ```
 
 **Parameters:**
-- `maxAttempts`: Maximum retry attempts (default: 0, no retries)
-- `backoff`: Retry delay strategy (`fixed`, `exponential`, `linear`)
-- `retryableErrors`: Only retry on specific error types
+- `maxAttempts`: Total attempts, including the first one (1–10)
+- `initialIntervalMs`: Delay before the first retry
+- `backoffCoefficient`: Multiplier applied to each delay (1–10)
+- `maxIntervalMs`: Upper bound for a single delay
 
-**Backoff Strategies:**
-- **Fixed**: Same delay between retries (e.g., 5s, 5s, 5s)
-- **Exponential**: Increasing delay (e.g., 2s, 4s, 8s)
-- **Linear**: Linearly increasing delay (e.g., 5s, 10s, 15s)
+The delay grows exponentially and is capped at `maxIntervalMs` — the example above waits about
+1s, then 2s, before the activity finally fails. Without a `retryPolicy` an activity is attempted
+once. Every attempt is retried the same way; there is no per-error-type filter.
 
 ## Variable Interpolation
 
@@ -281,14 +357,22 @@ Use `{{variable}}` syntax to inject workflow data into activity configurations.
 
 **Available Variables:**
 
-- `{{context.fieldName}}` - Workflow context data
+- `{{context.fieldName}}` - Workflow context data (nested paths supported)
 - `{{workflow.instanceId}}` - Current workflow instance ID
-- `{{workflow.definitionId}}` - Workflow definition ID
+- `{{workflow.workflowId}}` - Workflow ID
 - `{{workflow.version}}` - Workflow version number
-- `{{activities.activityId.output.field}}` - Output from previous activities
-- `{{env.ENV_VAR}}` - Environment variables
-- `{{now}}` - Current timestamp
-- `{{user.id}}` - Current user ID (if available)
+- `{{workflow.currentStepId}}` - Current step ID
+- `{{workflow.tenantId}}`, `{{workflow.organizationId}}` - Owning tenant and organization
+- `{{context.<activityId>_result.field}}` - Output of a completed async activity
+- `{{env.ENV_VAR}}` - Allowlisted environment variables
+- `{{now}}` - Current timestamp (ISO 8601)
+
+A token that stands alone in its value keeps the original type, so `"{{context.items}}"` passes an
+array rather than a string.
+
+> ⚠️ **Environment variables are allowlisted**: only `APP_URL` resolves by default, and anything
+> else returns an empty string. Add more keys with the `OM_WORKFLOWS_ENV_INTERPOLATION_ALLOWLIST`
+> environment variable (comma-separated) before referencing them.
 
 **Example:**
 
@@ -314,6 +398,8 @@ Configure an activity on the transition from an AUTOMATED step to a USER_TASK:
   "toStepId": "approve-request",
   "activities": [
     {
+      "activityId": "notify-approver",
+      "activityName": "Notify Approver",
       "activityType": "SEND_EMAIL",
       "config": {
         "to": "{{context.approverEmail}}",
@@ -325,37 +411,39 @@ Configure an activity on the transition from an AUTOMATED step to a USER_TASK:
 }
 ```
 
-### Call External API and Use Response
+### Call an Internal API and Use the Response
 
-Call an API, then use the response in subsequent steps:
+Call one of this app's endpoints asynchronously, then read the response in a later step:
 
 ```json
 {
   "activityId": "get-inventory",
+  "activityName": "Check Inventory",
   "activityType": "CALL_API",
   "config": {
-    "url": "https://inventory.example.com/check/{{context.productId}}"
-  }
+    "endpoint": "/api/inventory/levels?productId={{context.productId}}"
+  },
+  "async": true
 }
 ```
 
-Access the response: `{{activities.get-inventory.output.quantityAvailable}}`
+Access the response: `{{context.get-inventory_result.body.quantityAvailable}}`
 
 ### Update Record After Approval
 
-Update a database record when a task is completed:
+Update a record through a command when a task is completed:
 
 ```json
 {
   "activityId": "mark-approved",
+  "activityName": "Mark Request Approved",
   "activityType": "UPDATE_ENTITY",
   "config": {
-    "entityType": "PurchaseRequest",
-    "entityId": "{{context.requestId}}",
-    "updates": {
-      "status": "APPROVED",
-      "approvedBy": "{{user.id}}",
-      "approvedAt": "{{now}}"
+    "commandId": "sales.orders.update",
+    "statusDictionary": "sales.order_status",
+    "input": {
+      "id": "{{context.requestId}}",
+      "statusValue": "approved"
     }
   }
 }

--- a/apps/docs/docs/user-guide/workflows/transitions.mdx
+++ b/apps/docs/docs/user-guide/workflows/transitions.mdx
@@ -227,6 +227,7 @@ Transitions can execute activities as the workflow moves from one step to anothe
   "activities": [
     {
       "activityId": "send-approval-email",
+      "activityName": "Send Approval Email",
       "activityType": "SEND_EMAIL",
       "config": {
         "to": "{{context.requesterEmail}}",
@@ -236,12 +237,14 @@ Transitions can execute activities as the workflow moves from one step to anothe
     },
     {
       "activityId": "update-status",
+      "activityName": "Update Request Status",
       "activityType": "UPDATE_ENTITY",
       "config": {
-        "entityType": "PurchaseRequest",
-        "entityId": "{{context.requestId}}",
-        "updates": {
-          "status": "APPROVED"
+        "commandId": "sales.orders.update",
+        "statusDictionary": "sales.order_status",
+        "input": {
+          "id": "{{context.requestId}}",
+          "statusValue": "approved"
         }
       }
     }

--- a/packages/core/src/__tests__/shipped-workflow-activity-config.test.ts
+++ b/packages/core/src/__tests__/shipped-workflow-activity-config.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment node
+ *
+ * Repo-wide guard for #4232: every activity in a code-defined workflow this
+ * repo ships must satisfy `activityDefinitionSchema`, which now requires the
+ * config keys each executor reads at run time. Generalizes the EMIT_EVENT-only
+ * guard added for #4322 — a shipped example whose activity config the executor
+ * cannot use is a bug we hand to every install.
+ */
+import { activityDefinitionSchema } from '@open-mercato/core/modules/workflows/data/validators'
+import { workflowsConfig as coreWorkflows } from '@open-mercato/core/modules/workflows/workflows'
+import { workflowsConfig as salesWorkflows } from '@open-mercato/core/modules/sales/workflows'
+
+type ShippedActivity = {
+  label: string
+  activity: unknown
+}
+
+function collectActivities(
+  moduleId: string,
+  config: { workflows: Array<{ workflowId: string; definition: Record<string, unknown> }> },
+): ShippedActivity[] {
+  const collected: ShippedActivity[] = []
+  for (const workflow of config.workflows) {
+    const definition = workflow.definition as {
+      steps?: Array<{ stepId?: string; activities?: unknown[] }>
+      transitions?: Array<{ transitionId?: string; activities?: unknown[] }>
+    }
+    for (const step of definition.steps ?? []) {
+      for (const activity of step.activities ?? []) {
+        collected.push({
+          label: `${moduleId} / ${workflow.workflowId} / step ${step.stepId} / ${(activity as { activityId?: string }).activityId}`,
+          activity,
+        })
+      }
+    }
+    for (const transition of definition.transitions ?? []) {
+      for (const activity of transition.activities ?? []) {
+        collected.push({
+          label: `${moduleId} / ${workflow.workflowId} / transition ${transition.transitionId} / ${(activity as { activityId?: string }).activityId}`,
+          activity,
+        })
+      }
+    }
+  }
+  return collected
+}
+
+const shippedActivities = [
+  ...collectActivities('workflows', coreWorkflows as never),
+  ...collectActivities('sales', salesWorkflows as never),
+]
+
+describe('shipped code-defined workflow activities', () => {
+  test('there are shipped activities to guard', () => {
+    expect(shippedActivities.length).toBeGreaterThan(0)
+  })
+
+  test.each(shippedActivities.map((entry) => [entry.label, entry.activity] as const))(
+    '%s has a config its executor can run',
+    (label, activity) => {
+      const result = activityDefinitionSchema.safeParse(activity)
+      const problems = result.success
+        ? ''
+        : result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`).join('; ')
+      expect(problems).toBe('')
+    },
+  )
+})

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-002.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-002.spec.ts
@@ -55,7 +55,10 @@ function buildDefinitionPayload(timestamp: number) {
               activityName: 'Emit review requested',
               activityType: 'EMIT_EVENT',
               config: {
-                eventType: 'qa.workflow.review.requested',
+                // eventName, not eventType — the EMIT_EVENT executor reads
+                // eventName and this fixture would have failed at run time
+                // (same defect as #4322).
+                eventName: 'qa.workflow.review.requested',
                 payload: { workflow: '{{workflow.instanceId}}' },
               },
               async: true,

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-017.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-017.spec.ts
@@ -52,7 +52,10 @@ test.describe('TC-WF-017: branch failure cancels siblings and fails the instance
                 activityId: 'boom',
                 activityName: 'Boom',
                 activityType: 'EXECUTE_FUNCTION',
-                config: { functionId: 'qa-nonexistent-function-do-not-register' },
+                // functionName, not functionId — with the wrong key the activity
+                // failed on "requires functionName" rather than on the missing
+                // registration this test is actually about.
+                config: { functionName: 'qa-nonexistent-function-do-not-register' },
               },
             ],
           },

--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
@@ -11,6 +11,7 @@ import { useState, useCallback, useEffect } from 'react'
 import { useRouter, useSearchParams, usePathname } from 'next/navigation'
 import { graphToDefinition, definitionToGraph, validateWorkflowGraph, generateStepId, generateTransitionId, appendWorkflowEdge, ValidationError } from '../../../lib/graph-utils'
 import { performDeleteEdgeFlow, performDeleteNodeFlow } from '../../../lib/visual-editor-delete-flow'
+import { humanizeDefinitionIssuePath } from '../../../lib/format-validation-error'
 import { workflowDefinitionDataSchema } from '../../../data/validators'
 import { Page } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
@@ -357,11 +358,19 @@ export default function VisualEditorPage() {
       triggers: triggers.length > 0 ? triggers : undefined,
     }
 
-    // Run Zod schema validation before saving
+    // Run Zod schema validation before saving. Report every issue, not just the
+    // first: a save rejected for one missing activity field used to look like
+    // "nothing happened" once the operator fixed that field and hit a second
+    // one (#4232). Paths are humanized (steps.2.activities.0.config.endpoint →
+    // step 3 › activity 1 › endpoint) so the message points at the node to open.
     const schemaResult = workflowDefinitionDataSchema.safeParse(definitionData)
     if (!schemaResult.success) {
-      const firstIssue = schemaResult.error.issues[0]
-      flash(`Schema error: ${firstIssue.path.join('.')} - ${firstIssue.message}`, 'error')
+      const issues = schemaResult.error.issues
+      const described = issues
+        .slice(0, 3)
+        .map((issue) => `${humanizeDefinitionIssuePath(issue.path)}: ${issue.message}`)
+      const suffix = issues.length > described.length ? ` (+${issues.length - described.length} more)` : ''
+      flash(`Cannot save — ${described.join('; ')}${suffix}`, 'error')
       return
     }
 

--- a/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
+++ b/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
@@ -46,8 +46,59 @@ const ACTIVITY_TYPES = [
   { value: 'WAIT', label: 'Wait' },
 ]
 
+/**
+ * Per-activity draft of the raw JSON config text (#4234).
+ *
+ * The config textarea used to be controlled directly by
+ * `JSON.stringify(activity.config)`, and its onChange dropped anything that
+ * did not parse. Every intermediate keystroke of a hand edit is invalid JSON,
+ * so the state never advanced and React re-rendered the previous serialized
+ * value — the field read as frozen/non-editable right after a config was
+ * pasted. Keeping the raw text locally lets the user type freely; the parsed
+ * object is propagated whenever the text is valid, and an inline error is shown
+ * while it is not.
+ */
+type ConfigDraft = { text: string; error: string | null }
+
+function serializeConfig(config: Record<string, unknown> | undefined): string {
+  return JSON.stringify(config ?? {}, null, 2)
+}
+
 export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEditorProps) {
   const t = useT()
+  const [configDrafts, setConfigDrafts] = React.useState<Record<number, ConfigDraft>>({})
+
+  const configTextFor = (index: number, activity: Activity): string =>
+    configDrafts[index]?.text ?? serializeConfig(activity.config)
+
+  const handleConfigTextChange = (index: number, text: string) => {
+    let parsed: Record<string, unknown> | null = null
+    let parseError: string | null = null
+    try {
+      const candidate = JSON.parse(text) as unknown
+      if (candidate && typeof candidate === 'object' && !Array.isArray(candidate)) {
+        parsed = candidate as Record<string, unknown>
+      } else {
+        parseError = t('workflows.activities.configMustBeObject', 'Config must be a JSON object')
+      }
+    } catch (err) {
+      parseError = err instanceof Error ? err.message : t('workflows.activities.configInvalidJson', 'Invalid JSON')
+    }
+
+    setConfigDrafts((drafts) => ({ ...drafts, [index]: { text, error: parseError } }))
+    if (parsed) updateActivity(index, 'config', parsed)
+  }
+
+  // Drop the raw draft once the field loses focus and its content is valid, so
+  // the textarea goes back to mirroring the canonical (re-formatted) config.
+  const handleConfigBlur = (index: number) => {
+    setConfigDrafts((drafts) => {
+      if (!drafts[index] || drafts[index].error) return drafts
+      const next = { ...drafts }
+      delete next[index]
+      return next
+    })
+  }
 
   const addActivity = () => {
     const newActivity: Activity = {
@@ -85,6 +136,18 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
 
   const removeActivity = (index: number) => {
     onChange(value.filter((_, i) => i !== index))
+    // Keep the index-keyed drafts aligned with the re-indexed activities:
+    // drop the removed row's draft and shift every later draft down by one,
+    // otherwise a pending (invalid) draft would render over a different row.
+    setConfigDrafts((drafts) => {
+      const next: Record<number, ConfigDraft> = {}
+      for (const key of Object.keys(drafts)) {
+        const i = Number(key)
+        if (i === index) continue
+        next[i > index ? i - 1 : i] = drafts[i]
+      }
+      return next
+    })
   }
 
   const moveActivity = (index: number, direction: 'up' | 'down') => {
@@ -96,6 +159,18 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
     updated[index] = updated[newIndex]
     updated[newIndex] = temp
     onChange(updated)
+    // Swap the two rows' drafts too, so an in-progress edit follows its activity.
+    setConfigDrafts((drafts) => {
+      if (!(index in drafts) && !(newIndex in drafts)) return drafts
+      const next = { ...drafts }
+      const atIndex = drafts[index]
+      const atNew = drafts[newIndex]
+      if (atNew !== undefined) next[index] = atNew
+      else delete next[index]
+      if (atIndex !== undefined) next[newIndex] = atIndex
+      else delete next[newIndex]
+      return next
+    })
   }
 
   return (
@@ -318,19 +393,24 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
                 </Label>
                 <Textarea
                   id={`activity-${index}-config`}
-                  value={JSON.stringify(activity.config || {}, null, 2)}
-                  onChange={(e) => {
-                    try {
-                      const parsed = JSON.parse(e.target.value)
-                      updateActivity(index, 'config', parsed)
-                    } catch {
-                      // Invalid JSON, don't update
-                    }
-                  }}
+                  value={configTextFor(index, activity)}
+                  onChange={(e) => handleConfigTextChange(index, e.target.value)}
+                  onBlur={() => handleConfigBlur(index)}
+                  aria-invalid={configDrafts[index]?.error ? true : undefined}
+                  aria-describedby={configDrafts[index]?.error ? `activity-${index}-config-error` : undefined}
                   placeholder='{"key": "value"}'
                   rows={3}
                   className="mt-1 font-mono text-xs"
                 />
+                {configDrafts[index]?.error ? (
+                  <p
+                    id={`activity-${index}-config-error`}
+                    className="mt-1 text-xs text-status-error-text"
+                    role="alert"
+                  >
+                    {configDrafts[index]?.error}
+                  </p>
+                ) : null}
               </div>
               )}
             </div>

--- a/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
+++ b/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
@@ -26,7 +26,11 @@ interface Activity {
     retryDelay?: number
     backoffMultiplier?: number
   }
-  timeout?: number
+  // Milliseconds, matching the executor and the definition schema. This field
+  // used to be written as `timeout` (a number) while the schema typed `timeout`
+  // as an ISO 8601 string, so saving a timeout from this editor failed
+  // validation outright (#4424).
+  timeoutMs?: number
   compensation?: Record<string, any>
 }
 
@@ -286,8 +290,8 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
                   <Input
                     id={`activity-${index}-timeout`}
                     type="number"
-                    value={activity.timeout || ''}
-                    onChange={(e) => updateActivity(index, 'timeout', e.target.value ? parseInt(e.target.value) : undefined)}
+                    value={activity.timeoutMs || ''}
+                    onChange={(e) => updateActivity(index, 'timeoutMs', e.target.value ? parseInt(e.target.value) : undefined)}
                     placeholder="30000"
                     className="mt-1"
                   />

--- a/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
@@ -26,7 +26,11 @@ interface Activity {
     retryDelay?: number
     backoffMultiplier?: number
   }
-  timeout?: number
+  // Milliseconds, matching the executor and the definition schema. This field
+  // used to be written as `timeout` (a number) while the schema typed `timeout`
+  // as an ISO 8601 string, so saving a timeout from this editor failed
+  // validation outright (#4424).
+  timeoutMs?: number
   compensation?: Record<string, any>
 }
 
@@ -461,8 +465,8 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
                             <Input
                               id={`activity-${index}-${activityIndex}-timeout`}
                               type="number"
-                              value={activity.timeout || ''}
-                              onChange={(e) => updateActivity(index, activityIndex, 'timeout', e.target.value ? parseInt(e.target.value) : undefined)}
+                              value={activity.timeoutMs || ''}
+                              onChange={(e) => updateActivity(index, activityIndex, 'timeoutMs', e.target.value ? parseInt(e.target.value) : undefined)}
                               placeholder="30000"
                               className="mt-1 text-xs h-8"
                             />

--- a/packages/core/src/modules/workflows/components/__tests__/ActivitiesEditor.configJson.test.tsx
+++ b/packages/core/src/modules/workflows/components/__tests__/ActivitiesEditor.configJson.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Guards #4234: the activity config textarea was controlled by
+ * `JSON.stringify(activity.config)` and its onChange discarded anything that
+ * did not parse. Every intermediate keystroke of a hand edit is invalid JSON,
+ * so state never advanced and React restored the previous text — the field read
+ * as frozen right after a config was pasted, pushing users to the non-visual
+ * editor.
+ */
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallbackOrParams?: unknown) =>
+    typeof fallbackOrParams === 'string' ? fallbackOrParams : key,
+}))
+
+import { ActivitiesEditor } from '../ActivitiesEditor'
+
+type Activity = {
+  activityId: string
+  activityName: string
+  activityType: string
+  config?: Record<string, unknown>
+}
+
+const baseActivity: Activity = {
+  activityId: 'call_api_1',
+  activityName: 'Call API',
+  activityType: 'CALL_API',
+  config: { endpoint: '/api/sales/orders' },
+}
+
+/** Host that owns the activities array, like the real dialogs do. */
+function Harness({ initial = [baseActivity] }: { initial?: Activity[] }) {
+  const [activities, setActivities] = React.useState<Activity[]>(initial)
+  return <ActivitiesEditor value={activities as never} onChange={setActivities as never} />
+}
+
+function configTextarea(): HTMLTextAreaElement {
+  return screen.getByLabelText(/Configuration|workflows\.activities\.config/i) as HTMLTextAreaElement
+}
+
+describe('ActivitiesEditor config JSON field (#4234)', () => {
+  it('accepts a keystroke that leaves the JSON temporarily invalid', () => {
+    render(<Harness />)
+    const textarea = configTextarea()
+
+    // Deleting the closing brace is the first keystroke of any hand edit.
+    const brokenText = textarea.value.slice(0, -1)
+    fireEvent.change(textarea, { target: { value: brokenText } })
+
+    expect(textarea.value).toBe(brokenText)
+  })
+
+  it('surfaces an inline error while the JSON is invalid', () => {
+    render(<Harness />)
+    fireEvent.change(configTextarea(), { target: { value: '{"endpoint": ' } })
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(configTextarea()).toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('lets a pasted config be edited afterwards (the reported symptom)', () => {
+    render(<Harness />)
+    const textarea = configTextarea()
+
+    // Paste a doc snippet…
+    fireEvent.change(textarea, {
+      target: { value: '{"endpoint": "/api/sales/orders", "method": "POST"}' },
+    })
+    // …then hand-edit it: the intermediate state is invalid JSON.
+    fireEvent.change(textarea, {
+      target: { value: '{"endpoint": "/api/sales/orders", "method": "POS' },
+    })
+    expect(textarea.value).toBe('{"endpoint": "/api/sales/orders", "method": "POS')
+
+    // Finishing the edit clears the error and keeps the typed text.
+    fireEvent.change(textarea, {
+      target: { value: '{"endpoint": "/api/sales/orders", "method": "PUT"}' },
+    })
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(textarea.value).toBe('{"endpoint": "/api/sales/orders", "method": "PUT"}')
+  })
+
+  it('rejects a valid-JSON non-object (arrays would break config lookups)', () => {
+    render(<Harness />)
+    fireEvent.change(configTextarea(), { target: { value: '["nope"]' } })
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('re-serializes from the canonical config on blur once valid', () => {
+    render(<Harness />)
+    const textarea = configTextarea()
+
+    fireEvent.change(textarea, { target: { value: '{"endpoint":"/x"}' } })
+    fireEvent.blur(textarea)
+
+    // Back to the pretty-printed projection of the parsed config.
+    expect(textarea.value).toBe(JSON.stringify({ endpoint: '/x' }, null, 2))
+  })
+
+  it('keeps the raw text on blur while it is still invalid, so work is not lost', () => {
+    render(<Harness />)
+    const textarea = configTextarea()
+
+    fireEvent.change(textarea, { target: { value: '{"endpoint": ' } })
+    fireEvent.blur(textarea)
+
+    expect(textarea.value).toBe('{"endpoint": ')
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  // The config drafts are keyed by row index, so removing/moving a row must
+  // re-index the drafts map — otherwise a pending (invalid) draft renders over
+  // a different activity and can be saved onto the wrong config.
+  const secondActivity: Activity = {
+    activityId: 'call_api_2',
+    activityName: 'Call API 2',
+    activityType: 'CALL_API',
+    config: { endpoint: '/api/sales/quotes' },
+  }
+  const allConfigTextareas = () =>
+    screen.getAllByLabelText(/Configuration|workflows\.activities\.config/i) as HTMLTextAreaElement[]
+
+  it('keeps an in-progress invalid config draft with its activity when a row above is removed', () => {
+    render(<Harness initial={[baseActivity, secondActivity]} />)
+
+    // Start an edit on the second row that leaves the JSON invalid (draft at index 1).
+    fireEvent.change(allConfigTextareas()[1], { target: { value: '{"endpoint": ' } })
+    expect(allConfigTextareas()[1].value).toBe('{"endpoint": ')
+
+    // Remove the first row — the second activity becomes index 0.
+    fireEvent.click(screen.getAllByTitle('common.delete')[0])
+
+    const remaining = allConfigTextareas()
+    expect(remaining).toHaveLength(1)
+    // The draft follows its activity to the new index instead of vanishing or
+    // landing on another row.
+    expect(remaining[0].value).toBe('{"endpoint": ')
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('moves an in-progress config draft with its activity when the row is reordered', () => {
+    render(<Harness initial={[baseActivity, secondActivity]} />)
+
+    fireEvent.change(allConfigTextareas()[1], { target: { value: '{"endpoint": ' } })
+    // Move the second row up — it becomes index 0, its draft must move with it.
+    fireEvent.click(screen.getAllByTitle('common.moveUp')[1])
+
+    const after = allConfigTextareas()
+    expect(after[0].value).toBe('{"endpoint": ')
+    // The former first row (now index 1) shows its canonical config, no stale draft.
+    expect(after[1].value).toBe(JSON.stringify({ endpoint: '/api/sales/orders' }, null, 2))
+  })
+})

--- a/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
@@ -317,7 +317,10 @@ describe('Workflows Validators', () => {
             activityId: 'update-inventory-1',
             activityName: 'Update Inventory',
             activityType: 'UPDATE_ENTITY',
-            config: { entityType: 'inventory', updates: { count: 10 } },
+            // commandId + input are what executeUpdateEntity actually reads; the
+            // previous entityType/updates shape would have failed at runtime and
+            // is now rejected at validation time (#4232).
+            config: { commandId: 'sales.documents.update', input: { count: 10 } },
           },
         ],
       }
@@ -430,7 +433,10 @@ describe('Workflows Validators', () => {
             activityId: 'send-email-2',
             activityName: 'Send Email',
             activityType: 'SEND_EMAIL' as const,
-            config: { to: 'a@b.c' },
+            // Complete SEND_EMAIL config: the WAIT duration/until rules must not
+            // leak here, while SEND_EMAIL's own to/subject requirement applies
+            // (#4232).
+            config: { to: 'a@b.c', subject: 'Hello' },
           })
         ).not.toThrow()
       })

--- a/packages/core/src/modules/workflows/data/validators.ts
+++ b/packages/core/src/modules/workflows/data/validators.ts
@@ -202,6 +202,20 @@ export const activityRetryPolicySchema = z.object({
   maxIntervalMs: z.number().int().min(0),
 })
 
+/**
+ * Config fields each activity executor requires to run (see
+ * `lib/activity-executor.ts`). WAIT is handled separately below because it
+ * takes "duration" OR "until" rather than a fixed key set.
+ */
+const REQUIRED_ACTIVITY_CONFIG_KEYS: Partial<Record<ActivityType, readonly string[]>> = {
+  SEND_EMAIL: ['to', 'subject'],
+  CALL_API: ['endpoint'],
+  CALL_WEBHOOK: ['url'],
+  UPDATE_ENTITY: ['commandId', 'input'],
+  EMIT_EVENT: ['eventName'],
+  EXECUTE_FUNCTION: ['functionName'],
+}
+
 // Activity definition (embedded in transitions)
 export const activityDefinitionSchema = z.object({
   activityId: z.string().min(1).max(100).regex(/^[a-z0-9_-]+$/, 'Activity ID must contain only lowercase letters, numbers, hyphens, and underscores'),
@@ -216,6 +230,32 @@ export const activityDefinitionSchema = z.object({
     automatic: z.boolean().default(true).optional() // Auto-trigger on failure
   }).optional(), // Compensation configuration (Phase 8.2)
 }).superRefine((activity, ctx) => {
+  // Config keys each activity executor requires at runtime. Without this, an
+  // activity missing e.g. CALL_API's `endpoint` saved cleanly from the visual
+  // editor and only failed once an instance ran it — the "edit silently
+  // disappeared / nothing told me why" report in #4232 (and the class of bug
+  // #4322 was an instance of). Validating here surfaces the exact missing field
+  // at edit time, since both the editor's save path and the API route parse
+  // through this schema.
+  const requiredConfigKeys = REQUIRED_ACTIVITY_CONFIG_KEYS[activity.activityType]
+  if (requiredConfigKeys) {
+    const config = activity.config || {}
+    for (const key of requiredConfigKeys) {
+      const value = config[key]
+      const isEmpty =
+        value == null ||
+        (typeof value === 'string' && value.trim() === '') ||
+        (key === 'input' && typeof value !== 'object')
+      if (isEmpty) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['config', key],
+          message: `${activity.activityType} activity requires "${key}"`,
+        })
+      }
+    }
+  }
+
   if (activity.activityType !== 'WAIT') return
   const config = activity.config || {}
   const hasDuration = config.duration != null && config.duration !== ''

--- a/packages/core/src/modules/workflows/data/validators.ts
+++ b/packages/core/src/modules/workflows/data/validators.ts
@@ -224,7 +224,18 @@ export const activityDefinitionSchema = z.object({
   config: z.record(z.string(), z.any()),
   async: z.boolean().default(false).optional(), // For Phase 8.3
   retryPolicy: activityRetryPolicySchema.optional(),
-  timeout: z.string().optional(), // ISO 8601 duration
+  /**
+   * Per-activity timeout in milliseconds. This is what the editor writes and
+   * what `executeActivity` reads; it was missing from the schema, so
+   * `z.object()` stripped it on save and UI-configured timeouts silently did
+   * nothing (#4424).
+   */
+  timeoutMs: z.number().int().positive().optional(),
+  /**
+   * @deprecated Use `timeoutMs`. Accepted for definitions already stored with
+   * an ISO 8601 duration string; the executor normalizes it to milliseconds.
+   */
+  timeout: z.string().optional(),
   compensation: z.object({
     activityId: z.string().min(1), // ID of compensation activity
     automatic: z.boolean().default(true).optional() // Auto-trigger on failure

--- a/packages/core/src/modules/workflows/i18n/de.json
+++ b/packages/core/src/modules/workflows/i18n/de.json
@@ -80,6 +80,8 @@
   "workflows.activities.async": "Asynchron",
   "workflows.activities.compensation": "Kompensation",
   "workflows.activities.config": "Konfiguration",
+  "workflows.activities.configInvalidJson": "Ungültiges JSON",
+  "workflows.activities.configMustBeObject": "Konfiguration muss ein JSON-Objekt sein",
   "workflows.activities.deleteActivity": "Aktivität löschen",
   "workflows.activities.editActivity": "Aktivität bearbeiten",
   "workflows.activities.plural": "Aktivitäten",

--- a/packages/core/src/modules/workflows/i18n/en.json
+++ b/packages/core/src/modules/workflows/i18n/en.json
@@ -80,6 +80,8 @@
   "workflows.activities.async": "Asynchronous",
   "workflows.activities.compensation": "Compensation",
   "workflows.activities.config": "Configuration",
+  "workflows.activities.configInvalidJson": "Invalid JSON",
+  "workflows.activities.configMustBeObject": "Config must be a JSON object",
   "workflows.activities.deleteActivity": "Delete Activity",
   "workflows.activities.editActivity": "Edit Activity",
   "workflows.activities.plural": "Activities",

--- a/packages/core/src/modules/workflows/i18n/es.json
+++ b/packages/core/src/modules/workflows/i18n/es.json
@@ -80,6 +80,8 @@
   "workflows.activities.async": "Asincrona",
   "workflows.activities.compensation": "Compensacion",
   "workflows.activities.config": "Configuracion",
+  "workflows.activities.configInvalidJson": "JSON no válido",
+  "workflows.activities.configMustBeObject": "La configuración debe ser un objeto JSON",
   "workflows.activities.deleteActivity": "Eliminar actividad",
   "workflows.activities.editActivity": "Editar actividad",
   "workflows.activities.plural": "Actividades",

--- a/packages/core/src/modules/workflows/i18n/pl.json
+++ b/packages/core/src/modules/workflows/i18n/pl.json
@@ -80,6 +80,8 @@
   "workflows.activities.async": "Asynchroniczne",
   "workflows.activities.compensation": "Kompensacja",
   "workflows.activities.config": "Konfiguracja",
+  "workflows.activities.configInvalidJson": "Nieprawidłowy JSON",
+  "workflows.activities.configMustBeObject": "Konfiguracja musi być obiektem JSON",
   "workflows.activities.deleteActivity": "Usuń Działanie",
   "workflows.activities.editActivity": "Edytuj Działanie",
   "workflows.activities.plural": "Działania",

--- a/packages/core/src/modules/workflows/lib/__tests__/activity-config-required.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-config-required.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment node
+ *
+ * Guards #4232: activity configs were validated only for WAIT, so an activity
+ * missing a field its executor requires (CALL_API `endpoint`, EMIT_EVENT
+ * `eventName`, …) saved cleanly from the visual editor and only blew up when an
+ * instance ran it — the "my edit silently disappeared and nothing told me why"
+ * report. The schema now rejects them at edit/save time with the exact path.
+ */
+import { activityDefinitionSchema } from '../../data/validators'
+import { humanizeDefinitionIssuePath } from '../format-validation-error'
+
+function activity(activityType: string, config: Record<string, unknown>) {
+  return {
+    activityId: 'act_1',
+    activityName: 'Test activity',
+    activityType,
+    config,
+  }
+}
+
+describe('activityDefinitionSchema — required config per activity type (#4232)', () => {
+  const cases: Array<[string, Record<string, unknown>, string]> = [
+    ['CALL_API', {}, 'endpoint'],
+    ['EMIT_EVENT', {}, 'eventName'],
+    ['CALL_WEBHOOK', {}, 'url'],
+    ['EXECUTE_FUNCTION', {}, 'functionName'],
+    ['SEND_EMAIL', { to: 'a@b.c' }, 'subject'],
+    ['UPDATE_ENTITY', { commandId: 'sales.documents.update' }, 'input'],
+  ]
+
+  it.each(cases)('rejects %s missing %s', (activityType, config, missingKey) => {
+    const result = activityDefinitionSchema.safeParse(activity(activityType, config))
+    expect(result.success).toBe(false)
+    if (result.success) return
+    const issue = result.error.issues.find((candidate) => candidate.path.join('.') === `config.${missingKey}`)
+    expect(issue?.message).toBe(`${activityType} activity requires "${missingKey}"`)
+  })
+
+  it('rejects a blank string as missing (whitespace-only endpoint)', () => {
+    const result = activityDefinitionSchema.safeParse(activity('CALL_API', { endpoint: '   ' }))
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts activities whose required config is present', () => {
+    expect(activityDefinitionSchema.safeParse(activity('CALL_API', { endpoint: '/api/x' })).success).toBe(true)
+    expect(activityDefinitionSchema.safeParse(activity('EMIT_EVENT', { eventName: 'a.b.c' })).success).toBe(true)
+    expect(
+      activityDefinitionSchema.safeParse(
+        activity('UPDATE_ENTITY', { commandId: 'sales.documents.update', input: { id: '1' } }),
+      ).success,
+    ).toBe(true)
+  })
+
+  it('leaves the existing WAIT duration/until rules intact', () => {
+    expect(activityDefinitionSchema.safeParse(activity('WAIT', {})).success).toBe(false)
+    expect(activityDefinitionSchema.safeParse(activity('WAIT', { duration: 'PT5M' })).success).toBe(true)
+  })
+})
+
+describe('humanizeDefinitionIssuePath (#4232)', () => {
+  it('renders collection indexes 1-based with recognizable labels', () => {
+    expect(humanizeDefinitionIssuePath(['steps', 2, 'activities', 0, 'config', 'endpoint'])).toBe(
+      'step 3 › activity 1 › config.endpoint',
+    )
+    expect(humanizeDefinitionIssuePath(['transitions', 0, 'toStepId'])).toBe('transition 1 › toStepId')
+  })
+
+  it('falls back sensibly for short and empty paths', () => {
+    expect(humanizeDefinitionIssuePath(['workflowName'])).toBe('workflowName')
+    expect(humanizeDefinitionIssuePath([])).toBe('definition')
+  })
+})

--- a/packages/core/src/modules/workflows/lib/__tests__/activity-timeout.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-timeout.test.ts
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ *
+ * Guards #4424: a per-activity timeout set in the editor never took effect.
+ * Three layers disagreed on the field name — the editors wrote `timeoutMs`
+ * (number) or `timeout` (number, labelled "ms"), the definition schema accepted
+ * only `timeout` (ISO 8601 string), and the executor read only `timeoutMs`. So
+ * `z.object()` stripped `timeoutMs` on save, a numeric `timeout` failed
+ * validation, and a stored ISO `timeout` was ignored at run time.
+ */
+import { activityDefinitionSchema } from '../../data/validators'
+import { resolveActivityTimeoutMs } from '../activity-executor'
+
+const baseActivity = {
+  activityId: 'call_api_1',
+  activityName: 'Call API',
+  activityType: 'CALL_API' as const,
+  config: { endpoint: '/api/x' },
+}
+
+describe('activity timeout round-trip (#4424)', () => {
+  it('keeps timeoutMs through schema validation instead of stripping it', () => {
+    const result = activityDefinitionSchema.safeParse({ ...baseActivity, timeoutMs: 30000 })
+    expect(result.success).toBe(true)
+    if (result.success) expect(result.data.timeoutMs).toBe(30000)
+  })
+
+  it('rejects a non-positive or fractional timeoutMs', () => {
+    expect(activityDefinitionSchema.safeParse({ ...baseActivity, timeoutMs: 0 }).success).toBe(false)
+    expect(activityDefinitionSchema.safeParse({ ...baseActivity, timeoutMs: -1 }).success).toBe(false)
+    expect(activityDefinitionSchema.safeParse({ ...baseActivity, timeoutMs: 1.5 }).success).toBe(false)
+  })
+
+  it('still accepts the deprecated ISO 8601 timeout string (stored definitions)', () => {
+    const result = activityDefinitionSchema.safeParse({ ...baseActivity, timeout: 'PT30S' })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('resolveActivityTimeoutMs (#4424)', () => {
+  it('prefers timeoutMs', () => {
+    expect(resolveActivityTimeoutMs({ timeoutMs: 30000 })).toBe(30000)
+    expect(resolveActivityTimeoutMs({ timeoutMs: 30000, timeout: 'PT5M' })).toBe(30000)
+  })
+
+  it('normalizes a legacy ISO 8601 timeout to milliseconds', () => {
+    expect(resolveActivityTimeoutMs({ timeout: 'PT30S' })).toBe(30_000)
+    expect(resolveActivityTimeoutMs({ timeout: 'PT5M' })).toBe(300_000)
+    expect(resolveActivityTimeoutMs({ timeout: 'PT1H' })).toBe(3_600_000)
+  })
+
+  it('normalizes the simple duration format the parser also supports', () => {
+    expect(resolveActivityTimeoutMs({ timeout: '30s' })).toBe(30_000)
+    expect(resolveActivityTimeoutMs({ timeout: '5m' })).toBe(300_000)
+  })
+
+  it('returns undefined when no usable timeout is configured', () => {
+    expect(resolveActivityTimeoutMs({})).toBeUndefined()
+    expect(resolveActivityTimeoutMs({ timeout: '' })).toBeUndefined()
+    expect(resolveActivityTimeoutMs({ timeout: '   ' })).toBeUndefined()
+    expect(resolveActivityTimeoutMs({ timeoutMs: 0 })).toBeUndefined()
+  })
+
+  it('ignores a malformed timeout rather than failing the activity', () => {
+    expect(resolveActivityTimeoutMs({ timeout: 'not-a-duration' })).toBeUndefined()
+    expect(resolveActivityTimeoutMs({ timeout: 'PT' })).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -107,7 +107,40 @@ export interface ActivityDefinition {
   async?: boolean // Flag to execute activity asynchronously via queue
   retryPolicy?: RetryPolicy
   timeoutMs?: number
+  /**
+   * @deprecated Use `timeoutMs`. Legacy ISO 8601 duration string accepted by
+   * the definition schema before #4424; normalized by `resolveActivityTimeoutMs`.
+   */
+  timeout?: string
   compensate?: boolean // Flag to execute compensation on failure
+}
+
+/**
+ * Effective timeout for an activity, in milliseconds.
+ *
+ * The editor and this executor both speak `timeoutMs`, but the definition
+ * schema historically accepted only an ISO 8601 `timeout` string — so stored
+ * definitions can carry either. Prefer `timeoutMs`; fall back to parsing
+ * `timeout`, ignoring a malformed value rather than throwing mid-execution
+ * (an unparseable timeout must not fail an activity that would otherwise
+ * succeed). Returns undefined when no usable timeout is configured (#4424).
+ */
+export function resolveActivityTimeoutMs(activity: {
+  timeoutMs?: number
+  timeout?: string
+}): number | undefined {
+  if (typeof activity.timeoutMs === 'number' && activity.timeoutMs > 0) {
+    return activity.timeoutMs
+  }
+  if (typeof activity.timeout === 'string' && activity.timeout.trim().length > 0) {
+    try {
+      const parsed = parseDuration(activity.timeout.trim())
+      if (Number.isFinite(parsed) && parsed > 0) return parsed
+    } catch {
+      return undefined
+    }
+  }
+  return undefined
 }
 
 export interface RetryPolicy {
@@ -332,11 +365,13 @@ export async function executeActivity(
     try {
       const startTime = Date.now()
 
-      // Execute with timeout if specified
-      const result = activity.timeoutMs
+      // Execute with timeout if specified (timeoutMs, or a legacy ISO 8601
+      // `timeout` string normalized to ms — see resolveActivityTimeoutMs).
+      const timeoutMs = resolveActivityTimeoutMs(activity)
+      const result = timeoutMs
         ? await executeWithTimeout(
             () => executeActivityByType(em, container, activity, context),
-            activity.timeoutMs
+            timeoutMs
           )
         : await executeActivityByType(em, container, activity, context)
 

--- a/packages/core/src/modules/workflows/lib/format-validation-error.ts
+++ b/packages/core/src/modules/workflows/lib/format-validation-error.ts
@@ -8,6 +8,66 @@ type ApiErrorBody = {
   details?: ZodIssueLite[]
 }
 
+// Collection segments in a definition path, mapped to the label an operator
+// recognizes from the editor. Indexes are rendered 1-based.
+const COLLECTION_LABELS: Record<string, string> = {
+  steps: 'step',
+  transitions: 'transition',
+  activities: 'activity',
+  triggers: 'trigger',
+  preConditions: 'pre-condition',
+}
+
+/**
+ * Turn a raw Zod path into something an operator can act on:
+ * `steps.2.activities.0.config.endpoint` → `step 3 › activity 1 › config.endpoint`.
+ *
+ * The raw dotted path reads as internal JSON and gives no hint which node to
+ * open in the visual editor (#4232).
+ */
+export function humanizeDefinitionIssuePath(path: ReadonlyArray<PropertyKey>): string {
+  if (!path.length) return 'definition'
+  const parts: string[] = []
+  let pending: string | null = null
+
+  for (const rawSegment of path) {
+    // Zod types issue paths as PropertyKey; symbols can't appear in JSON data
+    // but narrow defensively rather than casting.
+    const segment = typeof rawSegment === 'symbol' ? rawSegment.toString() : rawSegment
+    if (typeof segment === 'number') {
+      parts.push(pending ? `${pending} ${segment + 1}` : `#${segment + 1}`)
+      pending = null
+      continue
+    }
+    const label = COLLECTION_LABELS[segment]
+    if (label) {
+      if (pending) parts.push(pending)
+      pending = label
+      continue
+    }
+    if (pending) {
+      parts.push(pending)
+      pending = null
+    }
+    parts.push(segment)
+  }
+  if (pending) parts.push(pending)
+
+  const [head, ...rest] = parts
+  if (!rest.length) return head
+  // Keep trailing field names dotted (config.endpoint), collections chevroned.
+  const grouped: string[] = [head]
+  for (const part of rest) {
+    const isIndexed = /\s\d+$/.test(part) || part.startsWith('#')
+    if (!isIndexed && grouped.length > 0 && !/\s\d+$/.test(grouped[grouped.length - 1]) && !grouped[grouped.length - 1].startsWith('#')) {
+      grouped[grouped.length - 1] = `${grouped[grouped.length - 1]}.${part}`
+      continue
+    }
+    grouped.push(part)
+  }
+  return grouped.join(' › ')
+}
+
 /**
  * Format an API validation error body into a user-readable message.
  *


### PR DESCRIPTION
## Summary

Consolidates four open PRs that all change how a workflow **activity is configured**, and which overlapped on the same two files. Every commit is the original work, unchanged; only the packaging is different.

| Replaces | What it fixes |
|---|---|
| #4423 | `Fixes #4232` — activity config is validated at edit time instead of failing once an instance runs |
| #4426 | `Fixes #4234` — the activity config JSON field stays editable while you type invalid JSON |
| #4432 | `Fixes #4424` — per-activity timeouts actually take effect (`timeoutMs` was stripped by the schema) |
| #4422 | docs aligned with the implementation |

## Why bundle them

They were on a collision course. `data/validators.ts` was touched by both #4423 and #4432; `components/ActivitiesEditor.tsx` by both #4426 and #4432. Whichever landed first would have left the others conflicting. Merged together the changes read as one coherent fix to the activity schema and its editor rather than three fragments.

## Verification

`packages/core` unit tests for the workflows module: **45 suites / 657 tests, all passing** (local run, after `yarn build:packages`).

The merges of the two shared files were reviewed by hand: in `validators.ts` the required-config-keys refinement (#4423) and the `timeoutMs` field (#4432) touch different parts of the same schema; in `ActivitiesEditor.tsx` the config-draft state (#4426) and the timeout input (#4432) are in different sections of the component. No change was dropped or duplicated.

## Labels

The author's account has `read` permission and cannot apply labels. Suggested: `bug`, `review`, `needs-qa`, `priority-medium`, `risk-medium`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
