### PR TITLE
fix(attachments): library interaction fixes — input focus and download-cell click

### DIFF
--- a/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
@@ -916,6 +916,7 @@ export function AttachmentLibrary() {
                     className="text-sm text-blue-600 underline"
                     target="_blank"
                     rel="noreferrer"
+                    onClick={(event) => event.stopPropagation()}
                   >
                     {content}
                   </a>
@@ -961,7 +962,12 @@ export function AttachmentLibrary() {
           const absolute = resolveAbsoluteUrl(downloadPath)
           return (
             <Button variant="ghost" size="icon" asChild>
-              <a href={absolute} download aria-label={t('attachments.library.table.download', 'Download')}>
+              <a
+                href={absolute}
+                download
+                aria-label={t('attachments.library.table.download', 'Download')}
+                onClick={(event) => event.stopPropagation()}
+              >
                 <Download className="h-4 w-4" />
               </a>
             </Button>

--- a/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
+++ b/packages/core/src/modules/attachments/components/AttachmentLibrary.tsx
@@ -199,7 +199,7 @@ type AssignmentsEditorProps = {
   disabled?: boolean
 }
 
-function AttachmentAssignmentsEditor({ value, onChange, labels, disabled }: AssignmentsEditorProps) {
+export function AttachmentAssignmentsEditor({ value, onChange, labels, disabled }: AssignmentsEditorProps) {
   const handleChange = React.useCallback(
     (index: number, patch: Partial<AssignmentDraft>) => {
       onChange(value.map((entry, idx) => (idx === index ? { ...entry, ...patch } : entry)))
@@ -229,7 +229,7 @@ function AttachmentAssignmentsEditor({ value, onChange, labels, disabled }: Assi
           <div className="text-xs text-muted-foreground">No assignments yet.</div>
         ) : (
           value.map((entry, index) => (
-            <div key={`${index}-${entry.type}-${entry.id}`} className="rounded border p-3 space-y-2">
+            <div key={index} className="rounded border p-3 space-y-2">
               <div className="grid gap-2 sm:grid-cols-2">
                 <div className="space-y-1">
                   <label className="text-xs font-medium">{labels.type}</label>

--- a/packages/core/src/modules/attachments/components/__tests__/AttachmentLibrary.downloadCell.test.tsx
+++ b/packages/core/src/modules/attachments/components/__tests__/AttachmentLibrary.downloadCell.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Guards issue #4342: the download cell anchor must not bubble its click to
+ * the DataTable row handler — the row click opens the "Edit metadata" dialog,
+ * so a missing stopPropagation made the Download icon open that dialog
+ * instead of just downloading the file.
+ *
+ * Follows the repo pattern of mocking DataTable and exercising captured
+ * column cells directly (see workflows page.toggleEnabled.optimisticLock
+ * test) so the test stays cheap while still covering the real cell markup.
+ */
+import * as React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ColumnDef } from '@tanstack/react-table'
+import { AttachmentLibrary } from '../AttachmentLibrary'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+  usePathname: () => '/backend/storage/attachments',
+  useSearchParams: () => new URLSearchParams(),
+}))
+
+type CapturedTableProps = {
+  columns: Array<ColumnDef<Record<string, unknown>> & { id?: string }>
+  onRowClick?: (row: Record<string, unknown>) => void
+}
+
+let capturedTableProps: CapturedTableProps | null = null
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: (props: CapturedTableProps) => {
+    capturedTableProps = props
+    return null
+  },
+}))
+
+const apiCallMock = jest.fn(async () => ({ ok: true, result: {} }))
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...(args as [])),
+}))
+
+const attachmentRow = {
+  id: 'att-1',
+  fileName: 'invoice.pdf',
+  fileSize: 2048,
+  mimeType: 'application/pdf',
+  partitionCode: 'default',
+  partitionTitle: 'Default',
+  createdAt: '2026-07-01T10:00:00.000Z',
+  tags: [],
+  assignments: [],
+}
+
+function renderLibraryAndCaptureTable(): CapturedTableProps {
+  capturedTableProps = null
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AttachmentLibrary />
+    </QueryClientProvider>,
+  )
+  expect(capturedTableProps).not.toBeNull()
+  return capturedTableProps as unknown as CapturedTableProps
+}
+
+function renderCellInsideClickableRow(tableProps: CapturedTableProps, columnId: string) {
+  const column = tableProps.columns.find((entry) => entry.id === columnId)
+  expect(column).toBeDefined()
+  const cell = (column as { cell?: (ctx: { row: { original: typeof attachmentRow } }) => React.ReactNode }).cell
+  expect(typeof cell).toBe('function')
+
+  // The spy stands in for DataTable's row onClick (which opens the metadata
+  // dialog); mounting the real dialog is out of scope for this bubbling test.
+  expect(typeof tableProps.onRowClick).toBe('function')
+  const rowClickSpy = jest.fn()
+  render(
+    <div data-testid={`row-${columnId}`} onClick={rowClickSpy}>
+      {cell!({ row: { original: attachmentRow } })}
+    </div>,
+  )
+  return rowClickSpy
+}
+
+describe('AttachmentLibrary download cell', () => {
+  it('a regular cell click bubbles to the row handler (sanity check)', () => {
+    const tableProps = renderLibraryAndCaptureTable()
+    const rowClickSpy = renderCellInsideClickableRow(tableProps, 'createdAt')
+
+    fireEvent.click(screen.getByTestId('row-createdAt').firstElementChild as Element)
+
+    expect(rowClickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('the download anchor click does not bubble to the row handler', () => {
+    const tableProps = renderLibraryAndCaptureTable()
+    const rowClickSpy = renderCellInsideClickableRow(tableProps, 'download')
+
+    fireEvent.click(screen.getByRole('link', { name: 'Download' }))
+
+    expect(rowClickSpy).not.toHaveBeenCalled()
+  })
+
+  it('assignment link clicks do not bubble to the row handler either', () => {
+    const tableProps = renderLibraryAndCaptureTable()
+    const rowWithAssignment = {
+      ...attachmentRow,
+      assignments: [{ type: 'customers:person', id: 'p-1', href: '/backend/customers/people/p-1', label: 'Ada' }],
+    }
+    const column = tableProps.columns.find((entry) => entry.id === 'assignments')
+    expect(column).toBeDefined()
+    const cell = (column as { cell?: (ctx: { row: { original: typeof rowWithAssignment } }) => React.ReactNode }).cell
+    const rowClickSpy = jest.fn()
+    render(
+      <div data-testid="row-assignments" onClick={rowClickSpy}>
+        {cell!({ row: { original: rowWithAssignment } })}
+      </div>,
+    )
+
+    fireEvent.click(screen.getByRole('link', { name: /Ada/ }))
+
+    expect(rowClickSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/attachments/components/__tests__/assignmentsEditorFocus.test.tsx
+++ b/packages/core/src/modules/attachments/components/__tests__/assignmentsEditorFocus.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for #4338: the upload dialog's assignment row key must
+ * stay stable while the user types — a value-derived key remounts the row on
+ * every keystroke, dropping focus after each character.
+ */
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { AttachmentAssignmentsEditor } from '../AttachmentLibrary'
+import type { AssignmentDraft } from '@open-mercato/ui/backend/detail'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+const labels = {
+  title: 'Assignments',
+  description: 'Link this attachment to records',
+  type: 'Type',
+  id: 'Record ID',
+  href: 'Link',
+  label: 'Label',
+  add: 'Add assignment',
+  remove: 'Remove',
+}
+
+function EditorHarness({ initial }: { initial: AssignmentDraft[] }) {
+  const [value, setValue] = React.useState<AssignmentDraft[]>(initial)
+  return <AttachmentAssignmentsEditor value={value} onChange={setValue} labels={labels} />
+}
+
+describe('AttachmentAssignmentsEditor (upload dialog)', () => {
+  it('keeps the Type input mounted and focused while typing multiple characters', () => {
+    render(<EditorHarness initial={[{ type: '', id: '', href: '', label: '' }]} />)
+
+    const typeInput = screen.getAllByRole('textbox')[0] as HTMLInputElement
+    typeInput.focus()
+
+    let typed = ''
+    for (const char of 'catalog.product') {
+      typed += char
+      fireEvent.change(typeInput, { target: { value: typed } })
+      expect(screen.getAllByRole('textbox')[0]).toBe(typeInput)
+      expect(document.activeElement).toBe(typeInput)
+    }
+
+    expect(typeInput.value).toBe('catalog.product')
+  })
+
+  it('keeps the Record ID input mounted and focused while typing', () => {
+    render(<EditorHarness initial={[{ type: 'catalog.product', id: '', href: '', label: '' }]} />)
+
+    const idInput = screen.getAllByRole('textbox')[1] as HTMLInputElement
+    idInput.focus()
+
+    fireEvent.change(idInput, { target: { value: 'a' } })
+    fireEvent.change(idInput, { target: { value: 'ab' } })
+
+    expect(screen.getAllByRole('textbox')[1]).toBe(idInput)
+    expect(document.activeElement).toBe(idInput)
+    expect(idInput.value).toBe('ab')
+  })
+})

--- a/packages/ui/src/backend/detail/AttachmentMetadataDialog.tsx
+++ b/packages/ui/src/backend/detail/AttachmentMetadataDialog.tsx
@@ -249,7 +249,7 @@ function AssignmentInputRow({
   )
 }
 
-function AttachmentAssignmentsEditor({
+export function AttachmentAssignmentsEditor({
   value,
   onChange,
   labels,
@@ -290,7 +290,7 @@ function AttachmentAssignmentsEditor({
       <div className="space-y-2">
         {value.length ? value.map((entry, idx) => (
           <AssignmentInputRow
-            key={`${entry.type}-${entry.id}-${idx}`}
+            key={idx}
             value={entry}
             labels={labels}
             disabled={disabled}

--- a/packages/ui/src/backend/detail/__tests__/AttachmentAssignmentsEditor.test.tsx
+++ b/packages/ui/src/backend/detail/__tests__/AttachmentAssignmentsEditor.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Regression coverage for #4338: the assignment row key must stay stable while
+ * the user types — a value-derived key remounts the row on every keystroke,
+ * which throws the input out of focus after each character.
+ */
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+jest.mock('@open-mercato/core/generated-shims/entities.ids.generated', () => ({
+  E: new Proxy({}, {
+    get: (_target, moduleId) => new Proxy({}, {
+      get: (_entity, entityId) => `${String(moduleId)}:${String(entityId)}`,
+    }),
+  }),
+}))
+
+import { AttachmentAssignmentsEditor, type AssignmentDraft } from '../AttachmentMetadataDialog'
+
+const labels = {
+  title: 'Assignments',
+  description: 'Link this attachment to records',
+  type: 'Type',
+  id: 'Record ID',
+  href: 'Link',
+  label: 'Label',
+  add: 'Add assignment',
+  remove: 'Remove assignment',
+}
+
+function EditorHarness({ initial }: { initial: AssignmentDraft[] }) {
+  const [value, setValue] = React.useState<AssignmentDraft[]>(initial)
+  return <AttachmentAssignmentsEditor value={value} onChange={setValue} labels={labels} />
+}
+
+describe('AttachmentAssignmentsEditor (metadata dialog)', () => {
+  it('keeps the Type input mounted and focused while typing multiple characters', () => {
+    render(<EditorHarness initial={[{ type: '', id: '', href: '', label: '' }]} />)
+
+    const typeInput = screen.getByPlaceholderText('catalog.product') as HTMLInputElement
+    typeInput.focus()
+
+    let typed = ''
+    for (const char of 'catalog.product') {
+      typed += char
+      fireEvent.change(typeInput, { target: { value: typed } })
+      expect(screen.getByPlaceholderText('catalog.product')).toBe(typeInput)
+      expect(document.activeElement).toBe(typeInput)
+    }
+
+    expect(typeInput.value).toBe('catalog.product')
+  })
+
+  it('keeps the Record ID input mounted and focused while typing', () => {
+    render(<EditorHarness initial={[{ type: 'catalog.product', id: '', href: '', label: '' }]} />)
+
+    const idInput = screen.getByPlaceholderText('Record ID') as HTMLInputElement
+    idInput.focus()
+
+    fireEvent.change(idInput, { target: { value: 'a' } })
+    fireEvent.change(idInput, { target: { value: 'ab' } })
+
+    expect(screen.getByPlaceholderText('Record ID')).toBe(idInput)
+    expect(document.activeElement).toBe(idInput)
+    expect(idInput.value).toBe('ab')
+  })
+
+  it('still adds and removes assignment rows', () => {
+    render(<EditorHarness initial={[]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add assignment' }))
+    expect(screen.getByPlaceholderText('catalog.product')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove assignment' }))
+    expect(screen.queryByPlaceholderText('catalog.product')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Consolidates two open PRs that both fix interaction bugs in the attachment library and both touched `components/AttachmentLibrary.tsx`.

| Replaces | What it fixes |
|---|---|
| #4405 | `Fixes #4338` — assignment inputs no longer lose focus on every keystroke |
| #4384 | `Fixes #4342` — clicking the download cell no longer opens the row |

## Why bundle them

Both edit `AttachmentLibrary.tsx`, so whichever landed first would have left the other conflicting. #4384 also carried `changes-requested`; its review comments are addressed in the commit as it stands here.

## Verification

`packages/core` unit tests for the attachments module: **25 suites / 189 tests, all passing** (local run, after `yarn build:packages`).

Hand-reviewed the shared file: #4405 changes the assignment row key and exports the editor, #4384 adds `stopPropagation` to the download and link anchors. Disjoint regions, nothing dropped.

## Labels

The author's account has `read` permission and cannot apply labels. Suggested: `bug`, `review`, `needs-qa`, `priority-low`, `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
