### PR TITLE
fix(customer_accounts): portal user surfaces — invite target and full-width page

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-person-link.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-person-link.test.ts
@@ -1,0 +1,143 @@
+/** @jest-environment node */
+
+import type { RateLimitConfig } from '@open-mercato/shared/lib/ratelimit/types'
+
+const inviteIpConfig: RateLimitConfig = { points: 20, duration: 60, blockDuration: 120, keyPrefix: 'customer-invite-ip' }
+const inviteCompoundConfig: RateLimitConfig = { points: 5, duration: 60, blockDuration: 120, keyPrefix: 'customer-invite' }
+
+const mockCheckAuthRateLimit = jest.fn()
+const mockCreateInvitation = jest.fn()
+const mockUserHasAllFeatures = jest.fn()
+const mockGetAuthFromRequest = jest.fn()
+const mockEmit = jest.fn(async () => undefined)
+const mockIsOwnedCompanyEntity = jest.fn()
+const mockIsOwnedPersonEntity = jest.fn()
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/rateLimiter', () => ({
+  checkAuthRateLimit: (...args: unknown[]) => mockCheckAuthRateLimit(...args),
+  customerInviteIpRateLimitConfig: inviteIpConfig,
+  customerInviteRateLimitConfig: inviteCompoundConfig,
+}))
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'rbacService') return { userHasAllFeatures: mockUserHasAllFeatures }
+    if (token === 'customerInvitationService') return { createInvitation: mockCreateInvitation }
+    if (token === 'em') return {}
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
+  emitCustomerAccountsEvent: (...args: unknown[]) => mockEmit(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership', () => ({
+  isOwnedCompanyEntity: (...args: unknown[]) => mockIsOwnedCompanyEntity(...args),
+  isOwnedPersonEntity: (...args: unknown[]) => mockIsOwnedPersonEntity(...args),
+}))
+
+const tenantId = '22222222-2222-4222-8222-222222222222'
+const organizationId = '33333333-3333-4333-8333-333333333333'
+const invitationId = '55555555-5555-4555-8555-555555555555'
+const roleId = '11111111-1111-4111-8111-111111111111'
+const personEntityId = '66666666-6666-4666-8666-666666666666'
+const companyEntityId = '77777777-7777-4777-8777-777777777777'
+
+function makeInviteRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/customer_accounts/admin/users-invite', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('admin users-invite — person link + company ownership (#4362)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCheckAuthRateLimit.mockResolvedValue({ error: null, compoundKey: null })
+    mockUserHasAllFeatures.mockResolvedValue(true)
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'staff-1', tenantId, orgId: organizationId })
+    mockIsOwnedCompanyEntity.mockResolvedValue(true)
+    mockIsOwnedPersonEntity.mockResolvedValue(true)
+    mockCreateInvitation.mockResolvedValue({
+      invitation: { id: invitationId, email: 'buyer@example.com', customerEntityId: null, expiresAt: new Date().toISOString() },
+      rawToken: 'raw-secret-token',
+    })
+  })
+
+  it('passes personEntityId through to the invitation service and does not require a company', async () => {
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(makeInviteRequest({ email: 'buyer@example.com', roleIds: [roleId], personEntityId }))
+
+    expect(res.status).toBe(201)
+    expect(mockIsOwnedCompanyEntity).not.toHaveBeenCalled()
+    expect(mockIsOwnedPersonEntity).toHaveBeenCalledWith(expect.anything(), personEntityId, { tenantId, organizationId })
+    expect(mockCreateInvitation).toHaveBeenCalledTimes(1)
+    const options = mockCreateInvitation.mock.calls[0][2] as Record<string, unknown>
+    expect(options.personEntityId).toBe(personEntityId)
+    expect(options.customerEntityId).toBeNull()
+  })
+
+  it('rejects a personEntityId that is not an owned person with 400 "Person not found"', async () => {
+    // Symmetric to the company guard: an id from another org (or a company id)
+    // would otherwise be copied onto the customer user and short-circuit
+    // autoLinkCrm, permanently cross-linking the portal user.
+    mockIsOwnedPersonEntity.mockResolvedValue(false)
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(makeInviteRequest({ email: 'buyer@example.com', roleIds: [roleId], personEntityId: companyEntityId }))
+
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json).toEqual({ ok: false, error: 'Person not found' })
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+  })
+
+  it('does not check person ownership when no personEntityId is supplied', async () => {
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(makeInviteRequest({ email: 'buyer@example.com', roleIds: [roleId], customerEntityId: companyEntityId }))
+
+    expect(res.status).toBe(201)
+    expect(mockIsOwnedPersonEntity).not.toHaveBeenCalled()
+  })
+
+  it('succeeds without any entity link', async () => {
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(makeInviteRequest({ email: 'buyer@example.com', roleIds: [roleId] }))
+
+    expect(res.status).toBe(201)
+    expect(mockIsOwnedCompanyEntity).not.toHaveBeenCalled()
+    expect(mockCreateInvitation).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects a customerEntityId that is not an owned company with 400 "Company not found"', async () => {
+    mockIsOwnedCompanyEntity.mockResolvedValue(false)
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(makeInviteRequest({ email: 'buyer@example.com', roleIds: [roleId], customerEntityId: personEntityId }))
+
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json).toEqual({ ok: false, error: 'Company not found' })
+    expect(mockCreateInvitation).not.toHaveBeenCalled()
+  })
+
+  it('accepts a customerEntityId that is an owned company with 201', async () => {
+    mockIsOwnedCompanyEntity.mockResolvedValue(true)
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(makeInviteRequest({ email: 'buyer@example.com', roleIds: [roleId], customerEntityId: companyEntityId }))
+
+    expect(res.status).toBe(201)
+    expect(mockIsOwnedCompanyEntity).toHaveBeenCalledWith(expect.anything(), companyEntityId, { tenantId, organizationId })
+    expect(mockCreateInvitation).toHaveBeenCalledTimes(1)
+    const options = mockCreateInvitation.mock.calls[0][2] as Record<string, unknown>
+    expect(options.customerEntityId).toBe(companyEntityId)
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
@@ -7,6 +7,7 @@ import { RbacService } from '@open-mercato/core/modules/auth/services/rbacServic
 import { CustomerInvitationService } from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { inviteUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
+import { isOwnedCompanyEntity, isOwnedPersonEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import {
   checkAuthRateLimit,
@@ -51,6 +52,35 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: 'Validation failed', details: parsed.error.flatten().fieldErrors }, { status: 400 })
   }
 
+  // Reject a customerEntityId the caller does not own. customerEntityId is the
+  // CRM company FK; without this check a non-company (e.g. a person) entity id
+  // or a company from another org poisons the invitation and every later user
+  // edit fails with "Company not found" (#4362, #2693).
+  if (parsed.data.customerEntityId) {
+    const em = container.resolve('em') as import('@mikro-orm/postgresql').EntityManager
+    const owned = await isOwnedCompanyEntity(em, parsed.data.customerEntityId, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+    if (!owned) {
+      return NextResponse.json({ ok: false, error: 'Company not found' }, { status: 400 })
+    }
+  }
+
+  // Same guard for the person FK: it is copied onto the customer user on accept
+  // and makes `autoLinkCrm` short-circuit, so an unowned id would permanently
+  // cross-link the portal user to another org's CRM person.
+  if (parsed.data.personEntityId) {
+    const em = container.resolve('em') as import('@mikro-orm/postgresql').EntityManager
+    const owned = await isOwnedPersonEntity(em, parsed.data.personEntityId, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+    if (!owned) {
+      return NextResponse.json({ ok: false, error: 'Person not found' }, { status: 400 })
+    }
+  }
+
   const customerInvitationService = container.resolve('customerInvitationService') as CustomerInvitationService
 
   const { invitation } = await customerInvitationService.createInvitation(
@@ -58,6 +88,7 @@ export async function POST(req: Request) {
     { tenantId: auth.tenantId!, organizationId: auth.orgId! },
     {
       customerEntityId: parsed.data.customerEntityId || null,
+      personEntityId: parsed.data.personEntityId || null,
       roleIds: parsed.data.roleIds,
       invitedByUserId: auth.sub,
       displayName: parsed.data.displayName || null,

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id].ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id].ts
@@ -11,7 +11,7 @@ import { CustomerRbacService } from '@open-mercato/core/modules/customer_account
 import { adminUpdateUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { isOwnedCompanyEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
+import { isOwnedCompanyEntity, isOwnedPersonEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
 import { enforceCommandOptimisticLockWithGuards } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
 import { isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 
@@ -165,6 +165,21 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
     })
     if (!owned) {
       return NextResponse.json({ ok: false, error: 'Company not found' }, { status: 400 })
+    }
+  }
+
+  // Same guard for the person FK. Without it the invite-side check is trivially
+  // bypassable: create the user normally, then PUT an unowned personEntityId.
+  // It persists (autoLinkCrm short-circuits on any non-null value) and leaks
+  // account status into the other org's people list via the account-status
+  // enricher. A null value (unlink) needs no ownership check.
+  if (parsed.data.personEntityId) {
+    const owned = await isOwnedPersonEntity(em, parsed.data.personEntityId, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId,
+    })
+    if (!owned) {
+      return NextResponse.json({ ok: false, error: 'Person not found' }, { status: 400 })
     }
   }
 

--- a/packages/core/src/modules/customer_accounts/data/entities.ts
+++ b/packages/core/src/modules/customer_accounts/data/entities.ts
@@ -291,6 +291,9 @@ export class CustomerUserInvitation {
   @Property({ name: 'customer_entity_id', type: 'uuid', nullable: true })
   customerEntityId?: string | null
 
+  @Property({ name: 'person_entity_id', type: 'uuid', nullable: true })
+  personEntityId?: string | null
+
   @Property({ name: 'role_ids_json', type: 'json', nullable: true })
   roleIdsJson?: string[] | null
 

--- a/packages/core/src/modules/customer_accounts/data/validators.ts
+++ b/packages/core/src/modules/customer_accounts/data/validators.ts
@@ -81,6 +81,7 @@ export const updateRoleAclSchema = z.object({
 export const inviteUserSchema = z.object({
   email: emailField,
   customerEntityId: z.string().uuid().optional(),
+  personEntityId: z.string().uuid().optional(),
   roleIds: z.array(z.string().uuid()).min(1),
   displayName: displayNameField.optional(),
 })

--- a/packages/core/src/modules/customer_accounts/lib/customerEntityOwnership.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerEntityOwnership.ts
@@ -21,6 +21,33 @@ export async function isOwnedCompanyEntity(
   customerEntityId: string,
   scope: CustomerEntityScope,
 ): Promise<boolean> {
+  return isOwnedEntityOfKind(em, customerEntityId, 'company', scope)
+}
+
+/**
+ * Confirms that a caller-supplied `personEntityId` (the CRM person FK linked
+ * onto a customer user) exists, is a person, is not soft-deleted, and belongs
+ * to the caller's tenant and organization.
+ *
+ * This is the symmetric guard to {@link isOwnedCompanyEntity}: the person FK is
+ * copied onto the customer user on accept and short-circuits CRM auto-linking,
+ * so an unvalidated id would permanently cross-link a portal user to another
+ * org's person (the #4362/#2693 class of bug, on the person side).
+ */
+export async function isOwnedPersonEntity(
+  em: EntityManager,
+  personEntityId: string,
+  scope: CustomerEntityScope,
+): Promise<boolean> {
+  return isOwnedEntityOfKind(em, personEntityId, 'person', scope)
+}
+
+async function isOwnedEntityOfKind(
+  em: EntityManager,
+  customerEntityId: string,
+  kind: 'company' | 'person',
+  scope: CustomerEntityScope,
+): Promise<boolean> {
   const { CustomerEntity } = await import('@open-mercato/core/modules/customers/data/entities')
   const entity = await findOneWithDecryption(
     em,
@@ -29,7 +56,7 @@ export async function isOwnedCompanyEntity(
       id: customerEntityId,
       tenantId: scope.tenantId,
       organizationId: scope.organizationId,
-      kind: 'company',
+      kind,
       deletedAt: null,
     } as any,
     undefined,

--- a/packages/core/src/modules/customer_accounts/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/customer_accounts/migrations/.snapshot-open-mercato.json
@@ -923,6 +923,22 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
+        "person_entity_id": {
+          "name": "person_entity_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
         "role_ids_json": {
           "name": "role_ids_json",
           "type": "jsonb",

--- a/packages/core/src/modules/customer_accounts/migrations/Migration20260723120000_customer_accounts.ts
+++ b/packages/core/src/modules/customer_accounts/migrations/Migration20260723120000_customer_accounts.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260723120000_customer_accounts extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "customer_user_invitations" add column "person_entity_id" uuid null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "customer_user_invitations" drop column "person_entity_id";`);
+  }
+
+}

--- a/packages/core/src/modules/customer_accounts/services/__tests__/customerInvitationService.test.ts
+++ b/packages/core/src/modules/customer_accounts/services/__tests__/customerInvitationService.test.ts
@@ -3,6 +3,7 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import { CustomerInvitationService } from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
 import {
   CustomerRole,
+  CustomerUser,
   CustomerUserInvitation,
   CustomerUserRole,
 } from '@open-mercato/core/modules/customer_accounts/data/entities'
@@ -140,6 +141,35 @@ describe('CustomerInvitationService.acceptInvitation — role lookup batching', 
     expect((linkCreates[0][1] as { role: { id: string } }).role.id).toBe(localRoleId)
   })
 
+  it('carries personEntityId from the invitation onto the new CustomerUser', async () => {
+    const personEntityId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+    const invitation = {
+      id: 'inv-person',
+      email: 'new@example.com',
+      tenantId,
+      organizationId,
+      customerEntityId: null,
+      personEntityId,
+      roleIdsJson: [],
+      expiresAt: new Date(Date.now() + 60_000),
+      acceptedAt: null,
+      cancelledAt: null,
+    } as unknown as CustomerUserInvitation
+
+    ;(mockEm.findOne as jest.Mock).mockImplementation(async (entity: unknown) => {
+      if (entity === CustomerUserInvitation) return invitation
+      return null
+    })
+    ;(mockEm.find as jest.Mock).mockResolvedValue([])
+
+    const result = await service.acceptInvitation('raw-token', 'Secret123!', 'New User')
+    expect(result).not.toBeNull()
+
+    const userCreates = (mockEm.create as jest.Mock).mock.calls.filter((call) => call[0] === CustomerUser)
+    expect(userCreates).toHaveLength(1)
+    expect((userCreates[0][1] as { personEntityId: string | null }).personEntityId).toBe(personEntityId)
+  })
+
   it('skips the role query entirely when the invitation carries no roleIds', async () => {
     const invitation = {
       id: 'inv-2',
@@ -211,11 +241,12 @@ describe('CustomerInvitationService.createInvitation — pending-invitation dedu
       return null
     })
 
+    const personEntityId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
     const beforeExpiresAt = existing.expiresAt.getTime()
     const result = await service.createInvitation(
       ' New@Example.COM ',
       { tenantId, organizationId },
-      { roleIds, invitedByUserId: 'inviter-1', displayName: 'Refreshed Name' },
+      { roleIds, personEntityId, invitedByUserId: 'inviter-1', displayName: 'Refreshed Name' },
     )
 
     expect(mockEm.create).not.toHaveBeenCalled()
@@ -223,6 +254,7 @@ describe('CustomerInvitationService.createInvitation — pending-invitation dedu
     expect(result.rawToken).toBe('raw-token')
     expect(existing.email).toBe('new@example.com')
     expect(existing.token).toBe('hashed-token')
+    expect(existing.personEntityId).toBe(personEntityId)
     expect(existing.roleIdsJson).toEqual(roleIds)
     expect(existing.invitedByUserId).toBe('inviter-1')
     expect(existing.displayName).toBe('Refreshed Name')
@@ -246,10 +278,11 @@ describe('CustomerInvitationService.createInvitation — pending-invitation dedu
   it('inserts a new invitation row when no pending invitation exists', async () => {
     ;(mockEm.findOne as jest.Mock).mockResolvedValue(null)
 
+    const personEntityId = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
     const result = await service.createInvitation(
       'fresh@example.com',
       { tenantId, organizationId },
-      { roleIds, invitedByUserId: 'inviter-2', displayName: 'Fresh' },
+      { roleIds, personEntityId, invitedByUserId: 'inviter-2', displayName: 'Fresh' },
     )
 
     const invitationCreates = (mockEm.create as jest.Mock).mock.calls.filter(
@@ -262,6 +295,7 @@ describe('CustomerInvitationService.createInvitation — pending-invitation dedu
       email: 'fresh@example.com',
       emailHash: 'email-hash',
       token: 'hashed-token',
+      personEntityId,
       roleIdsJson: roleIds,
     })
     expect(mockEm.persist).toHaveBeenCalled()

--- a/packages/core/src/modules/customer_accounts/services/customerInvitationService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerInvitationService.ts
@@ -21,6 +21,7 @@ export class CustomerInvitationService {
     scope: { tenantId: string; organizationId: string },
     options: {
       customerEntityId?: string | null
+      personEntityId?: string | null
       roleIds: string[]
       invitedByUserId?: string | null
       invitedByCustomerUserId?: string | null
@@ -56,6 +57,7 @@ export class CustomerInvitationService {
       existing.email = normalizedEmail
       existing.token = tokenHashed
       existing.customerEntityId = options.customerEntityId || null
+      existing.personEntityId = options.personEntityId || null
       existing.roleIdsJson = options.roleIds
       existing.invitedByUserId = options.invitedByUserId || null
       existing.invitedByCustomerUserId = options.invitedByCustomerUserId || null
@@ -72,6 +74,7 @@ export class CustomerInvitationService {
       emailHash,
       token: tokenHashed,
       customerEntityId: options.customerEntityId || null,
+      personEntityId: options.personEntityId || null,
       roleIdsJson: options.roleIds,
       invitedByUserId: options.invitedByUserId || null,
       invitedByCustomerUserId: options.invitedByCustomerUserId || null,
@@ -117,6 +120,7 @@ export class CustomerInvitationService {
       tenantId: invitation.tenantId,
       organizationId: invitation.organizationId,
       customerEntityId: invitation.customerEntityId || null,
+      personEntityId: invitation.personEntityId || null,
       isActive: true,
       emailVerifiedAt: new Date(), // Invitation implicitly verifies email
       failedLoginAttempts: 0,

--- a/packages/core/src/modules/customer_accounts/subscribers/__tests__/autoLinkCrm-normalize.test.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/__tests__/autoLinkCrm-normalize.test.ts
@@ -1,0 +1,144 @@
+/** @jest-environment node */
+
+import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
+
+const mockFindOneWithDecryption = jest.fn()
+const mockFindWithDecryption = jest.fn(async () => [] as unknown[])
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+}))
+
+class CustomerEntity {}
+class CustomerPersonProfile {}
+
+jest.mock('@open-mercato/core/modules/customers/data/entities', () => ({
+  CustomerEntity,
+  CustomerPersonProfile,
+}))
+
+jest.mock('@open-mercato/shared/lib/logger', () => ({
+  createLogger: () => ({ child: () => ({ error: jest.fn() }) }),
+}))
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const userId = '33333333-3333-4333-8333-333333333333'
+const personEntityId = '44444444-4444-4444-8444-444444444444'
+const companyEntityId = '55555555-5555-4555-8555-555555555555'
+const linkedPersonId = '66666666-6666-4666-8666-666666666666'
+
+type EmMock = {
+  findOne: jest.Mock
+  nativeUpdate: jest.Mock
+}
+
+function makeCtx(em: EmMock) {
+  return {
+    resolve: (<T = unknown>(name: string) => {
+      if (name === 'em') return em as unknown as T
+      return undefined as unknown as T
+    }),
+    eventName: 'customer_accounts.user.created',
+  }
+}
+
+describe('autoLinkCrm — poisoned customerEntityId normalization (#4362)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('replaces a person-pointing customerEntityId with the person profile company', async () => {
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId, customerEntityId: linkedPersonId }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === CustomerUser) return user
+      if (entity === CustomerEntity) return { id: linkedPersonId, kind: 'person' }
+      return null
+    })
+    const em: EmMock = {
+      findOne: jest.fn(async () => ({ companyEntityId })),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(CustomerUser, { id: userId }, { customerEntityId: companyEntityId })
+  })
+
+  it('clears a person-pointing customerEntityId when no company can be recovered', async () => {
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId, customerEntityId: linkedPersonId }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === CustomerUser) return user
+      if (entity === CustomerEntity) return { id: linkedPersonId, kind: 'person' }
+      return null
+    })
+    const em: EmMock = {
+      findOne: jest.fn(async () => null),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(CustomerUser, { id: userId }, { customerEntityId: null })
+  })
+
+  it('clears a customerEntityId that does not resolve inside the user own org', async () => {
+    // customerEntityId is the portal company scope key, so a cross-org value must
+    // be cleared, not left in place "because it is a company somewhere".
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId, customerEntityId: companyEntityId }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === CustomerUser) return user
+      if (entity === CustomerEntity) return null
+      return null
+    })
+    const em: EmMock = {
+      findOne: jest.fn(async () => null),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(CustomerUser, { id: userId }, { customerEntityId: null })
+  })
+
+  it('does not adopt a recovered company that belongs to another org', async () => {
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId, customerEntityId: linkedPersonId }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown, where: any) => {
+      if (entity === CustomerUser) return user
+      if (entity === CustomerEntity) {
+        // The ownership probe filters on kind:'company' — miss it to simulate a
+        // profile company sitting outside the user's organization.
+        if (where?.kind === 'company') return null
+        return { id: linkedPersonId, kind: 'person' }
+      }
+      return null
+    })
+    const em: EmMock = {
+      findOne: jest.fn(async () => ({ companyEntityId })),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(CustomerUser, { id: userId }, { customerEntityId: null })
+  })
+
+  it('leaves a correct company customerEntityId untouched', async () => {
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId, customerEntityId: companyEntityId }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === CustomerUser) return user
+      if (entity === CustomerEntity) return { id: companyEntityId, kind: 'company' }
+      return null
+    })
+    const em: EmMock = {
+      findOne: jest.fn(async () => null),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customer_accounts/subscribers/autoLinkCrm.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/autoLinkCrm.ts
@@ -1,6 +1,7 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isOwnedCompanyEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('customer_accounts').child({ component: 'auto-link-crm' })
@@ -26,12 +27,54 @@ export default async function handle(
   try {
     const user = await findOneWithDecryption(em, CustomerUser, { id: userId, tenantId, deletedAt: null }, undefined, { tenantId, organizationId })
     if (!user) return
+
+    const { CustomerEntity, CustomerPersonProfile } = await import('@open-mercato/core/modules/customers/data/entities')
+
+    // Defensive normalization: customerEntityId is the CRM company FK. Earlier
+    // invite flows (#4362) could poison it with a person entity id, which then
+    // breaks every later user edit ("Company not found"). If the linked entity
+    // is a person (not a company), drop it — or recover the person's real
+    // company from their profile. Correct company links are left untouched.
+    if (user.customerEntityId) {
+      // Normalize against the user's OWN org, not just the tenant: customerEntityId
+      // is the portal's company scope key (portal user/invite routes filter on it),
+      // so adopting a company from another org would widen the user's portal access
+      // instead of repairing it. Anything that is not an owned company here — a
+      // person id (the #4362 poisoning) or a cross-org entity — is recovered to the
+      // person's own company when that company is in-org, otherwise cleared.
+      const ownScope = { tenantId, organizationId: user.organizationId }
+      const linked = await findOneWithDecryption(
+        em,
+        CustomerEntity,
+        { id: user.customerEntityId, tenantId, organizationId: user.organizationId, deletedAt: null } as any,
+        undefined,
+        { tenantId, organizationId },
+      ) as any
+      if (!linked) {
+        // Not resolvable inside the user's own org — a cross-org (or deleted)
+        // entity. Clear it rather than leave it: this FK is the portal scope key.
+        await em.nativeUpdate(CustomerUser, { id: userId }, { customerEntityId: null })
+        user.customerEntityId = null
+      } else if (linked.kind === 'person') {
+        const profile = await em.findOne(CustomerPersonProfile as any, {
+          entity: user.customerEntityId,
+          tenantId,
+          organizationId: user.organizationId,
+        } as any) as any
+        const candidate = (profile?.companyEntityId as string | undefined) || null
+        // Only adopt a recovered company that is itself in the user's org.
+        const replacement = candidate && (await isOwnedCompanyEntity(em, candidate, ownScope))
+          ? candidate
+          : null
+        await em.nativeUpdate(CustomerUser, { id: userId }, { customerEntityId: replacement })
+        user.customerEntityId = replacement
+      }
+    }
+
     if (user.personEntityId) return
 
     const email = (data?.email ? (data.email as string) : user.email)?.toLowerCase().trim()
     if (!email) return
-
-    const { CustomerEntity } = await import('@open-mercato/core/modules/customers/data/entities')
 
     const personEntities = await findWithDecryption(
       em,
@@ -47,7 +90,6 @@ export default async function handle(
 
     if (!matchingEntity) return
 
-    const { CustomerPersonProfile } = await import('@open-mercato/core/modules/customers/data/entities')
     const profile = await em.findOne(CustomerPersonProfile as any, { entity: matchingEntity.id } as any) as any
     const companyEntityId = profile?.companyEntityId as string | undefined
 

--- a/packages/core/src/modules/customer_accounts/widgets/__tests__/injection-table.test.ts
+++ b/packages/core/src/modules/customer_accounts/widgets/__tests__/injection-table.test.ts
@@ -30,6 +30,7 @@ function expectSingleGroupWidget(
   spotId: string,
   widgetId: string,
   groupLabel: string,
+  column: 1 | 2,
 ) {
   const slots = table[spotId]
   expect(Array.isArray(slots)).toBe(true)
@@ -37,7 +38,7 @@ function expectSingleGroupWidget(
   expect(slot).toEqual({
     widgetId,
     kind: 'group',
-    column: 2,
+    column,
     groupLabel,
     priority: 200,
   })
@@ -51,17 +52,22 @@ describe('customer_accounts injection table', () => {
         spotId,
         'customer_accounts.injection.account-status',
         'customer_accounts.widgets.accountStatus',
+        2,
       )
     }
   })
 
-  it('registers the company-users widget on the spots the company detail host requests', () => {
+  // Regression guard for #4400: a column-2 group forces CrudForm into the narrow
+  // 7fr/3fr secondary-column layout on company details. Portal users must stay a
+  // full-width row in the column-1 stack.
+  it('registers the company-users widget in column 1 on the spots the company detail host requests', () => {
     for (const spotId of ['customers.company', 'crud-form:customers.company']) {
       expectSingleGroupWidget(
         injectionTable,
         spotId,
         'customer_accounts.injection.company-users',
         'customer_accounts.widgets.portalUsers',
+        1,
       )
     }
   })

--- a/packages/core/src/modules/customer_accounts/widgets/injection-table.ts
+++ b/packages/core/src/modules/customer_accounts/widgets/injection-table.ts
@@ -8,10 +8,13 @@ const accountStatusWidget = {
   priority: 200,
 } as const
 
+// Column 1 on purpose (#4400): any column-2 group makes CrudForm switch the
+// company detail page to the narrow 7fr/3fr two-column layout, compressing the
+// left-side groups. Portal users belongs in the left stack as a full-width row.
 const companyUsersWidget = {
   widgetId: 'customer_accounts.injection.company-users',
   kind: 'group',
-  column: 2,
+  column: 1,
   groupLabel: 'customer_accounts.widgets.portalUsers',
   priority: 200,
 } as const

--- a/packages/core/src/modules/customer_accounts/widgets/injection/account-status/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/customer_accounts/widgets/injection/account-status/__tests__/widget.client.test.tsx
@@ -105,7 +105,8 @@ describe('customer_accounts AccountStatusWidget invite form', () => {
       mutationPayload: Record<string, unknown>
     }
     expect(runArgs.context.entityType).toBe('customer_accounts:user')
-    expect(runArgs.mutationPayload.customerEntityId).toBe('person-entity-1')
+    expect(runArgs.mutationPayload.personEntityId).toBe('person-entity-1')
+    expect(runArgs.mutationPayload.customerEntityId).toBeUndefined()
 
     await waitFor(() => {
       const inviteCall = mockApiCall.mock.calls.find(
@@ -150,7 +151,7 @@ describe('customer_accounts AccountStatusWidget invite form', () => {
           email: 'buyer@example.test',
           roleIds: ['role-1'],
           displayName: 'Buyer Contact',
-          customerEntityId: 'person-entity-1',
+          personEntityId: 'person-entity-1',
         }),
       }),
     ))

--- a/packages/core/src/modules/customer_accounts/widgets/injection/account-status/widget.client.tsx
+++ b/packages/core/src/modules/customer_accounts/widgets/injection/account-status/widget.client.tsx
@@ -130,7 +130,7 @@ function InviteForm({ personEntityId, onSuccess }: { personEntityId: string; onS
     try {
       await runMutation({
         context: { entityType: 'customer_accounts:user' },
-        mutationPayload: { customerEntityId: personEntityId, roleIds: selectedRoleIds },
+        mutationPayload: { personEntityId, roleIds: selectedRoleIds },
         operation: async () => {
           // optimistic-lock-exempt: creates a new portal invitation, not a concurrent record edit
           const call = await apiCall<{ ok: boolean; error?: string }>(
@@ -142,7 +142,7 @@ function InviteForm({ personEntityId, onSuccess }: { personEntityId: string; onS
                 email: trimmedEmail,
                 roleIds: selectedRoleIds,
                 displayName: displayName.trim() || undefined,
-                customerEntityId: personEntityId,
+                personEntityId,
               }),
             },
           )

--- a/packages/ui/src/backend/__tests__/CrudForm.groupInjectionColumn.test.tsx
+++ b/packages/ui/src/backend/__tests__/CrudForm.groupInjectionColumn.test.tsx
@@ -1,0 +1,98 @@
+/** @jest-environment jsdom */
+jest.setTimeout(15000)
+
+// Regression guard for #4400: an injected group widget placed in column 1 must
+// render as a full-width row in the main stack — CrudForm must NOT switch to
+// the narrow 7fr/3fr secondary-column layout unless a widget explicitly asks
+// for column 2. The hook is mocked so the test drives the injected widgets
+// directly, following the CrudForm.fieldInjection.test.tsx pattern.
+let injectedGroupWidgets: unknown[] = []
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {} }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+}))
+jest.mock('remark-gfm', () => ({ __esModule: true, default: {} }))
+jest.mock('../injection/InjectionSpot', () => ({
+  __esModule: true,
+  InjectionSpot: () => null,
+  useInjectionWidgets: () => ({ widgets: injectedGroupWidgets, loading: false, error: null }),
+  useInjectionSpotEvents: () => ({ triggerEvent: jest.fn(async () => ({ ok: true, data: {} })) }),
+}))
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  __esModule: true,
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false, error: null }),
+}))
+
+import * as React from 'react'
+import { waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { CrudForm, type CrudField, type CrudFormGroup } from '../CrudForm'
+
+const fields: CrudField[] = [
+  { id: 'name', label: 'Name', type: 'text' },
+]
+
+const groups: CrudFormGroup[] = [
+  { id: 'contact', label: 'Contact', fields: ['name'] },
+]
+
+function makeGroupWidget(column: 1 | 2) {
+  return {
+    widgetId: 'customer_accounts.injection.company-users',
+    placement: { kind: 'group', column, groupLabel: 'Portal users', priority: 200 },
+    module: {
+      metadata: { title: 'Portal users', description: '' },
+      Widget: () => <div data-testid="portal-users-widget">portal users</div>,
+    },
+  }
+}
+
+function renderForm() {
+  return renderWithProviders(
+    React.createElement(CrudForm as never, {
+      title: 'Company',
+      entityId: 'customers:company',
+      fields,
+      groups,
+      onSubmit: () => {},
+    }),
+  )
+}
+
+describe('CrudForm injected group column placement (#4400)', () => {
+  afterEach(() => {
+    injectedGroupWidgets = []
+  })
+
+  it('renders a column-1 group widget as a full-width row without the secondary column', async () => {
+    injectedGroupWidgets = [makeGroupWidget(1)]
+
+    const { container } = renderForm()
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="portal-users-widget"]')).toBeTruthy()
+    })
+
+    expect(container.querySelector('[data-crud-injection-region]')).toBeNull()
+    const twoColumnGrid = Array.from(container.querySelectorAll('div')).find((node) =>
+      node.className.includes('7fr_3fr'),
+    )
+    expect(twoColumnGrid).toBeUndefined()
+  })
+
+  it('still supports an explicit column-2 group widget via the secondary column (sanity)', async () => {
+    injectedGroupWidgets = [makeGroupWidget(2)]
+
+    const { container } = renderForm()
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="portal-users-widget"]')).toBeTruthy()
+    })
+
+    const secondaryRegion = container.querySelector('[data-crud-injection-region]')
+    expect(secondaryRegion).toBeTruthy()
+    expect(secondaryRegion?.querySelector('[data-testid="portal-users-widget"]')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

Consolidates two open PRs on the customer-accounts portal user surfaces.

| Replaces | What it fixes |
|---|---|
| #4403 | `Fixes #4362` — portal invite links to the person, not the company |
| #4412 | `Fixes #4400` — Portal users render as a full-width page |

## Why bundle them

Same module, same surface, no overlapping files — one review context instead of two.

## Verification

Local run after `yarn build:packages`:

- `packages/core` customer_accounts: **56 suites / 463 tests passing**
- `packages/ui`: **204 suites / 1647 tests passing** (#4412 reaches into `packages/ui`, including a new `CrudForm.groupInjectionColumn` test)

## Labels

The author's account has `read` permission and cannot apply labels. Suggested: `bug`, `review`, `needs-qa`, `priority-medium`, `risk-medium`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
