### PR TITLE
fix(create-app,cli): scaffolded apps run their own tooling

### DIFF
--- a/packages/cli/src/lib/__tests__/eject.test.ts
+++ b/packages/cli/src/lib/__tests__/eject.test.ts
@@ -362,4 +362,89 @@ describe('eject', () => {
       )
     })
   })
+
+  // Regression guards for #4272: standalone installs resolve getModulePaths'
+  // pkgBase to node_modules/<pkg>/dist/modules (compiled JS, no index.ts), so
+  // eject reported every module as "not marked as ejectable" and --list came up
+  // (nearly) empty. Ejection must prefer the shipped src/modules TypeScript.
+  describe('standalone installs (#4272)', () => {
+    function createStandaloneResolver(baseDir: string, options: { shipSrc: boolean }): PackageResolver {
+      const appDir = path.join(baseDir, 'app')
+      const modulesTsPath = path.join(appDir, 'src', 'modules.ts')
+      const packageRoot = path.join(baseDir, 'node_modules', '@open-mercato', 'core')
+      const distModuleDir = path.join(packageRoot, 'dist', 'modules', 'customers')
+      const srcModuleDir = path.join(packageRoot, 'src', 'modules', 'customers')
+
+      fs.mkdirSync(path.join(appDir, 'src'), { recursive: true })
+      fs.mkdirSync(distModuleDir, { recursive: true })
+      fs.writeFileSync(
+        path.join(appDir, 'src', 'modules.ts'),
+        "export const enabledModules = [{ id: 'customers', from: '@open-mercato/core' }]\n",
+      )
+      fs.writeFileSync(
+        path.join(distModuleDir, 'index.js'),
+        'var metadata = { title: "Customers", description: "Compiled", ejectable: true };\nexport { metadata };\n',
+      )
+      fs.writeFileSync(path.join(distModuleDir, 'index.js.map'), '{}\n')
+
+      if (options.shipSrc) {
+        fs.mkdirSync(srcModuleDir, { recursive: true })
+        fs.writeFileSync(
+          path.join(srcModuleDir, 'index.ts'),
+          "export const metadata = { title: 'Customers', description: 'Source', ejectable: true }\n",
+        )
+        fs.writeFileSync(path.join(srcModuleDir, 'acl.ts'), 'export const features = []\n')
+      }
+
+      return {
+        getAppDir: () => appDir,
+        getModulesConfigPath: () => modulesTsPath,
+        loadEnabledModules: () => [{ id: 'customers', from: '@open-mercato/core' }],
+        getModulePaths: () => ({
+          appBase: path.join(appDir, 'src', 'modules', 'customers'),
+          pkgBase: distModuleDir,
+        }),
+        getPackageRoot: () => packageRoot,
+      } as unknown as PackageResolver
+    }
+
+    it('lists core modules as ejectable when pkgBase points at dist/modules', () => {
+      const resolver = createStandaloneResolver(tmpDir, { shipSrc: true })
+
+      expect(listEjectableModules(resolver)).toEqual([
+        {
+          id: 'customers',
+          title: 'Customers',
+          description: 'Source',
+          from: '@open-mercato/core',
+        },
+      ])
+    })
+
+    it('ejects the shipped TypeScript sources, not the compiled dist output', () => {
+      const resolver = createStandaloneResolver(tmpDir, { shipSrc: true })
+      const appModuleDir = path.join(tmpDir, 'app', 'src', 'modules', 'customers')
+      const modulesTsPath = path.join(tmpDir, 'app', 'src', 'modules.ts')
+
+      ejectModule(resolver, 'customers')
+
+      expect(fs.existsSync(path.join(appModuleDir, 'index.ts'))).toBe(true)
+      expect(fs.existsSync(path.join(appModuleDir, 'acl.ts'))).toBe(true)
+      expect(fs.existsSync(path.join(appModuleDir, 'index.js'))).toBe(false)
+      expect(fs.readFileSync(modulesTsPath, 'utf8')).toContain("{ id: 'customers', from: '@app' }")
+    })
+
+    it('falls back to compiled index.js metadata for dist-only packages', () => {
+      const resolver = createStandaloneResolver(tmpDir, { shipSrc: false })
+
+      expect(listEjectableModules(resolver)).toEqual([
+        {
+          id: 'customers',
+          title: 'Customers',
+          description: 'Compiled',
+          from: '@open-mercato/core',
+        },
+      ])
+    })
+  })
 })

--- a/packages/cli/src/lib/eject.ts
+++ b/packages/cli/src/lib/eject.ts
@@ -194,12 +194,34 @@ type ResolvedModuleSource = {
   metadata: ModuleMetadata
 }
 
+// Standalone installs resolve getModulePaths' pkgBase to the package's
+// dist/modules tree when it exists (compiled JS, no index.ts), which made every
+// ejectable module read as "not ejectable" and eject copies of compiled output
+// (#4272). Prefer the shipped TypeScript sources under src/modules; fall back
+// to the resolved base for packages that ship dist only.
+function resolveModuleSourceBase(resolver: PackageResolver, entry: ModuleEntry): string {
+  const { pkgBase } = resolver.getModulePaths(entry)
+  const from = entry.from || '@open-mercato/core'
+  if (from === '@app') return pkgBase
+  const sourceBase = path.join(resolver.getPackageRoot(from), 'src', 'modules', entry.id)
+  if (path.resolve(sourceBase) !== path.resolve(pkgBase) && fs.existsSync(sourceBase)) {
+    return sourceBase
+  }
+  return pkgBase
+}
+
+function readModuleMetadata(moduleDir: string): ModuleMetadata {
+  const tsIndex = path.join(moduleDir, 'index.ts')
+  if (fs.existsSync(tsIndex)) return parseModuleMetadata(tsIndex)
+  return parseModuleMetadata(path.join(moduleDir, 'index.js'))
+}
+
 function resolveModuleSource(
   resolver: PackageResolver,
   entry: ModuleEntry,
 ): ResolvedModuleSource {
-  const { pkgBase } = resolver.getModulePaths(entry)
-  const fallbackMetadata = parseModuleMetadata(path.join(pkgBase, 'index.ts'))
+  const pkgBase = resolveModuleSourceBase(resolver, entry)
+  const fallbackMetadata = readModuleMetadata(pkgBase)
   const from = entry.from || '@open-mercato/core'
 
   if (from === '@app' || from === '@open-mercato/core') {

--- a/packages/create-app/src/lib/template-script-targets.test.ts
+++ b/packages/create-app/src/lib/template-script-targets.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+
+const TEMPLATE_DIR = new URL('../../template/', import.meta.url)
+const PACKAGE_JSON_TEMPLATE = new URL('package.json.template', TEMPLATE_DIR)
+
+function readScripts(): Record<string, string> {
+  const raw = fs.readFileSync(PACKAGE_JSON_TEMPLATE, 'utf8')
+  const parsed = JSON.parse(raw) as { scripts?: Record<string, string> }
+  return parsed.scripts ?? {}
+}
+
+// #4328: `yarn test`, `yarn lint`, and `yarn install-skills` failed on a clean
+// scaffold because the template's package.json pointed at files it did not ship
+// (and at `next lint`, removed in Next 16). Keep those targets honest.
+test('every file a template script references is shipped by the template', () => {
+  const scripts = readScripts()
+  const referenced: Array<{ script: string; file: string }> = []
+
+  for (const [name, command] of Object.entries(scripts)) {
+    const configMatch = command.match(/--config\s+([^\s]+)/)
+    if (configMatch && !configMatch[1].startsWith('.ai/')) {
+      referenced.push({ script: name, file: configMatch[1] })
+    }
+    const shMatch = command.match(/\b(?:sh|bash|node)\s+(\.\/)?(scripts\/[^\s]+)/)
+    if (shMatch) referenced.push({ script: name, file: shMatch[2] })
+  }
+
+  assert.ok(referenced.length > 0, 'expected the template to reference at least one script file')
+
+  for (const { script, file } of referenced) {
+    assert.ok(
+      fs.existsSync(new URL(file, TEMPLATE_DIR)),
+      `template script "${script}" references ${file}, which the template does not ship`,
+    )
+  }
+})
+
+test('lint does not use `next lint` (removed in Next 16) and a flat config ships', () => {
+  const scripts = readScripts()
+  assert.ok(scripts.lint, 'template must define a lint script')
+  assert.ok(
+    !/\bnext\s+lint\b/.test(scripts.lint),
+    '`next lint` was removed in Next 16 — the template must call the ESLint CLI instead',
+  )
+  assert.ok(
+    fs.existsSync(new URL('eslint.config.mjs', TEMPLATE_DIR)),
+    'template must ship an eslint.config.mjs so `yarn lint` works out of the box',
+  )
+})

--- a/packages/create-app/template/eslint.config.mjs
+++ b/packages/create-app/template/eslint.config.mjs
@@ -1,0 +1,30 @@
+// Flat ESLint config for a standalone Open Mercato app.
+// `next lint` was removed in Next 16, so `yarn lint` runs the ESLint CLI
+// against this config instead.
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+
+const ignores = [
+  'node_modules/**',
+  '.next/**',
+  '.mercato/**',
+  'dist/**',
+  'out/**',
+  'build/**',
+  'next-env.d.ts',
+]
+
+const ruleOverrides = {
+  'react/display-name': 'off',
+  'react-hooks/immutability': 'off',
+  'react-hooks/preserve-manual-memoization': 'off',
+  'react-hooks/purity': 'off',
+  'react-hooks/refs': 'off',
+  'react-hooks/set-state-in-effect': 'off',
+  'react-hooks/static-components': 'off',
+}
+
+export default [
+  ...nextCoreWebVitals,
+  { ignores },
+  { name: 'app/rule-overrides', rules: ruleOverrides },
+]

--- a/packages/create-app/template/jest.config.cjs
+++ b/packages/create-app/template/jest.config.cjs
@@ -1,0 +1,34 @@
+/** @type {import('jest').Config} */
+// Unit-test config for a standalone Open Mercato app.
+// Integration tests run through Playwright (`yarn test:integration:ephemeral`)
+// and are excluded here.
+module.exports = {
+  testEnvironment: 'node',
+  testTimeout: 30000,
+  rootDir: '.',
+  roots: ['<rootDir>/src'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+  moduleNameMapper: {
+    '^@/\\.mercato/(.*)$': '<rootDir>/.mercato/$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^#generated/(.*)$': '<rootDir>/.mercato/generated/$1',
+  },
+  transform: {
+    '^.+\\.(t|j)sx?$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          jsx: 'react-jsx',
+          module: 'commonjs',
+          moduleResolution: 'node',
+          esModuleInterop: true,
+          allowJs: true,
+          isolatedModules: true,
+        },
+        diagnostics: false,
+      },
+    ],
+  },
+  transformIgnorePatterns: ['/node_modules/(?!(@open-mercato)/)'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/.mercato/', '/.ai/qa/'],
+}

--- a/packages/create-app/template/package.json.template
+++ b/packages/create-app/template/package.json.template
@@ -16,7 +16,7 @@
     "dev:reset": "node ./scripts/dev-reset.mjs",
     "build": "yarn generate && cross-env NODE_OPTIONS=--max-old-space-size=8192 next build",
     "start": "mercato server start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "jest --config jest.config.cjs",
     "test:integration": "npx playwright test --config .ai/qa/tests/playwright.config.ts",

--- a/packages/create-app/template/scripts/install-skills.sh
+++ b/packages/create-app/template/scripts/install-skills.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Placeholder shipped by the bare scaffold.
+#
+# The real installer lives in the agentic overlay and is copied over this file
+# by `create-mercato-app` (agentic setup) or by `mercato agentic:init`. If you
+# are reading this message, that step has not run for this app yet, so there is
+# nothing to install skills from.
+set -e
+
+cat <<'MESSAGE'
+Agent skills are not set up for this app yet.
+
+`yarn install-skills` installs the shared open-mercato/skills collection, which
+requires the agentic setup files. Run:
+
+    yarn mercato agentic:init
+
+then re-run `yarn install-skills`. (Scaffolding with --skip-agentic-setup or
+--agents none intentionally leaves this app without agent tooling.)
+MESSAGE
+
+exit 1


### PR DESCRIPTION
## Summary

Consolidates two open PRs that both make a freshly scaffolded app work out of the box.

| Replaces | What it fixes |
|---|---|
| #4416 | `Fixes #4272` — `eject` reads module metadata from shipped sources, not the app tree |
| #4419 | `Fixes #4328` — `yarn test` / `lint` / `install-skills` work on scaffolded apps |

## Why bundle them

Both answer the same question — "does a generated app actually run its own tooling?" — and share no files, so the merge is mechanical.

## Verification

Local run after `yarn build:packages`:

- `packages/create-app`: **109 tests passing**
- `packages/cli`: **64 suites / 1217 tests passing**

## Labels

The author's account has `read` permission and cannot apply labels. Suggested: `bug`, `review`, `skip-qa`, `priority-low`, `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
