### PR TITLE
fix(workflows): keep transition activity ids editable (follow-up to #4460)

### DIFF
--- a/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
@@ -76,8 +76,38 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
   const t = useT()
   const [configDrafts, setConfigDrafts] = React.useState<Record<string, ConfigDraft>>({})
 
+  // Drafts are keyed by identity (not by position) so an in-progress edit
+  // follows its activity across reordering. Both ids are user-editable, so the
+  // key has to be re-mapped whenever one of them is renamed.
   const configDraftKey = (transition: Transition, activity: Activity) =>
     `${transition.transitionId}:${activity.activityId}`
+
+  const renameConfigDraft = (previousKey: string, nextKey: string) => {
+    if (previousKey === nextKey) return
+    setConfigDrafts((drafts) => {
+      const draft = drafts[previousKey]
+      if (!draft) return drafts
+      const next = { ...drafts }
+      delete next[previousKey]
+      next[nextKey] = draft
+      return next
+    })
+  }
+
+  const renameTransitionConfigDrafts = (previousTransitionId: string, nextTransitionId: string) => {
+    if (previousTransitionId === nextTransitionId) return
+    setConfigDrafts((drafts) => {
+      const previousPrefix = `${previousTransitionId}:`
+      const affected = Object.keys(drafts).filter((key) => key.startsWith(previousPrefix))
+      if (!affected.length) return drafts
+      const next = { ...drafts }
+      for (const key of affected) {
+        next[`${nextTransitionId}:${key.slice(previousPrefix.length)}`] = drafts[key]
+        delete next[key]
+      }
+      return next
+    })
+  }
 
   const handleConfigTextChange = (
     transitionIndex: number,
@@ -135,8 +165,12 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
 
   const updateTransition = (index: number, field: keyof Transition, fieldValue: any) => {
     const updated = [...value]
-    updated[index] = { ...updated[index], [field]: fieldValue }
+    const previous = updated[index]
+    updated[index] = { ...previous, [field]: fieldValue }
     onChange(updated)
+    if (field === 'transitionId') {
+      renameTransitionConfigDrafts(previous.transitionId, String(fieldValue))
+    }
   }
 
   const removeTransition = (index: number) => {
@@ -178,9 +212,14 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
   const updateActivity = (transitionIndex: number, activityIndex: number, field: keyof Activity, fieldValue: any) => {
     const updated = [...value]
     const activities = [...(updated[transitionIndex].activities || [])]
-    activities[activityIndex] = { ...activities[activityIndex], [field]: fieldValue }
+    const previousActivity = activities[activityIndex]
+    activities[activityIndex] = { ...previousActivity, [field]: fieldValue }
     updated[transitionIndex] = { ...updated[transitionIndex], activities }
     onChange(updated)
+    if (field === 'activityId') {
+      const transitionId = updated[transitionIndex].transitionId
+      renameConfigDraft(`${transitionId}:${previousActivity.activityId}`, `${transitionId}:${String(fieldValue)}`)
+    }
   }
 
   const updateRetryPolicy = (transitionIndex: number, activityIndex: number, field: string, fieldValue: any) => {
@@ -423,7 +462,7 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
                     const draftKey = configDraftKey(transition, activity)
                     const configDraft = configDrafts[draftKey]
                     return (
-                      <div key={draftKey} className="p-3 border rounded-md bg-muted shadow-sm border-l-4 border-l-green-500">
+                      <div key={activityIndex} className="p-3 border rounded-md bg-muted shadow-sm border-l-4 border-l-green-500">
                         <div className="space-y-2">
                         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                           <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-2">

--- a/packages/core/src/modules/workflows/components/__tests__/TransitionsEditor.idFocus.test.tsx
+++ b/packages/core/src/modules/workflows/components/__tests__/TransitionsEditor.idFocus.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallbackOrParams?: unknown) =>
+    typeof fallbackOrParams === 'string' ? fallbackOrParams : key,
+}))
+
+import { TransitionsEditor } from '../TransitionsEditor'
+
+function Harness() {
+  const [transitions, setTransitions] = React.useState([
+    {
+      transitionId: 'transition_1',
+      transitionName: 'Transition 1',
+      fromStepId: 'start',
+      toStepId: 'end',
+      trigger: 'auto',
+      activities: [
+        {
+          activityId: 'call_api_1',
+          activityName: 'Call API 1',
+          activityType: 'CALL_API',
+          config: { endpoint: '/api/one' },
+        },
+      ],
+    },
+  ])
+  return (
+    <TransitionsEditor
+      value={transitions}
+      onChange={setTransitions}
+      steps={[
+        { stepId: 'start', stepName: 'Start' },
+        { stepId: 'end', stepName: 'End' },
+      ]}
+    />
+  )
+}
+
+const activityIdInput = () =>
+  document.getElementById('activity-0-0-id') as HTMLInputElement
+
+const configTextarea = () =>
+  document.getElementById('activity-0-0-config') as HTMLTextAreaElement
+
+describe('TransitionsEditor activity identity fields', () => {
+  it('keeps the activity id input mounted and focused while typing', () => {
+    render(<Harness />)
+    const before = activityIdInput()
+    before.focus()
+    expect(document.activeElement).toBe(before)
+
+    fireEvent.change(before, { target: { value: 'call_api_1x' } })
+
+    const after = activityIdInput()
+    expect(after).toHaveValue('call_api_1x')
+    expect(after).toBe(before)
+    expect(document.activeElement).toBe(after)
+  })
+
+  it('keeps an in-progress config draft when the activity id is edited', () => {
+    render(<Harness />)
+    fireEvent.change(configTextarea(), { target: { value: '{"endpoint": ' } })
+    expect(configTextarea()).toHaveValue('{"endpoint": ')
+
+    fireEvent.change(activityIdInput(), { target: { value: 'call_api_renamed' } })
+
+    expect(configTextarea()).toHaveValue('{"endpoint": ')
+  })
+
+  it('keeps an in-progress config draft when the transition id is edited', () => {
+    render(<Harness />)
+    fireEvent.change(configTextarea(), { target: { value: '{"endpoint": ' } })
+
+    const transitionIdInput = document.getElementById('transition-0-id') as HTMLInputElement
+    transitionIdInput.focus()
+    fireEvent.change(transitionIdInput, { target: { value: 'transition_renamed' } })
+
+    expect(document.activeElement).toBe(document.getElementById('transition-0-id'))
+    expect(configTextarea()).toHaveValue('{"endpoint": ')
+  })
+})


### PR DESCRIPTION
Follow-up fix targeting the `carry/pr-4449-ready` branch of #4460, so it can be merged into that PR before it lands on `develop`.

## Problem

The carry-forward commit `ecafdfac` ("keep transition config JSON editable") changed the rendered activity block in `TransitionsEditor` to `key={`${transitionId}:${activityId}`}`. Both ids are edited through plain inputs **inside that same block**, so:

1. **Activity ID / Transition ID become effectively uneditable.** Every keystroke changes the React key → React unmounts and remounts the whole activity block → the input loses focus after a single character. This is the same class of bug the PR set out to fix for the config textarea (#4234), just moved to the id fields.
2. **An in-progress config draft is lost when the activity is renamed.** The draft map is keyed by the same string, so renaming re-keys the draft away and the textarea snaps back to the stored config — the "invalid intermediate edit silently reverts" symptom from #4234.

Baseline check: the focus assertion passes on `develop` (where the key was positional) and fails on `carry/pr-4449-ready`, so this is a regression introduced by the carry-forward commit, not pre-existing behavior.

## Fix

- Render with a positional key again (`key={activityIndex}`), which is stable while the user types into the id fields.
- Keep drafts keyed by identity (`transitionId:activityId`) so an in-progress edit still follows its activity across reordering — the behavior #4460's own reorder test covers — and re-map that key when either id is renamed (`renameConfigDraft` / `renameTransitionConfigDrafts`).

## Tests

New `TransitionsEditor.idFocus.test.tsx` (3 cases), each verified to fail on the unfixed branch and pass with the fix:

- the activity id input stays mounted and focused while typing
- an in-progress config draft survives an activity rename
- an in-progress config draft survives a transition rename (and the transition id input keeps focus)

## Verification

- `yarn workspace @open-mercato/core test src/modules/workflows src/__tests__/shipped-workflow-activity-config.test.ts` — 48 suites / 677 tests passed
- `yarn workspace @open-mercato/core typecheck` — passed
- `yarn lint` — passed
- Runner: local

🤖 Generated with [Claude Code](https://claude.com/claude-code)