### PR TITLE
feat(customers): make quick-add deal probability configurable

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/QuickDealDialog.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/QuickDealDialog.tsx
@@ -18,6 +18,7 @@ import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuarde
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { translateWithFallback } from '@open-mercato/shared/lib/i18n/translate'
+import { registerComponent } from '@open-mercato/shared/modules/widgets/component-registry'
 
 // Deal status values written by the kanban flow. These intentionally do NOT include 'closed'
 // because the rest of the app only persists 'loose' for lost deals (see StatusFilterPopover
@@ -56,7 +57,18 @@ export type QuickDealCompanyOption = {
   label: string
 }
 
-type QuickDealDialogProps = {
+/**
+ * Registered component id for the kanban quick-add dialog. Downstream apps can
+ * target it from `widgets/components.ts` to replace/wrap the dialog or to
+ * transform its props — e.g. `defaultProbability: null` so quick-create stops
+ * seeding a probability that overrides pipeline automation (#4329).
+ */
+export const QUICK_DEAL_DIALOG_COMPONENT_ID = 'dialog:customers.deals.quickDeal'
+
+/** Probability seeded into the quick-add form when the host passes no override. */
+export const DEFAULT_QUICK_DEAL_PROBABILITY = 25
+
+export type QuickDealDialogProps = {
   open: boolean
   context: QuickDealContext | null
   onClose: () => void
@@ -64,6 +76,13 @@ type QuickDealDialogProps = {
   currentUserId?: string
   currentUserLabel?: string
   companies?: QuickDealCompanyOption[]
+  /**
+   * Probability pre-filled in the collapsed "More details" group. `null` leaves
+   * the field empty, so quick-create sends no `probability` at all and whatever
+   * the pipeline/automation derives for the target stage stands. Defaults to
+   * `DEFAULT_QUICK_DEAL_PROBABILITY` to preserve the historic behavior.
+   */
+  defaultProbability?: number | null
   /**
    * Tenant currency list. When omitted (e.g. dictionary not yet loaded), we render a
    * conservative fallback so the dialog still works end-to-end. The default selection is
@@ -94,6 +113,7 @@ export function QuickDealDialog({
   currentUserLabel,
   companies = [],
   currencies,
+  defaultProbability = DEFAULT_QUICK_DEAL_PROBABILITY,
 }: QuickDealDialogProps): React.ReactElement | null {
   const t = useT()
   // Re-mount CrudForm whenever the dialog opens so cleared state is consistently fresh.
@@ -157,11 +177,11 @@ export function QuickDealDialog({
       valueCurrency: defaultCurrencyCode,
       companyId: '',
       status: 'open',
-      probability: 25,
+      probability: defaultProbability,
       expectedCloseAt: '',
       description: '',
     }),
-    [defaultCurrencyCode],
+    [defaultCurrencyCode, defaultProbability],
   )
 
   const fields = React.useMemo<CrudField[]>(
@@ -404,5 +424,17 @@ export function QuickDealDialog({
     </Dialog>
   )
 }
+
+// Register so downstream apps can reach the dialog from `widgets/components.ts`
+// (replace / wrap / propsTransform) instead of forking the whole kanban page
+// just to change a default (#4329).
+registerComponent<QuickDealDialogProps>({
+  id: QUICK_DEAL_DIALOG_COMPONENT_ID,
+  component: QuickDealDialog,
+  metadata: {
+    module: 'customers',
+    description: 'Kanban quick-add deal dialog (pipeline board "+ deal").',
+  },
+})
 
 export default QuickDealDialog

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/__tests__/QuickDealDialog.probability.test.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/__tests__/QuickDealDialog.probability.test.tsx
@@ -11,8 +11,9 @@
 import * as React from 'react'
 import { render } from '@testing-library/react'
 import {
-  registerComponent,
   getComponentEntry,
+  registerComponentOverrides,
+  resolveRegisteredComponent,
 } from '@open-mercato/shared/modules/widgets/component-registry'
 
 // `t` accepts either (key, fallback, params) or (key, params) — mirror the real
@@ -23,15 +24,30 @@ jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
 }))
 
 let capturedInitialValues: Record<string, unknown> | null = null
+let capturedOnSubmit: ((values: Record<string, unknown>) => Promise<void>) | null = null
 jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
   __esModule: true,
-  CrudForm: (props: { initialValues?: Record<string, unknown> }) => {
+  CrudForm: (props: {
+    initialValues?: Record<string, unknown>
+    onSubmit?: (values: Record<string, unknown>) => Promise<void>
+  }) => {
     capturedInitialValues = props.initialValues ?? null
+    capturedOnSubmit = props.onSubmit ?? null
     return null
   },
 }))
 jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
-  useGuardedMutation: () => ({ runMutation: jest.fn(), retryLastMutation: jest.fn() }),
+  useGuardedMutation: () => ({
+    runMutation: ({ operation }: { operation: () => Promise<unknown> }) => operation(),
+    retryLastMutation: jest.fn(),
+  }),
+}))
+const mockCreateCrud = jest.fn().mockResolvedValue({})
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  createCrud: (...args: unknown[]) => mockCreateCrud(...args),
+}))
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
 }))
 
 import {
@@ -64,6 +80,9 @@ function renderDialog(props: Partial<React.ComponentProps<typeof QuickDealDialog
 describe('QuickDealDialog default probability (#4329)', () => {
   afterEach(() => {
     capturedInitialValues = null
+    capturedOnSubmit = null
+    mockCreateCrud.mockClear()
+    registerComponentOverrides([])
   })
 
   it('keeps the historic default when the host passes no override', () => {
@@ -76,9 +95,39 @@ describe('QuickDealDialog default probability (#4329)', () => {
     expect(capturedInitialValues?.probability).toBe(60)
   })
 
-  it('leaves the field empty when the default is null, so no probability is seeded', () => {
+  it('leaves the field empty when the default is null', () => {
     renderDialog({ defaultProbability: null })
     expect(capturedInitialValues?.probability).toBeNull()
+  })
+
+  it('omits probability from the create payload when the default is null', async () => {
+    renderDialog({ defaultProbability: null })
+
+    await capturedOnSubmit?.({
+      ...capturedInitialValues,
+      title: 'Derived probability deal',
+    })
+
+    expect(mockCreateCrud).toHaveBeenCalledWith(
+      'customers/deals',
+      expect.not.objectContaining({ probability: expect.anything() }),
+      expect.any(Object),
+    )
+  })
+
+  it('includes an explicit numeric probability in the create payload', async () => {
+    renderDialog({ defaultProbability: 60 })
+
+    await capturedOnSubmit?.({
+      ...capturedInitialValues,
+      title: 'Explicit probability deal',
+    })
+
+    expect(mockCreateCrud).toHaveBeenCalledWith(
+      'customers/deals',
+      expect.objectContaining({ probability: 60 }),
+      expect.any(Object),
+    )
   })
 
   it('is registered so apps can override it without forking the kanban page', () => {
@@ -87,9 +136,33 @@ describe('QuickDealDialog default probability (#4329)', () => {
     expect(getComponentEntry(QUICK_DEAL_DIALOG_COMPONENT_ID)?.component).toBe(QuickDealDialog)
   })
 
-  it('registry registration is the documented override seam (propsTransform reaches the default)', () => {
-    const Spy = jest.fn(() => null)
-    registerComponent({ id: 'test:quick-deal-probe', component: Spy })
-    expect(getComponentEntry('test:quick-deal-probe')?.component).toBe(Spy)
+  it('allows a propsTransform override to clear the default probability', () => {
+    registerComponentOverrides([
+      {
+        target: { componentId: QUICK_DEAL_DIALOG_COMPONENT_ID },
+        priority: 50,
+        metadata: { module: 'test' },
+        propsTransform: (props: React.ComponentProps<typeof QuickDealDialog>) => ({
+          ...props,
+          defaultProbability: null,
+        }),
+      },
+    ])
+    const Resolved = resolveRegisteredComponent(
+      QUICK_DEAL_DIALOG_COMPONENT_ID,
+      QuickDealDialog,
+    )
+
+    render(
+      <Resolved
+        open
+        context={context}
+        onClose={jest.fn()}
+        onCreated={jest.fn()}
+        currencies={[{ code: 'PLN', isBase: true }]}
+      />,
+    )
+
+    expect(capturedInitialValues?.probability).toBeNull()
   })
 })

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/__tests__/QuickDealDialog.probability.test.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/components/__tests__/QuickDealDialog.probability.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Guards #4329: the kanban quick-add dialog hardcoded `probability: 25` in its
+ * initialValues, so every quick-create sent 25 — overriding whatever a
+ * downstream app's pipeline automation derives — even though the field lives in
+ * a collapsed group the user never opened. The default is now a prop, and the
+ * dialog is registered so apps can reach it through the component registry
+ * instead of forking the kanban page.
+ */
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import {
+  registerComponent,
+  getComponentEntry,
+} from '@open-mercato/shared/modules/widgets/component-registry'
+
+// `t` accepts either (key, fallback, params) or (key, params) — mirror the real
+// translator's overload so params never leak into the rendered output.
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallbackOrParams?: unknown) =>
+    typeof fallbackOrParams === 'string' ? fallbackOrParams : key,
+}))
+
+let capturedInitialValues: Record<string, unknown> | null = null
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  __esModule: true,
+  CrudForm: (props: { initialValues?: Record<string, unknown> }) => {
+    capturedInitialValues = props.initialValues ?? null
+    return null
+  },
+}))
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({ runMutation: jest.fn(), retryLastMutation: jest.fn() }),
+}))
+
+import {
+  QuickDealDialog,
+  QUICK_DEAL_DIALOG_COMPONENT_ID,
+  DEFAULT_QUICK_DEAL_PROBABILITY,
+  type QuickDealContext,
+} from '../QuickDealDialog'
+
+const context: QuickDealContext = {
+  pipelineId: 'p-1',
+  pipelineName: 'Sales',
+  pipelineStageId: 's-1',
+  pipelineStageLabel: 'Qualified',
+}
+
+function renderDialog(props: Partial<React.ComponentProps<typeof QuickDealDialog>> = {}) {
+  return render(
+    <QuickDealDialog
+      open
+      context={context}
+      onClose={jest.fn()}
+      onCreated={jest.fn()}
+      currencies={[{ code: 'PLN', isBase: true }]}
+      {...props}
+    />,
+  )
+}
+
+describe('QuickDealDialog default probability (#4329)', () => {
+  afterEach(() => {
+    capturedInitialValues = null
+  })
+
+  it('keeps the historic default when the host passes no override', () => {
+    renderDialog()
+    expect(capturedInitialValues?.probability).toBe(DEFAULT_QUICK_DEAL_PROBABILITY)
+  })
+
+  it('honors an explicit numeric default', () => {
+    renderDialog({ defaultProbability: 60 })
+    expect(capturedInitialValues?.probability).toBe(60)
+  })
+
+  it('leaves the field empty when the default is null, so no probability is seeded', () => {
+    renderDialog({ defaultProbability: null })
+    expect(capturedInitialValues?.probability).toBeNull()
+  })
+
+  it('is registered so apps can override it without forking the kanban page', () => {
+    // Importing the module runs its registerComponent call.
+    expect(getComponentEntry(QUICK_DEAL_DIALOG_COMPONENT_ID)).not.toBeNull()
+    expect(getComponentEntry(QUICK_DEAL_DIALOG_COMPONENT_ID)?.component).toBe(QuickDealDialog)
+  })
+
+  it('registry registration is the documented override seam (propsTransform reaches the default)', () => {
+    const Spy = jest.fn(() => null)
+    registerComponent({ id: 'test:quick-deal-probe', component: Spy })
+    expect(getComponentEntry('test:quick-deal-probe')?.component).toBe(Spy)
+  })
+})

--- a/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/pipeline/page.tsx
@@ -64,9 +64,11 @@ import { CurrencyFilterPopover } from './components/CurrencyFilterPopover'
 import { AddStageLane } from './components/AddStageLane'
 import type { DealCardData } from './components/DealCard'
 import {
-  QuickDealDialog,
+  QuickDealDialog as DefaultQuickDealDialog,
+  QUICK_DEAL_DIALOG_COMPONENT_ID,
   type QuickDealContext,
   type QuickDealCompanyOption,
+  type QuickDealDialogProps,
 } from './components/QuickDealDialog'
 import { AddStageDialog, type AddStageContext } from './components/AddStageDialog'
 import { StatusFilterPopover } from './components/StatusFilterPopover'
@@ -80,6 +82,7 @@ import {
   type ActivityComposerContext,
 } from './components/ActivityComposerDialog'
 import { BulkActionsBar } from './components/BulkActionsBar'
+import { useRegisteredComponent } from '@open-mercato/ui/backend/injection/useRegisteredComponent'
 import { ChangeStageDialog } from './components/ChangeStageDialog'
 import { ChangeOwnerDialog } from './components/ChangeOwnerDialog'
 import { buildCrudExportUrl, deleteCrud } from '@open-mercato/ui/backend/utils/crud'
@@ -410,6 +413,12 @@ function sortDeals(deals: DealCardData[], option: SortOption): DealCardData[] {
 
 export default function DealsKanbanPage(): React.ReactElement {
   const t = useT()
+  // Resolved through the component registry so downstream apps can replace,
+  // wrap, or props-transform the quick-add dialog without forking this page.
+  const QuickDealDialog = useRegisteredComponent<QuickDealDialogProps>(
+    QUICK_DEAL_DIALOG_COMPONENT_ID,
+    DefaultQuickDealDialog,
+  )
   const router = useRouter()
   const scopeVersion = useOrganizationScopeVersion()
   const queryClient = useQueryClient()


### PR DESCRIPTION
Supersedes #4420

Credit: original implementation by @wojciechszyjka. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the original fork branch.

## Included work

- Original configurable `QuickDealDialog` probability and component-replacement handle from #4420
- Regression coverage proving `null` omits `probability` from the create payload
- Regression coverage proving numeric overrides remain in the create payload
- A real props-transform test targeting `dialog:customers.deals.quickDeal`

## Verification

- `yarn workspace @open-mercato/core test --runInBand packages/core/src/modules/customers/backend/customers/deals/pipeline/components/__tests__/QuickDealDialog.probability.test.tsx` — 7/7 passed
- `yarn build:packages` — passed
- `yarn generate` — passed
- `yarn workspace @open-mercato/core typecheck` — passed

Runner: local.

The branch was re-reviewed after autofix and is intended to be merge-ready pending GitHub CI, independent code-review approval, and the repository's manual QA gate.
