### PR TITLE
fix(audit_logs): return 400 for malformed uuid list filters (#3819)

### DIFF
--- a/packages/core/src/modules/audit_logs/api/__tests__/access.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/access.route.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
 import { GET } from '@open-mercato/core/modules/audit_logs/api/audit-logs/access/route'
+import { accessLogListSchema } from '@open-mercato/core/modules/audit_logs/data/validators'
 
 const mockRbac = { userHasAllFeatures: jest.fn() }
 const mockAccess = { list: jest.fn() }
@@ -114,5 +115,22 @@ describe('GET /api/audit_logs/audit-logs/access', () => {
       page: 2,
       pageSize: 25,
     }))
+  })
+
+  it('returns 400 (not 500) when a filter fails uuid validation', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    })
+    const parsed = accessLogListSchema.safeParse({ actorUserId: 'not-a-uuid' })
+    if (parsed.success) throw new Error('expected accessLogListSchema to reject a non-uuid actorUserId')
+    mockAccess.list.mockRejectedValueOnce(parsed.error)
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/access?actorUserId=not-a-uuid'))
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.error).toBe('Validation failed')
   })
 })

--- a/packages/core/src/modules/audit_logs/api/__tests__/actions.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/actions.route.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
 import { GET } from '@open-mercato/core/modules/audit_logs/api/audit-logs/actions/route'
+import { actionLogListSchema } from '@open-mercato/core/modules/audit_logs/data/validators'
 
 const mockRbac = { userHasAllFeatures: jest.fn() }
 const mockActionLogs = { list: jest.fn() }
@@ -203,5 +204,22 @@ describe('GET /api/audit_logs/audit-logs/actions', () => {
     expect(mockActionLogs.list).toHaveBeenCalledWith(expect.objectContaining({
       undoableOnly: true,
     }))
+  })
+
+  it('returns 400 (not 500) when a filter fails uuid validation', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    })
+    const parsed = actionLogListSchema.safeParse({ actorUserId: 'not-a-uuid' })
+    if (parsed.success) throw new Error('expected actionLogListSchema to reject a non-uuid actorUserId')
+    mockActionLogs.list.mockRejectedValueOnce(parsed.error)
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/actions?actorUserId=not-a-uuid'))
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.error).toBe('Validation failed')
   })
 })

--- a/packages/core/src/modules/audit_logs/api/__tests__/export.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/export.route.test.ts
@@ -1,0 +1,71 @@
+/** @jest-environment node */
+import { GET } from '@open-mercato/core/modules/audit_logs/api/audit-logs/actions/export/route'
+import { actionLogListSchema } from '@open-mercato/core/modules/audit_logs/data/validators'
+
+const mockRbac = { userHasAllFeatures: jest.fn() }
+const mockActionLogs = { list: jest.fn() }
+const mockEm = {}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => {
+      if (token === 'rbacService') return mockRbac
+      if (token === 'actionLogService') return mockActionLogs
+      if (token === 'em') return mockEm
+      return null
+    },
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveFeatureCheckContext: jest.fn(),
+}))
+
+jest.mock('@open-mercato/core/modules/audit_logs/api/audit-logs/display', () => ({
+  loadAuditLogDisplayMaps: jest.fn(),
+}))
+
+function makeRequest(url: string) {
+  return new Request(url, { method: 'GET' })
+}
+
+describe('GET /api/audit_logs/audit-logs/actions/export', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    const { resolveFeatureCheckContext } = await import('@open-mercato/core/modules/directory/utils/organizationScope')
+    ;(resolveFeatureCheckContext as jest.Mock).mockResolvedValue({
+      organizationId: 'org-1',
+      scope: { allowedIds: null },
+    })
+    mockRbac.userHasAllFeatures.mockResolvedValue(false)
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue(null)
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/actions/export'))
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 (not 500) when a filter fails uuid validation', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    })
+    const parsed = actionLogListSchema.safeParse({ actorUserId: 'not-a-uuid' })
+    if (parsed.success) throw new Error('expected actionLogListSchema to reject a non-uuid actorUserId')
+    mockActionLogs.list.mockRejectedValueOnce(parsed.error)
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/actions/export?actorUserId=not-a-uuid'))
+    expect(res.status).toBe(400)
+    const data = await res.json()
+    expect(data.error).toBe('Validation failed')
+  })
+})

--- a/packages/core/src/modules/audit_logs/api/audit-logs/access/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/access/route.ts
@@ -109,18 +109,26 @@ export async function GET(req: Request) {
     actorUserId = actorQuery
   }
 
-  const list = await accessLogs.list({
-    tenantId: auth.tenantId ?? undefined,
-    organizationId: organizationId ?? undefined,
-    actorUserId,
-    resourceKind: resourceKind ?? undefined,
-    accessType: accessType ?? undefined,
-    page,
-    pageSize,
-    limit: url.searchParams.get('limit') ? parseNumber(url.searchParams.get('limit'), { min: 1, max: 200, fallback: pageSize }) : undefined,
-    before,
-    after,
-  })
+  let list: Awaited<ReturnType<AccessLogService['list']>>
+  try {
+    list = await accessLogs.list({
+      tenantId: auth.tenantId ?? undefined,
+      organizationId: organizationId ?? undefined,
+      actorUserId,
+      resourceKind: resourceKind ?? undefined,
+      accessType: accessType ?? undefined,
+      page,
+      pageSize,
+      limit: url.searchParams.get('limit') ? parseNumber(url.searchParams.get('limit'), { min: 1, max: 200, fallback: pageSize }) : undefined,
+      before,
+      after,
+    })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Validation failed', details: err.issues }, { status: 400 })
+    }
+    throw err
+  }
 
   const displayMaps = await loadAuditLogDisplayMaps(em, {
     userIds: list.items.map((entry) => entry.actorUserId).filter((value): value is string => !!value),

--- a/packages/core/src/modules/audit_logs/api/audit-logs/actions/export/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/actions/export/route.ts
@@ -158,23 +158,31 @@ export async function GET(req: Request) {
     }
   }
 
-  const entriesResult = await actionLogs.list({
-    tenantId: auth.tenantId ?? undefined,
-    organizationId: organizationId ?? undefined,
-    actorUserId,
-    actorUserIds,
-    resourceKind,
-    resourceId,
-    actionTypes,
-    fieldNames,
-    includeRelated,
-    undoableOnly,
-    sortField,
-    sortDir,
-    limit,
-    before,
-    after,
-  })
+  let entriesResult: Awaited<ReturnType<ActionLogService['list']>>
+  try {
+    entriesResult = await actionLogs.list({
+      tenantId: auth.tenantId ?? undefined,
+      organizationId: organizationId ?? undefined,
+      actorUserId,
+      actorUserIds,
+      resourceKind,
+      resourceId,
+      actionTypes,
+      fieldNames,
+      includeRelated,
+      undoableOnly,
+      sortField,
+      sortDir,
+      limit,
+      before,
+      after,
+    })
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Validation failed', details: err.issues }, { status: 400 })
+    }
+    throw err
+  }
   const entries = entriesResult.items
 
   const displayMaps = await loadAuditLogDisplayMaps(em, {

--- a/packages/core/src/modules/audit_logs/api/audit-logs/actions/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/actions/route.ts
@@ -226,7 +226,15 @@ export async function GET(req: Request) {
   // includeTotal flag is retained for backward compatibility but page-based pagination
   // always returns total/totalPages from the list query's findAndCount.
   void includeTotal
-  const list = await actionLogs.list(listQuery)
+  let list: Awaited<ReturnType<ActionLogService['list']>>
+  try {
+    list = await actionLogs.list(listQuery)
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: 'Validation failed', details: err.issues }, { status: 400 })
+    }
+    throw err
+  }
 
   const displayMaps = await loadAuditLogDisplayMaps(em, {
     userIds: list.items.map((entry: any) => entry.actorUserId).filter((value: any): value is string => !!value),


### PR DESCRIPTION
## Summary

The audit-logs read routes forward a caller-supplied `actorUserId` (and, under a null org scope, `organizationId`) straight into `service.list()`, which validates them via `accessLogListSchema` / `actionLogListSchema` (`actorUserId: uuid.optional()`, `organizationId: uuid.optional()`). A non-UUID value throws an uncaught `ZodError`, surfacing as an **unhandled 500 instead of a 400**. No data exposure — a pure robustness / error-handling defect (issue #3819, `security` / `priority-low` / `risk-low`).

## Root cause

```
GET handler → service.list({ actorUserId, organizationId, ... })
                   └── <schema>.parse(...)   // uuid.optional()
                        └── ZodError ──(uncaught)──▶ HTTP 500
```

The handler never validates the input itself; validation happens deep inside the service and no `try/catch` maps it to a 400.

## Change

Wrap **only** the `service.list()` call in the three read routes and map `ZodError → 400`, matching the existing idiom in `customers/api/activities` and `inbox_ops/api/proposals`:

```ts
let list: Awaited<ReturnType<AccessLogService['list']>>
try {
  list = await accessLogs.list({ ... })
} catch (err) {
  if (err instanceof z.ZodError) {
    return NextResponse.json({ error: 'Validation failed', details: err.issues }, { status: 400 })
  }
  throw err // all other errors keep current behavior (framework 500)
}
```

Applied to all three read routes (root cause — the same bug exists in each):

- `packages/core/src/modules/audit_logs/api/audit-logs/access/route.ts`
- `packages/core/src/modules/audit_logs/api/audit-logs/actions/route.ts`
- `packages/core/src/modules/audit_logs/api/audit-logs/actions/export/route.ts`

**Why route-level catch over an `actorUserId`-only check:** the bug is not limited to `actorUserId`. Under a null org scope (`scope.allowedIds === null`, e.g. superadmin / all-orgs), the raw query `organizationId` passes the scope check unvalidated and reaches the same `.parse()`, where it is validated as `uuid.optional()` — so a non-UUID `organizationId` **also** throws → 500. A targeted `actorUserId`-only check would be a partial fix; catching the `ZodError` remaps every malformed uuid filter uniformly. The only `.parse()` in the handler chain runs on the list query (user input + auth-derived, guaranteed-valid values), so there is no realistic server-side `ZodError` to mis-map, and non-`ZodError` errors are re-thrown unchanged.

## Behavior

| Input | Before | After |
|---|---|---|
| valid UUID / no filter | 200 | 200 (unchanged) |
| `?actorUserId=abc` (non-UUID) | **500** | **400** `{ error: "Validation failed", details }` |
| `?organizationId=abc` (superadmin, null scope) | **500** | **400** |
| genuine server error (DB, etc.) | 500 | 500 (re-thrown, unchanged) |

## Tests

- `access.route.test.ts` / `actions.route.test.ts`: new case where the mocked `list` rejects with a **real** `ZodError` built from the actual schema → asserts `status === 400`.
- New `export.route.test.ts`: covers the export route (401 + 400).
- Full suite: 13/13 passing; `@open-mercato/core` typecheck clean.

## Backward compatibility

No wire change for valid callers — only 400 instead of 500 for malformed input.

Closes #3819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
