### PR TITLE
test(api_keys): guard bounded bcrypt candidate loop invariant (#3812)

### DIFF
--- a/packages/core/src/modules/api_keys/data/entities.ts
+++ b/packages/core/src/modules/api_keys/data/entities.ts
@@ -1,6 +1,9 @@
 import { Entity, Index, PrimaryKey, Property, Unique } from '@mikro-orm/decorators/legacy'
 
 @Entity({ tableName: 'api_keys' })
+// The unique keyPrefix bounds the bcrypt candidate loop in findApiKeyBySecret to at
+// most one live row. Do not drop this constraint or widen the prefix space without
+// re-evaluating that loop's per-request cost (see #3812).
 @Unique({ properties: ['keyPrefix'] })
 @Index({
   name: 'api_keys_opencode_session_id_uq',

--- a/packages/core/src/modules/api_keys/services/__tests__/apiKeyService.prefixCandidateGuard.test.ts
+++ b/packages/core/src/modules/api_keys/services/__tests__/apiKeyService.prefixCandidateGuard.test.ts
@@ -1,0 +1,41 @@
+import { MetadataStorage } from '@mikro-orm/core'
+import { findApiKeyBySecret, generateApiKeySecret } from '../apiKeyService'
+import { ApiKey } from '../../data/entities'
+
+// Regression guard for #3812: findApiKeyBySecret bcrypt-compares every live row that
+// shares the keyPrefix. The candidate set stays bounded only because the keyPrefix is
+// unique, has a fixed width, and the lookup filters on keyPrefix + deletedAt: null.
+// These tests fail if a refactor drops the unique constraint, widens the prefix space,
+// or drops the soft-delete filter.
+describe('api-key prefix candidate loop — bounded-set invariant (#3812)', () => {
+  it('keeps the unique constraint on keyPrefix (bounds the candidate set to <=1 live row)', () => {
+    const path = (ApiKey as unknown as Record<symbol, string>)[MetadataStorage.PATH_SYMBOL]
+    const meta = MetadataStorage.getMetadata(ApiKey.name, path)
+    const hasKeyPrefixUnique = (meta?.uniques ?? []).some((unique) => {
+      const properties = Array.isArray(unique.properties) ? unique.properties : [unique.properties]
+      return properties.includes('keyPrefix')
+    })
+    expect(hasKeyPrefixUnique).toBe(true)
+  })
+
+  it('generates a fixed-width 12-char prefix (omk_ + 8 hex)', () => {
+    for (let attempt = 0; attempt < 25; attempt++) {
+      const { secret, prefix } = generateApiKeySecret()
+      expect(prefix).toMatch(/^omk_[0-9a-f]{8}$/)
+      expect(prefix).toHaveLength(12)
+      expect(secret.startsWith(`${prefix}.`)).toBe(true)
+    }
+  })
+
+  it('narrows candidates by unique keyPrefix and excludes soft-deleted rows', async () => {
+    const findSpy = jest.fn(async () => [])
+    const mockEm = { find: findSpy } as unknown as Parameters<typeof findApiKeyBySecret>[0]
+    const { secret, prefix } = generateApiKeySecret()
+
+    const result = await findApiKeyBySecret(mockEm, secret)
+
+    expect(result).toBeNull()
+    expect(findSpy).toHaveBeenCalledTimes(1)
+    expect(findSpy).toHaveBeenCalledWith(ApiKey, { keyPrefix: prefix, deletedAt: null })
+  })
+})

--- a/packages/core/src/modules/api_keys/services/apiKeyService.ts
+++ b/packages/core/src/modules/api_keys/services/apiKeyService.ts
@@ -139,7 +139,10 @@ export async function findApiKeyBySecret(em: EntityManager, secret: string): Pro
   if (!secret) return null
   // Extract prefix from the secret for fast candidate lookup
   const prefix = secret.slice(0, 12)
-  // Find candidates by prefix (fast index lookup)
+  // Find candidates by prefix (fast index lookup). Invariant: the unique keyPrefix
+  // constraint plus the deletedAt: null filter keep this to at most one live row, so
+  // the bcrypt loop below stays bounded. Do not widen the prefix space or relax either
+  // filter without re-evaluating that cost (see #3812).
   const candidates = await em.find(ApiKey, { keyPrefix: prefix, deletedAt: null })
   // Verify each candidate with bcrypt until we find a match
   for (const candidate of candidates) {


### PR DESCRIPTION
## Summary

`findApiKeyBySecret` bcrypt-compares every live row that shares the 8-hex `keyPrefix`. Today this is **harmless**: the `@Unique({ properties: ['keyPrefix'] })` constraint plus the `deletedAt: null` filter keep the candidate set to at most one live row, so there is no bcrypt-per-candidate amplification. Issue #3812 asks only for a **guard-rail** so a future refactor cannot silently widen the prefix space or drop the uniqueness / soft-delete invariant without re-evaluating the loop. No behavior change.

## Invariant being protected

```
findApiKeyBySecret: candidates = em.find(ApiKey, { keyPrefix, deletedAt: null })
                    for (candidate of candidates) bcrypt.compare(...)   // cost = |candidates|
|candidates| ≤ 1  ⟸  @Unique(keyPrefix)  +  deletedAt: null  +  fixed prefix width (omk_ + 8 hex)
```

If a refactor narrowed the prefix or dropped `@Unique`, this loop would become a bcrypt-per-candidate DoS amplifier.

## Change (no runtime behavior change)

1. **Guard-rail comments** at the `@Unique({ properties: ['keyPrefix'] })` entity constraint and at the `findApiKeyBySecret` candidate lookup, documenting the invariant and referencing #3812.
2. **Regression test** `apiKeyService.prefixCandidateGuard.test.ts` with three assertions that fail if the invariant is weakened:
   - **uniqueness** — reads the MikroORM entity metadata and asserts `uniques` contains `keyPrefix` (fails if `@Unique` is removed);
   - **prefix width** — `generateApiKeySecret().prefix` matches `/^omk_[0-9a-f]{8}$/` (exactly 12 chars);
   - **narrowing** — `findApiKeyBySecret` calls `em.find(ApiKey, { keyPrefix, deletedAt: null })` (fails if the soft-delete filter or prefix slice changes).

The uniqueness assertion was validated negatively: temporarily removing `@Unique` makes that test fail; restoring it returns the suite to 3/3 green.

## Tests

- `apiKeyService.prefixCandidateGuard.test.ts`: 3/3 passing (full api_keys service suite green).
- `@open-mercato/core` typecheck clean.

## Backward compatibility

No behavioral or wire change — comments + test only. Flagged `risk-medium` solely because the path is authentication-adjacent.

Closes #3812

🤖 Generated with [Claude Code](https://claude.com/claude-code)
