### PR TITLE
fix(customers): inline hint when dictionary options need organization context

### DIFF
--- a/packages/core/src/modules/customers/api/dictionaries/[kind]/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/[kind]/__tests__/route.test.ts
@@ -36,6 +36,7 @@ jest.mock('../../../../commands/settings', () => ({
 
 import { GET } from '../route'
 import { resolveDictionaryRouteContext } from '../../context'
+import { CUSTOMER_DICTIONARY_ORGANIZATION_REQUIRED_CODE } from '../../../../lib/dictionaries'
 
 describe('customer dictionary route', () => {
   beforeEach(() => {
@@ -129,6 +130,28 @@ describe('customer dictionary route', () => {
       expect.any(Request),
       expect.objectContaining({ selectedId: organizationId }),
     )
+  })
+
+  it('returns a stable error code when organization context is unavailable', async () => {
+    jest.mocked(resolveDictionaryRouteContext).mockResolvedValueOnce({
+      translate: (_key: string, fallback?: string) => fallback ?? 'error',
+      em,
+      organizationId: null,
+      tenantId,
+      readableOrganizationIds: [],
+      cache: undefined,
+    } as never)
+
+    const response = await GET(
+      new Request('http://localhost/api/customers/dictionaries/statuses'),
+      { params: { kind: 'statuses' } },
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Organization context is required',
+      code: CUSTOMER_DICTIONARY_ORGANIZATION_REQUIRED_CODE,
+    })
   })
 
   it('does not seed/persist pipeline_stage entries for stages lacking one (read-only GET, #2735)', async () => {

--- a/packages/core/src/modules/customers/api/dictionaries/[kind]/route.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/[kind]/route.ts
@@ -22,6 +22,7 @@ import {
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { CUSTOMER_DICTIONARY_ORGANIZATION_REQUIRED_CODE } from '../../../lib/dictionaries'
 
 const logger = createLogger('customers')
 
@@ -55,7 +56,10 @@ export async function GET(req: Request, ctx: { params?: { kind?: string } }) {
     })
     const { kind, mappedKind } = mapDictionaryKind(ctx.params?.kind)
     if (!organizationId) {
-      throw new CrudHttpError(400, { error: translate('customers.errors.organization_required', 'Organization context is required') })
+      throw new CrudHttpError(400, {
+        error: translate('customers.errors.organization_required', 'Organization context is required'),
+        code: CUSTOMER_DICTIONARY_ORGANIZATION_REQUIRED_CODE,
+      })
     }
     const settings = await loadCustomerSettings(em, { tenantId, organizationId })
     const sortMode = resolveDictionaryEntrySortMode(settings?.dictionarySortModes?.[kind])

--- a/packages/core/src/modules/customers/api/dictionaries/[kind]/route.ts
+++ b/packages/core/src/modules/customers/api/dictionaries/[kind]/route.ts
@@ -296,6 +296,7 @@ const dictionaryListResponseSchema = z.object({
 
 const dictionaryErrorSchema = z.object({
   error: z.string(),
+  code: z.string().optional(),
 })
 
 export const openApi: OpenApiRouteDoc = {

--- a/packages/core/src/modules/customers/components/__tests__/DictionarySelectField.test.tsx
+++ b/packages/core/src/modules/customers/components/__tests__/DictionarySelectField.test.tsx
@@ -2,11 +2,16 @@
 
 import * as React from 'react'
 import { render, screen } from '@testing-library/react'
+import { DictionaryOptionsUnavailableError } from '@open-mercato/core/modules/dictionaries/components/DictionaryEntrySelect'
 import {
   CUSTOMER_DICTIONARIES_MANAGE_HREF,
   DictionarySelectField,
   getCustomerDictionaryManageHref,
 } from '../formConfig'
+import { CUSTOMER_DICTIONARY_ORGANIZATION_REQUIRED_CODE } from '../../lib/dictionaries'
+
+const mockEnsureCustomerDictionary = jest.fn()
+let capturedFetchOptions: (() => Promise<unknown>) | undefined
 
 jest.mock('@tanstack/react-query', () => ({
   useQueryClient: () => ({}),
@@ -21,11 +26,26 @@ jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
 }))
 
 jest.mock('@open-mercato/core/modules/dictionaries/components/DictionaryEntrySelect', () => ({
-  DictionaryEntrySelect: ({ manageHref }: { manageHref?: string }) => (
-    <a data-testid="manage-link" href={manageHref}>
-      Manage
-    </a>
-  ),
+  DictionaryOptionsUnavailableError: class DictionaryOptionsUnavailableError extends Error {},
+  DictionaryEntrySelect: ({
+    manageHref,
+    fetchOptions,
+  }: {
+    manageHref?: string
+    fetchOptions: () => Promise<unknown>
+  }) => {
+    capturedFetchOptions = fetchOptions
+    return (
+      <a data-testid="manage-link" href={manageHref}>
+        Manage
+      </a>
+    )
+  },
+}))
+
+jest.mock('../detail/hooks/useCustomerDictionary', () => ({
+  ensureCustomerDictionary: (...args: unknown[]) => mockEnsureCustomerDictionary(...args),
+  invalidateCustomerDictionary: jest.fn(),
 }))
 
 jest.mock('../AddressTiles', () => ({
@@ -54,6 +74,11 @@ const labels = {
 }
 
 describe('DictionarySelectField', () => {
+  beforeEach(() => {
+    capturedFetchOptions = undefined
+    mockEnsureCustomerDictionary.mockReset()
+  })
+
   it('links customer dictionaries to their configuration section by default', () => {
     render(
       <DictionarySelectField
@@ -104,5 +129,42 @@ describe('DictionarySelectField', () => {
     )
 
     expect(screen.getByTestId('manage-link')).toHaveAttribute('href', '/custom/manage')
+  })
+
+  it('maps the coded organization-required response to an unavailable-options error', async () => {
+    const responseError = Object.assign(new Error('Organization context is required'), {
+      status: 400,
+      code: CUSTOMER_DICTIONARY_ORGANIZATION_REQUIRED_CODE,
+    })
+    mockEnsureCustomerDictionary.mockRejectedValue(responseError)
+
+    render(
+      <DictionarySelectField
+        kind="job-titles"
+        value={undefined}
+        onChange={() => {}}
+        labels={labels}
+      />,
+    )
+
+    await expect(capturedFetchOptions?.()).rejects.toBeInstanceOf(DictionaryOptionsUnavailableError)
+  })
+
+  it('preserves unclassified 400 failures for the normal error path', async () => {
+    const responseError = Object.assign(new Error('Failed to load dictionary entries'), {
+      status: 400,
+    })
+    mockEnsureCustomerDictionary.mockRejectedValue(responseError)
+
+    render(
+      <DictionarySelectField
+        kind="job-titles"
+        value={undefined}
+        onChange={() => {}}
+        labels={labels}
+      />,
+    )
+
+    await expect(capturedFetchOptions?.()).rejects.toBe(responseError)
   })
 })

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -40,6 +40,7 @@ import type {
 } from '@open-mercato/ui/backend/CrudForm'
 import {
   DictionaryEntrySelect,
+  DictionaryOptionsUnavailableError,
   type DictionarySelectLabels,
 } from '@open-mercato/core/modules/dictionaries/components/DictionaryEntrySelect'
 import { RolesSection } from './detail/RolesSection'
@@ -188,14 +189,27 @@ export function DictionarySelectField({
   )
 
   const fetchOptions = React.useCallback(async () => {
-    const data = await ensureCustomerDictionary(queryClient, kind, scopeVersion)
-    return data.entries.map((entry) => ({
-      value: entry.value,
-      label: entry.label,
-      color: entry.color ?? null,
-      icon: entry.icon ?? null,
-    }))
-  }, [kind, queryClient, scopeVersion])
+    try {
+      const data = await ensureCustomerDictionary(queryClient, kind, scopeVersion)
+      return data.entries.map((entry) => ({
+        value: entry.value,
+        label: entry.label,
+        color: entry.color ?? null,
+        icon: entry.icon ?? null,
+      }))
+    } catch (err) {
+      const status = (err as { status?: unknown } | null)?.status
+      if (status === 400) {
+        const serverMessage = err instanceof Error ? err.message.trim() : ''
+        throw new DictionaryOptionsUnavailableError(
+          serverMessage.length
+            ? serverMessage
+            : translate('customers.errors.organization_required', 'Organization context is required'),
+        )
+      }
+      throw err
+    }
+  }, [kind, queryClient, scopeVersion, translate])
 
   const createOption = React.useCallback(
     async (input: { value: string; label?: string; color?: string | null; icon?: string | null }) => {

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -54,6 +54,7 @@ import {
 } from './detail/hooks/useCustomerDictionary'
 import {
   CUSTOMER_DICTIONARIES_MANAGE_HREF,
+  CUSTOMER_DICTIONARY_ORGANIZATION_REQUIRED_CODE,
   getCustomerDictionaryManageHref,
   type CustomerDictionaryKind,
 } from '../lib/dictionaries'
@@ -198,8 +199,11 @@ export function DictionarySelectField({
         icon: entry.icon ?? null,
       }))
     } catch (err) {
-      const status = (err as { status?: unknown } | null)?.status
-      if (status === 400) {
+      const responseError = err as { status?: unknown; code?: unknown } | null
+      if (
+        responseError?.status === 400 &&
+        responseError.code === CUSTOMER_DICTIONARY_ORGANIZATION_REQUIRED_CODE
+      ) {
         const serverMessage = err instanceof Error ? err.message.trim() : ''
         throw new DictionaryOptionsUnavailableError(
           serverMessage.length

--- a/packages/core/src/modules/customers/lib/dictionaries.ts
+++ b/packages/core/src/modules/customers/lib/dictionaries.ts
@@ -32,6 +32,7 @@ export type CustomerDictionaryDisplayEntry = DictionaryDisplayEntry
 export type CustomerDictionaryMap = DictionaryMap
 
 export const CUSTOMER_DICTIONARIES_MANAGE_HREF = '/backend/config/customers'
+export const CUSTOMER_DICTIONARY_ORGANIZATION_REQUIRED_CODE = 'customer_dictionary_organization_required'
 
 export function getCustomerDictionarySettingsSectionId(kind: CustomerDictionaryKind) {
   return `customer-dictionary-${kind}`

--- a/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
+++ b/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
@@ -31,6 +31,13 @@ import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('dictionaries').child({ component: 'DictionaryEntrySelect' })
 
+export class DictionaryOptionsUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DictionaryOptionsUnavailableError'
+  }
+}
+
 const DEFAULT_APPEARANCE_LABELS: AppearanceSelectorLabels = {
   colorLabel: 'Color',
   colorHelp: 'Pick a highlight color for this entry.',
@@ -126,17 +133,24 @@ export function DictionaryEntrySelect({
   const [newValue, setNewValue] = React.useState('')
   const [newLabel, setNewLabel] = React.useState('')
   const [formError, setFormError] = React.useState<string | null>(null)
+  const [unavailableMessage, setUnavailableMessage] = React.useState<string | null>(null)
   const appearance = useAppearanceState(null, null)
 
   const loadOptions = React.useCallback(async () => {
     setLoading(true)
+    setUnavailableMessage(null)
     try {
       const items = await fetchOptions()
       setOptions(sortOptions === 'none' ? items : items.slice().sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })))
     } catch (err) {
-      logger.error('Failed to fetch options', { err })
-      flash(labels.errorLoad, 'error')
-      setOptions([])
+      if (err instanceof DictionaryOptionsUnavailableError) {
+        setUnavailableMessage(err.message)
+        setOptions([])
+      } else {
+        logger.error('Failed to fetch options', { err })
+        flash(labels.errorLoad, 'error')
+        setOptions([])
+      }
     } finally {
       setLoading(false)
     }
@@ -276,7 +290,7 @@ export function DictionaryEntrySelect({
     return '⌘/Ctrl + Enter'
   }, [labels.saveShortcutHint])
 
-  const disabled = disabledProp || loading || saving
+  const disabled = disabledProp || loading || saving || unavailableMessage !== null
   const manageLink = manageHref ?? '/backend/config/dictionaries'
   const returnTo = React.useMemo(() => {
     const query = searchParams?.toString() ?? ''
@@ -294,6 +308,9 @@ export function DictionaryEntrySelect({
 
   return (
     <div className="space-y-2">
+      {unavailableMessage ? (
+        <p className="text-xs text-muted-foreground">{unavailableMessage}</p>
+      ) : null}
       <div className="flex items-center gap-2">
         <Select
           key={`dictionary-entry:${value ?? ''}:${optionsKey}`}

--- a/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
+++ b/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
@@ -124,6 +124,7 @@ export function DictionaryEntrySelect({
   sortOptions = 'label_asc',
   showActiveAppearance = true,
 }: DictionaryEntrySelectProps) {
+  const unavailableMessageId = React.useId()
   const pathname = usePathname()
   const searchParams = useSearchParams()
   const [options, setOptions] = React.useState<DictionaryOption[]>([])
@@ -309,7 +310,9 @@ export function DictionaryEntrySelect({
   return (
     <div className="space-y-2">
       {unavailableMessage ? (
-        <p className="text-xs text-muted-foreground">{unavailableMessage}</p>
+        <p id={unavailableMessageId} className="text-xs text-muted-foreground">
+          {unavailableMessage}
+        </p>
       ) : null}
       <div className="flex items-center gap-2">
         <Select
@@ -323,6 +326,7 @@ export function DictionaryEntrySelect({
         >
           <SelectTrigger
             id={id}
+            aria-describedby={unavailableMessage ? unavailableMessageId : undefined}
             className={selectClassName}
             title={activeOption?.label ?? undefined}
           >

--- a/packages/core/src/modules/dictionaries/components/__tests__/DictionaryEntrySelect.test.tsx
+++ b/packages/core/src/modules/dictionaries/components/__tests__/DictionaryEntrySelect.test.tsx
@@ -3,7 +3,12 @@
  */
 import * as React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
-import { DictionaryEntrySelect, type DictionarySelectLabels } from '../DictionaryEntrySelect'
+import {
+  DictionaryEntrySelect,
+  DictionaryOptionsUnavailableError,
+  type DictionarySelectLabels,
+} from '../DictionaryEntrySelect'
+import { flash } from '@open-mercato/ui/backend/FlashMessages'
 
 jest.mock('next/navigation', () => ({
   usePathname: () => '/backend/customers',
@@ -86,6 +91,7 @@ function optionLabels() {
 describe('DictionaryEntrySelect', () => {
   beforeEach(() => {
     fetchOptions.mockClear()
+    ;(flash as jest.Mock).mockClear()
   })
 
   it('keeps API order when sortOptions is none', async () => {
@@ -132,5 +138,48 @@ describe('DictionaryEntrySelect', () => {
     )
 
     await waitFor(() => expect(optionLabels()).toEqual(['legacy', 'Alpha', 'Beta']))
+  })
+
+  it('shows an inline hint instead of an error toast when options are unavailable (#4401)', async () => {
+    const unavailableFetch = jest.fn(async () => {
+      throw new DictionaryOptionsUnavailableError('Organization context is required')
+    })
+
+    render(
+      <DictionaryEntrySelect
+        value={undefined}
+        onChange={jest.fn()}
+        fetchOptions={unavailableFetch}
+        labels={labels}
+        allowInlineCreate={false}
+        showManage={false}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText('Organization context is required')).toBeInTheDocument(),
+    )
+    expect(flash).not.toHaveBeenCalled()
+    expect(optionLabels()).toEqual([])
+  })
+
+  it('still flashes the load error for unexpected failures', async () => {
+    const failingFetch = jest.fn(async () => {
+      throw new Error('boom')
+    })
+
+    render(
+      <DictionaryEntrySelect
+        value={undefined}
+        onChange={jest.fn()}
+        fetchOptions={failingFetch}
+        labels={labels}
+        allowInlineCreate={false}
+        showManage={false}
+      />,
+    )
+
+    await waitFor(() => expect(flash).toHaveBeenCalledWith('Load failed', 'error'))
+    expect(screen.queryByText('boom')).toBeNull()
   })
 })

--- a/packages/core/src/modules/dictionaries/components/__tests__/DictionaryEntrySelect.test.tsx
+++ b/packages/core/src/modules/dictionaries/components/__tests__/DictionaryEntrySelect.test.tsx
@@ -57,7 +57,11 @@ jest.mock('@open-mercato/ui/primitives/select', () => ({
   SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
     <option value={value}>{children}</option>
   ),
-  SelectTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectTrigger: ({ children, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+    <span data-testid="dictionary-entry-trigger" {...props}>
+      {children}
+    </span>
+  ),
   SelectValue: () => null,
 }))
 
@@ -158,6 +162,13 @@ describe('DictionaryEntrySelect', () => {
 
     await waitFor(() =>
       expect(screen.getByText('Organization context is required')).toBeInTheDocument(),
+    )
+    const hint = screen.getByText('Organization context is required')
+    await waitFor(() =>
+      expect(screen.getByTestId('dictionary-entry-trigger')).toHaveAttribute(
+        'aria-describedby',
+        hint.id,
+      ),
     )
     expect(flash).not.toHaveBeenCalled()
     expect(optionLabels()).toEqual([])


### PR DESCRIPTION
Supersedes #4406

Credit: original implementation by @wojciechszyjka. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the original fork branch.

## Included work

- Original inline dictionary-unavailable hint from #4406
- Machine-readable classification for the expected missing-organization response
- Preservation of normal toast/logger handling for unrelated HTTP 400 failures
- Adapter regression tests for classified and unclassified 400 responses

## Validation

- `yarn build:packages`
- `yarn generate`
- `yarn workspace @open-mercato/core typecheck`
- `yarn workspace @open-mercato/core test --runInBand src/modules/customers/components/__tests__/DictionarySelectField.test.tsx src/modules/dictionaries/components/__tests__/DictionaryEntrySelect.test.tsx` (10/10)

The carried-forward branch was re-reviewed after autofix and is intended to be merge-ready.
