### PR TITLE
fix(create-app): make yarn test pass on a fresh scaffold (#4328)

### DIFF
--- a/packages/create-app/src/lib/template-script-targets.test.ts
+++ b/packages/create-app/src/lib/template-script-targets.test.ts
@@ -1,11 +1,30 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import test from 'node:test'
 
 const TEMPLATE_DIR = new URL('../../template/', import.meta.url)
 const PACKAGE_JSON_TEMPLATE = new URL('package.json.template', TEMPLATE_DIR)
+// Mirrors SKIP_DIRS in src/index.ts — directories create-mercato-app never copies.
+const SCAFFOLD_SKIPPED_DIRS = new Set(['__tests__', '__integration__'])
+
+function listScaffoldedTestFiles(dir: string): string[] {
+  const found: string[] = []
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SCAFFOLD_SKIPPED_DIRS.has(entry.name)) continue
+      found.push(...listScaffoldedTestFiles(path.join(dir, entry.name)))
+    } else if (/\.(test|spec)\.[cm]?[jt]sx?$/.test(entry.name)) {
+      found.push(path.join(dir, entry.name))
+    }
+  }
+
+  return found
+}
 
 function readScripts(): Record<string, string> {
   const raw = fs.readFileSync(PACKAGE_JSON_TEMPLATE, 'utf8')
@@ -63,6 +82,24 @@ test('Jest ships the environment required by jsdom-annotated template tests', ()
   assert.ok(
     devDependencies['jest-environment-jsdom'],
     'template tests use @jest-environment jsdom, so standalone apps must install jest-environment-jsdom',
+  )
+})
+
+test('`yarn test` succeeds on a scaffold that ships no test files', () => {
+  const scaffoldedTestFiles = listScaffoldedTestFiles(fileURLToPath(new URL('src/', TEMPLATE_DIR)))
+  const jestConfig = createRequire(import.meta.url)(
+    fileURLToPath(new URL('jest.config.cjs', TEMPLATE_DIR)),
+  ) as { passWithNoTests?: boolean }
+
+  assert.equal(
+    scaffoldedTestFiles.length,
+    0,
+    'template test files live in __tests__/__integration__, which create-mercato-app skips',
+  )
+  assert.equal(
+    jestConfig.passWithNoTests,
+    true,
+    'the scaffold copies no test files, so `yarn test` needs passWithNoTests to avoid exiting 1 on a clean app',
   )
 })
 

--- a/packages/create-app/template/jest.config.cjs
+++ b/packages/create-app/template/jest.config.cjs
@@ -2,9 +2,12 @@
 // Unit-test config for a standalone Open Mercato app.
 // Integration tests run through Playwright (`yarn test:integration:ephemeral`)
 // and are excluded here.
+// `create-mercato-app` skips `__tests__`/`__integration__` while copying the
+// template, so a freshly scaffolded app owns no test files until you write one.
 module.exports = {
   testEnvironment: 'node',
   testTimeout: 30000,
+  passWithNoTests: true,
   rootDir: '.',
   roots: ['<rootDir>/src'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],


### PR DESCRIPTION
Follow-up to #4456, which carried #4454 forward and closed most of #4328 — but `yarn test` still fails out of the box on a clean scaffold.

## Problem

`create-mercato-app` skips `__tests__` and `__integration__` while copying the template (`packages/create-app/src/index.ts:366`), so a freshly scaffolded app owns **no test files at all**. The `jest.config.cjs` shipped by #4456 does not set `passWithNoTests`, so `yarn test` exits 1:

```
No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
  186 files checked.
  testMatch: **/__tests__/**/*.?([mc])[jt]s?(x), **/?(*.)+(spec|test).?([mc])[jt]s?(x) - 0 matches
```

That is the same out-of-the-box failure #4328 reported for `test`, just with a different message than the original config-not-found one.

## Change

- `template/jest.config.cjs`: set `passWithNoTests: true`, with a comment explaining that the scaffold ships no tests.
- `template-script-targets.test.ts`: regression test tying the flag to the scaffold's skipped directories — it asserts no template test file can reach a scaffolded app, and that the config therefore sets `passWithNoTests`.

## Verification

Runner: local

- `yarn node --import tsx --test --test-timeout=120000 packages/create-app/src/lib/template-script-targets.test.ts` — 5 passed; the new case fails (asserts) when the config change is reverted
- `yarn workspace create-mercato-app typecheck` — passed
- `yarn lint` — passed (0 errors)
- Simulated a real scaffold (template `src/` copied with `__tests__`/`__integration__` excluded, as `copyDirRecursive` does) and ran Jest with the shipped config: `No tests found, exiting with code 0`

Also re-verified the rest of #4456 on `develop` while investigating: `eject.test.ts` 22 passed, `@open-mercato/cli` typecheck passed, and `eslint .` with the new flat config runs clean on the scaffolded tree (0 errors, 11 warnings) in a sandbox with `next@16.2.9` + `eslint-config-next@16.2.11`.

Note: #4272 and #4328 are still open — merging #4456 into `develop` did not auto-close them.

Refs #4328