### PR TITLE
fix(customers): address the two Medium review findings on #4459

### DIFF
--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/__tests__/page.test.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/__tests__/page.test.tsx
@@ -139,19 +139,22 @@ jest.mock('../../../../../components/detail/DealDetailHeader', () => ({
 }))
 
 jest.mock('../../../../../components/detail/DealDetailTabs', () => ({
-  resolveLegacyTab: (tab?: string | null) => {
+  resolveLegacyTab: (tab?: string | null, knownTabIds?: Iterable<string>) => {
     if (tab === 'activities' || tab === 'people' || tab === 'companies' || tab === 'notes' || tab === 'files' || tab === 'changelog') {
       return tab
     }
+    if (tab && knownTabIds && new Set(knownTabIds).has(tab)) return tab
     return 'activities'
   },
   DealDetailTabs: ({
     children,
     activeTab,
+    injectedTabs = [],
     onTabChange,
   }: {
     children: React.ReactNode
     activeTab: string
+    injectedTabs?: Array<{ id: string; label: string }>
     onTabChange: (tab: string) => void
   }) => (
     <div>
@@ -160,6 +163,9 @@ jest.mock('../../../../../components/detail/DealDetailTabs', () => ({
       <button type="button" onClick={() => onTabChange('companies')}>tab-companies</button>
       <button type="button" onClick={() => onTabChange('files')}>tab-files</button>
       <button type="button" onClick={() => onTabChange('changelog')}>tab-changelog</button>
+      {injectedTabs.map((tab) => (
+        <button key={tab.id} type="button" onClick={() => onTabChange(tab.id)}>{`tab-${tab.id}`}</button>
+      ))}
       {children}
     </div>
   ),
@@ -361,6 +367,10 @@ describe('DealDetailPage', () => {
     updateCrudMock.mockReset()
     deleteCrudMock.mockReset()
     replaceMock.mockReset()
+    replaceMock.mockImplementation((url: string) => {
+      const query = url.split('?')[1] ?? ''
+      activeTabParam = new URLSearchParams(query).get('tab')
+    })
     pushMock.mockReset()
     inlineActivityComposerMock.mockClear()
     plannedActivitiesSectionMock.mockClear()
@@ -436,6 +446,47 @@ describe('DealDetailPage', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('active-tab')).toHaveTextContent('companies')
+    })
+  })
+
+  it('keeps an injected tab active when it is selected from another built-in tab (#4379)', async () => {
+    activeTabParam = 'people'
+    injectedTabWidgets = [{
+      widgetId: 'crm.custom-tab',
+      placement: { kind: 'tab', groupId: 'crm.custom-tab' },
+      module: { metadata: { title: 'Custom' }, Widget: () => <div>custom</div> },
+    }]
+
+    renderWithProviders(<DealDetailPage params={{ id: 'deal-123' }} />)
+
+    await screen.findByText('Expansion renewal')
+    fireEvent.click(screen.getByRole('button', { name: 'tab-crm.custom-tab' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-tab')).toHaveTextContent('crm.custom-tab')
+    })
+    expect(replaceMock).toHaveBeenCalledWith(
+      '/backend/customers/deals/deal-123?tab=crm.custom-tab',
+      { scroll: false },
+    )
+  })
+
+  it('resolves a deep link to an injected tab once the widgets load (#4379)', async () => {
+    activeTabParam = 'crm.custom-tab'
+    const view = renderWithProviders(<DealDetailPage params={{ id: 'deal-123' }} />)
+
+    await screen.findByText('Expansion renewal')
+    expect(screen.getByTestId('active-tab')).toHaveTextContent('activities')
+
+    injectedTabWidgets = [{
+      widgetId: 'crm.custom-tab',
+      placement: { kind: 'tab', groupId: 'crm.custom-tab' },
+      module: { metadata: { title: 'Custom' }, Widget: () => <div>custom</div> },
+    }]
+    view.rerender(<DealDetailPage params={{ id: 'deal-123' }} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-tab')).toHaveTextContent('crm.custom-tab')
     })
   })
 

--- a/packages/core/src/modules/customers/backend/customers/deals/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/[id]/page.tsx
@@ -68,14 +68,6 @@ export default function DealDetailPage({ params }: { params?: { id?: string } })
   } = useScheduleDialog()
   const formWrapperRef = React.useRef<HTMLDivElement>(null)
 
-  const initialTab = React.useMemo(() => resolveLegacyTab(searchParams?.get('tab')), [searchParams])
-  const [activeTab, setActiveTab] = React.useState<DealTabId>(initialTab)
-  const userSelectedTabRef = React.useRef(false)
-
-  React.useEffect(() => {
-    setActiveTab(initialTab)
-  }, [initialTab])
-
   const currentDealId = data?.deal.id ?? id
   const { injectionContext, runMutationWithContext } = useDealMutationContext({
     currentDealId,
@@ -108,15 +100,16 @@ export default function DealDetailPage({ params }: { params?: { id?: string } })
     setData,
   })
 
-  const restoredInjectedTabRef = React.useRef(false)
+  const injectedTabIds = React.useMemo(() => injectedTabs.map((tab) => tab.id), [injectedTabs])
+  const initialTab = React.useMemo(
+    () => resolveLegacyTab(searchParams?.get('tab'), injectedTabIds),
+    [injectedTabIds, searchParams],
+  )
+  const [activeTab, setActiveTab] = React.useState<DealTabId>(initialTab)
+
   React.useEffect(() => {
-    if (restoredInjectedTabRef.current || userSelectedTabRef.current) return
-    const requestedTab = searchParams?.get('tab')
-    if (!requestedTab || requestedTab === activeTab) return
-    if (!injectedTabs.some((tab) => tab.id === requestedTab)) return
-    restoredInjectedTabRef.current = true
-    setActiveTab(requestedTab)
-  }, [activeTab, injectedTabs, searchParams])
+    setActiveTab(initialTab)
+  }, [initialTab])
 
   const { searchPeoplePage, fetchPeopleByIds, searchCompaniesPage, fetchCompaniesByIds } = useDealAssociationLookups({
     excludeLinkedDealId: data?.deal.id ?? null,
@@ -233,7 +226,6 @@ export default function DealDetailPage({ params }: { params?: { id?: string } })
 
   const handleTabChange = React.useCallback(async (tab: DealTabId) => {
     if (!(await confirmDiscardIfDirty())) return
-    userSelectedTabRef.current = true
     setActiveTab(tab)
     const nextParams = new URLSearchParams(searchParams?.toString() ?? '')
     nextParams.set('tab', tab)

--- a/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/people-v2/[id]/page.tsx
@@ -91,23 +91,6 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
   const [isSaving, setIsSaving] = React.useState(false)
   const formWrapperRef = React.useRef<HTMLDivElement>(null)
 
-  const initialTab = React.useMemo(() => {
-    return resolveLegacyTab(searchParams?.get('tab'))
-  }, [searchParams])
-  const [activeTab, setActiveTab] = React.useState<PersonTabId>(initialTab)
-  const userSelectedTabRef = React.useRef(false)
-
-  const handleTabChange = React.useCallback(
-    (tab: PersonTabId) => {
-      userSelectedTabRef.current = true
-      setActiveTab(tab)
-      if (!pathname) return
-      const nextParams = new URLSearchParams(searchParams?.toString() ?? '')
-      nextParams.set('tab', tab)
-      router.replace(`${pathname}?${nextParams.toString()}`, { scroll: false })
-    },
-    [pathname, router, searchParams],
-  )
   const [sectionAction, setSectionAction] = React.useState<SectionAction | null>(null)
   const [scheduleDialogOpen, setScheduleDialogOpen] = React.useState(false)
   const [scheduleEditData, setScheduleEditData] = React.useState<ScheduleActivityEditData | null>(null)
@@ -341,15 +324,27 @@ export default function PersonDetailV2Page({ params }: { params?: { id?: string 
 
   const injectedTabMap = React.useMemo(() => new Map(injectedTabs.map((tab) => [tab.id, tab.render])), [injectedTabs])
 
-  const restoredInjectedTabRef = React.useRef(false)
+  const injectedTabIds = React.useMemo(() => injectedTabs.map((tab) => tab.id), [injectedTabs])
+  const initialTab = React.useMemo(
+    () => resolveLegacyTab(searchParams?.get('tab'), injectedTabIds),
+    [injectedTabIds, searchParams],
+  )
+  const [activeTab, setActiveTab] = React.useState<PersonTabId>(initialTab)
+
   React.useEffect(() => {
-    if (restoredInjectedTabRef.current || userSelectedTabRef.current) return
-    const requestedTab = searchParams?.get('tab')
-    if (!requestedTab || requestedTab === activeTab) return
-    if (!injectedTabs.some((tab) => tab.id === requestedTab)) return
-    restoredInjectedTabRef.current = true
-    setActiveTab(requestedTab)
-  }, [activeTab, injectedTabs, searchParams])
+    setActiveTab(initialTab)
+  }, [initialTab])
+
+  const handleTabChange = React.useCallback(
+    (tab: PersonTabId) => {
+      setActiveTab(tab)
+      if (!pathname) return
+      const nextParams = new URLSearchParams(searchParams?.toString() ?? '')
+      nextParams.set('tab', tab)
+      router.replace(`${pathname}?${nextParams.toString()}`, { scroll: false })
+    },
+    [pathname, router, searchParams],
+  )
 
   // Tags
   const handleTagsChange = React.useCallback((nextTags: TagSummary[]) => {

--- a/packages/core/src/modules/customers/commands/__tests__/personDealLinks.undo.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/personDealLinks.undo.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Undo of a person delete must restore the deal-link `isPrimary` flag, otherwise
+ * the deal silently loses its primary contact (and the activity-target default).
+ * Snapshots written before the flag existed restore as non-primary.
+ */
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+const mockFindWithDecryption = jest.fn(async () => [])
+const mockFindOneWithDecryption = jest.fn(async () => null)
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args as []),
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args as []),
+}))
+
+import '@open-mercato/core/modules/customers/commands'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler, CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import {
+  CustomerDeal,
+  CustomerDealPersonLink,
+  CustomerEntity,
+} from '../../data/entities'
+
+const ORG_ID = 'org-deal-link'
+const TENANT_ID = 'tenant-deal-link'
+const ENTITY_ID = 'person-deal-link'
+const DEAL_ID = 'deal-deal-link'
+const LINK_ID = 'link-deal-link'
+
+function makeEntity(): CustomerEntity {
+  return {
+    id: ENTITY_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    kind: 'person',
+    displayName: 'Primary Contact',
+    description: null,
+    ownerUserId: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    status: null,
+    lifecycleStage: null,
+    source: null,
+    nextInteractionAt: null,
+    nextInteractionName: null,
+    nextInteractionRefId: null,
+    nextInteractionIcon: null,
+    nextInteractionColor: null,
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  } as unknown as CustomerEntity
+}
+
+function makeEm(entity: CustomerEntity) {
+  const em: any = {
+    fork: jest.fn().mockReturnThis(),
+    findOne: jest.fn(async (ctor: any) => (ctor === CustomerEntity ? entity : null)),
+    find: jest.fn(async (ctor: any) => (ctor === CustomerDeal ? [{ id: DEAL_ID }] : [])),
+    count: jest.fn(async () => 0),
+    nativeDelete: jest.fn(async () => undefined),
+    remove: jest.fn().mockReturnValue({ flush: jest.fn().mockResolvedValue(undefined) }),
+    flush: jest.fn().mockResolvedValue(undefined),
+    transactional: jest.fn(async (fn: any) => fn(em)),
+    begin: jest.fn().mockResolvedValue(undefined),
+    commit: jest.fn().mockResolvedValue(undefined),
+    rollback: jest.fn().mockResolvedValue(undefined),
+    create: jest.fn((_ctor: any, data: any) => ({ id: 'new-id', ...data })),
+    persist: jest.fn(),
+    getReference: jest.fn((_ctor: any, id: string) => ({ id })),
+  }
+  return em
+}
+
+function makeCtx(em: any): CommandRuntimeContext {
+  const dataEngine: any = {
+    setCustomFields: jest.fn(async () => {}),
+    emitOrmEntityEvent: jest.fn(async () => {}),
+    markOrmEntityChange: jest.fn(),
+    flushOrmEntityChanges: jest.fn(async () => {}),
+  }
+  return {
+    container: {
+      resolve: (token: string): any => {
+        if (token === 'em') return em
+        if (token === 'dataEngine') return dataEngine
+        throw new Error(`Unexpected DI token: ${token}`)
+      },
+    } as any,
+    auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_ID } as any,
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: null,
+    request: undefined as any,
+  }
+}
+
+function makeBefore(dealLink: Record<string, unknown>) {
+  return {
+    entity: {
+      id: ENTITY_ID,
+      organizationId: ORG_ID,
+      tenantId: TENANT_ID,
+      kind: 'person' as const,
+      displayName: 'Primary Contact',
+      description: null,
+      ownerUserId: null,
+      primaryEmail: null,
+      primaryPhone: null,
+      status: null,
+      lifecycleStage: null,
+      source: null,
+      nextInteractionAt: null,
+      nextInteractionName: null,
+      nextInteractionRefId: null,
+      isActive: true,
+    },
+    profile: {
+      id: 'profile-1',
+      firstName: 'Primary',
+      lastName: 'Contact',
+      preferredName: null,
+      jobTitle: null,
+      department: null,
+      seniority: null,
+      timezone: null,
+      linkedInUrl: null,
+      twitterUrl: null,
+      companyEntityId: null,
+    },
+    deals: [dealLink],
+    comments: [],
+    addresses: [],
+    tagIds: [],
+    custom: {},
+  }
+}
+
+async function runUndo(before: Record<string, unknown>) {
+  const entity = makeEntity()
+  const em = makeEm(entity)
+  const ctx = makeCtx(em)
+  mockFindOneWithDecryption.mockImplementation(async (_em: unknown, ctor: unknown) => {
+    if (ctor === CustomerEntity) return entity
+    return null
+  })
+  const handler = commandRegistry.get('customers.people.delete') as CommandHandler
+  await handler.undo!({ input: undefined, logEntry: { commandPayload: { undo: { before } } } as any, ctx })
+  return (em.create as jest.Mock).mock.calls.find(([ctor]: [any]) => ctor === CustomerDealPersonLink)
+}
+
+describe('customers.people.delete — undo restores deal-link primary flag', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('restores isPrimary when the snapshot recorded a primary contact', async () => {
+    const call = await runUndo(makeBefore({
+      id: LINK_ID,
+      dealId: DEAL_ID,
+      participantRole: 'buyer',
+      isPrimary: true,
+      createdAt: new Date('2026-07-01T10:00:00.000Z'),
+    }))
+
+    expect(call).toBeDefined()
+    expect(call![1]).toMatchObject({ id: LINK_ID, participantRole: 'buyer', isPrimary: true })
+  })
+
+  it('restores a pre-flag snapshot as non-primary', async () => {
+    const call = await runUndo(makeBefore({
+      id: LINK_ID,
+      dealId: DEAL_ID,
+      participantRole: null,
+      createdAt: new Date('2026-07-01T10:00:00.000Z'),
+    }))
+
+    expect(call).toBeDefined()
+    expect(call![1]).toMatchObject({ id: LINK_ID, isPrimary: false })
+  })
+})

--- a/packages/core/src/modules/customers/commands/people.ts
+++ b/packages/core/src/modules/customers/commands/people.ts
@@ -181,6 +181,7 @@ type PersonSnapshot = {
     id: string
     dealId: string
     participantRole: string | null
+    isPrimary?: boolean
     createdAt: Date
   }>
   activities: PersonActivitySnapshot[]
@@ -345,6 +346,7 @@ function serializePersonSnapshot(
         id: link.id,
         dealId: link.deal.id,
         participantRole: link.participantRole ?? null,
+        isPrimary: link.isPrimary === true,
         createdAt: link.createdAt,
       })),
     activities: activities.map((activity) => ({
@@ -1522,6 +1524,7 @@ const deletePersonCommand: CommandHandler<{ body?: Record<string, unknown>; quer
           deal,
           person: entity,
           participantRole: link.participantRole,
+          isPrimary: link.isPrimary === true,
           createdAt: link.createdAt,
         })
         em.persist(restoredLink)


### PR DESCRIPTION
Follow-up to my code review on #4459 (`carry/pr-4451-ready`). Targets that branch directly so @pkarw can merge or cherry-pick it into the carry PR — I have no write access to this repo, so this is the only way I can hand the fixes over.

## Medium 1 — undo of a person delete dropped `isPrimary`

`commands/people.ts` was the one remaining path that recreates `CustomerDealPersonLink` rows without the flag: mark a person primary on a deal → delete the person → undo → the deal silently lost its primary contact and the activity-target default from #4376 changed.

- `PersonSnapshot['deals']` gains `isPrimary?: boolean` (optional, so snapshots written before this PR read back as `false`).
- `serializePersonSnapshot` records `link.isPrimary === true`; the undo restore passes it back into `em.create(CustomerDealPersonLink, …)`.

## Medium 2 — `knownTabIds` was dead code and injected tabs bounced back

`resolveLegacyTab(tab, knownTabIds?)` gained the parameter but no production call site passed it, so switching from a built-in tab **other than** Activities to an injected tab changed `initialTab` (injected id is not in `SUPPORTED_TAB_IDS`), the URL-sync effect re-fired and snapped the page back to the default tab. `restoredInjectedTabRef` could not recover it because `userSelectedTabRef` was already `true`.

- `deals/[id]/page.tsx` and `people-v2/[id]/page.tsx` now compute `injectedTabIds` from the loaded injected tabs and pass them into `resolveLegacyTab`; the `initialTab` memo moved below the injected-tabs hook.
- That also covers the late-injection deep link the refs were guarding: before the widgets load `initialTab` is the fallback, once they load it resolves to the injected id, and if the user already picked another tab the URL (and therefore `initialTab`) already reflects that choice. Both `userSelectedTabRef` and `restoredInjectedTabRef` are gone.

`companies-v2` is untouched: its `resolveLegacyTab` passes unknown ids through, so it has neither the bounce-back bug nor a broken deep link.

## Test coverage

- The deal page test now round-trips `router.replace` back into the mocked search params, so the URL-driven regression is actually exercised (previously `activeTabParam` was a constant the mock never updated). Its `resolveLegacyTab` mock honours the second argument and the tabs mock renders a button per injected tab.
- New: `keeps an injected tab active when it is selected from another built-in tab (#4379)` and `resolves a deep link to an injected tab once the widgets load (#4379)`.
- New `commands/__tests__/personDealLinks.undo.test.ts` — undo restores `isPrimary: true`, and a pre-flag snapshot restores as non-primary.
- Verified both new suites fail without the corresponding fix.

## Validation

Runner: local (no Docker app container running).

- `yarn build:packages` — passed
- `yarn generate` — passed
- `yarn typecheck` — passed
- `yarn lint` — passed (0 errors, 12 pre-existing warnings)
- `yarn workspace @open-mercato/core test` — 7780/7780 tests passed; 1 suite (`feature_toggles/api/overrides/optimistic-lock.test.ts`, unrelated) was killed by a local jest worker SIGSEGV and passes on its own rerun.

Not addressed here (all Low, from the same review, left as your call): `hiddenTabIds` has no wiring seam from the shipped pages, and `syncDealPeople` silently ignores a `primaryPersonEntityId` that is not among `personIds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)