### PR TITLE
fix(customer_accounts): scope CRM auto-link by org and link person invites to their company

### DIFF
--- a/packages/core/src/modules/customer_accounts/__integration__/TC-CACC-INVITE-PERSON-001.spec.ts
+++ b/packages/core/src/modules/customer_accounts/__integration__/TC-CACC-INVITE-PERSON-001.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { createCompanyFixture, createPersonFixture, deleteEntityIfExists } from '@open-mercato/core/helpers/integration/crmFixtures'
+
+/**
+ * TC-CACC-INVITE-PERSON-001: invite raised from a CRM person card (#4362)
+ *
+ * The account-status widget on a person detail page sends `personEntityId` only.
+ * The invitation must still carry the person's company, because `customerEntityId`
+ * is the portal company scope key: the portal Users page, portal invitations, and
+ * the company detail "Portal users" group all filter on it, and `autoLinkCrm`
+ * cannot derive it later for a user that already has a person link.
+ *
+ * This covers what unit tests with a mocked EntityManager cannot: that the profile
+ * lookup reads the real `customer_person_profiles.company_entity_id` relation and
+ * that the ownership probe accepts a genuinely in-org company.
+ *
+ * The invitation token is deliberately not returned by the API, so the accept half
+ * of the flow stays unit-tested (see TC-AUTH-032 for the same constraint).
+ */
+test.describe('TC-CACC-INVITE-PERSON-001: person invite resolves the company link', () => {
+  test('an invite carrying only personEntityId stores the person company', async ({ request }) => {
+    const stamp = Date.now()
+    let adminToken: string | null = null
+    let companyId: string | null = null
+    let personId: string | null = null
+
+    try {
+      adminToken = await getAuthToken(request, 'admin')
+
+      companyId = await createCompanyFixture(request, adminToken, `QA CACC IP001 Company ${stamp}`)
+
+      personId = await createPersonFixture(request, adminToken, {
+        firstName: 'QA',
+        lastName: `CACCIP001${stamp}`,
+        displayName: `QA CACC IP001 Person ${stamp}`,
+        companyEntityId: companyId,
+      })
+
+      const rolesRes = await apiRequest(request, 'GET', '/api/customer_accounts/admin/roles?pageSize=10', {
+        token: adminToken,
+      })
+      expect(rolesRes.ok(), 'roles list should succeed').toBeTruthy()
+      const rolesBody = (await rolesRes.json()) as { items: Array<{ id: string }> }
+      expect(rolesBody.items.length, 'tenant should have at least one customer role').toBeGreaterThan(0)
+      const roleId = rolesBody.items[0].id
+
+      const inviteRes = await apiRequest(request, 'POST', '/api/customer_accounts/admin/users-invite', {
+        token: adminToken,
+        data: {
+          email: `qa-cacc-ip001-${stamp}@test.local`,
+          roleIds: [roleId],
+          displayName: `QA CACC IP001 ${stamp}`,
+          personEntityId: personId,
+        },
+      })
+      expect(inviteRes.status(), 'person invite should return 201').toBe(201)
+      const inviteBody = (await inviteRes.json()) as {
+        invitation: { personEntityId: string | null; customerEntityId: string | null }
+      }
+      expect(inviteBody.invitation.personEntityId).toBe(personId)
+      expect(
+        inviteBody.invitation.customerEntityId,
+        'the person company must be resolved so the accepted user gets a portal scope key',
+      ).toBe(companyId)
+
+      // The same guard from the other side: a company id passed as a person id is
+      // rejected instead of being copied onto the future portal user.
+      const badRes = await apiRequest(request, 'POST', '/api/customer_accounts/admin/users-invite', {
+        token: adminToken,
+        data: {
+          email: `qa-cacc-ip001-bad-${stamp}@test.local`,
+          roleIds: [roleId],
+          personEntityId: companyId,
+        },
+      })
+      expect(badRes.status(), 'a company id used as personEntityId must be rejected').toBe(400)
+      const badBody = (await badRes.json()) as { ok: boolean; error?: string }
+      expect(badBody.ok).toBe(false)
+      expect(badBody.error).toBe('Person not found')
+    } finally {
+      // Invitations have no delete endpoint; the CRM fixtures are removed instead.
+      await deleteEntityIfExists(request, adminToken, '/api/customers/people', personId)
+      await deleteEntityIfExists(request, adminToken, '/api/customers/companies', companyId)
+    }
+  })
+})

--- a/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-person-link.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-person-link.test.ts
@@ -12,6 +12,7 @@ const mockGetAuthFromRequest = jest.fn()
 const mockEmit = jest.fn(async () => undefined)
 const mockIsOwnedCompanyEntity = jest.fn()
 const mockIsOwnedPersonEntity = jest.fn()
+const mockResolveOwnedCompanyForPerson = jest.fn()
 
 jest.mock('@open-mercato/core/modules/customer_accounts/lib/rateLimiter', () => ({
   checkAuthRateLimit: (...args: unknown[]) => mockCheckAuthRateLimit(...args),
@@ -43,6 +44,7 @@ jest.mock('@open-mercato/core/modules/customer_accounts/events', () => ({
 jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership', () => ({
   isOwnedCompanyEntity: (...args: unknown[]) => mockIsOwnedCompanyEntity(...args),
   isOwnedPersonEntity: (...args: unknown[]) => mockIsOwnedPersonEntity(...args),
+  resolveOwnedCompanyForPerson: (...args: unknown[]) => mockResolveOwnedCompanyForPerson(...args),
 }))
 
 const tenantId = '22222222-2222-4222-8222-222222222222'
@@ -68,10 +70,17 @@ describe('admin users-invite — person link + company ownership (#4362)', () =>
     mockGetAuthFromRequest.mockResolvedValue({ sub: 'staff-1', tenantId, orgId: organizationId })
     mockIsOwnedCompanyEntity.mockResolvedValue(true)
     mockIsOwnedPersonEntity.mockResolvedValue(true)
-    mockCreateInvitation.mockResolvedValue({
-      invitation: { id: invitationId, email: 'buyer@example.com', customerEntityId: null, expiresAt: new Date().toISOString() },
+    mockResolveOwnedCompanyForPerson.mockResolvedValue(null)
+    mockCreateInvitation.mockImplementation(async (_email: string, _scope: unknown, options: Record<string, unknown>) => ({
+      invitation: {
+        id: invitationId,
+        email: 'buyer@example.com',
+        customerEntityId: options.customerEntityId ?? null,
+        personEntityId: options.personEntityId ?? null,
+        expiresAt: new Date().toISOString(),
+      },
       rawToken: 'raw-secret-token',
-    })
+    }))
   })
 
   it('passes personEntityId through to the invitation service and does not require a company', async () => {
@@ -137,6 +146,54 @@ describe('admin users-invite — person link + company ownership (#4362)', () =>
     expect(res.status).toBe(201)
     expect(mockIsOwnedCompanyEntity).toHaveBeenCalledWith(expect.anything(), companyEntityId, { tenantId, organizationId })
     expect(mockCreateInvitation).toHaveBeenCalledTimes(1)
+    const options = mockCreateInvitation.mock.calls[0][2] as Record<string, unknown>
+    expect(options.customerEntityId).toBe(companyEntityId)
+  })
+
+  it('derives the company from the person profile so the accepted user gets a portal scope key', async () => {
+    // Without this the person-invited user accepts with customerEntityId null and
+    // autoLinkCrm short-circuits on personEntityId, leaving the portal Users page,
+    // portal invitations, and the company detail listing permanently empty.
+    mockResolveOwnedCompanyForPerson.mockResolvedValue(companyEntityId)
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(makeInviteRequest({ email: 'buyer@example.com', roleIds: [roleId], personEntityId }))
+
+    expect(res.status).toBe(201)
+    expect(mockResolveOwnedCompanyForPerson).toHaveBeenCalledWith(expect.anything(), personEntityId, { tenantId, organizationId })
+    const options = mockCreateInvitation.mock.calls[0][2] as Record<string, unknown>
+    expect(options.customerEntityId).toBe(companyEntityId)
+    expect(options.personEntityId).toBe(personEntityId)
+    // The response echoes the resolved links so callers (and integration tests)
+    // can observe which company the person invite landed on.
+    const json = await res.json() as { invitation: Record<string, unknown> }
+    expect(json.invitation.customerEntityId).toBe(companyEntityId)
+    expect(json.invitation.personEntityId).toBe(personEntityId)
+  })
+
+  it('leaves customerEntityId null when the person has no in-scope company', async () => {
+    // The helper returns null both for a person without a company and for one whose
+    // company sits outside the caller org; neither may become a portal scope key.
+    mockResolveOwnedCompanyForPerson.mockResolvedValue(null)
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(makeInviteRequest({ email: 'buyer@example.com', roleIds: [roleId], personEntityId }))
+
+    expect(res.status).toBe(201)
+    const options = mockCreateInvitation.mock.calls[0][2] as Record<string, unknown>
+    expect(options.customerEntityId).toBeNull()
+  })
+
+  it('keeps an explicit customerEntityId instead of deriving one from the person', async () => {
+    mockResolveOwnedCompanyForPerson.mockResolvedValue(personEntityId)
+    const { POST } = await import('../admin/users-invite')
+    const res = await POST(makeInviteRequest({
+      email: 'buyer@example.com',
+      roleIds: [roleId],
+      personEntityId,
+      customerEntityId: companyEntityId,
+    }))
+
+    expect(res.status).toBe(201)
+    expect(mockResolveOwnedCompanyForPerson).not.toHaveBeenCalled()
     const options = mockCreateInvitation.mock.calls[0][2] as Record<string, unknown>
     expect(options.customerEntityId).toBe(companyEntityId)
   })

--- a/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
@@ -7,7 +7,7 @@ import { RbacService } from '@open-mercato/core/modules/auth/services/rbacServic
 import { CustomerInvitationService } from '@open-mercato/core/modules/customer_accounts/services/customerInvitationService'
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { inviteUserSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
-import { isOwnedCompanyEntity, isOwnedPersonEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
+import { isOwnedCompanyEntity, isOwnedPersonEntity, resolveOwnedCompanyForPerson } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
 import { rateLimitErrorSchema } from '@open-mercato/shared/lib/ratelimit/helpers'
 import {
   checkAuthRateLimit,
@@ -70,6 +70,7 @@ export async function POST(req: Request) {
   // Same guard for the person FK: it is copied onto the customer user on accept
   // and makes `autoLinkCrm` short-circuit, so an unowned id would permanently
   // cross-link the portal user to another org's CRM person.
+  let resolvedCustomerEntityId = parsed.data.customerEntityId || null
   if (parsed.data.personEntityId) {
     const em = container.resolve('em') as import('@mikro-orm/postgresql').EntityManager
     const owned = await isOwnedPersonEntity(em, parsed.data.personEntityId, {
@@ -79,6 +80,17 @@ export async function POST(req: Request) {
     if (!owned) {
       return NextResponse.json({ ok: false, error: 'Person not found' }, { status: 400 })
     }
+
+    // An invitation raised from a person card carries only the person FK, and the
+    // accepted user then short-circuits `autoLinkCrm`. Resolve the person's company
+    // here so the user lands with a company scope key: the portal Users page, portal
+    // invitations, and the company detail "Portal users" group all filter on it.
+    if (!resolvedCustomerEntityId) {
+      resolvedCustomerEntityId = await resolveOwnedCompanyForPerson(em, parsed.data.personEntityId, {
+        tenantId: auth.tenantId,
+        organizationId: auth.orgId,
+      })
+    }
   }
 
   const customerInvitationService = container.resolve('customerInvitationService') as CustomerInvitationService
@@ -87,7 +99,7 @@ export async function POST(req: Request) {
     parsed.data.email,
     { tenantId: auth.tenantId!, organizationId: auth.orgId! },
     {
-      customerEntityId: parsed.data.customerEntityId || null,
+      customerEntityId: resolvedCustomerEntityId,
       personEntityId: parsed.data.personEntityId || null,
       roleIds: parsed.data.roleIds,
       invitedByUserId: auth.sub,
@@ -109,6 +121,10 @@ export async function POST(req: Request) {
     invitation: {
       id: invitation.id,
       email: invitation.email,
+      // Echo the stored CRM links so the caller can see which company the person
+      // invite resolved to. The token stays unexposed.
+      customerEntityId: invitation.customerEntityId || null,
+      personEntityId: invitation.personEntityId || null,
       expiresAt: invitation.expiresAt,
     },
   }, { status: 201 })
@@ -119,6 +135,8 @@ const successSchema = z.object({
   invitation: z.object({
     id: z.string().uuid(),
     email: z.string(),
+    customerEntityId: z.string().uuid().nullable(),
+    personEntityId: z.string().uuid().nullable(),
     expiresAt: z.string().datetime(),
   }),
 })

--- a/packages/core/src/modules/customer_accounts/lib/customerEntityOwnership.ts
+++ b/packages/core/src/modules/customer_accounts/lib/customerEntityOwnership.ts
@@ -42,9 +42,48 @@ export async function isOwnedPersonEntity(
   return isOwnedEntityOfKind(em, personEntityId, 'person', scope)
 }
 
+/**
+ * Resolves the CRM company a person belongs to, but only when both the profile
+ * lookup and the company itself stay inside the given tenant/organization scope.
+ * Returns null when the person has no company or that company is out of scope.
+ *
+ * Both the invite route and the CRM auto-link subscriber need this answer, and
+ * both write the result into `customerEntityId` — the portal company scope key —
+ * so they must agree on what counts as an in-scope company.
+ */
+export async function resolveOwnedCompanyForPerson(
+  em: EntityManager,
+  personEntityId: string,
+  scope: CustomerEntityScope,
+): Promise<string | null> {
+  const { CustomerPersonProfile } = await import('@open-mercato/core/modules/customers/data/entities')
+  const profile = await em.findOne(CustomerPersonProfile as any, {
+    entity: personEntityId,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+  } as any)
+  const candidate = readCompanyEntityId(profile)
+  if (!candidate) return null
+  return (await isOwnedCompanyEntity(em, candidate, scope)) ? candidate : null
+}
+
+/**
+ * `CustomerPersonProfile.company` is a relation on `company_entity_id`, not a
+ * scalar — MikroORM hands back either the raw id or an entity reference, never a
+ * `companyEntityId` property. Reading the wrong one silently yields undefined and
+ * turns every company recovery into a clear.
+ */
+function readCompanyEntityId(profile: unknown): string | null {
+  const company = (profile as { company?: unknown } | null | undefined)?.company
+  if (!company) return null
+  if (typeof company === 'string') return company
+  const id = (company as { id?: unknown }).id
+  return typeof id === 'string' ? id : null
+}
+
 async function isOwnedEntityOfKind(
   em: EntityManager,
-  customerEntityId: string,
+  entityId: string,
   kind: 'company' | 'person',
   scope: CustomerEntityScope,
 ): Promise<boolean> {
@@ -53,7 +92,7 @@ async function isOwnedEntityOfKind(
     em,
     CustomerEntity,
     {
-      id: customerEntityId,
+      id: entityId,
       tenantId: scope.tenantId,
       organizationId: scope.organizationId,
       kind,

--- a/packages/core/src/modules/customer_accounts/subscribers/__tests__/autoLinkCrm-normalize.test.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/__tests__/autoLinkCrm-normalize.test.ts
@@ -3,7 +3,7 @@
 import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
 
 const mockFindOneWithDecryption = jest.fn()
-const mockFindWithDecryption = jest.fn(async () => [] as unknown[])
+const mockFindWithDecryption = jest.fn()
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
@@ -28,6 +28,8 @@ const userId = '33333333-3333-4333-8333-333333333333'
 const personEntityId = '44444444-4444-4444-8444-444444444444'
 const companyEntityId = '55555555-5555-4555-8555-555555555555'
 const linkedPersonId = '66666666-6666-4666-8666-666666666666'
+const otherOrganizationId = '77777777-7777-4777-8777-777777777777'
+const otherOrgPersonId = '88888888-8888-4888-8888-888888888888'
 
 type EmMock = {
   findOne: jest.Mock
@@ -58,7 +60,7 @@ describe('autoLinkCrm — poisoned customerEntityId normalization (#4362)', () =
       return null
     })
     const em: EmMock = {
-      findOne: jest.fn(async () => ({ companyEntityId })),
+      findOne: jest.fn(async () => ({ company: { id: companyEntityId } })),
       nativeUpdate: jest.fn(async () => 1),
     }
     const { default: handle } = await import('../autoLinkCrm')
@@ -128,7 +130,7 @@ describe('autoLinkCrm — poisoned customerEntityId normalization (#4362)', () =
       return null
     })
     const em: EmMock = {
-      findOne: jest.fn(async () => ({ companyEntityId })),
+      findOne: jest.fn(async () => ({ company: { id: companyEntityId } })),
       nativeUpdate: jest.fn(async () => 1),
     }
     const { default: handle } = await import('../autoLinkCrm')
@@ -148,6 +150,188 @@ describe('autoLinkCrm — poisoned customerEntityId normalization (#4362)', () =
       if (entity === CustomerEntity) return { id: companyEntityId, kind: 'company' }
       return null
     })
+    const em: EmMock = {
+      findOne: jest.fn(async () => null),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+  })
+
+  it('scopes the person profile lookup by tenant and organization', async () => {
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId, customerEntityId: linkedPersonId }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => {
+      if (entity === CustomerUser) return user
+      if (entity === CustomerEntity) return { id: linkedPersonId, kind: 'person' }
+      return null
+    })
+    const em: EmMock = {
+      findOne: jest.fn(async () => ({ company: { id: companyEntityId } })),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.findOne).toHaveBeenCalledWith(CustomerPersonProfile, {
+      entity: linkedPersonId,
+      tenantId,
+      organizationId,
+    })
+  })
+})
+
+describe('autoLinkCrm — CRM auto-link path scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  // The fifth argument of findWithDecryption is a decryption scope, not a filter,
+  // so only the `where` clause keeps the candidate lookup inside the user's org.
+  // These mocks apply the `where` the way the database would.
+  function mockPersonEntities(rows: Array<Record<string, unknown>>) {
+    mockFindWithDecryption.mockImplementation(async (_em: unknown, _entity: unknown, where: any) => (
+      rows.filter((row) => !where?.organizationId || row.organizationId === where.organizationId)
+    ))
+  }
+
+  it('does not link a CRM person that belongs to another organization', async () => {
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId: null, customerEntityId: null }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => (
+      entity === CustomerUser ? user : null
+    ))
+    mockPersonEntities([
+      { id: otherOrgPersonId, kind: 'person', organizationId: otherOrganizationId, primaryEmail: 'a@b.co' },
+    ])
+    const em: EmMock = {
+      findOne: jest.fn(async () => ({ company: { id: companyEntityId } })),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(mockFindWithDecryption).toHaveBeenCalledWith(
+      expect.anything(),
+      CustomerEntity,
+      expect.objectContaining({ tenantId, organizationId, kind: 'person' }),
+      expect.anything(),
+      expect.anything(),
+    )
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+  })
+
+  it('links an in-org CRM person together with its in-org company', async () => {
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId: null, customerEntityId: null }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown, where: any) => {
+      if (entity === CustomerUser) return user
+      if (entity === CustomerEntity && where?.kind === 'company') return { id: companyEntityId, kind: 'company' }
+      return null
+    })
+    mockPersonEntities([
+      { id: linkedPersonId, kind: 'person', organizationId, primaryEmail: 'A@B.co' },
+    ])
+    const em: EmMock = {
+      findOne: jest.fn(async () => ({ company: { id: companyEntityId } })),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      CustomerUser,
+      { id: userId, tenantId, organizationId },
+      { personEntityId: linkedPersonId, customerEntityId: companyEntityId },
+    )
+  })
+
+  it('links the person but not a company that sits outside the user org', async () => {
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId: null, customerEntityId: null }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => (
+      entity === CustomerUser ? user : null
+    ))
+    mockPersonEntities([
+      { id: linkedPersonId, kind: 'person', organizationId, primaryEmail: 'a@b.co' },
+    ])
+    const em: EmMock = {
+      findOne: jest.fn(async () => ({ company: { id: companyEntityId } })),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      CustomerUser,
+      { id: userId, tenantId, organizationId },
+      { personEntityId: linkedPersonId },
+    )
+  })
+})
+
+describe('autoLinkCrm — person-invited users get a company scope key (#4362)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('derives customerEntityId from the linked person profile', async () => {
+    // These users accept with personEntityId already set, so the email-matching
+    // path never runs for them and customerEntityId would stay null forever.
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId, customerEntityId: null }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown, where: any) => {
+      if (entity === CustomerUser) return user
+      if (entity === CustomerEntity && where?.kind === 'company') return { id: companyEntityId, kind: 'company' }
+      return null
+    })
+    const em: EmMock = {
+      findOne: jest.fn(async () => ({ company: { id: companyEntityId } })),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.findOne).toHaveBeenCalledWith(CustomerPersonProfile, {
+      entity: personEntityId,
+      tenantId,
+      organizationId,
+    })
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      CustomerUser,
+      { id: userId, tenantId, organizationId },
+      { customerEntityId: companyEntityId },
+    )
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('reads the profile company relation in its raw id form too', async () => {
+    // MikroORM hands back either an entity reference or the bare uuid depending on
+    // whether the relation is loaded; both must resolve to the same company.
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId, customerEntityId: null }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown, where: any) => {
+      if (entity === CustomerUser) return user
+      if (entity === CustomerEntity && where?.kind === 'company') return { id: companyEntityId, kind: 'company' }
+      return null
+    })
+    const em: EmMock = {
+      findOne: jest.fn(async () => ({ company: companyEntityId })),
+      nativeUpdate: jest.fn(async () => 1),
+    }
+    const { default: handle } = await import('../autoLinkCrm')
+    await handle({ id: userId, tenantId, organizationId }, makeCtx(em))
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      CustomerUser,
+      { id: userId, tenantId, organizationId },
+      { customerEntityId: companyEntityId },
+    )
+  })
+
+  it('writes nothing when the linked person has no in-org company', async () => {
+    const user = { id: userId, tenantId, organizationId, email: 'a@b.co', personEntityId, customerEntityId: null }
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, entity: unknown) => (
+      entity === CustomerUser ? user : null
+    ))
     const em: EmMock = {
       findOne: jest.fn(async () => null),
       nativeUpdate: jest.fn(async () => 1),

--- a/packages/core/src/modules/customer_accounts/subscribers/autoLinkCrm.ts
+++ b/packages/core/src/modules/customer_accounts/subscribers/autoLinkCrm.ts
@@ -1,7 +1,7 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { isOwnedCompanyEntity } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
+import { resolveOwnedCompanyForPerson } from '@open-mercato/core/modules/customer_accounts/lib/customerEntityOwnership'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('customer_accounts').child({ component: 'auto-link-crm' })
@@ -28,21 +28,23 @@ export default async function handle(
     const user = await findOneWithDecryption(em, CustomerUser, { id: userId, tenantId, deletedAt: null }, undefined, { tenantId, organizationId })
     if (!user) return
 
-    const { CustomerEntity, CustomerPersonProfile } = await import('@open-mercato/core/modules/customers/data/entities')
+    const { CustomerEntity } = await import('@open-mercato/core/modules/customers/data/entities')
 
-    // Defensive normalization: customerEntityId is the CRM company FK. Earlier
-    // invite flows (#4362) could poison it with a person entity id, which then
-    // breaks every later user edit ("Company not found"). If the linked entity
-    // is a person (not a company), drop it — or recover the person's real
-    // company from their profile. Correct company links are left untouched.
+    // Every lookup and write below normalizes against the user's OWN org, not just
+    // the tenant: customerEntityId is the portal's company scope key (portal user
+    // and invite routes filter on it), so adopting an entity from another org would
+    // widen the user's portal access instead of repairing it.
+    const ownScope = { tenantId, organizationId: user.organizationId }
+
+    // Defensive normalization for NEW users only — this subscriber runs on
+    // `customer_accounts.user.created`, which is never re-emitted for an existing
+    // row. customerEntityId is the CRM company FK, and earlier invite flows (#4362)
+    // could poison it with a person entity id, which then breaks every later user
+    // edit ("Company not found"). If the linked entity is a person (not a company)
+    // or sits outside the user's org, drop it — or recover the person's real company
+    // from their profile. Correct company links are left untouched. Rows created
+    // before this change keep their bad FK; see #4473 for the backfill.
     if (user.customerEntityId) {
-      // Normalize against the user's OWN org, not just the tenant: customerEntityId
-      // is the portal's company scope key (portal user/invite routes filter on it),
-      // so adopting a company from another org would widen the user's portal access
-      // instead of repairing it. Anything that is not an owned company here — a
-      // person id (the #4362 poisoning) or a cross-org entity — is recovered to the
-      // person's own company when that company is in-org, otherwise cleared.
-      const ownScope = { tenantId, organizationId: user.organizationId }
       const linked = await findOneWithDecryption(
         em,
         CustomerEntity,
@@ -60,16 +62,8 @@ export default async function handle(
         )
         user.customerEntityId = null
       } else if (linked.kind === 'person') {
-        const profile = await em.findOne(CustomerPersonProfile as any, {
-          entity: user.customerEntityId,
-          tenantId,
-          organizationId: user.organizationId,
-        } as any) as any
-        const candidate = (profile?.companyEntityId as string | undefined) || null
         // Only adopt a recovered company that is itself in the user's org.
-        const replacement = candidate && (await isOwnedCompanyEntity(em, candidate, ownScope))
-          ? candidate
-          : null
+        const replacement = await resolveOwnedCompanyForPerson(em, user.customerEntityId, ownScope)
         await em.nativeUpdate(
           CustomerUser,
           { id: userId, tenantId, organizationId: user.organizationId },
@@ -79,15 +73,35 @@ export default async function handle(
       }
     }
 
-    if (user.personEntityId) return
+    // A user invited from a CRM person card arrives with personEntityId already
+    // set, so the email-matching path below never runs for it. Derive the company
+    // FK from that person's own profile instead of leaving it null forever — the
+    // portal Users page, portal invitations, and the company detail "Portal users"
+    // group all key off customerEntityId (#4362).
+    if (user.personEntityId) {
+      if (user.customerEntityId) return
+      const recovered = await resolveOwnedCompanyForPerson(em, user.personEntityId, ownScope)
+      if (recovered) {
+        await em.nativeUpdate(
+          CustomerUser,
+          { id: userId, tenantId, organizationId: user.organizationId },
+          { customerEntityId: recovered },
+        )
+      }
+      return
+    }
 
     const email = (data?.email ? (data.email as string) : user.email)?.toLowerCase().trim()
     if (!email) return
 
+    // Scope the candidate lookup to the user's own org. The fifth argument is a
+    // decryption scope, not a filter, so without organizationId in the `where`
+    // this matches people across every org in the tenant and writes a cross-org
+    // link that the normalization block above just cleared.
     const personEntities = await findWithDecryption(
       em,
       CustomerEntity,
-      { tenantId, kind: 'person', deletedAt: null } as any,
+      { tenantId, organizationId: user.organizationId, kind: 'person', deletedAt: null } as any,
       { limit: 500 } as any,
       { tenantId, organizationId },
     )
@@ -98,8 +112,7 @@ export default async function handle(
 
     if (!matchingEntity) return
 
-    const profile = await em.findOne(CustomerPersonProfile as any, { entity: matchingEntity.id } as any) as any
-    const companyEntityId = profile?.companyEntityId as string | undefined
+    const companyEntityId = await resolveOwnedCompanyForPerson(em, matchingEntity.id, ownScope)
 
     const updates: Record<string, unknown> = { personEntityId: matchingEntity.id }
     if (companyEntityId) {
@@ -115,3 +128,4 @@ export default async function handle(
     logger.error('Failed to link customer user to CRM person', { err })
   }
 }
+


### PR DESCRIPTION
Addresses the code review on #4457. Targets `carry/pr-4453-ready` so the fixes land on that PR's head rather than forking the work again — I have no push access to the branch.

## What the review asked for, and what changed

**⛔ Blocker — cross-organization CRM auto-link.** `subscribers/autoLinkCrm.ts` looked up person entities with `{ tenantId, kind: 'person' }` and no `organizationId`. The fifth argument of `findWithDecryption` is a decryption scope, not a filter, so the lookup spanned every org in the tenant and wrote `personEntityId` (and the derived `customerEntityId`) from a cross-org match — re-poisoning the FK the normalization block twelve lines above had just cleared, and bypassing the `isOwnedPersonEntity` / `isOwnedCompanyEntity` guards the PR adds to both admin routes. The `where` clause is now org-scoped, `ownScope` is hoisted so both paths share it, and the derived company is validated before it is written.

**⚠️ Major — person-invited users never got a company link.** With the widget sending `personEntityId`, `autoLinkCrm` returned early on exactly the users that flow creates, so `customerEntityId` — the portal company scope key — stayed null forever: `api/portal/users.ts:27` and `api/portal/users-invite.ts:46` bail out, and the company detail "Portal users" group queries `?customerEntityId=`. Fixed the way the review preferred: `api/admin/users-invite.ts` resolves the person's company at invite time. The subscriber additionally derives it from the linked person when `customerEntityId` is null, which costs nothing on signup (the branch only runs when a person link exists without a company) and repairs invitations created before this change.

**🔹 Minor — unscoped profile lookup.** The `CustomerPersonProfile` lookup on the auto-link path is now scoped by tenant and organization, identical to its sibling.

**🔹 Minor — comment promised a repair it cannot deliver.** Reworded to state that the block guards new users only, since `customer_accounts.user.created` is never re-emitted for an existing row. Opened #4473 for the backfill of already-poisoned rows, including the open question about reading `customers` tables from a `customer_accounts` migration.

**💅 Nit.** `isOwnedEntityOfKind`'s parameter renamed to `entityId`.

## One bug the review did not catch

`CustomerPersonProfile` has **no** `companyEntityId` property — the FK lives on the `company` relation (`fieldName: 'company_entity_id'`), which is why `commands/people.ts:305` reads `profile.company` and normalizes the reference-or-string duality. Every `profile?.companyEntityId` read in this subscriber therefore resolved to `undefined`, so the "recover the person's real company from their profile" path never recovered anything — it always cleared. That read is pre-existing on the auto-link path and was inherited by the new normalization block.

The scoped profile lookup, the relation read, and the ownership probe now live in one exported `resolveOwnedCompanyForPerson` helper in `lib/customerEntityOwnership.ts`, used by both the route and the subscriber, so the two cannot drift apart again.

## Tests

Closing the three gaps the review listed, plus the new ones:

- auto-link path is org-scoped, and a person from another organization is not linked (fails without the blocker fix — verified by reverting the `where` clause)
- an in-org person is linked together with its in-org company; a company outside the org is not adopted
- person-invited users get `customerEntityId` derived, on both the route and the subscriber
- both shapes of the `company` relation (entity reference and raw uuid)
- the profile lookup is asserted to carry `tenantId` and `organizationId`
- `TC-CACC-INVITE-PERSON-001` integration case: invite-from-person-card against the real schema, asserting the resolved company and the `Person not found` rejection

To make that end state observable at integration level, the invite response now echoes `customerEntityId` and `personEntityId` (additive; the token stays unexposed, and the OpenAPI success schema is updated).

## Validation

Runner: local (no `app` container running).

- `packages/core` jest, full suite: 7707 passed, 0 failed. 11 suites fail to *load* in this worktree because `#generated/*` is absent (catalog/sales/translations/entities) — pre-existing and unrelated.
- `packages/core` `tsc --noEmit`: clean apart from the same `#generated` resolution errors.
- Lint could not run in this worktree (`eslint-config-next` does not resolve from the worktree root); CI covers it.

## Merge order

Merge this into `carry/pr-4453-ready` first, then #4457.