### PR TITLE
fix(customer_accounts): backfill poisoned customer_entity_id links (#4473)

### DIFF
--- a/.ai/runs/2026-07-24-4473-backfill-poisoned-customer-entity-links.md
+++ b/.ai/runs/2026-07-24-4473-backfill-poisoned-customer-entity-links.md
@@ -66,4 +66,4 @@ PR: #4494
 ### Phase 3: Publish
 
 - [x] 3.1 Open the PR and answer the issue's open question — 51c95219d
-- [ ] 3.2 Run the authoritative code-review pass and post the run summary
+- [x] 3.2 Run the authoritative code-review pass and post the run summary — fa8afa0f2

--- a/.ai/runs/2026-07-24-4473-backfill-poisoned-customer-entity-links.md
+++ b/.ai/runs/2026-07-24-4473-backfill-poisoned-customer-entity-links.md
@@ -1,0 +1,69 @@
+# Backfill poisoned customer_users.customer_entity_id rows
+
+## Overview
+
+Goal: repair the `customer_users.customer_entity_id` rows that issue #4473 describes — portal users created before #4457 whose CRM company FK points at a person entity, or at an entity in another organization, and who therefore stay scoped to the wrong company and cannot be edited from the admin form.
+
+Source issue: #4473 (follow-up to the code review of #4457).
+
+## Scope
+
+- Add one data-repair migration under `packages/core/src/modules/customer_accounts/migrations/`.
+- Mirror the normalization semantics of the `autoLinkCrm` subscriber exactly, so the one-off repair and the ongoing guard cannot disagree.
+- Decide the open question the issue deferred: whether the cross-module read needs a `to_regclass` guard, or whether the repair belongs in a CLI command instead.
+- Cover the emitted SQL with unit tests, following the existing migration-test pattern in `packages/core/src/modules/workflows/migrations/__tests__/`.
+
+## Non-goals
+
+- No change to `autoLinkCrm`, the invite routes, or the ownership helpers — the prevention side is #4457's scope and is still open.
+- No schema change: no new columns, indexes, or constraints, so `.snapshot-open-mercato.json` stays untouched.
+- No UI change and no new API surface.
+
+## Implementation Plan
+
+### Phase 1: Establish the repair semantics
+
+1. Extract the exact normalization rules from #4457's `autoLinkCrm` diff and the `customerEntityOwnership` helpers.
+2. Determine whether the cross-module read needs a `to_regclass` guard by checking how `dbMigrate` orders modules.
+
+### Phase 2: Implement and verify
+
+1. Write the migration with the SQL exposed through an exported builder so it can be unit-tested.
+2. Add unit tests covering the guard, the recovery branch, the clear branch, the optimistic-lock bump, and the forward-only `down()`.
+3. Verify the emitted SQL against a real Postgres across every branch, plus idempotency and the tables-absent no-op.
+4. Run the configured validation gate.
+
+### Phase 3: Publish
+
+1. Open the PR against `develop`, request the label set, and answer the issue's open question in the issue thread.
+2. Run the authoritative code-review pass and post the run summary.
+
+## Risks
+
+- **Cross-module read from a `customer_accounts` migration.** `dbMigrate` sorts enabled modules with `localeCompare`, so `customer_accounts` runs *before* `customers` and the tables being read do not exist on a fresh database. Mitigated by the `to_regclass` guard; such a database has no poisoned rows either, so skipping is correct rather than a compromise.
+- **Silently undoing the repair.** A client holding the pre-repair optimistic-lock version could resubmit the poisoned value. Mitigated by bumping `updated_at` on repaired rows so the stale client gets a 409 instead.
+- **Recovery and clearing drifting apart.** Two separate statements could disagree about what counts as in-scope. Mitigated by making the recovery a scalar subquery that yields `NULL` in every unrecoverable case, so both branches are one statement.
+- **Repairing rows that should not be touched.** A correct company link must survive untouched. Mitigated by gating the whole `UPDATE` on a `NOT EXISTS` probe for an in-org, non-deleted company, which also makes the migration idempotent.
+
+## Progress
+
+PR: #4494
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Establish the repair semantics
+
+- [x] 1.1 Extract normalization rules from #4457 and the ownership helpers — 51c95219d
+- [x] 1.2 Decide the `to_regclass` question from the `dbMigrate` module ordering — 51c95219d
+
+### Phase 2: Implement and verify
+
+- [x] 2.1 Write the migration with an exported SQL builder — 51c95219d
+- [x] 2.2 Add unit tests for guard, recovery, clear, lock bump, forward-only down — 51c95219d
+- [x] 2.3 Verify the emitted SQL on a real Postgres across all branches — 51c95219d
+- [x] 2.4 Run the configured validation gate — 51c95219d
+
+### Phase 3: Publish
+
+- [x] 3.1 Open the PR and answer the issue's open question — 51c95219d
+- [ ] 3.2 Run the authoritative code-review pass and post the run summary

--- a/packages/core/src/modules/customer_accounts/migrations/Migration20260724120000_customer_accounts.ts
+++ b/packages/core/src/modules/customer_accounts/migrations/Migration20260724120000_customer_accounts.ts
@@ -28,6 +28,13 @@ import { Migration } from '@mikro-orm/migrations';
  * in alphabetical order, so `customer_accounts` migrations run BEFORE `customers`
  * ones — on a fresh database these tables do not exist yet. A database in that
  * state has no poisoned rows to repair either, so skipping is the correct no-op.
+ * `catalog/Migration20251116191744` already ships the same guarded `do $$` idiom.
+ *
+ * This SQL is hand-written rather than produced by `yarn db:generate`, which the
+ * review checklist otherwise requires. The generator only diffs entities against
+ * the schema snapshot, so it cannot emit a data repair, and there is no schema
+ * change here to diff: no column, index, or constraint is touched, which is why
+ * `.snapshot-open-mercato.json` is deliberately left untouched by this migration.
  *
  * @public Exported for testing
  */

--- a/packages/core/src/modules/customer_accounts/migrations/Migration20260724120000_customer_accounts.ts
+++ b/packages/core/src/modules/customer_accounts/migrations/Migration20260724120000_customer_accounts.ts
@@ -1,0 +1,89 @@
+import { Migration } from '@mikro-orm/migrations';
+
+/**
+ * Builds the one-off repair for `customer_users.customer_entity_id` (#4473).
+ *
+ * `customerEntityId` is the CRM *company* FK and the portal company scope key —
+ * the portal Users page, portal invitations, and the company detail "Portal
+ * users" group all filter on it. Earlier invite flows (#4362) could store a
+ * person entity id, or an entity from another organization, in that column.
+ * The `autoLinkCrm` subscriber normalizes it (#4457), but it only runs on
+ * `customer_accounts.user.created`, which is never re-emitted for a row that
+ * already exists — so users created before that fix keep the bad FK forever.
+ * They stay scoped to the wrong company and every admin edit that resubmits the
+ * pre-filled value fails with "Company not found".
+ *
+ * The repair mirrors the subscriber's normalization exactly: touch only rows
+ * whose FK does NOT resolve to an in-org, non-deleted `company` entity, and for
+ * those either recover the real company from the person's profile (when the FK
+ * points at an in-org person whose company is itself in-org) or clear it.
+ *
+ * `updated_at` is bumped on every repaired row on purpose: it is the optimistic
+ * lock version. Without the bump a client holding the pre-repair version could
+ * resubmit the poisoned value and silently undo the fix instead of getting a
+ * 409 conflict.
+ *
+ * The whole statement is wrapped in a `to_regclass` guard because the `customers`
+ * tables it reads belong to a different module. `dbMigrate` walks enabled modules
+ * in alphabetical order, so `customer_accounts` migrations run BEFORE `customers`
+ * ones — on a fresh database these tables do not exist yet. A database in that
+ * state has no poisoned rows to repair either, so skipping is the correct no-op.
+ *
+ * @public Exported for testing
+ */
+export function buildRepairPoisonedCustomerEntityLinksSql(): string {
+  return `do $$
+begin
+  if to_regclass('customer_entities') is null or to_regclass('customer_people') is null then
+    return;
+  end if;
+
+  update "customer_users" cu
+     set "customer_entity_id" = (
+           select company."id"
+             from "customer_entities" person
+             join "customer_people" profile
+               on profile."entity_id" = person."id"
+              and profile."tenant_id" = person."tenant_id"
+              and profile."organization_id" = person."organization_id"
+             join "customer_entities" company
+               on company."id" = profile."company_entity_id"
+              and company."tenant_id" = person."tenant_id"
+              and company."organization_id" = person."organization_id"
+              and company."kind" = 'company'
+              and company."deleted_at" is null
+            where person."id" = cu."customer_entity_id"
+              and person."tenant_id" = cu."tenant_id"
+              and person."organization_id" = cu."organization_id"
+              and person."kind" = 'person'
+              and person."deleted_at" is null
+            order by profile."created_at", profile."id"
+            limit 1
+         ),
+         "updated_at" = now()
+   where cu."customer_entity_id" is not null
+     and not exists (
+           select 1
+             from "customer_entities" company
+            where company."id" = cu."customer_entity_id"
+              and company."tenant_id" = cu."tenant_id"
+              and company."organization_id" = cu."organization_id"
+              and company."kind" = 'company'
+              and company."deleted_at" is null
+         );
+end
+$$;`;
+}
+
+export class Migration20260724120000_customer_accounts extends Migration {
+
+  override up(): void | Promise<void> {
+    this.addSql(buildRepairPoisonedCustomerEntityLinksSql());
+  }
+
+  override down(): void | Promise<void> {
+    // Forward-only: the poisoned values are not recorded anywhere, so there is
+    // nothing to restore. Re-poisoning the column would reintroduce the bug.
+  }
+
+}

--- a/packages/core/src/modules/customer_accounts/migrations/__tests__/Migration20260724120000_customer_accounts.test.ts
+++ b/packages/core/src/modules/customer_accounts/migrations/__tests__/Migration20260724120000_customer_accounts.test.ts
@@ -35,10 +35,12 @@ describe('Migration20260724120000_customer_accounts', () => {
     // order in dbMigrate), so on a fresh database these tables do not exist.
     const sql = normalize(buildRepairPoisonedCustomerEntityLinksSql())
 
-    expect(sql).toContain(`to_regclass('customer_entities') is null`)
-    expect(sql).toContain(`to_regclass('customer_people') is null`)
-    // The guard must short-circuit, not fall through into the update.
-    expect(sql).toMatch(/if to_regclass\(.+\) is null.+then return; end if;/)
+    // Asserted as one exact clause rather than loose fragments: a guard that
+    // checks only one table, or that falls through into the update instead of
+    // returning, must fail here.
+    expect(sql).toContain(
+      `if to_regclass('customer_entities') is null or to_regclass('customer_people') is null then return; end if;`,
+    )
   })
 
   test('only touches rows whose FK is not an in-org, non-deleted company', async () => {

--- a/packages/core/src/modules/customer_accounts/migrations/__tests__/Migration20260724120000_customer_accounts.test.ts
+++ b/packages/core/src/modules/customer_accounts/migrations/__tests__/Migration20260724120000_customer_accounts.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, jest, test } from '@jest/globals'
+import {
+  Migration20260724120000_customer_accounts,
+  buildRepairPoisonedCustomerEntityLinksSql,
+} from '../Migration20260724120000_customer_accounts'
+
+async function collectSql(direction: 'up' | 'down'): Promise<string[]> {
+  const migration = Object.create(
+    Migration20260724120000_customer_accounts.prototype,
+  ) as Migration20260724120000_customer_accounts
+  const statements: string[] = []
+  Object.defineProperty(migration, 'addSql', {
+    value: jest.fn((sql: string) => statements.push(sql)),
+  })
+
+  await migration[direction]()
+
+  return statements
+}
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim()
+}
+
+describe('Migration20260724120000_customer_accounts', () => {
+  test('up() emits exactly the shared repair SQL (single source of truth)', async () => {
+    const statements = await collectSql('up')
+
+    expect(statements).toHaveLength(1)
+    expect(statements[0]).toBe(buildRepairPoisonedCustomerEntityLinksSql())
+  })
+
+  test('skips the repair when the customers tables are absent', async () => {
+    // customer_accounts migrations run before customers ones (alphabetical
+    // order in dbMigrate), so on a fresh database these tables do not exist.
+    const sql = normalize(buildRepairPoisonedCustomerEntityLinksSql())
+
+    expect(sql).toContain(`to_regclass('customer_entities') is null`)
+    expect(sql).toContain(`to_regclass('customer_people') is null`)
+    // The guard must short-circuit, not fall through into the update.
+    expect(sql).toMatch(/if to_regclass\(.+\) is null.+then return; end if;/)
+  })
+
+  test('only touches rows whose FK is not an in-org, non-deleted company', async () => {
+    const sql = normalize(buildRepairPoisonedCustomerEntityLinksSql())
+
+    expect(sql).toContain('update "customer_users" cu')
+    // A correct link is left alone — the update is gated on the NOT EXISTS of a
+    // matching company, which also makes re-running the migration a no-op.
+    expect(sql).toContain('where cu."customer_entity_id" is not null and not exists')
+    expect(sql).toContain('where company."id" = cu."customer_entity_id"')
+    expect(sql).toContain('and company."tenant_id" = cu."tenant_id"')
+    expect(sql).toContain('and company."organization_id" = cu."organization_id"')
+    expect(sql).toContain(`and company."kind" = 'company'`)
+    expect(sql).toContain('and company."deleted_at" is null')
+  })
+
+  test('recovers the company only from an in-org person with an in-org company', async () => {
+    const sql = normalize(buildRepairPoisonedCustomerEntityLinksSql())
+
+    // The FK must resolve to a person in the user's OWN organization…
+    expect(sql).toContain('where person."id" = cu."customer_entity_id"')
+    expect(sql).toContain('and person."tenant_id" = cu."tenant_id"')
+    expect(sql).toContain('and person."organization_id" = cu."organization_id"')
+    expect(sql).toContain(`and person."kind" = 'person'`)
+    expect(sql).toContain('and person."deleted_at" is null')
+    // …the profile lookup stays inside that same scope…
+    expect(sql).toContain('on profile."entity_id" = person."id"')
+    expect(sql).toContain('and profile."tenant_id" = person."tenant_id"')
+    expect(sql).toContain('and profile."organization_id" = person."organization_id"')
+    // …and so does the recovered company, because it becomes the portal scope key.
+    expect(sql).toContain('on company."id" = profile."company_entity_id"')
+    expect(sql).toContain('and company."tenant_id" = person."tenant_id"')
+    expect(sql).toContain('and company."organization_id" = person."organization_id"')
+    // Deterministic pick if a person somehow carries more than one profile row.
+    expect(sql).toContain('order by profile."created_at", profile."id" limit 1')
+  })
+
+  test('clears the FK when nothing can be recovered', async () => {
+    const sql = normalize(buildRepairPoisonedCustomerEntityLinksSql())
+
+    // The recovery is a scalar subquery: no in-org person, no in-org company, or
+    // no profile at all all yield NULL, which is the intended clear. There is no
+    // separate "set null" statement to keep the two branches from disagreeing.
+    expect(sql).toContain('set "customer_entity_id" = ( select company."id"')
+    expect(sql).not.toContain('set "customer_entity_id" = null')
+  })
+
+  test('bumps the optimistic-lock version on every repaired row', async () => {
+    const sql = normalize(buildRepairPoisonedCustomerEntityLinksSql())
+
+    // Without this a client holding the pre-repair updated_at could resubmit the
+    // poisoned value and silently undo the fix instead of getting a 409.
+    expect(sql).toContain('"updated_at" = now()')
+  })
+
+  test('is forward-only so a rollback cannot re-poison the column', async () => {
+    const statements = await collectSql('down')
+
+    expect(statements).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #4473
Tracking plan: .ai/runs/2026-07-24-4473-backfill-poisoned-customer-entity-links.md
Status: complete

## 🎯 Goal

Repair the portal users whose `customer_users.customer_entity_id` was poisoned before #4457. That column is the CRM **company** FK and the portal company scope key, but earlier invite flows (#4362) could store a person entity id there, or an entity from another organization. `autoLinkCrm` normalizes it — only on `customer_accounts.user.created`, which is emitted from three creation-time call sites and never re-emitted for an existing row. Rows created earlier therefore keep the bad FK: they stay scoped to the wrong company, possibly one in another organization, and `api/admin/users/[id].ts` rejects the edit form with `Company not found` whenever an admin resubmits the pre-filled value. The only workaround — clearing the company field before saving — is undiscoverable.

## What Changed

- **`packages/core/src/modules/customer_accounts/migrations/Migration20260724120000_customer_accounts.ts`** (new) — a one-off data repair that mirrors the subscriber's normalization exactly. It touches only rows whose FK does **not** resolve to an in-org, non-deleted `company` entity, and for those either recovers the real company from `customer_people.company_entity_id` (when the FK points at an in-org person whose company is itself in-org) or clears it. Both branches are a single `UPDATE`: the recovery is a scalar subquery that yields `NULL` in every unrecoverable case, so the two paths cannot drift apart, and the `NOT EXISTS` gate makes a re-run a no-op. The SQL is exposed through an exported builder so it is unit-testable, and the whole statement sits inside a `to_regclass` guard.
- **`.../migrations/__tests__/Migration20260724120000_customer_accounts.test.ts`** (new) — 7 tests over the emitted SQL, following the pattern already used by `packages/core/src/modules/workflows/migrations/__tests__/`.
- **`.ai/runs/2026-07-24-4473-backfill-poisoned-customer-entity-links.md`** (new) — execution plan and Progress checklist.

No schema change: no columns, indexes, or constraints, so `.snapshot-open-mercato.json` is untouched.

### Decisions worth a reviewer's attention

**The `to_regclass` guard is required, not optional** — this answers the question the issue deferred. `dbMigrate` walks enabled modules through `sortModules` → `a.id.localeCompare(b.id)` (`packages/cli/src/lib/db/commands.ts:50`), and `customer_accounts` sorts *before* `customers`. The exposure is therefore not just "a deployment without the `customers` module", it is **every fresh database**, where those tables do not exist yet when this migration runs. A database in that state has no poisoned rows either, so skipping is the correct outcome rather than a compromise — which is also why this does not need to become a CLI command an operator must remember to run.

**`updated_at` is bumped on repaired rows** because it is the optimistic-lock version. Without the bump, a client holding the pre-repair version could resubmit the poisoned value and silently undo the repair instead of getting a 409.

**`down()` is forward-only.** The poisoned values are recorded nowhere, so there is nothing to restore, and re-poisoning the column would reintroduce the bug.

## 🧪 Tests

- `yarn build:packages` ✅ · `yarn generate` ✅ (no diff) · `yarn typecheck` ✅ · `yarn lint` ✅ (0 errors; the remaining warnings are pre-existing in untouched files)
- `yarn workspace @open-mercato/core test --testPathPatterns customer_accounts` — **458 passed / 55 suites**, including the 7 new migration tests
- The new tests lock in: the `to_regclass` short-circuit, the org-scoping of the person/profile/company chain, the `NOT EXISTS` gate that spares correct links and makes re-runs no-ops, the single-statement recovery (asserting no separate `set … = null` statement exists to drift), the `updated_at` bump, and that `down()` emits nothing.
- **Real-Postgres verification** of the exact SQL string extracted from the migration file, run on a throwaway `postgres:16-alpine` with 10 fixture users covering every branch:

| case | result |
|---|---|
| FK → in-org company | untouched, version **not** bumped |
| FK → in-org person with in-org company | replaced with that company |
| FK → in-org person with company in another org | cleared |
| FK → in-org person with soft-deleted company | cleared |
| FK → in-org person with no company on the profile | cleared |
| FK → person entity with no profile row | cleared |
| FK → company in another org | cleared |
| FK → soft-deleted company | cleared |
| FK → dangling id | cleared |
| FK already null | untouched |

  A second run changed 0 rows (idempotent), and with `customer_entities`/`customer_people` dropped the `DO` block completed as a no-op — confirming PL/pgSQL defers name resolution until execution.

## 💥 Breaking Changes

None. No contract surface is touched: no types, signatures, import paths, event ids, widget spot ids, API routes, DI keys, ACL features, or schema. The only behavioral change is that already-broken rows start resolving correctly.

## Merge order

This repairs data; the source of new poisoning is fixed by #4457, which is still open. The two are independent and can merge in either order — but until #4457 lands, `develop` can still create fresh poisoned rows.

## Labels

My account has no triage permission on this repo (`AddLabelsToLabelable` → 403), so a maintainer needs to apply these. Requested set, with the rationale per `AGENTS.md`: `bug`, `review`, `needs-qa`, `priority-high`, `risk-high` — reasoning in the label-rationale comment below.

## 📋 Progress

See the Progress section in the tracking plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
