### PR TITLE
fix(workflows): make activity timeouts reachable from the UI and stored definitions (#4424)

### DIFF
--- a/.ai/runs/2026-07-24-workflow-activity-timeout.md
+++ b/.ai/runs/2026-07-24-workflow-activity-timeout.md
@@ -1,0 +1,99 @@
+# Make workflow activity timeouts reachable (#4424)
+
+> Retro-fitted plan. The run itself was executed before the skills collection was
+> installed in this clone, so the work landed as a single commit without a tracked
+> plan. This file reconstructs the plan from the delivered change so
+> `om-auto-continue-pr` can resume it and so the PR carries the standard
+> `Tracking plan:` reference.
+
+## Overview
+
+Goal: make a per-activity timeout configured in the workflows backend actually bound the
+activity's execution, instead of being silently discarded on save and ignored at run time.
+
+Root cause: three layers disagreed on the field name. The activity editors write
+`timeoutMs` (visual editor) or `timeout` (CrudForm and classic editors),
+`activityDefinitionSchema` accepted only `timeout: z.string()` — so `z.object()` stripped
+`timeoutMs` before it reached the database — and `lib/activity-executor.ts` read only
+`timeoutMs`. Net effect: activity-level timeouts did nothing for any definition created
+through the API or the UI.
+
+## Scope
+
+- Accept the canonical `timeoutMs` in `activityDefinitionSchema` and keep `timeout` as a
+  deprecated alias (duration string or milliseconds), per `BACKWARD_COMPATIBILITY.md`.
+- Normalize both fields before execution on the sync path and the async (queue) path.
+- Make the three activity editors display the effective value regardless of which field
+  carries it, so the value round-trips between editors.
+- Document the behavior in the user guide.
+
+## Non-goals
+
+- No change to the hub's activity/step state machines or to the queue worker contract.
+- No schema/migration work — activities live in the definition JSON, so there is no
+  new column and no optimistic-locking obligation.
+- No new UI field or i18n key; the existing "Timeout" inputs are reused.
+
+## Implementation Plan
+
+### Phase 1: Runtime normalization
+
+1. Add `toTimeoutMs()` to `lib/duration.ts` — accepts ms numbers, ms strings and duration
+   strings (`PT30S`, `5m`), returns `undefined` for anything unusable.
+2. Add `resolveActivityTimeoutMs()` to `lib/activity-executor.ts` (canonical `timeoutMs`
+   wins over the deprecated alias) and apply it in `executeActivity` and in
+   `enqueueActivity`'s queue payload so the async worker path is covered too.
+
+### Phase 2: Save-time schema
+
+1. Accept `timeoutMs: z.number().int().positive().optional()` and widen `timeout` to
+   `string | number` in `activityDefinitionSchema`.
+2. Reject an alias that cannot be interpreted at save time instead of ignoring it.
+
+### Phase 3: Editors
+
+1. `NodeEditDialog`, `ActivityArrayEditor` and `TransitionsEditor` display the effective
+   timeout regardless of which field carries it and clear the other field on edit.
+
+### Phase 4: Tests and docs
+
+1. Regression tests: schema round-trip, `toTimeoutMs` unit coverage, and an activity that
+   actually times out through the deprecated alias.
+2. Document `timeoutMs` and the accepted alias forms in the workflows user guide.
+
+## Risks
+
+- **Behavior change, intentional and disclosed:** shipped example definitions
+  (`examples/sales-pipeline-definition.json`) and code-defined workflows (`workflows.ts`)
+  already carry activity-level `timeout: "PT10S"`-style values that were no-ops. They
+  become effective, so a slow `CALL_API` activity in those definitions is now bounded
+  where it previously ran unbounded. Called out in the PR body and summary comment so a
+  maintainer signs off on it rather than discovering it in production.
+- Rejecting an unusable `timeout` alias at save time could surface an error on re-saving a
+  definition that stored garbage there. Accepted: the alternative is keeping the silent
+  no-op this issue is about, and empty/absent values remain valid.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+PR: #4495
+
+### Phase 1: Runtime normalization
+
+- [x] 1.1 Add `toTimeoutMs()` to `lib/duration.ts` — f37ec9ba1
+- [x] 1.2 Add `resolveActivityTimeoutMs()` and apply it on the sync and async paths — f37ec9ba1
+
+### Phase 2: Save-time schema
+
+- [x] 2.1 Accept `timeoutMs`, widen the `timeout` alias to `string | number` — f37ec9ba1
+- [x] 2.2 Reject an uninterpretable alias at save time — f37ec9ba1
+
+### Phase 3: Editors
+
+- [x] 3.1 All three activity editors show the effective timeout and clear the other field — f37ec9ba1
+
+### Phase 4: Tests and docs
+
+- [x] 4.1 Regression tests (schema round-trip, `toTimeoutMs`, real timeout via the alias) — f37ec9ba1
+- [x] 4.2 Document timeouts in `apps/docs/docs/user-guide/workflows/activities.mdx` — f37ec9ba1

--- a/apps/docs/docs/user-guide/workflows/activities.mdx
+++ b/apps/docs/docs/user-guide/workflows/activities.mdx
@@ -251,6 +251,30 @@ The workflow continues immediately while the activity runs in the background.
 
 > 💡 **Tip**: Long-running API calls should be async to avoid blocking the workflow.
 
+## Timeouts
+
+Bound how long a single activity attempt may run. When the timeout elapses, the attempt fails with a
+timeout error and the retry policy (if any) decides whether another attempt follows.
+
+```json
+{
+  "timeoutMs": 30000
+}
+```
+
+`timeoutMs` (milliseconds) is the canonical field and is what the activity editors write. The older
+`timeout` field is still accepted for existing definitions and takes either a duration string or a
+millisecond value:
+
+```json
+{
+  "timeout": "30s"
+}
+```
+
+Both `"PT30S"` (ISO 8601) and `"30s"` (short form) are valid durations. When both fields are present,
+`timeoutMs` wins. A value that cannot be interpreted is rejected at save time rather than ignored.
+
 ## Retry Policies
 
 Configure automatic retries for activities that might fail temporarily (network errors, rate limits).

--- a/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
@@ -25,6 +25,7 @@ import {useT} from '@open-mercato/shared/lib/i18n/context'
 import {useDialogKeyHandler} from '@open-mercato/ui/hooks/useDialogKeyHandler'
 import {useConfirmDialog} from '@open-mercato/ui/backend/confirm-dialog'
 import {isFutureIsoDateString, isValidDurationString} from '../data/validators'
+import {toTimeoutMs} from '../lib/duration'
 
 export interface NodeEditDialogProps {
   node: Node | null
@@ -1023,10 +1024,14 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
                                   <Input
                                     type="text"
                                     size="sm"
-                                    value={activity.timeoutMs || ''}
+                                    value={activity.timeoutMs ?? toTimeoutMs(activity.timeout) ?? ''}
                                     onChange={(e) => {
                                       const updated = [...stepActivities]
-                                      updated[index].timeoutMs = e.target.value ? parseInt(e.target.value) : undefined
+                                      const { timeout: _deprecatedAlias, ...rest } = updated[index]
+                                      updated[index] = {
+                                        ...rest,
+                                        timeoutMs: e.target.value ? parseInt(e.target.value) : undefined,
+                                      }
                                       setStepActivities(updated)
                                     }}
                                     placeholder={t('workflows.form.placeholders.timeoutMs')}

--- a/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
@@ -14,6 +14,7 @@ import {
 import { Textarea } from '@open-mercato/ui/primitives/textarea'
 import { Trash2, Plus, ChevronUp, ChevronDown } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { toTimeoutMs } from '../lib/duration'
 
 interface Activity {
   activityId: string
@@ -26,7 +27,9 @@ interface Activity {
     retryDelay?: number
     backoffMultiplier?: number
   }
-  timeout?: number
+  timeoutMs?: number
+  /** @deprecated Use `timeoutMs`. Duration string ("PT30S") or milliseconds. */
+  timeout?: string | number
   compensation?: Record<string, any>
 }
 
@@ -130,6 +133,15 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
     const updated = [...value]
     const activities = [...(updated[transitionIndex].activities || [])]
     activities[activityIndex] = { ...activities[activityIndex], [field]: fieldValue }
+    updated[transitionIndex] = { ...updated[transitionIndex], activities }
+    onChange(updated)
+  }
+
+  const updateActivityTimeout = (transitionIndex: number, activityIndex: number, rawValue: string) => {
+    const updated = [...value]
+    const activities = [...(updated[transitionIndex].activities || [])]
+    const { timeout: _deprecatedAlias, ...activity } = activities[activityIndex]
+    activities[activityIndex] = { ...activity, timeoutMs: rawValue ? parseInt(rawValue) : undefined }
     updated[transitionIndex] = { ...updated[transitionIndex], activities }
     onChange(updated)
   }
@@ -461,8 +473,8 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
                             <Input
                               id={`activity-${index}-${activityIndex}-timeout`}
                               type="number"
-                              value={activity.timeout || ''}
-                              onChange={(e) => updateActivity(index, activityIndex, 'timeout', e.target.value ? parseInt(e.target.value) : undefined)}
+                              value={activity.timeoutMs ?? toTimeoutMs(activity.timeout) ?? ''}
+                              onChange={(e) => updateActivityTimeout(index, activityIndex, e.target.value)}
                               placeholder="30000"
                               className="mt-1 text-xs h-8"
                             />

--- a/packages/core/src/modules/workflows/components/fields/ActivityArrayEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/ActivityArrayEditor.tsx
@@ -26,8 +26,9 @@ export interface Activity {
   activityName: string
   activityType: 'SEND_EMAIL' | 'CALL_API' | 'UPDATE_ENTITY' | 'EMIT_EVENT' | 'CALL_WEBHOOK' | 'EXECUTE_FUNCTION' | 'WAIT'
   config: Record<string, any>
-  timeout?: string
   timeoutMs?: number
+  /** @deprecated Use `timeoutMs`. Duration string ("PT30S") or milliseconds. */
+  timeout?: string | number
   async?: boolean
   compensate?: boolean
   retryPolicy?: {
@@ -114,6 +115,13 @@ export function ActivityArrayEditor({ id, value = [], error, setValue, disabled 
   const updateActivity = (index: number, field: keyof Activity, fieldValue: any) => {
     const updated = [...activities]
     updated[index] = { ...updated[index], [field]: fieldValue }
+    setValue(updated)
+  }
+
+  const updateActivityTimeout = (index: number, rawValue: string) => {
+    const updated = [...activities]
+    const { timeoutMs: _canonical, ...activity } = updated[index]
+    updated[index] = { ...activity, timeout: rawValue }
     setValue(updated)
   }
 
@@ -251,8 +259,8 @@ export function ActivityArrayEditor({ id, value = [], error, setValue, disabled 
                       <Input
                         id={`${id}-${index}-timeout`}
                         type="text"
-                        value={activity.timeout || ''}
-                        onChange={(e) => updateActivity(index, 'timeout', e.target.value)}
+                        value={activity.timeout ?? activity.timeoutMs ?? ''}
+                        onChange={(e) => updateActivityTimeout(index, e.target.value)}
                         placeholder={t('workflows.fieldEditors.activities.timeoutPlaceholder')}
                         className="text-xs"
                         disabled={disabled}

--- a/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/workflows/data/__tests__/validators.test.ts
@@ -364,6 +364,31 @@ describe('Workflows Validators', () => {
       expect(result.retryPolicy?.backoffCoefficient).toBe(2)
     })
 
+    test('should keep timeoutMs so the executor can honor it', () => {
+      const result = activityDefinitionSchema.parse({ ...validActivity, timeoutMs: 30000 })
+      expect(result.timeoutMs).toBe(30000)
+    })
+
+    test('should keep the deprecated timeout alias as a duration string', () => {
+      const result = activityDefinitionSchema.parse({ ...validActivity, timeout: 'PT30S' })
+      expect(result.timeout).toBe('PT30S')
+    })
+
+    test('should keep the deprecated timeout alias as milliseconds', () => {
+      expect(activityDefinitionSchema.parse({ ...validActivity, timeout: 30000 }).timeout).toBe(30000)
+      expect(activityDefinitionSchema.parse({ ...validActivity, timeout: '30000' }).timeout).toBe('30000')
+    })
+
+    test('should reject an unusable timeout alias instead of silently dropping it', () => {
+      expect(() =>
+        activityDefinitionSchema.parse({ ...validActivity, timeout: 'whenever' })
+      ).toThrow(/Invalid timeout/i)
+    })
+
+    test('should reject a non-positive timeoutMs', () => {
+      expect(() => activityDefinitionSchema.parse({ ...validActivity, timeoutMs: 0 })).toThrow()
+    })
+
     test('should validate activity with compensation flag', () => {
       const withCompensation = {
         ...validActivity,

--- a/packages/core/src/modules/workflows/data/validators.ts
+++ b/packages/core/src/modules/workflows/data/validators.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { parseDuration } from '../lib/duration'
+import { parseDuration, toTimeoutMs } from '../lib/duration'
 
 /**
  * Workflows Module - Zod Validators
@@ -42,6 +42,7 @@ export function isFutureIsoDateString(value: unknown): boolean {
 const DURATION_ERROR = 'Invalid duration. Use ISO 8601 (e.g., PT5M, PT1H, P1D) or simple format (5m, 1h, 3d)'
 const UNTIL_ERROR = 'Invalid "until". Provide an ISO 8601 datetime string'
 const UNTIL_PAST_ERROR = '"until" must be a future datetime'
+const TIMEOUT_ERROR = 'Invalid timeout. Use milliseconds (e.g., 30000) or a duration (e.g., PT30S, 5m)'
 
 // ============================================================================
 // Enum Schemas - Workflow Types and Statuses
@@ -210,12 +211,23 @@ export const activityDefinitionSchema = z.object({
   config: z.record(z.string(), z.any()),
   async: z.boolean().default(false).optional(), // For Phase 8.3
   retryPolicy: activityRetryPolicySchema.optional(),
-  timeout: z.string().optional(), // ISO 8601 duration
+  timeoutMs: z.number().int().positive().optional(), // Canonical activity timeout
+  // Deprecated alias for `timeoutMs`: duration string ("PT30S", "5m") or milliseconds
+  timeout: z.union([z.string(), z.number()]).optional(),
   compensation: z.object({
     activityId: z.string().min(1), // ID of compensation activity
     automatic: z.boolean().default(true).optional() // Auto-trigger on failure
   }).optional(), // Compensation configuration (Phase 8.2)
 }).superRefine((activity, ctx) => {
+  const timeoutAlias = activity.timeout
+  if (timeoutAlias != null && timeoutAlias !== '' && toTimeoutMs(timeoutAlias) == null) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['timeout'],
+      message: TIMEOUT_ERROR,
+    })
+  }
+
   if (activity.activityType !== 'WAIT') return
   const config = activity.config || {}
   const hasDuration = config.duration != null && config.duration !== ''

--- a/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
@@ -1596,6 +1596,77 @@ describe('Activity Executor (Unit Tests)', () => {
       expect(result.success).toBe(false)
       expect(result.error).toContain('timeout after 50ms')
     })
+
+    test('should honor the deprecated timeout alias given as a millisecond string', async () => {
+      const mockFunction = jest.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200))
+        return { success: true }
+      })
+
+      mockContainer.resolve.mockReturnValue(mockFunction)
+
+      const activity: ActivityDefinition = {
+        activityId: 'activity-22',
+        activityName: 'Slow Function',
+        activityType: 'EXECUTE_FUNCTION',
+        config: {
+          functionName: 'slowFunction',
+          args: {},
+        },
+        timeout: '50',
+      }
+
+      const result = await activityExecutor.executeActivity(
+        mockEm,
+        mockContainer,
+        activity,
+        mockContext
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('timeout after 50ms')
+    })
+
+    test('should honor the deprecated timeout alias given as milliseconds', async () => {
+      const mockFunction = jest.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200))
+        return { success: true }
+      })
+
+      mockContainer.resolve.mockReturnValue(mockFunction)
+
+      const activity: ActivityDefinition = {
+        activityId: 'activity-23',
+        activityName: 'Slow Function',
+        activityType: 'EXECUTE_FUNCTION',
+        config: {
+          functionName: 'slowFunction',
+          args: {},
+        },
+        timeout: 50,
+      }
+
+      const result = await activityExecutor.executeActivity(
+        mockEm,
+        mockContainer,
+        activity,
+        mockContext
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('timeout after 50ms')
+    })
+
+    test('should prefer timeoutMs over the deprecated timeout alias', () => {
+      expect(
+        activityExecutor.resolveActivityTimeoutMs({ timeoutMs: 1000, timeout: 'PT30S' })
+      ).toBe(1000)
+      expect(activityExecutor.resolveActivityTimeoutMs({ timeout: 'PT30S' })).toBe(30_000)
+      expect(activityExecutor.resolveActivityTimeoutMs({ timeout: '5m' })).toBe(300_000)
+      expect(activityExecutor.resolveActivityTimeoutMs({ timeout: '30000' })).toBe(30_000)
+      expect(activityExecutor.resolveActivityTimeoutMs({ timeout: '' })).toBeUndefined()
+      expect(activityExecutor.resolveActivityTimeoutMs({})).toBeUndefined()
+    })
   })
 
   // ============================================================================

--- a/packages/core/src/modules/workflows/lib/__tests__/duration.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/duration.test.ts
@@ -1,4 +1,4 @@
-import { parseDuration } from '../duration'
+import { parseDuration, toTimeoutMs } from '../duration'
 
 describe('parseDuration', () => {
   describe('ISO 8601 format', () => {
@@ -66,5 +66,33 @@ describe('parseDuration', () => {
     test('throws on random text', () => {
       expect(() => parseDuration('abc')).toThrow('Invalid duration format')
     })
+  })
+})
+
+describe('toTimeoutMs', () => {
+  test('passes through positive millisecond numbers', () => {
+    expect(toTimeoutMs(30000)).toBe(30000)
+  })
+
+  test('parses millisecond strings', () => {
+    expect(toTimeoutMs('30000')).toBe(30000)
+    expect(toTimeoutMs(' 30000 ')).toBe(30000)
+  })
+
+  test('parses duration strings', () => {
+    expect(toTimeoutMs('PT30S')).toBe(30 * 1000)
+    expect(toTimeoutMs('5m')).toBe(5 * 60 * 1000)
+  })
+
+  test('returns undefined for absent, empty, or unusable values', () => {
+    expect(toTimeoutMs(undefined)).toBeUndefined()
+    expect(toTimeoutMs(null)).toBeUndefined()
+    expect(toTimeoutMs('')).toBeUndefined()
+    expect(toTimeoutMs('   ')).toBeUndefined()
+    expect(toTimeoutMs('whenever')).toBeUndefined()
+    expect(toTimeoutMs(0)).toBeUndefined()
+    expect(toTimeoutMs(-1)).toBeUndefined()
+    expect(toTimeoutMs(Number.NaN)).toBeUndefined()
+    expect(toTimeoutMs({})).toBeUndefined()
   })
 })

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -26,7 +26,7 @@ import { hasAllFeatures } from '@open-mercato/shared/security/features'
 import { callWebhookConfigSchema } from '../data/validators'
 import { WorkflowActivityJob, WORKFLOW_ACTIVITIES_QUEUE_NAME } from './activity-queue-types'
 import { logWorkflowEvent } from './event-logger'
-import { parseDuration } from './duration'
+import { parseDuration, toTimeoutMs } from './duration'
 import { getWorkflowSafeCommand } from './workflow-safe-commands'
 
 export { isPrivateUrl } from '@open-mercato/shared/lib/network'
@@ -106,7 +106,13 @@ export interface ActivityDefinition {
   config: any
   async?: boolean // Flag to execute activity asynchronously via queue
   retryPolicy?: RetryPolicy
-  timeoutMs?: number
+  timeoutMs?: number // Canonical timeout, in milliseconds
+  /**
+   * @deprecated Use `timeoutMs`. Kept for definitions authored with a duration
+   * string ("PT30S", "5m") or a raw millisecond value; resolved through
+   * `resolveActivityTimeoutMs()`.
+   */
+  timeout?: string | number
   compensate?: boolean // Flag to execute compensation on failure
 }
 
@@ -127,6 +133,18 @@ export interface ActivityContext {
   branchInstanceId?: string | null
   transitionId?: string
   userId?: string
+}
+
+/**
+ * Resolve the effective activity timeout in milliseconds
+ *
+ * `timeoutMs` is canonical; the deprecated `timeout` alias (duration string or
+ * milliseconds) is honored so definitions saved by any editor behave the same.
+ */
+export function resolveActivityTimeoutMs(
+  activity: Pick<ActivityDefinition, 'timeoutMs' | 'timeout'>
+): number | undefined {
+  return toTimeoutMs(activity.timeoutMs) ?? toTimeoutMs(activity.timeout)
 }
 
 type RbacFeatureResolver = {
@@ -230,7 +248,7 @@ export async function enqueueActivity(
     workflowContext,
     stepContext,
     retryPolicy: activity.retryPolicy,
-    timeoutMs: activity.timeoutMs,
+    timeoutMs: resolveActivityTimeoutMs(activity),
     tenantId: workflowInstance.tenantId,
     organizationId: workflowInstance.organizationId,
     userId: context.userId,
@@ -327,16 +345,17 @@ export async function executeActivity(
 
   let lastError: any
   let retryCount = 0
+  const timeoutMs = resolveActivityTimeoutMs(activity)
 
   for (let attempt = 0; attempt < retryPolicy.maxAttempts; attempt++) {
     try {
       const startTime = Date.now()
 
       // Execute with timeout if specified
-      const result = activity.timeoutMs
+      const result = timeoutMs
         ? await executeWithTimeout(
             () => executeActivityByType(em, container, activity, context),
-            activity.timeoutMs
+            timeoutMs
           )
         : await executeActivityByType(em, container, activity, context)
 

--- a/packages/core/src/modules/workflows/lib/duration.ts
+++ b/packages/core/src/modules/workflows/lib/duration.ts
@@ -49,3 +49,36 @@ export function parseDuration(duration: string): number {
 
   throw new Error(`Invalid duration format: ${duration}`)
 }
+
+/**
+ * Normalize a timeout value to milliseconds
+ *
+ * Accepts what the different workflow editors and stored definitions carry:
+ * - a millisecond number (30000)
+ * - a millisecond string ("30000")
+ * - a duration string ("PT30S", "5m")
+ *
+ * @param value - Raw timeout value
+ * @returns Milliseconds, or undefined when the value is absent or unusable
+ */
+export function toTimeoutMs(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value > 0 ? value : undefined
+  }
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  if (/^\d+$/.test(trimmed)) {
+    const ms = Number(trimmed)
+    return ms > 0 ? ms : undefined
+  }
+
+  try {
+    const ms = parseDuration(trimmed)
+    return Number.isFinite(ms) && ms > 0 ? ms : undefined
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
Closes #4424
Tracking plan: .ai/runs/2026-07-24-workflow-activity-timeout.md
Status: complete

## 🎯 Goal

A per-activity timeout configured in the workflows backend was silently discarded on save and ignored at run time, so activity-level timeouts did nothing for any definition created through the API or the UI. Root cause: three layers disagreed on the field name — the visual editor writes `timeoutMs`, the CrudForm and classic editors write `timeout`, `activityDefinitionSchema` accepted only `timeout: z.string()` (so `z.object()` stripped `timeoutMs` before it reached the database), and `lib/activity-executor.ts` read only `timeoutMs`.

## What Changed

- **`packages/core/src/modules/workflows/data/validators.ts`** — `activityDefinitionSchema` now accepts the canonical `timeoutMs` (`z.number().int().positive().optional()`), so the value the editors write survives validation, and keeps `timeout` as a deprecated alias widened to `string | number` for definitions already stored that way. A `timeout` alias that cannot be interpreted is now **rejected at save time** instead of silently ignored.
- **`packages/core/src/modules/workflows/lib/duration.ts`** — new `toTimeoutMs()` normalizes a millisecond number, a millisecond string, or a duration string (`PT30S`, `5m`) to milliseconds, returning `undefined` for anything unusable.
- **`packages/core/src/modules/workflows/lib/activity-executor.ts`** — new `resolveActivityTimeoutMs()` resolves an activity's effective timeout with `timeoutMs` taking precedence over the alias. Applied on the sync path (`executeActivity`) and on the async path (`enqueueActivity` → queue payload → worker), so the compensation handler is covered too since it routes through `executeActivity`.
- **`components/NodeEditDialog.tsx`, `components/fields/ActivityArrayEditor.tsx`, `components/TransitionsEditor.tsx`** — each editor now displays the effective timeout regardless of which field carries it and clears the other field when the user edits, so the value round-trips between the visual editor and the CrudForm editors instead of showing blank.
- **`apps/docs/docs/user-guide/workflows/activities.mdx`** — new Timeouts section documenting `timeoutMs`, the accepted alias forms, and the precedence rule.

## 🧪 Tests

- `yarn workspace @open-mercato/core test` — **1010 suites / 7752 tests passed**.
- Full configured gate green locally (Runner: local): `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`.
- New cases lock in exactly the round-trip this issue is about:
  - `data/__tests__/validators.test.ts` — `timeoutMs` survives parsing; the alias survives as duration string / ms number / ms string; a garbage alias throws; a non-positive `timeoutMs` throws.
  - `lib/__tests__/duration.test.ts` — `toTimeoutMs` unit coverage including the reject cases.
  - `lib/__tests__/activity-executor.test.ts` — an activity actually times out through the deprecated alias (string and number forms), and `timeoutMs` wins over the alias.

## 💥 Breaking Changes

No contract surface is removed — `timeout` stays accepted as a deprecated alias per `BACKWARD_COMPATIBILITY.md`, and `timeoutMs` is additive.

**One intentional runtime behavior change worth a maintainer's sign-off:** shipped example definitions (`examples/sales-pipeline-definition.json`) and code-defined workflows (`workflows.ts`) already carry activity-level `"timeout": "PT10S"`-style values that were no-ops until now. They become effective, so a slow `CALL_API` activity in those definitions is now bounded where it previously ran unbounded. That is the semantics their authors wrote them expecting, but it is a real change, not a pure no-op fix.

## 📋 Progress

See the Progress section in the tracking plan.

## Labels

My account has no triage rights on this repository (`AddLabelsToLabelable` → 403), so I cannot apply these myself. Requested set: `bug`, `review`, `needs-qa`, `priority-low`, `risk-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
