### PR TITLE
fix(ci): restore ESLint coverage in the lint job (#4472)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,8 +325,9 @@ jobs:
   # ── Lint ─────────────────────────────────────────────────────────────────────
   # Fast static analysis — runs in parallel with prepare and audit.
   # ESLint does not need compiled packages, so it can fail fast before heavy jobs.
-  # @open-mercato/app is excluded: its next lint script requires an ESLint config
-  # that is not yet present in the repo.
+  # @open-mercato/app is the only workspace with a `lint` script, so it must stay
+  # in scope: excluding it left turbo with zero commands and a permanently green
+  # no-op job (issue #4472).
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -362,8 +363,13 @@ jobs:
         if: steps.nm-cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
+      - name: Guard against an empty lint task graph
+        # Fails when `turbo run lint` resolves to zero commands, so a future
+        # filter or script rename cannot silently disable the gate again.
+        run: yarn lint:check-graph
+
       - name: Lint
-        run: yarn turbo run lint --filter=!@open-mercato/app
+        run: yarn lint
 
       - name: Guard against raw console.* logging
         # Blocking since the application-wide migration to the structured

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build:app": "turbo run build --filter=@open-mercato/app",
     "build:packages": "turbo run build --filter='./packages/*'",
     "lint": "turbo run lint",
+    "lint:check-graph": "node scripts/check-turbo-task-graph.mjs lint",
     "lint:ds": "eslint --config eslint.ds.config.mjs packages/core/src/modules packages/enterprise/src/modules packages/ui/src/backend",
     "typecheck": "turbo run typecheck",
     "test": "cross-env NODE_OPTIONS=--max-old-space-size=768 turbo run test --concurrency=2",

--- a/scripts/__tests__/lint-task-graph.test.mjs
+++ b/scripts/__tests__/lint-task-graph.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  NONEXISTENT_COMMAND,
+  collectExecutableTasks,
+  parseTurboDryRun,
+} from '../check-turbo-task-graph.mjs'
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..')
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'ci.yml')
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function collectWorkspaceManifests() {
+  const workspaceRoots = [path.join(repoRoot, 'apps'), path.join(repoRoot, 'packages')]
+  const manifests = []
+
+  for (const workspaceRoot of workspaceRoots) {
+    if (!fs.existsSync(workspaceRoot)) continue
+
+    for (const entry of fs.readdirSync(workspaceRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+
+      const manifestPath = path.join(workspaceRoot, entry.name, 'package.json')
+      if (fs.existsSync(manifestPath)) {
+        manifests.push({ manifestPath, manifest: readJson(manifestPath) })
+      }
+    }
+  }
+
+  return manifests
+}
+
+test('collectExecutableTasks ignores workspaces without the script', () => {
+  const dryRun = {
+    tasks: [
+      { taskId: '@open-mercato/core#lint', command: NONEXISTENT_COMMAND },
+      { taskId: '@open-mercato/ui#lint', command: '   ' },
+      { taskId: '@open-mercato/app#lint', command: 'eslint .' },
+    ],
+  }
+
+  assert.deepEqual(
+    collectExecutableTasks(dryRun).map((task) => task.taskId),
+    ['@open-mercato/app#lint'],
+  )
+})
+
+test('collectExecutableTasks reports an empty graph as zero commands', () => {
+  const dryRun = { tasks: [{ taskId: '@open-mercato/core#lint', command: NONEXISTENT_COMMAND }] }
+
+  assert.equal(collectExecutableTasks(dryRun).length, 0)
+  assert.equal(collectExecutableTasks({}).length, 0)
+  assert.equal(collectExecutableTasks(null).length, 0)
+})
+
+test('parseTurboDryRun tolerates output preceding the JSON payload', () => {
+  const parsed = parseTurboDryRun('turbo 2.10.5\n{"tasks":[{"taskId":"a#lint","command":"eslint ."}]}\n')
+
+  assert.equal(parsed.tasks[0].command, 'eslint .')
+  assert.throws(() => parseTurboDryRun('no json here'), /no JSON output/)
+})
+
+test('at least one workspace defines a lint script', () => {
+  const linted = collectWorkspaceManifests()
+    .filter(({ manifest }) => typeof manifest?.scripts?.lint === 'string')
+    .map(({ manifestPath }) => path.relative(repoRoot, manifestPath))
+
+  assert.ok(
+    linted.length > 0,
+    'No workspace defines a `lint` script, so `turbo run lint` would run nothing.',
+  )
+})
+
+test('the root lint script fans out to every workspace lint script', () => {
+  const rootManifest = readJson(path.join(repoRoot, 'package.json'))
+
+  assert.equal(rootManifest.scripts.lint, 'turbo run lint')
+  assert.equal(rootManifest.scripts['lint:check-graph'], 'node scripts/check-turbo-task-graph.mjs lint')
+})
+
+test('the CI lint job lints instead of filtering every lint script away', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8')
+
+  assert.match(workflow, /^\s+run: yarn lint:check-graph$/m)
+  assert.match(workflow, /^\s+run: yarn lint$/m)
+  assert.doesNotMatch(workflow, /turbo run lint[^\n]*--filter/)
+})

--- a/scripts/check-turbo-task-graph.mjs
+++ b/scripts/check-turbo-task-graph.mjs
@@ -1,0 +1,109 @@
+/**
+ * Turbo Task-Graph Guard
+ *
+ * `turbo run <task> [filters]` exits 0 when the resolved graph contains no
+ * runnable script, so a filter or a renamed script can silently turn a CI gate
+ * into a no-op. That is how the `lint` job stopped running ESLint entirely
+ * (issue #4472): `--filter=!@open-mercato/app` excluded the only workspace that
+ * defines a `lint` script, leaving 23 `<NONEXISTENT>` commands and a green job.
+ *
+ * This guard asks turbo for the dry-run graph and fails when the task resolves
+ * to zero executable commands.
+ *
+ * Usage:
+ *   node scripts/check-turbo-task-graph.mjs lint
+ *   node scripts/check-turbo-task-graph.mjs test --filter=./packages/*
+ *
+ * Exit code: 0 when at least one workspace runs a real command, 1 otherwise
+ * (or when turbo itself fails).
+ */
+
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resolveProjectBinary, resolveSpawnCommand } from './dev-spawn-utils.mjs'
+
+export const NONEXISTENT_COMMAND = '<NONEXISTENT>'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+export function parseTurboDryRun(stdout) {
+  const text = String(stdout ?? '')
+  const start = text.indexOf('{')
+  if (start === -1) {
+    throw new Error('Turbo dry-run produced no JSON output.')
+  }
+
+  return JSON.parse(text.slice(start))
+}
+
+export function collectExecutableTasks(dryRun) {
+  const tasks = Array.isArray(dryRun?.tasks) ? dryRun.tasks : []
+
+  return tasks.filter((task) => {
+    const command = typeof task?.command === 'string' ? task.command.trim() : ''
+    return command !== '' && command !== NONEXISTENT_COMMAND
+  })
+}
+
+function runTurboDryRun(turboArgs) {
+  const turboBinary = resolveProjectBinary('turbo', { cwd: ROOT })
+  const resolvedSpawn = resolveSpawnCommand(turboBinary, [...turboArgs, '--dry=json'])
+
+  return spawnSync(resolvedSpawn.command, resolvedSpawn.args, {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+    ...resolvedSpawn.spawnOptions,
+  })
+}
+
+function main() {
+  const [task, ...passthroughArgs] = process.argv.slice(2)
+  if (!task) {
+    console.error('Usage: node scripts/check-turbo-task-graph.mjs <task> [turbo args...]')
+    process.exit(1)
+  }
+
+  const turboArgs = ['run', task, ...passthroughArgs]
+  const printableCommand = `turbo ${turboArgs.join(' ')}`
+  const result = runTurboDryRun(turboArgs)
+
+  if (result.error) {
+    console.error(`Failed to run \`${printableCommand} --dry=json\`: ${result.error.message}`)
+    process.exit(1)
+  }
+
+  if (result.status !== 0) {
+    console.error(`\`${printableCommand} --dry=json\` exited with code ${result.status}.`)
+    if (result.stderr) console.error(result.stderr)
+    process.exit(1)
+  }
+
+  let dryRun
+  try {
+    dryRun = parseTurboDryRun(result.stdout)
+  } catch (error) {
+    console.error(`Could not read the task graph of \`${printableCommand}\`: ${error.message}`)
+    process.exit(1)
+  }
+
+  const executableTasks = collectExecutableTasks(dryRun)
+  if (executableTasks.length === 0) {
+    const scopedPackages = Array.isArray(dryRun?.packages) ? dryRun.packages.length : 0
+    console.error(`\`${printableCommand}\` resolves to zero executable commands.`)
+    console.error(
+      `${scopedPackages} package(s) are in scope but none of them defines a \`${task}\` script, so the command would exit 0 without doing any work.`,
+    )
+    console.error(`Add a \`${task}\` script to the packages that should run it, or fix the turbo filters.`)
+    process.exit(1)
+  }
+
+  const taskIds = executableTasks.map((entry) => entry.taskId ?? `${entry.package}#${entry.task}`)
+  console.log(`\`${printableCommand}\` runs ${executableTasks.length} command(s): ${taskIds.join(', ')}`)
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : ''
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main()
+}


### PR DESCRIPTION
## Summary

`.github/workflows/ci.yml` ran `yarn turbo run lint --filter=!@open-mercato/app`, but `@open-mercato/app` is the **only** workspace that defines a `lint` script. Excluding it left turbo with 23 `<NONEXISTENT>` commands, so the job exited 0 without linting a single file — the repo had no enforced ESLint coverage in CI.

This restores the gate (option 1 + 3 from the issue) and makes the failure mode impossible to reintroduce silently.

Fixes #4472

## Changes

- `.github/workflows/ci.yml`: the `Lint` step now runs `yarn lint` (`turbo run lint`, no filter), and the stale comment claiming the app "requires an ESLint config that is not yet present in the repo" is corrected — `eslint.config.mjs` has existed at the repo root for a while.
- New step `Guard against an empty lint task graph` runs `yarn lint:check-graph` before linting.
- `scripts/check-turbo-task-graph.mjs` (new): reads `turbo run <task> --dry=json` and exits 1 when the task resolves to zero executable commands, so a future filter change or script rename cannot turn the gate back into a no-op. Reusable for other turbo-backed gates (`node scripts/check-turbo-task-graph.mjs test --filter=./packages/*`).
- `package.json`: new `lint:check-graph` script.
- `scripts/__tests__/lint-task-graph.test.mjs` (new): unit tests for the guard's parsing/filtering plus repo invariants — at least one workspace defines `lint`, the root `lint` script fans out via turbo, and the CI lint job does not filter every lint script away.

Warnings stay non-blocking (no `--max-warnings`): `apps/mercato` currently reports 0 errors / 12 warnings, and pinning that count would be brittle. Adding real `lint` scripts to `packages/*` (option 2 in the issue) is deliberately out of scope — a full-repo `eslint .` runs for well over 10 minutes on this tree and would need its own triage pass.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:** N/A

## Testing

Runner: local (no `app` container running).

- `yarn lint` → `@open-mercato/app#lint` runs `eslint .`, 1 successful task, **0 errors / 12 warnings**, ~7 s cold. Verified against this branch's tree (rebased on `develop`).
- `yarn lint:check-graph` → `` `turbo run lint` runs 1 command(s): @open-mercato/app#lint `` (exit 0).
- Guard reproduces the bug: `node scripts/check-turbo-task-graph.mjs lint '--filter=!@open-mercato/app'` → `resolves to zero executable commands` (exit 1).
- `yarn test:scripts` → 330 tests, 330 pass, 0 fail.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (CI comment corrected; no docs reference the old command.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required) — CI-only change with no runtime/API/UI surface; covered by `scripts/__tests__/lint-task-graph.test.mjs`.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [ ] QA routing set.

Suggested labels (my account cannot set them on this repo): `bug`, `review`, `skip-qa`, `priority-medium`, `risk-low` — CI-only, no customer-facing surface.

### Design System Compliance

N/A — no UI code touched.

## Linked issues

Fixes #4472

🤖 Generated with [Claude Code](https://claude.com/claude-code)
