### PR TITLE
ci(audit): run a daily dependency audit and stop caching the audit result (#4479)

### DIFF
--- a/.ai/runs/2026-07-24-ci-scheduled-dependency-audit.md
+++ b/.ai/runs/2026-07-24-ci-scheduled-dependency-audit.md
@@ -43,6 +43,8 @@ Goal: close the trigger gap reported in issue #4479, where the CI `audit` job ca
 
 ## Progress
 
+PR: #4497
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Scheduled audit workflow
@@ -57,4 +59,4 @@ Goal: close the trigger gap reported in issue #4479, where the CI `audit` job ca
 ### Phase 3: Verify and publish
 
 - [x] 3.1 Validate both workflow files and the audit command behavior — 511be8cd7
-- [ ] 3.2 Open the PR against develop and record the label set
+- [x] 3.2 Open the PR against develop and record the label set — d0066e81c

--- a/.ai/runs/2026-07-24-ci-scheduled-dependency-audit.md
+++ b/.ai/runs/2026-07-24-ci-scheduled-dependency-audit.md
@@ -1,0 +1,60 @@
+# CI scheduled dependency audit
+
+## Overview
+
+Goal: close the trigger gap reported in issue #4479, where the CI `audit` job can only ever reflect the dependency graph at the moment a manifest changed, so advisories published against unchanged dependencies leave `develop` red — or, worse, silently green — for days.
+
+## Scope
+
+- Add a standalone scheduled workflow that re-audits the unchanged dependency graph daily on `develop` and `main`.
+- Run the audit there unconditionally: no `audit-scope` gate and no result cache.
+- Give a failing scheduled audit somewhere to land: a per-branch tracking issue that the workflow opens, refreshes, and closes on its own.
+- Remove the content-keyed `.audit-passed` cache from the `audit` job in `ci.yml` so the change-triggered half actually performs the scan it reports on.
+
+## Non-goals
+
+- No dependency bumps. The advisories currently open against the graph (4× `next`, `postcss`, `sharp`, `svgo`) are a separate remediation; the previous round shipped in #4363.
+- No change to the `audit-scope` gate on the PR path — the scheduled workflow, not a broader PR trigger, is what covers unchanged graphs.
+- No `schedule:` trigger bolted onto `ci.yml`, whose `concurrency: ci-${{ github.ref }}` with `cancel-in-progress: true` would make a cron run on `refs/heads/develop` cancel real CI.
+- No change to the severity threshold or to which advisories are considered blocking.
+
+## Implementation Plan
+
+### Phase 1: Scheduled audit workflow
+
+1. Add `.github/workflows/audit.yml`: daily cron plus `workflow_dispatch`, matrix over `develop` and `main` with `fail-fast: false`, auditing unconditionally with no result cache.
+2. Report the outcome: job summary on every run, and a per-branch tracking issue that is opened, refreshed only when the advisory set changes, and closed once the audit passes again.
+
+### Phase 2: Remove the stale-by-design result cache
+
+1. Drop the `.audit-passed` cache from the `ci.yml` `audit` job and re-gate the install step on the `node_modules` cache alone.
+
+### Phase 3: Verify and publish
+
+1. Validate both workflow files (YAML parse, `node --check` on the `github-script` bodies, `bash -n` on every `run:` block) and confirm the audit command's real behavior against the current lockfile.
+2. Open the PR against `develop` and record the label set.
+
+## Risks
+
+- The first scheduled run after merge will open a tracking issue immediately, because the current graph already carries high-severity advisories. That is the intended signal rather than a regression, but it should be called out in the PR so it is not mistaken for one.
+- Dropping the `.audit-passed` cache costs one `yarn install` on every run of an already-conditional job. Accepted deliberately: a cached security check that can silently not execute is worth less than the minutes it saves.
+- The tracking-issue automation needs `issues: write`. It is scoped to that one job, with the workflow default left at `contents: read`.
+- A `yarn npm audit` failure caused by a network or registry problem is reported the same way as a real advisory. The job summary and the issue body carry the raw output, so the distinction is visible to whoever triages it.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Scheduled audit workflow
+
+- [x] 1.1 Add the scheduled workflow with unconditional, uncached audit — 511be8cd7
+- [x] 1.2 Report via job summary and a self-closing per-branch tracking issue — 511be8cd7
+
+### Phase 2: Remove the stale-by-design result cache
+
+- [x] 2.1 Drop the `.audit-passed` cache from the ci.yml audit job — 511be8cd7
+
+### Phase 3: Verify and publish
+
+- [x] 3.1 Validate both workflow files and the audit command behavior — 511be8cd7
+- [ ] 3.2 Open the PR against develop and record the label set

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,213 @@
+name: Scheduled Dependency Audit
+
+# Time-triggered counterpart to the `audit` job in ci.yml (see #4479).
+#
+# ci.yml can only ever audit the dependency graph at the moment something
+# touched a manifest. Advisories are published continuously against
+# dependencies that never change, so between two dependency bumps the audit
+# result is simply unknown — that is how the four `next` advisories in #4399
+# sat unnoticed on an unchanged 16.2.10.
+#
+# This workflow re-evaluates the *unchanged* graph on a daily schedule, which
+# is the whole point of the trigger. Consequently it carries no `audit-scope`
+# gate and no result cache: `yarn npm audit` output is a function of the
+# dependency graph AND the advisory database at run time, so a marker keyed on
+# graph content would let the run skip the very scan it exists to perform.
+#
+# Deliberately kept out of ci.yml: that workflow uses
+# `concurrency: ci-${{ github.ref }}` with `cancel-in-progress: true`, so a
+# scheduled run on refs/heads/develop would share the group with push runs and
+# cancel real CI (or be cancelled by it).
+
+permissions:
+  contents: read
+
+env:
+  # Keep the captured report free of ANSI escapes so it stays readable when
+  # pasted into the tracking issue.
+  FORCE_COLOR: '0'
+
+on:
+  schedule:
+    # 06:17 UTC daily — off the hour, where GitHub's scheduler is less congested.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+# Queue rather than cancel: a run that is midway through creating or closing
+# the tracking issue should be allowed to finish.
+concurrency:
+  group: scheduled-dependency-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Audit ${{ matrix.branch }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    strategy:
+      # Both protected branches are reported independently — main going red
+      # must not hide the state of develop.
+      fail-fast: false
+      matrix:
+        branch:
+          - develop
+          - main
+    steps:
+      - name: Checkout ${{ matrix.branch }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ matrix.branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Cache Yarn packages
+        # Package *downloads* are safe to cache — only the audit result is not.
+        uses: actions/cache@v6
+        with:
+          path: .yarn/cache
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Audit dependencies for known CVEs
+        id: audit
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          yarn npm audit --all --recursive --severity high | tee audit.log
+
+      - name: Publish job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### \`yarn npm audit --all --recursive --severity high\` — \`${{ matrix.branch }}\`"
+            echo
+            if [ "${{ steps.audit.outcome }}" = "success" ]; then
+              echo "No advisories at severity \`high\` or above."
+            else
+              echo '```text'
+              cat audit.log 2>/dev/null || echo "(no audit output captured — the step failed before producing a report)"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or refresh tracking issue
+        if: steps.audit.outcome == 'failure'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs')
+            const branch = ${{ toJSON(matrix.branch) }}
+            const marker = `<!-- scheduled-dependency-audit:${branch} -->`
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+
+            let report = ''
+            try {
+              report = fs.readFileSync('audit.log', 'utf8')
+            } catch {
+              report = '(no audit output captured — the step failed before producing a report)'
+            }
+            report = report.replace(/\u001b\[[0-9;]*m/g, '').trim()
+
+            const maxReportLength = 40000
+            if (report.length > maxReportLength) {
+              report = `${report.slice(0, maxReportLength)}\n… truncated, see the workflow run for the full report …`
+            }
+
+            const workflowUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/blob/develop/.github/workflows/audit.yml`
+            const reportBlock = ['<!-- report:start -->', '```text', report, '```', '<!-- report:end -->'].join('\n')
+            const body = [
+              marker,
+              `\`yarn npm audit --all --recursive --severity high\` is failing on \`${branch}\`.`,
+              '',
+              `Opened and refreshed automatically by [\`.github/workflows/audit.yml\`](${workflowUrl}).`,
+              'It closes itself on the first scheduled run where the audit passes again — resolve it by bumping the affected dependencies.',
+              '',
+              `- Branch: \`${branch}\``,
+              `- Last checked: ${runUrl}`,
+              '',
+              reportBlock,
+            ].join('\n')
+
+            const extractReport = (text) => {
+              const match = /<!-- report:start -->([\s\S]*?)<!-- report:end -->/.exec(text ?? '')
+              return match ? match[1].trim() : null
+            }
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo,
+              state: 'open',
+              labels: 'security,dependencies',
+              per_page: 100,
+            })
+            const existing = openIssues.find((issue) => !issue.pull_request && (issue.body ?? '').includes(marker))
+
+            if (!existing) {
+              const created = await github.rest.issues.create({
+                ...context.repo,
+                title: `security: high-severity dependency advisories on \`${branch}\``,
+                body,
+                labels: ['security', 'dependencies', 'priority-high', 'risk-low'],
+              })
+              core.notice(`Opened tracking issue #${created.data.number} for ${branch}.`)
+              return
+            }
+
+            const advisoriesChanged = extractReport(existing.body) !== extractReport(body)
+            await github.rest.issues.update({ ...context.repo, issue_number: existing.number, body })
+
+            if (advisoriesChanged) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: existing.number,
+                body: `The advisory set on \`${branch}\` changed. Refreshed from ${runUrl}.`,
+              })
+            }
+            core.notice(`Refreshed tracking issue #${existing.number} for ${branch}.`)
+
+      - name: Close tracking issue
+        if: steps.audit.outcome == 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const branch = ${{ toJSON(matrix.branch) }}
+            const marker = `<!-- scheduled-dependency-audit:${branch} -->`
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+
+            const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo,
+              state: 'open',
+              labels: 'security,dependencies',
+              per_page: 100,
+            })
+            const existing = openIssues.find((issue) => !issue.pull_request && (issue.body ?? '').includes(marker))
+            if (!existing) return
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: existing.number,
+              body: `\`yarn npm audit --all --recursive --severity high\` passes again on \`${branch}\`. Closed from ${runUrl}.`,
+            })
+            await github.rest.issues.update({
+              ...context.repo,
+              issue_number: existing.number,
+              state: 'closed',
+              state_reason: 'completed',
+            })
+
+      - name: Fail the job when advisories were found
+        if: steps.audit.outcome == 'failure'
+        run: |
+          echo "::error::yarn npm audit reported advisories at severity high or above on ${{ matrix.branch }}."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,10 @@ jobs:
           fi
 
   # ── Security audit ──────────────────────────────────────────────────────────
-  # Runs only when package manifests or lockfiles changed.
+  # Runs only when package manifests or lockfiles changed. Advisories published
+  # against an unchanged graph are covered by the daily
+  # `.github/workflows/audit.yml` instead — this job is the change-triggered
+  # half of the pair (#4479).
   audit:
     runs-on: ubuntu-latest
     needs: audit-scope
@@ -290,19 +293,14 @@ jobs:
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-${{ runner.os }}-
 
-      - name: Cache audit result
-        # Keyed on package manifests and lockfiles — if none of these changed,
-        # a prior passing audit is still valid.
-        id: audit-cache
-        uses: actions/cache@v6
-        with:
-          path: .audit-passed
-          key: audit-${{ runner.os }}-${{ hashFiles('**/package.json', '**/yarn.lock', '**/package-lock.json', '**/npm-shrinkwrap.json', '**/pnpm-lock.yaml', '**/bun.lock', '**/bun.lockb') }}
-
+      # There is deliberately no cached `.audit-passed` marker here. It used to
+      # be keyed on manifest/lockfile content, but `yarn npm audit` output is a
+      # function of the dependency graph AND the advisory database at run time:
+      # a marker written before an advisory was published kept satisfying the
+      # key afterwards, so the scan silently did not execute and the job
+      # reported green on a graph that was by then vulnerable (#4479).
       - name: Cache node_modules
-        # Only needed when audit-cache misses (i.e. yarn.lock changed).
         # Shared key with other jobs — whichever runs first saves it.
-        if: steps.audit-cache.outputs.cache-hit != 'true'
         id: nm-cache
         uses: actions/cache@v6
         with:
@@ -313,14 +311,11 @@ jobs:
           key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install dependencies
-        if: steps.audit-cache.outputs.cache-hit != 'true' && steps.nm-cache.outputs.cache-hit != 'true'
+        if: steps.nm-cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
       - name: Audit dependencies for known CVEs
-        if: steps.audit-cache.outputs.cache-hit != 'true'
-        run: |
-          yarn npm audit --all --recursive --severity high
-          echo "passed" > .audit-passed
+        run: yarn npm audit --all --recursive --severity high
 
   # ── Lint ─────────────────────────────────────────────────────────────────────
   # Fast static analysis — runs in parallel with prepare and audit.


### PR DESCRIPTION
Closes #4479
Tracking plan: .ai/runs/2026-07-24-ci-scheduled-dependency-audit.md
Status: complete

## 🎯 Goal
- The CI `audit` job can only ever reflect the dependency graph at the moment something touched a manifest, so advisories published against unchanged dependencies go unseen — exactly how the four `next` advisories in #4399 sat unnoticed against an unchanged `16.2.10`. This PR adds a time-triggered audit that re-evaluates the unchanged graph daily, and removes the result cache that could make even a triggered audit skip its own scan.

## What Changed
- **`.github/workflows/audit.yml` (new)** — a standalone scheduled workflow: daily cron (06:17 UTC) plus `workflow_dispatch`, matrix over `develop` and `main` with `fail-fast: false` so one branch going red does not hide the other. It runs `yarn npm audit --all --recursive --severity high` **unconditionally** — no `audit-scope` gate and no result cache, since the whole point of a time trigger is to re-evaluate a graph that did not change. Only the `.yarn/cache` package-download cache is kept. Results go to the job summary, and a failing run opens or refreshes a per-branch tracking issue (`security`, `dependencies`, `priority-high`, `risk-low`) identified by an HTML marker in the body; it refreshes that body every run but comments only when the advisory set actually changes, and closes the issue itself on the first run where the audit passes again. The job still exits non-zero so the workflow shows red.
- **`.github/workflows/ci.yml`** — dropped the `.audit-passed` cache from the `audit` job. Its key was derived purely from manifest/lockfile content, but `yarn npm audit` output is a function of *content × the advisory database at run time*: a marker written before an advisory was published kept satisfying that key afterwards, so the scan silently did not execute and the job reported green on a graph that was by then vulnerable. `Install dependencies` is now gated on the `node_modules` cache alone and the audit step always runs when the job runs.

Kept out of `ci.yml` on purpose, as the issue suggests: `ci.yml` uses `concurrency: group: ci-${{ github.ref }}` with `cancel-in-progress: true`, so a scheduled run on `refs/heads/develop` would share that group and cancel real CI (or be cancelled by it).

## 🧪 Tests
- No unit tests — the change is entirely GitHub Actions workflow definitions, which the Jest suite does not cover. Validation was done against the artifacts themselves: both files parse as YAML; both `actions/github-script` bodies pass `node --check`; every `run:` block passes `bash -n`.
- `yarn npm audit --all --recursive --severity high` was exercised against the current lockfile to confirm the command behaves as the workflow assumes. It currently reports high-severity advisories (4× `next`, `postcss`, `sharp`, `svgo`) — which is precisely the drift this workflow exists to surface.
- **Expect the first scheduled run after merge to open a tracking issue immediately.** That is the intended signal, not a regression introduced here; remediating those advisories is a dependency bump outside this PR's scope (previous round: #4363).
- The `audit` job stays skipped on this PR's own CI run: the diff touches only `.github/workflows/**` and `.ai/runs/**`, so `audit-scope` reports `should_run=false`.

## 💥 Breaking Changes
- None. No runtime, API, schema, or package contract is touched. The only behavioral change inside CI is that a triggered `audit` job now always performs its scan instead of potentially short-circuiting on a cached marker — one `yarn install` on a job that is already conditional.

## 📋 Progress
See the Progress section in the tracking plan.

## Labels
Requested: `security`, `review`, `skip-qa`, `priority-medium`, `risk-low` — CI-only, no customer-facing surface, so QA is not required. My account has no triage permission on this repo, so a maintainer needs to apply them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
