### PR TITLE
fix(ci): restore ESLint coverage and keep audit green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,8 +325,9 @@ jobs:
   # ── Lint ─────────────────────────────────────────────────────────────────────
   # Fast static analysis — runs in parallel with prepare and audit.
   # ESLint does not need compiled packages, so it can fail fast before heavy jobs.
-  # @open-mercato/app is excluded: its next lint script requires an ESLint config
-  # that is not yet present in the repo.
+  # @open-mercato/app is the only workspace with a `lint` script, so it must stay
+  # in scope: excluding it left turbo with zero commands and a permanently green
+  # no-op job (issue #4472).
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -362,8 +363,13 @@ jobs:
         if: steps.nm-cache.outputs.cache-hit != 'true'
         run: yarn install --immutable
 
+      - name: Guard against an empty lint task graph
+        # Fails when `turbo run lint` resolves to zero commands, so a future
+        # filter or script rename cannot silently disable the gate again.
+        run: yarn lint:check-graph
+
       - name: Lint
-        run: yarn turbo run lint --filter=!@open-mercato/app
+        run: yarn lint
 
       - name: Guard against raw console.* logging
         # Blocking since the application-wide migration to the structured

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "undici@npm:^8.4.1": "8.5.0",
     "websocket-driver": "0.7.5",
     "nodemailer": "9.0.1",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "handlebars": "4.7.9",
     "path-to-regexp": "0.1.13",
     "protobufjs": "7.6.4",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build:app": "turbo run build --filter=@open-mercato/app",
     "build:packages": "turbo run build --filter='./packages/*'",
     "lint": "turbo run lint",
+    "lint:check-graph": "node scripts/check-turbo-task-graph.mjs lint",
     "lint:ds": "eslint --config eslint.ds.config.mjs packages/core/src/modules packages/enterprise/src/modules packages/ui/src/backend",
     "typecheck": "turbo run typecheck",
     "test": "cross-env NODE_OPTIONS=--max-old-space-size=768 turbo run test --concurrency=2",

--- a/scripts/__tests__/lint-task-graph.test.mjs
+++ b/scripts/__tests__/lint-task-graph.test.mjs
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  NONEXISTENT_COMMAND,
+  collectExecutableTasks,
+  parseTurboDryRun,
+} from '../check-turbo-task-graph.mjs'
+
+const repoRoot = path.resolve(import.meta.dirname, '..', '..')
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'ci.yml')
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function collectWorkspaceManifests() {
+  const workspaceRoots = [path.join(repoRoot, 'apps'), path.join(repoRoot, 'packages')]
+  const manifests = []
+
+  for (const workspaceRoot of workspaceRoots) {
+    if (!fs.existsSync(workspaceRoot)) continue
+
+    for (const entry of fs.readdirSync(workspaceRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+
+      const manifestPath = path.join(workspaceRoot, entry.name, 'package.json')
+      if (fs.existsSync(manifestPath)) {
+        manifests.push({ manifestPath, manifest: readJson(manifestPath) })
+      }
+    }
+  }
+
+  return manifests
+}
+
+test('collectExecutableTasks ignores workspaces without the script', () => {
+  const dryRun = {
+    tasks: [
+      { taskId: '@open-mercato/core#lint', command: NONEXISTENT_COMMAND },
+      { taskId: '@open-mercato/ui#lint', command: '   ' },
+      { taskId: '@open-mercato/app#lint', command: 'eslint .' },
+    ],
+  }
+
+  assert.deepEqual(
+    collectExecutableTasks(dryRun).map((task) => task.taskId),
+    ['@open-mercato/app#lint'],
+  )
+})
+
+test('collectExecutableTasks reports an empty graph as zero commands', () => {
+  const dryRun = { tasks: [{ taskId: '@open-mercato/core#lint', command: NONEXISTENT_COMMAND }] }
+
+  assert.equal(collectExecutableTasks(dryRun).length, 0)
+  assert.equal(collectExecutableTasks({}).length, 0)
+  assert.equal(collectExecutableTasks(null).length, 0)
+})
+
+test('parseTurboDryRun tolerates output preceding the JSON payload', () => {
+  const parsed = parseTurboDryRun('turbo 2.10.5\n{"tasks":[{"taskId":"a#lint","command":"eslint ."}]}\n')
+
+  assert.equal(parsed.tasks[0].command, 'eslint .')
+  assert.throws(() => parseTurboDryRun('no json here'), /no JSON output/)
+})
+
+test('at least one workspace defines a lint script', () => {
+  const linted = collectWorkspaceManifests()
+    .filter(({ manifest }) => typeof manifest?.scripts?.lint === 'string')
+    .map(({ manifestPath }) => path.relative(repoRoot, manifestPath))
+
+  assert.ok(
+    linted.length > 0,
+    'No workspace defines a `lint` script, so `turbo run lint` would run nothing.',
+  )
+})
+
+test('the root lint script fans out to every workspace lint script', () => {
+  const rootManifest = readJson(path.join(repoRoot, 'package.json'))
+
+  assert.equal(rootManifest.scripts.lint, 'turbo run lint')
+  assert.equal(rootManifest.scripts['lint:check-graph'], 'node scripts/check-turbo-task-graph.mjs lint')
+})
+
+test('the CI lint job lints instead of filtering every lint script away', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8')
+
+  assert.match(workflow, /^\s+run: yarn lint:check-graph$/m)
+  assert.match(workflow, /^\s+run: yarn lint$/m)
+  assert.doesNotMatch(workflow, /turbo run lint[^\n]*--filter/)
+})

--- a/scripts/check-turbo-task-graph.mjs
+++ b/scripts/check-turbo-task-graph.mjs
@@ -1,0 +1,109 @@
+/**
+ * Turbo Task-Graph Guard
+ *
+ * `turbo run <task> [filters]` exits 0 when the resolved graph contains no
+ * runnable script, so a filter or a renamed script can silently turn a CI gate
+ * into a no-op. That is how the `lint` job stopped running ESLint entirely
+ * (issue #4472): `--filter=!@open-mercato/app` excluded the only workspace that
+ * defines a `lint` script, leaving 23 `<NONEXISTENT>` commands and a green job.
+ *
+ * This guard asks turbo for the dry-run graph and fails when the task resolves
+ * to zero executable commands.
+ *
+ * Usage:
+ *   node scripts/check-turbo-task-graph.mjs lint
+ *   node scripts/check-turbo-task-graph.mjs test --filter=./packages/*
+ *
+ * Exit code: 0 when at least one workspace runs a real command, 1 otherwise
+ * (or when turbo itself fails).
+ */
+
+import { spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { resolveProjectBinary, resolveSpawnCommand } from './dev-spawn-utils.mjs'
+
+export const NONEXISTENT_COMMAND = '<NONEXISTENT>'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+export function parseTurboDryRun(stdout) {
+  const text = String(stdout ?? '')
+  const start = text.indexOf('{')
+  if (start === -1) {
+    throw new Error('Turbo dry-run produced no JSON output.')
+  }
+
+  return JSON.parse(text.slice(start))
+}
+
+export function collectExecutableTasks(dryRun) {
+  const tasks = Array.isArray(dryRun?.tasks) ? dryRun.tasks : []
+
+  return tasks.filter((task) => {
+    const command = typeof task?.command === 'string' ? task.command.trim() : ''
+    return command !== '' && command !== NONEXISTENT_COMMAND
+  })
+}
+
+function runTurboDryRun(turboArgs) {
+  const turboBinary = resolveProjectBinary('turbo', { cwd: ROOT })
+  const resolvedSpawn = resolveSpawnCommand(turboBinary, [...turboArgs, '--dry=json'])
+
+  return spawnSync(resolvedSpawn.command, resolvedSpawn.args, {
+    cwd: ROOT,
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+    ...resolvedSpawn.spawnOptions,
+  })
+}
+
+function main() {
+  const [task, ...passthroughArgs] = process.argv.slice(2)
+  if (!task) {
+    console.error('Usage: node scripts/check-turbo-task-graph.mjs <task> [turbo args...]')
+    process.exit(1)
+  }
+
+  const turboArgs = ['run', task, ...passthroughArgs]
+  const printableCommand = `turbo ${turboArgs.join(' ')}`
+  const result = runTurboDryRun(turboArgs)
+
+  if (result.error) {
+    console.error(`Failed to run \`${printableCommand} --dry=json\`: ${result.error.message}`)
+    process.exit(1)
+  }
+
+  if (result.status !== 0) {
+    console.error(`\`${printableCommand} --dry=json\` exited with code ${result.status}.`)
+    if (result.stderr) console.error(result.stderr)
+    process.exit(1)
+  }
+
+  let dryRun
+  try {
+    dryRun = parseTurboDryRun(result.stdout)
+  } catch (error) {
+    console.error(`Could not read the task graph of \`${printableCommand}\`: ${error.message}`)
+    process.exit(1)
+  }
+
+  const executableTasks = collectExecutableTasks(dryRun)
+  if (executableTasks.length === 0) {
+    const scopedPackages = Array.isArray(dryRun?.packages) ? dryRun.packages.length : 0
+    console.error(`\`${printableCommand}\` resolves to zero executable commands.`)
+    console.error(
+      `${scopedPackages} package(s) are in scope but none of them defines a \`${task}\` script, so the command would exit 0 without doing any work.`,
+    )
+    console.error(`Add a \`${task}\` script to the packages that should run it, or fix the turbo filters.`)
+    process.exit(1)
+  }
+
+  const taskIds = executableTasks.map((entry) => entry.taskId ?? `${entry.package}#${entry.task}`)
+  console.log(`\`${printableCommand}\` runs ${executableTasks.length} command(s): ${taskIds.join(', ')}`)
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : ''
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -14260,12 +14260,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.7":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+"brace-expansion@npm:5.0.8":
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/98c12de33fa53ab07b2b5179f6740045508c61c4319638faf47a0d72615db80058f66c0d1cb74dc8ed591bbf507c068027e80cfb86a2f467bfd330574e13ed7b
+  checksum: 10/75d2d2ebc8f5f65156d16706216d23e48f499a1164e4b045e0ca4045d3ce6b16ced11ea2e4c76e3670b6c38454123213f43d23127df8fc6840980aea9a35e061
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Supersedes #4496

Credit: original lint-gate implementation by @wojciechszyjka. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the original fork branch.

## Included work
- Original changes from #4496 restoring real ESLint coverage and guarding against an empty Turbo task graph
- Current `develop`, including #4500's postcss advisory fix
- Minimal `brace-expansion` 5.0.7 → 5.0.8 resolution bump for the newer GHSA-mh99-v99m-4gvg audit failure inherited from `develop`

## Validation
Runner: local

- `yarn test:scripts` — 330/330 pass
- `yarn lint:check-graph` — 1 executable lint task
- Old filtered graph guard — exits 1 as expected with zero executable commands
- `yarn lint` — pass, 0 errors / 12 existing non-blocking warnings
- `yarn npm audit --all --recursive --severity high` — no audit suggestions
- `git diff --check origin/develop...HEAD` — pass

The branch was re-reviewed after autofix and is intended to be merge-ready.