### PR TITLE
test(sync-akeneo): stub DNS in the redirect-hop tests so develop is green again (#4515)

### DIFF
--- a/.ai/runs/2026-07-25-akeneo-redirect-tests-dns.md
+++ b/.ai/runs/2026-07-25-akeneo-redirect-tests-dns.md
@@ -1,0 +1,53 @@
+# Execution Plan — sync-akeneo redirect tests must not hit real DNS
+
+**Date:** 2026-07-25
+**Slug:** akeneo-redirect-tests-dns
+**Branch:** fix/4515-akeneo-redirect-tests-dns
+**Issue:** #4515
+**Type:** test-only fix (unblocks a red `develop`)
+
+## Goal
+
+Make `develop` green again. The `test` job fails on
+`packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts`: three redirect-hop
+tests added by #3954 build the client without the suite's DNS stub, so they perform a real
+`node:dns` lookup of the fixture host `tenant.cloud.akeneo.com`, which does not resolve
+anywhere (`NXDOMAIN` from `8.8.8.8` and `1.1.1.1`). The lookup rejects inside
+`resolveSafeOutboundUrl` before the mocked `fetch` is reached, so the assertions see a DNS
+error instead of the expected `302` rejection.
+
+## Scope
+
+- Route the three `akeneo client security › does not automatically follow redirects …` tests
+  through the file's existing `createTestAkeneoClient()` helper (which injects
+  `lookupHost: publicAkeneoLookupHost` and `fetchImpl: global.fetch`), exactly like every
+  other test in the suite.
+- No production code changes. The redirect-hop SSRF guard from #3954 is correct — it was
+  simply never reached by these three tests.
+
+### Non-goals
+
+- Not touching `packages/shared/src/lib/url-safety.ts` or the client's redirect handling.
+- Not weakening the assertions: they still pin that a `302` surfaces as an error rather than
+  being followed.
+
+## Root cause
+
+`createAkeneoClient(validCredentials)` (lines 194, 209, 236) bypasses the stubbed resolver.
+`url-safety.ts` then calls the real `lookup()` and raises `dns_resolution_failed`. #3954's own
+green `test` run is dated 2026-07-07 while the branch merged 2026-07-25 — nothing in the test
+changed, the outside world did, which is exactly why a unit test must not depend on a third
+party's DNS zone.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands.
+
+### Phase 1: Fix
+
+- [x] 1.1 Route the three redirect tests through `createTestAkeneoClient()`
+- [x] 1.2 Verify the suite locally (31/31, was 3 failed / 28 passed)
+
+### Phase 2: PR finalization
+
+- [x] 2.1 Open PR, validation gate, summary comment

--- a/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
+++ b/packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts
@@ -191,7 +191,7 @@ describe('akeneo client security', () => {
         : new Response('internal metadata leaked through redirect', { status: 500 })
     ))
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient()
     await expect(client.getSystemProbe()).rejects.toThrow('Akeneo authentication failed (302)')
   })
 
@@ -206,7 +206,7 @@ describe('akeneo client security', () => {
         : new Response('internal metadata leaked through redirect', { status: 500 })
     })
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient()
     await expect(client.getSystemProbe()).rejects.toThrow('Akeneo request failed (302)')
   })
 
@@ -233,7 +233,7 @@ describe('akeneo client security', () => {
         : new Response('internal metadata leaked through redirect', { status: 500 })
     })
 
-    const client = createAkeneoClient(validCredentials)
+    const client = createTestAkeneoClient()
     await expect(client.downloadMediaFile('asset-1')).rejects.toThrow('Akeneo request failed (302)')
   })
 


### PR DESCRIPTION
Closes #4515
Tracking plan: .ai/runs/2026-07-25-akeneo-redirect-tests-dns.md
Status: complete

## 🎯 Goal

Make `develop` green again. Its `test` job is currently red on `packages/sync-akeneo/.../client.test.ts`: three redirect-hop tests added by #3954 perform a **real DNS lookup** of the fixture host `tenant.cloud.akeneo.com`, which does not resolve, so they fail for a reason unrelated to what they assert.

## What Changed

- `packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts` — the three `akeneo client security › does not automatically follow redirects …` tests (token acquisition, authenticated API request, media download) now build the client with the file's existing `createTestAkeneoClient()` helper instead of calling `createAkeneoClient(validCredentials)` directly. The helper injects `lookupHost: publicAkeneoLookupHost` (a stubbed resolver returning a public IP) plus `fetchImpl: global.fetch` — exactly what every other test in the suite already uses.
- **No production code changes.** The redirect-hop SSRF guard from #3954 is correct; these three tests just never reached it.

### Root cause

Without the stub, `resolveSafeOutboundUrl` (`packages/shared/src/lib/url-safety.ts`) calls the real `node:dns/promises` `lookup()` and rejects with `dns_resolution_failed` **before** the mocked `fetch` is consulted, so the assertion sees:

```
Expected substring: "Akeneo authentication failed (302)"
Received message:   "Akeneo URL host \"tenant.cloud.akeneo.com\" could not be resolved: lookup failed"
```

`tenant.cloud.akeneo.com` returns `NXDOMAIN` from both `8.8.8.8` and `1.1.1.1` (there is no wildcard under `*.cloud.akeneo.com`), which is equally true on the GitHub runner. #3954's own green `test` run ([28868016387](https://github.com/open-mercato/open-mercato/actions/runs/28868016387)) is dated **2026-07-07** while the branch merged **2026-07-25** — nothing in the test changed, the outside world did. That is precisely why a unit test should not depend on a third party's DNS zone.

Proof this is base-wide and not PR-local: `develop` CI run [30148288927](https://github.com/open-mercato/open-mercato/actions/runs/30148288927) (head `52f0b3781`), job `test`, fails with these same three cases.

## 🧪 Tests

- `yarn workspace @open-mercato/sync-akeneo test` — **62 passed / 9 suites** (was `3 failed, 59 passed`). The target file alone: 31/31.
- `yarn workspace @open-mercato/sync-akeneo typecheck` — clean.
- `npx eslint packages/sync-akeneo/src/modules/sync_akeneo/__tests__/client.test.ts` — clean.
- Runner: local.
- The assertions are unchanged: they still pin that a `302` is surfaced as an error rather than followed, so the SSRF guarantee stays locked in — it is now actually exercised instead of being short-circuited by DNS.

## 💥 Breaking Changes

None — test-only change.

## 📋 Progress

See the Progress section in the tracking plan (all steps complete).

---

Suggested labels: `bug`, `priority-high` (release-blocking: `develop` is red and every PR touching root manifests inherits it), `risk-low` (test-only, no production code), `skip-qa` (test-only, not customer-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
