### PR TITLE
security(business_rules): reject prototype keys in getNestedValue field paths (#3823)

### DIFF
--- a/packages/core/src/modules/business_rules/lib/__tests__/value-resolver.test.ts
+++ b/packages/core/src/modules/business_rules/lib/__tests__/value-resolver.test.ts
@@ -1,0 +1,118 @@
+import { describe, test, expect } from '@jest/globals'
+import { getNestedValue, resolveSpecialValue } from '../value-resolver'
+import type { EvaluationContext } from '../expression-evaluator'
+
+describe('getNestedValue', () => {
+  describe('legitimate field paths', () => {
+    test('resolves a top-level own property', () => {
+      expect(getNestedValue({ status: 'active' }, 'status')).toBe('active')
+    })
+
+    test('resolves a nested own property via dot notation', () => {
+      expect(getNestedValue({ user: { name: 'Ada' } }, 'user.name')).toBe('Ada')
+    })
+
+    test('resolves array notation', () => {
+      const data = { items: [{ quantity: 3 }, { quantity: 7 }] }
+      expect(getNestedValue(data, 'items[0].quantity')).toBe(3)
+      expect(getNestedValue(data, 'items[1].quantity')).toBe(7)
+    })
+
+    test('resolves array length and indexes', () => {
+      const data = { values: [10, 20, 30] }
+      expect(getNestedValue(data, 'values[2]')).toBe(30)
+      expect(getNestedValue(data, 'values.length')).toBe(3)
+    })
+
+    test('returns undefined for a missing own property', () => {
+      expect(getNestedValue({ user: { name: 'Ada' } }, 'user.email')).toBeUndefined()
+    })
+
+    test('returns undefined for empty object or path', () => {
+      expect(getNestedValue(null, 'status')).toBeUndefined()
+      expect(getNestedValue({ status: 'active' }, '')).toBeUndefined()
+    })
+
+    test('resolves falsy own values rather than treating them as missing', () => {
+      const data = { count: 0, flag: false, label: '' }
+      expect(getNestedValue(data, 'count')).toBe(0)
+      expect(getNestedValue(data, 'flag')).toBe(false)
+      expect(getNestedValue(data, 'label')).toBe('')
+    })
+  })
+
+  describe('prototype key rejection', () => {
+    test('rejects a __proto__ segment', () => {
+      expect(getNestedValue({ user: { name: 'Ada' } }, '__proto__')).toBeUndefined()
+    })
+
+    test('rejects the issue-reported __proto__.polluted path', () => {
+      expect(getNestedValue({ user: { name: 'Ada' } }, '__proto__.polluted')).toBeUndefined()
+    })
+
+    test('rejects a constructor segment', () => {
+      expect(getNestedValue({ user: { name: 'Ada' } }, 'constructor')).toBeUndefined()
+    })
+
+    test('rejects a nested constructor.prototype path', () => {
+      expect(getNestedValue({ user: { name: 'Ada' } }, 'constructor.prototype')).toBeUndefined()
+    })
+
+    test('rejects a prototype segment', () => {
+      expect(getNestedValue({ user: { name: 'Ada' } }, 'prototype')).toBeUndefined()
+    })
+
+    test('rejects a prototype key reached mid-path', () => {
+      expect(getNestedValue({ user: { name: 'Ada' } }, 'user.__proto__')).toBeUndefined()
+      expect(getNestedValue({ user: { name: 'Ada' } }, 'user.__proto__.polluted')).toBeUndefined()
+    })
+
+    test('does not leak a value assigned onto the prototype chain', () => {
+      const base = { inheritedSecret: 'leaked' }
+      const data = Object.create(base) as Record<string, unknown>
+      data.own = 'visible'
+
+      expect(getNestedValue(data, 'own')).toBe('visible')
+      expect(getNestedValue(data, 'inheritedSecret')).toBeUndefined()
+    })
+  })
+
+  describe('inherited property rejection', () => {
+    test('rejects built-in inherited members', () => {
+      const data = { user: { name: 'Ada' } }
+      expect(getNestedValue(data, 'toString')).toBeUndefined()
+      expect(getNestedValue(data, 'hasOwnProperty')).toBeUndefined()
+      expect(getNestedValue(data, 'user.valueOf')).toBeUndefined()
+    })
+
+    test('rejects inherited array members', () => {
+      expect(getNestedValue({ values: [1, 2] }, 'values.map')).toBeUndefined()
+    })
+  })
+})
+
+describe('resolveSpecialValue', () => {
+  const context: EvaluationContext = {
+    user: { id: 'user-1', email: 'ada@example.com' },
+    tenant: { id: 'tenant-1' },
+    today: new Date('2026-07-25T12:00:00.000Z'),
+    now: new Date('2026-07-25T12:00:00.000Z'),
+  }
+
+  test('resolves {{today}} and {{now}}', () => {
+    expect(resolveSpecialValue('{{today}}', context)).toBe('2026-07-25')
+    expect(resolveSpecialValue('{{now}}', context)).toBe('2026-07-25T12:00:00.000Z')
+  })
+
+  test('resolves legitimate context paths', () => {
+    expect(resolveSpecialValue('{{user.id}}', context)).toBe('user-1')
+    expect(resolveSpecialValue('{{tenant.id}}', context)).toBe('tenant-1')
+  })
+
+  test('rejects prototype key templates', () => {
+    expect(resolveSpecialValue('{{__proto__}}', context)).toBeUndefined()
+    expect(resolveSpecialValue('{{__proto__.polluted}}', context)).toBeUndefined()
+    expect(resolveSpecialValue('{{constructor.prototype}}', context)).toBeUndefined()
+    expect(resolveSpecialValue('{{user.__proto__}}', context)).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/business_rules/lib/value-resolver.ts
+++ b/packages/core/src/modules/business_rules/lib/value-resolver.ts
@@ -26,9 +26,17 @@ export function resolveSpecialValue(template: string, context: EvaluationContext
   return getNestedValue(context, path)
 }
 
+// Field paths come from rule authors, so a segment could name a prototype key.
+// Rejecting these — and requiring own-property access — keeps traversal on the
+// caller's own data instead of the prototype chain.
+const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'] as const
+
 /**
  * Get nested value from object using dot notation
  * Supports: 'user.name', 'items[0].quantity', 'data.values[2]'
+ *
+ * Segments naming a prototype key, or resolving to an inherited rather than an
+ * own property, yield `undefined`.
  */
 export function getNestedValue(obj: any, path: string): any {
   if (!obj || !path) {
@@ -43,6 +51,14 @@ export function getNestedValue(obj: any, path: string): any {
 
   for (const key of keys) {
     if (result === null || result === undefined) {
+      return undefined
+    }
+
+    if ((DANGEROUS_KEYS as readonly string[]).includes(key)) {
+      return undefined
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(result, key)) {
       return undefined
     }
 

--- a/packages/core/src/modules/business_rules/lib/value-resolver.ts
+++ b/packages/core/src/modules/business_rules/lib/value-resolver.ts
@@ -29,7 +29,7 @@ export function resolveSpecialValue(template: string, context: EvaluationContext
 // Field paths come from rule authors, so a segment could name a prototype key.
 // Rejecting these — and requiring own-property access — keeps traversal on the
 // caller's own data instead of the prototype chain.
-const DANGEROUS_KEYS = ['__proto__', 'constructor', 'prototype'] as const
+const DANGEROUS_KEYS = new Set<string>(['__proto__', 'constructor', 'prototype'])
 
 /**
  * Get nested value from object using dot notation
@@ -54,7 +54,7 @@ export function getNestedValue(obj: any, path: string): any {
       return undefined
     }
 
-    if ((DANGEROUS_KEYS as readonly string[]).includes(key)) {
+    if (DANGEROUS_KEYS.has(key)) {
       return undefined
     }
 


### PR DESCRIPTION
Closes #3823

## 🎯 Goal
Business-rule field paths can no longer reach outside the caller's own data. A rule author who writes `__proto__.polluted`, `constructor`, or any inherited member as a condition field now gets `undefined` instead of a value off the prototype chain.

## 🔍 Problem
`getNestedValue` in the business_rules value resolver splits a rule-author-controlled field path on `.` / `[n]` and indexes into `data`/`context` per segment. It had no own-property or prototype-key guard, so segments naming prototype keys resolved against inherited properties rather than the intended fields. Because the resolver only reads (`result[key]`) and never assigns, this is **not** prototype pollution today, and the 200-char field-path cap in `isSafeExpression` bounds any DoS — but it does leak inherited members into rule evaluation, and it is a latent pollution primitive if the helper is ever reused on a write path.

## 🔍 Root Cause
`packages/core/src/modules/business_rules/lib/value-resolver.ts` — the traversal loop did `result = result[key]` for every path segment, checking only for `null`/`undefined`. Plain `[]` indexing consults the whole prototype chain: `__proto__` yields `Object.prototype`, `constructor` yields the `Object` function, and inherited members like `toString`/`valueOf` resolve as if they were rule data.

The path is attacker-adjacent by design — it arrives as `condition.field` through `POST /api/business_rules/execute` (`data: z.any()`), reaches `resolveFieldPath` in `expression-evaluator.ts`, and reaches `resolveSpecialValue` for the `{{...}}` templates used by `action-executor.ts`. The only pre-existing guard, `isSafeExpression` in `payload-validation.ts`, caps nesting depth, rule count, and path length — it never inspects segment names.

## What Changed
- **`packages/core/src/modules/business_rules/lib/value-resolver.ts`** — added a module-local `DANGEROUS_KEYS` const (`__proto__`, `constructor`, `prototype`), mirroring the existing in-repo convention in `packages/ai-assistant/src/modules/ai_assistant/lib/scope-injection.ts`. Inside the `getNestedValue` traversal loop, each segment now returns `undefined` when it names a dangerous key, and when `Object.prototype.hasOwnProperty.call(result, key)` is false. 16 insertions, 0 deletions.
- **`packages/core/src/modules/business_rules/lib/__tests__/value-resolver.test.ts`** — new file; the module had no value-resolver suite at all.

Deliberately **not** changed: the four other independent `getNestedValue` copies under `packages/core/src/modules/workflows/lib/` (`parallel-handler.ts`, `step-handler.ts`, `activity-executor.ts`, `event-trigger-service.ts`) and `packages/ui/src/backend/charts/TopNTable.tsx` share the same unguarded `current[key]` pattern. They cover different surfaces with their own trust models and are out of scope for this issue — worth a follow-up.

## 🧪 Tests
- `yarn jest src/modules/business_rules` (packages/core) — **18 suites / 369 tests passed**.
- New suite is genuine regression coverage: with the `value-resolver.ts` change stashed, **8 of its 19 tests fail**; all 19 pass with it.
- Full validation gate from `.ai/agentic.config.json`: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn build:app` — **all exit 0**.
- `yarn test` exits 1 on **3 pre-existing failures in `@open-mercato/sync-akeneo` `client.test.ts`** ("does not automatically follow redirects…"). These reproduce identically on a clean `upstream/develop` with this branch's changes stashed, and are environmental — the assertions expect a 302 but the sandbox cannot DNS-resolve `tenant.cloud.akeneo.com`. Unrelated to this change.

What the new tests lock in:
- Legitimate paths keep working — nested dot notation, `items[0].quantity` array notation, `values.length`, and falsy own values (`0`, `false`, `''`) that must not be confused with "missing".
- `__proto__`, `constructor`, `prototype`, `constructor.prototype`, `user.__proto__`, and the issue's own `__proto__.polluted` all resolve to `undefined`, at the root and mid-path.
- A value reachable only via the prototype chain (`Object.create({ inheritedSecret })`) does not leak, while sibling own properties still resolve.
- Inherited built-ins (`toString`, `hasOwnProperty`, `valueOf`, `Array.prototype.map`) resolve to `undefined`.
- `resolveSpecialValue` keeps `{{today}}`, `{{now}}`, `{{user.id}}`, `{{tenant.id}}` intact while rejecting `{{__proto__}}`, `{{__proto__.polluted}}`, `{{constructor.prototype}}`, `{{user.__proto__}}`.

## 💥 Breaking Changes
None to any contract surface — the exported signature, the `undefined`-on-miss convention, and all call sites are unchanged.

One behavioral narrowing deserves reviewer attention: the `hasOwnProperty` half of the guard means a caller passing an object whose fields are **prototype-defined getters** (e.g. a class instance rather than a plain object) would now resolve `undefined` where it previously resolved a value. The primary path is `data: z.any()` from the execute route — plain parsed JSON, where every field is an own property — so real-world exposure is low, and array indices and `length` are own properties too. Flagging it rather than burying it.
