### PR TITLE
fix(search): avoid nested provider controls

### DIFF
--- a/packages/search/src/modules/search/frontend/components/sections/VectorSearchSection.tsx
+++ b/packages/search/src/modules/search/frontend/components/sections/VectorSearchSection.tsx
@@ -6,9 +6,18 @@ import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useAppEvent } from '@open-mercato/ui/backend/injection/useAppEvent'
 import { Button } from '@open-mercato/ui/primitives/button'
+import { Input } from '@open-mercato/ui/primitives/input'
 import { Label } from '@open-mercato/ui/primitives/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@open-mercato/ui/primitives/select'
 import { Spinner } from '@open-mercato/ui/primitives/spinner'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@open-mercato/ui/primitives/tabs'
+import { Check, Plus } from 'lucide-react'
 
 // Types
 type EmbeddingProviderId = 'openai' | 'google' | 'mistral' | 'cohere' | 'bedrock' | 'ollama'
@@ -554,109 +563,115 @@ export function VectorSearchSection({
                     const isSelected = displayProvider === providerId
                     const isCurrentlySaved = savedProvider === providerId
                     return (
-                      <button
+                      <div
                         key={providerId}
-                        type="button"
-                        onClick={() => isConfigured && handleProviderChange(providerId)}
-                        disabled={!isConfigured || embeddingLoading || embeddingSaving}
-                        className={`text-left p-3 rounded-lg border-2 transition-all ${
+                        className={`rounded-lg border-2 transition-all ${
                           isSelected
                             ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
                             : isConfigured
-                              ? 'border-border hover:border-primary/50 hover:bg-muted/50 cursor-pointer'
-                              : 'border-border bg-muted/30 opacity-50 cursor-not-allowed'
+                              ? 'border-border hover:border-primary/50 hover:bg-muted/50'
+                              : 'border-border bg-muted/30 opacity-50'
                         }`}
                       >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2">
-                              <p className={`text-sm font-medium ${isSelected ? 'text-primary' : isConfigured ? '' : 'text-muted-foreground'}`}>
-                                {info.name}
-                              </p>
-                              {isCurrentlySaved && isConfigured && (
-                                <span className="text-overline px-1.5 py-0.5 rounded bg-status-success-bg text-status-success-text">
-                                  {t('search.settings.vector.active', 'Active')}
-                                </span>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          onClick={() => handleProviderChange(providerId)}
+                          disabled={!isConfigured || embeddingLoading || embeddingSaving}
+                          aria-pressed={isSelected}
+                          aria-expanded={isSelected && isConfigured}
+                          aria-controls={isSelected && isConfigured ? `provider-${providerId}-configuration` : undefined}
+                          className="h-auto w-full justify-start whitespace-normal rounded-lg p-3 text-left hover:bg-transparent disabled:bg-transparent disabled:text-inherit dark:hover:bg-transparent"
+                        >
+                          <div className="flex w-full items-start justify-between gap-2">
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-center gap-2">
+                                <p className={`text-sm font-medium ${isSelected ? 'text-primary' : isConfigured ? '' : 'text-muted-foreground'}`}>
+                                  {info.name}
+                                </p>
+                                {isCurrentlySaved && isConfigured && (
+                                  <span className="text-overline rounded bg-status-success-bg px-1.5 py-0.5 text-status-success-text">
+                                    {t('search.settings.vector.active', 'Active')}
+                                  </span>
+                                )}
+                              </div>
+                              {isConfigured ? (
+                                <p className="mt-1 text-xs text-muted-foreground">
+                                  {info.models.length} {t('search.settings.vector.modelsAvailable', 'models available')}
+                                </p>
+                              ) : availability?.reason ? (
+                                <p className="mt-1 text-xs text-status-warning-text">
+                                  {availability.reason}
+                                </p>
+                              ) : (
+                                <p className="mt-1 text-xs text-muted-foreground">
+                                  {t('search.settings.vector.setEnvVar', 'Set')} <code className="rounded bg-muted px-1 font-mono text-overline">{info.envKeyRequired}</code>
+                                </p>
                               )}
                             </div>
-                            {isConfigured ? (
-                              <p className="text-xs text-muted-foreground mt-1">
-                                {info.models.length} {t('search.settings.vector.modelsAvailable', 'models available')}
-                              </p>
-                            ) : availability?.reason ? (
-                              <p className="text-xs text-status-warning-text mt-1">
-                                {availability.reason}
-                              </p>
-                            ) : (
-                              <p className="text-xs text-muted-foreground mt-1">
-                                {t('search.settings.vector.setEnvVar', 'Set')} <code className="font-mono text-overline bg-muted px-1 rounded">{info.envKeyRequired}</code>
-                              </p>
-                            )}
+                            <div className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full ${
+                              isSelected
+                                ? 'bg-primary text-primary-foreground'
+                                : isConfigured
+                                  ? 'bg-status-success-bg text-status-success-icon'
+                                  : 'bg-muted text-muted-foreground'
+                            }`}>
+                              {isConfigured ? (
+                                <Check className="size-3" strokeWidth={isSelected ? 3 : 2} aria-hidden="true" />
+                              ) : (
+                                <Plus className="size-3" aria-hidden="true" />
+                              )}
+                            </div>
                           </div>
-                          <div className={`flex h-5 w-5 items-center justify-center rounded-full flex-shrink-0 ${
-                            isSelected
-                              ? 'bg-primary text-primary-foreground'
-                              : isConfigured
-                                ? 'bg-status-success-bg text-status-success-icon'
-                                : 'bg-muted text-muted-foreground'
-                          }`}>
-                            {isSelected ? (
-                              <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                              </svg>
-                            ) : isConfigured ? (
-                              <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                              </svg>
-                            ) : (
-                              <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M12 4v16m8-8H4" />
-                              </svg>
-                            )}
-                          </div>
-                        </div>
+                        </Button>
 
                         {/* Model Selection */}
                         {isSelected && isConfigured && (
-                          <div className="mt-3 pt-3 border-t border-border space-y-2" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()} role="presentation">
+                          <div
+                            id={`provider-${providerId}-configuration`}
+                            className="mx-3 mb-3 space-y-2 border-t border-border pt-3"
+                          >
                             <div className="space-y-1">
                               <Label htmlFor={`model-${providerId}`} className="text-xs font-medium">
                                 {t('search.settings.model.label', 'Model')}
                               </Label>
-                              <select
-                                id={`model-${providerId}`}
-                                className="w-full rounded-md border border-input bg-background px-2 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                              <Select
                                 value={displayModel}
-                                onChange={(e) => handleModelChange(e.target.value)}
+                                onValueChange={handleModelChange}
                                 disabled={embeddingLoading || embeddingSaving}
                               >
-                                {savedCustomModel && displayProvider === savedProvider && (
-                                  <option key={savedCustomModel.id} value={savedCustomModel.id}>
-                                    {savedCustomModel.name} ({savedCustomModel.dimension}d)
-                                  </option>
-                                )}
-                                {displayProviderInfo.models.map((model) => (
-                                  <option key={model.id} value={model.id}>
-                                    {model.name} ({model.dimension}d)
-                                  </option>
-                                ))}
-                                <option value="custom">{t('search.settings.model.custom', 'Custom...')}</option>
-                              </select>
+                                <SelectTrigger id={`model-${providerId}`} size="sm">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {savedCustomModel && displayProvider === savedProvider && (
+                                    <SelectItem key={savedCustomModel.id} value={savedCustomModel.id}>
+                                      {savedCustomModel.name} ({savedCustomModel.dimension}d)
+                                    </SelectItem>
+                                  )}
+                                  {displayProviderInfo.models.map((model) => (
+                                    <SelectItem key={model.id} value={model.id}>
+                                      {model.name} ({model.dimension}d)
+                                    </SelectItem>
+                                  ))}
+                                  <SelectItem value="custom">{t('search.settings.model.custom', 'Custom...')}</SelectItem>
+                                </SelectContent>
+                              </Select>
                             </div>
 
                             {isCustomModel && (
-                              <div className="space-y-2 p-2 rounded border border-input bg-muted/30">
-                                <input
+                              <div className="space-y-2 rounded border border-input bg-muted/30 p-2">
+                                <Input
                                   type="text"
-                                  className="w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                                  size="sm"
                                   value={customModelName}
                                   onChange={(e) => setCustomModelName(e.target.value)}
                                   placeholder={t('search.settings.model.namePlaceholder', 'Model name')}
                                   disabled={embeddingLoading || embeddingSaving}
                                 />
-                                <input
+                                <Input
                                   type="number"
-                                  className="w-full rounded border border-input bg-background px-2 py-1 text-sm"
+                                  size="sm"
                                   value={customDimension}
                                   onChange={(e) => setCustomDimension(Number(e.target.value) || 768)}
                                   placeholder="768"
@@ -690,7 +705,7 @@ export function VectorSearchSection({
                             )}
                           </div>
                         )}
-                      </button>
+                      </div>
                     )
                   })}
                 </div>

--- a/packages/search/src/modules/search/frontend/components/sections/__tests__/VectorSearchSection.test.tsx
+++ b/packages/search/src/modules/search/frontend/components/sections/__tests__/VectorSearchSection.test.tsx
@@ -1,0 +1,92 @@
+/** @jest-environment jsdom */
+
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import {
+  VectorSearchSection,
+  type VectorSearchSectionProps,
+} from '../VectorSearchSection'
+
+jest.mock('@open-mercato/ui/backend/injection/useAppEvent', () => ({
+  useAppEvent: jest.fn(),
+}))
+
+const embeddingSettings: NonNullable<VectorSearchSectionProps['embeddingSettings']> = {
+  openaiConfigured: true,
+  autoIndexingEnabled: true,
+  autoIndexingLocked: false,
+  lockReason: null,
+  embeddingConfig: {
+    providerId: 'openai',
+    model: 'text-embedding-3-small',
+    dimension: 1536,
+    updatedAt: '2026-07-26T12:00:00.000Z',
+  },
+  embeddingConfigSource: 'tenant',
+  configuredProviders: ['openai', 'ollama'],
+  providerAvailability: [
+    { providerId: 'openai', available: true },
+    { providerId: 'ollama', available: true },
+  ],
+  indexedDimension: null,
+  reindexRequired: false,
+  documentCount: 0,
+}
+
+const vectorStoreConfig: NonNullable<VectorSearchSectionProps['vectorStoreConfig']> = {
+  currentDriver: 'pgvector',
+  configured: true,
+  drivers: [
+    {
+      id: 'pgvector',
+      name: 'pgvector',
+      configured: true,
+      implemented: true,
+      envVars: [],
+    },
+  ],
+}
+
+function renderSection() {
+  return render(
+    <I18nProvider locale="en" dict={{}}>
+      <VectorSearchSection
+        embeddingSettings={embeddingSettings}
+        embeddingLoading={false}
+        vectorStoreConfig={vectorStoreConfig}
+        vectorStoreConfigLoading={false}
+        vectorReindexLock={null}
+        onEmbeddingSettingsUpdate={jest.fn()}
+        onRefreshEmbeddings={jest.fn().mockResolvedValue(undefined)}
+      />
+    </I18nProvider>,
+  )
+}
+
+describe('VectorSearchSection provider controls', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      value: jest.fn(() => new Promise(() => undefined)),
+    })
+  })
+
+  it('renders the provider configuration controls outside the provider button', () => {
+    const { container } = renderSection()
+
+    const providerButton = screen.getByRole('button', { name: /Ollama \(Local\)/ })
+    fireEvent.click(providerButton)
+
+    const configuration = document.getElementById('provider-ollama-configuration')
+    const applyButton = screen.getByRole('button', { name: 'Apply' })
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' })
+
+    expect(configuration).not.toBeNull()
+    expect(providerButton.getAttribute('aria-expanded')).toBe('true')
+    expect(configuration?.contains(applyButton)).toBe(true)
+    expect(configuration?.contains(cancelButton)).toBe(true)
+    expect(providerButton.contains(configuration)).toBe(false)
+    expect(container.querySelector('button button')).toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #3797

## Summary
- Move the embedding-provider configuration panel outside the provider-selection `<button>` so model controls and Apply/Cancel actions no longer create invalid nested interactive markup.
- Preserve provider selection and inline model editing while exposing state through `aria-expanded`, `aria-pressed`, and `aria-controls`.
- Replace the touched native controls with the shared `Button`, `Select`, and `Input` primitives.
- Replace the touched inline provider-state SVGs with Lucide icons.
- Add a jsdom regression test asserting that configuration actions are outside the provider button and no `button button` structure is rendered.

## Testing
- `yarn dev:greenfield` — package build, generation, rebuild, and initialization passed
- `yarn workspace @open-mercato/search test --runInBand` — 25 suites / 253 tests passed
- Focused `VectorSearchSection.test.tsx` — pass
- `yarn workspace @open-mercato/search typecheck` — pass
- `yarn workspace @open-mercato/search build` — pass
- Target-file ESLint — pass
- `yarn i18n:check-sync` — pass
- `yarn i18n:check-usage` — pass with the existing advisory unused-key report
- `yarn typecheck` — pass across 21 tasks
- `yarn build:app` — pass

Known unrelated validation note:
- `yarn test` has one existing `explicit-sort-comparators.test.ts` failure for unchanged `scripts/check-agents-md-budget.mjs:93`; the same failure reproduces on `develop`.

## Manual QA
- On `/backend/config/search`, selecting a custom Ollama model showed Apply/Cancel outside the provider button.
- The page rendered zero nested `button button` elements and produced no hydration or `validateDOMNesting` warning.

## Backward Compatibility
- No API, database, event, ACL, DI, import-path, or other contract-surface changes.
- Existing provider selection and inline model-editing behavior is preserved.

## Risk / QA
- Priority: medium.
- Risk: medium for an isolated search-settings UI change with regression coverage.
- QA: `needs-qa` requested because the affected provider/model controls are manually exercisable.