### PR TITLE
fix(scripts): give the AGENTS.md budget chain sort an explicit comparator

### DIFF
--- a/.ai/runs/2026-07-26-bare-sort-agents-md-budget.md
+++ b/.ai/runs/2026-07-26-bare-sort-agents-md-budget.md
@@ -1,0 +1,68 @@
+# Execution plan — restore develop's green test job (bare sort in check-agents-md-budget)
+
+## Goal
+
+`develop` fails its `test` job: the explicit-sort-comparator audit
+(`packages/core/src/__tests__/explicit-sort-comparators.test.ts`, the #3620 guard) reports one
+violation in `scripts/check-agents-md-budget.mjs:93`. Because the guard runs in the shared `test`
+job, every PR that merges the current base inherits the red check. Give that sort an explicit
+comparator so the audit passes and the base is mergeable again.
+
+## Root cause
+
+`scripts/check-agents-md-budget.mjs` arrived in commit `09a84a85f`
+("fix(agents): ratchet only the nested part of over-budget instruction chains"), already merged to
+`develop`. Line 93 sorts the baseline chain keys with a bare `.sort()`:
+
+```js
+const chains = Object.keys(baseline.chains)
+  .sort()
+```
+
+The guard scans every non-test source file under a package `src` root **and under `scripts/`**, so a
+new script under `scripts/` is in scope. The violation was not visible on that PR because the guard
+and the script landed through different branches and only meet on `develop`.
+
+## Scope
+
+- One call site: `scripts/check-agents-md-budget.mjs:93` gets an explicit comparator.
+- The keys are canonical internal identifiers (directory paths from the baseline), so the guard's
+  documented canonical-key form applies: `(a, b) => (a < b ? -1 : a > b ? 1 : 0)`.
+
+## Non-goals
+
+- No change to the budget logic, the baseline format, or the ratchet behavior of
+  `check-agents-md-budget.mjs` — ordering of the chain keys is unchanged for the string keys it
+  actually holds, so this is behavior-preserving.
+- No change to the guard test itself. The guard is correct; the script is what violates it.
+- No sweep of other sort call sites — the audit reports exactly one violation on this base.
+
+## Risks
+
+- Low. The comparator reproduces the default lexicographic order for the string keys in scope, so
+  `analyze()` output ordering is unchanged; the existing `scripts/__tests__/check-agents-md-budget.test.mjs`
+  suite covers the behavior.
+
+## Implementation plan
+
+### Phase 1: Fix the violation
+
+- 1.1 Give the chain-key sort in `scripts/check-agents-md-budget.mjs` an explicit canonical-key
+  comparator.
+
+### Phase 2: Validation
+
+- 2.1 Confirm the guard passes and the script's own suite is green, then run the configured
+  validation gate.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fix the violation
+
+- [ ] 1.1 Add the explicit comparator to the chain-key sort
+
+### Phase 2: Validation
+
+- [ ] 2.1 Guard test, script suite, and the configured validation gate all green

--- a/.ai/runs/2026-07-26-bare-sort-agents-md-budget.md
+++ b/.ai/runs/2026-07-26-bare-sort-agents-md-budget.md
@@ -61,8 +61,31 @@ and the script landed through different branches and only meet on `develop`.
 
 ### Phase 1: Fix the violation
 
-- [ ] 1.1 Add the explicit comparator to the chain-key sort
+- [x] 1.1 Add the explicit comparator to the chain-key sort — c9fe3d62a
 
 ### Phase 2: Validation
 
-- [ ] 2.1 Guard test, script suite, and the configured validation gate all green
+- [x] 2.1 Guard test, script suite, and the configured validation gate all green — c9fe3d62a
+
+Runner: local. The #3620 guard (`packages/core/src/__tests__/explicit-sort-comparators.test.ts`) goes
+from one violation to 4/4 passing, and the script's own suite
+(`scripts/__tests__/check-agents-md-budget.test.mjs`, run by the `Test scripts` CI step) is 8/8.
+Configured gate: `yarn build:packages`, `yarn generate`, `yarn build:packages`,
+`yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck` and `yarn build:app` all pass.
+
+`yarn test` reports 1032/1033 suites passing with **zero failed assertions** across two full runs;
+each run lost one different suite to `A jest worker process was terminated ... signal=SIGSEGV`
+(`image.route` / `optimistic-lock` / `labels/scoping` in the first run, `ai-tools/settings-pack` in
+the second). Every one of them passes standalone under `--runInBand` (13/13 and 6/6), so this is
+local worker instability under parallel load, not a regression from this change. CI is the
+authoritative gate.
+
+## Note on CI visibility of this fix
+
+This PR touches only `scripts/`, and `.github/workflows/ci.yml` scopes the PR test run to
+`yarn turbo run test --filter=[origin/<base>]...` — which selects packages by dependency graph and
+will not pull in `@open-mercato/core`, where the guard lives. So the guard will not run on this PR's
+own CI, exactly as it did not run on the PR that introduced the violation; the unfiltered `yarn test`
+on the post-merge push is what turned `develop` red. The evidence that the guard is satisfied is the
+local run above plus the `Test scripts` step. This asymmetry is the same one `ci.yml` already
+documents for the create-app parity guards (#3779).

--- a/.ai/runs/2026-07-26-bare-sort-agents-md-budget.md
+++ b/.ai/runs/2026-07-26-bare-sort-agents-md-budget.md
@@ -57,6 +57,8 @@ and the script landed through different branches and only meet on `develop`.
 
 ## Progress
 
+PR: #4527
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Fix the violation

--- a/scripts/check-agents-md-budget.mjs
+++ b/scripts/check-agents-md-budget.mjs
@@ -90,7 +90,7 @@ export function analyze(root, baseline) {
   if (rootBytes === null) throw new Error(`Missing ${INSTRUCTION_FILE} in ${root}`)
 
   const chains = Object.keys(baseline.chains)
-    .sort()
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
     .map((chainDir) => {
       const files = collectChainFiles(root, chainDir)
       const bytes = files.reduce((total, file) => total + file.bytes, 0)


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-26-bare-sort-agents-md-budget.md
Status: complete

## 🎯 Goal
- Restore the green `test` job on `develop`. The #3620 explicit-sort-comparator audit reports one violation — a bare `.sort()` in `scripts/check-agents-md-budget.mjs:93` — which fails the unfiltered post-merge test run and leaves the base branch (and its snapshot/release builds) red.

## Root cause
`scripts/check-agents-md-budget.mjs` landed in `09a84a85f` ("fix(agents): ratchet only the nested part of over-budget instruction chains"). The guard in `packages/core/src/__tests__/explicit-sort-comparators.test.ts` scans every non-test source file under a package `src` root **and under `scripts/`**, so the new script is in scope and its bare `.sort()` on the baseline chain keys is a violation.

It slipped through because of a CI scoping asymmetry that `.github/workflows/ci.yml` already documents for the create-app parity guards (#3779): on pull requests the test step runs

```
yarn turbo run test --filter=[origin/<base>]...
```

which selects packages by dependency graph and never pulls in `@open-mercato/core` when only `scripts/` and `AGENTS.md` change — while the post-merge push runs `yarn test` unfiltered. So the introducing PR was green and `develop` went red on merge. Confirmed in the base branch's own run (`test` job `89770173435`): `FAIL src/__tests__/explicit-sort-comparators.test.ts` with `"scripts/check-agents-md-budget.mjs:93"`.

## What Changed
- `scripts/check-agents-md-budget.mjs` — the `Object.keys(baseline.chains)` sort in `analyze()` gets an explicit comparator. The keys are canonical internal identifiers (baseline chain directories), so this uses the canonical-key form the guard's own docstring prescribes, `(a, b) => (a < b ? -1 : a > b ? 1 : 0)`. For the string keys the baseline holds this reproduces the previous default ordering exactly, so the budget/ratchet behavior is unchanged.

Nothing else is touched: no budget logic, no baseline format, no change to the guard itself, and no sweep of other call sites — the audit reports exactly one violation on this base.

## 🧪 Tests
- `packages/core/src/__tests__/explicit-sort-comparators.test.ts` — **4 passed / 4** (was 1 failing with this violation). This existing guard *is* the regression test for the change; it goes red without the comparator and green with it, so no new test is added.
- `scripts/__tests__/check-agents-md-budget.test.mjs` (the `Test scripts` CI step) — **8 passed / 8**, covering the ratchet, `--update-baseline`, and the repository's own budget.
- Configured gate, runner local: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn build:app` — all pass.
- `yarn test`: 1032/1033 suites, **zero failed assertions** across two full runs. Each run lost one *different* suite to `A jest worker process was terminated ... signal=SIGSEGV` (`attachments/image.route`, `customer_accounts/optimistic-lock`, `customers/labels/scoping` in the first; `customers/ai-tools/settings-pack` in the second). All pass standalone under `--runInBand` (13/13 and 6/6) — local worker instability under parallel load, not a regression.

⚠️ **Note for the reviewer:** because this PR touches only `scripts/`, the turbo filter above means the guard will **not** run on this PR's own CI either — the same blind spot that let the violation in. The proof that it is fixed is the local guard run plus the `Test scripts` step. A follow-up worth considering (mirroring how `ci.yml` handles the create-app parity guards) is to run the repo-wide guards unfiltered on PRs so this class of breakage fails the PR instead of the base branch.

## 💥 Breaking Changes
- None. Behavior-preserving for the data the baseline holds; no contract, schema, or public surface is touched.

## 📋 Progress
See the Progress section in the tracking plan.
