### PR TITLE
feat(notifications): cache notification lists

### DIFF
--- a/packages/core/src/modules/notifications/__integration__/TC-NOTIF-011.spec.ts
+++ b/packages/core/src/modules/notifications/__integration__/TC-NOTIF-011.spec.ts
@@ -1,0 +1,131 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createRoleFixture,
+  createUserFixture,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setRoleAclFeatures,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  createNotificationFixture,
+  dismissNotificationIfExists,
+  listNotifications,
+} from '@open-mercato/core/helpers/integration/notificationsFixtures'
+
+const POLL_INTERVAL_MS = 5_000
+const CACHE_CONVERGENCE_TIMEOUT_MS = POLL_INTERVAL_MS * 2 + 1_000
+
+test.describe('TC-NOTIF-011: Notification list cache convergence and isolation', () => {
+  test('converges after creation within two poll ticks without sharing cached pages between users', async ({ request }) => {
+    const stamp = Date.now()
+    const password = 'Valid1!Pass'
+    const otherUserEmail = `qa-notif-cache-other-${stamp}@acme.com`
+    const type = `qa.notifications.cache.${stamp}`
+    const query = { type, status: 'unread', pageSize: 10 }
+
+    let superadminToken: string | null = null
+    let otherUserToken: string | null = null
+    let roleId: string | null = null
+    let otherUserId: string | null = null
+    let notificationId: string | null = null
+
+    try {
+      const ownerToken = await getAuthToken(request, 'superadmin')
+      superadminToken = ownerToken
+      const scope = getTokenScope(ownerToken)
+      roleId = await createRoleFixture(request, superadminToken, {
+        name: `qa_notif_cache_viewer_${stamp}`,
+        tenantId: scope.tenantId,
+      })
+      await setRoleAclFeatures(request, superadminToken, {
+        roleId,
+        features: ['notifications.view'],
+        organizations: null,
+      })
+      otherUserId = await createUserFixture(request, superadminToken, {
+        email: otherUserEmail,
+        password,
+        organizationId: scope.organizationId,
+        roles: [roleId],
+      })
+      otherUserToken = await getAuthToken(request, otherUserEmail, password)
+
+      const initialOwnerList = await listNotifications(request, superadminToken, query)
+      const initialOtherList = await listNotifications(request, otherUserToken, query)
+      expect(initialOwnerList.items).toEqual([])
+      expect(initialOtherList.items).toEqual([])
+
+      const createdNotificationId = await createNotificationFixture(request, superadminToken, {
+        type,
+        title: 'Notification list cache convergence',
+        recipientUserId: scope.userId,
+      })
+      notificationId = createdNotificationId
+
+      await expect.poll(
+        async () => {
+          const refreshedOwnerList = await listNotifications(request, ownerToken, query)
+          return refreshedOwnerList.items.some((item) => item.id === createdNotificationId)
+        },
+        {
+          intervals: [POLL_INTERVAL_MS],
+          timeout: CACHE_CONVERGENCE_TIMEOUT_MS,
+        },
+      ).toBe(true)
+
+      const isolatedOtherList = await listNotifications(request, otherUserToken, query)
+      expect(isolatedOtherList.items.some((item) => item.id === createdNotificationId)).toBe(false)
+    } finally {
+      await dismissNotificationIfExists(request, superadminToken, notificationId)
+      await deleteUserIfExists(request, superadminToken, otherUserId)
+      await deleteRoleIfExists(request, superadminToken, roleId)
+    }
+  })
+
+  test('converges after marking a notification read within two poll ticks', async ({ request }) => {
+    const stamp = Date.now()
+    const type = `qa.notifications.cache.read.${stamp}`
+    const query = { type, status: 'unread', pageSize: 10 }
+
+    let superadminToken: string | null = null
+    let notificationId: string | null = null
+
+    try {
+      const ownerToken = await getAuthToken(request, 'superadmin')
+      superadminToken = ownerToken
+      const scope = getTokenScope(ownerToken)
+      const createdNotificationId = await createNotificationFixture(request, ownerToken, {
+        type,
+        title: 'Notification read cache convergence',
+        recipientUserId: scope.userId,
+      })
+      notificationId = createdNotificationId
+
+      const initialUnreadList = await listNotifications(request, ownerToken, query)
+      expect(initialUnreadList.items.some((item) => item.id === createdNotificationId)).toBe(true)
+
+      const readResponse = await apiRequest(
+        request,
+        'PUT',
+        `/api/notifications/${encodeURIComponent(createdNotificationId)}/read`,
+        { token: ownerToken },
+      )
+      expect(readResponse.status()).toBe(200)
+
+      await expect.poll(
+        async () => {
+          const refreshedUnreadList = await listNotifications(request, ownerToken, query)
+          return refreshedUnreadList.items.some((item) => item.id === createdNotificationId)
+        },
+        {
+          intervals: [POLL_INTERVAL_MS],
+          timeout: CACHE_CONVERGENCE_TIMEOUT_MS,
+        },
+      ).toBe(false)
+    } finally {
+      await dismissNotificationIfExists(request, superadminToken, notificationId)
+    }
+  })
+})

--- a/packages/core/src/modules/notifications/api/__tests__/cache.test.ts
+++ b/packages/core/src/modules/notifications/api/__tests__/cache.test.ts
@@ -1,0 +1,231 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const orgId = '22222222-2222-4222-8222-222222222222'
+const firstUserId = '33333333-3333-4333-8333-333333333333'
+const secondUserId = '44444444-4444-4444-8444-444444444444'
+
+const find = jest.fn()
+const count = jest.fn()
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+} as { get: jest.Mock; set: jest.Mock }
+
+const em = {
+  find: (...args: unknown[]) => find(...args),
+  count: (...args: unknown[]) => count(...args),
+}
+
+let cacheAvailable = true
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'cache' && cacheAvailable) return cache
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+const resolveNotificationContextMock = jest.fn(async () => ({
+  ctx: { container },
+  scope: { userId: firstUserId, tenantId, organizationId: orgId },
+}))
+
+const runWithCacheTenantMock = jest.fn((_tenantId: string, fn: () => unknown) => fn())
+
+jest.mock('@open-mercato/core/modules/notifications/lib/routeHelpers', () => ({
+  resolveNotificationContext: (...args: unknown[]) => resolveNotificationContextMock(...args),
+}))
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: (...args: unknown[]) => runWithCacheTenantMock(...args),
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+const loadRoute = async () => {
+  jest.resetModules()
+  return import('../route')
+}
+
+describe('GET /api/notifications caching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+    cacheAvailable = true
+    resolveNotificationContextMock.mockResolvedValue({
+      ctx: { container },
+      scope: { userId: firstUserId, tenantId, organizationId: orgId },
+    })
+    find.mockResolvedValue([])
+    count.mockResolvedValue(0)
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('caches the assembled page for ten seconds in the tenant namespace', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+    count.mockResolvedValue(7)
+
+    const response = await GET(new Request('http://localhost/api/notifications?pageSize=50'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      items: [],
+      total: 7,
+      page: 1,
+      pageSize: 50,
+      totalPages: 1,
+    })
+    expect(runWithCacheTenantMock).toHaveBeenCalledWith(tenantId, expect.any(Function))
+    expect(cache.get).toHaveBeenCalledTimes(1)
+    expect(cache.set).toHaveBeenCalledTimes(1)
+    const [key, value, options] = cache.set.mock.calls[0]
+    expect(key).toContain(`notifications:list:v1:u=${firstUserId}:filters=`)
+    expect(value).toEqual({
+      items: [],
+      total: 7,
+      page: 1,
+      pageSize: 50,
+      totalPages: 1,
+    })
+    expect(options).toEqual({ ttl: 10_000 })
+  })
+
+  it('serves a cached page without querying the database', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    const cachedPayload = {
+      items: [],
+      total: 3,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+    }
+    cache.get.mockResolvedValue(cachedPayload)
+
+    const response = await GET(new Request('http://localhost/api/notifications'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(cachedPayload)
+    expect(find).not.toHaveBeenCalled()
+    expect(count).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('uses distinct cache keys for different users', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+
+    await GET(new Request('http://localhost/api/notifications?pageSize=50'))
+    resolveNotificationContextMock.mockResolvedValueOnce({
+      ctx: { container },
+      scope: { userId: secondUserId, tenantId, organizationId: orgId },
+    })
+    await GET(new Request('http://localhost/api/notifications?pageSize=50'))
+
+    const keys = cache.get.mock.calls.map(([key]) => key)
+    expect(keys[0]).toContain(`u=${firstUserId}:`)
+    expect(keys[1]).toContain(`u=${secondUserId}:`)
+    expect(keys[0]).not.toBe(keys[1])
+  })
+
+  it('uses distinct cache keys for different filter signatures', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue(null)
+
+    await GET(new Request('http://localhost/api/notifications?status=unread&pageSize=50'))
+    await GET(new Request('http://localhost/api/notifications?status=read&pageSize=50'))
+
+    const keys = cache.get.mock.calls.map(([key]) => key)
+    expect(keys[0]).not.toBe(keys[1])
+    expect(keys[0]).toContain('"status":"unread"')
+    expect(keys[1]).toContain('"status":"read"')
+  })
+
+  it('falls back to the database when cache access fails', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockRejectedValue(new Error('cache backend unavailable'))
+    cache.set.mockRejectedValue(new Error('cache backend unavailable'))
+    count.mockResolvedValue(2)
+
+    const response = await GET(new Request('http://localhost/api/notifications'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      items: [],
+      total: 2,
+      page: 1,
+      pageSize: 20,
+      totalPages: 1,
+    })
+    expect(find).toHaveBeenCalledTimes(1)
+    expect(count).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to the database when the cache service is unavailable', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    cacheAvailable = false
+    const { GET } = await loadRoute()
+    count.mockResolvedValue(4)
+
+    const response = await GET(new Request('http://localhost/api/notifications'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ total: 4 })
+    expect(find).toHaveBeenCalledTimes(1)
+    expect(count).toHaveBeenCalledTimes(1)
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('does not cache when the crud cache flag is off', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { GET } = await loadRoute()
+
+    const response = await GET(new Request('http://localhost/api/notifications'))
+
+    expect(response.status).toBe(200)
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('does not cache when there is no user in scope', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    resolveNotificationContextMock.mockResolvedValue({
+      ctx: { container },
+      scope: { userId: null, tenantId, organizationId: orgId },
+    })
+
+    const response = await GET(new Request('http://localhost/api/notifications'))
+
+    expect(response.status).toBe(200)
+    expect(cache.get).not.toHaveBeenCalled()
+    expect(cache.set).not.toHaveBeenCalled()
+  })
+
+  it('ignores malformed cached payloads', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { GET } = await loadRoute()
+    cache.get.mockResolvedValue({
+      items: 'not-an-array',
+      total: 99,
+    })
+    count.mockResolvedValue(2)
+
+    const response = await GET(new Request('http://localhost/api/notifications'))
+
+    await expect(response.json()).resolves.toMatchObject({ total: 2 })
+    expect(find).toHaveBeenCalledTimes(1)
+    expect(count).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/notifications/api/route.ts
+++ b/packages/core/src/modules/notifications/api/route.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/core'
+import { runWithCacheTenant } from '@open-mercato/cache'
+import {
+  isCrudCacheEnabled,
+  resolveCrudCache,
+} from '@open-mercato/shared/lib/crud/cache'
 import { Notification } from '../data/entities'
 import { listNotificationsSchema, createNotificationSchema } from '../data/validators'
 import { toNotificationDto } from '../lib/notificationMapper'
@@ -21,6 +26,48 @@ export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['notifications.create'] },
 }
 
+const NOTIFICATIONS_LIST_TTL_MS = 10_000
+const NOTIFICATIONS_LIST_CACHE_VERSION = 1
+
+type NotificationsListPayload = {
+  items: ReturnType<typeof toNotificationDto>[]
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+}
+
+function buildNotificationsListCacheKey(
+  userId: string,
+  input: z.infer<typeof listNotificationsSchema>,
+): string {
+  const filterSignature = JSON.stringify({
+    status: Array.isArray(input.status)
+      ? [...input.status].sort((left, right) => left.localeCompare(right))
+      : input.status ?? null,
+    type: input.type ?? null,
+    severity: input.severity ?? null,
+    sourceEntityType: input.sourceEntityType ?? null,
+    sourceEntityId: input.sourceEntityId ?? null,
+    since: input.since ?? null,
+    page: input.page,
+    pageSize: input.pageSize,
+  })
+  return `notifications:list:v${NOTIFICATIONS_LIST_CACHE_VERSION}:u=${userId}:filters=${filterSignature}`
+}
+
+function isNotificationsListPayload(value: unknown): value is NotificationsListPayload {
+  if (!value || typeof value !== 'object') return false
+  const payload = value as Partial<NotificationsListPayload>
+  return (
+    Array.isArray(payload.items)
+    && typeof payload.total === 'number'
+    && typeof payload.page === 'number'
+    && typeof payload.pageSize === 'number'
+    && typeof payload.totalPages === 'number'
+  )
+}
+
 export async function GET(req: Request) {
   const { ctx, scope } = await resolveNotificationContext(req)
   const em = ctx.container.resolve('em') as EntityManager
@@ -28,9 +75,23 @@ export async function GET(req: Request) {
   const url = new URL(req.url)
   const queryParams = Object.fromEntries(url.searchParams.entries())
   const input = listNotificationsSchema.parse(queryParams)
+  const userId = scope.userId
+  const cache = userId && isCrudCacheEnabled()
+    ? resolveCrudCache(ctx.container)
+    : null
+  const cacheKey = cache && userId ? buildNotificationsListCacheKey(userId, input) : null
+
+  if (cache && cacheKey) {
+    try {
+      const cached = await runWithCacheTenant(scope.tenantId, () => cache.get(cacheKey))
+      if (isNotificationsListPayload(cached)) {
+        return Response.json(cached)
+      }
+    } catch {}
+  }
 
   const filters: Record<string, unknown> = {
-    recipientUserId: scope.userId,
+    recipientUserId: userId,
     tenantId: scope.tenantId,
   }
 
@@ -66,13 +127,23 @@ export async function GET(req: Request) {
 
   const items = notifications.map(toNotificationDto)
 
-  return Response.json({
+  const payload: NotificationsListPayload = {
     items,
     total,
     page: input.page,
     pageSize: input.pageSize,
     totalPages: Math.ceil(total / input.pageSize),
-  })
+  }
+
+  if (cache && cacheKey) {
+    try {
+      await runWithCacheTenant(scope.tenantId, () =>
+        cache.set(cacheKey, payload, { ttl: NOTIFICATIONS_LIST_TTL_MS }),
+      )
+    } catch {}
+  }
+
+  return Response.json(payload)
 }
 
 export async function POST(req: Request) {


### PR DESCRIPTION
Fixes #2916

## Problem
- The five-second notification poll rebuilt `GET /api/notifications` through `find` and `count` queries on every request.
- Notification list responses are private to the recipient and vary by filters and pagination.

## Root Cause
- The custom notification list route assembled its response outside the shared CRUD list-cache path, so repeated identical polls always reached the database.

## What Changed
- Added an env-gated read-through cache around the assembled notification list response.
- Partitioned entries by tenant, recipient user, filters, and pagination.
- Used the requested 10-second TTL-only behavior without active invalidation tags.
- Cached only the existing `NotificationDto` response; notification action payload and result fields are not stored.
- Validated cached payloads before reuse and kept malformed entries, unavailable cache services, and cache failures on the existing database-backed path.

## Tests
- Added focused unit coverage for flag-off behavior, TTL, hit reuse, user/filter/page key isolation, unavailable cache, malformed entries, and failure fallback — 9 tests passed.
- Added `TC-NOTIF-011` for create and mark-read convergence within two poll ticks plus cross-user isolation — 2 Playwright tests passed.

## Validation
- `yarn workspace @open-mercato/core test --runInBand src/modules/notifications/api/__tests__/cache.test.ts` — pass
- `ENABLE_CRUD_API_CACHE=true npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/notifications/__integration__/TC-NOTIF-011.spec.ts --workers=1` — pass
- `yarn workspace @open-mercato/core typecheck` — pass
- `yarn workspace @open-mercato/core build` — pass
- Target-file ESLint — pass
- `git diff --check` — pass

Known unrelated validation note:
- The full core test run passed 7903/7904 tests; the sole failure is the existing `explicit-sort-comparators.test.ts` finding for unchanged `scripts/check-agents-md-budget.mjs:93`, also present on `develop`.

## Backward Compatibility
- No API route, method, response field, database schema, event ID, ACL ID, DI key, or import path changes.
- The cache is additive, gated by the existing CRUD API cache setting, and preserves the database-backed fallback.

## Risk / QA
- Priority: low, matching #2916.
- Risk: medium because a user-private polling response is now cached; entries remain tenant/user scoped and expire after 10 seconds.
- QA: `skip-qa` requested; no UI-rendering file, database structure, API surface, or backward-compatibility contract changes, and the behavior has unit and integration coverage.