### PR TITLE
fix(shared): await the dynamic import in compileAndImport so cache recovery runs (#4526)

### DIFF
--- a/.ai/runs/2026-07-27-compile-and-import-await-cache-recovery.md
+++ b/.ai/runs/2026-07-27-compile-and-import-await-cache-recovery.md
@@ -79,7 +79,14 @@ relevant subset plus the shared package test suite.
 
 ## Progress
 
-- [ ] 1.1 Await the dynamic import in `compileAndImport`
-- [ ] 2.1 Regression test for the reactive recovery path
-- [ ] 3.1 Validation gate
-- [ ] 4.1 PR opened with labels requested
+- [x] 1.1 Await the dynamic import in `compileAndImport` — `0e6274a99`
+- [x] 2.1 Regression test for the reactive recovery path — `0e6274a99`
+      (all three cases fail without the `await`, pass with it)
+- [x] 3.1 Validation gate (runner: local) — `yarn build:packages` ✅,
+      `yarn generate` ✅, `yarn i18n:check-sync` ✅, `yarn i18n:check-usage` ✅,
+      `yarn typecheck` ✅ (21/21), `yarn test` 22/23 packages green
+      (`@open-mercato/shared` 139 suites / 1501 tests pass; the single
+      `@open-mercato/core` failure is the pre-existing `develop` breakage in
+      `scripts/check-agents-md-budget.mjs:93` fixed by #4527, untouched here),
+      `yarn build:app` ✅
+- [x] 4.1 PR opened with labels requested

--- a/.ai/runs/2026-07-27-compile-and-import-await-cache-recovery.md
+++ b/.ai/runs/2026-07-27-compile-and-import-await-cache-recovery.md
@@ -1,0 +1,85 @@
+# Fix `compileAndImport` never reaching its MikroORM v7 cache recovery path
+
+Date: 2026-07-27
+Slug: compile-and-import-await-cache-recovery
+Branch: fix/issue-4526-compile-and-import-await
+Issue: #4526
+
+## Overview
+
+### Goal
+
+Make the reactive MikroORM v7 generated-cache recovery in
+`packages/shared/src/lib/bootstrap/dynamicLoader.ts` actually run when a compiled
+generated module fails to import, instead of surfacing the raw import rejection to
+the CLI/worker caller.
+
+### Background
+
+`compileAndImport` returns the dynamic import **without awaiting it** inside its
+`try` block:
+
+```ts
+try {
+  const fileUrl = `${pathToFileURL(jsPath).href}?mtime=${fs.statSync(jsPath).mtimeMs}`
+  return import(fileUrl)          // <-- not awaited
+} catch (error) {
+  ...
+  const recovered = recoverMikroOrmV7GeneratedCacheFromImportError(appRoot, error)
+  ...
+  return compileAndImport(tsPath, false)
+}
+```
+
+Because the promise is returned rather than awaited, an import-time rejection
+settles **after** the `try` block has already exited, so `catch` never runs.
+`recoverMikroOrmV7GeneratedCacheFromImportError` is dead code for exactly the
+failure it exists to repair — the `does not provide an export named 'Entity'`
+case caused by a stale MikroORM v7 generated cache written before the v7
+migration. The caller sees the raw import error instead of a recovered load.
+
+The proactive scan (`ensureMikroOrmV7GeneratedCacheCompatibility`, called once at
+the top of `loadBootstrapData`) still works; only the reactive per-import recovery
+is unreachable.
+
+### Scope
+
+- `packages/shared/src/lib/bootstrap/dynamicLoader.ts` — `await` the dynamic
+  import so an import-time rejection is caught by the existing `catch`.
+- `packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts`
+  — new regression guard: a rejecting import triggers the recovery once and the
+  retry loads the refreshed module; a rejection with no applicable recovery still
+  propagates, and the retry is attempted exactly once (`allowRecovery` guard).
+
+### Non-goals
+
+- No change to `generatedCacheRecovery.ts` (detection, deletion, marker) — it
+  already has its own tests.
+- No change to the proactive scan or to `loadBootstrapData`'s file set.
+- No new logging/diagnostics (that is #4491 / PR #4505, deliberately
+  behavior-preserving).
+
+## Implementation Plan
+
+### Phase 1: Fix
+
+1.1 `return import(fileUrl)` → `return await import(fileUrl)`.
+
+### Phase 2: Regression test
+
+2.1 Add `dynamicLoader.cacheRecovery.test.ts` covering: recovery applied → retry
+succeeds; recovery not applicable → original error propagates; recovery runs at
+most once (no infinite retry loop).
+
+### Phase 3: Validation
+
+3.1 Run the configured validation gate (`yarn build:packages`, `yarn generate`,
+`yarn typecheck`, `yarn test`, i18n checks, `yarn build:app`) or the smallest
+relevant subset plus the shared package test suite.
+
+## Progress
+
+- [ ] 1.1 Await the dynamic import in `compileAndImport`
+- [ ] 2.1 Regression test for the reactive recovery path
+- [ ] 3.1 Validation gate
+- [ ] 4.1 PR opened with labels requested

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment node
+ *
+ * Regression guard for #4526: compileAndImport must await its dynamic import so
+ * an import-time rejection is caught by the surrounding try/catch and reaches
+ * the MikroORM v7 generated-cache recovery. Returning the promise unawaited let
+ * it settle after the try block had exited, so the reactive recovery was dead
+ * code for exactly the failure it exists to repair (a stale generated cache
+ * whose top-level `@mikro-orm/core` decorator import no longer resolves).
+ *
+ * generatedCacheRecovery is mocked here: it owns cache detection/deletion and is
+ * covered by its own tests, while these cases only assert how dynamicLoader
+ * reacts to a rejecting import. The recovery double rewrites the compiled
+ * sibling the way a real cache wipe plus recompile would, so the retry loads the
+ * refreshed module without invoking esbuild.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { loadBootstrapData } from '../dynamicLoader'
+import {
+  ensureMikroOrmV7GeneratedCacheCompatibility,
+  recoverMikroOrmV7GeneratedCacheFromImportError,
+  type GeneratedCacheRecoveryResult,
+} from '../generatedCacheRecovery'
+
+jest.mock('../generatedCacheRecovery', () => ({
+  ensureMikroOrmV7GeneratedCacheCompatibility: jest.fn(),
+  recoverMikroOrmV7GeneratedCacheFromImportError: jest.fn(),
+}))
+
+const ensureCompatibilityMock = ensureMikroOrmV7GeneratedCacheCompatibility as jest.MockedFunction<
+  typeof ensureMikroOrmV7GeneratedCacheCompatibility
+>
+const recoverFromImportErrorMock = recoverMikroOrmV7GeneratedCacheFromImportError as jest.MockedFunction<
+  typeof recoverMikroOrmV7GeneratedCacheFromImportError
+>
+
+const NO_RECOVERY: GeneratedCacheRecoveryResult = { applied: false, deletedFiles: [], markerPath: null }
+const STALE_DECORATOR_IMPORT_ERROR =
+  "The requested module '@mikro-orm/core' does not provide an export named 'Entity'"
+
+const STALE_ENTITY_IDS_CACHE = `throw new SyntaxError(${JSON.stringify(STALE_DECORATOR_IMPORT_ERROR)})`
+const FRESH_ENTITY_IDS_CACHE = "module.exports = { E: { example: { todo: 'example:todo' } } }"
+
+const BASE_GENERATED_MODULES: Record<string, { ts: string; compiled: string }> = {
+  'modules.cli.generated': { ts: 'export const modules = []', compiled: 'module.exports = { modules: [] }' },
+  'entities.generated': { ts: 'export const entities = []', compiled: 'module.exports = { entities: [] }' },
+  'di.generated': { ts: 'export const diRegistrars = []', compiled: 'module.exports = { diRegistrars: [] }' },
+}
+
+let compiledCacheGeneration = 0
+
+function writeGeneratedModule(generatedDir: string, baseName: string, source: { ts: string; compiled: string }) {
+  fs.writeFileSync(path.join(generatedDir, `${baseName}.ts`), source.ts)
+  writeCompiledSibling(generatedDir, baseName, source.compiled)
+}
+
+/**
+ * Write the .mjs sibling with an mtime ahead of its .ts source so
+ * compileAndImport takes its cache path and never invokes esbuild. Each write
+ * advances the timestamp, which also gives the retry a distinct `?mtime=` import
+ * URL instead of the rejected module's cached one.
+ */
+function writeCompiledSibling(generatedDir: string, baseName: string, compiled: string) {
+  const compiledPath = path.join(generatedDir, `${baseName}.mjs`)
+  fs.writeFileSync(compiledPath, compiled)
+  compiledCacheGeneration += 1
+  const fresh = new Date(Date.now() + compiledCacheGeneration * 60_000)
+  fs.utimesSync(compiledPath, fresh, fresh)
+}
+
+function createAppRoot(entityIdsCache: string): string {
+  const appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-bootstrap-4526-'))
+  const generatedDir = path.join(appRoot, '.mercato', 'generated')
+  fs.mkdirSync(generatedDir, { recursive: true })
+  for (const [baseName, source] of Object.entries(BASE_GENERATED_MODULES)) {
+    writeGeneratedModule(generatedDir, baseName, source)
+  }
+  writeGeneratedModule(generatedDir, 'entities.ids.generated', {
+    ts: 'export const E = {}',
+    compiled: entityIdsCache,
+  })
+  return appRoot
+}
+
+function recoverByRewritingCache(appRoot: string, compiled: string): GeneratedCacheRecoveryResult {
+  const generatedDir = path.join(appRoot, '.mercato', 'generated')
+  writeCompiledSibling(generatedDir, 'entities.ids.generated', compiled)
+  // Node busts its ESM cache through the `?mtime=` query compileAndImport
+  // appends; Jest's registry keys on the resolved path alone, so the retry would
+  // otherwise replay the rejected evaluation instead of the rewritten file.
+  jest.resetModules()
+  return {
+    applied: true,
+    deletedFiles: [path.join(generatedDir, 'entities.ids.generated.mjs')],
+    markerPath: path.join(generatedDir, '.mikro-orm-v7-cache-recovery.json'),
+  }
+}
+
+describe('compileAndImport — a rejecting import reaches the cache recovery (#4526)', () => {
+  const appRoots: string[] = []
+
+  beforeEach(() => {
+    ensureCompatibilityMock.mockReset()
+    recoverFromImportErrorMock.mockReset()
+    ensureCompatibilityMock.mockReturnValue(NO_RECOVERY)
+    recoverFromImportErrorMock.mockReturnValue(NO_RECOVERY)
+  })
+
+  afterAll(() => {
+    for (const appRoot of appRoots) {
+      fs.rmSync(appRoot, { recursive: true, force: true })
+    }
+  })
+
+  function createTrackedAppRoot(entityIdsCache: string): string {
+    const appRoot = createAppRoot(entityIdsCache)
+    appRoots.push(appRoot)
+    return appRoot
+  }
+
+  it('recovers the stale cache and loads the refreshed module', async () => {
+    const appRoot = createTrackedAppRoot(STALE_ENTITY_IDS_CACHE)
+    recoverFromImportErrorMock.mockImplementation(() => recoverByRewritingCache(appRoot, FRESH_ENTITY_IDS_CACHE))
+
+    const data = await loadBootstrapData(appRoot)
+
+    expect(data.entityIds).toEqual({ example: { todo: 'example:todo' } })
+    expect(recoverFromImportErrorMock).toHaveBeenCalledTimes(1)
+    const [recoveryAppRoot, recoveryError] = recoverFromImportErrorMock.mock.calls[0]
+    expect(recoveryAppRoot).toBe(appRoot)
+    expect(String((recoveryError as Error).message)).toContain(STALE_DECORATOR_IMPORT_ERROR)
+  })
+
+  it('propagates the import error when no recovery applies', async () => {
+    const appRoot = createTrackedAppRoot(STALE_ENTITY_IDS_CACHE)
+
+    await expect(loadBootstrapData(appRoot)).rejects.toThrow(STALE_DECORATOR_IMPORT_ERROR)
+    expect(recoverFromImportErrorMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries at most once when the refreshed cache still fails to import', async () => {
+    const appRoot = createTrackedAppRoot(STALE_ENTITY_IDS_CACHE)
+    recoverFromImportErrorMock.mockImplementation(() => recoverByRewritingCache(appRoot, STALE_ENTITY_IDS_CACHE))
+
+    await expect(loadBootstrapData(appRoot)).rejects.toThrow(STALE_DECORATOR_IMPORT_ERROR)
+    expect(recoverFromImportErrorMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/shared/src/lib/bootstrap/dynamicLoader.ts
+++ b/packages/shared/src/lib/bootstrap/dynamicLoader.ts
@@ -91,7 +91,7 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
   // Import the compiled JavaScript
   try {
     const fileUrl = `${pathToFileURL(jsPath).href}?mtime=${fs.statSync(jsPath).mtimeMs}`
-    return import(fileUrl)
+    return await import(fileUrl)
   } catch (error) {
     if (!allowRecovery) {
       throw error


### PR DESCRIPTION
Closes #4526
Tracking plan: .ai/runs/2026-07-27-compile-and-import-await-cache-recovery.md
Status: complete

## 🎯 Goal

Make the reactive MikroORM v7 generated-cache recovery in the CLI/worker bootstrap actually run. `compileAndImport` returned its dynamic import **without awaiting it** inside the `try` block, so an import-time rejection settled after the block had exited and the `catch` never ran — `recoverMikroOrmV7GeneratedCacheFromImportError` was dead code for exactly the failure it exists to repair (a stale generated cache whose top-level `@mikro-orm/core` decorator import no longer resolves: `does not provide an export named 'Entity'`). Callers saw the raw import error instead of a recovered load.

## What Changed

- `packages/shared/src/lib/bootstrap/dynamicLoader.ts` — `return import(fileUrl)` → `return await import(fileUrl)` in `compileAndImport`. The rejection now settles inside the `try`, so the existing `catch` runs the recovery and retries once; the `allowRecovery` flag still caps it at a single retry, so a refreshed cache that still fails propagates instead of looping. Nothing else in the function or in `generatedCacheRecovery.ts` changed — the proactive scan (`ensureMikroOrmV7GeneratedCacheCompatibility`) already worked and is untouched.
- `packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts` (new) — regression guard driving `loadBootstrapData` against a temp app root whose compiled `entities.ids.generated.mjs` throws the stale-decorator error. `generatedCacheRecovery` is mocked (it owns cache detection/deletion and has its own tests); the double rewrites the compiled sibling the way a real cache wipe plus recompile would, so the retry loads the refreshed module without invoking esbuild.

## 🧪 Tests

- New: `dynamicLoader.cacheRecovery.test.ts` — three cases: (1) recovery applied → the retry loads the refreshed module and `recover…FromImportError` is called exactly once with the app root and the stale-decorator error; (2) no applicable recovery → the original import error propagates, recovery attempted once; (3) the refreshed cache still fails → rejects, retried at most once. **All three fail on the unfixed code** (`Received number of calls: 0` — the `catch` is never entered) and pass with the `await`.
- Validation gate (runner: local): `yarn build:packages` ✅ · `yarn generate` ✅ · `yarn i18n:check-sync` ✅ · `yarn i18n:check-usage` ✅ · `yarn typecheck` ✅ (21/21) · `yarn lint` ✅ · `yarn test` 22/23 packages green — `@open-mercato/shared` 139 suites / 1501 tests pass · `yarn build:app` ✅.
- ⚠️ The one red package in `yarn test` is **not from this PR**: `@open-mercato/core` → `explicit-sort-comparators.test.ts` flags `scripts/check-agents-md-budget.mjs:93`, the known `develop` breakage from `09a84a85f` that #4527 fixes (background: #4534). This PR touches nothing under `scripts/`; its diff is three files. Expect that guard to be red in CI here too until #4527 lands.

## 💥 Breaking Changes

- None. No contract surface changes — `compileAndImport` is module-private and its signature, return type, and success-path behavior are unchanged. The only behavioral difference is on the failure path, which previously could not be reached.

## 🏷️ Labels requested

My account has no triage rights (403), so please apply: `bug`, `priority-low`, `risk-medium`, `skip-qa`, `review`.

`risk-medium` because the re-armed branch deletes generated cache files on disk; `skip-qa` because the change is confined to the CLI/worker bootstrap with no customer-facing surface (no UI to exercise) and is covered by unit tests — happy to switch to `needs-qa` if you would rather have it manually verified.

## 📋 Progress

See the Progress section in the tracking plan.
