### PR TITLE
fix(progress): make job state transitions race-safe for horizontal scaling

### DIFF
--- a/packages/core/src/modules/progress/AGENTS.md
+++ b/packages/core/src/modules/progress/AGENTS.md
@@ -86,7 +86,17 @@ Use stable, grep-friendly ids:
 
 | Variable | Effect | Default |
 |----------|--------|---------|
-| `OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS` | Coalesces intermediate `progress.job.updated` flush+broadcasts per job: the service flushes and emits only when this many ms elapsed since the last broadcast **or** `progressPercent` advanced by ≥1; sub-threshold updates buffer in memory. Keeps bulk workers from firing one serialized `pg_notify` roundtrip + tenant-wide SSE fan-out per record. Terminal events (`created`/`started`/`completed`/`failed`/`cancelled`) are never throttled, so `ProgressTopBar` still converges and the 60s `STALE_JOB_TIMEOUT_SECONDS` heartbeat window is never exceeded. Set to `0` to restore per-record emission (tests/debugging). | `250` |
+| `OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS` | Coalesces intermediate `progress.job.updated` broadcasts per job: the service emits only when this many ms elapsed since the last broadcast **or** `progressPercent` advanced by ≥1; sub-threshold updates buffer in memory. Keeps bulk workers from firing one serialized `pg_notify` roundtrip + tenant-wide SSE fan-out per record. Persistence is throttled independently: heartbeats reach the database at least every `HEARTBEAT_INTERVAL_MS` (5s) regardless of this knob, so no value can starve the 60s `STALE_JOB_TIMEOUT_SECONDS` sweep. Terminal events (`created`/`started`/`completed`/`failed`/`cancelled`) are never throttled. Set to `0` to restore per-record emission (tests/debugging). | `250` |
+
+## Concurrency Semantics (multi-instance safe)
+
+`progressService` is safe to run across many app/worker instances. Do not reintroduce read-modify-write transitions:
+
+- **Every status transition is a status-guarded `nativeUpdate` (CAS).** An update that matches zero rows lost the race — it MUST NOT emit events or overwrite the row. Allowed transitions: start from `pending|running|failed` (never resurrects `completed`/`cancelled`; `failed` allows queue retries and recovery from a wrong stale sweep), complete from `pending|running|failed`, fail from `pending|running`, cancel from `pending|running|failed`.
+- **Progress writes are guarded on `status IN ('pending','running')`** — once another process finishes/cancels a job, buffered updaters stop writing to it.
+- **`incrementProgress` deltas persist as atomic SQL increments** (`processed_count + n`), so concurrent writers never lose counts.
+- **Update-path reads use `disableIdentityMap: true`** — `isCancellationRequested` and lifecycle reads must always see fresh cross-process state, never a stale managed entity.
+- **The stale sweep (`markStaleJobsFailed`) re-checks staleness per row inside the CAS**, so concurrent sweepers emit exactly one `JOB_FAILED` per job, and it also fails `pending` jobs that never started within `STALE_PENDING_TIMEOUT_SECONDS` (a late queue delivery recovers them via `startJob`'s `failed → running` transition).
 
 ## Cross-References
 

--- a/packages/core/src/modules/progress/__tests__/progressService.test.ts
+++ b/packages/core/src/modules/progress/__tests__/progressService.test.ts
@@ -1,6 +1,6 @@
 import { createProgressService } from '../lib/progressServiceImpl'
 import { PROGRESS_EVENTS } from '../lib/events'
-import { calculateEta, calculateProgressPercent } from '../lib/progressService'
+import { calculateEta, calculateProgressPercent, STALE_PENDING_TIMEOUT_SECONDS } from '../lib/progressService'
 import type { ProgressJob } from '../data/entities'
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
@@ -17,6 +17,8 @@ const baseCtx = {
   userId: '2d4a4c33-9c4b-4e39-8e15-0a3cd9a7f432',
 }
 
+const detached = expect.objectContaining({ disableIdentityMap: true })
+
 const buildEm = () => {
   const flush = jest.fn().mockResolvedValue(undefined)
   const persist = jest.fn((_entity: unknown) => ({ flush }))
@@ -27,6 +29,7 @@ const buildEm = () => {
     findOne: jest.fn(),
     findOneOrFail: jest.fn(),
     find: jest.fn(),
+    nativeUpdate: jest.fn().mockResolvedValue(1),
   }
   return em
 }
@@ -65,7 +68,7 @@ describe('progress service', () => {
     )
   })
 
-  it('startJob — sets running status, timestamps, emits JOB_STARTED', async () => {
+  it('startJob — transitions to running via a status-guarded update, emits JOB_STARTED', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
 
@@ -78,20 +81,74 @@ describe('progress service', () => {
     expect(result.status).toBe('running')
     expect(result.startedAt).toBeInstanceOf(Date)
     expect(result.heartbeatAt).toBeInstanceOf(Date)
-    expect(em.flush).toHaveBeenCalled()
+    expect(em.findOneOrFail).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ id: 'job-1' }), detached)
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', status: { $in: ['pending', 'running', 'failed'] } }),
+      expect.objectContaining({ status: 'running' })
+    )
     expect(eventBus.emit).toHaveBeenCalledWith(
       PROGRESS_EVENTS.JOB_STARTED,
       expect.objectContaining({ jobId: 'job-1', jobType: 'import', tenantId: baseCtx.tenantId })
     )
   })
 
-  it('updateProgress — auto-calculates progressPercent and ETA', async () => {
+  it('startJob — does not resurrect a completed job (at-least-once queue redelivery)', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', status: 'completed', jobType: 'import' } as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.startJob('job-1', baseCtx)
+
+    expect(result.status).toBe('completed')
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
+  })
+
+  it('startJob — restarts a failed job (queue retry after stale sweep)', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', status: 'failed', jobType: 'import', errorMessage: 'stale' } as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.startJob('job-1', baseCtx)
+
+    expect(result.status).toBe('running')
+    expect(result.errorMessage).toBeNull()
+    expect(result.finishedAt).toBeNull()
+    expect(eventBus.emit).toHaveBeenCalledWith(PROGRESS_EVENTS.JOB_STARTED, expect.objectContaining({ jobId: 'job-1' }))
+  })
+
+  it('startJob — lost transition race returns the fresh row without emitting', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', status: 'pending', jobType: 'import' } as ProgressJob
+    const fresh = { id: 'job-1', status: 'cancelled', jobType: 'import' } as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+    em.findOne.mockResolvedValue(fresh)
+    em.nativeUpdate.mockResolvedValue(0)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.startJob('job-1', baseCtx)
+
+    expect(result.status).toBe('cancelled')
+    expect(eventBus.emit).not.toHaveBeenCalled()
+  })
+
+  it('updateProgress — auto-calculates progressPercent and ETA, persists via guarded update', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
 
     const job = {
       id: 'job-1',
       jobType: 'import',
+      status: 'running',
       processedCount: 0,
       totalCount: 100,
       progressPercent: 0,
@@ -107,7 +164,11 @@ describe('progress service', () => {
     expect(result.progressPercent).toBe(50)
     expect(result.etaSeconds).toBeGreaterThan(0)
     expect(result.heartbeatAt).toBeInstanceOf(Date)
-    expect(em.flush).toHaveBeenCalled()
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', status: { $in: ['pending', 'running'] } }),
+      expect.objectContaining({ processedCount: 50, progressPercent: 50 })
+    )
     expect(eventBus.emit).toHaveBeenCalledWith(
       PROGRESS_EVENTS.JOB_UPDATED,
       expect.objectContaining({ jobId: 'job-1', processedCount: 50, progressPercent: 50 })
@@ -121,6 +182,7 @@ describe('progress service', () => {
     const job = {
       id: 'job-1',
       jobType: 'import',
+      status: 'running',
       processedCount: 0,
       totalCount: 100,
       progressPercent: 0,
@@ -142,6 +204,7 @@ describe('progress service', () => {
     const job = {
       id: 'job-1',
       jobType: 'import',
+      status: 'running',
       processedCount: 0,
       totalCount: null,
       progressPercent: 0,
@@ -156,13 +219,62 @@ describe('progress service', () => {
     expect(job.meta).toEqual({ existing: 'value', added: 'new' })
   })
 
-  it('incrementProgress — adds delta, recalculates percent, emits JOB_UPDATED', async () => {
+  it('updateProgress — returns early without writes when the job is already terminal', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', status: 'cancelled', jobType: 'import' } as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.updateProgress('job-1', { processedCount: 10 }, baseCtx)
+
+    expect(result.status).toBe('cancelled')
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
+  })
+
+  it('updateProgress — stops writing once the job went terminal in another process', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
 
     const job = {
       id: 'job-1',
       jobType: 'import',
+      status: 'running',
+      processedCount: 0,
+      totalCount: 100,
+      progressPercent: 0,
+      startedAt: null,
+      meta: null,
+    } as unknown as ProgressJob
+    const fresh = { id: 'job-1', status: 'failed', jobType: 'import' } as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+    em.findOne.mockResolvedValue(fresh)
+    em.nativeUpdate.mockResolvedValue(0)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.updateProgress('job-1', { processedCount: 10 }, baseCtx)
+
+    expect(result.status).toBe('failed')
+    expect(eventBus.emit).not.toHaveBeenCalled()
+
+    // The throttle cache was dropped, so the next call re-reads and hits the terminal guard.
+    em.findOneOrFail.mockResolvedValue(fresh)
+    em.nativeUpdate.mockClear()
+    const second = await service.updateProgress('job-1', { processedCount: 11 }, baseCtx)
+    expect(second.status).toBe('failed')
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+  })
+
+  it('incrementProgress — adds delta, persists an atomic SQL increment, emits JOB_UPDATED', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = {
+      id: 'job-1',
+      jobType: 'import',
+      status: 'running',
       processedCount: 40,
       totalCount: 100,
       progressPercent: 40,
@@ -176,14 +288,17 @@ describe('progress service', () => {
     expect(result.processedCount).toBe(50)
     expect(result.progressPercent).toBe(50)
     expect(result.heartbeatAt).toBeInstanceOf(Date)
-    expect(em.flush).toHaveBeenCalled()
+    const [, , data] = em.nativeUpdate.mock.calls[0]
+    // Deltas must persist as `processed_count + n`, never as an absolute value that
+    // could overwrite a concurrent writer's increments.
+    expect(typeof data.processedCount).not.toBe('number')
     expect(eventBus.emit).toHaveBeenCalledWith(
       PROGRESS_EVENTS.JOB_UPDATED,
       expect.objectContaining({ jobId: 'job-1', processedCount: 50, progressPercent: 50 })
     )
   })
 
-  it('completeJob — sets completed status, progress 100%, emits JOB_COMPLETED', async () => {
+  it('completeJob — guarded transition to completed, emits JOB_COMPLETED after the write', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
 
@@ -205,10 +320,15 @@ describe('progress service', () => {
     expect(result.etaSeconds).toBe(0)
     expect(result.finishedAt).toBeInstanceOf(Date)
     expect(result.resultSummary).toEqual({ imported: 100 })
-    expect(em.flush).toHaveBeenCalled()
     expect(em.findOne).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: baseCtx.tenantId })
+      expect.objectContaining({ id: 'job-1', tenantId: baseCtx.tenantId }),
+      detached
+    )
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', status: { $in: ['pending', 'running', 'failed'] } }),
+      expect.objectContaining({ status: 'completed', progressPercent: 100 })
     )
     expect(eventBus.emit).toHaveBeenCalledWith(
       PROGRESS_EVENTS.JOB_COMPLETED,
@@ -216,7 +336,59 @@ describe('progress service', () => {
     )
   })
 
-  it('failJob — sets failed status, records error, emits JOB_FAILED', async () => {
+  it('completeJob — recovers a job wrongly swept as stale (failed → completed)', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', jobType: 'import', status: 'failed', tenantId: baseCtx.tenantId } as unknown as ProgressJob
+    em.findOne.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.completeJob('job-1', undefined, baseCtx)
+
+    expect(result.status).toBe('completed')
+    expect(eventBus.emit).toHaveBeenCalledWith(PROGRESS_EVENTS.JOB_COMPLETED, expect.objectContaining({ jobId: 'job-1' }))
+  })
+
+  it('completeJob — never overwrites a cancelled job and stays idempotent when already completed', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const cancelled = { id: 'job-1', jobType: 'import', status: 'cancelled' } as ProgressJob
+    em.findOne.mockResolvedValue(cancelled)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.completeJob('job-1', undefined, baseCtx)
+
+    expect(result.status).toBe('cancelled')
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
+
+    const completed = { id: 'job-2', jobType: 'import', status: 'completed' } as ProgressJob
+    em.findOne.mockResolvedValue(completed)
+    const second = await service.completeJob('job-2', undefined, baseCtx)
+    expect(second.status).toBe('completed')
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
+  })
+
+  it('completeJob — lost transition race returns the fresh row without emitting', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', jobType: 'import', status: 'running' } as ProgressJob
+    const fresh = { id: 'job-1', jobType: 'import', status: 'cancelled' } as ProgressJob
+    em.findOne.mockResolvedValueOnce(job).mockResolvedValueOnce(fresh)
+    em.nativeUpdate.mockResolvedValue(0)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.completeJob('job-1', undefined, baseCtx)
+
+    expect(result.status).toBe('cancelled')
+    expect(eventBus.emit).not.toHaveBeenCalled()
+  })
+
+  it('failJob — guarded transition to failed, records error, emits JOB_FAILED', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
 
@@ -235,10 +407,10 @@ describe('progress service', () => {
     expect(result.finishedAt).toBeInstanceOf(Date)
     expect(result.errorMessage).toBe('Network error')
     expect(result.errorStack).toBe('stack...')
-    expect(em.flush).toHaveBeenCalled()
-    expect(em.findOne).toHaveBeenCalledWith(
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: baseCtx.tenantId })
+      expect.objectContaining({ id: 'job-1', status: { $in: ['pending', 'running'] } }),
+      expect.objectContaining({ status: 'failed', errorMessage: 'Network error' })
     )
     expect(eventBus.emit).toHaveBeenCalledWith(
       PROGRESS_EVENTS.JOB_FAILED,
@@ -246,7 +418,22 @@ describe('progress service', () => {
     )
   })
 
-  it('cancelJob (pending) — sets cancelled status immediately', async () => {
+  it('failJob — no-ops on terminal jobs (no overwrite of completed/cancelled outcomes)', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', jobType: 'import', status: 'completed' } as ProgressJob
+    em.findOne.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.failJob('job-1', { errorMessage: 'late failure' }, baseCtx)
+
+    expect(result.status).toBe('completed')
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
+  })
+
+  it('cancelJob (pending) — atomically transitions to cancelled', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
 
@@ -265,7 +452,11 @@ describe('progress service', () => {
     expect(result.finishedAt).toBeInstanceOf(Date)
     expect(result.cancelRequestedAt).toBeInstanceOf(Date)
     expect(result.cancelledByUserId).toBe(baseCtx.userId)
-    expect(em.flush).toHaveBeenCalled()
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', cancellable: true, status: 'pending' }),
+      expect.objectContaining({ status: 'cancelled' })
+    )
     expect(eventBus.emit).toHaveBeenCalledWith(
       PROGRESS_EVENTS.JOB_CANCELLED,
       expect.objectContaining({ jobId: 'job-1', tenantId: baseCtx.tenantId })
@@ -283,6 +474,7 @@ describe('progress service', () => {
       cancellable: true,
     } as unknown as ProgressJob
     em.findOneOrFail.mockResolvedValue(job)
+    em.nativeUpdate.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
 
     const service = createProgressService(em as never, eventBus)
     const result = await service.cancelJob('job-1', baseCtx)
@@ -291,10 +483,59 @@ describe('progress service', () => {
     expect(result.cancelRequestedAt).toBeInstanceOf(Date)
     expect(result.cancelledByUserId).toBe(baseCtx.userId)
     expect(result.finishedAt).toBeUndefined()
+    expect(em.nativeUpdate).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', cancellable: true, status: 'running' }),
+      expect.not.objectContaining({ status: expect.anything() })
+    )
     expect(eventBus.emit).toHaveBeenCalledWith(
       PROGRESS_EVENTS.JOB_CANCELLED,
       expect.objectContaining({ jobId: 'job-1' })
     )
+  })
+
+  it('cancelJob — returns the job untouched when it already finished (benign click race)', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', jobType: 'import', status: 'completed', cancellable: true } as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.cancelJob('job-1', baseCtx)
+
+    expect(result.status).toBe('completed')
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
+  })
+
+  it('cancelJob — throws for an active non-cancellable job', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', jobType: 'import', status: 'running', cancellable: false } as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    await expect(service.cancelJob('job-1', baseCtx)).rejects.toThrow('not cancellable')
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+  })
+
+  it('cancelJob — lost race against a terminal transition returns the fresh row without emitting', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', jobType: 'import', status: 'pending', cancellable: true } as ProgressJob
+    const fresh = { id: 'job-1', jobType: 'import', status: 'completed', cancellable: true } as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+    em.findOne.mockResolvedValue(fresh)
+    em.nativeUpdate.mockResolvedValue(0)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.cancelJob('job-1', baseCtx)
+
+    expect(result.status).toBe('completed')
+    expect(eventBus.emit).not.toHaveBeenCalled()
   })
 
   it('markCancelled — finalizes running jobs as cancelled', async () => {
@@ -316,19 +557,61 @@ describe('progress service', () => {
     expect(result.cancelRequestedAt).toBeInstanceOf(Date)
     expect(result.finishedAt).toBeInstanceOf(Date)
     expect(result.etaSeconds).toBe(0)
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', status: { $in: ['pending', 'running', 'failed'] } }),
+      expect.objectContaining({ status: 'cancelled' })
+    )
     expect(eventBus.emit).toHaveBeenCalledWith(
       PROGRESS_EVENTS.JOB_CANCELLED,
       expect.objectContaining({ jobId: 'job-1', tenantId: baseCtx.tenantId })
     )
   })
 
-  it('markStaleJobsFailed — marks stale jobs as failed, emits per job', async () => {
+  it('markCancelled — preserves the original cancel requester', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const requestedAt = new Date(Date.now() - 5000)
+    const job = {
+      id: 'job-1',
+      jobType: 'import',
+      status: 'running',
+      cancelRequestedAt: requestedAt,
+      cancelledByUserId: 'original-user',
+      tenantId: baseCtx.tenantId,
+    } as unknown as ProgressJob
+    em.findOne.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.markCancelled('job-1', baseCtx)
+
+    expect(result.cancelRequestedAt).toBe(requestedAt)
+    expect(result.cancelledByUserId).toBe('original-user')
+  })
+
+  it('markCancelled — leaves completed jobs alone', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const job = { id: 'job-1', jobType: 'import', status: 'completed' } as ProgressJob
+    em.findOne.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, eventBus)
+    const result = await service.markCancelled('job-1', baseCtx)
+
+    expect(result.status).toBe('completed')
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+    expect(eventBus.emit).not.toHaveBeenCalled()
+  })
+
+  it('markStaleJobsFailed — per-row guarded update, emits only after the write wins', async () => {
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
 
     const staleJob1 = { id: 'stale-1', jobType: 'export', status: 'running', tenantId: baseCtx.tenantId } as unknown as ProgressJob
     const staleJob2 = { id: 'stale-2', jobType: 'import', status: 'running', tenantId: baseCtx.tenantId } as unknown as ProgressJob
-    em.find.mockResolvedValue([staleJob1, staleJob2])
+    em.find.mockResolvedValueOnce([staleJob1, staleJob2]).mockResolvedValueOnce([])
 
     const service = createProgressService(em as never, eventBus)
     const count = await service.markStaleJobsFailed(baseCtx.tenantId, 60)
@@ -338,7 +621,6 @@ describe('progress service', () => {
     expect(staleJob1.finishedAt).toBeInstanceOf(Date)
     expect(staleJob1.errorMessage).toContain('no heartbeat for 60 seconds')
     expect(staleJob2.status).toBe('failed')
-    expect(em.flush).toHaveBeenCalled()
     expect(em.find).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -351,7 +633,15 @@ describe('progress service', () => {
             startedAt: { $lt: expect.any(Date) },
           },
         ],
-      })
+      }),
+      detached
+    )
+    // The per-row update re-checks the staleness condition so a heartbeat landing
+    // between SELECT and UPDATE aborts the failure.
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'stale-1', status: 'running', $or: expect.any(Array) }),
+      expect.objectContaining({ status: 'failed' })
     )
     expect(eventBus.emit).toHaveBeenCalledTimes(2)
     expect(eventBus.emit).toHaveBeenCalledWith(
@@ -361,6 +651,60 @@ describe('progress service', () => {
     expect(eventBus.emit).toHaveBeenCalledWith(
       PROGRESS_EVENTS.JOB_FAILED,
       expect.objectContaining({ jobId: 'stale-2', stale: true })
+    )
+  })
+
+  it('markStaleJobsFailed — a concurrent sweeper that lost the row emits nothing for it', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const staleJob1 = { id: 'stale-1', jobType: 'export', status: 'running', tenantId: baseCtx.tenantId } as unknown as ProgressJob
+    const staleJob2 = { id: 'stale-2', jobType: 'import', status: 'running', tenantId: baseCtx.tenantId } as unknown as ProgressJob
+    em.find.mockResolvedValueOnce([staleJob1, staleJob2]).mockResolvedValueOnce([])
+    em.nativeUpdate.mockResolvedValueOnce(0).mockResolvedValueOnce(1)
+
+    const service = createProgressService(em as never, eventBus)
+    const count = await service.markStaleJobsFailed(baseCtx.tenantId, 60)
+
+    expect(count).toBe(1)
+    expect(staleJob1.status).toBe('running')
+    expect(eventBus.emit).toHaveBeenCalledTimes(1)
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      PROGRESS_EVENTS.JOB_FAILED,
+      expect.objectContaining({ jobId: 'stale-2' })
+    )
+  })
+
+  it('markStaleJobsFailed — sweeps pending jobs that never started', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+
+    const orphan = { id: 'orphan-1', jobType: 'import', status: 'pending', tenantId: baseCtx.tenantId } as unknown as ProgressJob
+    em.find.mockResolvedValueOnce([]).mockResolvedValueOnce([orphan])
+
+    const service = createProgressService(em as never, eventBus)
+    const count = await service.markStaleJobsFailed(baseCtx.tenantId, 60)
+
+    expect(count).toBe(1)
+    expect(orphan.status).toBe('failed')
+    expect(orphan.errorMessage).toContain(`never started within ${STALE_PENDING_TIMEOUT_SECONDS} seconds`)
+    expect(em.find).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        tenantId: baseCtx.tenantId,
+        status: 'pending',
+        createdAt: { $lt: expect.any(Date) },
+      }),
+      detached
+    )
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'orphan-1', status: 'pending' }),
+      expect.objectContaining({ status: 'failed' })
+    )
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      PROGRESS_EVENTS.JOB_FAILED,
+      expect.objectContaining({ jobId: 'orphan-1', stale: true })
     )
   })
 
@@ -382,8 +726,21 @@ describe('progress service', () => {
     expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
       em,
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: baseCtx.tenantId })
+      expect.objectContaining({ id: 'job-1', tenantId: baseCtx.tenantId }),
+      detached
     )
+  })
+
+  it('isCancellationRequested — bypasses the identity map so worker polling sees fresh state', async () => {
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+    mockFindOneWithDecryption.mockResolvedValue(null)
+
+    const service = createProgressService(em as never, eventBus)
+    await service.isCancellationRequested('job-1', baseCtx.tenantId)
+
+    const options = mockFindOneWithDecryption.mock.calls[0][3]
+    expect(options).toEqual(expect.objectContaining({ disableIdentityMap: true }))
   })
 
   it('isCancellationRequested — returns false when job belongs to a different tenant', async () => {
@@ -399,7 +756,8 @@ describe('progress service', () => {
     expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
       em,
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: 'other-tenant-id' })
+      expect.objectContaining({ id: 'job-1', tenantId: 'other-tenant-id' }),
+      detached
     )
   })
 
@@ -491,7 +849,23 @@ describe('progress service — organization scoping (#2930)', () => {
 
     expect(em.findOneOrFail).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId })
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId }),
+      detached
+    )
+  })
+
+  it('updateProgress — scopes the guarded write by organizationId', async () => {
+    const em = buildEm()
+    const job = { id: 'job-1', status: 'running', processedCount: 0, totalCount: null, startedAt: null, meta: null } as unknown as ProgressJob
+    em.findOneOrFail.mockResolvedValue(job)
+
+    const service = createProgressService(em as never, { emit: jest.fn().mockResolvedValue(undefined) })
+    await service.updateProgress('job-1', { processedCount: 1 }, orgCtx)
+
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId }),
+      expect.anything()
     )
   })
 
@@ -505,13 +879,19 @@ describe('progress service — organization scoping (#2930)', () => {
 
     expect(em.findOneOrFail).toHaveBeenCalledWith(
       expect.anything(),
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId }),
+      detached
+    )
+    expect(em.nativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({
         id: 'job-1',
         tenantId: orgCtx.tenantId,
         organizationId: orgCtx.organizationId,
         cancellable: true,
-        status: { $in: ['pending', 'running'] },
-      })
+        status: 'pending',
+      }),
+      expect.anything()
     )
   })
 })
@@ -538,7 +918,8 @@ describe('progress service — worker lifecycle organization scoping (#3284)', (
 
     expect(em.findOneOrFail).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId })
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId }),
+      detached
     )
   })
 
@@ -552,7 +933,8 @@ describe('progress service — worker lifecycle organization scoping (#3284)', (
 
     expect(em.findOneOrFail).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId })
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId }),
+      detached
     )
   })
 
@@ -566,7 +948,8 @@ describe('progress service — worker lifecycle organization scoping (#3284)', (
 
     expect(em.findOne).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId })
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId }),
+      detached
     )
   })
 
@@ -580,7 +963,8 @@ describe('progress service — worker lifecycle organization scoping (#3284)', (
 
     expect(em.findOne).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId })
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId }),
+      detached
     )
   })
 
@@ -594,7 +978,8 @@ describe('progress service — worker lifecycle organization scoping (#3284)', (
 
     expect(em.findOne).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId })
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId }),
+      detached
     )
   })
 
@@ -622,7 +1007,8 @@ describe('progress service — worker lifecycle organization scoping (#3284)', (
     expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
       em,
       expect.anything(),
-      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId })
+      expect.objectContaining({ id: 'job-1', tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId }),
+      detached
     )
   })
 
@@ -647,7 +1033,8 @@ describe('progress service — worker lifecycle organization scoping (#3284)', (
 
     expect(em.find).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId, status: 'running' })
+      expect.objectContaining({ tenantId: orgCtx.tenantId, organizationId: orgCtx.organizationId, status: 'running' }),
+      detached
     )
   })
 
@@ -673,6 +1060,7 @@ describe('progress service — broadcast coalescing (#2972)', () => {
     } else {
       process.env.OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS = originalInterval
     }
+    jest.restoreAllMocks()
   })
 
   const buildRunningJob = (overrides: Partial<ProgressJob> = {}) =>
@@ -688,7 +1076,7 @@ describe('progress service — broadcast coalescing (#2972)', () => {
       ...overrides,
     }) as unknown as ProgressJob
 
-  it('coalesces rapid successive updates within the interval into a single flush + broadcast', async () => {
+  it('coalesces rapid successive updates within the interval into a single write + broadcast', async () => {
     process.env.OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS = '1000'
     const em = buildEm()
     const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
@@ -702,7 +1090,7 @@ describe('progress service — broadcast coalescing (#2972)', () => {
 
     // Leading edge broadcasts once; the sub-percent follow-ups stay buffered.
     expect(eventBus.emit).toHaveBeenCalledTimes(1)
-    expect(em.flush).toHaveBeenCalledTimes(1)
+    expect(em.nativeUpdate).toHaveBeenCalledTimes(1)
     // The job is cached after the first load, so no repeat SELECT per record.
     expect(em.findOneOrFail).toHaveBeenCalledTimes(1)
     // In-memory state still reflects the latest buffered update for the return contract.
@@ -739,7 +1127,31 @@ describe('progress service — broadcast coalescing (#2972)', () => {
     await service.updateProgress('job-1', { processedCount: 2 }, baseCtx)
 
     expect(eventBus.emit).toHaveBeenCalledTimes(2)
-    expect(em.flush).toHaveBeenCalledTimes(2)
+    expect(em.nativeUpdate).toHaveBeenCalledTimes(2)
+  })
+
+  it('persists heartbeats even when the broadcast interval suppresses emission', async () => {
+    // A broadcast interval far above the stale-job timeout must never starve the
+    // database of heartbeats — persistence is capped at HEARTBEAT_INTERVAL_MS.
+    process.env.OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS = String(10 * 60 * 1000)
+    const em = buildEm()
+    const eventBus = { emit: jest.fn().mockResolvedValue(undefined) }
+    const job = buildRunningJob({ totalCount: null })
+    em.findOneOrFail.mockResolvedValue(job)
+
+    let nowMs = Date.now()
+    jest.spyOn(Date, 'now').mockImplementation(() => nowMs)
+
+    const service = createProgressService(em as never, eventBus)
+    await service.updateProgress('job-1', { processedCount: 1 }, baseCtx) // leading edge: persist + broadcast
+    expect(em.nativeUpdate).toHaveBeenCalledTimes(1)
+    expect(eventBus.emit).toHaveBeenCalledTimes(1)
+
+    nowMs += 6000 // beyond HEARTBEAT_INTERVAL_MS, far below the broadcast interval
+    await service.updateProgress('job-1', { processedCount: 2 }, baseCtx)
+
+    expect(em.nativeUpdate).toHaveBeenCalledTimes(2)
+    expect(eventBus.emit).toHaveBeenCalledTimes(1)
   })
 
   it('flushes buffered progress into the terminal completeJob event', async () => {
@@ -760,6 +1172,11 @@ describe('progress service — broadcast coalescing (#2972)', () => {
 
     expect(job.processedCount).toBe(7)
     expect(job.status).toBe('completed')
+    expect(em.nativeUpdate).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: 'job-1' }),
+      expect.objectContaining({ status: 'completed', processedCount: 7 })
+    )
     expect(eventBus.emit).toHaveBeenLastCalledWith(
       PROGRESS_EVENTS.JOB_COMPLETED,
       expect.objectContaining({ jobId: 'job-1', processedCount: 7, progressPercent: 100 })

--- a/packages/core/src/modules/progress/lib/progressService.ts
+++ b/packages/core/src/modules/progress/lib/progressService.ts
@@ -25,6 +25,7 @@ export interface ProgressService {
 
 export const HEARTBEAT_INTERVAL_MS = 5000
 export const STALE_JOB_TIMEOUT_SECONDS = 60
+export const STALE_PENDING_TIMEOUT_SECONDS = 900
 
 export function calculateEta(
   processedCount: number,

--- a/packages/core/src/modules/progress/lib/progressServiceImpl.ts
+++ b/packages/core/src/modules/progress/lib/progressServiceImpl.ts
@@ -1,28 +1,55 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { ProgressJob } from '../data/entities'
+import { raw } from '@mikro-orm/core'
+import type { EntityData, FilterQuery } from '@mikro-orm/core'
+import { ProgressJob, type ProgressJobStatus } from '../data/entities'
 import type { ProgressService, ProgressServiceContext } from './progressService'
-import { calculateEta, calculateProgressPercent, STALE_JOB_TIMEOUT_SECONDS } from './progressService'
+import {
+  calculateEta,
+  calculateProgressPercent,
+  HEARTBEAT_INTERVAL_MS,
+  STALE_JOB_TIMEOUT_SECONDS,
+  STALE_PENDING_TIMEOUT_SECONDS,
+} from './progressService'
 import { PROGRESS_EVENTS } from './events'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 const DEFAULT_BROADCAST_MIN_INTERVAL_MS = 250
 
-// Minimum elapsed time between coalesced `progress.job.updated` flush+broadcasts for a
+// Minimum elapsed time between coalesced `progress.job.updated` broadcasts for a
 // single job. Bulk workers call updateProgress/incrementProgress once per record, and
 // every emit of the `clientBroadcast: true` event pays a serialized pg_notify roundtrip
 // plus a tenant-wide SSE fan-out. Setting the knob to 0 restores per-record emission.
+// Persistence is throttled separately: heartbeats hit the database at least every
+// HEARTBEAT_INTERVAL_MS regardless of this knob, so a high broadcast interval can
+// never starve the stale-job sweep of heartbeats.
 function resolveBroadcastMinIntervalMs(): number {
-  const raw = process.env.OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS
-  if (raw == null || raw.trim() === '') return DEFAULT_BROADCAST_MIN_INTERVAL_MS
-  const parsed = Number.parseInt(raw, 10)
+  const rawValue = process.env.OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS
+  if (rawValue == null || rawValue.trim() === '') return DEFAULT_BROADCAST_MIN_INTERVAL_MS
+  const parsed = Number.parseInt(rawValue, 10)
   if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_BROADCAST_MIN_INTERVAL_MS
   return parsed
 }
 
+// Statuses a given transition is allowed to move FROM. Every write below is a
+// compare-and-swap (`nativeUpdate` guarded on status), so concurrent writers in other
+// processes can never resurrect a terminal job or double-apply a transition — the
+// UPDATE that matches zero rows simply lost the race and must not emit events.
+const TERMINAL_STATUSES: readonly ProgressJobStatus[] = ['completed', 'failed', 'cancelled']
+const PROGRESS_WRITABLE_STATUSES: readonly ProgressJobStatus[] = ['pending', 'running']
+// `failed` is restartable/completable so a job wrongly swept as stale (worker alive but
+// slow) or retried by an at-least-once queue converges to its true outcome.
+const START_FROM_STATUSES: readonly ProgressJobStatus[] = ['pending', 'running', 'failed']
+const COMPLETE_FROM_STATUSES: readonly ProgressJobStatus[] = ['pending', 'running', 'failed']
+const FAIL_FROM_STATUSES: readonly ProgressJobStatus[] = ['pending', 'running']
+const CANCEL_FROM_STATUSES: readonly ProgressJobStatus[] = ['pending', 'running', 'failed']
+
 type JobUpdateThrottleEntry = {
   job: ProgressJob
   lastBroadcastAt: number
+  lastPersistedAt: number
   lastBroadcastPercent: number
+  pendingDelta: number
+  absoluteCountsPending: boolean
 }
 
 function buildJobPayload(job: ProgressJob): Record<string, unknown> {
@@ -46,10 +73,10 @@ function buildJobPayload(job: ProgressJob): Record<string, unknown> {
 export function createProgressService(em: EntityManager, eventBus: { emit: (event: string, payload: Record<string, unknown>) => Promise<void> }): ProgressService {
   const broadcastMinIntervalMs = resolveBroadcastMinIntervalMs()
   // Per-job coalescing state, scoped to this service instance (request/worker scope).
-  // The cached managed entity doubles as the in-memory buffer: intermediate updates mutate
-  // it without flushing, and a single flush+emit at the throttle boundary persists the
-  // accumulated change. Domain commands fork their own EntityManager, so no other operation
-  // queries this job on `em` between calls, keeping the buffered changes safe until flush.
+  // The cached entity is a DETACHED snapshot (loaded with disableIdentityMap) that doubles
+  // as the in-memory buffer: intermediate updates mutate it without touching the shared
+  // identity map or UnitOfWork, so an unrelated em.flush() elsewhere can never write the
+  // buffered values. Persistence happens exclusively through the CAS nativeUpdate below.
   const jobUpdateThrottle = new Map<string, JobUpdateThrottleEntry>()
 
   function jobScopeFilter(jobId: string, ctx: ProgressServiceContext) {
@@ -60,42 +87,88 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
     }
   }
 
-  async function loadUpdatableJob(jobId: string, ctx: ProgressServiceContext): Promise<ProgressJob> {
-    const cached = jobUpdateThrottle.get(jobId)
-    if (cached) return cached.job
-    return em.findOneOrFail(ProgressJob, jobScopeFilter(jobId, ctx))
+  async function loadFreshJob(jobId: string, ctx: ProgressServiceContext): Promise<ProgressJob | null> {
+    return em.findOne(ProgressJob, jobScopeFilter(jobId, ctx), { disableIdentityMap: true })
   }
 
-  async function commitJobUpdate(job: ProgressJob, ctx: ProgressServiceContext): Promise<ProgressJob> {
+  async function ensureThrottleEntry(jobId: string, ctx: ProgressServiceContext): Promise<JobUpdateThrottleEntry> {
+    const cached = jobUpdateThrottle.get(jobId)
+    if (cached) return cached
+    const job = await em.findOneOrFail(ProgressJob, jobScopeFilter(jobId, ctx), { disableIdentityMap: true })
+    const entry: JobUpdateThrottleEntry = {
+      job,
+      lastBroadcastAt: 0,
+      lastPersistedAt: 0,
+      lastBroadcastPercent: job.progressPercent,
+      pendingDelta: 0,
+      absoluteCountsPending: false,
+    }
+    jobUpdateThrottle.set(jobId, entry)
+    return entry
+  }
+
+  function forgetJobThrottle(jobId: string) {
+    jobUpdateThrottle.delete(jobId)
+  }
+
+  function buildBufferedCountData(entry: JobUpdateThrottleEntry): EntityData<ProgressJob> {
+    if (entry.absoluteCountsPending || !Number.isSafeInteger(entry.pendingDelta)) {
+      return { processedCount: entry.job.processedCount }
+    }
+    if (entry.pendingDelta !== 0) {
+      // Atomic SQL increment: concurrent writers on other instances never lose deltas.
+      return { processedCount: raw(`processed_count + ${entry.pendingDelta}`) }
+    }
+    return {}
+  }
+
+  async function persistAndMaybeBroadcast(entry: JobUpdateThrottleEntry, ctx: ProgressServiceContext): Promise<ProgressJob> {
+    const job = entry.job
     const now = Date.now()
-    const cached = jobUpdateThrottle.get(job.id)
     const shouldBroadcast =
       broadcastMinIntervalMs <= 0 ||
-      cached == null ||
-      now - cached.lastBroadcastAt >= broadcastMinIntervalMs ||
-      Math.abs(job.progressPercent - cached.lastBroadcastPercent) >= 1
+      now - entry.lastBroadcastAt >= broadcastMinIntervalMs ||
+      Math.abs(job.progressPercent - entry.lastBroadcastPercent) >= 1
+    const shouldPersist = shouldBroadcast || now - entry.lastPersistedAt >= HEARTBEAT_INTERVAL_MS
+
+    if (!shouldPersist) return job
+
+    const data: EntityData<ProgressJob> = {
+      progressPercent: job.progressPercent,
+      totalCount: job.totalCount ?? null,
+      etaSeconds: job.etaSeconds ?? null,
+      meta: job.meta ?? null,
+      heartbeatAt: job.heartbeatAt ?? new Date(),
+      updatedAt: new Date(),
+      ...buildBufferedCountData(entry),
+    }
+    const affected = await em.nativeUpdate(ProgressJob, {
+      ...jobScopeFilter(job.id, ctx),
+      status: { $in: PROGRESS_WRITABLE_STATUSES as ProgressJobStatus[] },
+    } as FilterQuery<ProgressJob>, data)
+
+    if (affected === 0) {
+      // The job reached a terminal state in another process; stop writing to it.
+      forgetJobThrottle(job.id)
+      const fresh = await loadFreshJob(job.id, ctx)
+      return fresh ?? job
+    }
+
+    entry.pendingDelta = 0
+    entry.absoluteCountsPending = false
+    entry.lastPersistedAt = now
 
     if (shouldBroadcast) {
-      await em.flush()
       await eventBus.emit(PROGRESS_EVENTS.JOB_UPDATED, {
         ...buildJobPayload(job),
         tenantId: ctx.tenantId,
         organizationId: job.organizationId ?? null,
       })
-      jobUpdateThrottle.set(job.id, { job, lastBroadcastAt: now, lastBroadcastPercent: job.progressPercent })
-    } else {
-      jobUpdateThrottle.set(job.id, {
-        job,
-        lastBroadcastAt: cached.lastBroadcastAt,
-        lastBroadcastPercent: cached.lastBroadcastPercent,
-      })
+      entry.lastBroadcastAt = now
+      entry.lastBroadcastPercent = job.progressPercent
     }
 
     return job
-  }
-
-  function forgetJobThrottle(jobId: string) {
-    jobUpdateThrottle.delete(jobId)
   }
 
   return {
@@ -128,20 +201,36 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
     },
 
     async startJob(jobId, ctx) {
-      const job = await em.findOneOrFail(ProgressJob, {
-        id: jobId,
-        tenantId: ctx.tenantId,
-        ...(ctx.organizationId ? { organizationId: ctx.organizationId } : {}),
-      })
-      if (job.status === 'cancelled') {
+      const job = await em.findOneOrFail(ProgressJob, jobScopeFilter(jobId, ctx), { disableIdentityMap: true })
+      if (job.status === 'cancelled' || job.status === 'completed') {
         return job
       }
 
-      job.status = 'running'
-      job.startedAt = new Date()
-      job.heartbeatAt = new Date()
+      const now = new Date()
+      const affected = await em.nativeUpdate(ProgressJob, {
+        ...jobScopeFilter(jobId, ctx),
+        status: { $in: START_FROM_STATUSES as ProgressJobStatus[] },
+      } as FilterQuery<ProgressJob>, {
+        status: 'running',
+        startedAt: now,
+        heartbeatAt: now,
+        finishedAt: null,
+        errorMessage: null,
+        errorStack: null,
+        updatedAt: now,
+      })
 
-      await em.flush()
+      if (affected === 0) {
+        const fresh = await loadFreshJob(jobId, ctx)
+        return fresh ?? job
+      }
+
+      job.status = 'running'
+      job.startedAt = now
+      job.heartbeatAt = now
+      job.finishedAt = null
+      job.errorMessage = null
+      job.errorStack = null
 
       await eventBus.emit(PROGRESS_EVENTS.JOB_STARTED, {
         ...buildJobPayload(job),
@@ -153,14 +242,17 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
     },
 
     async updateProgress(jobId, input, ctx) {
-      const job = await loadUpdatableJob(jobId, ctx)
-      if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
+      const entry = await ensureThrottleEntry(jobId, ctx)
+      const job = entry.job
+      if (TERMINAL_STATUSES.includes(job.status)) {
         forgetJobThrottle(jobId)
         return job
       }
 
       if (input.processedCount !== undefined) {
         job.processedCount = input.processedCount
+        entry.absoluteCountsPending = true
+        entry.pendingDelta = 0
       }
       if (input.totalCount !== undefined) {
         job.totalCount = input.totalCount
@@ -183,17 +275,19 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
 
       job.heartbeatAt = new Date()
 
-      return commitJobUpdate(job, ctx)
+      return persistAndMaybeBroadcast(entry, ctx)
     },
 
     async incrementProgress(jobId, delta, ctx) {
-      const job = await loadUpdatableJob(jobId, ctx)
-      if (job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled') {
+      const entry = await ensureThrottleEntry(jobId, ctx)
+      const job = entry.job
+      if (TERMINAL_STATUSES.includes(job.status)) {
         forgetJobThrottle(jobId)
         return job
       }
 
       job.processedCount += delta
+      entry.pendingDelta += delta
       job.heartbeatAt = new Date()
 
       if (job.totalCount) {
@@ -203,88 +297,168 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
         }
       }
 
-      return commitJobUpdate(job, ctx)
+      return persistAndMaybeBroadcast(entry, ctx)
     },
 
     async completeJob(jobId, input, ctx) {
-      const job = await em.findOne(ProgressJob, {
-        id: jobId,
-        tenantId: ctx.tenantId,
-        ...(ctx.organizationId ? { organizationId: ctx.organizationId } : {}),
-      })
+      const job = await loadFreshJob(jobId, ctx)
       if (!job) throw new Error(`Job ${jobId} not found`)
-      if (job.status === 'cancelled') {
+      if (job.status === 'cancelled' || job.status === 'completed') {
+        forgetJobThrottle(jobId)
         return job
       }
 
-      job.status = 'completed'
-      job.finishedAt = new Date()
-      job.progressPercent = 100
-      job.etaSeconds = 0
-      if (input?.resultSummary) {
-        job.resultSummary = input.resultSummary
+      const entry = jobUpdateThrottle.get(jobId)
+      const snapshot = entry?.job ?? job
+      const now = new Date()
+      const data: EntityData<ProgressJob> = {
+        status: 'completed',
+        finishedAt: now,
+        progressPercent: 100,
+        etaSeconds: 0,
+        updatedAt: now,
+        ...(input?.resultSummary ? { resultSummary: input.resultSummary } : {}),
+        ...(entry
+          ? {
+              totalCount: snapshot.totalCount ?? null,
+              meta: snapshot.meta ?? null,
+              ...buildBufferedCountData(entry),
+            }
+          : {}),
       }
 
-      await em.flush()
+      const affected = await em.nativeUpdate(ProgressJob, {
+        ...jobScopeFilter(jobId, ctx),
+        status: { $in: COMPLETE_FROM_STATUSES as ProgressJobStatus[] },
+      } as FilterQuery<ProgressJob>, data)
+      forgetJobThrottle(jobId)
+
+      if (affected === 0) {
+        const fresh = await loadFreshJob(jobId, ctx)
+        return fresh ?? job
+      }
+
+      snapshot.status = 'completed'
+      snapshot.finishedAt = now
+      snapshot.progressPercent = 100
+      snapshot.etaSeconds = 0
+      if (input?.resultSummary) {
+        snapshot.resultSummary = input.resultSummary
+      }
 
       await eventBus.emit(PROGRESS_EVENTS.JOB_COMPLETED, {
-        ...buildJobPayload(job),
-        resultSummary: job.resultSummary,
+        ...buildJobPayload(snapshot),
+        resultSummary: snapshot.resultSummary,
         tenantId: ctx.tenantId,
-        organizationId: job.organizationId ?? null,
+        organizationId: snapshot.organizationId ?? null,
       })
 
-      forgetJobThrottle(jobId)
-      return job
+      return snapshot
     },
 
     async failJob(jobId, input, ctx) {
-      const job = await em.findOne(ProgressJob, {
-        id: jobId,
-        tenantId: ctx.tenantId,
-        ...(ctx.organizationId ? { organizationId: ctx.organizationId } : {}),
-      })
+      const job = await loadFreshJob(jobId, ctx)
       if (!job) throw new Error(`Job ${jobId} not found`)
-      if (job.status === 'cancelled') {
+      if (TERMINAL_STATUSES.includes(job.status)) {
+        forgetJobThrottle(jobId)
         return job
       }
 
-      job.status = 'failed'
-      job.finishedAt = new Date()
-      job.errorMessage = input.errorMessage
-      job.errorStack = input.errorStack
+      const entry = jobUpdateThrottle.get(jobId)
+      const snapshot = entry?.job ?? job
+      const now = new Date()
+      const data: EntityData<ProgressJob> = {
+        status: 'failed',
+        finishedAt: now,
+        errorMessage: input.errorMessage,
+        errorStack: input.errorStack,
+        updatedAt: now,
+        ...(entry
+          ? {
+              totalCount: snapshot.totalCount ?? null,
+              meta: snapshot.meta ?? null,
+              ...buildBufferedCountData(entry),
+            }
+          : {}),
+      }
 
-      await em.flush()
+      const affected = await em.nativeUpdate(ProgressJob, {
+        ...jobScopeFilter(jobId, ctx),
+        status: { $in: FAIL_FROM_STATUSES as ProgressJobStatus[] },
+      } as FilterQuery<ProgressJob>, data)
+      forgetJobThrottle(jobId)
+
+      if (affected === 0) {
+        const fresh = await loadFreshJob(jobId, ctx)
+        return fresh ?? job
+      }
+
+      snapshot.status = 'failed'
+      snapshot.finishedAt = now
+      snapshot.errorMessage = input.errorMessage
+      snapshot.errorStack = input.errorStack
 
       await eventBus.emit(PROGRESS_EVENTS.JOB_FAILED, {
-        ...buildJobPayload(job),
-        errorMessage: job.errorMessage,
+        ...buildJobPayload(snapshot),
+        errorMessage: snapshot.errorMessage,
         tenantId: ctx.tenantId,
-        organizationId: job.organizationId ?? null,
+        organizationId: snapshot.organizationId ?? null,
       })
 
-      forgetJobThrottle(jobId)
-      return job
+      return snapshot
     },
 
     async cancelJob(jobId, ctx) {
-      const job = await em.findOneOrFail(ProgressJob, {
-        id: jobId,
-        tenantId: ctx.tenantId,
-        ...(ctx.organizationId ? { organizationId: ctx.organizationId } : {}),
-        cancellable: true,
-        status: { $in: ['pending', 'running'] },
-      })
-
-      job.cancelRequestedAt = new Date()
-      job.cancelledByUserId = ctx.userId
-
-      if (job.status === 'pending') {
-        job.status = 'cancelled'
-        job.finishedAt = new Date()
+      const job = await em.findOneOrFail(ProgressJob, jobScopeFilter(jobId, ctx), { disableIdentityMap: true })
+      if (TERMINAL_STATUSES.includes(job.status)) {
+        // The job finished while the user clicked cancel — a benign race, not an error.
+        return job
+      }
+      if (!job.cancellable) {
+        throw new Error(`Job ${jobId} is not cancellable`)
       }
 
-      await em.flush()
+      const now = new Date()
+      const cancelledNow = await em.nativeUpdate(ProgressJob, {
+        ...jobScopeFilter(jobId, ctx),
+        cancellable: true,
+        status: 'pending',
+      } as FilterQuery<ProgressJob>, {
+        status: 'cancelled',
+        cancelRequestedAt: now,
+        cancelledByUserId: ctx.userId ?? null,
+        finishedAt: now,
+        etaSeconds: 0,
+        updatedAt: now,
+      })
+
+      let requested = 0
+      if (cancelledNow === 0) {
+        requested = await em.nativeUpdate(ProgressJob, {
+          ...jobScopeFilter(jobId, ctx),
+          cancellable: true,
+          status: 'running',
+        } as FilterQuery<ProgressJob>, {
+          cancelRequestedAt: now,
+          cancelledByUserId: ctx.userId ?? null,
+          updatedAt: now,
+        })
+      }
+
+      if (cancelledNow === 0 && requested === 0) {
+        // Raced into a terminal state between the read and the CAS.
+        const fresh = await loadFreshJob(jobId, ctx)
+        return fresh ?? job
+      }
+
+      forgetJobThrottle(jobId)
+      if (cancelledNow > 0) {
+        job.status = 'cancelled'
+        job.finishedAt = now
+        job.etaSeconds = 0
+      }
+      job.cancelRequestedAt = now
+      job.cancelledByUserId = ctx.userId ?? null
 
       await eventBus.emit(PROGRESS_EVENTS.JOB_CANCELLED, {
         ...buildJobPayload(job),
@@ -292,28 +466,45 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
         organizationId: job.organizationId ?? null,
       })
 
-      forgetJobThrottle(jobId)
       return job
     },
 
     async markCancelled(jobId, ctx) {
-      const job = await em.findOne(ProgressJob, {
-        id: jobId,
-        tenantId: ctx.tenantId,
-        ...(ctx.organizationId ? { organizationId: ctx.organizationId } : {}),
-      })
+      const job = await loadFreshJob(jobId, ctx)
       if (!job) throw new Error(`Job ${jobId} not found`)
-      if (job.status === 'cancelled') {
+      if (job.status === 'cancelled' || job.status === 'completed') {
+        forgetJobThrottle(jobId)
         return job
       }
 
-      job.cancelRequestedAt = job.cancelRequestedAt ?? new Date()
-      job.cancelledByUserId = ctx.userId
-      job.status = 'cancelled'
-      job.finishedAt = job.finishedAt ?? new Date()
-      job.etaSeconds = 0
+      const now = new Date()
+      const cancelRequestedAt = job.cancelRequestedAt ?? now
+      const cancelledByUserId = job.cancelledByUserId ?? ctx.userId ?? null
+      const finishedAt = job.finishedAt ?? now
 
-      await em.flush()
+      const affected = await em.nativeUpdate(ProgressJob, {
+        ...jobScopeFilter(jobId, ctx),
+        status: { $in: CANCEL_FROM_STATUSES as ProgressJobStatus[] },
+      } as FilterQuery<ProgressJob>, {
+        status: 'cancelled',
+        cancelRequestedAt,
+        cancelledByUserId,
+        finishedAt,
+        etaSeconds: 0,
+        updatedAt: now,
+      })
+      forgetJobThrottle(jobId)
+
+      if (affected === 0) {
+        const fresh = await loadFreshJob(jobId, ctx)
+        return fresh ?? job
+      }
+
+      job.status = 'cancelled'
+      job.cancelRequestedAt = cancelRequestedAt
+      job.cancelledByUserId = cancelledByUserId
+      job.finishedAt = finishedAt
+      job.etaSeconds = 0
 
       await eventBus.emit(PROGRESS_EVENTS.JOB_CANCELLED, {
         ...buildJobPayload(job),
@@ -321,16 +512,18 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
         organizationId: job.organizationId ?? null,
       })
 
-      forgetJobThrottle(jobId)
       return job
     },
 
     async isCancellationRequested(jobId, tenantId, organizationId) {
+      // disableIdentityMap forces a fresh read: a managed copy of the job in this
+      // EntityManager (loaded by updateProgress) must never mask a cancellation
+      // requested from another process.
       const job = await findOneWithDecryption(em, ProgressJob, {
         id: jobId,
         tenantId,
         ...(organizationId ? { organizationId } : {}),
-      })
+      }, { disableIdentityMap: true })
       return job?.cancelRequestedAt != null
     },
 
@@ -369,12 +562,16 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
     },
 
     async markStaleJobsFailed(tenantId: string, timeoutSeconds = STALE_JOB_TIMEOUT_SECONDS, organizationId?: string | null) {
-      const cutoff = new Date(Date.now() - timeoutSeconds * 1000)
-
-      const staleJobs = await em.find(ProgressJob, {
+      const now = new Date()
+      const cutoff = new Date(now.getTime() - timeoutSeconds * 1000)
+      const scope = {
         tenantId,
         ...(organizationId ? { organizationId } : {}),
-        status: 'running',
+      }
+      let failedCount = 0
+
+      const staleFilter = {
+        status: 'running' as ProgressJobStatus,
         $or: [
           { heartbeatAt: { $lt: cutoff } },
           {
@@ -382,12 +579,29 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
             startedAt: { $lt: cutoff },
           },
         ],
-      })
+      }
+      const staleRunning = await em.find(ProgressJob, { ...scope, ...staleFilter }, { disableIdentityMap: true })
 
-      for (const job of staleJobs) {
+      for (const job of staleRunning) {
+        const errorMessage = `Job stale: no heartbeat for ${timeoutSeconds} seconds`
+        // Per-row CAS (re-checking the staleness condition): exactly one concurrent
+        // sweeper wins, and a heartbeat that landed after the SELECT aborts the failure.
+        const affected = await em.nativeUpdate(ProgressJob, {
+          id: job.id,
+          tenantId: job.tenantId,
+          ...staleFilter,
+        } as FilterQuery<ProgressJob>, {
+          status: 'failed',
+          finishedAt: now,
+          errorMessage,
+          updatedAt: now,
+        })
+        if (affected === 0) continue
+
+        failedCount += 1
         job.status = 'failed'
-        job.finishedAt = new Date()
-        job.errorMessage = `Job stale: no heartbeat for ${timeoutSeconds} seconds`
+        job.finishedAt = now
+        job.errorMessage = errorMessage
 
         await eventBus.emit(PROGRESS_EVENTS.JOB_FAILED, {
           ...buildJobPayload(job),
@@ -398,8 +612,45 @@ export function createProgressService(em: EntityManager, eventBus: { emit: (even
         })
       }
 
-      await em.flush()
-      return staleJobs.length
+      // Jobs stuck in `pending` (enqueue failed, worker died before startJob) have no
+      // heartbeat, so they need their own sweep or they stay in the active list forever.
+      // A late queue delivery still recovers such a job: startJob transitions failed → running.
+      const pendingCutoff = new Date(now.getTime() - STALE_PENDING_TIMEOUT_SECONDS * 1000)
+      const stalePendingFilter = {
+        status: 'pending' as ProgressJobStatus,
+        createdAt: { $lt: pendingCutoff },
+      }
+      const stalePending = await em.find(ProgressJob, { ...scope, ...stalePendingFilter }, { disableIdentityMap: true })
+
+      for (const job of stalePending) {
+        const errorMessage = `Job stale: never started within ${STALE_PENDING_TIMEOUT_SECONDS} seconds`
+        const affected = await em.nativeUpdate(ProgressJob, {
+          id: job.id,
+          tenantId: job.tenantId,
+          ...stalePendingFilter,
+        } as FilterQuery<ProgressJob>, {
+          status: 'failed',
+          finishedAt: now,
+          errorMessage,
+          updatedAt: now,
+        })
+        if (affected === 0) continue
+
+        failedCount += 1
+        job.status = 'failed'
+        job.finishedAt = now
+        job.errorMessage = errorMessage
+
+        await eventBus.emit(PROGRESS_EVENTS.JOB_FAILED, {
+          ...buildJobPayload(job),
+          errorMessage: job.errorMessage,
+          tenantId: job.tenantId,
+          stale: true,
+          organizationId: job.organizationId ?? null,
+        })
+      }
+
+      return failedCount
     },
   }
 }

--- a/scripts/check-agents-md-budget.mjs
+++ b/scripts/check-agents-md-budget.mjs
@@ -90,7 +90,7 @@ export function analyze(root, baseline) {
   if (rootBytes === null) throw new Error(`Missing ${INSTRUCTION_FILE} in ${root}`)
 
   const chains = Object.keys(baseline.chains)
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .map((chainDir) => {
       const files = collectChainFiles(root, chainDir)
       const bytes = files.reduce((total, file) => total + file.bytes, 0)


### PR DESCRIPTION
## Problem

`progressService` performed every state transition as read → mutate → `flush()` with no row locking, no version column, and no conditional `UPDATE`. With multiple app/worker instances this allowed:

- **Uncancellable jobs**: `isCancellationRequested` read through the worker's EntityManager identity map, so once the job was loaded (which `updateProgress` always does), a cancellation requested from the API process was never observed.
- **Zombie resurrection**: `cancelJob` (pending → cancelled) racing `startJob` left a cancelled job `running` forever; `completeJob`/`failJob` could overwrite terminal outcomes; duplicate queue delivery could flip a completed job back to running.
- **Duplicate/phantom events**: the stale sweep runs inside every `GET /api/progress/active` request, so N users polling meant N concurrent sweeps, each emitting its own `JOB_FAILED` for the same rows — and events were emitted *before* the flush.
- **Permanent phantom pending jobs**: the sweep only matched `status = 'running'`, so a job whose enqueue failed stayed in the top bar forever.
- **Heartbeat starvation**: the broadcast throttle also throttled persistence, so a high `OM_PROGRESS_BROADCAST_MIN_INTERVAL_MS` let healthy jobs be swept as stale.
- **Lost increments**: `processedCount += delta` + flush of the absolute value loses concurrent writers' increments.

## Fix

- Every status transition is now a **status-guarded `nativeUpdate` (CAS)**; an update matching zero rows lost the race and emits nothing. Allowed transitions: start from `pending|failed` (an already-running job is an idempotent no-op, so concurrent starters emit exactly one `JOB_STARTED`), complete from `pending|running|failed` (so queue retries and jobs wrongly swept as stale converge to their true outcome), fail from `pending|running`, cancel from `pending|running|failed`. `completed`/`cancelled` are never overwritten.
- Progress updates buffer on a **detached snapshot** (`disableIdentityMap`) and persist through a CAS guarded on `status IN ('pending','running')` — once another process finishes/cancels a job, buffered updaters stop writing to it.
- `incrementProgress` deltas persist as **atomic SQL increments** (`processed_count + n`); after a delta write the row is re-read so the **returned job and broadcast payload carry the database aggregate**, which completion gates keyed on the returned count (search reindex) depend on. A call whose local count reaches `totalCount` always persists immediately, bypassing the coalescing window.
- `isCancellationRequested` bypasses the identity map, so worker polling always sees fresh cross-process state.
- `markStaleJobsFailed` re-checks staleness **per row inside the CAS** (exactly one `JOB_FAILED` per job across concurrent sweepers, emitted only after the write commits) and now also sweeps `pending` jobs that never started within `STALE_PENDING_TIMEOUT_SECONDS` (15 min); a late queue delivery still recovers them via `startJob`'s `failed → running` transition.
- **Heartbeat persistence decoupled from broadcast throttling**: heartbeats reach the database at least every `HEARTBEAT_INTERVAL_MS` (5s) regardless of the broadcast knob.
- `cancelJob` treats a job that finished mid-click as a benign no-op instead of throwing; `markCancelled` preserves the original canceller.

Concurrency semantics are documented in the module's `AGENTS.md` and in `.ai/specs/2026-05-13-operation-progress-framework.md` (multi-instance transition matrix, atomic-increment return semantics, stale-pending policy, regression coverage) so the CAS contract isn't accidentally regressed.

The second commit fixes a comparator-less `.sort()` in `scripts/check-agents-md-budget.mjs` that was failing the `explicit-sort-comparators` (#3620) guard test on the full core suite.

## Testing

- Progress unit tests rewritten to pin the CAS semantics, including new race-scenario coverage (lost CAS races, concurrent sweepers, terminal-overwrite attempts, heartbeat persistence under a suppressed broadcast window): **67/67**
- Full `@open-mercato/core` suite: **7915/7915**; `@open-mercato/search`: 252/252; shared encryption find helpers: 66/66
- Typecheck + lint clean; `raw('processed_count + n')` inlining verified against the real `PostgreSqlPlatform.formatQuery` code path
- No DB schema, API surface, or `ProgressService` interface changes (one additive exported constant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
