### PR TITLE
fix(docs): index docs served at the site root so Cmd+K search works

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -29,6 +29,7 @@ const config: Config = {
         language: ['en'],
         indexDocs: true,
         indexBlog: false,
+        docsRouteBasePath: '/',
       },
     ],
     function disableModuleConcatenationPlugin() {


### PR DESCRIPTION
## Summary

Cmd+K search on [docs.openmercato.com](https://docs.openmercato.com/) returns nothing — and never has. It reads as "slow", but it is a hard failure: the search index is never generated at build time, so the client has nothing to query.

`apps/docs/docusaurus.config.ts` serves docs at the site root (`routeBasePath: '/'`), but `@easyops-cn/docusaurus-search-local` defaults `docsRouteBasePath` to `'docs'`. At build time:

1. `processDocInfos` tests every route against `docs/` — `introduction/use-cases` and friends don't match.
2. `indexPages` defaults to `false`, so the fallback branch drops them too.
3. Every route is filtered out, the result set is empty, and `postBuild` never writes `search-index.json`.

At runtime the client requests `/search-index.json?_=<hash>`, the host's SPA fallback answers with `index.html` (HTTP 200, `content-type: text/html`), and `JSON.parse` throws. Confirmed in the browser console on the live site:

```
Unexpected token '<', "<!doctype "... is not valid JSON
```

The error is swallowed, so the search box opens, accepts input, and silently shows no results.

Setting `docsRouteBasePath: '/'` makes the plugin's route matching agree with the docs preset. The plugin strips the leading slash internally, so `'/'` normalizes to `''`, which matches every route.

## Changes

- `apps/docs/docusaurus.config.ts`: add `docsRouteBasePath: '/'` to the `@easyops-cn/docusaurus-search-local` options so the plugin indexes docs served from the site root.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — one-line build-config fix. The specs under `.ai/specs/` that mention search (`2026-05-20-search-presenter-i18n.md`, `2026-06-15-tenant-scoped-search-settings.md`, `2026-07-24-search-architecture-clarification-and-evolution.md`) all cover the platform's `@open-mercato/search` module, not the Docusaurus docs site.

## Testing

**Build (`apps/docs`, clean `yarn clean && yarn build`)** — succeeds, and now emits the index that was previously absent:

| | before | after |
|---|---|---|
| `build/search-index.json` | not written | 8.1 MB |
| doc pages indexed | 0 | 254 |
| headings indexed | 0 | 2985 |
| content blocks indexed | 0 | 3009 |

**Runtime (served the production build, driven in a real browser)** — Cmd+K → typed `module` → 8 results (Module Registry, Core Modules, Sales Module, Module overrides, …) plus a working "See all results" → `/search/?q=module`. No console errors.

**Before-state on production**, for reference:

```
$ curl -sI https://docs.openmercato.com/search-index.json
HTTP/2 200
content-type: text/html; charset=utf-8      # SPA fallback — the file does not exist
content-disposition: inline; filename="index.html"
```

The pre-existing broken-anchor warning on `/installation/wsl2` is unrelated to this change and present before it.

**Repo-wide gate:** `yarn lint` and `yarn typecheck` resolve to *no tasks* for `apps/docs` (the workspace defines neither script — verified with `turbo run lint typecheck --filter=open-mercato-docs --dry`), and this path touches nothing in the packages/app build graph. CI's own `integration-scope` step classifies this diff as docs-only (`skip=true`), skipping integration, app-build and docker-build. The `apps/docs` build above is the check that actually exercises the changed file.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. *(N/A — no user-facing copy, locales or generated files involved.)*
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). *(N/A — see Specification above.)*
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [ ] QA routing set.

On the three unticked boxes that need a maintainer decision:

- **CLA** — deliberately left unticked; the PR author should tick this themselves rather than have it done on their behalf.
- **Tests** — `apps/docs` has no test harness (no `test` script, no runner). A regression test here means asserting the built site emits a non-empty `search-index.json`, which requires a full Docusaurus build in CI. That felt like a larger, more opinionated change than a one-line fix warrants, so I've left it to maintainers to decide whether it's worth adding. Worth noting the failure mode is silent and survived unnoticed until now, so some guard may be justified.
- **Labels** — the PR author lacks `triage` on this repo and cannot apply labels; they're proposed in a comment below.

## Linked issues

None.
