### PR TITLE
feat(feature_toggles): let frontend toggle hooks declare a defaultValue

### DIFF
--- a/apps/docs/docs/framework/feature-toggles/overview.mdx
+++ b/apps/docs/docs/framework/feature-toggles/overview.mdx
@@ -101,6 +101,36 @@ import { FeatureGuard } from '@open-mercato/core/modules/feature_toggles/compone
 const { enabled, isLoading } = useFeatureFlagBoolean({ id: 'checkout_flow_v2' });
 ```
 
+**Unresolved checks and `defaultValue`**
+
+A check can fail to resolve: the toggle may not be defined for the tenant, its
+type may not match, or the request may fail. Every frontend hook accepts a
+`defaultValue` that is used in those cases *and* while the request is in flight.
+
+`useFeatureFlagBoolean` defaults to `false`, which is right for toggles that
+switch a feature **on** — an unresolved toggle leaves it off. It is wrong for
+toggles that **hide** existing UI, because an unrelated failure would make that
+UI disappear. Those toggles should fail open:
+
+```tsx
+// Channels stay visible unless the toggle explicitly resolves to false.
+const { enabled } = useFeatureFlagBoolean({ id: 'sales_channels_enabled', defaultValue: true });
+```
+
+`FeatureGuard` takes the same option. Note that `defaultValue` and `fallback`
+are different things: `defaultValue` is the toggle value assumed when the check
+cannot be resolved, while `fallback` is the node rendered once the feature is
+known to be disabled.
+
+```tsx
+<FeatureGuard id="sales_channels_enabled" defaultValue>
+  <ChannelsSection />
+</FeatureGuard>
+```
+
+The string, number, and JSON hooks accept `defaultValue` too; theirs defaults to
+`null`.
+
 **Backend Service**
 
 ```ts

--- a/packages/core/src/modules/feature_toggles/components/FeatureGuard.tsx
+++ b/packages/core/src/modules/feature_toggles/components/FeatureGuard.tsx
@@ -8,23 +8,30 @@ export type FeatureGuardProps = {
   children: React.ReactNode
   fallback?: React.ReactNode
   loadingFallback?: React.ReactNode
+  defaultValue?: boolean
 }
 
 /**
  * FeatureGuard component that conditionally renders children based on feature toggle state.
- * 
+ *
  * @param id - The feature toggle identifier
  * @param children - Content to render when the feature is enabled
  * @param fallback - Optional content to render when the feature is disabled
  * @param loadingFallback - Optional content to render while loading the feature state
+ * @param defaultValue - Toggle value assumed when the check cannot be resolved
+ *   (undefined toggle, type mismatch, network or permission failure). Defaults
+ *   to `false`; pass `true` to keep guarded UI visible when the check fails.
+ *   Distinct from `fallback`, which is what gets rendered once the feature is
+ *   known to be disabled.
  */
 export function FeatureGuard({
   id,
   children,
   fallback = null,
   loadingFallback = null,
+  defaultValue = false,
 }: FeatureGuardProps) {
-  const { enabled, isLoading } = useFeatureFlagBoolean({ id })
+  const { enabled, isLoading } = useFeatureFlagBoolean({ id, defaultValue })
 
   if (isLoading) {
     return <>{loadingFallback}</>

--- a/packages/core/src/modules/feature_toggles/components/__tests__/useFeatureFlagBoolean.test.tsx
+++ b/packages/core/src/modules/feature_toggles/components/__tests__/useFeatureFlagBoolean.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { useFeatureFlagBoolean } from '../hooks/useFeatureFlagBoolean'
+import { FeatureGuard } from '../FeatureGuard'
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: jest.fn(),
+}))
+
+const readApiResultOrThrowMock = readApiResultOrThrow as jest.MockedFunction<typeof readApiResultOrThrow>
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function Probe({ defaultValue }: { defaultValue?: boolean }) {
+  const { enabled, isLoading } = useFeatureFlagBoolean({ id: 'demo_toggle', defaultValue })
+  return <div data-testid="probe" data-enabled={String(enabled)} data-loading={String(isLoading)} />
+}
+
+async function renderAndSettle(defaultValue?: boolean) {
+  const { unmount } = render(<Probe defaultValue={defaultValue} />, { wrapper: createWrapper() })
+  await waitFor(() => {
+    expect(screen.getByTestId('probe').getAttribute('data-loading')).toBe('false')
+  })
+  const enabled = screen.getByTestId('probe').getAttribute('data-enabled')
+  unmount()
+  return enabled
+}
+
+describe('useFeatureFlagBoolean', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns the resolved toggle value', async () => {
+    readApiResultOrThrowMock.mockResolvedValue({ ok: true, value: false } as never)
+    expect(await renderAndSettle()).toBe('false')
+
+    readApiResultOrThrowMock.mockResolvedValue({ ok: true, value: true } as never)
+    expect(await renderAndSettle()).toBe('true')
+  })
+
+  it('prefers the resolved value over defaultValue', async () => {
+    readApiResultOrThrowMock.mockResolvedValue({ ok: true, value: false } as never)
+    expect(await renderAndSettle(true)).toBe('false')
+  })
+
+  it('falls back to false when the check fails and no default is given', async () => {
+    readApiResultOrThrowMock.mockRejectedValue(new Error('Toggle "demo_toggle" not found (missing).'))
+    expect(await renderAndSettle()).toBe('false')
+  })
+
+  it('falls back to defaultValue when the check fails', async () => {
+    readApiResultOrThrowMock.mockRejectedValue(new Error('Toggle "demo_toggle" not found (missing).'))
+    expect(await renderAndSettle(true)).toBe('true')
+  })
+
+  it('reports defaultValue while the check is in flight', async () => {
+    readApiResultOrThrowMock.mockReturnValue(new Promise(() => {}) as never)
+    render(<Probe defaultValue />, { wrapper: createWrapper() })
+    const probe = screen.getByTestId('probe')
+    expect(probe.getAttribute('data-loading')).toBe('true')
+    expect(probe.getAttribute('data-enabled')).toBe('true')
+  })
+})
+
+describe('FeatureGuard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  async function renderGuard(props: { defaultValue?: boolean }) {
+    render(
+      <FeatureGuard id="demo_toggle" fallback={<span>disabled</span>} {...props}>
+        <span>enabled</span>
+      </FeatureGuard>,
+      { wrapper: createWrapper() },
+    )
+    await waitFor(() => {
+      expect(screen.getByText(/enabled|disabled/)).toBeTruthy()
+    })
+    return screen.getByText(/enabled|disabled/).textContent
+  }
+
+  it('renders the disabled fallback when the check fails', async () => {
+    readApiResultOrThrowMock.mockRejectedValue(new Error('missing toggle'))
+    expect(await renderGuard({})).toBe('disabled')
+  })
+
+  it('keeps children visible when the check fails and defaultValue is true', async () => {
+    readApiResultOrThrowMock.mockRejectedValue(new Error('missing toggle'))
+    expect(await renderGuard({ defaultValue: true })).toBe('enabled')
+  })
+})

--- a/packages/core/src/modules/feature_toggles/components/hooks/staleTime.ts
+++ b/packages/core/src/modules/feature_toggles/components/hooks/staleTime.ts
@@ -1,0 +1,5 @@
+// Mirrors the server-side toggle resolution cache TTL in
+// `lib/feature-flag-check.ts`, so several components reading the same toggle
+// share one request instead of refetching a value the server would not have
+// re-resolved anyway.
+export const FEATURE_FLAG_STALE_TIME_MS = 60_000

--- a/packages/core/src/modules/feature_toggles/components/hooks/useFeatureFlagBoolean.ts
+++ b/packages/core/src/modules/feature_toggles/components/hooks/useFeatureFlagBoolean.ts
@@ -2,9 +2,19 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { FEATURE_FLAG_STALE_TIME_MS } from './staleTime'
 
 export type UseFeatureFlagOptions = {
   id: string
+  /**
+   * Value used while the check is in flight and whenever the toggle cannot be
+   * resolved (undefined toggle, type mismatch, network or permission failure).
+   *
+   * Defaults to `false` so an unresolved toggle keeps a feature switched off.
+   * Pass `true` for toggles that hide existing UI — there a failed check must
+   * not make the feature disappear.
+   */
+  defaultValue?: boolean
 }
 
 export type UseFeatureFlagResult = {
@@ -21,6 +31,7 @@ type Result<T> = {
 }
 
 export function useFeatureFlagBoolean(options: UseFeatureFlagOptions): UseFeatureFlagResult {
+  const defaultValue = options.defaultValue ?? false
   const query = useQuery({
     queryKey: ['featureToggles', 'check', options?.id],
     queryFn: async () => {
@@ -37,9 +48,10 @@ export function useFeatureFlagBoolean(options: UseFeatureFlagOptions): UseFeatur
       return result
     },
     enabled: !!options.id,
+    staleTime: FEATURE_FLAG_STALE_TIME_MS,
   })
 
-  const enabled = query.data?.ok ? query.data.value : false
+  const enabled = query.data?.ok ? query.data.value : defaultValue
   const isLoading = query.isLoading
 
   return {

--- a/packages/core/src/modules/feature_toggles/components/hooks/useFeatureFlagJson.ts
+++ b/packages/core/src/modules/feature_toggles/components/hooks/useFeatureFlagJson.ts
@@ -2,9 +2,16 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { FEATURE_FLAG_STALE_TIME_MS } from './staleTime'
 
-export type UseFeatureFlagJsonOptions = {
+export type UseFeatureFlagJsonOptions<T = unknown> = {
     id: string
+    /**
+     * Value used while the check is in flight and whenever the toggle cannot be
+     * resolved (undefined toggle, type mismatch, network or permission failure).
+     * Defaults to `null`.
+     */
+    defaultValue?: T | null
 }
 
 export type UseFeatureFlagJsonResult<T = unknown> = {
@@ -20,7 +27,8 @@ type Result<T> = {
     error: unknown
 }
 
-export function useFeatureFlagJson<T = unknown>(options: UseFeatureFlagJsonOptions): UseFeatureFlagJsonResult<T> {
+export function useFeatureFlagJson<T = unknown>(options: UseFeatureFlagJsonOptions<T>): UseFeatureFlagJsonResult<T> {
+    const defaultValue = options.defaultValue ?? null
     const query = useQuery({
         queryKey: ['featureToggles', 'check', 'json', options?.id],
         queryFn: async () => {
@@ -37,9 +45,10 @@ export function useFeatureFlagJson<T = unknown>(options: UseFeatureFlagJsonOptio
             return result
         },
         enabled: !!options.id,
+        staleTime: FEATURE_FLAG_STALE_TIME_MS,
     })
 
-    const value = query.data?.ok ? query.data.value : null
+    const value = query.data?.ok ? query.data.value : defaultValue
     const isLoading = query.isLoading
 
     return {

--- a/packages/core/src/modules/feature_toggles/components/hooks/useFeatureFlagNumber.ts
+++ b/packages/core/src/modules/feature_toggles/components/hooks/useFeatureFlagNumber.ts
@@ -2,9 +2,16 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { FEATURE_FLAG_STALE_TIME_MS } from './staleTime'
 
 export type UseFeatureFlagNumberOptions = {
     id: string
+    /**
+     * Value used while the check is in flight and whenever the toggle cannot be
+     * resolved (undefined toggle, type mismatch, network or permission failure).
+     * Defaults to `null`.
+     */
+    defaultValue?: number | null
 }
 
 export type UseFeatureFlagNumberResult = {
@@ -21,6 +28,7 @@ type Result<T> = {
 }
 
 export function useFeatureFlagNumber(options: UseFeatureFlagNumberOptions): UseFeatureFlagNumberResult {
+    const defaultValue = options.defaultValue ?? null
     const query = useQuery({
         queryKey: ['featureToggles', 'check', 'number', options?.id],
         queryFn: async () => {
@@ -37,9 +45,10 @@ export function useFeatureFlagNumber(options: UseFeatureFlagNumberOptions): UseF
             return result
         },
         enabled: !!options.id,
+        staleTime: FEATURE_FLAG_STALE_TIME_MS,
     })
 
-    const value = query.data?.ok ? query.data.value : null
+    const value = query.data?.ok ? query.data.value : defaultValue
     const isLoading = query.isLoading
 
     return {

--- a/packages/core/src/modules/feature_toggles/components/hooks/useFeatureFlagString.ts
+++ b/packages/core/src/modules/feature_toggles/components/hooks/useFeatureFlagString.ts
@@ -2,9 +2,16 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { FEATURE_FLAG_STALE_TIME_MS } from './staleTime'
 
 export type UseFeatureFlagStringOptions = {
     id: string
+    /**
+     * Value used while the check is in flight and whenever the toggle cannot be
+     * resolved (undefined toggle, type mismatch, network or permission failure).
+     * Defaults to `null`.
+     */
+    defaultValue?: string | null
 }
 
 export type UseFeatureFlagStringResult = {
@@ -21,6 +28,7 @@ type Result<T> = {
 }
 
 export function useFeatureFlagString(options: UseFeatureFlagStringOptions): UseFeatureFlagStringResult {
+    const defaultValue = options.defaultValue ?? null
     const query = useQuery({
         queryKey: ['featureToggles', 'check', 'string', options?.id],
         queryFn: async () => {
@@ -37,9 +45,10 @@ export function useFeatureFlagString(options: UseFeatureFlagStringOptions): UseF
             return result
         },
         enabled: !!options.id,
+        staleTime: FEATURE_FLAG_STALE_TIME_MS,
     })
 
-    const value = query.data?.ok ? query.data.value : null
+    const value = query.data?.ok ? query.data.value : defaultValue
     const isLoading = query.isLoading
 
     return {

--- a/packages/core/src/modules/sales/components/__tests__/salesDocumentFormCurrency.test.tsx
+++ b/packages/core/src/modules/sales/components/__tests__/salesDocumentFormCurrency.test.tsx
@@ -9,6 +9,11 @@ jest.setTimeout(20000)
 const mockApiCall = jest.fn()
 let capturedInitialValues: Record<string, unknown> | undefined
 
+jest.mock('../useSalesChannelsEnabled', () => ({
+  SALES_CHANNELS_TOGGLE_ID: 'sales_channels_enabled',
+  useSalesChannelsEnabled: () => ({ enabled: true, isLoading: false }),
+}))
+
 jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
   apiCall: (...args: any[]) => mockApiCall(...args),
   apiCallOrThrow: jest.fn().mockResolvedValue({ items: [] }),

--- a/packages/core/src/modules/sales/components/__tests__/salesDocumentFormHoistedRenderers.test.tsx
+++ b/packages/core/src/modules/sales/components/__tests__/salesDocumentFormHoistedRenderers.test.tsx
@@ -19,6 +19,11 @@ jest.setTimeout(20000)
 
 const mockApiCall = jest.fn()
 
+jest.mock('../useSalesChannelsEnabled', () => ({
+  SALES_CHANNELS_TOGGLE_ID: 'sales_channels_enabled',
+  useSalesChannelsEnabled: () => ({ enabled: true, isLoading: false }),
+}))
+
 jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
   apiCall: (...args: any[]) => mockApiCall(...args),
   apiCallOrThrow: jest.fn().mockResolvedValue({ items: [] }),

--- a/packages/core/src/modules/sales/components/__tests__/salesDocumentFormQuickCreate.test.tsx
+++ b/packages/core/src/modules/sales/components/__tests__/salesDocumentFormQuickCreate.test.tsx
@@ -37,6 +37,11 @@ const personValues = {
   ],
 }
 
+jest.mock('../useSalesChannelsEnabled', () => ({
+  SALES_CHANNELS_TOGGLE_ID: 'sales_channels_enabled',
+  useSalesChannelsEnabled: () => ({ enabled: true, isLoading: false }),
+}))
+
 jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
   apiCall: (...args: any[]) => mockApiCall(...args),
   apiCallOrThrow: jest.fn().mockResolvedValue({ items: [] }),

--- a/packages/core/src/modules/sales/components/__tests__/useSalesChannelsEnabled.test.tsx
+++ b/packages/core/src/modules/sales/components/__tests__/useSalesChannelsEnabled.test.tsx
@@ -3,22 +3,32 @@
  */
 import * as React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-const mockApiCall = jest.fn()
+const mockReadApiResultOrThrow = jest.fn()
 
 jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
-  apiCall: (...args: unknown[]) => mockApiCall(...args),
+  readApiResultOrThrow: (...args: unknown[]) => mockReadApiResultOrThrow(...args),
 }))
 
-const { useSalesChannelsEnabled } = require('../useSalesChannelsEnabled')
+const { useSalesChannelsEnabled, SALES_CHANNELS_TOGGLE_ID } = require('../useSalesChannelsEnabled')
 
 function Probe() {
   const { enabled, isLoading } = useSalesChannelsEnabled()
   return <div data-testid="probe" data-enabled={String(enabled)} data-loading={String(isLoading)} />
 }
 
+function createWrapper(options?: { keepCache?: boolean }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, ...(options?.keepCache ? {} : { gcTime: 0 }) } },
+  })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
 async function renderAndSettle() {
-  const { unmount } = render(<Probe />)
+  const { unmount } = render(<Probe />, { wrapper: createWrapper() })
   await waitFor(() => {
     expect(screen.getByTestId('probe').getAttribute('data-loading')).toBe('false')
   })
@@ -28,44 +38,58 @@ async function renderAndSettle() {
 }
 
 describe('useSalesChannelsEnabled', () => {
-  let clock = 1_000_000
-
   beforeEach(() => {
     jest.clearAllMocks()
-    // The hook caches its result for 60s keyed off Date.now(); jump past the
-    // TTL so every test starts with a cold cache.
-    clock += 120_000
-    jest.spyOn(Date, 'now').mockImplementation(() => clock)
   })
 
-  afterEach(() => {
-    jest.restoreAllMocks()
+  it('checks the sales channels toggle', async () => {
+    mockReadApiResultOrThrow.mockResolvedValue({ ok: true, value: true })
+    await renderAndSettle()
+    expect(String(mockReadApiResultOrThrow.mock.calls[0][0])).toContain(
+      `identifier=${SALES_CHANNELS_TOGGLE_ID}`,
+    )
   })
 
   it('disables channels only when the toggle explicitly resolves to false', async () => {
-    mockApiCall.mockResolvedValue({ ok: true, status: 200, result: { ok: true, value: false } })
+    mockReadApiResultOrThrow.mockResolvedValue({ ok: true, value: false })
     expect(await renderAndSettle()).toBe('false')
   })
 
   it('keeps channels enabled when the toggle resolves to true', async () => {
-    mockApiCall.mockResolvedValue({ ok: true, status: 200, result: { ok: true, value: true } })
+    mockReadApiResultOrThrow.mockResolvedValue({ ok: true, value: true })
     expect(await renderAndSettle()).toBe('true')
   })
 
   it('fails open when the toggle definition is missing (404)', async () => {
-    mockApiCall.mockResolvedValue({ ok: false, status: 404, result: { ok: false } })
+    mockReadApiResultOrThrow.mockRejectedValue(Object.assign(new Error('not found'), { status: 404 }))
     expect(await renderAndSettle()).toBe('true')
   })
 
   it('fails open when the check request throws', async () => {
-    mockApiCall.mockRejectedValue(new Error('network down'))
+    mockReadApiResultOrThrow.mockRejectedValue(new Error('network down'))
     expect(await renderAndSettle()).toBe('true')
   })
 
-  it('reuses the cached result across consumers within the TTL', async () => {
-    mockApiCall.mockResolvedValue({ ok: true, status: 200, result: { ok: true, value: true } })
-    await renderAndSettle()
-    await renderAndSettle()
-    expect(mockApiCall).toHaveBeenCalledTimes(1)
+  it('keeps channels visible while the check is still in flight', () => {
+    mockReadApiResultOrThrow.mockReturnValue(new Promise(() => {}))
+    render(<Probe />, { wrapper: createWrapper() })
+    const probe = screen.getByTestId('probe')
+    expect(probe.getAttribute('data-loading')).toBe('true')
+    expect(probe.getAttribute('data-enabled')).toBe('true')
+  })
+
+  it('reuses the cached result across consumers', async () => {
+    mockReadApiResultOrThrow.mockResolvedValue({ ok: true, value: true })
+    const wrapper = createWrapper({ keepCache: true })
+    const first = render(<Probe />, { wrapper })
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').getAttribute('data-loading')).toBe('false')
+    })
+    first.unmount()
+    render(<Probe />, { wrapper })
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').getAttribute('data-loading')).toBe('false')
+    })
+    expect(mockReadApiResultOrThrow).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/core/src/modules/sales/components/documents/__tests__/SalesDocumentsTable.stickyColumn.test.tsx
+++ b/packages/core/src/modules/sales/components/documents/__tests__/SalesDocumentsTable.stickyColumn.test.tsx
@@ -5,6 +5,11 @@ import * as React from 'react'
 import { render, act } from '@testing-library/react'
 import { SalesDocumentsTable } from '../SalesDocumentsTable'
 
+jest.mock('../../useSalesChannelsEnabled', () => ({
+  SALES_CHANNELS_TOGGLE_ID: 'sales_channels_enabled',
+  useSalesChannelsEnabled: () => ({ enabled: true, isLoading: false }),
+}))
+
 // Capture the props handed to DataTable so we can assert the sticky-column wiring.
 const mockDataTable = jest.fn()
 const mockApiCall = jest.fn()

--- a/packages/core/src/modules/sales/components/useSalesChannelsEnabled.ts
+++ b/packages/core/src/modules/sales/components/useSalesChannelsEnabled.ts
@@ -1,59 +1,13 @@
 "use client"
 
-import * as React from 'react'
-import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { useFeatureFlagBoolean } from '@open-mercato/core/modules/feature_toggles/components/hooks/useFeatureFlagBoolean'
 import { SALES_CHANNELS_TOGGLE_ID } from '../lib/salesChannelsToggleId'
 
 export { SALES_CHANNELS_TOGGLE_ID }
 
-const CACHE_TTL_MS = 60_000
-
-type FeatureToggleCheckResponse = {
-  ok?: boolean
-  value?: unknown
-}
-
 // Fails open: channels stay visible unless the toggle explicitly resolves to
 // false. A missing toggle definition (404) or an absent feature_toggles module
 // must not hide sales channel UI.
-async function fetchSalesChannelsEnabled(): Promise<boolean> {
-  try {
-    const call = await apiCall<FeatureToggleCheckResponse>(
-      `/api/feature_toggles/check/boolean?identifier=${SALES_CHANNELS_TOGGLE_ID}`,
-    )
-    if (!call.ok) return true
-    return !(call.result?.ok === true && call.result.value === false)
-  } catch {
-    return true
-  }
-}
-
-let cache: { value: Promise<boolean>; at: number } | null = null
-
-function getSalesChannelsEnabled(): Promise<boolean> {
-  const now = Date.now()
-  if (!cache || now - cache.at > CACHE_TTL_MS) {
-    cache = { value: fetchSalesChannelsEnabled(), at: now }
-  }
-  return cache.value
-}
-
 export function useSalesChannelsEnabled(): { enabled: boolean; isLoading: boolean } {
-  const [resolved, setResolved] = React.useState<boolean | null>(null)
-
-  React.useEffect(() => {
-    let active = true
-    getSalesChannelsEnabled()
-      .then((value) => {
-        if (active) setResolved(value)
-      })
-      .catch(() => {
-        if (active) setResolved(true)
-      })
-    return () => {
-      active = false
-    }
-  }, [])
-
-  return { enabled: resolved !== false, isLoading: resolved === null }
+  return useFeatureFlagBoolean({ id: SALES_CHANNELS_TOGGLE_ID, defaultValue: true })
 }


### PR DESCRIPTION
## Summary

`useFeatureFlagBoolean` resolved to `false` whenever the check could not be resolved — an undefined toggle, a type mismatch, an auth failure, a network failure. That is the right default for a toggle that switches a feature **on**, and the wrong one for a toggle that **hides** existing UI, where an unrelated failure makes that UI disappear.

The first real consumer hit exactly that. #3935 added `sales_channels_enabled` to hide sales channel UI for tenants that don't use channels, could not use the shared hook, and shipped a bespoke `useSalesChannelsEnabled` with its own `apiCall`, its own 60s module-level cache, and an explicit fail-open contract. As of `develop`, `useFeatureFlagBoolean` and `<FeatureGuard>` have **zero production call sites** — the shared client API is unused because the first serious use case rejected it.

This adds an optional `defaultValue` to the frontend toggle hooks and to `FeatureGuard`, used both while the check is in flight and whenever it cannot be resolved. Defaults preserve today's behaviour exactly (`false` for boolean, `null` for string/number/json), so the change is purely additive. `useSalesChannelsEnabled` then becomes a two-line delegation, dropping ~50 lines of bespoke fetching and caching.

Two naming/design points worth stating up front:

- **`defaultValue`, not `fallback`.** `<FeatureGuard fallback={...}>` already exists and means something different — the ReactNode rendered once the feature is known to be disabled. `defaultValue` also matches `ModuleConfigService.getValue(moduleId, name, { defaultValue })`, the sibling runtime-config mechanism that already supports a code-side default. Feature toggles didn't, which is an inconsistency between two mechanisms rather than an open design question.
- **The server-side helper is deliberately left alone.** `isSalesChannelsEnabledForTenant` in `sales/lib/salesChannelsToggle.ts` isn't a defaulting problem — it resolves `feature_toggles` lazily as an *optional peer module*, which is the sanctioned cross-module pattern in `packages/core/AGENTS.md`. Collapsing it would break that.

Context: RFC discussion #3909 (configuration-mechanism conventions). This is the smallest self-contained piece of it.

## Changes

- `useFeatureFlagBoolean` accepts `defaultValue?: boolean` (default `false`) — applied while loading and on any unresolved check.
- `useFeatureFlagString` / `useFeatureFlagNumber` / `useFeatureFlagJson` accept `defaultValue` too (default `null`), so the four hooks stay symmetric. `UseFeatureFlagJsonOptions` gains a defaulted type parameter `<T = unknown>`; bare usage is unchanged.
- `<FeatureGuard defaultValue>` passes through to the hook. Its JSDoc now spells out how `defaultValue` differs from `fallback`.
- All four hooks get a 60s `staleTime` mirroring the server-side toggle-resolution TTL in `feature_toggles/lib/feature-flag-check.ts`. This isn't cosmetic: without it, migrating sales off its module-level cache would increase request volume across `SalesDocumentsTable`, `SalesDocumentForm` and three pages.
- `useSalesChannelsEnabled` delegates to `useFeatureFlagBoolean({ id, defaultValue: true })`, keeping its name, its call sites and its fail-open contract. −48 lines. The cross-module import lands in exactly one file, so all six consumers are untouched.
- `apps/docs/docs/framework/feature-toggles/overview.mdx` documents `defaultValue`, when to fail open, and the `defaultValue` vs `fallback` distinction.

### Behaviour deltas a reviewer should weigh

1. `useSalesChannelsEnabled` now requires react-query context. Fine in production (every backend page is under `QueryProvider`), but four existing sales test files rendered `SalesDocumentForm` / `SalesDocumentsTable` without one. They now mock `useSalesChannelsEnabled`, matching what the sibling `salesDocumentFormChannelToggle.test.tsx` already did.
2. A 401 on the toggle check now reaches `QueryProvider`'s `queryCache.onError` and triggers the session-refresh redirect. The bespoke sales hook swallowed it. Arguably more correct — a dead session should redirect, and every other query on the page already does — but it is a change.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

N/A. The broader convention this belongs to (which of env var / feature toggle / module config / domain setting to reach for, and declarative registration of toggle + config defaults) is RFC discussion #3909 and is intended as a follow-up spec PR. This change is the self-contained piece that doesn't depend on that discussion resolving.

## Testing

Full `validation.commands` from `.ai/agentic.config.json`, run locally:

| command | result |
|---|---|
| `yarn build:packages` | pass |
| `yarn generate` | pass |
| `yarn i18n:check-sync` | pass — all 4 locales in sync |
| `yarn i18n:check-usage` | pass (advisory; no locale keys added by this PR) |
| `yarn typecheck` | pass |
| `yarn test` | 7904/7905 in `@open-mercato/core`; all other packages pass |
| `yarn build:app` | pass |

The single `yarn test` failure is `src/__tests__/explicit-sort-comparators.test.ts`, which flags `scripts/check-agents-md-budget.mjs:93` — a file this branch does not touch. Verified pre-existing by stashing the branch and re-running it against a clean `develop`.

New and updated coverage:

- `feature_toggles/components/__tests__/useFeatureFlagBoolean.test.tsx` (new): resolved value wins over `defaultValue`; unresolved check falls back to `false` by default and to `defaultValue` when given; `defaultValue` is reported while the request is in flight; plus two `FeatureGuard` cases proving `defaultValue` keeps children visible on a failed check while `fallback` still renders on a genuine disable.
- `sales/components/__tests__/useSalesChannelsEnabled.test.tsx`: rewritten against the shared hook, keeping every original behavioural case (explicit `false` disables; `true` enables; 404 fails open; thrown request fails open) and adding in-flight visibility plus the cross-consumer cache reuse the old module-level cache guaranteed.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set.

Notes on the unticked boxes:

- **CLA** — deliberately left for a human to tick. I won't accept a legal agreement on the author's behalf.
- **Integration tests** — none added. The change has no new API surface and no new route; its whole observable behaviour is "what does a component render when the toggle check fails", which the Jest coverage above exercises directly at the hook and guard level. Happy to add a Playwright case if you'd rather see it exercised end to end.
- **Spec** — see the Specification section.
- **Priority / Risk / QA routing** — I have `read` permission only on this repo and cannot apply labels. Proposed values are in a separate comment below for a maintainer to apply.

### Design System Compliance

This change adds no UI markup — `FeatureGuard` renders only `children`/`fallback`, and the rest is hooks and a docs page.

- [x] No hardcoded status colors
- [x] No arbitrary text sizes
- [x] Uses existing DS components — no custom replacements
- Empty state / loading state / `aria-label`: N/A, no list page, no async page and no icon-only button introduced.

## Linked issues

Refs #3909
