### PR TITLE
docs: correct fabricated and stale query layer documentation

### DIFF
--- a/apps/docs/docs/framework/admin-ui/data-grids.mdx
+++ b/apps/docs/docs/framework/admin-ui/data-grids.mdx
@@ -54,12 +54,14 @@ On the server, map these filters to query engine constraints:
 
 ```ts title="api/get/inventory/items.ts"
 const filters = parseFilters(request); // your helper
-const result = await queryEngine.list({
-  entity: 'inventory:item',
+const result = await queryEngine.query('inventory:item', {
   filters,
-  select: ['sku', 'name', 'cf:priority'],
+  fields: ['sku', 'name', 'cf:priority'],
+  page: { page, pageSize },
+  tenantId, // required — the engine throws without a tenant scope
   organizationId,
 });
+// result: { items, page, pageSize, total }
 ```
 
 ## Performance tips

--- a/apps/docs/docs/framework/database/hybrid-query-engine.mdx
+++ b/apps/docs/docs/framework/database/hybrid-query-engine.mdx
@@ -1,54 +1,130 @@
 ---
 title: Hybrid query engine
-description: Accelerate entity queries with the optional JSONB index layer.
+description: How the runtime query engine routes between the JSONB index and the join-based plan.
 ---
 
 # Hybrid Query Engine
 
-The query engine can transparently route requests through a denormalised JSONB index. This hybrid approach keeps write operations on the primary tables while enabling fast reads for list and search screens. Its primary target is **user-defined entities** (from the Entities module) which are stored as JSONB documents.
+`HybridQueryEngine` is the implementation registered behind the `queryEngine` DI key at runtime. It answers a query from the shared `entity_indexes` JSONB index when it can, and delegates to `BasicQueryEngine` (the join-based plan) when it cannot.
 
-| Entity type | Defined in | Storage | Primary use | Example |
-| --- | --- | --- | --- | --- |
-| **System entities** | Module `data/entities.ts` (MikroORM) | Relational tables (one per entity) | Core platform objects extended with custom fields | `auth.user`, `directory.organization` |
-| **User entities** | Module `ce.ts` / admin UI | JSONB documents in the Entities module | Customer-specific records managed at runtime | `inventory:item`, CRM pipelines |
+:::tip Read this first
+There is **no per-module opt-in for the engine**. There is no `queryIndex` metadata option, no `hybridQuery: true` flag, and no per-entity `*_index` table — a single shared `entity_indexes` table backs every indexed entity. What is opt-in is *indexing*, not *routing*. See [Keeping the index populated](#keeping-the-index-populated).
+:::
 
-The hybrid query engine optimises **user entities**, while the [JSONB indexing layer](./query-index) targets **system entities with custom fields** (flattening base columns + `cf:<key>` values). Treat them as complementary mechanisms, not replacements for each other.
+## Which engine is live
 
-## How it works
+`createRequestContainer()` registers a `BasicQueryEngine` (`packages/shared/src/lib/di/container.ts`). The `query_index` module's DI registrar then unconditionally replaces that registration with a `HybridQueryEngine` that wraps the basic one as its fallback delegate (`packages/core/src/modules/query_index/di.ts`).
 
-1. Each entity that opts in gains an `*_index` table storing flattened rows (user entity payloads).
-2. Background jobs or CLI commands (`yarn mercato entities install --reindex`) populate and refresh the index.
-3. When the index is up to date, the query engine executes filters and sorts against the JSONB payload, bypassing expensive joins.
-4. If the index is missing or stale, the query engine automatically falls back to the relational query plan.
+Because `query_index` is a core module, **every consumer of `queryEngine` gets the hybrid engine**. `BasicQueryEngine` runs directly only when the `query_index` registration is absent or threw; otherwise it is reachable only as the hybrid engine's fallback.
 
-## Opting in
+Both implement the same interface, which has exactly one method (`packages/shared/src/lib/query/types.ts`):
 
-```ts title="src/modules/inventory/index.ts"
-export const metadata = {
-  id: 'inventory',
-  title: 'Inventory',
-  version: '0.1.0',
-  description: 'Track stock levels for sellable items.',
-  queryIndex: {
-    entities: ['inventory:item'],
-  },
-};
+```ts
+export interface QueryEngine {
+  query<T = any>(entity: EntityId, opts?: QueryOptions): Promise<QueryResult<T>>
+}
 ```
 
-- Add the entity id you want indexed.
-- Run `yarn generate` and `yarn db:generate` to create the index tables.
-- Trigger an initial backfill (for example, `yarn mercato entities sync-index --entity inventory:item --tenant <tenantId>`).
+See [Query engine](./query-engine) for the options and result shape, and [JSONB indexing layer](./query-index) for the index schema, document shape, and backfill CLI.
 
-## Working with custom fields
+## Routing decisions
 
-- User entities: custom fields are already part of the JSONB payload, so the hybrid index copies them verbatim.
-- System entities: continue using the [JSONB indexing layer](./query-index) to flatten base columns and `cf:<key>` values. The hybrid index does not replace that mechanism.
+For a given `query()` call the hybrid engine picks one of three paths.
 
-## Monitoring freshness
+### 1. Custom-entity document storage
 
-- Inspect `modules.generated.ts` to confirm the entity lists `hybridQuery: true`.
-- Each index record carries an `updated_at` timestamp. Use it to detect stale data and schedule incremental refreshes.
-- The engine logs when it falls back to relational mode, making it easy to flag missing indexes during development.
-- Use the Entities module dashboards to confirm user-entity records stay in sync after edits in the admin UI.
+When `opts.forceCustomEntityStorage === true`, or the entity id is classified as a custom entity, the query runs against `custom_entities_storage` instead of a base table. This is a separate reader, not the basic engine.
 
-When you need fast lists for system entities enriched with module-defined custom fields, enable the JSONB indexing layer. When you need performant queries over runtime-defined user entities, opt into the hybrid query engine.
+### 2. Fallback to `BasicQueryEngine`
+
+There are exactly four conditions, all in `packages/core/src/modules/query_index/lib/engine.ts`:
+
+| Condition | Profiler `reason` | Notes |
+| --- | --- | --- |
+| The base table does not exist | `missing_base` | |
+| `opts.omitAutomaticTenantOrgScope === true` | `omit_automatic_tenant_org_scope` | The caller owns scoping. `BasicQueryEngine` still handles `cf:*` filters/sorts and `search_tokens` fulltext, but the JSONB index path and the vector-search branch are bypassed |
+| No index rows exist for the entity type | `no_index_rows` | Only evaluated when the query wants custom fields |
+| A coverage gap was detected and `FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES` is off | `partial_index` | Additionally requires the entity to have at least one active custom-field definition. See [Partial coverage](#partial-coverage) |
+
+The last two are gated on the query actually wanting custom-field data — `opts.fields` containing a `cf:`/`l10n:` selector, a `cf:`/`l10n:` filter, or an array-form `includeCustomFields`. **A query that asks for no custom fields never falls back for coverage reasons**; it runs the hybrid engine's own SQL, which joins `entity_indexes` onto the base table only where needed.
+
+### 3. The index path
+
+Everything else. Filters, sorts, paging, tenant/organization scoping, joins, and soft-delete exclusion are applied against the base table plus `entity_indexes`.
+
+## What does *not* cause a fallback
+
+These are handled inside the hybrid engine and are easy to misread as fallback triggers:
+
+- **An unsupported sort field** is silently dropped from the `ORDER BY`, not escalated.
+- **An unknown filter field** is routed to `entity_indexes.doc ->> '<field>'` rather than rejected.
+- **Joins** (`opts.joins`, `opts.customFieldSources`) are compiled natively.
+- **Sorting on an encrypted column** uses a two-phase candidate scan and an in-memory sort. When the scan exceeds `OM_ENCRYPTED_SORT_MAX_ROWS` (unset means uncapped) the result carries `meta.encryptedSortRowCapWarning`.
+
+## Filter operators
+
+The supported set is exactly eleven (`packages/shared/src/lib/query/types.ts`):
+
+`eq` · `ne` · `gt` · `gte` · `lt` · `lte` · `in` · `nin` · `like` · `ilike` · `exists`
+
+:::warning Unsupported operators are silently ignored
+An operator outside that list does **not** raise. It is dropped during filter compilation, and the `default:` branches in both engines are permissive — the predicate is either skipped or compiled to `true`. The practical effect is that a filter you expected to narrow the result set may not narrow it at all. Validate operator names at the API boundary; do not rely on the engine to reject them.
+:::
+
+`like`/`ilike` are re-routed to hashed `search_tokens` lookups when search is active. If the tokenizer yields no hashes for the pattern, the predicate is skipped.
+
+## Partial coverage
+
+The engine compares `baseCount` (rows in the base table for the scope) against `indexedCount` (rows in `entity_indexes`), reading a snapshot from `entity_index_coverage`. A gap is any scope where `indexedCount` is below a non-zero `baseCount`, where `indexedCount` exceeds `baseCount` (stale rows), or where no snapshot exists yet.
+
+On a gap:
+
+1. An asynchronous reindex is scheduled — a persistent `query_index.reindex` event, unless `opts.skipAutoReindex` is set or `SCHEDULE_AUTO_REINDEX` is off. **This happens whether or not the query falls back.**
+2. `FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES` decides the read:
+   - **off (the code default)** — fall back to the basic engine. Correct results, join-plan latency.
+   - **on** — stay on the index. Fast, but rows missing from the index are missing from the result.
+3. Either way the result carries `meta.partialIndexWarning` (`entity`, `entityLabel`, `baseCount`, `indexedCount`, `scope`), which the CRUD factory forwards as the `x-om-partial-index` response header so the admin UI can prompt for a reindex via `/backend/query-indexes`.
+
+:::warning Forcing the index trades correctness for latency
+With a real coverage gap, `FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES=true` means unindexed rows silently disappear from filtered lists and counts. Close the gap with a reindex first; only then decide whether to force.
+:::
+
+Coverage snapshots are cached in the `entity_index_coverage` table with a TTL of `QUERY_INDEX_COVERAGE_CACHE_MS` (5 minutes by default). When a snapshot is stale or missing, `OPTIMIZE_INDEX_COVERAGE_STATS` decides what happens: off (the default) recomputes **inline on the request thread**; on schedules an asynchronous refresh and serves the stale snapshot.
+
+## Counts
+
+`QueryResult.total` always comes from a real count query — there is no cap, no cache, and no way to skip it.
+
+The hybrid engine takes an optimized path when the query has **no `cf:`/`l10n:` filters and no cross-entity search source**: it rebuilds the count from the base table with base, or-group, and join filters only, skipping the `entity_indexes` join entirely, then counts distinct base ids. Otherwise it counts `distinct b.id` over the full query shape.
+
+`BasicQueryEngine` uses `count(distinct <table>.id)` when joins, joined aggregates, or custom-field sources could multiply base rows, and `count(*)` when they cannot.
+
+## Keeping the index populated
+
+The query engine never writes index rows. Incremental maintenance runs through the `query_index` subscribers; bulk rebuilds are written directly by the reindexer behind the CLI and admin UI.
+
+| Event | Effect |
+| --- | --- |
+| `query_index.upsert_one` | Rebuild and upsert one row |
+| `query_index.delete_one` | Remove the row and its search tokens, adjust coverage |
+| `query_index.reindex` | Background (re)build for an entity/tenant/organization scope |
+| `query_index.purge` | Drop index rows for a scope |
+| `query_index.coverage.refresh` / `.warmup` | Recompute coverage snapshots |
+
+They are emitted by the DataEngine CRUD side-effect path when a route or command passes `indexer: { entityType }`, and by automatic `<module>.<entity>.created|updated|deleted` subscriptions that the `query_index` DI registrar installs for every entity id appearing in `custom_field_defs` (falling back to every generated entity id when that table is empty). Those handlers forward to the indexer only when the entity actually has an active custom-field definition for the scope.
+
+To rebuild by hand, use the CLI (`mercato query_index rebuild`, `rebuild-all`, `reindex`, `purge`; `yarn mercato reindex` is shorthand for `query_index reindex`) or the admin UI at `/backend/query-indexes`. Flags and partitioning are documented in [JSONB indexing layer](./query-index#backfill).
+
+## Observability
+
+- **Profiler** — set `OM_PROFILE` to emit `[qe:profile]` nodes. The `result` field is `ok`, `fallback` (with a `reason` from the table above), `custom_entity`, or `error`; SQL timings are labelled `query:sql:count` and `query:sql:data` (`query:sql:data:phase1` / `:phase2` when sorting on an encrypted column).
+- **Debug logs** — the engine's debug lines require **both** debug verbosity (`OM_QUERY_INDEX_DEBUG`, or `LOG_VERBOSITY`/`LOG_LEVEL` at `debug` or lower) **and** `QUERY_ENGINE_DEBUG_SQL=true`. Setting verbosity alone prints nothing from this engine.
+- **Warnings** — only the partial-coverage path logs at `warn`. The `missing_base`, `omit_automatic_tenant_org_scope`, and `no_index_rows` fallbacks are visible only through the profiler or debug logs.
+
+## Making a list endpoint fast
+
+1. Make sure the entity is actually indexed — check `/backend/query-indexes` for a coverage snapshot with `indexedCount` matching `baseCount`.
+2. Keep `omitAutomaticTenantOrgScope` off unless the entity's scoping genuinely does not fit `organization_id = X AND tenant_id = Y`. It forces the basic engine, so you lose the index path and vector search and take the join plan instead.
+3. Filter and sort on base columns where you can; `cf:*` predicates are JSONB extractions and are only as fast as the expression indexes you add for them.
+4. Add expression indexes for hot JSON paths — see [Performance tips](./query-index#performance-tips). Note that `entity_indexes` ships **no** GIN index on `doc`; the per-entity partial covering indexes that exist today were hand-written for three `customers:*` entity types and are not generated for other entities.
+5. Watch the count. It is a second query over the same shape, and on large tables an exact filtered total costs more than the page of rows itself.

--- a/apps/docs/docs/framework/database/query-engine.mdx
+++ b/apps/docs/docs/framework/database/query-engine.mdx
@@ -7,7 +7,7 @@ description: Fetch base entities, extensions, and custom fields through a single
 
 The query layer provides a consistent API to fetch data across base entities, module extensions, and custom fields. It is available via DI as `queryEngine`.
 
-When the optional hybrid JSONB index is enabled and populated for a given entity, queries are routed through the index automatically; otherwise the engine falls back to a join-based plan. See [JSONB indexing layer](./query-index) for the index design, backfill CLI, and performance tips.
+The implementation registered behind that key is `HybridQueryEngine`, which reads through the shared `entity_indexes` JSONB index and delegates to the join-based `BasicQueryEngine` under four specific conditions. See [Hybrid query engine](./hybrid-query-engine) for the routing and fallback rules, and [JSONB indexing layer](./query-index) for the index design, backfill CLI, and performance tips.
 
 ## Why
 - Build generic list/detail APIs and UI that work for any entity.

--- a/apps/docs/docs/framework/database/query-index.mdx
+++ b/apps/docs/docs/framework/database/query-index.mdx
@@ -7,12 +7,12 @@ description: Accelerate list queries by projecting entities and custom fields in
 
 Goal: make querying base entities together with custom fields fast and simple by maintaining a flat, query-friendly JSONB index per entity record, without breaking module isomorphism or schema agility. See the [Hybrid query engine](./hybrid-query-engine) for runtime usage.
 
-What you get
+## What you get
 - Hybrid engine: uses a JSONB-backed index when available; falls back to the join-based engine otherwise.
 - Event-driven updates: created/updated/deleted events keep the index synced. Custom-field updates also trigger reindex via the DataEngine write layer.
 - Zero-churn evolution: new fields (base or custom) are available immediately in the JSON document; promote hot fields later if needed.
 
-Storage
+## Storage
 - Table: `entity_indexes`
   - `id uuid` (PK)
   - `entity_type text` e.g., `example:todo`
@@ -21,41 +21,47 @@ Storage
   - `doc jsonb` flattened document of base fields + `cf:<key>` values
   - `index_version int` (default 1), `created_at`, `updated_at`, `deleted_at`
   - `organization_id_coalesced uuid generated always as (coalesce(organization_id, '00000000-0000-0000-0000-000000000000')) stored`
-- Indexes
-  - `gin(doc jsonb_path_ops)` for JSONB containment/path queries
-  - Unique: `unique(entity_type, entity_id, organization_id_coalesced)`
+- Indexes shipped on `entity_indexes` (see `data/entities.ts`)
+  - Unique: `unique(entity_type, entity_id, organization_id_coalesced)` — note that `tenant_id` is **not** part of the uniqueness key
+  - Btree: `(entity_type)`, `(entity_id)`, `(organization_id)`, `(entity_type, tenant_id)`
+  - Six hand-written partial covering indexes for `customers:customer_entity`, `customers:customer_person_profile`, and `customers:customer_company_profile` — one org-scoped and one tenant-scoped variant each:
+    - org-scoped: `(entity_id, organization_id, tenant_id) include (doc) where deleted_at is null and entity_type = '<id>' and organization_id is not null and tenant_id is not null`
+    - tenant-scoped: `(tenant_id, entity_id) include (doc) where deleted_at is null and entity_type = '<id>' and organization_id is null and tenant_id is not null`
+    
+    They are not generated. Any other entity type gets only the generic btrees above.
+  - There is **no GIN index on `doc`**. Adding one is a tuning decision you make per deployment — see [Performance tips](#performance-tips).
 
-Document shape
+## Document shape
 - Base fields are stored under their snake_case DB names.
 - Custom fields are stored as `cf:<key>` values.
 - Arrays are preserved as arrays; singletons are scalars.
 
-Encryption
+## Encryption
 - `entity_indexes.doc` is treated as “at rest” storage: it should contain the same encrypted values as the source tables / `custom_field_values`.
 - Decryption happens on read:
   - `HybridQueryEngine` decrypts entity payload fields via the tenant encryption service and also decrypts `cf:*` values before returning results.
 - Search token generation (for `like/ilike` token search) may decrypt values transiently to hash the plaintext tokens, but plaintext is never persisted into `entity_indexes.doc`.
   - Implementation helper: `packages/shared/src/lib/encryption/indexDoc.ts` (shared by Query Engine, indexers, and vector search).
 
-Indexer
+## Indexer
 - Build: merges base row with custom field values into a single plain object.
-- Upsert: inserts or updates the JSONB row keyed by `(entity_type, entity_id, organization_id_coalesced)`.
-- Delete: sets `deleted_at` on logical delete.
+- Upsert: inserts or updates the JSONB row keyed by `(entity_type, entity_id, organization_id_coalesced)`, always writing `deleted_at = null`.
+- Delete: `markDeleted()` **hard-deletes** the index row and its `search_tokens`. The `deleted_at` column exists and readers still filter on it, but the current writers never populate it — a removed base record leaves no index row behind.
 
-Events and consistency
+## Events and consistency
 - Subscribers are registered for all entities that have custom field definitions:
   - `<module>.<entity>.created|updated` → upsert index row.
-  - `<module>.<entity>.deleted` → mark index row deleted.
+  - `<module>.<entity>.deleted` → remove the index row.
 - Custom-field writes done via the DataEngine emit `<module>.<entity>.updated` as well, reusing the same subscriber path.
 
-Query routing
-- The `HybridQueryEngine` prefers the JSONB index when rows exist for the target entity; otherwise it falls back to the basic engine.
+## Query routing
+- The `HybridQueryEngine` prefers the JSONB index and falls back to the basic engine under four specific conditions — see [Routing decisions](./hybrid-query-engine#routing-decisions) for the full table. "No index rows exist" is only one of them, and it is evaluated only when the query actually asks for `cf:*`/`l10n:*` data.
 - Supported in index path:
   - Filters: base fields and `cf:*` via JSON path extraction and casting for common types.
   - Sorting: base fields and `cf:*` using casted expressions when possible.
   - Paging and multi-tenant scoping (`organization_id`, `tenant_id`) and soft-delete exclusion by default.
 
-Backfill
+## Backfill
 - CLI: `mercato query_index rebuild --entity <module:entity>` reindexes existing rows with a live progress bar.
   - All orgs/tenants: `mercato query_index rebuild --entity example:todo --global`
   - Scoped: `mercato query_index rebuild --entity example:todo --org <orgId> --tenant <tenantId>`
@@ -70,21 +76,22 @@ Backfill
 - Scheduling via events remains available: `mercato query_index reindex [...]` and `mercato query_index purge [...]` enqueue background jobs when you don’t need immediate writes. API callers can pass `partitionCount`, `partitionIndex`, and `batchSize` to mirror the CLI behaviour; omitting `partitionIndex` emits one event per partition automatically.
 - Bulk imports: build and insert index payloads alongside your ETL transaction with the `buildIndexDocument` helper (`packages/core/src/modules/query_index/lib/document.ts`) so large seeders can skip the post-import reindex sweep. The CRM stress-test seeder now follows this pattern.
 
-Performance tips
-- Start with `gin(doc jsonb_path_ops)`.
+## Performance tips
+- `gin(doc jsonb_path_ops)` is a reasonable starting point for containment/path queries, but no migration creates it — you have to add it yourself and measure. It does not help `->>` extraction used by `cf:*` equality, range, and sort predicates.
 - Add expression indexes for hot JSON paths (filters/sorts) before promoting to typed columns:
   - Example: `create index on entity_indexes (((doc->>'cf:priority')::int));`
 - Consider typed columns only for extreme hotspots.
 
-Limitations and notes
+## Limitations and notes
 - The index row appears after create/update events or backfill. Queries still work via fallback when the index is missing.
 - Cross-module relations remain by foreign key id only; no cross-module joins.
 - When the hybrid engine falls back because of partial index coverage it emits a warning and, by default, schedules an asynchronous reindex for the affected entity/tenant scope. Toggle this with `SCHEDULE_AUTO_REINDEX` (defaults to `true`) if you prefer to manage reindex jobs manually. For smaller datasets (≤10k customers) keep this flag enabled together with `OPTIMIZE_INDEX_COVERAGE_STATS=false` so coverage updates remain instant.
-- `OPTIMIZE_INDEX_COVERAGE_STATS=true` enables cached coverage snapshots. Leave it `false` to recalculate counts on every read, which is ideal for fast feedback during development or on small installations.
-- Keep the indexed path even when gaps are detected by setting `FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES=true` (enabled by default). When active, list responses include an `x-om-partial-index` response header (with `entity`, `baseCount`, `indexedCount`, and `scope`) so the admin UI can surface a banner prompting the user to reindex via `/backend/query-indexes`.
+- `OPTIMIZE_INDEX_COVERAGE_STATS` (code default `false`) controls what happens when a coverage snapshot is stale or missing. With `false` the snapshot is recomputed **inline on the request thread**, which keeps counts instant on small installations but means concurrent list queries can herd on the recompute when the TTL expires. With `true` the engine schedules an asynchronous `query_index.coverage.refresh` and serves the stale snapshot (or none, if there is no row yet). Snapshot freshness is governed by `QUERY_INDEX_COVERAGE_CACHE_MS` (default 5 minutes).
+- `FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES` keeps the indexed path even when a coverage gap is detected. **Its code default is `false`** — the shipped `.env.example` files set it to `true`, so a deployment that does not copy that file gets the fallback behaviour instead. Either way, list responses carry an `x-om-partial-index` response header (with `entity`, `baseCount`, `indexedCount`, and `scope`) so the admin UI can surface a banner prompting the user to reindex via `/backend/query-indexes`.
+  - Before turning it on, be sure the gap is small: forcing the index means rows that are not indexed are absent from filtered results and from the total count, with no error. Reindex first, force second.
 - Coverage statistics are tracked per tenant to avoid cross-organization leakage. Admin views surface the tenant snapshot directly and never blend organization-level scopes.
 
-Coverage refresh triggers
+## Coverage refresh triggers
 - Every login fires `query_index.coverage.warmup`, which sweeps stale entity types and schedules a `coverage.refresh` for each. It is a proactive nice-to-have on top of the query engine's own lazy, on-demand refresh (triggered on read when a coverage snapshot is missing or past its TTL) — coverage self-heals even with the warmup disabled.
 - The warmup sweep only re-checks entity types whose persisted coverage snapshot (`entity_index_coverage.refreshed_at`) is actually stale, so a process restart does not repeat the full sweep for scopes a prior warmup, a lazy refresh, or an incremental CRUD delta already kept fresh. Before dispatching any refresh it also batch-primes the shared `information_schema.columns` cache for every table involved, avoiding a query-per-table cache stampede when many refreshes are dispatched concurrently.
 - Tune the sweep with `QUERY_INDEX_WARMUP_ENABLED`, `QUERY_INDEX_WARMUP_THROTTLE_MS`, `QUERY_INDEX_WARMUP_CONCURRENCY`, and `QUERY_INDEX_WARMUP_STAGGER_MS` — see [System status variables](https://docs.openmercato.com/docs/framework/operations/system-status#query_index_warmup_enabled). All default to the prior always-on, unstaggered behaviour when unset.
@@ -92,14 +99,15 @@ Coverage refresh triggers
 
 ## Debugging SQL output
 
-- Standard debug logs honour `LOG_VERBOSITY=debug` (or a development `NODE_ENV`) and describe which path the hybrid engine picks.
-- To additionally print the SQL emitted for the count and data queries, set `QUERY_ENGINE_DEBUG_SQL=true`. The flag is disabled by default to keep development logs readable.
+- The hybrid engine's debug lines — including the ones describing which path it picked — require **both** debug verbosity (`OM_QUERY_INDEX_DEBUG=true`, or `LOG_VERBOSITY`/`LOG_LEVEL` set to `debug`/`trace`/`silly`) **and** `QUERY_ENGINE_DEBUG_SQL=true`. Verbosity alone prints nothing from this engine.
+- `QUERY_ENGINE_DEBUG_SQL=true` also prints the SQL emitted for the count and data queries. It is disabled by default to keep development logs readable.
+- For path selection without SQL noise, set `OM_PROFILE` instead: the `[qe:profile]` node reports `result: ok | fallback | custom_entity | error` plus the fallback `reason`.
 - To inspect the tokens generated for search, set `OM_SEARCH_DEBUG=true`. It logs field names, token **hashes**, and per-record counts during indexing — never the raw token text, document values, or decrypted PII — so the index shape can be debugged without disclosing data. Query behaviour is unchanged.
 
-Related files
+## Related files
 - `packages/core/src/modules/query_index/data/entities.ts`
 - `packages/core/src/modules/query_index/lib/indexer.ts`
 - `packages/core/src/modules/query_index/lib/engine.ts`
 - `packages/core/src/modules/query_index/di.ts`
-- `packages/core/src/modules/query_index/migrations/Migration20251001120000.ts`
-- `packages/core/src/modules/query_index/migrations/Migration20251001123000.ts`
+- `packages/core/src/modules/query_index/lib/coverage.ts`
+- `packages/core/src/modules/query_index/migrations/` — `Migration20251030150038.ts` creates `entity_indexes`; `Migration20260518162054_query_index.ts` adds `organization_id_coalesced` and the uniqueness key

--- a/apps/docs/docs/framework/modules/routes-and-pages.mdx
+++ b/apps/docs/docs/framework/modules/routes-and-pages.mdx
@@ -103,20 +103,28 @@ API routes are located in `src/modules/<module>/api/<path>/route.ts` and are aut
 ```typescript
 // packages/my-module/src/modules/my_module/api/todos/route.ts
 import { NextResponse } from 'next/server'
-import { createRequestContainer } from '@/lib/di/container'
-import { getAuthFromCookies } from '@/lib/auth/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
+import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
+
+const ENTITY_ID = 'my_module:todo' as const
 
 export async function GET(request: Request) {
   try {
+    // Fail closed: the query engine requires a tenant scope and throws without one
+    const auth = await getAuthFromCookies()
+    if (!auth?.tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
     const container = await createRequestContainer()
     const queryEngine = container.resolve<QueryEngine>('queryEngine')
-    
-    // Your logic here
-    const todos = await queryEngine.find('todo', {
-      // query options
+
+    // `query()` is the only method on the QueryEngine interface
+    const todos = await queryEngine.query(ENTITY_ID, {
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId ?? undefined,
     })
-    
-    return NextResponse.json({ items: todos, total: todos.length })
+
+    return NextResponse.json({ items: todos.items, total: todos.total })
   } catch (error) {
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
   }
@@ -498,10 +506,12 @@ export const metadata = {
 **API Route:**
 ```typescript
 // packages/my-module/src/modules/my_module/api/todos/route.ts
-import { createRequestContainer } from '@/lib/di/container'
-import { getAuthFromCookies } from '@/lib/auth/server'
-import { E } from '@/generated/entities.ids.generated'
+import { NextResponse } from 'next/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { getAuthFromCookies } from '@open-mercato/shared/lib/auth/server'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
+
+const ENTITY_ID = 'my_module:todo' as const
 
 export const metadata = {
   GET: {
@@ -516,18 +526,23 @@ export const metadata = {
 
 export async function GET(request: Request) {
   try {
+    const auth = await getAuthFromCookies()
+    if (!auth?.tenantId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
     const container = await createRequestContainer()
     const queryEngine = container.resolve<QueryEngine>('queryEngine')
-    
+
     const url = new URL(request.url)
     const page = parseInt(url.searchParams.get('page') || '1')
     const pageSize = parseInt(url.searchParams.get('pageSize') || '50')
-    
-    const todos = await queryEngine.find('todo', {
-      pagination: { page, pageSize },
+
+    const todos = await queryEngine.query(ENTITY_ID, {
+      page: { page, pageSize },
       filters: {
         // Add filters based on query parameters
-      }
+      },
+      tenantId: auth.tenantId,
+      organizationId: auth.orgId ?? undefined,
     })
     
     return NextResponse.json({

--- a/packages/shared/src/lib/query/types.ts
+++ b/packages/shared/src/lib/query/types.ts
@@ -108,11 +108,10 @@ export type QueryOptions = {
    * and MUST fail closed when the authenticated principal lacks a resolvable tenant/org, otherwise
    * queries return cross-tenant rows.
    *
-   * When this flag is set, the hybrid query engine delegates to the basic engine, which means
-   * custom-field (`cf:*`) filters/sorts, `search_tokens` fulltext filtering, and vector-search
-   * branches are BYPASSED. Only use this on entities whose scoping does not match the standard
-   * `organization_id = X AND tenant_id = Y` shape and which do not rely on custom-field/search
-   * features.
+   * When this flag is set, the hybrid query engine delegates to the basic engine. The basic engine
+   * still applies `cf:*` filters/sorts and `search_tokens` fulltext filtering, but the JSONB index
+   * read path and the vector-search branch are BYPASSED. Only use this on entities whose scoping
+   * does not match the standard `organization_id = X AND tenant_id = Y` shape.
    */
   omitAutomaticTenantOrgScope?: boolean
   // Soft-delete behavior: when false (default), rows with non-null deleted_at


### PR DESCRIPTION
## Summary

The query-layer documentation describes a design that was never built, and gets the
partial-index fallback default backwards. Both cost real debugging time: the fabricated
page sends you looking for CLI commands and module flags that do not exist, and the wrong
default inverts your mental model of what happens when index coverage is incomplete.

Every correction below was verified against the source in this PR's tree.

## Changes

**`framework/database/hybrid-query-engine.mdx` — rewritten**

The page documented per-entity `*_index` tables, a `queryIndex: { entities: [...] }` module
metadata opt-in, a `hybridQuery: true` flag in `modules.generated.ts`, and
`mercato entities sync-index`. None of these exist:

- no `queryIndex` metadata option anywhere in the repo
- the only occurrence of `hybridQuery` was line 49 of that page, telling you to grep for it
- `entities` CLI commands are `install`, `reinstall`, `add-field`, `seed-encryption`,
  `rotate-encryption-key`, `decrypt-database` — there is no `sync-index` and no
  `install --reindex`
- there is one shared `entity_indexes` table, not one table per entity

The page (still at the same URL — it is linked from `sidebars.ts` and two other pages) now
documents what actually runs: `HybridQueryEngine` registered over `BasicQueryEngine` by
`query_index/di.ts`, the four real fallback conditions with their profiler `reason` strings,
the `wantsCf` gate on two of them, what does *not* cause a fallback (unsupported sorts are
silently dropped, unknown filter fields route to `doc ->>`), the `canOptimizeCount` rule,
and the supported operator list.

**`framework/database/query-index.mdx` — corrections**

- `gin(doc jsonb_path_ops)` was listed under "Indexes" as part of the shipped schema. No
  migration creates it. Replaced with the eleven indexes that do exist — including the six
  hand-written partial covering indexes for three `customers:*` entity types, which are the
  only entity-specific tuning present today.
- "Delete: sets `deleted_at` on logical delete" — `markDeleted()` hard-deletes the row and
  its search tokens; no writer ever populates `deleted_at`.
- Two cited migration filenames (`Migration20251001120000.ts`, `Migration20251001123000.ts`)
  do not exist. Replaced with the real ones.
- The debugging section said standard verbosity describes which path the engine picks. The
  engine's `debug()` requires **both** verbosity and `QUERY_ENGINE_DEBUG_SQL=true`;
  verbosity alone prints nothing. Added `OM_PROFILE` as the quieter alternative.
- Section labels were bare paragraph lines, so nothing on the page was linkable. Promoted to
  `##` headings.

**`FORCE_QUERY_INDEX_ON_PARTIAL_INDEXES` default**

Documented as "enabled by default". The code default is `false`
(`query_index/lib/engine.ts`, and `configs/lib/system-status.ts` agrees). The
`.env.example` files set it to `true`, so a deployment that does not copy them gets the
opposite behaviour from what the docs promise. Now states the code default, notes the
env-file discrepancy, and spells out the trade-off: with a real coverage gap, forcing the
index means unindexed rows silently vanish from filtered results *and* from the total count.
Also documents that `OPTIMIZE_INDEX_COVERAGE_STATS=false` recomputes coverage inline on the
request thread.

**Nonexistent API in code samples**

`queryEngine.list()` (`admin-ui/data-grids.mdx`) and `queryEngine.find()`
(`modules/routes-and-pages.mdx`, twice) do not exist — `QueryEngine` has exactly one method,
`query(entity, opts)`. Fixed alongside the option names (`select` → `fields`,
`pagination` → `page`), the result-shape usage (one sample did `total: todos.length` on a
`QueryResult`), the unresolvable `@/lib/di/container` / `@/lib/auth/server` /
`@/generated/entities.ids.generated` import paths, and a missing `NextResponse` import. The
samples now fail closed on a missing tenant, since the engine throws
`QueryEngine: tenantId is required`.

**`packages/shared/src/lib/query/types.ts` — one JSDoc fix**

The `omitAutomaticTenantOrgScope` doc comment claimed that delegating to the basic engine
bypasses `cf:*` filters/sorts and `search_tokens` fulltext. It does not — `BasicQueryEngine`
implements both; only the JSONB index read path and the vector-search branch are bypassed.
This comment was the source of the same error in the docs, so correcting the docs without it
would leave the trap in place.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (documentation corrections, no behavior change)

## Testing

- `yarn build` in `apps/docs` — compiles, no new broken links or anchors. (One pre-existing
  broken anchor remains on `/installation/wsl2`; untouched here.)
- `yarn workspace @open-mercato/shared build` — passes (the `types.ts` change is comment-only).
- Every factual claim in the rewritten pages was re-checked against `packages/` source by a
  separate verification pass, which caught and corrected six inaccuracies in my own first
  draft before this commit.

No runtime behavior changes.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `apps/docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] N/A — tests: documentation and one comment; no behavior to cover.
- [x] N/A — integration tests: no API or UI surface changed.
- [x] N/A — spec: see above.
- [ ] Priority set — I only have `read` permission on this repo and cannot apply labels. Suggested: `priority-low`, `risk-low`, `skip-qa`, `documentation`.
- [ ] Risk set — see above.
- [ ] QA routing set — see above. No UI-rendering file, no database or API change, no `BACKWARD_COMPATIBILITY.md` contract touched, so `skip-qa` applies.

### Design System Compliance

N/A — no UI changes.

## Follow-ups (not in this PR)

Two things surfaced while verifying, both worth their own issue rather than riding along here:

1. **Unsupported filter operators are silently ignored, and one path widens the result set.**
   `join-utils.ts` drops an unrecognised `$op` with no `else`; downstream, the OR-group
   builder in `BasicQueryEngine` has `default: return eb.val(true)` — so an unsupported
   operator compiles to `TRUE` and the filter returns every row. The hybrid engine's
   equivalents return the builder unchanged (filter dropped). Supported ops are
   `eq ne gt gte lt lte in nin like ilike exists`; anything else fails open. This PR
   documents the behavior with a warning, but it should probably throw.
2. `engine.ts` has a coverage check labelled "global scope" that passes the same scoped
   arguments twice, so the `scope: 'global'` it reports is not derived from a global count.
   Deliberately not documented here pending a maintainer's read on whether it is dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
