### PR TITLE
fix(create-app): default the agentic wizard instead of hanging without a TTY

### DIFF
--- a/.ai/runs/2026-07-27-agentic-wizard-non-tty-default.md
+++ b/.ai/runs/2026-07-27-agentic-wizard-non-tty-default.md
@@ -1,6 +1,6 @@
 # create-mercato-app — agentic wizard must survive a non-interactive shell
 
-Status: in-progress
+Status: complete
 
 ## Goal
 
@@ -63,9 +63,9 @@ precedence and are unaffected — they bypass the prompt before this point.
 
 ### Phase 1: Fix and regression test
 
-- [ ] 1.1 Guard promptSelection on a non-interactive shell
-- [ ] 1.2 Add the regression test
+- [x] 1.1 Guard promptSelection on a non-interactive shell — 27216cc97
+- [x] 1.2 Add the regression test — 27216cc97
 
 ### Phase 2: Validation
 
-- [ ] 2.1 create-app suite and typecheck
+- [x] 2.1 create-app suite and typecheck — 112 pass / 4 pre-existing fail, typecheck clean

--- a/.ai/runs/2026-07-27-agentic-wizard-non-tty-default.md
+++ b/.ai/runs/2026-07-27-agentic-wizard-non-tty-default.md
@@ -1,0 +1,71 @@
+# create-mercato-app — agentic wizard must survive a non-interactive shell
+
+Status: in-progress
+
+## Goal
+
+Make `npx create-mercato-app <name>` complete without a TTY. Today it creates the app and then
+dies on the agentic-setup prompt, so the agent tooling — the whole point of the scaffold for
+CI and agent-driven use — is never installed.
+
+## Problem
+
+With stdin/stdout not a TTY:
+
+```
+   Enter number(s) separated by comma [1]: Warning: Detected unsettled top-level await at
+   .../create-mercato-app/bin/create-mercato-app:28
+   await cliModule.main();
+```
+
+Exit code **13**. The app directory exists, but `.ai/` contains only `qa` — no `.claude/`,
+no `.ai/harness`, no `.ai/skills`.
+
+Root cause: `packages/create-app/src/setup/wizard.ts` calls `ask()` unconditionally.
+It has no `isTTY` check anywhere, while `src/index.ts` guards both of its own prompts that
+way — the starter preset (line 212) and git init (line 259) — and falls back to a documented
+default instead of prompting.
+
+## Scope
+
+Apply the same guard the sibling prompts already use: in a non-interactive shell, take the
+default the prompt itself advertises (`[1]`, Claude Code), print a dim one-line notice naming
+`--agents` for explicit control, and continue. `--agents` / `--skip-agentic-setup` keep
+precedence and are unaffected — they bypass the prompt before this point.
+
+## Non-goals
+
+- No change to the interactive flow, to the tool list, or to what any tool generator writes.
+- No change to `--agents` parsing or to the preset/git-init prompts.
+
+## Implementation Plan
+
+### Phase 1: Fix and regression test
+
+- Guard `promptSelection` on `process.stdin.isTTY` / `process.stdout.isTTY`.
+- Add a regression test asserting the non-TTY path resolves without invoking `ask`, and that
+  an explicit selection still wins.
+
+### Phase 2: Validation
+
+- `packages/create-app` test suite and typecheck.
+
+## Risks
+
+- Choosing the advertised `[1]` default rather than skipping means a non-interactive scaffold
+  now installs Claude Code tooling where it previously installed nothing (by crashing). That
+  matches the documented default and the preset prompt's precedent; `--agents none` remains the
+  way to opt out.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fix and regression test
+
+- [ ] 1.1 Guard promptSelection on a non-interactive shell
+- [ ] 1.2 Add the regression test
+
+### Phase 2: Validation
+
+- [ ] 2.1 create-app suite and typecheck

--- a/packages/create-app/src/setup/wizard.test.ts
+++ b/packages/create-app/src/setup/wizard.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { AGENT_TOOL_IDS, parseAgentsValue } from './wizard.js'
+import { AGENT_TOOL_IDS, parseAgentsValue, promptSelection } from './wizard.js'
+import type { AskFn } from './wizard.js'
 
 test('parseAgentsValue: single tool', () => {
   assert.deepEqual(parseAgentsValue('claude-code'), { skip: false, tools: ['claude-code'] })
@@ -36,4 +37,44 @@ test('parseAgentsValue: none cannot combine with a tool', () => {
 
 test('parseAgentsValue: all cannot combine with a tool', () => {
   assert.throws(() => parseAgentsValue('all,codex'), /cannot be combined with individual agents/)
+})
+
+async function withTty(stdin: boolean, stdout: boolean, run: () => Promise<void>): Promise<void> {
+  const stdinDescriptor = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
+  const stdoutDescriptor = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  const log = console.log
+  try {
+    Object.defineProperty(process.stdin, 'isTTY', { value: stdin, configurable: true })
+    Object.defineProperty(process.stdout, 'isTTY', { value: stdout, configurable: true })
+    console.log = () => {}
+    await run()
+  } finally {
+    console.log = log
+    if (stdinDescriptor) Object.defineProperty(process.stdin, 'isTTY', stdinDescriptor)
+    else delete (process.stdin as { isTTY?: boolean }).isTTY
+    if (stdoutDescriptor) Object.defineProperty(process.stdout, 'isTTY', stdoutDescriptor)
+    else delete (process.stdout as { isTTY?: boolean }).isTTY
+  }
+}
+
+test('promptSelection: a non-interactive shell takes the advertised default without prompting', async () => {
+  await withTty(false, false, async () => {
+    const refuse: AskFn = () => Promise.reject(new Error('prompted in a non-interactive shell'))
+    assert.deepEqual(await promptSelection(refuse), ['claude-code'])
+  })
+})
+
+test('promptSelection: a piped stdout alone is enough to skip the prompt', async () => {
+  await withTty(true, false, async () => {
+    const refuse: AskFn = () => Promise.reject(new Error('prompted while stdout was piped'))
+    assert.deepEqual(await promptSelection(refuse), ['claude-code'])
+  })
+})
+
+test('promptSelection: an interactive shell still honors the answer', async () => {
+  await withTty(true, true, async () => {
+    assert.deepEqual(await promptSelection(() => Promise.resolve('2')), ['codex'])
+    assert.deepEqual(await promptSelection(() => Promise.resolve('')), ['claude-code'])
+    assert.deepEqual(await promptSelection(() => Promise.resolve('5')), ['skip'])
+  })
 })

--- a/packages/create-app/src/setup/wizard.ts
+++ b/packages/create-app/src/setup/wizard.ts
@@ -28,6 +28,9 @@ const TOOLS = [
 
 const SELECTABLE_TOOLS = TOOLS.filter((t) => t.id !== 'multiple' && t.id !== 'skip')
 
+/** The selection the prompt advertises as its default (`[1]`), used when no TTY can answer it. */
+const DEFAULT_TOOL_ID = TOOLS[0].id
+
 /** Concrete agent tool ids accepted by the `--agents` CLI flag. */
 export const AGENT_TOOL_IDS: readonly string[] = SELECTABLE_TOOLS.map((t) => t.id)
 
@@ -78,7 +81,12 @@ export function parseAgentsValue(raw: string): ParsedAgentsArg {
   return { skip: false, tools: [...new Set(toolTokens)] }
 }
 
-async function promptSelection(ask: AskFn): Promise<string[]> {
+/**
+ * Resolve the agent-tool selection interactively. Without a TTY there is nothing
+ * to answer the prompt, so this takes the default the prompt itself advertises
+ * rather than awaiting an answer that can never arrive.
+ */
+export async function promptSelection(ask: AskFn): Promise<string[]> {
   console.log('')
   console.log('🤖  Agentic workflow setup')
   console.log('')
@@ -88,6 +96,13 @@ async function promptSelection(ask: AskFn): Promise<string[]> {
     console.log(`   ${tool.key}. ${tool.label}`)
   }
   console.log('')
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    console.log(`   Non-interactive shell; using the default (${DEFAULT_TOOL_ID}).`)
+    console.log('   Pass --agents <list|all|none> to choose explicitly.')
+    console.log('')
+    return [DEFAULT_TOOL_ID]
+  }
 
   const answer = (await ask('   Enter number(s) separated by comma [1]: ')).trim() || '1'
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-07-27-agentic-wizard-non-tty-default.md
Status: complete

## 🎯 Goal

- Make `npx create-mercato-app <name>` complete without a TTY. Today it creates the app and then dies on the agentic-setup prompt, so the agent tooling is never installed — which is the one thing a CI job or a coding agent scaffolding an app actually needs.

Found while testing the standalone harness in #4529 on macOS; reported there. It reproduces on `develop`, so it is not from that PR.

## The bug

```
$ npx create-mercato-app@0.6.7-canary.317.1.106b9d993b my-app   # no TTY
...
   Enter number(s) separated by comma [1]: Warning: Detected unsettled top-level await at
   .../create-mercato-app/bin/create-mercato-app:28
       await cliModule.main();
$ echo $?
13
$ ls my-app/.ai
qa
```

The app directory exists but the run died before any agent tooling landed — no `.claude/`, no `.ai/harness`, no `.ai/skills`.

Root cause: `src/setup/wizard.ts` calls `ask()` unconditionally and has no `isTTY` check anywhere, while `src/index.ts` guards both of its own prompts that way — the starter preset (line 212) and git init (line 259) — falling back to a documented default rather than awaiting an answer that cannot arrive.

## What Changed

- `src/setup/wizard.ts` — `promptSelection` now returns the default the prompt itself advertises (`[1]`, Claude Code) when `process.stdin.isTTY` or `process.stdout.isTTY` is false, prints a two-line dim notice naming `--agents <list|all|none>` for explicit control, and skips the prompt. `DEFAULT_TOOL_ID` is derived from `TOOLS[0]` so it cannot drift from the `[1]` the menu prints. `promptSelection` is now exported so the guard is directly testable.
- `src/setup/wizard.test.ts` — three regression tests: a fully non-interactive shell resolves to the default without ever calling `ask` (the `ask` under test rejects, so a regression fails loudly rather than hanging); a piped stdout alone is enough; and an interactive shell still honors `2`, empty (default) and `5`.

`--agents` and `--skip-agentic-setup` are unaffected — they bypass the prompt before this point, which the second and third tests pin.

## ⚠️ Behavior decision for a maintainer

`packages/create-app/AGENTS.md` says to ask before changing agentic setup generation, so calling this out explicitly rather than burying it: **a non-interactive scaffold now installs Claude Code tooling where it previously installed nothing (by crashing).**

I chose the advertised `[1]` default because it matches what the prompt prints and mirrors how the sibling preset prompt already resolves without a TTY. The alternative is to default to `skip`. Happy to flip it if you prefer the conservative default — the change is one constant.

## 🧪 Tests

- `packages/create-app` suite: **112 pass / 4 fail / 0 skipped**, where the 4 are **pre-existing** — a `git stash` of this change on the same checkout gives 113 tests, 109 pass, the same 4 failures (`build emits the customers fact-sheet…`, `build emits a fact-sheet for every allowlisted D5 module`, `build no longer emits legacy core.<module>.md redirect stubs`, `published CLI bin executes the dist entrypoint`). They need built package output this environment does not have.
- `packages/create-app` typecheck: clean.
- Not run: `yarn test:create-app` / `yarn test:create-app:integration` (the Verdaccio publish-and-scaffold flows). The fix is covered by the unit regression above; the end-to-end reproduction I have is the canary transcript quoted at the top, not a local Verdaccio run. Flagging rather than claiming it.

## 💥 Breaking Changes

- None to any documented flag or to the interactive flow. The only behavior change is the one called out above: a non-interactive scaffold now succeeds with the default selection instead of exiting 13.

## 🏷️ Labels

My account cannot apply labels (no triage permission). Requesting: `bug`, `skip-qa`, `priority-medium`, `risk-low`, and the `review` pipeline state. Rationale: a crash on a documented invocation path, fixed in one function with regression tests in the same PR; no UI-rendering file, no database or API surface change, no `BACKWARD_COMPATIBILITY.md` contract touched.

## 📋 Progress

See the Progress section in the tracking plan.
