### PR TITLE
fix(docs): restore Cmd+K search indexing at the site root

### DIFF
--- a/apps/docs/__tests__/search-index.test.mjs
+++ b/apps/docs/__tests__/search-index.test.mjs
@@ -6,7 +6,14 @@ test('production build emits a non-empty docs search index', async () => {
   const searchIndexUrl = new URL('../build/search-index.json', import.meta.url);
   const searchIndex = JSON.parse(await readFile(searchIndexUrl, 'utf8'));
 
-  assert.equal(typeof searchIndex, 'object');
-  assert.notEqual(searchIndex, null);
-  assert.ok(Object.keys(searchIndex).length > 0);
+  assert.ok(Array.isArray(searchIndex), 'search index must contain language buckets');
+  const indexedDocuments = searchIndex.flatMap((bucket) =>
+    Array.isArray(bucket?.documents) ? bucket.documents : [],
+  );
+
+  assert.ok(indexedDocuments.length > 0, 'search index must contain searchable documents');
+  assert.ok(
+    indexedDocuments.some((document) => document.u === '/introduction/use-cases'),
+    'search index must contain the introduction page',
+  );
 });

--- a/apps/docs/__tests__/search-index.test.mjs
+++ b/apps/docs/__tests__/search-index.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('production build emits a non-empty docs search index', async () => {
+  const searchIndexUrl = new URL('../build/search-index.json', import.meta.url);
+  const searchIndex = JSON.parse(await readFile(searchIndexUrl, 'utf8'));
+
+  assert.equal(typeof searchIndex, 'object');
+  assert.notEqual(searchIndex, null);
+  assert.ok(Object.keys(searchIndex).length > 0);
+});

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -29,6 +29,7 @@ const config: Config = {
         language: ['en'],
         indexDocs: true,
         indexBlog: false,
+        docsRouteBasePath: '/',
       },
     ],
     function disableModuleConcatenationPlugin() {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,8 @@
     "start": "docusaurus build && docusaurus serve",
     "build": "docusaurus build",
     "serve": "docusaurus serve",
-    "clean": "rimraf build .docusaurus"
+    "clean": "rimraf build .docusaurus",
+    "test": "yarn clean && yarn build && node --test __tests__/search-index.test.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.2",


### PR DESCRIPTION
Supersedes #4550

Credit: original implementation by @jtomaszewski. This follow-up PR carries that work forward with the requested regression coverage so it can merge without waiting on the fork branch.

## Included work

- Original root-route search configuration from #4550
- Clean production-build regression test that verifies `search-index.json` exists, parses, and is non-empty
- Docs workspace test wiring so the root Turbo test gate executes the regression

## Validation

- `yarn workspace open-mercato-docs test` — passed; generated an 8,524,470-byte search index
- `node --check apps/docs/__tests__/search-index.test.mjs` — passed
- Original head GitHub checks — all reported checks successful or skipped

The carry-forward diff was re-reviewed after autofix and has no remaining code-review findings. Manual QA remains required for the Cmd+K user path.