### PR TITLE
fix(dev): surface swallowed Next.js dev startup errors, retry cold starts

### DIFF
--- a/apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs
+++ b/apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs
@@ -2,8 +2,12 @@ import test from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  buildUnexpectedChildExitReport,
   createRuntimeNoiseFilter,
   createSplashPassthroughIgnoreMatcher,
+  formatChildExitStatus,
+  resolveChildExitCode,
+  resolveUnexpectedExitCode,
   isIgnorableDerivedKeyWarningLine,
   isIgnorableExtraCertsWarningLine,
   isIgnorableQueueLogLine,
@@ -255,4 +259,96 @@ test('createRuntimeNoiseFilter instances do not share state', () => {
 
   // filterB should not see filterA's open block
   assert.equal(filterB('error: details'), false)
+})
+
+test('buildUnexpectedChildExitReport replays the buffered tail exactly once in compact mode', () => {
+  const report = buildUnexpectedChildExitReport({
+    label: 'App runtime',
+    exitStatus: 'exit code 1',
+    bufferedFailureLines: [
+      'Another next dev server is already running.',
+      '- PID:          4242',
+    ],
+    logsVisible: false,
+  })
+
+  const banner = '❌ App runtime exited unexpectedly with exit code 1'
+  assert.equal(report.banner, banner)
+  assert.deepEqual(report.terminalLines, [
+    banner,
+    '📄 Last 2 runtime log line(s) before the exit:',
+    'Another next dev server is already running.',
+    '- PID:          4242',
+    'ℹ️ Rerun with MERCATO_DEV_OUTPUT=verbose for the full runtime output.',
+  ])
+  // The banner is printed from terminalLines, so it must appear only once there.
+  assert.equal(report.terminalLines.filter((line) => line === banner).length, 1)
+  // Splash state keeps the buffered context plus the banner.
+  assert.deepEqual(report.failureLines, [
+    'Another next dev server is already running.',
+    '- PID:          4242',
+    banner,
+  ])
+})
+
+test('buildUnexpectedChildExitReport does not replay lines the user is already streaming', () => {
+  const report = buildUnexpectedChildExitReport({
+    label: 'App runtime',
+    exitStatus: 'exit code 1',
+    bufferedFailureLines: ['⨯ TurbopackInternalError'],
+    logsVisible: true,
+  })
+
+  assert.deepEqual(report.terminalLines, ['❌ App runtime exited unexpectedly with exit code 1'])
+  // Raw logs are on screen, but the splash still needs the context.
+  assert.deepEqual(report.failureLines, [
+    '⨯ TurbopackInternalError',
+    '❌ App runtime exited unexpectedly with exit code 1',
+  ])
+})
+
+test('buildUnexpectedChildExitReport prints only the banner when nothing was buffered', () => {
+  const report = buildUnexpectedChildExitReport({
+    label: 'Generator watch (legacy sidecar)',
+    exitStatus: 'signal SIGKILL',
+    bufferedFailureLines: [],
+  })
+
+  assert.deepEqual(report.terminalLines, [
+    '❌ Generator watch (legacy sidecar) exited unexpectedly with signal SIGKILL',
+  ])
+  assert.deepEqual(report.failureLines, [
+    '❌ Generator watch (legacy sidecar) exited unexpectedly with signal SIGKILL',
+  ])
+})
+
+test('buildUnexpectedChildExitReport caps splash failure lines at the newest entries', () => {
+  const buffered = Array.from({ length: 20 }, (_, index) => `line ${index}`)
+  const report = buildUnexpectedChildExitReport({
+    label: 'App runtime',
+    exitStatus: 'exit code 1',
+    bufferedFailureLines: buffered,
+  })
+
+  assert.equal(report.failureLines.length, 10)
+  assert.equal(report.failureLines[0], 'line 11')
+  assert.equal(report.failureLines.at(-1), '❌ App runtime exited unexpectedly with exit code 1')
+  // The terminal replay is not capped by maxFailureLines.
+  assert.equal(report.terminalLines.length, buffered.length + 3)
+})
+
+test('unexpected child exits resolve a non-zero exit code', () => {
+  assert.equal(formatChildExitStatus({ code: 1 }), 'exit code 1')
+  assert.equal(formatChildExitStatus({ code: null, signal: 'SIGTERM' }), 'signal SIGTERM')
+  assert.equal(formatChildExitStatus({ code: null, signal: null }), 'an unknown status')
+
+  assert.equal(resolveChildExitCode({ code: 3 }), 3)
+  assert.equal(resolveChildExitCode({ code: null, signal: 'SIGINT' }), 130)
+  assert.equal(resolveChildExitCode({ code: null, signal: 'SIGTERM' }), 143)
+  assert.equal(resolveChildExitCode({ code: null, signal: null }, 7), 7)
+
+  // A runtime that exits cleanly but unexpectedly must still fail the wrapper.
+  assert.equal(resolveUnexpectedExitCode({ code: 0 }), 1)
+  assert.equal(resolveUnexpectedExitCode({ code: 1 }), 1)
+  assert.equal(resolveUnexpectedExitCode({ code: null, signal: 'SIGTERM' }), 143)
 })

--- a/apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs
+++ b/apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict'
 
 import {
   buildUnexpectedChildExitReport,
+  createRuntimeFailureLatch,
   createRuntimeNoiseFilter,
+  isRuntimeRestartMarker,
   createSplashPassthroughIgnoreMatcher,
   formatChildExitStatus,
   resolveChildExitCode,
@@ -335,6 +337,69 @@ test('buildUnexpectedChildExitReport caps splash failure lines at the newest ent
   assert.equal(report.failureLines.at(-1), '❌ App runtime exited unexpectedly with exit code 1')
   // The terminal replay is not capped by maxFailureLines.
   assert.equal(report.terminalLines.length, buffered.length + 3)
+})
+
+test('isRuntimeRestartMarker recognises the restart announcements the CLI prints', () => {
+  assert.equal(
+    isRuntimeRestartMarker('[server] Next.js dev server exited before becoming ready (exit code 1). Retrying once...'),
+    true,
+  )
+  assert.equal(
+    isRuntimeRestartMarker('[server] Detected corrupted Turbopack dev cache. Clearing .mercato/next/dev and restarting Next.js once...'),
+    true,
+  )
+  assert.equal(isRuntimeRestartMarker('Another next dev server is already running.'), false)
+  assert.equal(isRuntimeRestartMarker('[server] Ready in 1ms'), false)
+  assert.equal(isRuntimeRestartMarker(undefined), false)
+})
+
+test('createRuntimeFailureLatch swallows output until the runtime announces a restart', () => {
+  const latch = createRuntimeFailureLatch()
+
+  assert.equal(latch.isLatched(), false)
+  // A line that arrives before any failure is classified normally.
+  assert.equal(latch.releaseOn('✓ Ready in 1ms'), false)
+
+  latch.latch()
+  assert.equal(latch.isLatched(), true)
+  // Ordinary output stays swallowed while the reporter is in raw passthrough.
+  assert.equal(latch.releaseOn('- PID:          4242'), false)
+  assert.equal(latch.isLatched(), true)
+
+  // The cold-start retry marker hands classification back, so the restart and
+  // ready lines that follow can reset the splash and start route warmup.
+  assert.equal(
+    latch.releaseOn('[server] Next.js dev server exited before becoming ready (exit code 1). Retrying once...'),
+    true,
+  )
+  assert.equal(latch.isLatched(), false)
+})
+
+test('createRuntimeFailureLatch releases on the Turbopack cache recovery marker', () => {
+  const latch = createRuntimeFailureLatch()
+  latch.latch()
+
+  assert.equal(
+    latch.releaseOn('[server] Detected corrupted Turbopack dev cache. Clearing .mercato/next/dev and restarting Next.js once...'),
+    true,
+  )
+  assert.equal(latch.isLatched(), false)
+})
+
+test('createRuntimeFailureLatch re-arms after a release and keeps instances independent', () => {
+  const latch = createRuntimeFailureLatch()
+  latch.latch()
+  latch.releaseOn('[server] Next.js dev server exited before becoming ready (exit code 1). Retrying once...')
+
+  // A second failure after the restart must latch again.
+  latch.latch()
+  assert.equal(latch.isLatched(), true)
+  assert.equal(latch.releaseOn('⨯ TurbopackInternalError'), false)
+
+  const other = createRuntimeFailureLatch()
+  assert.equal(other.isLatched(), false)
+  // A released latch reports no release for a marker it never latched on.
+  assert.equal(other.releaseOn('[server] Detected corrupted Turbopack dev cache. Clearing .mercato/next/dev and restarting Next.js once...'), false)
 })
 
 test('unexpected child exits resolve a non-zero exit code', () => {

--- a/apps/mercato/scripts/dev-runtime-log-policy.mjs
+++ b/apps/mercato/scripts/dev-runtime-log-policy.mjs
@@ -234,3 +234,38 @@ export function buildUnexpectedChildExitReport({
     failureLines: [...buffered, banner].slice(-maxFailureLines),
   }
 }
+
+// `mercato server dev` announces an in-flight restart on stdout before it respawns
+// Next.js. These are the markers it prints; the compact reporter keys on them to
+// leave its failure state, because the runtime it just declared failed is coming back.
+const RUNTIME_RESTART_MARKERS = [
+  '[server] Next.js dev server exited before becoming ready',
+  '[server] Detected corrupted Turbopack dev cache.',
+]
+
+export function isRuntimeRestartMarker(line) {
+  if (typeof line !== 'string') return false
+  return RUNTIME_RESTART_MARKERS.some((marker) => line.startsWith(marker))
+}
+
+// The compact reporter switches to raw passthrough on the first failure-looking
+// line and stops classifying everything after it. A runtime that self-heals — a
+// retried cold start, a Turbopack cache reset — would then stay reported as failed
+// forever: the restart and ready lines never reach `classifyServerLine`, so warmup
+// never starts and the splash never leaves the error state. The latch therefore
+// releases on a restart marker and re-arms on the next failure.
+export function createRuntimeFailureLatch() {
+  let latched = false
+
+  return {
+    isLatched: () => latched,
+    latch: () => {
+      latched = true
+    },
+    releaseOn: (line) => {
+      if (!latched || !isRuntimeRestartMarker(line)) return false
+      latched = false
+      return true
+    },
+  }
+}

--- a/apps/mercato/scripts/dev-runtime-log-policy.mjs
+++ b/apps/mercato/scripts/dev-runtime-log-policy.mjs
@@ -173,3 +173,64 @@ export function createRuntimeNoiseFilter() {
     return isStatelessRuntimeNoiseLine(normalized)
   }
 }
+
+export function formatChildExitStatus(result) {
+  if (typeof result?.code === 'number') {
+    return `exit code ${result.code}`
+  }
+  if (result?.signal) {
+    return `signal ${result.signal}`
+  }
+  return 'an unknown status'
+}
+
+export function resolveChildExitCode(result, fallback = 1) {
+  if (typeof result?.code === 'number') {
+    return result.code
+  }
+  if (result?.signal === 'SIGINT') {
+    return 130
+  }
+  if (result?.signal === 'SIGTERM') {
+    return 143
+  }
+  return fallback
+}
+
+export function resolveUnexpectedExitCode(result) {
+  const exitCode = resolveChildExitCode(result, 1)
+  return exitCode === 0 ? 1 : exitCode
+}
+
+// Compact mode classifies unmatched child output as `ignore`, so the error that
+// actually killed the runtime never reaches the terminal. Replay the buffered
+// tail alongside the exit banner — without it a startup crash reports only its
+// exit code. The banner is returned separately because callers print it once and
+// buffer it without echoing it a second time.
+export function buildUnexpectedChildExitReport({
+  label,
+  exitStatus,
+  bufferedFailureLines = [],
+  logsVisible = false,
+  maxFailureLines = 10,
+} = {}) {
+  const banner = `❌ ${label ?? 'Child process'} exited unexpectedly with ${exitStatus ?? 'an unknown status'}`
+  const buffered = Array.isArray(bufferedFailureLines) ? bufferedFailureLines : []
+  // Raw logs are already streaming to the terminal, so replaying them would
+  // duplicate every line the user can see.
+  const replay = logsVisible ? [] : buffered
+  const terminalLines = replay.length > 0
+    ? [
+        banner,
+        `📄 Last ${replay.length} runtime log line(s) before the exit:`,
+        ...replay,
+        'ℹ️ Rerun with MERCATO_DEV_OUTPUT=verbose for the full runtime output.',
+      ]
+    : [banner]
+
+  return {
+    banner,
+    terminalLines,
+    failureLines: [...buffered, banner].slice(-maxFailureLines),
+  }
+}

--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -141,6 +141,7 @@ let rawModeEnabled = false
 let lastRenderedStatus = null
 const rawLogBuffer = []
 const maxBufferedLogLines = 2000
+const failureLogTailLines = 20
 const RESET = '\u001B[0m'
 const BRIGHT_CYAN = '\u001B[96m'
 const CYAN_BORDER = '\u001B[46m\u001B[30m'
@@ -599,6 +600,10 @@ function looksLikeFailure(line) {
     || /\bfailed\b/i.test(line)
     || /\bexception\b/i.test(line)
     || /Unable to acquire lock/i.test(line)
+    || /Another next dev server is already running/i.test(line)
+    || /TurbopackInternalError/i.test(line)
+    || /\bpanicked\b/i.test(line)
+    || /EADDRINUSE/i.test(line)
 }
 
 function spawnMercato(args) {
@@ -674,12 +679,23 @@ function resolveUnexpectedExitCode(result) {
 
 function reportUnexpectedChildExit(result) {
   const message = `❌ ${result?.label ?? 'Child process'} exited unexpectedly with ${formatChildExitStatus(result)}`
+  // Compact mode classifies most child output as `ignore`, so the error that
+  // actually killed the runtime never reaches the terminal. Replay the buffered
+  // tail here — without it a startup crash reports only its exit code.
+  const precedingLines = collectRuntimeFailureLines(failureLogTailLines)
   console.error(message)
-  rememberRawLog(message)
+  if (!logsVisible && precedingLines.length > 0) {
+    console.error(`📄 Last ${precedingLines.length} runtime log line(s) before the exit:`)
+    for (const line of precedingLines) {
+      console.error(line)
+    }
+    console.error('ℹ️ Rerun with MERCATO_DEV_OUTPUT=verbose for the full runtime output.')
+  }
+  bufferRawLog(message)
   publishRuntimeFailure(message, {
     progressCurrent: splashState.progressCurrent >= runtimeProgressCurrent ? splashState.progressCurrent : runtimeProgressCurrent,
     progressLabel: splashState.progressLabel || startupProgress.label,
-    failureLines: [...collectRuntimeFailureLines(), message].slice(-10),
+    failureLines: [...precedingLines, message].slice(-10),
   })
 }
 
@@ -1346,7 +1362,7 @@ function resolveRawLogFileStream() {
   return rawLogFileStream
 }
 
-function rememberRawLog(line) {
+function bufferRawLog(line) {
   rawLogBuffer.push(line)
   if (rawLogBuffer.length > maxBufferedLogLines) {
     rawLogBuffer.shift()
@@ -1356,6 +1372,10 @@ function rememberRawLog(line) {
   if (fileStream && !rawLogFileFailed) {
     fileStream.write(`${line}\n`)
   }
+}
+
+function rememberRawLog(line) {
+  bufferRawLog(line)
 
   if (logsVisible) {
     process.stdout.write(`${line}\n`)
@@ -1811,6 +1831,21 @@ function classifyServerLine(line) {
       splashDetail: `Reason: ${reason}`,
       ready: false,
       activity: `App runtime restart: ${reason}`,
+      progressCurrent: runtimeProgressCurrent,
+      progressLabel: 'Restarting app runtime',
+    }
+  }
+
+  if (line.startsWith('[server] Next.js dev server exited before becoming ready')) {
+    const reason = 'a failed cold start'
+    resetWarmupForRuntimeRestart(reason)
+    return {
+      type: 'status',
+      message: `🔄 Restarting Next.js dev server: ${reason}`,
+      splashPhase: 'App runtime is restarting',
+      splashDetail: `Reason: ${reason}`,
+      ready: false,
+      activity: `Next.js restart: ${reason}`,
       progressCurrent: runtimeProgressCurrent,
       progressLabel: 'Restarting app runtime',
     }

--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -3,8 +3,12 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import spawn from 'cross-spawn'
 import {
+  buildUnexpectedChildExitReport,
   createRuntimeNoiseFilter,
+  formatChildExitStatus,
   isStatelessRuntimeNoiseLine,
+  resolveChildExitCode,
+  resolveUnexpectedExitCode,
 } from './dev-runtime-log-policy.mjs'
 import { getProcessTreeMemorySample } from './dev-memory-monitor.mjs'
 
@@ -649,53 +653,22 @@ function isGracefulShutdownResult(result) {
   return shuttingDown && (isExpectedShutdownSignal(result?.signal) || result?.code === 0)
 }
 
-function resolveChildExitCode(result, fallback = 1) {
-  if (typeof result?.code === 'number') {
-    return result.code
-  }
-  if (result?.signal === 'SIGINT') {
-    return 130
-  }
-  if (result?.signal === 'SIGTERM') {
-    return 143
-  }
-  return fallback
-}
-
-function formatChildExitStatus(result) {
-  if (typeof result?.code === 'number') {
-    return `exit code ${result.code}`
-  }
-  if (result?.signal) {
-    return `signal ${result.signal}`
-  }
-  return 'an unknown status'
-}
-
-function resolveUnexpectedExitCode(result) {
-  const exitCode = resolveChildExitCode(result, 1)
-  return exitCode === 0 ? 1 : exitCode
-}
-
 function reportUnexpectedChildExit(result) {
-  const message = `❌ ${result?.label ?? 'Child process'} exited unexpectedly with ${formatChildExitStatus(result)}`
-  // Compact mode classifies most child output as `ignore`, so the error that
-  // actually killed the runtime never reaches the terminal. Replay the buffered
-  // tail here — without it a startup crash reports only its exit code.
-  const precedingLines = collectRuntimeFailureLines(failureLogTailLines)
-  console.error(message)
-  if (!logsVisible && precedingLines.length > 0) {
-    console.error(`📄 Last ${precedingLines.length} runtime log line(s) before the exit:`)
-    for (const line of precedingLines) {
-      console.error(line)
-    }
-    console.error('ℹ️ Rerun with MERCATO_DEV_OUTPUT=verbose for the full runtime output.')
+  const report = buildUnexpectedChildExitReport({
+    label: result?.label,
+    exitStatus: formatChildExitStatus(result),
+    bufferedFailureLines: collectRuntimeFailureLines(failureLogTailLines),
+    logsVisible,
+  })
+  for (const line of report.terminalLines) {
+    console.error(line)
   }
-  bufferRawLog(message)
-  publishRuntimeFailure(message, {
+  // The banner was just printed, so buffer it without echoing it a second time.
+  bufferRawLog(report.banner)
+  publishRuntimeFailure(report.banner, {
     progressCurrent: splashState.progressCurrent >= runtimeProgressCurrent ? splashState.progressCurrent : runtimeProgressCurrent,
     progressLabel: splashState.progressLabel || startupProgress.label,
-    failureLines: [...precedingLines, message].slice(-10),
+    failureLines: report.failureLines,
   })
 }
 

--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import spawn from 'cross-spawn'
 import {
   buildUnexpectedChildExitReport,
+  createRuntimeFailureLatch,
   createRuntimeNoiseFilter,
   formatChildExitStatus,
   isStatelessRuntimeNoiseLine,
@@ -1518,7 +1519,8 @@ async function runInitialGenerate() {
 }
 
 function createFilteredReporter(label, classifyLine) {
-  let passthrough = false
+  const failureLatch = createRuntimeFailureLatch()
+  let autoRevealedLogs = false
   const ignoreLine = createRuntimeNoiseFilter()
 
   return (line) => {
@@ -1532,8 +1534,13 @@ function createFilteredReporter(label, classifyLine) {
     }
     captureBackgroundServiceLine(plain)
 
-    if (passthrough) {
-      return
+    if (failureLatch.isLatched()) {
+      if (!failureLatch.releaseOn(plain)) return
+      if (autoRevealedLogs) {
+        autoRevealedLogs = false
+        hideBufferedLogs()
+      }
+      lastRenderedStatus = null
     }
 
     if (ignoreLine(plain, { startupReady: splashState.ready })) {
@@ -1598,8 +1605,9 @@ function createFilteredReporter(label, classifyLine) {
       progressCurrent: splashState.progressCurrent >= runtimeProgressCurrent ? splashState.progressCurrent : runtimeProgressCurrent,
       progressLabel: splashState.progressLabel || startupProgress.label,
     })
-    passthrough = true
+    failureLatch.latch()
     if (interactiveLogToggle) {
+      autoRevealedLogs = !logsVisible
       showBufferedLogs(`❌ ${label} emitted raw output`)
       return
     }

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -70,7 +70,7 @@ yarn generate              # Run all generators
 The structural invalidation does two things:
 
 1. Deletes cache keys matching `nav:*` plus the admin/portal navigation CRUD cache shapes across all stored tenant scopes, so navigation/sidebar caches are rebuilt next render.
-2. Touches every `*.generated.ts` and `*.generated.checksum` file in the current app's `.mercato/generated/` directory by rewriting them with identical bytes. This advances mtime without changing content, which forces Turbopack's filesystem watcher to invalidate the import graph and recompile leaf files that imported a barrel. Without this, Turbopack can keep serving a cached compile error against a since-fixed module file until the dev server is restarted.
+2. Touches every `*.generated.ts` and `*.generated.checksum` file in the current app's `.mercato/generated/` directory via `fs.utimesSync`. This advances mtime without changing content, which forces Turbopack's filesystem watcher to invalidate the import graph and recompile leaf files that imported a barrel. Without this, Turbopack can keep serving a cached compile error against a since-fixed module file until the dev server is restarted. MUST NOT be implemented by rewriting the file with identical bytes — that truncates multi-megabyte registries that a concurrent Turbopack compile may be reading.
 
 The explicit `yarn mercato configs cache structural --all-tenants` command remains the DI-aware operator path. Use it when an app overrides the stock cache service through DI; the lightweight automatic path intentionally reads only the backend selected by the standard cache environment variables.
 

--- a/packages/cli/src/__tests__/mercato.test.ts
+++ b/packages/cli/src/__tests__/mercato.test.ts
@@ -37,7 +37,10 @@ function buildMockChildProcessModule(routeAutoExit: MockChildSpawnRouter) {
     if (autoExit) {
       queueMicrotask(() => {
         if (child.exitCode !== null || child.signalCode !== null) return
-        if (pathIncludes(spawnargs[1] ?? '', 'next/dist/bin/next') && spawnargs.includes('dev')) {
+        // A routed non-zero exit models a crash during startup, so the child must
+        // never announce readiness first — that is what the cold-start retry keys on.
+        const crashesBeforeReady = typeof autoExit.code === 'number' && autoExit.code !== 0
+        if (!crashesBeforeReady && pathIncludes(spawnargs[1] ?? '', 'next/dist/bin/next') && spawnargs.includes('dev')) {
           child.stdout.emit('data', '✓ Ready in 1ms\n')
         }
         queueMicrotask(() => {
@@ -862,6 +865,137 @@ describe('server dev managed process exits', () => {
     expect(exitCode).toBe(1)
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       '💥 Failed: [server] Queue worker (events) exited unexpectedly with exit code 0.',
+    )
+
+    consoleErrorSpy.mockRestore()
+    consoleLogSpy.mockRestore()
+  })
+
+  it('retries the Next.js dev server once when it exits before reporting ready', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+    process.env.AUTO_SPAWN_WORKERS = 'false'
+
+    jest.doMock('node:fs', () => {
+      const actual = jest.requireActual('node:fs')
+      return {
+        ...actual,
+        existsSync: jest.fn((candidate: string) =>
+          pathIncludes(candidate, 'next/dist/bin/next') || pathIncludes(candidate, '@open-mercato/cli/bin/mercato'),
+        ),
+        unlinkSync: jest.fn(),
+      }
+    })
+    jest.doMock('../lib/generators', () => ({
+      generateModulePackageSources: jest.fn().mockResolvedValue(undefined),
+    }))
+    jest.doMock('../lib/resolver', () => ({
+      resolveEnvironment: () => ({
+        appDir: '/tmp/test-app',
+        rootDir: '/tmp/test-root',
+      }),
+      createResolver: () => ({}),
+    }))
+    jest.doMock('child_process', () => {
+      const { EventEmitter } = jest.requireActual('node:events')
+      let nextSpawnCount = 0
+
+      const createChild = (autoExit?: { code: number | null; signal?: NodeJS.Signals | null; ready?: boolean }) => {
+        const child = new EventEmitter() as any
+        child.stdout = new EventEmitter()
+        child.stderr = new EventEmitter()
+        child.killed = false
+        child.exitCode = null
+        child.signalCode = null
+        child.kill = jest.fn(() => true)
+
+        if (autoExit) {
+          queueMicrotask(() => {
+            if (autoExit.ready) child.stdout.emit('data', '✓ Ready in 1ms\n')
+            queueMicrotask(() => {
+              child.exitCode = autoExit.code
+              child.signalCode = autoExit.signal ?? null
+              child.emit('exit', child.exitCode, child.signalCode)
+            })
+          })
+        }
+
+        return child
+      }
+
+      return {
+        spawn: jest.fn((_command: string, args: string[]) => {
+          if (pathIncludes(args[0] ?? '', 'next/dist/bin/next')) {
+            nextSpawnCount += 1
+            return nextSpawnCount === 1
+              ? createChild({ code: 1 })
+              : createChild({ code: null, signal: 'SIGTERM', ready: true })
+          }
+          return createChild()
+        }),
+      }
+    })
+
+    const mercato = await import('../mercato')
+    const exitCode = await mercato.run(['node', 'mercato', 'server', 'dev'])
+    const { spawn } = await import('child_process')
+    const nextSpawns = (spawn as jest.Mock).mock.calls.filter((call) =>
+      pathIncludes(call[1]?.[0] ?? '', 'next/dist/bin/next'),
+    )
+
+    expect(exitCode).toBe(0)
+    expect(nextSpawns).toHaveLength(2)
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '[server] Next.js dev server exited before becoming ready (exit code 1). Retrying once...',
+    )
+    expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
+    consoleLogSpy.mockRestore()
+  })
+
+  it('reports the failure when the retried Next.js dev server also exits before reporting ready', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+    process.env.AUTO_SPAWN_WORKERS = 'false'
+
+    jest.doMock('node:fs', () => {
+      const actual = jest.requireActual('node:fs')
+      return {
+        ...actual,
+        existsSync: jest.fn((candidate: string) =>
+          pathIncludes(candidate, 'next/dist/bin/next') || pathIncludes(candidate, '@open-mercato/cli/bin/mercato'),
+        ),
+        unlinkSync: jest.fn(),
+      }
+    })
+    jest.doMock('../lib/generators', () => ({
+      generateModulePackageSources: jest.fn().mockResolvedValue(undefined),
+    }))
+    jest.doMock('../lib/resolver', () => ({
+      resolveEnvironment: () => ({
+        appDir: '/tmp/test-app',
+        rootDir: '/tmp/test-root',
+      }),
+      createResolver: () => ({}),
+    }))
+    jest.doMock('child_process', () =>
+      buildMockChildProcessModule((args) =>
+        pathIncludes(args[0] ?? '', 'next/dist/bin/next') ? { code: 1 } : undefined,
+      ),
+    )
+
+    const mercato = await import('../mercato')
+    const exitCode = await mercato.run(['node', 'mercato', 'server', 'dev'])
+    const { spawn } = await import('child_process')
+    const nextSpawns = (spawn as jest.Mock).mock.calls.filter((call) =>
+      pathIncludes(call[1]?.[0] ?? '', 'next/dist/bin/next'),
+    )
+
+    expect(exitCode).toBe(1)
+    expect(nextSpawns).toHaveLength(2)
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '💥 Failed: [server] Next.js dev server exited unexpectedly with exit code 1.',
     )
 
     consoleErrorSpy.mockRestore()

--- a/packages/cli/src/__tests__/mercato.test.ts
+++ b/packages/cli/src/__tests__/mercato.test.ts
@@ -1002,6 +1002,194 @@ describe('server dev managed process exits', () => {
     consoleLogSpy.mockRestore()
   })
 
+  it.each([
+    ['Failed to restore task data (corrupted database or bug)'],
+    ['Unable to open static sorted file'],
+    ['TurbopackInternalError'],
+  ])('clears the Turbopack dev cache and restarts once on the lone signature %s', async (signature) => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+    process.env.AUTO_SPAWN_WORKERS = 'false'
+    const rmSync = jest.fn()
+
+    jest.doMock('node:fs', () => {
+      const actual = jest.requireActual('node:fs')
+      return {
+        ...actual,
+        existsSync: jest.fn((candidate: string) =>
+          pathIncludes(candidate, 'next/dist/bin/next') || pathIncludes(candidate, '@open-mercato/cli/bin/mercato'),
+        ),
+        unlinkSync: jest.fn(),
+        rmSync,
+      }
+    })
+    jest.doMock('../lib/generators', () => ({
+      generateModulePackageSources: jest.fn().mockResolvedValue(undefined),
+    }))
+    jest.doMock('../lib/resolver', () => ({
+      resolveEnvironment: () => ({
+        appDir: '/tmp/test-app',
+        rootDir: '/tmp/test-root',
+      }),
+      createResolver: () => ({}),
+    }))
+    jest.doMock('child_process', () => {
+      const { EventEmitter } = jest.requireActual('node:events')
+      let nextSpawnCount = 0
+
+      const createChild = (options?: { output?: string; code?: number | null; signal?: NodeJS.Signals | null; ready?: boolean }) => {
+        const child = new EventEmitter() as any
+        child.stdout = new EventEmitter()
+        child.stderr = new EventEmitter()
+        child.killed = false
+        child.exitCode = null
+        child.signalCode = null
+        child.kill = jest.fn(() => true)
+
+        if (options) {
+          queueMicrotask(() => {
+            if (options.output) child.stderr.emit('data', options.output)
+            if (options.ready) child.stdout.emit('data', '✓ Ready in 1ms\n')
+            queueMicrotask(() => {
+              child.exitCode = options.code ?? null
+              child.signalCode = options.signal ?? null
+              child.emit('exit', child.exitCode, child.signalCode)
+            })
+          })
+        }
+
+        return child
+      }
+
+      return {
+        spawn: jest.fn((_command: string, args: string[]) => {
+          if (pathIncludes(args[0] ?? '', 'next/dist/bin/next')) {
+            nextSpawnCount += 1
+            return nextSpawnCount === 1
+              ? createChild({ output: `⨯ ${signature}\n`, code: 1 })
+              : createChild({ code: null, signal: 'SIGTERM', ready: true })
+          }
+          return createChild()
+        }),
+      }
+    })
+
+    const mercato = await import('../mercato')
+    const exitCode = await mercato.run(['node', 'mercato', 'server', 'dev'])
+    const { spawn } = await import('child_process')
+    const nextSpawns = (spawn as jest.Mock).mock.calls.filter((call) =>
+      pathIncludes(call[1]?.[0] ?? '', 'next/dist/bin/next'),
+    )
+    const cacheRemovals = rmSync.mock.calls.filter(([target]) =>
+      pathIncludes(String(target), '.mercato/next/dev'),
+    )
+
+    expect(exitCode).toBe(0)
+    expect(nextSpawns).toHaveLength(2)
+    expect(cacheRemovals).toHaveLength(1)
+    expect(cacheRemovals[0][1]).toEqual({ recursive: true, force: true })
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '[server] Detected corrupted Turbopack dev cache. Clearing .mercato/next/dev and restarting Next.js once...',
+    )
+    // Corruption recovery owns this exit; the generic cold-start retry must not also fire.
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('exited before becoming ready'),
+    )
+
+    consoleErrorSpy.mockRestore()
+    consoleLogSpy.mockRestore()
+  })
+
+  it('takes the plain cold-start retry without purging the cache when no corruption signature is present', async () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
+    process.env.AUTO_SPAWN_WORKERS = 'false'
+    const rmSync = jest.fn()
+
+    jest.doMock('node:fs', () => {
+      const actual = jest.requireActual('node:fs')
+      return {
+        ...actual,
+        existsSync: jest.fn((candidate: string) =>
+          pathIncludes(candidate, 'next/dist/bin/next') || pathIncludes(candidate, '@open-mercato/cli/bin/mercato'),
+        ),
+        unlinkSync: jest.fn(),
+        rmSync,
+      }
+    })
+    jest.doMock('../lib/generators', () => ({
+      generateModulePackageSources: jest.fn().mockResolvedValue(undefined),
+    }))
+    jest.doMock('../lib/resolver', () => ({
+      resolveEnvironment: () => ({
+        appDir: '/tmp/test-app',
+        rootDir: '/tmp/test-root',
+      }),
+      createResolver: () => ({}),
+    }))
+    jest.doMock('child_process', () => {
+      const { EventEmitter } = jest.requireActual('node:events')
+      let nextSpawnCount = 0
+
+      const createChild = (options?: { output?: string; code?: number | null; signal?: NodeJS.Signals | null; ready?: boolean }) => {
+        const child = new EventEmitter() as any
+        child.stdout = new EventEmitter()
+        child.stderr = new EventEmitter()
+        child.killed = false
+        child.exitCode = null
+        child.signalCode = null
+        child.kill = jest.fn(() => true)
+
+        if (options) {
+          queueMicrotask(() => {
+            if (options.output) child.stderr.emit('data', options.output)
+            if (options.ready) child.stdout.emit('data', '✓ Ready in 1ms\n')
+            queueMicrotask(() => {
+              child.exitCode = options.code ?? null
+              child.signalCode = options.signal ?? null
+              child.emit('exit', child.exitCode, child.signalCode)
+            })
+          })
+        }
+
+        return child
+      }
+
+      return {
+        spawn: jest.fn((_command: string, args: string[]) => {
+          if (pathIncludes(args[0] ?? '', 'next/dist/bin/next')) {
+            nextSpawnCount += 1
+            return nextSpawnCount === 1
+              ? createChild({ output: 'Another next dev server is already running.\n', code: 1 })
+              : createChild({ code: null, signal: 'SIGTERM', ready: true })
+          }
+          return createChild()
+        }),
+      }
+    })
+
+    const mercato = await import('../mercato')
+    const exitCode = await mercato.run(['node', 'mercato', 'server', 'dev'])
+    const { spawn } = await import('child_process')
+    const nextSpawns = (spawn as jest.Mock).mock.calls.filter((call) =>
+      pathIncludes(call[1]?.[0] ?? '', 'next/dist/bin/next'),
+    )
+    const cacheRemovals = rmSync.mock.calls.filter(([target]) =>
+      pathIncludes(String(target), '.mercato/next/dev'),
+    )
+
+    expect(exitCode).toBe(0)
+    expect(nextSpawns).toHaveLength(2)
+    // A lock conflict is not cache corruption — the dev cache must survive.
+    expect(cacheRemovals).toHaveLength(0)
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '[server] Next.js dev server exited before becoming ready (exit code 1). Retrying once...',
+    )
+
+    consoleErrorSpy.mockRestore()
+    consoleLogSpy.mockRestore()
+  })
+
   it('starts the lazy worker supervisor instead of `queue worker --all` when OM_AUTO_SPAWN_WORKERS_LAZY=true', async () => {
     const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
     const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()

--- a/packages/cli/src/lib/__tests__/post-generate-invalidation.test.ts
+++ b/packages/cli/src/lib/__tests__/post-generate-invalidation.test.ts
@@ -47,6 +47,30 @@ describe('runPostGenerateStructuralInvalidation', () => {
     }
   })
 
+  it('advances mtime without reopening generated artifacts for writing', async () => {
+    const appDir = fs.mkdtempSync(path.join(os.tmpdir(), 'post-generate-invalidation-mtime-'))
+    try {
+      const generatedDir = path.join(appDir, '.mercato', 'generated')
+      fs.mkdirSync(generatedDir, { recursive: true })
+      const generatedTs = path.join(generatedDir, 'modules.generated.ts')
+      fs.writeFileSync(generatedTs, 'export const modules = []\n')
+      const staleTime = new Date(Date.now() - 60_000)
+      fs.utimesSync(generatedTs, staleTime, staleTime)
+      const before = fs.statSync(generatedTs)
+
+      await runPostGenerateStructuralInvalidation(appDir)
+
+      const after = fs.statSync(generatedTs)
+      expect(after.mtimeMs).toBeGreaterThan(before.mtimeMs)
+      expect(after.size).toBe(before.size)
+      // ctime advances on a metadata-only touch; a rewrite would also bump the
+      // inode's write generation, so assert the content survived byte for byte.
+      expect(fs.readFileSync(generatedTs, 'utf8')).toBe('export const modules = []\n')
+    } finally {
+      fs.rmSync(appDir, { recursive: true, force: true })
+    }
+  })
+
   it('still refreshes generated artifacts when cache maintenance fails', async () => {
     const appDir = fs.mkdtempSync(path.join(os.tmpdir(), 'post-generate-invalidation-failure-'))
     const error = new Error('cache unavailable')

--- a/packages/cli/src/lib/post-generate-invalidation.ts
+++ b/packages/cli/src/lib/post-generate-invalidation.ts
@@ -21,13 +21,16 @@ function touchGeneratedFiles(appDir: string): string[] {
   if (!fs.existsSync(generatedDir) || !fs.statSync(generatedDir).isDirectory()) return []
 
   const touched: string[] = []
+  // `utimes` advances mtime without opening the file for writing. Rewriting the
+  // identical bytes would truncate multi-megabyte registries first, and Turbopack
+  // reads them concurrently during a dev compile — it can observe the empty window.
+  const touchedAt = new Date()
   const entries = fs.readdirSync(generatedDir, { withFileTypes: true })
     .sort((left, right) => left.name.localeCompare(right.name))
   for (const entry of entries) {
     if (!entry.isFile() || !TOUCHABLE_GENERATED_FILE_PATTERN.test(entry.name)) continue
     const filePath = path.join(generatedDir, entry.name)
-    const contents = fs.readFileSync(filePath)
-    fs.writeFileSync(filePath, contents)
+    fs.utimesSync(filePath, touchedAt, touchedAt)
     touched.push(filePath)
   }
   return touched

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -100,6 +100,11 @@ const TURBOPACK_CORRUPTION_PATTERNS = [
   'TurbopackInternalError',
 ]
 
+// Next.js gives up on `.mercato/next/dev/lock` after 1000ms, so a dev server
+// that lost a startup race against a still-shutting-down sibling needs a
+// slightly longer pause before the retry can win the lock.
+const DEV_COLD_START_RETRY_DELAY_MS = 1500
+
 const BUILTIN_CLI_MODULE_IDS = new Set(['queue', 'generate', 'deploy', 'db', 'server', 'test'])
 
 function collectNestedErrors(error: unknown, seen = new Set<unknown>()): ErrorWithCause[] {
@@ -264,7 +269,7 @@ async function ensureDatabaseExists(dbUrl: string): Promise<boolean> {
 }
 
 function isTurbopackCacheCorruption(output: string): boolean {
-  return TURBOPACK_CORRUPTION_PATTERNS.every((pattern) => output.includes(pattern))
+  return TURBOPACK_CORRUPTION_PATTERNS.some((pattern) => output.includes(pattern))
 }
 
 function removeTurbopackDevCache(appDir: string): void {
@@ -1960,6 +1965,7 @@ export async function run(argv = process.argv) {
 
           let processes: ChildProcess[] = []
           let didRetryCorruptedTurbopackCache = false
+          let didRetryFailedColdStart = false
           let stopping = false
           let devRestartPromiseResolve: ((result: DevServerRestartResult) => void) | null = null
           let activeLazySupervisor: ReturnType<typeof startLazyWorkerSupervisor> | null = null
@@ -2121,6 +2127,30 @@ export async function run(argv = process.argv) {
                   const restarted = startNextDev(runtimeEnv)
                   restarted.readyPromise.then(readyResolve)
                   return resolve(await restarted.exitPromise)
+                }
+                // A dev server that dies before it ever reported "ready in" lost a
+                // startup race rather than crashing on user code: a sibling instance
+                // still holding the dev lock, a port that is about to free up, or a
+                // bundler init hiccup on a cold cache. Those all clear on their own,
+                // which is why a second `yarn dev` usually succeeds — retry once here
+                // so the first run succeeds too.
+                if (
+                  !didRetryFailedColdStart
+                  && !reportedReady
+                  && !stopping
+                  && typeof code === 'number'
+                  && code !== 0
+                ) {
+                  didRetryFailedColdStart = true
+                  lastRestartReason = 'a failed cold start'
+                  writeDevSplashRuntimeRestarting(lastRestartReason)
+                  console.log(`[server] Next.js dev server exited before becoming ready (exit code ${code}). Retrying once...`)
+                  await new Promise((wake) => setTimeout(wake, DEV_COLD_START_RETRY_DELAY_MS))
+                  if (!stopping) {
+                    const restarted = startNextDev(runtimeEnv)
+                    restarted.readyPromise.then(readyResolve)
+                    return resolve(await restarted.exitPromise)
+                  }
                 }
                 resolve({
                   label: 'Next.js dev server',

--- a/packages/create-app/src/lib/template-dev-log-files.test.ts
+++ b/packages/create-app/src/lib/template-dev-log-files.test.ts
@@ -63,6 +63,38 @@ test('standalone template dev wrapper defaults background services to lazy mode'
   assert.match(source, /env: buildAppDevEnv\(/)
 })
 
+test('standalone template dev runtime replays buffered output when a child exits unexpectedly', () => {
+  const runtimeScriptPath = new URL('../../template/scripts/dev-runtime.mjs', import.meta.url)
+  const source = fs.readFileSync(runtimeScriptPath, 'utf8')
+
+  // Compact mode drops unclassified child output, so a crash would otherwise
+  // report nothing but an exit code.
+  assert.match(source, /const precedingLines = collectRuntimeFailureLines\(failureLogTailLines\)/)
+  assert.match(source, /runtime log line\(s\) before the exit/)
+  assert.match(source, /MERCATO_DEV_OUTPUT=verbose/)
+  // The exit banner is printed directly, so buffering it must not echo it again.
+  assert.match(source, /bufferRawLog\(message\)/)
+  assert.doesNotMatch(source, /console\.error\(message\)\n {2}rememberRawLog\(message\)/)
+})
+
+test('standalone template dev runtime surfaces Next.js startup failures and cold-start retries', () => {
+  const runtimeScriptPath = new URL('../../template/scripts/dev-runtime.mjs', import.meta.url)
+  const source = fs.readFileSync(runtimeScriptPath, 'utf8')
+
+  assert.match(source, /Another next dev server is already running/)
+  assert.match(source, /TurbopackInternalError/)
+  assert.match(source, /EADDRINUSE/)
+  assert.match(source, /\[server\] Next\.js dev server exited before becoming ready/)
+})
+
+test('standalone template setup forwards the verbose flag to the dev orchestrator', () => {
+  const setupScriptPath = new URL('../../template/scripts/setup.mjs', import.meta.url)
+  const source = fs.readFileSync(setupScriptPath, 'utf8')
+
+  assert.match(source, /const verbose = argv\.includes\('--verbose'\)/)
+  assert.match(source, /\.\.\.\(verbose \? \['--verbose'\] : \[\]\)/)
+})
+
 test('standalone template dev wrapper owns shutdown notice for managed runtime', () => {
   const devScriptPath = new URL('../../template/scripts/dev.mjs', import.meta.url)
   const runtimeScriptPath = new URL('../../template/scripts/dev-runtime.mjs', import.meta.url)

--- a/packages/create-app/src/lib/template-dev-log-files.test.ts
+++ b/packages/create-app/src/lib/template-dev-log-files.test.ts
@@ -112,6 +112,35 @@ test('standalone template dev runtime wires the exit report into the child exit 
   assert.match(source, /reportUnexpectedChildExit\(result\)/)
 })
 
+test('standalone template dev runtime releases raw passthrough when the runtime restarts', async () => {
+  const moduleUrl = new URL('../../template/scripts/dev-runtime-log-policy.mjs', import.meta.url)
+  const { createRuntimeFailureLatch } = await import(moduleUrl.href)
+
+  const latch = createRuntimeFailureLatch()
+  latch.latch()
+  // Without a release the retried dev server would stay reported as failed:
+  // classification stops, so warmup never starts and the splash never turns ready.
+  assert.equal(latch.releaseOn('- PID:          4242'), false)
+  assert.equal(
+    latch.releaseOn('[server] Next.js dev server exited before becoming ready (exit code 1). Retrying once...'),
+    true,
+  )
+  assert.equal(latch.isLatched(), false)
+})
+
+test('standalone template dev runtime wires the failure latch into the compact reporter', () => {
+  const runtimeScriptPath = new URL('../../template/scripts/dev-runtime.mjs', import.meta.url)
+  const source = fs.readFileSync(runtimeScriptPath, 'utf8')
+
+  // The latch behavior lives in dev-runtime-log-policy.mjs; this guards the wiring
+  // so the reporter cannot go back to swallowing every line after a failure.
+  assert.match(source, /createRuntimeFailureLatch,/)
+  assert.match(source, /const failureLatch = createRuntimeFailureLatch\(\)/)
+  assert.match(source, /if \(!failureLatch\.releaseOn\(plain\)\) return/)
+  assert.match(source, /failureLatch\.latch\(\)/)
+  assert.doesNotMatch(source, /passthrough = true/)
+})
+
 test('standalone template dev runtime surfaces Next.js startup failures and cold-start retries', () => {
   const runtimeScriptPath = new URL('../../template/scripts/dev-runtime.mjs', import.meta.url)
   const source = fs.readFileSync(runtimeScriptPath, 'utf8')

--- a/packages/create-app/src/lib/template-dev-log-files.test.ts
+++ b/packages/create-app/src/lib/template-dev-log-files.test.ts
@@ -63,18 +63,53 @@ test('standalone template dev wrapper defaults background services to lazy mode'
   assert.match(source, /env: buildAppDevEnv\(/)
 })
 
-test('standalone template dev runtime replays buffered output when a child exits unexpectedly', () => {
-  const runtimeScriptPath = new URL('../../template/scripts/dev-runtime.mjs', import.meta.url)
-  const source = fs.readFileSync(runtimeScriptPath, 'utf8')
+test('standalone template dev runtime replays buffered output when a child exits unexpectedly', async () => {
+  const moduleUrl = new URL('../../template/scripts/dev-runtime-log-policy.mjs', import.meta.url)
+  const { buildUnexpectedChildExitReport } = await import(moduleUrl.href)
 
   // Compact mode drops unclassified child output, so a crash would otherwise
   // report nothing but an exit code.
-  assert.match(source, /const precedingLines = collectRuntimeFailureLines\(failureLogTailLines\)/)
-  assert.match(source, /runtime log line\(s\) before the exit/)
-  assert.match(source, /MERCATO_DEV_OUTPUT=verbose/)
-  // The exit banner is printed directly, so buffering it must not echo it again.
-  assert.match(source, /bufferRawLog\(message\)/)
-  assert.doesNotMatch(source, /console\.error\(message\)\n {2}rememberRawLog\(message\)/)
+  const compact = buildUnexpectedChildExitReport({
+    label: 'App runtime',
+    exitStatus: 'exit code 1',
+    bufferedFailureLines: ['Another next dev server is already running.'],
+    logsVisible: false,
+  })
+
+  const banner = '❌ App runtime exited unexpectedly with exit code 1'
+  assert.deepEqual(compact.terminalLines, [
+    banner,
+    '📄 Last 1 runtime log line(s) before the exit:',
+    'Another next dev server is already running.',
+    'ℹ️ Rerun with MERCATO_DEV_OUTPUT=verbose for the full runtime output.',
+  ])
+  assert.equal(compact.terminalLines.filter((line: string) => line === banner).length, 1)
+  assert.deepEqual(compact.failureLines, ['Another next dev server is already running.', banner])
+
+  // With raw logs already streaming, replaying them would duplicate the output.
+  const streaming = buildUnexpectedChildExitReport({
+    label: 'App runtime',
+    exitStatus: 'exit code 1',
+    bufferedFailureLines: ['Another next dev server is already running.'],
+    logsVisible: true,
+  })
+  assert.deepEqual(streaming.terminalLines, [banner])
+  assert.deepEqual(streaming.failureLines, ['Another next dev server is already running.', banner])
+})
+
+test('standalone template dev runtime wires the exit report into the child exit path', () => {
+  const runtimeScriptPath = new URL('../../template/scripts/dev-runtime.mjs', import.meta.url)
+  const source = fs.readFileSync(runtimeScriptPath, 'utf8')
+
+  // The behavior lives in dev-runtime-log-policy.mjs; this guards the wiring so
+  // the replay cannot silently stop running on an unexpected child exit.
+  assert.match(source, /buildUnexpectedChildExitReport,/)
+  assert.match(source, /const report = buildUnexpectedChildExitReport\(\{/)
+  assert.match(source, /for \(const line of report\.terminalLines\) \{\n {4}console\.error\(line\)/)
+  assert.match(source, /failureLines: report\.failureLines,/)
+  // The banner is printed from terminalLines, so buffering must not echo it again.
+  assert.match(source, /bufferRawLog\(report\.banner\)/)
+  assert.match(source, /reportUnexpectedChildExit\(result\)/)
 })
 
 test('standalone template dev runtime surfaces Next.js startup failures and cold-start retries', () => {
@@ -85,6 +120,17 @@ test('standalone template dev runtime surfaces Next.js startup failures and cold
   assert.match(source, /TurbopackInternalError/)
   assert.match(source, /EADDRINUSE/)
   assert.match(source, /\[server\] Next\.js dev server exited before becoming ready/)
+})
+
+test('standalone template dev runtime log policy mirrors the monorepo source', async () => {
+  const templateUrl = new URL('../../template/scripts/dev-runtime-log-policy.mjs', import.meta.url)
+  const monorepoUrl = new URL('../../../../apps/mercato/scripts/dev-runtime-log-policy.mjs', import.meta.url)
+
+  assert.equal(
+    fs.readFileSync(templateUrl, 'utf8'),
+    fs.readFileSync(monorepoUrl, 'utf8'),
+    'template/scripts/dev-runtime-log-policy.mjs must stay byte-identical to apps/mercato/scripts/dev-runtime-log-policy.mjs',
+  )
 })
 
 test('standalone template setup forwards the verbose flag to the dev orchestrator', () => {

--- a/packages/create-app/template/scripts/dev-runtime-log-policy.mjs
+++ b/packages/create-app/template/scripts/dev-runtime-log-policy.mjs
@@ -234,3 +234,38 @@ export function buildUnexpectedChildExitReport({
     failureLines: [...buffered, banner].slice(-maxFailureLines),
   }
 }
+
+// `mercato server dev` announces an in-flight restart on stdout before it respawns
+// Next.js. These are the markers it prints; the compact reporter keys on them to
+// leave its failure state, because the runtime it just declared failed is coming back.
+const RUNTIME_RESTART_MARKERS = [
+  '[server] Next.js dev server exited before becoming ready',
+  '[server] Detected corrupted Turbopack dev cache.',
+]
+
+export function isRuntimeRestartMarker(line) {
+  if (typeof line !== 'string') return false
+  return RUNTIME_RESTART_MARKERS.some((marker) => line.startsWith(marker))
+}
+
+// The compact reporter switches to raw passthrough on the first failure-looking
+// line and stops classifying everything after it. A runtime that self-heals — a
+// retried cold start, a Turbopack cache reset — would then stay reported as failed
+// forever: the restart and ready lines never reach `classifyServerLine`, so warmup
+// never starts and the splash never leaves the error state. The latch therefore
+// releases on a restart marker and re-arms on the next failure.
+export function createRuntimeFailureLatch() {
+  let latched = false
+
+  return {
+    isLatched: () => latched,
+    latch: () => {
+      latched = true
+    },
+    releaseOn: (line) => {
+      if (!latched || !isRuntimeRestartMarker(line)) return false
+      latched = false
+      return true
+    },
+  }
+}

--- a/packages/create-app/template/scripts/dev-runtime-log-policy.mjs
+++ b/packages/create-app/template/scripts/dev-runtime-log-policy.mjs
@@ -173,3 +173,64 @@ export function createRuntimeNoiseFilter() {
     return isStatelessRuntimeNoiseLine(normalized)
   }
 }
+
+export function formatChildExitStatus(result) {
+  if (typeof result?.code === 'number') {
+    return `exit code ${result.code}`
+  }
+  if (result?.signal) {
+    return `signal ${result.signal}`
+  }
+  return 'an unknown status'
+}
+
+export function resolveChildExitCode(result, fallback = 1) {
+  if (typeof result?.code === 'number') {
+    return result.code
+  }
+  if (result?.signal === 'SIGINT') {
+    return 130
+  }
+  if (result?.signal === 'SIGTERM') {
+    return 143
+  }
+  return fallback
+}
+
+export function resolveUnexpectedExitCode(result) {
+  const exitCode = resolveChildExitCode(result, 1)
+  return exitCode === 0 ? 1 : exitCode
+}
+
+// Compact mode classifies unmatched child output as `ignore`, so the error that
+// actually killed the runtime never reaches the terminal. Replay the buffered
+// tail alongside the exit banner — without it a startup crash reports only its
+// exit code. The banner is returned separately because callers print it once and
+// buffer it without echoing it a second time.
+export function buildUnexpectedChildExitReport({
+  label,
+  exitStatus,
+  bufferedFailureLines = [],
+  logsVisible = false,
+  maxFailureLines = 10,
+} = {}) {
+  const banner = `❌ ${label ?? 'Child process'} exited unexpectedly with ${exitStatus ?? 'an unknown status'}`
+  const buffered = Array.isArray(bufferedFailureLines) ? bufferedFailureLines : []
+  // Raw logs are already streaming to the terminal, so replaying them would
+  // duplicate every line the user can see.
+  const replay = logsVisible ? [] : buffered
+  const terminalLines = replay.length > 0
+    ? [
+        banner,
+        `📄 Last ${replay.length} runtime log line(s) before the exit:`,
+        ...replay,
+        'ℹ️ Rerun with MERCATO_DEV_OUTPUT=verbose for the full runtime output.',
+      ]
+    : [banner]
+
+  return {
+    banner,
+    terminalLines,
+    failureLines: [...buffered, banner].slice(-maxFailureLines),
+  }
+}

--- a/packages/create-app/template/scripts/dev-runtime.mjs
+++ b/packages/create-app/template/scripts/dev-runtime.mjs
@@ -119,6 +119,7 @@ let rawModeEnabled = false
 let lastRenderedStatus = null
 const rawLogBuffer = []
 const maxBufferedLogLines = 2000
+const failureLogTailLines = 20
 const RESET = '\u001B[0m'
 const BRIGHT_CYAN = '\u001B[96m'
 const CYAN_BORDER = '\u001B[46m\u001B[30m'
@@ -574,6 +575,10 @@ function looksLikeFailure(line) {
     || /\bfailed\b/i.test(line)
     || /\bexception\b/i.test(line)
     || /Unable to acquire lock/i.test(line)
+    || /Another next dev server is already running/i.test(line)
+    || /TurbopackInternalError/i.test(line)
+    || /\bpanicked\b/i.test(line)
+    || /EADDRINUSE/i.test(line)
 }
 
 function spawnMercato(args) {
@@ -649,12 +654,23 @@ function resolveUnexpectedExitCode(result) {
 
 function reportUnexpectedChildExit(result) {
   const message = `❌ ${result?.label ?? 'Child process'} exited unexpectedly with ${formatChildExitStatus(result)}`
+  // Compact mode classifies most child output as `ignore`, so the error that
+  // actually killed the runtime never reaches the terminal. Replay the buffered
+  // tail here — without it a startup crash reports only its exit code.
+  const precedingLines = collectRuntimeFailureLines(failureLogTailLines)
   console.error(message)
-  rememberRawLog(message)
+  if (!logsVisible && precedingLines.length > 0) {
+    console.error(`📄 Last ${precedingLines.length} runtime log line(s) before the exit:`)
+    for (const line of precedingLines) {
+      console.error(line)
+    }
+    console.error('ℹ️ Rerun with MERCATO_DEV_OUTPUT=verbose for the full runtime output.')
+  }
+  bufferRawLog(message)
   publishRuntimeFailure(message, {
     progressCurrent: splashState.progressCurrent >= runtimeProgressCurrent ? splashState.progressCurrent : runtimeProgressCurrent,
     progressLabel: splashState.progressLabel || startupProgress.label,
-    failureLines: [...collectRuntimeFailureLines(), message].slice(-10),
+    failureLines: [...precedingLines, message].slice(-10),
   })
 }
 
@@ -1311,11 +1327,15 @@ function shutdown(exitCode = 0) {
 process.on('SIGINT', () => shutdown(130))
 process.on('SIGTERM', () => shutdown(143))
 
-function rememberRawLog(line) {
+function bufferRawLog(line) {
   rawLogBuffer.push(line)
   if (rawLogBuffer.length > maxBufferedLogLines) {
     rawLogBuffer.shift()
   }
+}
+
+function rememberRawLog(line) {
+  bufferRawLog(line)
 
   if (logsVisible) {
     process.stdout.write(`${line}\n`)
@@ -1759,6 +1779,21 @@ function classifyServerLine(line) {
       splashDetail: `Reason: ${reason}`,
       ready: false,
       activity: `App runtime restart: ${reason}`,
+      progressCurrent: runtimeProgressCurrent,
+      progressLabel: 'Restarting app runtime',
+    }
+  }
+
+  if (line.startsWith('[server] Next.js dev server exited before becoming ready')) {
+    const reason = 'a failed cold start'
+    resetWarmupForRuntimeRestart(reason)
+    return {
+      type: 'status',
+      message: `🔄 Restarting Next.js dev server: ${reason}`,
+      splashPhase: 'App runtime is restarting',
+      splashDetail: `Reason: ${reason}`,
+      ready: false,
+      activity: `Next.js restart: ${reason}`,
       progressCurrent: runtimeProgressCurrent,
       progressLabel: 'Restarting app runtime',
     }

--- a/packages/create-app/template/scripts/dev-runtime.mjs
+++ b/packages/create-app/template/scripts/dev-runtime.mjs
@@ -3,8 +3,12 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import spawn from 'cross-spawn'
 import {
+  buildUnexpectedChildExitReport,
   createRuntimeNoiseFilter,
+  formatChildExitStatus,
   isStatelessRuntimeNoiseLine,
+  resolveChildExitCode,
+  resolveUnexpectedExitCode,
 } from './dev-runtime-log-policy.mjs'
 
 function resolveSplashHelpersImport() {
@@ -624,53 +628,22 @@ function isGracefulShutdownResult(result) {
   return shuttingDown && (isExpectedShutdownSignal(result?.signal) || result?.code === 0)
 }
 
-function resolveChildExitCode(result, fallback = 1) {
-  if (typeof result?.code === 'number') {
-    return result.code
-  }
-  if (result?.signal === 'SIGINT') {
-    return 130
-  }
-  if (result?.signal === 'SIGTERM') {
-    return 143
-  }
-  return fallback
-}
-
-function formatChildExitStatus(result) {
-  if (typeof result?.code === 'number') {
-    return `exit code ${result.code}`
-  }
-  if (result?.signal) {
-    return `signal ${result.signal}`
-  }
-  return 'an unknown status'
-}
-
-function resolveUnexpectedExitCode(result) {
-  const exitCode = resolveChildExitCode(result, 1)
-  return exitCode === 0 ? 1 : exitCode
-}
-
 function reportUnexpectedChildExit(result) {
-  const message = `❌ ${result?.label ?? 'Child process'} exited unexpectedly with ${formatChildExitStatus(result)}`
-  // Compact mode classifies most child output as `ignore`, so the error that
-  // actually killed the runtime never reaches the terminal. Replay the buffered
-  // tail here — without it a startup crash reports only its exit code.
-  const precedingLines = collectRuntimeFailureLines(failureLogTailLines)
-  console.error(message)
-  if (!logsVisible && precedingLines.length > 0) {
-    console.error(`📄 Last ${precedingLines.length} runtime log line(s) before the exit:`)
-    for (const line of precedingLines) {
-      console.error(line)
-    }
-    console.error('ℹ️ Rerun with MERCATO_DEV_OUTPUT=verbose for the full runtime output.')
+  const report = buildUnexpectedChildExitReport({
+    label: result?.label,
+    exitStatus: formatChildExitStatus(result),
+    bufferedFailureLines: collectRuntimeFailureLines(failureLogTailLines),
+    logsVisible,
+  })
+  for (const line of report.terminalLines) {
+    console.error(line)
   }
-  bufferRawLog(message)
-  publishRuntimeFailure(message, {
+  // The banner was just printed, so buffer it without echoing it a second time.
+  bufferRawLog(report.banner)
+  publishRuntimeFailure(report.banner, {
     progressCurrent: splashState.progressCurrent >= runtimeProgressCurrent ? splashState.progressCurrent : runtimeProgressCurrent,
     progressLabel: splashState.progressLabel || startupProgress.label,
-    failureLines: [...precedingLines, message].slice(-10),
+    failureLines: report.failureLines,
   })
 }
 

--- a/packages/create-app/template/scripts/dev-runtime.mjs
+++ b/packages/create-app/template/scripts/dev-runtime.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import spawn from 'cross-spawn'
 import {
   buildUnexpectedChildExitReport,
+  createRuntimeFailureLatch,
   createRuntimeNoiseFilter,
   formatChildExitStatus,
   isStatelessRuntimeNoiseLine,
@@ -1473,7 +1474,8 @@ async function runInitialGenerate() {
 }
 
 function createFilteredReporter(label, classifyLine) {
-  let passthrough = false
+  const failureLatch = createRuntimeFailureLatch()
+  let autoRevealedLogs = false
   const ignoreLine = createRuntimeNoiseFilter()
 
   return (line) => {
@@ -1483,8 +1485,13 @@ function createFilteredReporter(label, classifyLine) {
     rememberRawLog(line)
     captureBackgroundServiceLine(plain)
 
-    if (passthrough) {
-      return
+    if (failureLatch.isLatched()) {
+      if (!failureLatch.releaseOn(plain)) return
+      if (autoRevealedLogs) {
+        autoRevealedLogs = false
+        hideBufferedLogs()
+      }
+      lastRenderedStatus = null
     }
 
     if (ignoreLine(plain, { startupReady: splashState.ready })) {
@@ -1549,8 +1556,9 @@ function createFilteredReporter(label, classifyLine) {
       progressCurrent: splashState.progressCurrent >= runtimeProgressCurrent ? splashState.progressCurrent : runtimeProgressCurrent,
       progressLabel: splashState.progressLabel || startupProgress.label,
     })
-    passthrough = true
+    failureLatch.latch()
     if (interactiveLogToggle) {
+      autoRevealedLogs = !logsVisible
       showBufferedLogs(`❌ ${label} emitted raw output`)
       return
     }

--- a/packages/create-app/template/scripts/setup.mjs
+++ b/packages/create-app/template/scripts/setup.mjs
@@ -5,6 +5,7 @@ import { collectForwardedSetupFlags } from './dev-database-url.mjs'
 const argv = process.argv.slice(2)
 const reinstall = argv.includes('--reinstall')
 const classic = argv.includes('--classic')
+const verbose = argv.includes('--verbose')
 const forwardedDatabaseFlags = collectForwardedSetupFlags(argv)
 
 if (!existsSync('node_modules/cross-spawn')) {
@@ -22,6 +23,7 @@ const result = spawnSync(
     '--setup',
     ...(reinstall ? ['--reinstall'] : []),
     ...(classic ? ['--classic'] : []),
+    ...(verbose ? ['--verbose'] : []),
     ...forwardedDatabaseFlags,
   ],
   {


### PR DESCRIPTION
## Summary

A standalone `yarn setup --reinstall` could fail at the very end with `next dev` exiting 1, printing nothing but the exit code — a second run then succeeded. The missing error was the real bug: compact mode classifies unmatched child output as `ignore`, and none of Next 16's three exit-1 signatures matched `looksLikeFailure`, so the cause was buffered and silently dropped. This PR makes that output reachable, widens failure detection, and retries a `next dev` that dies before ever reporting ready. **The root cause is still unconfirmed** — it was never reproduced, so the retry mitigates the transient variants (dev-lock contention, a port mid-release, a cold-cache bundler hiccup) but would not help a state-dependent one; the diagnostics are the part that closes the loop next time it happens.

## Changes

- `dev-runtime.mjs` / `apps/mercato/scripts/dev.mjs`: replay the last 20 buffered runtime lines when a managed child exits unexpectedly, and stop double-printing the exit banner (`console.error` + `rememberRawLog` echoed it twice, and it was also double-counted in the splash `failureLines`).
- Match `Another next dev server is already running`, `TurbopackInternalError`, `panicked` and `EADDRINUSE` in `looksLikeFailure`.
- `mercato server dev`: retry `next dev` once, after 1500ms, when it exits non-zero before emitting `ready in`. One-shot, non-destructive (no cache wipe), scoped per process.
- `isTurbopackCacheCorruption`: `every` → `some`. Requiring all three patterns simultaneously made the existing one-shot self-heal effectively unreachable.
- `touchGeneratedFiles`: bump mtime with `fs.utimesSync` instead of `readFileSync` + `writeFileSync` of identical bytes, which truncated multi-megabyte registries that a concurrent Turbopack compile may be reading. `packages/cli/AGENTS.md` updated accordingly.
- Standalone `yarn setup` now forwards `--verbose` (it was silently dropped, so `yarn setup --reinstall --verbose` produced no extra output).

Both mirrored copies of the dev scripts received byte-identical edits; `yarn template:sync:fix` was deliberately not run because the pair already carries pre-existing intentional drift (monorepo-only memory tracing) that the fixer would have pushed into the template.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
n/a

## Testing

- `yarn typecheck` — clean.
- `yarn lint` — clean (12 pre-existing warnings, none in touched files).
- `yarn test` — 7963 core + 1224 CLI + 119 create-app pass. One unrelated suite (`sync_excel/api/upload`) hits a jest-worker SIGSEGV; it passes standalone and reproduces identically on a clean tree, so it is environmental and not from this change.
- `yarn workspace @open-mercato/cli build` — succeeds.
- New tests: two in `mercato.test.ts` (retry succeeds on the second attempt; a retried failure still reports), one asserting mtime advances with content byte-identical, three source guards in `template-dev-log-files.test.ts`.
- Not manually reproduced end-to-end — that needs a fresh Verdaccio scaffold plus a database.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required) — not required: dev-tooling only, no HTTP surface, no UI, no database or API change; covered by unit tests instead.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` — no `.tsx` outside tests, nothing under `packages/ui/src/` or `**/components/**`, database structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract touched, and automated tests ship for the changed behavior.

### Design System Compliance
- [x] No hardcoded status colors — n/a, no UI changes
- [x] No arbitrary text sizes — n/a, no UI changes
- [x] Empty state handled for list/data pages — n/a
- [x] Loading state handled for async pages — n/a
- [x] `aria-label` on all icon-only buttons — n/a
- [x] Uses existing DS components — n/a

## Linked issues

None.
