### PR TITLE
fix(cache): reap orphaned tag members when a Redis value key has expired

### DIFF
--- a/packages/cache/src/__tests__/redis.strategy.test.ts
+++ b/packages/cache/src/__tests__/redis.strategy.test.ts
@@ -43,6 +43,39 @@ class FakeRedis {
     return [...(this.sets.get(key) ?? [])]
   }
 
+  /**
+   * Mirrors the reap script's KEYS/ARGV contract rather than interpreting Lua —
+   * there is no Lua runtime here, and pulling one in for a single script is not
+   * worth the dependency. What this pins down is the strategy's side of the
+   * contract (key ordering, the tag/value split, member alignment, chunking)
+   * and the exists-guarded semantics. The script *body* is not covered; verify
+   * it against a real Redis when changing it.
+   */
+  async eval(_script: string, numKeys: number, ...args: (string | number)[]): Promise<number> {
+    const keys = args.slice(0, numKeys) as string[]
+    const argv = args.slice(numKeys).map(String)
+    const tagCount = Number(argv[0])
+    const tagKeys = keys.slice(0, tagCount)
+    const valueKeys = keys.slice(tagCount)
+    const members = argv.slice(1)
+
+    if (valueKeys.length !== members.length) {
+      throw new Error(`[internal] eval contract: ${valueKeys.length} value keys vs ${members.length} members`)
+    }
+
+    let removed = 0
+    for (const [index, valueKey] of valueKeys.entries()) {
+      if (this.values.has(valueKey)) continue
+      for (const tagKey of tagKeys) {
+        const set = this.sets.get(tagKey)
+        if (!set?.delete(members[index])) continue
+        removed++
+        if (set.size === 0) this.sets.delete(tagKey)
+      }
+    }
+    return removed
+  }
+
   pipeline() {
     const ops: PipelineOp[] = []
     const chain = {
@@ -152,6 +185,47 @@ describe('redis strategy tag index', () => {
     expect(deleted).toBe(1)
     expect(await currentRedis.smembers('tag:rbac:tenant:t1')).toEqual([])
     expect(await strategy.get('live')).toBeNull()
+  })
+
+  it('keeps a key indexed when a concurrent write rebuilds it mid-walk', async () => {
+    await strategy.set('nav:user-1', { v: 'old' }, { ttl: 60_000, tags: ['rbac:tenant:t1'] })
+    currentRedis.expire('cache:nav:user-1')
+
+    // deleteByTags walks members one round trip at a time, so an entry it read
+    // as missing can be rebuilt before the reap runs. Land that write in the
+    // window by hooking the GET that reports the key absent.
+    const readValue = currentRedis.get.bind(currentRedis)
+    let rebuilt = false
+    currentRedis.get = async (key: string) => {
+      const result = await readValue(key)
+      if (!rebuilt && key === 'cache:nav:user-1' && result === null) {
+        rebuilt = true
+        await strategy.set('nav:user-1', { v: 'fresh' }, { ttl: 60_000, tags: ['rbac:tenant:t1'] })
+      }
+      return result
+    }
+
+    await strategy.deleteByTags(['rbac:tenant:t1'])
+    currentRedis.get = readValue
+
+    // The rebuilt entry must stay in the index, or it silently outlives every
+    // future invalidation of this tag and serves stale data until its TTL.
+    expect(await currentRedis.smembers('tag:rbac:tenant:t1')).toEqual(['nav:user-1'])
+    expect(await strategy.deleteByTags(['rbac:tenant:t1'])).toBe(1)
+    expect(await strategy.get('nav:user-1')).toBeNull()
+  })
+
+  it('reaps orphans spanning multiple chunks', async () => {
+    const keyCount = 600 // REAP_CHUNK_SIZE is 256, so this spans three chunks.
+    for (let index = 0; index < keyCount; index++) {
+      const key = `bulk-${index}`
+      await strategy.set(key, { index }, { ttl: 60_000, tags: ['rbac:tenant:t1'] })
+      currentRedis.expire(`cache:${key}`)
+    }
+    expect((await currentRedis.smembers('tag:rbac:tenant:t1')).length).toBe(keyCount)
+
+    expect(await strategy.deleteByTags(['rbac:tenant:t1'])).toBe(0)
+    expect(await currentRedis.smembers('tag:rbac:tenant:t1')).toEqual([])
   })
 
   it('only reaps orphans from the tags it was asked to invalidate', async () => {

--- a/packages/cache/src/__tests__/redis.strategy.test.ts
+++ b/packages/cache/src/__tests__/redis.strategy.test.ts
@@ -1,0 +1,166 @@
+/** @jest-environment node */
+import type { CacheStrategy } from '../types'
+import { createRedisStrategy } from '../strategies/redis'
+
+type PipelineOp = () => void
+
+class FakeRedis {
+  values = new Map<string, string>()
+  sets = new Map<string, Set<string>>()
+
+  async ping(): Promise<string> {
+    return 'PONG'
+  }
+
+  async get(key: string): Promise<string | null> {
+    return this.values.get(key) ?? null
+  }
+
+  async set(key: string, value: string): Promise<unknown> {
+    this.values.set(key, value)
+    return 'OK'
+  }
+
+  async setex(key: string, _ttlSeconds: number, value: string): Promise<unknown> {
+    this.values.set(key, value)
+    return 'OK'
+  }
+
+  async del(key: string): Promise<unknown> {
+    return this.values.delete(key) ? 1 : 0
+  }
+
+  async exists(key: string): Promise<number> {
+    return this.values.has(key) ? 1 : 0
+  }
+
+  async keys(pattern: string): Promise<string[]> {
+    const prefix = pattern.endsWith('*') ? pattern.slice(0, -1) : pattern
+    return [...this.values.keys()].filter((key) => key.startsWith(prefix))
+  }
+
+  async smembers(key: string): Promise<string[]> {
+    return [...(this.sets.get(key) ?? [])]
+  }
+
+  pipeline() {
+    const ops: PipelineOp[] = []
+    const chain = {
+      set: (key: string, value: string) => {
+        ops.push(() => void this.values.set(key, value))
+        return chain
+      },
+      setex: (key: string, _ttlSeconds: number, value: string) => {
+        ops.push(() => void this.values.set(key, value))
+        return chain
+      },
+      sadd: (key: string, member: string) => {
+        ops.push(() => {
+          const members = this.sets.get(key) ?? new Set<string>()
+          members.add(member)
+          this.sets.set(key, members)
+        })
+        return chain
+      },
+      srem: (key: string, member: string) => {
+        ops.push(() => {
+          const members = this.sets.get(key)
+          if (!members) return
+          members.delete(member)
+          // Redis drops a set once its last member is removed.
+          if (members.size === 0) this.sets.delete(key)
+        })
+        return chain
+      },
+      del: (key: string) => {
+        ops.push(() => void this.values.delete(key))
+        return chain
+      },
+      exec: async () => {
+        for (const op of ops) op()
+        ops.length = 0
+        return []
+      },
+    }
+    return chain
+  }
+
+  async quit(): Promise<void> {}
+
+  /** Simulate a TTL firing: Redis expiry deletes the value key and nothing else. */
+  expire(cacheKey: string): void {
+    this.values.delete(cacheKey)
+  }
+}
+
+let currentRedis: FakeRedis
+
+jest.mock('ioredis', () => ({
+  __esModule: true,
+  default: class {
+    constructor() {
+      return currentRedis as unknown as object
+    }
+  },
+}))
+
+describe('redis strategy tag index', () => {
+  let strategy: CacheStrategy
+  let urlCounter = 0
+
+  beforeEach(() => {
+    currentRedis = new FakeRedis()
+    urlCounter += 1
+    // The client registry is module-global and keyed by URL; keep runs isolated.
+    strategy = createRedisStrategy(`redis://cache-test-${urlCounter}`)
+  })
+
+  afterEach(async () => {
+    await strategy.close?.()
+  })
+
+  it('reaps tag members whose value key already expired', async () => {
+    await strategy.set('nav:sidebar:abc123:pl:user-1', { groups: [] }, { ttl: 60_000, tags: ['rbac:tenant:t1'] })
+    expect(await currentRedis.smembers('tag:rbac:tenant:t1')).toEqual(['nav:sidebar:abc123:pl:user-1'])
+
+    currentRedis.expire('cache:nav:sidebar:abc123:pl:user-1')
+
+    const deleted = await strategy.deleteByTags(['rbac:tenant:t1'])
+
+    expect(deleted).toBe(0)
+    expect(await currentRedis.smembers('tag:rbac:tenant:t1')).toEqual([])
+  })
+
+  it('does not accumulate members when TTL entries rotate their key names', async () => {
+    for (const fingerprint of ['abc123', 'def456', 'ghi789']) {
+      const key = `nav:sidebar:${fingerprint}:pl:user-1`
+      await strategy.set(key, { groups: [] }, { ttl: 60_000, tags: ['rbac:tenant:t1'] })
+      currentRedis.expire(`cache:${key}`)
+      await strategy.deleteByTags(['rbac:tenant:t1'])
+    }
+
+    expect(await currentRedis.smembers('tag:rbac:tenant:t1')).toEqual([])
+  })
+
+  it('leaves live keys in the tag index alone and still reports them deleted', async () => {
+    await strategy.set('live', { value: 1 }, { ttl: 60_000, tags: ['rbac:tenant:t1'] })
+    await strategy.set('expired', { value: 2 }, { ttl: 60_000, tags: ['rbac:tenant:t1'] })
+    currentRedis.expire('cache:expired')
+
+    const deleted = await strategy.deleteByTags(['rbac:tenant:t1'])
+
+    expect(deleted).toBe(1)
+    expect(await currentRedis.smembers('tag:rbac:tenant:t1')).toEqual([])
+    expect(await strategy.get('live')).toBeNull()
+  })
+
+  it('only reaps orphans from the tags it was asked to invalidate', async () => {
+    await strategy.set('key-1', { value: 1 }, { ttl: 60_000, tags: ['tag-a', 'tag-b'] })
+    currentRedis.expire('cache:key-1')
+
+    await strategy.deleteByTags(['tag-a'])
+
+    expect(await currentRedis.smembers('tag:tag-a')).toEqual([])
+    expect(await currentRedis.smembers('tag:tag-b')).toEqual(['key-1'])
+  })
+})

--- a/packages/cache/src/__tests__/redis.strategy.test.ts
+++ b/packages/cache/src/__tests__/redis.strategy.test.ts
@@ -7,6 +7,8 @@ type PipelineOp = () => void
 class FakeRedis {
   values = new Map<string, string>()
   sets = new Map<string, Set<string>>()
+  /** Records the shape of each reap script call so tests can assert its cost. */
+  evalCalls: { numKeys: number; memberCount: number }[] = []
 
   async ping(): Promise<string> {
     return 'PONG'
@@ -47,17 +49,13 @@ class FakeRedis {
    * Mirrors the reap script's KEYS/ARGV contract rather than interpreting Lua —
    * there is no Lua runtime here, and pulling one in for a single script is not
    * worth the dependency. What this pins down is the strategy's side of the
-   * contract (key ordering, the tag/value split, member alignment, chunking)
-   * and the exists-guarded semantics. The script *body* is not covered; verify
-   * it against a real Redis when changing it.
+   * contract (key ordering, member alignment, chunking) and the exists-guarded
+   * semantics. The script *body* is not covered; verify it against a real Redis
+   * when changing it.
    */
-  async eval(_script: string, numKeys: number, ...args: (string | number)[]): Promise<number> {
-    const keys = args.slice(0, numKeys) as string[]
-    const argv = args.slice(numKeys).map(String)
-    const tagCount = Number(argv[0])
-    const tagKeys = keys.slice(0, tagCount)
-    const valueKeys = keys.slice(tagCount)
-    const members = argv.slice(1)
+  runEval(_script: string, numKeys: number, ...args: (string | number)[]): number {
+    const [tagKey, ...valueKeys] = args.slice(0, numKeys) as string[]
+    const members = args.slice(numKeys).map(String)
 
     if (valueKeys.length !== members.length) {
       throw new Error(`[internal] eval contract: ${valueKeys.length} value keys vs ${members.length} members`)
@@ -66,12 +64,10 @@ class FakeRedis {
     let removed = 0
     for (const [index, valueKey] of valueKeys.entries()) {
       if (this.values.has(valueKey)) continue
-      for (const tagKey of tagKeys) {
-        const set = this.sets.get(tagKey)
-        if (!set?.delete(members[index])) continue
-        removed++
-        if (set.size === 0) this.sets.delete(tagKey)
-      }
+      const set = this.sets.get(tagKey)
+      if (!set?.delete(members[index])) continue
+      removed++
+      if (set.size === 0) this.sets.delete(tagKey)
     }
     return removed
   }
@@ -107,6 +103,11 @@ class FakeRedis {
       },
       del: (key: string) => {
         ops.push(() => void this.values.delete(key))
+        return chain
+      },
+      eval: (script: string, numKeys: number, ...args: (string | number)[]) => {
+        this.evalCalls.push({ numKeys, memberCount: args.length - numKeys })
+        ops.push(() => void this.runEval(script, numKeys, ...args))
         return chain
       },
       exec: async () => {
@@ -226,6 +227,36 @@ describe('redis strategy tag index', () => {
 
     expect(await strategy.deleteByTags(['rbac:tenant:t1'])).toBe(0)
     expect(await currentRedis.smembers('tag:rbac:tenant:t1')).toEqual([])
+  })
+
+  it('keeps reap work linear in real memberships across disjoint tags', async () => {
+    const tagCount = 10
+    const perTag = 10
+    for (let tag = 0; tag < tagCount; tag++) {
+      for (let index = 0; index < perTag; index++) {
+        const key = `t${tag}-k${index}`
+        await strategy.set(key, { index }, { ttl: 60_000, tags: [`tag-${tag}`] })
+        currentRedis.expire(`cache:${key}`)
+      }
+    }
+
+    currentRedis.evalCalls = []
+    await strategy.deleteByTags(Array.from({ length: tagCount }, (_, tag) => `tag-${tag}`))
+
+    // Pairing every orphan with every requested tag would make this tagCount
+    // times larger — 1000 removals to clear 100 real memberships.
+    const removals = currentRedis.evalCalls.reduce((total, call) => total + call.memberCount, 0)
+    expect(removals).toBe(tagCount * perTag)
+
+    // No single atomic call may exceed the chunk bound, whatever the tag count.
+    for (const call of currentRedis.evalCalls) {
+      expect(call.memberCount).toBeLessThanOrEqual(256)
+      expect(call.numKeys).toBeLessThanOrEqual(256 + 1)
+    }
+
+    for (let tag = 0; tag < tagCount; tag++) {
+      expect(await currentRedis.smembers(`tag:tag-${tag}`)).toEqual([])
+    }
   })
 
   it('only reaps orphans from the tags it was asked to invalidate', async () => {

--- a/packages/cache/src/strategies/redis.ts
+++ b/packages/cache/src/strategies/redis.ts
@@ -21,6 +21,7 @@ type RedisClient = {
   exists(key: string): Promise<number>
   keys(pattern: string): Promise<string[]>
   smembers(key: string): Promise<string[]>
+  eval(script: string, numKeys: number, ...args: (string | number)[]): Promise<unknown>
   pipeline(): RedisPipeline
   quit(): Promise<void>
   once?(event: 'end', listener: () => void): void
@@ -30,6 +31,37 @@ type RedisConstructor = new (url?: string) => RedisClient
 type PossibleRedisModule = unknown
 
 type RequireFn = (id: string) => unknown
+
+/**
+ * Reaps orphaned tag members atomically.
+ *
+ * `KEYS` is `[...tagKeys, ...valueKeys]`, split at `ARGV[1]` (the tag count);
+ * `ARGV[2..]` are the member names aligned with the value-key half. Every key
+ * the script touches is declared in `KEYS` so the script stays valid if this
+ * ever runs against a slot-aware deployment.
+ *
+ * The `EXISTS` check and the `SREM`s run in one atomic step, which is the whole
+ * point: a member may only be dropped while its value key is genuinely absent.
+ * A concurrent `set()` either lands first (`EXISTS` is 1, so the member is left
+ * alone) or lands after (its own `sadd` re-adds the member). Either ordering
+ * leaves a live key indexed.
+ */
+const REAP_ORPHANED_TAG_MEMBERS = `
+local tagCount = tonumber(ARGV[1])
+local removed = 0
+for i = tagCount + 1, #KEYS do
+  local member = ARGV[i - tagCount + 1]
+  if redis.call('EXISTS', KEYS[i]) == 0 then
+    for t = 1, tagCount do
+      removed = removed + redis.call('SREM', KEYS[t], member)
+    end
+  end
+end
+return removed
+`
+
+/** Bounds both the script's blocking time on the server and the request size. */
+const REAP_CHUNK_SIZE = 256
 
 /**
  * Redis cache strategy with tag support
@@ -338,13 +370,19 @@ export function createRedisStrategy(redisUrl?: string, options?: { defaultTtl?: 
     // value keys rather than tag sets. Nothing else reaps them, so the sets grow
     // without bound whenever TTL'd entries also rotate their key names — and
     // every later invalidation pays a GET per orphan. Reap what we just walked.
+    //
+    // `deleteKey` reported these missing some time ago — the walk above is one
+    // round trip per member — so a concurrent request may have rebuilt any of
+    // them since. Re-check each value key atomically with the removal rather
+    // than trusting that stale read: dropping a live key from the index would
+    // silently exempt it from every future invalidation of this tag.
     if (orphans.length > 0) {
-      const pipeline = client.pipeline()
-      for (const tag of tags) {
-        const tagKey = getTagKey(tag)
-        for (const key of orphans) pipeline.srem(tagKey, key)
+      const tagKeys = tags.map(getTagKey)
+      for (let offset = 0; offset < orphans.length; offset += REAP_CHUNK_SIZE) {
+        const chunk = orphans.slice(offset, offset + REAP_CHUNK_SIZE)
+        const keys = [...tagKeys, ...chunk.map(getCacheKey)]
+        await client.eval(REAP_ORPHANED_TAG_MEMBERS, keys.length, ...keys, String(tagKeys.length), ...chunk)
       }
-      await pipeline.exec()
     }
 
     return deleted

--- a/packages/cache/src/strategies/redis.ts
+++ b/packages/cache/src/strategies/redis.ts
@@ -9,6 +9,7 @@ type RedisPipeline = {
   sadd(key: string, value: string): RedisPipeline
   srem(key: string, member: string): RedisPipeline
   del(key: string): RedisPipeline
+  eval(script: string, numKeys: number, ...args: (string | number)[]): RedisPipeline
   exec(): Promise<unknown>
 }
 
@@ -21,7 +22,6 @@ type RedisClient = {
   exists(key: string): Promise<number>
   keys(pattern: string): Promise<string[]>
   smembers(key: string): Promise<string[]>
-  eval(script: string, numKeys: number, ...args: (string | number)[]): Promise<unknown>
   pipeline(): RedisPipeline
   quit(): Promise<void>
   once?(event: 'end', listener: () => void): void
@@ -33,34 +33,34 @@ type PossibleRedisModule = unknown
 type RequireFn = (id: string) => unknown
 
 /**
- * Reaps orphaned tag members atomically.
+ * Reaps orphaned members from ONE tag set atomically.
  *
- * `KEYS` is `[...tagKeys, ...valueKeys]`, split at `ARGV[1]` (the tag count);
- * `ARGV[2..]` are the member names aligned with the value-key half. Every key
- * the script touches is declared in `KEYS` so the script stays valid if this
- * ever runs against a slot-aware deployment.
+ * `KEYS[1]` is the tag key and `KEYS[2..]` are the candidate value keys, with
+ * `ARGV[1..]` the member names aligned to them. Every key the script touches is
+ * declared in `KEYS` so it stays valid against a slot-aware deployment.
  *
- * The `EXISTS` check and the `SREM`s run in one atomic step, which is the whole
+ * The `EXISTS` check and the `SREM` run in one atomic step, which is the whole
  * point: a member may only be dropped while its value key is genuinely absent.
  * A concurrent `set()` either lands first (`EXISTS` is 1, so the member is left
  * alone) or lands after (its own `sadd` re-adds the member). Either ordering
  * leaves a live key indexed.
+ *
+ * Deliberately single-tag. Pairing every orphan with every requested tag would
+ * make the work quadratic in the tag count — and because a script blocks the
+ * server for its whole run, that lands as a stall rather than as throughput.
+ * Callers reap per tag using the membership each `smembers` actually returned.
  */
 const REAP_ORPHANED_TAG_MEMBERS = `
-local tagCount = tonumber(ARGV[1])
 local removed = 0
-for i = tagCount + 1, #KEYS do
-  local member = ARGV[i - tagCount + 1]
+for i = 2, #KEYS do
   if redis.call('EXISTS', KEYS[i]) == 0 then
-    for t = 1, tagCount do
-      removed = removed + redis.call('SREM', KEYS[t], member)
-    end
+    removed = removed + redis.call('SREM', KEYS[1], ARGV[i - 1])
   end
 end
 return removed
 `
 
-/** Bounds both the script's blocking time on the server and the request size. */
+/** Bounds a single script's blocking time on the server, and the request size. */
 const REAP_CHUNK_SIZE = 256
 
 /**
@@ -345,11 +345,15 @@ export function createRedisStrategy(redisUrl?: string, options?: { defaultTtl?: 
   const deleteByTags = async (tags: string[]): Promise<number> => {
     const client = await getRedisClient()
     const keysToDelete = new Set<string>()
+    // Keep which tag each key came from. Reaping needs it to stay linear in the
+    // memberships that actually exist rather than in tags x keys.
+    const membersByTagKey = new Map<string, string[]>()
 
     // Collect all keys that have any of the specified tags
     for (const tag of tags) {
       const tagKey = getTagKey(tag)
       const keys = await client.smembers(tagKey)
+      membersByTagKey.set(tagKey, keys)
       for (const key of keys) {
         keysToDelete.add(key)
       }
@@ -357,11 +361,11 @@ export function createRedisStrategy(redisUrl?: string, options?: { defaultTtl?: 
 
     // Delete all collected keys
     let deleted = 0
-    const orphans: string[] = []
+    const orphans = new Set<string>()
     for (const key of keysToDelete) {
       const success = await deleteKey(key)
       if (success) deleted++
-      else orphans.push(key)
+      else orphans.add(key)
     }
 
     // A key whose value has already expired leaves its name behind in every tag
@@ -376,13 +380,26 @@ export function createRedisStrategy(redisUrl?: string, options?: { defaultTtl?: 
     // them since. Re-check each value key atomically with the removal rather
     // than trusting that stale read: dropping a live key from the index would
     // silently exempt it from every future invalidation of this tag.
-    if (orphans.length > 0) {
-      const tagKeys = tags.map(getTagKey)
-      for (let offset = 0; offset < orphans.length; offset += REAP_CHUNK_SIZE) {
-        const chunk = orphans.slice(offset, offset + REAP_CHUNK_SIZE)
-        const keys = [...tagKeys, ...chunk.map(getCacheKey)]
-        await client.eval(REAP_ORPHANED_TAG_MEMBERS, keys.length, ...keys, String(tagKeys.length), ...chunk)
+    //
+    // Reap per tag, over that tag's own members, so the work stays linear in the
+    // memberships `smembers` actually returned. Each script is capped at
+    // REAP_CHUNK_SIZE members, so no single atomic call can stall the server for
+    // longer than a fixed bound however many tags were requested. The calls are
+    // pipelined into one round trip, but stay separate scripts so Redis can
+    // serve other clients between them.
+    if (orphans.size > 0) {
+      const pipeline = client.pipeline()
+      let queued = 0
+      for (const [tagKey, members] of membersByTagKey) {
+        const tagOrphans = members.filter((member) => orphans.has(member))
+        for (let offset = 0; offset < tagOrphans.length; offset += REAP_CHUNK_SIZE) {
+          const chunk = tagOrphans.slice(offset, offset + REAP_CHUNK_SIZE)
+          const keys = [tagKey, ...chunk.map(getCacheKey)]
+          pipeline.eval(REAP_ORPHANED_TAG_MEMBERS, keys.length, ...keys, ...chunk)
+          queued++
+        }
       }
+      if (queued > 0) await pipeline.exec()
     }
 
     return deleted

--- a/packages/cache/src/strategies/redis.ts
+++ b/packages/cache/src/strategies/redis.ts
@@ -325,9 +325,26 @@ export function createRedisStrategy(redisUrl?: string, options?: { defaultTtl?: 
 
     // Delete all collected keys
     let deleted = 0
+    const orphans: string[] = []
     for (const key of keysToDelete) {
       const success = await deleteKey(key)
       if (success) deleted++
+      else orphans.push(key)
+    }
+
+    // A key whose value has already expired leaves its name behind in every tag
+    // set it was added to: `set()` only prunes tags when it overwrites a live
+    // key, `deleteKey` only prunes when it finds one, and `cleanup()` scans
+    // value keys rather than tag sets. Nothing else reaps them, so the sets grow
+    // without bound whenever TTL'd entries also rotate their key names — and
+    // every later invalidation pays a GET per orphan. Reap what we just walked.
+    if (orphans.length > 0) {
+      const pipeline = client.pipeline()
+      for (const tag of tags) {
+        const tagKey = getTagKey(tag)
+        for (const key of orphans) pipeline.srem(tagKey, key)
+      }
+      await pipeline.exec()
     }
 
     return deleted


### PR DESCRIPTION
## Summary

The Redis strategy's tag index is a plain set of key **names** (`sadd(getTagKey(tag), key)`, `packages/cache/src/strategies/redis.ts:254-256`). It is pruned in exactly two places:

- `set()` srems the *old* tags of a key it is overwriting (`:216-228`)
- `deleteKey()` srems when it finds a live entry (`:288-302`)

Neither fires when a key disappears via `SETEX` expiry. `deleteByTags` (`:313-334`) calls `deleteKey`, which returns `false` on a missing key **without** sremming the orphan, and `cleanup()` (`:391`) scans value keys (`keyPrefix*`), never tag sets (`tagPrefix*`). `clear()` is the only thing in the package that touches `tagPrefix*`.

So for any TTL'd + tagged entry, the tag set only ever grows. The cost is not just Redis memory: `deleteByTags` issues a `GET` per member via `deleteKey`, so every later invalidation of that tag walks the accumulated orphans and misses on almost all of them.

Today this is bounded by key-name cardinality — `sadd` is idempotent, so a stable key name re-adds the same member. It becomes **unbounded** as soon as a TTL'd key also rotates its name, which is exactly what #4546 introduces for `nav:sidebar:*` (a per-deploy fingerprint in the key). `rbac:tenant:<T>` and `nav:entities:<T>` are tags that route writes *and* that other routes actively invalidate — `roles/acl/route.ts:254` on every role-ACL edit, `entities/api/entities.ts:202,245` on every custom-entity create/delete — so the walk cost lands on real user actions.

Filed as a standalone fix rather than inside #4546 because it is a pre-existing cache-layer bug: `rbacService.ts:120` and `configs/lib/module-config-service.ts:62` already write `ttl` + `tags` today. #4546 is what makes it load-bearing, so this should land first.

## Changes

`deleteByTags` now reaps the keys it could not delete from the tags it just walked, so each invalidation incrementally clears its own orphans. Scoped to the walked tags deliberately: once a key's entry is gone its other tag memberships are unknowable, and they heal the same way when those tags are invalidated.

The removal is **guarded by an atomic `EXISTS` check**, via a small Lua script, rather than issued blind. This matters — see below.

## Why the reap has to be atomic

`deleteKey` reports a key missing one round trip per member into the walk, so by the time the reap runs a concurrent request may have rebuilt any of those keys. Removing a live key from the tag index does not just lose a cleanup opportunity — it **silently exempts that key from every future invalidation of the tag**, so it serves stale data until its TTL runs out.

That would invert the failure direction of this code path. The races already present in `deleteByTags` (it is not atomic as a whole) fail toward *over*-invalidation — a redundant cache miss, harmless. An unguarded reap fails toward *under*-invalidation, which on `rbac:tenant:*` means serving stale permissions after an admin has explicitly revoked a role.

The script checks `EXISTS` on the value key and does the `SREM`s in one atomic step, so a member is only dropped while its value is genuinely absent. Both orderings against a concurrent `set()` are safe: it lands first and `EXISTS` is 1 (member left alone), or it lands after and its own `sadd` re-adds the member.

Every key the script touches is declared in `KEYS`, so it stays valid against a slot-aware deployment.

## Keeping the reap linear

An earlier revision paired every orphan with every requested tag, which made the work quadratic in the tag count: `T` disjoint tags holding `K` orphans each performed `T^2 x K` `SREM`s, so 100 tags with 100 orphans each turned 10,000 real memberships into 1,000,000 removals. Measured at `T=10`, that was 1,000 removals to clear 100 memberships. Chunking bounded only the orphan dimension, so all of it ran inside a single atomic script — the same `SREM` count the blind pipeline did, but blocking instead of interleaved.

`deleteByTags` already reads each tag's membership via `smembers`; it was discarding the association one loop before it was needed. It now keeps `membersByTagKey` and reaps each tag over its own members:

- Work is linear in the memberships that actually exist. The outcome is unchanged — a member is only ever paired with a tag it belonged to, and `SREM` of a non-member was always a no-op.
- The script takes a single tag key, so **every** atomic call is bounded by `REAP_CHUNK_SIZE` (256) whatever the tag count. The tag dimension is no longer a multiplier rather than merely being chunked.
- Calls are pipelined into one round trip but stay separate scripts, so Redis can serve other clients between them. A per-tag `await` loop would instead have cost one round trip per tag, which matters for `sidebar/preferences/route.ts:490` — it maps every role id into a single `deleteByTags` call.

## Other backends are already correct

Checked before fixing, so the change stays scoped to the one backend that leaks:

- **Memory** prunes its tag index on expiry (`cleanupExpiredEntry`), LRU eviction (`evictIfNeeded`), overwrite, and delete. No leak.
- **SQLite** deletes `cache_tags WHERE key = ?` unconditionally in `deleteKey` — it does not gate on the entry existing — and `cleanup()` deletes tag rows for expired keys. No leak.

Redis was the outlier. This aligns it with the contract the other two already implement.

## Testing

Adds `packages/cache/src/__tests__/redis.strategy.test.ts` — the first test coverage for this strategy — against an in-memory fake client. Expiry is simulated by deleting the value key, which is exactly what Redis TTL expiry does.

7 tests: the orphan is reaped; rotating key names across deploys do not accumulate; live keys are still deleted and counted; only the tags actually passed to `deleteByTags` are reaped; **a key rebuilt concurrently mid-walk stays indexed and is still invalidated by the next `deleteByTags`**; orphans spanning multiple chunks are all reaped; and **reap work across disjoint tags stays linear in real memberships with no call exceeding the chunk bound**.

Verified by reverting: the 4 original tests fail without the reap, the race test fails against an unguarded (blind `srem`) reap, and the workload test fails against the cartesian reap (`Expected: 100, Received: 1000`).

**One coverage gap, stated plainly:** there is no Lua runtime in the test environment, so the fake's `eval` mirrors the script's `KEYS`/`ARGV` contract and its exists-guarded semantics rather than interpreting the script body. That pins down the strategy's side (key ordering, tag/value split, member alignment, chunking) but **not the Lua text itself**. Adding a Lua interpreter as a dev dependency for one script did not seem worth it — happy to reconsider. Manual check against a real Redis: set a short-TTL tagged key, let it expire, `invalidateTag`, confirm `SMEMBERS tag:<tag>` is empty; then repeat while re-setting the key during the invalidation and confirm it is still a member afterwards.

Gates run: `yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn lint` (0 errors), `yarn workspace @open-mercato/cache test` (67 pass), `yarn workspace @open-mercato/cache build`.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it — N/A, no user-facing surface.
- [x] I added or adjusted tests that cover the change.
- [x] I added or adjusted integration tests — N/A: internal cache-layer behavior with no UI or API surface, covered by unit tests.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry — N/A.
- [ ] Priority / risk / QA routing — **cannot self-apply (`read` permission), requesting a maintainer.**

**Labels — suggested, with reasoning:**

- `bug`
- `priority-medium` — a slow-growing operational problem rather than a user-visible defect today, but it is a prerequisite for #4546 and gets worse silently.
- `risk-low` — the reap acts only on keys `deleteKey` reported as gone, and the `EXISTS` guard makes that check atomic with the removal, so it cannot drop a live key's tag membership. (An earlier revision of this PR did the removal blind and *could* — see "Why the reap has to be atomic".)
- `skip-qa` under the automated-verification exemption — no `.tsx` outside tests, nothing under `packages/ui/src/` or `**/components/**`, database structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract surface touched, and tests for the changed behavior ship here. Given the Lua coverage gap above, I would not object to `needs-qa` with a real-Redis pass instead — reviewer's call.

### Design System Compliance

N/A — no UI files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

