### PR TITLE
fix(workflows): cross-tenant write in task claim + missing assignee check on completion

### DIFF
--- a/packages/core/src/modules/workflows/api/tasks/[id]/claim/route.ts
+++ b/packages/core/src/modules/workflows/api/tasks/[id]/claim/route.ts
@@ -58,7 +58,7 @@ export async function POST(
     }
 
     // Call task handler to claim task
-    await claimUserTask(em, params.id, auth.sub)
+    await claimUserTask(em, params.id, auth.sub, { tenantId, organizationId })
 
     // Fetch updated task
     const { UserTask } = await import('../../../../data/entities')

--- a/packages/core/src/modules/workflows/api/tasks/[id]/complete/route.ts
+++ b/packages/core/src/modules/workflows/api/tasks/[id]/complete/route.ts
@@ -112,6 +112,7 @@ export async function POST(
       formData,
       userId: auth.sub,
       comments,
+      scope: { tenantId, organizationId },
     })
 
     // Fetch updated task

--- a/packages/core/src/modules/workflows/lib/__tests__/task-handler-scoping.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/task-handler-scoping.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tenant scoping and assignee authorization for user tasks.
+ *
+ * `claimUserTask` used to look a task up by id and status alone and mutate it
+ * before its route ever compared tenants, so a task id from another tenant was
+ * claimable — a cross-tenant write. `completeUserTask` was unscoped too (its
+ * route checked first, so only defence in depth) and enforced no assignee at
+ * all. These lock both down, and pin the case that must NOT regress: a task
+ * nobody is assigned to — an agent disposition, an unclaimed role queue — stays
+ * completable by anyone the route's feature gate already admitted.
+ */
+
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+import type { EntityManager } from '@mikro-orm/core'
+import type { AwilixContainer } from 'awilix'
+import { claimUserTask, completeUserTask, UserTaskError } from '../task-handler'
+
+const TENANT_A = '11111111-1111-1111-1111-111111111111'
+const TENANT_B = '22222222-2222-2222-2222-222222222222'
+const ORG_A = '33333333-3333-3333-3333-333333333333'
+const ORG_B = '44444444-4444-4444-4444-444444444444'
+const USER_A = '55555555-5555-5555-5555-555555555555'
+const USER_B = '66666666-6666-6666-6666-666666666666'
+const TASK_ID = '77777777-7777-7777-7777-777777777777'
+
+const scopeA = { tenantId: TENANT_A, organizationId: ORG_A }
+
+type TaskRow = Record<string, unknown>
+
+function makeTask(overrides: TaskRow = {}): TaskRow {
+  return {
+    id: TASK_ID,
+    tenantId: TENANT_A,
+    organizationId: ORG_A,
+    workflowInstanceId: '88888888-8888-8888-8888-888888888888',
+    stepInstanceId: '99999999-9999-9999-9999-999999999999',
+    taskName: 'Approve order',
+    status: 'PENDING',
+    assignedTo: null,
+    assignedToRoles: ['approver'],
+    claimedBy: null,
+    formSchema: null,
+    ...overrides,
+  }
+}
+
+/**
+ * Stands in for the identity map: only returns a row when every scalar in the
+ * filter matches, which is exactly what a missing tenant filter would bypass.
+ */
+function makeEm(rows: TaskRow[]) {
+  const flush = jest.fn(async () => undefined)
+  const findOne = jest.fn(async (_entity: unknown, where: Record<string, unknown>) => {
+    return (
+      rows.find((row) =>
+        Object.entries(where).every(([key, value]) => {
+          if (value !== null && typeof value === 'object' && '$in' in (value as Record<string, unknown>)) {
+            return ((value as { $in: unknown[] }).$in).includes(row[key])
+          }
+          return row[key] === value
+        }),
+      ) ?? null
+    )
+  })
+  return { em: { findOne, flush } as unknown as EntityManager, findOne, flush }
+}
+
+const container = { resolve: jest.fn(() => undefined) } as unknown as AwilixContainer
+
+describe('claimUserTask tenant scoping', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('refuses a task belonging to another tenant and writes nothing', async () => {
+    const row = makeTask({ tenantId: TENANT_B, organizationId: ORG_B })
+    const { em, flush } = makeEm([row])
+
+    await expect(claimUserTask(em, TASK_ID, USER_A, scopeA)).rejects.toThrow(UserTaskError)
+
+    expect(flush).not.toHaveBeenCalled()
+    expect(row.claimedBy).toBeNull()
+    expect(row.status).toBe('PENDING')
+  })
+
+  test('filters the lookup on tenant and organization', async () => {
+    const { em, findOne } = makeEm([makeTask()])
+
+    await claimUserTask(em, TASK_ID, USER_A, scopeA)
+
+    expect(findOne).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ id: TASK_ID, tenantId: TENANT_A, organizationId: ORG_A }),
+    )
+  })
+
+  test('still claims a role-queued task inside the caller scope', async () => {
+    const row = makeTask()
+    const { em } = makeEm([row])
+
+    await claimUserTask(em, TASK_ID, USER_A, scopeA)
+
+    expect(row.claimedBy).toBe(USER_A)
+    expect(row.status).toBe('IN_PROGRESS')
+  })
+})
+
+describe('completeUserTask authorization', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  const complete = (em: EntityManager, userId: string) =>
+    completeUserTask(em, container, { taskId: TASK_ID, formData: {}, userId, scope: scopeA })
+
+  test('refuses a task belonging to another tenant', async () => {
+    const { em } = makeEm([makeTask({ tenantId: TENANT_B, organizationId: ORG_B })])
+
+    await expect(complete(em, USER_A)).rejects.toMatchObject({ code: 'TASK_NOT_FOUND' })
+  })
+
+  test('refuses when the task is assigned to someone else', async () => {
+    const { em } = makeEm([makeTask({ assignedTo: USER_B, assignedToRoles: null })])
+
+    await expect(complete(em, USER_A)).rejects.toMatchObject({
+      code: 'TASK_ASSIGNED_TO_ANOTHER_USER',
+    })
+  })
+
+  test('refuses when another user has claimed it', async () => {
+    const { em } = makeEm([makeTask({ claimedBy: USER_B, status: 'IN_PROGRESS' })])
+
+    await expect(complete(em, USER_A)).rejects.toMatchObject({
+      code: 'TASK_ASSIGNED_TO_ANOTHER_USER',
+    })
+  })
+
+  test('lets the assignee through', async () => {
+    const { em } = makeEm([makeTask({ assignedTo: USER_A, assignedToRoles: null })])
+
+    await expect(complete(em, USER_A)).rejects.not.toMatchObject({
+      code: 'TASK_ASSIGNED_TO_ANOTHER_USER',
+    })
+  })
+
+  test('leaves an unassigned task completable — agent dispositions must not strand', async () => {
+    const { em } = makeEm([makeTask({ assignedTo: null, assignedToRoles: null, claimedBy: null })])
+
+    await expect(complete(em, USER_A)).rejects.not.toMatchObject({
+      code: 'TASK_ASSIGNED_TO_ANOTHER_USER',
+    })
+  })
+})

--- a/packages/core/src/modules/workflows/lib/task-handler.ts
+++ b/packages/core/src/modules/workflows/lib/task-handler.ts
@@ -30,11 +30,22 @@ const logger = createLogger('workflows')
 // Types and Interfaces
 // ============================================================================
 
+/**
+ * Tenant/organization the caller is acting within. Every task lookup filters on
+ * it, so a task id from another tenant resolves to "not found" instead of being
+ * mutated.
+ */
+export interface UserTaskScope {
+  tenantId: string
+  organizationId: string
+}
+
 export interface CompleteUserTaskOptions {
   taskId: string
   formData: Record<string, any>
   userId: string
   comments?: string
+  scope: UserTaskScope
 }
 
 export class UserTaskError extends Error {
@@ -72,11 +83,13 @@ export async function completeUserTask(
   container: AwilixContainer,
   options: CompleteUserTaskOptions
 ): Promise<void> {
-  const { taskId, formData, userId, comments } = options
+  const { taskId, formData, userId, comments, scope } = options
 
   // Fetch task
   const task = await em.findOne(UserTask, {
     id: taskId,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
     status: { $in: ['PENDING', 'IN_PROGRESS'] },
   })
 
@@ -85,6 +98,19 @@ export async function completeUserTask(
       'Task not found or already completed',
       'TASK_NOT_FOUND',
       { taskId }
+    )
+  }
+
+  // A task addressed to one person is that person's to finish. Tasks that name
+  // nobody — agent dispositions, role queues nobody has claimed — stay open to
+  // anyone the route's feature gate already admitted, so this narrows the
+  // over-permissive case without stranding the unassigned ones.
+  const claimant = task.claimedBy ?? task.assignedTo
+  if (claimant && claimant !== userId) {
+    throw new UserTaskError(
+      'Task is assigned to another user',
+      'TASK_ASSIGNED_TO_ANOTHER_USER',
+      { taskId, assignedTo: claimant }
     )
   }
 
@@ -263,15 +289,20 @@ export async function completeUserTask(
  * @param em - Entity manager
  * @param taskId - Task ID to claim
  * @param userId - User claiming the task
+ * @param scope - Tenant/organization the caller acts within; the lookup filters
+ *   on it, so a task belonging to another tenant is never reachable
  * @throws UserTaskError if task cannot be claimed
  */
 export async function claimUserTask(
   em: EntityManager,
   taskId: string,
-  userId: string
+  userId: string,
+  scope: UserTaskScope
 ): Promise<void> {
   const task = await em.findOne(UserTask, {
     id: taskId,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
     status: 'PENDING',
   })
 


### PR DESCRIPTION
## Cross-tenant write in the task claim endpoint

`claimUserTask` looked a task up by **id and status alone**, then mutated and flushed it *before* the route ever compared tenants:

```ts
// api/tasks/[id]/claim/route.ts:61 — runs first
await claimUserTask(em, params.id, auth.sub)

// lib/task-handler.ts — no tenant filter, then mutates + flushes
const task = await em.findOne(UserTask, { id: taskId, status: 'PENDING' })
task.claimedBy = userId; task.status = 'IN_PROGRESS'; await em.flush()
```

An authenticated user in tenant A holding `workflows.tasks.claim`, given a task id from tenant B, **successfully writes to tenant B's task** — hijacking it, locking out the legitimate assignee, stalling that tenant's workflow, and logging a workflow event into the victim tenant. The route's tenant-scoped lookup runs afterwards, so the HTTP response 404s and the caller sees nothing wrong while the write has already committed.

It needs a leaked task id, but task ids travel in URLs, logs, exports and event payloads. This violates the project's most fundamental rule: never skip tenant scoping.

**Pre-existing, not introduced by the workflows UX redesign** — the unscoped query is identical at `6f81cdf49`, before Phase 0.

## Second issue: completion enforced no assignee

`completeUserTask` checked nothing beyond the feature gate, so anyone with `workflows.tasks.complete` could finish anyone's task. Its route *does* verify tenant before mutating, so this one is intra-tenant only — an authorization gap rather than an isolation break.

## The fix

Both lookups now filter on `tenantId` and `organizationId`. The scope is a **required** argument, not optional — an optional one leaves the function unsafe by default, and a security fix that can be silently skipped isn't one. Only two in-repo call sites exist.

Completion gains an assignee check with a deliberate carve-out: **a task naming nobody stays completable.** Agent-disposition tasks are created without an assignee, so a strict "only the assignee may complete" rule would make every parked `INVOKE_AGENT` step permanently uncompletable. A test pins that case so a future tightening cannot quietly break agent flows.

## Verification

8 new tests in `lib/__tests__/task-handler-scoping.test.ts` — the first tests this file has ever had.

**5 of the 8 fail against the unfixed code** (verified by reverting the lib and re-running), which is what proves they detect the vulnerability rather than merely passing beside it. The 3 that pass either way are the must-not-regress cases. The cross-tenant test asserts the write **never happens** — `flush` uncalled, row untouched — not merely that an error is returned.

Full workflows module scope: **156 suites / 1916 tests passing.** `yarn typecheck` 22/22.

## Backward compatibility

`claimUserTask` and `CompleteUserTaskOptions` gain a required `scope`. This is a signature change on an exported function, taken deliberately: the alternative (optional scope) preserves the vulnerability for any caller that omits it. Both in-repo call sites are updated; a third-party caller gets a compile error naming exactly what it must supply, which is the outcome you want from a security fix.

No database migration, no API contract change, no new ACL feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF94ampefJBoJazhYDu9mX
