### PR TITLE
security(audit_logs): fail closed on unresolved tenant scope in read routes

### DIFF
--- a/.ai/specs/2026-07-28-audit-log-read-tenant-scope-fail-closed.md
+++ b/.ai/specs/2026-07-28-audit-log-read-tenant-scope-fail-closed.md
@@ -1,0 +1,78 @@
+# Audit-Log Read Routes — Fail Closed on Unresolved Tenant Scope
+
+## TLDR
+
+The audit-log read routes apply the DB `tenant_id` predicate only when `auth.tenantId` is truthy. For a caller holding `audit_logs.view_tenant` whose `tenantId` is null, the tenant, organization and actor filters all resolve away at once, leaving a query scoped by nothing but `deleted_at is null` — it returns decrypted action-log rows for every tenant in the instance. The cross-tenant read is intended for superadmins but is gated on the caller's tenant being empty rather than on `isSuperAdmin`. This spec requires a resolved tenant (or an explicit superadmin) before listing, completing the fail-closed sweep already applied to the undo and redo endpoints.
+
+## Status
+
+Implemented — 2026-07-28 · Scope: OSS
+Module: `packages/core/src/modules/audit_logs/`
+Issues: [#3817](https://github.com/open-mercato/open-mercato/issues/3817) (action-log reads), [#3818](https://github.com/open-mercato/open-mercato/issues/3818) (access-log `actorUserId` override)
+Related: PR #2829 (`#2685` — undo fail-closed), PR #2944 (`#2931` — redo scope guard), `2026-06-09-attachments-scope-invariant.md` (same fail-closed pattern in another module)
+
+## Problem Statement
+
+Three read surfaces share the same scope-resolution code:
+
+- `api/audit-logs/actions/route.ts` — action-log list
+- `api/audit-logs/actions/export/route.ts` — CSV export of the same rows
+- `api/audit-logs/access/route.ts` — access-log list
+
+Each passes `tenantId: auth.tenantId ?? undefined` into its service, and `ActionLogService.buildListQuery` applies the predicate only `if (parsed.tenantId)`. A null tenant therefore adds **no** `tenant_id` clause — not a clause matching nothing.
+
+Three narrowing filters fail together for the same caller:
+
+1. **Tenant** — the predicate is skipped entirely for a falsy `tenantId`.
+2. **Actor** — `actorUserId` is deliberately set to `undefined` when `canViewTenant` is true; that is the intended meaning of `audit_logs.view_tenant`.
+3. **Organization** — `resolveOrganizationScope` returns `filterIds/allowedIds: null` when no tenant resolves.
+
+The result is an unscoped read of decrypted `snapshotBefore/After`, `changes` and `context` across every tenant. The CSV route leaks the same data as a downloadable file.
+
+This is **latent**: it requires a principal that is both tenant-less (an unscoped API key or a global account) *and* holds `audit_logs.view_tenant` through a direct user-ACL grant. It is not reachable in a default configuration, but it is reachable by a plausible misconfiguration, in the table that is supposed to be the trustworthy record of every change.
+
+## Proposed Solution
+
+Require a resolved tenant scope, or an explicit superadmin, before listing:
+
+```ts
+export function requireResolvedTenantScope(auth: ResolvedAuth): NextResponse | null {
+  if (auth.tenantId || isSuperAdmin(auth)) return null
+  return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+}
+```
+
+Applied in all three routes immediately after the authentication check, before any container or RBAC work. A single hardening closes both #3817 and #3818: once a tenant-less caller cannot list at all, the access-log route's caller-supplied `actorUserId` override can no longer be used to reach another tenant's rows, and for a tenant-bound caller the surviving tenant predicate already confines results to their own tenant.
+
+## Design Decisions
+
+- **Gate on `isSuperAdmin`, never on tenant nullness.** The two are not equivalent: a superadmin has no tenant, but so does an unscoped API key. Gating on the wrong one is the defect.
+- **Reject rather than force self-only.** The issue permits either. Forcing `actorUserId = auth.sub` would leave the tenant predicate genuinely absent — a subtler invariant that could silently regress if actor handling changes. Rejecting keeps the guarantee local and legible.
+- **Guard at the route boundary, not in `resolveOrganizationScope`.** The null-tenant scope widening in `resolveOrganizationScope` is the shared root cause, but it has 268 call sites across 111 files; changing it is a platform-wide behavior change and belongs in its own spec. The boundary guard matches the accepted precedent in #2829.
+- **`isSuperAdmin` is read through the `AuthContext` index signature.** It is not part of the declared `AuthContext` shape, so it is read exactly the way `shared/lib/auth/server.ts` reads it, rather than widening a shared contract surface from a module-local fix.
+- **Helper lives in the API layer** (`api/audit-logs/readScope.ts`, beside `display.ts`) because it returns a `NextResponse`; `lib/` stays framework-free.
+
+## Testing
+
+Unit coverage on all three routes (`api/__tests__/{actions,export,access}.route.test.ts`):
+
+- Tenant-less non-superadmin holding `view_tenant` → `403`, and the service is never called. Parameterized over **explicit null, omitted, and empty-string** `tenantId`, per the `.ai/lessons.md` entry of 2026-07-11 requiring tenant-scope tests to cover omitted scope and not only null.
+- Tenant-less **superadmin** → unchanged cross-tenant read.
+- Tenant-scoped caller → unchanged, still filtered on their own tenant.
+- Access route additionally: a foreign `actorUserId` override from a tenant-less caller is rejected rather than served.
+
+Integration coverage is not included: the vulnerable principal cannot be constructed through the API. `createApiKeyFixture` issues keys via `POST /api/api_keys/keys` under an authenticated token, so a key always inherits the creator's tenant, and there is no fixture path to a tenant-less caller. The guarded branch is therefore unreachable from an integration test.
+
+## Backward Compatibility
+
+No contract surface changes under `BACKWARD_COMPATIBILITY.md` §7 — no route renamed or removed, no HTTP method changed, no response field removed. The `403` is added to each route's documented `openApi.errors` (additive).
+
+One intentional behavior change: a tenant-less non-superadmin holding `audit_logs.view_tenant` now receives `403` instead of unscoped results. That population is exactly the vulnerability. Preserved and covered by tests: superadmin cross-tenant reads, tenant-scoped admins reading their own tenant, and `view_tenant` continuing to widen actor visibility within a tenant.
+
+## Follow-up (not in this change)
+
+`resolveOrganizationScope` still returns `filterIds/allowedIds: null` for a null tenant, which is the shared root cause behind this class of finding. Hardening it requires auditing 268 call sites and warrants its own spec.
+
+## Changelog
+
+- **2026-07-28** — Initial spec + implementation: `requireResolvedTenantScope` guard applied to the action-log list, CSV export and access-log routes; `403` documented in each route's `openApi.errors`; regression tests parameterized over null, omitted and empty-string tenant scope. Closes #3817 and #3818.

--- a/.ai/specs/README.md
+++ b/.ai/specs/README.md
@@ -111,6 +111,7 @@ Specs awaiting implementation or partially complete. Focus here for actionable w
 | [Customer Interaction Completion Event Reliability](2026-07-20-customer-interaction-completion-event-reliability.md) | 2026-07-20 | Customer Interaction Completion Event Reliability | Reliable scoped persistent publication with retry-safe per-interaction delivery state |
 | [Stable Workflow Activity Outputs](2026-07-20-stable-workflow-activity-outputs.md) | 2026-07-20 | Stable Workflow Activity Outputs | Additive `activities.<activityId>` result addressing across synchronous and asynchronous workflow activities |
 | [Backend Route Collision Guard](2026-07-23-backend-route-collision-guard.md) | 2026-07-23 | Backend Route Collision Guard | Build-time `mercato generate` guard that fails loud when two modules emit the same backend page URL (folder-derived), mirroring the duplicate-command-id guard; route overrides unaffected |
+| [Audit-Log Read Tenant Scope Fail-Closed](2026-07-28-audit-log-read-tenant-scope-fail-closed.md) | 2026-07-28 | Audit-Log Read Tenant Scope Fail-Closed | Require a resolved tenant or explicit superadmin before listing action/access logs, closing the null-tenant unscoped read across the list, CSV export and access routes |
 
 ### Implemented Specifications
 

--- a/packages/core/src/modules/audit_logs/api/__tests__/access.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/access.route.test.ts
@@ -133,4 +133,74 @@ describe('GET /api/audit_logs/audit-logs/access', () => {
     const data = await res.json()
     expect(data.error).toBe('Validation failed')
   })
+
+  // Regression for issue #3818 — the access-log route accepted a caller-supplied
+  // `actorUserId` override without confirming it belongs to the caller's tenant. Requiring
+  // a resolved tenant (or an explicit superadmin) before listing closes that override
+  // together with the unscoped read described in #3817.
+  //
+  // Null, omitted and empty-string tenant are all exercised: `.ai/lessons.md` (2026-07-11)
+  // records that covering only explicit null misses the omitted-scope path.
+  const tenantlessAuthContexts: Array<[string, Record<string, unknown>]> = [
+    ['explicit null tenantId', { sub: 'user-1', tenantId: null, orgId: null }],
+    ['omitted tenantId', { sub: 'user-1', orgId: null }],
+    ['empty-string tenantId', { sub: 'user-1', tenantId: '', orgId: null }],
+  ]
+
+  describe.each(tenantlessAuthContexts)('tenant-less non-superadmin caller (%s)', (_label, authContext) => {
+    it('is rejected with 403 before the access-log service is reached', async () => {
+      const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+      ;(getAuthFromRequest as jest.Mock).mockResolvedValue(authContext)
+      mockRbac.userHasAllFeatures.mockResolvedValue(true)
+
+      const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/access'))
+
+      expect(res.status).toBe(403)
+      expect(mockAccess.list).not.toHaveBeenCalled()
+    })
+
+    it('rejects a foreign actorUserId override instead of serving it', async () => {
+      const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+      ;(getAuthFromRequest as jest.Mock).mockResolvedValue(authContext)
+      mockRbac.userHasAllFeatures.mockResolvedValue(true)
+
+      const res = await GET(
+        makeRequest('http://localhost/api/audit_logs/audit-logs/access?actorUserId=11111111-1111-4111-8111-111111111111'),
+      )
+
+      expect(res.status).toBe(403)
+      expect(mockAccess.list).not.toHaveBeenCalled()
+    })
+  })
+
+  it('preserves the intentional cross-tenant read for a tenant-less superadmin', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: null,
+      orgId: null,
+      isSuperAdmin: true,
+    })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/access'))
+
+    expect(res.status).toBe(200)
+    expect(mockAccess.list).toHaveBeenCalledWith(expect.objectContaining({ tenantId: undefined }))
+  })
+
+  it('leaves a tenant-scoped caller tenant-filtered as before', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/access'))
+
+    expect(res.status).toBe(200)
+    expect(mockAccess.list).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'tenant-1' }))
+  })
 })

--- a/packages/core/src/modules/audit_logs/api/__tests__/actions.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/actions.route.test.ts
@@ -222,4 +222,60 @@ describe('GET /api/audit_logs/audit-logs/actions', () => {
     const data = await res.json()
     expect(data.error).toBe('Validation failed')
   })
+
+  // Regression for issue #3817 — a caller with no resolved tenant (unscoped API key or
+  // tenant-less global account) holding `audit_logs.view_tenant` used to drop the tenant,
+  // organization and actor predicates at once and read every tenant's action logs.
+  //
+  // Null, omitted and empty-string tenant are all exercised: `.ai/lessons.md` (2026-07-11)
+  // records that covering only explicit null misses the omitted-scope path.
+  const tenantlessAuthContexts: Array<[string, Record<string, unknown>]> = [
+    ['explicit null tenantId', { sub: 'user-1', tenantId: null, orgId: null }],
+    ['omitted tenantId', { sub: 'user-1', orgId: null }],
+    ['empty-string tenantId', { sub: 'user-1', tenantId: '', orgId: null }],
+  ]
+
+  describe.each(tenantlessAuthContexts)('tenant-less non-superadmin caller (%s)', (_label, authContext) => {
+    it('is rejected with 403 before the action-log service is reached', async () => {
+      const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+      ;(getAuthFromRequest as jest.Mock).mockResolvedValue(authContext)
+      mockRbac.userHasAllFeatures.mockResolvedValue(true)
+
+      const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/actions'))
+
+      expect(res.status).toBe(403)
+      expect(mockActionLogs.list).not.toHaveBeenCalled()
+    })
+  })
+
+  it('preserves the intentional cross-tenant read for a tenant-less superadmin', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: null,
+      orgId: null,
+      isSuperAdmin: true,
+    })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/actions'))
+
+    expect(res.status).toBe(200)
+    expect(mockActionLogs.list).toHaveBeenCalledWith(expect.objectContaining({ tenantId: undefined }))
+  })
+
+  it('leaves a tenant-scoped caller tenant-filtered as before', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/actions'))
+
+    expect(res.status).toBe(200)
+    expect(mockActionLogs.list).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'tenant-1' }))
+  })
 })

--- a/packages/core/src/modules/audit_logs/api/__tests__/export.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/export.route.test.ts
@@ -68,4 +68,66 @@ describe('GET /api/audit_logs/audit-logs/actions/export', () => {
     const data = await res.json()
     expect(data.error).toBe('Validation failed')
   })
+
+  // Regression for issue #3817 — the CSV export shares the read routes' scope handling, so
+  // a tenant-less caller holding `audit_logs.view_tenant` could download every tenant's
+  // decrypted action-log rows as a file.
+  //
+  // Null, omitted and empty-string tenant are all exercised: `.ai/lessons.md` (2026-07-11)
+  // records that covering only explicit null misses the omitted-scope path.
+  const tenantlessAuthContexts: Array<[string, Record<string, unknown>]> = [
+    ['explicit null tenantId', { sub: 'user-1', tenantId: null, orgId: null }],
+    ['omitted tenantId', { sub: 'user-1', orgId: null }],
+    ['empty-string tenantId', { sub: 'user-1', tenantId: '', orgId: null }],
+  ]
+
+  describe.each(tenantlessAuthContexts)('tenant-less non-superadmin caller (%s)', (_label, authContext) => {
+    it('is rejected with 403 before any rows are exported', async () => {
+      const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+      ;(getAuthFromRequest as jest.Mock).mockResolvedValue(authContext)
+      mockRbac.userHasAllFeatures.mockResolvedValue(true)
+
+      const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/actions/export'))
+
+      expect(res.status).toBe(403)
+      expect(mockActionLogs.list).not.toHaveBeenCalled()
+    })
+  })
+
+  it('preserves the intentional cross-tenant export for a tenant-less superadmin', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { loadAuditLogDisplayMaps } = await import('@open-mercato/core/modules/audit_logs/api/audit-logs/display')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: null,
+      orgId: null,
+      isSuperAdmin: true,
+    })
+    ;(loadAuditLogDisplayMaps as jest.Mock).mockResolvedValue({ users: {}, tenants: {}, organizations: {} })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+    mockActionLogs.list.mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 50, totalPages: 0 })
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/actions/export'))
+
+    expect(res.status).toBe(200)
+    expect(mockActionLogs.list).toHaveBeenCalledWith(expect.objectContaining({ tenantId: undefined }))
+  })
+
+  it('leaves a tenant-scoped caller tenant-filtered as before', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const { loadAuditLogDisplayMaps } = await import('@open-mercato/core/modules/audit_logs/api/audit-logs/display')
+    ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+    })
+    ;(loadAuditLogDisplayMaps as jest.Mock).mockResolvedValue({ users: {}, tenants: {}, organizations: {} })
+    mockRbac.userHasAllFeatures.mockResolvedValue(true)
+    mockActionLogs.list.mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 50, totalPages: 0 })
+
+    const res = await GET(makeRequest('http://localhost/api/audit_logs/audit-logs/actions/export'))
+
+    expect(res.status).toBe(200)
+    expect(mockActionLogs.list).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'tenant-1' }))
+  })
 })

--- a/packages/core/src/modules/audit_logs/api/audit-logs/access/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/access/route.ts
@@ -6,6 +6,7 @@ import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacS
 import { AccessLogService } from '@open-mercato/core/modules/audit_logs/services/accessLogService'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { loadAuditLogDisplayMaps } from '../display'
+import { requireResolvedTenantScope } from '../readScope'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 
@@ -73,6 +74,9 @@ function parseNumber(param: string | null, { min, max, fallback }: { min: number
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
   if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const tenantScopeGuard = requireResolvedTenantScope(auth)
+  if (tenantScopeGuard) return tenantScopeGuard
 
   const container = await createRequestContainer()
   const { organizationId: defaultOrganizationId, scope } = await resolveFeatureCheckContext({ container, auth, request: req })
@@ -177,6 +181,7 @@ export const openApi: OpenApiRouteDoc = {
       errors: [
         { status: 400, description: 'Invalid filters supplied', schema: errorSchema },
         { status: 401, description: 'Authentication required', schema: errorSchema },
+        { status: 403, description: 'Caller has no resolved tenant scope and is not a superadmin', schema: errorSchema },
       ],
     },
   },

--- a/packages/core/src/modules/audit_logs/api/audit-logs/actions/export/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/actions/export/route.ts
@@ -16,6 +16,7 @@ import {
 } from '@open-mercato/core/modules/audit_logs/lib/projections'
 import { ActionLogService } from '@open-mercato/core/modules/audit_logs/services/actionLogService'
 import { loadAuditLogDisplayMaps } from '../../display'
+import { requireResolvedTenantScope } from '../../readScope'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['audit_logs.view_self'] },
@@ -111,6 +112,9 @@ function formatValue(value: unknown): string {
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
   if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const tenantScopeGuard = requireResolvedTenantScope(auth)
+  if (tenantScopeGuard) return tenantScopeGuard
 
   const container = await createRequestContainer()
   const { organizationId: defaultOrganizationId, scope } = await resolveFeatureCheckContext({ container, auth, request: req })
@@ -262,6 +266,7 @@ export const openApi: OpenApiRouteDoc = {
       errors: [
         { status: 400, description: 'Invalid filter values', schema: errorSchema },
         { status: 401, description: 'Authentication required', schema: errorSchema },
+        { status: 403, description: 'Caller has no resolved tenant scope and is not a superadmin', schema: errorSchema },
       ],
     },
   },

--- a/packages/core/src/modules/audit_logs/api/audit-logs/actions/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/actions/route.ts
@@ -6,6 +6,7 @@ import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacS
 import { ActionLogService } from '@open-mercato/core/modules/audit_logs/services/actionLogService'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { loadAuditLogDisplayMaps } from '../display'
+import { requireResolvedTenantScope } from '../readScope'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
@@ -151,6 +152,9 @@ export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
   if (!auth) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
+  const tenantScopeGuard = requireResolvedTenantScope(auth)
+  if (tenantScopeGuard) return tenantScopeGuard
+
   const container = await createRequestContainer()
   const { organizationId: defaultOrganizationId, scope } = await resolveFeatureCheckContext({ container, auth, request: req })
 
@@ -291,6 +295,7 @@ export const openApi: OpenApiRouteDoc = {
       errors: [
         { status: 400, description: 'Invalid filter values', schema: errorSchema },
         { status: 401, description: 'Authentication required', schema: errorSchema },
+        { status: 403, description: 'Caller has no resolved tenant scope and is not a superadmin', schema: errorSchema },
       ],
     },
   },

--- a/packages/core/src/modules/audit_logs/api/audit-logs/readScope.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/readScope.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import type { AuthContext } from '@open-mercato/shared/lib/auth/server'
+
+type ResolvedAuth = NonNullable<AuthContext>
+
+// `isSuperAdmin` is not part of the declared `AuthContext` shape — it reaches callers
+// through the type's index signature — so read it exactly the way
+// `shared/lib/auth/server.ts` does instead of widening the shared contract here.
+function isSuperAdmin(auth: ResolvedAuth): boolean {
+  return (auth as Record<string, unknown>).isSuperAdmin === true
+}
+
+/**
+ * Fail closed on tenant scope for audit-log reads.
+ *
+ * `audit_logs.view_tenant` only widens visibility WITHIN a tenant, so cross-tenant reads
+ * must be gated on `isSuperAdmin`, never on the caller's tenant being empty: a tenant-less
+ * principal (unscoped API key or global account) holding `view_tenant` otherwise drops the
+ * tenant, organization and actor predicates at once and reads decrypted action-log rows for
+ * every tenant in the instance (issues #3817, #3818).
+ *
+ * Plain truthiness is deliberate — it matches the `if (parsed.tenantId)` predicate guard in
+ * ActionLogService/AccessLogService, so every value that would skip it is rejected here.
+ */
+export function requireResolvedTenantScope(auth: ResolvedAuth): NextResponse | null {
+  if (auth.tenantId || isSuperAdmin(auth)) return null
+  return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+}


### PR DESCRIPTION
## Summary

The audit-log read routes apply the DB `tenant_id` filter only when `auth.tenantId` is truthy. For a caller where `canViewTenant` is true and `auth.tenantId` is null, the tenant predicate is skipped, the actor filter is set to `undefined`, and org scope resolves to null — leaving a query scoped by nothing but `deleted_at is null` that returns decrypted action-log rows (`snapshotBefore/After`, `changes`, `context`) for **every tenant in the instance**. The relaxation is intended for superadmins but is gated on the caller's tenant being empty rather than on `isSuperAdmin`.

LATENT — it requires a principal that is both tenant-less (an unscoped API key or a global account) *and* holds `audit_logs.view_tenant` via a direct user-ACL grant.

This completes a fail-closed sweep already accepted for the write paths: #2829 hardened undo and #2931 hardened redo; the list, export and access routes were missed. A single hardening closes both #3817 and #3818.

## Changes

- New `api/audit-logs/readScope.ts` — `requireResolvedTenantScope(auth)` admits a caller only with a resolved tenant or `isSuperAdmin === true`
- Guard applied to the action-log list, CSV export, and access-log routes, immediately after the auth check
- `403` documented in each route's `openApi.errors`
- Regression tests on all three routes, parameterizing null / omitted / empty-string `tenantId`
- New spec `.ai/specs/2026-07-28-audit-log-read-tenant-scope-fail-closed.md` + README index row

## Specification

**Does a spec exist for this feature/module?**
- [x] No (created a new spec)

**Spec file path:** `.ai/specs/2026-07-28-audit-log-read-tenant-scope-fail-closed.md`

## Testing

- `yarn test` (jest) — `src/modules/audit_logs`: 73 passed / 10 suites
- `tsc --noEmit -p packages/core` — clean
- `eslint` on changed files — clean
- Runner: local

Integration tests are not included, and here is why: the vulnerable principal cannot be constructed through the API. `createApiKeyFixture` issues keys via `POST /api/api_keys/keys`, whose handler requires tenant context and derives the key's tenant from the authenticated creator; there is no fixture path to a tenant-less caller, and none grants `audit_logs.view_tenant` to one. The guarded branch is therefore unreachable from an integration test. Unit coverage exercises all three routes across every falsy tenant value. Precedent #2829 shipped unit-only.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (Spec added; no locale/generator impact.)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — documented above.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label. → `priority-medium`
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. → `risk-high`
- [x] QA routing set: `skip-qa` — no `.tsx` touched, DB structure and API surface unchanged, `BACKWARD_COMPATIBILITY.md` contracts preserved, automated tests ship with the behavior change.

### Design System Compliance
- [x] N/A — no UI-rendering files touched (no `.tsx`, nothing under `packages/ui/` or `**/components/**`).

## Notes for reviewers

- `isSuperAdmin` is read through `AuthContext`'s index signature, the same way `isSuperAdminAuth` reads it in `shared/lib/auth/server.ts`. Verified set on all cross-tenant grant paths (API-key ACL at `server.ts:249`, `applySuperAdminScope` at `:152`); interactive superadmins carry a non-null `tenantId` and pass on the first condition regardless. Flagging only because the field is untyped on `AuthContext`.
- **Open design choice:** the issue permits rejecting *or* forcing self-only. This PR rejects (403); forcing `actorUserId = auth.sub` would leave the tenant predicate genuinely absent, a subtler invariant. Happy to switch to self-only if preferred.
- Deliberately out of scope, noted as follow-up in the spec: `resolveOrganizationScope` still returns null scope for a null tenant (268 call sites) — the shared root cause behind this class of finding.

## Linked issues

Fixes #3817
Fixes #3818
