### PR TITLE
refactor(portal): make notification delivery SSE-first with polling fallback

### DIFF
--- a/packages/core/src/modules/notifications/events.ts
+++ b/packages/core/src/modules/notifications/events.ts
@@ -8,6 +8,7 @@ const events = [
     entity: 'notification',
     category: 'system',
     clientBroadcast: true,
+    portalBroadcast: true,
   },
   {
     id: NOTIFICATION_SSE_EVENTS.BATCH_CREATED,
@@ -15,6 +16,7 @@ const events = [
     entity: 'notification',
     category: 'system',
     clientBroadcast: true,
+    portalBroadcast: true,
   },
 ] as const
 

--- a/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
+++ b/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
@@ -1,0 +1,112 @@
+/** @jest-environment jsdom */
+import * as React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { usePortalNotifications } from '../usePortalNotifications'
+
+const apiCallMock = jest.fn()
+
+jest.mock('../../backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+describe('usePortalNotifications strategy', () => {
+  const originalEventSource = globalThis.window?.EventSource
+  let setIntervalSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    apiCallMock.mockResolvedValue({
+      ok: true,
+      result: { ok: true, items: [], unreadCount: 0 },
+    })
+    setIntervalSpy = jest.spyOn(global, 'setInterval')
+    // Reset window flags
+    delete (window as any).__portalBridgeHealthy
+  })
+
+  afterEach(() => {
+    setIntervalSpy.mockRestore()
+    if (typeof originalEventSource === 'undefined') {
+      delete (window as unknown as { EventSource?: typeof EventSource }).EventSource
+    } else {
+      ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = originalEventSource
+    }
+  })
+
+  it('uses SSE strategy without installing the polling interval when EventSource is available', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+
+    renderHook(() => usePortalNotifications())
+
+    // Initial load happens, but no setInterval for polling
+    expect(apiCallMock).toHaveBeenCalled()
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to polling strategy when EventSource is unavailable', async () => {
+    delete (window as unknown as { EventSource?: typeof EventSource }).EventSource
+
+    renderHook(() => usePortalNotifications())
+
+    // Initial load + polling interval installed
+    expect(apiCallMock).toHaveBeenCalled()
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
+  })
+
+  it('activates polling when SSE is explicitly marked unhealthy', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+
+    // Explicitly unhealthy
+    (window as any).__portalBridgeHealthy = false
+
+    renderHook(() => usePortalNotifications())
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
+  })
+
+  it('switches to polling fallback dynamically when status becomes unhealthy', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+
+    renderHook(() => usePortalNotifications())
+
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+
+    // Dispatch unhealthy status
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
+      )
+    })
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
+  })
+
+  it('triggers refetch on portal bridge reconnect event', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+
+    renderHook(() => usePortalNotifications())
+    expect(apiCallMock).toHaveBeenCalledTimes(2) // list and count initially
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('om:portal-event', {
+          detail: {
+            id: 'om:portal-bridge:reconnected',
+            payload: {},
+          },
+        })
+      )
+    })
+
+    // apiCall called again (2 more times for list and count)
+    expect(apiCallMock).toHaveBeenCalledTimes(4)
+  })
+})

--- a/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
+++ b/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
@@ -1,11 +1,11 @@
 /** @jest-environment jsdom */
 import * as React from 'react'
-import { renderHook, act } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { usePortalNotifications } from '../usePortalNotifications'
 
 const apiCallMock = jest.fn()
 
-jest.mock('../../backend/utils/apiCall', () => ({
+jest.mock('../../../backend/utils/apiCall', () => ({
   apiCall: (...args: unknown[]) => apiCallMock(...args),
 }))
 
@@ -38,17 +38,19 @@ describe('usePortalNotifications strategy', () => {
       return {} as EventSource
     } as unknown as typeof EventSource
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     // Initial load happens, but no setInterval for polling
     expect(apiCallMock).toHaveBeenCalled()
-    expect(setIntervalSpy).not.toHaveBeenCalled()
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 8000)
   })
 
   it('falls back to polling strategy when EventSource is unavailable', async () => {
     delete (window as unknown as { EventSource?: typeof EventSource }).EventSource
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     // Initial load + polling interval installed
     expect(apiCallMock).toHaveBeenCalled()
@@ -63,7 +65,8 @@ describe('usePortalNotifications strategy', () => {
     // Explicitly unhealthy
     (window as any).__portalBridgeHealthy = false
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
   })
@@ -73,9 +76,10 @@ describe('usePortalNotifications strategy', () => {
       return {} as EventSource
     } as unknown as typeof EventSource
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    expect(setIntervalSpy).not.toHaveBeenCalled()
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 8000)
 
     // Dispatch unhealthy status
     act(() => {
@@ -92,7 +96,8 @@ describe('usePortalNotifications strategy', () => {
       return {} as EventSource
     } as unknown as typeof EventSource
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(apiCallMock).toHaveBeenCalledTimes(2) // list and count initially
 
     act(() => {
@@ -107,6 +112,6 @@ describe('usePortalNotifications strategy', () => {
     })
 
     // apiCall called again (2 more times for list and count)
-    expect(apiCallMock).toHaveBeenCalledTimes(4)
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalledTimes(4))
   })
 })

--- a/packages/ui/src/portal/hooks/usePortalEventBridge.ts
+++ b/packages/ui/src/portal/hooks/usePortalEventBridge.ts
@@ -62,6 +62,12 @@ export function usePortalEventBridge(): void {
       if (heartbeatTimer.current) clearTimeout(heartbeatTimer.current)
       heartbeatTimer.current = setTimeout(() => {
         logger.warn('Heartbeat timeout — reconnecting')
+        if (typeof window !== 'undefined') {
+          ;(window as any).__portalBridgeHealthy = false
+          window.dispatchEvent(
+            new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
+          )
+        }
         disconnect()
         scheduleReconnect()
       }, HEARTBEAT_TIMEOUT)
@@ -80,6 +86,12 @@ export function usePortalEventBridge(): void {
           hasEverConnected.current = true
           reconnectPending.current = false
           reconnectAttempts.current = 0
+          if (typeof window !== 'undefined') {
+            ;(window as any).__portalBridgeHealthy = true
+            window.dispatchEvent(
+              new CustomEvent('om:portal-bridge:status', { detail: { healthy: true } })
+            )
+          }
           resetHeartbeatTimer()
           if (shouldEmitReconnect) {
             window.dispatchEvent(
@@ -116,12 +128,24 @@ export function usePortalEventBridge(): void {
           if (hasEverConnected.current) {
             reconnectPending.current = true
           }
+          if (typeof window !== 'undefined') {
+            ;(window as any).__portalBridgeHealthy = false
+            window.dispatchEvent(
+              new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
+            )
+          }
           disconnect()
           if (mounted) scheduleReconnect()
         }
       } catch {
         if (hasEverConnected.current) {
           reconnectPending.current = true
+        }
+        if (typeof window !== 'undefined') {
+          ;(window as any).__portalBridgeHealthy = false
+          window.dispatchEvent(
+            new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
+          )
         }
         if (mounted) scheduleReconnect()
       }

--- a/packages/ui/src/portal/hooks/usePortalNotifications.ts
+++ b/packages/ui/src/portal/hooks/usePortalNotifications.ts
@@ -66,23 +66,60 @@ export function usePortalNotifications(): UsePortalNotificationsResult {
     setIsLoading(false)
   }, [])
 
-  // Poll
+  const [usePolling, setUsePolling] = React.useState(() => {
+    if (typeof window === 'undefined' || !('EventSource' in window)) {
+      return true
+    }
+    return (window as any).__portalBridgeHealthy === false
+  })
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !('EventSource' in window)) {
+      return
+    }
+    const handleStatusChange = (e: Event) => {
+      const detail = (e as CustomEvent).detail
+      if (detail && typeof detail.healthy === 'boolean') {
+        setUsePolling(!detail.healthy)
+      }
+    }
+    window.addEventListener('om:portal-bridge:status', handleStatusChange)
+    return () => {
+      window.removeEventListener('om:portal-bridge:status', handleStatusChange)
+    }
+  }, [])
+
+  // Poll when fallback is active
   React.useEffect(() => {
     fetchAll()
+    if (!usePolling) return
     const interval = setInterval(fetchAll, POLL_INTERVAL)
     return () => clearInterval(interval)
-  }, [fetchAll])
+  }, [fetchAll, usePolling])
 
-  // Listen for portal SSE notification events
+  // Listen for portal SSE notification and bridge events
   React.useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent).detail
-      if (detail?.id === 'notifications.notification.created' || detail?.id === 'notifications.notification.batch_created') {
+      if (
+        detail?.id === 'notifications.notification.created' ||
+        detail?.id === 'notifications.notification.batch_created' ||
+        detail?.id === 'om:portal-bridge:reconnected'
+      ) {
         fetchAll()
       }
     }
     window.addEventListener('om:portal-event', handler)
     return () => window.removeEventListener('om:portal-event', handler)
+  }, [fetchAll])
+
+  // Focus refetch
+  React.useEffect(() => {
+    const onFocus = () => {
+      fetchAll()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
   }, [fetchAll])
 
   const markAsRead = React.useCallback(async (id: string) => {


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary
Refactors the portal notification hook (`usePortalNotifications`) to prioritize SSE-first delivery over constant API polling. The hook now listens for real-time events via the portal event bridge and falls back to an 8-second polling cycle only if `EventSource` is unsupported or the connection is explicitly detected as unhealthy.

## Changes
- **Core**: Added `portalBroadcast: true` to notification created/batch created events.
- **UI Hooks**: 
  - Integrated status tracking (`window.__portalBridgeHealthy`) and event-based health updates inside `usePortalEventBridge`.
  - Refactored `usePortalNotifications` to conditionally run the polling interval and immediately refresh on SSE events or reconnection.
- **Tests**: Created `usePortalNotifications.test.tsx` to assert SSE prioritization, dynamic polling fallback, and reconnect behavior.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

Ran the workspace-scoped Jest test suites and verification gates:
```bash
# Verify UI hooks and strategy/polling logic
npx yarn workspace @open-mercato/ui test src/portal/hooks/__tests__/usePortalNotifications.test.tsx

# Verify customer portal event stream audience filtering
npx yarn workspace @open-mercato/core test src/modules/customer_accounts/api/portal/events/__tests__/stream.test.ts

npx yarn typecheck
npx yarn lint
```

Closes: #4544 