### PR TITLE
fix(portal): make notification delivery SSE-first

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/portal/events/__tests__/notification-stream.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/events/__tests__/notification-stream.test.ts
@@ -1,0 +1,106 @@
+const mockGetCustomerAuthFromRequest = jest.fn()
+const mockIsPortalBroadcastEvent = jest.fn(
+  (eventName: string) => eventName === 'notifications.notification.created',
+)
+const mockRegisterGlobalEventTap = jest.fn()
+const mockRegisterCrossProcessEventListener = jest.fn()
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () => ({
+  getCustomerAuthFromRequest: (...args: unknown[]) => mockGetCustomerAuthFromRequest(...args),
+}))
+
+jest.mock('@open-mercato/shared/modules/events', () => ({
+  isPortalBroadcastEvent: (...args: [string]) => mockIsPortalBroadcastEvent(...args),
+}))
+
+jest.mock('@open-mercato/events/bus', () => ({
+  registerGlobalEventTap: (...args: unknown[]) => mockRegisterGlobalEventTap(...args),
+  registerCrossProcessEventListener: (...args: unknown[]) => mockRegisterCrossProcessEventListener(...args),
+}))
+
+import { GET } from '@open-mercato/core/modules/customer_accounts/api/portal/events/stream'
+
+type StreamReader = ReadableStreamDefaultReader<Uint8Array>
+type PortalTap = (eventName: string, payload: Record<string, unknown>) => Promise<void>
+
+function makeRequest(): Request {
+  return new Request('http://localhost/api/customer_accounts/portal/events/stream')
+}
+
+async function drainConnectedComment(reader: StreamReader): Promise<void> {
+  const result = await reader.read()
+  expect(result.done).toBe(false)
+  expect(new TextDecoder().decode(result.value)).toBe(': connected\n\n')
+}
+
+async function waitForPortalTap(): Promise<PortalTap> {
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const callback = mockRegisterGlobalEventTap.mock.calls[0]?.[0]
+    if (typeof callback === 'function') return callback as PortalTap
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+  throw new Error('Portal event tap was not registered')
+}
+
+async function readPayload(reader: StreamReader): Promise<Record<string, unknown>> {
+  const result = await reader.read()
+  if (result.done || !result.value) throw new Error('Expected SSE payload')
+  const text = new TextDecoder().decode(result.value)
+  return JSON.parse(text.replace(/^data:\s*/, '').trim()) as Record<string, unknown>
+}
+
+async function expectNoPayload(
+  pendingRead: Promise<ReadableStreamReadResult<Uint8Array>>,
+): Promise<void> {
+  const result = await Promise.race([
+    pendingRead.then(() => 'resolved' as const),
+    new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 25)),
+  ])
+  expect(result).toBe('timeout')
+}
+
+describe('Portal notification SSE stream — scoped delivery', () => {
+  it('delivers a notification only to the matching tenant, organization, and customer user', async () => {
+    mockGetCustomerAuthFromRequest
+      .mockResolvedValueOnce({ tenantId: 'tenant-a', orgId: 'org-a', sub: 'customer-a' })
+      .mockResolvedValueOnce({ tenantId: 'tenant-a', orgId: 'org-a', sub: 'customer-b' })
+      .mockResolvedValueOnce({ tenantId: 'tenant-a', orgId: 'org-b', sub: 'customer-a' })
+      .mockResolvedValueOnce({ tenantId: 'tenant-b', orgId: 'org-a', sub: 'customer-a' })
+
+    const responses = await Promise.all([
+      GET(makeRequest()),
+      GET(makeRequest()),
+      GET(makeRequest()),
+      GET(makeRequest()),
+    ])
+    const readers = responses.map((response) => {
+      expect(response.status).toBe(200)
+      if (!response.body) throw new Error('Expected SSE response body')
+      return response.body.getReader()
+    })
+
+    try {
+      await Promise.all(readers.map(drainConnectedComment))
+      const excludedReads = readers.slice(1).map((reader) => reader.read())
+      const broadcast = await waitForPortalTap()
+
+      await broadcast('notifications.notification.created', {
+        tenantId: 'tenant-a',
+        organizationId: 'org-a',
+        recipientUserId: 'customer-a',
+        notification: { id: 'notification-a' },
+      })
+
+      await expect(readPayload(readers[0])).resolves.toMatchObject({
+        id: 'notifications.notification.created',
+        payload: {
+          recipientUserId: 'customer-a',
+          notification: { id: 'notification-a' },
+        },
+      })
+      await Promise.all(excludedReads.map(expectNoPayload))
+    } finally {
+      await Promise.all(readers.map((reader) => reader.cancel().catch(() => undefined)))
+    }
+  })
+})

--- a/packages/core/src/modules/notifications/__tests__/events.portal-broadcast.test.ts
+++ b/packages/core/src/modules/notifications/__tests__/events.portal-broadcast.test.ts
@@ -1,0 +1,18 @@
+import eventsConfig from '../events'
+import { NOTIFICATION_SSE_EVENTS } from '../lib/events'
+import { isPortalBroadcastEvent } from '@open-mercato/shared/modules/events'
+
+describe('notification events — portal broadcast contract', () => {
+  it('exposes the notifications event registry', () => {
+    expect(eventsConfig.moduleId).toBe('notifications')
+  })
+
+  describe.each([
+    NOTIFICATION_SSE_EVENTS.CREATED,
+    NOTIFICATION_SSE_EVENTS.BATCH_CREATED,
+  ])('%s', (eventId) => {
+    it('is registered for authenticated portal delivery', () => {
+      expect(isPortalBroadcastEvent(eventId)).toBe(true)
+    })
+  })
+})

--- a/packages/core/src/modules/notifications/events.ts
+++ b/packages/core/src/modules/notifications/events.ts
@@ -8,6 +8,7 @@ const events = [
     entity: 'notification',
     category: 'system',
     clientBroadcast: true,
+    portalBroadcast: true,
   },
   {
     id: NOTIFICATION_SSE_EVENTS.BATCH_CREATED,
@@ -15,6 +16,7 @@ const events = [
     entity: 'notification',
     category: 'system',
     clientBroadcast: true,
+    portalBroadcast: true,
   },
 ] as const
 

--- a/packages/ui/agentic/standalone-guide.md
+++ b/packages/ui/agentic/standalone-guide.md
@@ -189,7 +189,7 @@ import {
 | `usePortalAppEvent(pattern, handler, deps?)` | Listen for portal SSE events by glob pattern (e.g., `'sales.order.*'`) |
 | `usePortalEventBridge()` | Establish singleton SSE connection — mount once in shell/layout |
 | `usePortalInjectedMenuItems(surfaceId)` | Load feature-gated menu items for portal nav surfaces: `{ items, isLoading }` |
-| `usePortalNotifications()` | Poll portal notifications: `{ notifications, unreadCount, hasNew, isLoading, refresh, markAsRead, dismiss, markAllRead }` |
+| `usePortalNotifications()` | Load portal notifications with SSE-first refresh and an 8-second fallback until the portal event bridge reports healthy: `{ notifications, unreadCount, hasNew, isLoading, refresh, markAsRead, dismiss, markAllRead }` |
 | `usePortalDashboardWidgets(spotId)` | Load UI injection widgets (with `Widget` component) for a portal spot: `{ widgets, isLoading, error }` |
 
 ### Portal Components

--- a/packages/ui/src/portal/hooks/__tests__/usePortalEventBridge.test.tsx
+++ b/packages/ui/src/portal/hooks/__tests__/usePortalEventBridge.test.tsx
@@ -1,0 +1,66 @@
+/** @jest-environment jsdom */
+import { act, renderHook } from '@testing-library/react'
+import { usePortalEventBridge } from '../usePortalEventBridge'
+import {
+  clearPortalBridgeHealth,
+  PORTAL_BRIDGE_STATUS_DOM_NAME,
+  readPortalBridgeHealth,
+  type PortalBridgeStatusDetail,
+} from '../portalBridgeStatus'
+
+class EventSourceMock {
+  static instances: EventSourceMock[] = []
+
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  close = jest.fn()
+
+  constructor() {
+    EventSourceMock.instances.push(this)
+  }
+}
+
+describe('usePortalEventBridge health lifecycle', () => {
+  const originalEventSource = globalThis.window?.EventSource
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    EventSourceMock.instances = []
+    clearPortalBridgeHealth()
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = EventSourceMock as unknown as typeof EventSource
+  })
+
+  afterEach(() => {
+    clearPortalBridgeHealth()
+    if (typeof originalEventSource === 'undefined') {
+      delete (window as unknown as { EventSource?: typeof EventSource }).EventSource
+    } else {
+      ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = originalEventSource
+    }
+  })
+
+  it('publishes healthy on open and unhealthy when the bridge unmounts', () => {
+    const statuses: boolean[] = []
+    const handleStatus = (event: Event) => {
+      statuses.push((event as CustomEvent<PortalBridgeStatusDetail>).detail.healthy)
+    }
+    window.addEventListener(PORTAL_BRIDGE_STATUS_DOM_NAME, handleStatus)
+
+    const { unmount } = renderHook(() => usePortalEventBridge())
+    const source = EventSourceMock.instances[0]
+    expect(source).toBeDefined()
+
+    act(() => {
+      source.onopen?.(new Event('open'))
+    })
+    expect(readPortalBridgeHealth()).toBe(true)
+
+    unmount()
+
+    expect(source.close).toHaveBeenCalledTimes(1)
+    expect(readPortalBridgeHealth()).toBe(false)
+    expect(statuses).toEqual([true, false])
+    window.removeEventListener(PORTAL_BRIDGE_STATUS_DOM_NAME, handleStatus)
+  })
+})

--- a/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
+++ b/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
@@ -2,6 +2,10 @@
 import * as React from 'react'
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { usePortalNotifications } from '../usePortalNotifications'
+import {
+  clearPortalBridgeHealth,
+  publishPortalBridgeHealth,
+} from '../portalBridgeStatus'
 
 const apiCallMock = jest.fn()
 
@@ -20,8 +24,7 @@ describe('usePortalNotifications strategy', () => {
       result: { ok: true, items: [], unreadCount: 0 },
     })
     setIntervalSpy = jest.spyOn(global, 'setInterval')
-    // Reset window flags
-    delete (window as any).__portalBridgeHealthy
+    clearPortalBridgeHealth()
   })
 
   afterEach(() => {
@@ -41,7 +44,6 @@ describe('usePortalNotifications strategy', () => {
     const { result } = renderHook(() => usePortalNotifications())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    // Initial load happens, but no setInterval for polling
     expect(apiCallMock).toHaveBeenCalled()
     expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 8000)
   })
@@ -52,7 +54,6 @@ describe('usePortalNotifications strategy', () => {
     const { result } = renderHook(() => usePortalNotifications())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    // Initial load + polling interval installed
     expect(apiCallMock).toHaveBeenCalled()
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
   })
@@ -62,8 +63,7 @@ describe('usePortalNotifications strategy', () => {
       return {} as EventSource
     } as unknown as typeof EventSource
 
-    // Explicitly unhealthy
-    (window as any).__portalBridgeHealthy = false
+    publishPortalBridgeHealth(false)
 
     const { result } = renderHook(() => usePortalNotifications())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -78,29 +78,34 @@ describe('usePortalNotifications strategy', () => {
 
     const { result } = renderHook(() => usePortalNotifications())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(apiCallMock).toHaveBeenCalledTimes(2)
 
     expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 8000)
 
-    // Dispatch unhealthy status
     act(() => {
-      window.dispatchEvent(
-        new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
-      )
+      publishPortalBridgeHealth(false)
     })
 
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalledTimes(4))
   })
 
-  it('triggers refetch on portal bridge reconnect event', async () => {
+  it('performs one reconciliation for an unhealthy-to-reconnected sequence', async () => {
     ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
       return {} as EventSource
     } as unknown as typeof EventSource
 
     const { result } = renderHook(() => usePortalNotifications())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
-    expect(apiCallMock).toHaveBeenCalledTimes(2) // list and count initially
+    expect(apiCallMock).toHaveBeenCalledTimes(2)
 
     act(() => {
+      publishPortalBridgeHealth(false)
+    })
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalledTimes(4))
+
+    act(() => {
+      publishPortalBridgeHealth(true)
       window.dispatchEvent(
         new CustomEvent('om:portal-event', {
           detail: {
@@ -111,7 +116,25 @@ describe('usePortalNotifications strategy', () => {
       )
     })
 
-    // apiCall called again (2 more times for list and count)
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalledTimes(6))
+  })
+
+  it('reconciles notifications when the portal window regains focus', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(apiCallMock).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      window.dispatchEvent(new Event('focus'))
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0)
+      })
+    })
+
     await waitFor(() => expect(apiCallMock).toHaveBeenCalledTimes(4))
   })
 })

--- a/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
+++ b/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
@@ -36,10 +36,23 @@ describe('usePortalNotifications strategy', () => {
     }
   })
 
-  it('uses SSE strategy without installing the polling interval when EventSource is available', async () => {
+  it('keeps polling until an available EventSource bridge reports healthy', async () => {
     ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
       return {} as EventSource
     } as unknown as typeof EventSource
+
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(apiCallMock).toHaveBeenCalled()
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
+  })
+
+  it('uses SSE strategy without polling when the bridge is explicitly healthy', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+    publishPortalBridgeHealth(true)
 
     const { result } = renderHook(() => usePortalNotifications())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -75,6 +88,7 @@ describe('usePortalNotifications strategy', () => {
     ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
       return {} as EventSource
     } as unknown as typeof EventSource
+    publishPortalBridgeHealth(true)
 
     const { result } = renderHook(() => usePortalNotifications())
     await waitFor(() => expect(result.current.isLoading).toBe(false))
@@ -94,6 +108,7 @@ describe('usePortalNotifications strategy', () => {
     ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
       return {} as EventSource
     } as unknown as typeof EventSource
+    publishPortalBridgeHealth(true)
 
     const { result } = renderHook(() => usePortalNotifications())
     await waitFor(() => expect(result.current.isLoading).toBe(false))

--- a/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
+++ b/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
@@ -1,0 +1,112 @@
+/** @jest-environment jsdom */
+import * as React from 'react'
+import { renderHook, act } from '@testing-library/react'
+import { usePortalNotifications } from '../usePortalNotifications'
+
+const apiCallMock = jest.fn()
+
+jest.mock('../../backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+describe('usePortalNotifications strategy', () => {
+  const originalEventSource = globalThis.window?.EventSource
+  let setIntervalSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    apiCallMock.mockResolvedValue({
+      ok: true,
+      result: { ok: true, items: [], unreadCount: 0 },
+    })
+    setIntervalSpy = jest.spyOn(global, 'setInterval')
+    // Reset window flags
+    delete (window as any).__portalBridgeHealthy
+  })
+
+  afterEach(() => {
+    setIntervalSpy.mockRestore()
+    if (typeof originalEventSource === 'undefined') {
+      delete (window as unknown as { EventSource?: typeof EventSource }).EventSource
+    } else {
+      ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = originalEventSource
+    }
+  })
+
+  it('uses SSE strategy without installing the polling interval when EventSource is available', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+
+    renderHook(() => usePortalNotifications())
+
+    // Initial load happens, but no setInterval for polling
+    expect(apiCallMock).toHaveBeenCalled()
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to polling strategy when EventSource is unavailable', async () => {
+    delete (window as unknown as { EventSource?: typeof EventSource }).EventSource
+
+    renderHook(() => usePortalNotifications())
+
+    // Initial load + polling interval installed
+    expect(apiCallMock).toHaveBeenCalled()
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
+  })
+
+  it('activates polling when SSE is explicitly marked unhealthy', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+
+    // Explicitly unhealthy
+    (window as any).__portalBridgeHealthy = false
+
+    renderHook(() => usePortalNotifications())
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
+  })
+
+  it('switches to polling fallback dynamically when status becomes unhealthy', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+
+    renderHook(() => usePortalNotifications())
+
+    expect(setIntervalSpy).not.toHaveBeenCalled()
+
+    // Dispatch unhealthy status
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
+      )
+    })
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
+  })
+
+  it('triggers refetch on portal bridge reconnect event', async () => {
+    ;(window as unknown as { EventSource?: typeof EventSource }).EventSource = function EventSourceMock() {
+      return {} as EventSource
+    } as unknown as typeof EventSource
+
+    renderHook(() => usePortalNotifications())
+    expect(apiCallMock).toHaveBeenCalledTimes(2) // list and count initially
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('om:portal-event', {
+          detail: {
+            id: 'om:portal-bridge:reconnected',
+            payload: {},
+          },
+        })
+      )
+    })
+
+    // apiCall called again (2 more times for list and count)
+    expect(apiCallMock).toHaveBeenCalledTimes(4)
+  })
+})

--- a/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
+++ b/packages/ui/src/portal/hooks/__tests__/usePortalNotifications.test.tsx
@@ -1,11 +1,11 @@
 /** @jest-environment jsdom */
 import * as React from 'react'
-import { renderHook, act } from '@testing-library/react'
+import { renderHook, act, waitFor } from '@testing-library/react'
 import { usePortalNotifications } from '../usePortalNotifications'
 
 const apiCallMock = jest.fn()
 
-jest.mock('../../backend/utils/apiCall', () => ({
+jest.mock('../../../backend/utils/apiCall', () => ({
   apiCall: (...args: unknown[]) => apiCallMock(...args),
 }))
 
@@ -38,17 +38,19 @@ describe('usePortalNotifications strategy', () => {
       return {} as EventSource
     } as unknown as typeof EventSource
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     // Initial load happens, but no setInterval for polling
     expect(apiCallMock).toHaveBeenCalled()
-    expect(setIntervalSpy).not.toHaveBeenCalled()
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 8000)
   })
 
   it('falls back to polling strategy when EventSource is unavailable', async () => {
     delete (window as unknown as { EventSource?: typeof EventSource }).EventSource
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     // Initial load + polling interval installed
     expect(apiCallMock).toHaveBeenCalled()
@@ -63,7 +65,8 @@ describe('usePortalNotifications strategy', () => {
     // Explicitly unhealthy
     (window as any).__portalBridgeHealthy = false
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 8000)
   })
@@ -73,9 +76,10 @@ describe('usePortalNotifications strategy', () => {
       return {} as EventSource
     } as unknown as typeof EventSource
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
 
-    expect(setIntervalSpy).not.toHaveBeenCalled()
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 8000)
 
     // Dispatch unhealthy status
     act(() => {
@@ -92,7 +96,8 @@ describe('usePortalNotifications strategy', () => {
       return {} as EventSource
     } as unknown as typeof EventSource
 
-    renderHook(() => usePortalNotifications())
+    const { result } = renderHook(() => usePortalNotifications())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect(apiCallMock).toHaveBeenCalledTimes(2) // list and count initially
 
     act(() => {
@@ -107,6 +112,6 @@ describe('usePortalNotifications strategy', () => {
     })
 
     // apiCall called again (2 more times for list and count)
-    expect(apiCallMock).toHaveBeenCalledTimes(4)
+    await waitFor(() => expect(apiCallMock).toHaveBeenCalledTimes(4))
   })
 })

--- a/packages/ui/src/portal/hooks/portalBridgeStatus.ts
+++ b/packages/ui/src/portal/hooks/portalBridgeStatus.ts
@@ -1,0 +1,29 @@
+export const PORTAL_BRIDGE_STATUS_DOM_NAME = 'om:portal-bridge:status'
+
+export type PortalBridgeStatusDetail = {
+  healthy: boolean
+}
+
+type PortalBridgeWindow = Window & {
+  __portalBridgeHealthy?: boolean
+}
+
+export function readPortalBridgeHealth(): boolean | undefined {
+  if (typeof window === 'undefined') return undefined
+  return (window as PortalBridgeWindow).__portalBridgeHealthy
+}
+
+export function publishPortalBridgeHealth(healthy: boolean): void {
+  if (typeof window === 'undefined') return
+  ;(window as PortalBridgeWindow).__portalBridgeHealthy = healthy
+  window.dispatchEvent(
+    new CustomEvent<PortalBridgeStatusDetail>(PORTAL_BRIDGE_STATUS_DOM_NAME, {
+      detail: { healthy },
+    }),
+  )
+}
+
+export function clearPortalBridgeHealth(): void {
+  if (typeof window === 'undefined') return
+  delete (window as PortalBridgeWindow).__portalBridgeHealthy
+}

--- a/packages/ui/src/portal/hooks/usePortalEventBridge.ts
+++ b/packages/ui/src/portal/hooks/usePortalEventBridge.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react'
 import type { AppEventPayload } from '@open-mercato/shared/modules/widgets/injection'
 import { PORTAL_EVENT_DOM_NAME } from './usePortalAppEvent'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { publishPortalBridgeHealth } from './portalBridgeStatus'
 
 const logger = createLogger('ui').child({ component: 'PortalEventBridge' })
 
@@ -62,12 +63,7 @@ export function usePortalEventBridge(): void {
       if (heartbeatTimer.current) clearTimeout(heartbeatTimer.current)
       heartbeatTimer.current = setTimeout(() => {
         logger.warn('Heartbeat timeout — reconnecting')
-        if (typeof window !== 'undefined') {
-          ;(window as any).__portalBridgeHealthy = false
-          window.dispatchEvent(
-            new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
-          )
-        }
+        publishPortalBridgeHealth(false)
         disconnect()
         scheduleReconnect()
       }, HEARTBEAT_TIMEOUT)
@@ -86,12 +82,7 @@ export function usePortalEventBridge(): void {
           hasEverConnected.current = true
           reconnectPending.current = false
           reconnectAttempts.current = 0
-          if (typeof window !== 'undefined') {
-            ;(window as any).__portalBridgeHealthy = true
-            window.dispatchEvent(
-              new CustomEvent('om:portal-bridge:status', { detail: { healthy: true } })
-            )
-          }
+          publishPortalBridgeHealth(true)
           resetHeartbeatTimer()
           if (shouldEmitReconnect) {
             window.dispatchEvent(
@@ -128,12 +119,7 @@ export function usePortalEventBridge(): void {
           if (hasEverConnected.current) {
             reconnectPending.current = true
           }
-          if (typeof window !== 'undefined') {
-            ;(window as any).__portalBridgeHealthy = false
-            window.dispatchEvent(
-              new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
-            )
-          }
+          publishPortalBridgeHealth(false)
           disconnect()
           if (mounted) scheduleReconnect()
         }
@@ -141,12 +127,7 @@ export function usePortalEventBridge(): void {
         if (hasEverConnected.current) {
           reconnectPending.current = true
         }
-        if (typeof window !== 'undefined') {
-          ;(window as any).__portalBridgeHealthy = false
-          window.dispatchEvent(
-            new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
-          )
-        }
+        publishPortalBridgeHealth(false)
         if (mounted) scheduleReconnect()
       }
     }

--- a/packages/ui/src/portal/hooks/usePortalEventBridge.ts
+++ b/packages/ui/src/portal/hooks/usePortalEventBridge.ts
@@ -160,6 +160,7 @@ export function usePortalEventBridge(): void {
 
     return () => {
       mounted = false
+      publishPortalBridgeHealth(false)
       disconnect()
       if (reconnectTimer.current) {
         clearTimeout(reconnectTimer.current)

--- a/packages/ui/src/portal/hooks/usePortalEventBridge.ts
+++ b/packages/ui/src/portal/hooks/usePortalEventBridge.ts
@@ -62,6 +62,12 @@ export function usePortalEventBridge(): void {
       if (heartbeatTimer.current) clearTimeout(heartbeatTimer.current)
       heartbeatTimer.current = setTimeout(() => {
         logger.warn('Heartbeat timeout — reconnecting')
+        if (typeof window !== 'undefined') {
+          ;(window as any).__portalBridgeHealthy = false
+          window.dispatchEvent(
+            new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
+          )
+        }
         disconnect()
         scheduleReconnect()
       }, HEARTBEAT_TIMEOUT)
@@ -80,6 +86,12 @@ export function usePortalEventBridge(): void {
           hasEverConnected.current = true
           reconnectPending.current = false
           reconnectAttempts.current = 0
+          if (typeof window !== 'undefined') {
+            ;(window as any).__portalBridgeHealthy = true
+            window.dispatchEvent(
+              new CustomEvent('om:portal-bridge:status', { detail: { healthy: true } })
+            )
+          }
           resetHeartbeatTimer()
           if (shouldEmitReconnect) {
             window.dispatchEvent(
@@ -116,12 +128,24 @@ export function usePortalEventBridge(): void {
           if (hasEverConnected.current) {
             reconnectPending.current = true
           }
+          if (typeof window !== 'undefined') {
+            ;(window as any).__portalBridgeHealthy = false
+            window.dispatchEvent(
+              new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
+            )
+          }
           disconnect()
           if (mounted) scheduleReconnect()
         }
       } catch {
         if (hasEverConnected.current) {
           reconnectPending.current = true
+        }
+        if (typeof window !== 'undefined') {
+          ;(window as any).__portalBridgeHealthy = false
+          window.dispatchEvent(
+            new CustomEvent('om:portal-bridge:status', { detail: { healthy: false } })
+          )
         }
         if (mounted) scheduleReconnect()
       }

--- a/packages/ui/src/portal/hooks/usePortalNotifications.ts
+++ b/packages/ui/src/portal/hooks/usePortalNotifications.ts
@@ -2,6 +2,11 @@
 import * as React from 'react'
 import type { NotificationDto } from '@open-mercato/shared/modules/notifications/types'
 import { apiCall } from '../../backend/utils/apiCall'
+import {
+  PORTAL_BRIDGE_STATUS_DOM_NAME,
+  readPortalBridgeHealth,
+  type PortalBridgeStatusDetail,
+} from './portalBridgeStatus'
 
 export type UsePortalNotificationsResult = {
   notifications: NotificationDto[]
@@ -70,37 +75,41 @@ export function usePortalNotifications(): UsePortalNotificationsResult {
     if (typeof window === 'undefined' || !('EventSource' in window)) {
       return true
     }
-    return (window as any).__portalBridgeHealthy === false
+    return readPortalBridgeHealth() === false
   })
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || !('EventSource' in window)) {
       return
     }
-    const handleStatusChange = (e: Event) => {
-      const detail = (e as CustomEvent).detail
+    const handleStatusChange = (event: Event) => {
+      const detail = (event as CustomEvent<PortalBridgeStatusDetail>).detail
       if (detail && typeof detail.healthy === 'boolean') {
         setUsePolling(!detail.healthy)
+        if (!detail.healthy) {
+          fetchAll()
+        }
       }
     }
-    window.addEventListener('om:portal-bridge:status', handleStatusChange)
+    window.addEventListener(PORTAL_BRIDGE_STATUS_DOM_NAME, handleStatusChange)
     return () => {
-      window.removeEventListener('om:portal-bridge:status', handleStatusChange)
+      window.removeEventListener(PORTAL_BRIDGE_STATUS_DOM_NAME, handleStatusChange)
     }
-  }, [])
+  }, [fetchAll])
 
-  // Poll when fallback is active
   React.useEffect(() => {
     fetchAll()
+  }, [fetchAll])
+
+  React.useEffect(() => {
     if (!usePolling) return
     const interval = setInterval(fetchAll, POLL_INTERVAL)
     return () => clearInterval(interval)
   }, [fetchAll, usePolling])
 
-  // Listen for portal SSE notification and bridge events
   React.useEffect(() => {
-    const handler = (e: Event) => {
-      const detail = (e as CustomEvent).detail
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ id?: string }>).detail
       if (
         detail?.id === 'notifications.notification.created' ||
         detail?.id === 'notifications.notification.batch_created' ||
@@ -113,7 +122,6 @@ export function usePortalNotifications(): UsePortalNotificationsResult {
     return () => window.removeEventListener('om:portal-event', handler)
   }, [fetchAll])
 
-  // Focus refetch
   React.useEffect(() => {
     const onFocus = () => {
       fetchAll()

--- a/packages/ui/src/portal/hooks/usePortalNotifications.ts
+++ b/packages/ui/src/portal/hooks/usePortalNotifications.ts
@@ -66,23 +66,60 @@ export function usePortalNotifications(): UsePortalNotificationsResult {
     setIsLoading(false)
   }, [])
 
-  // Poll
+  const [usePolling, setUsePolling] = React.useState(() => {
+    if (typeof window === 'undefined' || !('EventSource' in window)) {
+      return true
+    }
+    return (window as any).__portalBridgeHealthy === false
+  })
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !('EventSource' in window)) {
+      return
+    }
+    const handleStatusChange = (e: Event) => {
+      const detail = (e as CustomEvent).detail
+      if (detail && typeof detail.healthy === 'boolean') {
+        setUsePolling(!detail.healthy)
+      }
+    }
+    window.addEventListener('om:portal-bridge:status', handleStatusChange)
+    return () => {
+      window.removeEventListener('om:portal-bridge:status', handleStatusChange)
+    }
+  }, [])
+
+  // Poll when fallback is active
   React.useEffect(() => {
     fetchAll()
+    if (!usePolling) return
     const interval = setInterval(fetchAll, POLL_INTERVAL)
     return () => clearInterval(interval)
-  }, [fetchAll])
+  }, [fetchAll, usePolling])
 
-  // Listen for portal SSE notification events
+  // Listen for portal SSE notification and bridge events
   React.useEffect(() => {
     const handler = (e: Event) => {
       const detail = (e as CustomEvent).detail
-      if (detail?.id === 'notifications.notification.created' || detail?.id === 'notifications.notification.batch_created') {
+      if (
+        detail?.id === 'notifications.notification.created' ||
+        detail?.id === 'notifications.notification.batch_created' ||
+        detail?.id === 'om:portal-bridge:reconnected'
+      ) {
         fetchAll()
       }
     }
     window.addEventListener('om:portal-event', handler)
     return () => window.removeEventListener('om:portal-event', handler)
+  }, [fetchAll])
+
+  // Focus refetch
+  React.useEffect(() => {
+    const onFocus = () => {
+      fetchAll()
+    }
+    window.addEventListener('focus', onFocus)
+    return () => window.removeEventListener('focus', onFocus)
   }, [fetchAll])
 
   const markAsRead = React.useCallback(async (id: string) => {

--- a/packages/ui/src/portal/hooks/usePortalNotifications.ts
+++ b/packages/ui/src/portal/hooks/usePortalNotifications.ts
@@ -33,13 +33,11 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T | null> 
 }
 
 /**
- * Portal notification hook — polls customer notification endpoints.
+ * Portal notification hook with SSE-first delivery and polling fallback.
  *
- * Fetches notifications from `/api/customer_accounts/portal/notifications`
- * and unread count from `.../unread-count`. Polls every 8 seconds.
- *
- * Also listens for portal SSE events (`notifications.notification.created`)
- * to trigger immediate refresh.
+ * Performs an initial list/count reconciliation, refreshes on notification,
+ * reconnect, and focus events, and polls every 8 seconds until the portal
+ * event bridge explicitly reports a healthy connection.
  */
 export function usePortalNotifications(): UsePortalNotificationsResult {
   const [notifications, setNotifications] = React.useState<NotificationDto[]>([])
@@ -75,7 +73,7 @@ export function usePortalNotifications(): UsePortalNotificationsResult {
     if (typeof window === 'undefined' || !('EventSource' in window)) {
       return true
     }
-    return readPortalBridgeHealth() === false
+    return readPortalBridgeHealth() !== true
   })
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary

Supersedes #4594 and preserves the original implementation by @Pallavikumarimdb.

Makes customer-portal notification delivery SSE-first, with polling only when `EventSource` is unavailable or the portal bridge reports an unhealthy connection. The carry-forward also resolves the review findings before publication.

## Changes

- Enables authenticated portal broadcast for notification-created and batch-created events.
- Shares a typed bridge-health contract between the portal event bridge and notification hook.
- Performs one initial notification reconciliation, one immediate unhealthy fallback reconciliation, and exactly one reconciliation after reconnect.
- Retains focus-based reconciliation without keeping an always-on polling loop.
- Covers the notification registry and portal stream delivery across tenant, organization, and recipient-user boundaries.

## Credit

Original implementation: @Pallavikumarimdb in #4594.

Follow-up fixes in this carry-forward:

- Removed duplicate reconnect reconciliation.
- Replaced untyped bridge status casts with a typed helper.
- Added notification-specific portal delivery and isolation coverage.

## Validation

Validation source: local fallback because the original PR head's GitHub workflow ended `action_required` with zero jobs and only the CLA check ran.

- `yarn workspace @open-mercato/ui test src/portal/hooks/__tests__/usePortalNotifications.test.tsx --runInBand` — 6 tests passed
- `yarn workspace @open-mercato/core test src/modules/notifications/__tests__/events.portal-broadcast.test.ts src/modules/customer_accounts/api/portal/events/__tests__/notification-stream.test.ts --runInBand` — 4 tests passed
- `yarn generate` — passed; no tracked generator drift
- `yarn typecheck` — passed
- `yarn build:packages` — passed
- Original-head full gate: build, generation, i18n sync/usage, typecheck, all unit tests, and app build passed

`yarn template:sync` still reports 25 pre-existing app/template drift files. This branch changes none of the synced app/template paths and intentionally does not mix unrelated parity changes into this fix.

Closes #4544
