### PR TITLE
docs(enterprise): publish Enterprise License Agreement Terms v2.2

### DIFF
--- a/packages/enterprise/TERMS.md
+++ b/packages/enterprise/TERMS.md
@@ -1,0 +1,252 @@
+# Open Mercato Enterprise License Agreement (Terms)
+
+**Version:** 2.2 · **Licensor:** Open Mercato sp. z o.o. · **Effective:** July 2026
+
+> The current version of these Terms (including the Product & Service Description, which forms an integral part of these Terms) is published in this repository. Each version of the Terms is published as a git tag; prior versions are available in the version history. Pricing is not part of these Terms — fees are set out in the applicable Order Form or at checkout.
+
+---
+
+## Part A — Terms
+
+These Terms (also referred to as the "Open Mercato Enterprise License Agreement") govern the Open Mercato Enterprise Subscription. The Product & Service Description forms an integral part of these Terms. The commercial details — selected tier, pricing, and the parties — are set out in the applicable Order Form, which together with these Terms forms the Contract.
+
+LICENSOR: OPEN MERCATO SP. Z O.O.   ·   VERSION 2.2   ·   EFFECTIVE: JULY 2026
+
+### Order forms; parties; structure
+
+1.1. Contract structure. These Terms, including the Open Mercato Enterprise Subscription (Product & Service Description) (also referred to as the "Subscription Description"), which forms an integral part of these Terms, and the applicable Order Form together form a single contract (the "Contract"). The Order Form is the commercial document; these Terms govern.
+
+1.2. Acceptance; Subscription. These Terms become binding between Licensor and Licensee when they agree to an order form that references these Terms (each, an "Order Form"). An Order Form may be agreed through Licensor's online checkout as described in Section 1.3 or by execution of an Order Form providing for payment by invoice as described in Section 1.4. Each Order Form identifies the Licensee and the Subscription details, including the Effective Date and billing selection. "Subscription" (also referred to as "Open Mercato Enterprise Subscription") means Licensee's time-limited entitlement under the Contract to use the Software and receive the services available under Licensee's selected tier.
+
+1.3. Self-serve checkout. In Licensor's online checkout, Licensee selects a tier for its Subscription, reviews the specific version of these Terms and the Subscription Description presented in checkout, accepts them by checkbox or other affirmative action, completes the order, and pays in advance for the first Billing Period. In this path, the Order Form is the order summary generated in checkout. The Contract becomes effective only upon successful first payment. If the first payment is not completed, no Contract is formed, the Subscription is not activated, and Licensor has no obligation to make the Software available or provide any services. Registration, creation of checkout credentials, or entry of billing details is a technical and identification step only and does not create a separate service, Contract, Subscription, or obligation to provide access.
+
+1.4. Invoice Order Forms. For an Order Form providing for payment by invoice, the Contract becomes effective upon execution of the Order Form. Unless the Order Form expressly states otherwise, payment is due before the start of the applicable Billing Period.
+
+1.5. Parties; business-only; authority. "Licensor" means Open Mercato sp. z o.o., as identified in the Order Form. "Licensee" means the legal entity (such as a company or other organization) identified in the Order Form. The Contract is offered and intended solely for business and professional use. Individuals acting as consumers do not qualify as Licensees and may not enter into the Contract. The person executing the Order Form on behalf of Licensee represents and warrants that they have full authority to bind Licensee to the Contract. If such person lacks authority, that person agrees that they are personally responsible for the obligations in the Contract.
+
+1.6. Precedence. If there is a conflict between an Order Form and these Terms, the Order Form controls only for the specific subject matter it addresses and only to the extent it expressly states an exception to these Terms; otherwise, these Terms control.
+
+### Software; license grant
+
+2.1. Software. "Open Mercato" is a modular software framework and related tooling intended to support implementation, operation, and upgrades of deployments based on it. "Software" (also referred to as "Enterprise Software Package") means the proprietary enterprise software package that Licensor makes available to Licensee under the Contract from time to time, as described in the Subscription Description, including proprietary modules not available in the open-source distribution, and any related forks, patches, enhancements, add-ons, connectors, modules, tooling, binaries, and upgrade or update packages delivered by Licensor under the Contract.
+
+2.2. License grant. Subject to timely payment of the applicable fees and Licensee's compliance with the Contract, Licensor grants Licensee a limited, non-exclusive, non-transferable, non-sublicensable license during the Term to install, run, and use the Software solely for Licensee's internal business purposes in connection with Licensee's own deployments and operations. The license is granted per Open Mercato project / per monorepo (not per seat); there is no limit on the number of users or servers within a licensed project.
+
+2.3. Contractors and implementation partners. Licensee may allow its contractors and implementation partners to access and use the Software solely to perform services for Licensee and solely for Licensee's benefit, provided that (i) they are bound by written obligations no less protective of Licensor than the Contract and (ii) Licensee remains responsible for their acts and omissions.
+
+2.4. Restrictions. The license is granted solely for Licensee's own internal business purposes. Subject to Section 2.3 (Contractors and implementation partners), Section 2.7 (Licensee Affiliates), and to any rights that may not be restricted under applicable law, Licensee will not, and will not cause or permit any third party to: (i) distribute, sublicense, rent, lease, or otherwise make the Software available to any third party; (ii) host or operate the Software for the benefit of any third party, including on a hosting, software-as-a-service, application-service-provider, managed-services, or service-bureau basis; (iii) use the Software to provide services to, or otherwise for the benefit of, any third party; (iv) reverse engineer, decompile, or disassemble the Software; or (v) remove or alter proprietary notices included in the Software.
+
+2.5. Open-source components. The Software may include components provided under open-source licenses, including the MIT license for the Open Mercato core codebase and other third-party open-source components ("Open-Source Components"). Open-Source Components remain subject to their applicable open-source license terms. The Contract governs Licensee's access to and use of the Software as provided by Licensor under the Contract but does not reduce any rights Licensee may have under the applicable open-source license terms for copies of Open-Source Components.
+
+2.6. Ownership. The Software is licensed, not sold. Except for the limited rights expressly granted in the Contract, Licensor retains all right, title, and interest in and to the Software.
+
+2.7. Licensee Affiliates. "Licensee Affiliate" means any entity that Controls, is Controlled by, or is under common Control with Licensee, or that is established or Controlled, directly or indirectly, by any shareholder, partner, or other owner of Licensee, regardless of ownership structure, in each case applying the definition of "Control" in Section 9.1, and that is identified as a covered Licensee Affiliate in the Order Form. Use of the Software by a covered Licensee Affiliate for its own internal business purposes is permitted under, and forms part of, the license granted to Licensee in Section 2.2, and does not constitute a sublicense, provided that: (a) each covered Licensee Affiliate uses the Software solely for its own internal business purposes and within the licensed project scope stated in Section 2.2; (b) Licensee notifies Licensor in writing before granting access to the Software to an entity not yet identified in the Order Form, and the parties record that entity in the Order Form; (c) Licensee remains fully responsible for each covered Licensee Affiliate's acts and omissions in connection with the Software as if they were Licensee's own, and any act or omission that would breach the Contract if committed by Licensee constitutes a breach by Licensee; (d) Section 2.3 applies to a covered Licensee Affiliate's contractors and implementation partners as it applies to Licensee's; and (e) covered Licensee Affiliates are not parties to the Contract, and no covered Licensee Affiliate may demand performance of, or enforce, the Contract against Licensor; rights and claims under the Contract are exercisable by Licensee alone. If an entity ceases to qualify as a Licensee Affiliate, its rights under this Section 2.7 terminate automatically ninety (90) days after it ceases to qualify, unless it enters into its own Order Form with Licensor. Upon termination of the Contract, the rights of all covered Licensee Affiliates end together with Licensee's rights under Section 5.5(a).
+
+### Scope of services and support delivery
+
+3.1. Services included. Subject to timely payment of the applicable fees and Licensee's compliance with the Contract, Licensee is entitled to receive the services available under its selected tier (as set out in the Order Form and the Subscription Description).
+
+3.2. Support delivery; business hours; channels. Unless the applicable Order Form expressly states otherwise, support under the Contract is provided during Licensor's normal business hours on business days in Poland. Licensor will provide advisory support primarily through (a) the priority helpdesk channel and (b) the ticketing system. Licensor may reasonably change the specific tools or channels used for support, provided that Licensor maintains a functionally equivalent means for Licensee to submit requests and receive responses.
+
+3.3. Time caps; counting rules; rollover. The time caps stated in Section 3.1(b) are monthly limits and do not roll over unless the applicable Order Form expressly states otherwise. Those caps cover Licensor's time spent on advisory work reasonably related to the applicable review scope, including reviewing materials provided by Licensee, responding to questions, preparing written feedback, and participation in calls or meetings related to such reviews. The customer success manager time described in Section 3.1(c) is separate from the monthly review caps.
+
+3.4. Response targets. Licensor will use commercially reasonable efforts to respond (measured during business hours) within: (a) 1 business day for critical issues (production down or severe security incident), (b) 2 business days for high priority issues (material degradation or elevated security concern), and (c) 5 business days for standard issues (general questions and routine guidance). These targets are service goals and not warranties or guarantees. Licensor determines the applicable severity level in its reasonable discretion and may reclassify at any time; response targets apply based on that classification.
+
+3.5. Exclusions; cooperation; exceeding caps. Support under the Contract is advisory only and does not include writing or delivering custom code or 24/7 incident response unless the applicable Order Form expressly provides for it. Licensor may reasonably suspend or limit support where Licensee's request requires access, information, or cooperation that Licensee has not provided. If Licensor reasonably determines that the work requested by Licensee would exceed the applicable monthly time caps, Licensor may defer the remaining work to the next month, propose a written change to scope or a separate paid engagement, or decline the excess work.
+
+### Fees and payment
+
+4.1. Fees and billing. The applicable fees, currency, and the Billing Period (monthly / annual) are as set out in the applicable Order Form. The fees are tier-based (Basic / Medium / Enterprise); the applicable tier is set out in the Order Form and, unless the Order Form states otherwise, is determined by Licensee's annual revenue, aggregated with the annual revenue of its covered Licensee Affiliates, for the most recently completed financial year. Licensee shall provide its latest approved annual financial statements or other verifiable supporting documentation upon Licensor's request. For on-premise deployments, the Software reports aggregate user/usage counts to Licensor (usage verification) to enable transparent billing verification. Licensee shall not disable, block, circumvent, or interfere with the usage-reporting functionality, and shall not modify the Software or its operating environment in a manner that prevents, suppresses, or distorts such reporting. Licensee shall keep the usage-reporting functionality operational for as long as the Contract remains in force.
+
+4.2. Invoicing and payment. Unless the applicable Order Form expressly states otherwise, the applicable fees are paid in advance for each Billing Period, through Licensor's online payment platform, using a payment method (such as a payment card) that Licensee registers and authorizes for recurring automatic charges; Licensee authorizes Licensor and its payment processor to charge the applicable fees to the registered payment method at the start of each Billing Period. Where invoicing applies, Licensor will invoice Licensee in advance for the applicable Billing Period, and payment is due within fourteen (14) days of the invoice date and, in any event, before the start of the applicable Billing Period. Licensee will pay all undisputed amounts when due, without setoff or deduction.
+
+4.3. Taxes; VAT; withholding; gross-up. Fees are net of any applicable taxes. Licensee is responsible for any VAT, sales, use, GST, or similar indirect taxes applicable to the Contract, excluding taxes based on Licensor's net income. If VAT (or a similar indirect tax) applies, Licensor may add it to the invoice at the applicable rate unless a reverse-charge mechanism applies, in which case Licensee will account for the tax as required and provide a valid VAT/tax ID upon request. If applicable law requires Licensee to withhold any tax from a payment to Licensor, Licensee may do so only if required by law and will provide Licensor with evidence of the withholding and payment to the relevant authority. In that case, Licensee will gross up the payment so Licensor receives the same net amount it would have received absent the withholding, unless Licensor timely provides documentation reasonably necessary to claim an exemption or reduced rate and Licensee applies it.
+
+4.4. No refunds; late payment; enforcement. To the maximum extent permitted by law, fees are non-cancelable and non-refundable, except that Licensor will refund prepaid fees for the unused part of the then-current Billing Period on a pro-rata basis if Licensee terminates the Contract under Section 5.4 due to Licensor's uncured material breach. If any undisputed amount is not paid when due, Licensor may charge interest at 1.5% per month (or the maximum rate permitted by law, if lower), accruing daily, and recover reasonable collection costs. Licensor may also suspend access and performance in accordance with Section 5.3.
+
+4.5. Indexation. Licensor may increase the fees once per calendar year by up to five percent (5%), upon at least thirty (30) days' prior written notice. Any increase applies starting with the next Billing Period that has not yet been invoiced (or, if invoiced, not yet paid).
+
+### Term and termination
+
+5.1. Term; paid access. The Contract begins on the Effective Date stated in the Order Form and remains in force for the billing period stated in the Order Form (the "Billing Period"). The Billing Period constitutes the contractual commitment period for the Contract. Unless either party gives timely notice of non-renewal under Section 5.2, including following Licensee's objection to updated Terms under Section 9.6, or the Contract is terminated earlier in accordance with Section 5.4, the Contract automatically renews for successive Billing Periods of the same length. Licensee's rights to access and use the Software and to receive the services under the Contract apply only during the then-current Billing Period and are subject to payment of the applicable fees in accordance with Section 4.
+
+5.2. Non-renewal for convenience. Either party may elect not to renew the Contract for convenience by giving written notice to the other party. Non-renewal is effective only at the end of the then-current Billing Period. If the Billing Period is annual, notice of non-renewal must be given at least thirty (30) days before the end of the then-current Billing Period. If the Billing Period is monthly, notice of non-renewal must be given at least seven (7) days before the end of the then-current Billing Period. For clarity, neither party may terminate the Contract for convenience before the end of the then-current Billing Period.
+
+5.3. Suspension and termination for non-payment. If any undisputed fee is not paid when due, Licensor may suspend Licensee's access to the Software, services, and enterprise-only resources until all overdue amounts are paid. Non-payment of undisputed fees constitutes a material breach capable of termination under Section 5.4, and any notice given under this Section 5.3 may also constitute notice of material breach under Section 5.4 if it identifies the non-payment as a material breach. Termination on grounds of non-payment does not relieve Licensee from its obligation to pay all fees due for the then-current Billing Period.
+
+5.4. Termination for cause. Either party may terminate the Contract with immediate effect if the other party materially breaches the Contract and fails to cure that breach within ten (10) days after receiving written notice specifying the breach. Either party may also terminate the Contract with immediate effect, to the extent permitted by applicable law, if the other party becomes insolvent, is unable to pay its debts as they fall due, makes an assignment for the benefit of creditors, enters into liquidation, bankruptcy, administration, receivership, restructuring, or similar proceedings, has a receiver, administrator, trustee, or similar officer appointed over all or a material part of its assets, or ceases or threatens to cease carrying on business.
+
+5.5. Effect of termination. Upon termination, (a) Licensee's rights to access and use the Software as provided under the Contract end as of the effective termination date, (b) Licensor may disable or terminate Licensee's access to enterprise-only channels, materials, repositories, binaries, upgrade packages, updates, and similar resources provided under the Contract, and (c) Licensor's obligation to provide the services in Section 3 ends as of the effective termination date. For clarity, termination of the Contract does not terminate any open-source license terms that may apply to Open-Source Components obtained independently of Licensor's enterprise distribution.
+
+### Disclaimer; limitation of liability
+
+6.1. Standard of performance. Licensor will use commercially reasonable efforts to provide the services in a timely and professional manner.
+
+6.2. As-is; no warranties. THE SOFTWARE AND THE SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE." TO THE MAXIMUM EXTENT PERMITTED BY LAW, LICENSOR DISCLAIMS ALL WARRANTIES AND CONDITIONS, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. LICENSEE ASSUMES ALL RISK ARISING OUT OF OR RELATING TO ITS USE OF THE SOFTWARE AND THE SERVICES.
+
+6.3. Exclusion of damages. TO THE MAXIMUM EXTENT PERMITTED BY LAW, IN NO EVENT WILL LICENSOR BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR FOR ANY LOSS OF PROFITS, REVENUE, BUSINESS, GOODWILL, DATA, OR BUSINESS INTERRUPTION, ARISING OUT OF OR RELATING TO THE CONTRACT, THE SOFTWARE, OR THE SERVICES, REGARDLESS OF THE THEORY OF LIABILITY, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+6.4. Liability cap. TO THE MAXIMUM EXTENT PERMITTED BY LAW, LICENSOR'S TOTAL AGGREGATE LIABILITY ARISING OUT OF OR RELATING TO THE CONTRACT (WHETHER IN CONTRACT, TORT, OR OTHERWISE) WILL NOT EXCEED THE AMOUNT OF FEES ACTUALLY PAID TO LICENSOR UNDER THE APPLICABLE ORDER FORM FOR ONE (1) MONTH OF THE THEN-CURRENT BILLING ARRANGEMENT (AND IF BILLED ANNUALLY, ONE-TWELFTH (1/12) OF THE ANNUAL FEE ACTUALLY PAID FOR THE THEN-CURRENT ANNUAL BILLING PERIOD).
+
+### Marketing and trademarks; basic operational points
+
+7.1. Consent. Licensee grants Licensor permission to use Licensee's name and logo for Licensor's marketing and promotional purposes in connection with Open Mercato and the services.
+
+7.2. Included uses. This consent includes: (a) placing Licensee's logo on Licensor's website (including Open Mercato-related pages), (b) using Licensee's name and logo in sales presentations and similar marketing materials, and (c) preparing and publishing case studies describing Licensee's adoption and use of Open Mercato, including the scale of such adoption.
+
+7.3. Manner of use. Licensor will not materially modify Licensee's logo and will not use Licensee's name or logo in a way that implies Licensee's sponsorship or endorsement of Licensor beyond being a Licensee/customer.
+
+7.4. Tail; post-termination use. Licensor may continue using Licensee's name and logo under this Section 7 for twelve (12) months following termination of the Contract. After that period, Licensor will remove Licensee's name and logo from Licensor-controlled marketing materials within a reasonable time after Licensee requests removal in writing, except that Licensor may retain archival copies and historical records not publicly displayed.
+
+### Confidentiality and data protection
+
+8.1. Confidentiality. "Confidential Information" means any non-public information disclosed by or on behalf of one party (the "Disclosing Party") to the other party (the "Receiving Party") that is designated as confidential or that should reasonably be understood to be confidential given its nature and the circumstances of disclosure, including business, technical, product, security, pricing, and customer information. The Receiving Party will use the Disclosing Party's Confidential Information solely to perform under the Contract, will protect it using at least the same degree of care it uses to protect its own confidential information (and no less than reasonable care), and will not disclose it except to its employees, covered Licensee Affiliates, contractors, and professional advisors who have a need to know and are bound by confidentiality obligations no less protective than this Section 8.1. Confidential Information does not include information that the Receiving Party can demonstrate: (a) is or becomes publicly available without breach of the Contract, (b) was lawfully known to the Receiving Party without restriction before disclosure, (c) is independently developed without use of the Confidential Information, or (d) is lawfully received from a third party without breach of any confidentiality obligation. If the Receiving Party is required by law or court order to disclose Confidential Information, it may do so only to the extent required and will use commercially reasonable efforts to give prior notice to the Disclosing Party (where legally permitted). Upon termination of the Contract or upon the Disclosing Party's written request, the Receiving Party will promptly return or destroy Confidential Information in its possession or control, except that it may retain copies as required for legal, regulatory, or bona fide archival purposes (and remains bound by this Section 8.1 for retained copies). This Section 8.1 applies during the Term and for three (3) years after termination, provided that trade secrets remain protected for so long as they remain trade secrets.
+
+8.2. Privacy notice. Each party may process personal data of the other party's representatives, employees, contractors, and other business contacts (such as name, business contact details, role, and correspondence content) for purposes of entering into and performing the Contract, handling communications, and maintaining the business relationship. Personal data will be retained no longer than necessary for the purposes stated above and then deleted or anonymized, except where further retention is required by applicable law or necessary to establish, exercise, or defend legal claims. Each party commits to reasonably assisting the other in disseminating this privacy notice to its concerned representatives. Data subjects are entitled to: (i) access their personal data; (ii) request rectification or erasure; (iii) request restriction of processing; and (iv) object to processing to the extent permitted under applicable law. Data subjects are also informed of their right to lodge a complaint with a competent supervisory authority in the event of any perceived infringement of their rights under applicable data protection law. Licensor does not intend to carry out automated decision-making, including profiling, with respect to such contact data. Licensor does not intend to transfer such contact data outside the EEA, and if any such transfer becomes necessary, Licensor will ensure appropriate safeguards required under applicable law. Privacy-related inquiries for Licensor should be directed to: info@openmercato.com.
+
+8.3. Simplified DPA. This Section 8.3 applies only to the extent Licensor processes personal data on behalf of Licensee in connection with the Contract in a manner that makes Licensor a processor within the meaning of the GDPR (a "Processing"). In that case, for the purposes of Article 28 GDPR: (a) Licensee is the controller and Licensor is the processor; (b) the subject matter, duration, nature, and purpose of the Processing, as well as the categories of data subjects and types of personal data, are as determined by Licensee and limited to what is reasonably necessary for Licensor to perform the services under the Contract (typically, business contact data in tickets and communications, and any diagnostic data Licensee elects to provide); (c) Licensor will process personal data only on documented instructions from Licensee, as set out in the Contract and as further documented in writing from time to time; (d) persons authorized to process personal data on behalf of Licensor are bound by confidentiality; (e) Licensor will implement appropriate technical and organizational measures to protect personal data, taking into account the nature of the Processing and risks; (f) Licensee grants Licensor a general authorization to engage sub-processors to support delivery of the services, provided that Licensor remains responsible for their performance and will impose data protection obligations that are no less protective than this Section 8.3; Licensor will provide reasonable advance notice of material changes to its sub-processors, and Licensee may object on reasonable data protection grounds, in which case the parties will cooperate in good faith to address the objection; (g) taking into account the nature of the Processing, Licensor will provide reasonable assistance to Licensee (at Licensee's cost, if such assistance requires material effort) to enable Licensee to respond to requests from data subjects and to meet Licensee's obligations under the GDPR; (h) Licensor will notify Licensee without undue delay after becoming aware of a personal data breach affecting the Processing; (i) upon termination of the Contract, Licensor will, at Licensee's written request and to the extent feasible, delete or return personal data processed on behalf of Licensee, except to the extent retention is required by applicable law or for bona fide archival backup practices for a limited period; (j) Licensor will make available to Licensee, on request, information reasonably necessary to demonstrate compliance with this Section 8.3, and the parties agree that audits will be limited to reasonable, proportionate measures (such as written questionnaires and review of available third-party assurance materials) unless applicable law requires otherwise; and (k) if Licensor transfers personal data outside the EEA in connection with a Processing, Licensor will ensure an appropriate transfer mechanism is in place as required by the GDPR. If there is a conflict between this Section 8.3 and any other part of the Contract solely with respect to Processing, this Section 8.3 controls.
+
+### General terms
+
+9.1. Assignment. Neither party may assign, novate, delegate, or otherwise transfer the Contract, or any rights or obligations under it, without the other party's prior written consent, except that either party may do so in connection with a merger, reorganization, change of control, or sale of all or substantially all of its assets or business, provided that the transferee assumes the transferring party's obligations under the Contract. Licensor may also, upon notice to Licensee, assign, novate, delegate, or otherwise transfer the Contract, or any rights or obligations under it, to any Licensor Affiliate without Licensee's further consent, and upon the transferee's assumption of Licensor's obligations, Licensor is released from the Contract to the extent permitted by law. "Licensor Affiliate" means any entity that Controls, is Controlled by, or is under common Control with Licensor, or is established or Controlled, directly or indirectly, by any shareholder, partner, or other owner of Licensor, regardless of ownership structure. "Control" means the power to direct an entity's management or policies, whether by ownership, contract, or otherwise.
+
+9.2. Entire agreement; amendments. The Contract is the entire agreement between the parties regarding its subject matter and supersedes all prior or contemporaneous understandings. Any amendment must be in writing and signed by both parties, except that Licensor may update these Terms in accordance with Section 9.6.
+
+9.3. Severability. If any provision of the Contract is held unenforceable, the remaining provisions remain in effect, and the unenforceable provision will be modified to the minimum extent necessary to make it enforceable while preserving the parties' intent.
+
+9.4. Governing law; jurisdiction. The Contract shall be governed by and construed in accordance with the laws of the Republic of Poland, excluding its conflict of laws rules. Any dispute arising out of or in connection with the Contract shall be subject to the exclusive jurisdiction of the court competent for Licensor's registered office.
+
+9.5. Writing; notices. Any reference in the Contract to "writing," "written," "in writing," "signed," or similar terms includes electronic communications that create a durable record, including email and execution via electronic signature, unless the Contract expressly requires a different form. Any notice under the Contract must be in writing. Notices to Licensee may be sent to Licensee's contact email stated in the Order Form or to any updated contact email notified by Licensee to Licensor in accordance with this Section 9.5. Notices to Licensor must be sent to the following details, unless Licensor notifies Licensee of updated notice details: address: address; email: notice email address. A notice sent by email is deemed received when sent, unless the sender receives an automated delivery-failure notice. Each party is responsible for keeping its notice details current. Operational, technical, billing, and account-related communications may also be sent through the Software, account interface, support channel, or other ordinary communication channel used between the parties, unless the Contract requires formal notice.
+
+9.6. Updates to these Terms. Licensor may update these Terms during the term of the Contract if there is an objectively justified reason for the update, including: (a) a change in applicable law, regulatory guidance, case law, or compliance requirements affecting the Contract, the Software, the Services, billing, payments, taxes, data protection, security, or electronic contracting; (b) a change in the Software, services, Subscription tiers, technical architecture, security model, authentication, access control, support, certification, review, or operational processes; (c) a change required by third-party providers, payment processors, hosting providers, identity providers, open-source components, or other dependencies used to provide the Software or services; (d) the introduction, modification, suspension, or withdrawal of features, modules, service elements, plans, billing models, or contracting flows; or (e) the need to clarify, correct, supplement, or improve the Terms, including to remove ambiguities, inconsistencies, errors, or provisions that have become obsolete. Licensor will notify Licensee of the updated Terms in accordance with Section 9.5. The notice will include either a copy of the updated Terms or a link allowing Licensee to access, download, retain, and reproduce them, and will state the effective date of the updated Terms. The updated Terms bind Licensee from that effective date unless Licensee gives Licensor written notice that Licensee does not accept the updated Terms and elects not to renew the Contract in accordance with Section 5.2. In that case, the then-current Terms will continue to apply until the end of the then-current Billing Period, and the Contract will not renew.
+
+---
+
+## Part B — Product & Service Description
+
+*The Product & Service Description forms an integral part of these Terms.*
+
+Open Mercato Enterprise Subscription
+
+The Open Mercato Enterprise Subscription combines proprietary enterprise software modules with certification, review, and operational support - so teams can take AI-built CRM/ERP systems to production with confidence. This document describes the subscription tiers, licensing rules, and services. It forms an integral part of the Open Mercato Enterprise License Agreement (the "Terms").
+
+LICENSOR: OPEN MERCATO SP. Z O.O.   ·   VERSION 2.2   ·   EFFECTIVE: JULY 2026
+
+### 01 - SOFTWARE
+
+Enterprise Software Package
+
+The Open Mercato Enterprise Subscription includes access to proprietary modules not available in the open-source distribution. These extend the platform with enterprise-grade security, identity management and collaboration controls:
+
+* MFA & Security Enforcement - mandatory multi-factor authentication with enforcement policies and protected re-authentication for sensitive actions.
+* SSO & Directory Sync - single sign-on via your corporate identity provider, with automated user provisioning synchronized from your company directory.
+* Record Locking - protection against concurrent edit conflicts, with presence indicators and controlled conflict resolution for shared records.
+* Agent Orchestrator - governed execution of AI agents inside your workflows: agents run as workflow steps with defined context, confidence thresholds route uncertain cases to human sign-off, and every agent action is audited like a user action.
+
+Modules are built to documented specifications: github.com/open-mercato/open-mercato/tree/main/.ai/specs/enterprise
+
+---
+
+### 02 - LICENSING
+
+Licensing model
+
+Per project, not per seat. The license is charged per Open Mercato project / per monorepo - never per developer or per end user.
+
+* Unlimited Seats - no limits on the number of users or servers within a given system, so your licensing never blocks customer or team growth.
+* Revenue-based tiering - the applicable tier is determined by the Licensee's annual revenue.
+* Usage verification ("Phone Home") - for on-premise deployments, the system reports aggregate user/usage counts to Open Mercato. This enables transparent billing verification without Open Mercato needing standing access to your code repository.
+
+Project definition: single business domain / department / business purpose or goal-oriented deployment of Open Mercato - not limited to a physical single instance (can be a multi-server deployment)
+
+### 03 - TIERS
+
+Subscription tiers
+
+Three tiers scale the level of service with company size. All tiers include the Enterprise Software Package and unlimited seats. Prices are net; annual billing is available at a 10% discount.
+
+| TIER | ANNUAL REVENUE (VERIFIED) | PRICING | DESIGNED FOR |
+|---|---|---|---|
+| Basic | Below $25M | Set out in the Order Form / at checkout | Smaller companies & agency-led builds: enterprise software + AI-assisted support. Covers Open Mercato open source libraries. |
+| Medium | $25M - $250M | Set out in the Order Form / at checkout | Mid-market: enterprise software + upgrade assistance + higher support limits. Covers Open Mercato open source libraries and custom code. |
+| Enterprise | Above $250M | Ask for price | Large/regulated orgs: full proactive monitoring, homologation & managed upgrades. Covers Open Mercato open source libraries and custom code. |
+
+Note: Paid discovery workshops and paid Proof-of-Concept engagements are separate elements of the engagement and are priced independently of the subscription.
+
+Note: If you are a startup with less than $5M in annual revenue you can request a startup discount via info@openmercato.com.
+
+### 04 - WHAT'S INCLUDED
+
+Services by tier
+
+| SERVICE / CAPABILITY | BASIC | MEDIUM | ENTERPRISE |
+|---|---|---|---|
+| Enterprise software modules (MFA, SSO & Directory Sync, Record Locking, Agents Orchestrator). If your license expires, you can continue using these modules in their last deployed version, but they will no longer receive updates, security patches, new features, or ongoing support. | Included | Included | Included |
+| Unlimited users & servers (per instance / project / monorepo) | Included | Included | Included |
+| Time-limited offer: Open Mercato project sandboxes with dev/staging and production environment, CI/CD and AI SDLC pipeline (backup & 7-day restore) — early access (beta) | 1 active project | 3 active projects | 10 active projects |
+| Priority support (AI-assisted helpdesk via Discord / ticketing / automatic issue triage by selected Github accounts) | up to 5 Accounts, 1 issue in the pipeline | up to 10 Accounts, includes Discord, 3 issues in the pipeline | Unlimited Accounts, includes Discord, 10 issues in the pipeline |
+| Software updates (security patches, breaking-changes upgrade scripts, platform & partner-ready upgrades) | Self-serve | Assisted | Managed for you |
+| Pre-deployment Architecture Audit | - | Included | Included |
+| Monthly Security / Performance / Custom-code Reviews | - | Optional | Included |
+| Production Approval (Homologation) & go-live recommendation | - | Optional | Included |
+| Proactive deployment monitoring & Open Mercato Lead Application Upgrade | - | - | Included |
+| Dedicated Customer Success Manager (pre-go-live) | - | Optional | Included |
+| Open Mercato system documentation for GDPR compliance & production-config advisory | Templates | Included | Included |
+| Penetration tests performed on production release | - | - | Included |
+
+Note: "Optional" items in the Medium tier can be added as scoped add-ons. "Managed for you" means Open Mercato proactively checks whether you should adopt available upgrades and, in the Enterprise tier, applies them on your behalf.
+
+### 05 - SERVICE DETAIL
+
+Service detail
+
+**Architecture Audit (pre-deployment).** A structured architecture review before production deployment: review of overall system architecture, identification of structural risks, and recommendations for production readiness.
+
+**Monthly Security Review (up to 4h/mo).** Application code review, infrastructure & environment configuration review, identification of security risks and remediation guidance.
+
+**Monthly Performance Review - custom code (up to 4h/mo).** Detection of performance bottlenecks, review of scalability risks, optimization recommendations.
+
+**Monthly Custom Module Code Review (up to 4h/mo).** Alignment with Open Mercato best practices, code quality & maintainability, agent-friendly architecture patterns, upgrade safety.
+
+**Customer Success Support (pre-go-live).** A dedicated CSM supports the Product Owner and technical team until launch: one 1-hour online meeting per month, ongoing ticketing support, rollout-readiness guidance.
+
+**Priority Technical Support.** Priority helpdesk (Slack / Discord or ticketing) for architecture and development questions, handled with AI-assistance within tier limits. Advisory only - it does not include custom software development.
+
+**Software Updates.** Security patches, new platform features, and partner-ready upgrade packages with documented risks and upgrade procedures.
+
+* Basic: Update packages are provided, and customers apply upgrades independently.
+* Medium: Update packages are provided, with support and guidance from our team during the upgrade process.
+* Enterprise: Managed upgrades, including planning, validation, and application of updates by our team.
+
+Customers may continue using the software after license expiration, but access to new updates, security patches, and platform enhancements requires an active license.
+
+**Production Approval (Homologation).** A formal production-readiness assessment before go-live: production approval report, risk summary and go-live recommendation.
+
+**Production Hosting Reference.** Reference self-hosted deployment setup (including Dokploy and parallel queue processing), with an optional fully managed Developer Sandbox Cloud offering for development and testing environments, currently in early access (beta).
+
+### 06 - TRIAL & SANDBOXES
+
+Time-limited offer: project sandboxes & data safety — early access (beta): the Developer Sandbox Cloud / DevCloud is provided as-is and is maturing toward general availability; early adopters get access first.
+
+* Sandboxes - spin up Open Mercato project with your coding agents and live previews in ~30 seconds. Build and learn in the sandbox, then move the application to your main infrastructure. Its unified trial path in the cloud replaces ad-hoc free demos. Teams can start building and learning AI-engineering immediately, without first going through their security department.
+* Backups & restore - download a backup of sandbox data to your computer and restore the system state up to 7 days back.
+
+### 07 - ENGAGEMENT
+
+How the engagement works
+
+Open Mercato with their Implementation Partners works directly with end customers and runs these processes end-to-end. The path is designed to de-risk adoption and transfer AI-engineering capability to customer's team:
+
+1. Paid discovery workshop - align on the use case, architecture and the way of working.
+2. Paid Proof of Concept - a working, scoped POC that proves value and teaches the customer's team the Open Mercato Way.
+3. Enterprise Subscription - license the platform so your team can extend the system independently, on a safe, certified foundation.
+
+Implementation Partners. Certified software consultancies handle efficient delivery. The cheaper Basic tier makes the license easy for partners to attach to their projects. Partners do not build or modify the commercial core.
+
+### 08 - WHY IT MATTERS
+
+Executive peace of mind
+
+The ultimate goal of the Open Mercato Enterprise Subscription is simple: a homologated, ISO/GDPR-aligned, performant foundation for AI-built software - so your teams can code with AI under clear guard-rails, and your leadership can sign off on production with confidence.
+
+Confidence for the CTO. Confidence for the CIO. Confidence at scale.


### PR DESCRIPTION
The Agreement and the Order Form both reference `packages/enterprise/TERMS.md` as the version of the Terms binding on the Effective Date. That file was never published in this repo, so the reference in every contract we send resolves to a 404.

This publishes the signed-off v2.2 text:

- **Part A - Terms**, matching the current Agreement document clause for clause, including the new §2.7 (Licensee Affiliates) and the references it adds in §2.4, §4.1 and §8.1. Tier is now determined by Licensee revenue aggregated with covered Licensee Affiliates.
- **Part B - Product & Service Description**, which forms an integral part of the Terms.

Pricing is deliberately not included: fees are set out in the Order Form or at checkout, so the tier table here carries revenue bands without amounts.

The header states that each version is published as a git tag, so this needs a tag once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)