### PR TITLE
fix(workflows): unify canvas handle geometry and move the default route into the outcome footer

### DIFF
--- a/packages/core/src/modules/workflows/AGENTS.md
+++ b/packages/core/src/modules/workflows/AGENTS.md
@@ -235,6 +235,16 @@ as it always did (guarded by a regression test in `lib/__tests__/error-routing.t
   run agree by construction.
 - **The dot IS the connection handle** — wiring a disposition is drawing a line from the row that
   names it.
+- **The step's DEFAULT route is the footer's last row**, `buildDefaultRouteRow()`. Its handle id is
+  still `DEFAULT_SOURCE_HANDLE_ID` (`'source'`, `lib/route-kinds.ts`) — the move is presentation, so
+  every stored transition keeps resolving to it. It renders as a row only when a footer renders at
+  all; without one the node keeps its own `<Handle>` unchanged. It is named `default`, NOT
+  `otherwise`: `resolveAgentOutcomeHandling` returns `{ kind: 'default' }` for a step that wired no
+  outcome and for an unwired `approved`, while every OTHER unwired outcome inherits the error
+  directive — a row promising "everything else comes here" would be wrong.
+- **Every handle on the canvas is sized from `NODE_HANDLE_CLASS`** (`lib/node-geometry.ts`), footer
+  dots included. MUST NOT spell `!w-3 !h-3` in a node component; `nodeHandleGeometry.test.ts` fails
+  if you do. `countOutcomeRows` adds one for the default row, or dagre under-reserves the card.
 - **The LABEL carries the meaning, never the dot colour** (§4.6 acceptance criterion). Two rows paint
   the same red (`rejected`, `guardrailBlocked`), which at 10px and at canvas zoom is not a
   distinction anyone can read, so every row also carries its own GLYPH and every handle is named.

--- a/packages/core/src/modules/workflows/components/__tests__/nodeHandleGeometry.test.ts
+++ b/packages/core/src/modules/workflows/components/__tests__/nodeHandleGeometry.test.ts
@@ -59,4 +59,11 @@ describe('node connection handles share one geometry constant', () => {
       .map(({ file }) => file)
     expect(offenders).toEqual([])
   })
+
+  it('names the default source handle from the frozen constant, never a literal', () => {
+    const offenders = readNodeSources()
+      .filter(({ source }) => source.includes('id="source"'))
+      .map(({ file }) => file)
+    expect(offenders).toEqual([])
+  })
 })

--- a/packages/core/src/modules/workflows/components/__tests__/nodeHandleGeometry.test.ts
+++ b/packages/core/src/modules/workflows/components/__tests__/nodeHandleGeometry.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Handle geometry comes from ONE constant.
+ *
+ * Every node component used to spell its own `!w-3 !h-3 !border-2
+ * !border-background`, and the outcome-row footer spelled a smaller one — so a
+ * footer dot and the generic source handle floating beside it rendered at
+ * different diameters on the same card, which is what the maintainer reported
+ * as "different sizes". A previous fix already found three private copies of
+ * node geometry drifting apart; this pins the handle half of it so a fourth
+ * cannot appear.
+ */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import {
+  NODE_HANDLE_BORDER_CLASS,
+  NODE_HANDLE_CLASS,
+  NODE_HANDLE_EDGE_OFFSET,
+  NODE_HANDLE_SIZE,
+  NODE_HANDLE_SIZE_CLASS,
+  NODE_PORT_HANDLE_CLASS,
+} from '../../lib/node-geometry'
+
+const NODES_DIR = path.join(__dirname, '..', 'nodes')
+
+function readNodeSources(): Array<{ file: string; source: string }> {
+  return fs
+    .readdirSync(NODES_DIR)
+    .filter((file) => file.endsWith('.tsx'))
+    .map((file) => ({ file, source: fs.readFileSync(path.join(NODES_DIR, file), 'utf8') }))
+}
+
+describe('node connection handles share one geometry constant', () => {
+  it('derives the Tailwind size from the pixel size', () => {
+    expect(NODE_HANDLE_SIZE).toBe(12)
+    expect(NODE_HANDLE_SIZE_CLASS).toBe('!h-3 !w-3')
+    expect(NODE_HANDLE_CLASS).toBe(`${NODE_HANDLE_SIZE_CLASS} ${NODE_HANDLE_BORDER_CLASS}`)
+  })
+
+  it('overhangs an edge by exactly half a handle, so it straddles rather than floats', () => {
+    expect(NODE_HANDLE_EDGE_OFFSET).toBe(-NODE_HANDLE_SIZE / 2)
+  })
+
+  it('keeps the smaller sub-workflow port size a deliberate decision in the same file', () => {
+    expect(NODE_PORT_HANDLE_CLASS).not.toContain(NODE_HANDLE_SIZE_CLASS)
+    expect(NODE_PORT_HANDLE_CLASS).toContain('!h-2.5 !w-2.5')
+  })
+
+  it('leaves no node component spelling a handle size of its own', () => {
+    const offenders = readNodeSources()
+      .filter(({ source }) => /!(?:w|h)-(?:3|2\.5)\b/.test(source))
+      .map(({ file }) => file)
+    expect(offenders).toEqual([])
+  })
+
+  it('renders every handle through the shared class', () => {
+    const offenders = readNodeSources()
+      .filter(({ source }) => source.includes('<Handle'))
+      .filter(({ source }) => !/NODE_(?:PORT_)?HANDLE_CLASS/.test(source))
+      .map(({ file }) => file)
+    expect(offenders).toEqual([])
+  })
+})

--- a/packages/core/src/modules/workflows/components/__tests__/nodeOutcomeRows.test.tsx
+++ b/packages/core/src/modules/workflows/components/__tests__/nodeOutcomeRows.test.tsx
@@ -14,20 +14,23 @@ import { fireEvent, screen } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { NodeOutcomeRows } from '../nodes/NodeOutcomeRows'
 import { InvokeAgentNode } from '../nodes/InvokeAgentNode'
+import { UserTaskNode } from '../nodes/UserTaskNode'
 import {
   buildAgentOutcomeRows,
   buildAllAgentOutcomeRows,
   buildDecisionOutcomeRows,
+  buildDefaultRouteRow,
   isDecisionSourceHandle,
   readDecisionLabel,
 } from '../../lib/node-outcome-rows'
 import { outcomeSourceHandleId } from '../../lib/outcome-routing'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 
 jest.mock('@xyflow/react', () => ({
   Handle: ({ id, 'aria-label': ariaLabel }: { id: string; 'aria-label'?: string }) => (
     <span data-testid="handle" data-handle-id={id} aria-label={ariaLabel} />
   ),
-  Position: { Right: 'right' },
+  Position: { Right: 'right', Left: 'left' },
 }))
 
 const agentStep = 'assess'
@@ -155,6 +158,100 @@ describe('the footer never lets colour carry the meaning', () => {
   it('renders nothing at all when a node has no rows', () => {
     const { container } = renderWithProviders(<NodeOutcomeRows rows={[]} />)
     expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('the default route is the footer last row, not a floating handle', () => {
+  it('keeps the handle id the canvas and every stored transition already use', () => {
+    expect(buildDefaultRouteRow().handleId).toBe(DEFAULT_SOURCE_HANDLE_ID)
+    expect(DEFAULT_SOURCE_HANDLE_ID).toBe('source')
+  })
+
+  it('pairs the row with a label and a glyph of its own, never colour alone', () => {
+    const row = buildDefaultRouteRow()
+    expect(row.labelFallback).toBe('default')
+    expect(row.labelKey).toBe('workflows.outcomes.default')
+    expect(row.glyph).toBe('corner')
+    expect(buildAllAgentOutcomeRows().map((outcome) => outcome.glyph)).not.toContain(row.glyph)
+  })
+
+  it('renders last, so every outgoing connection leaves from a row', () => {
+    const rows = buildAgentOutcomeRows([outcomeTransition('rejected')], agentStep)
+    const { container } = renderWithProviders(
+      <NodeOutcomeRows rows={rows} defaultRow={buildDefaultRouteRow()} isConnectable />,
+    )
+
+    const handleIds = Array.from(container.querySelectorAll('[data-handle-id]')).map((node) =>
+      node.getAttribute('data-handle-id'),
+    )
+    expect(handleIds).toEqual([
+      outcomeSourceHandleId('approved'),
+      outcomeSourceHandleId('rejected'),
+      DEFAULT_SOURCE_HANDLE_ID,
+    ])
+    expect(screen.getByText('default')).toBeInTheDocument()
+  })
+
+  it('stays out of the footer when a node passes none, so its own handle still renders', () => {
+    const { container } = renderWithProviders(
+      <NodeOutcomeRows rows={buildAgentOutcomeRows([], agentStep)} isConnectable />,
+    )
+    expect(container.querySelector(`[data-handle-id="${DEFAULT_SOURCE_HANDLE_ID}"]`)).toBeNull()
+  })
+
+  it('gives an agent node with no outcome routes a default exit, in the footer', () => {
+    const props = {
+      id: agentStep,
+      data: { label: 'Assess request', outcomeRows: buildAgentOutcomeRows([], agentStep) },
+      isConnectable: true,
+      selected: false,
+    } as unknown as React.ComponentProps<typeof InvokeAgentNode>
+
+    renderWithProviders(<InvokeAgentNode {...props} />)
+
+    expect(
+      document.querySelectorAll(`[data-handle-id="${DEFAULT_SOURCE_HANDLE_ID}"]`),
+    ).toHaveLength(1)
+    expect(
+      document.querySelector(`[data-default-route-handle="${DEFAULT_SOURCE_HANDLE_ID}"]`),
+    ).not.toBeNull()
+  })
+
+  it('leaves a user task with no decisions exactly as it was', () => {
+    const props = {
+      id: 'approve',
+      data: { label: 'Approve order' },
+      isConnectable: true,
+      selected: false,
+    } as unknown as React.ComponentProps<typeof UserTaskNode>
+
+    renderWithProviders(<UserTaskNode {...props} />)
+
+    expect(
+      document.querySelectorAll(`[data-handle-id="${DEFAULT_SOURCE_HANDLE_ID}"]`),
+    ).toHaveLength(1)
+    expect(document.querySelector('[data-default-route-handle]')).toBeNull()
+  })
+
+  it('moves a decision-bearing user task default route into the footer', () => {
+    const props = {
+      id: 'approve',
+      data: {
+        label: 'Approve order',
+        decisions: [{ id: 'done', label: 'Done', transitionId: 't_done', style: 'primary' }],
+      },
+      isConnectable: true,
+      selected: false,
+    } as unknown as React.ComponentProps<typeof UserTaskNode>
+
+    renderWithProviders(<UserTaskNode {...props} />)
+
+    expect(
+      document.querySelectorAll(`[data-handle-id="${DEFAULT_SOURCE_HANDLE_ID}"]`),
+    ).toHaveLength(1)
+    expect(
+      document.querySelector(`[data-default-route-handle="${DEFAULT_SOURCE_HANDLE_ID}"]`),
+    ).not.toBeNull()
   })
 })
 

--- a/packages/core/src/modules/workflows/components/nodes/AutomatedNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/AutomatedNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
@@ -76,7 +77,7 @@ export function AutomatedNode({ id, data, isConnectable, selected }: NodeProps) 
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/components/nodes/AutomatedNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/AutomatedNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 import { buildNodeConfigSummary } from '../../lib/node-config-summary'
@@ -54,7 +55,7 @@ export function AutomatedNode({ id, data, isConnectable, selected }: NodeProps) 
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -77,7 +78,7 @@ export function AutomatedNode({ id, data, isConnectable, selected }: NodeProps) 
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <ErrorOutputHandle isConnectable={isConnectable} />

--- a/packages/core/src/modules/workflows/components/nodes/EndNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/EndNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 
@@ -34,7 +35,7 @@ export function EndNode({ id, data, isConnectable, selected }: NodeProps) {
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard

--- a/packages/core/src/modules/workflows/components/nodes/ErrorOutputHandle.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/ErrorOutputHandle.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { ERROR_SOURCE_HANDLE_ID } from '../../lib/error-routing'
 
@@ -25,7 +26,7 @@ export function ErrorOutputHandle({ isConnectable }: { isConnectable?: boolean }
       aria-label={label}
       data-testid="workflow-error-handle"
       style={{ top: '75%' }}
-      className="!w-3 !h-3 !bg-status-error-icon !border-2 !border-background"
+      className={`${NODE_HANDLE_CLASS} !bg-status-error-icon`}
     />
   )
 }

--- a/packages/core/src/modules/workflows/components/nodes/IfElseNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/IfElseNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 
@@ -34,7 +35,7 @@ export function IfElseNode({ id, data, isConnectable, selected }: NodeProps) {
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -55,7 +56,7 @@ export function IfElseNode({ id, data, isConnectable, selected }: NodeProps) {
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
     </div>
   )

--- a/packages/core/src/modules/workflows/components/nodes/IfElseNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/IfElseNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
@@ -54,7 +55,7 @@ export function IfElseNode({ id, data, isConnectable, selected }: NodeProps) {
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/components/nodes/InvokeAgentNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/InvokeAgentNode.tsx
@@ -9,7 +9,12 @@ import { buildNodeConfigSummary } from '../../lib/node-config-summary'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { ErrorOutputHandle } from './ErrorOutputHandle'
 import { NodeOutcomeRows } from './NodeOutcomeRows'
-import { buildAllAgentOutcomeRows, type NodeOutcomeRow } from '../../lib/node-outcome-rows'
+import {
+  buildAllAgentOutcomeRows,
+  buildDefaultRouteRow,
+  type NodeOutcomeRow,
+} from '../../lib/node-outcome-rows'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 
 export interface InvokeAgentNodeData {
   label: string
@@ -49,6 +54,8 @@ export function InvokeAgentNode({ id, data, isConnectable, selected }: NodeProps
   const canRevealOutcomes = Boolean(
     isConnectable && !showAllOutcomes && outcomeRows.length < availableOutcomeRows.length,
   )
+  const hasOutcomeFooter = outcomeRows.length > 0
+  const defaultRouteRow = buildDefaultRouteRow()
 
   const workflowStatus = toWorkflowStatus(nodeData.status)
   const summary = buildNodeConfigSummary('invokeAgent', nodeData as never)
@@ -112,6 +119,7 @@ export function InvokeAgentNode({ id, data, isConnectable, selected }: NodeProps
           footer={
             <NodeOutcomeRows
               rows={outcomeRows}
+              defaultRow={hasOutcomeFooter ? defaultRouteRow : undefined}
               isConnectable={isConnectable}
               inheritanceNote={t(
                 'workflows.outcomes.inheritsErrorDirective',
@@ -136,13 +144,19 @@ export function InvokeAgentNode({ id, data, isConnectable, selected }: NodeProps
         )}
       </div>
 
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="source"
-        isConnectable={isConnectable}
-        className={`${NODE_HANDLE_CLASS} !bg-brand-violet`}
-      />
+      {/* The default route leaves from the footer's last row whenever there is
+          a footer, so it shares the outcome rows' x-position, size and rhythm
+          instead of floating over the first of them. Without a footer there is
+          nothing to hang it off, so it stays exactly where it always was. */}
+      {!hasOutcomeFooter && (
+        <Handle
+          type="source"
+          position={Position.Right}
+          id={DEFAULT_SOURCE_HANDLE_ID}
+          isConnectable={isConnectable}
+          className={`${NODE_HANDLE_CLASS} !bg-brand-violet`}
+        />
+      )}
 
       <ErrorOutputHandle isConnectable={isConnectable} />
     </div>

--- a/packages/core/src/modules/workflows/components/nodes/InvokeAgentNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/InvokeAgentNode.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 import { buildNodeConfigSummary } from '../../lib/node-config-summary'
@@ -92,7 +93,7 @@ export function InvokeAgentNode({ id, data, isConnectable, selected }: NodeProps
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-brand-violet !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-brand-violet`}
       />
 
       <div className="relative">
@@ -140,7 +141,7 @@ export function InvokeAgentNode({ id, data, isConnectable, selected }: NodeProps
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-brand-violet !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-brand-violet`}
       />
 
       <ErrorOutputHandle isConnectable={isConnectable} />

--- a/packages/core/src/modules/workflows/components/nodes/NodeOutcomeRows.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/NodeOutcomeRows.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Handle, Position } from '@xyflow/react'
-import { Check, CircleAlert, Info, ShieldMinus, Slash, Dot } from 'lucide-react'
+import { Check, CircleAlert, CornerDownLeft, Info, ShieldMinus, Slash, Dot } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import type { NodeOutcomeRow, NodeOutcomeRowGlyph, NodeOutcomeRowTone } from '../../lib/node-outcome-rows'
@@ -44,10 +44,19 @@ const GLYPH_COMPONENTS: Record<NodeOutcomeRowGlyph, typeof Check> = {
   shield: ShieldMinus,
   alert: CircleAlert,
   dot: Dot,
+  corner: CornerDownLeft,
 }
 
 export interface NodeOutcomeRowsProps {
   rows: NodeOutcomeRow[]
+  /**
+   * The step's ordinary output, rendered as the LAST row so every outgoing
+   * connection leaves the card from a footer row — one x-position, one dot
+   * size, one vertical rhythm. Passing it is what tells the node not to render
+   * its own floating source handle; omitting it keeps the node's handle where
+   * it always was.
+   */
+  defaultRow?: NodeOutcomeRow
   isConnectable?: boolean
   /**
    * Announced when an outcome has no route: §7.2 requires the node face to
@@ -61,6 +70,7 @@ export interface NodeOutcomeRowsProps {
 
 export function NodeOutcomeRows({
   rows,
+  defaultRow,
   isConnectable,
   inheritanceNote,
   revealLabel,
@@ -68,7 +78,9 @@ export function NodeOutcomeRows({
   testId,
 }: NodeOutcomeRowsProps) {
   const t = useT()
-  if (rows.length === 0) return null
+  if (rows.length === 0 && !defaultRow) return null
+
+  const allRows = defaultRow ? [...rows, defaultRow] : rows
 
   return (
     <div
@@ -76,14 +88,16 @@ export function NodeOutcomeRows({
       data-testid={testId ?? 'workflow-node-outcome-rows'}
     >
       <div className="grid gap-0.5">
-        {rows.map((row) => {
+        {allRows.map((row) => {
           const label = row.labelKey ? t(row.labelKey, row.labelFallback) : row.labelFallback
           const Glyph = GLYPH_COMPONENTS[row.glyph]
           return (
             <div
               key={row.handleId}
               className="relative flex min-h-4 items-center justify-end gap-1 pr-2"
-              data-outcome-handle={row.handleId}
+              {...(row === defaultRow
+                ? { 'data-default-route-handle': row.handleId }
+                : { 'data-outcome-handle': row.handleId })}
             >
               <Glyph className={`h-3 w-3 shrink-0 ${TONE_TEXT_CLASSES[row.tone]}`} aria-hidden="true" />
               <span className="truncate text-overline text-muted-foreground">{label}</span>

--- a/packages/core/src/modules/workflows/components/nodes/NodeOutcomeRows.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/NodeOutcomeRows.tsx
@@ -5,6 +5,7 @@ import { Check, CircleAlert, Info, ShieldMinus, Slash, Dot } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Button } from '@open-mercato/ui/primitives/button'
 import type { NodeOutcomeRow, NodeOutcomeRowGlyph, NodeOutcomeRowTone } from '../../lib/node-outcome-rows'
+import { NODE_HANDLE_CLASS, NODE_HANDLE_EDGE_OFFSET } from '../../lib/node-geometry'
 
 /**
  * The node's outcome-row footer (fidelity gap #4, spec §7.2).
@@ -93,8 +94,8 @@ export function NodeOutcomeRows({
                 isConnectable={isConnectable}
                 title={label}
                 aria-label={label}
-                style={{ right: -6, top: '50%' }}
-                className={`!h-2.5 !w-2.5 !border-2 !border-background ${TONE_DOT_CLASSES[row.tone]}`}
+                style={{ right: NODE_HANDLE_EDGE_OFFSET, top: '50%' }}
+                className={`${NODE_HANDLE_CLASS} ${TONE_DOT_CLASSES[row.tone]}`}
               />
             </div>
           )

--- a/packages/core/src/modules/workflows/components/nodes/ParallelForkNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/ParallelForkNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
@@ -59,7 +60,7 @@ export function ParallelForkNode({ id, data, isConnectable, selected }: NodeProp
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/components/nodes/ParallelForkNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/ParallelForkNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 
@@ -39,7 +40,7 @@ export function ParallelForkNode({ id, data, isConnectable, selected }: NodeProp
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -60,7 +61,7 @@ export function ParallelForkNode({ id, data, isConnectable, selected }: NodeProp
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
     </div>
   )

--- a/packages/core/src/modules/workflows/components/nodes/ParallelJoinNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/ParallelJoinNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 
@@ -39,7 +40,7 @@ export function ParallelJoinNode({ id, data, isConnectable, selected }: NodeProp
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -60,7 +61,7 @@ export function ParallelJoinNode({ id, data, isConnectable, selected }: NodeProp
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
     </div>
   )

--- a/packages/core/src/modules/workflows/components/nodes/ParallelJoinNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/ParallelJoinNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
@@ -59,7 +60,7 @@ export function ParallelJoinNode({ id, data, isConnectable, selected }: NodeProp
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/components/nodes/StartNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/StartNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
@@ -46,7 +47,7 @@ export function StartNode({ id, data, isConnectable, selected }: NodeProps) {
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/components/nodes/StartNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/StartNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 
@@ -47,7 +48,7 @@ export function StartNode({ id, data, isConnectable, selected }: NodeProps) {
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
     </div>
   )

--- a/packages/core/src/modules/workflows/components/nodes/SubWorkflowNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/SubWorkflowNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS, NODE_PORT_HANDLE_CLASS } from '../../lib/node-geometry'
 import { ArrowUpRight } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
@@ -85,7 +86,7 @@ export function SubWorkflowNode({ id, data, isConnectable, selected }: NodeProps
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -117,7 +118,7 @@ export function SubWorkflowNode({ id, data, isConnectable, selected }: NodeProps
                     id={`in:${port.name}`}
                     isConnectable={isConnectable}
                     style={{ left: `${((index + 1) / (inputs.length + 1)) * 100}%` }}
-                    className="!w-2.5 !h-2.5 !bg-primary !border !border-background"
+                    className={`${NODE_PORT_HANDLE_CLASS} !bg-primary`}
                   />
                   <span className="truncate text-foreground">{port.label || port.name}</span>
                   <span className="shrink-0 text-muted-foreground">{t(`workflows.ports.types.${port.type}`)}</span>
@@ -140,7 +141,7 @@ export function SubWorkflowNode({ id, data, isConnectable, selected }: NodeProps
                     id={`out:${port.name}`}
                     isConnectable={isConnectable}
                     style={{ left: `${((index + 1) / (outputs.length + 1)) * 100}%` }}
-                    className="!w-2.5 !h-2.5 !bg-muted-foreground !border !border-background"
+                    className={`${NODE_PORT_HANDLE_CLASS} !bg-muted-foreground`}
                   />
                 </div>
               ))}
@@ -155,7 +156,7 @@ export function SubWorkflowNode({ id, data, isConnectable, selected }: NodeProps
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <ErrorOutputHandle isConnectable={isConnectable} />

--- a/packages/core/src/modules/workflows/components/nodes/SubWorkflowNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/SubWorkflowNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS, NODE_PORT_HANDLE_CLASS } from '../../lib/node-geometry'
 import { ArrowUpRight } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
@@ -154,7 +155,7 @@ export function SubWorkflowNode({ id, data, isConnectable, selected }: NodeProps
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/components/nodes/SwitchNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/SwitchNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 
@@ -34,7 +35,7 @@ export function SwitchNode({ id, data, isConnectable, selected }: NodeProps) {
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -55,7 +56,7 @@ export function SwitchNode({ id, data, isConnectable, selected }: NodeProps) {
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
     </div>
   )

--- a/packages/core/src/modules/workflows/components/nodes/SwitchNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/SwitchNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
@@ -54,7 +55,7 @@ export function SwitchNode({ id, data, isConnectable, selected }: NodeProps) {
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/components/nodes/UserTaskNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/UserTaskNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 import { buildNodeConfigSummary } from '../../lib/node-config-summary'
@@ -51,7 +52,7 @@ export function UserTaskNode({ id, data, isConnectable, selected }: NodeProps) {
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -75,7 +76,7 @@ export function UserTaskNode({ id, data, isConnectable, selected }: NodeProps) {
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <ErrorOutputHandle isConnectable={isConnectable} />

--- a/packages/core/src/modules/workflows/components/nodes/UserTaskNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/UserTaskNode.tsx
@@ -7,7 +7,12 @@ import { toWorkflowStatus } from '../../lib/status-colors'
 import { buildNodeConfigSummary } from '../../lib/node-config-summary'
 import { ErrorOutputHandle } from './ErrorOutputHandle'
 import { NodeOutcomeRows } from './NodeOutcomeRows'
-import { buildDecisionOutcomeRows, type DecisionRowLike } from '../../lib/node-outcome-rows'
+import {
+  buildDecisionOutcomeRows,
+  buildDefaultRouteRow,
+  type DecisionRowLike,
+} from '../../lib/node-outcome-rows'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { useLocale } from '@open-mercato/shared/lib/i18n/context'
 
 export interface UserTaskNodeData {
@@ -43,6 +48,7 @@ export function UserTaskNode({ id, data, isConnectable, selected }: NodeProps) {
   const workflowStatus = toWorkflowStatus(nodeData.status)
   const summary = buildNodeConfigSummary('userTask', nodeData as never)
   const decisionRows = buildDecisionOutcomeRows(nodeData.decisions, locale)
+  const hasDecisionFooter = decisionRows.length > 0
 
   return (
     <div className="user-task-node" title={nodeData.tooltip}>
@@ -67,17 +73,28 @@ export function UserTaskNode({ id, data, isConnectable, selected }: NodeProps) {
         errorCount={nodeData.errorCount}
         nodeId={id}
         editable={isConnectable}
-        footer={<NodeOutcomeRows rows={decisionRows} isConnectable={isConnectable} testId="workflow-task-decision-rows" />}
+        footer={
+          <NodeOutcomeRows
+            rows={decisionRows}
+            defaultRow={hasDecisionFooter ? buildDefaultRouteRow() : undefined}
+            isConnectable={isConnectable}
+            testId="workflow-task-decision-rows"
+          />
+        }
       />
 
-      {/* Source Handle */}
-      <Handle
-        type="source"
-        position={Position.Right}
-        id="source"
-        isConnectable={isConnectable}
-        className={`${NODE_HANDLE_CLASS} !bg-primary`}
-      />
+      {/* The default route joins the decision rows in the footer when there is
+          one, so it stops floating over the first decision. A task with no
+          authored decisions has no footer, and keeps its handle unchanged. */}
+      {!hasDecisionFooter && (
+        <Handle
+          type="source"
+          position={Position.Right}
+          id={DEFAULT_SOURCE_HANDLE_ID}
+          isConnectable={isConnectable}
+          className={`${NODE_HANDLE_CLASS} !bg-primary`}
+        />
+      )}
 
       <ErrorOutputHandle isConnectable={isConnectable} />
     </div>

--- a/packages/core/src/modules/workflows/components/nodes/WaitForConditionNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/WaitForConditionNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 
@@ -34,7 +35,7 @@ export function WaitForConditionNode({ id, data, isConnectable, selected }: Node
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -55,7 +56,7 @@ export function WaitForConditionNode({ id, data, isConnectable, selected }: Node
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
     </div>
   )

--- a/packages/core/src/modules/workflows/components/nodes/WaitForConditionNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/WaitForConditionNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
@@ -54,7 +55,7 @@ export function WaitForConditionNode({ id, data, isConnectable, selected }: Node
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/components/nodes/WaitForSignalNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/WaitForSignalNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 import { buildNodeConfigSummary } from '../../lib/node-config-summary'
@@ -41,7 +42,7 @@ export function WaitForSignalNode({ id, data, isConnectable, selected }: NodePro
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -64,7 +65,7 @@ export function WaitForSignalNode({ id, data, isConnectable, selected }: NodePro
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
     </div>
   )

--- a/packages/core/src/modules/workflows/components/nodes/WaitForSignalNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/WaitForSignalNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
@@ -63,7 +64,7 @@ export function WaitForSignalNode({ id, data, isConnectable, selected }: NodePro
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/components/nodes/WaitForTimerNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/WaitForTimerNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
 import { buildNodeConfigSummary } from '../../lib/node-config-summary'
@@ -44,7 +45,7 @@ export function WaitForTimerNode({ id, data, isConnectable, selected }: NodeProp
         position={Position.Left}
         id="target"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
 
       <WorkflowNodeCard
@@ -66,7 +67,7 @@ export function WaitForTimerNode({ id, data, isConnectable, selected }: NodeProp
         position={Position.Right}
         id="source"
         isConnectable={isConnectable}
-        className="!w-3 !h-3 !bg-primary !border-2 !border-background"
+        className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />
     </div>
   )

--- a/packages/core/src/modules/workflows/components/nodes/WaitForTimerNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/WaitForTimerNode.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Handle, Position, NodeProps } from '@xyflow/react'
+import { DEFAULT_SOURCE_HANDLE_ID } from '../../lib/route-kinds'
 import { NODE_HANDLE_CLASS } from '../../lib/node-geometry'
 import { WorkflowNodeCard } from '../WorkflowNodeCard'
 import { toWorkflowStatus } from '../../lib/status-colors'
@@ -65,7 +66,7 @@ export function WaitForTimerNode({ id, data, isConnectable, selected }: NodeProp
       <Handle
         type="source"
         position={Position.Right}
-        id="source"
+        id={DEFAULT_SOURCE_HANDLE_ID}
         isConnectable={isConnectable}
         className={`${NODE_HANDLE_CLASS} !bg-primary`}
       />

--- a/packages/core/src/modules/workflows/i18n/de.json
+++ b/packages/core/src/modules/workflows/i18n/de.json
@@ -1322,6 +1322,7 @@
   "workflows.orderApproval.submitDecision": "Entscheidung einreichen",
   "workflows.outcomes.add": "+ Ergebnis",
   "workflows.outcomes.approved": "genehmigt",
+  "workflows.outcomes.default": "Standard",
   "workflows.outcomes.error": "Fehler",
   "workflows.outcomes.guardrailBlocked": "durch Schutzregel blockiert",
   "workflows.outcomes.informative": "informativ",

--- a/packages/core/src/modules/workflows/i18n/en.json
+++ b/packages/core/src/modules/workflows/i18n/en.json
@@ -1322,6 +1322,7 @@
   "workflows.orderApproval.submitDecision": "Submit Decision",
   "workflows.outcomes.add": "+ outcome",
   "workflows.outcomes.approved": "approved",
+  "workflows.outcomes.default": "default",
   "workflows.outcomes.error": "error",
   "workflows.outcomes.guardrailBlocked": "guardrail blocked",
   "workflows.outcomes.informative": "informative",

--- a/packages/core/src/modules/workflows/i18n/es.json
+++ b/packages/core/src/modules/workflows/i18n/es.json
@@ -1322,6 +1322,7 @@
   "workflows.orderApproval.submitDecision": "Enviar decisión",
   "workflows.outcomes.add": "+ resultado",
   "workflows.outcomes.approved": "aprobado",
+  "workflows.outcomes.default": "por defecto",
   "workflows.outcomes.error": "error",
   "workflows.outcomes.guardrailBlocked": "bloqueado por salvaguarda",
   "workflows.outcomes.informative": "informativo",

--- a/packages/core/src/modules/workflows/i18n/pl.json
+++ b/packages/core/src/modules/workflows/i18n/pl.json
@@ -1322,6 +1322,7 @@
   "workflows.orderApproval.submitDecision": "Zatwierdź decyzję",
   "workflows.outcomes.add": "+ wynik",
   "workflows.outcomes.approved": "zatwierdzone",
+  "workflows.outcomes.default": "domyślne",
   "workflows.outcomes.error": "błąd",
   "workflows.outcomes.guardrailBlocked": "zablokowane przez zabezpieczenie",
   "workflows.outcomes.informative": "informacyjne",

--- a/packages/core/src/modules/workflows/lib/__tests__/route-kinds.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/route-kinds.test.ts
@@ -4,12 +4,14 @@ import { reattachWorkflowEdge } from '../edge-reattachment'
 import { ERROR_SOURCE_HANDLE_ID, ERROR_TRANSITION_KIND } from '../error-routing'
 import { SLA_BREACH_SOURCE_HANDLE_ID, SLA_BREACH_TRANSITION_KIND } from '../breach-routing'
 import {
+  DEFAULT_SOURCE_HANDLE_ID,
   findRouteKindDescriptor,
   findRouteKindDescriptorForHandle,
   isNonNormalRouteKind,
   listRouteKindDescriptors,
   resolveEdgeRouteKind,
 } from '../route-kinds'
+import { buildDefaultRouteRow } from '../node-outcome-rows'
 
 const steps = [
   { stepId: 'start', stepName: 'Start', stepType: 'START' },
@@ -117,6 +119,48 @@ describe('transition kind round trip through the canvas', () => {
     }
     const roundTripped = graphToDefinition(nodes, edges)
     expect((roundTripped.transitions[0] as any).activities).toBeUndefined()
+  })
+})
+
+describe('the default handle is presentation, never routing', () => {
+  test('no route kind claims it, so a connection drawn from it is still a normal route', () => {
+    expect(findRouteKindDescriptorForHandle(DEFAULT_SOURCE_HANDLE_ID)).toBeNull()
+    expect(resolveEdgeRouteKind(undefined, DEFAULT_SOURCE_HANDLE_ID)).toBeNull()
+  })
+
+  test('the footer row that now renders it carries the same id it always had', () => {
+    expect(buildDefaultRouteRow().handleId).toBe(DEFAULT_SOURCE_HANDLE_ID)
+  })
+
+  test('an agent step with a plain outgoing route round-trips unchanged', () => {
+    const definition = {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        {
+          stepId: 'assess',
+          stepName: 'Assess',
+          stepType: 'AUTOMATED',
+          activities: [{ activityId: 'a1', activityType: 'INVOKE_AGENT', config: { agentId: 'x' } }],
+        },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [
+        { transitionId: 't_a', fromStepId: 'start', toStepId: 'assess', trigger: 'auto' },
+        { transitionId: 't_b', fromStepId: 'assess', toStepId: 'end', trigger: 'auto' },
+      ],
+    } as any
+
+    const { nodes, edges } = definitionToGraph(definition)
+    const plain = edges.find((edge) => edge.id === 't_b')
+    expect(plain?.sourceHandle).toBeUndefined()
+
+    const persisted = graphToDefinition(nodes, edges).transitions.find(
+      (transition: any) => transition.transitionId === 't_b',
+    )
+    expect(persisted).not.toHaveProperty('kind')
+    expect(persisted).not.toHaveProperty('outcomeKind')
+    expect(persisted?.fromStepId).toBe('assess')
+    expect(persisted?.toStepId).toBe('end')
   })
 })
 

--- a/packages/core/src/modules/workflows/lib/graph-utils.ts
+++ b/packages/core/src/modules/workflows/lib/graph-utils.ts
@@ -677,8 +677,20 @@ export function nodeFootprint(
  * shows its WIRED outcomes plus `approved`; a user task shows one row per
  * authored decision. Both are derived here rather than measured, because dagre
  * runs before React Flow has laid a single card out.
+ *
+ * A footer that renders at all also carries the step's DEFAULT route as its last
+ * row, which is why a non-empty count gets one more: under-estimating here is
+ * exactly what makes dagre pack ranks into each other.
  */
 function countOutcomeRows(
+  step: NodeFootprintLike,
+  transitions: OutcomeLayoutTransitionLike[],
+): number {
+  const rows = countAuthoredOutcomeRows(step, transitions)
+  return rows > 0 ? rows + 1 : 0
+}
+
+function countAuthoredOutcomeRows(
   step: NodeFootprintLike,
   transitions: OutcomeLayoutTransitionLike[],
 ): number {

--- a/packages/core/src/modules/workflows/lib/node-geometry.ts
+++ b/packages/core/src/modules/workflows/lib/node-geometry.ts
@@ -1,6 +1,6 @@
 /**
  * Rendered node geometry — the SINGLE source of truth for how much space a
- * workflow node occupies.
+ * workflow node occupies AND for how big its connection handles are.
  *
  * Two consumers need the same numbers and used to keep private copies in sync
  * behind a comment: `components/WorkflowNodeCard.tsx` (which renders the card)
@@ -9,6 +9,13 @@
  * here instead. This module stays PURE — no React, no `lucide-react`, no
  * `@xyflow/react` — so the layout transform can import it in node and jest
  * contexts without pulling in the editor's render chain.
+ *
+ * The handle constants below joined it for the same reason: every node
+ * component spelled its own `!w-3 !h-3 !border-2 !border-background` and the
+ * outcome-row footer spelled a smaller one, so a footer dot and the source
+ * handle floating beside it rendered at different diameters on the same card.
+ * Tailwind scans this file (`@source ".../@open-mercato/core/src/**\/*.{ts,tsx}"`),
+ * so the literals here are real utilities, not dead strings.
  */
 
 /** Narrowest a `w-fit` card may render. */
@@ -46,3 +53,41 @@ export const NODE_OUTCOME_FOOTER_CHROME_HEIGHT = 22
  */
 export const TERMINAL_NODE_MIN_WIDTH = 96
 export const TERMINAL_NODE_HEIGHT = 36
+
+/**
+ * Diameter, in px, of a connection handle. One number for the target handle,
+ * every source handle, the error handle and the terminal pills' handles: a
+ * canvas where the dots differ in size reads as a rendering bug, and the
+ * maintainer's report of "different sizes" was exactly a 10px footer dot next
+ * to a 12px floating one.
+ */
+export const NODE_HANDLE_SIZE = 12
+
+/** Tailwind form of {@link NODE_HANDLE_SIZE}. */
+export const NODE_HANDLE_SIZE_CLASS = '!h-3 !w-3'
+
+/**
+ * The ring that lifts a handle off whatever it overlaps. Kept with the size so
+ * a handle can never be resized without its border following.
+ */
+export const NODE_HANDLE_BORDER_CLASS = '!border-2 !border-background'
+
+/** Size + ring. Callers add only the DS colour token the handle speaks with. */
+export const NODE_HANDLE_CLASS = `${NODE_HANDLE_SIZE_CLASS} ${NODE_HANDLE_BORDER_CLASS}`
+
+/**
+ * How far a handle overhangs the edge it sits on — half its diameter, so it
+ * straddles the border rather than floating beside it. React Flow positions
+ * edge-anchored handles itself; this is for handles placed by a row's own
+ * layout (the outcome footer), which have to reproduce the same overhang.
+ */
+export const NODE_HANDLE_EDGE_OFFSET = -(NODE_HANDLE_SIZE / 2)
+
+/**
+ * Sub-workflow IO ports are deliberately smaller than a control-flow handle:
+ * a sub-workflow fans out one per declared input/output along an edge a
+ * control-flow handle owns alone. Registered here anyway so the two sizes are
+ * a decision made in one file rather than a drift discovered on a card.
+ */
+export const NODE_PORT_HANDLE_SIZE_CLASS = '!h-2.5 !w-2.5'
+export const NODE_PORT_HANDLE_CLASS = `${NODE_PORT_HANDLE_SIZE_CLASS} !border !border-background`

--- a/packages/core/src/modules/workflows/lib/node-outcome-rows.ts
+++ b/packages/core/src/modules/workflows/lib/node-outcome-rows.ts
@@ -25,6 +25,7 @@ import {
   outcomeSourceHandleId,
   type AgentOutcomeKind,
 } from './outcome-routing'
+import { DEFAULT_SOURCE_HANDLE_ID } from './route-kinds'
 
 /**
  * How a row reads at a glance. Paired with the row's LABEL, never standing in
@@ -33,7 +34,7 @@ import {
  * status token; the glyph gives each row a second, non-colour discriminator.
  */
 export type NodeOutcomeRowTone = 'success' | 'warning' | 'error' | 'info' | 'neutral'
-export type NodeOutcomeRowGlyph = 'check' | 'info' | 'slash' | 'shield' | 'alert' | 'dot'
+export type NodeOutcomeRowGlyph = 'check' | 'info' | 'slash' | 'shield' | 'alert' | 'dot' | 'corner'
 
 export interface NodeOutcomeRow {
   /** Stable key AND the React Flow source handle id the dot binds to. */
@@ -93,6 +94,36 @@ export function buildAllAgentOutcomeRows(): NodeOutcomeRow[] {
     labelKey: `workflows.outcomes.${outcome}`,
     ...OUTCOME_ROW_PRESENTATION[outcome],
   }))
+}
+
+/**
+ * The step's ORDINARY output, as the footer's last row.
+ *
+ * It used to render as a lone handle floating at the card's right edge, roughly
+ * level with the first outcome row it then collided with. It is not decorative
+ * and deleting it would be a regression: `resolveAgentOutcomeHandling` returns
+ * `{ kind: 'default' }` — "route exactly as this instance always would have" —
+ * for a step that wired NO outcome at all (so this handle carries every
+ * disposition, which is how every definition written before §7.2 still runs)
+ * and for `approved` whenever `approved` is not separately wired.
+ *
+ * It is NOT a catch-all, which is why it is named `default` rather than
+ * `otherwise`: an unwired `rejected` / `informative` / `guardrailBlocked` /
+ * `error` inherits the step's error directive instead, exactly as the footer's
+ * inheritance note states. A row promising "everything else comes here" would
+ * be the one label on this card an author could act on and be wrong.
+ *
+ * The handle id is unchanged (`source`), so a stored transition that resolves
+ * to it keeps resolving to it — this is presentation, not routing.
+ */
+export function buildDefaultRouteRow(): NodeOutcomeRow {
+  return {
+    handleId: DEFAULT_SOURCE_HANDLE_ID,
+    labelKey: 'workflows.outcomes.default',
+    labelFallback: 'default',
+    tone: 'neutral',
+    glyph: 'corner',
+  }
 }
 
 export interface DecisionRowLike {

--- a/packages/core/src/modules/workflows/lib/route-kinds.ts
+++ b/packages/core/src/modules/workflows/lib/route-kinds.ts
@@ -37,6 +37,18 @@ import {
  */
 export const NORMAL_TRANSITION_KIND = 'normal'
 
+/**
+ * The canvas source handle a normal route leaves from — every node's ordinary
+ * output, and the one handle no `RouteKindDescriptor` claims.
+ *
+ * FROZEN: stored transitions re-attach to it by id (`definitionToGraph` emits
+ * no `sourceHandle` for a normal route, which React Flow resolves to the node's
+ * only unnamed source), and moving where it RENDERS must never change what it
+ * is called. It moved into the outcome-row footer so every outgoing connection
+ * leaves from a row; the id did not move with it.
+ */
+export const DEFAULT_SOURCE_HANDLE_ID = 'source'
+
 export interface RouteKindTransitionLike {
   kind?: string
   outcomeKind?: string


### PR DESCRIPTION
## Connection handles: one geometry, and the default route joins the footer

Two problems the maintainer spotted on a shipped INVOKE_AGENT node: connection dots at different sizes, and a floating lavender source handle that read as a sixth outcome while colliding with the first footer row.

## The default handle is not redundant — but it was in the wrong place

With no outcome routes wired, that handle carries **every** disposition — it is the backward-compatibility guarantee for every agent step authored before §7.2 outcome routes existed. Deleting it would break all of them. What made it feel redundant is that it rendered as a floating dot at the card's edge rather than as one of the node's exits.

It is now the **last row of the outcome footer**, so every outgoing connection leaves from a footer row sharing one x-position, one size and one vertical rhythm. Nodes without a footer keep their handle exactly where it was.

**The row is named `default`, not `otherwise`** — and that distinction matters. `resolveAgentOutcomeHandling` returns `default` in exactly two cases: the step wired no outcome route at all, or the outcome is `approved` and `approved` is unwired. Every *other* unwired outcome returns `inherit` and takes the step's error directive — which is exactly what the footer note two lines below already says (`unhandled → error directive`). Labelling it `otherwise` would have contradicted that note and told an author they had covered `rejected` and `error` when they had not. The `↩` glyph is kept so it still reads as kin to the Phase 3a `otherwise` route chip.

## The size drift was three-way, not two

The Start and agent handles were already the same size (12px, differing only in colour). The real drift: **12px control-flow handles, 10px outcome-row dots, and 10px-with-border sub-workflow IO ports** — a 10px footer dot beside a 12px floating handle *on the same card* is what was visible.

`lib/node-geometry.ts` — already the single source of truth for node dimensions since Phase 5 — now also owns `NODE_HANDLE_SIZE`, its class, border and edge offset (derived as `−size/2` rather than restated), plus a separately named port constant. All 14 node components, `ErrorOutputHandle` and the footer read them. Sub-workflow ports stay smaller, but as a named constant with the reasoning recorded: a sub-workflow fans out one port per declared field along an edge a single handle owns elsewhere.

A previous fix in this module found three private copies of node geometry drifting apart; new guards assert that **no node component can spell a handle size or the `id="source"` literal**, so this cannot quietly return.

## Not a routing change

The handle keeps its id (`source`, now the frozen `DEFAULT_SOURCE_HANDLE_ID`). No route kind claims it, `definitionToGraph` still emits no `sourceHandle` for a normal route, and `graphToDefinition` still writes no `kind`/`outcomeKind`. Pinned by an agent-step round-trip test. No engine file changed.

## Verification

**231 suites / 2990 tests** passing. `typecheck`, `lint` (0 errors), `i18n:check-sync` (4 locales) all green. New tests: handle-geometry guards (5), the default-footer-row block (7, including that an agent node with no outcome routes still offers an exit and a user-task node without decisions is unchanged), and a "presentation, never routing" block (3). `canvasAccessibility.test.tsx` untouched and passing — the default row pairs its dot with a label and glyph like every other outcome.

## Noted, not fixed

`InvokeAgentNode`'s run-status chip is absolutely positioned and overlaps the bottom of the footer. It pre-dates this change and only appears under the run overlay, not in the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF94ampefJBoJazhYDu9mX
