### PR TITLE
fix(workflows): stop agent-node output reveal opening the dialog and overlapping the rows

### DIFF
--- a/packages/core/src/modules/workflows/components/__tests__/nodeOutcomeRows.test.tsx
+++ b/packages/core/src/modules/workflows/components/__tests__/nodeOutcomeRows.test.tsx
@@ -155,6 +155,27 @@ describe('the footer never lets colour carry the meaning', () => {
     expect(onReveal).toHaveBeenCalledTimes(1)
   })
 
+  it('reveals in place without bubbling to the node click that opens the dialog', () => {
+    // Regression: the reveal control lives inside the React Flow node, so a
+    // click that bubbles reaches onNodeClick and opens the edit dialog instead
+    // of disclosing the rows on the card.
+    const onReveal = jest.fn()
+    const onNodeClick = jest.fn()
+    renderWithProviders(
+      <div onClick={onNodeClick}>
+        <NodeOutcomeRows
+          rows={buildAgentOutcomeRows([], agentStep)}
+          revealLabel="+ outcome"
+          onReveal={onReveal}
+        />
+      </div>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: '+ outcome' }))
+    expect(onReveal).toHaveBeenCalledTimes(1)
+    expect(onNodeClick).not.toHaveBeenCalled()
+  })
+
   it('renders nothing at all when a node has no rows', () => {
     const { container } = renderWithProviders(<NodeOutcomeRows rows={[]} />)
     expect(container).toBeEmptyDOMElement()
@@ -214,6 +235,29 @@ describe('the default route is the footer last row, not a floating handle', () =
     ).toHaveLength(1)
     expect(
       document.querySelector(`[data-default-route-handle="${DEFAULT_SOURCE_HANDLE_ID}"]`),
+    ).not.toBeNull()
+  })
+
+  it('drops the floating error handle when the outcome footer renders, so nothing overlaps the rows', () => {
+    // Regression: the floating ErrorOutputHandle (pinned at top:75%) was
+    // rendered unconditionally, so once the footer grew — e.g. after revealing
+    // every outcome — the red handle covered the newly shown rows. The footer
+    // already expresses error routing (the `error` disposition row plus the
+    // inheritance note), so the floating handle must follow the default handle
+    // and stay off a footered node.
+    const props = {
+      id: agentStep,
+      data: { label: 'Assess request', outcomeRows: buildAllAgentOutcomeRows() },
+      isConnectable: true,
+      selected: false,
+    } as unknown as React.ComponentProps<typeof InvokeAgentNode>
+
+    renderWithProviders(<InvokeAgentNode {...props} />)
+
+    expect(document.querySelector('[data-testid="workflow-error-handle"]')).toBeNull()
+    // The error routing is still present as a footer row, not a floating dot.
+    expect(
+      document.querySelector(`[data-outcome-handle="${outcomeSourceHandleId('error')}"]`),
     ).not.toBeNull()
   })
 

--- a/packages/core/src/modules/workflows/components/nodes/InvokeAgentNode.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/InvokeAgentNode.tsx
@@ -158,7 +158,13 @@ export function InvokeAgentNode({ id, data, isConnectable, selected }: NodeProps
         />
       )}
 
-      <ErrorOutputHandle isConnectable={isConnectable} />
+      {/* Like the default source handle above, the floating error handle only
+          belongs on a node WITHOUT an outcome footer. When the footer renders,
+          error routing is already expressed there (the `error` disposition row
+          plus the "unhandled → error directive" inheritance note), so a second
+          floating red handle pinned at top:75% only overlaps the revealed
+          rows. */}
+      {!hasOutcomeFooter && <ErrorOutputHandle isConnectable={isConnectable} />}
     </div>
   )
 }

--- a/packages/core/src/modules/workflows/components/nodes/NodeOutcomeRows.tsx
+++ b/packages/core/src/modules/workflows/components/nodes/NodeOutcomeRows.tsx
@@ -122,7 +122,14 @@ export function NodeOutcomeRows({
             variant="ghost"
             size="2xs"
             className="nodrag nopan"
-            onClick={onReveal}
+            onClick={(event) => {
+              // Reveal the remaining outcome rows in place. Without stopping
+              // propagation the click also bubbles to React Flow's onNodeClick,
+              // which opens the node edit dialog — the wrong surface for a
+              // canvas-local disclosure.
+              event.stopPropagation()
+              onReveal()
+            }}
           >
             {revealLabel}
           </Button>


### PR DESCRIPTION
## Problem

Two defects on the INVOKE_AGENT node's outcome footer in the workflow canvas (reported from the Studio):

1. **Clicking the `+ outcome` reveal opens the node edit dialog** instead of just disclosing the remaining outcome rows on the card. The reveal control lives inside the React Flow node, so its click bubbled to `onNodeClick → handleNodeClick → setSelectedNode`, which opens the dialog.
2. **A "bigger red dot" stays on top of the newly revealed outputs.** The floating `ErrorOutputHandle` (pinned at `top:75%`) was rendered unconditionally, while the default source handle right beside it is already guarded by `!hasOutcomeFooter`. Once the footer grows (e.g. after revealing every outcome), the red handle overlaps the rows — it sits over the footer's own (warning-toned) `error` disposition handle.

## Fix

- `NodeOutcomeRows`: the reveal button now `stopPropagation()`s, so it reveals in place without triggering the node click that opens the dialog.
- `InvokeAgentNode`: the floating `ErrorOutputHandle` is now guarded by the same `!hasOutcomeFooter` condition as the default source handle. On an agent node the footer always renders and already expresses error routing (the `error` disposition row plus the `unhandled → error directive` inheritance note, §7.2), so the floating handle is redundant there and only caused the overlap.

## Tests

`nodeOutcomeRows.test.tsx` gains two regression cases:
- the reveal control does not bubble to a parent node click;
- a footered agent node renders no floating error handle (error routing stays a footer row).

All 23 tests in the suite pass; `packages/core` typechecks clean.

## Scope

Scoped to the reported INVOKE_AGENT node. `UserTaskNode` renders the same unconditional `ErrorOutputHandle`, but its footer is decision rows (not error routing), so hiding the handle there could remove its only error-route surface — deliberately left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)