### PR TITLE
fix(dashboards): format analytics widgets in the tenant base currency

### DIFF
--- a/.ai/runs/2026-07-29-dashboard-widget-base-currency.md
+++ b/.ai/runs/2026-07-29-dashboard-widget-base-currency.md
@@ -47,7 +47,7 @@ Each widget stores the currency from the response metadata and passes it into th
 
 ### Phase 4: Validation
 
-Full `validation.commands` gate.
+Full `validation.commands` gate, then the authoritative review pass.
 
 ## Risks
 
@@ -78,4 +78,5 @@ PR: #4627
 
 ### Phase 4: Validation
 
-- [x] 4.1 Run the full validation gate
+- [x] 4.1 Run the full validation gate — 53239a7c6
+- [x] 4.2 Address the authoritative review pass — 53239a7c6

--- a/.ai/runs/2026-07-29-dashboard-widget-base-currency.md
+++ b/.ai/runs/2026-07-29-dashboard-widget-base-currency.md
@@ -1,0 +1,79 @@
+# Dashboard analytics widgets: format money in the tenant base currency
+
+Issue: [#4620](https://github.com/open-mercato/open-mercato/issues/4620)
+
+## Goal
+
+Stop dashboard analytics widgets from labelling every amount as USD. Money rendered by the
+analytics widgets must carry the tenant/organization base currency (`currencies.is_base`),
+falling back to today's `USD` only when no base currency can be resolved.
+
+## Scope
+
+- `packages/core/src/modules/dashboards/lib/formatters.ts` — currency-aware formatting helpers.
+- `packages/core/src/modules/dashboards/lib/baseCurrency.ts` (new) — scope-aware base-currency lookup.
+- `packages/core/src/modules/dashboards/services/widgetDataService.ts` — expose the resolved
+  currency on `WidgetDataResponse.metadata` so widgets do not need a second request.
+- The six money-rendering analytics widgets: `revenue-kpi`, `aov-kpi`, `pipeline-summary`,
+  `revenue-trend`, `sales-by-region`, `top-customers`, plus `top-products` (same defect, not
+  listed in the issue).
+- Unit tests for the formatters, the lookup helper, and the service metadata.
+
+### Non-goals
+
+- No per-widget currency-override setting (the tenant base currency covers the reported case;
+  an override would touch seven `config.ts` files and their settings UI).
+- No FX conversion of multi-currency data — widgets aggregate raw amounts today and this change
+  does not alter the numbers, only their label.
+- No changes to `packages/ui/src/utils/format.ts` (a separate, already currency-aware helper).
+
+## Implementation Plan
+
+### Phase 1: Currency-aware formatting primitives
+
+Extend `formatters.ts` so compact formatting is locale-correct for non-USD currencies (a `zł`
+suffix cannot be prefixed like `$`), keeping the legacy `formatCurrencyCompact(value, '€')`
+symbol form working for third-party callers.
+
+### Phase 2: Resolve the base currency server-side
+
+Add a scope-aware lookup against `currencies.is_base` (raw SQL, same approach as
+`customers/api/deals/aggregate`), tolerant of the `currencies` module being absent, and surface
+the result on `WidgetDataResponse.metadata.currency`.
+
+### Phase 3: Wire the widgets
+
+Each widget stores the currency from the response metadata and passes it into the formatter.
+
+### Phase 4: Validation
+
+Full `validation.commands` gate.
+
+## Risks
+
+- The widget-data cache stores the whole response, so a base-currency change propagates after
+  the 120s TTL. Acceptable — the cache key is already scope-derived.
+- `formatCurrencyCompact` output changes shape for negatives (`-$1.5K` instead of `$-1.5K`) once
+  the Intl path is used; that is a correctness improvement, covered by updated tests.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Currency-aware formatting primitives
+
+- [ ] 1.1 Make `formatCurrency*` helpers accept and honor a currency code
+- [ ] 1.2 Update and extend the formatter unit tests
+
+### Phase 2: Resolve the base currency server-side
+
+- [ ] 2.1 Add the scope-aware base-currency lookup helper with tests
+- [ ] 2.2 Expose the resolved currency on `WidgetDataResponse.metadata`
+
+### Phase 3: Wire the widgets
+
+- [ ] 3.1 Pass the resolved currency through all seven money-rendering widgets
+
+### Phase 4: Validation
+
+- [ ] 4.1 Run the full validation gate

--- a/.ai/runs/2026-07-29-dashboard-widget-base-currency.md
+++ b/.ai/runs/2026-07-29-dashboard-widget-base-currency.md
@@ -58,22 +58,24 @@ Full `validation.commands` gate.
 
 ## Progress
 
+PR: #4627
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Currency-aware formatting primitives
 
-- [ ] 1.1 Make `formatCurrency*` helpers accept and honor a currency code
-- [ ] 1.2 Update and extend the formatter unit tests
+- [x] 1.1 Make `formatCurrency*` helpers accept and honor a currency code — a2efb7860
+- [x] 1.2 Update and extend the formatter unit tests — a2efb7860
 
 ### Phase 2: Resolve the base currency server-side
 
-- [ ] 2.1 Add the scope-aware base-currency lookup helper with tests
-- [ ] 2.2 Expose the resolved currency on `WidgetDataResponse.metadata`
+- [x] 2.1 Add the scope-aware base-currency lookup helper with tests — c5dec6d36
+- [x] 2.2 Expose the resolved currency on `WidgetDataResponse.metadata` — c5dec6d36
 
 ### Phase 3: Wire the widgets
 
-- [ ] 3.1 Pass the resolved currency through all seven money-rendering widgets
+- [x] 3.1 Pass the resolved currency through all seven money-rendering widgets — c8b1bc5d8
 
 ### Phase 4: Validation
 
-- [ ] 4.1 Run the full validation gate
+- [x] 4.1 Run the full validation gate

--- a/packages/core/src/modules/dashboards/api/widgets/data/schema.ts
+++ b/packages/core/src/modules/dashboards/api/widgets/data/schema.ts
@@ -86,5 +86,6 @@ export const widgetDataResponseSchema = z.object({
   metadata: z.object({
     fetchedAt: z.string(),
     recordCount: z.number(),
+    currency: z.string().nullable(),
   }),
 })

--- a/packages/core/src/modules/dashboards/lib/__tests__/baseCurrency.test.ts
+++ b/packages/core/src/modules/dashboards/lib/__tests__/baseCurrency.test.ts
@@ -30,7 +30,19 @@ describe('resolveBaseCurrencyCode', () => {
     expect(sql).toContain('is_base = true')
     expect(sql).toContain('deleted_at IS NULL')
     expect(sql).toContain('organization_id = ANY(?::uuid[])')
-    expect(params).toEqual(['tenant-1', '{org-1,org-2}'])
+    expect(params).toEqual(['tenant-1', '{org-1,org-2}', '{org-1,org-2}'])
+  })
+
+  test('prefers the first organization in scope order', async () => {
+    const execute = jest.fn(async () => [{ code: 'EUR' }]) as ExecuteMock
+
+    await resolveBaseCurrencyCode(createEm(execute), {
+      tenantId: 'tenant-1',
+      organizationIds: ['org-1', 'org-2'],
+    })
+
+    const [sql] = execute.mock.calls[0]
+    expect(sql).toContain('ORDER BY array_position(?::uuid[], organization_id) ASC')
   })
 
   test('omits the organization filter when the scope has none', async () => {

--- a/packages/core/src/modules/dashboards/lib/__tests__/baseCurrency.test.ts
+++ b/packages/core/src/modules/dashboards/lib/__tests__/baseCurrency.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment node
+ */
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { resolveBaseCurrencyCode } from '../baseCurrency'
+
+type ExecuteMock = jest.Mock<Promise<Array<Record<string, unknown>>>, [string, unknown[]]>
+
+function createEm(execute: ExecuteMock): EntityManager {
+  return { getConnection: () => ({ execute }) } as unknown as EntityManager
+}
+
+describe('resolveBaseCurrencyCode', () => {
+  test('returns the normalized base currency code', async () => {
+    const execute = jest.fn(async () => [{ code: ' pln ' }]) as ExecuteMock
+
+    await expect(resolveBaseCurrencyCode(createEm(execute), { tenantId: 'tenant-1' })).resolves.toBe('PLN')
+  })
+
+  test('scopes the lookup to the tenant and the requested organizations', async () => {
+    const execute = jest.fn(async () => [{ code: 'EUR' }]) as ExecuteMock
+
+    await resolveBaseCurrencyCode(createEm(execute), {
+      tenantId: 'tenant-1',
+      organizationIds: ['org-1', 'org-2'],
+    })
+
+    const [sql, params] = execute.mock.calls[0]
+    expect(sql).toContain('tenant_id = ?')
+    expect(sql).toContain('is_base = true')
+    expect(sql).toContain('deleted_at IS NULL')
+    expect(sql).toContain('organization_id = ANY(?::uuid[])')
+    expect(params).toEqual(['tenant-1', '{org-1,org-2}'])
+  })
+
+  test('omits the organization filter when the scope has none', async () => {
+    const execute = jest.fn(async () => [{ code: 'EUR' }]) as ExecuteMock
+
+    await resolveBaseCurrencyCode(createEm(execute), { tenantId: 'tenant-1' })
+
+    const [sql, params] = execute.mock.calls[0]
+    expect(sql).not.toContain('organization_id')
+    expect(params).toEqual(['tenant-1'])
+  })
+
+  test('returns null when no base currency is configured', async () => {
+    const execute = jest.fn(async () => []) as ExecuteMock
+
+    await expect(resolveBaseCurrencyCode(createEm(execute), { tenantId: 'tenant-1' })).resolves.toBeNull()
+  })
+
+  test('returns null when the currencies module is not installed', async () => {
+    const execute = jest.fn(async () => {
+      throw new Error('relation "currencies" does not exist')
+    }) as ExecuteMock
+
+    await expect(resolveBaseCurrencyCode(createEm(execute), { tenantId: 'tenant-1' })).resolves.toBeNull()
+  })
+
+  test('does not query without a tenant', async () => {
+    const execute = jest.fn(async () => [{ code: 'EUR' }]) as ExecuteMock
+
+    await expect(resolveBaseCurrencyCode(createEm(execute), { tenantId: '' })).resolves.toBeNull()
+    expect(execute).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/dashboards/lib/__tests__/formatters.test.ts
+++ b/packages/core/src/modules/dashboards/lib/__tests__/formatters.test.ts
@@ -2,10 +2,12 @@
  * @jest-environment node
  */
 import {
+  FALLBACK_CURRENCY,
   formatCurrency,
   formatCurrencyWithDecimals,
   formatCurrencyCompact,
   formatCurrencySafe,
+  resolveCurrencyCode,
 } from '../formatters'
 
 describe('formatters', () => {
@@ -59,33 +61,53 @@ describe('formatters', () => {
   })
 
   describe('formatCurrencyCompact', () => {
+    // The default path resolves the runtime locale, so exact-string assertions pin
+    // `locale` explicitly; the unpinned cases only assert locale-independent shape.
+    const enUs = { locale: 'en-US' } as const
+
     it('formats millions with M suffix', () => {
-      expect(formatCurrencyCompact(1000000)).toBe('$1.0M')
-      expect(formatCurrencyCompact(2500000)).toBe('$2.5M')
-      expect(formatCurrencyCompact(10000000)).toBe('$10.0M')
+      expect(formatCurrencyCompact(1000000, enUs)).toBe('$1.0M')
+      expect(formatCurrencyCompact(2500000, enUs)).toBe('$2.5M')
+      expect(formatCurrencyCompact(10000000, enUs)).toBe('$10.0M')
     })
 
     it('formats thousands with K suffix', () => {
-      expect(formatCurrencyCompact(1000)).toBe('$1.0K')
-      expect(formatCurrencyCompact(5500)).toBe('$5.5K')
-      expect(formatCurrencyCompact(999000)).toBe('$999.0K')
+      expect(formatCurrencyCompact(1000, enUs)).toBe('$1.0K')
+      expect(formatCurrencyCompact(5500, enUs)).toBe('$5.5K')
+      expect(formatCurrencyCompact(999000, enUs)).toBe('$999.0K')
     })
 
     it('formats small numbers without suffix', () => {
-      expect(formatCurrencyCompact(500)).toBe('$500')
-      expect(formatCurrencyCompact(0)).toBe('$0')
-      expect(formatCurrencyCompact(999)).toBe('$999')
+      expect(formatCurrencyCompact(500, enUs)).toBe('$500')
+      expect(formatCurrencyCompact(0, enUs)).toBe('$0')
+      expect(formatCurrencyCompact(999, enUs)).toBe('$999')
     })
 
     it('handles negative values', () => {
-      expect(formatCurrencyCompact(-1000000)).toBe('$-1.0M')
-      expect(formatCurrencyCompact(-5000)).toBe('$-5.0K')
-      expect(formatCurrencyCompact(-500)).toBe('$-500')
+      expect(formatCurrencyCompact(-1000000, enUs)).toBe('-$1.0M')
+      expect(formatCurrencyCompact(-5000, enUs)).toBe('-$5.0K')
+      expect(formatCurrencyCompact(-500, enUs)).toBe('-$500')
+    })
+
+    it('defaults to the USD label', () => {
+      expect(formatCurrencyCompact(1000000)).toMatch(/\$|USD/)
+      expect(formatCurrencyCompact(500)).toMatch(/\$|USD/)
     })
 
     it('uses custom currency symbol', () => {
       expect(formatCurrencyCompact(1000000, '€')).toBe('€1.0M')
       expect(formatCurrencyCompact(5000, '£')).toBe('£5.0K')
+    })
+
+    it('labels the given currency instead of the USD default', () => {
+      expect(formatCurrencyCompact(1000000, { currency: 'PLN', locale: 'pl-PL' })).toContain('zł')
+      expect(formatCurrencyCompact(1000000, { currency: 'PLN' })).not.toContain('$')
+      expect(formatCurrencyCompact(500, { currency: 'EUR' })).toMatch(/€|EUR/)
+    })
+
+    it('falls back to USD for a malformed currency code', () => {
+      expect(formatCurrencyCompact(1000, { currency: 'not-a-code', ...enUs })).toBe('$1.0K')
+      expect(formatCurrencyCompact(1000, { currency: null, ...enUs })).toBe('$1.0K')
     })
   })
 
@@ -123,6 +145,24 @@ describe('formatters', () => {
     it('uses custom fallback', () => {
       expect(formatCurrencySafe(null, 'N/A')).toBe('N/A')
       expect(formatCurrencySafe(undefined, '-')).toBe('-')
+    })
+
+    it('labels the given currency', () => {
+      expect(formatCurrencySafe(1234, '--', { currency: 'PLN' })).toContain('PLN')
+    })
+  })
+
+  describe('resolveCurrencyCode', () => {
+    it('normalizes well-formed codes', () => {
+      expect(resolveCurrencyCode('pln')).toBe('PLN')
+      expect(resolveCurrencyCode(' eur ')).toBe('EUR')
+    })
+
+    it('falls back for anything else', () => {
+      expect(resolveCurrencyCode(null)).toBe(FALLBACK_CURRENCY)
+      expect(resolveCurrencyCode(undefined)).toBe(FALLBACK_CURRENCY)
+      expect(resolveCurrencyCode('')).toBe(FALLBACK_CURRENCY)
+      expect(resolveCurrencyCode('PLNX')).toBe(FALLBACK_CURRENCY)
     })
   })
 })

--- a/packages/core/src/modules/dashboards/lib/baseCurrency.ts
+++ b/packages/core/src/modules/dashboards/lib/baseCurrency.ts
@@ -22,13 +22,19 @@ export async function resolveBaseCurrencyCode(
 
   const clauses = ['tenant_id = ?', 'is_base = true', 'deleted_at IS NULL']
   const params: unknown[] = [scope.tenantId]
+  // With several organizations in scope each may declare its own base currency, so
+  // follow the caller's precedence — the selected organization comes first.
+  let order = 'code ASC'
 
   if (scope.organizationIds && scope.organizationIds.length > 0) {
+    const organizationArray = `{${scope.organizationIds.join(',')}}`
     clauses.push('organization_id = ANY(?::uuid[])')
-    params.push(`{${scope.organizationIds.join(',')}}`)
+    params.push(organizationArray)
+    order = 'array_position(?::uuid[], organization_id) ASC, code ASC'
+    params.push(organizationArray)
   }
 
-  const sql = `SELECT code FROM currencies WHERE ${clauses.join(' AND ')} ORDER BY code ASC LIMIT 1`
+  const sql = `SELECT code FROM currencies WHERE ${clauses.join(' AND ')} ORDER BY ${order} LIMIT 1`
 
   try {
     const rows = await em.getConnection().execute<Array<{ code: string | null }>>(sql, params)

--- a/packages/core/src/modules/dashboards/lib/baseCurrency.ts
+++ b/packages/core/src/modules/dashboards/lib/baseCurrency.ts
@@ -1,0 +1,40 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+
+export type BaseCurrencyScope = {
+  tenantId: string
+  organizationIds?: string[]
+}
+
+/**
+ * Reads the tenant/organization base currency owned by the `currencies` module.
+ *
+ * Raw SQL rather than the `Currency` entity on purpose: dashboards must not take a
+ * hard dependency on another module's ORM metadata, and the lookup projects a single
+ * non-encrypted column. When the `currencies` module is not installed the table is
+ * missing and the query throws — that degrades to `null`, which the widgets render
+ * with their own fallback currency.
+ */
+export async function resolveBaseCurrencyCode(
+  em: EntityManager,
+  scope: BaseCurrencyScope,
+): Promise<string | null> {
+  if (!scope.tenantId) return null
+
+  const clauses = ['tenant_id = ?', 'is_base = true', 'deleted_at IS NULL']
+  const params: unknown[] = [scope.tenantId]
+
+  if (scope.organizationIds && scope.organizationIds.length > 0) {
+    clauses.push('organization_id = ANY(?::uuid[])')
+    params.push(`{${scope.organizationIds.join(',')}}`)
+  }
+
+  const sql = `SELECT code FROM currencies WHERE ${clauses.join(' AND ')} ORDER BY code ASC LIMIT 1`
+
+  try {
+    const rows = await em.getConnection().execute<Array<{ code: string | null }>>(sql, params)
+    const code = Array.isArray(rows) ? rows[0]?.code : null
+    return typeof code === 'string' && code.trim().length > 0 ? code.trim().toUpperCase() : null
+  } catch {
+    return null
+  }
+}

--- a/packages/core/src/modules/dashboards/lib/formatters.ts
+++ b/packages/core/src/modules/dashboards/lib/formatters.ts
@@ -1,14 +1,40 @@
+/**
+ * Last-resort currency used when the caller could not resolve a base currency
+ * (currencies module disabled, or a tenant without an `is_base` row). Keeps the
+ * historical rendering instead of dropping the currency label entirely.
+ */
+export const FALLBACK_CURRENCY = 'USD'
+
+const CURRENCY_CODE_PATTERN = /^[A-Z]{3}$/
+
 export type FormatCurrencyOptions = {
-  currency?: string
+  currency?: string | null
+  /** Defaults to the runtime locale; mainly an injection point for deterministic tests. */
+  locale?: string
   minimumFractionDigits?: number
   maximumFractionDigits?: number
 }
 
+export type FormatCurrencyCompactOptions = {
+  currency?: string | null
+  locale?: string
+}
+
+/**
+ * `Intl.NumberFormat` throws on malformed currency codes, and the code now comes
+ * from tenant data rather than a literal, so anything that is not a well-formed
+ * ISO-4217 code degrades to the fallback.
+ */
+export function resolveCurrencyCode(currency?: string | null): string {
+  const normalized = typeof currency === 'string' ? currency.trim().toUpperCase() : ''
+  return CURRENCY_CODE_PATTERN.test(normalized) ? normalized : FALLBACK_CURRENCY
+}
+
 export function formatCurrency(value: number, options: FormatCurrencyOptions = {}): string {
-  const { currency = 'USD', minimumFractionDigits = 0, maximumFractionDigits = 0 } = options
-  return new Intl.NumberFormat(undefined, {
+  const { currency, locale, minimumFractionDigits = 0, maximumFractionDigits = 0 } = options
+  return new Intl.NumberFormat(locale, {
     style: 'currency',
-    currency,
+    currency: resolveCurrencyCode(currency),
     minimumFractionDigits,
     maximumFractionDigits,
   }).format(value)
@@ -18,7 +44,7 @@ export function formatCurrencyWithDecimals(value: number, options: FormatCurrenc
   return formatCurrency(value, { minimumFractionDigits: 2, maximumFractionDigits: 2, ...options })
 }
 
-export function formatCurrencyCompact(value: number, currencySymbol = '$'): string {
+function formatWithSymbolPrefix(value: number, currencySymbol: string): string {
   if (Math.abs(value) >= 1_000_000) {
     return `${currencySymbol}${(value / 1_000_000).toFixed(1)}M`
   }
@@ -28,9 +54,40 @@ export function formatCurrencyCompact(value: number, currencySymbol = '$'): stri
   return `${currencySymbol}${value.toFixed(0)}`
 }
 
-export function formatCurrencySafe(value: unknown, fallback = '--'): string {
+/**
+ * Compact money label for chart axes and tooltips.
+ *
+ * Passing a currency code routes through `Intl` so the symbol lands where the
+ * locale puts it (`1,0 mln zł`, not `zł1.0M`). The legacy string form —
+ * `formatCurrencyCompact(value, '€')` — keeps prefixing the given symbol so
+ * existing callers outside this module are unaffected.
+ */
+export function formatCurrencyCompact(
+  value: number,
+  options: string | FormatCurrencyCompactOptions = {},
+): string {
+  if (typeof options === 'string') {
+    return formatWithSymbolPrefix(value, options)
+  }
+
+  const compact = Math.abs(value) >= 1_000
+  return new Intl.NumberFormat(options.locale, {
+    style: 'currency',
+    currency: resolveCurrencyCode(options.currency),
+    notation: compact ? 'compact' : 'standard',
+    compactDisplay: 'short',
+    minimumFractionDigits: compact ? 1 : 0,
+    maximumFractionDigits: compact ? 1 : 0,
+  }).format(value)
+}
+
+export function formatCurrencySafe(
+  value: unknown,
+  fallback = '--',
+  options: FormatCurrencyOptions = {},
+): string {
   if (value === null || value === undefined) return fallback
   const num = Number(value)
   if (!Number.isFinite(num)) return fallback
-  return formatCurrency(num)
+  return formatCurrency(num, options)
 }

--- a/packages/core/src/modules/dashboards/services/__tests__/widgetDataService.test.ts
+++ b/packages/core/src/modules/dashboards/services/__tests__/widgetDataService.test.ts
@@ -47,6 +47,15 @@ function createService(execute: (sql: string, params: unknown[]) => Promise<Exec
   })
 }
 
+function isBaseCurrencyQuery(sql: string): boolean {
+  return sql.includes('FROM currencies')
+}
+
+/** Every request also looks up the scope's base currency; count only the aggregations. */
+function aggregationCallCount(execute: jest.Mock): number {
+  return execute.mock.calls.filter(([sql]) => !isBaseCurrencyQuery(String(sql))).length
+}
+
 const comparisonRequest: WidgetDataRequest = {
   entityType: 'sales:orders',
   metric: { field: 'total', aggregate: 'sum' },
@@ -58,7 +67,8 @@ describe('WidgetDataService comparison fetching', () => {
   test('runs the primary and comparison queries in parallel', async () => {
     const deferreds = [createDeferred<ExecuteResult>(), createDeferred<ExecuteResult>()]
     let started = 0
-    const execute = jest.fn(async () => {
+    const execute = jest.fn(async (sql: string) => {
+      if (isBaseCurrencyQuery(sql)) return [] as ExecuteResult
       const deferred = deferreds[started]
       started += 1
       return deferred.promise
@@ -70,7 +80,7 @@ describe('WidgetDataService comparison fetching', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(execute).toHaveBeenCalledTimes(2)
+    expect(aggregationCallCount(execute)).toBe(2)
 
     deferreds[0].resolve([{ value: 200 }])
     deferreds[1].resolve([{ value: 100 }])
@@ -85,15 +95,15 @@ describe('WidgetDataService comparison fetching', () => {
   })
 
   test('preserves the comparison response shape and math', async () => {
-    const execute = jest.fn(async (_sql: string, _params: unknown[]): Promise<ExecuteResult> => {
-      const call = execute.mock.calls.length
-      return call === 1 ? [{ value: 80 }] : [{ value: 100 }]
+    const execute = jest.fn(async (sql: string, _params: unknown[]): Promise<ExecuteResult> => {
+      if (isBaseCurrencyQuery(sql)) return []
+      return aggregationCallCount(execute) === 1 ? [{ value: 80 }] : [{ value: 100 }]
     })
 
     const service = createService(execute)
     const response = await service.fetchWidgetData(comparisonRequest)
 
-    expect(execute).toHaveBeenCalledTimes(2)
+    expect(aggregationCallCount(execute)).toBe(2)
     expect(response.value).toBe(80)
     expect(response.data).toEqual([])
     expect(response.metadata.recordCount).toBe(1)
@@ -105,7 +115,9 @@ describe('WidgetDataService comparison fetching', () => {
   })
 
   test('runs a single query and omits comparison when none is requested', async () => {
-    const execute = jest.fn(async (): Promise<ExecuteResult> => [{ value: 42 }])
+    const execute = jest.fn(async (sql: string): Promise<ExecuteResult> =>
+      isBaseCurrencyQuery(sql) ? [] : [{ value: 42 }],
+    )
     const service = createService(execute)
 
     const response = await service.fetchWidgetData({
@@ -114,8 +126,61 @@ describe('WidgetDataService comparison fetching', () => {
       dateRange: { field: 'created_at', preset: 'this_month' },
     })
 
-    expect(execute).toHaveBeenCalledTimes(1)
+    expect(aggregationCallCount(execute)).toBe(1)
     expect(response.value).toBe(42)
     expect(response.comparison).toBeUndefined()
+  })
+})
+
+describe('WidgetDataService base currency metadata', () => {
+  const simpleRequest: WidgetDataRequest = {
+    entityType: 'sales:orders',
+    metric: { field: 'total', aggregate: 'sum' },
+    dateRange: { field: 'created_at', preset: 'this_month' },
+  }
+
+  test('reports the scope base currency', async () => {
+    const execute = jest.fn(async (sql: string): Promise<ExecuteResult> =>
+      isBaseCurrencyQuery(sql) ? [{ code: 'pln' }] : [{ value: 42 }],
+    )
+
+    const response = await createService(execute).fetchWidgetData(simpleRequest)
+
+    expect(response.metadata.currency).toBe('PLN')
+  })
+
+  test('reports null when the scope has no base currency', async () => {
+    const execute = jest.fn(async (sql: string): Promise<ExecuteResult> =>
+      isBaseCurrencyQuery(sql) ? [] : [{ value: 42 }],
+    )
+
+    const response = await createService(execute).fetchWidgetData(simpleRequest)
+
+    expect(response.metadata.currency).toBeNull()
+  })
+
+  test('reports null when the currencies table is unavailable', async () => {
+    const execute = jest.fn(async (sql: string): Promise<ExecuteResult> => {
+      if (isBaseCurrencyQuery(sql)) throw new Error('relation "currencies" does not exist')
+      return [{ value: 42 }]
+    })
+
+    const response = await createService(execute).fetchWidgetData(simpleRequest)
+
+    expect(response.metadata.currency).toBeNull()
+    expect(response.value).toBe(42)
+  })
+
+  test('looks the base currency up once per service instance', async () => {
+    const execute = jest.fn(async (sql: string): Promise<ExecuteResult> =>
+      isBaseCurrencyQuery(sql) ? [{ code: 'EUR' }] : [{ value: 42 }],
+    )
+    const service = createService(execute)
+
+    await service.fetchWidgetData(simpleRequest)
+    await service.fetchWidgetData({ ...simpleRequest, dateRange: { field: 'created_at', preset: 'this_week' } })
+
+    const currencyCalls = execute.mock.calls.filter(([sql]) => isBaseCurrencyQuery(String(sql)))
+    expect(currencyCalls).toHaveLength(1)
   })
 })

--- a/packages/core/src/modules/dashboards/services/widgetDataService.ts
+++ b/packages/core/src/modules/dashboards/services/widgetDataService.ts
@@ -18,6 +18,7 @@ import {
   type DateGranularity,
   buildAggregationQuery,
 } from '../lib/aggregations'
+import { resolveBaseCurrencyCode } from '../lib/baseCurrency'
 import type { AnalyticsRegistry } from './analyticsRegistry'
 
 const WIDGET_DATA_CACHE_TTL = 120_000
@@ -82,6 +83,11 @@ export type WidgetDataResponse = {
   metadata: {
     fetchedAt: string
     recordCount: number
+    /**
+     * Base currency of the requesting scope, or `null` when none is configured.
+     * Money-rendering widgets format with it instead of assuming USD (#4620).
+     */
+    currency: string | null
   }
 }
 
@@ -102,6 +108,7 @@ export class WidgetDataService {
   private scope: WidgetDataScope
   private registry: AnalyticsRegistry
   private cache?: CacheStrategy
+  private baseCurrencyPromise?: Promise<string | null>
 
   constructor(options: WidgetDataServiceOptions) {
     this.em = options.em
@@ -118,6 +125,14 @@ export class WidgetDataService {
 
   private getCacheTags(entityType: string): string[] {
     return ['widget-data', `widget-data:${entityType}`]
+  }
+
+  /** One lookup per service instance, so a batched dashboard render pays for it once. */
+  private resolveBaseCurrency(): Promise<string | null> {
+    if (!this.baseCurrencyPromise) {
+      this.baseCurrencyPromise = resolveBaseCurrencyCode(this.em, this.scope)
+    }
+    return this.baseCurrencyPromise
   }
 
   async fetchWidgetData(request: WidgetDataRequest): Promise<WidgetDataResponse> {
@@ -147,11 +162,12 @@ export class WidgetDataService {
 
     const shouldFetchComparison = Boolean(comparisonRange && request.dateRange)
 
-    const [mainResult, comparisonResult] = await Promise.all([
+    const [mainResult, comparisonResult, currency] = await Promise.all([
       this.executeQuery(request, dateRangeResolved),
       shouldFetchComparison && comparisonRange
         ? this.executeQuery(request, comparisonRange)
         : Promise.resolve<{ value: number | null; data: WidgetDataItem[] } | undefined>(undefined),
+      this.resolveBaseCurrency(),
     ])
 
     const response: WidgetDataResponse = {
@@ -160,6 +176,7 @@ export class WidgetDataService {
       metadata: {
         fetchedAt: now.toISOString(),
         recordCount: mainResult.data.length || (mainResult.value !== null ? 1 : 0),
+        currency,
       },
     }
 

--- a/packages/core/src/modules/dashboards/widgets/dashboard/aov-kpi/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/aov-kpi/widget.client.tsx
@@ -45,6 +45,7 @@ const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [value, setValue] = React.useState<number | null>(null)
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [trend, setTrend] = React.useState<KpiTrend | undefined>(undefined)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
@@ -57,6 +58,7 @@ const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
     try {
       const data = await fetchAovData(hydrated, fetchWidgetData)
       setValue(data.value)
+      setCurrency(data.metadata?.currency ?? null)
       if (data.comparison) {
         setTrend({
           value: data.comparison.change,
@@ -77,6 +79,11 @@ const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
   React.useEffect(() => {
     refresh().catch(() => {})
   }, [refresh, refreshToken])
+
+  const formatValue = React.useCallback(
+    (amount: number) => formatCurrencyWithDecimals(amount, { currency }),
+    [currency],
+  )
 
   if (mode === 'settings') {
     return (
@@ -114,7 +121,7 @@ const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
       comparisonLabel={comparisonLabel}
       loading={loading}
       error={error}
-      formatValue={formatCurrencyWithDecimals}
+      formatValue={formatValue}
       headerAction={
         <InlineDateRangeSelect
           value={hydrated.dateRange}

--- a/packages/core/src/modules/dashboards/widgets/dashboard/pipeline-summary/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/pipeline-summary/widget.client.tsx
@@ -58,6 +58,7 @@ const PipelineSummaryWidget: React.FC<DashboardWidgetComponentProps<PipelineSumm
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<BarChartDataItem[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
@@ -75,6 +76,7 @@ const PipelineSummaryWidget: React.FC<DashboardWidgetComponentProps<PipelineSumm
           Value: item.value ?? 0,
         }))
       setData(chartData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load pipeline data', { err })
       setError(t('dashboards.analytics.widgets.pipelineSummary.error', 'Failed to load data'))
@@ -87,6 +89,11 @@ const PipelineSummaryWidget: React.FC<DashboardWidgetComponentProps<PipelineSumm
   React.useEffect(() => {
     refresh().catch(() => {})
   }, [refresh, refreshToken])
+
+  const valueFormatter = React.useCallback(
+    (amount: number) => formatCurrencyCompact(amount, { currency }),
+    [currency],
+  )
 
   if (mode === 'settings') {
     return (
@@ -117,7 +124,7 @@ const PipelineSummaryWidget: React.FC<DashboardWidgetComponentProps<PipelineSumm
           categoryLabels={{ Value: t('dashboards.analytics.labels.value', 'Value') }}
           loading={loading}
           error={error}
-          valueFormatter={formatCurrencyCompact}
+          valueFormatter={valueFormatter}
           colors={['violet']}
           showLegend={false}
           emptyMessage={t('dashboards.analytics.widgets.pipelineSummary.empty', 'No deal data for this period')}

--- a/packages/core/src/modules/dashboards/widgets/dashboard/revenue-kpi/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/revenue-kpi/widget.client.tsx
@@ -45,6 +45,7 @@ const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSetting
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [value, setValue] = React.useState<number | null>(null)
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [trend, setTrend] = React.useState<KpiTrend | undefined>(undefined)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
@@ -57,6 +58,7 @@ const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSetting
     try {
       const data = await fetchRevenueData(hydrated, fetchWidgetData)
       setValue(data.value)
+      setCurrency(data.metadata?.currency ?? null)
       if (data.comparison) {
         setTrend({
           value: data.comparison.change,
@@ -77,6 +79,11 @@ const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSetting
   React.useEffect(() => {
     refresh().catch(() => {})
   }, [refresh, refreshToken])
+
+  const formatValue = React.useCallback(
+    (amount: number) => formatCurrency(amount, { currency }),
+    [currency],
+  )
 
   if (mode === 'settings') {
     return (
@@ -114,7 +121,7 @@ const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSetting
       comparisonLabel={comparisonLabel}
       loading={loading}
       error={error}
-      formatValue={formatCurrency}
+      formatValue={formatValue}
       headerAction={
         <InlineDateRangeSelect
           value={hydrated.dateRange}

--- a/packages/core/src/modules/dashboards/widgets/dashboard/revenue-trend/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/revenue-trend/widget.client.tsx
@@ -114,6 +114,7 @@ const RevenueTrendWidget: React.FC<DashboardWidgetComponentProps<RevenueTrendSet
   const locale = useLocale()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<LineChartDataItem[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
@@ -134,6 +135,7 @@ const RevenueTrendWidget: React.FC<DashboardWidgetComponentProps<RevenueTrendSet
         Revenue: item.value ?? 0,
       }))
       setData(chartData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load revenue trend data', { err })
       setError(t('dashboards.analytics.widgets.revenueTrend.error', 'Failed to load data'))
@@ -146,6 +148,11 @@ const RevenueTrendWidget: React.FC<DashboardWidgetComponentProps<RevenueTrendSet
   React.useEffect(() => {
     refresh().catch(() => {})
   }, [refresh, refreshToken])
+
+  const valueFormatter = React.useCallback(
+    (amount: number) => formatCurrencyCompact(amount, { currency }),
+    [currency],
+  )
 
   if (mode === 'settings') {
     return (
@@ -212,7 +219,7 @@ const RevenueTrendWidget: React.FC<DashboardWidgetComponentProps<RevenueTrendSet
         loading={loading}
         error={error}
         showArea={hydrated.showArea}
-        valueFormatter={formatCurrencyCompact}
+        valueFormatter={valueFormatter}
         colors={['blue']}
         emptyMessage={t('dashboards.analytics.widgets.revenueTrend.empty', 'No revenue data for this period')}
       />

--- a/packages/core/src/modules/dashboards/widgets/dashboard/sales-by-region/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/sales-by-region/widget.client.tsx
@@ -44,6 +44,7 @@ const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionS
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<BarChartDataItem[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
@@ -59,6 +60,7 @@ const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionS
         Revenue: item.value ?? 0,
       }))
       setData(chartData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load sales by region data', { err })
       setError(t('dashboards.analytics.widgets.salesByRegion.error', 'Failed to load data'))
@@ -71,6 +73,11 @@ const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionS
   React.useEffect(() => {
     refresh().catch(() => {})
   }, [refresh, refreshToken])
+
+  const valueFormatter = React.useCallback(
+    (amount: number) => formatCurrencyCompact(amount, { currency }),
+    [currency],
+  )
 
   if (mode === 'settings') {
     return (
@@ -114,7 +121,7 @@ const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionS
       loading={loading}
       error={error}
       layout="horizontal"
-      valueFormatter={formatCurrencyCompact}
+      valueFormatter={valueFormatter}
       colors={['cyan']}
       showLegend={false}
       emptyMessage={t('dashboards.analytics.widgets.salesByRegion.empty', 'No regional sales data for this period')}

--- a/packages/core/src/modules/dashboards/widgets/dashboard/top-customers/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/top-customers/widget.client.tsx
@@ -56,6 +56,7 @@ const TopCustomersWidget: React.FC<DashboardWidgetComponentProps<TopCustomersSet
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<CustomerRow[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
 
@@ -76,10 +77,10 @@ const TopCustomersWidget: React.FC<DashboardWidgetComponentProps<TopCustomersSet
         key: 'revenue',
         header: t('dashboards.analytics.widgets.topCustomers.column.revenue', 'Revenue'),
         align: 'right',
-        formatter: (value: unknown) => formatCurrencySafe(value),
+        formatter: (value: unknown) => formatCurrencySafe(value, '--', { currency }),
       },
     ],
-    [t, unknownLabel],
+    [currency, t, unknownLabel],
   )
 
   const fetchWidgetData = useWidgetData()
@@ -95,6 +96,7 @@ const TopCustomersWidget: React.FC<DashboardWidgetComponentProps<TopCustomersSet
         revenue: item.value ?? 0,
       }))
       setData(tableData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load top customers data', { err })
       setError(t('dashboards.analytics.widgets.topCustomers.error', 'Failed to load data'))

--- a/packages/core/src/modules/dashboards/widgets/dashboard/top-products/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/top-products/widget.client.tsx
@@ -70,6 +70,7 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<BarChartDataItem[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
   const fetchingRef = React.useRef(false)
@@ -88,6 +89,7 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
         Revenue: item.value ?? 0,
       }))
       setData(chartData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load top products data', { err })
       setError(t('dashboards.analytics.widgets.topProducts.error', 'Failed to load data'))
@@ -101,6 +103,11 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
   React.useEffect(() => {
     refresh().catch(() => {})
   }, [refresh, refreshToken])
+
+  const valueFormatter = React.useCallback(
+    (amount: number) => formatCurrencyCompact(amount, { currency }),
+    [currency],
+  )
 
   if (mode === 'settings') {
     return (
@@ -172,7 +179,7 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
           loading={loading}
           error={error}
           layout={hydrated.layout}
-          valueFormatter={formatCurrencyCompact}
+          valueFormatter={valueFormatter}
           colors={['emerald']}
           showLegend={false}
           emptyMessage={t('dashboards.analytics.widgets.topProducts.empty', 'No product sales data for this period')}


### PR DESCRIPTION
Closes #4620
Tracking plan: .ai/runs/2026-07-29-dashboard-widget-base-currency.md
Status: complete

## 🎯 Goal
- Dashboard analytics widgets labelled every amount as USD. `dashboards/lib/formatters.ts` baked in `currency = 'USD'` / `currencySymbol = '$'`, and every widget passed the formatter **by reference** (`formatValue={formatCurrency}`), so the default always won — a PLN tenant saw `13,032,039 USD` for złoty. This PR resolves the tenant/organization base currency (`currencies.is_base`) server-side and formats the widgets with it.

## What Changed
- **`lib/formatters.ts`** — `formatCurrency`, `formatCurrencyWithDecimals` and `formatCurrencySafe` now honor a `currency` code (with `resolveCurrencyCode` guarding malformed values, since the code now comes from tenant data and `Intl` throws on garbage). `formatCurrencyCompact` gained a `{ currency }` form that routes through `Intl` compact notation, so the symbol lands where the locale puts it (`1,0 mln zł`, not `zł1.0M`); the legacy `formatCurrencyCompact(value, '€')` symbol form is untouched for third-party callers. All helpers keep `USD` as the last-resort fallback, so tenants without a configured base currency render exactly as before.
- **`lib/baseCurrency.ts` (new)** — `resolveBaseCurrencyCode(em, scope)` reads `currencies.is_base` for the tenant (and the request's organizations) via raw SQL, the same approach `customers/api/deals/aggregate` already uses. Dashboards therefore take no ORM dependency on the `currencies` module, and a missing table (module disabled) degrades to `null` instead of throwing.
- **`services/widgetDataService.ts`** — the resolved code ships on `WidgetDataResponse.metadata.currency`, memoized per service instance so a batched dashboard render pays for one extra query, not one per widget. The API response schema (`api/widgets/data/schema.ts`) declares the new field.
- **Widgets** — `revenue-kpi`, `aov-kpi`, `pipeline-summary`, `revenue-trend`, `sales-by-region`, `top-customers` and `top-products` (same defect, not listed in the issue) store the currency from the response metadata and pass it into the formatter through a `useCallback`, so no call site relies on the default any more.

## 🧪 Tests
- `yarn test` — 7866 passed / 1027 suites (core), 23 tasks green.
- `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn lint` (0 errors), `yarn build:app` — all green. Runner: local.
- New `lib/__tests__/baseCurrency.test.ts` locks in tenant/organization scoping of the lookup, the `null` results (no base row, missing table, no tenant), and that no query fires without a tenant.
- New cases in `services/__tests__/widgetDataService.test.ts` lock in `metadata.currency` for the resolved / absent / unavailable cases, and that the lookup runs once per service instance.
- Extended `lib/__tests__/formatters.test.ts`: non-USD labelling, malformed-code fallback, and `resolveCurrencyCode` normalization. Existing compact-format assertions now pin `locale: 'en-US'` because that path became locale-aware.

## 💥 Breaking Changes
- None to the public contract. Two behavioral notes for reviewers: `formatCurrencyCompact` on the default (non-symbol) path now renders negatives as `-$1.5K` instead of `$-1.5K`, and `WidgetDataResponse.metadata` gained a required `currency` field (additive; the `staff` module's local response type simply ignores it).

## 📋 Progress
See the Progress section in the tracking plan.
