### PR TITLE
fix(shared): keep client-only widget modules out of the CLI bundle graph

### DIFF
--- a/.ai/docs/module-development.md
+++ b/.ai/docs/module-development.md
@@ -50,6 +50,7 @@
 - Events: use `createModuleEvents()` with `as const` for typed emit
 - Translations: when adding entities with user-facing text fields (title, name, description, label), create `translations.ts` at module root declaring translatable fields. Run `yarn generate` after adding.
 - Widget injection: declare in `widgets/injection/`, map via `injection-table.ts`
+- Browser components MUST live in a `*.client.tsx` file loaded through a dynamic import (`lazyDashboardWidget(() => import('./widget.client'))`). The CLI bundler stubs local `*.client` imports out of its graph, so the owning `widget.ts` stays importable in Node while browser-only dependencies (charts, editors, anything reaching `next/dynamic`) never execute on CLI start. Putting such an import in the server-side `widget.ts` breaks every CLI entry point, including `yarn dev`.
 - Optional peer modules: resolve a non-required dependency inside `try/catch` (a per-module local `tryResolve` helper wrapping `container.resolve()`) and degrade when absent — never a hard `requires` on a module that should be optional. (Cross-module ORM relations and side-effect imports are already banned — see root `AGENTS.md` § Architecture.) Detail: `packages/core/AGENTS.md` → Cross-Module Coupling
 - API interception: declare interceptors in `api/interceptors.ts`; keep hooks fail-closed and scoped by route + method
 - Interceptors that narrow CRUD list results SHOULD prefer rewriting `query.ids` (comma-separated UUID list) instead of post-filtering response arrays

--- a/.ai/runs/2026-07-29-cli-client-only-widget-bundle.md
+++ b/.ai/runs/2026-07-29-cli-client-only-widget-bundle.md
@@ -41,6 +41,8 @@ Package-provided widgets are unaffected because their sources stay external and 
 
 ## Progress
 
+PR: #4628
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Cut the browser-only subgraph
@@ -52,4 +54,15 @@ Package-provided widgets are unaffected because their sources stay external and 
 
 - [x] 2.1 Unit tests with an esbuild control case — 98416658e
 - [x] 2.2 Module-development documentation — cdf7374fb
-- [ ] 2.3 Full validation gate
+- [x] 2.3 Full validation gate — d2cc5d305
+
+## Verification
+
+Runner: local. All eight `validation.commands` passed in order: `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`.
+
+End-to-end reproduction against `apps/mercato`, using the existing `@app` module `example`. Adding `import { BarChart } from '@open-mercato/ui/backend/charts'` to `widgets/dashboard/welcome/widget.client.tsx` and clearing the compiled `.mjs` bundles:
+
+- with the plugin, `yarn mercato dashboards` boots and lists its commands; `modules.cli.generated.mjs` contains zero references to `backend/charts` and zero to `next/dynamic`, and two client-only stubs;
+- with the plugin removed, the same command dies with the exact error from the issue — `Cannot find module '.../node_modules/next/dynamic' imported from .../packages/ui/dist/backend/charts/BarChart.js`.
+
+The probe import and the temporary plugin removal were both reverted; the working tree is clean.

--- a/.ai/runs/2026-07-29-cli-client-only-widget-bundle.md
+++ b/.ai/runs/2026-07-29-cli-client-only-widget-bundle.md
@@ -1,0 +1,55 @@
+# Keep client-only widget modules out of the CLI bundle graph
+
+## Overview
+
+Goal: fix issue #4623 — a dashboard widget in a standalone app that imports `@open-mercato/ui/backend/charts` from its `widget.client.tsx` kills every CLI entry point, including `yarn dev`, with `Cannot find module '.../node_modules/next/dynamic'`.
+
+Root cause: `compileAndImport` in `packages/shared/src/lib/bootstrap/dynamicLoader.ts` bundles the generated CLI registry with esbuild. App-module sources are not external, so esbuild follows `lazyDashboardWidget(() => import('./widget.client'))`, inlines the client file into the single output bundle, and hoists its static imports to the top. `@open-mercato/ui/backend/charts` therefore executes on every CLI start, and `charts/BarChart.js` does `import dynamic from 'next/dynamic'` — a bare specifier Node's ESM resolver cannot resolve outside a bundler.
+
+Package-provided widgets are unaffected because their sources stay external and their loaders are never invoked in CLI context.
+
+## Scope
+
+- Add a `client-only-stub` esbuild plugin that resolves local (`./`, `../`, `@/`) `*.client` imports to an inert stub inside the CLI bundle.
+- Register the plugin ahead of the existing alias and external-import plugins in `compileAndImport`.
+- Cover the behavior with unit tests, including a control case that proves the fixture regresses without the plugin.
+- Document the `*.client.tsx` contract for module authors.
+
+## Non-goals
+
+- No change to `@open-mercato/ui` chart components. Keeping `next/dynamic` there is intentional: the wrappers are `"use client"` and are only ever loaded by the Next.js bundler. The class of failures is cut where the CLI graph is built, not per component.
+- No change to the CLI registry shape. Dashboard widget loaders must keep working in CLI — `packages/core/src/modules/dashboards/cli.ts` calls `loadAllWidgets()` to seed default dashboards from widget metadata, so `widget.ts` has to stay importable in Node.
+- No change to `modules.generated.ts` or the Next.js runtime, which resolve these imports through the app bundler.
+
+## Implementation Plan
+
+### Phase 1: Cut the browser-only subgraph
+
+1. Add `packages/shared/src/lib/bootstrap/clientOnlyModules.ts` with `isClientOnlyModulePath`, `renderClientOnlyModuleStub`, and `createClientOnlyStubPlugin`.
+2. Register the plugin first in the `compileAndImport` esbuild build so it wins over the alias and external plugins.
+
+### Phase 2: Prove and document
+
+1. Add `packages/shared/src/lib/bootstrap/__tests__/clientOnlyModules.test.ts` — predicate unit tests plus a real esbuild bundle over a fixture that mirrors the issue's reproduction, with and without the plugin.
+2. Add the `*.client.tsx` rule to `.ai/docs/module-development.md`.
+3. Run the configured validation gate.
+
+## Risks
+
+- Convention-based matching on the `*.client` suffix: a server module named `something.client.ts` and reachable from the CLI graph would be stubbed. Mitigated by restricting the match to local imports of files whose basename ends in `.client`, which is the repo-wide convention for browser components (65 `*.client.tsx` files), and by a stub that fails loudly with an `[internal]` message rather than silently returning `undefined`.
+- Bare package specifiers are deliberately left to the existing external-import plugin, so package-provided client modules keep their current behavior.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Cut the browser-only subgraph
+
+- [ ] 1.1 Add the client-only stub helper
+- [ ] 1.2 Register the plugin in `compileAndImport`
+
+### Phase 2: Prove and document
+
+- [ ] 2.1 Unit tests with an esbuild control case
+- [ ] 2.2 Module-development documentation
+- [ ] 2.3 Full validation gate

--- a/.ai/runs/2026-07-29-cli-client-only-widget-bundle.md
+++ b/.ai/runs/2026-07-29-cli-client-only-widget-bundle.md
@@ -45,11 +45,11 @@ Package-provided widgets are unaffected because their sources stay external and 
 
 ### Phase 1: Cut the browser-only subgraph
 
-- [ ] 1.1 Add the client-only stub helper
-- [ ] 1.2 Register the plugin in `compileAndImport`
+- [x] 1.1 Add the client-only stub helper — 98416658e
+- [x] 1.2 Register the plugin in `compileAndImport` — 98416658e
 
 ### Phase 2: Prove and document
 
-- [ ] 2.1 Unit tests with an esbuild control case
-- [ ] 2.2 Module-development documentation
+- [x] 2.1 Unit tests with an esbuild control case — 98416658e
+- [x] 2.2 Module-development documentation — cdf7374fb
 - [ ] 2.3 Full validation gate

--- a/packages/shared/src/lib/bootstrap/__tests__/clientOnlyModules.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/clientOnlyModules.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  createClientOnlyStubPlugin,
+  isClientOnlyModulePath,
+  renderClientOnlyModuleStub,
+} from '../clientOnlyModules'
+
+const CHART_IMPORT = '@open-mercato/ui/backend/charts'
+
+function createAppModuleFixture(tempDir: string): string {
+  const widgetDir = path.join(tempDir, 'src', 'modules', 'demo', 'widgets', 'dashboard', 'sales')
+  fs.mkdirSync(widgetDir, { recursive: true })
+
+  fs.writeFileSync(
+    path.join(widgetDir, 'widget.client.tsx'),
+    [
+      '"use client"',
+      `import { BarChart } from '${CHART_IMPORT}'`,
+      'export default function DemoWidget() { return BarChart }',
+      '',
+    ].join('\n'),
+  )
+
+  const entry = path.join(tempDir, 'modules.cli.generated.ts')
+  fs.writeFileSync(
+    entry,
+    [
+      'export const modules = [{',
+      "  id: 'demo',",
+      '  dashboardWidgets: [{',
+      "    moduleId: 'demo',",
+      "    key: 'demo:sales:widget',",
+      "    loader: () => import('./src/modules/demo/widgets/dashboard/sales/widget.client').then((mod) => mod.default ?? mod),",
+      '  }],',
+      '}]',
+      '',
+    ].join('\n'),
+  )
+
+  return entry
+}
+
+async function bundle(entry: string, outfile: string, withStubPlugin: boolean): Promise<string> {
+  const esbuild = await import('esbuild')
+  await esbuild.build({
+    entryPoints: [entry],
+    outfile,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: 'node18',
+    external: ['@open-mercato/*'],
+    plugins: withStubPlugin ? [createClientOnlyStubPlugin()] : [],
+  })
+  return fs.readFileSync(outfile, 'utf8')
+}
+
+describe('isClientOnlyModulePath', () => {
+  it('matches local client modules with and without an extension', () => {
+    expect(isClientOnlyModulePath('./widget.client')).toBe(true)
+    expect(isClientOnlyModulePath('./widget.client.tsx')).toBe(true)
+    expect(isClientOnlyModulePath('../dashboard/sales/widget.client.ts')).toBe(true)
+    expect(isClientOnlyModulePath('@/modules/demo/widgets/dashboard/sales/widget.client')).toBe(true)
+    expect(isClientOnlyModulePath('./notifications.client.ts')).toBe(true)
+  })
+
+  it('leaves bare package specifiers to the external-import plugin', () => {
+    expect(isClientOnlyModulePath('@open-mercato/ui/backend/charts')).toBe(false)
+    expect(isClientOnlyModulePath('@open-mercato/core/modules/demo/widget.client')).toBe(false)
+    expect(isClientOnlyModulePath('react')).toBe(false)
+  })
+
+  it('does not match server modules that merely mention client', () => {
+    expect(isClientOnlyModulePath('./widget.ts')).toBe(false)
+    expect(isClientOnlyModulePath('./clientFactory.ts')).toBe(false)
+    expect(isClientOnlyModulePath('./client/index.ts')).toBe(false)
+  })
+})
+
+describe('renderClientOnlyModuleStub', () => {
+  it('exports a default that throws when the browser component is actually used', () => {
+    const stub = renderClientOnlyModuleStub('./widget.client')
+    expect(stub).toContain('export default clientOnlyModuleUnavailable')
+    expect(stub).toContain('./widget.client')
+  })
+})
+
+describe('CLI bundle graph', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'open-mercato-client-only-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('keeps browser-only widget imports out of the CLI bundle', async () => {
+    const entry = createAppModuleFixture(tempDir)
+    const output = await bundle(entry, path.join(tempDir, 'stubbed.mjs'), true)
+
+    expect(output).not.toContain(CHART_IMPORT)
+    expect(output).toContain('clientOnlyModuleUnavailable')
+  })
+
+  it('without the plugin the same fixture hoists the browser-only import (regression guard)', async () => {
+    const entry = createAppModuleFixture(tempDir)
+    const output = await bundle(entry, path.join(tempDir, 'plain.mjs'), false)
+
+    expect(output).toContain(CHART_IMPORT)
+  })
+})

--- a/packages/shared/src/lib/bootstrap/clientOnlyModules.ts
+++ b/packages/shared/src/lib/bootstrap/clientOnlyModules.ts
@@ -1,0 +1,51 @@
+/**
+ * Client-only modules (`*.client.tsx`) hold browser components and must never enter the
+ * CLI bundle graph. App modules are bundled from source by `compileAndImport`, and esbuild
+ * inlines dynamic imports into the single output file, hoisting the client file's static
+ * imports to the top of the bundle. A wrapper such as `@open-mercato/ui/backend/charts`
+ * would then execute on every CLI start and fail on bare Next.js specifiers that Node's
+ * ESM resolver cannot resolve.
+ *
+ * Resolving these files to an inert stub keeps the owning `widget.ts` importable (the CLI
+ * reads its metadata when seeding dashboards) while cutting the browser-only subgraph.
+ */
+
+export const CLIENT_ONLY_STUB_NAMESPACE = 'om-client-only-stub'
+
+const LOCAL_IMPORT_PATTERN = /^(\.{1,2}\/|@\/)/
+const CLIENT_ONLY_SUFFIX_PATTERN = /(^|[\\/])[^\\/]+\.client(\.[cm]?[jt]sx?)?$/
+
+/**
+ * Local (relative or `@/` aliased) imports of a `*.client` module. Bare package specifiers
+ * are left alone because the bundler already marks them external, so they never get inlined.
+ */
+export function isClientOnlyModulePath(importPath: string): boolean {
+  if (!LOCAL_IMPORT_PATTERN.test(importPath)) return false
+  return CLIENT_ONLY_SUFFIX_PATTERN.test(importPath)
+}
+
+export function renderClientOnlyModuleStub(importPath: string): string {
+  const message =
+    `[internal] Client-only module ${importPath} is not available in the CLI runtime. ` +
+    'It is excluded from the CLI bundle because it renders browser components.'
+  return [
+    `function clientOnlyModuleUnavailable() { throw new Error(${JSON.stringify(message)}) }`,
+    'export default clientOnlyModuleUnavailable',
+  ].join('\n')
+}
+
+export function createClientOnlyStubPlugin(): import('esbuild').Plugin {
+  return {
+    name: 'client-only-stub',
+    setup(build) {
+      build.onResolve({ filter: CLIENT_ONLY_SUFFIX_PATTERN }, (args) => {
+        if (!isClientOnlyModulePath(args.path)) return null
+        return { path: args.path, namespace: CLIENT_ONLY_STUB_NAMESPACE }
+      })
+      build.onLoad({ filter: /.*/, namespace: CLIENT_ONLY_STUB_NAMESPACE }, (args) => ({
+        contents: renderClientOnlyModuleStub(args.path),
+        loader: 'js',
+      }))
+    },
+  }
+}

--- a/packages/shared/src/lib/bootstrap/dynamicLoader.ts
+++ b/packages/shared/src/lib/bootstrap/dynamicLoader.ts
@@ -5,6 +5,7 @@ import {
   ensureMikroOrmV7GeneratedCacheCompatibility,
   recoverMikroOrmV7GeneratedCacheFromImportError,
 } from './generatedCacheRecovery'
+import { createClientOnlyStubPlugin } from './clientOnlyModules'
 import path from 'node:path'
 import fs from 'node:fs'
 import { pathToFileURL } from 'node:url'
@@ -82,7 +83,7 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
       format: 'esm',
       platform: 'node',
       target: 'node18',
-      plugins: [aliasPlugin, externalNonJsonPlugin],
+      plugins: [createClientOnlyStubPlugin(), aliasPlugin, externalNonJsonPlugin],
       // Allow JSON imports
       loader: { '.json': 'json' },
     })


### PR DESCRIPTION
Closes #4623
Tracking plan: .ai/runs/2026-07-29-cli-client-only-widget-bundle.md
Status: complete

## 🎯 Goal
- A dashboard widget in a standalone app whose `widget.client.tsx` imports `@open-mercato/ui/backend/charts` kills every CLI entry point, including `yarn dev`, with `Cannot find module '.../node_modules/next/dynamic'`. This PR keeps browser-only widget code out of the CLI bundle graph so the CLI boots regardless of what a widget's client component imports.
- Root cause: `compileAndImport` in `packages/shared/src/lib/bootstrap/dynamicLoader.ts` bundles the generated CLI registry with esbuild. App-module sources are not external, so esbuild follows `lazyDashboardWidget(() => import('./widget.client'))`, inlines the client file into the single output bundle and hoists its static imports to the top. `@open-mercato/ui/backend/charts` therefore executes on every CLI start, and `charts/BarChart.js` does `import dynamic from 'next/dynamic'` — a bare specifier Node's ESM resolver cannot resolve outside a bundler. Package-provided widgets are unaffected because their sources stay external.

## What Changed
- **`packages/shared/src/lib/bootstrap/clientOnlyModules.ts` (new)** — an esbuild plugin (`client-only-stub`) plus its two pure helpers. `isClientOnlyModulePath` matches local (`./`, `../`, `@/`) imports of a `*.client` module; `renderClientOnlyModuleStub` produces an inert module whose default export throws an `[internal]` error if a browser component is ever actually used from Node. Bare package specifiers are deliberately left alone — the existing external-import plugin already keeps them out of the bundle.
- **`packages/shared/src/lib/bootstrap/dynamicLoader.ts`** — registers the new plugin ahead of the alias and external-import plugins in `compileAndImport`, so it wins for any local `*.client` path.
- **`.ai/docs/module-development.md`** — documents the contract for module authors: browser components belong in a `*.client.tsx` file loaded through a dynamic import; the CLI bundler stubs those out, and putting such an import in the server-side `widget.ts` still breaks every CLI entry point.
- The CLI registry keeps emitting dashboard widget loaders unchanged. That was deliberate: `packages/core/src/modules/dashboards/cli.ts` calls `loadAllWidgets()` when seeding default dashboards, so `widget.ts` must stay importable in Node. Only the browser-only subgraph below it is cut.

## 🧪 Tests
- `packages/shared/src/lib/bootstrap/__tests__/clientOnlyModules.test.ts` (new) — 6 cases. Unit coverage for the path predicate (local client modules with and without an extension, bare specifiers left alone, server modules that merely mention "client" not matched) and the stub renderer, plus two real esbuild bundles over a fixture that mirrors the issue's reproduction: with the plugin the browser-only import is gone from the output, and **without** it the same fixture still hoists `@open-mercato/ui/backend/charts` — a control case that proves the test would catch a regression.
- Full configured validation gate, runner `local`, all green in order: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`.
- End-to-end reproduction against `apps/mercato` using the existing `@app` module `example`: adding the chart import to `widgets/dashboard/welcome/widget.client.tsx` and clearing the compiled `.mjs` bundles, `yarn mercato dashboards` boots normally and `modules.cli.generated.mjs` contains zero references to `backend/charts` or `next/dynamic`; with the plugin temporarily removed the same command dies with the exact error from the issue. Both the probe and the temporary removal were reverted.

## 💥 Breaking Changes
- No contract surface changes: no type, signature, event ID, route, DI key, ACL feature, or auto-discovery convention was touched, and the new module is purely additive.
- One behavioral note for third-party module authors: a **local** `*.client` file reachable from the CLI graph is now stubbed there. That is the intended semantics of the repo-wide convention (all 65 `*.client.tsx` files hold browser components), the Next.js runtime is unaffected, and a module that genuinely needed server-safe code from such a file would fail loudly with an `[internal]` message rather than silently misbehave.

## 📋 Progress
See the Progress section in the tracking plan.
