### PR TITLE
fix(query_index): honour OM_SEARCH_FIELD_BLOCKLIST in the search_text aggregate (#4624)

### DIFF
--- a/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
+++ b/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
@@ -118,6 +118,12 @@ rule) with the entity-scoped syntax.
 
 ## Progress
 
+PR: #4630
+
+### Review pass (om-auto-review-pr, self-authored → autofix eligible)
+
+- [x] R.1 Guard the entity blocklist lookup against inherited `Object.prototype` keys — 213d8aad7
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Entity-aware blocklist in the shared search config

--- a/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
+++ b/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
@@ -128,10 +128,10 @@ rule) with the entity-scoped syntax.
 
 ### Phase 2: Honour the blocklist in the aggregate and unify the per-field path
 
-- [ ] 2.1 Thread entityType and config into the aggregate composition
-- [ ] 2.2 Route shouldIndexField through the shared matcher
-- [ ] 2.3 Pass entityType from indexer, batch, and customers CLI call sites
-- [ ] 2.4 Unit tests for the aggregate and token paths
+- [x] 2.1 Thread entityType and config into the aggregate composition — d038deab5
+- [x] 2.2 Route shouldIndexField through the shared matcher — d038deab5
+- [x] 2.3 Pass entityType from indexer, batch, and customers CLI call sites — d038deab5
+- [x] 2.4 Unit tests for the aggregate and token paths — d038deab5
 
 ### Phase 3: Documentation
 

--- a/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
+++ b/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
@@ -122,9 +122,9 @@ rule) with the entity-scoped syntax.
 
 ### Phase 1: Entity-aware blocklist in the shared search config
 
-- [ ] 1.1 Parse entity-scoped blocklist entries in resolveSearchConfig
-- [ ] 1.2 Export the shared isSearchFieldBlocklisted matcher
-- [ ] 1.3 Unit tests for the parser and matcher
+- [x] 1.1 Parse entity-scoped blocklist entries in resolveSearchConfig — 3822d340e
+- [x] 1.2 Export the shared isSearchFieldBlocklisted matcher — 3822d340e
+- [x] 1.3 Unit tests for the parser and matcher — 3822d340e
 
 ### Phase 2: Honour the blocklist in the aggregate and unify the per-field path
 

--- a/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
+++ b/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
@@ -1,0 +1,139 @@
+# Execution plan — `search_text` aggregate honours `OM_SEARCH_FIELD_BLOCKLIST` (+ per-entity opt-out)
+
+Issue: [#4624](https://github.com/open-mercato/open-mercato/issues/4624)
+Engine: om-auto-create-pr (steps: 9, --loop: no)
+
+## Goal
+
+Make the aggregate search field `search_text` respect `OM_SEARCH_FIELD_BLOCKLIST`, and add an
+entity-scoped opt-out so a deployment can keep large free-text columns (e-mail bodies, notes) out of
+the token index for one entity type without losing them everywhere.
+
+## Problem / root cause
+
+`OM_SEARCH_FIELD_BLOCKLIST` is consulted in exactly one place — `shouldIndexField()` in
+`packages/core/src/modules/query_index/lib/search-tokens.ts` — which gates **per-field** token rows.
+The aggregate field is composed independently by `collectAggregateSearchValues()` in
+`packages/core/src/modules/query_index/lib/document.ts`, which receives no `SearchConfig` at all and
+filters only structural keys (`id`, `*_id`, `*_at`, `tenant_id`, `organization_id`).
+
+Consequence: blocklisting `body` removes the `body` token rows, but the same text is concatenated into
+`doc.search_text`, and `search_text` is itself tokenized — so the tokens come straight back under a
+different field name. On the reporter's tenant `customer_interaction/search_text` alone held 9.27 M of
+14.0 M rows. Blocklisting `search_text` is not an option: it is the field every entity's search
+actually queries.
+
+A second, quieter consequence: the built-in default blocklist (`password`, `token`, `secret`, `hash`)
+was likewise bypassed by the aggregate, so secret-ish column values were being tokenized into
+`search_text` despite the guard that exists to prevent exactly that.
+
+## Scope
+
+- `packages/shared/src/lib/search/config.ts` — parse entity-scoped blocklist entries; export a single
+  shared matcher used by both the per-field and the aggregate path.
+- `packages/core/src/modules/query_index/lib/document.ts` — thread `entityType` + `SearchConfig` into
+  the aggregate composition and skip blocklisted fields.
+- `packages/core/src/modules/query_index/lib/search-tokens.ts` — route the existing per-field check
+  through the shared matcher so both paths cannot drift apart again.
+- Call sites that build index documents: `query_index/lib/indexer.ts`, `query_index/lib/batch.ts`,
+  `customers/cli.ts`.
+- Env examples (`apps/mercato/.env.example` + the create-app template, per the template-sync rule) and
+  the hybrid-search docs page.
+
+## Non-goals
+
+- No wildcard entity patterns (`customers:*@body`). Exact entity-type match only; a wildcard syntax can
+  be added later additively if a real need appears.
+- No change to the tokenizer, to `expandToken` prefix expansion, or to `minTokenLength` defaults —
+  the 4.4× partial-token multiplier described in the issue is a separate tuning question.
+- No data migration or automatic purge of already-indexed tokens. Existing rows keep the old
+  `search_text` until the affected entities are reindexed; the PR documents this.
+- No per-tenant (DB-backed) configuration surface — this stays an env-level deployment concern.
+
+## Design
+
+`OM_SEARCH_FIELD_BLOCKLIST` stays a comma-separated list; an entry may now carry an optional
+entity-type prefix separated by `@`:
+
+```
+OM_SEARCH_FIELD_BLOCKLIST=body,customers:customer_interaction@notes
+```
+
+- `body` — global, matches any entity (unchanged semantics).
+- `customers:customer_interaction@notes` — matches only that entity type.
+
+Matching keeps today's substring semantics (`fieldName.toLowerCase().includes(pattern)`) so existing
+configurations behave identically, and entity types are compared case-insensitively on an exact match.
+Malformed entries (empty field part) are ignored rather than throwing, because this is env input read
+during indexing.
+
+`SearchConfig` gains `entityBlocklistedFields: Record<string, string[]>` alongside the existing
+`blocklistedFields: string[]`, which keeps holding the global entries only — so the two existing
+consumers of that field (debug logging in `packages/shared/src/lib/query/engine.ts` and
+`query_index/lib/engine.ts`) are unaffected.
+
+Public signatures stay backward compatible: `attachAggregateSearchField(doc)` and
+`buildIndexDocument(row, cfs, scope)` keep working with an omitted trailing options argument, falling
+back to `resolveSearchConfig()` and an unknown entity type (global entries still apply).
+
+## Risks
+
+- **Behavioural change on reindex.** After this lands, `search_text` no longer contains blocklisted
+  field text — including the built-in `password`/`token`/`secret`/`hash` defaults. Any deployment that
+  (unknowingly) relied on finding records through a blocklisted column via the aggregate will stop
+  matching those terms. This is the intended fix, but it is user-visible and belongs in the PR body.
+- **Stale index.** The change only takes effect for documents rebuilt after deploy; existing rows are
+  untouched until reindex.
+- **Per-record config resolution.** `resolveSearchConfig()` parses env on every call; the batch and CLI
+  paths resolve it once outside their loops so the hot indexing path does not re-parse per record.
+
+## Implementation Plan
+
+### Phase 1: Entity-aware blocklist in the shared search config
+
+1.1 Parse `entityType@field` entries in `resolveSearchConfig()` into `entityBlocklistedFields`, keeping
+`blocklistedFields` as the global-only list.
+1.2 Export `isSearchFieldBlocklisted(field, entityType, config)` as the single matcher for both paths.
+1.3 Unit-test the parser and matcher (global entry, entity-scoped entry, non-matching entity, default
+blocklist, malformed input, case-insensitivity).
+
+### Phase 2: Honour the blocklist in the aggregate and unify the per-field path
+
+2.1 Thread an optional `{ entityType, config }` options argument through
+`attachAggregateSearchField()` / `buildIndexDocument()` and skip blocklisted fields when composing
+`search_text`.
+2.2 Route `shouldIndexField()` in `search-tokens.ts` through `isSearchFieldBlocklisted` so per-field
+tokens honour entity-scoped entries too.
+2.3 Pass `entityType` (and a once-resolved config where the call site loops) from `indexer.ts`,
+`batch.ts`, and `customers/cli.ts`.
+2.4 Unit-test the aggregate and token paths: blocklisted field excluded from `search_text`,
+entity-scoped entry applies only to its own entity, defaults excluded, unrelated fields untouched.
+
+### Phase 3: Documentation
+
+3.1 Update `apps/mercato/.env.example` and `packages/create-app/template/.env.example` (template-sync
+rule) with the entity-scoped syntax.
+3.2 Document the variable and the reindex requirement in
+`apps/docs/docs/framework/database/hybrid-search.mdx`.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Entity-aware blocklist in the shared search config
+
+- [ ] 1.1 Parse entity-scoped blocklist entries in resolveSearchConfig
+- [ ] 1.2 Export the shared isSearchFieldBlocklisted matcher
+- [ ] 1.3 Unit tests for the parser and matcher
+
+### Phase 2: Honour the blocklist in the aggregate and unify the per-field path
+
+- [ ] 2.1 Thread entityType and config into the aggregate composition
+- [ ] 2.2 Route shouldIndexField through the shared matcher
+- [ ] 2.3 Pass entityType from indexer, batch, and customers CLI call sites
+- [ ] 2.4 Unit tests for the aggregate and token paths
+
+### Phase 3: Documentation
+
+- [ ] 3.1 Update both .env.example files with the entity-scoped syntax
+- [ ] 3.2 Document the variable and reindex requirement in the hybrid-search docs

--- a/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
+++ b/.ai/runs/2026-07-29-search-text-blocklist-per-entity.md
@@ -135,5 +135,5 @@ rule) with the entity-scoped syntax.
 
 ### Phase 3: Documentation
 
-- [ ] 3.1 Update both .env.example files with the entity-scoped syntax
-- [ ] 3.2 Document the variable and reindex requirement in the hybrid-search docs
+- [x] 3.1 Update both .env.example files with the entity-scoped syntax — 3383fdf1c
+- [x] 3.2 Document the variable and reindex requirement in the hybrid-search docs — 3383fdf1c

--- a/apps/docs/docs/framework/database/hybrid-search.mdx
+++ b/apps/docs/docs/framework/database/hybrid-search.mdx
@@ -342,8 +342,30 @@ The `OM_SEARCH_*` flags below are **token/Postgres-only** — they tune the `sea
 | `OM_SEARCH_ENABLE_PARTIAL` | `true` | Prefix/partial expansion — indexing "john" stores hashes for `joh`,`john`. Enables prefix matching at the cost of ~5–6× more `search_tokens` rows. |
 | `OM_SEARCH_HASH_ALGO` | `sha256` | Token hash algorithm (`sha1`/`md5` also accepted). |
 | `OM_SEARCH_STORE_RAW_TOKENS` | `false` | Store plaintext token alongside the hash — **security-sensitive**; avoid in production. |
-| `OM_SEARCH_FIELD_BLOCKLIST` | — | Comma-separated extra field names excluded from tokenization (merged with built-in `password,token,secret,hash`). |
+| `OM_SEARCH_FIELD_BLOCKLIST` | — | Comma-separated extra field names excluded from tokenization (merged with built-in `password,token,secret,hash`). See below for entity-scoped entries. |
 | `OM_SEARCH_DEBUG` | `false` | Verbose token/indexing debug logging (redacted — never logs raw tokens or PII). |
+
+### Excluding fields from the token index
+
+`OM_SEARCH_FIELD_BLOCKLIST` gates both the per-field tokens and the aggregate `search_text`
+field that every entity's search actually queries. Because `search_text` concatenates the
+record's string fields, a field must be blocklisted for it to stay out of the index — you
+cannot blocklist `search_text` itself without disabling search for that entity.
+
+Each comma-separated entry matches field names by substring (case-insensitive), and may carry
+an optional `entityType@` prefix to scope it to a single entity type:
+
+```bash
+# `body` is excluded everywhere; `notes` only on customer interactions
+OM_SEARCH_FIELD_BLOCKLIST=body,customers:customer_interaction@notes
+```
+
+This matters for volume as much as for privacy: with prefix expansion enabled, a large
+free-text column such as an imported e-mail body can dominate `search_tokens`.
+
+Changes take effect for documents built after the change — **reindex the affected entities**
+(`yarn mercato query_index reindex --entity <entityType>`) to drop tokens that are already
+stored.
 
 ## Adding Custom Strategies
 

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -190,8 +190,11 @@ OM_SEARCH_MIN_LEN=3
 OM_SEARCH_ENABLE_PARTIAL=true
 OM_SEARCH_HASH_ALGO=sha256
 OM_SEARCH_STORE_RAW_TOKENS=false
-# Optional comma-separated blocklist of field name substrings to skip during tokenization
-# OM_SEARCH_FIELD_BLOCKLIST=password,token,secret,hash
+# Optional comma-separated blocklist of field name substrings to skip during tokenization.
+# Applies to per-field tokens AND to the aggregate `search_text` field, so blocklisting a
+# large free-text column genuinely keeps it out of the token index. password,token,secret,hash
+# are always blocked. Prefix an entry with `entityType@` to scope it to one entity type.
+# OM_SEARCH_FIELD_BLOCKLIST=body,customers:customer_interaction@notes
 
 # Search module debug logging (Meilisearch, vector search, reindex operations)
 OM_SEARCH_DEBUG=false

--- a/packages/core/src/modules/customers/cli.ts
+++ b/packages/core/src/modules/customers/cli.ts
@@ -12,6 +12,7 @@ import { E as CoreEntities } from '#generated/entities.ids.generated'
 import { createProgressBar } from '@open-mercato/shared/lib/cli/progress'
 import { buildIndexDocument, type IndexCustomFieldValue } from '@open-mercato/core/modules/query_index/lib/document'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import {
@@ -1994,6 +1995,7 @@ async function seedCustomerStressTest(
       updated_at: Date
       deleted_at: null
     }> = []
+    const searchConfig = resolveSearchConfig()
     for (const [entityType, bucket] of pendingIndexDocs.entries()) {
       for (const entry of bucket.values()) {
         if (!entry.baseRow || Object.keys(entry.baseRow).length === 0) continue
@@ -2002,10 +2004,15 @@ async function seedCustomerStressTest(
           entity_id: entry.recordId,
           organization_id: entry.organizationId,
           tenant_id: entry.tenantId,
-          doc: buildIndexDocument(entry.baseRow, entry.customFields, {
-            organizationId: entry.organizationId,
-            tenantId: entry.tenantId,
-          }),
+          doc: buildIndexDocument(
+            entry.baseRow,
+            entry.customFields,
+            {
+              organizationId: entry.organizationId,
+              tenantId: entry.tenantId,
+            },
+            { entityType, config: searchConfig },
+          ),
           index_version: 1,
           created_at: entry.createdAt,
           updated_at: entry.updatedAt,

--- a/packages/core/src/modules/query_index/__tests__/search-field-blocklist.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/search-field-blocklist.test.ts
@@ -1,0 +1,112 @@
+import { attachAggregateSearchField, buildIndexDocument } from '../lib/document'
+import { buildSearchTokenRows } from '../lib/search-tokens'
+
+const INTERACTION = 'customers:customer_interaction'
+const PERSON = 'customers:person'
+
+const originalBlocklist = process.env.OM_SEARCH_FIELD_BLOCKLIST
+
+afterEach(() => {
+  if (originalBlocklist === undefined) delete process.env.OM_SEARCH_FIELD_BLOCKLIST
+  else process.env.OM_SEARCH_FIELD_BLOCKLIST = originalBlocklist
+})
+
+describe('search_text aggregate honours the field blocklist', () => {
+  it('keeps a globally blocklisted field out of the aggregate', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = 'body'
+    const doc = attachAggregateSearchField(
+      { subject: 'Quarterly review', body: 'Confidential long email text' },
+      { entityType: INTERACTION },
+    )
+    expect(doc.search_text).toContain('Quarterly review')
+    expect(doc.search_text).not.toContain('Confidential long email text')
+  })
+
+  it('excludes the built-in defaults even when the env var is unset', () => {
+    delete process.env.OM_SEARCH_FIELD_BLOCKLIST
+    const doc = attachAggregateSearchField(
+      { email: 'ada@example.com', password_hash: 'bcrypt-digest-value' },
+      { entityType: PERSON },
+    )
+    expect(doc.search_text).toContain('ada@example.com')
+    expect(doc.search_text).not.toContain('bcrypt-digest-value')
+  })
+
+  it('applies an entity-scoped entry only to the entity it names', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = `${INTERACTION}@body`
+
+    const interaction = attachAggregateSearchField(
+      { subject: 'Quarterly review', body: 'Confidential long email text' },
+      { entityType: INTERACTION },
+    )
+    expect(interaction.search_text).not.toContain('Confidential long email text')
+
+    const person = attachAggregateSearchField(
+      { display_name: 'Ada Lovelace', body: 'Short profile note' },
+      { entityType: PERSON },
+    )
+    expect(person.search_text).toContain('Short profile note')
+  })
+
+  it('applies only global entries when no entity type is supplied', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = `${INTERACTION}@body`
+    const doc = attachAggregateSearchField({ body: 'Confidential long email text' })
+    expect(doc.search_text).toContain('Confidential long email text')
+  })
+
+  it('omits the aggregate entirely when every source field is blocklisted', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = 'body'
+    const doc = attachAggregateSearchField({ id: 'rec-1', body: 'Only blocklisted text' }, { entityType: INTERACTION })
+    expect(doc.search_text).toBeUndefined()
+  })
+
+  it('threads the blocklist through buildIndexDocument, custom fields included', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = `${INTERACTION}@cf:body`
+    const doc = buildIndexDocument(
+      { id: 'rec-1', subject: 'Quarterly review' },
+      [{ key: 'body', value: 'Confidential long email text' }],
+      {},
+      { entityType: INTERACTION },
+    )
+    expect(doc['cf:body']).toBe('Confidential long email text')
+    expect(doc.search_text).toContain('Quarterly review')
+    expect(doc.search_text).not.toContain('Confidential long email text')
+  })
+})
+
+describe('per-field search tokens honour entity-scoped blocklist entries', () => {
+  const buildRows = (entityType: string, doc: Record<string, unknown>) =>
+    buildSearchTokenRows({ entityType, recordId: 'rec-1', doc })
+
+  it('drops tokens for an entity-scoped blocklisted field', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = `${INTERACTION}@body`
+    const fields = new Set(buildRows(INTERACTION, { subject: 'Quarterly', body: 'Confidential' }).map((row) => row.field))
+    expect(fields.has('subject')).toBe(true)
+    expect(fields.has('body')).toBe(false)
+  })
+
+  it('keeps the same field indexed for a different entity type', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = `${INTERACTION}@body`
+    const fields = new Set(buildRows(PERSON, { body: 'Profile note' }).map((row) => row.field))
+    expect(fields.has('body')).toBe(true)
+  })
+
+  it('still honours global entries for every entity type', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = 'body'
+    expect(buildRows(PERSON, { body: 'Profile note' })).toHaveLength(0)
+  })
+
+  it('no longer re-indexes blocklisted text through the aggregate field', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = `${INTERACTION}@body`
+    const doc = attachAggregateSearchField(
+      { subject: 'Quarterly', body: 'Confidential' },
+      { entityType: INTERACTION },
+    )
+    const aggregateTokens = buildRows(INTERACTION, doc).filter((row) => row.field === 'search_text')
+    expect(aggregateTokens.length).toBeGreaterThan(0)
+
+    const blocklistedHashes = new Set(buildRows(PERSON, { note: 'Confidential' }).map((row) => row.token_hash))
+    expect(blocklistedHashes.size).toBeGreaterThan(0)
+    expect(aggregateTokens.some((row) => blocklistedHashes.has(row.token_hash))).toBe(false)
+  })
+})

--- a/packages/core/src/modules/query_index/lib/batch.ts
+++ b/packages/core/src/modules/query_index/lib/batch.ts
@@ -4,6 +4,7 @@ import { isUniqueViolation } from '@open-mercato/shared/lib/db/pg-errors'
 import { buildIndexDocument, type IndexCustomFieldValue } from './document'
 import { replaceSearchTokensForBatch, isSearchDebugEnabled } from './search-tokens'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
 
 const logger = createLogger('query_index').child({ component: 'reindex-batch' })
 
@@ -228,6 +229,7 @@ export async function upsertIndexBatch(
   const basePayloads: IndexRowPayload[] = []
 
   const debugEnabled = isSearchDebugEnabled()
+  const searchConfig = resolveSearchConfig()
 
   for (const row of rows) {
     const recordId = normalizeId(row.id)
@@ -264,10 +266,15 @@ export async function upsertIndexBatch(
       if (!entityRow) return row
       return { ...entityRow, ...row }
     })()
-    let doc = buildIndexDocument(mergedRow, values, {
-      organizationId: scopeOrg ?? null,
-      tenantId: scopeTenant ?? null,
-    })
+    let doc = buildIndexDocument(
+      mergedRow,
+      values,
+      {
+        organizationId: scopeOrg ?? null,
+        tenantId: scopeTenant ?? null,
+      },
+      { entityType, config: searchConfig },
+    )
     let tokenDoc: Record<string, unknown> = doc
     if (typeof options.encryptDoc === 'function') {
       try {

--- a/packages/core/src/modules/query_index/lib/document.ts
+++ b/packages/core/src/modules/query_index/lib/document.ts
@@ -1,3 +1,9 @@
+import {
+  isSearchFieldBlocklisted,
+  resolveSearchConfig,
+  type SearchConfig,
+} from '@open-mercato/shared/lib/search/config'
+
 export type IndexDocumentScope = {
   organizationId?: string | null
   tenantId?: string | null
@@ -11,6 +17,18 @@ export type IndexCustomFieldValue = {
 }
 
 export const AGGREGATE_SEARCH_FIELD = 'search_text'
+
+/**
+ * Controls which fields may contribute text to the `search_text` aggregate.
+ *
+ * Both properties are optional so existing callers keep working unchanged: an
+ * omitted `config` is resolved from the environment, and an omitted `entityType`
+ * means only the global blocklist entries apply.
+ */
+export type AggregateSearchOptions = {
+  entityType?: string | null
+  config?: SearchConfig
+}
 
 function normalizeScopeValue(value: string | null | undefined): string | null {
   if (value === undefined || value === null || value === '') return null
@@ -30,7 +48,12 @@ function normalizeValue(value: unknown): unknown {
   return value
 }
 
-function collectAggregateSearchValues(field: string, value: unknown): string[] {
+function collectAggregateSearchValues(
+  field: string,
+  value: unknown,
+  entityType: string | null,
+  config: SearchConfig,
+): string[] {
   const lower = field.toLowerCase()
   if (
     lower === AGGREGATE_SEARCH_FIELD
@@ -42,6 +65,8 @@ function collectAggregateSearchValues(field: string, value: unknown): string[] {
   ) {
     return []
   }
+
+  if (isSearchFieldBlocklisted(field, entityType, config)) return []
 
   if (typeof value === 'string') {
     const trimmed = value.trim()
@@ -58,12 +83,17 @@ function collectAggregateSearchValues(field: string, value: unknown): string[] {
   return []
 }
 
-export function attachAggregateSearchField(doc: Record<string, unknown>): Record<string, unknown> {
+export function attachAggregateSearchField(
+  doc: Record<string, unknown>,
+  options: AggregateSearchOptions = {},
+): Record<string, unknown> {
+  const config = options.config ?? resolveSearchConfig()
+  const entityType = options.entityType ?? null
   const parts: string[] = []
   const seen = new Set<string>()
 
   for (const [field, value] of Object.entries(doc)) {
-    const values = collectAggregateSearchValues(field, value)
+    const values = collectAggregateSearchValues(field, value, entityType, config)
     for (const entry of values) {
       const key = entry.toLowerCase()
       if (seen.has(key)) continue
@@ -83,6 +113,7 @@ export function buildIndexDocument(
   baseRow: Record<string, unknown>,
   customFieldValues: Iterable<IndexCustomFieldValue> = [],
   scope: IndexDocumentScope = {},
+  options: AggregateSearchOptions = {},
 ): Record<string, unknown> {
   const doc: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(baseRow)) {
@@ -123,5 +154,5 @@ export function buildIndexDocument(
     }
   }
 
-  return attachAggregateSearchField(doc)
+  return attachAggregateSearchField(doc, options)
 }

--- a/packages/core/src/modules/query_index/lib/indexer.ts
+++ b/packages/core/src/modules/query_index/lib/indexer.ts
@@ -122,7 +122,7 @@ export async function buildIndexDoc(em: EntityManager, params: BuildDocParams): 
   } catch {}
 
   try {
-    doc = attachAggregateSearchField(doc)
+    doc = attachAggregateSearchField(doc, { entityType: params.entityType })
     const encryption = resolveTenantEncryptionService(em as any)
     doc = await encryptIndexDocForStorage(
       params.entityType,

--- a/packages/core/src/modules/query_index/lib/search-tokens.ts
+++ b/packages/core/src/modules/query_index/lib/search-tokens.ts
@@ -1,5 +1,9 @@
 import { type Kysely, sql } from 'kysely'
-import { resolveSearchConfig, type SearchConfig } from '@open-mercato/shared/lib/search/config'
+import {
+  isSearchFieldBlocklisted,
+  resolveSearchConfig,
+  type SearchConfig,
+} from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import { createLogger } from '@open-mercato/shared/lib/logger'
@@ -62,13 +66,18 @@ function collectTextValues(value: unknown): string[] {
   return []
 }
 
-function shouldIndexField(field: string, value: unknown, config: SearchConfig): boolean {
+function shouldIndexField(
+  field: string,
+  value: unknown,
+  config: SearchConfig,
+  entityType: string | null,
+): boolean {
   if (typeof value !== 'string' && !Array.isArray(value)) return false
   const lower = field.toLowerCase()
   if (lower === 'id' || lower.endsWith('_id') || lower.endsWith('.id')) return false
   if (lower.endsWith('_at')) return false
   if (['created_at', 'updated_at', 'deleted_at', 'tenant_id', 'organization_id'].includes(lower)) return false
-  if (config.blocklistedFields.some((blocked) => lower.includes(blocked))) return false
+  if (isSearchFieldBlocklisted(field, entityType, config)) return false
   const values = collectTextValues(value)
   if (!values.length) return false
   return values.some((text) => tokenizeText(text, config).tokens.length > 0)
@@ -87,7 +96,7 @@ export function buildSearchTokenRows(params: BuildTokenOptions): SearchTokenRow[
   }
 
   for (const [field, rawValue] of Object.entries(params.doc)) {
-    if (!shouldIndexField(field, rawValue, config)) continue
+    if (!shouldIndexField(field, rawValue, config, params.entityType)) continue
     const values = collectTextValues(rawValue)
     const seen = new Set<string>()
     for (const text of values) {

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -212,8 +212,11 @@ OM_SEARCH_MIN_LEN=3
 OM_SEARCH_ENABLE_PARTIAL=true
 OM_SEARCH_HASH_ALGO=sha256
 OM_SEARCH_STORE_RAW_TOKENS=false
-# Optional comma-separated blocklist of field name substrings to skip during tokenization
-# OM_SEARCH_FIELD_BLOCKLIST=password,token,secret,hash
+# Optional comma-separated blocklist of field name substrings to skip during tokenization.
+# Applies to per-field tokens AND to the aggregate `search_text` field, so blocklisting a
+# large free-text column genuinely keeps it out of the token index. password,token,secret,hash
+# are always blocked. Prefix an entry with `entityType@` to scope it to one entity type.
+# OM_SEARCH_FIELD_BLOCKLIST=body,customers:customer_interaction@notes
 
 # Search module debug logging (Meilisearch, vector search, reindex operations)
 OM_SEARCH_DEBUG=false

--- a/packages/shared/src/lib/search/__tests__/config.test.ts
+++ b/packages/shared/src/lib/search/__tests__/config.test.ts
@@ -132,6 +132,13 @@ describe('isSearchFieldBlocklisted', () => {
     expect(isSearchFieldBlocklisted('BODY', ' Customers:Customer_Interaction ', config)).toBe(true)
   })
 
+  it('ignores inherited Object.prototype keys when looking up an entity type', () => {
+    const config = { ...baseConfig, blocklistedFields: [], entityBlocklistedFields: {} }
+    expect(isSearchFieldBlocklisted('body', 'constructor', config)).toBe(false)
+    expect(isSearchFieldBlocklisted('body', 'toString', config)).toBe(false)
+    expect(isSearchFieldBlocklisted('body', '__proto__', config)).toBe(false)
+  })
+
   it('tolerates a config without the per-entity map', () => {
     const config = { ...baseConfig, blocklistedFields: ['secret'] }
     expect(isSearchFieldBlocklisted('client_secret', 'customers:person', config)).toBe(true)

--- a/packages/shared/src/lib/search/__tests__/config.test.ts
+++ b/packages/shared/src/lib/search/__tests__/config.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SEARCH_MIN_TOKEN_LENGTH,
+  isSearchFieldBlocklisted,
   resolveSearchConfig,
   resolveSearchMinTokenLength,
 } from '../config'
@@ -38,5 +39,102 @@ describe('resolveSearchMinTokenLength', () => {
   it('keeps resolveSearchConfig().minTokenLength in sync', () => {
     process.env.OM_SEARCH_MIN_LEN = '5'
     expect(resolveSearchConfig().minTokenLength).toBe(resolveSearchMinTokenLength())
+  })
+})
+
+describe('OM_SEARCH_FIELD_BLOCKLIST parsing', () => {
+  const originalValue = process.env.OM_SEARCH_FIELD_BLOCKLIST
+
+  afterEach(() => {
+    if (originalValue === undefined) {
+      delete process.env.OM_SEARCH_FIELD_BLOCKLIST
+    } else {
+      process.env.OM_SEARCH_FIELD_BLOCKLIST = originalValue
+    }
+  })
+
+  it('always includes the built-in defaults', () => {
+    delete process.env.OM_SEARCH_FIELD_BLOCKLIST
+    const config = resolveSearchConfig()
+    expect(config.blocklistedFields).toEqual(expect.arrayContaining(['password', 'token', 'secret', 'hash']))
+    expect(config.entityBlocklistedFields).toEqual({})
+  })
+
+  it('treats an unprefixed entry as global and lowercases it', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = ' Body , body '
+    const config = resolveSearchConfig()
+    expect(config.blocklistedFields.filter((entry) => entry === 'body')).toHaveLength(1)
+    expect(config.entityBlocklistedFields).toEqual({})
+  })
+
+  it('routes an entityType@field entry into the per-entity map only', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = 'customers:customer_interaction@body'
+    const config = resolveSearchConfig()
+    expect(config.blocklistedFields).not.toContain('body')
+    expect(config.entityBlocklistedFields).toEqual({ 'customers:customer_interaction': ['body'] })
+  })
+
+  it('groups several fields under the same entity type', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = 'customers:customer_interaction@body,customers:customer_interaction@subject'
+    expect(resolveSearchConfig().entityBlocklistedFields).toEqual({
+      'customers:customer_interaction': ['body', 'subject'],
+    })
+  })
+
+  it('ignores entries whose field part is empty', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = 'customers:customer_interaction@,@,body'
+    const config = resolveSearchConfig()
+    expect(config.blocklistedFields).toContain('body')
+    expect(config.entityBlocklistedFields).toEqual({})
+  })
+
+  it('treats a leading separator as a global entry', () => {
+    process.env.OM_SEARCH_FIELD_BLOCKLIST = '@body'
+    const config = resolveSearchConfig()
+    expect(config.blocklistedFields).toContain('body')
+    expect(config.entityBlocklistedFields).toEqual({})
+  })
+})
+
+describe('isSearchFieldBlocklisted', () => {
+  const baseConfig = {
+    enabled: true,
+    minTokenLength: 3,
+    enablePartials: true,
+    hashAlgorithm: 'sha256' as const,
+    storeRawTokens: false,
+  }
+
+  it('matches global entries by substring for any entity type', () => {
+    const config = { ...baseConfig, blocklistedFields: ['password'], entityBlocklistedFields: {} }
+    expect(isSearchFieldBlocklisted('password_hash', 'customers:person', config)).toBe(true)
+    expect(isSearchFieldBlocklisted('password_hash', null, config)).toBe(true)
+    expect(isSearchFieldBlocklisted('display_name', 'customers:person', config)).toBe(false)
+  })
+
+  it('applies an entity-scoped entry only to its own entity type', () => {
+    const config = {
+      ...baseConfig,
+      blocklistedFields: [],
+      entityBlocklistedFields: { 'customers:customer_interaction': ['body'] },
+    }
+    expect(isSearchFieldBlocklisted('body', 'customers:customer_interaction', config)).toBe(true)
+    expect(isSearchFieldBlocklisted('body', 'customers:person', config)).toBe(false)
+    expect(isSearchFieldBlocklisted('body', null, config)).toBe(false)
+  })
+
+  it('compares entity types case-insensitively', () => {
+    const config = {
+      ...baseConfig,
+      blocklistedFields: [],
+      entityBlocklistedFields: { 'customers:customer_interaction': ['body'] },
+    }
+    expect(isSearchFieldBlocklisted('BODY', ' Customers:Customer_Interaction ', config)).toBe(true)
+  })
+
+  it('tolerates a config without the per-entity map', () => {
+    const config = { ...baseConfig, blocklistedFields: ['secret'] }
+    expect(isSearchFieldBlocklisted('client_secret', 'customers:person', config)).toBe(true)
+    expect(isSearchFieldBlocklisted('body', 'customers:person', config)).toBe(false)
   })
 })

--- a/packages/shared/src/lib/search/config.ts
+++ b/packages/shared/src/lib/search/config.ts
@@ -1,5 +1,6 @@
 import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { parseNumberWithDefault } from '@open-mercato/shared/lib/number'
+import { parseCommaSeparatedList } from '@open-mercato/shared/lib/string'
 
 export type SearchConfig = {
   enabled: boolean
@@ -8,11 +9,14 @@ export type SearchConfig = {
   hashAlgorithm: 'sha256' | 'sha1' | 'md5'
   storeRawTokens: boolean
   blocklistedFields: string[]
+  entityBlocklistedFields?: Record<string, string[]>
 }
 
 export const DEFAULT_SEARCH_MIN_TOKEN_LENGTH = 3
 
 const DEFAULT_BLOCKLIST = ['password', 'token', 'secret', 'hash']
+
+const ENTITY_BLOCKLIST_SEPARATOR = '@'
 
 function parseBoolean(raw: string | undefined, fallback: boolean): boolean {
   return parseBooleanWithDefault(raw, fallback)
@@ -29,22 +33,85 @@ function parseHashAlgorithm(raw: string | undefined): 'sha256' | 'sha1' | 'md5' 
   return 'sha256'
 }
 
+/**
+ * Parses `OM_SEARCH_FIELD_BLOCKLIST` into a global list plus per-entity-type lists.
+ *
+ * Why: a deployment often needs to keep one large free-text column out of the token
+ * index (e-mail bodies on `customers:customer_interaction`) while still indexing the
+ * same-named column elsewhere. A flat global list cannot express that.
+ *
+ * How to apply: entries are comma-separated; an entry may carry an optional
+ * `entityType@` prefix — `body` blocks the field everywhere, while
+ * `customers:customer_interaction@body` blocks it only for that entity type. Entries
+ * whose field part is empty are ignored so malformed env input cannot break indexing.
+ */
+function parseFieldBlocklist(raw: string | undefined): {
+  global: string[]
+  byEntity: Record<string, string[]>
+} {
+  const global: string[] = []
+  const byEntity: Record<string, string[]> = {}
+
+  for (const rawEntry of parseCommaSeparatedList(raw)) {
+    const entry = rawEntry.toLowerCase()
+    const separatorIndex = entry.indexOf(ENTITY_BLOCKLIST_SEPARATOR)
+    const entityType = separatorIndex >= 0 ? entry.slice(0, separatorIndex).trim() : ''
+    const field = separatorIndex >= 0 ? entry.slice(separatorIndex + 1).trim() : entry
+    if (!field.length) continue
+
+    if (!entityType.length) {
+      if (!global.includes(field)) global.push(field)
+      continue
+    }
+
+    const scoped = byEntity[entityType] ?? []
+    if (!scoped.includes(field)) scoped.push(field)
+    byEntity[entityType] = scoped
+  }
+
+  for (const fallback of DEFAULT_BLOCKLIST) {
+    if (!global.includes(fallback)) global.push(fallback)
+  }
+
+  return { global, byEntity }
+}
+
 export function resolveSearchConfig(): SearchConfig {
+  const blocklist = parseFieldBlocklist(process.env.OM_SEARCH_FIELD_BLOCKLIST)
   return {
     enabled: parseBoolean(process.env.OM_SEARCH_ENABLED, true),
     minTokenLength: resolveSearchMinTokenLength(),
     enablePartials: parseBoolean(process.env.OM_SEARCH_ENABLE_PARTIAL, true),
     hashAlgorithm: parseHashAlgorithm(process.env.OM_SEARCH_HASH_ALGO),
     storeRawTokens: parseBoolean(process.env.OM_SEARCH_STORE_RAW_TOKENS, false),
-    blocklistedFields: (process.env.OM_SEARCH_FIELD_BLOCKLIST ?? '')
-      .split(',')
-      .map((entry) => entry.trim())
-      .filter((entry) => entry.length > 0)
-      .filter((value, index, arr) => arr.indexOf(value) === index)
-      .map((entry) => entry.toLowerCase())
-      .concat(DEFAULT_BLOCKLIST)
-      .filter((value, index, arr) => arr.indexOf(value) === index),
+    blocklistedFields: blocklist.global,
+    entityBlocklistedFields: blocklist.byEntity,
   }
+}
+
+/**
+ * Single matcher for "should this field be kept out of the search index?".
+ *
+ * Why: the per-field token path and the `search_text` aggregate previously each
+ * decided this on their own, and the aggregate simply never consulted the config —
+ * so a blocklisted column's text came back into the index under the aggregate's
+ * field name (#4624). Both paths now share this function so they cannot drift.
+ *
+ * How to apply: pass the document's field name and the entity type being indexed;
+ * `entityType` may be omitted when unknown, in which case only global entries apply.
+ * Matching keeps the historical substring semantics (`fieldName.includes(pattern)`).
+ */
+export function isSearchFieldBlocklisted(
+  field: string,
+  entityType: string | null | undefined,
+  config: SearchConfig,
+): boolean {
+  const lower = field.toLowerCase()
+  if (config.blocklistedFields.some((blocked) => lower.includes(blocked))) return true
+  if (!entityType) return false
+  const scoped = config.entityBlocklistedFields?.[entityType.trim().toLowerCase()]
+  if (!scoped?.length) return false
+  return scoped.some((blocked) => lower.includes(blocked))
 }
 
 /**

--- a/packages/shared/src/lib/search/config.ts
+++ b/packages/shared/src/lib/search/config.ts
@@ -110,7 +110,7 @@ export function isSearchFieldBlocklisted(
   if (config.blocklistedFields.some((blocked) => lower.includes(blocked))) return true
   if (!entityType) return false
   const scoped = config.entityBlocklistedFields?.[entityType.trim().toLowerCase()]
-  if (!scoped?.length) return false
+  if (!Array.isArray(scoped) || !scoped.length) return false
   return scoped.some((blocked) => lower.includes(blocked))
 }
 


### PR DESCRIPTION
Closes #4624
Tracking plan: .ai/runs/2026-07-29-search-text-blocklist-per-entity.md
Status: complete

## 🎯 Goal
- Make the aggregate search field `search_text` respect `OM_SEARCH_FIELD_BLOCKLIST`, and add an entity-scoped opt-out so a deployment can keep one large free-text column (e-mail bodies, notes) out of the token index without losing that column name everywhere.
- Root cause: the blocklist was consulted only in `shouldIndexField()` (`query_index/lib/search-tokens.ts`), which gates **per-field** token rows. The aggregate is composed independently by `collectAggregateSearchValues()` (`query_index/lib/document.ts`), which received no `SearchConfig` at all — it filtered structural keys (`id`, `*_id`, `*_at`, `tenant_id`, `organization_id`) and nothing else. So blocklisting `body` removed the `body` rows, while the same text was concatenated into `doc.search_text` and tokenized right back in under the aggregate's field name. Blocklisting `search_text` itself is not a workaround: it is the field every entity's search actually queries.

## What Changed
- **`packages/shared/src/lib/search/config.ts`** — `OM_SEARCH_FIELD_BLOCKLIST` entries may now carry an optional `entityType@` prefix. `body` still blocks the field everywhere; `customers:customer_interaction@body` blocks it only for that entity type. Parsed into a new optional `SearchConfig.entityBlocklistedFields` map, while `blocklistedFields` keeps holding the global entries exactly as before (its only two consumers are debug-log payloads in the two query engines, which are untouched). Adds `isSearchFieldBlocklisted(field, entityType, config)` as the single matcher, keeping the historical substring semantics and comparing entity types case-insensitively. Malformed entries (empty field part) are ignored rather than thrown, because this is env input read on the indexing path.
- **`packages/core/src/modules/query_index/lib/document.ts`** — `collectAggregateSearchValues()` now consults that matcher, and `attachAggregateSearchField()` / `buildIndexDocument()` take an optional trailing `{ entityType, config }` argument. Both arguments are optional and fall back to `resolveSearchConfig()` plus an unknown entity type, so every existing call site keeps compiling and behaving.
- **`packages/core/src/modules/query_index/lib/search-tokens.ts`** — `shouldIndexField()` routes through the same shared matcher instead of inlining its own `blocklistedFields.some(...)` check, so the per-field path also honours entity-scoped entries and the two paths can no longer drift apart.
- **Call sites** — `query_index/lib/indexer.ts`, `query_index/lib/batch.ts`, and `customers/cli.ts` now pass the entity type being indexed. The two looping call sites resolve `SearchConfig` once outside their loop rather than re-parsing env per record.
- **Docs** — both `.env.example` files (app + create-app template, per the template-sync rule) and `apps/docs/docs/framework/database/hybrid-search.mdx`, including the fact that the change only affects documents built after deploy, so affected entities must be reindexed.

## 🧪 Tests
- `yarn test` — 23/23 workspaces green (core: 8263 passed, shared: 1524, ui: 1680, ai-assistant: 1379, cli: 1225, enterprise: 462, scheduler: 336, search: 254 …).
- ⚠️ Flaky, unrelated: one full-suite run hit `packages/core/src/__tests__/module-decoupling.test.ts:231` (`resolveDefaultPartitionCode('catalog:catalog_product')`), and an earlier run hit a Jest worker `SIGSEGV` in `@open-mercato/enterprise` (457 assertions passed, none failed). Both pass in isolation and on re-run — the decoupling case asserts on **global module-registry state**, so it is order-dependent across suites. Two consecutive clean `@open-mercato/core` runs afterwards: 8263/8263. This PR touches neither attachments/partitions nor the module registry.
- `yarn typecheck` — 21/21 tasks successful. `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn build:app` — all green.
- ⚠️ `yarn i18n:check-usage` fails on this branch **and on `develop`**: `ui.customFields.phone.defaultCountry` / `.defaultCountryAuto` are referenced from `packages/ui/src/backend/fields/phone.tsx` but missing from `en.json`. This PR touches no i18n file and no UI file — the failure is pre-existing and out of scope.
- New `packages/core/src/modules/query_index/__tests__/search-field-blocklist.test.ts` (10 cases) locks in: a globally blocklisted field is excluded from `search_text`; the built-in `password`/`token`/`secret`/`hash` defaults are excluded even with the env var unset; an entity-scoped entry applies only to the entity it names; only global entries apply when no entity type is supplied; the aggregate is omitted entirely when every source field is blocklisted; custom fields (`cf:*`) route through the same gate; per-field tokens honour entity-scoped entries; and — the regression this PR exists for — the aggregate's tokens no longer contain any hash produced by the blocklisted text.
- New cases in `packages/shared/src/lib/search/__tests__/config.test.ts` (11 cases) cover parsing: defaults always present, unprefixed entries global and lowercased, `entityType@field` routed to the per-entity map only, several fields grouped under one entity, empty-field entries ignored, a leading `@` treated as global — plus matcher behavior including case-insensitive entity comparison, a config that omits the new optional map, and inherited `Object.prototype` keys (`constructor`, `toString`, `__proto__`) as entity types.

## 💥 Breaking Changes
- **No contract-surface break.** `SearchConfig.entityBlocklistedFields` is optional, and both new function arguments are optional trailing parameters, so third-party code constructing a `SearchConfig` or calling `attachAggregateSearchField(doc)` / `buildIndexDocument(row, cfs, scope)` compiles and behaves unchanged.
- **Behavioural change, by design.** After a reindex, `search_text` no longer contains text from blocklisted fields — including the built-in `password`/`token`/`secret`/`hash` defaults, which the aggregate previously bypassed entirely. Any deployment that (unknowingly) found records by a term that only existed in a blocklisted column will stop matching it through the aggregate. That is the fix; it is also a small security improvement, since secret-ish column values were being tokenized into `search_text` despite the guard that exists to prevent exactly that. Note this covers both search paths: the token index **and** the `$ilike` fallback that `sales/api/utils.ts:23` and `customers/api/utils.ts:95` run against `doc.search_text`.
- **Reindex required.** Existing `entity_indexes` rows and `search_tokens` keep their old contents until the affected entities are reindexed (`yarn mercato query_index reindex --entity <entityType>`). No migration and no automatic purge are included.

## 📋 Progress
See the Progress section in the tracking plan.
