### PR TITLE
fix(dashboards): format analytics amounts in the tenant base currency (#4620)

### DIFF
--- a/.ai/runs/2026-07-29-dashboards-base-currency-formatting.md
+++ b/.ai/runs/2026-07-29-dashboards-base-currency-formatting.md
@@ -38,4 +38,4 @@ in the tenant's own currency without a second round-trip and without a per-widge
 - [x] 7 widgets format via the resolved currency
 - [x] Unit tests (formatters + service)
 - [x] Validation gate
-- [ ] PR opened
+- [x] PR opened — https://github.com/open-mercato/open-mercato/pull/4631

--- a/.ai/runs/2026-07-29-dashboards-base-currency-formatting.md
+++ b/.ai/runs/2026-07-29-dashboards-base-currency-formatting.md
@@ -1,0 +1,41 @@
+# Dashboard analytics widgets hardcode USD currency formatting (#4620)
+
+Issue: https://github.com/open-mercato/open-mercato/issues/4620
+
+## Problem
+
+`packages/core/src/modules/dashboards/lib/formatters.ts` defaults every money formatter to
+USD (`currency = 'USD'`, `currencySymbol = '$'`) and all analytics widgets pass the formatter
+by reference, so a tenant whose base currency is PLN sees correct numbers labelled `USD`/`$`.
+
+## Approach
+
+Resolve the tenant/organization base currency server-side (the `currencies` module already
+stores `is_base`) and ship it with the widget-data response, so every analytics widget formats
+in the tenant's own currency without a second round-trip and without a per-widget setting.
+
+1. `services/widgetDataService.ts` — resolve the base currency code once per request
+   (memoized), scoped by tenant + the request's organization ids; expose it as
+   `metadata.currency`. Ambiguous scope (several organizations with different base
+   currencies) or a missing/unavailable `currencies` table resolves to `null`.
+2. `api/widgets/data/schema.ts` — extend the response schema with the optional
+   `metadata.currency` field (additive, OpenAPI-visible).
+3. `lib/formatters.ts` — drop the USD/`$` defaults. Without a currency the helpers format a
+   plain number (never a wrong label); with one they use `Intl.NumberFormat`. Add
+   `createCurrencyFormatters(currency)` so widgets pass a stable single-argument formatter.
+4. Widgets (`revenue-kpi`, `aov-kpi`, `pipeline-summary`, `revenue-trend`, `top-customers`,
+   `top-products`, `sales-by-region`) — read `metadata.currency` from the response and format
+   through the memoized formatters.
+5. Tests — formatter unit tests (no currency, explicit currency, compact, legacy symbol
+   argument) and widget-data service tests for base-currency resolution.
+
+## Progress
+
+- [x] Triage (`om-verify-in-repo`): real, unfixed, no PR in flight
+- [x] `lib/formatters.ts` rewritten (no USD default + formatter factory)
+- [x] `services/widgetDataService.ts` resolves and returns `metadata.currency`
+- [x] `api/widgets/data/schema.ts` extended
+- [x] 7 widgets format via the resolved currency
+- [x] Unit tests (formatters + service)
+- [x] Validation gate
+- [ ] PR opened

--- a/packages/core/src/modules/dashboards/api/widgets/data/schema.ts
+++ b/packages/core/src/modules/dashboards/api/widgets/data/schema.ts
@@ -86,5 +86,6 @@ export const widgetDataResponseSchema = z.object({
   metadata: z.object({
     fetchedAt: z.string(),
     recordCount: z.number(),
+    currency: z.string().nullable().optional(),
   }),
 })

--- a/packages/core/src/modules/dashboards/lib/__tests__/formatters.test.ts
+++ b/packages/core/src/modules/dashboards/lib/__tests__/formatters.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 import {
+  createCurrencyFormatters,
   formatCurrency,
   formatCurrencyWithDecimals,
   formatCurrencyCompact,
@@ -60,32 +61,37 @@ describe('formatters', () => {
 
   describe('formatCurrencyCompact', () => {
     it('formats millions with M suffix', () => {
-      expect(formatCurrencyCompact(1000000)).toBe('$1.0M')
-      expect(formatCurrencyCompact(2500000)).toBe('$2.5M')
-      expect(formatCurrencyCompact(10000000)).toBe('$10.0M')
+      expect(formatCurrencyCompact(1000000)).toBe('1.0M')
+      expect(formatCurrencyCompact(2500000)).toBe('2.5M')
+      expect(formatCurrencyCompact(10000000)).toBe('10.0M')
     })
 
     it('formats thousands with K suffix', () => {
-      expect(formatCurrencyCompact(1000)).toBe('$1.0K')
-      expect(formatCurrencyCompact(5500)).toBe('$5.5K')
-      expect(formatCurrencyCompact(999000)).toBe('$999.0K')
+      expect(formatCurrencyCompact(1000)).toBe('1.0K')
+      expect(formatCurrencyCompact(5500)).toBe('5.5K')
+      expect(formatCurrencyCompact(999000)).toBe('999.0K')
     })
 
     it('formats small numbers without suffix', () => {
-      expect(formatCurrencyCompact(500)).toBe('$500')
-      expect(formatCurrencyCompact(0)).toBe('$0')
-      expect(formatCurrencyCompact(999)).toBe('$999')
+      expect(formatCurrencyCompact(500)).toBe('500')
+      expect(formatCurrencyCompact(0)).toBe('0')
+      expect(formatCurrencyCompact(999)).toBe('999')
     })
 
     it('handles negative values', () => {
-      expect(formatCurrencyCompact(-1000000)).toBe('$-1.0M')
-      expect(formatCurrencyCompact(-5000)).toBe('$-5.0K')
-      expect(formatCurrencyCompact(-500)).toBe('$-500')
+      expect(formatCurrencyCompact(-1000000)).toBe('-1.0M')
+      expect(formatCurrencyCompact(-5000)).toBe('-5.0K')
+      expect(formatCurrencyCompact(-500)).toBe('-500')
     })
 
     it('uses custom currency symbol', () => {
       expect(formatCurrencyCompact(1000000, '€')).toBe('€1.0M')
       expect(formatCurrencyCompact(5000, '£')).toBe('£5.0K')
+    })
+
+    it('resolves the symbol from an ISO currency code', () => {
+      expect(formatCurrencyCompact(1000000, 'USD')).toMatch(/^(\$|US\$|USD)1\.0M$/)
+      expect(formatCurrencyCompact(5000, 'pln')).toMatch(/^(zł|PLN)5\.0K$/)
     })
   })
 
@@ -123,6 +129,58 @@ describe('formatters', () => {
     it('uses custom fallback', () => {
       expect(formatCurrencySafe(null, 'N/A')).toBe('N/A')
       expect(formatCurrencySafe(undefined, '-')).toBe('-')
+    })
+
+    it('formats in the requested currency', () => {
+      expect(formatCurrencySafe(1234, '--', { currency: 'PLN' })).toMatch(/zł|PLN/)
+    })
+  })
+
+  describe('currency labelling (#4620)', () => {
+    it('never labels an amount when no currency is known', () => {
+      expect(formatCurrency(1234)).not.toMatch(/\$|USD/)
+      expect(formatCurrencyWithDecimals(1234)).not.toMatch(/\$|USD/)
+      expect(formatCurrencyCompact(1234)).not.toMatch(/\$|USD/)
+      expect(formatCurrencySafe(1234)).not.toMatch(/\$|USD/)
+    })
+
+    it('labels the amount with the tenant currency when it is known', () => {
+      expect(formatCurrency(1234, { currency: 'PLN' })).toMatch(/zł|PLN/)
+      expect(formatCurrency(1234, { currency: 'pln' })).toMatch(/zł|PLN/)
+    })
+
+    it('falls back to an appended code for an unknown currency', () => {
+      expect(formatCurrency(1234, { currency: 'ZZZ' })).toMatch(/ZZZ/)
+    })
+
+    it('ignores values that are not ISO currency codes', () => {
+      expect(formatCurrency(1234, { currency: '' })).not.toMatch(/[A-Za-z]/)
+      expect(formatCurrency(1234, { currency: null })).not.toMatch(/[A-Za-z]/)
+    })
+  })
+
+  describe('createCurrencyFormatters', () => {
+    it('binds the currency into single-argument formatters', () => {
+      const money = createCurrencyFormatters('PLN')
+      expect(money.currency).toBe('PLN')
+      expect(money.format(1234)).toMatch(/zł|PLN/)
+      expect(money.formatWithDecimals(1234)).toMatch(/zł|PLN/)
+      expect(money.formatCompact(1_000_000)).toMatch(/^(zł|PLN)1\.0M$/)
+      expect(money.formatSafe(1234)).toMatch(/zł|PLN/)
+    })
+
+    it('ignores extra arguments passed by chart libraries', () => {
+      const money = createCurrencyFormatters('PLN')
+      const formatter = money.formatCompact as (value: number, ...rest: unknown[]) => string
+      expect(formatter(1_000_000, 0)).toBe(money.formatCompact(1_000_000))
+    })
+
+    it('leaves amounts unlabelled when the currency is unknown', () => {
+      const money = createCurrencyFormatters(null)
+      expect(money.currency).toBeNull()
+      expect(money.format(1234)).not.toMatch(/\$|USD/)
+      expect(money.formatCompact(1_000_000)).toBe('1.0M')
+      expect(money.formatSafe(null)).toBe('--')
     })
   })
 })

--- a/packages/core/src/modules/dashboards/lib/formatters.ts
+++ b/packages/core/src/modules/dashboards/lib/formatters.ts
@@ -1,36 +1,116 @@
 export type FormatCurrencyOptions = {
-  currency?: string
+  currency?: string | null
   minimumFractionDigits?: number
   maximumFractionDigits?: number
 }
 
-export function formatCurrency(value: number, options: FormatCurrencyOptions = {}): string {
-  const { currency = 'USD', minimumFractionDigits = 0, maximumFractionDigits = 0 } = options
+const CURRENCY_CODE_PATTERN = /^[A-Za-z]{3}$/
+
+function normalizeCurrencyCode(currency?: string | null): string | null {
+  if (typeof currency !== 'string') return null
+  const trimmed = currency.trim()
+  if (!CURRENCY_CODE_PATTERN.test(trimmed)) return null
+  return trimmed.toUpperCase()
+}
+
+function formatDecimal(value: number, minimumFractionDigits: number, maximumFractionDigits: number): string {
   return new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency,
+    style: 'decimal',
     minimumFractionDigits,
     maximumFractionDigits,
   }).format(value)
+}
+
+/**
+ * Formats a monetary amount. Without a currency code the amount renders as a plain
+ * number: analytics values carry no currency of their own, and labelling them with a
+ * guessed one (see #4620) is worse than leaving them unlabelled.
+ */
+export function formatCurrency(value: number, options: FormatCurrencyOptions = {}): string {
+  const { currency, minimumFractionDigits = 0, maximumFractionDigits = 0 } = options
+  const code = normalizeCurrencyCode(currency)
+  if (!code) return formatDecimal(value, minimumFractionDigits, maximumFractionDigits)
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: code,
+      minimumFractionDigits,
+      maximumFractionDigits,
+    }).format(value)
+  } catch {
+    return `${formatDecimal(value, minimumFractionDigits, maximumFractionDigits)} ${code}`
+  }
 }
 
 export function formatCurrencyWithDecimals(value: number, options: FormatCurrencyOptions = {}): string {
   return formatCurrency(value, { minimumFractionDigits: 2, maximumFractionDigits: 2, ...options })
 }
 
-export function formatCurrencyCompact(value: number, currencySymbol = '$'): string {
-  if (Math.abs(value) >= 1_000_000) {
-    return `${currencySymbol}${(value / 1_000_000).toFixed(1)}M`
+function resolveCurrencySymbol(currency?: string | null): string {
+  const code = normalizeCurrencyCode(currency)
+  if (!code) return typeof currency === 'string' ? currency : ''
+  try {
+    const parts = new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: code,
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).formatToParts(0)
+    return parts.find((part) => part.type === 'currency')?.value ?? code
+  } catch {
+    return code
   }
-  if (Math.abs(value) >= 1_000) {
-    return `${currencySymbol}${(value / 1_000).toFixed(1)}K`
-  }
-  return `${currencySymbol}${value.toFixed(0)}`
 }
 
-export function formatCurrencySafe(value: unknown, fallback = '--'): string {
+/**
+ * Compact money formatting for chart axes and tooltips. Accepts either an ISO 4217
+ * code (resolved to the locale's symbol) or a ready-made symbol.
+ */
+export function formatCurrencyCompact(value: number, currency?: string | null): string {
+  const symbol = resolveCurrencySymbol(currency)
+  if (Math.abs(value) >= 1_000_000) {
+    return `${symbol}${(value / 1_000_000).toFixed(1)}M`
+  }
+  if (Math.abs(value) >= 1_000) {
+    return `${symbol}${(value / 1_000).toFixed(1)}K`
+  }
+  return `${symbol}${value.toFixed(0)}`
+}
+
+export function formatCurrencySafe(
+  value: unknown,
+  fallback = '--',
+  options: FormatCurrencyOptions = {},
+): string {
   if (value === null || value === undefined) return fallback
   const num = Number(value)
   if (!Number.isFinite(num)) return fallback
-  return formatCurrency(num)
+  return formatCurrency(num, options)
+}
+
+export type CurrencyFormatters = {
+  currency: string | null
+  format: (value: number) => string
+  formatWithDecimals: (value: number) => string
+  formatCompact: (value: number) => string
+  formatSafe: (value: unknown) => string
+}
+
+/**
+ * Binds the resolved currency once so widgets can hand chart and KPI components a
+ * stable single-argument formatter — passing `formatCurrency` by reference is what
+ * made its currency option unreachable in the first place (#4620).
+ */
+export function createCurrencyFormatters(
+  currency?: string | null,
+  fallback = '--',
+): CurrencyFormatters {
+  const code = normalizeCurrencyCode(currency)
+  return {
+    currency: code,
+    format: (value: number) => formatCurrency(value, { currency: code }),
+    formatWithDecimals: (value: number) => formatCurrencyWithDecimals(value, { currency: code }),
+    formatCompact: (value: number) => formatCurrencyCompact(value, code),
+    formatSafe: (value: unknown) => formatCurrencySafe(value, fallback, { currency: code }),
+  }
 }

--- a/packages/core/src/modules/dashboards/services/__tests__/widgetDataService.test.ts
+++ b/packages/core/src/modules/dashboards/services/__tests__/widgetDataService.test.ts
@@ -36,13 +36,24 @@ function createRegistry(): AnalyticsRegistry {
   }
 }
 
-function createService(execute: (sql: string, params: unknown[]) => Promise<ExecuteResult>) {
+function isBaseCurrencyQuery(sql: string): boolean {
+  return sql.includes('FROM currencies')
+}
+
+function countAggregationCalls(execute: jest.Mock): number {
+  return execute.mock.calls.filter(([sql]: [string]) => !isBaseCurrencyQuery(sql)).length
+}
+
+function createService(
+  execute: (sql: string, params: unknown[]) => Promise<ExecuteResult>,
+  scope: { tenantId: string; organizationIds?: string[] } = { tenantId: 'tenant-1' },
+) {
   const em = {
     getConnection: () => ({ execute }),
   } as unknown as EntityManager
   return new WidgetDataService({
     em,
-    scope: { tenantId: 'tenant-1' },
+    scope,
     registry: createRegistry(),
   })
 }
@@ -58,7 +69,8 @@ describe('WidgetDataService comparison fetching', () => {
   test('runs the primary and comparison queries in parallel', async () => {
     const deferreds = [createDeferred<ExecuteResult>(), createDeferred<ExecuteResult>()]
     let started = 0
-    const execute = jest.fn(async () => {
+    const execute = jest.fn(async (sql: string) => {
+      if (isBaseCurrencyQuery(sql)) return []
       const deferred = deferreds[started]
       started += 1
       return deferred.promise
@@ -70,7 +82,7 @@ describe('WidgetDataService comparison fetching', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    expect(execute).toHaveBeenCalledTimes(2)
+    expect(countAggregationCalls(execute)).toBe(2)
 
     deferreds[0].resolve([{ value: 200 }])
     deferreds[1].resolve([{ value: 100 }])
@@ -85,15 +97,15 @@ describe('WidgetDataService comparison fetching', () => {
   })
 
   test('preserves the comparison response shape and math', async () => {
-    const execute = jest.fn(async (_sql: string, _params: unknown[]): Promise<ExecuteResult> => {
-      const call = execute.mock.calls.length
-      return call === 1 ? [{ value: 80 }] : [{ value: 100 }]
+    const execute = jest.fn(async (sql: string, _params: unknown[]): Promise<ExecuteResult> => {
+      if (isBaseCurrencyQuery(sql)) return []
+      return countAggregationCalls(execute) === 1 ? [{ value: 80 }] : [{ value: 100 }]
     })
 
     const service = createService(execute)
     const response = await service.fetchWidgetData(comparisonRequest)
 
-    expect(execute).toHaveBeenCalledTimes(2)
+    expect(countAggregationCalls(execute)).toBe(2)
     expect(response.value).toBe(80)
     expect(response.data).toEqual([])
     expect(response.metadata.recordCount).toBe(1)
@@ -105,7 +117,9 @@ describe('WidgetDataService comparison fetching', () => {
   })
 
   test('runs a single query and omits comparison when none is requested', async () => {
-    const execute = jest.fn(async (): Promise<ExecuteResult> => [{ value: 42 }])
+    const execute = jest.fn(async (sql: string): Promise<ExecuteResult> =>
+      isBaseCurrencyQuery(sql) ? [] : [{ value: 42 }],
+    )
     const service = createService(execute)
 
     const response = await service.fetchWidgetData({
@@ -114,8 +128,79 @@ describe('WidgetDataService comparison fetching', () => {
       dateRange: { field: 'created_at', preset: 'this_month' },
     })
 
-    expect(execute).toHaveBeenCalledTimes(1)
+    expect(countAggregationCalls(execute)).toBe(1)
     expect(response.value).toBe(42)
     expect(response.comparison).toBeUndefined()
+  })
+})
+
+describe('WidgetDataService base currency resolution', () => {
+  const request: WidgetDataRequest = {
+    entityType: 'sales:orders',
+    metric: { field: 'total', aggregate: 'sum' },
+    dateRange: { field: 'created_at', preset: 'this_month' },
+  }
+
+  function createCurrencyExecute(rows: ExecuteResult) {
+    return jest.fn(async (sql: string): Promise<ExecuteResult> =>
+      isBaseCurrencyQuery(sql) ? rows : [{ value: 10 }],
+    )
+  }
+
+  test('reports the scope base currency instead of a hard-coded default', async () => {
+    const execute = createCurrencyExecute([{ code: 'PLN' }])
+    const service = createService(execute, { tenantId: 'tenant-1', organizationIds: ['org-1'] })
+
+    const response = await service.fetchWidgetData(request)
+
+    expect(response.metadata.currency).toBe('PLN')
+    const currencyCall = execute.mock.calls.find(([sql]: [string]) => isBaseCurrencyQuery(sql))
+    expect(currencyCall?.[0]).toContain('is_base = true')
+    expect(currencyCall?.[1]).toEqual(['tenant-1', '{org-1}'])
+  })
+
+  test('resolves to null when the scope spans different base currencies', async () => {
+    const execute = createCurrencyExecute([{ code: 'PLN' }, { code: 'EUR' }])
+    const service = createService(execute, {
+      tenantId: 'tenant-1',
+      organizationIds: ['org-1', 'org-2'],
+    })
+
+    const response = await service.fetchWidgetData(request)
+
+    expect(response.metadata.currency).toBeNull()
+  })
+
+  test('resolves to null when no base currency is configured', async () => {
+    const execute = createCurrencyExecute([])
+    const service = createService(execute)
+
+    const response = await service.fetchWidgetData(request)
+
+    expect(response.metadata.currency).toBeNull()
+  })
+
+  test('degrades to null when the currencies lookup fails', async () => {
+    const execute = jest.fn(async (sql: string): Promise<ExecuteResult> => {
+      if (isBaseCurrencyQuery(sql)) throw new Error('relation "currencies" does not exist')
+      return [{ value: 10 }]
+    })
+    const service = createService(execute)
+
+    const response = await service.fetchWidgetData(request)
+
+    expect(response.value).toBe(10)
+    expect(response.metadata.currency).toBeNull()
+  })
+
+  test('resolves the base currency once per service instance', async () => {
+    const execute = createCurrencyExecute([{ code: 'PLN' }])
+    const service = createService(execute)
+
+    await service.fetchWidgetData(request)
+    await service.fetchWidgetData({ ...request, metric: { field: 'total', aggregate: 'avg' } })
+
+    const currencyCalls = execute.mock.calls.filter(([sql]: [string]) => isBaseCurrencyQuery(sql))
+    expect(currencyCalls).toHaveLength(1)
   })
 })

--- a/packages/core/src/modules/dashboards/services/widgetDataService.ts
+++ b/packages/core/src/modules/dashboards/services/widgetDataService.ts
@@ -82,6 +82,7 @@ export type WidgetDataResponse = {
   metadata: {
     fetchedAt: string
     recordCount: number
+    currency?: string | null
   }
 }
 
@@ -102,6 +103,7 @@ export class WidgetDataService {
   private scope: WidgetDataScope
   private registry: AnalyticsRegistry
   private cache?: CacheStrategy
+  private baseCurrencyPromise?: Promise<string | null>
 
   constructor(options: WidgetDataServiceOptions) {
     this.em = options.em
@@ -147,11 +149,12 @@ export class WidgetDataService {
 
     const shouldFetchComparison = Boolean(comparisonRange && request.dateRange)
 
-    const [mainResult, comparisonResult] = await Promise.all([
+    const [mainResult, comparisonResult, currency] = await Promise.all([
       this.executeQuery(request, dateRangeResolved),
       shouldFetchComparison && comparisonRange
         ? this.executeQuery(request, comparisonRange)
         : Promise.resolve<{ value: number | null; data: WidgetDataItem[] } | undefined>(undefined),
+      this.resolveBaseCurrency(),
     ])
 
     const response: WidgetDataResponse = {
@@ -160,6 +163,7 @@ export class WidgetDataService {
       metadata: {
         fetchedAt: now.toISOString(),
         recordCount: mainResult.data.length || (mainResult.value !== null ? 1 : 0),
+        currency,
       },
     }
 
@@ -186,6 +190,38 @@ export class WidgetDataService {
     }
 
     return response
+  }
+
+  /**
+   * Resolves the base currency of the current scope so money widgets can label amounts
+   * with the tenant's own currency instead of a hard-coded default (#4620). The lookup
+   * is soft: a scope spanning organizations with different base currencies, a missing
+   * base currency, or an unavailable currencies module all resolve to `null`, and the
+   * widgets then render unlabelled numbers rather than a wrong currency.
+   */
+  private resolveBaseCurrency(): Promise<string | null> {
+    if (!this.baseCurrencyPromise) {
+      this.baseCurrencyPromise = this.queryBaseCurrency().catch(() => null)
+    }
+    return this.baseCurrencyPromise
+  }
+
+  private async queryBaseCurrency(): Promise<string | null> {
+    const clauses = ['tenant_id = ?', 'is_base = true', 'deleted_at IS NULL']
+    const params: unknown[] = [this.scope.tenantId]
+
+    if (this.scope.organizationIds && this.scope.organizationIds.length > 0) {
+      clauses.push('organization_id = ANY(?::uuid[])')
+      params.push(`{${this.scope.organizationIds.join(',')}}`)
+    }
+
+    const sql = `SELECT DISTINCT code FROM currencies WHERE ${clauses.join(' AND ')} LIMIT 2`
+    const rows = await this.em.getConnection().execute(sql, params)
+    const codes = (Array.isArray(rows) ? rows : [])
+      .map((row: Record<string, unknown>) => (typeof row.code === 'string' ? row.code.trim() : ''))
+      .filter((code: string) => code.length > 0)
+
+    return codes.length === 1 ? codes[0] : null
   }
 
   private validateRequest(request: WidgetDataRequest): void {

--- a/packages/core/src/modules/dashboards/widgets/dashboard/aov-kpi/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/aov-kpi/widget.client.tsx
@@ -13,7 +13,7 @@ import {
 } from '@open-mercato/ui/backend/date-range'
 import { DEFAULT_SETTINGS, hydrateSettings, type AovKpiSettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
-import { formatCurrencyWithDecimals } from '../../../lib/formatters'
+import { createCurrencyFormatters } from '../../../lib/formatters'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('dashboards').child({ component: 'aov-kpi' })
@@ -46,8 +46,10 @@ const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [value, setValue] = React.useState<number | null>(null)
   const [trend, setTrend] = React.useState<KpiTrend | undefined>(undefined)
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const money = React.useMemo(() => createCurrencyFormatters(currency), [currency])
 
   const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
@@ -57,6 +59,7 @@ const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
     try {
       const data = await fetchAovData(hydrated, fetchWidgetData)
       setValue(data.value)
+      setCurrency(data.metadata?.currency ?? null)
       if (data.comparison) {
         setTrend({
           value: data.comparison.change,
@@ -114,7 +117,7 @@ const AovKpiWidget: React.FC<DashboardWidgetComponentProps<AovKpiSettings>> = ({
       comparisonLabel={comparisonLabel}
       loading={loading}
       error={error}
-      formatValue={formatCurrencyWithDecimals}
+      formatValue={money.formatWithDecimals}
       headerAction={
         <InlineDateRangeSelect
           value={hydrated.dateRange}

--- a/packages/core/src/modules/dashboards/widgets/dashboard/pipeline-summary/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/pipeline-summary/widget.client.tsx
@@ -12,7 +12,7 @@ import {
 } from '@open-mercato/ui/backend/date-range'
 import { DEFAULT_SETTINGS, hydrateSettings, type PipelineSummarySettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
-import { formatCurrencyCompact } from '../../../lib/formatters'
+import { createCurrencyFormatters } from '../../../lib/formatters'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('dashboards').child({ component: 'pipeline-summary' })
@@ -58,8 +58,10 @@ const PipelineSummaryWidget: React.FC<DashboardWidgetComponentProps<PipelineSumm
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<BarChartDataItem[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const money = React.useMemo(() => createCurrencyFormatters(currency), [currency])
 
   const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
@@ -75,6 +77,7 @@ const PipelineSummaryWidget: React.FC<DashboardWidgetComponentProps<PipelineSumm
           Value: item.value ?? 0,
         }))
       setData(chartData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load pipeline data', { err })
       setError(t('dashboards.analytics.widgets.pipelineSummary.error', 'Failed to load data'))
@@ -117,7 +120,7 @@ const PipelineSummaryWidget: React.FC<DashboardWidgetComponentProps<PipelineSumm
           categoryLabels={{ Value: t('dashboards.analytics.labels.value', 'Value') }}
           loading={loading}
           error={error}
-          valueFormatter={formatCurrencyCompact}
+          valueFormatter={money.formatCompact}
           colors={['violet']}
           showLegend={false}
           emptyMessage={t('dashboards.analytics.widgets.pipelineSummary.empty', 'No deal data for this period')}

--- a/packages/core/src/modules/dashboards/widgets/dashboard/revenue-kpi/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/revenue-kpi/widget.client.tsx
@@ -13,7 +13,7 @@ import {
 } from '@open-mercato/ui/backend/date-range'
 import { DEFAULT_SETTINGS, hydrateSettings, type RevenueKpiSettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
-import { formatCurrency } from '../../../lib/formatters'
+import { createCurrencyFormatters } from '../../../lib/formatters'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('dashboards').child({ component: 'revenue-kpi' })
@@ -46,8 +46,10 @@ const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSetting
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [value, setValue] = React.useState<number | null>(null)
   const [trend, setTrend] = React.useState<KpiTrend | undefined>(undefined)
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const money = React.useMemo(() => createCurrencyFormatters(currency), [currency])
 
   const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
@@ -57,6 +59,7 @@ const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSetting
     try {
       const data = await fetchRevenueData(hydrated, fetchWidgetData)
       setValue(data.value)
+      setCurrency(data.metadata?.currency ?? null)
       if (data.comparison) {
         setTrend({
           value: data.comparison.change,
@@ -114,7 +117,7 @@ const RevenueKpiWidget: React.FC<DashboardWidgetComponentProps<RevenueKpiSetting
       comparisonLabel={comparisonLabel}
       loading={loading}
       error={error}
-      formatValue={formatCurrency}
+      formatValue={money.format}
       headerAction={
         <InlineDateRangeSelect
           value={hydrated.dateRange}

--- a/packages/core/src/modules/dashboards/widgets/dashboard/revenue-trend/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/revenue-trend/widget.client.tsx
@@ -20,7 +20,7 @@ import {
 import type { DateGranularity } from '@open-mercato/shared/modules/analytics'
 import { DEFAULT_SETTINGS, hydrateSettings, type RevenueTrendSettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
-import { formatCurrencyCompact } from '../../../lib/formatters'
+import { createCurrencyFormatters } from '../../../lib/formatters'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('dashboards').child({ component: 'revenue-trend' })
@@ -114,8 +114,10 @@ const RevenueTrendWidget: React.FC<DashboardWidgetComponentProps<RevenueTrendSet
   const locale = useLocale()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<LineChartDataItem[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const money = React.useMemo(() => createCurrencyFormatters(currency), [currency])
 
   const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
@@ -134,6 +136,7 @@ const RevenueTrendWidget: React.FC<DashboardWidgetComponentProps<RevenueTrendSet
         Revenue: item.value ?? 0,
       }))
       setData(chartData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load revenue trend data', { err })
       setError(t('dashboards.analytics.widgets.revenueTrend.error', 'Failed to load data'))
@@ -212,7 +215,7 @@ const RevenueTrendWidget: React.FC<DashboardWidgetComponentProps<RevenueTrendSet
         loading={loading}
         error={error}
         showArea={hydrated.showArea}
-        valueFormatter={formatCurrencyCompact}
+        valueFormatter={money.formatCompact}
         colors={['blue']}
         emptyMessage={t('dashboards.analytics.widgets.revenueTrend.empty', 'No revenue data for this period')}
       />

--- a/packages/core/src/modules/dashboards/widgets/dashboard/sales-by-region/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/sales-by-region/widget.client.tsx
@@ -9,7 +9,7 @@ import { DateRangeSelect, type DateRangePreset } from '@open-mercato/ui/backend/
 import { Input } from '@open-mercato/ui/primitives/input'
 import { DEFAULT_SETTINGS, hydrateSettings, type SalesByRegionSettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
-import { formatCurrencyCompact } from '../../../lib/formatters'
+import { createCurrencyFormatters } from '../../../lib/formatters'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('dashboards').child({ component: 'sales-by-region' })
@@ -44,8 +44,10 @@ const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionS
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<BarChartDataItem[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const money = React.useMemo(() => createCurrencyFormatters(currency), [currency])
 
   const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
@@ -59,6 +61,7 @@ const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionS
         Revenue: item.value ?? 0,
       }))
       setData(chartData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load sales by region data', { err })
       setError(t('dashboards.analytics.widgets.salesByRegion.error', 'Failed to load data'))
@@ -114,7 +117,7 @@ const SalesByRegionWidget: React.FC<DashboardWidgetComponentProps<SalesByRegionS
       loading={loading}
       error={error}
       layout="horizontal"
-      valueFormatter={formatCurrencyCompact}
+      valueFormatter={money.formatCompact}
       colors={['cyan']}
       showLegend={false}
       emptyMessage={t('dashboards.analytics.widgets.salesByRegion.empty', 'No regional sales data for this period')}

--- a/packages/core/src/modules/dashboards/widgets/dashboard/top-customers/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/top-customers/widget.client.tsx
@@ -9,7 +9,7 @@ import { DateRangeSelect, type DateRangePreset } from '@open-mercato/ui/backend/
 import { Input } from '@open-mercato/ui/primitives/input'
 import { DEFAULT_SETTINGS, hydrateSettings, type TopCustomersSettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
-import { formatCurrencySafe } from '../../../lib/formatters'
+import { createCurrencyFormatters } from '../../../lib/formatters'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('dashboards').child({ component: 'top-customers' })
@@ -56,8 +56,10 @@ const TopCustomersWidget: React.FC<DashboardWidgetComponentProps<TopCustomersSet
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<CustomerRow[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
+  const money = React.useMemo(() => createCurrencyFormatters(currency), [currency])
 
   const unknownLabel = t('dashboards.analytics.labels.unknown', 'Unknown')
   const columns: TopNTableColumn<CustomerRow>[] = React.useMemo(
@@ -76,10 +78,10 @@ const TopCustomersWidget: React.FC<DashboardWidgetComponentProps<TopCustomersSet
         key: 'revenue',
         header: t('dashboards.analytics.widgets.topCustomers.column.revenue', 'Revenue'),
         align: 'right',
-        formatter: (value: unknown) => formatCurrencySafe(value),
+        formatter: (value: unknown) => money.formatSafe(value),
       },
     ],
-    [t, unknownLabel],
+    [t, unknownLabel, money],
   )
 
   const fetchWidgetData = useWidgetData()
@@ -95,6 +97,7 @@ const TopCustomersWidget: React.FC<DashboardWidgetComponentProps<TopCustomersSet
         revenue: item.value ?? 0,
       }))
       setData(tableData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load top customers data', { err })
       setError(t('dashboards.analytics.widgets.topCustomers.error', 'Failed to load data'))

--- a/packages/core/src/modules/dashboards/widgets/dashboard/top-products/widget.client.tsx
+++ b/packages/core/src/modules/dashboards/widgets/dashboard/top-products/widget.client.tsx
@@ -16,7 +16,7 @@ import {
 } from '@open-mercato/ui/primitives/select'
 import { DEFAULT_SETTINGS, hydrateSettings, type TopProductsSettings } from './config'
 import type { WidgetDataResponse } from '../../../services/widgetDataService'
-import { formatCurrencyCompact } from '../../../lib/formatters'
+import { createCurrencyFormatters } from '../../../lib/formatters'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('dashboards').child({ component: 'top-products' })
@@ -70,9 +70,11 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
   const t = useT()
   const hydrated = React.useMemo(() => hydrateSettings(settings), [settings])
   const [data, setData] = React.useState<BarChartDataItem[]>([])
+  const [currency, setCurrency] = React.useState<string | null>(null)
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
   const fetchingRef = React.useRef(false)
+  const money = React.useMemo(() => createCurrencyFormatters(currency), [currency])
 
   const fetchWidgetData = useWidgetData()
   const refresh = React.useCallback(async () => {
@@ -88,6 +90,7 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
         Revenue: item.value ?? 0,
       }))
       setData(chartData)
+      setCurrency(result.metadata?.currency ?? null)
     } catch (err) {
       logger.error('Failed to load top products data', { err })
       setError(t('dashboards.analytics.widgets.topProducts.error', 'Failed to load data'))
@@ -172,7 +175,7 @@ const TopProductsWidget: React.FC<DashboardWidgetComponentProps<TopProductsSetti
           loading={loading}
           error={error}
           layout={hydrated.layout}
-          valueFormatter={formatCurrencyCompact}
+          valueFormatter={money.formatCompact}
           colors={['emerald']}
           showLegend={false}
           emptyMessage={t('dashboards.analytics.widgets.topProducts.empty', 'No product sales data for this period')}


### PR DESCRIPTION
Closes #4620
Tracking plan: .ai/runs/2026-07-29-dashboards-base-currency-formatting.md
Status: complete

## 🎯 Goal
Dashboard analytics widgets stop labelling amounts `USD`/`$` on tenants that trade in another currency — they now format in the tenant/organization base currency the `currencies` module already stores.

## 🔍 Problem
Every money helper in `packages/core/src/modules/dashboards/lib/formatters.ts` had USD baked in as the default (`currency = 'USD'`, `currencySymbol = '$'`). A PLN tenant saw `13,032,039 USD` for values that are złoty — numbers that look authoritative and are simply mislabelled.

## 🔍 Root Cause
The widgets pass the formatters **by reference** (`formatValue={formatCurrency}`, `valueFormatter={formatCurrencyCompact}`), so the `options`/`currencySymbol` parameter is never supplied by a caller and the hard-coded default always wins. Nothing in the widget-data pipeline carried a currency, so a call site had nothing to pass either.

## What Changed
- **`services/widgetDataService.ts`** — resolves the base currency of the request scope (`currencies.is_base`, scoped by tenant and the request's organization ids) and returns it as `metadata.currency`. The lookup is memoized per service instance, so a batched dashboard render costs one extra query for the whole batch, and it runs alongside the aggregation queries rather than ahead of them. It is deliberately soft: a scope spanning organizations with **different** base currencies, no base currency, or an unavailable currencies module all resolve to `null` — the widgets then show unlabelled numbers rather than a currency that is only probably right.
- **`api/widgets/data/schema.ts`** — additive optional `metadata.currency` on the response schema (single and batch endpoints share it, so both are covered).
- **`lib/formatters.ts`** — the USD/`$` defaults are gone. Without a currency the helpers format a plain number via `Intl.NumberFormat({style:'decimal'})`; with one they format as currency, falling back to `1,234 XYZ` for a code `Intl` rejects. `formatCurrencyCompact` now accepts an ISO code (resolved to the locale's symbol) **or** a ready-made symbol, so its previous callers keep working. New `createCurrencyFormatters(currency)` binds the currency once and returns the single-argument formatters the KPI/chart components expect.
- **7 widgets** (`revenue-kpi`, `aov-kpi`, `top-customers`, `top-products`, `sales-by-region`, `revenue-trend`, `pipeline-summary`) — read `metadata.currency` from the response and format through a memoized formatter set instead of a bare module-level function reference.
- Side effect worth noting: the chart formatters were previously handed straight to Recharts' `tickFormatter`, which calls them as `(value, index)` — the index landed in the `currencySymbol` slot and rendered axis ticks like `01.5M`. The bound single-argument formatters ignore extra arguments, and a test locks that in.

## 🧪 Tests
- Full gate (`yarn build:packages && yarn generate && yarn build:packages && yarn i18n:check-sync && yarn i18n:check-usage && yarn typecheck && yarn test && yarn build:app`) — green. Runner: local. `@open-mercato/core`: 1026 suites / 7864 tests passed; app build succeeded.
- `lib/__tests__/formatters.test.ts` — no currency never yields a `$`/`USD` label; an explicit currency labels correctly (including a lower-case code); an unknown code degrades to an appended code; `createCurrencyFormatters` binds the currency across all four helpers and ignores the extra argument chart libraries pass. Existing compact-format expectations were updated from `$1.0M` to `1.0M` — that USD symbol was exactly the defect.
- `services/__tests__/widgetDataService.test.ts` — base currency reported for a single-organization scope (with the tenant/org parameters asserted), `null` for a mixed-currency scope, `null` when none is configured, `null` when the lookup throws, and resolved once per service instance.

## 💥 Breaking Changes
None for the API contract (`metadata.currency` is additive and optional). Behavior change by design: money on the analytics widgets is no longer labelled with a currency the platform cannot prove — a tenant with no base currency configured now sees unlabelled numbers instead of a `$` that was wrong. Module-internal helpers keep their signatures; `formatCurrencyCompact`'s second argument still accepts a symbol.

Out of scope, called out deliberately: `seed/analytics.ts` still creates demo orders/deals with `currencyCode: 'USD'`, and the aggregations sum across order currencies without grouping by them. Both are separate concerns from the formatting defect this issue reports.

## 📋 Progress
See the Progress section in the tracking plan.
