### PR TITLE
feat(agent_orchestrator): route file-agent delegation through delegate_agent (fix sub-agent no_active_run)

### DIFF
--- a/packages/cli/src/lib/generators/__tests__/agent-files-extension.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/agent-files-extension.test.ts
@@ -101,6 +101,84 @@ describe('createAgentFilesExtension', () => {
     expect(dockerContent).toContain('mode: primary')
     expect(dockerContent).toContain('open-mercato_agent_orchestrator_submit_outcome')
     expect(dockerContent).toContain('write: deny')
+    // No sub-agents declared → `task` denied and no delegate tool (unchanged).
+    expect(dockerContent).toContain('task: deny')
+    expect(dockerContent).not.toContain('delegate_agent')
+  })
+
+  it('routes file-agent delegation through delegate_agent instead of the task tool', () => {
+    const fixture = makeRepoFixture()
+    repoRoot = fixture.repoRoot
+    const agentDir = path.join(fixture.appBase, 'agents', 'deals_health_check')
+
+    // Declare a sub-agent under sub-agents/<subid>/ (informative + non-delegating).
+    fs.writeFileSync(
+      path.join(agentDir, 'AGENT.md'),
+      [
+        '---',
+        'id: deals.health_check',
+        'label: Deal health check',
+        'description: Assess a deal.',
+        '---',
+        'You assess a deal.',
+      ].join('\n'),
+      'utf8',
+    )
+    const subDir = path.join(agentDir, 'sub-agents', 'company_researcher')
+    fs.mkdirSync(subDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(subDir, 'AGENT.md'),
+      [
+        '---',
+        'id: deals.company_researcher',
+        'label: Company researcher',
+        'description: Research a company.',
+        '---',
+        'You research a company.',
+      ].join('\n'),
+      'utf8',
+    )
+    fs.writeFileSync(
+      path.join(subDir, 'OUTCOME.md'),
+      [
+        '---',
+        'kind: informative',
+        '---',
+        '```json',
+        JSON.stringify({ type: 'object', properties: { summary: { type: 'string' } } }),
+        '```',
+      ].join('\n'),
+      'utf8',
+    )
+
+    const extension = createAgentFilesExtension()
+    extension.scanModule(createScanContext('agent_examples', fixture.appBase, fixture.pkgBase))
+    extension.generateOutput()
+
+    const primary = fs.readFileSync(
+      path.join(repoRoot, 'docker/opencode/agents/deals_health_check.md'),
+      'utf8',
+    )
+    // The orchestrator gains the delegate_agent MCP tool, denies `task`, and
+    // never grants the built-in task tool.
+    expect(primary).toContain('open-mercato_agent_orchestrator_delegate_agent')
+    expect(primary).toContain('task: deny')
+    expect(primary).not.toContain('"task": true')
+    // The prompt delegates through delegate_agent (not `task`) using the FULL
+    // sub-agent id.
+    expect(primary).toContain('## Sub-agents')
+    expect(primary).toContain('delegate_agent')
+    expect(primary).toContain('deals.company_researcher')
+    expect(primary).not.toContain('by calling the `task` tool')
+
+    // The sub-agent file gets neither the delegate tool nor `task` (depth cap = 1).
+    const sub = fs.readFileSync(
+      path.join(repoRoot, 'docker/opencode/agents/deals_company_researcher.md'),
+      'utf8',
+    )
+    expect(sub).toContain('mode: subagent')
+    expect(sub).toContain('task: deny')
+    expect(sub).not.toContain('delegate_agent')
   })
 
   it('emits an agent SAMPLE.json into the manifest as sampleInput', () => {

--- a/packages/cli/src/lib/generators/extensions/agent-files.ts
+++ b/packages/cli/src/lib/generators/extensions/agent-files.ts
@@ -830,9 +830,6 @@ function renderToolPermissionLine(toolName: string): string {
   return `  ${JSON.stringify(toolName)}: true`
 }
 
-/** Built-in OpenCode delegation tool a primary agent uses to fan out to sub-agents. */
-const TASK_TOOL_NAME = 'task'
-
 // OpenCode names every MCP tool `<serverKey>_<toolName with dots→underscores>`
 // (verified against the running image). Keep in sync with
 // `lib/sdk/defineFileAgent.ts`.
@@ -842,36 +839,49 @@ const CORE_FILE_AGENT_TOOL_IDS = [
   'agent_orchestrator.load_skill',
   'agent_orchestrator.run_skill_script',
 ]
+/**
+ * MCP tool a file-agent orchestrator uses to run a sub-agent SERVER-SIDE. We
+ * route delegation through this tool instead of OpenCode's built-in `task` tool:
+ * `task` spawns each sub-agent in a fresh session that never receives the run's
+ * `_sessionToken`, so the sub-agent's MCP calls fail with `no_active_run`. The
+ * delegate tool runs the sub-agent via `agentRuntime.run`, which mints its own
+ * per-run session token + correlation, so sub-agent tool calls authenticate.
+ */
+const DELEGATE_AGENT_TOOL_ID = 'agent_orchestrator.delegate_agent'
 function toOpenCodeMcpToolId(omToolId: string): string {
   return `${OPENCODE_MCP_SERVER_KEY}_${omToolId.replace(/\./g, '_')}`
 }
 
 /**
  * Render an OpenCode agent .md file. Must stay in sync with
- * `lib/sdk/defineFileAgent.ts` `renderOpenCodeAgentFile`. Sub-agent files
- * (`mode: subagent`) get NO `task` allowance and `permission.task: deny` (depth
- * cap = 1). A primary that declares sub-agents allows the built-in `task` tool,
- * whitelists ONLY its sub-agents' sanitized names under `permission.task`, and
- * gains a "Sub-agents" prompt section nudging parallel fan-out.
+ * `lib/sdk/defineFileAgent.ts` `renderOpenCodeAgentFile`. The built-in OpenCode
+ * `task` tool is NEVER granted (`permission.task: deny` for every agent): it
+ * spawns each sub-agent in a fresh session that does not inherit the run's
+ * `_sessionToken`, so the sub-agent's MCP calls fail with `no_active_run`.
+ * Instead, a primary that declares sub-agents is granted the
+ * `agent_orchestrator.delegate_agent` MCP tool (runs each sub-agent server-side
+ * under its own minted session token) and gains a "Sub-agents" prompt section
+ * nudging parallel fan-out through that tool. Sub-agent files (`mode: subagent`)
+ * get neither the delegate tool nor `task` (depth cap = 1).
  */
 function renderOpenCodeAgentFile(agent: DiscoveredAgent): string {
-  const subAgentNames =
-    agent.mode === 'primary' ? agent.subAgentsContent.map((sub) => sub.openCodeAgentName) : []
-  const hasSubAgents = subAgentNames.length > 0
-  const omMcpToolIds = Array.from(new Set([...agent.tools, ...CORE_FILE_AGENT_TOOL_IDS]))
-  const allowedTools = [
-    ...omMcpToolIds.map(toOpenCodeMcpToolId),
-    ...(hasSubAgents ? [TASK_TOOL_NAME] : []),
-  ]
+  const subAgentIds =
+    agent.mode === 'primary' ? agent.subAgentsContent.map((sub) => sub.id) : []
+  const hasSubAgents = subAgentIds.length > 0
+  const omMcpToolIds = Array.from(
+    new Set([
+      ...agent.tools,
+      ...CORE_FILE_AGENT_TOOL_IDS,
+      ...(hasSubAgents ? [DELEGATE_AGENT_TOOL_ID] : []),
+    ]),
+  )
+  const allowedTools = omMcpToolIds.map(toOpenCodeMcpToolId)
   const modelLine =
     agent.provider && agent.model
       ? `model: ${agent.provider}/${agent.model}`
       : agent.model
         ? `model: ${agent.model}`
         : null
-  const taskPermissionLines = hasSubAgents
-    ? ['  task:', '    "*": deny', ...subAgentNames.map((name) => `    ${JSON.stringify(name)}: allow`)]
-    : ['  task: deny']
   const frontmatterLines = [
     '---',
     `description: ${JSON.stringify(agent.description)}`,
@@ -884,13 +894,14 @@ function renderOpenCodeAgentFile(agent: DiscoveredAgent): string {
     '  write: deny',
     '  edit: deny',
     '  bash: deny',
-    ...taskPermissionLines,
+    '  task: deny',
     '---',
   ]
   const terminalInstruction =
     `Finish by calling the \`${toOpenCodeMcpToolId('agent_orchestrator.submit_outcome')}\` tool with a value matching the outcome contract (pass it as the \`outcome\` argument). You MUST call the tool — do not answer in prose or emit the result as a code block.`
+  const delegateToolName = toOpenCodeMcpToolId(DELEGATE_AGENT_TOOL_ID)
   const subAgentSection = hasSubAgents
-    ? `## Sub-agents\nYou may delegate independent read-only sub-tasks to these sub-agents by calling the \`task\` tool. When several sub-tasks are independent, issue multiple \`task\` calls in the SAME step so they run in parallel, then combine their results before submitting your outcome. Available sub-agents: ${subAgentNames.join(', ')}.`
+    ? `## Sub-agents\nDelegate a sub-task by calling the \`${delegateToolName}\` tool with \`{ agentId: "<sub-agent id>", input: <sub-task input object> }\`. Issue multiple \`${delegateToolName}\` calls in the SAME step to fan out in parallel, then combine their results before submitting your outcome. Available sub-agents: ${subAgentIds.join(', ')}.`
     : null
   // Inject the OUTCOME contract so the agent SEES the exact shape it must submit
   // (otherwise it guesses and learns the shape only from validation errors). Keep

--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/defineFileAgent.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/defineFileAgent.test.ts
@@ -177,11 +177,14 @@ describe('loadFileAgentDir', () => {
     expect(sub.openCodeAgentFile).toContain('task: deny')
     expect(sub.openCodeAgentFile).not.toContain('"task": true')
 
-    // Primary allows the task tool and whitelists ONLY its sub-agent's name.
+    // Primary delegates via the server-side delegate_agent tool, NEVER OpenCode's `task`.
     expect(loaded!.openCodeAgentFile).toContain('mode: primary')
-    expect(loaded!.openCodeAgentFile).toContain('"task": true')
-    expect(loaded!.openCodeAgentFile).toContain('"deals_activity_scan": allow')
+    expect(loaded!.openCodeAgentFile).toContain('task: deny')
+    expect(loaded!.openCodeAgentFile).not.toContain('"task": true')
+    expect(loaded!.openCodeAgentFile).toContain('"open-mercato_agent_orchestrator_delegate_agent": true')
     expect(loaded!.openCodeAgentFile).toContain('## Sub-agents')
+    // The delegation prompt names the sub-agent by its FULL registry id.
+    expect(loaded!.openCodeAgentFile).toContain('deals.activity_scan')
   })
 
   it('rejects an actionable sub-agent (only the primary proposes)', () => {

--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/delegate-agent-parent-run.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/delegate-agent-parent-run.test.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod'
+import { aiTools } from '../ai-tools'
+import { DELEGATE_TOOL_ID, defineAgent } from '../lib/sdk/defineAgent'
+
+// On the OpenCode path the delegate_agent tool runs in the separate
+// `mcp:serve-http` process, where the in-process run-context AsyncLocalStorage is
+// never set (`getCurrentRunId()` is undefined). The handler must then resolve the
+// parent run id from the caller's run session via `agentRunSessionStore` so the
+// nested sub-agent run still records `parent_run_id`.
+describe('delegate_agent parentRunId fallback (OpenCode/MCP path)', () => {
+  const schema = z.object({ kind: z.literal('informative'), data: z.unknown() })
+
+  it('resolves parentRunId from the caller session when the run context is absent', async () => {
+    defineAgent({
+      id: 'test.delegate_target',
+      moduleId: 'agent_orchestrator',
+      label: 'Target',
+      description: 'Informative sub-agent.',
+      instructions: 'BASE',
+      result: { kind: 'informative', schema },
+    })
+
+    const delegateTool = aiTools.find((tool) => tool.name === DELEGATE_TOOL_ID)
+    expect(delegateTool).toBeDefined()
+
+    let capturedParentRunId: string | undefined
+    const agentRuntime = {
+      run: async (_agentId: string, _input: unknown, opts: { parentRunId?: string }) => {
+        capturedParentRunId = opts.parentRunId
+        return { kind: 'informative' as const, data: { ok: true } }
+      },
+    }
+    const agentRunSessionStore = {
+      resolveActiveRunId: async (token: string) =>
+        token === 'sess_test' ? 'run-from-session' : null,
+    }
+    const container = {
+      resolve: (name: string) =>
+        name === 'agentRuntime'
+          ? agentRuntime
+          : name === 'agentRunSessionStore'
+            ? agentRunSessionStore
+            : undefined,
+    }
+    const ctx = {
+      tenantId: 't1',
+      organizationId: 'o1',
+      userId: 'u1',
+      sessionId: 'sess_test',
+      container,
+      userFeatures: [],
+      isSuperAdmin: false,
+    }
+
+    const result = await delegateTool!.handler(
+      { agentId: 'test.delegate_target', input: { foo: 1 } },
+      ctx as never,
+    )
+    expect(result).toMatchObject({ ok: true, agentId: 'test.delegate_target' })
+    expect(capturedParentRunId).toBe('run-from-session')
+  })
+
+  it('omits parentRunId when the caller session resolves no active run', async () => {
+    defineAgent({
+      id: 'test.delegate_target_2',
+      moduleId: 'agent_orchestrator',
+      label: 'Target 2',
+      description: 'Informative sub-agent.',
+      instructions: 'BASE',
+      result: { kind: 'informative', schema },
+    })
+
+    const delegateTool = aiTools.find((tool) => tool.name === DELEGATE_TOOL_ID)
+    let sawParentRunIdKey = true
+    const agentRuntime = {
+      run: async (_agentId: string, _input: unknown, opts: Record<string, unknown>) => {
+        sawParentRunIdKey = 'parentRunId' in opts
+        return { kind: 'informative' as const, data: { ok: true } }
+      },
+    }
+    const agentRunSessionStore = {
+      resolveActiveRunId: async () => null,
+    }
+    const container = {
+      resolve: (name: string) =>
+        name === 'agentRuntime'
+          ? agentRuntime
+          : name === 'agentRunSessionStore'
+            ? agentRunSessionStore
+            : undefined,
+    }
+    const ctx = {
+      tenantId: 't1',
+      organizationId: 'o1',
+      userId: 'u1',
+      sessionId: 'sess_no_run',
+      container,
+      userFeatures: [],
+      isSuperAdmin: false,
+    }
+
+    await delegateTool!.handler(
+      { agentId: 'test.delegate_target_2', input: {} },
+      ctx as never,
+    )
+    expect(sawParentRunIdKey).toBe(false)
+  })
+})

--- a/packages/enterprise/src/modules/agent_orchestrator/ai-tools.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/ai-tools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { defineAiTool } from '@open-mercato/ai-assistant/modules/ai_assistant/lib/ai-tool-definition'
-import type { AiToolDefinition } from '@open-mercato/ai-assistant/modules/ai_assistant/lib/types'
+import type { AiToolDefinition, McpToolContext } from '@open-mercato/ai-assistant/modules/ai_assistant/lib/types'
 import { DELEGATE_TOOL_ID, getAgentEntry, ensureAgentsLoaded } from './lib/sdk/defineAgent'
 import type { AgentRuntimeService } from './lib/runtime/agentRuntime'
 import type { AgentRunSessionStore } from './lib/runtime/agentRunSessionStore'
@@ -22,6 +22,26 @@ const delegateInput = z.object({
   agentId: z.string().min(1).describe('Id of the sub-agent to run (must be an informative agent).'),
   input: z.unknown().describe('Input payload passed to the sub-agent (shape is sub-agent specific).'),
 })
+
+/**
+ * Resolve the parent run id from the caller's run session when the in-process
+ * run context is absent. On the OpenCode path this tool runs in the separate
+ * `mcp:serve-http` process where `getCurrentRunId()` is always undefined, so the
+ * nested-run `parent_run_id` trace link would be lost. Mirrors how
+ * `submit_outcome` (this file) and `lib/webSearch/guardrails.ts` resolve the run
+ * from the session token via `agentRunSessionStore`. Never throws — a missing
+ * session or an unresolvable store yields `undefined` (a top-level nested run).
+ */
+async function resolveParentRunIdFromSession(ctx: McpToolContext): Promise<string | undefined> {
+  const sessionToken = ctx.sessionId
+  if (!sessionToken) return undefined
+  try {
+    const store = ctx.container.resolve('agentRunSessionStore') as AgentRunSessionStore
+    return (await store.resolveActiveRunId(sessionToken)) ?? undefined
+  } catch {
+    return undefined
+  }
+}
 
 /**
  * Sub-agent-as-tool: lets a parent agent run another agent as a read-only
@@ -69,9 +89,12 @@ const delegateAgentTool: AiToolDefinition = {
       const agentRuntime = ctx.container.resolve('agentRuntime') as AgentRuntimeService
       // The parent run is the in-process run currently executing (bound via the
       // run-context AsyncLocalStorage); pass its id so the nested sub-agent run
-      // records `parent_run_id` for traceability (Phase 4). Undefined outside a
-      // run context (the nested run is then a top-level run).
-      const parentRunId = getCurrentRunId()
+      // records `parent_run_id` for traceability (Phase 4). On the OpenCode path
+      // this tool runs in the separate mcp:serve-http process where that async
+      // context is never set — fall back to the cross-process correlation store,
+      // resolving the parent run from THIS run's session token. Undefined when
+      // neither resolves (the nested run is then a top-level run).
+      const parentRunId = getCurrentRunId() ?? (await resolveParentRunIdFromSession(ctx))
       const delegatedSource = getCurrentRunSource()
       const result = await agentRuntime.run(agentId, input, {
         tenantId: ctx.tenantId,

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/sdk/defineFileAgent.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/sdk/defineFileAgent.ts
@@ -209,8 +209,14 @@ function renderToolPermissionLine(toolName: string): string {
   return `  ${JSON.stringify(toolName)}: true`
 }
 
-/** Built-in OpenCode delegation tool a primary agent uses to fan out to sub-agents. */
-const TASK_TOOL_NAME = 'task'
+/**
+ * File-agent delegation goes through the server-side `agent_orchestrator.delegate_agent`
+ * MCP tool (runs each sub-agent as its own authenticated run), NOT OpenCode's built-in
+ * `task` tool — a `task` sub-session runs in a fresh session that never inherits the
+ * run's session token, so its MCP calls fail with no_active_run. Kept in sync with the
+ * CLI generator (`packages/cli/src/lib/generators/extensions/agent-files.ts`).
+ */
+const DELEGATE_AGENT_TOOL_ID = 'agent_orchestrator.delegate_agent'
 
 /**
  * The MCP server key OpenCode connects under (the `mcp.<key>` in opencode.jsonc;
@@ -258,6 +264,8 @@ function renderOpenCodeAgentFile(args: {
   mode?: 'primary' | 'subagent'
   /** Sanitized OpenCode names of this primary's reachable sub-agents (empty otherwise). */
   subAgentNames?: string[]
+  /** Full registry ids of this primary's reachable sub-agents — the `agentId` values passed to delegate_agent. */
+  subAgentIds?: string[]
   /** The OUTCOME contract — injected into the prompt so the agent sees its exact shape. */
   outcomeKind: OutcomeKind
   outcomeSchema: JsonSchemaNode
@@ -266,30 +274,27 @@ function renderOpenCodeAgentFile(args: {
   files?: FileAgentFilesConfig
 }): string {
   const mode = args.mode ?? 'primary'
-  const subAgentNames = mode === 'primary' ? (args.subAgentNames ?? []) : []
-  const hasSubAgents = subAgentNames.length > 0
+  const subAgentIds = mode === 'primary' ? (args.subAgentIds ?? []) : []
+  const hasSubAgents = subAgentIds.length > 0
   // The agent's MCP tools = its declared read tools + the core file-agent tools
   // (submit_outcome / load_skill / run_skill_script). OpenCode names every MCP
   // tool `<serverKey>_<toolName with dots→underscores>`, so the allowlist key and
   // the prompt MUST use that form — a dotted OM id never matches and `"*": false`
   // would silently drop it. `task` is an OpenCode built-in (not prefixed).
-  const omMcpToolIds = Array.from(new Set([...args.tools, ...CORE_FILE_AGENT_TOOL_IDS]))
-  const allowedTools = [
-    ...omMcpToolIds.map(toOpenCodeMcpToolId),
-    ...(hasSubAgents ? [TASK_TOOL_NAME] : []),
-  ]
+  const omMcpToolIds = Array.from(
+    new Set([...args.tools, ...CORE_FILE_AGENT_TOOL_IDS, ...(hasSubAgents ? [DELEGATE_AGENT_TOOL_ID] : [])]),
+  )
+  const allowedTools = omMcpToolIds.map(toOpenCodeMcpToolId)
   const modelLine =
     args.provider && args.model
       ? `model: ${args.provider}/${args.model}`
       : args.model
         ? `model: ${args.model}`
         : null
-  // Sub-agents may NOT delegate further: deny `task` entirely. A primary that
-  // declares sub-agents denies `task` by default then whitelists ONLY its own
-  // sub-agents' sanitized names.
-  const taskPermissionLines = hasSubAgents
-    ? ['  task:', '    "*": deny', ...subAgentNames.map((name) => `    ${JSON.stringify(name)}: allow`)]
-    : ['  task: deny']
+  // OpenCode's built-in `task` tool is NEVER granted — delegation goes through the
+  // server-side `agent_orchestrator.delegate_agent` tool instead (see DELEGATE_AGENT_TOOL_ID),
+  // so no agent (primary or sub-agent) can spawn a `task` sub-session.
+  const taskPermissionLines = ['  task: deny']
 
   // File plane (#12): a primary that opted in gets sandbox-scoped write/edit/read
   // ONLY when the global kill-switch `OM_OPENCODE_FILES_ENABLED` is on — otherwise
@@ -339,8 +344,9 @@ function renderOpenCodeAgentFile(args: {
   const submitToolId = toOpenCodeMcpToolId('agent_orchestrator.submit_outcome')
   const terminalInstruction =
     `Finish by calling the \`${submitToolId}\` tool with a value matching the outcome contract (pass it as the \`outcome\` argument). You MUST call the tool — do not answer in prose or emit the result as a code block.`
+  const delegateToolName = toOpenCodeMcpToolId(DELEGATE_AGENT_TOOL_ID)
   const subAgentSection = hasSubAgents
-    ? `## Sub-agents\nYou may delegate independent read-only sub-tasks to these sub-agents by calling the \`task\` tool. When several sub-tasks are independent, issue multiple \`task\` calls in the SAME step so they run in parallel, then combine their results before submitting your outcome. Available sub-agents: ${subAgentNames.join(', ')}.`
+    ? `## Sub-agents\nDelegate a sub-task by calling the \`${delegateToolName}\` tool with \`{ agentId: "<sub-agent id>", input: <sub-task input object> }\`. Issue multiple \`${delegateToolName}\` calls in the SAME step to fan out in parallel, then combine their results before submitting your outcome. Available sub-agents: ${subAgentIds.join(', ')}.`
     : null
   const outcomeSection = renderOutcomeSection(args.outcomeKind, args.outcomeSchema, args.outcomeProse)
   const body = [
@@ -706,6 +712,7 @@ export function loadFileAgentDir(dir: string): LoadedFileAgent | null {
     tools: effectiveTools,
     mode: 'primary',
     subAgentNames,
+    subAgentIds: subAgents.map((sub) => sub.entry.id),
     outcomeKind: outcome.kind,
     outcomeSchema: outcome.schema,
     outcomeProse: outcome.prose,


### PR DESCRIPTION
## Problem

File-defined (OpenCode) agents delegate to sub-agents via OpenCode's built-in `task` tool, which spawns each sub-agent in a **fresh OpenCode session**. MCP auth is per-tool-call via a model-passed `_sessionToken` injected only into the *orchestrator's* first message, so a `task` sub-session never receives it → every sub-agent MCP call (registry lookups, `submit_outcome`) fails with **`no_active_run`**. This structurally breaks any file-agent that both delegates and calls MCP tools. It can't be fixed reliably at the model layer (small models won't copy the token) nor safely at the MCP layer (single static shared connection, stateless-per-request, session-token semantics are Ask-First).

## Fix

Route file-agent delegation through the existing **`agent_orchestrator.delegate_agent`** MCP tool instead of `task`. That tool runs the sub-agent **server-side** via `agentRuntime.run(agentId, input, …)` — for a file-defined sub-agent this routes through `OpenCodeAgentRunner`, which **mints its own per-run session token + correlation**, so the sub-agent's tool calls authenticate as a first-class run. `no_active_run` becomes impossible — no model token-copying, **no MCP-auth/session-token change**, no OpenCode-upstream change. The tool already enforces the propose-only invariants (informative-only target, depth cap = 1, same ACL scope).

### Changes
- **Generator** (`packages/cli/.../agent-files.ts`): a file-agent orchestrator with sub-agents now gets `agent_orchestrator.delegate_agent` in its tool allowlist, `permission.task: deny` (the `task` tool is never granted to any agent), and a `## Sub-agents` prompt instructing delegation via `delegate_agent` with `{ agentId, input }` and parallel same-step fan-out (naming sub-agents by full registry id).
- **`delegate_agent`** (`agent_orchestrator/ai-tools.ts`): resolves `parentRunId` from the caller session (`agentRunSessionStore.resolveActiveRunId(ctx.sessionId)`) when the in-process run context is absent — i.e. the OpenCode/MCP path — so nested-run tracing (`parent_run_id`) survives.
- **`defineFileAgent.ts`** SDK renderer kept in sync with the CLI generator (the two are contractually required to match).

### Verification
- `agentRuntime` **is** resolvable in the `mcp:serve-http` process (built by `createRequestContainer()` from the generated DI, same path that already resolves `agentRunSessionStore` for `submit_outcome`), so the delegate path actually runs server-side. No runtime-wiring gap.
- Typecheck: cli + enterprise **0 errors**. Tests: agent-files generator suite, `defineFileAgent`/`subagents` renderer suites, and a new `delegate_agent` parentRunId-fallback test all pass; full `agent_orchestrator` suite green.

### Note on generated artifacts
The committed OpenCode agent files (`docker/opencode/agents/*.md`) and `file-agents.generated.ts` are produced by `yarn generate` and are **not hand-included** here (regenerating them requires the built toolchain and would otherwise mix in unrelated downstream agents). Run `yarn generate` to materialize them; the output is deterministic from the generator change and is asserted directly by the generator unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)