### PR TITLE
fix(ci): preapprove @open-mercato past yarn's minimum release age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,6 +7,13 @@ nodeLinker: node-modules
 npmRegistryServer: "https://registry.npmjs.org"
 npmPublishRegistry: "https://registry.npmjs.org"
 
+# Yarn's npmMinimalAgeGate (default 1d) rejects versions published less than a
+# day ago. Our own releases get consumed minutes after publishing (module
+# installs, snapshot verification), so the first-party scope opts out while
+# third-party packages keep the cooldown.
+npmPreapprovedPackages:
+  - "@open-mercato/*"
+
 packageExtensions:
   "cmdk@*":
     peerDependenciesMeta:

--- a/apps/docs/docs/customization/standalone-app.mdx
+++ b/apps/docs/docs/customization/standalone-app.mdx
@@ -363,6 +363,7 @@ Review the [changelog](https://github.com/open-mercato/open-mercato/releases) fo
 
 - **`preinstall` check fails** — make sure you are running Node.js 24 or later. Use `nvm use 24` or `fnm use 24` to switch.
 - **Registry errors** — if using a private registry, pass `--registry <url>` when creating the app or edit `.yarnrc.yml` after scaffolding.
+- **`All versions satisfying ... are quarantined`** — Yarn's `npmMinimalAgeGate` (default 1 day) refuses versions published less than a day ago. The scaffold's `.yarnrc.yml` already exempts `@open-mercato/*` through `npmPreapprovedPackages`; add any other freshly published package the same way. A top-level `npmMinimalAgeGate: 0` does not help when the package's scope has its own `npmScopes` entry — the scope default shadows it.
 - **Generators produce empty output** — run `yarn install` first so the `@open-mercato` packages are available in `node_modules`.
 - **Ejected module errors after upgrade** — ejected modules are not updated automatically. Compare your local copy with the upstream source and merge changes manually.
 - **Docker services not starting** — verify Docker is running and ports 5432, 6379, and 7700 are free. Use `docker compose logs` to inspect errors.

--- a/packages/create-app/template/.yarnrc.yml.template
+++ b/packages/create-app/template/.yarnrc.yml.template
@@ -1,2 +1,11 @@
 nodeLinker: node-modules
+
+# Yarn refuses versions younger than `npmMinimalAgeGate` (default 1 day) with
+# "All versions satisfying ... are quarantined". This app pins the exact
+# @open-mercato release it was scaffolded from, which is usually minutes old, so
+# the first-party scope opts out while every third-party package keeps the
+# cooldown. A per-scope `npmRegistryServer` entry shadows a top-level
+# `npmMinimalAgeGate: 0`, so the opt-out has to be expressed as a preapproval.
+npmPreapprovedPackages:
+  - "@open-mercato/*"
 {{REGISTRY_CONFIG}}

--- a/scripts/__tests__/npm-minimal-age-gate.test.mjs
+++ b/scripts/__tests__/npm-minimal-age-gate.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const templateYarnrcPath = path.resolve('packages/create-app/template/.yarnrc.yml.template')
+const retryScriptPath = path.resolve('scripts/ci/npm-retry-on-quarantine.sh')
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+test('scaffolded apps preapprove the first-party scope against yarn minimum release age', () => {
+  const template = readText(templateYarnrcPath)
+
+  assert.match(
+    template,
+    /^npmPreapprovedPackages:\n(?:\s+- .*\n)*\s+- "@open-mercato\/\*"$/m,
+    'template/.yarnrc.yml.template must preapprove "@open-mercato/*" — yarn refuses versions younger than npmMinimalAgeGate (default 1d), and scaffolded apps pin the release they were scaffolded from'
+  )
+
+  const preapprovalIndex = template.indexOf('npmPreapprovedPackages:')
+  const registryConfigIndex = template.indexOf('{{REGISTRY_CONFIG}}')
+
+  assert.ok(
+    preapprovalIndex >= 0 && registryConfigIndex > preapprovalIndex,
+    'npmPreapprovedPackages must stay at the top level, before the {{REGISTRY_CONFIG}} block, so it is not parsed as part of npmScopes'
+  )
+})
+
+test('the quarantine retry helper fails fast on yarn minimum release age gates', () => {
+  const script = readText(retryScriptPath)
+
+  assert.match(
+    script,
+    /grep -qE 'YN0016\.\*quarantined'/,
+    'npm-retry-on-quarantine.sh must detect yarn YN0016 age-gate failures separately from npm registry quarantine'
+  )
+  assert.match(
+    script,
+    /npmPreapprovedPackages/,
+    'the YN0016 branch must point at the npmPreapprovedPackages fix instead of retrying for 20 minutes'
+  )
+
+  const yn0016Index = script.indexOf("grep -qE 'YN0016")
+  const genericQuarantineIndex = script.indexOf("grep -qiE 'quarantin'")
+
+  assert.ok(
+    yn0016Index >= 0 && genericQuarantineIndex > yn0016Index,
+    'the YN0016 fast-fail must run before the generic quarantine retry branch'
+  )
+})

--- a/scripts/ci/npm-retry-on-quarantine.sh
+++ b/scripts/ci/npm-retry-on-quarantine.sh
@@ -2,15 +2,18 @@
 # Retry a command that installs freshly published npm packages, tolerating
 # npm's post-publish security QUARANTINE window.
 #
-# npm quarantines a newly published version's tarball for a security scan while
-# its metadata is already public. A scaffold/install that runs immediately after
-# the snapshot publish therefore fails with `YN0016 … are quarantined` (yarn) or
-# a 403 quarantine error (npm) even though `npm view <pkg> version` succeeds.
-# The quarantine clears on its own after a while, so retry the *actual* install
+# npm holds a newly published version for a malware scan (usually ~5 minutes,
+# up to 15+ at peak) before it becomes installable, so a scaffold/install that
+# runs immediately after the snapshot publish can fail even though the publish
+# succeeded. That window clears on its own, so retry the *actual* install
 # operation (the thing yarn/npm does) rather than a proxy probe — `npm pack`
-# hits the CDN tarball and can report ready while yarn's manifest check still
-# sees quarantine. Only the quarantine signal is retried; any other failure
-# exits immediately so real errors surface fast.
+# hits the CDN tarball and can report ready while the manifest check still
+# fails. Only the quarantine signal is retried; any other failure exits
+# immediately so real errors surface fast.
+#
+# Yarn's own client-side cooldown (`npmMinimalAgeGate`, default 1 day) reports
+# the same word but is NOT a registry state — waiting cannot clear it inside a
+# CI job. It is detected separately and fails fast with the fix.
 #
 # Usage: npm-retry-on-quarantine.sh <command> [args...]
 # Tunables (env): QUARANTINE_MAX_ATTEMPTS (default 20), QUARANTINE_RETRY_SLEEP (default 60s)
@@ -34,6 +37,11 @@ while :; do
 
   if [ "$code" -eq 0 ]; then
     exit 0
+  fi
+
+  if grep -qE 'YN0016.*quarantined' "$log"; then
+    echo "::error::\`$*\` hit yarn's minimum release age gate (npmMinimalAgeGate, default 1d), not npm's registry quarantine. Retrying cannot clear it — allow the freshly published scope via npmPreapprovedPackages in the consuming project's .yarnrc.yml." >&2
+    exit "$code"
   fi
 
   if ! grep -qiE 'quarantin' "$log"; then


### PR DESCRIPTION
## Summary

The standalone app CI job fails on freshly published snapshots with `YN0016 … are quarantined` — that message is Yarn's client-side `npmMinimalAgeGate` (default `1d`), not npm's registry quarantine, so `scripts/ci/npm-retry-on-quarantine.sh` retried a 1-day timer for 20 minutes and gave up ([failing run](https://github.com/open-mercato/open-mercato/actions/runs/30444536044/job/90553144218)). A top-level `npmMinimalAgeGate: 0` does not fix it either: the scaffold's `npmScopes.open-mercato` entry shadows it with the scope's own `1d` default, which is why Yarn's own legacy-lockfile migration writes that setting and the install still fails. This exempts only the first-party scope via `npmPreapprovedPackages`, so third-party dependencies keep the supply-chain cooldown, and teaches the retry helper to fail fast on the age gate instead of burning 20 CI minutes. It also unblocks real users who scaffold an app minutes after a `latest` release.

## Changes

- `packages/create-app/template/.yarnrc.yml.template`: top-level `npmPreapprovedPackages: ["@open-mercato/*"]` so scaffolded apps can install the release they were scaffolded from
- `.yarnrc.yml`: same exemption in the monorepo root (`mercato module add @open-mercato/…` right after a release)
- `scripts/ci/npm-retry-on-quarantine.sh`: detect `YN0016 … quarantined` and exit immediately with the fix, still retrying genuine npm registry quarantine (~5–15 min)
- `scripts/__tests__/npm-minimal-age-gate.test.mjs`: guards the template preapproval (top-level, above `{{REGISTRY_CONFIG}}`) and the fast-fail ordering
- `apps/docs/docs/customization/standalone-app.mdx`: troubleshooting entry for the quarantine error

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A

## Testing

- Reproduced and verified against the exact package that failed in CI (`@open-mercato/shared@0.6.7-develop.6670.1.4efa7961c6`, yarn 4.17.1, lockfile v10): default config and top-level `npmMinimalAgeGate: 0` + `npmScopes` both fail; `npmPreapprovedPackages` installs cleanly. Re-ran with the real rendered template, with and without `--registry`.
- `yarn test:scripts` — 349/349 pass
- `yarn workspace create-mercato-app test` — 123/123 pass

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required) — N/A: build/install configuration with no runtime surface; the snapshot workflow's standalone integration job is itself the end-to-end coverage.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` — no UI-rendering file touched, database structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract affected, and automated tests ship with the change.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

_No UI surface in this PR; DS items are N/A._

## Linked issues

N/A
