### PR TITLE
feat(workflows): agent-authoring tool pack (spec §9, Phase 6b)

### DIFF
--- a/packages/core/src/modules/workflows/__tests__/ai-tools/authoring-pack.test.ts
+++ b/packages/core/src/modules/workflows/__tests__/ai-tools/authoring-pack.test.ts
@@ -1,0 +1,523 @@
+/**
+ * Unit tests for the `workflows.*` agent-authoring tool pack.
+ *
+ * The pack's whole value is that it does NOT reimplement the engine, so these
+ * tests assert agreement with the surfaces it wraps — most importantly that
+ * `validate_definition` returns exactly what the Studio's Problems-panel path
+ * returns — plus the two safety invariants: writes never publish, and a foreign
+ * definition is invisible rather than merely forbidden.
+ */
+import workflowsAiTools from '../../ai-tools'
+import features from '../../acl'
+import {
+  WorkflowDefinition,
+  WorkflowDefinitionDraft,
+  type WorkflowDefinitionData,
+} from '../../data/entities'
+import { collectValidationIssues } from '../../lib/collect-validation-issues'
+import { definitionToGraph, validateWorkflowGraph } from '../../lib/graph-utils'
+import { workflowDefinitionDataSchema } from '../../data/validators'
+import { collectActivityConfigWarnings } from '../../data/activity-config-warnings'
+
+const knownFeatureIds = new Set(features.map((entry) => entry.id))
+
+const ALL_FEATURES = [
+  'workflows.definitions.view',
+  'workflows.definitions.create',
+  'workflows.definitions.edit',
+  'workflows.definitions.test_run',
+  'workflows.instances.view',
+  'workflows.instances.create',
+]
+
+function findTool(name: string) {
+  const tool = workflowsAiTools.find((entry) => entry.name === name)
+  if (!tool) throw new Error(`tool ${name} missing`)
+  return tool as unknown as {
+    name: string
+    requiredFeatures?: string[]
+    isMutation?: boolean
+    handler: (input: unknown, ctx: unknown) => Promise<Record<string, unknown>>
+  }
+}
+
+const validDefinition = {
+  steps: [
+    { stepId: 'start', stepName: 'Start', stepType: 'START' },
+    { stepId: 'end', stepName: 'Done', stepType: 'END' },
+  ],
+  transitions: [
+    {
+      transitionId: 'start_to_end',
+      transitionName: 'Go',
+      fromStepId: 'start',
+      toStepId: 'end',
+      trigger: 'auto',
+      priority: 100,
+    },
+  ],
+} as unknown as WorkflowDefinitionData
+
+/** No START step: a graph error the zod schema alone does NOT catch. */
+const graphInvalidDefinition = {
+  steps: [
+    { stepId: 'middle', stepName: 'Middle', stepType: 'AUTOMATED' },
+    { stepId: 'end', stepName: 'Done', stepType: 'END' },
+  ],
+  transitions: [
+    {
+      transitionId: 'middle_to_end',
+      transitionName: 'Go',
+      fromStepId: 'middle',
+      toStepId: 'end',
+      trigger: 'auto',
+      priority: 100,
+    },
+  ],
+} as unknown as WorkflowDefinitionData
+
+type Row = Record<string, unknown>
+
+/**
+ * An EntityManager fake that actually FILTERS by the supplied where clause, so
+ * "tenant scoping" is proven by the row being unreachable rather than by
+ * asserting a call argument.
+ */
+function makeEm(seed: { definitions?: Row[]; drafts?: Row[] } = {}) {
+  const tables = new Map<unknown, Row[]>([
+    [WorkflowDefinition, [...(seed.definitions ?? [])]],
+    [WorkflowDefinitionDraft, [...(seed.drafts ?? [])]],
+  ])
+  const matches = (row: Row, where: Row): boolean =>
+    Object.entries(where).every(([key, expected]) => {
+      if (expected === null) return row[key] === null || row[key] === undefined
+      if (expected && typeof expected === 'object' && '$in' in (expected as Row)) {
+        return ((expected as { $in: unknown[] }).$in ?? []).includes(row[key])
+      }
+      return row[key] === expected
+    })
+
+  const persisted: Row[] = []
+  const em = {
+    findOne: jest.fn(async (entity: unknown, where: Row) => {
+      return (tables.get(entity) ?? []).find((row) => matches(row, where)) ?? null
+    }),
+    find: jest.fn(async (entity: unknown, where: Row) =>
+      (tables.get(entity) ?? []).filter((row) => matches(row, where)),
+    ),
+    create: jest.fn((entity: unknown, data: Row) => {
+      const row = { id: `generated-${persisted.length + 1}`, ...data, __entity: entity }
+      return row
+    }),
+    persist: jest.fn((row: Row) => {
+      persisted.push(row)
+      const entity = row.__entity
+      tables.get(entity)?.push(row)
+      return em
+    }),
+    flush: jest.fn(async () => undefined),
+    persisted,
+    tables,
+  }
+  return em
+}
+
+function makeCtx(
+  overrides: Partial<{
+    tenantId: string | null
+    organizationId: string | null
+    userId: string | null
+    userFeatures: string[]
+    isSuperAdmin: boolean
+    em: ReturnType<typeof makeEm>
+    workflowExecutor: Record<string, unknown>
+  }> = {},
+) {
+  const em = overrides.em ?? makeEm()
+  const workflowExecutor = overrides.workflowExecutor ?? {
+    startWorkflow: jest.fn(async () => ({ id: 'instance-1', status: 'RUNNING' })),
+    executeWorkflow: jest.fn(async () => undefined),
+  }
+  const container = {
+    resolve: jest.fn((name: string) => {
+      if (name === 'em') return em
+      if (name === 'workflowExecutor') return workflowExecutor
+      throw new Error(`unexpected resolve: ${name}`)
+    }),
+  }
+  return {
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    userId: 'user-1',
+    userFeatures: [...ALL_FEATURES],
+    isSuperAdmin: false,
+    container,
+    em,
+    workflowExecutor,
+    ...overrides,
+  }
+}
+
+describe('workflows AI tool pack — declaration', () => {
+  it('ships exactly the six tools the spec names', () => {
+    expect(workflowsAiTools.map((tool) => tool.name).sort()).toEqual([
+      'workflows.create_definition',
+      'workflows.get_context_schema',
+      'workflows.list_activity_types',
+      'workflows.start_test_run',
+      'workflows.update_definition',
+      'workflows.validate_definition',
+    ])
+  })
+
+  it('gates every tool on EXISTING workflows.* acl features', () => {
+    for (const tool of workflowsAiTools) {
+      const required = (tool as { requiredFeatures?: string[] }).requiredFeatures ?? []
+      expect(required.length).toBeGreaterThan(0)
+      for (const feature of required) expect(knownFeatureIds.has(feature)).toBe(true)
+    }
+  })
+
+  it('marks the three writing tools as mutations and the three reads as not', () => {
+    const mutations = workflowsAiTools
+      .filter((tool) => (tool as { isMutation?: boolean }).isMutation)
+      .map((tool) => tool.name)
+      .sort()
+    expect(mutations).toEqual([
+      'workflows.create_definition',
+      'workflows.start_test_run',
+      'workflows.update_definition',
+    ])
+  })
+
+  it('requires definitions.test_run ON TOP of instances.create to start a dry run', () => {
+    expect(findTool('workflows.start_test_run').requiredFeatures).toEqual(
+      expect.arrayContaining(['workflows.instances.create', 'workflows.definitions.test_run']),
+    )
+  })
+})
+
+describe('workflows.list_activity_types', () => {
+  const tool = findTool('workflows.list_activity_types')
+
+  it('returns the registry with JSON-Schema config contracts', async () => {
+    const result = await tool.handler({}, makeCtx())
+    expect(result.ok).toBe(true)
+    const types = result.activityTypes as Array<Record<string, unknown>>
+    expect(types.length).toBeGreaterThan(0)
+    const updateEntity = types.find((entry) => entry.id === 'UPDATE_ENTITY')
+    expect(updateEntity).toBeDefined()
+    expect(updateEntity!.configSchema).toBeTruthy()
+    expect(updateEntity).toHaveProperty('dryRunMock')
+  })
+
+  it('refuses without workflows.definitions.view', async () => {
+    const result = await tool.handler({}, makeCtx({ userFeatures: [] }))
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('insufficient_permissions')
+  })
+
+  it('answers a structured issue for an unknown activity type', async () => {
+    const result = await tool.handler({ activityType: 'NOPE' }, makeCtx())
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('unknown_activity_type')
+  })
+})
+
+describe('workflows.get_context_schema', () => {
+  const tool = findTool('workflows.get_context_schema')
+
+  const definitionRow = {
+    id: 'def-1',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    deletedAt: null,
+    definition: validDefinition,
+    updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+  }
+
+  it('serves the per-step ledger for a definition in the caller tenant', async () => {
+    const ctx = makeCtx({ em: makeEm({ definitions: [definitionRow] }) })
+    const result = await tool.handler({ definitionId: 'def-1' }, ctx)
+    expect(result.ok).toBe(true)
+    expect(Object.keys(result.steps as Record<string, unknown>).sort()).toEqual(['end', 'start'])
+  })
+
+  it('narrows to one step and 404s an unknown step', async () => {
+    const ctx = makeCtx({ em: makeEm({ definitions: [definitionRow] }) })
+    const ok = await tool.handler({ definitionId: 'def-1', stepId: 'end' }, ctx)
+    expect(Object.keys(ok.steps as Record<string, unknown>)).toEqual(['end'])
+    const miss = await tool.handler({ definitionId: 'def-1', stepId: 'ghost' }, ctx)
+    expect(miss.ok).toBe(false)
+    expect((miss.issues as Array<{ code: string }>)[0].code).toBe('not_found')
+  })
+
+  it('makes a foreign-tenant definition INVISIBLE, not merely unauthorized', async () => {
+    const foreign = { ...definitionRow, id: 'def-foreign', tenantId: 'tenant-2' }
+    const ctx = makeCtx({ em: makeEm({ definitions: [foreign] }) })
+    const result = await tool.handler({ definitionId: 'def-foreign' }, ctx)
+    expect(result.ok).toBe(false)
+    const issues = result.issues as Array<{ code: string }>
+    expect(issues[0].code).toBe('not_found')
+    expect(issues[0].code).not.toBe('insufficient_permissions')
+  })
+
+  it('refuses without workflows.definitions.view', async () => {
+    const ctx = makeCtx({ em: makeEm({ definitions: [definitionRow] }), userFeatures: [] })
+    const result = await tool.handler({ definitionId: 'def-1' }, ctx)
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('insufficient_permissions')
+  })
+})
+
+describe('workflows.validate_definition', () => {
+  const tool = findTool('workflows.validate_definition')
+
+  it('passes a well-formed definition', async () => {
+    const result = await tool.handler({ definition: validDefinition }, makeCtx())
+    expect(result.ok).toBe(true)
+    expect(result.valid).toBe(true)
+    expect(result.errorCount).toBe(0)
+  })
+
+  it('AGREES with the Problems-panel path on a deliberately invalid definition', async () => {
+    const result = await tool.handler({ definition: graphInvalidDefinition }, makeCtx())
+    expect(result.ok).toBe(false)
+    expect(result.errorCount).toBeGreaterThan(0)
+
+    // Recompute the panel's own recipe independently and demand identity.
+    const { nodes, edges } = definitionToGraph(graphInvalidDefinition, { autoLayout: false })
+    const parsed = workflowDefinitionDataSchema.safeParse(graphInvalidDefinition)
+    const expected = collectValidationIssues({
+      graphErrors: validateWorkflowGraph(nodes, edges),
+      zodIssues: parsed.success ? [] : parsed.error.issues,
+      configWarnings: [...collectActivityConfigWarnings(graphInvalidDefinition)],
+      nodes,
+      edges,
+      definition: graphInvalidDefinition,
+    })
+    expect(result.problems).toEqual(expected)
+    expect(expected.some((entry) => /START/i.test(entry.message))).toBe(true)
+  })
+
+  it('returns structured issues (never prose) for malformed JSON', async () => {
+    const result = await tool.handler({ definition: { steps: 'nope' } }, makeCtx())
+    expect(result.ok).toBe(false)
+    const issues = result.issues as Array<Record<string, unknown>>
+    expect(issues.length).toBeGreaterThan(0)
+    for (const entry of issues) {
+      expect(Array.isArray(entry.path)).toBe(true)
+      expect(typeof entry.code).toBe('string')
+      expect(typeof entry.message).toBe('string')
+    }
+  })
+
+  it('rejects supplying both or neither input', async () => {
+    const both = await tool.handler(
+      { definition: validDefinition, definitionId: 'def-1' },
+      makeCtx(),
+    )
+    expect(both.ok).toBe(false)
+    const neither = await tool.handler({}, makeCtx())
+    expect(neither.ok).toBe(false)
+  })
+
+  it('refuses without workflows.definitions.view', async () => {
+    const result = await tool.handler({ definition: validDefinition }, makeCtx({ userFeatures: [] }))
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('insufficient_permissions')
+  })
+})
+
+describe('workflows.create_definition', () => {
+  const tool = findTool('workflows.create_definition')
+
+  const input = {
+    workflowId: 'agent.authored',
+    workflowName: 'Agent authored',
+    definition: validDefinition,
+  }
+
+  it('creates the definition DISABLED — an agent write never publishes', async () => {
+    const ctx = makeCtx()
+    const result = await tool.handler(input, ctx)
+    expect(result.ok).toBe(true)
+    expect(result.enabled).toBe(false)
+    expect(result.published).toBe(false)
+
+    const created = ctx.em.persisted.find((row) => row.__entity === WorkflowDefinition)
+    expect(created).toBeDefined()
+    // The engine refuses to resolve a disabled definition for execution.
+    expect(created!.enabled).toBe(false)
+    expect(created!.tenantId).toBe('tenant-1')
+    // Nothing may set the row to the published lifecycle from this path.
+    expect(created!.lifecycle).toBeUndefined()
+  })
+
+  it('returns the route-identical structured body for an invalid definition', async () => {
+    const result = await tool.handler({ ...input, definition: { steps: [] } }, makeCtx())
+    expect(result.ok).toBe(false)
+    const issues = result.issues as Array<Record<string, unknown>>
+    expect(issues.length).toBeGreaterThan(0)
+    expect(issues[0]).toHaveProperty('path')
+    expect(issues[0]).toHaveProperty('code')
+  })
+
+  it('refuses a duplicate workflowId in the same tenant', async () => {
+    const ctx = makeCtx({
+      em: makeEm({
+        definitions: [{ id: 'def-1', workflowId: 'agent.authored', tenantId: 'tenant-1', version: 1 }],
+      }),
+    })
+    const result = await tool.handler(input, ctx)
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('already_exists')
+  })
+
+  it('refuses without workflows.definitions.create', async () => {
+    const ctx = makeCtx({ userFeatures: ['workflows.definitions.view'] })
+    const result = await tool.handler(input, ctx)
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('insufficient_permissions')
+    expect(ctx.em.persisted).toHaveLength(0)
+  })
+})
+
+describe('workflows.update_definition', () => {
+  const tool = findTool('workflows.update_definition')
+
+  const definitionUpdatedAt = new Date('2026-01-01T00:00:00.000Z')
+  const definitionRow = {
+    id: '11111111-1111-4111-8111-111111111111',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    deletedAt: null,
+    definition: validDefinition,
+    updatedAt: definitionUpdatedAt,
+    enabled: true,
+  }
+  const input = {
+    definitionId: definitionRow.id,
+    definition: validDefinition,
+  }
+
+  it('writes a per-user DRAFT and never touches the definition or its lock', async () => {
+    const ctx = makeCtx({ em: makeEm({ definitions: [definitionRow] }) })
+    const result = await tool.handler(input, ctx)
+
+    expect(result.ok).toBe(true)
+    expect(result.published).toBe(false)
+
+    const draft = ctx.em.persisted.find((row) => row.__entity === WorkflowDefinitionDraft)
+    expect(draft).toBeDefined()
+    expect(draft!.userId).toBe('user-1')
+    expect(draft!.tenantId).toBe('tenant-1')
+    expect(draft!.definitionId).toBe(definitionRow.id)
+
+    // The definition row is untouched: same object, same optimistic-lock token.
+    expect(ctx.em.persisted.some((row) => row.__entity === WorkflowDefinition)).toBe(false)
+    expect(definitionRow.updatedAt).toBe(definitionUpdatedAt)
+    expect(definitionRow.enabled).toBe(true)
+    expect(definitionRow.definition).toBe(validDefinition)
+  })
+
+  it('updates an existing draft in place rather than creating a second one', async () => {
+    const existing = {
+      id: 'draft-1',
+      definitionId: definitionRow.id,
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      definition: { steps: [], transitions: [] },
+      deletedAt: new Date(),
+    }
+    const ctx = makeCtx({ em: makeEm({ definitions: [definitionRow], drafts: [existing] }) })
+    const result = await tool.handler(input, ctx)
+    expect(result.draftId).toBe('draft-1')
+    expect(existing.deletedAt).toBeNull()
+    expect(ctx.em.persisted).toHaveLength(0)
+  })
+
+  it('makes a foreign-tenant definition INVISIBLE', async () => {
+    const foreign = { ...definitionRow, tenantId: 'tenant-2' }
+    const ctx = makeCtx({ em: makeEm({ definitions: [foreign] }) })
+    const result = await tool.handler(input, ctx)
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('not_found')
+    expect(ctx.em.persisted).toHaveLength(0)
+  })
+
+  it('refuses without a user context — a draft is a per-user review copy', async () => {
+    const ctx = makeCtx({ em: makeEm({ definitions: [definitionRow] }), userId: null })
+    const result = await tool.handler(input, ctx)
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('missing_user_context')
+  })
+
+  it('refuses without workflows.definitions.edit', async () => {
+    const ctx = makeCtx({
+      em: makeEm({ definitions: [definitionRow] }),
+      userFeatures: ['workflows.definitions.view'],
+    })
+    const result = await tool.handler(input, ctx)
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('insufficient_permissions')
+    expect(ctx.em.persisted).toHaveLength(0)
+  })
+})
+
+describe('workflows.start_test_run', () => {
+  const tool = findTool('workflows.start_test_run')
+
+  const definitionRow = {
+    id: 'def-1',
+    workflowId: 'agent.authored',
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    deletedAt: null,
+    enabled: true,
+    lifecycle: 'published',
+    version: 1,
+    definition: validDefinition,
+  }
+
+  it('ALWAYS forces isDryRun — there is no way to make the run real', async () => {
+    const ctx = makeCtx({ em: makeEm({ definitions: [definitionRow] }) })
+    const result = await tool.handler(
+      { workflowId: 'agent.authored', initialContext: { orderId: 'o-1' } },
+      ctx,
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.isDryRun).toBe(true)
+    const startWorkflow = ctx.workflowExecutor.startWorkflow as jest.Mock
+    expect(startWorkflow).toHaveBeenCalledTimes(1)
+    const options = startWorkflow.mock.calls[0][1] as Record<string, unknown>
+    expect(options.isDryRun).toBe(true)
+    expect(options.tenantId).toBe('tenant-1')
+    expect(options.organizationId).toBe('org-1')
+  })
+
+  it('makes a foreign-tenant workflow INVISIBLE and starts nothing', async () => {
+    const ctx = makeCtx({
+      em: makeEm({ definitions: [{ ...definitionRow, tenantId: 'tenant-2' }] }),
+    })
+    const result = await tool.handler({ workflowId: 'agent.authored' }, ctx)
+    expect(result.ok).toBe(false)
+    expect((result.issues as Array<{ code: string }>)[0].code).toBe('not_found')
+    expect(ctx.workflowExecutor.startWorkflow as jest.Mock).not.toHaveBeenCalled()
+  })
+
+  it('refuses without workflows.definitions.test_run even with instances.create', async () => {
+    const ctx = makeCtx({
+      em: makeEm({ definitions: [definitionRow] }),
+      userFeatures: ['workflows.instances.view', 'workflows.instances.create'],
+    })
+    const result = await tool.handler({ workflowId: 'agent.authored' }, ctx)
+    expect(result.ok).toBe(false)
+    const issues = result.issues as Array<{ code: string; message: string }>
+    expect(issues[0].code).toBe('insufficient_permissions')
+    expect(issues[0].message).toContain('workflows.definitions.test_run')
+    expect(ctx.workflowExecutor.startWorkflow as jest.Mock).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/workflows/ai-tools.ts
+++ b/packages/core/src/modules/workflows/ai-tools.ts
@@ -1,0 +1,20 @@
+/**
+ * Module-root AI tool contribution for the workflows module (spec §9.5,
+ * roadmap Phase 6 — "Agent-as-author (MCP tool pack)").
+ *
+ * The generator walks every module for a top-level `ai-tools.ts` and takes the
+ * default/`aiTools` export as the contribution; `ai-tools.generated.ts` is then
+ * loaded by the ai-assistant tool-loader, which registers each tool through
+ * `registerMcpTool`. That single registry serves BOTH consumers: the MCP server
+ * (external agents) and the in-app `<AiChat>` agent runtime.
+ *
+ * Requires `yarn generate` to be discovered.
+ */
+import workflowsAuthoringAiTools from './ai-tools/authoring-pack'
+import type { WorkflowsAiToolDefinition } from './ai-tools/types'
+
+export const aiTools: WorkflowsAiToolDefinition<never, never>[] = [
+  ...workflowsAuthoringAiTools,
+]
+
+export default aiTools

--- a/packages/core/src/modules/workflows/ai-tools/authoring-pack.ts
+++ b/packages/core/src/modules/workflows/ai-tools/authoring-pack.ts
@@ -1,0 +1,729 @@
+/**
+ * `workflows.*` agent-authoring tool pack (spec §9.5 "Agent-as-author").
+ *
+ * A person can author a workflow in the Studio; this pack lets an agent do the
+ * same through the SAME surfaces. It is deliberately thin: the activity
+ * registry, the context ledger and the structured issue body already ARE the
+ * agent API, so every tool below delegates to an existing exported function
+ * rather than growing a parallel engine surface.
+ *
+ * What each tool reuses:
+ *  - `list_activity_types`  → `listActivityTypes()` + the OpenAPI `zodToJsonSchema`
+ *  - `get_context_schema`   → the context-schema route's own resolver + ledger
+ *  - `validate_definition`  → `evaluateWorkflowDefinition` (Problems panel + 400 body)
+ *  - `create_definition`    → `createWorkflowDefinitionInputCheckedSchema` (the route's gate)
+ *  - `update_definition`    → the per-user `workflow_definition_drafts` layer
+ *  - `start_test_run`       → `startWorkflow({ isDryRun: true })` + `buildWouldDoReport`
+ *
+ * Two safety invariants hold for every write here:
+ *  1. NEVER auto-published. `create_definition` mints the row with
+ *     `enabled: false`, which `findWorkflowDefinition` treats as unresolvable
+ *     for execution, and `update_definition` writes a draft, never the
+ *     definition. Neither tool exposes `enabled` or `lifecycle` as an input.
+ *  2. NEVER cross-tenant. Every read and write is scoped by `tenantId`, so a
+ *     foreign definition is invisible rather than merely forbidden.
+ */
+
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { z } from 'zod'
+import { zodToJsonSchema } from '@open-mercato/shared/lib/openapi'
+import {
+  WorkflowDefinition,
+  WorkflowDefinitionDraft,
+  WorkflowEvent,
+  WorkflowInstance,
+  StepInstance,
+  type WorkflowDefinitionData,
+} from '../data/entities'
+import {
+  createWorkflowDefinitionInputCheckedSchema,
+  workflowDefinitionDataSchema,
+} from '../data/validators'
+import { isComponentKind } from '../lib/component-guard'
+import {
+  computeDefinitionContextLedger,
+  narrowLedgerToStep,
+  resolveDefinitionDataForLedger,
+  warmContextLedgerResolvers,
+} from '../lib/definition-context-schema'
+import { evaluateWorkflowDefinition } from '../lib/definition-evaluation'
+import { normalizeDefinitionValidationIssues } from '../lib/definition-error-body'
+import {
+  DRY_RUN_EVENT_TYPES,
+  buildWouldDoReport,
+  type WouldDoSourceEvent,
+} from '../lib/dry-run'
+import { findWorkflowDefinition } from '../lib/find-definition'
+import { listActivityTypes } from '../lib/activity-registry'
+import '../lib/activity-registry-bootstrap'
+import { invalidateTriggerCache } from '../lib/event-trigger-service'
+import {
+  MISSING_TENANT_ISSUE,
+  failure,
+  featureRefusal,
+  issue,
+  missingFeatures,
+  organizationWhere,
+  resolveScope,
+  type WorkflowsAiToolDefinition,
+  type WorkflowsToolContext,
+} from './types'
+
+const DEFINITIONS_VIEW = 'workflows.definitions.view'
+const DEFINITIONS_CREATE = 'workflows.definitions.create'
+const DEFINITIONS_EDIT = 'workflows.definitions.edit'
+const DEFINITIONS_TEST_RUN = 'workflows.definitions.test_run'
+const INSTANCES_VIEW = 'workflows.instances.view'
+const INSTANCES_CREATE = 'workflows.instances.create'
+
+function resolveEm(ctx: WorkflowsToolContext): EntityManager {
+  return ctx.container.resolve<EntityManager>('em')
+}
+
+/**
+ * Definition ids accepted by the context-schema route: a DB UUID, or
+ * `code:<workflowId>` / the synthetic code UUID for code-defined workflows.
+ */
+const definitionIdSchema = z
+  .string()
+  .min(1)
+  .describe('Definition UUID, or "code:<workflowId>" for a code-defined workflow')
+
+const rawDefinitionSchema = z
+  .record(z.string(), z.unknown())
+  .describe('The workflow definition JSON — the same object the Studio Code view round-trips')
+
+function asDefinitionData(value: Record<string, unknown>): WorkflowDefinitionData {
+  return value as unknown as WorkflowDefinitionData
+}
+
+/** Compute the server ledger for a definition, tolerating a malformed graph. */
+async function tryComputeLedger(
+  ctx: WorkflowsToolContext,
+  definition: WorkflowDefinitionData,
+) {
+  try {
+    await warmContextLedgerResolvers(ctx.container)
+    return computeDefinitionContextLedger(definition)
+  } catch {
+    return null
+  }
+}
+
+// ===========================================================================
+// workflows.list_activity_types
+// ===========================================================================
+
+const listActivityTypesInput = z.object({
+  activityType: z
+    .string()
+    .optional()
+    .describe('Return only this activity type instead of the whole registry'),
+})
+
+const listActivityTypesTool: WorkflowsAiToolDefinition<
+  z.infer<typeof listActivityTypesInput>
+> = {
+  name: 'workflows.list_activity_types',
+  displayName: 'List workflow activity types',
+  description:
+    'List every registered workflow activity type with its JSON-Schema config contract, form fields, async capability, compensability and dry-run mock mode. This registry IS the authoring contract — read it before writing any activity config so the config validates on the first attempt.',
+  inputSchema: listActivityTypesInput,
+  requiredFeatures: [DEFINITIONS_VIEW],
+  tags: ['read', 'workflows', 'authoring'],
+  isMutation: false,
+  handler: async (input, ctx) => {
+    const missing = missingFeatures(ctx, [DEFINITIONS_VIEW])
+    if (missing.length) return featureRefusal(missing)
+
+    const entries = listActivityTypes().filter(
+      (entry) => !input.activityType || entry.id === input.activityType,
+    )
+
+    if (input.activityType && entries.length === 0) {
+      return failure(
+        issue(
+          ['activityType'],
+          'unknown_activity_type',
+          `Unknown activity type "${input.activityType}"`,
+          { expected: listActivityTypes().map((entry) => entry.id).join(' | '), got: input.activityType },
+        ),
+      )
+    }
+
+    return {
+      ok: true,
+      issues: [],
+      activityTypes: entries.map((entry) => ({
+        id: entry.id,
+        icon: entry.icon,
+        i18nKey: entry.i18nKey,
+        configSchema: zodToJsonSchema(entry.configSchema) ?? null,
+        form: entry.form.map((field) => ({
+          id: field.id,
+          component: field.component,
+          required: field.required ?? false,
+        })),
+        async: entry.async,
+        compensable: entry.compensable ?? false,
+        // 'refuse' and 'none' both stop a dry run at this activity.
+        dryRunMock:
+          entry.mock === 'refuse' ? 'refuse' : entry.mock === undefined ? 'none' : 'simulated',
+      })),
+    }
+  },
+}
+
+// ===========================================================================
+// workflows.get_context_schema
+// ===========================================================================
+
+const getContextSchemaInput = z.object({
+  definitionId: definitionIdSchema,
+  stepId: z
+    .string()
+    .optional()
+    .describe('Narrow the response to one step instead of returning every step'),
+})
+
+const getContextSchemaTool: WorkflowsAiToolDefinition<
+  z.infer<typeof getContextSchemaInput>
+> = {
+  name: 'workflows.get_context_schema',
+  displayName: 'Get workflow context ledger',
+  description:
+    'Return the per-step context ledger for a saved workflow definition: for every step, which context paths are available when it runs, with type, presence (always/maybe) and the producing source. Use this to discover the exact {{context.*}} paths a step may reference before writing any expression.',
+  inputSchema: getContextSchemaInput,
+  requiredFeatures: [DEFINITIONS_VIEW],
+  tags: ['read', 'workflows', 'authoring'],
+  isMutation: false,
+  handler: async (input, ctx) => {
+    const missing = missingFeatures(ctx, [DEFINITIONS_VIEW])
+    if (missing.length) return featureRefusal(missing)
+
+    const scope = resolveScope(ctx)
+    if (!scope) return failure(MISSING_TENANT_ISSUE)
+
+    await warmContextLedgerResolvers(ctx.container)
+
+    const definitionData = await resolveDefinitionDataForLedger(
+      resolveEm(ctx),
+      input.definitionId,
+      { tenantId: scope.tenantId, organizationWhere: organizationWhere(scope) },
+    )
+
+    if (!definitionData) {
+      return failure(
+        issue(
+          ['definitionId'],
+          'not_found',
+          'Workflow definition not found',
+          { got: input.definitionId },
+        ),
+      )
+    }
+
+    const ledger = computeDefinitionContextLedger(definitionData)
+
+    if (input.stepId === undefined) {
+      return { ok: true, issues: [], steps: ledger.steps }
+    }
+
+    const stepView = narrowLedgerToStep(ledger, input.stepId)
+    if (!stepView) {
+      return failure(
+        issue(
+          ['stepId'],
+          'not_found',
+          'Step not found in workflow definition',
+          { got: input.stepId },
+        ),
+      )
+    }
+
+    return { ok: true, issues: [], steps: { [input.stepId]: stepView } }
+  },
+}
+
+// ===========================================================================
+// workflows.validate_definition
+// ===========================================================================
+
+const validateDefinitionInput = z
+  .object({
+    definition: rawDefinitionSchema
+      .optional()
+      .describe('Validate this definition JSON directly, without saving anything'),
+    definitionId: definitionIdSchema
+      .optional()
+      .describe('Validate the definition stored under this id instead'),
+  })
+  .describe('Supply exactly one of `definition` or `definitionId`')
+
+const validateDefinitionTool: WorkflowsAiToolDefinition<
+  z.infer<typeof validateDefinitionInput>
+> = {
+  name: 'workflows.validate_definition',
+  displayName: 'Validate a workflow definition',
+  description:
+    'Run the full workflow validation pass over a definition without saving it. Returns `issues` (the same structured {path, code, message, expected, got} list the definition API returns on a 400) and `problems` (exactly what the Studio Problems panel would show, errors first). Call this before create_definition or update_definition and fix every error.',
+  inputSchema: validateDefinitionInput,
+  requiredFeatures: [DEFINITIONS_VIEW],
+  tags: ['read', 'workflows', 'authoring'],
+  isMutation: false,
+  handler: async (input, ctx) => {
+    const missing = missingFeatures(ctx, [DEFINITIONS_VIEW])
+    if (missing.length) return featureRefusal(missing)
+
+    if ((input.definition && input.definitionId) || (!input.definition && !input.definitionId)) {
+      return failure(
+        issue(
+          ['definition'],
+          'invalid_input',
+          'Supply exactly one of `definition` or `definitionId`',
+          { expected: 'definition | definitionId' },
+        ),
+      )
+    }
+
+    let definitionData: WorkflowDefinitionData
+    if (input.definitionId) {
+      const scope = resolveScope(ctx)
+      if (!scope) return failure(MISSING_TENANT_ISSUE)
+      const resolved = await resolveDefinitionDataForLedger(
+        resolveEm(ctx),
+        input.definitionId,
+        { tenantId: scope.tenantId, organizationWhere: organizationWhere(scope) },
+      )
+      if (!resolved) {
+        return failure(
+          issue(['definitionId'], 'not_found', 'Workflow definition not found', {
+            got: input.definitionId,
+          }),
+        )
+      }
+      definitionData = resolved
+    } else {
+      definitionData = asDefinitionData(input.definition!)
+    }
+
+    const ledger = await tryComputeLedger(ctx, definitionData)
+    const evaluation = evaluateWorkflowDefinition(definitionData, { ledger })
+
+    return {
+      ok: evaluation.valid,
+      issues: evaluation.issues,
+      problems: evaluation.problems,
+      valid: evaluation.valid,
+      errorCount: evaluation.errorCount,
+      warningCount: evaluation.warningCount,
+    }
+  },
+}
+
+// ===========================================================================
+// workflows.create_definition
+// ===========================================================================
+
+const createDefinitionInput = z.object({
+  workflowId: z
+    .string()
+    .min(1)
+    .max(100)
+    .describe('Stable machine id, lowercase letters/numbers/dots/hyphens/underscores'),
+  workflowName: z.string().min(1).max(255),
+  description: z.string().max(2000).optional().nullable(),
+  definition: rawDefinitionSchema,
+  metadata: z.record(z.string(), z.unknown()).optional().nullable(),
+})
+
+const createDefinitionTool: WorkflowsAiToolDefinition<
+  z.infer<typeof createDefinitionInput>
+> = {
+  name: 'workflows.create_definition',
+  displayName: 'Create a workflow definition (disabled draft)',
+  description:
+    'Create a new workflow definition. It is ALWAYS created disabled: it appears in the Studio for a human to review and enable, and the engine will not resolve it for execution or fire its triggers until a person publishes it. Validate with validate_definition first — this tool applies the identical schema gate the REST API applies and returns the same structured issues on rejection.',
+  inputSchema: createDefinitionInput,
+  requiredFeatures: [DEFINITIONS_CREATE],
+  tags: ['write', 'workflows', 'authoring'],
+  isMutation: true,
+  handler: async (input, ctx) => {
+    const missing = missingFeatures(ctx, [DEFINITIONS_CREATE])
+    if (missing.length) return featureRefusal(missing)
+
+    const scope = resolveScope(ctx)
+    if (!scope) return failure(MISSING_TENANT_ISSUE)
+    if (!scope.organizationId) {
+      return failure(
+        issue(
+          ['organizationId'],
+          'missing_organization_context',
+          'An organization context is required to create a workflow definition',
+        ),
+      )
+    }
+
+    // The exact gate the POST /api/workflows/definitions route applies, so an
+    // agent-authored payload is rejected for exactly the same reasons, with
+    // exactly the same structured issues, as a human-authored one.
+    const validation = createWorkflowDefinitionInputCheckedSchema.safeParse({
+      workflowId: input.workflowId,
+      workflowName: input.workflowName,
+      description: input.description,
+      definition: input.definition,
+      metadata: input.metadata,
+    })
+    if (!validation.success) {
+      return failure(...normalizeDefinitionValidationIssues(validation.error))
+    }
+
+    const em = resolveEm(ctx)
+    const existing = await em.findOne(
+      WorkflowDefinition,
+      { workflowId: input.workflowId, tenantId: scope.tenantId },
+      { orderBy: { version: 'DESC' } },
+    )
+    if (existing) {
+      return failure(
+        issue(
+          ['workflowId'],
+          'already_exists',
+          `Workflow definition with ID "${input.workflowId}" already exists`,
+          { got: input.workflowId },
+        ),
+      )
+    }
+
+    // New definitions default to strict interpolation, matching the create route.
+    const definitionData = validation.data.definition.interpolation
+      ? validation.data.definition
+      : { ...validation.data.definition, interpolation: 'strict' as const }
+
+    const created = em.create(WorkflowDefinition, {
+      workflowId: validation.data.workflowId,
+      workflowName: validation.data.workflowName,
+      description: validation.data.description,
+      version: validation.data.version,
+      definition: definitionData,
+      metadata: validation.data.metadata,
+      // NEVER auto-published (spec §9.5). `findWorkflowDefinition` requires
+      // `enabled = true` to resolve a workflow for execution, so a human
+      // enabling it in the Studio is the only way this ever runs.
+      enabled: false,
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      createdBy: ctx.userId ?? null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+
+    await em.persist(created).flush()
+    invalidateTriggerCache(scope.tenantId, scope.organizationId ?? undefined)
+
+    const ledger = await tryComputeLedger(ctx, definitionData as WorkflowDefinitionData)
+    const evaluation = evaluateWorkflowDefinition(definitionData as WorkflowDefinitionData, {
+      ledger,
+    })
+
+    return {
+      ok: true,
+      issues: [],
+      definitionId: created.id,
+      workflowId: created.workflowId,
+      version: created.version,
+      enabled: false,
+      published: false,
+      problems: evaluation.problems,
+      errorCount: evaluation.errorCount,
+      warningCount: evaluation.warningCount,
+    }
+  },
+}
+
+// ===========================================================================
+// workflows.update_definition
+// ===========================================================================
+
+const updateDefinitionInput = z.object({
+  definitionId: z.uuid().describe('UUID of the saved definition to draft changes against'),
+  definition: rawDefinitionSchema,
+  metadata: z.record(z.string(), z.unknown()).optional().nullable(),
+})
+
+const updateDefinitionTool: WorkflowsAiToolDefinition<
+  z.infer<typeof updateDefinitionInput>
+> = {
+  name: 'workflows.update_definition',
+  displayName: 'Update a workflow definition (as a review draft)',
+  description:
+    'Write proposed changes to a saved workflow definition as a per-user editor DRAFT. The published definition is never modified: the next person to open that definition in the Studio sees the draft offered for restore, reviews the visual and JSON diff, and decides whether to save it. Returns the Problems-panel result for the drafted definition so you can self-correct before a human looks.',
+  inputSchema: updateDefinitionInput,
+  requiredFeatures: [DEFINITIONS_EDIT],
+  tags: ['write', 'workflows', 'authoring'],
+  isMutation: true,
+  handler: async (input, ctx) => {
+    const missing = missingFeatures(ctx, [DEFINITIONS_EDIT])
+    if (missing.length) return featureRefusal(missing)
+
+    const scope = resolveScope(ctx)
+    if (!scope) return failure(MISSING_TENANT_ISSUE)
+
+    // A draft belongs to a person — it is the working copy they will be shown
+    // on their next Studio visit. Without a user there is nobody to review it.
+    if (!ctx.userId) {
+      return failure(
+        issue(
+          ['userId'],
+          'missing_user_context',
+          'A user context is required: drafts are per-user review copies',
+        ),
+      )
+    }
+
+    const parsed = workflowDefinitionDataSchema.safeParse(input.definition)
+    if (!parsed.success) {
+      return failure(...normalizeDefinitionValidationIssues(parsed.error))
+    }
+
+    const em = resolveEm(ctx)
+    const definition = await em.findOne(WorkflowDefinition, {
+      id: input.definitionId,
+      tenantId: scope.tenantId,
+      ...organizationWhere(scope),
+      deletedAt: null,
+    })
+
+    if (!definition) {
+      return failure(
+        issue(['definitionId'], 'not_found', 'Workflow definition not found', {
+          got: input.definitionId,
+        }),
+      )
+    }
+
+    // Matches the draft route's upsert key: (definitionId, userId, tenantId).
+    const existingDraft = await em.findOne(WorkflowDefinitionDraft, {
+      definitionId: input.definitionId,
+      userId: ctx.userId,
+      tenantId: scope.tenantId,
+    })
+
+    let draft: WorkflowDefinitionDraft
+    if (existingDraft) {
+      existingDraft.deletedAt = null
+      existingDraft.organizationId = scope.organizationId ?? existingDraft.organizationId
+      existingDraft.definition = parsed.data as WorkflowDefinitionData
+      if (input.metadata !== undefined) {
+        existingDraft.metadata = input.metadata as WorkflowDefinitionDraft['metadata']
+      }
+      existingDraft.baseUpdatedAt = definition.updatedAt
+      draft = existingDraft
+    } else {
+      draft = em.create(WorkflowDefinitionDraft, {
+        definitionId: input.definitionId,
+        userId: ctx.userId,
+        definition: parsed.data as WorkflowDefinitionData,
+        metadata: (input.metadata ?? null) as WorkflowDefinitionDraft['metadata'],
+        baseUpdatedAt: definition.updatedAt,
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId ?? definition.organizationId,
+      })
+      em.persist(draft)
+    }
+
+    await em.flush()
+
+    const definitionData = parsed.data as WorkflowDefinitionData
+    const ledger = await tryComputeLedger(ctx, definitionData)
+    const evaluation = evaluateWorkflowDefinition(definitionData, { ledger })
+
+    return {
+      ok: true,
+      issues: [],
+      draftId: draft.id,
+      definitionId: input.definitionId,
+      // The published definition was not touched, and its optimistic lock was
+      // not taken — drafts deliberately sit outside it.
+      published: false,
+      definitionUpdatedAt: definition.updatedAt.toISOString(),
+      problems: evaluation.problems,
+      errorCount: evaluation.errorCount,
+      warningCount: evaluation.warningCount,
+    }
+  },
+}
+
+// ===========================================================================
+// workflows.start_test_run
+// ===========================================================================
+
+const startTestRunInput = z.object({
+  workflowId: z.string().min(1).describe('The definition workflowId to test'),
+  version: z.number().int().positive().optional(),
+  initialContext: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Starting workflow context, shaped by the definition contextSchema.input'),
+  correlationKey: z.string().optional(),
+})
+
+const startTestRunTool: WorkflowsAiToolDefinition<z.infer<typeof startTestRunInput>> = {
+  name: 'workflows.start_test_run',
+  displayName: 'Start a workflow dry run',
+  description:
+    'Start an isolated DRY RUN of a workflow and return the "would do" report: every side effect the run suppressed, in order. Activities are simulated from their registry mocks (an activity with no mock refuses and stops the run), user tasks are recorded but never created, and nothing reaches real data. This is always a dry run — there is no option to make it real.',
+  inputSchema: startTestRunInput,
+  requiredFeatures: [INSTANCES_VIEW, INSTANCES_CREATE, DEFINITIONS_TEST_RUN],
+  tags: ['write', 'workflows', 'testing'],
+  isMutation: true,
+  handler: async (input, ctx) => {
+    const missing = missingFeatures(ctx, [INSTANCES_VIEW, INSTANCES_CREATE, DEFINITIONS_TEST_RUN])
+    if (missing.length) return featureRefusal(missing)
+
+    const scope = resolveScope(ctx)
+    if (!scope) return failure(MISSING_TENANT_ISSUE)
+    if (!scope.organizationId) {
+      return failure(
+        issue(
+          ['organizationId'],
+          'missing_organization_context',
+          'An organization context is required to start a workflow run',
+        ),
+      )
+    }
+
+    const em = resolveEm(ctx)
+    const definition = await findWorkflowDefinition(em, {
+      workflowId: input.workflowId,
+      version: input.version,
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+    })
+
+    if (!definition) {
+      return failure(
+        issue(['workflowId'], 'not_found', 'Workflow definition not found', {
+          got: input.workflowId,
+        }),
+      )
+    }
+
+    if (isComponentKind(definition.kind)) {
+      return failure(
+        issue(
+          ['workflowId'],
+          'component_not_startable',
+          'This workflow is a reusable component and cannot be started standalone; invoke it from a SUB_WORKFLOW step',
+        ),
+      )
+    }
+
+    const workflowExecutor = ctx.container.resolve<{
+      startWorkflow: (
+        em: EntityManager,
+        options: Record<string, unknown>,
+      ) => Promise<WorkflowInstance>
+      executeWorkflow: (
+        em: EntityManager,
+        container: unknown,
+        instanceId: string,
+        options: { userId?: string | null },
+      ) => Promise<unknown>
+    }>('workflowExecutor')
+
+    const instance = await workflowExecutor.startWorkflow(em, {
+      workflowId: input.workflowId,
+      version: input.version,
+      initialContext: input.initialContext ?? {},
+      correlationKey: input.correlationKey,
+      metadata: { initiatedBy: ctx.userId ?? null },
+      // Forced, never an input. Dry-run isolation is the engine's own
+      // mechanism: mocked effectors, suppressed USER_TASKs, no enqueueing.
+      isDryRun: true,
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+    })
+
+    let executionError: string | null = null
+    try {
+      await workflowExecutor.executeWorkflow(em, ctx.container, instance.id, {
+        userId: ctx.userId,
+      })
+    } catch (error) {
+      executionError = error instanceof Error ? error.message : String(error)
+    }
+
+    const events = await em.find(
+      WorkflowEvent,
+      {
+        workflowInstanceId: instance.id,
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        eventType: {
+          $in: [
+            DRY_RUN_EVENT_TYPES.activitySimulated,
+            DRY_RUN_EVENT_TYPES.activityRefused,
+            DRY_RUN_EVENT_TYPES.userTaskSimulated,
+            DRY_RUN_EVENT_TYPES.businessRuleActionsSuppressed,
+          ],
+        },
+      },
+      { orderBy: [{ occurredAt: 'ASC' }, { id: 'ASC' }], limit: 100 },
+    )
+
+    const stepInstanceIds = Array.from(
+      new Set(
+        events
+          .map((event) => event.stepInstanceId)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0),
+      ),
+    )
+    const stepInstances = stepInstanceIds.length
+      ? await em.find(StepInstance, {
+          id: { $in: stepInstanceIds },
+          tenantId: scope.tenantId,
+          organizationId: scope.organizationId,
+        })
+      : []
+    const stepIdByInstanceId = new Map(stepInstances.map((step) => [step.id, step.stepId]))
+
+    const sourceEvents: WouldDoSourceEvent[] = events.map((event) => ({
+      id: event.id,
+      eventType: event.eventType,
+      stepId: event.stepInstanceId ? stepIdByInstanceId.get(event.stepInstanceId) ?? null : null,
+      occurredAt: event.occurredAt,
+      eventData: (event.eventData ?? null) as Record<string, unknown> | null,
+    }))
+    const report = buildWouldDoReport(sourceEvents)
+
+    const refreshed = await em.findOne(WorkflowInstance, {
+      id: instance.id,
+      tenantId: scope.tenantId,
+    })
+
+    return {
+      ok: executionError === null,
+      issues: executionError
+        ? [issue(['execution'], 'execution_failed', executionError)]
+        : [],
+      instanceId: instance.id,
+      isDryRun: true,
+      status: refreshed?.status ?? instance.status,
+      currentStepId: refreshed?.currentStepId ?? null,
+      wouldDo: report.entries,
+      stoppedByRefusal: report.stoppedByRefusal,
+    }
+  },
+}
+
+export const workflowsAuthoringAiTools: WorkflowsAiToolDefinition<never, never>[] = [
+  listActivityTypesTool,
+  getContextSchemaTool,
+  validateDefinitionTool,
+  createDefinitionTool,
+  updateDefinitionTool,
+  startTestRunTool,
+] as unknown as WorkflowsAiToolDefinition<never, never>[]
+
+export default workflowsAuthoringAiTools

--- a/packages/core/src/modules/workflows/ai-tools/types.ts
+++ b/packages/core/src/modules/workflows/ai-tools/types.ts
@@ -1,0 +1,117 @@
+/**
+ * Local AI tool shape for the workflows module.
+ *
+ * `@open-mercato/core` carries `@open-mercato/ai-assistant` only as a dev/peer
+ * dependency, so — exactly as `customers` and `inbox_ops` already do — this
+ * module declares its tools as plain objects against a structural subset of
+ * `AiToolDefinition` instead of importing the framework at runtime. The
+ * generator walks every module root for a default/`aiTools` export of this
+ * shape and emits it into `ai-tools.generated.ts`, which the ai-assistant
+ * tool-loader registers through `registerMcpTool`.
+ */
+import type { z } from 'zod'
+import type { AwilixContainer } from 'awilix'
+import { hasFeature } from '@open-mercato/shared/security/features'
+import type { DefinitionValidationIssue } from '../lib/definition-error-body'
+
+export interface WorkflowsToolContext {
+  tenantId: string | null
+  organizationId: string | null
+  userId: string | null
+  container: AwilixContainer
+  userFeatures: string[]
+  isSuperAdmin: boolean
+  apiKeySecret?: string
+  sessionId?: string
+}
+
+export interface WorkflowsAiToolDefinition<TInput = unknown, TOutput = unknown> {
+  name: string
+  displayName?: string
+  description: string
+  inputSchema: z.ZodType<TInput>
+  requiredFeatures?: string[]
+  tags?: string[]
+  isMutation?: boolean
+  isDestructive?: boolean | ((input: TInput) => boolean)
+  handler: (input: TInput, context: WorkflowsToolContext) => Promise<TOutput>
+}
+
+/**
+ * Every tool in this pack answers with the same envelope: a boolean outcome and
+ * a list of STRUCTURED issues — never a prose error string. `issues` is the
+ * identical `{path, code, message, expected?, got?}` shape the definition
+ * create/update routes return in their 400 body.
+ */
+export interface WorkflowsToolEnvelope {
+  ok: boolean
+  issues: DefinitionValidationIssue[]
+}
+
+export function issue(
+  path: Array<string | number>,
+  code: string,
+  message: string,
+  extra: { expected?: string; got?: string } = {},
+): DefinitionValidationIssue {
+  return { path, code, message, ...extra }
+}
+
+export function failure(...issues: DefinitionValidationIssue[]): WorkflowsToolEnvelope {
+  return { ok: false, issues }
+}
+
+export interface WorkflowsToolScope {
+  tenantId: string
+  organizationId: string | null
+}
+
+/**
+ * Tenant scope is mandatory for every tool in this pack. An agent principal is
+ * still a principal: without a tenant there is no safe query to run, so the
+ * tool refuses rather than reading across tenants.
+ */
+export function resolveScope(ctx: WorkflowsToolContext): WorkflowsToolScope | null {
+  if (!ctx.tenantId) return null
+  return { tenantId: ctx.tenantId, organizationId: ctx.organizationId }
+}
+
+export const MISSING_TENANT_ISSUE = issue(
+  ['tenantId'],
+  'missing_tenant_context',
+  'Tenant context is required for workflows.* tools',
+)
+
+/**
+ * Defense in depth. The tool runtime already gates `requiredFeatures` through
+ * the wildcard-aware matcher before a handler runs; re-checking here keeps the
+ * guarantee when a handler is invoked directly (tests, in-process callers) and
+ * makes the refusal a structured issue rather than a thrown string.
+ */
+export function missingFeatures(
+  ctx: WorkflowsToolContext,
+  required: readonly string[],
+): string[] {
+  if (ctx.isSuperAdmin) return []
+  return required.filter((feature) => !hasFeature(ctx.userFeatures, feature))
+}
+
+export function featureRefusal(missing: readonly string[]): WorkflowsToolEnvelope {
+  return failure(
+    issue(
+      ['requiredFeatures'],
+      'insufficient_permissions',
+      `Missing required feature(s): ${missing.join(', ')}`,
+      { expected: missing.join(', ') },
+    ),
+  )
+}
+
+/**
+ * Organization where-clause fragment for a tenant-scoped lookup. A null
+ * organization stays tenant-wide, matching the REST routes' behaviour when the
+ * caller's scope spans every organization.
+ */
+export function organizationWhere(scope: WorkflowsToolScope): Record<string, unknown> {
+  return scope.organizationId ? { organizationId: scope.organizationId } : {}
+}

--- a/packages/core/src/modules/workflows/api/definitions/[id]/context-schema/route.ts
+++ b/packages/core/src/modules/workflows/api/definitions/[id]/context-schema/route.ts
@@ -20,26 +20,20 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server'
+import type { EntityManager } from '@mikro-orm/core'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { resolveOrganizationScopeFilter } from '@open-mercato/core/modules/directory/utils/organizationScopeFilter'
-import { getDeclaredEvents } from '@open-mercato/shared/modules/events'
-import { WorkflowDefinition, type WorkflowDefinitionData } from '../../../../data/entities'
+import { type WorkflowDefinitionData } from '../../../../data/entities'
 import {
-  buildTriggerPayloadContracts,
-  computeContextLedger,
-  type LedgerWorkflowDefinition,
-} from '../../../../lib/context-ledger'
-import { ensureWorkflowEndpointCatalog } from '../../../../lib/endpoint-catalog'
-import {
-  ensureWorkflowAgentOutcomeContracts,
-  resolveServerOutputContract,
-} from '../../../../lib/server-output-contract'
-import { getCodeWorkflow, getAllCodeWorkflows } from '../../../../lib/code-registry'
-import { codeWorkflowUuid } from '../../../../lib/find-definition'
+  computeDefinitionContextLedger,
+  narrowLedgerToStep,
+  resolveDefinitionDataForLedger,
+  warmContextLedgerResolvers,
+} from '../../../../lib/definition-context-schema'
 import {
   workflowsTag,
   workflowErrorSchema,
@@ -60,23 +54,12 @@ interface RouteContext {
   }>
 }
 
-function toLedgerDefinition(definition: WorkflowDefinitionData): LedgerWorkflowDefinition {
-  return definition as unknown as LedgerWorkflowDefinition
-}
-
 function respondWithLedger(definition: WorkflowDefinitionData, stepId: string | null) {
-  const ledgerDefinition = toLedgerDefinition(definition)
-  const ledger = computeContextLedger(ledgerDefinition, {
-    resolveOutputContract: resolveServerOutputContract,
-    triggerPayloadContracts: buildTriggerPayloadContracts(
-      ledgerDefinition.triggers ?? [],
-      getDeclaredEvents(),
-    ),
-  })
+  const ledger = computeDefinitionContextLedger(definition)
   if (stepId === null) {
     return NextResponse.json({ steps: ledger.steps })
   }
-  const stepView = ledger.steps[stepId]
+  const stepView = narrowLedgerToStep(ledger, stepId)
   if (!stepView) {
     return NextResponse.json(
       { error: 'Step not found in workflow definition' },
@@ -98,9 +81,7 @@ export async function GET(
   try {
     const params = await context.params
     const container = await createRequestContainer()
-    const em = container.resolve('em') as {
-      findOne: (entity: unknown, where: Record<string, unknown>) => Promise<unknown>
-    }
+    const em = container.resolve('em') as EntityManager
     const auth = await getAuthFromRequest(request)
 
     if (!auth || !auth.sub) {
@@ -134,37 +115,19 @@ export async function GET(
 
     const stepId = new URL(request.url).searchParams.get('stepId')
 
-    await ensureWorkflowEndpointCatalog()
-    await ensureWorkflowAgentOutcomeContracts(container)
-
-    if (params.id.startsWith('code:')) {
-      const workflowId = params.id.slice(5)
-      const codeDef = getCodeWorkflow(workflowId)
-      if (!codeDef) {
-        return NextResponse.json({ error: 'Workflow definition not found' }, { status: 404 })
-      }
-      return respondWithLedger(codeDef.definition as unknown as WorkflowDefinitionData, stepId)
-    }
+    await warmContextLedgerResolvers(container)
 
     const orgFilter = resolveOrganizationScopeFilter(scope, auth)
-    const definition = (await em.findOne(WorkflowDefinition, {
-      id: params.id,
+    const definitionData = await resolveDefinitionDataForLedger(em, params.id, {
       tenantId,
-      ...orgFilter.where,
-      deletedAt: null,
-    })) as WorkflowDefinition | null
+      organizationWhere: orgFilter.where,
+    })
 
-    if (!definition) {
-      const codeDef = getAllCodeWorkflows().find(
-        (workflow) => codeWorkflowUuid(workflow.workflowId) === params.id,
-      )
-      if (codeDef) {
-        return respondWithLedger(codeDef.definition as unknown as WorkflowDefinitionData, stepId)
-      }
+    if (!definitionData) {
       return NextResponse.json({ error: 'Workflow definition not found' }, { status: 404 })
     }
 
-    return respondWithLedger(definition.definition, stepId)
+    return respondWithLedger(definitionData, stepId)
   } catch (error) {
     logger.error('Error computing workflow context schema', { err: error })
     return NextResponse.json(

--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
@@ -95,7 +95,7 @@ import {
   type LedgerWorkflowDefinition,
 } from '../../../lib/context-ledger'
 import { useAvailableEvents } from '@open-mercato/ui/backend/inputs/EventSelect'
-import { collectUnresolvedContextRefWarnings } from '../../../lib/expression-refs'
+import { toUnresolvedContextRefIssues } from '../../../lib/definition-evaluation'
 import type { PinnedSampleEnvelope } from '../../../lib/sample-resolver'
 import { Page } from '@open-mercato/ui/backend/Page'
 import { Button } from '@open-mercato/ui/primitives/button'
@@ -185,14 +185,7 @@ function collectContextRefWarnings(
   triggerPayloadContracts?: Record<string, LedgerContract>,
 ): ZodIssueLike[] {
   const ledger = computeClientContextLedger(definitionData, triggerPayloadContracts)
-  return collectUnresolvedContextRefWarnings(definitionData, ledger).map((warning) => ({
-    path: warning.path,
-    message: translate(
-      'workflows.visualEditor.problems.unresolvedContextRef',
-      'Context reference "{path}" is not provided by any earlier step, trigger, or input',
-      { path: warning.refPath },
-    ),
-  }))
+  return toUnresolvedContextRefIssues(definitionData, ledger, translate)
 }
 
 /**

--- a/packages/core/src/modules/workflows/lib/definition-context-schema.ts
+++ b/packages/core/src/modules/workflows/lib/definition-context-schema.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared context-ledger resolution for a workflow definition.
+ *
+ * Extracted verbatim from `api/definitions/[id]/context-schema/route.ts` so the
+ * REST route and the `workflows.get_context_schema` AI tool serve the SAME
+ * ledger from the SAME id forms. The output-contract seam stays single-sourced:
+ * both callers reach `resolveServerOutputContract` through
+ * {@link computeDefinitionContextLedger} and never resolve contracts a second
+ * way (the browser editor deliberately pins the seam to `'unknown'` and
+ * consumes this response instead).
+ */
+
+import type { EntityManager } from '@mikro-orm/core'
+import { getDeclaredEvents } from '@open-mercato/shared/modules/events'
+import { WorkflowDefinition, type WorkflowDefinitionData } from '../data/entities'
+import {
+  buildTriggerPayloadContracts,
+  computeContextLedger,
+  type ContextLedger,
+  type LedgerStepView,
+  type LedgerWorkflowDefinition,
+} from './context-ledger'
+import { ensureWorkflowEndpointCatalog } from './endpoint-catalog'
+import {
+  ensureWorkflowAgentOutcomeContracts,
+  resolveServerOutputContract,
+} from './server-output-contract'
+import { getCodeWorkflow, getAllCodeWorkflows } from './code-registry'
+import { codeWorkflowUuid } from './find-definition'
+
+export type DefinitionLookupScope = {
+  tenantId: string
+  /**
+   * Organization where-clause fragment. The route passes
+   * `resolveOrganizationScopeFilter(...).where`; other callers pass
+   * `{ organizationId }` (or `{}` when the caller is tenant-wide).
+   */
+  organizationWhere: Record<string, unknown>
+}
+
+/**
+ * Warm the two sync-lookup caches the server output-contract seam reads.
+ * MUST run before {@link computeDefinitionContextLedger} or CALL_API and
+ * INVOKE_AGENT contracts silently degrade to `'unknown'`.
+ */
+export async function warmContextLedgerResolvers(container: {
+  resolve: <T>(name: string) => T
+}): Promise<void> {
+  await ensureWorkflowEndpointCatalog()
+  await ensureWorkflowAgentOutcomeContracts(container)
+}
+
+export function computeDefinitionContextLedger(definition: WorkflowDefinitionData): ContextLedger {
+  const ledgerDefinition = definition as unknown as LedgerWorkflowDefinition
+  return computeContextLedger(ledgerDefinition, {
+    resolveOutputContract: resolveServerOutputContract,
+    triggerPayloadContracts: buildTriggerPayloadContracts(
+      ledgerDefinition.triggers ?? [],
+      getDeclaredEvents(),
+    ),
+  })
+}
+
+export function narrowLedgerToStep(ledger: ContextLedger, stepId: string): LedgerStepView | null {
+  return ledger.steps[stepId] ?? null
+}
+
+/**
+ * Resolve a definition's `definition` JSON from any of the three id forms the
+ * context-schema route accepts: `code:<workflowId>`, a tenant/org-scoped DB
+ * UUID, and the synthetic `codeWorkflowUuid(workflowId)` fallback.
+ *
+ * Tenant scoping is not optional — a definition outside `scope.tenantId` is
+ * INVISIBLE (returns `null`, indistinguishable from "does not exist"), never
+ * merely unauthorized.
+ */
+export async function resolveDefinitionDataForLedger(
+  em: EntityManager,
+  id: string,
+  scope: DefinitionLookupScope,
+): Promise<WorkflowDefinitionData | null> {
+  if (id.startsWith('code:')) {
+    const codeDef = getCodeWorkflow(id.slice(5))
+    if (!codeDef) return null
+    return codeDef.definition as unknown as WorkflowDefinitionData
+  }
+
+  const definition = (await em.findOne(WorkflowDefinition, {
+    id,
+    tenantId: scope.tenantId,
+    ...scope.organizationWhere,
+    deletedAt: null,
+  })) as WorkflowDefinition | null
+
+  if (definition) return definition.definition
+
+  const codeDef = getAllCodeWorkflows().find(
+    (workflow) => codeWorkflowUuid(workflow.workflowId) === id,
+  )
+  if (codeDef) return codeDef.definition as unknown as WorkflowDefinitionData
+
+  return null
+}

--- a/packages/core/src/modules/workflows/lib/definition-evaluation.ts
+++ b/packages/core/src/modules/workflows/lib/definition-evaluation.ts
@@ -1,0 +1,156 @@
+/**
+ * One evaluation path for a workflow definition.
+ *
+ * The Studio's Problems panel and the definition API routes historically ran
+ * the same checks through two different normalizers: the panel builds
+ * `WorkflowValidationIssue[]` via `collectValidationIssues`, the routes build
+ * the structured `{path, code, message, expected?, got?}` body via
+ * `normalizeDefinitionValidationIssues`. Neither reimplements the checks — they
+ * share `workflowDefinitionDataSchema` — but nothing composed both.
+ *
+ * This module composes them, and NOTHING ELSE. Every check below is an existing
+ * exported function; a second validator that could disagree with the panel is
+ * precisely the failure mode to avoid, so callers that need "what would the
+ * Studio show me?" MUST come through here rather than re-deriving the recipe.
+ */
+
+import { collectActivityConfigWarnings } from '../data/activity-config-warnings'
+import { workflowDefinitionDataSchema } from '../data/validators'
+import type { WorkflowDefinitionData } from '../data/entities'
+import {
+  collectValidationIssues,
+  countIssuesBySeverity,
+  type WorkflowIssueTranslator,
+  type WorkflowValidationIssue,
+  type ZodIssueLike,
+} from './collect-validation-issues'
+import type { ContextLedger } from './context-ledger'
+import {
+  normalizeDefinitionValidationIssues,
+  type DefinitionValidationIssue,
+} from './definition-error-body'
+import { collectUnresolvedContextRefWarnings } from './expression-refs'
+import { definitionToGraph, validateWorkflowGraph } from './graph-utils'
+
+/**
+ * Problems-panel copy for an unresolved `{{context.*}}` reference. Shared so
+ * the Studio and every server-side evaluator emit the identical warning instead
+ * of drifting apart on the message text.
+ */
+export const UNRESOLVED_CONTEXT_REF_MESSAGE = {
+  key: 'workflows.visualEditor.problems.unresolvedContextRef',
+  fallback: 'Context reference "{path}" is not provided by any earlier step, trigger, or input',
+} as const
+
+function interpolateFallback(fallback: string, params: Record<string, string>): string {
+  return fallback.replace(/\{(\w+)\}/g, (match, name: string) =>
+    Object.prototype.hasOwnProperty.call(params, name) ? params[name] : match,
+  )
+}
+
+/**
+ * Map unresolved `{{context.*}}` references onto Problems-panel warnings.
+ * `translate` is optional — omit it (server, agent tools) to get the English
+ * fallback the panel itself falls back to.
+ */
+export function toUnresolvedContextRefIssues(
+  definition: WorkflowDefinitionData,
+  ledger: ContextLedger,
+  translate?: WorkflowIssueTranslator,
+): ZodIssueLike[] {
+  return collectUnresolvedContextRefWarnings(definition, ledger).map((warning) => ({
+    path: warning.path,
+    message: translate
+      ? translate(UNRESOLVED_CONTEXT_REF_MESSAGE.key, UNRESOLVED_CONTEXT_REF_MESSAGE.fallback, {
+          path: warning.refPath,
+        })
+      : interpolateFallback(UNRESOLVED_CONTEXT_REF_MESSAGE.fallback, { path: warning.refPath }),
+  }))
+}
+
+export interface EvaluateWorkflowDefinitionOptions {
+  /**
+   * Server-computed context ledger. When supplied, unresolved-reference
+   * warnings join the result exactly as they do in the Studio; when omitted
+   * those warnings are skipped (they are advisory and never blocking).
+   */
+  ledger?: ContextLedger | null
+}
+
+export interface WorkflowDefinitionEvaluation {
+  /** No blocking errors — the same bar the Studio's Save handler enforces. */
+  valid: boolean
+  errorCount: number
+  warningCount: number
+  /**
+   * The structured issue format: identical in shape and content to the
+   * `details[]` array the definition create/update routes return on a 400.
+   * Empty when the definition parses.
+   */
+  issues: DefinitionValidationIssue[]
+  /** Exactly what the Studio's Problems panel renders, in its order. */
+  problems: WorkflowValidationIssue[]
+}
+
+/**
+ * Run the Studio Problems-panel evaluation plus the API routes' structured-body
+ * normalizer over one definition.
+ */
+export function evaluateWorkflowDefinition(
+  definition: WorkflowDefinitionData,
+  options: EvaluateWorkflowDefinitionOptions = {},
+): WorkflowDefinitionEvaluation {
+  // The Studio only ever evaluates well-formed canvas state, but an agent can
+  // hand us anything. A definition whose `steps`/`transitions` are not arrays
+  // cannot be turned into a graph at all, so it answers with the schema issues
+  // alone rather than throwing out of a validation call.
+  const shaped =
+    Array.isArray((definition as { steps?: unknown })?.steps) &&
+    Array.isArray((definition as { transitions?: unknown })?.transitions)
+  if (!shaped) {
+    const parsedShape = workflowDefinitionDataSchema.safeParse(definition)
+    const structuralIssues = parsedShape.success
+      ? []
+      : normalizeDefinitionValidationIssues(parsedShape.error)
+    return {
+      valid: false,
+      errorCount: structuralIssues.length,
+      warningCount: 0,
+      issues: structuralIssues,
+      problems: structuralIssues.map((entry, index) => ({
+        id: `schema-${index}`,
+        severity: 'error' as const,
+        message: entry.path.length ? `${entry.path.join('.')} - ${entry.message}` : entry.message,
+      })),
+    }
+  }
+
+  const { nodes, edges } = definitionToGraph(definition, { autoLayout: false })
+  const graphErrors = validateWorkflowGraph(nodes, edges)
+  const parsed = workflowDefinitionDataSchema.safeParse(definition)
+  const zodIssues: ZodIssueLike[] = parsed.success ? [] : parsed.error.issues
+  const ledger = options.ledger ?? null
+  const configWarnings: ZodIssueLike[] = [
+    ...collectActivityConfigWarnings(definition),
+    ...(ledger ? toUnresolvedContextRefIssues(definition, ledger) : []),
+  ]
+
+  const problems = collectValidationIssues({
+    graphErrors,
+    zodIssues,
+    configWarnings,
+    nodes,
+    edges,
+    definition,
+    ledger: ledger ?? undefined,
+  })
+  const { errors, warnings } = countIssuesBySeverity(problems)
+
+  return {
+    valid: errors === 0,
+    errorCount: errors,
+    warningCount: warnings,
+    issues: parsed.success ? [] : normalizeDefinitionValidationIssues(parsed.error),
+    problems,
+  }
+}


### PR DESCRIPTION
Step 5 of `.ai/analysis/2026-07-29-workflows-redesign-remaining-plan.md` — spec §9 "Agent-as-author (MCP tool pack)", Phase 6b. A person can author a workflow in the Studio; an agent could not. This makes the engine agent-authorable.

Two commits: a refactor extracting the seams, then the tool pack itself.

---

## ⚠️ Requires `yarn generate` to do anything

`ai-tools.generated.ts` is gitignored, so **nothing in this PR can substitute for a generator run**. Until `yarn generate` runs, the pack is inert — the tools appear in neither the MCP server nor `<AiChat>`.

It was deliberately not run here: in this checkout `yarn generate` still deletes the nine committed files under `docker/opencode/` when `OM_ENABLE_ENTERPRISE_MODULES=false`, which is what `apps/mercato/.env` says. That is a separate known issue the maintainer is handling.

Two more things gate visibility once it is generated: MCP tool visibility is filtered by the API key's ACL (a key whose roles lack `workflows.definitions.*` won't see these), and no agent's `allowedTools` lists them yet — an **in-app** agent needs that added explicitly; the MCP surface does not.

## What the investigation found first

`registerMcpTool` and `defineAiTool` are not two conventions or two generations. They are **two layers of one pipeline**:

```
<module>/ai-tools.ts (defineAiTool) → yarn generate → ai-tools.generated.ts
  → loadGeneratedModuleAiTools() → registerMcpTool() → toolRegistry
```

`defineAiTool` is the public authoring API; `registerMcpTool` is the private sink it lands in (five production call sites in `tool-loader.ts` and `codemode-tools.ts`). One registry serves **both** consumers — the MCP servers that Claude Code / OpenCode reach, and the in-app `<AiChat>` runtime. So authoring via `ai-tools.ts` reaches both, and that is what this PR does. Dotted names are safe: the agent runtime sanitises `.` → `__` for the model, so the spec's `workflows.create_definition` works verbatim.

Following the `customers` / `inbox_ops` precedent, the tools use a local structural type rather than importing the framework — core carries `@open-mercato/ai-assistant` only as a dev/peer dependency.

## The six tools, and what each reuses

The premise held: this is a thin wrapper. The only new code that is not a tool definition is two composition modules that make existing surfaces callable from one place.

| Tool | Reuses rather than reimplements |
|---|---|
| `list_activity_types` | `listActivityTypes()` + the OpenAPI `zodToJsonSchema`, so config contracts match the documented API surface |
| `get_context_schema` | the context-schema route's own resolver and ledger, through a seam extracted so route and tool are the same code |
| `validate_definition` | `evaluateWorkflowDefinition` |
| `create_definition` | `createWorkflowDefinitionInputCheckedSchema` — the exact gate the POST route applies |
| `update_definition` | the `workflow_definition_drafts` upsert key and semantics |
| `start_test_run` | `startWorkflow({ isDryRun: true })` + `buildWouldDoReport` |

**On the validator, the brief was wrong and the correction matters.** There was no single shared path to call: the Problems panel and the definition routes share only `workflowDefinitionDataSchema`, each wrapping it in its own normaliser, and neither calls the other. Rather than pick a side, `lib/definition-evaluation.ts` **composes both** and returns both projections — `issues` (the spec's structured format, byte-identical to the route's 400 `details[]`) and `problems` (what the panel renders). It adds no checks of its own, which is what makes the "agrees with the Problems-panel path" test meaningful rather than circular.

## Never auto-published — and why the two writes differ

`create_definition` writes a real row with **`enabled: false`**. `update_definition` writes a **draft**.

They differ because the draft layer structurally cannot serve create: `api/definitions/[id]/draft` requires a saved definition and 404s otherwise, so there is nothing to draft against for a new workflow.

For create, `lifecycle` looks like the lever but is vestigial on the CRUD path — the POST route accepts it and silently drops it, and every API-created row is born `'published'`. The lever with actual engine teeth is `enabled`: `findWorkflowDefinition`'s unpinned resolution filters `enabled = true AND lifecycle = 'published'`, so a disabled row cannot be resolved for execution or fired by a trigger. Neither tool exposes `enabled` or `lifecycle` as an input.

For update, the draft layer is exactly what the spec sentence describes: per-user, never mutates the definition, never takes its optimistic lock, never 409s across sessions. The human opens the Studio, gets the restore banner, reviews the diff and decides — the spec's "canvas⇄code round-trip guarantees human review" implemented rather than asserted.

## ACL and scoping

| Tool | Features | Mutates |
|---|---|---|
| `list_activity_types` | `definitions.view` | no |
| `get_context_schema` | `definitions.view` | no |
| `validate_definition` | `definitions.view` | no |
| `create_definition` | `definitions.create` | yes |
| `update_definition` | `definitions.edit` | yes |
| `start_test_run` | `instances.view` + `instances.create` + `definitions.test_run` | yes |

**No new ACL features**, so nothing was added to `acl.ts` or `setup.ts` and `sync-role-acls` is not required. This is a stated deviation from the spec's own appendix, which lists a new `workflows.definitions.ai_author`: it would be dead ACL surface here, since per-operation gating already covers every tool, and a tenant-wide AI-authoring kill switch is a separate concern worth designing on its own.

Every read and write is tenant-scoped and answers `not_found`, never `insufficient_permissions`, for a foreign row. `list_activity_types` is the only tool touching no tenant data. `create_definition` and `start_test_run` additionally require an organization; `update_definition` requires a user, since a draft is a per-user review copy.

## Validation

| Command | Result |
|---|---|
| `yarn workspace @open-mercato/core typecheck` | pass |
| `yarn workspace @open-mercato/core test` (full, not a slice) | 1243 suites / 10521 tests pass; the only 2 failures are the known-bad baseline pair |
| `yarn lint` | 0 errors (12 pre-existing warnings in `@open-mercato/app`) |
| `yarn i18n:check-sync` | in sync — no new copy |
| `yarn build:packages` · `yarn build:app --force` | pass |

28 new tests. **Bite verification: 11 source mutations, every one confirmed to fail the tests it should** — create writing `enabled: true`, `isDryRun` forced false, `tenantId` dropped from the ledger and update lookups, writing the definition instead of a draft, graph errors dropped from the evaluator, each ACL guard neutered, null `userId` allowed, the duplicate-`workflowId` check removed. Nothing here is an absence-guard, so nothing passes vacuously.

The in-handler ACL checks are defence in depth — `tool-executor.ts` already gates `requiredFeatures` before a handler runs — but without them a directly-invoked handler is unguarded and the refusal tests would be vacuous, which is why mutation #10 bites six tests.

One flake, stated rather than hidden: an early full run reported `customers/api/settings/address-format/route.guard.test.ts` as "failed to run". It passes standalone and did not reproduce on three subsequent full runs, including the two used for the numbers above. No import path from anything this PR touches.

**Not verified: manual QA.** `needs-qa` stays; `qa-approved` deliberately not applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CF94ampefJBoJazhYDu9mX
