### PR TITLE
fix(agent_orchestrator): bound delegated sub-agent runs with a short wall-clock deadline

### DIFF
--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/delegate-agent-run-timeout.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/delegate-agent-run-timeout.test.ts
@@ -1,0 +1,73 @@
+import { z } from 'zod'
+import { aiTools } from '../ai-tools'
+import { DELEGATE_TOOL_ID, defineAgent } from '../lib/sdk/defineAgent'
+
+// A hung sub-agent tool (e.g. a wedged web_search browser navigation) must not
+// pin the orchestrator for the full top-level deadline: delegate_agent bounds the
+// nested run with a short wall-clock budget so it fails fast and returns an error
+// to the parent instead of blocking it.
+describe('delegate_agent delegated-run wall-clock budget', () => {
+  const schema = z.object({ kind: z.literal('informative'), data: z.unknown() })
+
+  it('passes a short runTimeoutMs (default 3m, env-overridable) to the delegated run', async () => {
+    defineAgent({
+      id: 'test.delegate_timeout_target',
+      moduleId: 'agent_orchestrator',
+      label: 'Timeout target',
+      description: 'Informative sub-agent.',
+      instructions: 'BASE',
+      result: { kind: 'informative', schema },
+    })
+
+    const delegateTool = aiTools.find((tool) => tool.name === DELEGATE_TOOL_ID)
+    expect(delegateTool).toBeDefined()
+
+    let capturedRunTimeoutMs: unknown
+    const agentRuntime = {
+      run: async (_agentId: string, _input: unknown, opts: { runTimeoutMs?: number }) => {
+        capturedRunTimeoutMs = opts.runTimeoutMs
+        return { kind: 'informative' as const, data: { ok: true } }
+      },
+    }
+    const container = {
+      resolve: (name: string) => (name === 'agentRuntime' ? agentRuntime : undefined),
+    }
+    const ctx = {
+      tenantId: 't1',
+      organizationId: 'o1',
+      userId: 'u1',
+      container,
+      userFeatures: [],
+      isSuperAdmin: false,
+    }
+
+    const prev = process.env.OM_AGENT_DELEGATE_RUN_TIMEOUT_MS
+    try {
+      delete process.env.OM_AGENT_DELEGATE_RUN_TIMEOUT_MS
+      const result = await delegateTool!.handler(
+        { agentId: 'test.delegate_timeout_target', input: { foo: 1 } },
+        ctx as never,
+      )
+      expect(result).toMatchObject({ ok: true, agentId: 'test.delegate_timeout_target' })
+      expect(capturedRunTimeoutMs).toBe(3 * 60_000)
+
+      process.env.OM_AGENT_DELEGATE_RUN_TIMEOUT_MS = '45000'
+      await delegateTool!.handler(
+        { agentId: 'test.delegate_timeout_target', input: { foo: 1 } },
+        ctx as never,
+      )
+      expect(capturedRunTimeoutMs).toBe(45000)
+
+      // A non-positive / non-numeric override is ignored → back to the default.
+      process.env.OM_AGENT_DELEGATE_RUN_TIMEOUT_MS = 'not-a-number'
+      await delegateTool!.handler(
+        { agentId: 'test.delegate_timeout_target', input: { foo: 1 } },
+        ctx as never,
+      )
+      expect(capturedRunTimeoutMs).toBe(3 * 60_000)
+    } finally {
+      if (prev === undefined) delete process.env.OM_AGENT_DELEGATE_RUN_TIMEOUT_MS
+      else process.env.OM_AGENT_DELEGATE_RUN_TIMEOUT_MS = prev
+    }
+  })
+})

--- a/packages/enterprise/src/modules/agent_orchestrator/ai-tools.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/ai-tools.ts
@@ -23,6 +23,23 @@ const delegateInput = z.object({
   input: z.unknown().describe('Input payload passed to the sub-agent (shape is sub-agent specific).'),
 })
 
+/** Default wall-clock budget for a delegated sub-agent run (ms) — deliberately far
+ * below the top-level `OM_OPENCODE_RUN_TIMEOUT_MS` so a hung sub-agent tool (e.g. a
+ * wedged web_search navigation) fails fast and returns an error to the orchestrator
+ * instead of blocking it for the full top-level deadline. */
+const DEFAULT_DELEGATE_RUN_TIMEOUT_MS = 3 * 60_000
+
+/** Resolve the delegated-run wall-clock budget from `OM_AGENT_DELEGATE_RUN_TIMEOUT_MS`,
+ * falling back to {@link DEFAULT_DELEGATE_RUN_TIMEOUT_MS}. A non-positive/NaN override is ignored. */
+function resolveDelegateRunTimeoutMs(): number {
+  const raw = process.env.OM_AGENT_DELEGATE_RUN_TIMEOUT_MS
+  if (raw != null && raw !== '') {
+    const parsed = Number(raw)
+    if (Number.isFinite(parsed) && parsed > 0) return parsed
+  }
+  return DEFAULT_DELEGATE_RUN_TIMEOUT_MS
+}
+
 /**
  * Sub-agent-as-tool: lets a parent agent run another agent as a read-only
  * sub-agent and fan several out in parallel (the model emits multiple calls in
@@ -77,6 +94,10 @@ const delegateAgentTool: AiToolDefinition = {
         tenantId: ctx.tenantId,
         organizationId: ctx.organizationId,
         userId: ctx.userId,
+        // Bound the delegated run well below the top-level budget so a hung
+        // sub-agent tool (e.g. a wedged web_search navigation) fails fast and
+        // returns an error to the orchestrator instead of blocking it for an hour.
+        runTimeoutMs: resolveDelegateRunTimeoutMs(),
         ...(parentRunId ? { parentRunId } : {}),
         // Inherit the parent's origin so an eval replay's sub-agent runs are not
         // counted as production traffic in the agent's metric rollups.

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
@@ -106,10 +106,14 @@ const OUTCOME_POLL_MS = 750
  * or a silently-dropped stream can leave both pending forever — which would pin
  * the run and defer the per-run session token's revocation to its 120m TTL. This
  * deadline guarantees the run always terminates and reaches the `finally` cleanup.
- * Override with `OM_OPENCODE_RUN_TIMEOUT_MS` (ms); defaults to 5 minutes.
+ * Override with `OM_OPENCODE_RUN_TIMEOUT_MS` (ms); defaults to 5 minutes. A caller
+ * may also pass a per-run override (`ctx.runTimeoutMs`) which wins when valid —
+ * delegated sub-agent runs use this to bound a hung sub-agent well below the
+ * top-level budget.
  */
 const DEFAULT_RUN_TIMEOUT_MS = 5 * 60_000
-function resolveRunTimeoutMs(): number {
+function resolveRunTimeoutMs(overrideMs?: number): number {
+  if (typeof overrideMs === 'number' && Number.isFinite(overrideMs) && overrideMs > 0) return overrideMs
   const raw = Number.parseInt(process.env.OM_OPENCODE_RUN_TIMEOUT_MS ?? '', 10)
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_RUN_TIMEOUT_MS
 }
@@ -302,6 +306,7 @@ export class OpenCodeAgentRunner {
         store,
         toolCallSink: capturedToolCalls,
         onProgress: emitProgress,
+        runTimeoutMs: resolveRunTimeoutMs(ctx.runTimeoutMs),
       })
 
       if (capturedOutcome === NO_OUTCOME) {
@@ -516,14 +521,16 @@ export class OpenCodeAgentRunner {
     store: AgentRunSessionStore
     toolCallSink: CapturedToolCall[]
     onProgress?: (transition: CapturedTransition) => void
+    /** Wall-clock budget for this run (already resolved by the caller). */
+    runTimeoutMs: number
   }): Promise<unknown | typeof NO_OUTCOME> {
     const idleSignal = this.subscribeSession(args.sessionId, args.toolCallSink, args.onProgress)
-    const deadline = createDeadline(resolveRunTimeoutMs())
+    const deadline = createDeadline(args.runTimeoutMs)
     // The send is synchronous server-side (holds until the loop finishes), so use
     // the long run deadline as its timeout — aborting at the 30s chat default
     // would CANCEL the OpenCode run. Completion is driven by the store/SSE, never
     // the HTTP response, so fire-and-forget (errors only logged).
-    const sendTimeoutMs = resolveRunTimeoutMs()
+    const sendTimeoutMs = args.runTimeoutMs
     const read = () => args.store.readOutcome(args.sessionToken)
     try {
       this.client

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/persistence.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/persistence.ts
@@ -26,6 +26,14 @@ export type AgentRunCtx = {
    */
   parentRunId?: string
   /**
+   * Per-run wall-clock deadline override (ms). Delegated sub-agent runs pass a
+   * SHORT budget here (see the `delegate_agent` tool) so a hung sub-agent tool
+   * fails fast and cleanly, rather than blocking its parent orchestrator for the
+   * full top-level run timeout. Undefined for top-level runs, which use
+   * `OM_OPENCODE_RUN_TIMEOUT_MS` / the default.
+   */
+  runTimeoutMs?: number
+  /**
    * On-behalf-of attribution (Agent Identity & On-Behalf-Of, Wave 4 P2). When the
    * run executes under a provisioned agent principal, this carries the agent's
    * `auth.User` id (the actor stamped on every write) and the invoking human's


### PR DESCRIPTION
## Problem

A hung sub-agent tool can pin its parent orchestrator for the **full top-level run deadline**. In a Lighthouse `klient` run we observed a delegated sub-agent (`analiza_zewnetrzna`, running `web_search` in the Playwright browser sidecar) wedge for **~66 minutes** — the parent agent stayed blocked the entire time and eventually failed with "agent finished without calling submit_outcome".

Root cause: `delegate_agent` awaits `agentRuntime.run(...)` with **no per-run budget of its own**. The nested run inherits only the top-level wall-clock deadline, so a stuck sub-agent tool holds the orchestrator (and its per-run session token) for the whole window.

## Fix

Thread an optional per-run wall-clock override through the shared run context so delegated runs can be bounded independently of the top-level budget:

- **`persistence.ts`** — `AgentRunCtx` gains `runTimeoutMs?: number` (additive, optional). Top-level runs leave it undefined and keep `OM_OPENCODE_RUN_TIMEOUT_MS` / the 5-minute default — byte-for-byte unchanged.
- **`openCodeAgentRunner.ts`** — `resolveRunTimeoutMs(overrideMs?)` now honours a valid `ctx.runTimeoutMs`, and drives **both** the run deadline (`createDeadline`) and the per-message send timeout from it.
- **`ai-tools.ts`** — `delegate_agent` passes a short budget via `resolveDelegateRunTimeoutMs()` (`OM_AGENT_DELEGATE_RUN_TIMEOUT_MS`, default **3 min**). A hung sub-agent now fails fast and returns an error to the orchestrator instead of blocking it, and its per-run session token is revoked promptly rather than lingering to its 120-minute TTL.

## Behavior / contract

- Purely additive: `runTimeoutMs` is optional; existing callers and top-level runs are unaffected.
- New env knob `OM_AGENT_DELEGATE_RUN_TIMEOUT_MS` (ms); a non-positive / non-numeric value is ignored and the 3-minute default applies.

## Tests

`delegate-agent-run-timeout.test.ts` asserts the delegated run receives the default 3-minute budget, respects a valid env override, and ignores an invalid one.

- `tsc --noEmit -p packages/enterprise/tsconfig.json` → 0 errors
- `jest .../delegate-agent-run-timeout.test.ts` → passing

## Follow-ups (not in this PR)

- **Bound the web tool itself** — wrap `web_search`/`web_fetch` with an `AbortController` so a wedged browser navigation aborts at the tool boundary (defense-in-depth beneath this run-level deadline).
- **Config mitigation** — point `OM_WEB_SEARCH_ADAPTERS` at a keyed HTTP API (tavily/serp) instead of the browser sidecar, which is the hang-prone path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)