### PR TITLE
fix(web-research): hard-bound the fetch/browser-escalation path so a wedged render can't hang the run

### DIFF
--- a/packages/web-research/src/engine/__tests__/engine.test.ts
+++ b/packages/web-research/src/engine/__tests__/engine.test.ts
@@ -1,4 +1,5 @@
 import type { SearchAdapter } from '../../contract/adapter'
+import type { FetchOutcome } from '../../contract/outcomes'
 import { resolvePolicy, type SearchPolicyInput } from '../../contract/policy'
 import type { RawResult } from '../../contract/results'
 import type { SearchStep } from '../../contract/steps'
@@ -227,6 +228,43 @@ describe('search engine scheduling', () => {
     await engine.fetch({ url: 'https://example.com/app' })
 
     expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('bounds a browser fetch that ignores its abort signal instead of hanging', async () => {
+    const browser = createFakeAdapter({ id: 'wedged-browser', kind: 'browser', capabilities: { fetch: true } })
+    // A browser adapter whose render neither honours the abort signal nor ever
+    // settles — the wedged-Playwright case behind the 66-minute run hang.
+    const neverSettles: SearchAdapter['fetch'] = () => new Promise<FetchOutcome>(() => {})
+    const engine = createSearchEngine({
+      policy: resolvePolicy({ escalateToBrowser: true, hardDeadlineMs: 500 }),
+      adapters: [entry({ ...browser, fetch: neverSettles }, { order: 0 })],
+      http,
+    })
+
+    const outcome = await engine.fetch({ url: 'https://example.com/app', render: 'always' })
+
+    expect(outcome.status).toBe('timeout')
+  })
+
+  it('a wedged browser escalation during content enrichment does not hang the search', async () => {
+    // A client-side-render shell classifies as `js-shell` and asks for a browser
+    // render, so enrichment escalates the top result into the wedged adapter.
+    const shell = createStubHttpClient(() => ({ body: '<html><body><div id="root"></div></body></html>' }))
+    const browser = createFakeAdapter({ id: 'wedged-browser', kind: 'browser', capabilities: { fetch: true } })
+    const neverSettles: SearchAdapter['fetch'] = () => new Promise<FetchOutcome>(() => {})
+    const engine = createSearchEngine({
+      policy: resolvePolicy({ escalateToBrowser: true, hardDeadlineMs: 500, minResults: 1, lastResort: null }),
+      adapters: [
+        entry(createFakeAdapter({ id: 'api', results: hits('example.com', 3) }), { order: 0 }),
+        entry({ ...browser, fetch: neverSettles }, { order: 1 }),
+      ],
+      http: shell,
+    })
+
+    const result = await engine.search({ query: 'x', includeContent: true })
+
+    // The search still returns its results rather than blocking on the escalation.
+    expect(result.results.length).toBeGreaterThan(0)
   })
 
   it('gives an adapter its own timeout when the policy sets one', async () => {

--- a/packages/web-research/src/engine/engine.ts
+++ b/packages/web-research/src/engine/engine.ts
@@ -1,5 +1,5 @@
 import { silentLogger } from '../contract/http'
-import { toOutcomeFailure, type FetchOutcome } from '../contract/outcomes'
+import { timedOut, toOutcomeFailure, type FetchOutcome } from '../contract/outcomes'
 import type { SearchPolicy } from '../contract/policy'
 import {
   searchRequestSchema,
@@ -189,6 +189,47 @@ export function createSearchEngine(options: SearchEngineOptions): SearchEngine {
     return rendered ?? { status: 'unavailable', reason: 'no browser adapter is configured for rendering' }
   }
 
+  /**
+   * Races a fetch against a hard wall-clock budget so an adapter that ignores its
+   * abort signal — a wedged headless-browser navigation is the classic case —
+   * can never hang the caller. When the timer fires it both aborts the signal (so
+   * a cooperative adapter cancels) and wins the race, returning a `timeout`
+   * outcome; the leaked adapter promise keeps running in the background without
+   * blocking anyone. This is the abort+deadline the search scheduler already
+   * gives the adapter wave (`runAdapter` + `deadlineRace`); the fetch/escalation
+   * path previously passed only a cooperative signal and awaited directly, so a
+   * misbehaving browser render could pin the run for the full parent deadline.
+   */
+  async function withFetchDeadline(
+    budgetMs: number,
+    parentSignal: AbortSignal | undefined,
+    run: (signal: AbortSignal) => Promise<FetchOutcome>,
+  ): Promise<FetchOutcome> {
+    const budget = Math.max(0, budgetMs)
+    const controller = new AbortController()
+    const linked = linkSignals(parentSignal ? [parentSignal, controller.signal] : [controller.signal])
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const timeout = new Promise<{ readonly kind: 'deadline' }>((resolve) => {
+      timer = setTimeout(() => {
+        controller.abort()
+        resolve({ kind: 'deadline' })
+      }, budget)
+      timer.unref?.()
+    })
+    try {
+      const raced = await Promise.race([
+        run(linked.signal)
+          .then((outcome) => ({ kind: 'outcome' as const, outcome }))
+          .catch((error) => ({ kind: 'outcome' as const, outcome: toOutcomeFailure(error) })),
+        timeout,
+      ])
+      return raced.kind === 'deadline' ? timedOut(`fetch exceeded ${budget}ms`) : raced.outcome
+    } finally {
+      if (timer) clearTimeout(timer)
+      linked.dispose()
+    }
+  }
+
   /** Re-reads a page through a browser adapter when the HTTP read was insufficient. */
   async function escalateFetch(
     request: FetchRequest,
@@ -202,26 +243,16 @@ export function createSearchEngine(options: SearchEngineOptions): SearchEngine {
         candidate.enabled && candidate.adapter.fetch !== undefined && candidate.adapter.readiness().ready,
     )
     if (!entry?.adapter.fetch) return null
+    const browserFetch = entry.adapter.fetch
 
-    const linked = linkSignals([runOptions.signal])
-    try {
-      const outcome = await entry.adapter.fetch(
+    return withFetchDeadline(policy.hardDeadlineMs, runOptions.signal, async (signal) => {
+      const outcome = await browserFetch(
         { url: request.url, maxBytes, render: 'always' },
-        {
-          signal: linked.signal,
-          http,
-          report: () => {},
-          deadlineAt: now() + policy.hardDeadlineMs,
-          logger,
-        },
+        { signal, http, report: () => {}, deadlineAt: now() + policy.hardDeadlineMs, logger },
       )
       if (outcome.status !== 'ok') return outcome
       return { status: 'ok', page: { ...outcome.page, renderedWith: 'browser', escalatedBecause: because } }
-    } catch (error) {
-      return toOutcomeFailure(error)
-    } finally {
-      linked.dispose()
-    }
+    })
   }
 
   async function runSearch(
@@ -559,5 +590,17 @@ export function createSearchEngine(options: SearchEngineOptions): SearchEngine {
     )
   }
 
-  return { search, fetch: fetchPage, health, dispose }
+  /**
+   * Public single-URL fetch. Wraps `fetchPage` in the same hard deadline so a
+   * direct `web_fetch` — which carries no caller signal — is bounded end-to-end
+   * (HTTP read AND any browser escalation) at `hardDeadlineMs`, symmetric with the
+   * scheduler-bounded search path.
+   */
+  async function boundedFetch(request: FetchRequest, runOptions: RunOptions = {}): Promise<FetchOutcome> {
+    return withFetchDeadline(policy.hardDeadlineMs, runOptions.signal, (signal) =>
+      fetchPage(request, { ...runOptions, signal }),
+    )
+  }
+
+  return { search, fetch: boundedFetch, health, dispose }
 }


### PR DESCRIPTION
## Problem

Follow-up to #4662 (which caps the *delegated run* wall-clock). This closes the actual hole one level down: a stuck `web_fetch` / browser render.

Tracing the web-research engine, the two tool paths are **not** bounded the same way:

| Path | Hard-bounded before this PR? |
|------|------------------------------|
| `web_search` adapter wave | **Yes** — `runAdapter` gives each adapter an `AbortController` timer *and* the scheduler races `hardDeadlineMs` (`Promise.race([...inflight, deadlineRace])`). A signal-ignoring adapter's promise leaks harmlessly; the search still returns. |
| `web_search` content-enrichment → `escalateFetch` (browser render) | **No** |
| `web_fetch` (`engine.fetch` = `fetchPage`, called with no caller signal) → browser render | **No** |

`escalateFetch` and the public `fetch` `await`ed the adapter **directly**, passing only a *cooperative* abort signal. When a headless-browser navigation wedges and ignores that signal, the `await` never returns — the mechanism behind a Lighthouse `klient` sub-agent pinning its run for **~66 minutes**. The scheduler's per-adapter timeout (the operator-set `timeoutMs` in the UI) only covers the search wave, never this path.

## Fix

Introduce `withFetchDeadline(budgetMs, parentSignal, run)`: it races the fetch against a hard budget and, when the timer fires, **both** aborts the signal (so a cooperative adapter cancels) **and** wins the race — returning a `timeout` outcome. The leaked adapter promise keeps running in the background without blocking anyone. This is exactly the abort+deadline the search scheduler already applies to the adapter wave.

Applied at:
- **`escalateFetch`** — the browser-render `await`. Covers content enrichment *inside* search **and** direct fetch escalation (both funnel through here).
- **The public `fetch`** (`boundedFetch` wrapping `fetchPage`) — so `web_fetch` is bounded end-to-end, HTTP read included, symmetric with the scheduler-bounded search path.

The budget is the **existing** `hardDeadlineMs` policy value — **no new timeout knob**, so this does not duplicate the per-adapter `timeoutMs` operators already set in the Web Search settings UI (that one governs the search wave; this governs the previously-unbounded fetch/render path).

## Contract / behavior

- Additive and behavior-preserving on the happy path: a fetch that completes within budget is unchanged. Only a fetch that would otherwise hang now returns a `timeout` — already a valid `FetchOutcome`/`SearchOutcome` status the callers handle.
- No new config, no signature changes to the public engine surface.

## Tests (`engine.test.ts`)

Two new cases with a browser adapter whose `fetch` never settles and ignores its signal (the wedged-Playwright double):
- `engine.fetch({ render: 'always' })` returns `timeout` instead of hanging.
- A `search({ includeContent: true })` whose enrichment escalates into that adapter still returns its results.

- `tsc --noEmit -p packages/web-research/tsconfig.json` → 0 errors
- `jest src/engine/__tests__/engine.test.ts` → **27 passed** (25 existing + 2 new)

## Relationship to the other fix

- #4662 (delegated-run deadline) is the **outer** safety net — it caps *any* hung sub-agent, whatever the cause.
- This PR is the **surgical** inner fix — a stuck render aborts at the fetch boundary (seconds) and the agent gets a `timeout` result it can narrate/degrade on, instead of losing the whole sub-agent run to the outer deadline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)