### PR TITLE
fix(shared): await the dynamic import so generated-cache recovery is reachable (#4526)

### DIFF
--- a/.ai/runs/2026-07-30-issue-4526-await-dynamic-import.md
+++ b/.ai/runs/2026-07-30-issue-4526-await-dynamic-import.md
@@ -35,5 +35,5 @@ observable proof that the `catch` ran, and they are absent without the fix.
 - [x] Apply the one-line fix (`return await import(fileUrl)`)
 - [x] Add the regression test for the import-time recovery path
 - [x] Confirm the test fails without the fix and passes with it
-- [ ] Run the full validation gate
-- [ ] Open the PR and request labels from a maintainer
+- [x] Run the full validation gate (green, local runner)
+- [x] Open the PR (#4682) and request labels from a maintainer

--- a/.ai/runs/2026-07-30-issue-4526-await-dynamic-import.md
+++ b/.ai/runs/2026-07-30-issue-4526-await-dynamic-import.md
@@ -1,0 +1,39 @@
+# Await the dynamic import in compileAndImport (#4526)
+
+## Goal
+
+Make the MikroORM v7 generated-cache recovery in `compileAndImport` reachable. The
+function returned its dynamic `import()` without awaiting it, so an import-time
+rejection settled outside the surrounding `try` and the `catch` — the only caller of
+`recoverMikroOrmV7GeneratedCacheFromImportError` — never ran.
+
+## Scope
+
+- `packages/shared/src/lib/bootstrap/dynamicLoader.ts` — await the dynamic import so the
+  rejection reaches the recovery `catch`.
+- `packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.generatedCacheRecovery.test.ts` —
+  new regression coverage that the import-time recovery path runs.
+
+## Notes
+
+The startup scan (`ensureMikroOrmV7GeneratedCacheCompatibility`) already deletes a stale
+cache it can see, so the import-time `catch` covers the narrower window where a stale
+compiled file only becomes visible after that scan has run. The regression fixture
+reproduces exactly that window: the staged `.mjs` carries no decorator import at scan
+time, writes a stale sibling as it loads, and then rejects with the decorator-export
+error Node raises for a v6 import.
+
+Assertions stop at the recovery boundary. Jest's module registry keeps serving a file it
+has already evaluated, so the single guarded retry re-runs the rejecting module from
+memory regardless of what recovery wrote to disk — the retry's outcome is a property of
+the runner, not of the loader. The marker file and the deleted-file list are the
+observable proof that the `catch` ran, and they are absent without the fix.
+
+## Progress
+
+- [x] Verify the defect still exists on `develop` (`dynamicLoader.ts:94`)
+- [x] Apply the one-line fix (`return await import(fileUrl)`)
+- [x] Add the regression test for the import-time recovery path
+- [x] Confirm the test fails without the fix and passes with it
+- [ ] Run the full validation gate
+- [ ] Open the PR and request labels from a maintainer

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.generatedCacheRecovery.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.generatedCacheRecovery.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment node
+ *
+ * Regression guard for #4526: compileAndImport must await its dynamic import so
+ * that an import-time rejection settles inside the try block. Returning the
+ * promise unawaited let the rejection escape the surrounding try, which made the
+ * MikroORM v7 generated-cache recovery in the catch dead code for exactly the
+ * failure it exists to repair.
+ *
+ * The fixture reproduces the window the catch exists for: a stale compiled file
+ * that the startup scan (ensureMikroOrmV7GeneratedCacheCompatibility) cannot see
+ * because it appears only once loading is already under way. The staged .mjs
+ * therefore carries no decorator import at scan time — it writes a stale sibling
+ * and then rejects with the error Node raises for a v6 decorator import, which
+ * is what the import-time recovery is meant to repair.
+ *
+ * The assertions stop at the recovery boundary on purpose. Jest's module
+ * registry keeps serving a file it has already evaluated, so the guarded retry
+ * re-runs the rejecting module from memory no matter what recovery wrote to
+ * disk — the outcome of the retry is a property of the test runner, not of the
+ * loader. What #4526 broke, and what this guards, is that the catch runs at
+ * all: before the fix the rejection escaped the try, so no import-time recovery
+ * ever happened.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { loadBootstrapData } from '../dynamicLoader'
+
+const STALE_SIBLING_BASENAME = 'stale-entity.generated.mjs'
+
+/**
+ * The decorator import is assembled at runtime rather than written literally:
+ * a literal would make this fixture itself match the startup scan's staleness
+ * pattern, so the scan would delete the cache before the import ever runs and
+ * the import-time path under test would never be exercised.
+ */
+const REJECTING_COMPILED_SOURCE = [
+  "const nodeFs = require('node:fs')",
+  "const nodePath = require('node:path')",
+  "const quote = String.fromCharCode(39)",
+  "const staleImport = 'import { Entity, PrimaryKey } from ' + quote + '@mikro-orm/core' + quote",
+  `nodeFs.writeFileSync(nodePath.join(__dirname, ${JSON.stringify(STALE_SIBLING_BASENAME)}), staleImport + '\\nexport const stale = true\\n')`,
+  `throw new Error('The requested module ' + quote + '@mikro-orm/core' + quote + ' does not provide an export named ' + quote + 'Entity' + quote)`,
+].join('\n')
+
+const GENERATED_MODULES: Record<string, { ts: string; compiled: string }> = {
+  'entities.ids.generated': { ts: 'export const E = {}', compiled: 'module.exports = { E: {} }' },
+  'modules.cli.generated': { ts: 'export const modules = []', compiled: 'module.exports = { modules: [] }' },
+  'entities.generated': { ts: 'export const entities = []', compiled: 'module.exports = { entities: [] }' },
+  'di.generated': { ts: 'export const diRegistrars = []', compiled: 'module.exports = { diRegistrars: [] }' },
+}
+
+function writeGeneratedModule(generatedDir: string, baseName: string, source: { ts: string; compiled: string }) {
+  fs.writeFileSync(path.join(generatedDir, `${baseName}.ts`), source.ts)
+  fs.writeFileSync(path.join(generatedDir, `${baseName}.mjs`), source.compiled)
+  const fresh = new Date(Date.now() + 60_000)
+  fs.utimesSync(path.join(generatedDir, `${baseName}.mjs`), fresh, fresh)
+}
+
+describe('compileAndImport — generated-cache recovery is reachable (#4526)', () => {
+  let appRoot: string
+  let generatedDir: string
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-bootstrap-4526-'))
+    generatedDir = path.join(appRoot, '.mercato', 'generated')
+    fs.mkdirSync(generatedDir, { recursive: true })
+    for (const [baseName, source] of Object.entries(GENERATED_MODULES)) {
+      writeGeneratedModule(generatedDir, baseName, source)
+    }
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+    fs.rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  it('runs cache recovery when the compiled cache rejects on import', async () => {
+    const rejectingPath = path.join(generatedDir, 'entities.ids.generated.mjs')
+    writeGeneratedModule(generatedDir, 'entities.ids.generated', {
+      ts: 'export const E = { recovered: true }',
+      compiled: REJECTING_COMPILED_SOURCE,
+    })
+
+    await loadBootstrapData(appRoot).catch(() => undefined)
+
+    const markerPath = path.join(generatedDir, '.mikro-orm-v7-cache-recovery.json')
+    expect(fs.existsSync(markerPath)).toBe(true)
+
+    const marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'))
+    expect(marker.reason).toBe('runtime-import-error')
+    expect(marker.deletedFiles).toContain(rejectingPath)
+    expect(marker.deletedFiles).toContain(path.join(generatedDir, STALE_SIBLING_BASENAME))
+
+    expect(fs.readFileSync(rejectingPath, 'utf8')).not.toContain('does not provide an export named')
+  })
+
+  it('does not run recovery when the compiled cache imports cleanly', async () => {
+    await loadBootstrapData(appRoot)
+
+    expect(fs.existsSync(path.join(generatedDir, '.mikro-orm-v7-cache-recovery.json'))).toBe(false)
+  })
+})

--- a/packages/shared/src/lib/bootstrap/dynamicLoader.ts
+++ b/packages/shared/src/lib/bootstrap/dynamicLoader.ts
@@ -91,7 +91,7 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
   // Import the compiled JavaScript
   try {
     const fileUrl = `${pathToFileURL(jsPath).href}?mtime=${fs.statSync(jsPath).mtimeMs}`
-    return import(fileUrl)
+    return await import(fileUrl)
   } catch (error) {
     if (!allowRecovery) {
       throw error


### PR DESCRIPTION
Closes #4526
Tracking plan: .ai/runs/2026-07-30-issue-4526-await-dynamic-import.md
Status: complete

## 🎯 Goal
- Restore the MikroORM v7 generated-cache recovery in the CLI/worker bootstrap loader: a stale compiled cache that rejects on import is repaired and retried instead of surfacing the raw import error to the caller.

## 🔍 Problem
`compileAndImport` in `packages/shared/src/lib/bootstrap/dynamicLoader.ts` returned its dynamic `import()` without awaiting it. The promise left the `try` block before it settled, so an import-time rejection was never caught. `recoverMikroOrmV7GeneratedCacheFromImportError` is only ever called from that `catch`, which made it dead code for exactly the failure it exists to repair — the `does not provide an export named 'Entity'` case caused by a stale generated cache.

## 🔍 Root Cause
`return import(fileUrl)` inside a `try` returns the pending promise to the caller. Rejection therefore settles in the caller's context, outside the `try`, and the `catch` never runs. `return await import(fileUrl)` keeps the rejection inside the guarded block.

## What Changed
- `packages/shared/src/lib/bootstrap/dynamicLoader.ts` — await the dynamic import so the rejection reaches the recovery `catch`. Behavior change: the recovery branch, which deletes stale generated cache files and retries the load once (`allowRecovery` still guards the single retry), is now actually reachable.
- `packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.generatedCacheRecovery.test.ts` — new regression coverage for the import-time recovery path.

## 🧪 Tests
- `yarn jest src/lib/bootstrap/__tests__/dynamicLoader.generatedCacheRecovery.test.ts` — 2 passed. Verified the new case fails without the fix (no recovery marker is written) and passes with it.
- Full configured gate: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`. Runner: local.

Two notes on how the test is scoped, both deliberate:

- The startup scan (`ensureMikroOrmV7GeneratedCacheCompatibility`) already deletes a stale cache it can see, so the import-time `catch` only covers the narrower window where a stale file becomes visible *after* that scan. The fixture reproduces that window: the staged `.mjs` carries no decorator import at scan time, writes a stale sibling as it loads, then rejects with the decorator-export error Node raises.
- Assertions stop at the recovery boundary. Jest's module registry keeps serving a file it has already evaluated, so the guarded retry re-runs the rejecting module from memory regardless of what recovery wrote to disk — the retry's outcome is a property of the runner, not of the loader. The recovery marker and its deleted-file list are the observable proof that the `catch` ran, and they are absent without the fix.

## 💥 Breaking Changes
- None to any contract surface. The behavioral change is that a previously unreachable recovery branch now runs: on a matching import failure it deletes `.mjs` files under `.mercato/generated`, writes a recovery marker, and recompiles once. That is the documented intent of the code, and #4526 was filed to make it a change with its own test rather than a silent rider on the diagnostics work in #4505.

## 📋 Progress
See the Progress section in the tracking plan.

## 🏷️ Labels requested
This account cannot apply labels (no triage permission). Requesting a maintainer set: `bug`, `priority-low`, `risk-medium`, `review`, `skip-qa`.
