### PR TITLE
fix(query_index): never return an unencrypted index document (#4677)

### DIFF
--- a/.ai/runs/2026-07-30-query-index-unencrypted-doc.md
+++ b/.ai/runs/2026-07-30-query-index-unencrypted-doc.md
@@ -1,0 +1,71 @@
+# Fix #4677 — `buildIndexDoc` must never return an unencrypted index document
+
+**Issue:** [#4677](https://github.com/open-mercato/open-mercato/issues/4677)
+**Branch:** `fix/issue-4677-unencrypted-index-doc`
+**Base:** `develop`
+
+## Goal
+
+Make it impossible for `buildIndexDoc` to hand its caller a plaintext document that then gets
+written into `entity_indexes`, which must stay encrypted at rest.
+
+## Problem
+
+`packages/core/src/modules/query_index/lib/indexer.ts` wrapped both the aggregate-search-field
+step and the encryption step in a single `try { … } catch {}`. Any throw inside that block —
+from the aggregation, from resolving the tenant encryption service, or from
+`encryptIndexDocForStorage` itself — was swallowed, `encryptIndexDocForStorage` never ran, and
+the function returned the **plaintext** document. `upsertIndexRow` then wrote it straight into
+`entity_indexes.doc`.
+
+## Root cause
+
+The empty `catch {}` conflated three different failures (aggregation bug, encryption-service
+resolution, genuine encryption failure) and treated all of them as "carry on with whatever
+`doc` currently holds". Because `encryptIndexDocForStorage` already returns the document
+untouched when encryption is absent or disabled, a throw out of it is *always* a real
+encryption failure — never a benign "not applicable" — so falling through could only ever
+mean persisting plaintext.
+
+## Approach
+
+1. Move `attachAggregateSearchField(doc)` **above** the guard, so an aggregation or
+   search-config bug fails loudly instead of being mistaken for an encryption failure.
+2. Narrow the guard to the encryption call and stop swallowing: log via the structured logger
+   and rethrow.
+
+Rethrow rather than `return null`: `null` is the established "record no longer exists" signal
+and makes `upsertIndexRow` **delete** the index row and its search tokens, so returning it on a
+transient encryption failure would destroy a healthy, correctly-encrypted row. Throwing leaves
+the projection untouched; the sole caller (`query_index.upsert_one`) already persists the error
+via `recordIndexerError` and rethrows, and the event bus logs it without failing the user's
+CRUD write. This mirrors `packages/search/src/vector/services/vector-index.service.ts:210`
+("Vector entry encryption failed; refusing to persist plaintext").
+
+## Progress
+
+- [x] Triage the issue against `develop` (`om-verify-in-repo`) — real and unfixed
+- [x] Root-cause the swallow and map every caller of `buildIndexDoc` / `upsertIndexRow`
+- [x] Move `attachAggregateSearchField` out of the guarded block
+- [x] Replace the empty `catch {}` with a logged rethrow
+- [x] Add regression tests (encryption throws, aggregate throws, no write and no delete)
+- [x] Verify the new tests fail against the pre-fix code
+- [x] Run the full validation gate
+- [x] Open the PR
+
+## Scope notes
+
+- **The batch path is untouched.** The issue cites `batch.ts:283-296` as already refusing
+  plaintext ("Falling through would write the plaintext document…"). That guard does **not**
+  exist on `develop`, nor in PR #4654's diff — `upsertIndexBatch` still has
+  `catch { /* best-effort; ignore encrypt errors during indexing */ }` and pushes the plaintext
+  doc into `basePayloads`. So the same defect is live on the reindex path. It is a separate
+  change with a different blast radius (a batch must decide per row whether to skip or abort),
+  and the issue's acceptance criteria are scoped to `buildIndexDoc`, so it is reported back on
+  the issue rather than folded in here.
+- **The optional `SearchConfig.entityBlocklistedFields` item is not applicable to `develop`.**
+  That field is introduced by the still-open PR #4654; `packages/shared/src/lib/search/config.ts`
+  does not have it yet. The null-prototype hardening belongs in that PR's own diff.
+- **`attachAggregateSearchField` takes one argument on `develop`.** PR #4654 adds the
+  `{ entityType }` second argument the issue quotes. Both PRs touch these lines, so whichever
+  merges second needs a trivial conflict resolution.

--- a/packages/core/src/modules/query_index/__tests__/indexer.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/indexer.test.ts
@@ -5,6 +5,21 @@ jest.mock('@open-mercato/shared/lib/encryption/customFieldValues', () => ({
   resolveTenantEncryptionService: jest.fn(),
 }))
 
+// Lets a single test force the aggregate-search-field step to throw while every other test
+// keeps the real implementation. The `mock` prefix is what allows jest's hoisted factory to
+// close over it.
+let mockAggregateOverride: ((doc: Record<string, unknown>) => Record<string, unknown>) | null = null
+
+jest.mock('../lib/document', () => {
+  const actual = jest.requireActual('../lib/document')
+  return {
+    ...actual,
+    attachAggregateSearchField: (doc: Record<string, unknown>) => (
+      mockAggregateOverride ? mockAggregateOverride(doc) : actual.attachAggregateSearchField(doc)
+    ),
+  }
+})
+
 type TableData = {
   baseTable: string
   baseRows: any[]
@@ -116,6 +131,7 @@ const resolveEncryptionMock = resolveTenantEncryptionService as jest.Mock
 describe('Indexer', () => {
   beforeEach(() => {
     resolveEncryptionMock.mockReset()
+    mockAggregateOverride = null
   })
 
   test('buildIndexDoc composes base row and custom fields (singleton and arrays)', async () => {
@@ -156,6 +172,78 @@ describe('Indexer', () => {
     expect(doc).toBeTruthy()
     expect(doc!.title).toBe('Encrypted')
     expect(doc!['cf:secret']).toBe('enc')
+  })
+
+  test('buildIndexDoc returns the encrypted document when encryption succeeds', async () => {
+    resolveEncryptionMock.mockReturnValue({
+      isEnabled: () => true,
+      encryptEntityPayload: async (_entityId: string, payload: Record<string, unknown>) => ({
+        ...payload,
+        title: 'enc:A',
+      }),
+    })
+    const fake = createFakeKysely({
+      baseTable: 'todos',
+      baseRows: [{ id: '1', title: 'A', organization_id: 'org1', tenant_id: 't1' }],
+      cfValues: [],
+    })
+    const em: any = { getKysely: () => fake.db }
+    const doc = await buildIndexDoc(em, { entityType: 'example:todo', recordId: '1', organizationId: 'org1', tenantId: 't1' })
+    expect(doc!.title).toBe('enc:A')
+  })
+
+  test('buildIndexDoc rejects instead of returning the plaintext document when encryption throws', async () => {
+    resolveEncryptionMock.mockReturnValue({
+      isEnabled: () => true,
+      encryptEntityPayload: async () => { throw new Error('kms unavailable') },
+    })
+    const fake = createFakeKysely({
+      baseTable: 'todos',
+      baseRows: [{ id: '1', title: 'Sensitive', organization_id: 'org1', tenant_id: 't1' }],
+      cfValues: [{ field_key: 'secret', value_text: 'plaintext-secret' }],
+    })
+    const em: any = { getKysely: () => fake.db }
+    await expect(
+      buildIndexDoc(em, { entityType: 'example:todo', recordId: '1', organizationId: 'org1', tenantId: 't1' }),
+    ).rejects.toThrow('kms unavailable')
+  })
+
+  test('upsertIndexRow writes nothing and keeps the existing row when encryption throws', async () => {
+    resolveEncryptionMock.mockReturnValue({
+      isEnabled: () => true,
+      encryptEntityPayload: async () => { throw new Error('kms unavailable') },
+    })
+    const fake = createFakeKysely({
+      baseTable: 'todos',
+      baseRows: [{ id: '1', title: 'Sensitive', organization_id: 'org1', tenant_id: 't1' }],
+      cfValues: [],
+      indexRows: [{ entity_type: 'example:todo', entity_id: '1', organization_id: 'org1', deleted_at: null }],
+    })
+    const em: any = { getKysely: () => fake.db }
+    await expect(
+      upsertIndexRow(em, { entityType: 'example:todo', recordId: '1', organizationId: 'org1', tenantId: 't1' }),
+    ).rejects.toThrow('kms unavailable')
+    // No plaintext document reaches `entity_indexes`, and the healthy row is not treated as
+    // a missing record and deleted.
+    expect(fake.inserts.filter((entry) => entry.table === 'entity_indexes')).toHaveLength(0)
+    expect(fake.updates.filter((entry) => entry.table === 'entity_indexes')).toHaveLength(0)
+    expect(fake.deletes.filter((entry) => entry.table === 'entity_indexes')).toHaveLength(0)
+  })
+
+  test('buildIndexDoc surfaces an aggregate-search-field failure instead of skipping encryption', async () => {
+    mockAggregateOverride = () => { throw new TypeError('scoped.includes is not a function') }
+    const encryptEntityPayload = jest.fn()
+    resolveEncryptionMock.mockReturnValue({ isEnabled: () => true, encryptEntityPayload })
+    const fake = createFakeKysely({
+      baseTable: 'todos',
+      baseRows: [{ id: '1', title: 'Sensitive', organization_id: 'org1', tenant_id: 't1' }],
+      cfValues: [],
+    })
+    const em: any = { getKysely: () => fake.db }
+    await expect(
+      buildIndexDoc(em, { entityType: 'example:todo', recordId: '1', organizationId: 'org1', tenantId: 't1' }),
+    ).rejects.toThrow('scoped.includes is not a function')
+    expect(encryptEntityPayload).not.toHaveBeenCalled()
   })
 
   test('upsertIndexRow inserts or merges index row with built doc', async () => {

--- a/packages/core/src/modules/query_index/lib/indexer.ts
+++ b/packages/core/src/modules/query_index/lib/indexer.ts
@@ -3,8 +3,11 @@ import { resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
 import { resolveTenantEncryptionService } from '@open-mercato/shared/lib/encryption/customFieldValues'
 import { decryptIndexDocForSearch, encryptIndexDocForStorage } from '@open-mercato/shared/lib/encryption/indexDoc'
 import { sql } from 'kysely'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import { replaceSearchTokensForRecord, deleteSearchTokensForRecord } from './search-tokens'
 import { attachAggregateSearchField } from './document'
+
+const logger = createLogger('query_index').child({ component: 'indexer' })
 
 type BuildDocParams = {
   entityType: string // '<module>:<entity>'
@@ -121,8 +124,12 @@ export async function buildIndexDoc(em: EntityManager, params: BuildDocParams): 
     }
   } catch {}
 
+  // Kept outside the guard below: a failure while building the aggregate search field is a
+  // bug in the aggregation or its configuration, and must surface instead of being mistaken
+  // for an encryption failure and silently skipping encryption.
+  doc = attachAggregateSearchField(doc)
+
   try {
-    doc = attachAggregateSearchField(doc)
     const encryption = resolveTenantEncryptionService(em as any)
     doc = await encryptIndexDocForStorage(
       params.entityType,
@@ -130,7 +137,23 @@ export async function buildIndexDoc(em: EntityManager, params: BuildDocParams): 
       { tenantId: params.tenantId ?? null, organizationId: params.organizationId ?? null },
       encryption,
     )
-  } catch {}
+  } catch (error) {
+    // `encryptIndexDocForStorage` already returns the document untouched when encryption is
+    // absent or disabled, so a throw here is always a genuine encryption failure. Returning
+    // `doc` would hand the caller the plaintext document to write into `entity_indexes`,
+    // which must stay encrypted at rest; returning `null` would mean "record gone" and make
+    // `upsertIndexRow` delete a healthy index row. Fail loudly instead: the projection keeps
+    // its previous, correctly encrypted contents and the `query_index.upsert_one` subscriber
+    // persists the error via `recordIndexerError`.
+    logger.error('Index document encryption failed; refusing to return an unencrypted document', {
+      entityType: params.entityType,
+      recordId: params.recordId,
+      tenantId: params.tenantId ?? null,
+      organizationId: params.organizationId ?? null,
+      err: error,
+    })
+    throw error
+  }
 
   return doc
 }


### PR DESCRIPTION
Closes #4677
Tracking plan: .ai/runs/2026-07-30-query-index-unencrypted-doc.md
Status: complete

## 🎯 Goal

Make it impossible for the query-index write path to persist a plaintext document into `entity_indexes.doc`, a column that must stay encrypted at rest. An encryption failure now fails loudly and leaves the existing row alone, instead of silently downgrading the row to plaintext.

## 🔍 Problem

`packages/core/src/modules/query_index/lib/indexer.ts` wrapped both the aggregate-search-field step and the encryption step in a single `try { … } catch {}`:

```ts
try {
  doc = attachAggregateSearchField(doc)
  const encryption = resolveTenantEncryptionService(em as any)
  doc = await encryptIndexDocForStorage(/* … */)
} catch {}

return doc
```

If anything in that block threw, the `catch` swallowed it, `encryptIndexDocForStorage` never ran, and the function returned the **plaintext** document. `upsertIndexRow` then wrote it straight into `entity_indexes.doc`. Nothing was logged, so the only symptom was an index row that quietly stopped being encrypted.

## 🔍 Root Cause

The empty `catch` conflated three unrelated failures — a bug in the aggregation, a failure resolving the tenant encryption service, and a genuine encryption failure — and treated all of them as "carry on with whatever `doc` currently holds".

That fallback is never safe for the encryption step. `encryptIndexDocForStorage` already returns the document untouched when no encryption service is present or when encryption is disabled, so a throw out of it is *always* a real encryption failure and never a benign "not applicable" case. Falling through could therefore only ever mean persisting plaintext.

## What Changed

- **`packages/core/src/modules/query_index/lib/indexer.ts`**
  - `attachAggregateSearchField(doc)` moved **above** the guarded block, so an aggregation or search-config bug surfaces as itself instead of being misread as an encryption failure and silently skipping encryption. This is fix (1) from the issue.
  - The guard now wraps only the encryption call, and its `catch` logs through the structured logger (`query_index:indexer`) and rethrows, instead of swallowing.
  - Added the module logger (`createLogger('query_index').child({ component: 'indexer' })`), matching `batch.ts`.

  **Why rethrow rather than `return null`** (the issue offered both): `null` is the established "record no longer exists" signal on this path — `upsertIndexRow` reacts to it by **deleting** the `entity_indexes` row and its search tokens. Returning `null` on a transient encryption failure would therefore destroy a healthy, correctly-encrypted row, trading a confidentiality bug for a data-loss bug. Throwing leaves the projection exactly as it was. The propagation is already handled: the sole caller `query_index.upsert_one` records the error via `recordIndexerError` and rethrows, and the event bus catches and logs subscriber errors — so the failure is recorded and visible, and the user's CRUD write still succeeds. This mirrors `packages/search/src/vector/services/vector-index.service.ts:210`, which likewise refuses to persist plaintext when encryption throws.

- **`packages/core/src/modules/query_index/__tests__/indexer.test.ts`** — four tests, including a `jest.mock` of `../lib/document` that delegates to the real implementation and lets one test force the aggregate step to throw.

## 🧪 Tests

Full configured gate, run locally (no compose `app` container was up):

- `yarn build:packages` — ✅ 21/21
- `yarn generate` — ✅ (no diff produced)
- `yarn build:packages` (2nd) — ✅ 21/21
- `yarn i18n:check-sync` — ✅ all 4 locales in sync
- `yarn i18n:check-usage` — ✅ advisory only (3737 pre-existing unused keys, unchanged)
- `yarn typecheck` — ✅ 21/21
- `yarn test` — ✅ **7807 passed, 0 failed**. One suite (`auth/services/__tests__/rbacService.test.ts`) died to a `jest worker … SIGSEGV`; it is untouched by this PR and passes in isolation (48/48) — the known local worker/heap flake, not a regression.
- `yarn build:app` — ✅

New cases, all in `query_index/__tests__/indexer.test.ts`:

| Test | Locks in |
|---|---|
| `buildIndexDoc returns the encrypted document when encryption succeeds` | The happy path still encrypts after the reordering |
| `buildIndexDoc rejects instead of returning the plaintext document when encryption throws` | Acceptance criterion 1 + 2 — no plaintext escapes |
| `upsertIndexRow writes nothing and keeps the existing row when encryption throws` | No insert/update writes plaintext, **and** no delete wipes the healthy row |
| `buildIndexDoc surfaces an aggregate-search-field failure instead of skipping encryption` | Acceptance criterion 1 — an aggregate throw is loud, and encryption is never reached with a half-built doc |

Verified non-vacuous: with `indexer.ts` reverted to its `develop` contents, **3 of the 4 fail** (the fourth is the happy-path guard for the reordering, which passes either way).

## 💥 Breaking Changes

None to any contract surface — `buildIndexDoc`'s signature and return type are unchanged.

One intentional behavior change worth a reviewer's eye, and it is on a surface third parties can reach (`packages/core`'s export map exposes `@open-mercato/core/modules/query_index/lib/indexer` through its path wildcards): an encryption failure on this path used to be invisible (write succeeded, index silently plaintext) and is now loud (error logged, `recordIndexerError` row written, index row left at its previous contents). That is the point of the issue — "Returning a plaintext document should not be a reachable outcome of this function". The user-facing CRUD write is unaffected, because the event bus catches and logs subscriber errors rather than propagating them.

## Scope notes for the reviewer

Three findings from working the issue that the reviewer should know about:

1. **The batch path has the same defect and is *not* fixed here.** The issue cites `batch.ts:283-296` as the correct precedent that "catches an `encryptDoc` failure and *skips the row* with a recorded error". That guard does not exist — not on `develop`, and not in #4654's diff either. `upsertIndexBatch` still has `catch { /* best-effort; ignore encrypt errors during indexing */ }` and pushes the plaintext `doc` into `basePayloads`, which get written to `entity_indexes`. So reindex can still persist plaintext. It is left out because it is a genuinely different change (a batch must decide per row whether to skip or abort the run) and the issue's acceptance criteria are scoped to `buildIndexDoc`. Reported back on the issue — happy to follow up in a separate PR.
2. **The optional `SearchConfig.entityBlocklistedFields` item does not apply to `develop`.** That field is added by the still-open #4654; `packages/shared/src/lib/search/config.ts` has no `Object.fromEntries(byEntity)` yet. The null-prototype hardening belongs in that PR's own diff.
3. **Minor conflict with #4654 is expected.** On `develop` `attachAggregateSearchField` takes one argument; #4654 adds the `{ entityType }` second argument the issue quotes. Both PRs touch these exact lines, so whichever merges second needs a one-line resolution (keep this PR's structure, add #4654's second argument).

## 🏷️ Labels

This automation runs under a `read`-permission account and **cannot apply labels** (`AddLabelsToLabelable` → 403). Requesting a maintainer apply:

- `bug` — corrects defective behavior on the query-index write path.
- `security` — the defect's consequence is data-at-rest confidentiality: an index document that should be encrypted is persisted in plaintext.
- `review` — ready for review, not in any other pipeline state.
- `priority-high` — silent, unbounded, and invisible in normal operation: nothing logs, so plaintext rows accumulate undetected until someone inspects `entity_indexes`. Not `extreme` because it needs an encryption failure to trigger, which is not the steady state.
- `risk-low` — 27 lines in one function, no contract or schema change, one call path, all of it covered by new tests.
- `skip-qa` — qualifies for the automated-verification exemption: no `.tsx` outside tests, nothing under `packages/ui/src/` or `**/components/**`, database structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract touched, and automated tests for the changed behavior ship in this PR.

## 📋 Progress

See the Progress section in the tracking plan — all steps checked.
