### PR TITLE
fix(customers): read deal status through one closed/won vocabulary

### DIFF
--- a/.ai/runs/2026-07-30-deal-status-single-source.md
+++ b/.ai/runs/2026-07-30-deal-status-single-source.md
@@ -27,16 +27,37 @@ so tenant-specific stages are never silently reclassified.
 
 ## Progress
 
-- [x] Add `packages/core/src/modules/customers/lib/dealStatus.ts` (won / lost / closed sets + predicates)
-- [x] `api/companies/[id]/route.ts` — `activeDeals` / `wonDeals` consume the helpers
-- [x] `components/detail/dashboard/helpers.ts` — three inline tests replaced
-- [x] `components/detail/CompanyKpiBar.tsx` — five inline tests replaced
-- [x] `components/detail/ActiveDealCard.tsx` — inline test replaced
-- [x] `api/people/[id]/companies/enriched/route.ts` — aligned (also picks up `closed`)
-- [x] Unit tests for `dealStatus.ts`
-- [x] Regression tests: a `useDealClosure`-closed deal (`status: 'win'`) counts as won, not active
-- [x] Validation gate
-- [x] PR opened
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+- [x] Add `packages/core/src/modules/customers/lib/dealStatus.ts` (won / lost / closed sets + predicates) — 60adcbc72, refined in 15d5a9937
+- [x] `api/companies/[id]/route.ts` — `activeDeals` / `wonDeals` consume the helpers — 60adcbc72
+- [x] `components/detail/dashboard/helpers.ts` — three inline tests replaced — 60adcbc72
+- [x] `components/detail/CompanyKpiBar.tsx` — five inline tests replaced — 60adcbc72
+- [x] `components/detail/ActiveDealCard.tsx` — inline test replaced — 60adcbc72
+- [x] `api/people/[id]/companies/enriched/route.ts` — aligned (also picks up `closed`) — 60adcbc72
+- [x] Unit tests for `dealStatus.ts` — 60adcbc72
+- [x] Regression tests: a `useDealClosure`-closed deal (`status: 'win'`) counts as won, not active — 60adcbc72, enriched-route coverage added in 15d5a9937
+- [x] Validation gate — verified from GitHub checks on head `15d5a9937` (see Validation below)
+- [x] PR opened — #4705 (replacement for the superseded #4689)
+
+## Validation
+
+**Source:** GitHub Actions checks on head `15d5a9937b111f1fac70e764772829775d8c4752`. **Runner:** GitHub Actions; no local fallback was required.
+
+Every command in the configured `validation.commands` gate maps to a passing CI step:
+
+| Gate command | CI job / step | Result |
+|--------------|---------------|--------|
+| `yarn build:packages` | `prepare` — "Build packages" | ✅ pass |
+| `yarn generate` | `prepare` — "Prepare generated modules" | ✅ pass |
+| `yarn build:packages` (rebuild) | `prepare` — "Rebuild packages with generated files" | ✅ pass |
+| `yarn i18n:check-sync` | `test` — "Check i18n sync" | ✅ pass |
+| `yarn i18n:check-usage` | `test` — "Check i18n usage" | ✅ pass |
+| `yarn typecheck` | `test` — "Checking types" | ✅ pass |
+| `yarn test` | `test` — "Test" | ✅ pass |
+| `yarn build:app` | `prepare` — "Build app" | ✅ pass |
+
+Supporting checks also passed: `lint`, `docker-build`, `ephemeral-integration (none)`, `audit-scope`, `CodeQL` and all three CodeQL language analyses, and `license/cla`. `audit` and `merge-coverage` report `skipping` by design. Branch protection exposes no required-check list, so every reported check was treated as required. The PR is mergeable with no conflicts.
 
 ## Notes
 

--- a/.ai/runs/2026-07-30-deal-status-single-source.md
+++ b/.ai/runs/2026-07-30-deal-status-single-source.md
@@ -1,0 +1,47 @@
+# Deal status single source of truth (#4667)
+
+**Issue:** open-mercato/open-mercato#4667
+**Branch:** `fix/issue-4667-deal-status-vocabulary`
+**Base:** `develop`
+
+## Problem
+
+`customer_deals.status` is a lenient `text` column and the writers disagree on the spelling:
+
+| Writer | Persists |
+|--------|----------|
+| `backend/customers/deals/[id]/hooks/useDealClosure.ts` | `win` / `loose` |
+| `backend/customers/deals/pipeline/page.tsx` (`updateDealStatus`) | `win` / `loose` |
+| `ai-tools/deals-pack.ts` (`customers.update_deal_stage`) | `won` / `lost` |
+| `cli.ts` seed vocabulary | `closed`, `win`, `loose` |
+
+Company read-side surfaces test only for `won` / `lost` / `closed`, so a deal closed through the
+supported UI (`win` / `loose`) keeps counting as **active**, while won-deal count, completed-deal
+count and LTV read **0**.
+
+## Approach
+
+Mirror the existing house pattern in `lib/interactionStatus.ts`: one exported definition of the
+terminal vocabulary plus predicates, consumed by every call site. Unknown statuses stay **open**
+so tenant-specific stages are never silently reclassified.
+
+## Progress
+
+- [x] Add `packages/core/src/modules/customers/lib/dealStatus.ts` (won / lost / closed sets + predicates)
+- [x] `api/companies/[id]/route.ts` — `activeDeals` / `wonDeals` consume the helpers
+- [x] `components/detail/dashboard/helpers.ts` — three inline tests replaced
+- [x] `components/detail/CompanyKpiBar.tsx` — five inline tests replaced
+- [x] `components/detail/ActiveDealCard.tsx` — inline test replaced
+- [x] `api/people/[id]/companies/enriched/route.ts` — aligned (also picks up `closed`)
+- [x] Unit tests for `dealStatus.ts`
+- [x] Regression tests: a `useDealClosure`-closed deal (`status: 'win'`) counts as won, not active
+- [x] Validation gate
+- [x] PR opened
+
+## Notes
+
+- Scope stays inside the customers module. The `dashboards` pipeline-summary widget has its own
+  denylist landing in the still-open #4629; wiring it to this helper belongs to a follow-up so the
+  two PRs do not conflict.
+- `data/validators.ts` and `api/deals/[id]/stats/route.ts` keep the `closureOutcome` enum
+  (`won` / `lost`) — that is a separate, well-defined column and not part of this mismatch.

--- a/.ai/runs/2026-07-30-deal-status-single-source.md
+++ b/.ai/runs/2026-07-30-deal-status-single-source.md
@@ -41,7 +41,6 @@ so tenant-specific stages are never silently reclassified.
 ## Notes
 
 - Scope stays inside the customers module. The `dashboards` pipeline-summary widget has its own
-  denylist landing in the still-open #4629; wiring it to this helper belongs to a follow-up so the
-  two PRs do not conflict.
+  status and `closureOutcome` handling in #4683; direct cross-module imports are not allowed.
 - `data/validators.ts` and `api/deals/[id]/stats/route.ts` keep the `closureOutcome` enum
   (`won` / `lost`) — that is a separate, well-defined column and not part of this mismatch.

--- a/packages/core/src/modules/customers/api/companies/[id]/__tests__/route.dealKpis.test.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/__tests__/route.dealKpis.test.ts
@@ -1,0 +1,235 @@
+/** @jest-environment node */
+
+// Regression for issue #4667: `activeDeals` / `wonDeals` tested for `won` / `lost` / `closed`,
+// a vocabulary no writer persists. A deal closed through useDealClosure (`win` / `loose`) was
+// therefore still reported as active, and completedDealsCount / ltvValue read 0.
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockResolveCustomerInteractionFeatureFlags = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockResolveCompanyCustomFieldRouting = jest.fn()
+const mockMergeCompanyCustomFieldValues = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+
+const mockEm = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+jest.mock('../../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn((...args: unknown[]) => mockResolveCustomerInteractionFeatureFlags(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+jest.mock('../../../../lib/customFieldRouting', () => ({
+  resolveCompanyCustomFieldRouting: jest.fn((...args: unknown[]) => mockResolveCompanyCustomFieldRouting(...args)),
+  mergeCompanyCustomFieldValues: jest.fn((...args: unknown[]) => mockMergeCompanyCustomFieldValues(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('../../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_entity: 'customer_entity',
+      customer_company_profile: 'customer_company_profile',
+    },
+  },
+}), { virtual: true })
+
+const COMPANY_ID = '2408107d-0000-4000-8000-000000004667'
+
+type DealRow = {
+  id: string
+  status: string | null
+  valueAmount: string | null
+  valueCurrency: string | null
+}
+
+function buildDeal(row: DealRow) {
+  return {
+    ...row,
+    tenantId: 'tenant-1',
+    organizationId: 'org-1',
+    deletedAt: null,
+    createdAt: new Date('2026-01-10T10:00:00.000Z'),
+  }
+}
+
+function mockCompany() {
+  mockFindOneWithDecryption
+    .mockResolvedValueOnce({
+      id: COMPANY_ID,
+      kind: 'company',
+      deletedAt: null,
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      companyProfile: null,
+      displayName: 'Acme Corp',
+      description: null,
+      ownerUserId: null,
+      primaryEmail: null,
+      primaryPhone: null,
+      status: null,
+      lifecycleStage: null,
+      source: null,
+      nextInteractionAt: null,
+      nextInteractionName: null,
+      nextInteractionRefId: null,
+      nextInteractionIcon: null,
+      nextInteractionColor: null,
+      isActive: true,
+      createdAt: new Date('2026-01-01T08:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T08:00:00.000Z'),
+    })
+    .mockResolvedValueOnce(null)
+}
+
+function mockDealLinks(deals: DealRow[]) {
+  mockFindWithDecryption.mockImplementation(async (_em: unknown, entity: { name?: string }) => {
+    if (entity?.name === 'CustomerDealCompanyLink') {
+      return deals.map((deal, index) => ({ id: `link-${index}`, deal: buildDeal(deal) }))
+    }
+    return []
+  })
+}
+
+async function fetchKpis() {
+  const { GET } = await import('../route')
+  const response = await GET(
+    new Request(`http://localhost/api/customers/companies/${COMPANY_ID}`),
+    { params: { id: COMPANY_ID } },
+  )
+  const body = await response.json()
+  expect(response.status).toBe(200)
+  return body.kpis
+}
+
+describe('GET /api/customers/companies/[id] — deal KPI status vocabulary (#4667)', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockResolveCustomerInteractionFeatureFlags.mockReset()
+    mockLoadCustomFieldValues.mockReset()
+    mockResolveCompanyCustomFieldRouting.mockReset()
+    mockMergeCompanyCustomFieldValues.mockReset()
+    mockFindWithDecryption.mockReset()
+    mockFindOneWithDecryption.mockReset()
+    mockEm.findOne.mockReset()
+    mockEm.find.mockReset()
+    mockEm.count.mockReset()
+    mockEm.count.mockResolvedValue(0)
+    mockContainer.resolve.mockClear()
+
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      isApiKey: false,
+    })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      filterIds: ['org-1'],
+      selectedId: 'org-1',
+      tenantId: 'tenant-1',
+    })
+    mockResolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    mockLoadCustomFieldValues.mockResolvedValue({})
+    mockResolveCompanyCustomFieldRouting.mockResolvedValue({})
+    mockMergeCompanyCustomFieldValues.mockReturnValue({})
+    mockEm.find.mockResolvedValue([])
+  })
+
+  it('reports a deal closed through useDealClosure as won, not active', async () => {
+    mockCompany()
+    mockDealLinks([
+      { id: 'deal-won', status: 'win', valueAmount: '4000', valueCurrency: 'PLN' },
+      { id: 'deal-lost', status: 'loose', valueAmount: '2500', valueCurrency: 'PLN' },
+    ])
+
+    const kpis = await fetchKpis()
+
+    expect(kpis.activeDealsCount).toBe(0)
+    expect(kpis.activeDealsValue).toBeNull()
+    expect(kpis.completedDealsCount).toBe(1)
+    expect(kpis.ltvValue).toBe(4000)
+  })
+
+  it('also recognises the won/lost spelling the AI stage tool persists', async () => {
+    mockCompany()
+    mockDealLinks([
+      { id: 'deal-won', status: 'won', valueAmount: '1200', valueCurrency: 'PLN' },
+      { id: 'deal-lost', status: 'lost', valueAmount: '800', valueCurrency: 'PLN' },
+      { id: 'deal-closed', status: 'closed', valueAmount: '300', valueCurrency: 'PLN' },
+    ])
+
+    const kpis = await fetchKpis()
+
+    expect(kpis.activeDealsCount).toBe(0)
+    expect(kpis.completedDealsCount).toBe(1)
+    expect(kpis.ltvValue).toBe(1200)
+  })
+
+  it('keeps open and tenant-specific statuses in the active pipeline', async () => {
+    mockCompany()
+    mockDealLinks([
+      { id: 'deal-open', status: 'negotiations', valueAmount: '1000', valueCurrency: 'PLN' },
+      { id: 'deal-tenant-stage', status: 'awaiting_legal_signoff', valueAmount: '700', valueCurrency: 'PLN' },
+      { id: 'deal-no-status', status: null, valueAmount: '300', valueCurrency: 'PLN' },
+      { id: 'deal-won', status: 'win', valueAmount: '4000', valueCurrency: 'PLN' },
+    ])
+
+    const kpis = await fetchKpis()
+
+    expect(kpis.activeDealsCount).toBe(3)
+    expect(kpis.activeDealsValue).toBe(2000)
+    expect(kpis.completedDealsCount).toBe(1)
+    expect(kpis.ltvValue).toBe(4000)
+  })
+
+  it('leaves ltv null when nothing has been won yet', async () => {
+    mockCompany()
+    mockDealLinks([
+      { id: 'deal-open', status: 'open', valueAmount: '500', valueCurrency: 'PLN' },
+      { id: 'deal-lost', status: 'loose', valueAmount: '900', valueCurrency: 'PLN' },
+    ])
+
+    const kpis = await fetchKpis()
+
+    expect(kpis.activeDealsCount).toBe(1)
+    expect(kpis.completedDealsCount).toBe(0)
+    expect(kpis.ltvValue).toBeNull()
+  })
+})

--- a/packages/core/src/modules/customers/api/companies/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/route.ts
@@ -29,6 +29,7 @@ import {
   mergeCompanyCustomFieldValues,
 } from '../../../lib/customFieldRouting'
 import { isOpenInteractionStatus, TERMINAL_INTERACTION_STATUS_LIST } from '../../../lib/interactionStatus'
+import { isOpenDealStatus, isWonDealStatus } from '../../../lib/dealStatus'
 import {
   CUSTOMER_INTERACTION_ACTIVITY_ADAPTER_SOURCE,
   EXAMPLE_TODO_SOURCE,
@@ -1015,10 +1016,8 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       .map((value) => (value instanceof Date ? value.toISOString() : typeof value === 'string' ? value : ''))
       .filter((value) => value.length > 0),
   )
-  const activeDeals = dealLinksForMetrics.filter(
-    (deal) => deal.status !== 'won' && deal.status !== 'lost' && deal.status !== 'closed',
-  )
-  const wonDeals = dealLinksForMetrics.filter((deal) => deal.status === 'won')
+  const activeDeals = dealLinksForMetrics.filter((deal) => isOpenDealStatus(deal.status))
+  const wonDeals = dealLinksForMetrics.filter((deal) => isWonDealStatus(deal.status))
   const activeDealsValue = activeDeals.reduce((sum, deal) => sum + (parseDealAmount(deal.valueAmount) ?? 0), 0)
   const ltvValue = wonDeals.length
     ? wonDeals.reduce((sum, deal) => sum + (parseDealAmount(deal.valueAmount) ?? 0), 0)

--- a/packages/core/src/modules/customers/api/people/[id]/companies/enriched/__tests__/route.dealStatus.test.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/enriched/__tests__/route.dealStatus.test.ts
@@ -1,0 +1,142 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const personId = '33333333-3333-4333-8333-333333333333'
+const companyId = '44444444-4444-4444-8444-444444444444'
+
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+
+const em = {
+  fork: jest.fn(),
+}
+
+const container = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return em
+    throw new Error(`[internal] Unexpected container token: ${token}`)
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn(async () => ({
+    sub: '55555555-5555-4555-8555-555555555555',
+    tenantId,
+    orgId: organizationId,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    tenantId,
+    selectedId: organizationId,
+    filterIds: [organizationId],
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: jest.fn(() => true),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
+}))
+
+jest.mock('../../../../../../lib/personCompanyLinkTable', () => ({
+  withActiveCustomerPersonCompanyLinkFilter: jest.fn(async () => ({ active: true })),
+  filterActivePersonCompanyLinks: jest.fn((links: unknown[]) => links),
+}))
+
+jest.mock('@open-mercato/shared/lib/logger', () => ({
+  createLogger: jest.fn(() => ({ error: jest.fn() })),
+}))
+
+import { GET } from '../route'
+
+function buildDeal(
+  id: string,
+  status: string,
+  valueAmount: string,
+  createdAt: string,
+) {
+  return {
+    id,
+    status,
+    title: id,
+    valueAmount,
+    valueCurrency: 'PLN',
+    deletedAt: null,
+    createdAt: new Date(createdAt),
+  }
+}
+
+describe('GET /api/customers/people/[id]/companies/enriched deal status vocabulary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    em.fork.mockReturnValue(em)
+
+    const person = {
+      id: personId,
+      kind: 'person',
+      tenantId,
+      organizationId,
+    }
+    const company = {
+      id: companyId,
+      displayName: 'Acme Corp',
+      status: null,
+      lifecycleStage: null,
+      temperature: null,
+      renewalQuarter: null,
+    }
+    const personCompanyLinks = [{ id: 'link-1', isPrimary: true, company }]
+    const dealLinks = [
+      { company, deal: buildDeal('won-by-ui', 'win', '200', '2026-01-10T00:00:00.000Z') },
+      { company, deal: buildDeal('won-by-ai', 'won', '500', '2026-01-11T00:00:00.000Z') },
+      { company, deal: buildDeal('lost-by-ui', 'loose', '300', '2026-01-12T00:00:00.000Z') },
+      { company, deal: buildDeal('lost-by-ai', 'lost', '400', '2026-01-13T00:00:00.000Z') },
+      { company, deal: buildDeal('closed', 'closed', '600', '2026-01-14T00:00:00.000Z') },
+      { company, deal: buildDeal('tenant-stage', 'awaiting_legal_signoff', '100', '2026-01-09T00:00:00.000Z') },
+    ]
+
+    mockFindOneWithDecryption.mockResolvedValue(person)
+    mockFindWithDecryption
+      .mockResolvedValueOnce(personCompanyLinks)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(dealLinks)
+      .mockResolvedValueOnce([])
+  })
+
+  it('excludes every closed spelling from activeDeal and includes both won spellings in CLV', async () => {
+    const response = await GET(
+      new Request(`http://localhost/api/customers/people/${personId}/companies/enriched`),
+      { params: { id: personId } },
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0].activeDeal).toEqual({
+      title: 'tenant-stage',
+      valueAmount: '100',
+      valueCurrency: 'PLN',
+    })
+    expect(body.items[0].clv).toEqual({ amount: 700, currency: 'PLN' })
+  })
+})

--- a/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
@@ -25,6 +25,7 @@ import {
   filterActivePersonCompanyLinks,
   withActiveCustomerPersonCompanyLinkFilter,
 } from '../../../../../lib/personCompanyLinkTable'
+import { isOpenDealStatus, isWonDealStatus } from '../../../../../lib/dealStatus'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('customers')
@@ -280,13 +281,13 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
 
       const activeDeals = companyDealLinks
         .map((dcl) => dcl.deal as CustomerDeal)
-        .filter((deal) => deal.status !== 'win' && deal.status !== 'loose' && !deal.deletedAt)
+        .filter((deal) => isOpenDealStatus(deal.status) && !deal.deletedAt)
         .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
       const activeDeal = activeDeals.length > 0 ? activeDeals[0] : null
 
       const wonDeals = companyDealLinks
         .map((dcl) => dcl.deal as CustomerDeal)
-        .filter((deal) => deal.status === 'win' && !deal.deletedAt)
+        .filter((deal) => isWonDealStatus(deal.status) && !deal.deletedAt)
       let clv: { amount: number; currency: string } | null = null
       if (wonDeals.length > 0) {
         const currencies = new Map<string, number>()

--- a/packages/core/src/modules/customers/components/detail/ActiveDealCard.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActiveDealCard.tsx
@@ -7,6 +7,7 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { Badge } from '@open-mercato/ui/primitives/badge'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import { isOpenDealStatus } from '../../lib/dealStatus'
 import type { DealSummary } from '../formConfig'
 import { formatCurrency } from './utils'
 
@@ -25,7 +26,7 @@ export function ActiveDealCard({ deals, onHide }: ActiveDealCardProps) {
   const [pipelineStages, setPipelineStages] = React.useState<PipelineStageOption[]>([])
 
   const activeDeals = React.useMemo(
-    () => deals.filter((d) => d.status !== 'won' && d.status !== 'lost' && d.status !== 'closed'),
+    () => deals.filter((d) => isOpenDealStatus(d.status)),
     [deals],
   )
 

--- a/packages/core/src/modules/customers/components/detail/CompanyKpiBar.tsx
+++ b/packages/core/src/modules/customers/components/detail/CompanyKpiBar.tsx
@@ -11,6 +11,7 @@ import {
   writeVersionedIdSet,
   clearVersionedPreference,
 } from '@open-mercato/shared/lib/browser/versionedPreference'
+import { isOpenDealStatus, isWonDealStatus } from '../../lib/dealStatus'
 import type { CompanyOverview, DealSummary, InteractionSummary } from '../formConfig'
 import { formatCurrency } from './utils'
 
@@ -19,7 +20,7 @@ const STORAGE_VERSION = 1
 
 function sumActiveDeals(deals: DealSummary[]): number {
   return deals
-    .filter((d) => d.status !== 'won' && d.status !== 'lost' && d.status !== 'closed')
+    .filter((d) => isOpenDealStatus(d.status))
     .reduce((sum, d) => {
       const amount = typeof d.valueAmount === 'number' ? d.valueAmount : parseFloat(String(d.valueAmount ?? '0'))
       return sum + (Number.isFinite(amount) ? amount : 0)
@@ -27,7 +28,7 @@ function sumActiveDeals(deals: DealSummary[]): number {
 }
 
 function getActiveDeals(deals: DealSummary[]): DealSummary[] {
-  return deals.filter((d) => d.status !== 'won' && d.status !== 'lost' && d.status !== 'closed')
+  return deals.filter((d) => isOpenDealStatus(d.status))
 }
 
 function computeActivityTrend(interactions: InteractionSummary[]): KpiTrend | undefined {
@@ -51,7 +52,7 @@ function computeActivityTrend(interactions: InteractionSummary[]): KpiTrend | un
 }
 
 function computeDealTrend(deals: DealSummary[]): KpiTrend | undefined {
-  const active = deals.filter((d) => d.status !== 'won' && d.status !== 'lost' && d.status !== 'closed')
+  const active = deals.filter((d) => isOpenDealStatus(d.status))
   if (active.length === 0) return undefined
   const now = Date.now()
   const monthMs = 30 * 86_400_000
@@ -81,7 +82,7 @@ export function CompanyKpiBar({ data }: CompanyKpiBarProps) {
 
   const ltvValue = React.useMemo(() => {
     if (data.kpis?.ltvValue !== undefined) return data.kpis.ltvValue
-    const wonDeals = data.deals.filter((d) => d.status === 'won')
+    const wonDeals = data.deals.filter((d) => isWonDealStatus(d.status))
     if (wonDeals.length === 0) return null
     return wonDeals.reduce((sum, d) => {
       const amt = typeof d.valueAmount === 'number' ? d.valueAmount : parseFloat(String(d.valueAmount ?? '0'))
@@ -154,7 +155,7 @@ export function CompanyKpiBar({ data }: CompanyKpiBarProps) {
           : `${v} ${v === 1 ? t('customers.companies.dashboard.kpi.year', 'year') : t('customers.companies.dashboard.kpi.years', 'years')}`
         : undefined,
       comparisonLabel: clientTenureYears !== null
-        ? `${data.kpis?.completedDealsCount ?? data.deals.filter((d) => d.status === 'won').length} ${t('customers.companies.dashboard.kpi.completedDeals', 'completed deals')}`
+        ? `${data.kpis?.completedDealsCount ?? data.deals.filter((d) => isWonDealStatus(d.status)).length} ${t('customers.companies.dashboard.kpi.completedDeals', 'completed deals')}`
         : t('customers.companies.dashboard.kpi.noInteractions', 'No interactions yet'),
     },
   ], [t, activeDealsValue, dealTrend, dealCurrency, activeDeals.length, activityTrend, ltvValue, clientTenureYears, data.deals, data.interactions.length, data.kpis])

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActiveDealCard.dealStatus.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActiveDealCard.dealStatus.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import type { DealSummary } from '../../formConfig'
+
+const readApiResultOrThrowMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+}))
+
+import { ActiveDealCard } from '../ActiveDealCard'
+
+// Regression for issue #4667: the card highlighted the highest-value deal among those it
+// considered active. It tested for `won` / `lost` / `closed`, so the biggest deal already
+// closed through useDealClosure (`status: 'win'`) was still presented as the active one.
+
+const CLOSED_WON_DEAL: DealSummary = {
+  id: 'deal-won',
+  title: 'Closed through useDealClosure',
+  status: 'win',
+  closureOutcome: 'won',
+  valueAmount: 9000,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-10T10:00:00.000Z',
+}
+
+const CLOSED_LOST_DEAL: DealSummary = {
+  id: 'deal-lost',
+  title: 'Lost through useDealClosure',
+  status: 'loose',
+  valueAmount: 8000,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-11T10:00:00.000Z',
+}
+
+const OPEN_DEAL: DealSummary = {
+  id: 'deal-open',
+  title: 'Still negotiating',
+  status: 'negotiations',
+  valueAmount: 1000,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-12T10:00:00.000Z',
+}
+
+describe('ActiveDealCard — deal status vocabulary (#4667)', () => {
+  beforeEach(() => {
+    readApiResultOrThrowMock.mockReset()
+    readApiResultOrThrowMock.mockResolvedValue({ items: [] })
+  })
+
+  it('skips the bigger win deal and highlights the open one', () => {
+    renderWithProviders(<ActiveDealCard deals={[CLOSED_WON_DEAL, OPEN_DEAL]} />)
+
+    expect(screen.getByText('Still negotiating')).toBeInTheDocument()
+    expect(screen.queryByText('Closed through useDealClosure')).not.toBeInTheDocument()
+  })
+
+  it('renders the empty state when every deal was closed through the UI', () => {
+    renderWithProviders(<ActiveDealCard deals={[CLOSED_WON_DEAL, CLOSED_LOST_DEAL]} />)
+
+    expect(screen.getByText('No active deals')).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/__tests__/CompanyKpiBar.dealStatus.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/CompanyKpiBar.dealStatus.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, within } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { CompanyKpiBar } from '../CompanyKpiBar'
+import type { CompanyOverview, DealSummary } from '../../formConfig'
+
+// Regression for issue #4667: a deal closed through useDealClosure persists
+// `status: 'win'`, but this bar tested for `won` / `lost` / `closed`. Every closed deal
+// therefore stayed in ACTIVE DEALS and the LTV fallback read 0 for a tenant that closes
+// deals entirely through the supported UI. The assertions below read the tile values
+// because KpiCard only renders `comparisonLabel` alongside a trend.
+
+const CLOSED_WON_DEAL: DealSummary = {
+  id: 'deal-won',
+  title: 'Closed through useDealClosure',
+  status: 'win',
+  closureOutcome: 'won',
+  valueAmount: 4000,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-10T10:00:00.000Z',
+}
+
+const CLOSED_LOST_DEAL: DealSummary = {
+  id: 'deal-lost',
+  title: 'Lost through useDealClosure',
+  status: 'loose',
+  closureOutcome: 'lost',
+  valueAmount: 2500,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-11T10:00:00.000Z',
+}
+
+const AI_CLOSED_WON_DEAL: DealSummary = {
+  id: 'deal-ai-won',
+  title: 'Closed through customers.update_deal_stage',
+  status: 'won',
+  valueAmount: 900,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-09T10:00:00.000Z',
+}
+
+const OPEN_DEAL: DealSummary = {
+  id: 'deal-open',
+  title: 'Still negotiating',
+  status: 'negotiations',
+  valueAmount: 1000,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-12T10:00:00.000Z',
+}
+
+const TENANT_STAGE_DEAL: DealSummary = {
+  id: 'deal-tenant-stage',
+  title: 'Awaiting legal sign-off',
+  status: 'awaiting_legal_signoff',
+  valueAmount: 700,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-13T10:00:00.000Z',
+}
+
+function buildOverview(deals: DealSummary[]): CompanyOverview {
+  return {
+    company: { id: 'company-1', displayName: 'Acme Corp' },
+    profile: null,
+    customFields: {},
+    tags: [],
+    comments: [],
+    activities: [],
+    interactions: [],
+    deals,
+    todos: [],
+    people: [],
+  }
+}
+
+function tile(title: string): HTMLElement {
+  const card = screen.getByText(title).closest('div.rounded-lg')
+  if (!card) throw new Error(`[internal] KPI tile "${title}" is not rendered`)
+  return card as HTMLElement
+}
+
+const ACTIVE_DEALS = 'ACTIVE DEALS'
+const LTV = 'CUSTOMER VALUE (LTV)'
+
+describe('CompanyKpiBar — deal status vocabulary (#4667)', () => {
+  it('keeps a win deal out of the active total and counts it as won', () => {
+    renderWithProviders(<CompanyKpiBar data={buildOverview([CLOSED_WON_DEAL, OPEN_DEAL])} />)
+
+    expect(within(tile(ACTIVE_DEALS)).getByText('PLN 1,000')).toBeInTheDocument()
+    expect(within(tile(ACTIVE_DEALS)).getByText('1 pipeline')).toBeInTheDocument()
+    expect(within(tile(LTV)).getByText('PLN 4,000')).toBeInTheDocument()
+  })
+
+  it('also recognises the won spelling the AI stage tool persists', () => {
+    renderWithProviders(<CompanyKpiBar data={buildOverview([AI_CLOSED_WON_DEAL, OPEN_DEAL])} />)
+
+    expect(within(tile(ACTIVE_DEALS)).getByText('PLN 1,000')).toBeInTheDocument()
+    expect(within(tile(LTV)).getByText('PLN 900')).toBeInTheDocument()
+  })
+
+  it('leaves the LTV tile empty while every deal is still open', () => {
+    renderWithProviders(<CompanyKpiBar data={buildOverview([OPEN_DEAL, TENANT_STAGE_DEAL])} />)
+
+    expect(within(tile(ACTIVE_DEALS)).getByText('PLN 1,700')).toBeInTheDocument()
+    expect(within(tile(ACTIVE_DEALS)).getByText('2 pipelines')).toBeInTheDocument()
+    expect(within(tile(LTV)).getByText('--')).toBeInTheDocument()
+  })
+
+  it('reports an empty active total when both deals were closed through the UI', () => {
+    renderWithProviders(<CompanyKpiBar data={buildOverview([CLOSED_WON_DEAL, CLOSED_LOST_DEAL])} />)
+
+    expect(within(tile(ACTIVE_DEALS)).getByText('PLN 0')).toBeInTheDocument()
+    expect(within(tile(LTV)).getByText('PLN 4,000')).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/dashboard/__tests__/helpers.test.ts
+++ b/packages/core/src/modules/customers/components/detail/dashboard/__tests__/helpers.test.ts
@@ -1,0 +1,84 @@
+import { computeDealTrend, getActiveDeals, sumActiveDeals } from '../helpers'
+import type { DealSummary } from '../../../formConfig'
+
+// Regression for issue #4667: the supported closure flows persist `win` / `loose`
+// (useDealClosure, the kanban board) while the AI stage tool persists `won` / `lost`.
+// These helpers used to test only for `won` / `lost` / `closed`, so a deal closed
+// through the UI stayed "active" on the company dashboard.
+
+const CLOSED_WON_DEAL: DealSummary = {
+  id: 'deal-won',
+  title: 'Closed through useDealClosure',
+  status: 'win',
+  closureOutcome: 'won',
+  valueAmount: 4000,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-10T10:00:00.000Z',
+}
+
+const CLOSED_LOST_DEAL: DealSummary = {
+  id: 'deal-lost',
+  title: 'Lost through useDealClosure',
+  status: 'loose',
+  closureOutcome: 'lost',
+  valueAmount: 2500,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-11T10:00:00.000Z',
+}
+
+const AI_CLOSED_WON_DEAL: DealSummary = {
+  id: 'deal-ai-won',
+  title: 'Closed through customers.update_deal_stage',
+  status: 'won',
+  valueAmount: 900,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-09T10:00:00.000Z',
+}
+
+const OPEN_DEAL: DealSummary = {
+  id: 'deal-open',
+  title: 'Still negotiating',
+  status: 'negotiations',
+  valueAmount: 1000,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-12T10:00:00.000Z',
+}
+
+const TENANT_STAGE_DEAL: DealSummary = {
+  id: 'deal-tenant-stage',
+  title: 'Awaiting legal sign-off',
+  status: 'awaiting_legal_signoff',
+  valueAmount: 700,
+  valueCurrency: 'PLN',
+  createdAt: '2026-01-13T10:00:00.000Z',
+}
+
+describe('company dashboard helpers — deal status vocabulary (#4667)', () => {
+  const deals = [CLOSED_WON_DEAL, CLOSED_LOST_DEAL, AI_CLOSED_WON_DEAL, OPEN_DEAL, TENANT_STAGE_DEAL]
+
+  it('excludes every closed spelling from the active list', () => {
+    expect(getActiveDeals(deals).map((deal) => deal.id)).toEqual(['deal-open', 'deal-tenant-stage'])
+  })
+
+  it('sums only the open deals', () => {
+    expect(sumActiveDeals(deals)).toBe(1700)
+  })
+
+  it('keeps a tenant-specific stage open so it is never silently reclassified', () => {
+    expect(getActiveDeals([TENANT_STAGE_DEAL])).toHaveLength(1)
+    expect(sumActiveDeals([TENANT_STAGE_DEAL])).toBe(700)
+  })
+
+  it('keeps a status-less deal open', () => {
+    const withoutStatus: DealSummary = { id: 'deal-no-status', title: 'No status', valueAmount: 100 }
+    expect(getActiveDeals([withoutStatus])).toHaveLength(1)
+  })
+
+  it('reports no deal trend once every deal is closed', () => {
+    expect(computeDealTrend([CLOSED_WON_DEAL, CLOSED_LOST_DEAL, AI_CLOSED_WON_DEAL])).toBeUndefined()
+  })
+
+  it('still reports a trend while an open deal remains', () => {
+    expect(computeDealTrend([CLOSED_WON_DEAL, OPEN_DEAL])).toBeDefined()
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/dashboard/helpers.ts
+++ b/packages/core/src/modules/customers/components/detail/dashboard/helpers.ts
@@ -1,9 +1,10 @@
 import type { KpiTrend } from '@open-mercato/ui/backend/charts/KpiCard'
+import { isOpenDealStatus } from '../../../lib/dealStatus'
 import type { DealSummary, InteractionSummary, TodoLinkSummary } from '../../formConfig'
 
 export function sumActiveDeals(deals: DealSummary[]): number {
   return deals
-    .filter((d) => d.status !== 'won' && d.status !== 'lost' && d.status !== 'closed')
+    .filter((d) => isOpenDealStatus(d.status))
     .reduce((sum, d) => {
       const amount = typeof d.valueAmount === 'number' ? d.valueAmount : parseFloat(String(d.valueAmount ?? '0'))
       return sum + (Number.isFinite(amount) ? amount : 0)
@@ -11,7 +12,7 @@ export function sumActiveDeals(deals: DealSummary[]): number {
 }
 
 export function getActiveDeals(deals: DealSummary[]): DealSummary[] {
-  return deals.filter((d) => d.status !== 'won' && d.status !== 'lost' && d.status !== 'closed')
+  return deals.filter((d) => isOpenDealStatus(d.status))
 }
 
 export function getOpenTasks(todos: TodoLinkSummary[]): TodoLinkSummary[] {
@@ -68,7 +69,7 @@ export function computeActivityTrend(interactions: InteractionSummary[]): KpiTre
 }
 
 export function computeDealTrend(deals: DealSummary[]): KpiTrend | undefined {
-  const active = deals.filter((d) => d.status !== 'won' && d.status !== 'lost' && d.status !== 'closed')
+  const active = deals.filter((d) => isOpenDealStatus(d.status))
   if (active.length === 0) return undefined
   const now = Date.now()
   const monthMs = 30 * 86_400_000

--- a/packages/core/src/modules/customers/lib/__tests__/dealStatus.test.ts
+++ b/packages/core/src/modules/customers/lib/__tests__/dealStatus.test.ts
@@ -1,0 +1,92 @@
+import {
+  CLOSED_DEAL_STATUS_LIST,
+  DEAL_STATUS_CLOSED,
+  DEAL_STATUS_LOSE,
+  DEAL_STATUS_WIN,
+  LOST_DEAL_STATUS_LIST,
+  WON_DEAL_STATUS_LIST,
+  isClosedDealStatus,
+  isLostDealStatus,
+  isOpenDealStatus,
+  isWonDealStatus,
+} from '../dealStatus'
+
+describe('deal status semantics', () => {
+  describe('isClosedDealStatus', () => {
+    it.each(['win', 'won', 'loose', 'lost', 'closed'])('treats %s as closed', (value) => {
+      expect(isClosedDealStatus(value)).toBe(true)
+    })
+
+    it.each(['open', 'lead', 'offering', 'negotiations', 'stalled'])(
+      'treats seeded open status %s as not closed',
+      (value) => {
+        expect(isClosedDealStatus(value)).toBe(false)
+      },
+    )
+
+    it('treats a tenant-specific unknown status as not closed', () => {
+      expect(isClosedDealStatus('awaiting_legal_signoff')).toBe(false)
+    })
+
+    it('treats null/undefined as not closed', () => {
+      expect(isClosedDealStatus(null)).toBe(false)
+      expect(isClosedDealStatus(undefined)).toBe(false)
+    })
+  })
+
+  describe('isOpenDealStatus', () => {
+    it.each(['open', 'negotiations', 'awaiting_legal_signoff'])('treats %s as open', (value) => {
+      expect(isOpenDealStatus(value)).toBe(true)
+    })
+
+    it.each(['win', 'won', 'loose', 'lost', 'closed'])('treats closed status %s as not open', (value) => {
+      expect(isOpenDealStatus(value)).toBe(false)
+    })
+
+    it('treats null/undefined as open, so a status-less deal stays visible', () => {
+      expect(isOpenDealStatus(null)).toBe(true)
+      expect(isOpenDealStatus(undefined)).toBe(true)
+    })
+  })
+
+  describe('isWonDealStatus', () => {
+    it.each(['win', 'won'])('treats %s as won', (value) => {
+      expect(isWonDealStatus(value)).toBe(true)
+    })
+
+    it.each(['loose', 'lost', 'closed', 'open', null, undefined])('treats %s as not won', (value) => {
+      expect(isWonDealStatus(value)).toBe(false)
+    })
+  })
+
+  describe('isLostDealStatus', () => {
+    it.each(['loose', 'lost'])('treats %s as lost', (value) => {
+      expect(isLostDealStatus(value)).toBe(true)
+    })
+
+    it.each(['win', 'won', 'closed', 'open', null, undefined])('treats %s as not lost', (value) => {
+      expect(isLostDealStatus(value)).toBe(false)
+    })
+  })
+
+  it('exposes the canonical status constants persisted by the UI closure flows', () => {
+    expect(DEAL_STATUS_WIN).toBe('win')
+    expect(DEAL_STATUS_LOSE).toBe('loose')
+    expect(DEAL_STATUS_CLOSED).toBe('closed')
+  })
+
+  it('covers both spellings every writer persists', () => {
+    expect([...WON_DEAL_STATUS_LIST].sort()).toEqual(['win', 'won'])
+    expect([...LOST_DEAL_STATUS_LIST].sort()).toEqual(['loose', 'lost'])
+    expect([...CLOSED_DEAL_STATUS_LIST].sort()).toEqual(['closed', 'loose', 'lost', 'win', 'won'])
+  })
+
+  it('keeps won and lost disjoint', () => {
+    for (const value of WON_DEAL_STATUS_LIST) {
+      expect(isLostDealStatus(value)).toBe(false)
+    }
+    for (const value of LOST_DEAL_STATUS_LIST) {
+      expect(isWonDealStatus(value)).toBe(false)
+    }
+  })
+})

--- a/packages/core/src/modules/customers/lib/dealStatus.ts
+++ b/packages/core/src/modules/customers/lib/dealStatus.ts
@@ -1,0 +1,47 @@
+// Single source of truth for deal open/closed (terminal) semantics.
+//
+// `customer_deals.status` is a lenient text column and the supported writers do not agree on
+// one spelling: the closure hooks and the kanban board persist `win` / `loose`, the AI tool
+// `customers.update_deal_stage` persists `won` / `lost`, and the seeded vocabulary also carries
+// `closed`. The terminal set below therefore covers every spelling a writer persists, so a deal
+// closed through any supported path is reported the same way by every read-side surface.
+//
+// A status not known to code counts as OPEN. Deal stages are configurable per tenant, so the
+// lenient column can hold values this module has never seen — treating them as open keeps them
+// visible in active-deal counts instead of silently reclassifying them as closed.
+
+export const DEAL_STATUS_WIN = 'win' as const
+export const DEAL_STATUS_LOSE = 'loose' as const
+export const DEAL_STATUS_CLOSED = 'closed' as const
+
+// `won` / `lost` are the spellings the AI stage tool writes; `win` / `loose` are what the UI
+// closure flows persist. Both are accepted so neither writer produces an unreadable status.
+export const WON_DEAL_STATUS_LIST: readonly string[] = [DEAL_STATUS_WIN, 'won']
+
+export const LOST_DEAL_STATUS_LIST: readonly string[] = [DEAL_STATUS_LOSE, 'lost']
+
+export const CLOSED_DEAL_STATUS_LIST: readonly string[] = [
+  ...WON_DEAL_STATUS_LIST,
+  ...LOST_DEAL_STATUS_LIST,
+  DEAL_STATUS_CLOSED,
+]
+
+const WON_DEAL_STATUSES = new Set<string>(WON_DEAL_STATUS_LIST)
+const LOST_DEAL_STATUSES = new Set<string>(LOST_DEAL_STATUS_LIST)
+const CLOSED_DEAL_STATUSES = new Set<string>(CLOSED_DEAL_STATUS_LIST)
+
+export function isWonDealStatus(value: string | null | undefined): boolean {
+  return value != null && WON_DEAL_STATUSES.has(value)
+}
+
+export function isLostDealStatus(value: string | null | undefined): boolean {
+  return value != null && LOST_DEAL_STATUSES.has(value)
+}
+
+export function isClosedDealStatus(value: string | null | undefined): boolean {
+  return value != null && CLOSED_DEAL_STATUSES.has(value)
+}
+
+export function isOpenDealStatus(value: string | null | undefined): boolean {
+  return !isClosedDealStatus(value)
+}

--- a/packages/core/src/modules/customers/lib/dealStatus.ts
+++ b/packages/core/src/modules/customers/lib/dealStatus.ts
@@ -3,8 +3,9 @@
 // `customer_deals.status` is a lenient text column and the supported writers do not agree on
 // one spelling: the closure hooks and the kanban board persist `win` / `loose`, the AI tool
 // `customers.update_deal_stage` persists `won` / `lost`, and the seeded vocabulary also carries
-// `closed`. The terminal set below therefore covers every spelling a writer persists, so a deal
-// closed through any supported path is reported the same way by every read-side surface.
+// `closed`. The terminal set below therefore covers every spelling a status writer persists, so
+// status-based readers can share one classification. `closureOutcome` is a separate signal and
+// callers that combine both columns must handle it explicitly.
 //
 // A status not known to code counts as OPEN. Deal stages are configurable per tenant, so the
 // lenient column can hold values this module has never seen — treating them as open keeps them


### PR DESCRIPTION
Supersedes #4689.

Credit: the original implementation is by @wojciechszyjka. This replacement carries that work forward with the requested review fix while preserving the original scope.

## Included

- Carries forward the centralized status-only deal vocabulary from #4689.
- Adds route-level regression coverage for enriched company deal filtering and customer lifetime value.
- Clarifies that `closureOutcome` is handled separately from the legacy `status` vocabulary.
- Keeps unrelated app/template drift out of scope, as explicitly requested.

## Validation

Runner: local fallback for the carry-forward commit; GitHub checks remain authoritative.

- `yarn build:packages`
- `yarn generate`
- `yarn workspace @open-mercato/core typecheck`
- Six focused Jest suites: 57 tests passed
- `yarn lint` (0 errors; 12 pre-existing warnings)
- Focused ESLint and `git diff --check`
