### PR TITLE
fix(shared): honor app tsconfig in dynamic loader builds

### DIFF
--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts
@@ -78,16 +78,23 @@ function writeGeneratedModule(generatedDir: string, baseName: string, source: { 
 function writeCompiledSibling(generatedDir: string, baseName: string, compiled: string) {
   const source = fs.readFileSync(path.join(generatedDir, `${baseName}.ts`), 'utf8')
   const inputHash = hash(JSON.stringify({
-    version: 2,
+    version: 3,
     sourceHash: hash(source),
     tsconfigHash: hash(APP_TSCONFIG),
   }))
+  const sourceRelativePath = path.relative(
+    path.dirname(path.dirname(generatedDir)),
+    path.join(generatedDir, `${baseName}.ts`),
+  ).split(path.sep).join('/')
   const compiledPath = path.join(generatedDir, `${baseName}.mjs`)
   fs.writeFileSync(compiledPath, compiled)
   fs.writeFileSync(`${compiledPath}.cache.json`, JSON.stringify({
-    version: 2,
+    version: 3,
     inputHash,
     outputHash: hash(compiled),
+    dependencies: {
+      [sourceRelativePath]: hash(source),
+    },
   }))
   compiledCacheGeneration += 1
   const fresh = new Date(Date.now() + compiledCacheGeneration * 60_000)

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts
@@ -17,6 +17,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import crypto from 'node:crypto'
 import { loadBootstrapData } from '../dynamicLoader'
 import {
   ensureMikroOrmV7GeneratedCacheCompatibility,
@@ -50,6 +51,18 @@ const BASE_GENERATED_MODULES: Record<string, { ts: string; compiled: string }> =
 }
 
 let compiledCacheGeneration = 0
+const APP_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+    useDefineForClassFields: false,
+    target: 'ES2022',
+  },
+})
+
+function hash(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex')
+}
 
 function writeGeneratedModule(generatedDir: string, baseName: string, source: { ts: string; compiled: string }) {
   fs.writeFileSync(path.join(generatedDir, `${baseName}.ts`), source.ts)
@@ -63,8 +76,19 @@ function writeGeneratedModule(generatedDir: string, baseName: string, source: { 
  * URL instead of the rejected module's cached one.
  */
 function writeCompiledSibling(generatedDir: string, baseName: string, compiled: string) {
+  const source = fs.readFileSync(path.join(generatedDir, `${baseName}.ts`), 'utf8')
+  const inputHash = hash(JSON.stringify({
+    version: 2,
+    sourceHash: hash(source),
+    tsconfigHash: hash(APP_TSCONFIG),
+  }))
   const compiledPath = path.join(generatedDir, `${baseName}.mjs`)
   fs.writeFileSync(compiledPath, compiled)
+  fs.writeFileSync(`${compiledPath}.cache.json`, JSON.stringify({
+    version: 2,
+    inputHash,
+    outputHash: hash(compiled),
+  }))
   compiledCacheGeneration += 1
   const fresh = new Date(Date.now() + compiledCacheGeneration * 60_000)
   fs.utimesSync(compiledPath, fresh, fresh)
@@ -74,6 +98,7 @@ function createAppRoot(entityIdsCache: string): string {
   const appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-bootstrap-4526-'))
   const generatedDir = path.join(appRoot, '.mercato', 'generated')
   fs.mkdirSync(generatedDir, { recursive: true })
+  fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), APP_TSCONFIG)
   for (const [baseName, source] of Object.entries(BASE_GENERATED_MODULES)) {
     writeGeneratedModule(generatedDir, baseName, source)
   }

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.commandInterceptors.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.commandInterceptors.test.ts
@@ -49,16 +49,23 @@ function hash(content: string): string {
 function writeGeneratedModule(generatedDir: string, baseName: string, source: { ts: string; compiled: string }) {
   const sourcePath = path.join(generatedDir, `${baseName}.ts`)
   const compiledPath = path.join(generatedDir, `${baseName}.mjs`)
+  const sourceRelativePath = path.relative(
+    path.dirname(path.dirname(generatedDir)),
+    sourcePath,
+  ).split(path.sep).join('/')
   fs.writeFileSync(sourcePath, source.ts)
   fs.writeFileSync(compiledPath, source.compiled)
   fs.writeFileSync(`${compiledPath}.cache.json`, JSON.stringify({
-    version: 2,
+    version: 3,
     inputHash: hash(JSON.stringify({
-      version: 2,
+      version: 3,
       sourceHash: hash(source.ts),
       tsconfigHash: hash(APP_TSCONFIG),
     })),
     outputHash: hash(source.compiled),
+    dependencies: {
+      [sourceRelativePath]: hash(source.ts),
+    },
   }))
 }
 

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.commandInterceptors.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.commandInterceptors.test.ts
@@ -17,6 +17,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import crypto from 'node:crypto'
 import { loadBootstrapData } from '../dynamicLoader'
 
 const GENERATED_MODULES: Record<string, { ts: string; compiled: string }> = {
@@ -32,11 +33,33 @@ const GENERATED_MODULES: Record<string, { ts: string; compiled: string }> = {
   },
 }
 
+const APP_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+    useDefineForClassFields: false,
+    target: 'ES2022',
+  },
+})
+
+function hash(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex')
+}
+
 function writeGeneratedModule(generatedDir: string, baseName: string, source: { ts: string; compiled: string }) {
-  fs.writeFileSync(path.join(generatedDir, `${baseName}.ts`), source.ts)
-  fs.writeFileSync(path.join(generatedDir, `${baseName}.mjs`), source.compiled)
-  const fresh = new Date(Date.now() + 60_000)
-  fs.utimesSync(path.join(generatedDir, `${baseName}.mjs`), fresh, fresh)
+  const sourcePath = path.join(generatedDir, `${baseName}.ts`)
+  const compiledPath = path.join(generatedDir, `${baseName}.mjs`)
+  fs.writeFileSync(sourcePath, source.ts)
+  fs.writeFileSync(compiledPath, source.compiled)
+  fs.writeFileSync(`${compiledPath}.cache.json`, JSON.stringify({
+    version: 2,
+    inputHash: hash(JSON.stringify({
+      version: 2,
+      sourceHash: hash(source.ts),
+      tsconfigHash: hash(APP_TSCONFIG),
+    })),
+    outputHash: hash(source.compiled),
+  }))
 }
 
 describe('loadBootstrapData — command interceptors reach worker/CLI bootstrap (#4327)', () => {
@@ -46,6 +69,7 @@ describe('loadBootstrapData — command interceptors reach worker/CLI bootstrap 
     appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-bootstrap-4327-'))
     const generatedDir = path.join(appRoot, '.mercato', 'generated')
     fs.mkdirSync(generatedDir, { recursive: true })
+    fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), APP_TSCONFIG)
     for (const [baseName, source] of Object.entries(GENERATED_MODULES)) {
       writeGeneratedModule(generatedDir, baseName, source)
     }

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.tsconfig.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.tsconfig.test.ts
@@ -39,6 +39,8 @@ function writeFixture(): string {
 
     @Entity()
     export class ProbeEntity {
+      static revision = 1
+
       @PrimaryKey()
       id!: string
     }
@@ -53,6 +55,7 @@ function readCacheMetadata(appRoot: string, baseName: string): {
   version: number
   inputHash: string
   outputHash: string
+  dependencies: Record<string, string>
 } {
   return JSON.parse(
     fs.readFileSync(
@@ -62,13 +65,17 @@ function readCacheMetadata(appRoot: string, baseName: string): {
   )
 }
 
-function loadBootstrapDataInNode(appRoot: string): { entityNames: string[] } {
+function loadBootstrapDataInNode(appRoot: string): {
+  entityNames: string[]
+  entityRevisions: number[]
+} {
   const loaderUrl = pathToFileURL(path.resolve(__dirname, '../dynamicLoader.ts')).href
   const script = `
     import { loadBootstrapData } from ${JSON.stringify(loaderUrl)}
     const data = await loadBootstrapData(process.argv[1])
     process.stdout.write(JSON.stringify({
       entityNames: data.entities.map((entity) => entity.name),
+      entityRevisions: data.entities.map((entity) => entity.revision),
     }))
   `
   return JSON.parse(execFileSync(
@@ -122,7 +129,7 @@ describe('dynamic loader app tsconfig and content-addressed cache', () => {
     loadBootstrapDataInNode(appRoot)
     const after = readCacheMetadata(appRoot, 'entities')
 
-    expect(after.version).toBe(2)
+    expect(after.version).toBe(3)
     expect(after.inputHash).not.toBe(before.inputHash)
   })
 
@@ -142,6 +149,35 @@ describe('dynamic loader app tsconfig and content-addressed cache', () => {
     const after = readCacheMetadata(appRoot, 'entities')
 
     expect(after.inputHash).not.toBe(before.inputHash)
+  })
+
+  it('invalidates compiled output when only a bundled local dependency changes', async () => {
+    const appRoot = createAppRoot()
+    const generatedSourcePath = path.join(
+      appRoot,
+      '.mercato',
+      'generated',
+      'entities.generated.ts',
+    )
+    const generatedSource = fs.readFileSync(generatedSourcePath, 'utf8')
+    const first = loadBootstrapDataInNode(appRoot)
+    const before = readCacheMetadata(appRoot, 'entities')
+    const entityPath = path.join(appRoot, 'src', 'modules', 'probe', 'data', 'entities.ts')
+
+    fs.writeFileSync(
+      entityPath,
+      fs.readFileSync(entityPath, 'utf8').replace('static revision = 1', 'static revision = 2'),
+    )
+    const second = loadBootstrapDataInNode(appRoot)
+    const after = readCacheMetadata(appRoot, 'entities')
+
+    expect(first.entityRevisions).toEqual([1])
+    expect(second.entityRevisions).toEqual([2])
+    expect(after.outputHash).not.toBe(before.outputHash)
+    expect(after.dependencies['src/modules/probe/data/entities.ts']).not.toBe(
+      before.dependencies['src/modules/probe/data/entities.ts'],
+    )
+    expect(fs.readFileSync(generatedSourcePath, 'utf8')).toBe(generatedSource)
   })
 
   it('rebuilds a compiled file whose bytes do not match its sidecar', async () => {
@@ -166,10 +202,10 @@ describe('dynamic loader app tsconfig and content-addressed cache', () => {
       'entities.generated.mjs.cache.json',
     )
     const stale = readCacheMetadata(appRoot, 'entities')
-    fs.writeFileSync(metadataPath, JSON.stringify({ ...stale, version: 1 }))
+    fs.writeFileSync(metadataPath, JSON.stringify({ ...stale, version: 2 }))
 
     loadBootstrapDataInNode(appRoot)
 
-    expect(readCacheMetadata(appRoot, 'entities').version).toBe(2)
+    expect(readCacheMetadata(appRoot, 'entities').version).toBe(3)
   })
 })

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.tsconfig.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.tsconfig.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const LEGACY_TSCONFIG = {
+  compilerOptions: {
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+    useDefineForClassFields: false,
+    target: 'ES2022',
+    module: 'ESNext',
+    moduleResolution: 'Bundler',
+  },
+}
+
+const GENERATED_MODULES: Record<string, string> = {
+  'entities.ids.generated': 'export const E = {}',
+  'modules.cli.generated': 'export const modules = []',
+  'di.generated': 'export const diRegistrars = []',
+  'entities.generated': `
+    import { ProbeEntity } from '@/src/modules/probe/data/entities'
+    export const entities = [ProbeEntity]
+  `,
+}
+
+function writeFixture(): string {
+  const appRoot = fs.mkdtempSync(path.join(process.cwd(), '.tmp-dynamic-loader-'))
+  const generatedDir = path.join(appRoot, '.mercato', 'generated')
+  const entityDir = path.join(appRoot, 'src', 'modules', 'probe', 'data')
+  fs.mkdirSync(generatedDir, { recursive: true })
+  fs.mkdirSync(entityDir, { recursive: true })
+  fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), JSON.stringify(LEGACY_TSCONFIG))
+  fs.writeFileSync(path.join(entityDir, 'entities.ts'), `
+    import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy'
+
+    @Entity()
+    export class ProbeEntity {
+      @PrimaryKey()
+      id!: string
+    }
+  `)
+  for (const [baseName, source] of Object.entries(GENERATED_MODULES)) {
+    fs.writeFileSync(path.join(generatedDir, `${baseName}.ts`), source)
+  }
+  return appRoot
+}
+
+function readCacheMetadata(appRoot: string, baseName: string): {
+  version: number
+  inputHash: string
+  outputHash: string
+} {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(appRoot, '.mercato', 'generated', `${baseName}.generated.mjs.cache.json`),
+      'utf8',
+    ),
+  )
+}
+
+function loadBootstrapDataInNode(appRoot: string): { entityNames: string[] } {
+  const loaderUrl = pathToFileURL(path.resolve(__dirname, '../dynamicLoader.ts')).href
+  const script = `
+    import { loadBootstrapData } from ${JSON.stringify(loaderUrl)}
+    const data = await loadBootstrapData(process.argv[1])
+    process.stdout.write(JSON.stringify({
+      entityNames: data.entities.map((entity) => entity.name),
+    }))
+  `
+  return JSON.parse(execFileSync(
+    process.execPath,
+    ['--import', 'tsx', '--input-type=module', '-e', script, appRoot],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  ))
+}
+
+describe('dynamic loader app tsconfig and content-addressed cache', () => {
+  const appRoots: string[] = []
+
+  afterAll(() => {
+    for (const appRoot of appRoots) {
+      fs.rmSync(appRoot, { recursive: true, force: true })
+    }
+  })
+
+  function createAppRoot(): string {
+    const appRoot = writeFixture()
+    appRoots.push(appRoot)
+    return appRoot
+  }
+
+  it('imports a real MikroORM legacy-decorated local entity', async () => {
+    const appRoot = createAppRoot()
+
+    const data = loadBootstrapDataInNode(appRoot)
+
+    expect(data.entityNames).toEqual(['ProbeEntity'])
+    const compiled = fs.readFileSync(
+      path.join(appRoot, '.mercato', 'generated', 'entities.generated.mjs'),
+      'utf8',
+    )
+    expect(compiled).toContain('__decorateClass')
+    expect(compiled).not.toContain('__decorateElement')
+  })
+
+  it('invalidates compiled output when only app tsconfig content changes', async () => {
+    const appRoot = createAppRoot()
+    loadBootstrapDataInNode(appRoot)
+    const before = readCacheMetadata(appRoot, 'entities')
+
+    fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), JSON.stringify({
+      ...LEGACY_TSCONFIG,
+      compilerOptions: {
+        ...LEGACY_TSCONFIG.compilerOptions,
+        useDefineForClassFields: true,
+      },
+    }))
+    loadBootstrapDataInNode(appRoot)
+    const after = readCacheMetadata(appRoot, 'entities')
+
+    expect(after.version).toBe(2)
+    expect(after.inputHash).not.toBe(before.inputHash)
+  })
+
+  it('invalidates compiled output when generated source content changes', async () => {
+    const appRoot = createAppRoot()
+    loadBootstrapDataInNode(appRoot)
+    const before = readCacheMetadata(appRoot, 'entities')
+    const sourcePath = path.join(
+      appRoot,
+      '.mercato',
+      'generated',
+      'entities.generated.ts',
+    )
+
+    fs.appendFileSync(sourcePath, '\nexport const sourceRevision = 2\n')
+    loadBootstrapDataInNode(appRoot)
+    const after = readCacheMetadata(appRoot, 'entities')
+
+    expect(after.inputHash).not.toBe(before.inputHash)
+  })
+
+  it('rebuilds a compiled file whose bytes do not match its sidecar', async () => {
+    const appRoot = createAppRoot()
+    loadBootstrapDataInNode(appRoot)
+    const compiledPath = path.join(appRoot, '.mercato', 'generated', 'entities.generated.mjs')
+    fs.writeFileSync(compiledPath, 'this is not valid JavaScript')
+
+    const data = loadBootstrapDataInNode(appRoot)
+
+    expect(data.entityNames).toEqual(['ProbeEntity'])
+    expect(fs.readFileSync(compiledPath, 'utf8')).toContain('__decorateClass')
+  })
+
+  it('rebuilds a cache sidecar from an older loader format version', async () => {
+    const appRoot = createAppRoot()
+    loadBootstrapDataInNode(appRoot)
+    const metadataPath = path.join(
+      appRoot,
+      '.mercato',
+      'generated',
+      'entities.generated.mjs.cache.json',
+    )
+    const stale = readCacheMetadata(appRoot, 'entities')
+    fs.writeFileSync(metadataPath, JSON.stringify({ ...stale, version: 1 }))
+
+    loadBootstrapDataInNode(appRoot)
+
+    expect(readCacheMetadata(appRoot, 'entities').version).toBe(2)
+  })
+})

--- a/packages/shared/src/lib/bootstrap/dynamicLoader.ts
+++ b/packages/shared/src/lib/bootstrap/dynamicLoader.ts
@@ -10,12 +10,13 @@ import fs from 'node:fs'
 import crypto from 'node:crypto'
 import { pathToFileURL } from 'node:url'
 
-const DYNAMIC_LOADER_CACHE_VERSION = 2
+const DYNAMIC_LOADER_CACHE_VERSION = 3
 
 type DynamicLoaderCacheMetadata = {
   version: number
   inputHash: string
   outputHash: string
+  dependencies: Record<string, string>
 }
 
 function cacheMetadataPath(jsPath: string): string {
@@ -36,6 +37,31 @@ function cacheInputHash(tsPath: string, appTsconfig: string): string {
   return hash.digest('hex')
 }
 
+function dependenciesAreValid(appRoot: string, dependencies: Record<string, string>): boolean {
+  return Object.entries(dependencies).every(([relativePath, expectedHash]) => {
+    const dependencyPath = path.resolve(appRoot, relativePath)
+    return fs.existsSync(dependencyPath)
+      && contentHash(fs.readFileSync(dependencyPath)) === expectedHash
+  })
+}
+
+function collectDependencyHashes(
+  appRoot: string,
+  inputs: Record<string, unknown>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.keys(inputs)
+      .map((inputPath) => {
+        const absolutePath = path.isAbsolute(inputPath)
+          ? inputPath
+          : path.resolve(appRoot, inputPath)
+        const relativePath = path.relative(appRoot, absolutePath).split(path.sep).join('/')
+        return [relativePath, contentHash(fs.readFileSync(absolutePath))]
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  )
+}
+
 function readCacheMetadata(metadataPath: string): DynamicLoaderCacheMetadata | null {
   try {
     const parsed: unknown = JSON.parse(fs.readFileSync(metadataPath, 'utf8'))
@@ -48,11 +74,16 @@ function readCacheMetadata(metadataPath: string): DynamicLoaderCacheMetadata | n
       && typeof parsed.inputHash === 'string'
       && 'outputHash' in parsed
       && typeof parsed.outputHash === 'string'
+      && 'dependencies' in parsed
+      && typeof parsed.dependencies === 'object'
+      && parsed.dependencies !== null
+      && Object.values(parsed.dependencies).every((hash) => typeof hash === 'string')
     ) {
       return {
         version: parsed.version,
         inputHash: parsed.inputHash,
         outputHash: parsed.outputHash,
+        dependencies: parsed.dependencies as Record<string, string>,
       }
     }
   } catch {}
@@ -60,6 +91,7 @@ function readCacheMetadata(metadataPath: string): DynamicLoaderCacheMetadata | n
 }
 
 function cacheIsValid(
+  appRoot: string,
   jsPath: string,
   metadataPath: string,
   expectedInputHash: string,
@@ -68,6 +100,7 @@ function cacheIsValid(
   const metadata = readCacheMetadata(metadataPath)
   if (!metadata || metadata.inputHash !== expectedInputHash) return false
   return contentHash(fs.readFileSync(jsPath)) === metadata.outputHash
+    && dependenciesAreValid(appRoot, metadata.dependencies)
 }
 
 /**
@@ -92,7 +125,7 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
   }
 
   const expectedInputHash = cacheInputHash(tsPath, appTsconfig)
-  const needsCompile = !cacheIsValid(jsPath, metadataPath, expectedInputHash)
+  const needsCompile = !cacheIsValid(appRoot, jsPath, metadataPath, expectedInputHash)
 
   if (needsCompile) {
     // Dynamically import esbuild only when needed
@@ -140,10 +173,12 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
     }
 
     // Use esbuild.build with bundling to handle JSON imports
-    await esbuild.build({
+    const result = await esbuild.build({
       entryPoints: [tsPath],
       outfile: jsPath,
+      absWorkingDir: appRoot,
       bundle: true,
+      metafile: true,
       format: 'esm',
       platform: 'node',
       target: 'node18',
@@ -156,6 +191,7 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
       version: DYNAMIC_LOADER_CACHE_VERSION,
       inputHash: expectedInputHash,
       outputHash: contentHash(fs.readFileSync(jsPath)),
+      dependencies: collectDependencyHashes(appRoot, result.metafile.inputs),
     }
     fs.writeFileSync(metadataPath, JSON.stringify(metadata))
   }

--- a/packages/shared/src/lib/bootstrap/dynamicLoader.ts
+++ b/packages/shared/src/lib/bootstrap/dynamicLoader.ts
@@ -7,7 +7,68 @@ import {
 } from './generatedCacheRecovery'
 import path from 'node:path'
 import fs from 'node:fs'
+import crypto from 'node:crypto'
 import { pathToFileURL } from 'node:url'
+
+const DYNAMIC_LOADER_CACHE_VERSION = 2
+
+type DynamicLoaderCacheMetadata = {
+  version: number
+  inputHash: string
+  outputHash: string
+}
+
+function cacheMetadataPath(jsPath: string): string {
+  return `${jsPath}.cache.json`
+}
+
+function contentHash(content: Buffer | string): string {
+  return crypto.createHash('sha256').update(content).digest('hex')
+}
+
+function cacheInputHash(tsPath: string, appTsconfig: string): string {
+  const hash = crypto.createHash('sha256')
+  hash.update(JSON.stringify({
+    version: DYNAMIC_LOADER_CACHE_VERSION,
+    sourceHash: contentHash(fs.readFileSync(tsPath)),
+    tsconfigHash: contentHash(fs.readFileSync(appTsconfig)),
+  }))
+  return hash.digest('hex')
+}
+
+function readCacheMetadata(metadataPath: string): DynamicLoaderCacheMetadata | null {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(metadataPath, 'utf8'))
+    if (
+      typeof parsed === 'object'
+      && parsed !== null
+      && 'version' in parsed
+      && parsed.version === DYNAMIC_LOADER_CACHE_VERSION
+      && 'inputHash' in parsed
+      && typeof parsed.inputHash === 'string'
+      && 'outputHash' in parsed
+      && typeof parsed.outputHash === 'string'
+    ) {
+      return {
+        version: parsed.version,
+        inputHash: parsed.inputHash,
+        outputHash: parsed.outputHash,
+      }
+    }
+  } catch {}
+  return null
+}
+
+function cacheIsValid(
+  jsPath: string,
+  metadataPath: string,
+  expectedInputHash: string,
+): boolean {
+  if (!fs.existsSync(jsPath)) return false
+  const metadata = readCacheMetadata(metadataPath)
+  if (!metadata || metadata.inputHash !== expectedInputHash) return false
+  return contentHash(fs.readFileSync(jsPath)) === metadata.outputHash
+}
 
 /**
  * Compile a TypeScript file to JavaScript using esbuild bundler.
@@ -17,17 +78,21 @@ import { pathToFileURL } from 'node:url'
 async function compileAndImport(tsPath: string, allowRecovery: boolean = true): Promise<Record<string, unknown>> {
   const jsPath = tsPath.replace(/\.ts$/, '.mjs')
   const appRoot = path.dirname(path.dirname(path.dirname(tsPath)))
+  const appTsconfig = path.join(appRoot, 'tsconfig.json')
+  const metadataPath = cacheMetadataPath(jsPath)
 
-  // Check if we need to recompile (source newer than compiled)
   const tsExists = fs.existsSync(tsPath)
-  const jsExists = fs.existsSync(jsPath)
+  const tsconfigExists = fs.existsSync(appTsconfig)
 
   if (!tsExists) {
     throw new Error(`Generated file not found: ${tsPath}`)
   }
+  if (!tsconfigExists) {
+    throw new Error(`App TypeScript config not found: ${appTsconfig}`)
+  }
 
-  const needsCompile = !jsExists ||
-    fs.statSync(tsPath).mtimeMs > fs.statSync(jsPath).mtimeMs
+  const expectedInputHash = cacheInputHash(tsPath, appTsconfig)
+  const needsCompile = !cacheIsValid(jsPath, metadataPath, expectedInputHash)
 
   if (needsCompile) {
     // Dynamically import esbuild only when needed
@@ -82,15 +147,23 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
       format: 'esm',
       platform: 'node',
       target: 'node18',
+      tsconfig: appTsconfig,
       plugins: [aliasPlugin, externalNonJsonPlugin],
       // Allow JSON imports
       loader: { '.json': 'json' },
     })
+    const metadata: DynamicLoaderCacheMetadata = {
+      version: DYNAMIC_LOADER_CACHE_VERSION,
+      inputHash: expectedInputHash,
+      outputHash: contentHash(fs.readFileSync(jsPath)),
+    }
+    fs.writeFileSync(metadataPath, JSON.stringify(metadata))
   }
 
   // Import the compiled JavaScript
   try {
-    const fileUrl = `${pathToFileURL(jsPath).href}?mtime=${fs.statSync(jsPath).mtimeMs}`
+    const outputHash = contentHash(fs.readFileSync(jsPath))
+    const fileUrl = `${pathToFileURL(jsPath).href}?cache=${outputHash}`
     return await import(fileUrl)
   } catch (error) {
     if (!allowRecovery) {


### PR DESCRIPTION
## Summary
- compile generated bootstrap modules with the consuming application tsconfig
- replace mtime-only reuse with a versioned content-addressed cache sidecar covering generated source, app tsconfig, and loader format
- fingerprint every bundled esbuild input so local dependency changes invalidate cached bootstrap output
- verify cached output bytes before import and rebuild corrupt or stale cache entries
- add runtime regression coverage using a real MikroORM legacy-decorated entity

## Root cause
The dynamic loader bundled generated application modules without the app tsconfig. esbuild therefore emitted Stage 3 decorator semantics for MikroORM legacy decorators, causing PrimaryKey to receive an invalid class target during queue CLI bootstrap.

## Validation
- focused dynamic loader suites: 3 passed, 11 tests passed
- full shared suite: 141 passed, 1519 tests passed
- shared build: passed
- shared typecheck: passed
- git diff --check: passed

## Scope
Only packages/shared dynamic loader implementation and its tests are changed. No application override, generated cache patch, dependency override, or database mutation is included.