### PR TITLE
fix(workflows): declutter definitions list + open step inspector as a wide drawer

### DIFF
--- a/packages/core/src/modules/workflows/backend/definitions/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/page.tsx
@@ -7,6 +7,7 @@ import { DataTable } from '@open-mercato/ui/backend/DataTable'
 import type { ColumnDef } from '@tanstack/react-table'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Badge } from '@open-mercato/ui/primitives/badge'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@open-mercato/ui/primitives/tooltip'
 import { RowActions } from '@open-mercato/ui/backend/RowActions'
 import { ErrorMessage } from '@open-mercato/ui/backend/detail'
 import { ConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
@@ -278,42 +279,54 @@ export default function WorkflowDefinitionsListPage() {
 
   const columns: ColumnDef<WorkflowDefinition>[] = [
     {
-      id: 'workflowId',
-      header: t('workflows.fields.workflowId'),
-      accessorKey: 'workflowId',
-      meta: { truncate: false },
-      cell: ({ row }) => (
-        <span className="font-mono text-sm">{row.original.workflowId}</span>
-      ),
-    },
-    {
       id: 'workflowName',
       header: t('workflows.fields.workflowName'),
       accessorKey: 'workflowName',
       meta: { truncate: false },
-      cell: ({ row }) => (
-        <div>
-          <div className="flex items-center gap-2">
-            <span className="font-medium">{row.original.workflowName}</span>
-            {row.original.source === 'code' && (
-              <Badge variant="secondary">{t('workflows.source.code')}</Badge>
-            )}
-            {row.original.source === 'code_override' && (
-              <Badge variant="outline">{t('workflows.source.code_override')}</Badge>
+      // The Workflow ID column and the inline description were dropped — the row
+      // was three lines tall. Both now live in a hover tooltip on the name.
+      cell: ({ row }) => {
+        const nameBlock = (
+          <div className="cursor-default">
+            <div className="flex items-center gap-2">
+              <span className="font-medium">{row.original.workflowName}</span>
+              {row.original.source === 'code' && (
+                <Badge variant="secondary">{t('workflows.source.code')}</Badge>
+              )}
+              {row.original.source === 'code_override' && (
+                <Badge variant="outline">{t('workflows.source.code_override')}</Badge>
+              )}
+            </div>
+            {row.original.metadata?.category && (
+              <div className="text-xs text-muted-foreground mt-0.5">
+                {row.original.metadata.category}
+              </div>
             )}
           </div>
-          {row.original.description && (
-            <div className="text-xs text-muted-foreground">
-              {row.original.description}
-            </div>
-          )}
-          {row.original.metadata?.category && (
-            <div className="text-xs text-muted-foreground mt-0.5">
-              {row.original.metadata.category}
-            </div>
-          )}
-        </div>
-      ),
+        )
+        if (!row.original.workflowId && !row.original.description) return nameBlock
+        return (
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>{nameBlock}</TooltipTrigger>
+              <TooltipContent
+                side="right"
+                align="start"
+                variant="light"
+                size="lg"
+                className="max-w-md space-y-1"
+              >
+                <div className="font-mono text-xs">{row.original.workflowId}</div>
+                {row.original.description ? (
+                  <p className="text-xs text-muted-foreground whitespace-pre-wrap">
+                    {row.original.description}
+                  </p>
+                ) : null}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )
+      },
     },
     {
       id: 'version',

--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/__tests__/dockedInspector.test.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/__tests__/dockedInspector.test.tsx
@@ -115,17 +115,18 @@ describe('visual editor — docked inspector', () => {
     window.localStorage.clear()
   })
 
-  test('a wide viewport renders the step inspector inside the canvas row', () => {
+  test('a wide viewport opens the step inspector as a wide overlay drawer', () => {
     stubViewport(1600)
     renderWithProviders(<VisualEditorPage />)
     addStep()
 
     openStepInspector()
 
+    // The dense step form always uses the wide overlay Drawer (mirroring the
+    // definition metadata drawer), not the 384px docked rail — the rail is kept
+    // for the lighter route inspector only.
     const panel = screen.getByTestId('node-inspector')
-    expect(panel).toHaveAttribute('data-variant', 'docked')
-    // Sibling of the canvas, not a portal over it.
-    expect(screen.getByTestId('workflow-editor-row').contains(panel)).toBe(true)
+    expect(panel).toHaveAttribute('data-variant', 'overlay')
     expect(screen.getByTestId('canvas')).toBeInTheDocument()
   })
 

--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
@@ -2851,7 +2851,11 @@ export default function VisualEditorPage() {
   const inspectorPanels = (
     <>
       {crudFormDialogsEnabled ? (
-        <NodeEditDialogCrudForm node={selectedNode} isOpen={showNodeDialog} onClose={() => setShowNodeDialog(false)} onSave={handleSaveNode} onDelete={handleDeleteNode} ledgerEntries={nodeDialogLedgerEntries} definitionId={definitionId} samples={editorSamples} onPinSample={handlePinSample} onUnpinSample={handleUnpinSample} branchingRoutes={branchingRoutesValue} onSaveBranchingRoutes={handleSaveBranchingRoutes} routeOrder={routeOrderValue} onSaveRouteOrder={handleSaveRouteOrder} onConvertType={handleConvertNodeType} variant={inspectorVariant} />
+        // The step form is dense (Invoke-Agent, timeout, sub-editors) and the 384px
+        // docked rail made it unusable, so it always opens as the wide overlay
+        // Drawer that mirrors the definition metadata drawer. The route inspector
+        // stays on the docked rail (`inspectorVariant`) — its config is light.
+        <NodeEditDialogCrudForm node={selectedNode} isOpen={showNodeDialog} onClose={() => setShowNodeDialog(false)} onSave={handleSaveNode} onDelete={handleDeleteNode} ledgerEntries={nodeDialogLedgerEntries} definitionId={definitionId} samples={editorSamples} onPinSample={handlePinSample} onUnpinSample={handleUnpinSample} branchingRoutes={branchingRoutesValue} onSaveBranchingRoutes={handleSaveBranchingRoutes} routeOrder={routeOrderValue} onSaveRouteOrder={handleSaveRouteOrder} onConvertType={handleConvertNodeType} variant="overlay" wide />
       ) : (
         <NodeEditDialog node={selectedNode} isOpen={showNodeDialog} onClose={() => setShowNodeDialog(false)} onSave={handleSaveNode} onDelete={handleDeleteNode} />
       )}

--- a/packages/core/src/modules/workflows/components/InspectorPanel.tsx
+++ b/packages/core/src/modules/workflows/components/InspectorPanel.tsx
@@ -50,6 +50,13 @@ export interface InspectorPanelProps {
    * belongs beside the id rather than inside the scrolling form.
    */
   headerExtra?: React.ReactNode
+  /**
+   * Widen the `overlay` Drawer to match the definition metadata drawer
+   * (`sm:w-4/5`) instead of the DS default 400px. Content-dense inspectors — the
+   * step editor with its Invoke-Agent, timeout and sub-editor sections — are
+   * unusable at 400px, so they opt in. No effect on the `docked` rail.
+   */
+  wide?: boolean
   children: React.ReactNode
 }
 
@@ -138,6 +145,7 @@ export function InspectorPanel({
   recordId,
   recordIdLabel,
   headerExtra,
+  wide,
   children,
 }: InspectorPanelProps) {
   const t = useT()
@@ -165,7 +173,7 @@ export function InspectorPanel({
           aria-labelledby={titleId}
           aria-describedby={description ? descriptionId : undefined}
           closeAriaLabel={t('workflows.inspector.close', 'Close inspector')}
-          className="p-0"
+          className={wide ? 'p-0 w-full max-w-none sm:w-4/5' : 'p-0'}
         >
           <DrawerHeader className="border-b border-border/70">
             <InspectorHeading

--- a/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
@@ -214,6 +214,8 @@ export interface NodeEditDialogCrudFormProps {
    * not opted in keeps the modal shape it had.
    */
   variant?: InspectorPanelVariant
+  /** Widen the overlay Drawer to the metadata-drawer width — the step form is dense. */
+  wide?: boolean
 }
 
 /**
@@ -236,7 +238,7 @@ export interface NodeEditDialogCrudFormProps {
  * - waitForCondition: ConditionBuilder predicate + mandatory timeout policy
  * - decision: Basic fields only
  */
-export function NodeEditDialogCrudForm({ node, isOpen, onClose, onSave, onDelete, ledgerEntries, definitionId, samples, onPinSample, onUnpinSample, branchingRoutes, onSaveBranchingRoutes, routeOrder, onSaveRouteOrder, onConvertType, variant = 'overlay' }: NodeEditDialogCrudFormProps) {
+export function NodeEditDialogCrudForm({ node, isOpen, onClose, onSave, onDelete, ledgerEntries, definitionId, samples, onPinSample, onUnpinSample, branchingRoutes, onSaveBranchingRoutes, routeOrder, onSaveRouteOrder, onConvertType, variant = 'overlay', wide }: NodeEditDialogCrudFormProps) {
   const t = useT()
   const activityTypeOptions = useActivityTypeOptions()
   const [initialValues, setInitialValues] = useState<Partial<NodeFormValues>>({})
@@ -1100,6 +1102,7 @@ export function NodeEditDialogCrudForm({ node, isOpen, onClose, onSave, onDelete
       open={isOpen}
       onClose={onClose}
       variant={variant}
+      wide={wide}
       title={t('workflows.nodeEditor.title')}
       typeLabel={nodeTypeLabel}
       description={t('workflows.nodeEditor.description')}


### PR DESCRIPTION
Two usability fixes on the workflow-definition surfaces.

## 1. Definitions list — the rows were three lines tall
The list rendered a standalone **Workflow ID** column *and* dumped the full description (plus category) inline under each name, so every row was 3 lines and long definitions blew the row height out entirely.

- Removed the `Workflow ID` column.
- Removed the inline description.
- The name column now shows **name + source badge + category** only; the **workflow id and full description move into a hover tooltip** on the name (light variant, `max-w-md`).
- The `workflowId` *filter* is unchanged — you can still filter by id.

## 2. Visual editor — the Edit Step form was crammed into the 384px docked rail
The step inspector is a dense form (Invoke-Agent config, timeout, sub-editors). Forcing it into the `w-96` docked rail destroyed its usability. The definition **metadata drawer** already opens as a wide overlay (`sm:w-4/5`, maintainer-sanctioned for dense forms).

- The **step inspector now always opens as that same wide overlay Drawer**, via a new opt-in `wide` prop on `InspectorPanel` (forwarded by `NodeEditDialogCrudForm`, passed at the mount).
- The lighter **route inspector keeps the docked rail** (its config is small) — no behavior change there.
- `wide` has no effect on the `docked` variant, so nothing else regresses.

## Implementation
- `InspectorPanel`: new `wide?: boolean`; the `overlay` `DrawerContent` uses `w-full max-w-none sm:w-4/5` when set (else the DS default). No arbitrary values.
- `NodeEditDialogCrudForm`: threads `wide` to `InspectorPanel`.
- `visual-editor/page.tsx`: the step dialog mounts with `variant="overlay" wide`; the route dialog is untouched.
- `definitions/page.tsx`: column changes + tooltip.

## Tests
- Updated `dockedInspector.test.tsx`: on a wide viewport the step inspector now asserts `data-variant="overlay"` (was `docked`); route-rail and Escape behavior unchanged.
- `jest` workflows editor + definitions suites: **31 passing** (dockedInspector, metadataDrawer, definitions page, drawer contract).
- `tsc --noEmit -p packages/core` → 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)