### PR TITLE
fix(customers): example-seed guard no-ops under tenant data encryption

### DIFF
--- a/apps/docs/docs/architecture/data-encryption.mdx
+++ b/apps/docs/docs/architecture/data-encryption.mdx
@@ -81,6 +81,24 @@ flowchart TD
 2. Hook uses map + tenant DEK to decrypt mapped fields.
 3. API/CRUD receives hydrated plaintext while the DB keeps ciphertext.
 
+### Querying encrypted columns
+
+Decryption happens on **load**, not on **filter**. A `where` clause is passed to the database as
+written, so a plaintext predicate against an encrypted column is compared to ciphertext:
+
+- **It matches nothing, and it does not raise.** `{ title: 'Renewal' }`, `{ title: { $in: [...] } }`
+  and `em.count()` with such a filter return empty/zero rather than an error. Guard clauses and
+  idempotency checks built this way silently no-op once encryption is enabled — and keep working in
+  local dev with `TENANT_DATA_ENCRYPTION=no`, which is how the mistake survives review.
+- **For exact lookups, declare a hash column.** Add `hashField` to the field's rule in the module's
+  encryption map and filter on the hash (this is how `users.email_hash` supports login).
+- **Otherwise read, then compare in memory.** `findWithDecryption` / `findOneWithDecryption` /
+  `findAndCountWithDecryption` (`@open-mercato/shared/lib/encryption/find`) hydrate plaintext, so the
+  comparison happens on decrypted values. Scope the query by tenant/organization first so the set
+  stays bounded.
+- Sorting and `LIKE` have the same limitation — see the encrypted-sort helpers in the `customers`
+  module for the established pattern.
+
 ### Failure modes
 
 - **KMS unreachable** – encryption layer logs a warning and (per requirements) continues without encryption; maps are still evaluated so we can re-enable later.

--- a/packages/core/src/modules/customers/__integration__/TC-CUSTOMERS-SEED-001.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CUSTOMERS-SEED-001.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createOrganizationFixture,
+  deleteOrganizationIfExists,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+
+/**
+ * TC-CUSTOMERS-SEED-001: `mercato customers seed-examples` stays idempotent when tenant
+ * data encryption is active.
+ *
+ * Reproduces the defect fixed in `modules/customers/cli.ts`: the idempotency guard filtered
+ * `customer_deal.title` with a plaintext `$in`, but that column is encryption-mapped
+ * (`modules/customers/encryption.ts`). Decryption happens on load, not on filter, so the
+ * predicate reached Postgres as written, compared against ciphertext, matched nothing, and
+ * raised nothing — the guard fell through and every re-run duplicated the whole example batch.
+ *
+ * Why this needs an integration test rather than a unit test: the bug *is* the encryption
+ * boundary. A unit test has to mock the decryption helper, which is precisely the component
+ * that was broken, so it can only prove the guard calls a helper — never that the guard works
+ * against a real encrypted column. This exercises the real CLI, a real database, and a real
+ * derived-key KMS.
+ *
+ * Verified-against-source contract (`modules/customers/cli.ts`, `seed-examples` command):
+ * - seeding an untouched organization logs `Customer example data seeded for organization <id>`
+ * - a re-run whose guard fires logs `Customer example data already present; skipping`
+ * so the second run's stdout is a direct oracle for the guard, with no row counting needed.
+ *
+ * Two preconditions have to hold or this test passes vacuously, so both are asserted rather than
+ * assumed:
+ *
+ * 1. **A real KMS.** Without one the runtime falls back to a noop provider that stores plaintext.
+ *    `TENANT_DATA_ENCRYPTION_FALLBACK_KEY` selects the derived-key KMS
+ *    (`shared/lib/encryption/kms.ts`, `createKmsService`) so mapped columns are genuinely encrypted.
+ * 2. **An active encryption map row.** `TenantDataEncryptionService` resolves which fields to
+ *    encrypt from the `encryption_maps` table, scoped by `(entity_id, tenant_id, organization_id)`
+ *    (`shared/lib/encryption/tenantDataEncryptionService.ts:223`). A freshly created organization has
+ *    no such row, so `mercato entities seed-encryption` must run first — an earlier draft of this
+ *    test omitted it and passed even against the unfixed guard, proving nothing.
+ *
+ * Both runs share one environment, keeping the test independent of the surrounding harness config.
+ */
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(currentDir, '..', '..', '..', '..', '..', '..');
+const cliBin = path.join(repoRoot, 'packages', 'cli', 'dist', 'bin.js');
+const appDir = path.join(repoRoot, 'apps', 'mercato');
+
+const ENCRYPTION_ENV = {
+  TENANT_DATA_ENCRYPTION: 'yes',
+  // Selects the derived-key KMS instead of the noop provider, so mapped columns are really
+  // encrypted. Test-only value; it never leaves this process.
+  TENANT_DATA_ENCRYPTION_FALLBACK_KEY: 'tc-customers-seed-001-derived-key',
+  ALLOW_DERIVED_KMS_FALLBACK: 'true',
+};
+
+function runMercato(args: string[]): string {
+  return execFileSync(process.execPath, [cliBin, ...args], {
+    cwd: appDir,
+    encoding: 'utf8',
+    env: { ...process.env, ...ENCRYPTION_ENV, FORCE_COLOR: '0', NODE_NO_WARNINGS: '1' },
+  });
+}
+
+function runSeedExamples(tenantId: string, organizationId: string): string {
+  return runMercato(['customers', 'seed-examples', '--tenant', tenantId, '--org', organizationId]);
+}
+
+/**
+ * Activates the module encryption maps for this tenant/organization and proves they are active.
+ * Without this the deal title is stored as plaintext and the defect cannot manifest.
+ */
+function activateEncryptionMaps(tenantId: string, organizationId: string): void {
+  const output = runMercato(['entities', 'seed-encryption', '--tenant', tenantId, '--org', organizationId]);
+  expect(
+    output,
+    'TENANT_DATA_ENCRYPTION must be active for this test to mean anything — the CLI reported it disabled',
+  ).not.toContain('TENANT_DATA_ENCRYPTION is disabled');
+  expect(output, 'encryption maps should be seeded for the target scope').toContain('Encryption maps seeded');
+  expect(
+    output,
+    'the customer_deal map must be among the seeded maps, since its title column is the one under test',
+  ).toContain('customers:customer_deal');
+}
+
+test.describe('customers seed-examples idempotency under encryption', () => {
+  test('declines to re-seed an organization that already has the example data', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const { tenantId } = getTokenScope(token);
+    expect(tenantId, 'admin token should carry a tenant id').toBeTruthy();
+
+    const organizationId = await createOrganizationFixture(request, token, {
+      name: `TC-CUSTOMERS-SEED-001 ${Date.now()}`,
+      tenantId,
+    });
+
+    try {
+      activateEncryptionMaps(tenantId, organizationId);
+
+      const firstRun = runSeedExamples(tenantId, organizationId);
+      expect(
+        firstRun,
+        'first run against an untouched organization should seed the example data',
+      ).toContain('Customer example data seeded for organization');
+
+      const secondRun = runSeedExamples(tenantId, organizationId);
+      expect(
+        secondRun,
+        'second run must detect the existing example deals through the encrypted title column and skip; '
+          + 'seeding again is the duplication defect this test guards',
+      ).toContain('Customer example data already present; skipping');
+      expect(
+        secondRun,
+        'second run must not report seeding a second batch',
+      ).not.toContain('Customer example data seeded for organization');
+    } finally {
+      await deleteOrganizationIfExists(request, token, organizationId);
+    }
+  });
+
+  test('reports the example data as present when the same organization is seeded repeatedly', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin');
+    const { tenantId } = getTokenScope(token);
+
+    const organizationId = await createOrganizationFixture(request, token, {
+      name: `TC-CUSTOMERS-SEED-001-repeat ${Date.now()}`,
+      tenantId,
+    });
+
+    try {
+      activateEncryptionMaps(tenantId, organizationId);
+      runSeedExamples(tenantId, organizationId);
+
+      // Two further runs: a guard that only worked by accident on the first repeat would show up here.
+      for (const attempt of [2, 3]) {
+        const output = runSeedExamples(tenantId, organizationId);
+        expect(output, `run ${attempt} should still skip`).toContain('already present; skipping');
+      }
+    } finally {
+      await deleteOrganizationIfExists(request, token, organizationId);
+    }
+  });
+});

--- a/packages/core/src/modules/customers/__tests__/seedExamplesEncryptionGuard.test.ts
+++ b/packages/core/src/modules/customers/__tests__/seedExamplesEncryptionGuard.test.ts
@@ -1,0 +1,103 @@
+// Regression guard: `seedCustomerExamples`'s idempotency check must read deal titles back through
+// the decryption-aware helper. `customer_deal.title` is encryption-mapped (see ../encryption.ts), so
+// with TENANT_DATA_ENCRYPTION enabled the stored column holds ciphertext — a plaintext
+// `title: { $in: [...] }` filter matches nothing, the guard falls through, and every re-run against
+// an already-seeded tenant silently duplicates the whole example batch.
+//
+// The fake EM below encodes exactly that asymmetry: `count()` always returns 0 (what a plaintext
+// filter does against ciphertext) while `find()` returns the rows that really exist.
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  // Forward the query through to the fake EM so the test can assert what the guard asked for.
+  findWithDecryption: async (
+    em: { find: (...args: unknown[]) => Promise<unknown> },
+    entityName: unknown,
+    where: unknown,
+    options: unknown,
+  ) => em.find(entityName, where, options),
+  findOneWithDecryption: async (em: { findOne: (...args: unknown[]) => Promise<unknown> }) => em.findOne(),
+  findAndCountWithDecryption: async () => [[], 0],
+}))
+
+import { CUSTOMER_EXAMPLES, seedCustomerExamples } from '../cli'
+
+const TENANT_ID = '11111111-1111-4111-8111-111111111111'
+const ORG_ID = '22222222-2222-4222-8222-222222222222'
+
+// Thrown by every EM method the seed would only reach *after* the guard declines to short-circuit.
+const SENTINEL = 'SEED_PROCEEDED_PAST_GUARD'
+
+const exampleDealTitle = (() => {
+  for (const company of CUSTOMER_EXAMPLES) {
+    for (const deal of company.deals ?? []) {
+      if (typeof deal.title === 'string') return deal.title
+    }
+  }
+  throw new Error('fixture drift: CUSTOMER_EXAMPLES contains no deal titles')
+})()
+
+type FindCall = { entityName: unknown; where: unknown }
+
+function makeEm(existingDeals: Array<{ title: string }>) {
+  const findCalls: FindCall[] = []
+  const beyondGuard = () => {
+    throw new Error(SENTINEL)
+  }
+  const em = {
+    // A plaintext equality/$in filter against an encrypted column matches nothing.
+    count: async () => 0,
+    find: async (entityName: unknown, where: unknown) => {
+      findCalls.push({ entityName, where })
+      return existingDeals
+    },
+    findOne: beyondGuard,
+    create: beyondGuard,
+    persist: beyondGuard,
+    persistAndFlush: beyondGuard,
+    flush: beyondGuard,
+    getConnection: beyondGuard,
+    fork: beyondGuard,
+  }
+  return { em: em as any, findCalls }
+}
+
+const container = { resolve: () => { throw new Error(SENTINEL) } } as any
+
+describe('seedCustomerExamples idempotency guard under TENANT_DATA_ENCRYPTION', () => {
+  it('declines to re-seed when example deals exist, even though a plaintext count matches nothing', async () => {
+    const { em } = makeEm([{ title: exampleDealTitle }])
+
+    const seeded = await seedCustomerExamples(em, container, {
+      tenantId: TENANT_ID,
+      organizationId: ORG_ID,
+    })
+
+    expect(seeded).toBe(false)
+  })
+
+  it('scopes the guard to the target tenant and organization', async () => {
+    const { em, findCalls } = makeEm([{ title: exampleDealTitle }])
+
+    await seedCustomerExamples(em, container, { tenantId: TENANT_ID, organizationId: ORG_ID })
+
+    expect(findCalls.length).toBeGreaterThan(0)
+    expect(findCalls[0].where).toMatchObject({ tenantId: TENANT_ID, organizationId: ORG_ID })
+  })
+
+  it('does not short-circuit when the tenant holds no example deals', async () => {
+    const { em } = makeEm([])
+
+    // The guard must fall through and let seeding proceed; the fake EM throws as soon as it does.
+    await expect(
+      seedCustomerExamples(em, container, { tenantId: TENANT_ID, organizationId: ORG_ID }),
+    ).rejects.toThrow(SENTINEL)
+  })
+
+  it('ignores deals whose titles are not part of the example set', async () => {
+    const { em } = makeEm([{ title: 'A deal the operator created themselves' }])
+
+    await expect(
+      seedCustomerExamples(em, container, { tenantId: TENANT_ID, organizationId: ORG_ID }),
+    ).rejects.toThrow(SENTINEL)
+  })
+})

--- a/packages/core/src/modules/customers/cli.ts
+++ b/packages/core/src/modules/customers/cli.ts
@@ -12,6 +12,7 @@ import { E as CoreEntities } from '#generated/entities.ids.generated'
 import { createProgressBar } from '@open-mercato/shared/lib/cli/progress'
 import { buildIndexDocument, type IndexCustomFieldValue } from '@open-mercato/core/modules/query_index/lib/document'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import {
@@ -1395,12 +1396,24 @@ async function seedCustomerExamples(
     )
   )
   if (exampleDealTitles.length > 0) {
-    const already = await em.count(CustomerDeal, {
-      tenantId,
-      organizationId,
-      title: { $in: exampleDealTitles as any },
-    })
-    if (already > 0) {
+    // `customer_deal.title` is encryption-mapped (see ./encryption.ts), so with
+    // TENANT_DATA_ENCRYPTION enabled the stored column holds ciphertext. A plaintext
+    // `title: { $in: [...] }` filter therefore matches nothing, the guard falls through, and every
+    // re-run duplicates the whole example batch. Read the deals back through the decryption-aware
+    // helper and compare plaintext titles in memory instead; this behaves identically whether or
+    // not encryption is enabled.
+    const exampleTitles = new Set(exampleDealTitles)
+    const existingDeals = await findWithDecryption(
+      em,
+      CustomerDeal,
+      { tenantId, organizationId },
+      undefined,
+      { tenantId, organizationId },
+    )
+    const already = existingDeals.some(
+      (deal) => typeof deal.title === 'string' && exampleTitles.has(deal.title),
+    )
+    if (already) {
       return false
     }
   }


### PR DESCRIPTION
## User impact

Re-running the customers example seed against an already-seeded tenant silently duplicates the entire
example data set, whenever `TENANT_DATA_ENCRYPTION=yes`.

## The bug

`seedCustomerExamples` guarded idempotency with a plaintext filter on `customer_deal.title`
(`packages/core/src/modules/customers/cli.ts`):

```ts
const already = await em.count(CustomerDeal, {
  tenantId,
  organizationId,
  title: { $in: exampleDealTitles as any },
})
if (already > 0) return false
```

That column is encryption-mapped (`packages/core/src/modules/customers/encryption.ts`):

```ts
{
  entityId: 'customers:customer_deal',
  fields: [{ field: 'title' }, { field: 'description' }],
},
```

Decryption happens on load, not on filter. The predicate reaches the database as written and is
compared against ciphertext, so it matches nothing — and raises nothing. `already` is always `0`, the
guard always falls through, and the whole batch is re-seeded. With encryption disabled the guard
works correctly, which is why this went unnoticed.

## The fix

Read the deals back through `findWithDecryption` and compare plaintext titles in memory. This keeps
the guard's original exact-title semantics — no widening to a coarser scope — and behaves identically
whether or not encryption is enabled, so there is one code path rather than two.

The alternative would be declaring a `hashField` for `customer_deal.title` and filtering on the hash,
which is the canonical mechanism for exact lookups on an encrypted column. That needs a new column, a
migration and a backfill, and changes an encryption map, so it is deliberately out of scope here — but
it is the better long-term shape if exact title lookups are wanted elsewhere.

## Also in this PR

`apps/docs/docs/architecture/data-encryption.mdx` gains a **Querying encrypted columns** section. The
underlying sharp edge is not specific to this seed: any equality / `$in` / `count` predicate against an
encrypted column matches nothing and reports no error, and it keeps working in local dev with
`TENANT_DATA_ENCRYPTION=no`. The doc now states that, points to `hashField` for exact lookups and to
the `findWithDecryption` family otherwise.

## Testing

`packages/core/src/modules/customers/__tests__/seedExamplesEncryptionGuard.test.ts` — 4 cases. The fake
EM encodes the asymmetry that defines the bug: `count()` returns `0` (what a plaintext filter does
against ciphertext) while `find()` returns rows that really exist.

- declines to re-seed when example deals exist despite the plaintext count matching nothing
- scopes the guard to the target tenant and organization
- does not short-circuit when the tenant holds no example deals
- ignores deals whose titles are not part of the example set

**Verified against the unpatched guard**: two of the four fail, and fail for the right reason — control
reaches `seedCustomerDictionaries`, which is the duplication path.

Also run: `packages/core` customers suite (208 suites / 1231 tests, all passing) and lint on the
touched files. Typecheck in a fresh worktree reports only pre-existing `TS2307` on `#generated/*`
(those artifacts are not built until `yarn generate`); none are attributable to this change.

## Provenance

Found while building a standalone downstream application on `@open-mercato/*` `0.6.7-canary.317`, and
re-verified against `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
