### PR TITLE
fix(cli): warn when an injection table references a widget nothing declares

### DIFF
--- a/packages/cli/src/lib/__tests__/injection-widget-id-validation.test.ts
+++ b/packages/cli/src/lib/__tests__/injection-widget-id-validation.test.ts
@@ -1,0 +1,184 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createInjectionWidgetsExtension } from '../generators/extensions/injection-widgets'
+import type { ModuleScanContext } from '../generators/extension'
+
+// A widget's `metadata.id` and the `widgetId` that mounts it are two hand-typed literals in two
+// different files. Nothing linked them, so a typo in either failed silently — the widget was never
+// mounted, or the table entry resolved to nothing. These cases drive the real scan → generate seam
+// (real filesystem fixtures, real AST extraction) and assert the reconciliation warnings.
+
+let tmpRoot: string
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-injection-widgets-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true })
+  jest.restoreAllMocks()
+})
+
+function widgetSource(id: string): string {
+  return [
+    "import type { InjectionWidgetModule } from '@open-mercato/shared/modules/widgets/injection'",
+    "import Impl from './widget.client'",
+    '',
+    'const widget: InjectionWidgetModule = {',
+    '  metadata: {',
+    `    id: '${id}',`,
+    "    title: 'Fixture widget',",
+    '  },',
+    '  Widget: Impl,',
+    '}',
+    '',
+    'export default widget',
+  ].join('\n')
+}
+
+function tableSource(widgetIds: string[]): string {
+  const entries = widgetIds
+    .map((id, index) => `  'detail:fixture:tab${index}': [{ widgetId: '${id}', kind: 'tab' }],`)
+    .join('\n')
+  return [
+    "import type { ModuleInjectionTable } from '@open-mercato/shared/modules/widgets/injection'",
+    '',
+    'export const injectionTable: ModuleInjectionTable = {',
+    entries,
+    '}',
+    '',
+    'export default injectionTable',
+  ].join('\n')
+}
+
+/**
+ * Lays out one module on disk in the shape the scanner expects and returns a scan context for it.
+ * `declaredIds` each get `widgets/injection/<name>/widget.ts`; `referencedIds` go into the module's
+ * `widgets/injection-table.ts` (omitted entirely when the list is empty).
+ */
+function makeModule(moduleId: string, declaredIds: string[], referencedIds: string[]): ModuleScanContext {
+  const base = path.join(tmpRoot, moduleId)
+  const injectionDir = path.join(base, 'widgets', 'injection')
+  fs.mkdirSync(injectionDir, { recursive: true })
+
+  declaredIds.forEach((id, index) => {
+    const dir = path.join(injectionDir, `w${index}`)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'widget.ts'), widgetSource(id))
+  })
+
+  const tablePath = path.join(base, 'widgets', 'injection-table.ts')
+  if (referencedIds.length > 0) fs.writeFileSync(tablePath, tableSource(referencedIds))
+
+  const roots = { appBase: base, pkgBase: base }
+  return {
+    moduleId,
+    roots,
+    imps: { appBase: `@fixture/${moduleId}`, pkgBase: `@fixture/${moduleId}` },
+    importIdRef: { value: 0 },
+    sharedImports: [],
+    resolveModuleFile: (() =>
+      referencedIds.length > 0
+        ? { absolutePath: tablePath, importPath: `@fixture/${moduleId}/widgets/injection-table` }
+        : null) as unknown as ModuleScanContext['resolveModuleFile'],
+    resolveFirstModuleFile: (() => null) as unknown as ModuleScanContext['resolveFirstModuleFile'],
+    processStandaloneConfig: () => null,
+    sanitizeGeneratedModuleSpecifier: (importPath: string) => importPath,
+  }
+}
+
+function runGenerate(contexts: ModuleScanContext[]): string[] {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  const extension = createInjectionWidgetsExtension()
+  for (const ctx of contexts) extension.scanModule(ctx)
+  extension.generateOutput()
+  return warn.mock.calls.map((call) => String(call[0]))
+}
+
+describe('injection widget id reconciliation at generate time', () => {
+  it('stays silent when every declared widget is referenced and vice versa', () => {
+    const warnings = runGenerate([makeModule('alpha', ['alpha.one', 'alpha.two'], ['alpha.one', 'alpha.two'])])
+
+    expect(warnings).toEqual([])
+  })
+
+  it('warns when an injection table references a widget id nothing declares', () => {
+    const warnings = runGenerate([makeModule('alpha', ['alpha.one'], ['alpha.one', 'alpha.typo'])])
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('alpha.typo')
+    expect(warnings[0]).toContain('references widget id')
+    expect(warnings[0]).toContain('alpha')
+  })
+
+  it('stays silent about a declared widget that no table references', () => {
+    // The mirror check is deliberately not implemented: `extractInjectionTableWidgetIds` reads only
+    // statically-analyzable literals, so a table built by composition or computation exposes no ids
+    // and every widget in such a module would be reported as unreferenced. Pinned so the omission is
+    // a decision rather than an oversight.
+    const warnings = runGenerate([makeModule('alpha', ['alpha.one', 'alpha.orphan'], ['alpha.one'])])
+
+    expect(warnings).toEqual([])
+  })
+
+  it('reports only the unresolvable reference when the two sides disagree entirely', () => {
+    const warnings = runGenerate([makeModule('alpha', ['alpha.declared'], ['alpha.referenced'])])
+
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0]).toContain('alpha.referenced')
+  })
+
+  it('does not warn about a table assembled by composition, whose ids are invisible statically', () => {
+    // Mirrors the real `example` module: `cond ? { ...a, ...b } : a`. The extractor sees no ids, so
+    // there is nothing to reconcile — and critically, no false warning.
+    const base = path.join(tmpRoot, 'composed')
+    fs.mkdirSync(path.join(base, 'widgets', 'injection', 'w0'), { recursive: true })
+    fs.writeFileSync(path.join(base, 'widgets', 'injection', 'w0', 'widget.ts'), widgetSource('composed.one'))
+    const tablePath = path.join(base, 'widgets', 'injection-table.ts')
+    fs.writeFileSync(
+      tablePath,
+      [
+        "import type { ModuleInjectionTable } from '@open-mercato/shared/modules/widgets/injection'",
+        "const a: ModuleInjectionTable = { 'detail:x:tab': [{ widgetId: 'composed.one' }] }",
+        "const b: ModuleInjectionTable = { 'detail:y:tab': [{ widgetId: 'composed.two' }] }",
+        'export const injectionTable: ModuleInjectionTable = process.env.FLAG ? { ...a, ...b } : a',
+        'export default injectionTable',
+      ].join('\n'),
+    )
+
+    const ctx: ModuleScanContext = {
+      ...makeModule('composed', [], []),
+      resolveModuleFile: (() => ({
+        absolutePath: tablePath,
+        importPath: '@fixture/composed/widgets/injection-table',
+      })) as unknown as ModuleScanContext['resolveModuleFile'],
+    }
+
+    expect(runGenerate([ctx])).toEqual([])
+  })
+
+  it('accepts a table in one module referencing a widget declared in another', () => {
+    const warnings = runGenerate([
+      makeModule('alpha', ['alpha.shared'], []),
+      makeModule('beta', [], ['alpha.shared']),
+    ])
+
+    expect(warnings).toEqual([])
+  })
+
+  it('does not warn for the single-widget id inference', () => {
+    // A lone widget whose metadata.id cannot be extracted adopts the table's single id; that
+    // convenience path must not then report itself as a mismatch.
+    const ctx = makeModule('gamma', [], ['gamma.inferred'])
+    const dir = path.join(tmpRoot, 'gamma', 'widgets', 'injection', 'solo')
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'widget.ts'), 'export default { Widget: () => null }\n')
+
+    expect(runGenerate([ctx])).toEqual([])
+  })
+
+  it('stays silent for a module with no injection widgets and no table', () => {
+    expect(runGenerate([makeModule('delta', [], [])])).toEqual([])
+  })
+})

--- a/packages/cli/src/lib/generators/extensions/injection-widgets.ts
+++ b/packages/cli/src/lib/generators/extensions/injection-widgets.ts
@@ -183,9 +183,52 @@ function resolveScannedWidgetPath(roots: ModuleRoots, fromApp: boolean, relPath:
   return path.join(base, 'widgets', 'injection', ...relPath.split('/'))
 }
 
+/**
+ * A widget's `metadata.id` and the injection-table entry that mounts it are two hand-typed string
+ * literals in two different files, and nothing links them. A typo in either fails silently: the spot
+ * resolves to no widget and nothing is logged, so it only surfaces as "why isn't my widget
+ * rendering" during manual QA.
+ *
+ * Reports table entries whose `widgetId` no scanned widget declares. Diagnostics only — generated
+ * output is unchanged and the build is not failed, since a table entry may legitimately point at a
+ * widget supplied by a module that is not enabled in this app.
+ *
+ * Deliberately one-directional. The mirror check ("a widget nothing references is never mounted")
+ * cannot be done reliably yet: `extractInjectionTableWidgetIds` only reads statically-analyzable
+ * object literals, so a table assembled by composition or computation contributes **no** visible
+ * ids — `example` exports `cond ? { ...a, ...b } : a` and `translations` exports
+ * `buildInjectionTable()`, and both would have every one of their widgets reported as unreferenced.
+ * Under-reporting is harmless in the direction implemented here (a reference the extractor never saw
+ * cannot produce a warning) but fatal in the other. Teaching the extractor to resolve spreads,
+ * conditionals and call expressions is the prerequisite for adding it.
+ */
+function reportUnresolvableWidgetReferences(
+  widgetEntries: Map<string, InjectionWidgetEntry>,
+  tableWidgetRefs: Map<string, Set<string>>,
+): void {
+  const declaredIds = new Set<string>()
+  for (const entry of widgetEntries.values()) {
+    if (entry.widgetId) declaredIds.add(entry.widgetId)
+  }
+
+  for (const [widgetId, modules] of Array.from(tableWidgetRefs.entries()).sort(([a], [b]) => a.localeCompare(b))) {
+    if (declaredIds.has(widgetId)) continue
+    const owners = Array.from(modules).sort().join(', ')
+    console.warn(
+      `[generate] ⚠ Injection table in "${owners}" references widget id "${widgetId}", but no scanned ` +
+        'widget declares it — that spot will render nothing. Check the id against the widget\'s ' +
+        'metadata.id, and that the widget lives in a file the scanner reads ' +
+        '(widgets/injection/**/widget.ts|tsx — note that widget.client.tsx alone is not scanned).',
+    )
+  }
+}
+
 export function createInjectionWidgetsExtension(): GeneratorExtension {
   const widgetEntries = new Map<string, InjectionWidgetEntry>()
   const tableEntries: InjectionTableEntry[] = []
+  // widgetId -> module ids whose injection table references it. Collected across every module so a
+  // table may legitimately reference a widget another module owns.
+  const tableWidgetRefs = new Map<string, Set<string>>()
 
   return {
     id: 'registry.injection-widgets',
@@ -217,6 +260,12 @@ export function createInjectionWidgetsExtension(): GeneratorExtension {
         moduleWidgetEntries[0].widgetId = tableWidgetIds[0]
       }
 
+      for (const widgetId of tableWidgetIds) {
+        const modules = tableWidgetRefs.get(widgetId) ?? new Set<string>()
+        modules.add(ctx.moduleId)
+        tableWidgetRefs.set(widgetId, modules)
+      }
+
       for (const entry of moduleWidgetEntries) {
         const existing = widgetEntries.get(entry.key)
         if (!existing || (existing.source !== 'app' && entry.source === 'app')) {
@@ -233,6 +282,8 @@ export function createInjectionWidgetsExtension(): GeneratorExtension {
       }
     },
     generateOutput() {
+      reportUnresolvableWidgetReferences(widgetEntries, tableWidgetRefs)
+
       const widgetDecls = Array.from(widgetEntries.entries())
         .sort(([left], [right]) => left.localeCompare(right))
         .map(([, entry]) =>

--- a/packages/cli/src/lib/generators/extensions/injection-widgets.ts
+++ b/packages/cli/src/lib/generators/extensions/injection-widgets.ts
@@ -213,7 +213,7 @@ function reportUnresolvableWidgetReferences(
 
   for (const [widgetId, modules] of Array.from(tableWidgetRefs.entries()).sort(([a], [b]) => a.localeCompare(b))) {
     if (declaredIds.has(widgetId)) continue
-    const owners = Array.from(modules).sort().join(', ')
+    const owners = Array.from(modules).sort((left, right) => left.localeCompare(right)).join(', ')
     console.warn(
       `[generate] ⚠ Injection table in "${owners}" references widget id "${widgetId}", but no scanned ` +
         'widget declares it — that spot will render nothing. Check the id against the widget\'s ' +


### PR DESCRIPTION
## User impact

A mistyped injection widget id fails silently. The spot resolves to no widget, nothing is logged, and
the only symptom is "why isn't my widget rendering" during manual QA.

## Why it can happen

A widget's `metadata.id` and the `widgetId` that mounts it are two hand-typed string literals in two
different files:

- the id is parsed out of `widgets/injection/**/widget.ts`'s AST (`extractWidgetMetadataId`)
- the reference is parsed out of `widgets/injection-table.ts` (`extractInjectionTableWidgetIds`)

Nothing reconciles them. The only existing link is a convenience inference for the single-widget case
(`if (moduleWidgetEntries.length === 1 && tableWidgetIds.length === 1 && !widgetId)`), which does not
apply to any module with more than one injection widget.

## Change

`yarn generate` now reconciles the two sides across every scanned module and warns for each table
entry whose `widgetId` no scanned widget declares:

```
[generate] ⚠ Injection table in "<module>" references widget id "<id>", but no scanned widget
declares it — that spot will render nothing. …
```

Diagnostics only. Generated output is unchanged and the build is not failed — a table entry may
legitimately point at a widget from a module this app does not enable.

## It finds a real bug on the current tree

```
[generate] ⚠ Injection table in "integrations" references widget id
"integrations.injection.external-ids", but no scanned widget declares it
```

`integrations` ships the External IDs sidebar widget only as
`widgets/injection/external-ids/widget.client.tsx`, attaching metadata to the component
(`ExternalIdsWidget.metadata = { id: 'integrations.injection.external-ids', … }`). The scanner's
`isWidgetFile` is `/^widget\.(t|j)sx?$/`, which does not match `widget.client.tsx`, so the module
contributes **no** injection widget — while its table maps `detail:*:sidebar` to that id, and the
runtime loader reads `metadata` from the module's default export, not from the component.

Confirmed against a generated app: `injection-tables.generated.ts` carries the integrations table
(`InjTable_integrations_*`), and `injection-widgets.generated.ts` contains no entry for the id — the
module contributes zero widget entries. So the widget, whose own table comment says it "auto-appears
on entity detail pages via wildcard spot matching", has never rendered in any app.

Fixed on its own PR so this change stays diagnostics-only.

## Why the check is one-directional

The mirror check — "a declared widget that no table references is never mounted" — is deliberately
**not** implemented. `extractInjectionTableWidgetIds` reads only statically-analyzable object
literals, and two shipped tables are not that:

- `example`: `export const injectionTable = cond ? { ...a, ...b } : a`
- `translations`: `export const injectionTable = buildInjectionTable()`

Neither exposes a single statically-visible id, so every widget in those modules would be reported as
unreferenced. A prototype of that direction emitted **16 false positives from those two tables against
1 true finding**, which is why it is not here.

Under-reporting is harmless in the direction shipped (a reference the extractor never saw cannot
produce a warning) but fatal in the other. Teaching the extractor to resolve spreads, conditionals and
call expressions is the prerequisite for adding it. The omission is pinned by a test so it reads as a
decision rather than an oversight.

## Testing

`packages/cli/src/lib/__tests__/injection-widget-id-validation.test.ts` — 8 cases driving the real
`scanModule` → `generateOutput` seam with on-disk fixtures and the real AST extraction:

- matching declarations and references stay silent
- a table reference nothing declares warns, naming the id and the owning module
- a module whose table lives in another module's package still resolves (cross-module reference)
- the existing single-widget id inference does not report itself
- a declared-but-unreferenced widget stays silent (pins the deliberate omission)
- a composition-built table (`cond ? { ...a, ...b } : a`) produces no false warning
- a module with no widgets and no table stays silent

Also run: `packages/cli` suite (66 suites / 1240 tests, all passing), `tsc --noEmit` clean, lint clean.

**End-to-end**: `yarn generate` against this tree emits exactly the one warning quoted above and no
others.

## Provenance

Found while building a standalone downstream application on `@open-mercato/*` `0.6.7-canary.317`,
where a mistyped widget id cost real debugging time, and re-verified against `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
