### PR TITLE
fix(integrations): register the External IDs widget so its sidebar spot renders

### DIFF
--- a/packages/core/src/modules/integrations/widgets/injection/external-ids/__tests__/widget.test.ts
+++ b/packages/core/src/modules/integrations/widgets/injection/external-ids/__tests__/widget.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The External IDs widget is mounted by the module's injection table, which references it by id. The
+ * generator only registers widgets declared in a scanned entry file (`widget.ts|tsx` — `widget.client.tsx`
+ * alone is not scanned), and it resolves the id from that file's `metadata`. This module previously
+ * shipped only `widget.client.tsx`, so nothing was registered and the table's `detail:*:sidebar` entry
+ * resolved to no widget: the sidebar section never rendered in any app.
+ *
+ * Pins the two halves together — the entry module must exist, and every id the table references must be
+ * declared by it.
+ */
+import injectionTable from '../../../injection-table'
+import widget from '../widget'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => fallback ?? key,
+}))
+
+function collectWidgetIds(table: unknown): string[] {
+  const ids: string[] = []
+  const visit = (value: unknown): void => {
+    if (typeof value === 'string') {
+      ids.push(value)
+      return
+    }
+    if (Array.isArray(value)) {
+      value.forEach(visit)
+      return
+    }
+    if (value && typeof value === 'object') {
+      const widgetId = (value as { widgetId?: unknown }).widgetId
+      if (typeof widgetId === 'string') ids.push(widgetId)
+    }
+  }
+  for (const entry of Object.values(table as Record<string, unknown>)) visit(entry)
+  return ids
+}
+
+describe('integrations external-ids injection widget registration', () => {
+  it('exposes a scannable entry module with the id the injection table references', () => {
+    expect(widget.metadata.id).toBe('integrations.injection.external-ids')
+    expect(widget.Widget).toBeDefined()
+  })
+
+  it('declares every widget id the integrations injection table references', () => {
+    const referenced = collectWidgetIds(injectionTable)
+
+    expect(referenced).toContain('integrations.injection.external-ids')
+    expect(referenced.filter((id) => id !== widget.metadata.id)).toEqual([])
+  })
+
+  it('keeps the view feature gate that the widget was shipped with', () => {
+    expect(widget.metadata.features).toEqual(['integrations.view'])
+  })
+})

--- a/packages/core/src/modules/integrations/widgets/injection/external-ids/widget.client.tsx
+++ b/packages/core/src/modules/integrations/widgets/injection/external-ids/widget.client.tsx
@@ -87,8 +87,3 @@ export default function ExternalIdsWidget({ data }: InjectionWidgetComponentProp
   )
 }
 
-ExternalIdsWidget.metadata = {
-  id: 'integrations.injection.external-ids',
-  title: 'External IDs',
-  features: ['integrations.view'],
-}

--- a/packages/core/src/modules/integrations/widgets/injection/external-ids/widget.ts
+++ b/packages/core/src/modules/integrations/widgets/injection/external-ids/widget.ts
@@ -1,0 +1,13 @@
+import type { InjectionWidgetModule } from '@open-mercato/shared/modules/widgets/injection'
+import ExternalIdsWidget from './widget.client'
+
+const widget: InjectionWidgetModule = {
+  metadata: {
+    id: 'integrations.injection.external-ids',
+    title: 'External IDs',
+    features: ['integrations.view'],
+  },
+  Widget: ExternalIdsWidget,
+}
+
+export default widget


### PR DESCRIPTION
## User impact

The **External IDs** sidebar widget has never rendered in any app.

Its own injection table maps it to `detail:*:sidebar` — every entity detail page — and the file's
comment states it "auto-appears on entity detail pages via wildcard spot matching". It does not appear
anywhere.

## Root cause

The module shipped the widget only as `widgets/injection/external-ids/widget.client.tsx`, attaching
metadata to the component:

```ts
ExternalIdsWidget.metadata = { id: 'integrations.injection.external-ids', title: 'External IDs', features: ['integrations.view'] }
```

Two separate mechanisms both miss that:

1. **The generator never registers it.** `SCAN_CONFIGS.injectionWidgets` uses
   `isWidgetFile = /^widget\.(t|j)sx?$/`, which does not match the name `widget.client.tsx`. With no
   `widget.ts` entry file, the module contributes no injection widget entry at all.
2. **The loader would not read it anyway.** `injection-loader.ts` resolves `metadata` from the loaded
   module's default export (`'metadata' in widget`, `module.metadata.id`), not from the component
   function.

So the table entry resolved to no widget, and nothing was logged.

### Evidence, before this change

From a generated app:

- `injection-tables.generated.ts` — contains the integrations table (`InjTable_integrations_*`)
- `injection-widgets.generated.ts` — contains **no** entry for `integrations.injection.external-ids`,
  and zero entries for the `integrations` module

## Change

Adds the missing `widget.ts` entry module in the shape every other module uses:

```ts
const widget: InjectionWidgetModule = {
  metadata: { id: 'integrations.injection.external-ids', title: 'External IDs', features: ['integrations.view'] },
  Widget: ExternalIdsWidget,
}
export default widget
```

and drops the now-redundant component-level `metadata` assignment, so the id has a single source of
truth rather than two that can drift.

`integrations.view` gating is preserved exactly.

### Evidence, after this change

Regenerating adds the entry:

```
key: "integrations:external-ids:widget",
source: "package",
widgetId: "integrations.injection.external-ids",
loader: () => import("@open-mercato/core/modules/integrations/widgets/injection/external-ids/widget").then((mod) => mod.default ?? mod)
```

## How it was found

By the generate-time reconciliation check added in the CLI, which warns when an injection table
references a widget id no scanned widget declares. This was the only true finding it reported against
the whole tree.

## Testing

`__tests__/widget.test.ts` pins the two halves together:

- the entry module exists and its `metadata.id` matches the id the table references
- the component is present on the module
- the `integrations.view` feature gate survives
- every widget id the integrations table references is declared by this module

Verified as a real oracle: with `widget.ts` removed the suite fails outright (`Cannot find module
'../widget'`).

The pre-existing `widget.client.test.tsx` render suite still passes, which confirms the removed
component-level assignment was dead. Module suite: 17 suites / 86 tests passing. Lint clean.

## Provenance

Found while building a standalone downstream application on `@open-mercato/*` `0.6.7-canary.317`, and
re-verified against `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
