### PR TITLE
feat(auth): return the user's display name from GET /api/auth/profile

### DIFF
--- a/.ai/specs/2026-05-09-auth-user-display-name-exposure.md
+++ b/.ai/specs/2026-05-09-auth-user-display-name-exposure.md
@@ -229,6 +229,25 @@ Add or update tests:
 - [x] UI visibility coverage required
 - [x] Regression coverage for create/edit flows required
 
+## Migration & Backward Compatibility
+
+No migration is required, for applications or for data.
+
+- **`GET /api/auth/profile`** gains `name` as a new response field. `BACKWARD_COMPATIBILITY.md` §7 permits
+  adding optional fields to a response schema; no existing field is removed, renamed, or retyped, and the
+  route URL and method are unchanged.
+- **Consumers**: `auth/backend/auth/profile/page.tsx` and `auth/backend/profile/change-password/page.tsx`
+  widen their local `ProfileResponse` type. Both tolerate the field being absent, so an older client
+  reading a newer server, or the reverse, keeps working.
+- **`__integration__/TC-AUTH-017.spec.ts`** asserts only `profile.email`, so it is unaffected.
+- **No backfill needed.** Users with no stored name receive `null`; blank and whitespace-only values
+  normalise to `null` rather than surfacing an empty label. The column already exists, so there is no
+  schema change.
+- **The admin create/update contract is untouched** by this addition — it already accepted and returned
+  `name`.
+- **Deliberately not changed**: self-service editing of one's own display name. The profile form still
+  does not submit `name`, so no new write path or permission question is introduced here.
+
 ## Changelog
 - 2026-05-09: Drafted spec to expose `User.name` in auth admin UI and user API payloads.
 - 2026-07-30: Added the Profile Self-Read section and implemented it — `GET /api/auth/profile` now returns `name` (blank normalised to `null`). Reported from a downstream app whose backend chrome could only show an email address. Note for a maintainer: the admin-surface phases of this spec appear already implemented on `develop` (`/api/auth/users` accepts `name` on create/update, returns it in list responses, and supports search by display name), so this file may be a candidate for `.ai/specs/implemented/` — not moved here, since confirming that is a maintainer call.

--- a/.ai/specs/2026-05-09-auth-user-display-name-exposure.md
+++ b/.ai/specs/2026-05-09-auth-user-display-name-exposure.md
@@ -88,6 +88,19 @@ The user list payload should include `name` alongside the existing fields so UIs
 Expected shape additions:
 - `name: string | null`
 
+### Profile Self-Read (`GET /api/auth/profile`)
+The admin surfaces above let an operator *set* a display name. The signed-in user's own profile endpoint must also *return* it, or any UI rendering the current user — backend chrome, account blocks, profile menus — is forced back to the email address even when a name is stored.
+
+Response shape addition:
+- `name: string | null`
+
+Expected semantics:
+- return the stored value for the authenticated user
+- normalise blank or whitespace-only values to `null`, so "set but empty" never surfaces as a label
+- unauthenticated requests are unaffected and still return `401`
+
+This is read-only. Whether a user may edit their *own* display name is a separate product decision: the admin route can already set it and the self-service profile form deliberately does not, so that question is left open rather than answered by implication.
+
 ### Internal Serialization
 Any existing serialization helper that already maps `user.name` should remain aligned with the route response shape. The spec does not introduce a second serialization path; it requires the API response to match the established internal representation.
 
@@ -218,3 +231,4 @@ Add or update tests:
 
 ## Changelog
 - 2026-05-09: Drafted spec to expose `User.name` in auth admin UI and user API payloads.
+- 2026-07-30: Added the Profile Self-Read section and implemented it — `GET /api/auth/profile` now returns `name` (blank normalised to `null`). Reported from a downstream app whose backend chrome could only show an email address. Note for a maintainer: the admin-surface phases of this spec appear already implemented on `develop` (`/api/auth/users` accepts `name` on create/update, returns it in list responses, and supports search by display name), so this file may be a candidate for `.ai/specs/implemented/` — not moved here, since confirming that is a maintainer call.

--- a/.ai/specs/2026-05-09-auth-user-display-name-exposure.md
+++ b/.ai/specs/2026-05-09-auth-user-display-name-exposure.md
@@ -169,6 +169,7 @@ Add or update tests:
 - `POST /api/auth/users`
 - `PUT /api/auth/users`
 - `GET /api/auth/users`
+- `GET /api/auth/profile` — covered by `modules/auth/__integration__/TC-AUTH-PROFILE-NAME-001.spec.ts`
 
 ### UI Paths
 - `/backend/users/create`
@@ -180,6 +181,14 @@ Add or update tests:
 - list users and verify `name` is returned in the payload
 - open create form and confirm `name` is visible
 - open edit form and confirm `name` is visible and prefilled
+
+Profile self-read (`TC-AUTH-PROFILE-NAME-001`, executable):
+- create a user with a display name through the admin API, authenticate **as that user**, and verify
+  the name comes back from `GET /api/auth/profile` — closing the write/read loop that unit tests
+  cannot, since they mock the container, ORM and decryption helper
+- a user with no display name reads back `null`
+- a whitespace-only display name normalises to `null` rather than an empty label
+- an unauthenticated read is rejected with `401`
 
 ## Risks & Impact Review
 
@@ -250,4 +259,5 @@ No migration is required, for applications or for data.
 
 ## Changelog
 - 2026-05-09: Drafted spec to expose `User.name` in auth admin UI and user API payloads.
+- 2026-07-31: Review follow-up. `name` is declared `.nullable().optional()` on the response schema so the contract is additive for clients generated against an older schema; the endpoint's OpenAPI description now mentions the display name and roles; and `TC-AUTH-PROFILE-NAME-001` adds executable route-level coverage, listed above.
 - 2026-07-30: Added the Profile Self-Read section and implemented it — `GET /api/auth/profile` now returns `name` (blank normalised to `null`). Reported from a downstream app whose backend chrome could only show an email address. Note for a maintainer: the admin-surface phases of this spec appear already implemented on `develop` (`/api/auth/users` accepts `name` on create/update, returns it in list responses, and supports search by display name), so this file may be a candidate for `.ai/specs/implemented/` — not moved here, since confirming that is a maintainer call.

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-PROFILE-NAME-001.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-PROFILE-NAME-001.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api';
+import { getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures';
+import {
+  createUserFixture,
+  deleteUserIfExists,
+} from '@open-mercato/core/helpers/integration/authFixtures';
+
+/**
+ * TC-AUTH-PROFILE-NAME-001: `GET /api/auth/profile` returns the signed-in user's display name.
+ * Source spec: .ai/specs/2026-05-09-auth-user-display-name-exposure.md ("Profile Self-Read").
+ *
+ * The unit coverage for this endpoint mocks the container, the ORM and the decryption helper, so it
+ * proves the handler's shaping logic but never that a name written through the admin user API comes
+ * back out of the self-read endpoint. This closes that loop: a user is created with a display name via
+ * `POST /api/auth/users`, then authenticates as that user and reads their own profile.
+ *
+ * Verified-against-source contract (`modules/auth/api/profile/route.ts`):
+ * - `GET` requires authentication; without a token it is `401`
+ * - the response carries `email`, `name` and `roles`
+ * - `name` is `null` when unset, and blank or whitespace-only values normalise to `null` rather than
+ *   surfacing as an empty label
+ */
+
+const PROFILE_PATH = '/api/auth/profile';
+const PASSWORD = 'Integration-Passw0rd!';
+
+type ProfileResponse = {
+  email?: string;
+  name?: string | null;
+  roles?: string[];
+};
+
+async function readOwnProfile(
+  request: Parameters<typeof apiRequest>[0],
+  token: string,
+): Promise<ProfileResponse> {
+  const response = await apiRequest(request, 'GET', PROFILE_PATH, { token });
+  expect(response.status(), `GET ${PROFILE_PATH} should return 200`).toBe(200);
+  return (await readJsonSafe<ProfileResponse>(response)) ?? {};
+}
+
+test.describe('profile self-read display name', () => {
+  test('returns a display name set through the admin user API', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin');
+    const { organizationId } = getTokenScope(adminToken);
+    const email = `tc-auth-profile-name-${Date.now()}@example.com`;
+    let userId: string | null = null;
+
+    try {
+      userId = await createUserFixture(request, adminToken, {
+        email,
+        password: PASSWORD,
+        organizationId,
+        roles: [],
+        name: 'Ada Lovelace',
+      });
+
+      const userToken = await getAuthToken(request, email, PASSWORD);
+      const profile = await readOwnProfile(request, userToken);
+
+      expect(profile.email, 'the profile should describe the authenticated user').toBe(email);
+      expect(
+        profile.name,
+        'a display name written through the admin API must be readable by the user themselves',
+      ).toBe('Ada Lovelace');
+    } finally {
+      await deleteUserIfExists(request, adminToken, userId);
+    }
+  });
+
+  test('returns null for a user with no display name', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin');
+    const { organizationId } = getTokenScope(adminToken);
+    const email = `tc-auth-profile-noname-${Date.now()}@example.com`;
+    let userId: string | null = null;
+
+    try {
+      userId = await createUserFixture(request, adminToken, {
+        email,
+        password: PASSWORD,
+        organizationId,
+        roles: [],
+      });
+
+      const userToken = await getAuthToken(request, email, PASSWORD);
+      const profile = await readOwnProfile(request, userToken);
+
+      expect(profile.email).toBe(email);
+      expect(profile.name ?? null, 'an unset display name should read as null, not undefined-as-empty').toBeNull();
+    } finally {
+      await deleteUserIfExists(request, adminToken, userId);
+    }
+  });
+
+  test('normalises a whitespace-only display name to null', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin');
+    const { organizationId } = getTokenScope(adminToken);
+    const email = `tc-auth-profile-blank-${Date.now()}@example.com`;
+    let userId: string | null = null;
+
+    try {
+      userId = await createUserFixture(request, adminToken, {
+        email,
+        password: PASSWORD,
+        organizationId,
+        roles: [],
+        name: '   ',
+      });
+
+      const userToken = await getAuthToken(request, email, PASSWORD);
+      const profile = await readOwnProfile(request, userToken);
+
+      expect(
+        profile.name ?? null,
+        'a blank name must not surface as an empty label in the chrome',
+      ).toBeNull();
+    } finally {
+      await deleteUserIfExists(request, adminToken, userId);
+    }
+  });
+
+  test('still requires authentication', async ({ request }) => {
+    const response = await request.get(PROFILE_PATH);
+
+    expect(response.status(), 'an unauthenticated profile read should be rejected').toBe(401);
+  });
+});

--- a/packages/core/src/modules/auth/api/profile/__tests__/profile-display-name.test.ts
+++ b/packages/core/src/modules/auth/api/profile/__tests__/profile-display-name.test.ts
@@ -1,10 +1,5 @@
 /** @jest-environment node */
 
-// `User.name` is settable through the admin user API (`/api/auth/users`) but the self-read profile
-// endpoint did not return it, so a signed-in user's own chrome could only ever show their email
-// address. These cases pin the field onto the GET contract, including the empty-string normalisation
-// that keeps "set but blank" from surfacing as a name.
-
 import { GET } from '../route'
 
 const TENANT_ID = '123e4567-e89b-12d3-a456-426614174001'

--- a/packages/core/src/modules/auth/api/profile/__tests__/profile-display-name.test.ts
+++ b/packages/core/src/modules/auth/api/profile/__tests__/profile-display-name.test.ts
@@ -1,0 +1,108 @@
+/** @jest-environment node */
+
+// `User.name` is settable through the admin user API (`/api/auth/users`) but the self-read profile
+// endpoint did not return it, so a signed-in user's own chrome could only ever show their email
+// address. These cases pin the field onto the GET contract, including the empty-string normalisation
+// that keeps "set but blank" from surfacing as a name.
+
+import { GET } from '../route'
+
+const TENANT_ID = '123e4567-e89b-12d3-a456-426614174001'
+const ORG_ID = '123e4567-e89b-12d3-a456-426614174002'
+const USER_ID = '123e4567-e89b-12d3-a456-426614174010'
+
+const mockGetAuthFromRequest = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+
+const mockEm = { find: jest.fn(), findOne: jest.fn() }
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    locale: 'en',
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (...args: unknown[]) => mockFindOneWithDecryption(...args),
+  findWithDecryption: jest.fn(),
+}))
+
+function profileRequest(): Request {
+  return new Request('http://localhost/api/auth/profile', { method: 'GET' })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGetAuthFromRequest.mockResolvedValue({
+    sub: USER_ID,
+    tenantId: TENANT_ID,
+    orgId: ORG_ID,
+    roles: ['admin'],
+  })
+})
+
+describe('GET /api/auth/profile display name', () => {
+  it('returns the stored display name alongside the email', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({
+      id: USER_ID,
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+    })
+
+    const response = await GET(profileRequest())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({ email: 'ada@example.com', name: 'Ada Lovelace', roles: ['admin'] })
+  })
+
+  it('returns null when the user has no display name', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({ id: USER_ID, email: 'ada@example.com', name: null })
+
+    const body = await (await GET(profileRequest())).json()
+
+    expect(body.name).toBeNull()
+    expect(body.email).toBe('ada@example.com')
+  })
+
+  it('normalises a blank display name to null rather than reporting an empty label', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({ id: USER_ID, email: 'ada@example.com', name: '   ' })
+
+    const body = await (await GET(profileRequest())).json()
+
+    expect(body.name).toBeNull()
+  })
+
+  it('trims surrounding whitespace from the stored name', async () => {
+    mockFindOneWithDecryption.mockResolvedValue({ id: USER_ID, email: 'ada@example.com', name: '  Ada  ' })
+
+    const body = await (await GET(profileRequest())).json()
+
+    expect(body.name).toBe('Ada')
+  })
+
+  it('still requires authentication', async () => {
+    mockGetAuthFromRequest.mockResolvedValue(null)
+
+    const response = await GET(profileRequest())
+
+    expect(response.status).toBe(401)
+    expect(mockFindOneWithDecryption).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/auth/api/profile/route.ts
+++ b/packages/core/src/modules/auth/api/profile/route.ts
@@ -18,6 +18,10 @@ const logger = createLogger('auth').child({ component: 'profile' })
 
 const profileResponseSchema = z.object({
   email: z.string().email(),
+  // Display name as stored on the user row. Settable via the admin user API (`/api/auth/users`) but
+  // previously unreadable by the signed-in user themselves, so any UI wanting a real label had only
+  // the email address to work with. `null` when unset or blank.
+  name: z.string().nullable(),
   roles: z.array(z.string()),
 })
 
@@ -106,7 +110,12 @@ export async function GET(req: Request) {
     if (!user) {
       return NextResponse.json({ error: translate('auth.users.form.errors.notFound', 'User not found') }, { status: 404 })
     }
-    return NextResponse.json({ email: String(user.email), roles: auth.roles ?? [] })
+    const displayName = typeof user.name === 'string' ? user.name.trim() : ''
+    return NextResponse.json({
+      email: String(user.email),
+      name: displayName.length > 0 ? displayName : null,
+      roles: auth.roles ?? [],
+    })
   } catch (err) {
     logger.error('Profile load failed', { err })
     return NextResponse.json({ error: translate('auth.profile.form.errors.load', 'Failed to load profile.') }, { status: 400 })

--- a/packages/core/src/modules/auth/api/profile/route.ts
+++ b/packages/core/src/modules/auth/api/profile/route.ts
@@ -18,10 +18,9 @@ const logger = createLogger('auth').child({ component: 'profile' })
 
 const profileResponseSchema = z.object({
   email: z.string().email(),
-  // Display name as stored on the user row. Settable via the admin user API (`/api/auth/users`) but
-  // previously unreadable by the signed-in user themselves, so any UI wanting a real label had only
-  // the email address to work with. `null` when unset or blank.
-  name: z.string().nullable(),
+  // Optional so the contract stays additive: a client generated from this schema must not reject a
+  // response from a server that predates the field. Every current response includes it.
+  name: z.string().nullable().optional(),
   roles: z.array(z.string()),
 })
 
@@ -216,7 +215,7 @@ export const openApi: OpenApiRouteDoc = {
   methods: {
     GET: {
       summary: 'Get current profile',
-      description: 'Returns the email address for the signed-in user.',
+      description: 'Returns the email address, display name, and roles for the signed-in user. The display name is null when unset.',
       responses: [
         { status: 200, description: 'Profile payload', schema: profileResponseSchema },
         { status: 401, description: 'Unauthorized', schema: z.object({ error: z.string() }) },

--- a/packages/core/src/modules/auth/backend/auth/profile/page.tsx
+++ b/packages/core/src/modules/auth/backend/auth/profile/page.tsx
@@ -18,6 +18,7 @@ const logger = createLogger('auth').child({ component: 'profile-page' })
 
 type ProfileResponse = {
   email?: string | null
+  name?: string | null
 }
 
 type ProfileUpdateResponse = {

--- a/packages/core/src/modules/auth/backend/profile/change-password/page.tsx
+++ b/packages/core/src/modules/auth/backend/profile/change-password/page.tsx
@@ -17,6 +17,7 @@ const logger = createLogger('auth').child({ component: 'change-password-page' })
 
 type ProfileResponse = {
   email?: string | null
+  name?: string | null
 }
 
 type ProfileUpdateResponse = {


### PR DESCRIPTION
## User impact

An administrator can set a user's display name today, but that user's own UI cannot read it back — so
backend chrome, account blocks and profile menus fall back to the email address even when a real name
is stored.

## The gap

`User.name` is **not** a dead column. `/api/auth/users` fully supports it:

- create and update schemas accept it (`displayNameSchema`)
- list responses return it (`name: u.name ? String(u.name) : null`)
- search matches on display name (`findUserIdsBySearchTokens(..., 'name')`)
- the OpenAPI copy advertises "optional display name"

But `GET /api/auth/profile` — the endpoint a signed-in user reads about themselves — declared:

```ts
const profileResponseSchema = z.object({
  email: z.string().email(),
  roles: z.array(z.string()),
})
```

So the write path existed with no matching read path.

## Change

Adds `name: string | null` to `profileResponseSchema` and to the GET payload.

The handler already loads the full decrypted `User` row via `findOneWithDecryption` before responding,
so there is **no additional query**. Blank and whitespace-only values normalise to `null`, so a name
that is set-but-empty never surfaces as a label; surrounding whitespace is trimmed.

Read-only by design. Whether a user may edit their *own* display name is a separate product decision —
the admin route can already set it, and the self-service profile form deliberately does not — so this
PR does not answer that by implication.

## Compatibility

Additive optional response field. `BACKWARD_COMPATIBILITY.md` §7 already states "MAY add new optional
fields to request/response schemas", so no entry is added there — the per-change sections in that
document record multi-surface specs rather than single fields. Say the word if you'd prefer one anyway.

Consumers checked:

- `backend/auth/profile/page.tsx` and `backend/profile/change-password/page.tsx` both type the response
  as `ProfileResponse` — widened here
- `__integration__/TC-AUTH-017.spec.ts` asserts on `profile.email` only, so it is unaffected

## Spec

Updates the **pending** `.ai/specs/2026-05-09-auth-user-display-name-exposure.md` with a *Profile
Self-Read* section rather than adding a new spec, following that folder's own trigger ("update an
existing spec when changing APIs"; "skip specs for small bug fixes"). That spec already covers the
admin CRUD surface — this fills in the self-read half it did not address.

**Note for a maintainer**: the admin-surface phases of that spec appear to be **already implemented**
on `develop` (see the `/api/auth/users` capabilities listed above), yet the file still sits in the
pending directory. It may belong in `.ai/specs/implemented/`. Not moved here, since `.ai/specs/AGENTS.md`
says to ask before moving a spec when completion evidence is incomplete.

## Testing

`packages/core/src/modules/auth/api/profile/__tests__/profile-display-name.test.ts` — 5 cases:

- returns the stored display name alongside the email
- returns `null` when no name is set
- normalises a blank name to `null`
- trims surrounding whitespace
- still returns `401` without auth, before any user load

Auth module suite: 65 suites / 505 tests passing. Lint clean.

## Provenance

Found while building a standalone downstream application on `@open-mercato/*` `0.6.7-canary.317`, whose
sidebar account block had to display an email address for want of this field, and re-verified against
`develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
