### PR TITLE
fix(workflows): sticky side ledger in the step drawer + move the route inspector into the drawer

### DIFF
--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
@@ -2860,7 +2860,7 @@ export default function VisualEditorPage() {
         <NodeEditDialog node={selectedNode} isOpen={showNodeDialog} onClose={() => setShowNodeDialog(false)} onSave={handleSaveNode} onDelete={handleDeleteNode} />
       )}
       {crudFormDialogsEnabled ? (
-        <EdgeEditDialogCrudForm edge={selectedEdge} isOpen={showEdgeDialog} onClose={() => setShowEdgeDialog(false)} onSave={handleSaveEdge} onDelete={handleDeleteEdge} ledgerEntries={edgeDialogLedgerEntries} focusFieldId={edgeDialogFocusFieldId} variant={inspectorVariant} />
+        <EdgeEditDialogCrudForm edge={selectedEdge} isOpen={showEdgeDialog} onClose={() => setShowEdgeDialog(false)} onSave={handleSaveEdge} onDelete={handleDeleteEdge} ledgerEntries={edgeDialogLedgerEntries} focusFieldId={edgeDialogFocusFieldId} variant="overlay" wide />
       ) : (
         <EdgeEditDialog edge={selectedEdge} isOpen={showEdgeDialog} onClose={() => setShowEdgeDialog(false)} onSave={handleSaveEdge} onDelete={handleDeleteEdge} />
       )}

--- a/packages/core/src/modules/workflows/components/EdgeEditDialogCrudForm.tsx
+++ b/packages/core/src/modules/workflows/components/EdgeEditDialogCrudForm.tsx
@@ -48,6 +48,8 @@ export interface EdgeEditDialogCrudFormProps {
    * not opted in keeps the modal shape it had.
    */
   variant?: InspectorPanelVariant
+  /** Widen the overlay Drawer and lay the ledger out as a sticky side column. */
+  wide?: boolean
 }
 
 /**
@@ -67,7 +69,7 @@ export interface EdgeEditDialogCrudFormProps {
  * - Delete functionality with confirmation
  * - Keyboard shortcuts (Cmd/Ctrl+Enter save, Escape cancel)
  */
-export function EdgeEditDialogCrudForm({ edge, isOpen, onClose, onSave, onDelete, ledgerEntries, focusFieldId, variant = 'overlay' }: EdgeEditDialogCrudFormProps) {
+export function EdgeEditDialogCrudForm({ edge, isOpen, onClose, onSave, onDelete, ledgerEntries, focusFieldId, variant = 'overlay', wide }: EdgeEditDialogCrudFormProps) {
   const t = useT()
   const [initialValues, setInitialValues] = useState<Partial<EdgeFormValues>>({})
   const bodyRef = useRef<HTMLDivElement | null>(null)
@@ -251,6 +253,7 @@ export function EdgeEditDialogCrudForm({ edge, isOpen, onClose, onSave, onDelete
       open={isOpen}
       onClose={onClose}
       variant={variant}
+      wide={wide}
       title={t('workflows.edgeEditor.title')}
       typeLabel={t(`workflows.transitions.triggers.${trigger}`)}
       typeLabelVariant={triggerVariant}
@@ -266,36 +269,38 @@ export function EdgeEditDialogCrudForm({ edge, isOpen, onClose, onSave, onDelete
         </div>
       }
     >
-      <div ref={bodyRef}>
-        {/* Remount on re-target — see the note in NodeEditDialogCrudForm. */}
-        <CrudForm
-          key={edge.id}
-          density="compact"
-          fields={fields}
-          groups={groups}
-          initialValues={initialValues}
-          onSubmit={handleSubmit}
-          embedded={true}
-          submitLabel={t('workflows.edgeEditor.saveTransition')}
-          extraActions={
-            <Button
-              type="button"
-              variant="destructive-outline"
-              onClick={handleDelete}
-            >
-              <Trash2 className="size-4 mr-2" />
-              {t('workflows.edgeEditor.deleteTransition')}
-            </Button>
-          }
-        />
+      <div className={wide ? 'flex gap-6' : undefined}>
+        <div ref={bodyRef} className={wide ? 'min-w-0 flex-1' : undefined}>
+          {/* Remount on re-target — see the note in NodeEditDialogCrudForm. */}
+          <CrudForm
+            key={edge.id}
+            density="compact"
+            fields={fields}
+            groups={groups}
+            initialValues={initialValues}
+            onSubmit={handleSubmit}
+            embedded={true}
+            submitLabel={t('workflows.edgeEditor.saveTransition')}
+            extraActions={
+              <Button
+                type="button"
+                variant="destructive-outline"
+                onClick={handleDelete}
+              >
+                <Trash2 className="size-4 mr-2" />
+                {t('workflows.edgeEditor.deleteTransition')}
+              </Button>
+            }
+          />
+        </div>
+        <div className={wide ? 'sticky top-0 w-96 shrink-0 self-start' : 'mt-4'}>
+          <InputDataPanel
+            entries={ledgerEntries}
+            stepId={edge.target}
+            defaultCollapsed={!wide}
+          />
+        </div>
       </div>
-
-      <InputDataPanel
-        entries={ledgerEntries}
-        stepId={edge.target}
-        className="mt-4"
-        defaultCollapsed
-      />
     </InspectorPanel>
   )
 }

--- a/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
@@ -1117,43 +1117,48 @@ export function NodeEditDialogCrudForm({ node, isOpen, onClose, onSave, onDelete
         </Alert>
       )}
 
-      {/* Remount when the inspected step changes. A docked rail re-targets on a
-          canvas click, and CrudForm deliberately preserves fields the author has
-          already edited when `initialValues` changes — correct for late-arriving
-          field definitions, wrong here: it would carry an unsaved edit from the
-          previous step onto this one. */}
-      <CrudForm
-        key={node.id}
-        density="compact"
-        fields={fields}
-        groups={groups}
-        initialValues={initialValues}
-        onSubmit={handleSubmit}
-        embedded={true}
-        submitLabel={t('workflows.form.saveStep')}
-        extraActions={
-          canDelete ? (
-            <Button
-              type="button"
-              variant="destructive-outline"
-              onClick={handleDelete}
-            >
-              <Trash2 className="size-4 mr-2" />
-              {t('workflows.form.deleteStep')}
-            </Button>
-          ) : undefined
-        }
-      />
-
-      {/* The rail is too narrow for the side column the 1280px modal used, so
-          the ledger stacks under the form, folded until it is wanted. */}
-      <InputDataPanel
-        entries={ledgerEntries}
-        stepId={node.id}
-        samples={samples}
-        className="mt-4"
-        defaultCollapsed
-      />
+      {/* Wide drawer: the ledger is a sticky right column so a field can be
+          dragged onto any parameter no matter how far the form is scrolled. The
+          narrow docked rail keeps the old stacked-and-folded layout (a side
+          column would leave no room for the form). */}
+      <div className={wide ? 'flex gap-6' : undefined}>
+        <div className={wide ? 'min-w-0 flex-1' : undefined}>
+          {/* Remount when the inspected step changes. CrudForm preserves fields
+              the author already edited across `initialValues` changes, which
+              would leak an unsaved edit from the previous step onto this one —
+              the key forces a fresh mount. */}
+          <CrudForm
+            key={node.id}
+            density="compact"
+            fields={fields}
+            groups={groups}
+            initialValues={initialValues}
+            onSubmit={handleSubmit}
+            embedded={true}
+            submitLabel={t('workflows.form.saveStep')}
+            extraActions={
+              canDelete ? (
+                <Button
+                  type="button"
+                  variant="destructive-outline"
+                  onClick={handleDelete}
+                >
+                  <Trash2 className="size-4 mr-2" />
+                  {t('workflows.form.deleteStep')}
+                </Button>
+              ) : undefined
+            }
+          />
+        </div>
+        <div className={wide ? 'sticky top-0 w-96 shrink-0 self-start' : 'mt-4'}>
+          <InputDataPanel
+            entries={ledgerEntries}
+            stepId={node.id}
+            samples={samples}
+            defaultCollapsed={!wide}
+          />
+        </div>
+      </div>
     </InspectorPanel>
   )
 }


### PR DESCRIPTION
Follows up #4708 (the wide step drawer) with the layout it enables, and extends the same treatment to the route inspector.

## 1. Input data (context ledger) → sticky side column
In the wide drawer the **Input data** panel stacked at the very bottom, below Save/Delete — and you *drag its fields onto the form's parameters*, so once the form is scrolled the ledger is unreachable. It now sits in a **sticky right column beside the form** (expanded), so any field is draggable onto any parameter at any scroll position. This restores the side-column layout the old 1280px modal had (the code comment noted it was only stacked because the 384px rail was too narrow).

The narrow **docked rail keeps the old stacked-and-folded layout** — a side column there would leave no room for the form.

## 2. Route (transition) inspector → the drawer
The transition inspector was still the docked rail next to the canvas. It now opens as the **same wide overlay Drawer as the step inspector**, with the same two-column sticky-ledger layout. Consistent editing surface for steps and routes.

## Implementation
Reuses the existing `InspectorPanel` `wide` prop from #4708:
- `NodeEditDialogCrudForm` + `EdgeEditDialogCrudForm`: when `wide`, arrange `CrudForm` (left, `flex-1`) and `InputDataPanel` (right, `sticky top-0 w-96 self-start`, expanded); otherwise the prior stacked+`defaultCollapsed` layout. No arbitrary Tailwind values.
- `EdgeEditDialogCrudForm` gains the `wide` prop and forwards it to `InspectorPanel`.
- `visual-editor/page.tsx`: both the step and route dialogs now mount with `variant="overlay" wide`.

## Tests
- `tsc --noEmit -p packages/core` → 0 errors.
- **92 workflow inspector/editor tests pass** (dockedInspector, inputDataPanel, inspectorPanel, runStepInspector, taskInspectorSections, nodeOutcomeRows, metadataDrawer, workflowDrawerContract). No test asserted the route inspector docked, so none needed changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)