### PR TITLE
fix(workflows): show the resolved agent input in the run step inspector

### DIFF
--- a/packages/core/src/modules/workflows/lib/__tests__/run-inspector-step-input.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/run-inspector-step-input.test.ts
@@ -1,0 +1,122 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+import type { EntityManager } from '@mikro-orm/core'
+import { StepInstance, type WorkflowDefinition, type WorkflowInstance } from '../../data/entities'
+
+/**
+ * The run inspector shows a step's `StepInstance.inputData`. It used to be seeded
+ * only from the workflow trigger data (null for a manually-started run), so an
+ * INVOKE_AGENT step showed `Input: null` even though the agent received a real,
+ * interpolated payload. handleAutomatedStep now captures the resolved
+ * `config.input` onto `inputData` — this test locks that in.
+ *
+ * Only `executeActivities` is mocked (so the step parks without a live agent
+ * bridge); `interpolateVariables` stays real, so the assertion proves the exact
+ * value the agent runs on is what the inspector will display.
+ */
+jest.mock('../activity-executor', () => {
+  const actual = jest.requireActual('../activity-executor') as Record<string, unknown>
+  return { __esModule: true, ...actual, executeActivities: jest.fn() }
+})
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { executeActivities } = require('../activity-executor') as { executeActivities: jest.Mock }
+import { executeStep } from '../step-handler'
+
+const tenantId = '00000000-0000-4000-8000-000000000001'
+const orgId = '00000000-0000-4000-8000-000000000002'
+
+describe('run inspector — INVOKE_AGENT step input capture', () => {
+  let mockEm: jest.Mocked<EntityManager>
+  let createdStepInstance: any
+
+  const definition: Partial<WorkflowDefinition> = {
+    id: 'def-1',
+    workflowId: 'wf-1',
+    definition: {
+      steps: [
+        { stepId: 'start', stepName: 'Start', stepType: 'START' },
+        {
+          stepId: 'step_klient',
+          stepName: 'Klient',
+          stepType: 'AUTOMATED',
+          activities: [
+            {
+              activityId: 'invoke_klient',
+              activityName: 'Invoke Klient',
+              activityType: 'INVOKE_AGENT',
+              config: {
+                agentId: 'lighthouse.klient',
+                input: { client_identifiers: '{{context.client_identifiers}}' },
+                onResult: { autoApproveThreshold: 1 },
+              },
+            },
+          ],
+        },
+        { stepId: 'end', stepName: 'End', stepType: 'END' },
+      ],
+      transitions: [],
+    },
+    tenantId,
+    organizationId: orgId,
+  }
+
+  const instance: Partial<WorkflowInstance> = {
+    id: 'inst-1',
+    definitionId: 'def-1',
+    workflowId: 'wf-1',
+    status: 'RUNNING',
+    currentStepId: 'step_klient',
+    context: {},
+    tenantId,
+    organizationId: orgId,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    createdStepInstance = undefined
+    mockEm = {
+      findOne: jest.fn().mockResolvedValue(definition),
+      find: jest.fn(),
+      create: jest.fn((entity: any, data: any) => {
+        const row = { ...data }
+        if (entity === StepInstance) createdStepInstance = row
+        return row
+      }),
+      persist: jest.fn(function persist(this: any) { return this }),
+      flush: jest.fn(),
+      nativeDelete: jest.fn(),
+    } as any
+
+    // The agent proposal routes to a human → the step parks on the signal. The
+    // input capture runs before this, so the parked step already carries it.
+    executeActivities.mockResolvedValue([
+      {
+        activityId: 'invoke_klient',
+        activityName: 'Invoke Klient',
+        activityType: 'INVOKE_AGENT',
+        success: true,
+        async: false,
+        retryCount: 0,
+        executionTimeMs: 1,
+        output: { __park: { signalName: 'agent_orchestrator.proposal.ready' }, proposalId: 'p1' },
+      },
+    ])
+  })
+
+  test('persists the resolved agent input onto the step instance', async () => {
+    const result = await executeStep(
+      mockEm,
+      instance as WorkflowInstance,
+      'step_klient',
+      { workflowContext: { client_identifiers: { nip: '5272961101', regon: '388921133' } } } as any,
+      {},
+    )
+
+    expect(result.status).toBe('WAITING')
+    expect(executeActivities).toHaveBeenCalledTimes(1)
+    // Not the trigger data (null) — the interpolated agent input.
+    expect(createdStepInstance.inputData).toEqual({
+      client_identifiers: { nip: '5272961101', regon: '388921133' },
+    })
+  })
+})

--- a/packages/core/src/modules/workflows/lib/step-handler.ts
+++ b/packages/core/src/modules/workflows/lib/step-handler.ts
@@ -559,7 +559,35 @@ async function handleAutomatedStep(
   }
 
   // Import activity executor
-  const { executeActivities } = await import('./activity-executor')
+  const { executeActivities, interpolateVariables } = await import('./activity-executor')
+
+  // Persist the resolved INVOKE_AGENT input so the run inspector shows what this
+  // step actually received. `inputData` was seeded at step entry from the
+  // workflow trigger data (null for a manually-started run), never the agent's
+  // real, interpolated `config.input` — the same value the executor computes via
+  // `interpolateActivityConfig` (a thin wrapper over `interpolateVariables`), so
+  // re-interpolating the input field here yields exactly what the agent runs on.
+  const agentActivity = activities.find(
+    (activity: any) => activity.activityType === 'INVOKE_AGENT' && activity?.config?.input !== undefined,
+  )
+  if (agentActivity) {
+    try {
+      const resolvedInput = interpolateVariables(
+        (agentActivity as any).config.input,
+        context.workflowContext,
+        instance,
+        { mode: context.interpolationMode },
+      )
+      if (resolvedInput !== undefined) {
+        stepInstance.inputData = resolvedInput
+        stepInstance.updatedAt = new Date()
+        await em.flush()
+      }
+    } catch {
+      // Display-only capture: an interpolation error is surfaced by the actual
+      // activity run below, so it must never abort the step here.
+    }
+  }
 
   try {
     // Execute activities with proper context


### PR DESCRIPTION
## Problem
In the instance (run) view, the **Step Inspector** shows `Input: null` for an INVOKE_AGENT step — e.g. the Lighthouse **Klient** step shows null input even while the agent is Running and clearly received a payload.

Root cause: the inspector renders `StepInstance.inputData`, and that field is only ever set at step *entry* to `context.triggerData || null` (`step-handler.ts`). For a manually-started run the trigger data is null, and it is **never** replaced with the step's actual resolved input.

## Fix
`handleAutomatedStep` now captures the resolved INVOKE_AGENT `config.input` onto `inputData` before running the activity. The value is produced by the **same** `interpolateVariables` the executor uses (`interpolateActivityConfig` is a thin wrapper over it), so the inspector displays exactly what the agent runs on — `{ client_identifiers: {...} }` for the Klient step.

- Display-only capture wrapped in `try/catch`: an interpolation error is surfaced by the real activity run and never aborts the step.
- No schema or API change (`inputData` already exists and is already read by the inspector).
- Covers the common synchronous INVOKE_AGENT path (the Lighthouse agents). The authored-`async` activity path resolves input in the worker and is out of scope here.

## Tests
- New `run-inspector-step-input.test.ts`: mocks only `executeActivities` (keeps interpolation real) and asserts the parked Klient step carries `{ client_identifiers: {...} }` as `inputData`, not null.
- `tsc --noEmit -p packages/core` → 0 errors.
- 76 existing workflow-engine tests (step-handler, invoke-agent-async, invoke-agent-queue-split, workflow-executor) still pass — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)