### PR TITLE
fix(shared): close CRUD fail-open paths (identity-partitioned list cache, create-command guards, DI registrar logging)

### DIFF
--- a/.ai/specs/2026-07-30-crud-fail-open-hardening.md
+++ b/.ai/specs/2026-07-30-crud-fail-open-hardening.md
@@ -1,0 +1,166 @@
+# CRUD Fail-Open Hardening — Identity-Partitioned List Cache, Create-Command Mutation Guards, DI Registrar Logging
+
+## TLDR
+
+Three fail-open defects in shared CRUD infrastructure (`packages/shared`) are fixed in one change:
+
+1. **Cross-user list cache leak.** `buildCrudCacheKey` in `packages/shared/src/lib/crud/factory.ts` had no caller-identity segment and read the original request URL, so two users in the same tenant/org scope requesting the identical URL shared one cache entry. With `ENABLE_CRUD_API_CACHE=true` this leaks live today on `staff` time-projects (`?mine=true` narrows by `ctx.auth.sub` inside `buildFilters`) and on `scheduler` jobs (the `isSuperAdmin` branch adds a system-jobs filter, exposing system-job rows including `target_payload` to non-superadmins). The key now carries a `user:` segment derived from `auth.keyId ?? auth.sub`.
+2. **Mutation guards never ran on command-based creates.** The POST command branch of `makeCrudRoute` never invoked `runMutationGuards` (the direct branch has run create guards since the optimistic-locking coverage work). Guards now run on the create command branch with `operation: 'create'` and `resourceId: null`, mirroring the direct branch. The separate id-less update/delete skip (`&& candidateId`) is deliberately **kept**: the `{ body }`-wrap `mapInput` idiom is a documented row-level guard opt-out (see Design Decisions).
+3. **Silent DI registrar failures.** A module `di.ts` registrar that threw during `createRequestContainer` was swallowed by an empty `catch {}` (`packages/shared/src/lib/di/container.ts`), so a miswired module lost all its services with no trace. The catch now logs through the shared logger facade (`Module DI registrar failed`, with `registrarIndex` and `err`) while keeping fail-open boot semantics.
+
+## Overview
+
+`makeCrudRoute` is the shared CRUD factory every module list/mutation route builds on, and `createRequestContainer` wires every request container. All three defects share one failure mode: a security- or correctness-relevant mechanism degrades to "not enforced" without any error or log — the same silent fail-open pattern already remediated for organization scope in `.ai/specs/implemented/2026-05-29-org-scope-fail-open-authorization-hardening.md`.
+
+Related specs and docs:
+
+- `.ai/specs/2026-05-24-crud-api-performance-quick-wins.md` — names the `ENABLE_CRUD_API_CACHE` response cache as pre-existing and out of its scope.
+- `.ai/specs/2026-06-05-cache-safety-always-consistent.md` — covers invalidation consistency of the same cache; key partitioning was out of its scope.
+- `.ai/specs/implemented/2026-05-25-oss-optimistic-locking.md` and `.ai/specs/2026-05-28-optimistic-locking-coverage-completion.md` — introduced `crudMutationGuardService` and the guard registry this change extends to the create command branch.
+- `apps/docs/docs/framework/data-integrity/concurrency-locking.mdx` — documents the `{ body }`-wrap row-level guard opt-out this change preserves.
+
+## Problem Statement
+
+### 1. List cache shared across identities
+
+`buildCrudCacheKey` segments were `crud | resource | GET | pathname | tenant | selectedOrg | scope | query (original URL) [| enrichers]`. Nothing derived from the caller's identity was included, while the cached payload can vary per caller through at least four channels:
+
+- `opts.list.buildFilters(validated, ctx)` can narrow by `ctx.auth` — live examples: `packages/core/src/modules/staff/api/timesheets/time-projects/route.ts` (`?mine=true` → assigned-project ids of the calling user, or a zero-UUID empty page) and `packages/scheduler/src/modules/scheduler/api/jobs/buildFilters.ts` (`isSuperAdmin` gates a system-jobs branch under `omitAutomaticTenantOrgScope: true`).
+- Before-interceptor query rewrites feed the engine query (`interceptorRequest.query` re-parses into `validated`), and interceptor execution itself is feature-gated per user.
+- The stored payload embeds `hooks.afterList` and after-interceptor output (the store runs after both).
+- Response enrichers produce per-user output (e.g. `customers.private-email-count`, `staff.timesheets-projects-portfolio`); they are currently kept out of the stored payload only because no enricher sets `cacheableOnListHit: true` yet — the enricher signature partitions by enricher set, never by user.
+
+**Attack precondition:** `ENABLE_CRUD_API_CACHE=true` (default off, global, no per-route opt-out) plus two callers in the same tenant/org scope on the same URL. The priming caller's rows are then served to every subsequent caller until invalidation.
+
+### 2. Guards skipped on the create command branch
+
+The POST `useCommand` branch had no `runMutationGuards` call between input mapping and `commandBus.execute`. The direct branch has run create guards since the optimistic-locking coverage work. Any guard declaring `operations: ['create']` was silently ignored for command-based creates — including the create-app template's own `example.todo-limit` reference guard on a command-based todos route.
+
+The related-looking `&& candidateId` skip on the PUT/DELETE command branches is **not** part of this defect: commands whose `mapInput` wraps the payload (`{ body: payload }` in `makeSalesLineRoute` and the order/quote-adjustment routes) null `candidateId` deliberately, opting out of row-level guards and leaving the command-level `enforceCommandOptimisticLock` check as the sole guard. That contract is documented in `concurrency-locking.mdx` and the shipped UI relies on it (those PUTs carry the parent document's lock header, which must not be compared against the line row).
+
+### 3. Swallowed DI registrar errors
+
+`for (const reg of diRegistrars) { try { reg?.(container) } catch {} }` dropped the error entirely. The failure surfaced only later as an unrelated Awilix resolution error, with no root cause in any log — in conflict with the repo's structured-logging facade rules (`.ai/specs/2026-07-02-structured-logging-facade.md`).
+
+## Proposed Solution
+
+1. **Identity segment in the cache key.** `buildCrudCacheKey` appends `user:${normalizeTagSegment((ctx.auth?.keyId ?? ctx.auth?.sub) ?? null)}` after the `scope:` segment. `keyId ?? sub` mirrors the existing `actorUserId` precedent in the same file, so API-key callers partition by key id. Entries are never shared across identities.
+2. **Guards on the create command branch.** After the sync `*.creating` block and before `commandBus.execute`, the branch resolves user features, collects guards (`collectAndRunGuards`), and calls `runMutationGuards` with `operation: 'create'`, `resourceId: null`, and the mapped command input as `mutationPayload`. `modifiedPayload` merges spread-style into the command input (command-branch convention; no schema re-parse after `mapInput`). `afterSuccess` callbacks run after the response is built, with `resourceId` resolved via `pickFirstIdentifier(result.id, resolvedPayload.id)` — the payload fallback covers commands that expose the id under another key but map it into the response (e.g. `lineId` → `id` in `makeSalesLineRoute`). When neither yields an id, `afterSuccess` is skipped (`MutationGuardAfterInput.resourceId` is non-nullable).
+3. **Log DI registrar failures.** The catch logs `logger.error('Module DI registrar failed', { registrarIndex, err })` and continues. Fail-open boot semantics are preserved deliberately: one broken optional module must not take down every request container, and the sibling app-level registrar failure a few lines below already logs-and-continues.
+
+### Design Decisions
+
+- **Identity segment is unconditional**, not "only when interceptors are registered": the live leaks come from `buildFilters`, which is invisible to any registry probe, and enricher/after-hook variance would bypass an interceptor-scoped partition too. Correctness beats hit-rate here; the cache is opt-in and off by default.
+- **The id-less update/delete guard skip is retained.** An earlier iteration of this change removed `&& candidateId`; adversarial review refuted it: (a) the `{ body }`-wrap opt-out is a documented contract downstream guards may rely on, and (b) in the default deployment the legacy bridge coerces `resourceId: null` to `''`, so every sales line/adjustment edit (whose UI always sends the parent document's lock header) would fire a guaranteed-failing `em.findOne({ id: '' })` and a false-alarm `Reader query failed — optimistic locking is DISABLED` error log per save. Closing the id-less gap properly requires a designed contract change (e.g. an explicit per-action `resourceId` resolver so guards receive the real row id) — deferred to the platform work tracked for the record-level permissions design.
+- **DI registrar failures stay fail-open (log, not rethrow)**: rethrowing would turn one broken third-party module into a process-wide request failure. A fail-closed canary is a module-level concern (out of scope here).
+
+### Alternatives Considered
+
+- *Key from the post-interceptor effective query* — covers only the query-rewrite channel; buildFilters/after-hook/enricher variance still leaks. Rejected as insufficient alone.
+- *Per-route `cache: { sharedAcrossUsers: true }` opt-in to restore cross-user sharing* — viable additive follow-up if hit rates matter later; not needed for correctness now.
+- *Running id-less update/delete commands through guards with `resourceId: null`* — rejected after adversarial review (see Design Decisions).
+- *Module-id in the DI registrar log* — the generated `diRegistrars` array carries bare `register` functions; attaching module ids is an additive generator/`BootstrapData` change (BC-allowed) but beyond this surgical fix. The loop index is deterministic (enabled-module order) and logged instead.
+
+### Known Limitations
+
+- **Command-branch guard payload shape.** On command routes, `mutationPayload` is the post-`mapInput` command input (matching the existing update/delete command-branch convention), so for enveloping routes a guard sees `{ body: {...} }` rather than the domain payload, and a `modifiedPayload` returned by a guard merges at the envelope's top level. Guards targeting command routes must account for the envelope.
+- **resourceKind granularity.** Command routes derive `resourceKind` from the command id (`deriveResourceFromCommandId`), so sub-resource commands collide with their parent (e.g. `sales.orders.lines.upsert` → `sales.order`). A create guard targeting `sales.order` also runs for line/adjustment creates.
+- **Identity segment sanitization.** `normalizeTagSegment` maps characters outside `[a-zA-Z0-9._-]` to `-`; distinct non-UUID subs could collide post-sanitization (e.g. email-shaped subs). Platform user subs and API key ids are UUIDs, so there is no in-platform exposure; deployments minting JWTs with free-form subs should be aware.
+
+## User Stories / Use Cases
+
+- A staff member requesting `?mine=true` lists never receives another user's assigned projects, cache on or off.
+- A non-superadmin never receives cached system-job rows (including payloads) primed by a superadmin.
+- A module (e.g. the create-app template's `example.todo-limit`, or a future permissions module) registering a create guard sees it enforced on command-based creates.
+- A platform operator sees a `Module DI registrar failed` error log the moment a module's `di.ts` breaks, instead of debugging downstream resolution errors.
+
+## Architecture
+
+All changes stay inside `packages/shared`; no new services, DI keys, or module contracts. The guard call added to the create command branch reuses the existing `collectAndRunGuards` / `runMutationGuards` / `runGuardAfterSuccessCallbacks` helpers.
+
+## Data Models
+
+None. No database structure changes.
+
+## API Contracts
+
+No route URLs, request schemas, or response schemas change. Behavior changes (intended):
+
+- Command-based POST routes now return the guard's error (default 422/`Operation blocked by guard`) when a registered create guard blocks; previously the command executed unconditionally. The OSS optimistic-lock guard is unaffected (its bridge registers update/delete only, and it short-circuits creates).
+- `x-om-cache: hit` responses are now always same-identity hits.
+- Id-less command PUT/DELETE behavior is unchanged (documented opt-out preserved).
+
+Backward compatibility per `BACKWARD_COMPATIBILITY.md`: no listed contract surface is touched — no exported type narrowed, no DI key changes, `makeCrudRoute(opts)` signature unchanged, cache key shape is not a contract surface.
+
+## Internationalization (i18n)
+
+None. The new log line is operator-facing diagnostics through the logger facade, not user-facing copy; guard rejection bodies come from the guards themselves.
+
+## UI/UX
+
+None. No UI-rendering files touched (the two `apps/docs` edits are documentation content).
+
+## Configuration
+
+No new configuration. `ENABLE_CRUD_API_CACHE` semantics unchanged (global, default off); its entries are now identity-partitioned.
+
+## Migration & Compatibility
+
+- Cache entries written under the pre-fix key shape are never read again (every lookup now includes the `user:` segment). They are removed by the existing tag-based invalidation on the next mutation of their resource; entries for never-mutated resources persist as bounded dead weight (the CRUD cache stores no TTL), which is storage overhead, not a leak. No migration or manual flush required.
+- Expected hit-rate drop on multi-user shared lists is the correctness cost; a shared-cache opt-in can be added later as an additive `ListConfig` field if needed.
+- Downstream guards declaring `operations: ['create']` now run on command-based creates; that is the guards' declared intent.
+
+## Implementation Plan
+
+Single phase, shipped with this spec.
+
+### File Manifest
+
+- `packages/shared/src/lib/crud/factory.ts` — `user:` cache-key segment; create-command-branch guard run + afterSuccess (with response-payload id fallback); clarifying comment on the retained id-less opt-out.
+- `packages/shared/src/lib/di/container.ts` — registrar loop logs failures (`registrarIndex`, `err`).
+- `packages/shared/src/lib/crud/__tests__/crud-factory.cache-user-scope.test.ts` — new; route-level identity-partition coverage.
+- `packages/shared/src/lib/crud/__tests__/crud-factory.test.ts` — create-command guard tests (block, modifiedPayload merge, afterSuccess incl. payload-id fallback) and regression pins for the id-less opt-out; `registerMutationGuards([])` reset in `beforeEach`.
+- `packages/shared/src/lib/di/__tests__/registrar-error-log.test.ts` — new; throwing registrar is logged and skipped, container stays usable.
+- `apps/docs/docs/framework/api/crud-factory.mdx` — cache-key section documents the `user:` segment.
+- `apps/docs/docs/framework/data-integrity/concurrency-locking.mdx` — FAQ disambiguates the lock guard (never on create) from registry create guards (both branches).
+
+### Testing Strategy
+
+Route-level jest tests exercise the full factory pipeline (auth → interceptors → cache → engine → guards → command bus) with a Map-backed cache and switchable caller identity — the same harness style as `crud-factory.enricher-cache.test.ts`, which is the repo's existing coverage vehicle for cache-key partitioning:
+
+- Same identity: miss then hit; engine queried once.
+- Second identity, identical URL: miss, own rows, distinct entry; first identity still hits its own entry.
+- Key contains `user:<keyId ?? sub>`; API-key callers partition by key id.
+- POST command branch: blocking create guard → 4xx and `commandBus.execute` not called; passing guard → `modifiedPayload` merged into command input; `afterSuccess` receives the command result id, with the response-payload fallback covered separately.
+- Id-less command PUT/DELETE: regression pins assert both static registry guards and the DI guard service are NOT invoked and the command executes (the documented opt-out).
+- DI: throwing registrar → `logger.error('Module DI registrar failed', …)`, subsequent registrar still runs, container resolves its services.
+
+Playwright integration tests are not applicable to this change: `ENABLE_CRUD_API_CACHE` is off in the integration environment (the leak is unobservable either way there), and the guard-branch change is observable only with a blocking guard registered, which cannot be installed through the public API. The route-level suites above cross the same component boundaries end-to-end in-process.
+
+## Risks & Impact Review
+
+### Tenant & Data Isolation Risks
+
+- The identity segment strictly tightens partitioning; tenant/org segments are unchanged. Residual risk: an interceptor varying its rewrite on a non-identity request header would still share entries within one identity — no such interceptor exists in-repo; noted for the future shared-cache opt-in design.
+- Enricher outputs remain excluded from stored payloads until an enricher opts into `cacheableOnListHit`; with identity partitioning, a future per-user cacheable enricher no longer leaks across users.
+
+### Risk Register
+
+| Risk | Severity | Affected area | Mitigation | Residual |
+|---|---|---|---|---|
+| Cache hit-rate drop on shared lists | Low | Perf (flag-gated feature) | Flag default off; additive shared-cache opt-in possible later | Accepted |
+| A downstream create guard newly runs on command creates and blocks traffic | Medium | Third-party guards | That is the guard's declared intent (`operations: ['create']`); direct branch already behaved this way; called out in this spec | Low |
+| Guard `afterSuccess` skipped when neither the command result nor the response payload exposes an id | Low | Guard callbacks | `pickFirstIdentifier` fallback covers the known `lineId`/`adjustmentId` family; documented | Accepted |
+| Create guards written for a parent resource also run for sub-resource commands (resourceKind collision) | Low | Third-party guards | Documented under Known Limitations; inherent to `deriveResourceFromCommandId` | Accepted |
+| Registrar log floods if a module throws per request | Low | Log volume | Single error-level line per registrar per container build | Accepted |
+
+## Final Compliance Report — 2026-07-30
+
+- `packages/shared` only (plus two `apps/docs` content edits); no domain imports added; no `any` on exported surfaces.
+- No contract surface from `BACKWARD_COMPATIBILITY.md` modified; no deprecation protocol required. The documented `{ body }`-wrap guard opt-out is preserved.
+- Validation (Runner: local): full ordered gate from `.ai/agentic.config.json` — `build:packages`, `generate` (no drift), `build:packages`, `i18n:check-sync`, `typecheck`, `test`, `build:app` all green; `i18n:check-usage` fails on the develop baseline (2 keys from `packages/ui/.../phone.tsx`, introduced by #4147) — pre-existing, unrelated to this change.
+- Adversarial verification: 3 independent reviewers (correctness, downstream impact, tests+spec accuracy); the id-less guard change was refuted and reverted, afterSuccess id fallback and doc updates added in response; remaining findings recorded as Known Limitations.
+
+## Changelog
+
+- 2026-07-30 — Spec written and implemented in the same change (cache identity partitioning, create-command-branch guard coverage, DI registrar logging). Id-less update/delete guard skip retained as a documented opt-out after adversarial review; docs updated (cache-key section, lock-guard FAQ).

--- a/apps/docs/docs/framework/api/crud-factory.mdx
+++ b/apps/docs/docs/framework/api/crud-factory.mdx
@@ -439,12 +439,17 @@ Cache keys include:
 - Tenant ID
 - Selected organization ID
 - Organization scope (array of allowed org IDs)
+- Caller identity (`user:` segment — the API key id, or the user id for session callers)
 - Active-enricher signature (only when the route has enrichers active for the caller)
 
 ```ts
 // Example cache key structure
-crud|customers.customer_entity|GET|/api/customers/people|tenant:123|selectedOrg:456|scope:456,789|query:page=1&pageSize=50&search=test
+crud|customers.customer_entity|GET|/api/customers/people|tenant:123|selectedOrg:456|scope:456,789|user:abc|query:page=1&pageSize=50&search=test
 ```
+
+Entries are never shared across caller identities: `buildFilters`, interceptor
+query rewrites, and `afterList`/after-interceptor output can all vary per user,
+and the stored payload embeds them.
 
 ### Response Enrichers and the List Cache
 

--- a/apps/docs/docs/framework/data-integrity/concurrency-locking.mdx
+++ b/apps/docs/docs/framework/data-integrity/concurrency-locking.mdx
@@ -574,8 +574,10 @@ existing clients while making every page that opts into the header
 protected automatically.
 
 **Q: Does the guard run on `create`?**
-A: No. Only `update` and `delete`. There is no "expected previous
-version" for a create.
+A: The optimistic-lock guard does not — only `update` and `delete`; there
+is no "expected previous version" for a create. Registry mutation guards
+declaring `operations: ['create']` do run on creates, on both the direct
+and the command branch of `makeCrudRoute`.
 
 **Q: Can the enterprise module override the resolved token source?**
 A: Yes — `createOptimisticLockGuardService({ resolveExpected: … })` is

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.cache-user-scope.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.cache-user-scope.test.ts
@@ -1,0 +1,171 @@
+// Regression coverage for the CRUD list cache key missing a caller-identity
+// segment: two callers in the same tenant/org scope requesting the identical
+// URL must NOT share cache entries, because list payloads can vary per caller —
+// buildFilters may narrow by ctx.auth (e.g. ?mine=true on staff time-projects,
+// the isSuperAdmin branch on scheduler jobs), before-interceptor query rewrites
+// are feature-gated per user, and afterList/after-interceptor output is
+// embedded in the stored payload.
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: async (_tenantId: string | null, fn: () => Promise<unknown>) => fn(),
+}), { virtual: true })
+
+import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
+import { registerApiInterceptors } from '@open-mercato/shared/lib/crud/interceptor-registry'
+import { z } from 'zod'
+
+const defaultOrganizationId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const defaultTenantId = '123e4567-e89b-12d3-a456-426614174000'
+
+let mockAuthSub = 'user-a'
+let mockAuthKeyId: string | null = null
+
+const em = {}
+
+// Returns rows derived from the per-caller filter buildFilters produced, so a
+// cross-user cache hit is observable as one user's rows in another's response.
+const queryEngine = {
+  query: jest.fn(async (_entity: string, opts: Record<string, any>) => {
+    const owner = opts?.filters?.owner_user_id?.$eq ?? 'unfiltered'
+    return {
+      items: [{ id: `todo-of-${owner}`, title: `Owned by ${owner}`, organization_id: defaultOrganizationId, tenant_id: defaultTenantId }],
+      total: 1,
+    }
+  }),
+}
+
+const store = new Map<string, unknown>()
+const cache = {
+  get: jest.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
+  set: jest.fn(async (key: string, value: unknown) => { store.set(key, value) }),
+  delete: jest.fn(async (key: string) => { store.delete(key) }),
+  deleteByTags: jest.fn(async () => 0),
+}
+
+const accessLogService = { log: jest.fn(async () => {}) }
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({
+    resolve: (name: string) => ({
+      em,
+      queryEngine,
+      cache,
+      accessLogService,
+    } as any)[name],
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => {
+  const buildAuth = () => ({
+    sub: mockAuthSub,
+    keyId: mockAuthKeyId ?? undefined,
+    orgId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    tenantId: '123e4567-e89b-12d3-a456-426614174000',
+    roles: ['admin'],
+  })
+  return {
+    getAuthFromCookies: async () => buildAuth(),
+    getAuthFromRequest: async () => buildAuth(),
+  }
+})
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn(async () => ({
+    selectedId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    filterIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+    allowedIds: ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'],
+    tenantId: '123e4567-e89b-12d3-a456-426614174000',
+  })),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/lib/helpers', () => ({
+  setRecordCustomFields: jest.fn(async () => {}),
+}))
+
+class Todo {}
+
+const querySchema = z.object({
+  page: z.coerce.number().default(1),
+  pageSize: z.coerce.number().default(50),
+  sortField: z.string().default('id'),
+  sortDir: z.enum(['asc', 'desc']).default('asc'),
+})
+
+const route = makeCrudRoute({
+  metadata: { GET: { requireAuth: true } },
+  orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+  indexer: { entityType: 'example.todo' },
+  list: {
+    schema: querySchema,
+    entityId: 'example.todo',
+    fields: ['id', 'title'],
+    sortFieldMap: { id: 'id', title: 'title' },
+    buildFilters: (_query: any, ctx: any) => ({ owner_user_id: { $eq: ctx.auth?.sub ?? null } } as any),
+    transformItem: (i: any) => ({ id: i.id, title: i.title }),
+  },
+})
+
+const url = 'http://x/api/example/todos?page=1&pageSize=10&sortField=id&sortDir=asc'
+
+describe('CRUD Factory — list cache is partitioned per caller identity', () => {
+  const previousCacheFlag = process.env.ENABLE_CRUD_API_CACHE
+
+  beforeAll(() => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+  })
+
+  afterAll(() => {
+    if (previousCacheFlag === undefined) delete process.env.ENABLE_CRUD_API_CACHE
+    else process.env.ENABLE_CRUD_API_CACHE = previousCacheFlag
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    store.clear()
+    mockAuthSub = 'user-a'
+    mockAuthKeyId = null
+    registerApiInterceptors([])
+  })
+
+  it('caches per user and still serves same-user repeat requests from cache', async () => {
+    const first = await route.GET(new Request(url))
+    expect(first.status).toBe(200)
+    expect(first.headers.get('x-om-cache')).toBe('miss')
+    expect((await first.json()).items[0].id).toBe('todo-of-user-a')
+
+    const second = await route.GET(new Request(url))
+    expect(second.headers.get('x-om-cache')).toBe('hit')
+    expect((await second.json()).items[0].id).toBe('todo-of-user-a')
+    expect(queryEngine.query).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not serve one user\'s cached rows to another user on the identical URL', async () => {
+    mockAuthSub = 'user-a'
+    const aRes = await route.GET(new Request(url))
+    expect((await aRes.json()).items[0].id).toBe('todo-of-user-a')
+    expect(store.size).toBe(1)
+
+    mockAuthSub = 'user-b'
+    const bRes = await route.GET(new Request(url))
+    expect(bRes.headers.get('x-om-cache')).toBe('miss')
+    expect((await bRes.json()).items[0].id).toBe('todo-of-user-b')
+    expect(store.size).toBe(2)
+
+    mockAuthSub = 'user-a'
+    const aAgain = await route.GET(new Request(url))
+    expect(aAgain.headers.get('x-om-cache')).toBe('hit')
+    expect((await aAgain.json()).items[0].id).toBe('todo-of-user-a')
+  })
+
+  it('keys every entry with an identity segment, preferring the API key id over the user id', async () => {
+    await route.GET(new Request(url))
+    const userKey = Array.from(store.keys())[0] as string
+    expect(userKey).toContain('user:user-a')
+
+    store.clear()
+    mockAuthKeyId = 'api-key-9'
+    await route.GET(new Request(url))
+    const apiKeyKey = Array.from(store.keys())[0] as string
+    expect(apiKeyKey).toContain('user:api-key-9')
+  })
+})

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -10,6 +10,7 @@ import {
   registerOptimisticLockReaders,
 } from '@open-mercato/shared/lib/crud/optimistic-lock-store'
 import { loadCustomFieldDefinitionIndex } from '@open-mercato/shared/lib/crud/custom-fields'
+import { registerMutationGuards } from '@open-mercato/shared/lib/crud/mutation-guard-store'
 import { z } from 'zod'
 
 // Keep the real custom-field helpers but spy on the definition loader so we can
@@ -201,6 +202,7 @@ describe('CRUD Factory', () => {
     }
     crudMutationGuardService = null
     registerApiInterceptors([])
+    registerMutationGuards([])
   })
 
   const querySchema = z.object({
@@ -719,6 +721,193 @@ describe('CRUD Factory', () => {
     // CommandBus via flushCrudSideEffects(). The factory itself must NOT emit events
     // to avoid duplicates (see commit 3f999f35).
     expect(mockDataEngine.emitOrmEntityEvent).not.toHaveBeenCalled()
+  })
+
+  it('POST command route runs mutation guards before executing the command', async () => {
+    const guardValidate = jest.fn(async (_input: any) => ({ ok: false, status: 403, message: 'Blocked by test guard' }))
+    registerMutationGuards([{ moduleId: 'example', guards: [{
+      id: 'example.block-command-create',
+      targetEntity: 'example.todo',
+      operations: ['create'],
+      validate: guardValidate,
+    }] }])
+    const commandRoute = makeCrudRoute({
+      metadata: { POST: { requireAuth: true } },
+      orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+      indexer: { entityType: 'example.todo' },
+      actions: {
+        create: {
+          commandId: 'example.todo.create',
+          schema: createSchema,
+          response: () => ({ ok: true }),
+        },
+      },
+    })
+
+    const res = await commandRoute.POST(new Request('http://x/api/example/todos/command', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'A' }),
+      headers: { 'content-type': 'application/json' },
+    }))
+
+    expect(res.status).toBe(403)
+    expect(guardValidate).toHaveBeenCalledWith(expect.objectContaining({
+      resourceKind: 'example.todo',
+      resourceId: null,
+      operation: 'create',
+      mutationPayload: expect.objectContaining({ title: 'A' }),
+    }))
+    expect(commandBus.execute).not.toHaveBeenCalled()
+  })
+
+  it('POST command route merges guard modifiedPayload and runs afterSuccess with the command result id', async () => {
+    commandBus.execute.mockResolvedValue({ result: { id: 'cmd-created-1' }, logEntry: { id: 'log-1' } })
+    const guardAfterSuccess = jest.fn(async () => {})
+    registerMutationGuards([{ moduleId: 'example', guards: [{
+      id: 'example.rewrite-command-create',
+      targetEntity: 'example.todo',
+      operations: ['create'],
+      validate: async (_input: any) => ({ ok: true, modifiedPayload: { title: 'FROM-GUARD' }, shouldRunAfterSuccess: true }),
+      afterSuccess: guardAfterSuccess,
+    }] }])
+    const commandRoute = makeCrudRoute({
+      metadata: { POST: { requireAuth: true } },
+      orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+      indexer: { entityType: 'example.todo' },
+      actions: {
+        create: {
+          commandId: 'example.todo.create',
+          schema: createSchema,
+          response: () => ({ ok: true }),
+        },
+      },
+    })
+
+    const res = await commandRoute.POST(new Request('http://x/api/example/todos/command', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'A' }),
+      headers: { 'content-type': 'application/json' },
+    }))
+
+    expect(res.status).toBe(201)
+    expect(commandBus.execute).toHaveBeenCalledWith('example.todo.create', expect.objectContaining({
+      input: expect.objectContaining({ title: 'FROM-GUARD' }),
+    }))
+    expect(guardAfterSuccess).toHaveBeenCalledWith(expect.objectContaining({
+      resourceId: 'cmd-created-1',
+      operation: 'create',
+    }))
+  })
+
+  it('POST command route falls back to the response payload id for guard afterSuccess', async () => {
+    commandBus.execute.mockResolvedValue({ result: { lineId: 'line-42' }, logEntry: { id: 'log-1' } })
+    const guardAfterSuccess = jest.fn(async () => {})
+    registerMutationGuards([{ moduleId: 'example', guards: [{
+      id: 'example.after-command-create',
+      targetEntity: 'example.todo',
+      operations: ['create'],
+      validate: async (_input: any) => ({ ok: true, shouldRunAfterSuccess: true }),
+      afterSuccess: guardAfterSuccess,
+    }] }])
+    const commandRoute = makeCrudRoute({
+      metadata: { POST: { requireAuth: true } },
+      orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+      indexer: { entityType: 'example.todo' },
+      actions: {
+        create: {
+          commandId: 'example.todo.create',
+          schema: createSchema,
+          response: ({ result }: any) => ({ id: result.lineId }),
+        },
+      },
+    })
+
+    const res = await commandRoute.POST(new Request('http://x/api/example/todos/command', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'A' }),
+      headers: { 'content-type': 'application/json' },
+    }))
+
+    expect(res.status).toBe(201)
+    expect(guardAfterSuccess).toHaveBeenCalledWith(expect.objectContaining({
+      resourceId: 'line-42',
+      operation: 'create',
+    }))
+  })
+
+  // Commands whose mapInput wraps the payload (e.g. `{ body }`) null the factory
+  // candidateId and thereby OPT OUT of row-level mutation guards, leaving the
+  // command-level optimistic-lock check as the sole guard — a documented contract
+  // (apps/docs/docs/framework/data-integrity/concurrency-locking.mdx) that sales
+  // line/adjustment routes rely on.
+  it('PUT command route without a top-level id keeps the documented row-level guard opt-out', async () => {
+    crudMutationGuardService = {
+      validateMutation: jest.fn().mockResolvedValue({ ok: true, shouldRunAfterSuccess: false }),
+      afterMutationSuccess: jest.fn().mockResolvedValue(undefined),
+    }
+    const guardValidate = jest.fn(async (_input: any) => ({ ok: false, status: 409, message: 'must not run' }))
+    registerMutationGuards([{ moduleId: 'example', guards: [{
+      id: 'example.idless-update-opt-out',
+      targetEntity: 'example.todo',
+      operations: ['update'],
+      validate: guardValidate,
+    }] }])
+    const commandRoute = makeCrudRoute({
+      metadata: { PUT: { requireAuth: true } },
+      orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+      indexer: { entityType: 'example.todo' },
+      actions: {
+        update: {
+          commandId: 'example.todo.update',
+          schema: z.object({ title: z.string() }),
+          mapInput: ({ parsed }: any) => ({ body: parsed }),
+          response: () => ({ ok: true }),
+        },
+      },
+    })
+
+    const res = await commandRoute.PUT(new Request('http://x/api/example/todos/command', {
+      method: 'PUT',
+      body: JSON.stringify({ title: 'nested id shape' }),
+      headers: { 'content-type': 'application/json' },
+    }))
+
+    expect(res.status).toBe(200)
+    expect(guardValidate).not.toHaveBeenCalled()
+    expect(crudMutationGuardService.validateMutation).not.toHaveBeenCalled()
+    expect(commandBus.execute).toHaveBeenCalledWith('example.todo.update', expect.anything())
+  })
+
+  it('DELETE command route without any id keeps the documented row-level guard opt-out', async () => {
+    const guardValidate = jest.fn(async (_input: any) => ({ ok: false, status: 403, message: 'must not run' }))
+    registerMutationGuards([{ moduleId: 'example', guards: [{
+      id: 'example.idless-delete-opt-out',
+      targetEntity: 'example.todo',
+      operations: ['delete'],
+      validate: guardValidate,
+    }] }])
+    const commandRoute = makeCrudRoute({
+      metadata: { DELETE: { requireAuth: true } },
+      orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+      indexer: { entityType: 'example.todo' },
+      actions: {
+        delete: {
+          commandId: 'example.todo.delete',
+          schema: z.any(),
+          response: () => ({ ok: true }),
+        },
+      },
+    })
+
+    const res = await commandRoute.DELETE(new Request('http://x/api/example/todos/command', {
+      method: 'DELETE',
+      body: JSON.stringify({}),
+      headers: { 'content-type': 'application/json' },
+    }))
+
+    expect(res.status).toBe(200)
+    expect(guardValidate).not.toHaveBeenCalled()
+    expect(commandBus.execute).toHaveBeenCalledWith('example.todo.delete', expect.anything())
   })
 
   it('POST is blocked by interceptor before hook', async () => {

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -57,6 +57,7 @@ import {
   isCrudCacheEnabled,
   normalizeIdentifierValue,
   normalizeTagSegment,
+  pickFirstIdentifier,
   resolveCrudCache,
 } from './cache'
 import { deriveCrudSegmentTag } from './cache-stats'
@@ -915,6 +916,12 @@ function buildCrudCacheKey(
     `tenant:${normalizeTagSegment(ctx.auth?.tenantId ?? null)}`,
     `selectedOrg:${normalizeTagSegment(ctx.selectedOrganizationId ?? null)}`,
     `scope:${scopeSegment}`,
+    // List payloads can vary per caller identity beyond tenant/org scope:
+    // buildFilters may narrow by ctx.auth (e.g. ?mine=true), before-interceptor
+    // query rewrites are feature-gated per user, and afterList/after-interceptor
+    // output is embedded in the stored payload — so entries MUST be partitioned
+    // per actor (API key or user), never shared across identities.
+    `user:${normalizeTagSegment((ctx.auth?.keyId ?? ctx.auth?.sub) ?? null)}`,
     `query:${serializeSearchParams(url.searchParams)}`,
   ]
   // The cached list payload already embeds enricher output (enrichment runs before
@@ -2140,6 +2147,31 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
           }
         }
 
+        // Mutation guard registry — command path (mirrors the direct create branch)
+        const createCmdUserFeatures = await resolveUserFeatures(ctx)
+        const { allGuards: createCmdAllGuards } = collectAndRunGuards(ctx.container)
+        let createCmdGuardAfterCallbacks: Array<{ guard: MutationGuard; metadata: Record<string, unknown> | null }> = []
+        if (createCmdAllGuards.length && ctx.auth.tenantId) {
+          const guardResult = await runMutationGuards(createCmdAllGuards, {
+            tenantId: ctx.auth.tenantId,
+            organizationId: ctx.selectedOrganizationId ?? ctx.auth.orgId ?? null,
+            userId: ctx.auth.sub,
+            resourceKind,
+            resourceId: null,
+            operation: 'create',
+            requestMethod: request.method,
+            requestHeaders: request.headers,
+            mutationPayload: input && typeof input === 'object' ? (input as Record<string, unknown>) : null,
+          }, { userFeatures: createCmdUserFeatures ?? [] })
+          if (!guardResult.ok) {
+            return json(guardResult.errorBody ?? { error: 'Operation blocked by guard' }, { status: guardResult.errorStatus ?? 422 })
+          }
+          if (guardResult.modifiedPayload && typeof input === 'object' && input) {
+            input = { ...input as Record<string, unknown>, ...guardResult.modifiedPayload }
+          }
+          createCmdGuardAfterCallbacks = guardResult.afterSuccessCallbacks
+        }
+
         const baseMetadata: CommandLogMetadata = {
           tenantId: ctx.auth?.tenantId ?? null,
           organizationId: ctx.selectedOrganizationId ?? ctx.auth.orgId ?? null,
@@ -2182,6 +2214,22 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         const status = action.status ?? 201
         const response = json(resolvedPayload, { status })
         attachOperationHeader(response, logEntry)
+        const commandResultId = pickFirstIdentifier(
+          (result as Record<string, unknown> | null | undefined)?.id,
+          (resolvedPayload as Record<string, unknown> | null | undefined)?.id,
+        )
+        if (createCmdGuardAfterCallbacks.length && ctx.auth.tenantId && commandResultId) {
+          await runGuardAfterSuccessCallbacks(createCmdGuardAfterCallbacks, {
+            tenantId: ctx.auth.tenantId,
+            organizationId: ctx.selectedOrganizationId ?? ctx.auth.orgId ?? null,
+            userId: ctx.auth.sub,
+            resourceKind,
+            resourceId: commandResultId,
+            operation: 'create',
+            requestMethod: request.method,
+            requestHeaders: request.headers,
+          })
+        }
         // Note: side effects (events + indexing) are already flushed by CommandBus.execute()
         // via flushCrudSideEffects(). Calling markCommandResultForIndexing here would cause
         // duplicate event emissions.
@@ -2422,6 +2470,10 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         const updateUserFeatures = await resolveUserFeatures(ctx)
         const { allGuards: updateAllGuards } = collectAndRunGuards(ctx.container)
         let cmdUpdateGuardAfterCallbacks: Array<{ guard: MutationGuard; metadata: Record<string, unknown> | null }> = []
+        // Commands whose mapInput wraps the payload (e.g. `{ body }`) intentionally
+        // null candidateId and OPT OUT of row-level guards, leaving the command-level
+        // optimistic-lock check as the sole guard — a documented contract, see
+        // apps/docs/docs/framework/data-integrity/concurrency-locking.mdx.
         if (updateAllGuards.length && ctx.auth.tenantId && candidateId) {
           const guardResult = await runMutationGuards(updateAllGuards, {
             tenantId: ctx.auth.tenantId,

--- a/packages/shared/src/lib/di/__tests__/registrar-error-log.test.ts
+++ b/packages/shared/src/lib/di/__tests__/registrar-error-log.test.ts
@@ -1,0 +1,154 @@
+// A module DI registrar that throws is skipped fail-open (one broken module
+// must not take down every request container), but the failure MUST be logged —
+// a silent catch leaves the module's services missing with no trace until an
+// unrelated Awilix resolution error surfaces much later.
+
+import { asValue } from 'awilix'
+import type { AwilixContainer } from 'awilix'
+
+const mockLoggerError = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/logger', () => {
+  const makeLogger = (): Record<string, unknown> => ({
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+    child: () => makeLogger(),
+  })
+  return {
+    __esModule: true,
+    createLogger: () => makeLogger(),
+    getLogLevel: () => 'info',
+    isLevelEnabled: () => false,
+  }
+})
+
+jest.mock(
+  '@open-mercato/shared/lib/db/mikro',
+  () => {
+    const baseEm: any = {
+      fork: () => baseEm,
+      getRepository: () => ({ find: async () => [], findOne: async () => null }),
+    }
+    return {
+      __esModule: true,
+      getOrm: async () => ({ em: baseEm }),
+      getOrmEntities: () => [],
+      registerOrmEntities: () => {},
+    }
+  },
+  { virtual: false },
+)
+
+jest.mock(
+  '@mikro-orm/core',
+  () => ({
+    __esModule: true,
+    RequestContext: { getEntityManager: () => null },
+  }),
+  { virtual: true },
+)
+
+jest.mock(
+  '@open-mercato/shared/lib/query/engine',
+  () => ({ __esModule: true, BasicQueryEngine: class {} }),
+  { virtual: false },
+)
+
+jest.mock(
+  '@open-mercato/shared/lib/data/engine',
+  () => ({ __esModule: true, DefaultDataEngine: class {} }),
+  { virtual: false },
+)
+
+jest.mock(
+  '@open-mercato/shared/lib/commands',
+  () => ({
+    __esModule: true,
+    commandRegistry: {},
+    CommandBus: class { constructor() {} },
+  }),
+  { virtual: false },
+)
+
+jest.mock(
+  '@open-mercato/shared/modules/overrides',
+  () => ({
+    __esModule: true,
+    applyDiOverridesToContainer: () => {},
+    applyModuleOverridesToModules: (modules: unknown[]) => modules,
+    applyComponentOverridesToEntries: (entries: unknown[]) => entries,
+  }),
+  { virtual: false },
+)
+
+jest.mock(
+  '@open-mercato/core/bootstrap',
+  () => ({
+    __esModule: true,
+    bootstrap: async () => {},
+  }),
+  { virtual: true },
+)
+
+jest.mock(
+  '@open-mercato/shared/lib/encryption/subscriber',
+  () => ({
+    __esModule: true,
+    registerTenantEncryptionSubscriber: () => {},
+  }),
+  { virtual: true },
+)
+
+const {
+  createRequestContainer,
+  registerAppDiRegistrar,
+  registerDiRegistrars,
+  resetBootstrapCache,
+} = require('@open-mercato/shared/lib/di/container')
+
+describe('createRequestContainer — module DI registrar failures', () => {
+  beforeEach(() => {
+    resetBootstrapCache()
+    registerAppDiRegistrar(null)
+    mockLoggerError.mockClear()
+  })
+
+  afterAll(() => {
+    registerDiRegistrars([])
+  })
+
+  it('logs the error and continues with the remaining registrars', async () => {
+    const boom = new Error('di exploded')
+    const workingRegistrar = jest.fn((container: AwilixContainer) => {
+      container.register({ registrarProbeService: asValue('registered') })
+    })
+    registerDiRegistrars([
+      () => { throw boom },
+      workingRegistrar,
+    ])
+
+    const container = await createRequestContainer()
+
+    expect(workingRegistrar).toHaveBeenCalledTimes(1)
+    expect(container.resolve('registrarProbeService')).toBe('registered')
+    expect(mockLoggerError).toHaveBeenCalledWith('Module DI registrar failed', {
+      registrarIndex: 0,
+      err: boom,
+    })
+  })
+
+  it('does not log when every registrar succeeds', async () => {
+    registerDiRegistrars([
+      (container: AwilixContainer) => {
+        container.register({ registrarProbeService: asValue('ok') })
+      },
+    ])
+
+    await createRequestContainer()
+
+    expect(mockLoggerError).not.toHaveBeenCalled()
+  })
+})

--- a/packages/shared/src/lib/di/container.ts
+++ b/packages/shared/src/lib/di/container.ts
@@ -197,9 +197,14 @@ export async function createRequestContainer(): Promise<AppContainer> {
       createCommandOptimisticLockGuardService(),
     ).scoped(),
   })
-  // Allow modules to override/extend
-  for (const reg of diRegistrars) {
-    try { reg?.(container) } catch {}
+  // Allow modules to override/extend. Fail-open by design (one broken module's
+  // di.ts must not take down every request container), but never silently: the
+  // module's services would otherwise vanish with no trace until an unrelated
+  // Awilix resolution error surfaces much later.
+  for (const [registrarIndex, reg] of diRegistrars.entries()) {
+    try { reg?.(container) } catch (error) {
+      logger.error('Module DI registrar failed', { registrarIndex, err: error })
+    }
   }
   // Core bootstrap (cache, event bus, encryption subscriber/KMS, module subscribers)
   // Phase 5 — process-scoped once-guard. The first request runs the full


### PR DESCRIPTION
## Summary

Fixes three fail-open defects in shared CRUD infrastructure, per spec `.ai/specs/2026-07-30-crud-fail-open-hardening.md` (shipped in this PR):

1. **Cross-user list cache leak.** `buildCrudCacheKey` had no caller-identity segment, so with `ENABLE_CRUD_API_CACHE=true` two users in the same tenant/org scope shared one entry. This leaks live today: `staff` time-projects (`?mine=true` narrows by `ctx.auth.sub` inside `buildFilters`) and `scheduler` jobs (`isSuperAdmin` branch exposes system-job rows incl. `target_payload`). The key now carries `user:<keyId ?? sub>`; tags (and therefore invalidation) are unchanged, and orphaned pre-fix entries are cleared by the existing tag-based invalidation.
2. **Mutation guards never ran on command-based creates.** The POST command branch of `makeCrudRoute` executed the command without invoking `runMutationGuards` (the direct branch has run create guards since the optimistic-locking coverage work). Guards now run there with `operation: 'create'` / `resourceId: null`, mirroring the direct branch; `afterSuccess` resolves the record id from the command result with a fallback to the mapped response payload (covers the `lineId`/`adjustmentId` family).
3. **Silent DI registrar failures.** The empty `catch {}` around module `di.ts` registrars in `createRequestContainer` now logs `Module DI registrar failed` (`registrarIndex`, `err`) via the logger facade, keeping fail-open boot semantics.

**Deliberately NOT changed:** the `&& candidateId` skip on id-less command PUT/DELETE. Adversarial review showed the `{ body }`-wrap `mapInput` idiom is a documented row-level-guard opt-out (`concurrency-locking.mdx`), and removing the skip would fire a guaranteed-failing `em.findOne({ id: '' })` plus a false-alarm error log on every sales line/adjustment save in the default deployment. The opt-out is now regression-pinned by tests and the proper fix (per-action resourceId resolver) is recorded in the spec as follow-up.

## Validation

Runner: **local** (no compose `app` container running). Ordered gate from `.ai/agentic.config.json`:

- `build:packages`, `generate` (no drift), `build:packages`, `i18n:check-sync`, `typecheck`, `test`, `build:app` — all green.
- `i18n:check-usage` — fails on the **develop baseline**: 2 missing keys in `packages/ui/src/backend/fields/phone.tsx` introduced by #4147 (merged 2026-07-29). Unrelated to this diff (no `packages/ui` files touched).

New coverage (route-level jest through the full factory pipeline): per-identity cache partitioning (leak test fails pre-fix), API-key vs user key segments, create-command guard block/merge/afterSuccess (+ payload-id fallback), id-less opt-out pins, DI registrar error logging. Shared crud+di suites: 24 suites / 287 tests green.

## Labels & QA rationale

`priority-high` (security hardening, tenant-scope-adjacent), `risk-high` (shared CRUD factory + DI container, wide blast radius), `bug` + `security`. `skip-qa` per the automated-verification exemption: no UI-rendering files (docs `.mdx` only), DB structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract touched, automated tests in-PR. A Playwright integration test cannot observe this change in the standard environment (`ENABLE_CRUD_API_CACHE` is off there, and the guard change is observable only with a blocking guard installed); the route-level suites exercise the same boundaries in-process — rationale detailed in the spec's Testing Strategy.

## Adversarial review

3 independent reviewers (correctness / downstream impact / tests+spec accuracy) ran before this PR; the id-less guard change was refuted and reverted, the afterSuccess id fallback and both docs updates (cache-key section, lock-guard FAQ) were added in response, and residual items are recorded as Known Limitations in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)