### PR TITLE
perf(query_index): only probe search_tokens when the query actually searches

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -1,4 +1,6 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
 import { HybridQueryEngine, coerceSortDirection } from '../../query_index/lib/engine'
+import { BasicQueryEngine } from '@open-mercato/shared/lib/query/engine'
 import { SortDir } from '@open-mercato/shared/lib/query/types'
 
 jest.mock('@open-mercato/shared/lib/logger', () => {
@@ -1148,14 +1150,16 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
   })
 
   describe('search_tokens coverage probe', () => {
-    const countProbes = (db: any): number =>
-      (db._chains as ChainLog[]).filter((chain) => chain.table === 'search_tokens').length
+    type ChainRecordingDb = { _chains: ChainLog[] }
 
-    const buildDb = () => createFakeKysely({
+    const countProbes = (db: ChainRecordingDb): number =>
+      db._chains.filter((chain) => chain.table === 'search_tokens').length
+
+    const buildDb = (): ChainRecordingDb => createFakeKysely({
       baseTable: 'todos', hasIndexAny: true, baseCount: 10, indexCount: 10, customFieldKeys: {},
     })
 
-    const buildCustomEntityDb = () => createFakeKysely({
+    const buildCustomEntityDb = (): ChainRecordingDb => createFakeKysely({
       baseTable: 'unused',
       hasIndexAny: false,
       baseCount: 0,
@@ -1164,9 +1168,12 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
       rows: { custom_entities_storage: [{ entity_id: 'record-1' }] },
     })
 
+    const buildHybridEngine = (em: EntityManager): HybridQueryEngine =>
+      new HybridQueryEngine(em, new BasicQueryEngine(em))
+
     test('is skipped when the query carries no like/ilike filter', async () => {
       const db = buildDb()
-      const engine = new HybridQueryEngine(buildEm(db), { query: jest.fn() } as any)
+      const engine = buildHybridEngine(buildEm(db))
 
       await engine.query('example:todo', {
         fields: ['id'],
@@ -1180,7 +1187,7 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
 
     test('still runs when the query actually searches', async () => {
       const db = buildDb()
-      const engine = new HybridQueryEngine(buildEm(db), { query: jest.fn() } as any)
+      const engine = buildHybridEngine(buildEm(db))
 
       await engine.query('example:todo', {
         fields: ['id'],
@@ -1194,7 +1201,7 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
 
     test('is skipped on the custom-entity storage path without a like/ilike filter', async () => {
       const db = buildCustomEntityDb()
-      const engine = new HybridQueryEngine(buildEmWithOrmMetadata(db, {}), { query: jest.fn() } as any)
+      const engine = buildHybridEngine(buildEmWithOrmMetadata(db, {}))
 
       await engine.query('example:calendar_entity', {
         fields: ['id'],
@@ -1208,7 +1215,7 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
 
     test('still runs on the custom-entity storage path when the query searches', async () => {
       const db = buildCustomEntityDb()
-      const engine = new HybridQueryEngine(buildEmWithOrmMetadata(db, {}), { query: jest.fn() } as any)
+      const engine = buildHybridEngine(buildEmWithOrmMetadata(db, {}))
 
       await engine.query('example:calendar_entity', {
         fields: ['id'],

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -1146,4 +1146,78 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
     expect(chains.some((chain) => chain.table === 'custom_entities_storage' && chain.selects.length > 0)).toBe(true)
     expect(chains.some((chain) => chain.table === 'todos')).toBe(false)
   })
+
+  describe('search_tokens coverage probe', () => {
+    const countProbes = (db: any): number =>
+      (db._chains as ChainLog[]).filter((chain) => chain.table === 'search_tokens').length
+
+    const buildDb = () => createFakeKysely({
+      baseTable: 'todos', hasIndexAny: true, baseCount: 10, indexCount: 10, customFieldKeys: {},
+    })
+
+    const buildCustomEntityDb = () => createFakeKysely({
+      baseTable: 'unused',
+      hasIndexAny: false,
+      baseCount: 0,
+      indexCount: 0,
+      customFieldKeys: {},
+      rows: { custom_entities_storage: [{ entity_id: 'record-1' }] },
+    })
+
+    test('is skipped when the query carries no like/ilike filter', async () => {
+      const db = buildDb()
+      const engine = new HybridQueryEngine(buildEm(db), { query: jest.fn() } as any)
+
+      await engine.query('example:todo', {
+        fields: ['id'],
+        organizationId: 'org1',
+        tenantId: 't1',
+        filters: [{ field: 'is_done', op: 'eq', value: false }],
+      })
+
+      expect(countProbes(db)).toBe(0)
+    })
+
+    test('still runs when the query actually searches', async () => {
+      const db = buildDb()
+      const engine = new HybridQueryEngine(buildEm(db), { query: jest.fn() } as any)
+
+      await engine.query('example:todo', {
+        fields: ['id'],
+        organizationId: 'org1',
+        tenantId: 't1',
+        filters: [{ field: 'title', op: 'ilike', value: '%abc%' }],
+      })
+
+      expect(countProbes(db)).toBeGreaterThan(0)
+    })
+
+    test('is skipped on the custom-entity storage path without a like/ilike filter', async () => {
+      const db = buildCustomEntityDb()
+      const engine = new HybridQueryEngine(buildEmWithOrmMetadata(db, {}), { query: jest.fn() } as any)
+
+      await engine.query('example:calendar_entity', {
+        fields: ['id'],
+        organizationIds: ['org1'],
+        tenantId: 't1',
+        filters: [{ field: 'is_active', op: 'eq', value: true }],
+      })
+
+      expect(countProbes(db)).toBe(0)
+    })
+
+    test('still runs on the custom-entity storage path when the query searches', async () => {
+      const db = buildCustomEntityDb()
+      const engine = new HybridQueryEngine(buildEmWithOrmMetadata(db, {}), { query: jest.fn() } as any)
+
+      await engine.query('example:calendar_entity', {
+        fields: ['id'],
+        organizationIds: ['org1'],
+        tenantId: 't1',
+        filters: [{ field: 'title', op: 'ilike', value: '%abc%' }],
+      })
+
+      expect(countProbes(db)).toBeGreaterThan(0)
+    })
+  })
 })

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -415,12 +415,16 @@ export class HybridQueryEngine implements QueryEngine {
       const searchSources: SearchTokenSource[] = indexSources
         .map((src) => ({ entity: String(src.entityId), recordIdColumn: src.recordIdColumn }))
         .filter((src) => src.recordIdColumn && src.entity)
-      const hasSearchTokens = searchEnabled && searchSources.length
+      const searchFilters = normalizedFilters.filter((filter) => filter.op === 'like' || filter.op === 'ilike')
+      // Probe `search_tokens` only when this query actually searches. Every consumer of
+      // `searchRuntime.enabled` already sits behind a like/ilike guard, so on a plain list load the
+      // answer is unused — and the probe is a `LIMIT 1` the planner can resolve as a seq scan over a
+      // large `search_tokens`. The join path below already probes lazily for the same reason.
+      const hasSearchTokens = searchEnabled && searchSources.length && searchFilters.length
         ? await this.searchSourcesHaveTokens(searchSources, opts.tenantId ?? null, orgScope)
         : false
       const searchRuntime: SearchRuntime = { ...searchRuntimeBase, searchSources, enabled: searchEnabled && hasSearchTokens }
       const joinSearchAvailability = new Map<string, boolean>()
-      const searchFilters = normalizeFilters(opts.filters).filter((filter) => filter.op === 'like' || filter.op === 'ilike')
       if (searchFilters.length) {
         this.logSearchDebug('search:init', {
           entity,
@@ -1636,9 +1640,13 @@ export class HybridQueryEngine implements QueryEngine {
     const orgScope = this.resolveOrganizationScope(opts)
     if (!opts.tenantId) throw new Error('QueryEngine: tenantId is required')
 
+    const normalizedFilters = normalizeFilters(opts.filters)
+    const hasSearchFilter = normalizedFilters.some((filter) => filter.op === 'like' || filter.op === 'ilike')
+
     const searchConfig = resolveSearchConfig()
     const searchEnabled = searchConfig.enabled && await this.tableExists('search_tokens')
-    const hasSearchTokens = searchEnabled
+    // Same gate as `query()`: without a like/ilike filter the probe's answer is never read.
+    const hasSearchTokens = searchEnabled && hasSearchFilter
       ? await this.hasSearchTokens(entity, opts.tenantId ?? null, orgScope)
       : false
     const searchRuntime: SearchRuntime = {
@@ -1648,8 +1656,6 @@ export class HybridQueryEngine implements QueryEngine {
       tenantId: opts.tenantId ?? null,
       mintAlias: createSearchAliasMinter(),
     }
-
-    const normalizedFilters = normalizeFilters(opts.filters)
 
     const applyScope = (q: AnyBuilder): AnyBuilder => {
       let next = q


### PR DESCRIPTION
## Summary

`HybridQueryEngine` asks *"does this entity have any search tokens?"* on **every** query, before
looking at whether the query contains a search term at all. The probe is:

```sql
select 1 as "one" from "search_tokens"
where "entity_type" = $1 and tenant_id is not distinct from $2
  and "search_tokens"."organization_id" in ($3) limit 1
```

On a large `search_tokens` this is pathological. `EXPLAIN` from a production instance:

```
Limit  (cost=0.00..0.21 rows=1)
  ->  Seq Scan on search_tokens  (cost=0.00..20260450.90 rows=98078943)
```

The table there is **412M rows / 132 GB**. The planner estimates ~98M matching rows, so with
`LIMIT 1` it prices the seq scan at **0.21**, picks it, and then grinds through the heap because the
rows it wants sit late in it. Statistics were fresh — this is a local estimate failure, not stale
stats. `tenant_id is not distinct from` cannot be an index condition either, so no index rescues the
query in its current shape.

Measured over 24 h on that instance: **median 1 ms, p95 12.5 s, max 69.3 s.** A single plain
order-list load — *no search term* — spent **12.5 s of its 12.9 s** server time inside this one
probe.

Worth noting the cost is per **source**, not per query: `searchSourcesHaveTokens()` walks the base
entity plus every `customFieldSources` entry and returns on the first hit, so an entity whose tokens
are missing entirely — the case the probe exists to detect — pays the full scan once per source
before answering `false`. The miss is the expensive answer.

**The fix is a gate, not a cache.** Every consumer of `searchRuntime.enabled` already sits behind an
`op === 'like' | 'ilike'` guard, so when a query carries no like/ilike filter the probe's answer is
never read and the work is pure waste. Notably, the join path *in the same method*
(`applyJoinSearchFilterOp`) already probes lazily for exactly this reason — this change makes
`query()` and `queryCustomEntity()` consistent with the pattern already shipped a few lines below
them.

A cache would have been the wrong tool here, and this is worth knowing generally:
`createRequestContainer()` builds a **fresh `HybridQueryEngine` per request**, so the engine's
instance-level caches (e.g. `customFieldKeysCache`, TTL 5 min) never survive a request. Anything
relying on them for cross-request reuse is not doing what it looks like it does.

**Behavior is unchanged.** An entity with no tokens still falls back to plain `ilike` on the base
column, because the probe still runs whenever the query actually searches.

### Scope note

This gate removes the probe from plain list loads. A query that *does* search still runs it and can
still hit the same plan. That is deliberately left out of this PR to keep it behavior-preserving and
small, but it is worth naming the fix rather than leaving it implied.

**The durable fix is a counter, not a cache.** Add `search_token_count` to `entity_index_coverage`
alongside the `base_count` / `indexed_count` / `vector_indexed_count` it already carries, maintained
by the warmup / refresh / delta machinery in `lib/coverage.ts` and `subscribers/coverage_warmup.ts`
that already keeps those columns current, and have `hasSearchTokens()` read it. That makes the
answer O(1) for the **false** case as well as the true one — which a cache does not, since it still
pays one pathological probe per process to learn the answer — needs no new index on a table this
size, and surfaces token-absence on `/backend/query-indexes` instead of letting it silently degrade
search to plain `ilike`. `vector_indexed_count` already established this exact shape for the vector
store, so this is following existing precedent rather than introducing a mechanism. The one wrinkle
to design around: coverage rows are keyed per `(entity_type, tenant_id, organization_id,
with_deleted)` while the probe takes an organization *scope*, so a multi-org scope becomes "any
matching coverage row with a non-zero count" rather than a single row read — still O(rows in scope)
against a small table instead of a scan of a large one.

Happy to file that as a follow-up if maintainers agree with the shape.

**This is not the same problem as #4685, and that PR landing does not fix it.** #4685 addresses
*runaway* growth — its reported signature is 221M rows for 2,205 records, roughly 100,000 rows per
record, from non-idempotent token replacement and an auto-reindex stampede. A table can reach this
size perfectly legitimately: `expandToken` emits every prefix from `minTokenLength` up, so an
8-character word becomes 6 rows, and a record with ~10 indexed fields of a few words each lands
around 150–200 rows. At that ratio a few million indexed records across orders, order lines,
products and customers is a few hundred million rows with nothing wrong at all. Rows-per-indexed-
record is what separates the two cases, and it differs by about three orders of magnitude.

Nor is absolute size the mechanism here. The probe's plan failure comes from `LIMIT 1` plus a
mis-estimated row count and an unlucky *physical distribution* — the wanted `entity_type` sitting
late in the heap. A table an order of magnitude smaller with the same distribution still burns
seconds on it. So the gate is worth having on its own terms, on a deployment where `search_tokens`
is exactly the size it should be.

One thing NOT to do, recorded here so nobody re-derives it: nudging the planner off the seq scan
with an `ORDER BY` on the probe is **not** a safe general fix. It works when tokens exist for the
first probed source, and roughly doubles the worst case when they don't — so it is only sound under
deployment-specific preconditions (single scope, tokens known present) that upstream cannot assume.

## Changes

- `packages/core/src/modules/query_index/lib/engine.ts` — `query()`: hoist `searchFilters` above the
  probe and add `&& searchFilters.length` to the condition. The hoist also drops a redundant second
  `normalizeFilters(opts.filters)` pass; it now reuses the `normalizedFilters` already computed at
  the top of the method.
- `packages/core/src/modules/query_index/lib/engine.ts` — `queryCustomEntity()`: hoist
  `normalizedFilters` above the probe and gate on `hasSearchFilter`. This path was not gated on
  `searchSources.length` either, so it probed unconditionally.
- `packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts` — four cases covering both
  engine paths.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — behavior-preserving perf fix, 16 changed lines in one file. Related context:
`.ai/specs/2026-07-24-search-architecture-clarification-and-evolution.md` and #4685
(`search_tokens` unbounded growth), which addresses the table size this bug is triggered by.

## Testing

Four new cases in `hybrid-engine.test.ts`, counting `search_tokens` chains on the existing
fake-Kysely harness — both engine paths × (no search filter → 0 probes, ilike filter → >0):

| call | probes |
|---|---|
| `query()`, `op: 'eq'` filter | **0** (was 1) |
| `query()`, `op: 'ilike'` filter | **1** — probe still runs, token path still used |
| custom-entity storage path, `op: 'eq'` filter | **0** (was 1) |
| custom-entity storage path, `op: 'ilike'` filter | **1** |

Verified the tests are not vacuous: with the fix reverted, the two "is skipped" cases fail
(`Expected: 0, Received: 1`) while the two "still runs" cases pass — so the latter pair genuinely
guards against over-gating rather than riding along.

Commands run (local mode — no compose `app` container in this environment), per
`.ai/agentic.config.json` → `validation.commands`:

- `yarn build:packages`
- `yarn generate`
- `yarn i18n:check-sync`, `yarn i18n:check-usage`
- `yarn typecheck`
- `yarn test`
- `yarn build:app`
- `npx eslint` on both changed files

No integration tests added: the change alters no API surface, no database structure and no UI, and
is fully covered by the unit tests above — it is a query-plan-level fix with no manually exercisable
surface.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. *(none required —
  no public API, locale string or generated file is affected)*
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration
  coverage is not required). *(documented under Testing)*
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). *(not
  applicable — see Specification)*
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [ ] QA routing set.

> The three label checkboxes are unticked because this PR is opened from a fork by a contributor
> with `read` permission, who cannot apply labels. The intended labels and their rationale are in a
> comment below for a maintainer to apply.

### Design System Compliance

N/A — no UI files touched. The diff contains no `.tsx`, nothing under `packages/ui/` and nothing
under any `components/` tree; it is two files in `packages/core/src/modules/query_index/`.

## Linked issues

None filed upstream for this. #4685 (`search_tokens` unbounded growth) is adjacent but **not** a
substitute — see the scope note: it fixes pathological duplicate growth, whereas this probe is slow
on a `search_tokens` that is large for entirely legitimate reasons.
