### PR TITLE
fix(shared): honor app tsconfig in dynamic loader builds

### DIFF
--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.cacheRecovery.test.ts
@@ -17,6 +17,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import crypto from 'node:crypto'
 import { loadBootstrapData } from '../dynamicLoader'
 import {
   ensureMikroOrmV7GeneratedCacheCompatibility,
@@ -50,6 +51,18 @@ const BASE_GENERATED_MODULES: Record<string, { ts: string; compiled: string }> =
 }
 
 let compiledCacheGeneration = 0
+const APP_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+    useDefineForClassFields: false,
+    target: 'ES2022',
+  },
+})
+
+function hash(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex')
+}
 
 function writeGeneratedModule(generatedDir: string, baseName: string, source: { ts: string; compiled: string }) {
   fs.writeFileSync(path.join(generatedDir, `${baseName}.ts`), source.ts)
@@ -57,14 +70,33 @@ function writeGeneratedModule(generatedDir: string, baseName: string, source: { 
 }
 
 /**
- * Write the .mjs sibling with an mtime ahead of its .ts source so
- * compileAndImport takes its cache path and never invokes esbuild. Each write
- * advances the timestamp, which also gives the retry a distinct `?mtime=` import
- * URL instead of the rejected module's cached one.
+ * Write a compiled sibling and matching sidecar so compileAndImport can take its
+ * cache path without invoking esbuild. Each rewrite changes the output hash,
+ * which gives the retry a distinct `?cache=` import URL.
  */
 function writeCompiledSibling(generatedDir: string, baseName: string, compiled: string) {
+  const source = fs.readFileSync(path.join(generatedDir, `${baseName}.ts`), 'utf8')
+  const inputHash = hash(JSON.stringify({
+    version: 4,
+    sourceHash: hash(source),
+    tsconfigHashes: {
+      'tsconfig.json': hash(APP_TSCONFIG),
+    },
+  }))
+  const sourceRelativePath = path.relative(
+    path.dirname(path.dirname(generatedDir)),
+    path.join(generatedDir, `${baseName}.ts`),
+  ).split(path.sep).join('/')
   const compiledPath = path.join(generatedDir, `${baseName}.mjs`)
   fs.writeFileSync(compiledPath, compiled)
+  fs.writeFileSync(`${compiledPath}.cache.json`, JSON.stringify({
+    version: 4,
+    inputHash,
+    outputHash: hash(compiled),
+    dependencies: {
+      [sourceRelativePath]: hash(source),
+    },
+  }))
   compiledCacheGeneration += 1
   const fresh = new Date(Date.now() + compiledCacheGeneration * 60_000)
   fs.utimesSync(compiledPath, fresh, fresh)
@@ -74,6 +106,7 @@ function createAppRoot(entityIdsCache: string): string {
   const appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-bootstrap-4526-'))
   const generatedDir = path.join(appRoot, '.mercato', 'generated')
   fs.mkdirSync(generatedDir, { recursive: true })
+  fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), APP_TSCONFIG)
   for (const [baseName, source] of Object.entries(BASE_GENERATED_MODULES)) {
     writeGeneratedModule(generatedDir, baseName, source)
   }
@@ -87,7 +120,7 @@ function createAppRoot(entityIdsCache: string): string {
 function recoverByRewritingCache(appRoot: string, compiled: string): GeneratedCacheRecoveryResult {
   const generatedDir = path.join(appRoot, '.mercato', 'generated')
   writeCompiledSibling(generatedDir, 'entities.ids.generated', compiled)
-  // Node busts its ESM cache through the `?mtime=` query compileAndImport
+  // Node busts its ESM cache through the `?cache=` query compileAndImport
   // appends; Jest's registry keys on the resolved path alone, so the retry would
   // otherwise replay the rejected evaluation instead of the rewritten file.
   jest.resetModules()

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.commandInterceptors.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.commandInterceptors.test.ts
@@ -17,6 +17,7 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
+import crypto from 'node:crypto'
 import { loadBootstrapData } from '../dynamicLoader'
 
 const GENERATED_MODULES: Record<string, { ts: string; compiled: string }> = {
@@ -32,11 +33,42 @@ const GENERATED_MODULES: Record<string, { ts: string; compiled: string }> = {
   },
 }
 
+const APP_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+    useDefineForClassFields: false,
+    target: 'ES2022',
+  },
+})
+
+function hash(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex')
+}
+
 function writeGeneratedModule(generatedDir: string, baseName: string, source: { ts: string; compiled: string }) {
-  fs.writeFileSync(path.join(generatedDir, `${baseName}.ts`), source.ts)
-  fs.writeFileSync(path.join(generatedDir, `${baseName}.mjs`), source.compiled)
-  const fresh = new Date(Date.now() + 60_000)
-  fs.utimesSync(path.join(generatedDir, `${baseName}.mjs`), fresh, fresh)
+  const sourcePath = path.join(generatedDir, `${baseName}.ts`)
+  const compiledPath = path.join(generatedDir, `${baseName}.mjs`)
+  const sourceRelativePath = path.relative(
+    path.dirname(path.dirname(generatedDir)),
+    sourcePath,
+  ).split(path.sep).join('/')
+  fs.writeFileSync(sourcePath, source.ts)
+  fs.writeFileSync(compiledPath, source.compiled)
+  fs.writeFileSync(`${compiledPath}.cache.json`, JSON.stringify({
+    version: 4,
+    inputHash: hash(JSON.stringify({
+      version: 4,
+      sourceHash: hash(source.ts),
+      tsconfigHashes: {
+        'tsconfig.json': hash(APP_TSCONFIG),
+      },
+    })),
+    outputHash: hash(source.compiled),
+    dependencies: {
+      [sourceRelativePath]: hash(source.ts),
+    },
+  }))
 }
 
 describe('loadBootstrapData — command interceptors reach worker/CLI bootstrap (#4327)', () => {
@@ -46,6 +78,7 @@ describe('loadBootstrapData — command interceptors reach worker/CLI bootstrap 
     appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-bootstrap-4327-'))
     const generatedDir = path.join(appRoot, '.mercato', 'generated')
     fs.mkdirSync(generatedDir, { recursive: true })
+    fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), APP_TSCONFIG)
     for (const [baseName, source] of Object.entries(GENERATED_MODULES)) {
       writeGeneratedModule(generatedDir, baseName, source)
     }

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.tsconfig.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.tsconfig.test.ts
@@ -1,0 +1,272 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const LEGACY_TSCONFIG = {
+  compilerOptions: {
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+    useDefineForClassFields: false,
+    target: 'ES2022',
+    module: 'ESNext',
+    moduleResolution: 'Bundler',
+  },
+}
+
+const GENERATED_MODULES: Record<string, string> = {
+  'entities.ids.generated': 'export const E = {}',
+  'modules.cli.generated': 'export const modules = []',
+  'di.generated': 'export const diRegistrars = []',
+  'entities.generated': `
+    import { ProbeEntity } from '@/src/modules/probe/data/entities'
+    export const entities = [ProbeEntity]
+  `,
+}
+
+function writeFixture(): string {
+  const appRoot = fs.mkdtempSync(path.join(process.cwd(), '.tmp-dynamic-loader-'))
+  const generatedDir = path.join(appRoot, '.mercato', 'generated')
+  const entityDir = path.join(appRoot, 'src', 'modules', 'probe', 'data')
+  fs.mkdirSync(generatedDir, { recursive: true })
+  fs.mkdirSync(entityDir, { recursive: true })
+  fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), JSON.stringify(LEGACY_TSCONFIG))
+  fs.writeFileSync(path.join(entityDir, 'entities.ts'), `
+    import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy'
+
+    @Entity()
+    export class ProbeEntity {
+      static revision = 1
+
+      @PrimaryKey()
+      id!: string
+    }
+  `)
+  for (const [baseName, source] of Object.entries(GENERATED_MODULES)) {
+    fs.writeFileSync(path.join(generatedDir, `${baseName}.ts`), source)
+  }
+  return appRoot
+}
+
+function readCacheMetadata(appRoot: string, baseName: string): {
+  version: number
+  inputHash: string
+  outputHash: string
+  dependencies: Record<string, string>
+} {
+  return JSON.parse(
+    fs.readFileSync(
+      path.join(appRoot, '.mercato', 'generated', `${baseName}.generated.mjs.cache.json`),
+      'utf8',
+    ),
+  )
+}
+
+function loadBootstrapDataInNode(appRoot: string): {
+  entityNames: string[]
+  entityRevisions: number[]
+} {
+  const loaderUrl = pathToFileURL(path.resolve(__dirname, '../dynamicLoader.ts')).href
+  const script = `
+    import { loadBootstrapData } from ${JSON.stringify(loaderUrl)}
+    const data = await loadBootstrapData(process.argv[1])
+    process.stdout.write(JSON.stringify({
+      entityNames: data.entities.map((entity) => entity.name),
+      entityRevisions: data.entities.map((entity) => entity.revision),
+    }))
+  `
+  return JSON.parse(execFileSync(
+    process.execPath,
+    ['--import', 'tsx', '--input-type=module', '-e', script, appRoot],
+    { cwd: process.cwd(), encoding: 'utf8' },
+  ))
+}
+
+describe('dynamic loader app tsconfig and content-addressed cache', () => {
+  const appRoots: string[] = []
+
+  afterAll(() => {
+    for (const appRoot of appRoots) {
+      fs.rmSync(appRoot, { recursive: true, force: true })
+    }
+  })
+
+  function createAppRoot(): string {
+    const appRoot = writeFixture()
+    appRoots.push(appRoot)
+    return appRoot
+  }
+
+  it('imports a real MikroORM legacy-decorated local entity', async () => {
+    const appRoot = createAppRoot()
+
+    const data = loadBootstrapDataInNode(appRoot)
+
+    expect(data.entityNames).toEqual(['ProbeEntity'])
+    const compiled = fs.readFileSync(
+      path.join(appRoot, '.mercato', 'generated', 'entities.generated.mjs'),
+      'utf8',
+    )
+    expect(compiled).toContain('__decorateClass')
+    expect(compiled).not.toContain('__decorateElement')
+  })
+
+  it('invalidates compiled output when only app tsconfig content changes', async () => {
+    const appRoot = createAppRoot()
+    loadBootstrapDataInNode(appRoot)
+    const before = readCacheMetadata(appRoot, 'entities')
+
+    fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), JSON.stringify({
+      ...LEGACY_TSCONFIG,
+      compilerOptions: {
+        ...LEGACY_TSCONFIG.compilerOptions,
+        useDefineForClassFields: true,
+      },
+    }))
+    loadBootstrapDataInNode(appRoot)
+    const after = readCacheMetadata(appRoot, 'entities')
+
+    expect(after.version).toBe(4)
+    expect(after.inputHash).not.toBe(before.inputHash)
+  })
+
+  it('invalidates compiled output when only an extended tsconfig changes', async () => {
+    const appRoot = createAppRoot()
+    const appTsconfigPath = path.join(appRoot, 'tsconfig.json')
+    const baseTsconfigPath = path.join(appRoot, 'tsconfig.base.json')
+    fs.writeFileSync(baseTsconfigPath, JSON.stringify(LEGACY_TSCONFIG))
+    fs.writeFileSync(appTsconfigPath, `{
+      // The loader must follow JSONC extends references.
+      "extends": "./tsconfig.base.json",
+    }`)
+    loadBootstrapDataInNode(appRoot)
+    const before = readCacheMetadata(appRoot, 'entities')
+
+    fs.writeFileSync(baseTsconfigPath, JSON.stringify({
+      ...LEGACY_TSCONFIG,
+      compilerOptions: {
+        ...LEGACY_TSCONFIG.compilerOptions,
+        useDefineForClassFields: true,
+      },
+    }))
+    loadBootstrapDataInNode(appRoot)
+    const after = readCacheMetadata(appRoot, 'entities')
+
+    expect(after.inputHash).not.toBe(before.inputHash)
+    expect(after.dependencies['tsconfig.base.json']).not.toBe(
+      before.dependencies['tsconfig.base.json'],
+    )
+  })
+
+  it('invalidates compiled output when a package-resolved tsconfig changes', async () => {
+    const appRoot = createAppRoot()
+    const configPackageRoot = path.join(appRoot, 'node_modules', 'probe-tsconfig')
+    const packageTsconfigPath = path.join(configPackageRoot, 'tsconfig.json')
+    fs.mkdirSync(configPackageRoot, { recursive: true })
+    fs.writeFileSync(path.join(configPackageRoot, 'package.json'), JSON.stringify({
+      name: 'probe-tsconfig',
+      version: '1.0.0',
+      main: 'tsconfig.json',
+    }))
+    fs.writeFileSync(packageTsconfigPath, JSON.stringify(LEGACY_TSCONFIG))
+    fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), JSON.stringify({
+      extends: 'probe-tsconfig',
+    }))
+    loadBootstrapDataInNode(appRoot)
+    const before = readCacheMetadata(appRoot, 'entities')
+
+    fs.writeFileSync(packageTsconfigPath, JSON.stringify({
+      ...LEGACY_TSCONFIG,
+      compilerOptions: {
+        ...LEGACY_TSCONFIG.compilerOptions,
+        useDefineForClassFields: true,
+      },
+    }))
+    loadBootstrapDataInNode(appRoot)
+    const after = readCacheMetadata(appRoot, 'entities')
+
+    expect(after.inputHash).not.toBe(before.inputHash)
+    expect(after.dependencies['node_modules/probe-tsconfig/tsconfig.json']).not.toBe(
+      before.dependencies['node_modules/probe-tsconfig/tsconfig.json'],
+    )
+  })
+
+  it('invalidates compiled output when generated source content changes', async () => {
+    const appRoot = createAppRoot()
+    loadBootstrapDataInNode(appRoot)
+    const before = readCacheMetadata(appRoot, 'entities')
+    const sourcePath = path.join(
+      appRoot,
+      '.mercato',
+      'generated',
+      'entities.generated.ts',
+    )
+
+    fs.appendFileSync(sourcePath, '\nexport const sourceRevision = 2\n')
+    loadBootstrapDataInNode(appRoot)
+    const after = readCacheMetadata(appRoot, 'entities')
+
+    expect(after.inputHash).not.toBe(before.inputHash)
+  })
+
+  it('invalidates compiled output when only a bundled local dependency changes', async () => {
+    const appRoot = createAppRoot()
+    const generatedSourcePath = path.join(
+      appRoot,
+      '.mercato',
+      'generated',
+      'entities.generated.ts',
+    )
+    const generatedSource = fs.readFileSync(generatedSourcePath, 'utf8')
+    const first = loadBootstrapDataInNode(appRoot)
+    const before = readCacheMetadata(appRoot, 'entities')
+    const entityPath = path.join(appRoot, 'src', 'modules', 'probe', 'data', 'entities.ts')
+
+    fs.writeFileSync(
+      entityPath,
+      fs.readFileSync(entityPath, 'utf8').replace('static revision = 1', 'static revision = 2'),
+    )
+    const second = loadBootstrapDataInNode(appRoot)
+    const after = readCacheMetadata(appRoot, 'entities')
+
+    expect(first.entityRevisions).toEqual([1])
+    expect(second.entityRevisions).toEqual([2])
+    expect(after.outputHash).not.toBe(before.outputHash)
+    expect(after.dependencies['src/modules/probe/data/entities.ts']).not.toBe(
+      before.dependencies['src/modules/probe/data/entities.ts'],
+    )
+    expect(fs.readFileSync(generatedSourcePath, 'utf8')).toBe(generatedSource)
+  })
+
+  it('rebuilds a compiled file whose bytes do not match its sidecar', async () => {
+    const appRoot = createAppRoot()
+    loadBootstrapDataInNode(appRoot)
+    const compiledPath = path.join(appRoot, '.mercato', 'generated', 'entities.generated.mjs')
+    fs.writeFileSync(compiledPath, 'this is not valid JavaScript')
+
+    const data = loadBootstrapDataInNode(appRoot)
+
+    expect(data.entityNames).toEqual(['ProbeEntity'])
+    expect(fs.readFileSync(compiledPath, 'utf8')).toContain('__decorateClass')
+  })
+
+  it('rebuilds a cache sidecar from an older loader format version', async () => {
+    const appRoot = createAppRoot()
+    loadBootstrapDataInNode(appRoot)
+    const metadataPath = path.join(
+      appRoot,
+      '.mercato',
+      'generated',
+      'entities.generated.mjs.cache.json',
+    )
+    const stale = readCacheMetadata(appRoot, 'entities')
+    fs.writeFileSync(metadataPath, JSON.stringify({ ...stale, version: 2 }))
+
+    loadBootstrapDataInNode(appRoot)
+
+    expect(readCacheMetadata(appRoot, 'entities').version).toBe(4)
+  })
+})

--- a/packages/shared/src/lib/bootstrap/dynamicLoader.ts
+++ b/packages/shared/src/lib/bootstrap/dynamicLoader.ts
@@ -7,7 +7,219 @@ import {
 } from './generatedCacheRecovery'
 import path from 'node:path'
 import fs from 'node:fs'
+import crypto from 'node:crypto'
+import { createRequire } from 'node:module'
 import { pathToFileURL } from 'node:url'
+
+const DYNAMIC_LOADER_CACHE_VERSION = 4
+
+type DynamicLoaderCacheMetadata = {
+  version: number
+  inputHash: string
+  outputHash: string
+  dependencies: Record<string, string>
+}
+
+function cacheMetadataPath(jsPath: string): string {
+  return `${jsPath}.cache.json`
+}
+
+function contentHash(content: Buffer | string): string {
+  return crypto.createHash('sha256').update(content).digest('hex')
+}
+
+function parseJsonConfig(content: string): unknown {
+  let normalized = ''
+  let inString = false
+  let escaped = false
+
+  for (let index = 0; index < content.length; index += 1) {
+    const character = content[index]
+    const nextCharacter = content[index + 1]
+
+    if (inString) {
+      normalized += character
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === '"') {
+        inString = false
+      }
+      continue
+    }
+
+    if (character === '"') {
+      inString = true
+      normalized += character
+      continue
+    }
+
+    if (character === '/' && nextCharacter === '/') {
+      while (index < content.length && content[index] !== '\n') index += 1
+      normalized += '\n'
+      continue
+    }
+
+    if (character === '/' && nextCharacter === '*') {
+      index += 2
+      while (index < content.length && !(content[index] === '*' && content[index + 1] === '/')) {
+        index += 1
+      }
+      index += 1
+      continue
+    }
+
+    if (character === ',') {
+      let lookahead = index + 1
+      while (lookahead < content.length && /\s/.test(content[lookahead])) lookahead += 1
+      if (content[lookahead] === '}' || content[lookahead] === ']') continue
+    }
+
+    normalized += character
+  }
+
+  return JSON.parse(normalized)
+}
+
+function resolveExistingConfigPath(candidate: string): string | null {
+  for (const configPath of [candidate, `${candidate}.json`, path.join(candidate, 'tsconfig.json')]) {
+    if (fs.existsSync(configPath) && fs.statSync(configPath).isFile()) return configPath
+  }
+  return null
+}
+
+function resolvePackageConfig(configPath: string, reference: string): string | null {
+  try {
+    const resolved = createRequire(pathToFileURL(configPath)).resolve(reference)
+    return path.extname(resolved) === '.json' ? resolved : null
+  } catch {
+    return null
+  }
+}
+
+function resolveExtendedConfig(configPath: string, reference: string): string {
+  if (path.isAbsolute(reference) || reference.startsWith('.')) {
+    const resolved = resolveExistingConfigPath(path.resolve(path.dirname(configPath), reference))
+    if (resolved) return resolved
+  } else {
+    for (const packageReference of [reference, `${reference}/tsconfig.json`]) {
+      const resolved = resolvePackageConfig(configPath, packageReference)
+      if (resolved) return resolved
+    }
+  }
+
+  throw new Error(`[internal] TypeScript config extends target not found: ${reference}`)
+}
+
+function collectTsconfigPaths(entryPath: string, visited: Set<string> = new Set()): string[] {
+  const configPath = path.resolve(entryPath)
+  if (visited.has(configPath)) return []
+  visited.add(configPath)
+
+  const parsed = parseJsonConfig(fs.readFileSync(configPath, 'utf8'))
+  if (typeof parsed !== 'object' || parsed === null || !('extends' in parsed)) return [configPath]
+
+  const extendsValue = parsed.extends
+  const references = typeof extendsValue === 'string'
+    ? [extendsValue]
+    : Array.isArray(extendsValue) && extendsValue.every((value) => typeof value === 'string')
+      ? extendsValue
+      : []
+
+  return [
+    ...references.flatMap((reference) => collectTsconfigPaths(
+      resolveExtendedConfig(configPath, reference),
+      visited,
+    )),
+    configPath,
+  ]
+}
+
+function hashFilesRelativeTo(appRoot: string, filePaths: string[]): Record<string, string> {
+  return Object.fromEntries(filePaths.map((filePath) => [
+    path.relative(appRoot, filePath).split(path.sep).join('/'),
+    contentHash(fs.readFileSync(filePath)),
+  ]))
+}
+
+function cacheInputHash(tsPath: string, appRoot: string, tsconfigPaths: string[]): string {
+  const hash = crypto.createHash('sha256')
+  hash.update(JSON.stringify({
+    version: DYNAMIC_LOADER_CACHE_VERSION,
+    sourceHash: contentHash(fs.readFileSync(tsPath)),
+    tsconfigHashes: hashFilesRelativeTo(appRoot, tsconfigPaths),
+  }))
+  return hash.digest('hex')
+}
+
+function dependenciesAreValid(appRoot: string, dependencies: Record<string, string>): boolean {
+  return Object.entries(dependencies).every(([relativePath, expectedHash]) => {
+    const dependencyPath = path.resolve(appRoot, relativePath)
+    return fs.existsSync(dependencyPath)
+      && contentHash(fs.readFileSync(dependencyPath)) === expectedHash
+  })
+}
+
+function collectDependencyHashes(
+  appRoot: string,
+  inputs: Record<string, unknown>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.keys(inputs)
+      .map((inputPath) => {
+        const absolutePath = path.isAbsolute(inputPath)
+          ? inputPath
+          : path.resolve(appRoot, inputPath)
+        const relativePath = path.relative(appRoot, absolutePath).split(path.sep).join('/')
+        return [relativePath, contentHash(fs.readFileSync(absolutePath))]
+      })
+      .sort(([left], [right]) => left.localeCompare(right)),
+  )
+}
+
+function readCacheMetadata(metadataPath: string): DynamicLoaderCacheMetadata | null {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(metadataPath, 'utf8'))
+    if (
+      typeof parsed === 'object'
+      && parsed !== null
+      && 'version' in parsed
+      && parsed.version === DYNAMIC_LOADER_CACHE_VERSION
+      && 'inputHash' in parsed
+      && typeof parsed.inputHash === 'string'
+      && 'outputHash' in parsed
+      && typeof parsed.outputHash === 'string'
+      && 'dependencies' in parsed
+      && typeof parsed.dependencies === 'object'
+      && parsed.dependencies !== null
+      && Object.values(parsed.dependencies).every((hash) => typeof hash === 'string')
+    ) {
+      return {
+        version: parsed.version,
+        inputHash: parsed.inputHash,
+        outputHash: parsed.outputHash,
+        dependencies: parsed.dependencies as Record<string, string>,
+      }
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+function cacheIsValid(
+  appRoot: string,
+  jsPath: string,
+  metadataPath: string,
+  expectedInputHash: string,
+): boolean {
+  if (!fs.existsSync(jsPath)) return false
+  const metadata = readCacheMetadata(metadataPath)
+  if (!metadata || metadata.inputHash !== expectedInputHash) return false
+  return contentHash(fs.readFileSync(jsPath)) === metadata.outputHash
+    && dependenciesAreValid(appRoot, metadata.dependencies)
+}
 
 /**
  * Compile a TypeScript file to JavaScript using esbuild bundler.
@@ -17,17 +229,22 @@ import { pathToFileURL } from 'node:url'
 async function compileAndImport(tsPath: string, allowRecovery: boolean = true): Promise<Record<string, unknown>> {
   const jsPath = tsPath.replace(/\.ts$/, '.mjs')
   const appRoot = path.dirname(path.dirname(path.dirname(tsPath)))
+  const appTsconfig = path.join(appRoot, 'tsconfig.json')
+  const metadataPath = cacheMetadataPath(jsPath)
 
-  // Check if we need to recompile (source newer than compiled)
   const tsExists = fs.existsSync(tsPath)
-  const jsExists = fs.existsSync(jsPath)
+  const tsconfigExists = fs.existsSync(appTsconfig)
 
   if (!tsExists) {
     throw new Error(`Generated file not found: ${tsPath}`)
   }
+  if (!tsconfigExists) {
+    throw new Error(`App TypeScript config not found: ${appTsconfig}`)
+  }
 
-  const needsCompile = !jsExists ||
-    fs.statSync(tsPath).mtimeMs > fs.statSync(jsPath).mtimeMs
+  const tsconfigPaths = collectTsconfigPaths(appTsconfig)
+  const expectedInputHash = cacheInputHash(tsPath, appRoot, tsconfigPaths)
+  const needsCompile = !cacheIsValid(appRoot, jsPath, metadataPath, expectedInputHash)
 
   if (needsCompile) {
     // Dynamically import esbuild only when needed
@@ -75,22 +292,36 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
     }
 
     // Use esbuild.build with bundling to handle JSON imports
-    await esbuild.build({
+    const result = await esbuild.build({
       entryPoints: [tsPath],
       outfile: jsPath,
+      absWorkingDir: appRoot,
       bundle: true,
+      metafile: true,
       format: 'esm',
       platform: 'node',
       target: 'node18',
+      tsconfig: appTsconfig,
       plugins: [aliasPlugin, externalNonJsonPlugin],
       // Allow JSON imports
       loader: { '.json': 'json' },
     })
+    const metadata: DynamicLoaderCacheMetadata = {
+      version: DYNAMIC_LOADER_CACHE_VERSION,
+      inputHash: expectedInputHash,
+      outputHash: contentHash(fs.readFileSync(jsPath)),
+      dependencies: {
+        ...collectDependencyHashes(appRoot, result.metafile.inputs),
+        ...hashFilesRelativeTo(appRoot, tsconfigPaths),
+      },
+    }
+    fs.writeFileSync(metadataPath, JSON.stringify(metadata))
   }
 
   // Import the compiled JavaScript
   try {
-    const fileUrl = `${pathToFileURL(jsPath).href}?mtime=${fs.statSync(jsPath).mtimeMs}`
+    const outputHash = contentHash(fs.readFileSync(jsPath))
+    const fileUrl = `${pathToFileURL(jsPath).href}?cache=${outputHash}`
     return await import(fileUrl)
   } catch (error) {
     if (!allowRecovery) {


### PR DESCRIPTION
Supersedes #4707

Credit: original implementation by @goer. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the original fork branch. The branch history was rebuilt on current `main` as one maintainer-authored commit to satisfy the CLA gate; the implementation credit remains here and in the commit narrative.

## Included work
- Original dynamic-loader tsconfig and content-addressed cache changes from #4707
- Fingerprint transitive relative and package-resolved tsconfig `extends` chains
- Persist inherited config hashes in the cache sidecar and bump the cache format to v4
- Update stale cache-recovery documentation
- Add relative JSONC and package-resolved inheritance regression coverage

## Verification
- `license/cla`: passed — all committers have signed
- Focused dynamic-loader tests: 3 suites, 13 tests passed
- Configured local gate (local runner): `build:packages` (twice), `generate`, `i18n:check-sync`, `typecheck`, `test`, and `build:app` passed
- Full `yarn test`: 23/23 tasks passed; shared/core and the remaining package suites completed successfully
- `git diff --check`: passed
- Supplemental `i18n:check-usage`: reports two keys already missing on current `main` in `packages/ui/src/backend/fields/phone.tsx`; this PR does not touch that file
- Supplemental `template:sync`: reports unrelated app/template drift already present on current `main`; this PR does not touch the app or template

The carried-forward branch was re-reviewed after the CLA-safe history rewrite and is code-review ready. GitHub CI is tracked on the rewritten head.
