### PR TITLE
feat(ci): enable community PR label commands

### DIFF
--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -1,0 +1,47 @@
+name: Community labels
+
+on:
+  issue_comment:
+    types: [created]
+
+# Pull requests are GitHub issues for labeling purposes. No repository checkout
+# or contributor-supplied code is used by this workflow.
+permissions:
+  issues: write
+
+jobs:
+  add-label:
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/label ')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add requested label
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Only safe, existing taxonomy labels may be added by contributors.
+            const allowedLabels = new Set([
+              'bug',
+              'documentation',
+              'feature',
+            ]);
+
+            const requestedLabels = context.payload.comment.body
+              .slice('/label '.length)
+              .split(',')
+              .map((label) => label.trim())
+              .filter((label) => allowedLabels.has(label));
+
+            if (requestedLabels.length === 0) {
+              core.setFailed('No allowed labels were requested.');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: requestedLabels,
+            });


### PR DESCRIPTION
## Summary

Adds a safe PR-comment command for public contributors to request labels.

## Changes

- Adds an `issue_comment` workflow that accepts `/label` commands on pull requests.
- Restricts writes to safe existing taxonomy labels and uses only `issues: write`.

## Specification

**Does a spec exist for this feature/module?**
- [x] N/A (minor change, no spec needed)

**Spec file path:**

## Testing

- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/community-labels.yml\")"`
- Embedded GitHub Script syntax check with Node.js
- `git diff --check origin/develop...`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes — and for changes with no manually exercisable UI surface that leave the database structure and API surface unchanged, preserve `BACKWARD_COMPATIBILITY.md` contracts, and ship automated tests for the behavior they change — otherwise `needs-qa`.

No application integration test applies: this is a GitHub-hosted event workflow, validated by static YAML and JavaScript syntax checks.