### PR TITLE
docs(github): certified-partners registry (companies + GitHub contributors)

### DIFF
--- a/.github/certified-partners.yml
+++ b/.github/certified-partners.yml
@@ -1,0 +1,50 @@
+# Certified partners of Open Mercato and their GitHub contributors.
+#
+# To add a contributor: open a PR extending your company's list.
+# An Open Mercato review + merge of that PR is the approval.
+
+partners:
+  - company: 10clouds
+    contributors: [cielecki]
+  - company: 300.codes
+    contributors: [strzesniewski, B0G3, AK-300codes]
+  - company: FilaNovum
+    contributors: [mkadziolka]
+  - company: AMT Solution
+    contributors: [amtmich]
+  - company: Cognize
+    contributors: [jakubmatwiejew-wq]
+  - company: Commerce Weavers
+    contributors: [lchrusciel]
+  - company: Dev4You
+    contributors: [PawelSydorow, Paul-Mlodochowki]
+  - company: Fast White Cat
+    contributors: [adeptofvoltron, lbajsarowicz]
+  - company: Freight Tech
+    contributors: [fto-aubergine, karolina-fto]
+  - company: GoNextStage
+    contributors: [truongx, mat-kruk]
+  - company: Itrix
+    contributors: [itrixjarek]
+  - company: LemonMind
+    contributors: [msoroka]
+  - company: Omdyo
+    contributors: [zielivia, haxiorz]
+  - company: 8lines
+    contributors: [jtomaszewski, RadnoK, KamilGrocholski, patrykbojczuk, KubaBir, frshy]
+  - company: Evojam
+    contributors: [marcinwadon, abankowski]
+  - company: Idego
+    contributors: [Gajam19]
+  - company: Softiq
+    contributors: [adam-marszowski, wwaleszczykSoftiq, Heppe-SOFTIQ]
+  - company: Tandemite
+    contributors: [mat89c]
+  - company: The Good Code
+    contributors: [migsilva89, mpiatko]
+  - company: they.dev
+    contributors: [pmadajthey]
+  - company: Univio
+    contributors: [gsobczyk, szymonkilar]
+  - company: White Label Coders
+    contributors: [redjungle-as, ArtSadWLC, KBraneckiWLC]


### PR DESCRIPTION
## What

Adds `.github/certified-partners.yml` — the registry of certified partner companies and their GitHub contributors (seeded from the internal partner list: 22 companies, 41 contributors; all handles verified to exist).

## How it works

1. A partner adds a person by opening a PR that extends their company's `contributors` list.
2. An Open Mercato review + merge of that PR is the approval — git history is the audit trail.

## Scope note

An earlier revision of this PR also shipped a partner-gated `/label` workflow; it was dropped in favor of the community label commands from #4726. This file stays as the canonical public list of certified partners and their GitHub accounts, and can back label-gating or other partner automation later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)