### PR TITLE
feat: Add community labels

### DIFF
--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -1,0 +1,45 @@
+name: Community labels
+
+on:
+  issue_comment:
+    types: [created]
+
+# Pull requests are GitHub issues for labeling purposes. No repository checkout
+# or contributor-supplied code is used by this workflow.
+permissions:
+  issues: write
+
+jobs:
+  add-label:
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/label ')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add requested label
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Only safe, existing taxonomy labels may be added by contributors.
+            const allowedLabels = new Set([
+              'partner-request',
+            ]);
+
+            const requestedLabels = context.payload.comment.body
+              .slice('/label '.length)
+              .split(',')
+              .map((label) => label.trim())
+              .filter((label) => allowedLabels.has(label));
+
+            if (requestedLabels.length === 0) {
+              core.setFailed('No allowed labels were requested.');
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: requestedLabels,
+            });


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Provide a concise description of the problem and the proposed solution.

## Changes

- bullet the key code or documentation updates

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->


## Testing

List the tests or commands you ran to validate the change.

## Checklist

- [ ] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes — and for changes with no manually exercisable UI surface that leave the database structure and API surface unchanged, preserve `BACKWARD_COMPATIBILITY.md` contracts, and ship automated tests for the behavior they change — otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified` — without `triage` permission, post the evidence and ask a maintainer to apply those two labels). See `.github/QA-DEPLOYMENT.md` and `AGENTS.md` → PR Workflow for the authoritative rules.

### Design System Compliance
- [ ] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [ ] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [ ] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [ ] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons (`<IconButton>`)
- [ ] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Reference any related issues with `Fixes #...` when applicable.
