### PR TITLE
fix(data_sync): stop the 401 session-refresh loop on "all organizations"

### DIFF
--- a/packages/core/src/modules/data_sync/AGENTS.md
+++ b/packages/core/src/modules/data_sync/AGENTS.md
@@ -9,6 +9,7 @@ The `data_sync` module provides a streaming data synchronization hub for import/
 ## Always
 
 - **Always scope by organizationId + tenantId** — every entity query
+- **Resolve the organization in API routes with `resolveActiveOrganizationId(auth)`** from `@open-mercato/shared/lib/auth/organizationScope`, never with raw `auth.orgId` — a super-admin viewing "all organizations" has `auth.orgId === null`, and answering `401` there sends `apiFetch` into a session-refresh loop
 - **Use the queue system** — never run syncs inline in API handlers
 - **New sync providers MUST support provider-owned env preconfiguration** when fresh installs need credentials or default mappings/locales/channels from deployment env
 - **Persist cursor after each batch** — enables resume on failure

--- a/packages/core/src/modules/data_sync/AGENTS.md
+++ b/packages/core/src/modules/data_sync/AGENTS.md
@@ -9,7 +9,7 @@ The `data_sync` module provides a streaming data synchronization hub for import/
 ## Always
 
 - **Always scope by organizationId + tenantId** — every entity query
-- **Resolve the organization in API routes with `resolveActiveOrganizationId(auth)`** from `@open-mercato/shared/lib/auth/organizationScope`, never with raw `auth.orgId` — a super-admin viewing "all organizations" has `auth.orgId === null`, and answering `401` there sends `apiFetch` into a session-refresh loop
+- **Resolve the organization in API routes with `resolveActiveOrganizationId(auth)`** from `@open-mercato/shared/lib/auth/organizationScope`, never with raw `auth.orgId` — a super-admin viewing "all organizations" has `auth.orgId === null`. The fallback is tenant-aware: it never pairs the actor organization with a foreign selected tenant. When it returns `null` for an authenticated caller, answer with `organizationScopeRequiredResponse()` (400) — never 401, which sends `apiFetch` into a session-refresh loop
 - **Use the queue system** — never run syncs inline in API handlers
 - **New sync providers MUST support provider-owned env preconfiguration** when fresh installs need credentials or default mappings/locales/channels from deployment env
 - **Persist cursor after each batch** — enables resume on failure

--- a/packages/core/src/modules/data_sync/api/__tests__/organization-scope.test.ts
+++ b/packages/core/src/modules/data_sync/api/__tests__/organization-scope.test.ts
@@ -1,0 +1,145 @@
+/** @jest-environment node */
+
+const ACTOR_ORG_ID = '22222222-2222-4222-8222-222222222222'
+const SCHEDULE_ID = '123e4567-e89b-12d3-a456-426614174070'
+const INTEGRATION_ID = 'demo-provider'
+
+const mockGetAuthFromRequest = jest.fn()
+
+const mockSyncRunService = {
+  listRuns: jest.fn(),
+}
+
+const mockScheduleService = {
+  listSchedules: jest.fn(),
+  saveSchedule: jest.fn(),
+}
+
+const mockCrudMutationGuardService = {
+  validateMutation: jest.fn(),
+  afterMutationSuccess: jest.fn(),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/shared/lib/http/readJsonSafe', () => ({
+  readJsonSafe: jest.fn((req: Request) => req.json()),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({
+    resolve: (token: string) => {
+      if (token === 'dataSyncRunService') return mockSyncRunService
+      if (token === 'dataSyncScheduleService') return mockScheduleService
+      if (token === 'crudMutationGuardService') return mockCrudMutationGuardService
+      return null
+    },
+  })),
+}))
+
+import { GET as listRuns } from '../runs'
+import { GET as listSchedules, POST as createSchedule } from '../schedules/route'
+
+// `orgId: null` + `actorOrgId` set is exactly the shape `applySuperAdminScope` produces when the
+// operator picks "all organizations". These routes used to answer 401 for it, and `apiFetch` reads
+// 401 as an expired session — so the integrations page looped through /api/auth/session/refresh
+// forever. Integrations was fixed in #4224; data_sync kept reproducing the loop.
+function allOrganizationsAuth() {
+  return { sub: 'user-1', tenantId: 'tenant-1', orgId: null, actorOrgId: ACTOR_ORG_ID }
+}
+
+function createScheduleRequest() {
+  return new Request('http://localhost/api/data_sync/schedules', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      integrationId: INTEGRATION_ID,
+      entityType: 'products',
+      direction: 'import',
+      scheduleType: 'cron',
+      scheduleValue: '0 * * * *',
+      timezone: 'UTC',
+      fullSync: false,
+      isEnabled: true,
+    }),
+  })
+}
+
+describe('data_sync routes in the all-organizations scope', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetAuthFromRequest.mockResolvedValue(allOrganizationsAuth())
+    mockSyncRunService.listRuns.mockResolvedValue({ items: [], total: 0 })
+    mockScheduleService.listSchedules.mockResolvedValue({ items: [], total: 0 })
+    mockScheduleService.saveSchedule.mockResolvedValue({
+      id: SCHEDULE_ID,
+      integrationId: INTEGRATION_ID,
+      entityType: 'products',
+      direction: 'import',
+      scheduleType: 'cron',
+      scheduleValue: '0 * * * *',
+      timezone: 'UTC',
+      fullSync: false,
+      isEnabled: true,
+      scheduledJobId: SCHEDULE_ID,
+      lastRunAt: null,
+      organizationId: ACTOR_ORG_ID,
+      tenantId: 'tenant-1',
+      createdAt: new Date('2026-05-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-06-01T10:00:00.000Z'),
+      deletedAt: null,
+    })
+    mockCrudMutationGuardService.validateMutation.mockResolvedValue({
+      ok: true,
+      shouldRunAfterSuccess: true,
+      metadata: null,
+    })
+    mockCrudMutationGuardService.afterMutationSuccess.mockResolvedValue(undefined)
+  })
+
+  it('lists runs scoped to the actor organization instead of answering 401', async () => {
+    const response = await listRuns(new Request('http://localhost/api/data_sync/runs'))
+
+    expect(response.status).toBe(200)
+    expect(mockSyncRunService.listRuns).toHaveBeenCalledWith(
+      expect.anything(),
+      { organizationId: ACTOR_ORG_ID, tenantId: 'tenant-1' },
+    )
+  })
+
+  it('lists schedules scoped to the actor organization instead of answering 401', async () => {
+    const response = await listSchedules(new Request('http://localhost/api/data_sync/schedules'))
+
+    expect(response.status).toBe(200)
+    expect(mockScheduleService.listSchedules).toHaveBeenCalledWith(
+      expect.anything(),
+      { organizationId: ACTOR_ORG_ID, tenantId: 'tenant-1' },
+    )
+  })
+
+  it('writes a schedule into the actor organization instead of answering 401', async () => {
+    const response = await createSchedule(createScheduleRequest())
+
+    expect(response.status).toBe(201)
+    expect(mockScheduleService.saveSchedule).toHaveBeenCalledWith(
+      expect.anything(),
+      { organizationId: ACTOR_ORG_ID, tenantId: 'tenant-1' },
+      expect.anything(),
+    )
+    // The mutation guard must see the resolved organization too, not the null selection.
+    expect(mockCrudMutationGuardService.validateMutation).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: ACTOR_ORG_ID }),
+    )
+  })
+
+  it('still answers 401 when the caller has no organization to fall back to', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: null })
+
+    const response = await listRuns(new Request('http://localhost/api/data_sync/runs'))
+
+    expect(response.status).toBe(401)
+    expect(mockSyncRunService.listRuns).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/data_sync/api/__tests__/organization-scope.test.ts
+++ b/packages/core/src/modules/data_sync/api/__tests__/organization-scope.test.ts
@@ -3,8 +3,11 @@
 const ACTOR_ORG_ID = '22222222-2222-4222-8222-222222222222'
 const SCHEDULE_ID = '123e4567-e89b-12d3-a456-426614174070'
 const INTEGRATION_ID = 'demo-provider'
+const ACTOR_TENANT_ID = 'tenant-1'
+const FOREIGN_TENANT_ID = 'tenant-2'
 
 const mockGetAuthFromRequest = jest.fn()
+const mockStartDataSyncRun = jest.fn()
 
 const mockSyncRunService = {
   listRuns: jest.fn(),
@@ -20,6 +23,15 @@ const mockCrudMutationGuardService = {
   afterMutationSuccess: jest.fn(),
 }
 
+const mockCreateRequestContainer = jest.fn(async () => ({
+  resolve: (token: string) => {
+    if (token === 'dataSyncRunService') return mockSyncRunService
+    if (token === 'dataSyncScheduleService') return mockScheduleService
+    if (token === 'crudMutationGuardService') return mockCrudMutationGuardService
+    return null
+  },
+}))
+
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
 }))
@@ -29,25 +41,38 @@ jest.mock('@open-mercato/shared/lib/http/readJsonSafe', () => ({
 }))
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
-  createRequestContainer: jest.fn(async () => ({
-    resolve: (token: string) => {
-      if (token === 'dataSyncRunService') return mockSyncRunService
-      if (token === 'dataSyncScheduleService') return mockScheduleService
-      if (token === 'crudMutationGuardService') return mockCrudMutationGuardService
-      return null
-    },
-  })),
+  createRequestContainer: jest.fn(() => mockCreateRequestContainer()),
+}))
+
+jest.mock('../../lib/start-run', () => ({
+  startDataSyncRun: jest.fn((params: unknown) => mockStartDataSyncRun(params)),
 }))
 
 import { GET as listRuns } from '../runs'
 import { GET as listSchedules, POST as createSchedule } from '../schedules/route'
+import { POST as startRun } from '../run'
 
 // `orgId: null` + `actorOrgId` set is exactly the shape `applySuperAdminScope` produces when the
 // operator picks "all organizations". These routes used to answer 401 for it, and `apiFetch` reads
 // 401 as an expired session — so the integrations page looped through /api/auth/session/refresh
 // forever. Integrations was fixed in #4224; data_sync kept reproducing the loop.
 function allOrganizationsAuth() {
-  return { sub: 'user-1', tenantId: 'tenant-1', orgId: null, actorOrgId: ACTOR_ORG_ID }
+  return { sub: 'user-1', tenantId: ACTOR_TENANT_ID, orgId: null, actorOrgId: ACTOR_ORG_ID }
+}
+
+// When the super-admin cookie override also switches tenants, `actorTenantId` preserves the
+// actor's own tenant while `tenantId` is the selected one. Falling back to `actorOrgId` here
+// would pair a tenant-1 organization with tenant-2 — a cross-tenant scope that must never
+// reach services, persistence, or queues.
+function foreignTenantAllOrganizationsAuth() {
+  return {
+    sub: 'user-1',
+    tenantId: FOREIGN_TENANT_ID,
+    orgId: null,
+    actorOrgId: ACTOR_ORG_ID,
+    actorTenantId: ACTOR_TENANT_ID,
+    isSuperAdmin: true,
+  }
 }
 
 function createScheduleRequest() {
@@ -67,36 +92,51 @@ function createScheduleRequest() {
   })
 }
 
-describe('data_sync routes in the all-organizations scope', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-    mockGetAuthFromRequest.mockResolvedValue(allOrganizationsAuth())
-    mockSyncRunService.listRuns.mockResolvedValue({ items: [], total: 0 })
-    mockScheduleService.listSchedules.mockResolvedValue({ items: [], total: 0 })
-    mockScheduleService.saveSchedule.mockResolvedValue({
-      id: SCHEDULE_ID,
+function startRunRequest() {
+  return new Request('http://localhost/api/data_sync/run', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
       integrationId: INTEGRATION_ID,
       entityType: 'products',
       direction: 'import',
-      scheduleType: 'cron',
-      scheduleValue: '0 * * * *',
-      timezone: 'UTC',
-      fullSync: false,
-      isEnabled: true,
-      scheduledJobId: SCHEDULE_ID,
-      lastRunAt: null,
-      organizationId: ACTOR_ORG_ID,
-      tenantId: 'tenant-1',
-      createdAt: new Date('2026-05-01T10:00:00.000Z'),
-      updatedAt: new Date('2026-06-01T10:00:00.000Z'),
-      deletedAt: null,
-    })
-    mockCrudMutationGuardService.validateMutation.mockResolvedValue({
-      ok: true,
-      shouldRunAfterSuccess: true,
-      metadata: null,
-    })
-    mockCrudMutationGuardService.afterMutationSuccess.mockResolvedValue(undefined)
+    }),
+  })
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockSyncRunService.listRuns.mockResolvedValue({ items: [], total: 0 })
+  mockScheduleService.listSchedules.mockResolvedValue({ items: [], total: 0 })
+  mockScheduleService.saveSchedule.mockResolvedValue({
+    id: SCHEDULE_ID,
+    integrationId: INTEGRATION_ID,
+    entityType: 'products',
+    direction: 'import',
+    scheduleType: 'cron',
+    scheduleValue: '0 * * * *',
+    timezone: 'UTC',
+    fullSync: false,
+    isEnabled: true,
+    scheduledJobId: SCHEDULE_ID,
+    lastRunAt: null,
+    organizationId: ACTOR_ORG_ID,
+    tenantId: ACTOR_TENANT_ID,
+    createdAt: new Date('2026-05-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-06-01T10:00:00.000Z'),
+    deletedAt: null,
+  })
+  mockCrudMutationGuardService.validateMutation.mockResolvedValue({
+    ok: true,
+    shouldRunAfterSuccess: true,
+    metadata: null,
+  })
+  mockCrudMutationGuardService.afterMutationSuccess.mockResolvedValue(undefined)
+})
+
+describe('data_sync routes in the all-organizations scope', () => {
+  beforeEach(() => {
+    mockGetAuthFromRequest.mockResolvedValue(allOrganizationsAuth())
   })
 
   it('lists runs scoped to the actor organization instead of answering 401', async () => {
@@ -105,7 +145,7 @@ describe('data_sync routes in the all-organizations scope', () => {
     expect(response.status).toBe(200)
     expect(mockSyncRunService.listRuns).toHaveBeenCalledWith(
       expect.anything(),
-      { organizationId: ACTOR_ORG_ID, tenantId: 'tenant-1' },
+      { organizationId: ACTOR_ORG_ID, tenantId: ACTOR_TENANT_ID },
     )
   })
 
@@ -115,7 +155,7 @@ describe('data_sync routes in the all-organizations scope', () => {
     expect(response.status).toBe(200)
     expect(mockScheduleService.listSchedules).toHaveBeenCalledWith(
       expect.anything(),
-      { organizationId: ACTOR_ORG_ID, tenantId: 'tenant-1' },
+      { organizationId: ACTOR_ORG_ID, tenantId: ACTOR_TENANT_ID },
     )
   })
 
@@ -125,7 +165,7 @@ describe('data_sync routes in the all-organizations scope', () => {
     expect(response.status).toBe(201)
     expect(mockScheduleService.saveSchedule).toHaveBeenCalledWith(
       expect.anything(),
-      { organizationId: ACTOR_ORG_ID, tenantId: 'tenant-1' },
+      { organizationId: ACTOR_ORG_ID, tenantId: ACTOR_TENANT_ID },
       expect.anything(),
     )
     // The mutation guard must see the resolved organization too, not the null selection.
@@ -134,12 +174,59 @@ describe('data_sync routes in the all-organizations scope', () => {
     )
   })
 
-  it('still answers 401 when the caller has no organization to fall back to', async () => {
-    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: null })
+  // 400, never 401: a valid session must not be pushed through the session-refresh loop just
+  // because no organization can be resolved.
+  it('answers 400 organization_scope_required when the caller has no organization to fall back to', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: ACTOR_TENANT_ID, orgId: null })
+
+    const response = await listRuns(new Request('http://localhost/api/data_sync/runs'))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ code: 'organization_scope_required' })
+    expect(mockSyncRunService.listRuns).not.toHaveBeenCalled()
+  })
+
+  it('still answers 401 when there is no authenticated tenant', async () => {
+    mockGetAuthFromRequest.mockResolvedValue(null)
 
     const response = await listRuns(new Request('http://localhost/api/data_sync/runs'))
 
     expect(response.status).toBe(401)
     expect(mockSyncRunService.listRuns).not.toHaveBeenCalled()
+  })
+})
+
+describe('data_sync routes in a foreign-tenant all-organizations scope', () => {
+  beforeEach(() => {
+    mockGetAuthFromRequest.mockResolvedValue(foreignTenantAllOrganizationsAuth())
+  })
+
+  it('refuses to list runs with the actor organization of another tenant', async () => {
+    const response = await listRuns(new Request('http://localhost/api/data_sync/runs'))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ code: 'organization_scope_required' })
+    expect(mockSyncRunService.listRuns).not.toHaveBeenCalled()
+    expect(mockCreateRequestContainer).not.toHaveBeenCalled()
+  })
+
+  it('never persists a schedule with a cross-tenant organization/tenant pair', async () => {
+    const response = await createSchedule(createScheduleRequest())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ code: 'organization_scope_required' })
+    expect(mockScheduleService.saveSchedule).not.toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.validateMutation).not.toHaveBeenCalled()
+    expect(mockCreateRequestContainer).not.toHaveBeenCalled()
+  })
+
+  it('never starts or enqueues a run with a cross-tenant organization/tenant pair', async () => {
+    const response = await startRun(startRunRequest())
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ code: 'organization_scope_required' })
+    expect(mockStartDataSyncRun).not.toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.validateMutation).not.toHaveBeenCalled()
+    expect(mockCreateRequestContainer).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/data_sync/api/mappings/[id]/route.ts
+++ b/packages/core/src/modules/data_sync/api/mappings/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -37,9 +37,12 @@ async function resolveParams(ctx: { params?: Promise<{ id?: string }> | { id?: s
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const parsedParams = await resolveParams(ctx)
@@ -79,9 +82,12 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const parsedParams = await resolveParams(ctx)
@@ -158,9 +164,12 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function DELETE(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const parsedParams = await resolveParams(ctx)

--- a/packages/core/src/modules/data_sync/api/mappings/[id]/route.ts
+++ b/packages/core/src/modules/data_sync/api/mappings/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -36,7 +37,8 @@ async function resolveParams(ctx: { params?: Promise<{ id?: string }> | { id?: s
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -47,14 +49,14 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const mapping = await findOneWithDecryption(
     em,
     SyncMapping,
     {
       id: parsedParams.data.id,
-      organizationId: auth.orgId as string,
+      organizationId,
       tenantId: auth.tenantId,
     },
     undefined,
@@ -77,7 +79,8 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -94,14 +97,14 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const mapping = await findOneWithDecryption(
     em,
     SyncMapping,
     {
       id: parsedParams.data.id,
-      organizationId: auth.orgId as string,
+      organizationId,
       tenantId: auth.tenantId,
     },
     undefined,
@@ -155,7 +158,8 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function DELETE(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -166,14 +170,14 @@ export async function DELETE(req: Request, ctx: { params?: Promise<{ id?: string
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const mapping = await findOneWithDecryption(
     em,
     SyncMapping,
     {
       id: parsedParams.data.id,
-      organizationId: auth.orgId as string,
+      organizationId,
       tenantId: auth.tenantId,
     },
     undefined,

--- a/packages/core/src/modules/data_sync/api/mappings/route.ts
+++ b/packages/core/src/modules/data_sync/api/mappings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { findAndCountWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -35,7 +36,8 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -53,7 +55,7 @@ export async function GET(req: Request) {
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const where: FilterQuery<SyncMapping> = {
     organizationId: scope.organizationId,
@@ -92,7 +94,8 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -104,7 +107,7 @@ export async function POST(req: Request) {
 
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const existing = await findOneWithDecryption(
     em,

--- a/packages/core/src/modules/data_sync/api/mappings/route.ts
+++ b/packages/core/src/modules/data_sync/api/mappings/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { findAndCountWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
@@ -36,9 +36,12 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const url = new URL(req.url)
@@ -94,9 +97,12 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const payload = await req.json().catch(() => null)

--- a/packages/core/src/modules/data_sync/api/options.ts
+++ b/packages/core/src/modules/data_sync/api/options.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAllIntegrations } from '@open-mercato/shared/modules/integrations/types'
 import type { CredentialsService } from '../../integrations/lib/credentials-service'
@@ -17,14 +18,15 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const container = await createRequestContainer()
   const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
   const stateService = container.resolve('integrationStateService') as IntegrationStateService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const items = await Promise.all(
     getAllIntegrations()

--- a/packages/core/src/modules/data_sync/api/options.ts
+++ b/packages/core/src/modules/data_sync/api/options.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAllIntegrations } from '@open-mercato/shared/modules/integrations/types'
 import type { CredentialsService } from '../../integrations/lib/credentials-service'
@@ -18,9 +18,12 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const container = await createRequestContainer()

--- a/packages/core/src/modules/data_sync/api/run.ts
+++ b/packages/core/src/modules/data_sync/api/run.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { getIntegration } from '@open-mercato/shared/modules/integrations/types'
@@ -29,7 +30,8 @@ export const openApi = {
 export async function POST(req: Request) {
   try {
     const auth = await getAuthFromRequest(req)
-    if (!auth?.tenantId || !auth.orgId) {
+    const organizationId = resolveActiveOrganizationId(auth)
+    if (!auth?.tenantId || !organizationId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
@@ -45,7 +47,7 @@ export async function POST(req: Request) {
     const integrationStateService = container.resolve('integrationStateService') as IntegrationStateService
 
     const scope = {
-      organizationId: auth.orgId as string,
+      organizationId,
       tenantId: auth.tenantId,
     }
 

--- a/packages/core/src/modules/data_sync/api/run.ts
+++ b/packages/core/src/modules/data_sync/api/run.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { getIntegration } from '@open-mercato/shared/modules/integrations/types'
@@ -30,9 +30,12 @@ export const openApi = {
 export async function POST(req: Request) {
   try {
     const auth = await getAuthFromRequest(req)
-    const organizationId = resolveActiveOrganizationId(auth)
-    if (!auth?.tenantId || !organizationId) {
+    if (!auth?.tenantId) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const organizationId = resolveActiveOrganizationId(auth)
+    if (!organizationId) {
+      return organizationScopeRequiredResponse()
     }
 
     const payload = await readJsonSafe(req)

--- a/packages/core/src/modules/data_sync/api/runs.ts
+++ b/packages/core/src/modules/data_sync/api/runs.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { listSyncRunsQuerySchema } from '../data/validators'
 import type { SyncRunService } from '../lib/sync-run-service'
@@ -16,9 +16,12 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const url = new URL(req.url)

--- a/packages/core/src/modules/data_sync/api/runs.ts
+++ b/packages/core/src/modules/data_sync/api/runs.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { listSyncRunsQuerySchema } from '../data/validators'
 import type { SyncRunService } from '../lib/sync-run-service'
@@ -15,7 +16,8 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -38,7 +40,7 @@ export async function GET(req: Request) {
   const syncRunService = container.resolve('dataSyncRunService') as SyncRunService
 
   const { items, total } = await syncRunService.listRuns(parsed.data, {
-    organizationId: auth.orgId as string,
+    organizationId,
     tenantId: auth.tenantId,
   })
 

--- a/packages/core/src/modules/data_sync/api/runs/[id]/__tests__/cancel.test.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/__tests__/cancel.test.ts
@@ -85,6 +85,33 @@ describe('data_sync cancel run route', () => {
     expect(response.status).toBe(401)
   })
 
+  // `orgId: null` + `actorOrgId` is the shape `applySuperAdminScope` produces for an
+  // all-organizations selection. Answering 401 for it sent `apiFetch` into a refresh loop.
+  it('falls back to the actor organization instead of answering 401 in the all-organizations scope', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-1',
+      orgId: null,
+      actorOrgId: 'org-1',
+    })
+
+    const response = await postHandler(
+      new Request('http://localhost/api/data_sync/runs/11111111-1111-4111-8111-111111111111/cancel', { method: 'POST' }),
+      { params: { id: '11111111-1111-4111-8111-111111111111' } },
+    )
+
+    expect(response.status).toBe(200)
+    expect(mockSyncRunService.getRun).toHaveBeenCalledWith(
+      '11111111-1111-4111-8111-111111111111',
+      { organizationId: 'org-1', tenantId: 'tenant-1' },
+    )
+    expect(mockProgressService.markCancelled).toHaveBeenCalledWith('22222222-2222-4222-8222-222222222222', {
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    })
+  })
+
   it('marks the run as cancelled and records operational state and logs', async () => {
     const response = await postHandler(
       new Request('http://localhost/api/data_sync/runs/11111111-1111-4111-8111-111111111111/cancel', { method: 'POST' }),

--- a/packages/core/src/modules/data_sync/api/runs/[id]/__tests__/cancel.test.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/__tests__/cancel.test.ts
@@ -112,6 +112,32 @@ describe('data_sync cancel run route', () => {
     })
   })
 
+  // When the super-admin override also switched tenants, the actor organization belongs to
+  // another tenant — the fallback must not fabricate a cross-tenant scope, and the answer
+  // must not be a 401 (which would re-enter the session-refresh loop).
+  it('answers 400 and cancels nothing when the actor organization belongs to another tenant', async () => {
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId: 'tenant-2',
+      orgId: null,
+      actorOrgId: 'org-1',
+      actorTenantId: 'tenant-1',
+      isSuperAdmin: true,
+    })
+
+    const response = await postHandler(
+      new Request('http://localhost/api/data_sync/runs/11111111-1111-4111-8111-111111111111/cancel', { method: 'POST' }),
+      { params: { id: '11111111-1111-4111-8111-111111111111' } },
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ code: 'organization_scope_required' })
+    expect(mockSyncRunService.getRun).not.toHaveBeenCalled()
+    expect(mockSyncRunService.markStatus).not.toHaveBeenCalled()
+    expect(mockProgressService.markCancelled).not.toHaveBeenCalled()
+    expect(mockCrudMutationGuardService.validateMutation).not.toHaveBeenCalled()
+  })
+
   it('marks the run as cancelled and records operational state and logs', async () => {
     const response = await postHandler(
       new Request('http://localhost/api/data_sync/runs/11111111-1111-4111-8111-111111111111/cancel', { method: 'POST' }),

--- a/packages/core/src/modules/data_sync/api/runs/[id]/cancel.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/cancel.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { IntegrationLogService } from '../../../../integrations/lib/log-service'
 import type { IntegrationStateService } from '../../../../integrations/lib/state-service'
@@ -24,7 +25,8 @@ export const openApi = {
 
 export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -42,7 +44,7 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
   const progressService = container.resolve('progressService') as ProgressService
   const integrationLogService = container.resolve('integrationLogService') as IntegrationLogService
   const integrationStateService = container.resolve('integrationStateService') as IntegrationStateService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const run = await syncRunService.getRun(parsed.data.id, scope)
   if (!run) {
@@ -69,7 +71,7 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
 
   const progressCtx = {
     tenantId: auth.tenantId,
-    organizationId: auth.orgId,
+    organizationId,
     userId: auth.sub,
   }
 

--- a/packages/core/src/modules/data_sync/api/runs/[id]/cancel.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/cancel.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { IntegrationLogService } from '../../../../integrations/lib/log-service'
 import type { IntegrationStateService } from '../../../../integrations/lib/state-service'
@@ -25,9 +25,12 @@ export const openApi = {
 
 export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')

--- a/packages/core/src/modules/data_sync/api/runs/[id]/retry.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/retry.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import type { ProgressService } from '../../../../progress/lib/progressService'
@@ -25,7 +26,8 @@ export const openApi = {
 
 export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -47,7 +49,7 @@ export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }
   const container = await createRequestContainer()
   const syncRunService = container.resolve('dataSyncRunService') as SyncRunService
   const progressService = container.resolve('progressService') as ProgressService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const previous = await syncRunService.getRun(parsedParams.data.id, scope)
   if (!previous) {

--- a/packages/core/src/modules/data_sync/api/runs/[id]/retry.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/retry.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import type { ProgressService } from '../../../../progress/lib/progressService'
@@ -26,9 +26,12 @@ export const openApi = {
 
 export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')

--- a/packages/core/src/modules/data_sync/api/runs/[id]/route.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { ProgressService } from '../../../../progress/lib/progressService'
 import type { SyncRunService } from '../../../lib/sync-run-service'
@@ -19,9 +19,12 @@ export const openApi = {
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')

--- a/packages/core/src/modules/data_sync/api/runs/[id]/route.ts
+++ b/packages/core/src/modules/data_sync/api/runs/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { ProgressService } from '../../../../progress/lib/progressService'
 import type { SyncRunService } from '../../../lib/sync-run-service'
@@ -18,7 +19,8 @@ export const openApi = {
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -34,7 +36,7 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
   const container = await createRequestContainer()
   const syncRunService = container.resolve('dataSyncRunService') as SyncRunService
   const progressService = container.resolve('progressService') as ProgressService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const run = await syncRunService.getRun(parsed.data.id, scope)
   if (!run) {
@@ -44,7 +46,7 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
   const progressJob = run.progressJobId
     ? await progressService.getJob(run.progressJobId, {
       tenantId: auth.tenantId,
-      organizationId: auth.orgId,
+      organizationId,
       userId: auth.sub,
     })
     : null

--- a/packages/core/src/modules/data_sync/api/schedules/[id]/route.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { readOptimisticLockExpected } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
@@ -31,9 +31,12 @@ export const openApi = {
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')
@@ -61,9 +64,12 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')
@@ -144,9 +150,12 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function DELETE(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')

--- a/packages/core/src/modules/data_sync/api/schedules/[id]/route.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { readOptimisticLockExpected } from '@open-mercato/shared/lib/crud/optimistic-lock-command'
@@ -30,7 +31,8 @@ export const openApi = {
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -46,7 +48,7 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
   const container = await createRequestContainer()
   const scheduleService = container.resolve('dataSyncScheduleService') as SyncScheduleService
   const schedule = await scheduleService.getById(parsedParams.data.id, {
-    organizationId: auth.orgId as string,
+    organizationId,
     tenantId: auth.tenantId,
   })
 
@@ -59,7 +61,8 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -80,7 +83,7 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
 
   const container = await createRequestContainer()
   const scheduleService = container.resolve('dataSyncScheduleService') as SyncScheduleService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
   const current = await scheduleService.getById(parsedParams.data.id, scope)
 
   if (!current) {
@@ -141,7 +144,8 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function DELETE(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -156,7 +160,7 @@ export async function DELETE(req: Request, ctx: { params?: Promise<{ id?: string
 
   const container = await createRequestContainer()
   const scheduleService = container.resolve('dataSyncScheduleService') as SyncScheduleService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const guardResult = await validateCrudMutationGuard(container, {
     tenantId: auth.tenantId,

--- a/packages/core/src/modules/data_sync/api/schedules/route.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { createSyncScheduleSchema, listSyncSchedulesQuerySchema } from '../../data/validators'
@@ -24,7 +25,8 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -43,7 +45,7 @@ export async function GET(req: Request) {
 
   const container = await createRequestContainer()
   const scheduleService = container.resolve('dataSyncScheduleService') as SyncScheduleService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
   const { items, total } = await scheduleService.listSchedules(parsed.data, scope)
 
   return NextResponse.json({
@@ -57,7 +59,8 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -69,7 +72,7 @@ export async function POST(req: Request) {
 
   const container = await createRequestContainer()
   const scheduleService = container.resolve('dataSyncScheduleService') as SyncScheduleService
-  const scope = { organizationId: auth.orgId as string, tenantId: auth.tenantId }
+  const scope = { organizationId, tenantId: auth.tenantId }
 
   const guardResult = await validateCrudMutationGuard(container, {
     tenantId: auth.tenantId,

--- a/packages/core/src/modules/data_sync/api/schedules/route.ts
+++ b/packages/core/src/modules/data_sync/api/schedules/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { readJsonSafe } from '@open-mercato/shared/lib/http/readJsonSafe'
 import { createSyncScheduleSchema, listSyncSchedulesQuerySchema } from '../../data/validators'
@@ -25,9 +25,12 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const url = new URL(req.url)
@@ -59,9 +62,12 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const payload = await readJsonSafe(req)

--- a/packages/core/src/modules/data_sync/api/validate.ts
+++ b/packages/core/src/modules/data_sync/api/validate.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getIntegration } from '@open-mercato/shared/modules/integrations/types'
 import type { CredentialsService } from '../../integrations/lib/credentials-service'
@@ -17,7 +18,8 @@ export const openApi = {
 
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)
-  if (!auth?.tenantId || !auth.orgId) {
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
@@ -39,7 +41,7 @@ export async function POST(req: Request) {
   const container = await createRequestContainer()
   const credentialsService = container.resolve('integrationCredentialsService') as CredentialsService
   const credentials = await credentialsService.resolve(integration.id, {
-    organizationId: auth.orgId as string,
+    organizationId,
     tenantId: auth.tenantId,
   })
 
@@ -50,7 +52,7 @@ export async function POST(req: Request) {
   const mapping = await adapter.getMapping({
     entityType: parsed.data.entityType,
     scope: {
-      organizationId: auth.orgId as string,
+      organizationId,
       tenantId: auth.tenantId,
     },
   })
@@ -64,7 +66,7 @@ export async function POST(req: Request) {
     credentials,
     mapping,
     scope: {
-      organizationId: auth.orgId as string,
+      organizationId,
       tenantId: auth.tenantId,
     },
   })

--- a/packages/core/src/modules/data_sync/api/validate.ts
+++ b/packages/core/src/modules/data_sync/api/validate.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getIntegration } from '@open-mercato/shared/modules/integrations/types'
 import type { CredentialsService } from '../../integrations/lib/credentials-service'
@@ -18,9 +18,12 @@ export const openApi = {
 
 export async function POST(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const parsed = validateConnectionSchema.safeParse(await req.json())

--- a/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
@@ -21,7 +21,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
-import { resolveIntegrationsOrganizationId } from '../../../lib/organization-scope'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -45,7 +45,7 @@ function resolveParams(ctx: { params?: Promise<{ id?: string }> | { id?: string 
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveIntegrationsOrganizationId(auth)
+  const organizationId = resolveActiveOrganizationId(auth)
   if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -91,7 +91,7 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveIntegrationsOrganizationId(auth)
+  const organizationId = resolveActiveOrganizationId(auth)
   if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
@@ -21,7 +21,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -45,9 +45,12 @@ function resolveParams(ctx: { params?: Promise<{ id?: string }> | { id?: string 
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = await resolveParams(ctx)
@@ -91,9 +94,12 @@ export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }>
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = await resolveParams(ctx)

--- a/packages/core/src/modules/integrations/api/[id]/health/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/health/route.ts
@@ -9,7 +9,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -24,9 +24,12 @@ export const openApi = {
 
 export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')

--- a/packages/core/src/modules/integrations/api/[id]/health/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/health/route.ts
@@ -9,7 +9,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
-import { resolveIntegrationsOrganizationId } from '../../../lib/organization-scope'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -24,7 +24,7 @@ export const openApi = {
 
 export async function POST(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveIntegrationsOrganizationId(auth)
+  const organizationId = resolveActiveOrganizationId(auth)
   if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/packages/core/src/modules/integrations/api/[id]/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/route.ts
@@ -12,7 +12,7 @@ import {
   integrationApiRoutePaths,
   runIntegrationsReadBeforeInterceptors,
 } from '../umes-read'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -27,9 +27,12 @@ export const openApi = {
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')

--- a/packages/core/src/modules/integrations/api/[id]/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/route.ts
@@ -12,7 +12,7 @@ import {
   integrationApiRoutePaths,
   runIntegrationsReadBeforeInterceptors,
 } from '../umes-read'
-import { resolveIntegrationsOrganizationId } from '../../lib/organization-scope'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -27,7 +27,7 @@ export const openApi = {
 
 export async function GET(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveIntegrationsOrganizationId(auth)
+  const organizationId = resolveActiveOrganizationId(auth)
   if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/packages/core/src/modules/integrations/api/[id]/state/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/state/route.ts
@@ -13,7 +13,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
-import { resolveIntegrationsOrganizationId } from '../../../lib/organization-scope'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -28,7 +28,7 @@ export const openApi = {
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveIntegrationsOrganizationId(auth)
+  const organizationId = resolveActiveOrganizationId(auth)
   if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/packages/core/src/modules/integrations/api/[id]/state/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/state/route.ts
@@ -13,7 +13,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -28,9 +28,12 @@ export const openApi = {
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')

--- a/packages/core/src/modules/integrations/api/[id]/version/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/version/route.ts
@@ -14,7 +14,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
-import { resolveIntegrationsOrganizationId } from '../../../lib/organization-scope'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -29,7 +29,7 @@ export const openApi = {
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveIntegrationsOrganizationId(auth)
+  const organizationId = resolveActiveOrganizationId(auth)
   if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/packages/core/src/modules/integrations/api/[id]/version/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/version/route.ts
@@ -14,7 +14,7 @@ import {
   runIntegrationMutationGuardAfterSuccess,
   runIntegrationMutationGuards,
 } from '../../guards'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 const idParamsSchema = z.object({ id: z.string().min(1) })
 
@@ -29,9 +29,12 @@ export const openApi = {
 
 export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }> | { id?: string } }) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const rawParams = (ctx.params && typeof (ctx.params as Promise<unknown>).then === 'function')

--- a/packages/core/src/modules/integrations/api/logs/route.ts
+++ b/packages/core/src/modules/integrations/api/logs/route.ts
@@ -8,7 +8,7 @@ import {
   integrationApiRoutePaths,
   runIntegrationsReadBeforeInterceptors,
 } from '../umes-read'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['integrations.manage'] },
@@ -21,9 +21,12 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const container = await createRequestContainer()

--- a/packages/core/src/modules/integrations/api/logs/route.ts
+++ b/packages/core/src/modules/integrations/api/logs/route.ts
@@ -8,7 +8,7 @@ import {
   integrationApiRoutePaths,
   runIntegrationsReadBeforeInterceptors,
 } from '../umes-read'
-import { resolveIntegrationsOrganizationId } from '../../lib/organization-scope'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['integrations.manage'] },
@@ -21,7 +21,7 @@ export const openApi = {
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveIntegrationsOrganizationId(auth)
+  const organizationId = resolveActiveOrganizationId(auth)
   if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/packages/core/src/modules/integrations/api/route.ts
+++ b/packages/core/src/modules/integrations/api/route.ts
@@ -14,7 +14,7 @@ import {
   integrationApiRoutePaths,
   runIntegrationsReadBeforeInterceptors,
 } from './umes-read'
-import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
+import { organizationScopeRequiredResponse, resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['integrations.view'] },
@@ -47,9 +47,12 @@ function matchesSearchQuery(
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveActiveOrganizationId(auth)
-  if (!auth?.tenantId || !organizationId) {
+  if (!auth?.tenantId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const organizationId = resolveActiveOrganizationId(auth)
+  if (!organizationId) {
+    return organizationScopeRequiredResponse()
   }
 
   const url = new URL(req.url)

--- a/packages/core/src/modules/integrations/api/route.ts
+++ b/packages/core/src/modules/integrations/api/route.ts
@@ -14,7 +14,7 @@ import {
   integrationApiRoutePaths,
   runIntegrationsReadBeforeInterceptors,
 } from './umes-read'
-import { resolveIntegrationsOrganizationId } from '../lib/organization-scope'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['integrations.view'] },
@@ -47,7 +47,7 @@ function matchesSearchQuery(
 
 export async function GET(req: Request) {
   const auth = await getAuthFromRequest(req)
-  const organizationId = resolveIntegrationsOrganizationId(auth)
+  const organizationId = resolveActiveOrganizationId(auth)
   if (!auth?.tenantId || !organizationId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }

--- a/packages/core/src/modules/integrations/api/umes-read.ts
+++ b/packages/core/src/modules/integrations/api/umes-read.ts
@@ -4,7 +4,7 @@ import type { AwilixContainer } from 'awilix'
 import { runApiInterceptorsAfter, runApiInterceptorsBefore, type RunInterceptorsBeforeResult } from '@open-mercato/shared/lib/crud/interceptor-runner'
 import { applyResponseEnrichers, applyResponseEnricherToRecord } from '@open-mercato/shared/lib/crud/enricher-runner'
 import type { ApiInterceptorMethod, InterceptorRequest } from '@open-mercato/shared/lib/crud/api-interceptor'
-import { resolveIntegrationsOrganizationId } from '../lib/organization-scope'
+import { resolveActiveOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'
 
 export const integrationApiRoutePaths = {
   list: 'integrations',
@@ -67,7 +67,7 @@ function mergeAdditiveBody(
 
 function getEnricherContext(input: ReadRouteContext) {
   return {
-    organizationId: resolveIntegrationsOrganizationId(input.auth) as string,
+    organizationId: resolveActiveOrganizationId(input.auth) as string,
     tenantId: input.auth.tenantId as string,
     userId: input.auth.sub ?? '',
     em: input.container.resolve('em') as EntityManager,

--- a/packages/core/src/modules/integrations/lib/__tests__/organization-scope.test.ts
+++ b/packages/core/src/modules/integrations/lib/__tests__/organization-scope.test.ts
@@ -20,6 +20,20 @@ describe('integrations organization scope', () => {
     ).toBe(accountOrgId)
   })
 
+  // The shared resolver behind this deprecated alias is tenant-aware: a super-admin who
+  // switched to another tenant with "all organizations" selected must not scope to the
+  // actor organization of their own tenant.
+  it('refuses the fallback when the effective tenant is not the actor tenant', () => {
+    expect(
+      resolveIntegrationsOrganizationId({
+        orgId: null,
+        actorOrgId: accountOrgId,
+        tenantId: '55555555-5555-4555-8555-555555555555',
+        actorTenantId: '44444444-4444-4444-8444-444444444444',
+      }),
+    ).toBeNull()
+  })
+
   it('returns null when the caller has no organization at all', () => {
     expect(resolveIntegrationsOrganizationId({ orgId: null })).toBeNull()
     expect(resolveIntegrationsOrganizationId({ orgId: null, actorOrgId: null })).toBeNull()

--- a/packages/core/src/modules/integrations/lib/organization-scope.ts
+++ b/packages/core/src/modules/integrations/lib/organization-scope.ts
@@ -1,27 +1,7 @@
-type OrganizationScopedAuth = {
-  orgId?: string | null
-  actorOrgId?: unknown
-} | null | undefined
-
 /**
- * Resolves the organization an integrations request is scoped to.
- *
- * Integrations are configured per organization — `integration_credentials` and
- * `integration_states` both require a non-null `organization_id` — so there is no
- * meaningful "all organizations" view of this module. When an operator selects that
- * option the super-admin cookie override clears `auth.orgId` and preserves the actor's
- * own organization in `actorOrgId`; fall back to it so the module keeps showing the
- * operator's own configuration instead of failing.
- *
- * Answering 401 for that case is not merely wrong but self-perpetuating: `apiFetch`
- * reads 401 as an expired session and redirects through `/api/auth/session/refresh`,
- * which succeeds and returns to the same page, reloading forever.
+ * @deprecated Moved to `@open-mercato/shared/lib/auth/organizationScope` as
+ * `resolveActiveOrganizationId`, because `data_sync` needs the same resolution and
+ * `integrations` is not the right owner for it. This alias stays for third-party
+ * modules that already import from here.
  */
-export function resolveIntegrationsOrganizationId(auth: OrganizationScopedAuth): string | null {
-  if (!auth) return null
-  const selected = auth.orgId
-  if (typeof selected === 'string' && selected.trim().length > 0) return selected
-  const actorOrgId = auth.actorOrgId
-  if (typeof actorOrgId === 'string' && actorOrgId.trim().length > 0) return actorOrgId
-  return null
-}
+export { resolveActiveOrganizationId as resolveIntegrationsOrganizationId } from '@open-mercato/shared/lib/auth/organizationScope'

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -34,6 +34,7 @@ yarn workspace @open-mercato/shared build
 |-----------|-------------|-------------|
 | `api/` | When building scoped API payloads | `@open-mercato/shared/lib/api/scoped` |
 | `auth/` | When you need wildcard-aware feature matching or shared auth helpers | `@open-mercato/shared/lib/auth/featureMatch` |
+| `auth/organizationScope` | When an organization-scoped API route must resolve the caller's organization — falls back to `actorOrgId` for an "all organizations" selection instead of failing | `@open-mercato/shared/lib/auth/organizationScope` — `resolveActiveOrganizationId(auth)` |
 | `boolean/` | When parsing boolean strings from env/query params | `@open-mercato/shared/lib/boolean` |
 | `browser/` | When persisting client UI state to `localStorage` — use the safe wrappers and the versioned-envelope helper instead of raw `localStorage` reads/writes | `@open-mercato/shared/lib/browser/safeLocalStorage`, `@open-mercato/shared/lib/browser/versionedPreference` |
 | `commands/` | When implementing undo/redo command pattern | `@open-mercato/shared/lib/commands` |

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -34,7 +34,7 @@ yarn workspace @open-mercato/shared build
 |-----------|-------------|-------------|
 | `api/` | When building scoped API payloads | `@open-mercato/shared/lib/api/scoped` |
 | `auth/` | When you need wildcard-aware feature matching or shared auth helpers | `@open-mercato/shared/lib/auth/featureMatch` |
-| `auth/organizationScope` | When an organization-scoped API route must resolve the caller's organization — falls back to `actorOrgId` for an "all organizations" selection instead of failing | `@open-mercato/shared/lib/auth/organizationScope` — `resolveActiveOrganizationId(auth)` |
+| `auth/organizationScope` | When an organization-scoped API route must resolve the caller's organization — falls back to `actorOrgId` for an "all organizations" selection, but only while the effective tenant is still the actor's tenant. On `null` for an authenticated caller answer with `organizationScopeRequiredResponse()` (400, code `organization_scope_required`) — never 401 | `@open-mercato/shared/lib/auth/organizationScope` — `resolveActiveOrganizationId(auth)`, `organizationScopeRequiredResponse()` |
 | `boolean/` | When parsing boolean strings from env/query params | `@open-mercato/shared/lib/boolean` |
 | `browser/` | When persisting client UI state to `localStorage` — use the safe wrappers and the versioned-envelope helper instead of raw `localStorage` reads/writes | `@open-mercato/shared/lib/browser/safeLocalStorage`, `@open-mercato/shared/lib/browser/versionedPreference` |
 | `commands/` | When implementing undo/redo command pattern | `@open-mercato/shared/lib/commands` |

--- a/packages/shared/src/lib/auth/__tests__/organizationScope.test.ts
+++ b/packages/shared/src/lib/auth/__tests__/organizationScope.test.ts
@@ -1,0 +1,34 @@
+/** @jest-environment node */
+
+import { resolveActiveOrganizationId } from '../organizationScope'
+
+const accountOrgId = '22222222-2222-4222-8222-222222222222'
+const selectedOrgId = '33333333-3333-4333-8333-333333333333'
+
+describe('resolveActiveOrganizationId', () => {
+  it('uses the selected organization when one is set', () => {
+    expect(
+      resolveActiveOrganizationId({ orgId: selectedOrgId, actorOrgId: accountOrgId }),
+    ).toBe(selectedOrgId)
+  })
+
+  // `orgId: null` + `actorOrgId` set is exactly the shape `applySuperAdminScope` produces for an
+  // all-organizations selection. Answering 401 for it sent `apiFetch` into a refresh loop.
+  it('falls back to the actor organization for an all-organizations selection', () => {
+    expect(
+      resolveActiveOrganizationId({ orgId: null, actorOrgId: accountOrgId }),
+    ).toBe(accountOrgId)
+  })
+
+  it('returns null when the caller has no organization at all', () => {
+    expect(resolveActiveOrganizationId({ orgId: null })).toBeNull()
+    expect(resolveActiveOrganizationId({ orgId: null, actorOrgId: null })).toBeNull()
+    expect(resolveActiveOrganizationId(null)).toBeNull()
+  })
+
+  it('ignores blank and non-string values rather than scoping to them', () => {
+    expect(resolveActiveOrganizationId({ orgId: '   ', actorOrgId: accountOrgId })).toBe(accountOrgId)
+    expect(resolveActiveOrganizationId({ orgId: null, actorOrgId: '  ' })).toBeNull()
+    expect(resolveActiveOrganizationId({ orgId: null, actorOrgId: 42 })).toBeNull()
+  })
+})

--- a/packages/shared/src/lib/auth/__tests__/organizationScope.test.ts
+++ b/packages/shared/src/lib/auth/__tests__/organizationScope.test.ts
@@ -1,9 +1,15 @@
 /** @jest-environment node */
 
-import { resolveActiveOrganizationId } from '../organizationScope'
+import {
+  ORGANIZATION_SCOPE_REQUIRED_ERROR_CODE,
+  organizationScopeRequiredResponse,
+  resolveActiveOrganizationId,
+} from '../organizationScope'
 
 const accountOrgId = '22222222-2222-4222-8222-222222222222'
 const selectedOrgId = '33333333-3333-4333-8333-333333333333'
+const actorTenantId = '44444444-4444-4444-8444-444444444444'
+const foreignTenantId = '55555555-5555-4555-8555-555555555555'
 
 describe('resolveActiveOrganizationId', () => {
   it('uses the selected organization when one is set', () => {
@@ -20,6 +26,51 @@ describe('resolveActiveOrganizationId', () => {
     ).toBe(accountOrgId)
   })
 
+  // `actorTenantId` is only present when the super-admin cookie override switched tenants.
+  // Selecting the actor's own tenant explicitly keeps the fallback valid.
+  it('keeps the fallback when the tenant override selects the actor tenant', () => {
+    expect(
+      resolveActiveOrganizationId({
+        orgId: null,
+        actorOrgId: accountOrgId,
+        tenantId: actorTenantId,
+        actorTenantId,
+      }),
+    ).toBe(accountOrgId)
+  })
+
+  // The reviewed blocker: tenant B + "all organizations" must not pair the actor's
+  // tenant-A organization with tenant B. No fallback — the route answers 400 instead.
+  it('refuses the fallback when the effective tenant is not the actor tenant', () => {
+    expect(
+      resolveActiveOrganizationId({
+        orgId: null,
+        actorOrgId: accountOrgId,
+        tenantId: foreignTenantId,
+        actorTenantId,
+      }),
+    ).toBeNull()
+  })
+
+  it('refuses the fallback when the tenant override cleared the tenant entirely', () => {
+    expect(
+      resolveActiveOrganizationId({
+        orgId: null,
+        actorOrgId: accountOrgId,
+        tenantId: null,
+        actorTenantId,
+      }),
+    ).toBeNull()
+    expect(
+      resolveActiveOrganizationId({
+        orgId: null,
+        actorOrgId: accountOrgId,
+        tenantId: foreignTenantId,
+        actorTenantId: null,
+      }),
+    ).toBeNull()
+  })
+
   it('returns null when the caller has no organization at all', () => {
     expect(resolveActiveOrganizationId({ orgId: null })).toBeNull()
     expect(resolveActiveOrganizationId({ orgId: null, actorOrgId: null })).toBeNull()
@@ -30,5 +81,27 @@ describe('resolveActiveOrganizationId', () => {
     expect(resolveActiveOrganizationId({ orgId: '   ', actorOrgId: accountOrgId })).toBe(accountOrgId)
     expect(resolveActiveOrganizationId({ orgId: null, actorOrgId: '  ' })).toBeNull()
     expect(resolveActiveOrganizationId({ orgId: null, actorOrgId: 42 })).toBeNull()
+  })
+
+  it('still honours an explicit organization selection across tenants', () => {
+    expect(
+      resolveActiveOrganizationId({
+        orgId: selectedOrgId,
+        actorOrgId: accountOrgId,
+        tenantId: foreignTenantId,
+        actorTenantId,
+      }),
+    ).toBe(selectedOrgId)
+  })
+})
+
+describe('organizationScopeRequiredResponse', () => {
+  // 401 would send `apiFetch` back into the session-refresh loop; the scope error must not.
+  it('answers 400 with a machine-readable code', async () => {
+    const response = organizationScopeRequiredResponse()
+    expect(response.status).toBe(400)
+    const body = await response.json()
+    expect(body.code).toBe(ORGANIZATION_SCOPE_REQUIRED_ERROR_CODE)
+    expect(typeof body.error).toBe('string')
   })
 })

--- a/packages/shared/src/lib/auth/organizationScope.ts
+++ b/packages/shared/src/lib/auth/organizationScope.ts
@@ -1,7 +1,15 @@
 type OrganizationScopedAuth = {
   orgId?: string | null
   actorOrgId?: unknown
+  tenantId?: string | null
+  actorTenantId?: unknown
 } | null | undefined
+
+function normalizeId(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
 
 /**
  * Resolves the organization a request is scoped to when the caller may be viewing
@@ -14,15 +22,44 @@ type OrganizationScopedAuth = {
  * organization in `actorOrgId`; fall back to it so those modules keep showing the
  * operator's own configuration instead of failing.
  *
- * Answering 401 for that case is not merely wrong but self-perpetuating: `apiFetch`
- * reads 401 as an expired session and redirects through `/api/auth/session/refresh`,
- * which succeeds and returns to the same page, reloading forever.
+ * The fallback is only valid while the effective tenant is still the actor's own tenant.
+ * When the super-admin cookie override also switched tenants (`actorTenantId` is present
+ * and differs from `auth.tenantId`), the actor's organization belongs to another tenant —
+ * scoping to it would persist a cross-tenant `{ organizationId, tenantId }` pair. Return
+ * `null` instead and let the route answer with `organizationScopeRequiredResponse()`.
+ *
+ * Answering 401 for an unresolvable scope is not merely wrong but self-perpetuating:
+ * `apiFetch` reads 401 as an expired session and redirects through
+ * `/api/auth/session/refresh`, which succeeds and returns to the same page, reloading
+ * forever. That is why the missing-scope answer is a 400, never a 401.
  */
 export function resolveActiveOrganizationId(auth: OrganizationScopedAuth): string | null {
   if (!auth) return null
-  const selected = auth.orgId
-  if (typeof selected === 'string' && selected.trim().length > 0) return selected
-  const actorOrgId = auth.actorOrgId
-  if (typeof actorOrgId === 'string' && actorOrgId.trim().length > 0) return actorOrgId
-  return null
+  const selected = normalizeId(auth.orgId)
+  if (selected) return selected
+  const actorOrgId = normalizeId(auth.actorOrgId)
+  if (!actorOrgId) return null
+  if ('actorTenantId' in auth) {
+    const actorTenantId = normalizeId(auth.actorTenantId)
+    const effectiveTenantId = normalizeId(auth.tenantId)
+    if (!actorTenantId || actorTenantId !== effectiveTenantId) return null
+  }
+  return actorOrgId
+}
+
+export const ORGANIZATION_SCOPE_REQUIRED_ERROR_CODE = 'organization_scope_required'
+
+/**
+ * 400 response for an authenticated caller whose organization scope cannot be resolved
+ * (e.g. a super-admin viewing a foreign tenant with "all organizations" selected).
+ * Deliberately not a 401: the session is valid, so refreshing it would loop.
+ */
+export function organizationScopeRequiredResponse(): Response {
+  return Response.json(
+    {
+      error: 'Select an organization to access this resource',
+      code: ORGANIZATION_SCOPE_REQUIRED_ERROR_CODE,
+    },
+    { status: 400 },
+  )
 }

--- a/packages/shared/src/lib/auth/organizationScope.ts
+++ b/packages/shared/src/lib/auth/organizationScope.ts
@@ -1,0 +1,28 @@
+type OrganizationScopedAuth = {
+  orgId?: string | null
+  actorOrgId?: unknown
+} | null | undefined
+
+/**
+ * Resolves the organization a request is scoped to when the caller may be viewing
+ * "all organizations".
+ *
+ * Organization-scoped configuration modules (integrations credentials/state, data sync
+ * mappings/schedules/runs) all require a non-null `organization_id`, so there is no
+ * meaningful "all organizations" view of them. When an operator selects that option the
+ * super-admin cookie override clears `auth.orgId` and preserves the actor's own
+ * organization in `actorOrgId`; fall back to it so those modules keep showing the
+ * operator's own configuration instead of failing.
+ *
+ * Answering 401 for that case is not merely wrong but self-perpetuating: `apiFetch`
+ * reads 401 as an expired session and redirects through `/api/auth/session/refresh`,
+ * which succeeds and returns to the same page, reloading forever.
+ */
+export function resolveActiveOrganizationId(auth: OrganizationScopedAuth): string | null {
+  if (!auth) return null
+  const selected = auth.orgId
+  if (typeof selected === 'string' && selected.trim().length > 0) return selected
+  const actorOrgId = auth.actorOrgId
+  if (typeof actorOrgId === 'string' && actorOrgId.trim().length > 0) return actorOrgId
+  return null
+}


### PR DESCRIPTION
## Problem

`#4224` fixed the "all organizations" 401 loop for `/api/integrations/*`, but the integration
detail page also drives `data_sync` endpoints — so the same page still loops.

When a super-admin selects "all organizations", `applySuperAdminScope` clears `auth.orgId` and
preserves the account organization in `actorOrgId`
(`packages/shared/src/lib/auth/server.ts:109-119,149`). Every `data_sync` route answered `401` for
that shape. `apiFetch` reads `401` as an expired session and redirects through
`/api/auth/session/refresh`, which succeeds and returns to the same page — reloading forever
(`packages/ui/src/backend/utils/api.ts:173-177`).

Reproduces on the "Sync schedules" tab (`IntegrationScheduleTab.tsx:165` → `/api/data_sync/schedules`)
and on the run detail widget (`integrations/backend/integrations/[id]/page.tsx:564` →
`/api/data_sync/runs/...`).

## Change

Applies the fix `integrations` already received, and promotes the helper so both modules share one
implementation instead of two copies.

- **New**: `resolveActiveOrganizationId(auth)` in `@open-mercato/shared/lib/auth/organizationScope`
  — returns the selected organization, falling back to `actorOrgId` for a broad selection.
- **`integrations`**: `lib/organization-scope.ts` is now a `@deprecated` re-export of the shared
  helper. The old import path and the `resolveIntegrationsOrganizationId` name keep working for
  third-party modules; its existing test is left untouched and now exercises the alias.
- **`data_sync`**: 41 `auth.orgId` reads across 11 route files now go through the resolver — 17
  guards plus 24 downstream uses. Both had to change together: swapping only the guard would pass
  `null` into the services. The `as string` casts are gone; the guard narrows the type.

Reads and writes behave identically, matching `#4224`. Rejecting broad scope on writes with a
`409` was considered and dropped: it would split behavior across one screen and add error handling
plus translations in the UI for no safety gain over scoping to the operator's own organization.

Unchanged database schema, unchanged API surface, no new response codes.

## Tests

- `packages/shared/src/lib/auth/__tests__/organizationScope.test.ts` — resolver units, including
  the blank/non-string cases.
- `packages/core/src/modules/data_sync/api/__tests__/organization-scope.test.ts` — `runs` GET,
  `schedules` GET/POST resolve to `actorOrgId` instead of `401`, the mutation guard sees the
  resolved organization, and a caller with no organization at all still gets `401`.
- `packages/core/src/modules/data_sync/api/runs/[id]/__tests__/cancel.test.ts` — same coverage for
  an action route.
