### PR TITLE
fix(ci): allow community-labels workflow to label pull requests

### DIFF
--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -8,7 +8,7 @@ on:
 # or contributor-supplied code is used by this workflow.
 permissions:
   issues: write
-
+  pull-requests: write
 jobs:
   add-label:
     if: >


### PR DESCRIPTION
## What

One line: grants `pull-requests: write` to the community-labels workflow.

## Why

The workflow only had `issues: write`, but adding a label to a **pull request** through the issues API requires `pull-requests: write` — so every `/label` command on a PR died with `403 Resource not accessible by integration` (see the `x-accepted-github-permissions: issues=write; pull_requests=write` response header in the failed run logs). Since the job condition restricts the workflow to PR comments only, this affected every use.

Evidence: run [30626342833](https://github.com/open-mercato/open-mercato/actions/runs/30626342833) — a clean `/label partner-request` comment on the test PR #4742 that passed the label filter and failed on the API call.

Note: the earlier failed test on #4742 (`/label partner-request Testing`) failed differently — trailing text after the label name is parsed as part of the label list, so it never reached the API. Worth knowing when testing: the comment must contain the label name only.

Mirror PR for `main` (where the workflow actually executes from): see the companion PR targeting main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)