### PR TITLE
fix(ci): allow community-labels workflow to label pull requests (main)

### DIFF
--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -8,7 +8,7 @@ on:
 # or contributor-supplied code is used by this workflow.
 permissions:
   issues: write
-
+  pull-requests: write
 jobs:
   add-label:
     if: >

--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   issues: write
   pull-requests: write
+
 jobs:
   add-label:
     if: >

--- a/scripts/__tests__/community-labels-workflow.test.mjs
+++ b/scripts/__tests__/community-labels-workflow.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const workflowPath = path.resolve('.github/workflows/community-labels.yml')
+
+test('community label commands retain PR write permission and safety guards', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8')
+
+  assert.match(workflow, /^permissions:\n(?:  .+\n)*  pull-requests: write$/m)
+  assert.match(workflow, /github\.event\.issue\.pull_request/)
+  assert.match(workflow, /startsWith\(github\.event\.comment\.body, '\/label '\)/)
+  assert.match(workflow, /const allowedLabels = new Set\(\[\s*'partner-request',\s*\]\)/)
+  assert.doesNotMatch(workflow, /actions\/checkout@/)
+})


### PR DESCRIPTION
## What

One line: grants `pull-requests: write` to the community-labels workflow.

## Why

The workflow only had `issues: write`, but adding a label to a **pull request** through the issues API requires `pull-requests: write` — so every `/label` command on a PR died with `403 Resource not accessible by integration` (see the `x-accepted-github-permissions: issues=write; pull_requests=write` response header in the failed run logs). Since the job condition restricts the workflow to PR comments only, this affected every use.

Evidence: run [30626342833](https://github.com/open-mercato/open-mercato/actions/runs/30626342833) — a clean `/label partner-request` comment on the test PR #4742 that passed the label filter and failed on the API call.

Note: the earlier failed test on #4742 (`/label partner-request Testing`) failed differently — trailing text after the label name is parsed as part of the label list, so it never reached the API. Worth knowing when testing: the comment must contain the label name only.

Mirror of the develop-targeted PR — the file exists on both branches (#4726/#4730 on develop, #4740 on main) and `issue_comment` workflows execute from the default branch, so main needs the fix for the command to work at all, and develop needs it so the next release does not reintroduce the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)