### PR TITLE
feat(ui): surface defaultCountryIso2 through customer phone form configs

### DIFF
--- a/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
+++ b/packages/core/src/modules/customers/components/__tests__/formConfig.test.ts
@@ -7,6 +7,12 @@ jest.mock('../AddressTiles', () => ({
 jest.mock('../detail/RolesSection', () => ({
   RolesSection: () => null,
 }))
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 
 import {
   buildCompanyEditPayload,
@@ -15,8 +21,10 @@ import {
   buildPersonPayload,
   createCompanyDaneFiremyGroups,
   createCompanyEditSchema,
+  createCompanyFormFields,
   createCompanyFormSchema,
   createPersonEditSchema,
+  createPersonFormFields,
   createPersonPersonalDataGroups,
   mapCompanyOverviewToFormValues,
   mapPersonOverviewToFormValues,
@@ -308,5 +316,45 @@ describe('clearing v2 company plain-text & revenue edit fields (#3050)', () => {
     expect('sizeBucket' in payload).toBe(false)
     expect('annualRevenue' in payload).toBe(false)
     expect('description' in payload).toBe(false)
+  })
+})
+
+describe('PhoneNumberField defaultCountryIso2 forwarding', () => {
+  const mockRenderProps = {
+    value: null,
+    setValue: () => {},
+    error: undefined,
+    disabled: false,
+    autoFocus: false,
+    recordId: undefined,
+  }
+
+  it('renders phone input with +48 country code in person form when defaultCountryIso2: PL is provided', () => {
+    const fields = createPersonFormFields(t, { defaultCountryIso2: 'PL' })
+    const phoneField = fields.find((f) => f.id === 'primaryPhone')
+    expect(phoneField).toBeDefined()
+    expect(phoneField?.type).toBe('custom')
+
+    const html = renderToStaticMarkup(React.createElement(phoneField!.component as any, mockRenderProps))
+    expect(html).toContain('+48')
+  })
+
+  it('renders phone input with +48 country code in company form when defaultCountryIso2: PL is provided', () => {
+    const fields = createCompanyFormFields(t, { defaultCountryIso2: 'PL' })
+    const phoneField = fields.find((f) => f.id === 'primaryPhone')
+    expect(phoneField).toBeDefined()
+    expect(phoneField?.type).toBe('custom')
+
+    const html = renderToStaticMarkup(React.createElement(phoneField!.component as any, mockRenderProps))
+    expect(html).toContain('+48')
+  })
+
+  it('renders phone input with default +1 country code when options are omitted', () => {
+    const fields = createPersonFormFields(t)
+    const phoneField = fields.find((f) => f.id === 'primaryPhone')
+    expect(phoneField).toBeDefined()
+
+    const html = renderToStaticMarkup(React.createElement(phoneField!.component as any, mockRenderProps))
+    expect(html).toContain('+1')
   })
 })

--- a/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
@@ -99,6 +99,8 @@ interface ScheduleActivityDialogProps {
   onActivityCreated?: () => void
   /** When provided, dialog opens in edit mode with pre-filled data */
   editData?: ScheduleActivityEditData | null
+  /** Default country ISO2 code for phone number input when value is empty/unparsed */
+  defaultCountryIso2?: string
 }
 
 export function ScheduleActivityDialog({
@@ -111,6 +113,7 @@ export function ScheduleActivityDialog({
   entityType,
   onActivityCreated,
   editData,
+  defaultCountryIso2,
 }: ScheduleActivityDialogProps) {
   const t = useT()
   const state = useScheduleFormState({ open, editData: editData ?? null })
@@ -689,6 +692,7 @@ export function ScheduleActivityDialog({
               externalError={callPhoneError}
               invalidLabel={callPhoneInvalidMessage}
               minDigits={7}
+              defaultCountryIso2={defaultCountryIso2}
             />
           </div>
         ) : (

--- a/packages/core/src/modules/customers/components/formConfig.tsx
+++ b/packages/core/src/modules/customers/components/formConfig.tsx
@@ -418,7 +418,7 @@ const companyDictionaryFieldDefinitions: DictionaryFieldDefinition[] = [
   },
 ]
 
-const createPrimaryPhoneField = (t: Translator): CrudField => ({
+const createPrimaryPhoneField = (t: Translator, defaultCountryIso2?: string): CrudField => ({
   id: 'primaryPhone',
   label: t('customers.people.form.primaryPhone'),
   type: 'custom',
@@ -447,6 +447,7 @@ const createPrimaryPhoneField = (t: Translator): CrudField => ({
         invalidLabel={t('customers.people.form.primaryPhone.invalid', 'Enter a valid phone number with country code (e.g. +1 212 555 1234)')}
         minDigits={7}
         onDuplicateLookup={!disabled && !error ? duplicateLookup : undefined}
+        defaultCountryIso2={defaultCountryIso2}
       />
     )
   },
@@ -869,7 +870,8 @@ export const createDisplayNameSection = (t: Translator) =>
     )
   }
 
-export const createPersonFormFields = (t: Translator): CrudField[] => {
+export const createPersonFormFields = (t: Translator, options?: { defaultCountryIso2?: string }): CrudField[] => {
+  const defaultCountryIso2 = options?.defaultCountryIso2
   const contactSection = createSectionHeadingField('__contactInformationSection', t('customers.people.form.sections.contactInformation'))
   const companySection = createSectionHeadingField('__companyInformationSection', t('customers.people.form.sections.companyInformation'))
   const dictionaryFields: CrudField[] = dictionaryFieldDefinitions.map((definition) => ({
@@ -930,7 +932,7 @@ export const createPersonFormFields = (t: Translator): CrudField[] => {
     },
     contactSection,
     createPrimaryEmailField(t),
-    createPrimaryPhoneField(t),
+    createPrimaryPhoneField(t, defaultCountryIso2),
     companySection,
     {
       id: 'companyEntityId',
@@ -1225,7 +1227,8 @@ export const createCompanyFormSchema = () =>
     })
     .passthrough()
 
-export const createCompanyFormFields = (t: Translator): CrudField[] => {
+export const createCompanyFormFields = (t: Translator, options?: { defaultCountryIso2?: string }): CrudField[] => {
+  const defaultCountryIso2 = options?.defaultCountryIso2
   const dictionaryFields: CrudField[] = companyDictionaryFieldDefinitions.map((definition) => ({
     id: definition.id,
     label: t(definition.labelKey),
@@ -1270,6 +1273,7 @@ export const createCompanyFormFields = (t: Translator): CrudField[] => {
           placeholder={t('customers.companies.form.primaryPhonePlaceholder', '+1 555 123 4567')}
           invalidLabel={t('customers.people.form.primaryPhone.invalid', 'Enter a valid phone number with country code (e.g. +1 212 555 1234)')}
           minDigits={7}
+          defaultCountryIso2={defaultCountryIso2}
         />
       ),
     } as CrudField,
@@ -1651,8 +1655,8 @@ const buildIndustryLabels = (t: Translator): DictionarySelectLabels => ({
   manageTitle: t('customers.people.form.dictionary.manage'),
 })
 
-export const createCompanyEditFields = (t: Translator): CrudField[] => {
-  const baseFields = createCompanyFormFields(t)
+export const createCompanyEditFields = (t: Translator, options?: { defaultCountryIso2?: string }): CrudField[] => {
+  const baseFields = createCompanyFormFields(t, options)
   const industryLabels = buildIndustryLabels(t)
 
   return baseFields.map((field) => {
@@ -1676,8 +1680,8 @@ export const createCompanyEditFields = (t: Translator): CrudField[] => {
   })
 }
 
-export const createPersonEditFields = (t: Translator): CrudField[] => {
-  const baseFields = createPersonFormFields(t)
+export const createPersonEditFields = (t: Translator, options?: { defaultCountryIso2?: string }): CrudField[] => {
+  const baseFields = createPersonFormFields(t, options)
   return [
     ...baseFields,
     {


### PR DESCRIPTION
## Summary
`PhoneNumberField`'s `defaultCountryIso2` prop existed but no core call site
passed it, so every deployment defaulted to the US flag / +1 prefix. This
surfaces the prop through the customer phone form config factories.

## Changes
- `createPrimaryPhoneField`, `createPersonFormFields`, `createCompanyFormFields`,
  `createCompanyEditFields`, `createPersonEditFields` accept an optional
  `options?: { defaultCountryIso2?: string }`, forwarded to `PhoneNumberField`.
- `ScheduleActivityDialog` accepts an optional `defaultCountryIso2` prop.
- Purely additive — all 9 existing call sites of these functions were checked
  and continue to call them without the new option; behavior is unchanged
  for every current deployment. No concrete default value is wired up — a
  follow-up issue (#4750) proposes where it should come from.

## Specification
Does a spec exist for this feature/module?
- [x] N/A (minor change, no spec needed)

## Testing
Scope of this change: two files (`formConfig.tsx`, `ScheduleActivityDialog.tsx`),
both in `packages/core/src/modules/customers/components/`.

- Added 3 tests in `formConfig.test.ts` rendering the real `PhoneNumberField`
  and asserting on the rendered dial code (`+48` when `defaultCountryIso2:
  'PL'` is passed for both person and company forms, `+1` by default when
  omitted) — `yarn workspace @open-mercato/core test -- formConfig`:
  18/18 passing (15 pre-existing + 3 new).
- `yarn lint` on the changed files: 0 errors.
- `yarn workspace @open-mercato/core typecheck`: passing.
- Full `@open-mercato/core` package test suite (8363/8363) run once as a
  regression sanity check, not scoped to this change.

## Checklist
- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [ ] I updated documentation, locales, or generators if the change requires it. — N/A, no user-facing copy or docs affected.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` — not added; this is a pure function-signature/prop-forwarding change with unit coverage in `formConfig.test.ts`, no new user-facing flow to exercise end-to-end.
- [ ] I created or updated the spec in `.ai/specs/` — N/A per Specification section above (minor, additive change).
- [ ] Priority set — leaving to maintainers to triage.
- [ ] Risk set — leaving to maintainers to triage; this is additive-only and should be `risk-low`.
- [ ] QA routing set — leaving to maintainers; no manually-exercisable behavior changes for existing deployments (no concrete default is wired up yet), so this should qualify for `skip-qa`.

## Design System Compliance
N/A — this PR only threads an existing prop through existing function
signatures and components. No new UI, colors, text sizes, states, or
components are introduced.
- [x] No hardcoded status colors
- [x] No arbitrary text sizes
- [x] Empty state handled for list/data pages
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons
- [x] Uses existing DS components — no custom replacements

## Linked issues
Refs #4737 (using `Refs` rather than `Fixes` since this only partially
addresses it — see Scope in Changes above; #4750 tracks the remainder)