### PR TITLE
feat(ci): gate /label on the certified partner registry (develop mirror of #4761)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,3 +25,12 @@ packages/core/src/modules/customer_accounts/  @open-mercato/maintainers
 # Security policy and tooling
 SECURITY.md                            @open-mercato/maintainers
 .github/CODEOWNERS                     @open-mercato/maintainers
+
+# Certified partner gate. These two files decide who may run `/label` on pull
+# requests, so each one needs sign-off from @matgren specifically — a single
+# owner, because any owner on a line can approve alone.
+#
+# Listed last on purpose: CODEOWNERS applies the LAST matching pattern, so these
+# lines must stay below the `.github/workflows/` rule above to take effect.
+.github/certified-partners.yml         @matgren
+.github/workflows/community-labels.yml @matgren

--- a/.github/certified-partners.yml
+++ b/.github/certified-partners.yml
@@ -1,5 +1,8 @@
 # Certified partners of Open Mercato and their GitHub contributors.
 #
+# Contributors listed here may run `/label <label>` on pull requests
+# (see .github/workflows/community-labels.yml); everyone else is ignored.
+#
 # To add a contributor: open a PR extending your company's list.
 # An Open Mercato review + merge of that PR is the approval.
 

--- a/.github/certified-partners.yml
+++ b/.github/certified-partners.yml
@@ -1,0 +1,50 @@
+# Certified partners of Open Mercato and their GitHub contributors.
+#
+# To add a contributor: open a PR extending your company's list.
+# An Open Mercato review + merge of that PR is the approval.
+
+partners:
+  - company: 10clouds
+    contributors: [cielecki]
+  - company: 300.codes
+    contributors: [strzesniewski, B0G3, AK-300codes]
+  - company: FilaNovum
+    contributors: [mkadziolka]
+  - company: AMT Solution
+    contributors: [amtmich]
+  - company: Cognize
+    contributors: [jakubmatwiejew-wq]
+  - company: Commerce Weavers
+    contributors: [lchrusciel]
+  - company: Dev4You
+    contributors: [PawelSydorow, Paul-Mlodochowki]
+  - company: Fast White Cat
+    contributors: [adeptofvoltron, lbajsarowicz]
+  - company: Freight Tech
+    contributors: [fto-aubergine, karolina-fto]
+  - company: GoNextStage
+    contributors: [truongx, mat-kruk]
+  - company: Itrix
+    contributors: [itrixjarek]
+  - company: LemonMind
+    contributors: [msoroka]
+  - company: Omdyo
+    contributors: [zielivia, haxiorz]
+  - company: 8lines
+    contributors: [jtomaszewski, RadnoK, KamilGrocholski, patrykbojczuk, KubaBir, frshy]
+  - company: Evojam
+    contributors: [marcinwadon, abankowski]
+  - company: Idego
+    contributors: [Gajam19]
+  - company: Softiq
+    contributors: [adam-marszowski, wwaleszczykSoftiq, Heppe-SOFTIQ]
+  - company: Tandemite
+    contributors: [mat89c]
+  - company: The Good Code
+    contributors: [migsilva89, mpiatko]
+  - company: they.dev
+    contributors: [pmadajthey]
+  - company: Univio
+    contributors: [gsobczyk, szymonkilar]
+  - company: White Label Coders
+    contributors: [redjungle-as, ArtSadWLC, KBraneckiWLC]

--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -5,8 +5,10 @@ on:
     types: [created]
 
 # Pull requests are GitHub issues for labeling purposes. No repository checkout
-# or contributor-supplied code is used by this workflow.
+# or contributor-supplied code is used by this workflow: the partner registry is
+# read from the default branch through the API, never from the pull request head.
 permissions:
+  contents: read
   issues: write
   pull-requests: write
 
@@ -22,6 +24,8 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            const partnerRegistryPath = '.github/certified-partners.yml';
+
             // Only safe, existing taxonomy labels may be added by contributors.
             const allowedLabels = new Set([
               'partner-request',
@@ -33,8 +37,127 @@ jobs:
               .map((label) => label.trim())
               .filter((label) => allowedLabels.has(label));
 
+            const commentId = context.payload.comment.id;
+            const react = (content) => github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: commentId,
+              content,
+            });
+
             if (requestedLabels.length === 0) {
+              await react('confused');
               core.setFailed('No allowed labels were requested.');
+              return;
+            }
+
+            const parsePartnerLogins = (registryText) => {
+              const logins = new Set();
+              const addLogin = (rawLogin) => {
+                const login = rawLogin.trim().replace(/^['"]|['"]$/g, '').trim();
+                if (/^[A-Za-z0-9][A-Za-z0-9-]*$/.test(login)) logins.add(login.toLowerCase());
+              };
+
+              let insideContributorsBlock = false;
+              let contributorsIndent = 0;
+
+              for (const rawLine of registryText.split('\n')) {
+                const line = rawLine.replace(/\s+#.*$/, '').replace(/\s+$/, '');
+                const trimmed = line.trim();
+                if (!trimmed || trimmed.startsWith('#')) continue;
+                const indent = line.length - line.trimStart().length;
+
+                const flowList = trimmed.match(/^(?:-\s+)?contributors:\s*\[(.*)\]$/);
+                if (flowList) {
+                  insideContributorsBlock = false;
+                  flowList[1].split(',').forEach(addLogin);
+                  continue;
+                }
+
+                if (/^(?:-\s+)?contributors:\s*$/.test(trimmed)) {
+                  insideContributorsBlock = true;
+                  contributorsIndent = indent;
+                  continue;
+                }
+
+                if (insideContributorsBlock && trimmed.startsWith('- ') && indent > contributorsIndent) {
+                  addLogin(trimmed.slice(2));
+                  continue;
+                }
+
+                insideContributorsBlock = false;
+              }
+
+              return logins;
+            };
+
+            const readPartnerLogins = async () => {
+              const { data } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: partnerRegistryPath,
+                ref: context.payload.repository.default_branch,
+              });
+              if (!data || typeof data.content !== 'string' || data.content.length === 0) {
+                throw new Error(`${partnerRegistryPath} could not be read from the default branch.`);
+              }
+              return parsePartnerLogins(Buffer.from(data.content, 'base64').toString('utf8'));
+            };
+
+            const hasWriteAccess = async (username) => {
+              try {
+                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username,
+                });
+                return data.permission === 'admin' || data.permission === 'write' || data.permission === 'maintain';
+              } catch (error) {
+                core.info(`Could not resolve repository permission for @${username}: ${error.message}`);
+                return false;
+              }
+            };
+
+            const requester = context.payload.comment.user.login;
+
+            let partnerLogins;
+            try {
+              partnerLogins = await readPartnerLogins();
+            } catch (error) {
+              await react('confused');
+              core.setFailed(`Certified partner registry is unavailable: ${error.message}`);
+              return;
+            }
+
+            if (partnerLogins.size === 0) {
+              await react('confused');
+              core.setFailed(`No contributors could be parsed from ${partnerRegistryPath}.`);
+              return;
+            }
+
+            const isCertifiedPartner = partnerLogins.has(requester.toLowerCase());
+
+            if (!isCertifiedPartner && !(await hasWriteAccess(requester))) {
+              const registryUrl = [
+                context.payload.repository.html_url,
+                'blob',
+                context.payload.repository.default_branch,
+                partnerRegistryPath,
+              ].join('/');
+
+              await react('confused');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  `@${requester} is not listed as a certified partner contributor, so \`/label\` was ignored.`,
+                  '',
+                  `Certified partners and their GitHub accounts live in [\`${partnerRegistryPath}\`](${registryUrl}).`,
+                  'To be added, open a pull request extending your company\'s `contributors` list.',
+                ].join('\n'),
+              });
+              core.setFailed(`@${requester} is not a certified partner contributor.`);
               return;
             }
 
@@ -44,3 +167,5 @@ jobs:
               issue_number: context.issue.number,
               labels: requestedLabels,
             });
+
+            await react('+1');

--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -4,9 +4,10 @@ on:
   issue_comment:
     types: [created]
 
-# Pull requests are GitHub issues for labeling purposes. No repository checkout
-# or contributor-supplied code is used by this workflow: the partner registry is
-# read from the default branch through the API, never from the pull request head.
+# Pull requests are GitHub issues for labeling purposes. The only checkout is a
+# sparse, credential-free copy of the certified partner registry pinned to the
+# default branch, so no pull request head and no contributor-supplied code ever
+# reaches this job.
 permissions:
   contents: read
   issues: write
@@ -20,6 +21,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out the certified partner registry
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/certified-partners.yml
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+          fetch-depth: 1
+
       - name: Add requested label
         uses: actions/github-script@v9
         with:
@@ -91,17 +101,12 @@ jobs:
               return logins;
             };
 
-            const readPartnerLogins = async () => {
-              const { data } = await github.rest.repos.getContent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: partnerRegistryPath,
-                ref: context.payload.repository.default_branch,
-              });
-              if (!data || typeof data.content !== 'string' || data.content.length === 0) {
-                throw new Error(`${partnerRegistryPath} could not be read from the default branch.`);
+            const readPartnerLogins = () => {
+              const fs = require('fs');
+              if (!fs.existsSync(partnerRegistryPath)) {
+                throw new Error(`${partnerRegistryPath} is missing from the default branch.`);
               }
-              return parsePartnerLogins(Buffer.from(data.content, 'base64').toString('utf8'));
+              return parsePartnerLogins(fs.readFileSync(partnerRegistryPath, 'utf8'));
             };
 
             const hasWriteAccess = async (username) => {
@@ -122,7 +127,7 @@ jobs:
 
             let partnerLogins;
             try {
-              partnerLogins = await readPartnerLogins();
+              partnerLogins = readPartnerLogins();
             } catch (error) {
               await react('confused');
               core.setFailed(`Certified partner registry is unavailable: ${error.message}`);


### PR DESCRIPTION
## What

Mirrors #4761 onto `develop`, so the branches do not diverge on the `/label` gate. The three gate files are byte-identical between the two pull requests.

The functional change ships in #4761 against `main`: `issue_comment` workflows always run the copy of the workflow on the **default branch**, so a version merged only here never executes. This pull request exists to keep `develop` in sync — merging it alone changes nothing at runtime.

See #4761 for the full description of the check, the CODEOWNERS rules, verification, and the two prerequisites before any of it enforces (`require_code_owner_reviews` is off; the `@open-mercato/maintainers` team is an unknown owner).

## Contents

- `.github/certified-partners.yml` — the registry from #4727, original commit preserved
- `.github/workflows/community-labels.yml` — partner check before the label is applied
- `.github/CODEOWNERS` — `@matgren` required on the registry and on the workflow

## Relationship to #4727

Carries #4727's registry commit because the gate cannot work without the file. #4727 can be closed as superseded, or merged first — in which case this pull request needs a trivial conflict resolution on the file header (three added comment lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
