### PR TITLE
fix(ci): make the certified partner registry the only way to pass the /label gate

### DIFF
--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -109,20 +109,6 @@ jobs:
               return parsePartnerLogins(fs.readFileSync(partnerRegistryPath, 'utf8'));
             };
 
-            const hasWriteAccess = async (username) => {
-              try {
-                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  username,
-                });
-                return data.permission === 'admin' || data.permission === 'write' || data.permission === 'maintain';
-              } catch (error) {
-                core.info(`Could not resolve repository permission for @${username}: ${error.message}`);
-                return false;
-              }
-            };
-
             const requester = context.payload.comment.user.login;
 
             let partnerLogins;
@@ -140,9 +126,10 @@ jobs:
               return;
             }
 
-            const isCertifiedPartner = partnerLogins.has(requester.toLowerCase());
-
-            if (!isCertifiedPartner && !(await hasWriteAccess(requester))) {
+            // Membership in the registry is the only way to pass. Repository
+            // permission grants nothing here: maintainers who want to use
+            // /label must add themselves to the registry like everyone else.
+            if (!partnerLogins.has(requester.toLowerCase())) {
               const registryUrl = [
                 context.payload.repository.html_url,
                 'blob',


### PR DESCRIPTION
## What

Makes `.github/certified-partners.yml` the **only** way to pass the `/label` gate, following up #4761.

As merged, the gate had a second door: a requester who was not in the registry still passed if they held write access on the repository.

```js
if (!isCertifiedPartner && !(await hasWriteAccess(requester))) {
```

That fallback is removed. Membership in the registry is now the sole criterion.

```js
if (!partnerLogins.has(requester.toLowerCase())) {
```

`getCollaboratorPermissionLevel` is gone from the workflow entirely.

## Consequence worth being explicit about

Repository permission no longer grants anything here. **Maintainers who want to use `/label` must add themselves to the registry like everyone else** — including @matgren, who is not currently listed. Worth adding whoever needs the command in the same pull request or a follow-up, otherwise `/label` is usable only by the 41 listed partner contributors.

This does not affect labeling through the GitHub UI, which remains available to anyone with write access. The gate covers the `/label` comment command only.

## Verification

Workflow YAML parses, both steps resolve, the embedded script compiles under `github-script`'s async wrapper, and the registry parser still returns exactly the 41 logins with correct case-insensitive matching.

## Mirror

A matching pull request targets `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
