### PR TITLE
fix(ci): make the certified partner registry the only way to pass the /label gate (develop mirror of #4764)

### DIFF
--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -109,20 +109,6 @@ jobs:
               return parsePartnerLogins(fs.readFileSync(partnerRegistryPath, 'utf8'));
             };
 
-            const hasWriteAccess = async (username) => {
-              try {
-                const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  username,
-                });
-                return data.permission === 'admin' || data.permission === 'write' || data.permission === 'maintain';
-              } catch (error) {
-                core.info(`Could not resolve repository permission for @${username}: ${error.message}`);
-                return false;
-              }
-            };
-
             const requester = context.payload.comment.user.login;
 
             let partnerLogins;
@@ -140,9 +126,10 @@ jobs:
               return;
             }
 
-            const isCertifiedPartner = partnerLogins.has(requester.toLowerCase());
-
-            if (!isCertifiedPartner && !(await hasWriteAccess(requester))) {
+            // Membership in the registry is the only way to pass. Repository
+            // permission grants nothing here: maintainers who want to use
+            // /label must add themselves to the registry like everyone else.
+            if (!partnerLogins.has(requester.toLowerCase())) {
               const registryUrl = [
                 context.payload.repository.html_url,
                 'blob',


### PR DESCRIPTION
## What

Mirrors #4764 onto `develop`. The workflow file is byte-identical between the two pull requests.

Removes the repository write-access fallback from the `/label` gate, so membership in `.github/certified-partners.yml` is the only way to pass. See #4764 for the full description and the consequence for maintainers — including that @matgren is not currently in the registry and would need adding to use the command.

As with the earlier pair, the functional change is the one against `main`: `issue_comment` workflows run the default branch's copy, so merging this alone changes nothing at runtime. It exists to keep `develop` in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
