### PR TITLE
fix(staff): use nil UUID sentinel instead of string in leave-requests…

### DIFF
--- a/packages/core/src/modules/staff/api/__tests__/leave-requests.filters.test.ts
+++ b/packages/core/src/modules/staff/api/__tests__/leave-requests.filters.test.ts
@@ -1,0 +1,123 @@
+import { buildLeaveRequestFilters } from '../leave-requests'
+import type { CrudCtx } from '@open-mercato/shared/lib/crud/factory'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(),
+  findOneWithDecryption: jest.fn(),
+}))
+
+const { findWithDecryption, findOneWithDecryption } = jest.requireMock('@open-mercato/shared/lib/encryption/find')
+
+describe('buildLeaveRequestFilters (#4739)', () => {
+  const NIL_UUID = '00000000-0000-0000-0000-000000000000'
+
+  function createMockCtx(opts?: {
+    userId?: string
+    canManage?: boolean
+    canSend?: boolean
+    canViewSelf?: boolean
+    memberRecord?: { id: string } | null
+    foundMembers?: Array<{ id: string }>
+  }): CrudCtx {
+    const userId = opts?.userId ?? '11111111-1111-1111-1111-111111111111'
+    const canManage = opts?.canManage ?? false
+    const canSend = opts?.canSend ?? false
+    const canViewSelf = opts?.canViewSelf ?? false
+    const memberRecord = opts?.memberRecord ?? null
+    const foundMembers = opts?.foundMembers ?? []
+
+    const mockRbac = {
+      userHasAllFeatures: jest.fn().mockImplementation((sub: string, features: string[]) => {
+        if (features.includes('staff.leave_requests.manage')) return Promise.resolve(canManage)
+        if (features.includes('staff.leave_requests.send')) return Promise.resolve(canSend)
+        if (features.includes('staff.my_leave_requests.send')) return Promise.resolve(canSend)
+        if (features.includes('staff.my_leave_requests.view')) return Promise.resolve(canViewSelf)
+        return Promise.resolve(false)
+      }),
+    }
+
+    const mockEm = {
+      fork: jest.fn().mockReturnThis(),
+    }
+
+    findOneWithDecryption.mockResolvedValue(memberRecord)
+    findWithDecryption.mockResolvedValue(foundMembers)
+
+    return {
+      auth: {
+        sub: userId,
+        tenantId: 'tenant-1',
+        orgId: 'org-1',
+      },
+      organizationScope: { tenantId: 'tenant-1', selectedId: 'org-1' },
+      selectedOrganizationId: 'org-1',
+      container: {
+        resolve: jest.fn((name: string) => {
+          if (name === 'rbacService') return mockRbac
+          if (name === 'em') return mockEm
+          return null
+        }),
+      },
+    } as unknown as CrudCtx
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('assigns NIL_UUID (not string sentinel __no_access__) when viewer has no manage access and no team-member record', async () => {
+    const ctx = createMockCtx({
+      canManage: false,
+      canViewSelf: true,
+      memberRecord: null,
+    })
+
+    const filters = await buildLeaveRequestFilters({ page: 1, pageSize: 50 }, ctx)
+
+    expect(filters.id).toBe(NIL_UUID)
+    expect(filters.id).not.toBe('__no_access__')
+    expect(filters.id).not.toBe('__no_match__')
+  })
+
+  it('assigns NIL_UUID (not string sentinel __no_match__) when search query finds no team members', async () => {
+    const ctx = createMockCtx({
+      canManage: true,
+      foundMembers: [],
+    })
+
+    const filters = await buildLeaveRequestFilters({ page: 1, pageSize: 50, search: 'NonExistent' }, ctx)
+
+    expect(filters.id).toBe(NIL_UUID)
+    expect(filters.id).not.toBe('__no_match__')
+    expect(filters.id).not.toBe('__no_access__')
+  })
+
+  it('filters by member_id when viewer is not manager but has a valid team member record', async () => {
+    const memberId = '22222222-2222-2222-2222-222222222222'
+    const ctx = createMockCtx({
+      canManage: false,
+      canViewSelf: true,
+      memberRecord: { id: memberId },
+    })
+
+    const filters = await buildLeaveRequestFilters({ page: 1, pageSize: 50 }, ctx)
+
+    expect(filters.member_id).toBe(memberId)
+    expect(filters.id).toBeUndefined()
+  })
+
+  it('combines search NIL_UUID filter and member_id scope for non-manager searching with no matches', async () => {
+    const memberId = '22222222-2222-2222-2222-222222222222'
+    const ctx = createMockCtx({
+      canManage: false,
+      canViewSelf: true,
+      memberRecord: { id: memberId },
+      foundMembers: [],
+    })
+
+    const filters = await buildLeaveRequestFilters({ page: 1, pageSize: 50, search: 'NonExistent' }, ctx)
+
+    expect(filters.id).toBe(NIL_UUID)
+    expect(filters.member_id).toBe(memberId)
+  })
+})

--- a/packages/core/src/modules/staff/api/leave-requests.ts
+++ b/packages/core/src/modules/staff/api/leave-requests.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
-import { makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
+import { makeCrudRoute, type CrudCtx } from '@open-mercato/shared/lib/crud/factory'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { resolveCrudRecordId, parseScopedCommandInput } from '@open-mercato/shared/lib/api/scoped'
@@ -21,6 +21,8 @@ const MANAGE_FEATURE = 'staff.leave_requests.manage'
 const SEND_FEATURE = 'staff.leave_requests.send'
 const MY_VIEW_FEATURE = 'staff.my_leave_requests.view'
 const MY_SEND_FEATURE = 'staff.my_leave_requests.send'
+
+const NIL_UUID = '00000000-0000-0000-0000-000000000000'
 
 const routeMetadata = {
   GET: { requireAuth: true },
@@ -113,6 +115,56 @@ async function resolveLeaveRequestAccess(ctx: any): Promise<LeaveRequestAccess> 
   return { canManage, canSend, canView, memberId: member?.id ?? null }
 }
 
+export async function buildLeaveRequestFilters(
+  query: z.infer<typeof listSchema>,
+  ctx: CrudCtx,
+) {
+  const filters: Record<string, unknown> = {}
+  if (typeof query.ids === 'string' && query.ids.trim().length > 0) {
+    const ids = query.ids
+      .split(',')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0)
+    if (ids.length > 0) {
+      filters[F.id] = { $in: ids }
+    }
+  }
+  if (query.status) {
+    filters[F.status] = query.status
+  }
+  if (query.memberId) {
+    filters[F.member_id] = query.memberId
+  }
+  const term = sanitizeSearchTerm(query.search)
+  if (term) {
+    const like = `%${escapeLikePattern(term)}%`
+    const em = (ctx.container.resolve('em') as EntityManager).fork()
+    const members = await findWithDecryption(
+      em,
+      StaffTeamMember,
+      { displayName: { $ilike: like }, deletedAt: null },
+      { fields: ['id'] },
+      { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.selectedOrganizationId ?? null },
+    )
+    const memberIds = members.map((member) => member.id)
+    if (!memberIds.length) {
+      filters[F.id] = NIL_UUID
+    } else {
+      filters[F.member_id] = { $in: memberIds }
+    }
+  }
+
+  const access = await resolveLeaveRequestAccess(ctx)
+  if (!access.canManage) {
+    if (!access.canView || !access.memberId) {
+      filters[F.id] = NIL_UUID
+    } else {
+      filters[F.member_id] = access.memberId
+    }
+  }
+  return filters
+}
+
 const crud = makeCrudRoute({
   metadata: routeMetadata,
   orm: {
@@ -151,52 +203,7 @@ const crud = makeCrudRoute({
       createdAt: F.created_at,
       updatedAt: F.updated_at,
     },
-    buildFilters: async (query, ctx) => {
-      const filters: Record<string, unknown> = {}
-      if (typeof query.ids === 'string' && query.ids.trim().length > 0) {
-        const ids = query.ids
-          .split(',')
-          .map((value) => value.trim())
-          .filter((value) => value.length > 0)
-        if (ids.length > 0) {
-          filters[F.id] = { $in: ids }
-        }
-      }
-      if (query.status) {
-        filters[F.status] = query.status
-      }
-      if (query.memberId) {
-        filters[F.member_id] = query.memberId
-      }
-      const term = sanitizeSearchTerm(query.search)
-      if (term) {
-        const like = `%${escapeLikePattern(term)}%`
-        const em = (ctx.container.resolve('em') as EntityManager).fork()
-        const members = await findWithDecryption(
-          em,
-          StaffTeamMember,
-          { displayName: { $ilike: like }, deletedAt: null },
-          { fields: ['id'] },
-          { tenantId: ctx.auth?.tenantId ?? null, organizationId: ctx.selectedOrganizationId ?? null },
-        )
-        const memberIds = members.map((member) => member.id)
-        if (!memberIds.length) {
-          filters[F.id] = '__no_match__'
-        } else {
-          filters[F.member_id] = { $in: memberIds }
-        }
-      }
-
-      const access = await resolveLeaveRequestAccess(ctx)
-      if (!access.canManage) {
-        if (!access.canView || !access.memberId) {
-          filters[F.id] = '__no_access__'
-        } else {
-          filters[F.member_id] = access.memberId
-        }
-      }
-      return filters
-    },
+    buildFilters: buildLeaveRequestFilters,
   },
   hooks: {
     afterList: async (payload, ctx) => {


### PR DESCRIPTION
## Summary
`buildFilters` in `staff/api/leave-requests.ts` assigned string sentinels
(`__no_access__`, `__no_match__`) to a uuid-typed column. Postgres rejects
the literal, so the request died with a 500 instead of an empty list.

## Changes
- Replaced both sentinels with the nil UUID
  (`00000000-0000-0000-0000-000000000000`) — matches the existing pattern
  used across the repo (catalog, customers, sales, messages).
- Extracted the inline `buildFilters` into an exported, typed
  `buildLeaveRequestFilters` (matches the `buildXFilters` pattern used
  elsewhere) so it's directly unit-testable.

## Specification
Does a spec exist for this feature/module?
- [x] N/A (minor bugfix, no spec needed)

## Testing
- 4 new tests in `leave-requests.filters.test.ts`, all passing.
- `yarn lint`: 0 errors.
- `yarn workspace @open-mercato/core typecheck`: passing.

## Checklist
- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement — already signed via #4749.
- [ ] I updated documentation, locales, or generators — N/A, no user-facing copy affected.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` — not added; backend filter-logic fix with direct unit coverage, no new user-facing flow.
- [ ] I created or updated the spec in `.ai/specs/` — N/A per Specification section above.
- [ ] Priority set — leaving to maintainers to triage.
- [ ] Risk set — leaving to maintainers to triage.
- [ ] QA routing set — leaving to maintainers; this only changes a server-side filter value on an existing 500-error path, no new UI.

## Design System Compliance
N/A — this is a backend-only fix (`.ts` filter logic), no `.tsx`/UI files
touched.

## Linked issues
Fixes #4739