### PR TITLE
perf(query_index): make the search_tokens availability probe cheap and single-sourced

### DIFF
--- a/.ai/specs/2026-07-24-search-architecture-clarification-and-evolution.md
+++ b/.ai/specs/2026-07-24-search-architecture-clarification-and-evolution.md
@@ -9,7 +9,8 @@
   - `.ai/specs/implemented/SPEC-041-2026-02-24-search-organization-scoping.md` (scopes search **results**)
   - `.ai/specs/2026-05-20-search-presenter-i18n.md`
   - Docs: `apps/docs/docs/framework/database/hybrid-search.mdx`, `.../query-index.mdx`, `.../vector-search.mdx`
-  - Code: `packages/search/**`, `packages/core/src/modules/query_index/**`, `packages/shared/src/{modules/search.ts,lib/search/**}`
+  - Code: `packages/search/**`, `packages/core/src/modules/query_index/**`, `packages/shared/src/{modules/search.ts,lib/search/**,lib/query/engine.ts}`
+  - PRs: #4723 (gates the `search_tokens` probe on the hybrid-engine paths), #4685 (`search_tokens` unbounded growth), #4558 (ground-truth docs for hybrid routing)
 
 ## TLDR
 
@@ -161,7 +162,49 @@ Narrow, legitimate consolidations worth considering instead of a grand merge:
 
 Recommendation: **do not merge the stores.** Invest B.1 (unified control plane) + optional B.2 (Postgres profile) to get most of the operational simplicity people actually want, without the security/relevance regressions a true merge would cause.
 
-### B.4 Decision matrix
+### B.4 Phase 4 — Unify the query-time availability decision (read path)
+
+B.1 unifies the **write-side control plane** (reindex/status). This phase is its read-path twin: one place that answers *"is token search usable for (entity, tenantId, orgScope)?"* at query time, instead of every consumer hand-assembling the decision.
+
+**Problem.** The decision `resolveSearchConfig().enabled && tableExists('search_tokens') && hasSearchTokens(entity, tenantId, orgScope)` is independently assembled at five call sites across two engines:
+
+| Copy | Where | Probe gated on an actual `like`/`ilike` filter? |
+|---|---|---|
+| `HybridQueryEngine.query()` | `packages/core/src/modules/query_index/lib/engine.ts` (~L251–449) | Only after #4723 |
+| `HybridQueryEngine.queryCustomEntity()` | same file (~L1639–1645) | Only after #4723 |
+| Hybrid join path `applyJoinSearchFilterOp` | same file (~L731–760) | Yes (lazy, ad-hoc `joinSearchAvailability` memo map) |
+| `BasicQueryEngine.query()` | `packages/shared/src/lib/query/engine.ts` (~L295–304) | **No — probes unconditionally** |
+| Basic join path | same file (~L401) | Yes (its own ad-hoc memo map) |
+
+Both engines additionally carry **private duplicate copies** of `tableExists`, `hasSearchTokens`, `applySearchTokens`, `logSearchDebug`, and `applyOrganizationScope` (plus `searchSourcesHaveTokens` in the hybrid engine), and the identical `search:init` / `search:disabled` / `search:no-search-tokens` debug block. The copies have already drifted: `BasicQueryEngine` memoizes `tableExists` (`tableCache`); `HybridQueryEngine` re-queries `information_schema` per call. #4723 documents why the un-gated probe is pathological on large `search_tokens` tables (seq-scan plan, p95 12.5 s on plain list loads) — but it is call-site discipline: it fixed the two hybrid paths and nothing prevents the next call site from being written un-gated, and the `BasicQueryEngine` copy (live — it is the delegate the hybrid falls back to, `query_index/di.ts`) still probes unconditionally.
+
+**Design constraint.** Kysely `where((eb) => …)` callbacks are synchronous, so the availability answer must exist **before** builder code runs. Laziness therefore lives at query-orchestration level: resolve once per `query()` invocation, and only when the normalized filters actually contain a `like`/`ilike` op (the #4723 gate, made structural). The join paths are already async and probe lazily per joined entity; they keep that shape, backed by the resolver's memo instead of ad-hoc maps.
+
+**Proposed shape** — a small resolver in `packages/shared/src/lib/search/availability.ts` (final naming at implementer's discretion), constructed by each engine and injected with the engine's `db` accessor, `SearchConfig`, org-scope applier, and debug logger:
+
+```ts
+const availability = createSearchTokenAvailability({ getDb, config, applyOrganizationScope, logDebug })
+await availability.staticEnabled()                              // config.enabled && tableExists('search_tokens'); memoized
+await availability.hasTokens(entity, tenantId, orgScope)        // memoized per (entity, tenantId, org-signature)
+await availability.anySourceHasTokens(sources, tenantId, orgScope) // first-hit semantics of searchSourcesHaveTokens
+```
+
+Memoization is per engine instance; engines are constructed per request (`createRequestContainer`), so entries never outlive a request — the same staleness contract the ad-hoc join maps have today. `staticEnabled()` is the cheap eager half (still needed pre-gate by `shouldAttachCustomSources`); `hasTokens()` is the expensive half that only runs behind the search-filter gate.
+
+**Deliverables:**
+
+1. The resolver in `packages/shared/src/lib/search/availability.ts`, with per-instance memoization and debug hooks that preserve the existing `search:*` event names and payloads (`search:init`, `search:disabled`, `search:no-search-tokens`, `search:has-tokens-error`, `search:source-has-tokens` — operators grep these).
+2. A shared `hasSearchFilter(filters)` predicate next to it, so the gate condition (`op === 'like' || op === 'ilike'`) is defined once instead of re-derived per call site.
+3. `HybridQueryEngine` adoption: `query()`, `queryCustomEntity()`, and `applyJoinSearchFilterOp` consume the resolver; delete the private `hasSearchTokens`, `searchSourcesHaveTokens`, the `joinSearchAvailability` map, and the un-memoized search use of `tableExists`.
+4. `BasicQueryEngine` adoption: same, plus gate its eager probe on `hasSearchFilter` — the **one intended behavior change** of this phase (extends #4723's argument to the base engine: without a search filter the probe's answer is never read).
+5. Optional follow-up (may ship separately): move the module-private `SearchRuntime` / `SearchTokenSource` types to shared and have `BasicQueryEngine` adopt them instead of threading `searchActive`/`searchConfig` through per-helper opts objects.
+6. Tests: #4723's four probe-count tests pass **unchanged**; add `BasicQueryEngine` parity cases (`eq` filter → 0 probes, `ilike` → probe runs) and a memoization case (two joins on the same entity → one probe).
+
+**What this phase deliberately enables:** the durable probe fix from #4723's scope note (reshaping `tenant_id is not distinct from $x` into index-usable predicates, or a coverage-backed existence flag) lands in exactly one function — `hasTokens()` — instead of being re-derived per engine. That fix stays out of this phase's scope.
+
+**Sequencing:** after #4723 merges (this phase edits the same lines and subsumes its gate structurally) and preferably after #4685 (same module, avoids conflicts). Before any durable probe-shape change.
+
+### B.5 Decision matrix
 
 | Direction | Effort | Risk | Operator value | Recommendation |
 |---|---|---|---|---|
@@ -169,6 +212,7 @@ Recommendation: **do not merge the stores.** Invest B.1 (unified control plane) 
 | B.1 Unified control plane (reindex `--target all`, status, admin) | M | Medium | High | **Do next** |
 | B.2 More fulltext/vector drivers + Postgres tsvector | M per driver | Low–Med | Medium (deployment flexibility) | On demand, provider packages |
 | B.3 Merge stores into one | L | High | Low (security/relevance regressions) | **Reject**; do Postgres profile instead |
+| B.4 Read-path availability resolver | S–M | Low–Med (read path of every list endpoint; mitigated by probe-count tests) | Medium (deletes ~5 duplicated decision sites; prevents #4723-class regressions structurally) | **Do after #4723/#4685 land** |
 
 ---
 
@@ -177,12 +221,14 @@ Recommendation: **do not merge the stores.** Invest B.1 (unified control plane) 
 - **Phase 0**: docs + one CLI help string (non-behavioral) + a stale code comment. No contract surface changes. `BACKWARD_COMPATIBILITY.md` unaffected.
 - **Phase 1**: strictly additive — new CLI flags/commands, a new orchestration service, a new admin action. The three existing reindex entry points and their feature IDs (`search.reindex`, `query_index.reindex`, `search.manage`) are preserved and delegated to. Any change to the bare `reindex` default must follow the deprecation protocol (help-text `@deprecated`, bridge ≥1 minor, `UPGRADE_NOTES.md`).
 - **Phase 2/3**: new drivers/packages are additive and env-gated; a Postgres-only profile is opt-in. `SearchStrategyId`, `SearchStrategy`, event IDs (`search.index_record`, `search.delete_record`, `query_index.*`), queue names (`fulltext-indexing`, `vector-indexing`), and DI keys (`searchService`, `searchIndexer`, `searchStrategies`) are FROZEN/STABLE surfaces — extend, never rename.
+- **Phase 4**: no contract surfaces touched — every deleted/moved member is `private` (`hasSearchTokens`, `searchSourcesHaveTokens`, `tableExists`, `applySearchTokens`) or a module-private type (`SearchRuntime`, `SearchTokenSource`); the new shared module is an additive export; no DB schema, API route, event ID, or DI key changes. The only behavior change (gating `BasicQueryEngine`'s probe) is observable solely as absent SQL statements on queries that carry no search filter.
 
 ## Non-goals
 
 - No change to how `SearchService.search()` merges/ranks (RRF) in this spec.
 - No change to tenant-scoping of settings (owned by `2026-06-15-tenant-scoped-search-settings.md`) or results (SPEC-041).
 - Phase 0 changes no runtime search behavior.
+- Phase 4 adds no schema. Of the durable probe fixes discussed on #4723, two no-schema measures landed inside the resolver at the maintainer's direction (index-usable `= / IS NULL` tenant predicates replacing `IS NOT DISTINCT FROM`, and a process-level TTL presence cache, `OM_SEARCH_TOKEN_PRESENCE_CACHE_MS`); the durable worst-case fix is the probe-shaped index specced in `2026-07-31-search-token-probe-index.md` (the earlier "measure after #4685" gate was dropped once multi-million-row `search_tokens` was confirmed as production steady state, not a #4685 artifact).
 
 ## Verification
 
@@ -190,7 +236,12 @@ Recommendation: **do not merge the stores.** Invest B.1 (unified control plane) 
 - **Docs build**: `cd apps/docs && yarn build` (Docusaurus) — no broken MDX/links; sidebar entry resolves.
 - **CLI help**: `yarn mercato search help` and `yarn mercato search reindex-help` read correctly and point to the fulltext reindex endpoint.
 - **Phase 1+ (when implemented)**: integration coverage for every reindex target (tokens/fulltext/vector/all), the status command, and the admin action, per `.ai/qa/AGENTS.md`; self-contained fixtures with teardown.
+- **Phase 4 (when implemented)**: `yarn workspace @open-mercato/shared test` + `yarn workspace @open-mercato/core test`; the four probe-count tests from #4723 pass without modification; new `BasicQueryEngine` parity and memoization tests as listed in B.4; no integration tests required (no API/DB/UI surface changes — same exemption #4723 claims).
 
 ## Changelog
 
 - 2026-07-24 — Initial draft: current-architecture clarification (Part A) + evolution roadmap (Part B).
+- 2026-07-31 — Added Phase 4 (B.4): unified read-path token-availability resolver shared by both query engines — makes the #4723 probe gate structural, extends it to `BasicQueryEngine`, and gives the future durable probe fix a single landing site. Renumbered the decision matrix to B.5 and added its row.
+- 2026-07-31 — Implemented Phase 4: `createSearchTokenAvailability` + `hasSearchFilter`/`isSearchFilterOp` in `packages/shared/src/lib/search/availability.ts`; both engines adopted it (private `hasSearchTokens`/`searchSourcesHaveTokens`, `BasicQueryEngine.tableExists`/`tableCache`, and both ad-hoc join memo maps deleted). Folds in #4723's gate and tests rather than waiting on that PR (its four probe-count cases are ported verbatim and pass unchanged). One deviation from the plan: implemented before #4723/#4685 merge at the maintainer's direction — #4685 was verified non-overlapping (its `engine.ts` hunks touch only the auto-reindex scheduling region). Deliverable 5 (moving `SearchRuntime`/`SearchTokenSource` types to shared) deferred as specced.
+- 2026-07-31 — Cheapened the probe itself (maintainer request on review): (1) tenant predicate reshaped from `IS NOT DISTINCT FROM` to `= / IS NULL` so `search_tokens_lookup_idx` stays usable as an access path; (2) process-level TTL cache for the presence answer (`OM_SEARCH_TOKEN_PRESENCE_CACHE_MS`, default 30 s, `0` disables; module-level on purpose — engines are per-request so instance memos never amortize; error-driven `false` never cached; size-capped at 10 k entries). Documented in both `.env.example` files (template-sync) and `packages/search/AGENTS.md`. Worst case is now one pathological probe per (entity, tenant, org) per process per TTL rather than per request; the guaranteed-O(1)-miss fix stays the schema-backed existence flag noted in Non-goals.
+- 2026-07-31 — Made the probe's worst case cheap via `.ai/specs/2026-07-31-search-token-probe-index.md` after the maintainer confirmed large `search_tokens` is steady state (drops the measure-first gate): a `search_tokens_presence_idx (entity_type, tenant_id, organization_id)` prefix index serves the reshaped probe as a B-tree seek for hit AND miss. A `search_token_presence` marker table was implemented first and then replaced by the index at the maintainer's direction — zero drift risk and zero maintenance code beat the table's smaller disk footprint; the comparison is recorded in that spec.

--- a/.ai/specs/2026-07-31-search-token-probe-index.md
+++ b/.ai/specs/2026-07-31-search-token-probe-index.md
@@ -1,0 +1,65 @@
+# Search Token Probe Index — O(1)-class Availability Answer
+
+- **Status:** Implemented (pending review)
+- **Scope:** OSS
+- **Date:** 2026-07-31
+- **Related:**
+  - `.ai/specs/2026-07-24-search-architecture-clarification-and-evolution.md` (Phase 4 / B.4 — the availability resolver whose probe this index serves)
+  - PR #4723 (probe gate + the original analysis of the pathological plan), PR #4685 (adds `search_tokens_unique_tuple_idx` — different column order, no overlap)
+  - Code: `packages/shared/src/lib/search/availability.ts`, `packages/core/src/modules/query_index/data/entities.ts`, `packages/core/src/modules/query_index/migrations/Migration20260731105052_query_index.ts`
+
+## TLDR
+
+Make the query engines' "does (entity_type, tenant, org) have any search tokens?" probe cheap for **both** answers by adding one index in the probe's exact column order:
+
+```sql
+create index concurrently "search_tokens_presence_idx"
+  on "search_tokens" ("entity_type", "tenant_id", "organization_id");
+```
+
+The measures already shipped in Phase 4 (like/ilike gate, `= / IS NULL` predicates, 30 s process-level TTL cache) gate and amortize the probe but cannot make its worst case cheap: the **miss** — an entity whose tokens exist for other tenants but not the caller's — had to exhaust every index entry for that `entity_type`, because no existing index exposes `tenant_id` as an access column (`search_tokens_lookup_idx` interposes `field, token_hash`). Production experience confirms multi-million-row `search_tokens` is the steady state for real deployments — not an artifact of the #4685 growth bug — so the miss cost does not go away on its own.
+
+With this index, the probe `WHERE entity_type = ? AND tenant_id = ? [AND organization_id IN (...)] LIMIT 1` is a pure B-tree prefix seek: a few page reads whether the answer is yes **or no**.
+
+## Why an index and not a summary table
+
+An earlier draft of this spec proposed a `search_token_presence` marker table (one row per scope with tokens), maintained by the four token write/purge sites. It was implemented and then replaced by this index at the maintainer's direction ("can we avoid a third table?"), because the index dominates on every axis that matters:
+
+| | Marker table | This index |
+|---|---|---|
+| Drift risk | 4 write hooks + stale-marker analysis + pinning tests | **Zero — Postgres maintains it** |
+| Code | ~500 lines (entity, helpers, wiring, resolver layer, tests) | **Zero — the probe already has the right shape after Phase 4's predicate reshape** |
+| Rollout | "table exists ⇒ authoritative" fallback protocol | None — the probe just gets fast |
+| Miss cost | 1 row read | ~3–4 page reads (equivalent in practice) |
+| Disk | ~KBs | ~1–3 GB on a 412M-row table (PG13+ B-tree deduplication compresses the low-cardinality keys heavily) |
+| Write cost | 1 upsert per token batch | One more index on a high-churn table — the cost class #4685's 6-column unique index already accepts |
+
+The key unlock: #4723's original "no index rescues this query" conclusion was true only for the `IS NOT DISTINCT FROM` predicate shape, which cannot be an index access condition. Phase 4 replaced it with `= / IS NULL`; after that, a purpose-ordered index serves the probe directly. `IS NULL` is a B-tree access condition, and an org-scope filter within the `(entity_type, tenant_id)` prefix touches only that tenant's distinct org keys.
+
+`entity_index_coverage` was also evaluated as a host for the answer and rejected: its rows are created lazily (absent ≠ "no tokens"), its refresh machinery rewrites rows the flag would ride on, and its NULL-tenant keying needs a prune-duplicates workaround — a tri-state column there re-introduces the expensive miss for every scope its warmup has not visited.
+
+## Changes
+
+- `data/entities.ts` — `@Index({ name: 'search_tokens_presence_idx', properties: ['entityType', 'tenantId', 'organizationId'] })` on `SearchToken`.
+- `Migration20260731105052_query_index.ts` — `create index concurrently if not exists`, with `isTransactional() => false` (CREATE INDEX CONCURRENTLY cannot run inside a transaction; same pattern as `Migration20260611103000_query_index`). Snapshot updated additively.
+- No API, resolver, or engine code changes — the resolver's probe already emits the served shape.
+
+## Backward Compatibility
+
+Additive index only. No table, column, API route, event, DI key, or type changes. Rollback: drop the index — behavior returns to the Phase 4 state (gated, reshaped, cached probe). The migration is online (`CONCURRENTLY`); on very large instances the build takes a while but does not block token writes.
+
+## Testing
+
+- The Phase 4 unit suites already pin the probe's predicate shape (`tenant_id = ? / IS NULL`) and count probes on both engines; an index changes no observable SQL, so they pass unchanged.
+- Integration: `packages/core/src/modules/query_index/__integration__/TC-QIDX-4731-token-presence.spec.ts` — records-API search finds a created record, then still finds it via the plain-column fallback after its scope's tokens are deleted (polling past the process TTL cache).
+- Perf evidence for the PR: `EXPLAIN` of the probe's miss case on a large-table instance, before/after the index.
+
+## Non-goals
+
+- No change to what the availability answer means or to any routing decision.
+- No summary/marker table (analyzed above; revisit only if the index's disk/write cost proves problematic in practice).
+- No changes to token content, caps, or growth behavior (#4685's domain).
+
+## Changelog
+
+- 2026-07-31 — Initial version. Supersedes the same-day `search-token-presence-marker` draft: the marker table was implemented, then replaced by this index once the maintainer asked whether a third table was avoidable — the Phase 4 predicate reshape had made a purpose-ordered index sufficient, with zero drift risk and zero maintenance code.

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -192,6 +192,8 @@ OM_SEARCH_HASH_ALGO=sha256
 OM_SEARCH_STORE_RAW_TOKENS=false
 # Optional comma-separated blocklist of field name substrings to skip during tokenization
 # OM_SEARCH_FIELD_BLOCKLIST=password,token,secret,hash
+# TTL for the process-level "does this entity have search tokens?" probe cache (ms, 0 disables)
+OM_SEARCH_TOKEN_PRESENCE_CACHE_MS=30000
 
 # Search module debug logging (Meilisearch, vector search, reindex operations)
 OM_SEARCH_DEBUG=false

--- a/packages/core/src/modules/query_index/__integration__/TC-QIDX-4731-token-presence.spec.ts
+++ b/packages/core/src/modules/query_index/__integration__/TC-QIDX-4731-token-presence.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { withClient } from '@open-mercato/core/helpers/integration/dbFixtures'
+import {
+  createCustomEntity,
+  createRecord,
+  deleteCustomEntityIfExists,
+  deleteRecordIfExists,
+  listRecords,
+  saveFieldDefinitions,
+  uniqueEntityId,
+} from '../../entities/__integration__/helpers/entitiesApi'
+
+/**
+ * Search token availability routing (.ai/specs/2026-07-31-search-token-probe-index.md).
+ *
+ * The records list API's server-side search builds an $or of $ilike clauses that route
+ * through the query engine's token-availability decision. This exercises both routings:
+ *  1. a record is findable while its scope has tokens (whichever of the token or
+ *     plain-column path serves it), and
+ *  2. after the scope's tokens are removed (what a purge does), the same search still
+ *     finds the record via the plain-column fallback — the observable difference
+ *     between the availability answers `true` and `false`.
+ *
+ * The second poll allows generous time because the availability answer is cached
+ * process-wide for OM_SEARCH_TOKEN_PRESENCE_CACHE_MS (default 30 s): right after the
+ * SQL cleanup the server may still route through the (now empty) token path until the
+ * cache entry expires, and token writes after record creation are deferred.
+ */
+test.describe('TC-QIDX-4731: token presence routing', () => {
+  test('search falls back to plain-column matching after a scope purge', async ({ request }) => {
+    test.setTimeout(120_000)
+    const token = await getAuthToken(request, 'admin')
+    const entityId = uniqueEntityId('presence_item')
+    const marker = `presenceprobe${Date.now().toString(36)}`
+    let recordId: string | null = null
+
+    try {
+      const created = await createCustomEntity(request, token, {
+        entityId,
+        label: 'Presence probe item',
+      })
+      expect(created.ok(), `entity create failed: ${created.status()}`).toBeTruthy()
+
+      const fields = await saveFieldDefinitions(request, token, entityId, [
+        { key: 'title', kind: 'text' },
+      ])
+      expect(fields.ok(), `field definitions failed: ${fields.status()}`).toBeTruthy()
+
+      const record = await createRecord(request, token, entityId, { title: `The ${marker} record` })
+      expect(record.ok(), `record create failed: ${record.status()}`).toBeTruthy()
+      recordId = ((await record.json()) as { id?: string }).id ?? null
+      expect(recordId, 'record id').toBeTruthy()
+
+      const searchQuery = `&search=${encodeURIComponent(marker)}&searchFields=title`
+      const findRecord = async (): Promise<boolean> => {
+        const response = await listRecords(request, token, entityId, searchQuery)
+        if (!response.ok()) return false
+        const body = (await response.json()) as { items?: Array<{ id?: string }> }
+        return (body.items ?? []).some((item) => item.id === recordId)
+      }
+
+      await expect
+        .poll(findRecord, { timeout: 30_000, message: 'record should be findable after creation' })
+        .toBe(true)
+
+      // Simulate what TokenSearchStrategy.purge does for this scope: drop the tokens.
+      // From here the availability answer must become `false` (once the process cache
+      // expires) and search must keep working via ilike.
+      await withClient(async (client) => {
+        await client.query('delete from search_tokens where entity_type = $1', [entityId])
+      })
+
+      await expect
+        .poll(findRecord, {
+          timeout: 60_000,
+          message: 'record should remain findable via the plain-column fallback after purge',
+        })
+        .toBe(true)
+    } finally {
+      await deleteRecordIfExists(request, token, entityId, recordId)
+      await deleteCustomEntityIfExists(request, token, entityId)
+    }
+  })
+})

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -1,5 +1,12 @@
 import { HybridQueryEngine, coerceSortDirection } from '../../query_index/lib/engine'
 import { SortDir } from '@open-mercato/shared/lib/query/types'
+import { clearSearchTokenPresenceCache } from '@open-mercato/shared/lib/search/availability'
+
+// The token-presence answer is cached process-wide (TTL); without clearing it,
+// probe-count assertions would observe hits from earlier tests in this file.
+beforeEach(() => {
+  clearSearchTokenPresenceCache()
+})
 
 jest.mock('@open-mercato/shared/lib/logger', () => {
   const mocked = {
@@ -1145,5 +1152,96 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
     const chains = db._chains as ChainLog[]
     expect(chains.some((chain) => chain.table === 'custom_entities_storage' && chain.selects.length > 0)).toBe(true)
     expect(chains.some((chain) => chain.table === 'todos')).toBe(false)
+  })
+
+  describe('search_tokens coverage probe (#4723)', () => {
+    const countProbes = (db: any): number =>
+      (db._chains as ChainLog[]).filter((chain) => chain.table === 'search_tokens').length
+
+    const buildDb = () => createFakeKysely({
+      baseTable: 'todos', hasIndexAny: true, baseCount: 10, indexCount: 10, customFieldKeys: {},
+    })
+
+    const buildCustomEntityDb = () => createFakeKysely({
+      baseTable: 'unused',
+      hasIndexAny: false,
+      baseCount: 0,
+      indexCount: 0,
+      customFieldKeys: {},
+      rows: { custom_entities_storage: [{ entity_id: 'record-1' }] },
+    })
+
+    test('is skipped when the query carries no like/ilike filter', async () => {
+      const db = buildDb()
+      const engine = new HybridQueryEngine(buildEm(db), { query: jest.fn() } as any)
+
+      await engine.query('example:todo', {
+        fields: ['id'],
+        organizationId: 'org1',
+        tenantId: 't1',
+        filters: [{ field: 'is_done', op: 'eq', value: false }],
+      })
+
+      expect(countProbes(db)).toBe(0)
+    })
+
+    test('still runs when the query actually searches', async () => {
+      const db = buildDb()
+      const engine = new HybridQueryEngine(buildEm(db), { query: jest.fn() } as any)
+
+      await engine.query('example:todo', {
+        fields: ['id'],
+        organizationId: 'org1',
+        tenantId: 't1',
+        filters: [{ field: 'title', op: 'ilike', value: '%abc%' }],
+      })
+
+      expect(countProbes(db)).toBeGreaterThan(0)
+    })
+
+    test('is skipped on the custom-entity storage path without a like/ilike filter', async () => {
+      const db = buildCustomEntityDb()
+      const engine = new HybridQueryEngine(buildEmWithOrmMetadata(db, {}), { query: jest.fn() } as any)
+
+      await engine.query('example:calendar_entity', {
+        fields: ['id'],
+        organizationIds: ['org1'],
+        tenantId: 't1',
+        filters: [{ field: 'is_active', op: 'eq', value: true }],
+      })
+
+      expect(countProbes(db)).toBe(0)
+    })
+
+    test('still runs on the custom-entity storage path when the query searches', async () => {
+      const db = buildCustomEntityDb()
+      const engine = new HybridQueryEngine(buildEmWithOrmMetadata(db, {}), { query: jest.fn() } as any)
+
+      await engine.query('example:calendar_entity', {
+        fields: ['id'],
+        organizationIds: ['org1'],
+        tenantId: 't1',
+        filters: [{ field: 'title', op: 'ilike', value: '%abc%' }],
+      })
+
+      expect(countProbes(db)).toBeGreaterThan(0)
+    })
+
+    test('probes each joined-source entity once even when several filters hit the same source', async () => {
+      const db = buildDb()
+      const engine = new HybridQueryEngine(buildEm(db), { query: jest.fn() } as any)
+
+      await engine.query('example:todo', {
+        fields: ['id'],
+        organizationId: 'org1',
+        tenantId: 't1',
+        filters: [
+          { field: 'title', op: 'ilike', value: '%abc%' },
+          { field: 'description', op: 'ilike', value: '%def%' },
+        ],
+      })
+
+      expect(countProbes(db)).toBe(1)
+    })
   })
 })

--- a/packages/core/src/modules/query_index/data/entities.ts
+++ b/packages/core/src/modules/query_index/data/entities.ts
@@ -255,6 +255,13 @@ export class IndexerStatusLog {
 @Index({ name: 'search_tokens_lookup_idx', properties: ['entityType', 'field', 'tokenHash', 'tenantId', 'organizationId'] })
 @Index({ name: 'search_tokens_entity_idx', properties: ['entityType', 'entityId'] })
 @Index({ name: 'search_tokens_tenant_token_hash_idx', properties: ['tenantId', 'tokenHash'] })
+// Serves the availability probe ("does this scope have any tokens?") as a pure
+// B-tree prefix seek, making the MISS as cheap as the hit — neither existing
+// index can (lookup_idx buries tenant_id behind field/token_hash), which is how
+// the probe degraded to a seq scan on large tables (#4723). Requires the
+// index-usable `= / IS NULL` predicates the availability resolver emits; see
+// .ai/specs/2026-07-31-search-token-probe-index.md.
+@Index({ name: 'search_tokens_presence_idx', properties: ['entityType', 'tenantId', 'organizationId'] })
 export class SearchToken {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -20,6 +20,12 @@ import {
   type ResolvedJoin,
 } from '@open-mercato/shared/lib/query/join-utils'
 import { resolveSearchConfig, type SearchConfig } from '@open-mercato/shared/lib/search/config'
+import {
+  createSearchTokenAvailability,
+  isSearchFilterOp,
+  hasSearchFilter,
+  type SearchTokenAvailability,
+} from '@open-mercato/shared/lib/search/availability'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
 import { runBeforeQueryPipeline, runAfterQueryPipeline, type QueryExtensionContext } from '@open-mercato/shared/lib/query/query-extension-runner'
 import { resolveEncryptedSortFields, resolveEncryptedSortMaxRows, sortRowsInMemory } from '@open-mercato/shared/lib/query/encrypted-sort'
@@ -145,6 +151,7 @@ export class HybridQueryEngine implements QueryEngine {
   private autoReindexEnabled: boolean | null = null
   private coverageOptimizationEnabled: boolean | null = null
   private pendingCoverageRefreshKeys = new Set<string>()
+  private searchAvailabilityInstance: SearchTokenAvailability | null = null
 
   constructor(
     private em: EntityManager,
@@ -171,6 +178,18 @@ export class HybridQueryEngine implements QueryEngine {
     const emAny = this.em as any
     if (typeof emAny.getKysely === 'function') return emAny.getKysely() as AnyDb
     throw new Error('HybridQueryEngine requires an EntityManager exposing getKysely() (MikroORM v7)')
+  }
+
+  private searchAvailability(): SearchTokenAvailability {
+    if (!this.searchAvailabilityInstance) {
+      this.searchAvailabilityInstance = createSearchTokenAvailability({
+        getDb: () => this.getDb() as any,
+        getConfig: resolveSearchConfig,
+        applyOrganizationScope: (query, column, scope) => this.applyOrganizationScope(query as AnyBuilder, column, scope) as any,
+        logDebug: (event, payload) => this.logSearchDebug(event, payload),
+      })
+    }
+    return this.searchAvailabilityInstance
   }
 
   async query<T = unknown>(entity: EntityId, opts: QueryOptions = {}): Promise<QueryResult<T>> {
@@ -250,7 +269,7 @@ export class HybridQueryEngine implements QueryEngine {
       profiler.mark('query:base_table_resolved')
       const searchConfig = resolveSearchConfig()
       const orgScope = this.resolveOrganizationScope(opts)
-      const searchEnabled = searchConfig.enabled && await this.tableExists('search_tokens')
+      const searchEnabled = await this.searchAvailability().staticEnabled()
 
       const baseExists = await profiler.measure('base_table_exists', () => this.tableExists(baseTable))
       if (!baseExists) {
@@ -415,12 +434,15 @@ export class HybridQueryEngine implements QueryEngine {
       const searchSources: SearchTokenSource[] = indexSources
         .map((src) => ({ entity: String(src.entityId), recordIdColumn: src.recordIdColumn }))
         .filter((src) => src.recordIdColumn && src.entity)
-      const hasSearchTokens = searchEnabled && searchSources.length
-        ? await this.searchSourcesHaveTokens(searchSources, opts.tenantId ?? null, orgScope)
+      const searchFilters = normalizedFilters.filter((filter) => isSearchFilterOp(filter.op))
+      // Probe `search_tokens` only when this query actually searches (#4723). Every consumer of
+      // `searchRuntime.enabled` already sits behind a like/ilike guard, so on a plain list load the
+      // answer is unused — and the probe is a `LIMIT 1` the planner can resolve as a seq scan over a
+      // large `search_tokens`. The join path below already probes lazily for the same reason.
+      const hasSearchTokens = searchEnabled && searchSources.length && searchFilters.length
+        ? await this.searchAvailability().anySourceHasTokens(searchSources, opts.tenantId ?? null, orgScope)
         : false
       const searchRuntime: SearchRuntime = { ...searchRuntimeBase, searchSources, enabled: searchEnabled && hasSearchTokens }
-      const joinSearchAvailability = new Map<string, boolean>()
-      const searchFilters = normalizeFilters(opts.filters).filter((filter) => filter.op === 'like' || filter.op === 'ilike')
       if (searchFilters.length) {
         this.logSearchDebug('search:init', {
           entity,
@@ -738,11 +760,7 @@ export class HybridQueryEngine implements QueryEngine {
         if (!['like', 'ilike'].includes(filter.op)) return false
         if (typeof filter.value !== 'string' || filter.value.trim().length === 0) return false
 
-        let searchAvailable = joinSearchAvailability.get(join.entityId)
-        if (searchAvailable === undefined) {
-          searchAvailable = await this.hasSearchTokens(String(join.entityId), opts.tenantId ?? null, orgScope)
-          joinSearchAvailability.set(join.entityId, searchAvailable)
-        }
+        const searchAvailable = await this.searchAvailability().hasTokens(String(join.entityId), opts.tenantId ?? null, orgScope)
         if (!searchAvailable) return false
 
         const tokens = tokenizeText(String(filter.value), searchConfig)
@@ -1636,10 +1654,13 @@ export class HybridQueryEngine implements QueryEngine {
     const orgScope = this.resolveOrganizationScope(opts)
     if (!opts.tenantId) throw new Error('QueryEngine: tenantId is required')
 
+    const normalizedFilters = normalizeFilters(opts.filters)
+
     const searchConfig = resolveSearchConfig()
-    const searchEnabled = searchConfig.enabled && await this.tableExists('search_tokens')
-    const hasSearchTokens = searchEnabled
-      ? await this.hasSearchTokens(entity, opts.tenantId ?? null, orgScope)
+    const searchEnabled = await this.searchAvailability().staticEnabled()
+    // Same gate as `query()` (#4723): without a like/ilike filter the probe's answer is never read.
+    const hasSearchTokens = searchEnabled && hasSearchFilter(normalizedFilters)
+      ? await this.searchAvailability().hasTokens(entity, opts.tenantId ?? null, orgScope)
       : false
     const searchRuntime: SearchRuntime = {
       enabled: searchEnabled && hasSearchTokens,
@@ -1648,8 +1669,6 @@ export class HybridQueryEngine implements QueryEngine {
       tenantId: opts.tenantId ?? null,
       mintAlias: createSearchAliasMinter(),
     }
-
-    const normalizedFilters = normalizeFilters(opts.filters)
 
     const applyScope = (q: AnyBuilder): AnyBuilder => {
       let next = q
@@ -1779,50 +1798,6 @@ export class HybridQueryEngine implements QueryEngine {
       .where('table_name', '=', table)
       .executeTakeFirst()
     return !!exists
-  }
-
-  private async hasSearchTokens(
-    entity: string,
-    tenantId: string | null,
-    orgScope?: { ids: string[]; includeNull: boolean } | null
-  ): Promise<boolean> {
-    try {
-      const db = this.getDb() as any
-      let query = db
-        .selectFrom('search_tokens')
-        .select(sql<number>`1`.as('one'))
-        .where('entity_type', '=', entity)
-      if (tenantId !== undefined) {
-        query = query.where(sql<boolean>`tenant_id is not distinct from ${tenantId}`)
-      }
-      if (orgScope) {
-        query = this.applyOrganizationScope(query, 'search_tokens.organization_id', orgScope)
-      }
-      const row = await query.limit(1).executeTakeFirst()
-      return !!row
-    } catch (err) {
-      this.logSearchDebug('search:has-tokens-error', {
-        entity, tenantId, organizationScope: orgScope,
-        error: err instanceof Error ? err.message : String(err),
-      })
-      return false
-    }
-  }
-
-  private async searchSourcesHaveTokens(
-    sources: SearchTokenSource[],
-    tenantId: string | null,
-    orgScope?: { ids: string[]; includeNull: boolean } | null
-  ): Promise<boolean> {
-    for (const source of sources) {
-      const ok = await this.hasSearchTokens(source.entity, tenantId, orgScope)
-      this.logSearchDebug('search:source-has-tokens', {
-        entity: source.entity, recordIdColumn: source.recordIdColumn,
-        tenantId, organizationScope: orgScope, hasTokens: ok,
-      })
-      if (ok) return true
-    }
-    return false
   }
 
   private async resolveAvailableCustomFieldKeys(entityIds: string[], tenantId: string | null): Promise<string[]> {

--- a/packages/core/src/modules/query_index/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/query_index/migrations/.snapshot-open-mercato.json
@@ -1367,6 +1367,18 @@
         },
         {
           "columnNames": [
+            "entity_type",
+            "tenant_id",
+            "organization_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "search_tokens_presence_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
             "id"
           ],
           "composite": false,

--- a/packages/core/src/modules/query_index/migrations/Migration20260731105052_query_index.ts
+++ b/packages/core/src/modules/query_index/migrations/Migration20260731105052_query_index.ts
@@ -1,0 +1,32 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// Availability-probe index (.ai/specs/2026-07-31-search-token-probe-index.md).
+// The query engines gate like/ilike routing on "does (entity_type, tenant, org)
+// have any search tokens?". Neither existing index serves that probe as an
+// access path — lookup_idx buries tenant_id behind field/token_hash — so on a
+// large search_tokens the planner degraded the probe to a seq scan and the MISS
+// answer had to exhaust every entry for the entity type (p95 12.5 s in
+// production, #4723). With this (entity_type, tenant_id, organization_id)
+// prefix and the index-usable `= / IS NULL` predicates the availability
+// resolver emits, both the hit AND the miss become a B-tree prefix seek.
+//
+// search_tokens is high-churn, so the index is built CONCURRENTLY to avoid
+// blocking writes during the build. CREATE INDEX CONCURRENTLY cannot run
+// inside a transaction, hence isTransactional() => false; the migration runner
+// applies migrations one-by-one, so this opt-out is safe (same pattern as
+// Migration20260611103000_query_index).
+export class Migration20260731105052_query_index extends Migration {
+
+  override isTransactional(): boolean {
+    return false;
+  }
+
+  override up(): void | Promise<void> {
+    this.addSql(`create index concurrently if not exists "search_tokens_presence_idx" on "search_tokens" ("entity_type", "tenant_id", "organization_id");`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`drop index if exists "search_tokens_presence_idx";`);
+  }
+
+}

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -214,6 +214,8 @@ OM_SEARCH_HASH_ALGO=sha256
 OM_SEARCH_STORE_RAW_TOKENS=false
 # Optional comma-separated blocklist of field name substrings to skip during tokenization
 # OM_SEARCH_FIELD_BLOCKLIST=password,token,secret,hash
+# TTL for the process-level "does this entity have search tokens?" probe cache (ms, 0 disables)
+OM_SEARCH_TOKEN_PRESENCE_CACHE_MS=30000
 
 # Search module debug logging (Meilisearch, vector search, reindex operations)
 OM_SEARCH_DEBUG=false

--- a/packages/search/AGENTS.md
+++ b/packages/search/AGENTS.md
@@ -542,6 +542,7 @@ curl "https://your-app.com/api/search?q=john%20doe&limit=20" \
 | `OM_SEARCH_HASH_ALGO` | When choosing the token hash algorithm | Default: `sha256` (accepts `sha1`, `md5`). **Token strategy only** |
 | `OM_SEARCH_STORE_RAW_TOKENS` | Almost never — debugging tokenization only | Default: `false`. Stores plaintext token alongside the hash — **security-sensitive**, retains plaintext of otherwise-hashed values. **Token strategy only** |
 | `OM_SEARCH_FIELD_BLOCKLIST` | When extra fields must never be tokenized | Comma-separated field names, merged with built-in `password,token,secret,hash`. **Token strategy only** |
+| `OM_SEARCH_TOKEN_PRESENCE_CACHE_MS` | When tuning the query engines' "does this entity have search tokens?" probe | Default: `30000` (ms); `0` disables. Process-level TTL cache in `@open-mercato/shared/lib/search/availability` — bounds how long a token purge or first-index is invisible to like/ilike routing. **Token strategy only** |
 | `SEARCH_EXCLUDE_ENCRYPTED_FIELDS` | When you need to keep encrypted fields out of fulltext | Set to `true` to exclude encrypted fields from fulltext index |
 | `OM_LOG_LEVEL` | When debugging presenter enrichment | Set to `debug` to surface presenter enricher diagnostics (replaces the former `DEBUG_SEARCH_ENRICHER` flag) |
 

--- a/packages/shared/src/lib/query/__tests__/engine.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.test.ts
@@ -1,6 +1,13 @@
 import { BasicQueryEngine } from '../engine'
 import { SortDir } from '../types'
 import { registerModules } from '../../i18n/server'
+import { clearSearchTokenPresenceCache } from '../../search/availability'
+
+// The token-presence answer is cached process-wide (TTL); without clearing it,
+// probe-count assertions would observe hits from earlier tests in this file.
+beforeEach(() => {
+  clearSearchTokenPresenceCache()
+})
 
 // Mock modules with one entity extension
 const mockModules = [
@@ -355,6 +362,8 @@ describe('BasicQueryEngine (Kysely)', () => {
     const fakeDb = createFakeKysely({
       customer_entities: [],
       customer_people: [],
+      search_tokens: [{ one: 1 }],
+      'information_schema.tables': [{ table_name: 'search_tokens' }],
       'information_schema.columns': [
         { table_name: 'customer_entities', column_name: 'tenant_id' },
         { table_name: 'customer_people', column_name: 'id' },
@@ -362,8 +371,6 @@ describe('BasicQueryEngine (Kysely)', () => {
       ],
     })
     const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
-    jest.spyOn(engine as any, 'tableExists').mockResolvedValue(true)
-    jest.spyOn(engine as any, 'hasSearchTokens').mockResolvedValue(true)
     const applySearchTokensSpy = jest.spyOn(engine as any, 'applySearchTokens')
 
     await engine.query('customers:customer_entity', {
@@ -409,7 +416,6 @@ describe('BasicQueryEngine (Kysely)', () => {
       ],
     })
     const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
-    jest.spyOn(engine as any, 'tableExists').mockResolvedValue(false)
     const applySearchTokensSpy = jest.spyOn(engine as any, 'applySearchTokens')
 
     await engine.query('customers:customer_entity', {
@@ -445,10 +451,10 @@ describe('BasicQueryEngine (Kysely)', () => {
   test('uses search tokens for index document fields on base entities', async () => {
     const fakeDb = createFakeKysely({
       todos: [],
+      search_tokens: [{ one: 1 }],
+      'information_schema.tables': [{ table_name: 'search_tokens' }],
     })
     const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
-    const tableExistsSpy = jest.spyOn(engine as any, 'tableExists').mockResolvedValue(true)
-    const hasSearchTokensSpy = jest.spyOn(engine as any, 'hasSearchTokens').mockResolvedValue(true)
     const applySearchTokensSpy = jest.spyOn(engine as any, 'applySearchTokens')
 
     await engine.query('example:todo', {
@@ -461,12 +467,14 @@ describe('BasicQueryEngine (Kysely)', () => {
       page: { page: 1, pageSize: 10 },
     })
 
-    expect(tableExistsSpy).toHaveBeenCalledWith('search_tokens')
-    expect(hasSearchTokensSpy).toHaveBeenCalledWith(
-      'example:todo',
-      't1',
-      expect.objectContaining({ ids: ['org1'] }),
-    )
+    const tableProbe = fakeDb._calls.find((call: any) =>
+      call._ops.table === 'information_schema.tables' &&
+      call._ops.wheres.some((w: any) => Array.isArray(w) && w[0] === 'table_name' && w[2] === 'search_tokens'))
+    expect(tableProbe).toBeTruthy()
+    const tokenProbe = fakeDb._calls.find((call: any) =>
+      call._ops.table === 'search_tokens' &&
+      call._ops.wheres.some((w: any) => Array.isArray(w) && w[0] === 'entity_type' && w[2] === 'example:todo'))
+    expect(tokenProbe).toBeTruthy()
     expect(applySearchTokensSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -488,7 +496,6 @@ describe('BasicQueryEngine (Kysely)', () => {
       ],
     })
     const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
-    const hasSearchTokensSpy = jest.spyOn(engine as any, 'hasSearchTokens').mockResolvedValue(true)
     const applySearchTokensSpy = jest.spyOn(engine as any, 'applySearchTokens')
 
     await engine.query('example:todo', {
@@ -501,7 +508,7 @@ describe('BasicQueryEngine (Kysely)', () => {
       page: { page: 1, pageSize: 10 },
     })
 
-    expect(hasSearchTokensSpy).not.toHaveBeenCalled()
+    expect(fakeDb._calls.some((call: any) => call._ops.table === 'search_tokens')).toBe(false)
     expect(applySearchTokensSpy).not.toHaveBeenCalled()
     const baseCall = fakeDb._calls.find((builder: any) => builder._ops.table === 'todos')
     expect(baseCall?._ops.wheres).toContainEqual(['todos.search_text', 'ilike', '%avision%'])
@@ -932,5 +939,41 @@ describe('BasicQueryEngine (Kysely)', () => {
     expect(baseCall._ops.orderBys).toEqual([['customer_entities.display_name', 'asc']])
     expect(baseCall._ops.limits).toBe(10)
     expect(baseCall._ops.offsets).toBe(10)
+  })
+
+  describe('search_tokens coverage probe (#4723 parity)', () => {
+    const countProbes = (fakeDb: any): number =>
+      fakeDb._calls.filter((call: any) => call._ops.table === 'search_tokens').length
+
+    const buildDb = () => createFakeKysely({
+      users: [],
+      'information_schema.tables': [{ table_name: 'search_tokens' }],
+    })
+
+    test('is skipped when the query carries no like/ilike filter', async () => {
+      const fakeDb = buildDb()
+      const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
+
+      await engine.query('auth:user', {
+        tenantId: 't1',
+        organizationId: 'org1',
+        filters: { is_active: { $eq: true } },
+      })
+
+      expect(countProbes(fakeDb)).toBe(0)
+    })
+
+    test('still runs when the query actually searches', async () => {
+      const fakeDb = buildDb()
+      const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
+
+      await engine.query('auth:user', {
+        tenantId: 't1',
+        organizationId: 'org1',
+        filters: { email: { $ilike: '%abc%' } },
+      })
+
+      expect(countProbes(fakeDb)).toBeGreaterThan(0)
+    })
   })
 })

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -12,6 +12,11 @@ import {
   type ResolvedJoin,
 } from './join-utils'
 import { resolveSearchConfig } from '../search/config'
+import {
+  createSearchTokenAvailability,
+  isSearchFilterOp,
+  type SearchTokenAvailability,
+} from '../search/availability'
 import { tokenizeText } from '../search/tokenize'
 import { runBeforeQueryPipeline, runAfterQueryPipeline, type QueryExtensionContext } from './query-extension-runner'
 import {
@@ -206,8 +211,8 @@ function computeCustomFieldScore(cfg: Record<string, unknown>, kind: string, ent
  */
 export class BasicQueryEngine implements QueryEngine {
   private columnCache = new Map<string, boolean>()
-  private tableCache = new Map<string, boolean>()
   private searchAliasSeq = 0
+  private searchAvailabilityInstance: SearchTokenAvailability | null = null
 
   constructor(
     private em: EntityManager,
@@ -228,6 +233,18 @@ export class BasicQueryEngine implements QueryEngine {
     const emAny = this.em as any
     if (typeof emAny?.getKysely === 'function') return emAny.getKysely() as AnyDb
     throw new Error('BasicQueryEngine requires an EntityManager exposing getKysely() (MikroORM v7)')
+  }
+
+  private searchAvailability(): SearchTokenAvailability {
+    if (!this.searchAvailabilityInstance) {
+      this.searchAvailabilityInstance = createSearchTokenAvailability({
+        getDb: () => this.getDb() as any,
+        getConfig: resolveSearchConfig,
+        applyOrganizationScope: (query, column, scope) => this.applyOrganizationScope(query as AnyBuilder, column, scope) as any,
+        logDebug: (event, payload) => this.logSearchDebug(event, payload),
+      })
+    }
+    return this.searchAvailabilityInstance
   }
 
   async query<T = any>(entity: EntityId, opts: QueryOptions = {}): Promise<QueryResult<T>> {
@@ -293,17 +310,20 @@ export class BasicQueryEngine implements QueryEngine {
     const { baseFilters, joinFilters } = partitionFilters(table, normalizedFilters, joinMap)
     const cfFilters = normalizedFilters.filter((filter) => String(filter.field).startsWith('cf:'))
     const searchConfig = resolveSearchConfig()
+    const searchFilters = [...baseFilters, ...cfFilters].filter((filter) => isSearchFilterOp(filter.op))
     // Callers that opt out of automatic tenant/org scoping own the full
     // visibility predicate. Search-token filtering has its own tenant/org
     // guards, so it must be disabled on this direct-query path as documented
     // by QueryOptions.omitAutomaticTenantOrgScope.
-    const searchEnabled = !skipAutoScope && searchConfig.enabled && await this.tableExists('search_tokens')
-    const hasSearchTokens = searchEnabled
-      ? await this.hasSearchTokens(String(entity), opts.tenantId ?? null, orgScope)
+    const searchEnabled = !skipAutoScope && await this.searchAvailability().staticEnabled()
+    // Probe `search_tokens` only when this query actually searches (#4723): every consumer of
+    // `searchActive` sits behind a like/ilike guard, so on a plain list load the answer is never
+    // read — and the probe is a `LIMIT 1` the planner can resolve as a seq scan over a large
+    // `search_tokens`. The join path below already probes lazily for the same reason.
+    const hasSearchTokens = searchEnabled && searchFilters.length
+      ? await this.searchAvailability().hasTokens(String(entity), opts.tenantId ?? null, orgScope)
       : false
     const searchActive = searchEnabled && hasSearchTokens
-    const joinSearchAvailability = new Map<string, boolean>()
-    const searchFilters = [...baseFilters, ...cfFilters].filter((filter) => filter.op === 'like' || filter.op === 'ilike')
     if (searchFilters.length) {
       const fields = searchFilters.map((filter) => String(filter.field))
       this.logSearchDebug('search:init', {
@@ -396,11 +416,7 @@ export class BasicQueryEngine implements QueryEngine {
       if (!['like', 'ilike'].includes(filter.op)) return { applied: false, builder }
       if (typeof filter.value !== 'string' || filter.value.trim().length === 0) return { applied: false, builder }
 
-      let searchAvailable = joinSearchAvailability.get(join.entityId)
-      if (searchAvailable === undefined) {
-        searchAvailable = await this.hasSearchTokens(join.entityId, opts.tenantId ?? null, orgScope)
-        joinSearchAvailability.set(join.entityId, searchAvailable)
-      }
+      const searchAvailable = await this.searchAvailability().hasTokens(join.entityId, opts.tenantId ?? null, orgScope)
       if (!searchAvailable) return { applied: false, builder }
 
       const tokens = tokenizeText(String(filter.value), searchConfig)
@@ -471,8 +487,8 @@ export class BasicQueryEngine implements QueryEngine {
     // today's complete selection (base fields + CF projections + extension joins).
     // `projection: 'sortKeys'` selects only `id` + the sort columns — the slim phase-1
     // candidate scan used when `requiresPlaintextSort`. Re-running the WHERE/JOIN logic
-    // twice is cheap: every `columnExists`/`tableExists` check is memoized on
-    // `this.columnCache`/`this.tableCache`, so the second pass hits no extra DB calls.
+    // twice is cheap: every `columnExists` check is memoized on `this.columnCache`,
+    // so the second pass hits no extra DB calls.
     const buildQuery = async (projection: 'full' | 'sortKeys'): Promise<BuiltQuery> => {
       const isSortKeysProjection = projection === 'sortKeys'
       let q: AnyBuilder = db.selectFrom(table as any)
@@ -1134,51 +1150,6 @@ export class BasicQueryEngine implements QueryEngine {
     if (present) this.columnCache.set(key, true)
     else this.columnCache.delete(key)
     return present
-  }
-
-  private async tableExists(table: string): Promise<boolean> {
-    if (this.tableCache.has(table)) return this.tableCache.get(table) ?? false
-    const db = this.getDb()
-    const exists = await db
-      .selectFrom('information_schema.tables' as any)
-      .select(sql<number>`1`.as('one'))
-      .where('table_name' as any, '=', table)
-      .limit(1)
-      .executeTakeFirst()
-    const present = !!exists
-    this.tableCache.set(table, present)
-    return present
-  }
-
-  private async hasSearchTokens(
-    entity: string,
-    tenantId: string | null,
-    orgScope?: { ids: string[]; includeNull: boolean } | null
-  ): Promise<boolean> {
-    try {
-      const db = this.getDb()
-      let query: AnyBuilder = db
-        .selectFrom('search_tokens' as any)
-        .select(sql<number>`1`.as('one'))
-        .where('entity_type' as any, '=', entity)
-        .limit(1)
-      if (tenantId !== undefined) {
-        query = query.where(sql<boolean>`tenant_id is not distinct from ${tenantId}`)
-      }
-      if (orgScope) {
-        query = this.applyOrganizationScope(query, 'search_tokens.organization_id', orgScope)
-      }
-      const row = await query.executeTakeFirst()
-      return !!row
-    } catch (err) {
-      this.logSearchDebug('search:has-tokens-error', {
-        entity,
-        tenantId,
-        organizationScope: orgScope,
-        error: err instanceof Error ? err.message : String(err),
-      })
-      return false
-    }
   }
 
   private applySearchTokens(

--- a/packages/shared/src/lib/search/__tests__/availability.test.ts
+++ b/packages/shared/src/lib/search/__tests__/availability.test.ts
@@ -1,0 +1,210 @@
+import {
+  clearSearchTokenPresenceCache,
+  createSearchTokenAvailability,
+  hasSearchFilter,
+  isSearchFilterOp,
+  type OrganizationScope,
+} from '../availability'
+
+beforeEach(() => {
+  clearSearchTokenPresenceCache()
+  delete process.env.OM_SEARCH_TOKEN_PRESENCE_CACHE_MS
+})
+
+afterAll(() => {
+  delete process.env.OM_SEARCH_TOKEN_PRESENCE_CACHE_MS
+})
+
+type ProbeLog = { table: string; wheres: unknown[][] }
+
+function createFakeDb(options?: { rowsByTable?: Record<string, unknown>; failTables?: string[] }) {
+  const probes: ProbeLog[] = []
+  const db = {
+    selectFrom(table: string) {
+      const log: ProbeLog = { table, wheres: [] }
+      probes.push(log)
+      const chain = {
+        select: () => chain,
+        where: (...args: unknown[]) => {
+          log.wheres.push(args)
+          return chain
+        },
+        limit: () => chain,
+        executeTakeFirst: async () => {
+          if (options?.failTables?.includes(table)) throw new Error(`probe failed for ${table}`)
+          return options?.rowsByTable?.[table]
+        },
+      }
+      return chain
+    },
+  }
+  return { db, probes }
+}
+
+function buildAvailability(options?: Parameters<typeof createFakeDb>[0] & { enabled?: boolean }) {
+  const { db, probes } = createFakeDb(options)
+  const logDebug = jest.fn()
+  const applyOrganizationScope = jest.fn((query: any) => query)
+  const availability = createSearchTokenAvailability({
+    getDb: () => db,
+    getConfig: () => ({ enabled: options?.enabled ?? true }),
+    applyOrganizationScope,
+    logDebug,
+  })
+  return { availability, probes, logDebug, applyOrganizationScope }
+}
+
+const countProbes = (probes: ProbeLog[], table: string) => probes.filter((probe) => probe.table === table).length
+
+describe('hasSearchFilter / isSearchFilterOp', () => {
+  test('recognizes like and ilike only', () => {
+    expect(isSearchFilterOp('like')).toBe(true)
+    expect(isSearchFilterOp('ilike')).toBe(true)
+    expect(isSearchFilterOp('eq')).toBe(false)
+    expect(hasSearchFilter([{ op: 'eq' }, { op: 'in' }])).toBe(false)
+    expect(hasSearchFilter([{ op: 'eq' }, { op: 'ilike' }])).toBe(true)
+    expect(hasSearchFilter([])).toBe(false)
+  })
+})
+
+describe('createSearchTokenAvailability', () => {
+  test('staticEnabled probes the table once per instance and rechecks config each call', async () => {
+    const { availability, probes } = buildAvailability({
+      rowsByTable: { 'information_schema.tables': { one: 1 } },
+    })
+    await expect(availability.staticEnabled()).resolves.toBe(true)
+    await expect(availability.staticEnabled()).resolves.toBe(true)
+    expect(countProbes(probes, 'information_schema.tables')).toBe(1)
+  })
+
+  test('staticEnabled short-circuits on disabled config without probing', async () => {
+    const { availability, probes } = buildAvailability({ enabled: false })
+    await expect(availability.staticEnabled()).resolves.toBe(false)
+    expect(probes).toHaveLength(0)
+  })
+
+  test('staticEnabled retries after a failed table probe instead of caching the rejection', async () => {
+    const options = { rowsByTable: { 'information_schema.tables': { one: 1 } }, failTables: ['information_schema.tables'] }
+    const { availability, probes } = buildAvailability(options)
+    await expect(availability.staticEnabled()).rejects.toThrow('probe failed')
+    options.failTables.length = 0
+    await expect(availability.staticEnabled()).resolves.toBe(true)
+    expect(countProbes(probes, 'information_schema.tables')).toBe(2)
+  })
+
+  test('hasTokens memoizes per (entity, tenant, org) key', async () => {
+    const { availability, probes } = buildAvailability({ rowsByTable: { search_tokens: { one: 1 } } })
+    const orgScope: OrganizationScope = { ids: ['org1'], includeNull: false }
+
+    await expect(availability.hasTokens('example:todo', 't1', orgScope)).resolves.toBe(true)
+    await expect(availability.hasTokens('example:todo', 't1', orgScope)).resolves.toBe(true)
+    expect(countProbes(probes, 'search_tokens')).toBe(1)
+
+    await availability.hasTokens('example:todo', 't2', orgScope)
+    await availability.hasTokens('example:other', 't1', orgScope)
+    await availability.hasTokens('example:todo', 't1', { ids: ['org2'], includeNull: false })
+    expect(countProbes(probes, 'search_tokens')).toBe(4)
+  })
+
+  test('hasTokens applies the injected organization scope', async () => {
+    const { availability, applyOrganizationScope } = buildAvailability()
+    const orgScope: OrganizationScope = { ids: ['org1'], includeNull: true }
+    await availability.hasTokens('example:todo', 't1', orgScope)
+    expect(applyOrganizationScope).toHaveBeenCalledWith(expect.anything(), 'search_tokens.organization_id', orgScope)
+
+    applyOrganizationScope.mockClear()
+    await availability.hasTokens('example:todo', 't1', null)
+    expect(applyOrganizationScope).not.toHaveBeenCalled()
+  })
+
+  test('hasTokens resolves false and logs search:has-tokens-error on probe failure', async () => {
+    const { availability, logDebug } = buildAvailability({ failTables: ['search_tokens'] })
+    await expect(availability.hasTokens('example:todo', 't1', null)).resolves.toBe(false)
+    expect(logDebug).toHaveBeenCalledWith('search:has-tokens-error', expect.objectContaining({
+      entity: 'example:todo',
+      tenantId: 't1',
+      error: expect.stringContaining('probe failed'),
+    }))
+  })
+
+  test('anySourceHasTokens stops at the first source with tokens and logs each probed source', async () => {
+    const { availability, probes, logDebug } = buildAvailability({ rowsByTable: { search_tokens: { one: 1 } } })
+    const result = await availability.anySourceHasTokens(
+      [
+        { entity: 'example:todo', recordIdColumn: 'b.id' },
+        { entity: 'example:other', recordIdColumn: 'cfs0.entity_id' },
+      ],
+      't1',
+      null,
+    )
+    expect(result).toBe(true)
+    expect(countProbes(probes, 'search_tokens')).toBe(1)
+    expect(logDebug).toHaveBeenCalledTimes(1)
+    expect(logDebug).toHaveBeenCalledWith('search:source-has-tokens', expect.objectContaining({
+      entity: 'example:todo',
+      recordIdColumn: 'b.id',
+      hasTokens: true,
+    }))
+  })
+
+  test('process-level TTL cache serves later resolver instances without re-probing', async () => {
+    const first = buildAvailability({ rowsByTable: { search_tokens: { one: 1 } } })
+    await expect(first.availability.hasTokens('example:todo', 't1', null)).resolves.toBe(true)
+    expect(countProbes(first.probes, 'search_tokens')).toBe(1)
+
+    const second = buildAvailability()
+    await expect(second.availability.hasTokens('example:todo', 't1', null)).resolves.toBe(true)
+    expect(countProbes(second.probes, 'search_tokens')).toBe(0)
+  })
+
+  test('process-level TTL cache expires and can be disabled', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000)
+    try {
+      const first = buildAvailability()
+      await first.availability.hasTokens('example:todo', 't1', null)
+
+      nowSpy.mockReturnValue(1_000_000 + 30_001)
+      const second = buildAvailability()
+      await second.availability.hasTokens('example:todo', 't1', null)
+      expect(countProbes(second.probes, 'search_tokens')).toBe(1)
+
+      process.env.OM_SEARCH_TOKEN_PRESENCE_CACHE_MS = '0'
+      const third = buildAvailability()
+      await third.availability.hasTokens('example:todo', 't1', null)
+      expect(countProbes(third.probes, 'search_tokens')).toBe(1)
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
+  test('error-driven false results are not TTL-cached', async () => {
+    const first = buildAvailability({ failTables: ['search_tokens'] })
+    await expect(first.availability.hasTokens('example:todo', 't1', null)).resolves.toBe(false)
+
+    const second = buildAvailability({ rowsByTable: { search_tokens: { one: 1 } } })
+    await expect(second.availability.hasTokens('example:todo', 't1', null)).resolves.toBe(true)
+    expect(countProbes(second.probes, 'search_tokens')).toBe(1)
+  })
+
+  test('probe uses index-friendly tenant predicates instead of IS NOT DISTINCT FROM', async () => {
+    const { availability, probes } = buildAvailability()
+    await availability.hasTokens('example:todo', 't1', null)
+    await availability.hasTokens('example:todo', null, null)
+    const [scoped, global] = probes.filter((probe) => probe.table === 'search_tokens')
+    expect(scoped.wheres).toContainEqual(['tenant_id', '=', 't1'])
+    expect(global.wheres).toContainEqual(['tenant_id', 'is', null])
+  })
+
+  test('anySourceHasTokens sweeps all sources when none has tokens, sharing the memo with hasTokens', async () => {
+    const { availability, probes } = buildAvailability()
+    const sources = [
+      { entity: 'example:todo', recordIdColumn: 'b.id' },
+      { entity: 'example:other', recordIdColumn: 'cfs0.entity_id' },
+    ]
+    await expect(availability.anySourceHasTokens(sources, 't1', null)).resolves.toBe(false)
+    expect(countProbes(probes, 'search_tokens')).toBe(2)
+
+    await expect(availability.hasTokens('example:todo', 't1', null)).resolves.toBe(false)
+    expect(countProbes(probes, 'search_tokens')).toBe(2)
+  })
+})

--- a/packages/shared/src/lib/search/availability.ts
+++ b/packages/shared/src/lib/search/availability.ts
@@ -1,0 +1,217 @@
+import { sql } from 'kysely'
+import { parseNumberWithDefault } from '@open-mercato/shared/lib/number'
+
+export type OrganizationScope = { ids: string[]; includeNull: boolean }
+
+export type SearchTokenSourceRef = { entity: string; recordIdColumn?: string }
+
+type ProbeQueryBuilder = {
+  select: (...args: unknown[]) => ProbeQueryBuilder
+  where: (...args: unknown[]) => ProbeQueryBuilder
+  limit: (count: number) => ProbeQueryBuilder
+  executeTakeFirst: () => Promise<unknown>
+}
+
+type ProbeDb = { selectFrom: (table: string) => ProbeQueryBuilder }
+
+export type SearchTokenAvailabilityDeps = {
+  getDb: () => ProbeDb
+  getConfig: () => { enabled: boolean }
+  applyOrganizationScope: (query: ProbeQueryBuilder, column: string, scope: OrganizationScope) => ProbeQueryBuilder
+  logDebug: (event: string, payload: Record<string, unknown>) => void
+}
+
+export type SearchTokenAvailability = {
+  /**
+   * The cheap, statically-known half of the decision: search is configured on
+   * AND the `search_tokens` table exists. Safe to resolve eagerly (consumers
+   * like custom-field source attachment need it before any filter is
+   * inspected); the table probe is memoized per instance.
+   */
+  staticEnabled: () => Promise<boolean>
+  /**
+   * The expensive half: does `search_tokens` hold any row for this
+   * (entity, tenant, organization scope)? Historically the `LIMIT 1` probe
+   * could degenerate into a seq scan on a large table (#4723), so callers MUST
+   * only ask when the query actually carries a like/ilike filter — use
+   * `hasSearchFilter` for the gate. Three layers keep it cheap for the end
+   * user: index-usable predicates (no `IS NOT DISTINCT FROM`) served by the
+   * dedicated `search_tokens_presence_idx (entity_type, tenant_id,
+   * organization_id)` prefix — which makes the MISS as cheap as the hit — a
+   * per-request instance memo, and a process-level TTL cache
+   * (`OM_SEARCH_TOKEN_PRESENCE_CACHE_MS`, default 30s) that amortizes the
+   * probe across requests. Probe errors log `search:has-tokens-error`,
+   * resolve to `false`, and are never TTL-cached.
+   */
+  hasTokens: (entity: string, tenantId: string | null, orgScope?: OrganizationScope | null) => Promise<boolean>
+  /** First-hit sweep over token sources; logs `search:source-has-tokens` per probed source. */
+  anySourceHasTokens: (
+    sources: SearchTokenSourceRef[],
+    tenantId: string | null,
+    orgScope?: OrganizationScope | null,
+  ) => Promise<boolean>
+}
+
+export function isSearchFilterOp(op: unknown): boolean {
+  return op === 'like' || op === 'ilike'
+}
+
+/**
+ * The single definition of "this query actually searches". Every consumer of
+ * the token-availability answer sits behind a like/ilike guard, so when this
+ * returns `false` the `hasTokens` probe's answer would never be read — gate
+ * the probe on it.
+ */
+export function hasSearchFilter(filters: ReadonlyArray<{ op?: unknown }>): boolean {
+  return filters.some((filter) => isSearchFilterOp(filter.op))
+}
+
+function orgScopeKey(scope: OrganizationScope | null | undefined): string {
+  if (!scope) return 'none'
+  return `${scope.includeNull ? '1' : '0'}:${[...scope.ids].sort((left, right) => left.localeCompare(right)).join(',')}`
+}
+
+const PRESENCE_CACHE_DEFAULT_TTL_MS = 30_000
+const PRESENCE_CACHE_MAX_ENTRIES = 10_000
+
+// Process-level TTL cache for the token-presence answer. Module-level (process-global) on
+// purpose: `createRequestContainer` builds fresh engines — and with them fresh resolver
+// instances — per request, so an instance-scoped memo alone re-pays the probe on every
+// request. On a large `search_tokens` one probe can be pathologically expensive (#4723),
+// so the answer is amortized across requests here and only re-checked once per TTL.
+// Staleness contract: a stale `false` keeps like/ilike on the plain-column fallback for up
+// to the TTL after an entity's first tokens are written; a stale `true` routes search
+// through an emptied token set for up to the TTL after a purge. Both converge within the
+// TTL; set OM_SEARCH_TOKEN_PRESENCE_CACHE_MS=0 to disable and probe per request again.
+const presenceCache = new Map<string, { value: boolean; expiresAt: number }>()
+
+function resolvePresenceCacheTtlMs(): number {
+  return parseNumberWithDefault(process.env.OM_SEARCH_TOKEN_PRESENCE_CACHE_MS, PRESENCE_CACHE_DEFAULT_TTL_MS, { integer: true, min: 0 })
+}
+
+function storePresence(key: string, value: boolean, ttlMs: number): void {
+  if (presenceCache.size >= PRESENCE_CACHE_MAX_ENTRIES) {
+    const now = Date.now()
+    for (const [entryKey, entry] of presenceCache) {
+      if (entry.expiresAt <= now) presenceCache.delete(entryKey)
+    }
+    if (presenceCache.size >= PRESENCE_CACHE_MAX_ENTRIES) presenceCache.clear()
+  }
+  presenceCache.set(key, { value, expiresAt: Date.now() + ttlMs })
+}
+
+export function clearSearchTokenPresenceCache(): void {
+  presenceCache.clear()
+}
+
+/**
+ * One place that answers "is token search usable here?" for both query
+ * engines, instead of each hand-assembling config + table-existence +
+ * token-presence probes with private duplicate helpers and ad-hoc memo maps.
+ *
+ * Memoization is per instance; engines are constructed per request
+ * (`createRequestContainer`), so entries never outlive a request — the same
+ * staleness contract the engines' previous per-query join maps had. A
+ * rejected table probe is evicted so the next call retries instead of
+ * observing a poisoned cache entry.
+ */
+export function createSearchTokenAvailability(deps: SearchTokenAvailabilityDeps): SearchTokenAvailability {
+  const tablePresence = new Map<string, Promise<boolean>>()
+  const tokenPresence = new Map<string, Promise<boolean>>()
+
+  const tableExists = (table: string): Promise<boolean> => {
+    const cached = tablePresence.get(table)
+    if (cached) return cached
+    const probe = (async () => {
+      const row = await deps.getDb()
+        .selectFrom('information_schema.tables')
+        .select(sql<number>`1`.as('one'))
+        .where('table_name', '=', table)
+        .limit(1)
+        .executeTakeFirst()
+      return !!row
+    })()
+    tablePresence.set(table, probe)
+    probe.catch(() => tablePresence.delete(table))
+    return probe
+  }
+
+  const probeTokens = async (
+    entity: string,
+    tenantId: string | null,
+    orgScope?: OrganizationScope | null,
+  ): Promise<boolean> => {
+    let query = deps.getDb()
+      .selectFrom('search_tokens')
+      .select(sql<number>`1`.as('one'))
+      .where('entity_type', '=', entity)
+    // Deliberately `= / IS NULL` instead of `IS NOT DISTINCT FROM` (identical semantics
+    // for a string|null tenant): the latter cannot serve as an index condition, which is
+    // part of why the planner degraded this probe to a seq scan on large tables (#4723).
+    // With plain predicates the probe is a pure prefix seek on
+    // `search_tokens_presence_idx (entity_type, tenant_id, organization_id)`, making the
+    // miss as cheap as the hit.
+    query = tenantId == null
+      ? query.where('tenant_id', 'is', null)
+      : query.where('tenant_id', '=', tenantId)
+    if (orgScope) {
+      query = deps.applyOrganizationScope(query, 'search_tokens.organization_id', orgScope)
+    }
+    const row = await query.limit(1).executeTakeFirst()
+    return !!row
+  }
+
+  const hasTokens = (
+    entity: string,
+    tenantId: string | null,
+    orgScope?: OrganizationScope | null,
+  ): Promise<boolean> => {
+    const key = `${entity}|${tenantId ?? '__null__'}|${orgScopeKey(orgScope)}`
+    const ttlMs = resolvePresenceCacheTtlMs()
+    if (ttlMs > 0) {
+      const entry = presenceCache.get(key)
+      if (entry && entry.expiresAt > Date.now()) return Promise.resolve(entry.value)
+    }
+    const cached = tokenPresence.get(key)
+    if (cached) return cached
+    const probe = (async () => {
+      try {
+        const value = await probeTokens(entity, tenantId, orgScope)
+        // Only genuine probe results enter the process-level cache — caching an
+        // error-driven `false` would pin degraded search for a full TTL after a
+        // transient DB failure.
+        if (ttlMs > 0) storePresence(key, value, ttlMs)
+        return value
+      } catch (err) {
+        deps.logDebug('search:has-tokens-error', {
+          entity,
+          tenantId,
+          organizationScope: orgScope,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        return false
+      }
+    })()
+    tokenPresence.set(key, probe)
+    return probe
+  }
+
+  return {
+    staticEnabled: async () => deps.getConfig().enabled && await tableExists('search_tokens'),
+    hasTokens,
+    anySourceHasTokens: async (sources, tenantId, orgScope) => {
+      for (const source of sources) {
+        const ok = await hasTokens(source.entity, tenantId, orgScope)
+        deps.logDebug('search:source-has-tokens', {
+          entity: source.entity,
+          recordIdColumn: source.recordIdColumn,
+          tenantId,
+          organizationScope: orgScope,
+          hasTokens: ok,
+        })
+        if (ok) return true
+      }
+      return false
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Two query engines each hand-assembled the same decision — *"is token search usable for (entity, tenant, org)?"* — at **five call sites**, with duplicate private helpers (`hasSearchTokens`, `tableExists`, `applySearchTokens`, `logSearchDebug`, `applyOrganizationScope`) and ad-hoc per-query memo maps that had already drifted (`BasicQueryEngine` memoizes `tableExists`; `HybridQueryEngine` didn't).

The probe behind that decision was pathological on a large `search_tokens`:

```sql
select 1 from search_tokens
where entity_type = $1 and tenant_id is not distinct from $2
  and organization_id in ($3) limit 1
```

Three separate problems, which is why this needs more than one fix:

1. **It ran unconditionally.** Every consumer of the answer sits behind an `op === 'like' | 'ilike'` guard, so on a plain list load the result was computed and thrown away.
2. **`IS NOT DISTINCT FROM` can never be an index access condition**, so the planner had no index path and — with `LIMIT 1` making a seq scan look cheap — chose to walk the heap.
3. **The miss is the expensive answer.** Proving *no* tokens exist for a scope means exhausting every index entry for that `entity_type`. `searchSourcesHaveTokens()` walks the base entity plus every `customFieldSources` entry, so the "tokens are missing entirely" case — precisely what the probe exists to detect — paid that cost once per source.

Measured over 24 h on a production instance (412M rows / 132 GB): **median 1 ms, p95 12.5 s, max 69.3 s.** One plain order-list load — *no search term* — spent **12.5 s of its 12.9 s** server time inside this probe.

## Changes

Four layers, cheapest first. Each is independently defensible; together they make the worst case cheap rather than merely rare.

**1. Gate the probe on an actual search filter.** Includes and supersedes #4723, which fixed the two `HybridQueryEngine` paths. Note `BasicQueryEngine` — the live delegate the hybrid engine falls back to — was never gated at all.

**2. One resolver instead of five call sites.** `createSearchTokenAvailability()` in `packages/shared/src/lib/search/availability.ts` owns the decision for both engines; `hasSearchFilter()` defines the gate condition once. This deletes the duplicated private helpers and both ad-hoc memo maps, and turns #4723's gate from call-site discipline into a structural property — the next call site cannot forget it. It also gives any future probe change exactly one landing site, which is what made layers 3 and 4 one-liners.

**3. Index-usable predicates.** `tenant_id = $x` / `tenant_id IS NULL` instead of `IS NOT DISTINCT FROM` — identical semantics for a `string | null` tenant, but now a candidate index condition.

**4. `search_tokens_presence_idx (entity_type, tenant_id, organization_id)`**, built `CONCURRENTLY`. With layer 3 in place the probe becomes a B-tree prefix seek, so **the miss costs the same as the hit**. Plus a process-level TTL cache (`OM_SEARCH_TOKEN_PRESENCE_CACHE_MS`, default 30 s, `0` disables) — `createRequestContainer()` builds a fresh engine per request, so an instance-level memo never survived one; error results are never cached.

Worth recording: the original "no index can rescue this query" conclusion was true **only for the `IS NOT DISTINCT FROM` shape**. Once layer 3 landed, a purpose-ordered index became sufficient. Neither existing index can serve the probe — `search_tokens_lookup_idx` buries `tenant_id` behind `field, token_hash`. #4685's new `search_tokens_unique_tuple_idx` puts tenant last, so no overlap either.

### Rejected alternative, recorded so nobody re-derives it

A `search_token_presence` summary table (one row per scope with tokens, maintained at the four token write/purge sites) was **fully implemented and then dropped** in favour of the index:

| | Marker table | This index |
|---|---|---|
| Drift risk | 4 write hooks + stale-marker analysis + pinning tests | **zero — Postgres maintains it** |
| Code | ~500 lines | **zero — the probe already had the right shape** |
| Rollout | "table exists ⇒ authoritative" fallback protocol | none |
| Disk | ~KBs | ~1–3 GB (PG13+ B-tree dedup compresses these low-cardinality keys heavily) |

Zero drift risk and zero maintenance code beat the smaller disk footprint. `entity_index_coverage` was also evaluated as a host and rejected: its rows are created lazily (absent ≠ "no tokens"), its refresh machinery rewrites the rows a flag would ride on, and its NULL-tenant keying already needs a prune-duplicates workaround.

### Files

- `packages/shared/src/lib/search/availability.ts` — new resolver + `hasSearchFilter`/`isSearchFilterOp` + TTL cache.
- `packages/shared/src/lib/query/engine.ts` — `BasicQueryEngine` adopts it; **the one intended behavior change** is gating its previously unconditional probe.
- `packages/core/src/modules/query_index/lib/engine.ts` — `query()`, `queryCustomEntity()`, join path adopt it; duplicated privates deleted.
- `packages/core/src/modules/query_index/data/entities.ts` + `Migration20260731105052_query_index.ts` — the index, `isTransactional() => false` (CIC cannot run in a transaction; same pattern as `Migration20260611103000_query_index`).
- `.ai/specs/` — Phase 4 (B.4) added to the search-architecture spec; new `2026-07-31-search-token-probe-index.md`.
- Both `.env.example` files (template-sync) + `packages/search/AGENTS.md` for the new env var.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes

**Spec file path:**
`.ai/specs/2026-07-24-search-architecture-clarification-and-evolution.md` (Phase 4 / B.4 — the read-path twin of B.1's control-plane unification) and `.ai/specs/2026-07-31-search-token-probe-index.md`.

## Testing

Unit — both engines, on the existing fake-Kysely harnesses:

| call | probes |
|---|---|
| `query()`, `op: 'eq'` | **0** (was 1) |
| `query()`, `op: 'ilike'` | **1** — probe still runs, token path still used |
| custom-entity storage path, `op: 'eq'` | **0** (was 1) |
| custom-entity storage path, `op: 'ilike'` | **1** |
| `BasicQueryEngine`, `op: 'eq'` | **0** (was 1 — never gated before) |
| `BasicQueryEngine`, `op: 'ilike'` | **1** |
| two joins on the same entity | **1** (memoized) |

Plus 9 resolver unit tests (TTL hit/expiry/disable, error-never-cached, predicate shape, first-hit sweep, org-scope application).

**Verified the tests are not vacuous:** with the gates reverted, exactly the three "is skipped" cases fail (`Expected: 0, Received: 1`) while the "still runs" cases pass — so the latter genuinely guard against over-gating rather than riding along.

Integration — `packages/core/src/modules/query_index/__integration__/TC-QIDX-4731-token-presence.spec.ts`: create a record → records-API search finds it → delete the scope's tokens → the same search **still** finds it via the plain-column fallback (polling past the process TTL cache). That transition is the crisp observable difference between the two routings.

Commands run (local mode — no compose `app` container in this environment), per `.ai/agentic.config.json` → `validation.commands`:

- `yarn generate`, `yarn build:packages`, `yarn build:app --force`
- `yarn typecheck` (21/21), `yarn lint`, `npx eslint` on every changed file
- `yarn test` — shared **1529**, core **8368**, search **254**, all green
- `yarn db:generate` → `query_index: no changes` (snapshot parity verified after a hand-splice; the generator's unrelated `wms` output and its unrelated index-entry deletions were discarded per the coding-agent exception in `AGENTS.md`)
- `yarn i18n:check-sync` / `check-usage` (2 pre-existing `wms` misses, untouched), `git diff --check`

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [ ] QA routing set.

> The three label checkboxes are unticked because this PR is opened from a fork by a contributor without label permissions on this repo. Intended labels are in a comment below for a maintainer to apply.

### Design System Compliance

N/A — no UI files touched. No `.tsx` outside tests, nothing under `packages/ui/` or any `components/` tree.

## Linked issues

Supersedes #4723 (its gate and all four of its tests are included here verbatim; original analysis and production measurements are that PR's). Complementary to #4685, which addresses *why* `search_tokens` grows this large — this PR addresses why a table that size degrades an unrelated query. #4685 touches the same `search-tokens.ts` region only in its own hunks; conflicts are mechanical and whoever merges second resolves them.
