### PR TITLE
fix(sales): reject order payment totals on create instead of discarding them

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -50,6 +50,14 @@ Scheduler-owned `tenantId`/`organizationId`/`_idempotencyKey` are applied after 
 
 **Action for downstream:** workers written to the documented flat contract need no change and now also work under the local scheduler. A worker that relied on the undocumented local envelope (reading `job.payload.payload.*` or `scheduleId`/`scheduleName`/`triggeredAt` from the payload) must switch to the flat fields; include any identifiers it needs in `targetPayload` when registering the schedule.
 
+### Order creation rejects payment totals instead of discarding them (#4695)
+
+`orderCreateSchema` declared `paidTotalAmount`, `refundedTotalAmount` and `outstandingAmount`, so `sales.orders.create` (and `POST /api/sales/orders`) validated them — and then built the order with the ledger hardcoded to `"0"` and recomputed the totals from those zeros. A caller creating a 100.00 order with `paidTotalAmount: 100` got `paid_total_amount 0` and `outstanding_amount 100` back, with no error, warning or log.
+
+These three columns are a projection of the order's payments: `recomputeOrderPaymentTotals` rebuilds them from the `SalesPayment` / `SalesPaymentAllocation` rows on every payment create, update, delete and refund. A value seeded on the document has no payment rows behind it, so the next payment touch overwrites it — honouring the input would have created a second, unreconciled source of truth that silently loses to the first payment. The create surface now rejects them: supplying any of the three (including `0` or `null`) fails validation with `Order payment totals are derived from recorded payments and cannot be set on the order. Record a payment instead (POST /api/sales/payments).` on that field's path, which the CRUD factory returns as a `400`. The documented OpenAPI create schema no longer lists the three keys. `documentUpdateSchema` never declared them and is unchanged.
+
+**Action for downstream:** callers that never sent these fields are unaffected — an order still starts unpaid and its outstanding balance is the grand total. A caller that echoed a full order payload back into `POST /api/sales/orders` (including a `paidTotalAmount: 0` read from a GET) must drop the three keys from the create body; it was already receiving a zeroed ledger, so no behavior it relied on is lost. To create an already-settled order, create the order and then record its payment with `sales.payments.create` / `POST /api/sales/payments`, which recomputes the ledger from the payment rows.
+
 ## 0.6.5 → 0.6.6 (unreleased)
 
 ### Standalone apps: optimistic-lock guard restored; `src/di.ts` now requires explicit bootstrap wiring (#4201)

--- a/packages/core/src/modules/sales/api/documents/factory.ts
+++ b/packages/core/src/modules/sales/api/documents/factory.ts
@@ -559,7 +559,17 @@ export function buildDocumentCrudOptions(binding: DocumentBinding) {
 }
 
 export function buildDocumentOpenApi(binding: DocumentBinding) {
-  const createSchema = binding.kind === 'order' ? orderCreateSchema : quoteCreateSchema
+  // The payment-ledger keys exist on the runtime schema only so a supplied value
+  // is rejected with an actionable message instead of silently dropped (#4695);
+  // they are not part of the documented create surface.
+  const createSchema =
+    binding.kind === 'order'
+      ? orderCreateSchema.omit({
+          paidTotalAmount: true,
+          refundedTotalAmount: true,
+          outstandingAmount: true,
+        })
+      : quoteCreateSchema
   const itemSchema = z.object({
     id: z.string().uuid(),
     [binding.numberField]: z.string().nullable(),

--- a/packages/core/src/modules/sales/commands/__tests__/documents.create-payment-totals.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/documents.create-payment-totals.test.ts
@@ -1,0 +1,215 @@
+/** @jest-environment node */
+
+// Regression coverage for #4695: `orderCreateSchema` accepted `paidTotalAmount`,
+// `refundedTotalAmount` and `outstandingAmount`, and `sales.orders.create` then
+// hardcoded the ledger to "0" and recomputed totals from those zeros — the
+// caller's values vanished with no error, warning or log.
+//
+// They are not a create-time input at all: `recomputeOrderPaymentTotals`
+// (commands/payments.ts) rebuilds these three columns from the SalesPayment /
+// SalesPaymentAllocation rows on every payment write, so a value seeded on the
+// document has no payment history behind it and is erased by the next payment
+// touch. The create surface therefore rejects them, and an order starts unpaid
+// until a payment is recorded.
+
+import { asValue, createContainer, InjectionMode } from 'awilix'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands/types'
+import {
+  ORDER_PAYMENT_LEDGER_FIELDS,
+  ORDER_PAYMENT_LEDGER_INPUT_MESSAGE,
+  orderCreateSchema,
+} from '../../data/validators'
+import { DefaultSalesCalculationService } from '../../services/salesCalculationService'
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    sales: {
+      sales_order: 'sales.sales_order',
+      sales_order_line: 'sales.sales_order_line',
+      sales_order_adjustment: 'sales.sales_order_adjustment',
+      sales_quote: 'sales.sales_quote',
+      sales_quote_line: 'sales.sales_quote_line',
+      sales_quote_adjustment: 'sales.sales_quote_adjustment',
+    },
+  },
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn(async () => ({})),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/lib/helpers', () => ({
+  setRecordCustomFields: jest.fn(async () => undefined),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+  findOneWithDecryption: jest.fn(async () => null),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  emitCrudSideEffects: jest.fn(async () => undefined),
+}))
+
+// The order-created notification fan-out needs a real database; it is non-critical
+// to the create command and irrelevant to the totals under test.
+jest.mock('@open-mercato/core/modules/notifications/lib/notificationService', () => ({
+  resolveNotificationService: () => ({ createForFeature: jest.fn(async () => undefined) }),
+}))
+
+const TEST_TENANT_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const TEST_ORG_ID = 'bbbbbbbb-bbbb-4bbb-abbb-bbbbbbbbbbbb'
+
+type OrderCreateResult = { orderId: string }
+
+function num(value: unknown): number {
+  return Number(value ?? 0)
+}
+
+function buildHarness() {
+  const createdOrders: Record<string, unknown>[] = []
+  const generatedNumbers: string[] = []
+  const em: Record<string, any> = {
+    fork: () => em,
+    create: (_entity: unknown, data: Record<string, unknown>) => ({ ...data }),
+    persist: (entity: Record<string, unknown>) => {
+      if (typeof entity.orderNumber === 'string') createdOrders.push(entity)
+    },
+    find: async () => [],
+    findOne: async () => null,
+    nativeDelete: async () => 0,
+    remove: jest.fn(),
+    flush: async () => undefined,
+    begin: async () => undefined,
+    commit: async () => undefined,
+    rollback: async () => undefined,
+    getReference: (_entity: unknown, id: unknown) => ({ id }),
+  }
+
+  const container = createContainer({ injectionMode: InjectionMode.PROXY })
+  container.register({
+    em: asValue(em),
+    dataEngine: asValue({}),
+    eventBus: asValue({
+      emit: async () => undefined,
+      emitEvent: async () => undefined,
+    }),
+    salesCalculationService: asValue(new DefaultSalesCalculationService(null)),
+    salesDocumentNumberGenerator: asValue({
+      generate: async () => {
+        const number = `SO-${generatedNumbers.length + 1}`
+        generatedNumbers.push(number)
+        return { number }
+      },
+    }),
+  })
+
+  const ctx: CommandRuntimeContext = {
+    container,
+    auth: null,
+    organizationScope: null,
+    selectedOrganizationId: TEST_ORG_ID,
+    organizationIds: [TEST_ORG_ID],
+  }
+
+  return { createdOrders, generatedNumbers, ctx }
+}
+
+// One 100.00 gross line; net equals gross so the grand total is exactly 100.00.
+function buildInput(extra: Record<string, unknown> = {}) {
+  return {
+    organizationId: TEST_ORG_ID,
+    tenantId: TEST_TENANT_ID,
+    currencyCode: 'USD',
+    lines: [
+      {
+        name: 'Item',
+        currencyCode: 'USD',
+        quantity: 1,
+        unitPriceNet: 100,
+        unitPriceGross: 100,
+        taxRate: 0,
+        discountAmount: 0,
+        discountPercent: 0,
+      },
+    ],
+    ...extra,
+  }
+}
+
+describe('orderCreateSchema — rejects payment ledger input (#4695)', () => {
+  it.each(ORDER_PAYMENT_LEDGER_FIELDS)('rejects %s with an actionable message', (field) => {
+    const result = orderCreateSchema.safeParse(buildInput({ [field]: 100 }))
+
+    expect(result.success).toBe(false)
+    const issue = result.error?.issues.find((entry) => entry.path.join('.') === field)
+    expect(issue?.message).toBe(ORDER_PAYMENT_LEDGER_INPUT_MESSAGE)
+  })
+
+  it('rejects a zero ledger value too — the field is not part of the create surface', () => {
+    const result = orderCreateSchema.safeParse(buildInput({ paidTotalAmount: 0 }))
+
+    expect(result.success).toBe(false)
+  })
+
+  it('reports every supplied ledger field at once', () => {
+    const result = orderCreateSchema.safeParse(
+      buildInput({ paidTotalAmount: 100, refundedTotalAmount: 25, outstandingAmount: 0 }),
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues.map((issue) => issue.path.join('.')).sort()).toEqual(
+      [...ORDER_PAYMENT_LEDGER_FIELDS].sort(),
+    )
+  })
+
+  it('accepts a payload that leaves the ledger to the payments module', () => {
+    expect(orderCreateSchema.safeParse(buildInput()).success).toBe(true)
+  })
+})
+
+describe('sales.orders.create — payment ledger (#4695)', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../documents')
+  })
+
+  function getHandler() {
+    const handler = commandRegistry.get<unknown, OrderCreateResult>('sales.orders.create')
+    expect(handler).toBeTruthy()
+    return handler!
+  }
+
+  it('rejects a supplied paidTotalAmount instead of discarding it', async () => {
+    const { createdOrders, generatedNumbers, ctx } = buildHarness()
+
+    await expect(
+      getHandler().execute(buildInput({ paidTotalAmount: 100, outstandingAmount: 0 }) as never, ctx),
+    ).rejects.toThrow(ORDER_PAYMENT_LEDGER_INPUT_MESSAGE)
+
+    // Validation runs before the document number is drawn, so a rejected create
+    // burns neither an order number nor a persisted row.
+    expect(createdOrders).toHaveLength(0)
+    expect(generatedNumbers).toHaveLength(0)
+  })
+
+  it('creates an unpaid order whose outstanding balance is the full grand total', async () => {
+    const { createdOrders, ctx } = buildHarness()
+
+    await getHandler().execute(buildInput() as never, ctx)
+
+    expect(createdOrders).toHaveLength(1)
+    const order = createdOrders[0]
+    expect(num(order.grandTotalGrossAmount)).toBeCloseTo(100, 4)
+    expect(num(order.paidTotalAmount)).toBeCloseTo(0, 4)
+    expect(num(order.refundedTotalAmount)).toBeCloseTo(0, 4)
+    expect(num(order.outstandingAmount)).toBeCloseTo(100, 4)
+  })
+})

--- a/packages/core/src/modules/sales/data/validators.ts
+++ b/packages/core/src/modules/sales/data/validators.ts
@@ -624,6 +624,38 @@ export const quoteAdjustmentUpdateSchema = z
   })
   .merge(quoteAdjustmentCreateSchema.partial())
 
+// An order's payment ledger is a projection of its recorded payments:
+// `recomputeOrderPaymentTotals` (commands/payments.ts) sums the SalesPayment /
+// SalesPaymentAllocation rows and overwrites these three columns on every
+// payment create, update, delete and refund. A value supplied on the document
+// itself has no payment rows behind it, so the next payment touch silently
+// erases it — the order would report a balance its payment history contradicts.
+// Document commands therefore reject them instead of accepting a second,
+// unreconciled source of truth (#4695). Record payments with
+// `sales.payments.create` / `POST /api/sales/payments`.
+export const ORDER_PAYMENT_LEDGER_FIELDS = [
+  'paidTotalAmount',
+  'refundedTotalAmount',
+  'outstandingAmount',
+] as const
+
+export const ORDER_PAYMENT_LEDGER_INPUT_MESSAGE =
+  'Order payment totals are derived from recorded payments and cannot be set on the order. Record a payment instead (POST /api/sales/payments).'
+
+// `z.never()` rather than an omitted key: an undeclared key is stripped silently,
+// which is the bug being fixed. Declaring it rejects any supplied value —
+// including 0 and null — with the message above on that field's path, and makes
+// it a compile error for TypeScript callers. `buildDocumentOpenApi` omits these
+// keys so the documented create surface stays accurate.
+const rejectedPaymentLedgerField = () =>
+  z.never({ error: ORDER_PAYMENT_LEDGER_INPUT_MESSAGE }).optional()
+
+const orderPaymentLedgerShape = {
+  paidTotalAmount: rejectedPaymentLedgerField(),
+  refundedTotalAmount: rejectedPaymentLedgerField(),
+  outstandingAmount: rejectedPaymentLedgerField(),
+}
+
 const orderTotalsSchema = z.object({
   subtotalNetAmount: decimal({ min: 0 }).optional(),
   subtotalGrossAmount: decimal({ min: 0 }).optional(),
@@ -634,9 +666,6 @@ const orderTotalsSchema = z.object({
   surchargeTotalAmount: decimal({ min: 0 }).optional(),
   grandTotalNetAmount: decimal({ min: 0 }).optional(),
   grandTotalGrossAmount: decimal({ min: 0 }).optional(),
-  paidTotalAmount: decimal({ min: 0 }).optional(),
-  refundedTotalAmount: decimal({ min: 0 }).optional(),
-  outstandingAmount: decimal().optional(),
   lineItemCount: z.coerce.number().int().min(0).optional(),
 })
 
@@ -690,6 +719,7 @@ export const orderCreateSchema = scoped.extend({
   adjustments: z.array(orderAdjustmentCreateSchema.omit({ organizationId: true, tenantId: true, orderId: true })).optional(),
   tags: z.array(uuid()).optional(),
   ...orderTotalsSchema.shape,
+  ...orderPaymentLedgerShape,
 })
 
 export const orderUpdateSchema = z


### PR DESCRIPTION
## Summary

`orderCreateSchema` declared `paidTotalAmount`, `refundedTotalAmount` and `outstandingAmount` (via `...orderTotalsSchema.shape`), so zod validated them and they arrived as `parsed.*` — but `sales.orders.create` built the `SalesOrder` with the ledger hardcoded to `"0"` and then recomputed the totals with `existingTotals: resolveExistingPaymentTotals(order)`, i.e. the zeros it had just written. A 100.00 order created with `paidTotalAmount: 100` persisted as `paid_total_amount = 0` / `outstanding_amount = 100`, with no error, warning or log.

This PR makes that failure **visible** rather than silent: the three keys are now rejected on the create surface.

**Why reject rather than honour the value.** Those three columns are a projection of the order's payments — `recomputeOrderPaymentTotals` (`commands/payments.ts:252`) rebuilds them by summing the `SalesPayment` / `SalesPaymentAllocation` rows and assigns the result, on every payment create, update, delete and refund (10 call sites). A value seeded on the document has no payment rows behind it, so the next payment touch overwrites it: on an order created with `paidTotalAmount: 100`, a first real payment of 20 would set paid to **20**, not 120. Honouring the input would have introduced a second, unreconciled source of truth that silently loses to the first payment write — an order whose balance its own payment history contradicts.

## Changes

- `data/validators.ts` — the three keys stay declared on `orderCreateSchema` but as `z.never({ error: … }).optional()`. Declaring them matters: an *undeclared* key is silently stripped by zod, which is the same silent-discard bug one layer down. Any supplied value (including `0` and `null`) now fails validation with an actionable message on that field's path; the CRUD factory maps the `ZodError` to a **400** (`shared/lib/crud/factory.ts:556`). Exported `ORDER_PAYMENT_LEDGER_FIELDS` / `ORDER_PAYMENT_LEDGER_INPUT_MESSAGE` as the single definition.
- `api/documents/factory.ts` — `buildDocumentOpenApi` omits the three keys, so the documented create surface stays accurate. (Left in the runtime schema they would render as a bare `{}` property, which reads as "any value accepted".)
- Enforcement is single-point: the route parses `orderCreateSchema` in `mapInput` and the command parses it again, so HTTP callers, direct `executeCommand` callers (inbox actions, AI tools, bulk import) and third parties all get the identical failure. TypeScript callers now get a compile error too.
- `commands/documents.ts` is **untouched** — its hardcoded `"0"` and `resolveExistingPaymentTotals(order)` were always correct for an order that has no payments yet.
- `UPGRADE_NOTES.md` — entry under 0.6.6 → 0.6.7.

`documentUpdateSchema` never declared these fields and is unchanged — see *Scope* below.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

`.ai/specs/SPEC-058-2026-03-05-sales-native-payment-gateway-refactor.md` is related but only *reads* these columns (payment-status badge derivation); it does not document the create surface, so it needs no update.

## Testing

`packages/core/src/modules/sales/commands/__tests__/documents.create-payment-totals.test.ts` (new, 8 cases, modelled on the existing `returns.payment-totals.test.ts` harness):

- schema level — each of the three fields rejected with the actionable message on its own path; `0` rejected too; all three reported at once; a clean payload accepted;
- command level — a supplied `paidTotalAmount` rejects **before** the document number is drawn (no burned order number, no persisted row), and a normal create yields paid 0 / refunded 0 / outstanding = grand total.

Commands run:

- `yarn jest src/modules/sales` (in `packages/core`) — 473 passed / 69 suites. Two suites fail in my sandbox only because `yarn generate` has never run there (`#generated/entities/sales_channel`, `…/sales_shipment` unresolved) — `api/__tests__/channels.route.test.ts` and `api/__tests__/shipments.afterList.test.ts`, both failing identically on `develop` before this change.
- `yarn typecheck` (core) — clean apart from the same pre-existing `#generated` resolution errors.
- `eslint` on all changed files — clean.
- `yarn i18n:check-sync` — in sync. `yarn i18n:check-usage` — the 2 missing keys are pre-existing and in `modules/wms`. `yarn i18n:check-hardcoded` does not flag the new constant (it follows the `RETURN_ADJUSTMENT_*_MESSAGE` convention already in that file).

No integration test added: I could not run the Playwright harness in my environment. `POST /api/sales/orders` with `paidTotalAmount` → 400 would be a reasonable addition under `.ai/qa/tests/` if you want it before merge — the behaviour is covered at the schema layer the route parses through, but not end-to-end over HTTP.

## Scope — what this PR deliberately does not do

1. **Update path untouched.** #4695 also covers `sales.orders.update`. `documentUpdateSchema` (the schema the PUT route actually uses) never declared these fields, so making update accept — or reject — them is a separate contract decision, not this bug. Filed as `Refs`, not `Fixes`, for that reason; close it if you read the scope differently.
2. **The ERP-import use case in #4695 is not solved.** The issue's Impact section describes a Subiekt GT import with header-level payment aggregates and no per-payment rows, where 473k settled orders landed as unpaid. This PR turns that silent loss into a loud 400 — strictly better than discarding, but it does not add a supported way to state a header-level aggregate. Within the current model the supported path is to create **one `SalesPayment` row per imported order** carrying the ERP aggregate; `seed/examples.ts` already does exactly that (creates payments + allocations, then lets the projection follow), and it keeps the ledger reconcilable. If a genuine header-only aggregate is wanted, that is a deliberate data-model change and deserves its own spec.

## Backward compatibility

This tightens a public API contract: `POST /api/sales/orders` used to accept these keys (and ignore them) and now returns 400. Flagging it explicitly because `BACKWARD_COMPATIBILITY.md` classifies API routes and types as contract surfaces, and the deprecation protocol would otherwise suggest a bridge release (warn for one minor, reject in the next).

My reading is that no *working* behaviour is lost — the fields never had an effect, so any caller sending them was already getting a zeroed ledger back — which is why I went straight to rejection and documented it in `UPGRADE_NOTES.md` rather than adding a deprecation cycle. Happy to switch to warn-then-reject if you'd rather protect existing integrations for a release; that is a maintainer call.

Blast radius checked: no in-repo caller sends these fields (the admin `SalesDocumentForm`, `inbox-actions.ts`, and the seeds all avoid them — the seeds create real payment rows). The plausible external break is an integration echoing a GET response back into a POST, which the upgrade note calls out with the migration.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set.

The CLA box is left unticked deliberately — that is the author's acceptance to give, not an agent's. The last three boxes are label writes the PR author's account cannot perform (no `triage` on this repo); the intended values and their rationale are in a follow-up comment.

### Design System Compliance

N/A — this PR touches no `.tsx` file and nothing under `packages/ui/src/` or `**/components/**`. The six DS boxes are left unticked as not applicable rather than ticked vacuously.

## Linked issues

Refs #4695
