### PR TITLE
fix(agent_orchestrator): recompute eval-case input_key on approve so golden-match works

### DIFF
--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/eval-case-from-run.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/eval-case-from-run.test.ts
@@ -6,7 +6,17 @@ jest.mock('../events', () => ({
   emitAgentOrchestratorEvent: jest.fn(async () => {}),
 }))
 
-import { createEvalCaseFromRunCommand } from '../commands/corrections'
+// The approve command uses withAtomicFlush (needs a transactional em the in-memory
+// fake lacks). Run its phases inline + flush — createFromRun doesn't use it.
+jest.mock('@open-mercato/shared/lib/commands/flush', () => ({
+  withAtomicFlush: async (em: { flush?: () => Promise<void> }, phases: Array<() => unknown>) => {
+    for (const phase of phases) await phase()
+    await em.flush?.()
+  },
+}))
+
+import { createEvalCaseFromRunCommand, approveEvalCaseCommand } from '../commands/corrections'
+import { canonicalInputKey } from '../lib/eval/canonicalInputKey'
 import { emitAgentOrchestratorEvent } from '../events'
 
 const TENANT = '11111111-1111-4111-8111-111111111111'
@@ -161,5 +171,62 @@ describe('evalCases.createFromRun command', () => {
     })
     expect(storeFor(AgentEvalCase)).toHaveLength(0)
     expect(emitAgentOrchestratorEvent).not.toHaveBeenCalled()
+  })
+})
+
+const APPROVER = '33333333-3333-4333-8333-333333333333'
+
+describe('evalCases.approve — input_key recompute', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('self-heals a null input_key on an already-approved case so it can golden-match', async () => {
+    const { em, storeFor } = createFakeEm()
+    storeFor(AgentEvalCase).push({
+      __entity: AgentEvalCase,
+      id: '44444444-4444-4444-8444-444444444444',
+      tenantId: TENANT,
+      organizationId: ORG,
+      agentDefinitionId: 'deals.health_check',
+      input: { dealId: 'deal-1' },
+      inputKey: null, // legacy row created before the match-key feature
+      status: 'approved',
+      updatedAt: new Date(),
+      deletedAt: null,
+    })
+
+    const result = await approveEvalCaseCommand.execute(
+      { tenantId: TENANT, organizationId: ORG, evalCaseId: '44444444-4444-4444-8444-444444444444', approvedByUserId: APPROVER },
+      makeCtx(em),
+    )
+
+    expect(result.status).toBe('approved')
+    // Now equals canonicalInputKey(decrypted input) — the exact key evaluateRun
+    // computes from a live run, so the golden match now fires.
+    expect(storeFor(AgentEvalCase)[0].inputKey).toBe(canonicalInputKey({ dealId: 'deal-1' }))
+  })
+
+  it('sets input_key from the input when approving a draft', async () => {
+    const { em, storeFor } = createFakeEm()
+    storeFor(AgentEvalCase).push({
+      __entity: AgentEvalCase,
+      id: '66666666-6666-4666-8666-666666666666',
+      tenantId: TENANT,
+      organizationId: ORG,
+      agentDefinitionId: 'deals.health_check',
+      input: { dealId: 'deal-2' },
+      inputKey: null,
+      status: 'draft',
+      updatedAt: new Date(),
+      deletedAt: null,
+    })
+
+    await approveEvalCaseCommand.execute(
+      { tenantId: TENANT, organizationId: ORG, evalCaseId: '66666666-6666-4666-8666-666666666666', approvedByUserId: APPROVER },
+      makeCtx(em),
+    )
+
+    const row = storeFor(AgentEvalCase)[0]
+    expect(row.status).toBe('approved')
+    expect(row.inputKey).toBe(canonicalInputKey({ dealId: 'deal-2' }))
   })
 })

--- a/packages/enterprise/src/modules/agent_orchestrator/commands/corrections.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/commands/corrections.ts
@@ -12,6 +12,7 @@ import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { AgentRun, AgentEvalCase } from '../data/entities'
 import { correctionAction } from '../data/validators'
 import { draftEvalCase, recordCorrection } from '../lib/trace/correctionService'
+import { canonicalInputKey } from '../lib/eval/canonicalInputKey'
 import { emitAgentOrchestratorEvent } from '../events'
 
 const EVAL_CASE_RESOURCE = 'agent_orchestrator.eval_case'
@@ -200,12 +201,23 @@ const approveEvalCaseCommand: CommandHandler<ApproveEvalCaseCommandInput, Approv
     const input = approveEvalCaseCommandSchema.parse(rawInput)
     const em = (ctx.container.resolve('em') as EntityManager).fork()
 
-    const evalCase = await em.findOne(AgentEvalCase, {
-      id: input.evalCaseId,
-      tenantId: input.tenantId,
-      organizationId: input.organizationId,
-      deletedAt: null,
-    })
+    // Decrypt the input so the match key is recomputed over PLAINTEXT — the same
+    // basis `evaluateRun` uses to golden-match a live run. Legacy/pre-feature
+    // rows carry a null `input_key` (and an edited input can drift), so an
+    // "Approved" case could silently be unmatchable; recomputing on approve
+    // guarantees an approved case is always match-eligible against its input.
+    const evalCase = await findOneWithDecryption(
+      em,
+      AgentEvalCase,
+      {
+        id: input.evalCaseId,
+        tenantId: input.tenantId,
+        organizationId: input.organizationId,
+        deletedAt: null,
+      },
+      undefined,
+      { tenantId: input.tenantId, organizationId: input.organizationId },
+    )
     if (!evalCase) {
       enforceRecordGoneIsConflict({
         resourceKind: EVAL_CASE_RESOURCE,
@@ -215,8 +227,18 @@ const approveEvalCaseCommand: CommandHandler<ApproveEvalCaseCommandInput, Approv
       throw new CrudHttpError(404, { error: '[internal] eval case not found' })
     }
 
-    // Idempotent: approving an already-approved case is a no-op.
+    const freshInputKey = canonicalInputKey(evalCase.input ?? {})
+
+    // Idempotent, but still self-heal a missing/stale match key on an
+    // already-approved case (the legacy-null-key row this fix targets).
     if (evalCase.status === 'approved') {
+      if (evalCase.inputKey !== freshInputKey) {
+        await withAtomicFlush(
+          em,
+          [() => { evalCase.inputKey = freshInputKey }],
+          { transaction: true, label: 'agent_orchestrator.evalCases.approve.healKey' },
+        )
+      }
       return { evalCaseId: evalCase.id, status: evalCase.status, updatedAt: evalCase.updatedAt.toISOString() }
     }
     if (evalCase.status !== 'draft') {
@@ -236,6 +258,7 @@ const approveEvalCaseCommand: CommandHandler<ApproveEvalCaseCommandInput, Approv
         () => {
           evalCase.status = 'approved'
           evalCase.approvedByUserId = input.approvedByUserId
+          evalCase.inputKey = freshInputKey
         },
       ],
       { transaction: true, label: 'agent_orchestrator.evalCases.approve' },


### PR DESCRIPTION
## Problem
An approved golden eval case never matches a playground/live run with the same input, so the eval "isn't matched" in the Playground.

I traced it against real data (decrypting through the app's own encryption path):
- The online golden-match plane matches by `agent_eval_cases.input_key == canonicalInputKey(run.input)` — a SHA-256 over the **decrypted** input (`evalRuntimeService`).
- The specific case being tested has **`input_key = NULL`** (a legacy row created before the match-key feature) → it can never equal a hash.
- The write path is otherwise **correct**: a recent case's stored key exactly equals `canonicalInputKey(its decrypted input)` (verified), and different cases differ only because they're different clients.

So: null/stale `input_key`s make an "Approved" case silently unmatchable.

## Fix
`evalCases.approve` now loads the case **with decryption** and recomputes `input_key = canonicalInputKey(decrypted input)`:
- **draft → approved**: stamps the correct key alongside the status flip.
- **already-approved**: self-heals a missing/stale key, so re-approving repairs a legacy row — no separate backfill needed (per the chosen approach).

`input_key` is plaintext by design (SQL-queryable, not encrypted), so recomputing and persisting it is safe. This is the exact key `evaluateRun` derives from a live run, so the golden match fires.

## Tests
`eval-case-from-run.test.ts` adds an approve suite:
- self-heals a null `input_key` on an already-approved case;
- stamps `input_key` from the input when approving a draft.

- `jest` → 6 passing (4 existing + 2 new).
- `tsc --noEmit -p packages/enterprise` → 0 errors.

## Note for existing data
Re-approving your stale case (or re-adding it) now gives it the correct key and it will match. No backfill command is included (by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)