### PR TITLE
fix(agent_orchestrator): keep the trace of a failed OpenCode run

### DIFF
--- a/packages/enterprise/src/modules/agent_orchestrator/__tests__/opencode-runner.test.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/__tests__/opencode-runner.test.ts
@@ -344,6 +344,17 @@ describe('OpenCodeAgentRunner (integration, fake client)', () => {
     expect(ids).toContain('agent_orchestrator.runs.fail')
     expect(ids).not.toContain('agent_orchestrator.runs.complete')
     expect(deleteSessionApiKeyMock).toHaveBeenCalled()
+
+    // A failed run is exactly the one an operator opens to find out what happened,
+    // so its telemetry must survive the failure: the ingest used to sit on the
+    // success path only, leaving the trace view with no duration and no spans.
+    const ingest = calls.find((call) => call.id === 'agent_orchestrator.trace.ingest')
+    expect(ingest).toBeDefined()
+    const payload = (ingest!.input as { payload: { latencyMs?: number; status?: string } }).payload
+    expect(typeof payload.latencyMs).toBe('number')
+    // The run row keeps the status `runs.fail` wrote — the ingest must not carry
+    // one of its own, or it would resurrect a failed run as something else.
+    expect(payload.status).toBeUndefined()
   })
 
   it('dispatches opencode-runtime agents through the runner from AgentRuntimeService.run', async () => {

--- a/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
+++ b/packages/enterprise/src/modules/agent_orchestrator/lib/runtime/openCodeAgentRunner.ts
@@ -262,6 +262,11 @@ export class OpenCodeAgentRunner {
       (entry.files.outputs ?? true) &&
       parseBooleanWithDefault(process.env.OM_OPENCODE_FILES_ENABLED, false)
     let workspace: AgentWorkspaceLease | null = null
+    // Hoisted so the `finally` can time a run that ended in an error too: a
+    // failed run used to reach the trace ingest only through the success path,
+    // leaving the debugger with no duration, no spans and no tool calls — the
+    // exact evidence needed to see WHERE it broke.
+    let startedAtMs: number | null = null
 
     try {
       if (filesEnabled) {
@@ -297,7 +302,7 @@ export class OpenCodeAgentRunner {
 
       const message = this.buildMessage(sessionToken, businessInput, workspace, stagedInputs)
 
-      const startedAtMs = Date.now()
+      startedAtMs = Date.now()
       const capturedOutcome = await this.driveSession({
         sessionId: session.id,
         message,
@@ -327,7 +332,6 @@ export class OpenCodeAgentRunner {
       }
 
       const result = shapeResult(entry.resultKind, parsed.data)
-      const latencyMs = Math.max(0, Math.round(Date.now() - startedAtMs))
 
       await completeRun(this.commandBus, commandCtx, {
         runId,
@@ -351,15 +355,6 @@ export class OpenCodeAgentRunner {
           stepId: ctx.stepId ?? null,
         })
       }
-
-      await this.ingestSessionTrace(commandCtx, {
-        tenantId: ctx.tenantId,
-        organizationId: ctx.organizationId,
-        agentId,
-        externalRunId: session.id,
-        toolCalls: capturedToolCalls,
-        latencyMs,
-      })
 
       // File plane (#12): scan the sandbox `out/` and capture agent-authored files
       // as encrypted AgentRunArtifacts — BEFORE the `finally` wipes the sandbox.
@@ -387,6 +382,22 @@ export class OpenCodeAgentRunner {
 
       return result
     } finally {
+      // Persist the telemetry on EVERY exit path — success, a `failRun` throw, or
+      // an unexpected one. Whatever the session produced before it broke is the
+      // debugging material, and it is already in `capturedToolCalls`; skipping the
+      // ingest on failure discarded it. Best-effort by contract (see the method),
+      // so this can never turn a completed run into a failed one.
+      if (startedAtMs != null) {
+        await this.ingestSessionTrace(commandCtx, {
+          tenantId: ctx.tenantId,
+          organizationId: ctx.organizationId,
+          agentId,
+          externalRunId: session.id,
+          toolCalls: capturedToolCalls,
+          latencyMs: Math.max(0, Math.round(Date.now() - startedAtMs)),
+        })
+      }
+
       // Wipe + release the sandbox lease first (frees the pooled container slot),
       // then remove the shared correlation row and best-effort revoke the per-run
       // token so it cannot be reused after the run.


### PR DESCRIPTION
## Problem

A failed OpenCode run renders as a dead end in the trace view — `0 spans`, "No tool calls recorded for this run.", no duration, no tokens — even though the run was alive for minutes and the failure is precisely what someone opened the page to debug.

<img width="800" alt="failed run with no telemetry" src="https://github.com/user-attachments/assets/placeholder" />

## Cause

The telemetry was never missing: `capturedToolCalls` is filled from the OpenCode session stream throughout the run. But `ingestSessionTrace(...)` was called on the **success path only**, after `completeRun`. Every `failRun` path — no `submit_outcome`, outcome failing re-validation, attachment staging error — returns or throws before reaching it, so everything observed up to the failure was discarded.

## Fix

Move the ingest into the method's `finally` so it runs on every exit path: success, a `failRun` throw, or an unexpected one. `startedAtMs` is hoisted next to it, which also gives a failed run its duration — `ingestSessionTrace` only early-returns when there is neither a tool call nor a latency to record, so even a run that failed before its first tool call now shows how long it took.

### Why ingesting after `failRun` is safe

The ingest payload carries no `status`, and `applyRunFields` assigns one only when present. The row keeps the `failed` status and error message that `runs.fail` wrote, and merely gains spans, tool calls and latency. `completedAt` is likewise guarded against overwrite.

## Tests

The existing "fails the run when the agent never submits an outcome" case now also asserts that `agent_orchestrator.trace.ingest` was issued, with a numeric `latencyMs` and no `status` of its own. Verified it fails without the production change (`expect(ingest).toBeDefined()`) and passes with it.

`packages/enterprise` — `agent_orchestrator` suite: **121 suites / 918 tests, all green**.

## Scope

OpenCode runner only. The native runner already stamps usage on its failure paths; this brings the OpenCode path in line for spans, tool calls and duration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)