### PR TITLE
fix(search): shared search_tokens lookup + stop silently ILIKE-ing encrypted columns (#2990)

### DIFF
--- a/packages/checkout/src/modules/checkout/api/transactions/__tests__/route.test.ts
+++ b/packages/checkout/src/modules/checkout/api/transactions/__tests__/route.test.ts
@@ -1,0 +1,113 @@
+/** @jest-environment node */
+
+import { GET } from '../route'
+import { CheckoutTransaction } from '../../../data/entities'
+
+const mockFindAndCountWithDecryption = jest.fn()
+const mockFindWithDecryption = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findAndCountWithDecryption: (...args: unknown[]) => mockFindAndCountWithDecryption(...args),
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+}))
+
+const mockFindEntityIdsBySearchTokens = jest.fn(async () => ({ matched: false, reason: 'no-tokens' as const }))
+
+jest.mock('@open-mercato/shared/lib/search/tokenLookup', () => ({
+  findEntityIdsBySearchTokens: (...args: unknown[]) => mockFindEntityIdsBySearchTokens(...(args as [])),
+}))
+
+const mockEm = { getKysely: jest.fn(() => ({})) }
+const auth = { tenantId: 'tenant-1', orgId: 'org-1', sub: 'user-1' }
+
+jest.mock('../../helpers', () => ({
+  requireAdminContext: jest.fn(async () => ({ auth, container: {}, em: mockEm, commandBus: {} })),
+  userHasCheckoutFeature: jest.fn(async () => true),
+  handleCheckoutRouteError: (error: unknown) => {
+    throw error
+  },
+}))
+
+function makeRequest(params?: Record<string, string>) {
+  const url = new URL('http://localhost/api/checkout/transactions')
+  for (const [key, value] of Object.entries(params ?? {})) url.searchParams.set(key, value)
+  return new Request(url.toString(), { method: 'GET' })
+}
+
+function capturedWhere(): Record<string, unknown> {
+  return mockFindAndCountWithDecryption.mock.calls[0][2] as Record<string, unknown>
+}
+
+describe('GET /api/checkout/transactions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockFindAndCountWithDecryption.mockResolvedValue([[], 0])
+    mockFindWithDecryption.mockResolvedValue([])
+    mockFindEntityIdsBySearchTokens.mockResolvedValue({ matched: false, reason: 'no-tokens' } as never)
+  })
+
+  it('applies no search predicate when no term is supplied', async () => {
+    await GET(makeRequest())
+
+    expect(mockFindAndCountWithDecryption).toHaveBeenCalledWith(
+      mockEm,
+      CheckoutTransaction,
+      { organizationId: 'org-1', tenantId: 'tenant-1' },
+      expect.any(Object),
+      expect.any(Object),
+    )
+    expect(mockFindEntityIdsBySearchTokens).not.toHaveBeenCalled()
+  })
+
+  it('keeps the escaped ILIKE predicates for the PII columns', async () => {
+    await GET(makeRequest({ search: '100%_off' }))
+
+    expect(capturedWhere().$or).toEqual([
+      { email: { $ilike: '%100\\%\\_off%' } },
+      { firstName: { $ilike: '%100\\%\\_off%' } },
+      { lastName: { $ilike: '%100\\%\\_off%' } },
+    ])
+  })
+
+  it('unions the encrypted-column token matches into the search predicate', async () => {
+    mockFindEntityIdsBySearchTokens.mockResolvedValueOnce({
+      matched: true,
+      ids: ['tx-1', 'tx-2'],
+    } as never)
+
+    await GET(makeRequest({ search: 'ada@example.com' }))
+
+    expect(mockFindEntityIdsBySearchTokens).toHaveBeenCalledWith(expect.objectContaining({
+      entityType: 'checkout:checkout_transaction',
+      query: 'ada@example.com',
+      fields: ['email', 'first_name', 'last_name'],
+      scope: { tenantId: 'tenant-1', organizationId: 'org-1' },
+    }))
+    expect(capturedWhere().$or).toContainEqual({ id: { $in: ['tx-1', 'tx-2'] } })
+  })
+
+  it('never emits an ILIKE against the uuid id column', async () => {
+    await GET(makeRequest({ search: 'abc' }))
+
+    const or = capturedWhere().$or as Array<Record<string, unknown>>
+    expect(or.some((clause) => 'id' in clause)).toBe(false)
+  })
+
+  it('matches a uuid search term against the id column exactly', async () => {
+    const id = '3f2504e0-4f89-41d3-9a0c-0305e82c3301'
+    await GET(makeRequest({ search: id }))
+
+    expect(capturedWhere().$or).toContainEqual({ id })
+  })
+
+  it('keeps link and status filters alongside the search predicate', async () => {
+    await GET(makeRequest({ search: 'ada', status: 'completed', linkId: 'link-1' }))
+
+    expect(capturedWhere()).toMatchObject({
+      organizationId: 'org-1',
+      tenantId: 'tenant-1',
+      status: 'completed',
+      linkId: 'link-1',
+    })
+  })
+})

--- a/packages/checkout/src/modules/checkout/api/transactions/route.ts
+++ b/packages/checkout/src/modules/checkout/api/transactions/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from 'next/server'
 import { findAndCountWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { findEntityIdsBySearchTokens } from '@open-mercato/shared/lib/search/tokenLookup'
 import { CheckoutLink, CheckoutTransaction } from '../../data/entities'
+import { CHECKOUT_ENTITY_IDS } from '../../lib/constants'
 import { handleCheckoutRouteError, requireAdminContext, userHasCheckoutFeature } from '../helpers'
 import { checkoutTag } from '../openapi'
 import { serializeTransaction } from '../../lib/utils'
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 
 export const metadata = {
   path: '/checkout/transactions',
@@ -27,12 +31,32 @@ export async function GET(req: Request) {
     }
     if (linkId) where.linkId = linkId
     if (status) where.status = status
-    if (search) where.$or = [
-      { email: { $ilike: `%${escapeLikePattern(search)}%` } },
-      { firstName: { $ilike: `%${escapeLikePattern(search)}%` } },
-      { lastName: { $ilike: `%${escapeLikePattern(search)}%` } },
-      { id: { $ilike: `%${escapeLikePattern(search)}%` } },
-    ]
+    if (search) {
+      const pattern = `%${escapeLikePattern(search)}%`
+      // email/first_name/last_name are covered by the checkout encryption map,
+      // so an ILIKE alone compares the pattern against ciphertext and matches
+      // nothing once encryption is on. Union it with the token index, which
+      // stores hashes of the plaintext. Issue #2990.
+      const searchOr: Record<string, unknown>[] = [
+        { email: { $ilike: pattern } },
+        { firstName: { $ilike: pattern } },
+        { lastName: { $ilike: pattern } },
+      ]
+      // `id` is a uuid column: ILIKE against it has no Postgres operator and
+      // raises 42883, so only an exact id lookup is meaningful here.
+      if (UUID_PATTERN.test(search)) searchOr.push({ id: search })
+      const tokenMatch = await findEntityIdsBySearchTokens({
+        db: em.getKysely<any>(),
+        entityType: CHECKOUT_ENTITY_IDS.transaction,
+        query: search,
+        fields: ['email', 'first_name', 'last_name'],
+        scope: { tenantId: auth.tenantId, organizationId: auth.orgId },
+      })
+      if (tokenMatch.matched && tokenMatch.ids.length) {
+        searchOr.push({ id: { $in: tokenMatch.ids } })
+      }
+      where.$or = searchOr
+    }
     const [items, total] = await findAndCountWithDecryption(
       em,
       CheckoutTransaction,

--- a/packages/core/src/modules/auth/api/users/route.ts
+++ b/packages/core/src/modules/auth/api/users/route.ts
@@ -23,9 +23,7 @@ import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/
 import { buildPasswordSchema } from '@open-mercato/shared/lib/auth/passwordPolicy'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
 import { parseBooleanFlag } from '@open-mercato/shared/lib/boolean'
-import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
-import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
-import { sql } from 'kysely'
+import { findEntityIdsBySearchTokensCompat } from '@open-mercato/shared/lib/search/tokenLookup'
 import { normalizeDisplayNameInput } from '@open-mercato/core/modules/auth/lib/displayName'
 import {
   getSelectedTenantFromRequest,
@@ -504,31 +502,13 @@ async function findUserIdsBySearchTokens(
   tenantScope: string | null | undefined,
   field?: string,
 ): Promise<string[] | null> {
-  const trimmed = search.trim()
-  if (!trimmed) return null
-  const searchConfig = resolveSearchConfig()
-  if (!searchConfig.enabled) return []
-  const { hashes } = tokenizeText(trimmed, searchConfig)
-  if (!hashes.length) return []
-
-  const db = (em as any).getKysely() as any
-  let query = db
-    .selectFrom('search_tokens')
-    .select('entity_id')
-    .where('entity_type', '=', entityType)
-    .where('token_hash', 'in', hashes)
-    .groupBy('entity_id')
-    .having(sql<boolean>`count(distinct token_hash) >= ${hashes.length}`)
-  if (field) {
-    query = query.where('field', '=', field)
-  }
-  if (tenantScope !== undefined) {
-    query = query.where(sql<boolean>`tenant_id is not distinct from ${tenantScope}`)
-  }
-  const rows = (await query.execute()) as Array<{ entity_id?: unknown }>
-  return rows
-    .map((row) => (typeof row.entity_id === 'string' ? row.entity_id : null))
-    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+  return findEntityIdsBySearchTokensCompat({
+    db: (em as any).getKysely(),
+    entityType,
+    query: search,
+    fields: field ? [field] : undefined,
+    scope: { tenantId: tenantScope },
+  })
 }
 
 async function assertCanModifySuperAdminTarget(req: Request, targetUserId: string) {

--- a/packages/core/src/modules/customers/api/utils.ts
+++ b/packages/core/src/modules/customers/api/utils.ts
@@ -4,8 +4,7 @@ import { sql } from 'kysely'
 import type { CrudCtx } from '@open-mercato/shared/lib/crud/factory'
 import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { QueryCustomFieldSource, QueryJoinEdge, QueryEngine } from '@open-mercato/shared/lib/query/types'
-import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
-import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
+import { findEntityIdsBySearchTokensCompat } from '@open-mercato/shared/lib/search/tokenLookup'
 import { SortDir } from '@open-mercato/shared/lib/query/types'
 
 const { withScopedPayload, parseScopedCommandInput } = createScopedApiHelpers({
@@ -106,36 +105,18 @@ async function findSearchTokenEntityIds({
   fields,
   query,
 }: SearchTokenMatchInput): Promise<string[] | null> {
-  const trimmed = query.trim()
-  if (!trimmed) return null
-
-  const tokens = tokenizeText(trimmed, resolveSearchConfig())
-  if (!tokens.hashes.length) return []
-
   const em = ctx.container.resolve('em') as EntityManager
-  const db = em.getKysely<any>() as any
-  let searchQuery = db
-    .selectFrom('search_tokens')
-    .select('entity_id')
-    .where('entity_type', '=', entityType)
-    .where('field', 'in', fields)
-    .where('token_hash', 'in', tokens.hashes)
-    .groupBy('entity_id')
-    .having(sql<boolean>`count(distinct token_hash) >= ${tokens.hashes.length}`)
-
-  if (ctx.auth?.tenantId !== undefined) {
-    searchQuery = searchQuery.where(sql<boolean>`tenant_id is not distinct from ${ctx.auth?.tenantId ?? null}`)
-  }
-  if (ctx.selectedOrganizationId) {
-    searchQuery = searchQuery.where('organization_id', '=', ctx.selectedOrganizationId)
-  } else if (Array.isArray(ctx.organizationIds) && ctx.organizationIds.length > 0) {
-    searchQuery = searchQuery.where('organization_id', 'in', ctx.organizationIds)
-  }
-
-  const rows = await searchQuery.execute() as Array<{ entity_id?: unknown }>
-  return rows
-    .map((row) => (typeof row.entity_id === 'string' ? row.entity_id : null))
-    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+  return findEntityIdsBySearchTokensCompat({
+    db: em.getKysely<any>(),
+    entityType,
+    query,
+    fields,
+    scope: {
+      tenantId: ctx.auth?.tenantId !== undefined ? ctx.auth?.tenantId ?? null : undefined,
+      organizationId: ctx.selectedOrganizationId ?? undefined,
+      organizationIds: ctx.organizationIds,
+    },
+  })
 }
 
 async function mapScopedEntityIds({

--- a/packages/core/src/modules/inbox_ops/api/proposals/__tests__/route.test.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/__tests__/route.test.ts
@@ -15,6 +15,12 @@ jest.mock('@open-mercato/shared/lib/db/escapeLikePattern', () => ({
   escapeLikePattern: (value: string) => value.replace(/\\/g, '\\\\').replace(/[%_]/g, '\\$&'),
 }))
 
+const mockFindEntityIdsBySearchTokens = jest.fn(async () => ({ matched: false, reason: 'no-tokens' as const }))
+
+jest.mock('@open-mercato/shared/lib/search/tokenLookup', () => ({
+  findEntityIdsBySearchTokens: (...args: unknown[]) => mockFindEntityIdsBySearchTokens(...(args as [])),
+}))
+
 const authResult = {
   sub: 'user-1',
   tenantId: 'tenant-1',
@@ -25,7 +31,7 @@ jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: jest.fn(async () => authResult),
 }))
 
-const mockEm = { fork: jest.fn() }
+const mockEm = { fork: jest.fn(), getKysely: jest.fn(() => ({})) }
 
 const mockContainer = {
   resolve: jest.fn((token: string) => {
@@ -126,8 +132,52 @@ describe('GET /api/inbox_ops/proposals', () => {
       mockEm,
       InboxProposal,
       expect.objectContaining({
-        summary: { $ilike: '%100\\%\\_off%' },
+        $or: [{ summary: { $ilike: '%100\\%\\_off%' } }],
       }),
+      expect.any(Object),
+      expect.any(Object),
+    )
+  })
+
+  it('unions the encrypted-summary token matches into the search predicate', async () => {
+    mockFindAndCountWithDecryption.mockResolvedValueOnce([[], 0])
+    mockFindEntityIdsBySearchTokens.mockResolvedValueOnce({
+      matched: true,
+      ids: ['proposal-7', 'proposal-9'],
+    } as never)
+
+    await GET(makeRequest({ search: 'widgets' }))
+
+    expect(mockFindEntityIdsBySearchTokens).toHaveBeenCalledWith(expect.objectContaining({
+      entityType: 'inbox_ops:inbox_proposal',
+      query: 'widgets',
+      fields: ['summary'],
+      scope: { tenantId: 'tenant-1', organizationId: 'org-1' },
+    }))
+    expect(mockFindAndCountWithDecryption).toHaveBeenCalledWith(
+      mockEm,
+      InboxProposal,
+      expect.objectContaining({
+        $or: [
+          { summary: { $ilike: '%widgets%' } },
+          { id: { $in: ['proposal-7', 'proposal-9'] } },
+        ],
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    )
+  })
+
+  it('keeps the plain ILIKE predicate when the token index has nothing to say', async () => {
+    mockFindAndCountWithDecryption.mockResolvedValueOnce([[], 0])
+    mockFindEntityIdsBySearchTokens.mockResolvedValueOnce({ matched: true, ids: [] } as never)
+
+    await GET(makeRequest({ search: 'widgets' }))
+
+    expect(mockFindAndCountWithDecryption).toHaveBeenCalledWith(
+      mockEm,
+      InboxProposal,
+      expect.objectContaining({ $or: [{ summary: { $ilike: '%widgets%' } }] }),
       expect.any(Object),
       expect.any(Object),
     )

--- a/packages/core/src/modules/inbox_ops/api/proposals/route.ts
+++ b/packages/core/src/modules/inbox_ops/api/proposals/route.ts
@@ -4,6 +4,8 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { FilterQuery } from '@mikro-orm/postgresql'
 import { findAndCountWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { findEntityIdsBySearchTokens } from '@open-mercato/shared/lib/search/tokenLookup'
+import { E } from '#generated/entities.ids.generated'
 import { InboxProposal, InboxEmail, InboxProposalAction, InboxDiscrepancy, type InboxProposalCategory } from '../../data/entities'
 import { proposalListQuerySchema } from '../../data/validators'
 import { resolveRequestContext, UnauthorizedError } from '../routeHelpers'
@@ -47,7 +49,24 @@ export async function GET(req: Request) {
       }
     }
     if (query.search) {
-      where.summary = { $ilike: `%${escapeLikePattern(query.search)}%` }
+      // `summary` is covered by the inbox_ops encryption map, so an ILIKE alone
+      // compares the pattern against ciphertext and matches nothing once
+      // encryption is on. Union it with the token index, which stores hashes of
+      // the plaintext. Issue #2990.
+      const searchOr: FilterQuery<InboxProposal>[] = [
+        { summary: { $ilike: `%${escapeLikePattern(query.search)}%` } },
+      ]
+      const tokenMatch = await findEntityIdsBySearchTokens({
+        db: ctx.em.getKysely<any>(),
+        entityType: E.inbox_ops.inbox_proposal,
+        query: query.search,
+        fields: ['summary'],
+        scope: { tenantId: ctx.tenantId, organizationId: ctx.organizationId },
+      })
+      if (tokenMatch.matched && tokenMatch.ids.length) {
+        searchOr.push({ id: { $in: tokenMatch.ids } })
+      }
+      where.$or = searchOr
     }
 
     const offset = (query.page - 1) * query.pageSize

--- a/packages/core/src/modules/messages/lib/searchLookup.ts
+++ b/packages/core/src/modules/messages/lib/searchLookup.ts
@@ -1,7 +1,6 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { type Kysely, sql } from 'kysely'
-import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
-import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
+import type { Kysely } from 'kysely'
+import { findEntityIdsBySearchTokensCompat } from '@open-mercato/shared/lib/search/tokenLookup'
 
 function getDb(em: EntityManager): Kysely<any> {
   return em.getKysely<any>()
@@ -20,33 +19,11 @@ export async function findMessageIdsBySearchTokens({
   organizationId: string | null
   fields?: string[]
 }): Promise<string[] | null> {
-  const trimmed = query.trim()
-  if (!trimmed) return null
-
-  const tokens = tokenizeText(trimmed, resolveSearchConfig())
-  if (!tokens.hashes.length) return []
-
-  const db = getDb(em) as any
-  let searchQuery = db
-    .selectFrom('search_tokens')
-    .select('entity_id')
-    .where('entity_type', '=', 'messages:message')
-    .where('field', 'in', fields)
-    .where('token_hash', 'in', tokens.hashes)
-    .where(sql<boolean>`tenant_id is not distinct from ${tenantId}`)
-
-  if (organizationId) {
-    searchQuery = searchQuery.where('organization_id', '=', organizationId)
-  } else {
-    searchQuery = searchQuery.where(sql<boolean>`organization_id is not distinct from ${null}`)
-  }
-
-  const rows = await searchQuery
-    .groupBy('entity_id')
-    .having(sql<boolean>`count(distinct token_hash) >= ${tokens.hashes.length}`)
-    .execute()
-
-  return rows
-    .map((row: { entity_id?: unknown }) => (typeof row.entity_id === 'string' ? row.entity_id : null))
-    .filter((id: string | null): id is string => typeof id === 'string' && id.length > 0)
+  return findEntityIdsBySearchTokensCompat({
+    db: getDb(em),
+    entityType: 'messages:message',
+    query,
+    fields,
+    scope: { tenantId, organizationId },
+  })
 }

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -22,6 +22,7 @@ import {
 import { resolveSearchConfig, type SearchConfig } from '@open-mercato/shared/lib/search/config'
 import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
 import { runBeforeQueryPipeline, runAfterQueryPipeline, type QueryExtensionContext } from '@open-mercato/shared/lib/query/query-extension-runner'
+import { warnOnCiphertextLikeFallback } from '@open-mercato/shared/lib/query/ciphertext-search-warning'
 import { resolveEncryptedSortFields, resolveEncryptedSortMaxRows, sortRowsInMemory } from '@open-mercato/shared/lib/query/encrypted-sort'
 import { mapWithConcurrency } from '@open-mercato/shared/lib/query/bounded-decrypt'
 import { createLogger } from '@open-mercato/shared/lib/logger'
@@ -446,6 +447,17 @@ export class HybridQueryEngine implements QueryEngine {
           organizationScope: orgScope,
           searchSources,
         })
+        if (!searchRuntime.enabled) {
+          await warnOnCiphertextLikeFallback({
+            entity: String(entity),
+            fields: searchFilters.map((filter) => String(filter.field)),
+            tenantId: opts.tenantId ?? null,
+            // `searchEnabled` also folds in the missing-table case, which is
+            // "no usable tokens" rather than "the operator switched search off".
+            reason: searchConfig.enabled ? 'no-search-tokens' : 'search-disabled',
+            service: this.getEncryptionService(),
+          })
+        }
       }
       const hasNonBaseSearchSource = searchSources.some(
         (src) => src.entity !== String(entity) || src.recordIdColumn !== 'b.id'

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -52,6 +52,7 @@ yarn workspace @open-mercato/shared build
 | `number.ts` | When parsing numeric strings from env/query params with a fallback and optional min/integer constraint | `@open-mercato/shared/lib/number` |
 | `openapi/` | When generating CRUD OpenAPI specs | `@open-mercato/shared/lib/openapi/crud` |
 | `profiler/` | When profiling with `OM_PROFILE` env flag | `@open-mercato/shared/lib/profiler` |
+| `search/` | When resolving record ids from the `search_tokens` index — MUST use instead of hand-rolling the Kysely lookup, and MUST be unioned into (or replace) any `$ilike` filter on a column an encryption map covers | `@open-mercato/shared/lib/search/tokenLookup` |
 | `string.ts` | When parsing comma-separated lists from CLI args/query params, or coercing a string to `undefined` when blank | `@open-mercato/shared/lib/string` |
 | `testing/` | When bootstrapping tests — register only what the test needs | `@open-mercato/shared/lib/testing/bootstrap` |
 
@@ -88,6 +89,35 @@ peak connection demand of all processes against one database is additive.
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 const results = await findWithDecryption(em, 'Entity', filter, { tenantId, organizationId })
 ```
+
+### Search Tokens — MUST use instead of `$ilike` on encrypted columns
+
+```typescript
+import { findEntityIdsBySearchTokens } from '@open-mercato/shared/lib/search/tokenLookup'
+
+const match = await findEntityIdsBySearchTokens({
+  db: em.getKysely<any>(),
+  entityType: E.customers.customer_entity,
+  query: term,
+  fields: ['display_name', 'primary_email'],
+  scope: { tenantId, organizationId },
+})
+if (match.matched && match.ids.length) filters.$or.push({ id: { $in: match.ids } })
+```
+
+An `$ilike` predicate runs against the stored column value. For a field covered by a
+module encryption map that value is ciphertext, so the filter matches nothing and the
+endpoint returns an empty page indistinguishable from a genuine no-result. The token
+index stores hashes of the plaintext, so it keeps matching. Issue #2990.
+
+- `matched: false` means the index was **not consulted** (blank query, `OM_SEARCH_ENABLED=off`,
+  or the term produced no tokens) — it is NOT "nothing matched". Keep the caller's own
+  predicate in that case.
+- `matched: true` with `ids: []` is a real empty result.
+- Queries that go through the query engine get this routing automatically; raw
+  `em.find` / Kysely list routes must wire it themselves. When the fallback would run
+  `ILIKE` against an encrypted column, both query engines now log a warning
+  (`lib/query/ciphertext-search-warning`) instead of degrading silently.
 
 ### Boolean Parsing — MUST use instead of ad-hoc parsing
 

--- a/packages/shared/src/lib/query/__tests__/ciphertext-search-warning.test.ts
+++ b/packages/shared/src/lib/query/__tests__/ciphertext-search-warning.test.ts
@@ -1,0 +1,160 @@
+import {
+  normalizeColumnName,
+  resetCiphertextLikeWarnCache,
+  warnOnCiphertextLikeFallback,
+} from '../ciphertext-search-warning'
+import { createLogger } from '../../logger'
+
+jest.mock('../../logger', () => {
+  const warn = jest.fn()
+  const debug = jest.fn()
+  const child = jest.fn(() => ({ warn, debug }))
+  return { createLogger: jest.fn(() => ({ child })), __warn: warn, __debug: debug }
+})
+
+const loggerModule = jest.requireMock('../../logger') as { __warn: jest.Mock; __debug: jest.Mock }
+
+function createService(encryptedFields: string[], overrides: Record<string, unknown> = {}) {
+  return {
+    isEnabled: () => true,
+    getEncryptedFieldNames: jest.fn(async () => encryptedFields),
+    ...overrides,
+  }
+}
+
+describe('warnOnCiphertextLikeFallback', () => {
+  beforeEach(() => {
+    resetCiphertextLikeWarnCache()
+    loggerModule.__warn.mockClear()
+    loggerModule.__debug.mockClear()
+  })
+
+  it('warns when the filtered column is covered by an encryption map', async () => {
+    const service = createService(['email', 'display_name'])
+    await warnOnCiphertextLikeFallback({
+      entity: 'customers:customer_entity',
+      fields: ['display_name'],
+      tenantId: 'tenant-1',
+      reason: 'no-search-tokens',
+      service,
+    })
+
+    expect(loggerModule.__warn).toHaveBeenCalledTimes(1)
+    const [message, payload] = loggerModule.__warn.mock.calls[0]
+    expect(message).toBe('Text search filter cannot match an encrypted column')
+    expect(payload).toMatchObject({
+      entity: 'customers:customer_entity',
+      field: 'display_name',
+      reason: 'no-search-tokens',
+    })
+  })
+
+  it('stays quiet for columns outside the encryption map', async () => {
+    await warnOnCiphertextLikeFallback({
+      entity: 'currencies:currency',
+      fields: ['code', 'symbol'],
+      tenantId: 'tenant-1',
+      reason: 'no-search-tokens',
+      service: createService(['unrelated']),
+    })
+    expect(loggerModule.__warn).not.toHaveBeenCalled()
+  })
+
+  it('matches camelCase filter fields against snake_case map entries', async () => {
+    await warnOnCiphertextLikeFallback({
+      entity: 'checkout:checkout_transaction',
+      fields: ['firstName'],
+      tenantId: null,
+      reason: 'no-search-tokens',
+      service: createService(['first_name']),
+    })
+    expect(loggerModule.__warn).toHaveBeenCalledTimes(1)
+    expect(loggerModule.__warn.mock.calls[0][1]).toMatchObject({ field: 'first_name' })
+  })
+
+  it('warns once per entity, tenant and field', async () => {
+    const service = createService(['email'])
+    const params = {
+      entity: 'auth:user',
+      fields: ['email'],
+      tenantId: 'tenant-1',
+      reason: 'no-search-tokens' as const,
+      service,
+    }
+    await warnOnCiphertextLikeFallback(params)
+    await warnOnCiphertextLikeFallback(params)
+    await warnOnCiphertextLikeFallback(params)
+
+    expect(loggerModule.__warn).toHaveBeenCalledTimes(1)
+    expect(service.getEncryptedFieldNames).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns separately for a different tenant', async () => {
+    const service = createService(['email'])
+    await warnOnCiphertextLikeFallback({
+      entity: 'auth:user', fields: ['email'], tenantId: 'tenant-1', reason: 'no-search-tokens', service,
+    })
+    await warnOnCiphertextLikeFallback({
+      entity: 'auth:user', fields: ['email'], tenantId: 'tenant-2', reason: 'no-search-tokens', service,
+    })
+    expect(loggerModule.__warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing when encryption is unavailable or disabled', async () => {
+    await warnOnCiphertextLikeFallback({
+      entity: 'auth:user', fields: ['email'], tenantId: null, reason: 'no-search-tokens', service: null,
+    })
+    await warnOnCiphertextLikeFallback({
+      entity: 'auth:user',
+      fields: ['email'],
+      tenantId: null,
+      reason: 'no-search-tokens',
+      service: createService(['email'], { isEnabled: () => false }),
+    })
+    expect(loggerModule.__warn).not.toHaveBeenCalled()
+  })
+
+  it('ignores custom-field filters', async () => {
+    const service = createService(['cf:secret_note'])
+    await warnOnCiphertextLikeFallback({
+      entity: 'example:todo', fields: ['cf:secret_note'], tenantId: null, reason: 'no-search-tokens', service,
+    })
+    expect(service.getEncryptedFieldNames).not.toHaveBeenCalled()
+    expect(loggerModule.__warn).not.toHaveBeenCalled()
+  })
+
+  it('reports the disabled-search reason with its own hint', async () => {
+    await warnOnCiphertextLikeFallback({
+      entity: 'auth:user', fields: ['email'], tenantId: null, reason: 'search-disabled', service: createService(['email']),
+    })
+    expect(loggerModule.__warn.mock.calls[0][1]).toMatchObject({ reason: 'search-disabled' })
+    expect(loggerModule.__warn.mock.calls[0][1].hint).toContain('OM_SEARCH_ENABLED')
+  })
+
+  it('never rethrows when the encryption lookup fails', async () => {
+    const service = {
+      isEnabled: () => true,
+      getEncryptedFieldNames: jest.fn(async () => { throw new Error('kms down') }),
+    }
+    await expect(warnOnCiphertextLikeFallback({
+      entity: 'auth:user', fields: ['email'], tenantId: null, reason: 'no-search-tokens', service,
+    })).resolves.toBeUndefined()
+    expect(loggerModule.__warn).not.toHaveBeenCalled()
+    expect(loggerModule.__debug).toHaveBeenCalled()
+  })
+})
+
+describe('normalizeColumnName', () => {
+  it('converts camelCase to snake_case and lowercases', () => {
+    expect(normalizeColumnName('firstName')).toBe('first_name')
+    expect(normalizeColumnName('primaryEmail')).toBe('primary_email')
+    expect(normalizeColumnName('display_name')).toBe('display_name')
+    expect(normalizeColumnName('Email')).toBe('email')
+  })
+})
+
+describe('logger wiring', () => {
+  it('uses the shared query logger namespace', () => {
+    expect(createLogger).toHaveBeenCalledWith('shared')
+  })
+})

--- a/packages/shared/src/lib/query/ciphertext-search-warning.ts
+++ b/packages/shared/src/lib/query/ciphertext-search-warning.ts
@@ -1,0 +1,92 @@
+import { createLogger } from '../logger'
+
+const logger = createLogger('shared').child({ component: 'query' })
+
+/**
+ * Minimal slice of `TenantDataEncryptionService` needed to decide whether a
+ * text filter targets an encrypted column.
+ */
+export type CiphertextWarningEncryptionService = {
+  getEncryptedFieldNames?: (
+    entityId: any,
+    tenantId?: string | null,
+    organizationId?: string | null,
+  ) => Promise<readonly string[]>
+  isEnabled?: () => boolean
+} | null | undefined
+
+export type CiphertextLikeFallbackReason = 'no-search-tokens' | 'search-disabled'
+
+// One warning per entity/tenant/field per process — the fallback repeats on
+// every request, and an operator only needs to learn about it once.
+const WARN_CACHE_CAP = 5000
+const warned = new Set<string>()
+
+const warnKey = (entity: string, tenantId: string | null, field: string): string =>
+  `${entity}|${tenantId ?? 'null'}|${field}`
+
+export const normalizeColumnName = (value: string): string =>
+  value.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+
+/** Test seam: the warn-once cache is process-global by design. */
+export function resetCiphertextLikeWarnCache(): void {
+  warned.clear()
+}
+
+/**
+ * Warn when a `like`/`ilike` filter is about to run against a column that an
+ * encryption map covers while the token index is unavailable.
+ *
+ * Without this the query degrades silently: the predicate compares a plaintext
+ * pattern against ciphertext, matches nothing, and the endpoint returns an
+ * empty page that is indistinguishable from a genuine no-result. Issue #2990.
+ *
+ * Never throws and never blocks the query — a failure here is logged at debug
+ * level and the caller proceeds unchanged.
+ */
+export async function warnOnCiphertextLikeFallback(params: {
+  entity: string
+  fields: readonly string[]
+  tenantId: string | null
+  reason: CiphertextLikeFallbackReason
+  service: CiphertextWarningEncryptionService
+}): Promise<void> {
+  const { entity, tenantId, reason, service } = params
+  if (!service || service.isEnabled?.() === false) return
+  if (typeof service.getEncryptedFieldNames !== 'function') return
+
+  const candidates = params.fields
+    .filter((field) => typeof field === 'string' && !field.startsWith('cf:'))
+    .map((field) => normalizeColumnName(field))
+    .filter((field, index, all) => field.length > 0 && all.indexOf(field) === index)
+    .filter((field) => !warned.has(warnKey(entity, tenantId, field)))
+  if (!candidates.length) return
+
+  try {
+    // `organizationId: null` resolves the global map plus every per-organization
+    // override, so a field encrypted for any organization is reported.
+    const encrypted = new Set(
+      (await service.getEncryptedFieldNames(entity, tenantId, null)).map((field) =>
+        normalizeColumnName(String(field)),
+      ),
+    )
+    for (const field of candidates) {
+      if (warned.size >= WARN_CACHE_CAP) warned.clear()
+      warned.add(warnKey(entity, tenantId, field))
+      if (!encrypted.has(field)) continue
+      logger.warn('Text search filter cannot match an encrypted column', {
+        entity,
+        field,
+        reason,
+        hint: reason === 'search-disabled'
+          ? 'OM_SEARCH_ENABLED is off, so the filter runs as ILIKE against ciphertext and matches nothing.'
+          : 'No search_tokens exist for this entity and scope, so the filter runs as ILIKE against ciphertext and matches nothing. Index the entity through query_index and reindex, or filter on the deterministic hash column.',
+      })
+    }
+  } catch (err) {
+    logger.debug('Ciphertext search warning check failed', {
+      entity,
+      err: err instanceof Error ? err.message : String(err),
+    })
+  }
+}

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -20,6 +20,7 @@ import {
   type CustomFieldDefinitionRow,
   type ResolvedCustomFieldDefinitions,
 } from '../crud/custom-field-definition-index'
+import { warnOnCiphertextLikeFallback } from './ciphertext-search-warning'
 import { resolveEncryptedSortFields, resolveEncryptedSortMaxRows, sortRowsInMemory } from './encrypted-sort'
 import { mapWithConcurrency } from './bounded-decrypt'
 import { createLogger } from '../logger'
@@ -331,6 +332,18 @@ export class BasicQueryEngine implements QueryEngine {
           table,
           tenantId: opts.tenantId ?? null,
           organizationScope: orgScope,
+        })
+      }
+      if (!searchActive) {
+        await warnOnCiphertextLikeFallback({
+          entity: String(entity),
+          fields,
+          tenantId: opts.tenantId ?? null,
+          // `searchEnabled` also folds in the missing-table and
+          // omitAutomaticTenantOrgScope cases, which are "no usable tokens"
+          // rather than "the operator switched search off".
+          reason: searchConfig.enabled ? 'no-search-tokens' : 'search-disabled',
+          service: this.getEncryptionService(),
         })
       }
     }

--- a/packages/shared/src/lib/search/__tests__/tokenLookup.test.ts
+++ b/packages/shared/src/lib/search/__tests__/tokenLookup.test.ts
@@ -1,0 +1,205 @@
+import {
+  findEntityIdsBySearchTokens,
+  findEntityIdsBySearchTokensCompat,
+} from '../tokenLookup'
+import { resolveSearchConfig } from '../config'
+import { tokenizeText } from '../tokenize'
+
+type KyselyCall = {
+  method: string
+  args: unknown[]
+}
+
+function createKyselyMock(rows: Array<{ entity_id: unknown }>) {
+  const calls: KyselyCall[] = []
+  const tableNameRef: { value: string | null } = { value: null }
+  const builder: Record<string, unknown> = {}
+  const passthrough = (method: string) =>
+    (...args: unknown[]) => {
+      calls.push({ method, args })
+      return builder
+    }
+  builder.select = passthrough('select')
+  builder.where = passthrough('where')
+  builder.groupBy = passthrough('groupBy')
+  builder.having = passthrough('having')
+  builder.execute = jest.fn(async () => rows)
+
+  const db = {
+    selectFrom: (table: string) => {
+      tableNameRef.value = table
+      return builder
+    },
+  }
+  return { db: db as never, calls, tableNameRef, builder }
+}
+
+function compileSql(raw: any): string {
+  if (typeof raw?.toOperationNode === 'function') {
+    const node = raw.toOperationNode()
+    return Array.isArray(node?.sqlFragments) ? node.sqlFragments.join(' ? ') : ''
+  }
+  return String(raw?.sql ?? raw)
+}
+
+function rawWhereFragments(calls: KyselyCall[]): string[] {
+  return calls
+    .filter((call) => call.method === 'where' && call.args.length === 1)
+    .map((call) => compileSql(call.args[0]))
+}
+
+describe('findEntityIdsBySearchTokens', () => {
+  const baseInput = {
+    entityType: 'customers:customer_entity',
+    query: 'Hello',
+  }
+
+  it('skips the lookup for a blank query', async () => {
+    const { db, builder } = createKyselyMock([])
+    const result = await findEntityIdsBySearchTokens({ ...baseInput, db, query: '   ' })
+    expect(result).toEqual({ matched: false, reason: 'empty-query' })
+    expect(builder.execute).not.toHaveBeenCalled()
+  })
+
+  it('skips the lookup when token search is disabled', async () => {
+    const { db, builder } = createKyselyMock([])
+    const result = await findEntityIdsBySearchTokens({
+      ...baseInput,
+      db,
+      config: { ...resolveSearchConfig(), enabled: false },
+    })
+    expect(result).toEqual({ matched: false, reason: 'search-disabled' })
+    expect(builder.execute).not.toHaveBeenCalled()
+  })
+
+  it('skips the lookup when the query yields no indexable tokens', async () => {
+    const { db, builder } = createKyselyMock([])
+    const result = await findEntityIdsBySearchTokens({ ...baseInput, db, query: '!' })
+    expect(result).toEqual({ matched: false, reason: 'no-tokens' })
+    expect(builder.execute).not.toHaveBeenCalled()
+  })
+
+  it('requires every query token to be present on the record', async () => {
+    const { db, calls } = createKyselyMock([{ entity_id: 'a' }])
+    await findEntityIdsBySearchTokens({ ...baseInput, db, query: 'ada lovelace' })
+
+    const expectedHashes = tokenizeText('ada lovelace', resolveSearchConfig()).hashes
+    const hashFilter = calls.find((call) => call.args[0] === 'token_hash' && call.args[1] === 'in')
+    expect(hashFilter?.args[2]).toEqual(expectedHashes)
+
+    const having = calls.find((call) => call.method === 'having')
+    expect(compileSql(having?.args[0])).toContain('count(distinct token_hash) >=')
+  })
+
+  it('returns the matched ids and drops non-string rows', async () => {
+    const { db, tableNameRef } = createKyselyMock([
+      { entity_id: 'id-1' },
+      { entity_id: null },
+      { entity_id: 42 },
+      { entity_id: '' },
+      { entity_id: 'id-2' },
+    ])
+    const result = await findEntityIdsBySearchTokens({ ...baseInput, db })
+    expect(result).toEqual({ matched: true, ids: ['id-1', 'id-2'] })
+    expect(tableNameRef.value).toBe('search_tokens')
+  })
+
+  it('reports an empty match instead of a skip when nothing matched', async () => {
+    const { db } = createKyselyMock([])
+    const result = await findEntityIdsBySearchTokens({ ...baseInput, db })
+    expect(result).toEqual({ matched: true, ids: [] })
+  })
+
+  it('narrows a single field with equality and multiple fields with IN', async () => {
+    const single = createKyselyMock([])
+    await findEntityIdsBySearchTokens({ ...baseInput, db: single.db, fields: ['name'] })
+    expect(single.calls).toContainEqual({ method: 'where', args: ['field', '=', 'name'] })
+
+    const multi = createKyselyMock([])
+    await findEntityIdsBySearchTokens({ ...baseInput, db: multi.db, fields: ['name', 'email'] })
+    expect(multi.calls).toContainEqual({ method: 'where', args: ['field', 'in', ['name', 'email']] })
+  })
+
+  it('omits the field predicate when no fields are supplied', async () => {
+    const { db, calls } = createKyselyMock([])
+    await findEntityIdsBySearchTokens({ ...baseInput, db, fields: [] })
+    expect(calls.some((call) => call.args[0] === 'field')).toBe(false)
+  })
+
+  it('omits tenant and organization predicates when the scope is absent', async () => {
+    const { db, calls } = createKyselyMock([])
+    await findEntityIdsBySearchTokens({ ...baseInput, db })
+    expect(rawWhereFragments(calls)).toEqual([])
+    expect(calls.some((call) => call.args[0] === 'organization_id')).toBe(false)
+  })
+
+  it('emits a null-safe tenant predicate for an explicit null tenant', async () => {
+    const { db, calls } = createKyselyMock([])
+    await findEntityIdsBySearchTokens({ ...baseInput, db, scope: { tenantId: null } })
+    expect(rawWhereFragments(calls).some((s) => s.includes('tenant_id is not distinct from'))).toBe(true)
+  })
+
+  it('emits a null-safe organization predicate for an explicit null organization', async () => {
+    const { db, calls } = createKyselyMock([])
+    await findEntityIdsBySearchTokens({ ...baseInput, db, scope: { organizationId: null } })
+    expect(rawWhereFragments(calls).some((s) => s.includes('organization_id is not distinct from'))).toBe(true)
+  })
+
+  it('prefers a concrete organization over the visible-organization list', async () => {
+    const { db, calls } = createKyselyMock([])
+    await findEntityIdsBySearchTokens({
+      ...baseInput,
+      db,
+      scope: { organizationId: 'org-1', organizationIds: ['org-1', 'org-2'] },
+    })
+    expect(calls).toContainEqual({ method: 'where', args: ['organization_id', '=', 'org-1'] })
+    expect(calls.some((call) => call.args[1] === 'in' && call.args[0] === 'organization_id')).toBe(false)
+  })
+
+  it('falls back to the visible-organization list when no organization is selected', async () => {
+    const { db, calls } = createKyselyMock([])
+    await findEntityIdsBySearchTokens({
+      ...baseInput,
+      db,
+      scope: { organizationIds: ['org-1', 'org-2'] },
+    })
+    expect(calls).toContainEqual({ method: 'where', args: ['organization_id', 'in', ['org-1', 'org-2']] })
+  })
+})
+
+describe('findEntityIdsBySearchTokensCompat', () => {
+  it('returns null only for a blank query', async () => {
+    const { db } = createKyselyMock([])
+    await expect(findEntityIdsBySearchTokensCompat({
+      db,
+      entityType: 'customers:customer_entity',
+      query: ' ',
+    })).resolves.toBeNull()
+  })
+
+  it('returns an empty array for the remaining skip reasons', async () => {
+    const noTokens = createKyselyMock([])
+    await expect(findEntityIdsBySearchTokensCompat({
+      db: noTokens.db,
+      entityType: 'customers:customer_entity',
+      query: '!',
+    })).resolves.toEqual([])
+
+    const disabled = createKyselyMock([])
+    await expect(findEntityIdsBySearchTokensCompat({
+      db: disabled.db,
+      entityType: 'customers:customer_entity',
+      query: 'Hello',
+      config: { ...resolveSearchConfig(), enabled: false },
+    })).resolves.toEqual([])
+  })
+
+  it('returns the matched ids', async () => {
+    const { db } = createKyselyMock([{ entity_id: 'id-1' }])
+    await expect(findEntityIdsBySearchTokensCompat({
+      db,
+      entityType: 'customers:customer_entity',
+      query: 'Hello',
+    })).resolves.toEqual(['id-1'])
+  })
+})

--- a/packages/shared/src/lib/search/tokenLookup.ts
+++ b/packages/shared/src/lib/search/tokenLookup.ts
@@ -1,0 +1,125 @@
+import { type Kysely, sql } from 'kysely'
+import { resolveSearchConfig, type SearchConfig } from './config'
+import { tokenizeText } from './tokenize'
+
+type AnyDb = Kysely<any>
+type AnyBuilder = any
+
+/**
+ * Tenant/organization scoping for a `search_tokens` lookup.
+ *
+ * `undefined` and `null` are NOT interchangeable:
+ * - `undefined` omits the predicate entirely (the caller owns visibility).
+ * - `null` emits a null-safe predicate that matches only globally scoped rows.
+ */
+export type SearchTokenScope = {
+  tenantId?: string | null
+  organizationId?: string | null
+  organizationIds?: readonly string[] | null
+}
+
+/**
+ * Why a lookup could not produce an id set. Callers MUST NOT read these as
+ * "nothing matched" — the token index was never consulted, so the caller's own
+ * predicate (usually an `ilike`) is still the authoritative one.
+ */
+export type SearchTokenLookupSkipReason = 'empty-query' | 'search-disabled' | 'no-tokens'
+
+export type SearchTokenLookupResult =
+  | { matched: true; ids: string[] }
+  | { matched: false; reason: SearchTokenLookupSkipReason }
+
+export type FindEntityIdsBySearchTokensInput = {
+  db: AnyDb
+  entityType: string
+  query: string
+  fields?: readonly string[] | null
+  scope?: SearchTokenScope
+  config?: SearchConfig
+}
+
+/**
+ * Resolve the record ids whose indexed `search_tokens` cover every token in
+ * `query`.
+ *
+ * This is the encryption-safe replacement for `ilike` filtering on columns an
+ * encryption map covers: the stored column holds ciphertext, so
+ * `ilike '%term%'` silently matches nothing, while the token index stores
+ * hashes of the plaintext and keeps matching. See issue #2990.
+ *
+ * Matching requires ALL query tokens to be present on the record. The token
+ * search strategy in `@open-mercato/search` uses a looser match ratio; list
+ * endpoints want the stricter behavior so a two-word query narrows rather than
+ * widens the result set.
+ */
+export async function findEntityIdsBySearchTokens({
+  db,
+  entityType,
+  query,
+  fields,
+  scope,
+  config,
+}: FindEntityIdsBySearchTokensInput): Promise<SearchTokenLookupResult> {
+  const trimmed = query.trim()
+  if (!trimmed) return { matched: false, reason: 'empty-query' }
+
+  const searchConfig = config ?? resolveSearchConfig()
+  if (!searchConfig.enabled) return { matched: false, reason: 'search-disabled' }
+
+  const { hashes } = tokenizeText(trimmed, searchConfig)
+  if (!hashes.length) return { matched: false, reason: 'no-tokens' }
+
+  let builder: AnyBuilder = (db as AnyBuilder)
+    .selectFrom('search_tokens')
+    .select('entity_id')
+    .where('entity_type', '=', entityType)
+    .where('token_hash', 'in', hashes)
+
+  const scopedFields = (fields ?? []).filter((field) => typeof field === 'string' && field.length > 0)
+  if (scopedFields.length === 1) {
+    builder = builder.where('field', '=', scopedFields[0])
+  } else if (scopedFields.length > 1) {
+    builder = builder.where('field', 'in', Array.from(scopedFields))
+  }
+
+  if (scope?.tenantId !== undefined) {
+    builder = builder.where(sql<boolean>`tenant_id is not distinct from ${scope.tenantId}`)
+  }
+
+  if (scope?.organizationId !== undefined) {
+    builder = scope.organizationId === null
+      ? builder.where(sql<boolean>`organization_id is not distinct from ${null}`)
+      : builder.where('organization_id', '=', scope.organizationId)
+  } else if (scope?.organizationIds?.length) {
+    builder = builder.where('organization_id', 'in', Array.from(scope.organizationIds))
+  }
+
+  const rows = (await builder
+    .groupBy('entity_id')
+    .having(sql<boolean>`count(distinct token_hash) >= ${hashes.length}`)
+    .execute()) as Array<{ entity_id?: unknown }>
+
+  const ids = rows
+    .map((row) => (typeof row.entity_id === 'string' ? row.entity_id : null))
+    .filter((id): id is string => typeof id === 'string' && id.length > 0)
+
+  return { matched: true, ids }
+}
+
+/**
+ * Legacy-shaped adapter for call sites that predate
+ * {@link SearchTokenLookupResult}: `null` for a blank query, `[]` for every
+ * other non-answer, otherwise the matched ids.
+ *
+ * Prefer {@link findEntityIdsBySearchTokens} in new code — the discriminated
+ * result distinguishes "the index says nothing matched" from "the index was
+ * never consulted", and that distinction is exactly what a `null`/`[]` pair
+ * loses.
+ */
+export async function findEntityIdsBySearchTokensCompat(
+  input: FindEntityIdsBySearchTokensInput,
+): Promise<string[] | null> {
+  const result = await findEntityIdsBySearchTokens(input)
+  if (result.matched) return result.ids
+  return result.reason === 'empty-query' ? null : []
+}


### PR DESCRIPTION
## Summary

First slice of #2990 (the `$ilike` → `query-engine`/`search_tokens` migration). It does **not** attempt the ~62-file sweep — it lands the missing prerequisite, closes the silent-failure mode that makes this class of bug invisible, and fixes the two routes where the defect is already provable today.

Scope was agreed as "PR A" of three:

- **PR A (this one)** — shared helper, loud fallback, the two confirmed-broken routes.
- **PR B** — the `AGENTS.md` avoid-clause (AC 3) and the extended `$ilike` regression guard (AC 4).
- **PR C+** — the long tail, per module, behind a spec (see *Why not the full sweep* below).

## What changed

**1. One shared `search_tokens` lookup** (`@open-mercato/shared/lib/search/tokenLookup`)

`customers`, `auth` and `messages` each carried a hand-rolled Kysely lookup against `search_tokens` with subtly different tenant/organization scoping. Migrating 25 more call sites on top of that would have produced 28 copies. All three now delegate to one helper.

The helper returns a discriminated result:

```ts
{ matched: true, ids: string[] }                                   // the index answered
{ matched: false, reason: 'empty-query'|'search-disabled'|'no-tokens' }  // never consulted
```

That distinction is exactly what the previous `string[] | null` shape lost, and it is what every future migration needs to decide whether it may drop the caller's own predicate. The three existing call sites keep their old shape via `findEntityIdsBySearchTokensCompat`, so this part is behavior-preserving.

**2. The silent fallback is now loud** (`lib/query/ciphertext-search-warning`)

Both query engines already route `like`/`ilike` through `search_tokens` when tokens exist — and fall back to a raw column predicate when they do not. On an encrypted column that fallback compares a plaintext pattern against ciphertext: it matches nothing, and the endpoint returns an empty page indistinguishable from a genuine no-result. The only trace was a debug line behind `OM_SEARCH_DEBUG`.

This is arguably worse than the bug in the issue, because it hides it. The engines now `logger.warn` with the entity, the field and why tokens were unavailable. Cost control: the check runs **only** on the fallback path, **only** when encryption is enabled, and warns **once per entity/tenant/field per process**.

**3. The two provably broken routes**

Both read through `findAndCountWithDecryption` — so the author knew the columns are encrypted — yet filtered them with `$ilike`:

| Route | Encrypted columns filtered with `$ilike` |
|---|---|
| `checkout/api/transactions` | `email`, `first_name`, `last_name` |
| `inbox_ops/api/proposals` | `summary` |

The token match is **unioned into** the existing predicate rather than replacing it: where tokens exist the encrypted columns become searchable again; where they do not, the request behaves exactly as before. **No entity needs reindexing for this to be safe to ship.**

**4. Drive-by, same lines:** checkout also filtered `{ id: { $ilike } }` against a `uuid` column. Postgres has no `uuid ~~* text` operator, so *any* search term on that endpoint raised 42883 and 500'd. A term that parses as a UUID now matches the id exactly; otherwise the clause is omitted.

## Why not the full sweep

Two things AC 2 does not resolve, which is why the remaining ~25 raw-ORM sites need a spec first:

- **Token search is not substring search.** `OM_SEARCH_MIN_LEN=3`, expansion is prefix-only. `ilike '%ohn%'` finds "John" today; tokens will not. `currencies` searches `symbol` (`$`, `zł`) and 2-letter codes — below the tokenizer floor. A blanket migration is a regression on non-encrypted, short-token fields, so it needs a per-field decision (encrypted → tokens; codes/symbols → keep `ilike` or add a deterministic hash column).
- **Several affected entities are not in `query_index` at all.** The generic indexer only picks up entities that have custom-field definitions (`query_index/di.ts`), so for those, "migrate the filter" is really "index the entity + backfill + reindex" — a different order of magnitude.

## Verification

Full CI-mirroring gate from `.ai/agentic.config.json`, run locally:

| Command | Result |
|---|---|
| `yarn build:packages` | pass |
| `yarn generate` | pass |
| `yarn i18n:check-sync` | pass — all locales in sync |
| `yarn i18n:check-usage` | pass (advisory) |
| `yarn typecheck` | pass — 21/21 |
| `yarn test` | pass — 22/22 packages¹ |
| `yarn build:app` | pass |

¹ `create-mercato-app` has 4 failing suites (`agent-harness-evaluator`, `*-oracles`). Verified pre-existing: they fail identically on a clean `origin/develop` with this branch stashed.

New coverage: 16 cases for the lookup helper (scope shapes, skip reasons, all-tokens matching), 11 for the warning (encrypted vs not, camelCase↔snake_case, warn-once, never-throws), 6 for the checkout route, 2 added to inbox_ops.

## Reviewer notes

- The `search-disabled` reason is derived from `searchConfig.enabled` rather than the engines' `searchEnabled`, because the latter also folds in the missing-table and `omitAutomaticTenantOrgScope` cases — those are "no usable tokens", not "the operator switched search off".
- The warn cache is process-global and capped at 5000 entries (cleared wholesale on overflow); `resetCiphertextLikeWarnCache()` is exported as a test seam.
- `findEntityIdsBySearchTokens` uses `field = x` for a single field and `field IN (…)` for several — equivalent SQL, kept so the existing auth-route assertions stay untouched.

Refs #2990. Related: #2946, #2932.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
