### PR TITLE
docs(changelog): complete the 0.6.7 entry with PRs merged through 2026-08-01

### DIFF
--- a/.ai/runs/2026-08-01-changelog-0.6.7-tail.md
+++ b/.ai/runs/2026-08-01-changelog-0.6.7-tail.md
@@ -1,0 +1,86 @@
+# Execution plan — changelog-0.6.7-tail
+
+Engine: om-auto-create-pr (steps: 5, --loop: no)
+Base branch: develop
+Branch: feat/changelog-0.6.7-tail
+
+## Goal
+
+Complete the unreleased `# 0.6.7` block in `CHANGELOG.md` so it covers every pull request merged into
+`develop` up to 2026-08-01, not only the window the previous changelog run (#4674) captured.
+
+## Context
+
+The `0.6.7` block landed on `develop` via #4674 on 2026-07-30 and covers 134 pull requests merged
+between 2026-07-17 and the moment that run took its snapshot. `0.6.7` has **not** been released — the
+newest tag is `v0.6.6` and `package.json` still reads `0.6.6` — so the block is still the open,
+in-progress release section. Eighteen further pull requests have merged into `develop` since that
+snapshot, including eight that merged on 2026-07-30 after the run had already enumerated its window.
+
+Because the release is unreleased, the correct product decision is to **extend the existing `0.6.7`
+block** rather than open a `0.6.8` heading: cutting a new heading for two days of work would split one
+release across two sections and misrepresent what `v0.6.7` will contain when it is tagged.
+
+## Scope
+
+- `CHANGELOG.md` only — the `# 0.6.7` block: its heading date, five existing sections, and the
+  Contributors list.
+
+## Non-goals
+
+- No `package.json` version bump, no tagging, no release automation.
+- No edits to the `0.6.6` block or any earlier release.
+- No Highlights paragraph — the `<!-- TODO: Highlights -->` marker stays for the human release author.
+- No entry for #4725, which supersedes @wojciechszyjka's #4507: it is still **open**, so it belongs in
+  a later changelog run, not this one.
+- No changes to any other file in the repository.
+
+## Implementation plan
+
+### Phase 1: Draft and apply the changelog delta
+
+- **Step 1.1** — Enumerate merged PRs. List every PR merged into `develop` between 2026-07-17 and
+  2026-08-01, subtract the 134 PR numbers already credited in the `0.6.7` block, and drop #4674 itself
+  (a prior run of `om-auto-update-changelog`, excluded by the skill's own rule). Result: 18 entries.
+- **Step 1.2** — Resolve credited authors with the Supersede Credit Rule. Scan each PR body for
+  `Supersedes #N` (Path A) and `Credit: original implementation by @user` (Path B), then resolve the
+  superseded PR's author through the tracker. Two carry-forward PRs are expected to match.
+- **Step 1.3** — Categorize and write the bullets. Derive the section from labels first, then the
+  conventional-commit prefix, and match the emoji vocabulary the file already uses
+  (🔐 auth/encryption, 🌍 i18n, 🔧 core/infrastructure, 📦 packaging, 💰 money, 🔄 sync, 🖼️ media,
+  🐳 containers). Insert each bullet in descending PR-number order inside its section, extend the
+  Contributors list with newly-appearing handles, and move the heading date to 2026-08-01.
+
+### Phase 2: Verify and ship
+
+- **Step 2.1** — Verify the diff mechanically: confirm the change is additive apart from the heading
+  date, that every one of the 18 PR numbers now appears exactly once, that no previously-credited
+  number was disturbed, and that no file other than `CHANGELOG.md` changed.
+- **Step 2.2** — Run the docs-only validation gate, open the PR, run the review pass, and label it.
+
+## Risks
+
+- **Miscredited carry-forward work.** A PR carried forward by a reviewer credits the reviewer unless
+  the Supersede Credit Rule fires. Mitigated by scanning Paths A and B on every one of the 18 PRs and
+  resolving the original author through the tracker rather than inferring it.
+- **Duplicate entries.** Overlapping windows could re-list a PR the previous run already credited.
+  Mitigated by subtracting the 134 already-credited numbers parsed straight out of the existing block,
+  and by re-verifying uniqueness in Step 2.1.
+- **Section drift.** Label-derived categories can put a CI change under Features. Accepted: the skill's
+  documented derivation order (labels before title prefix) is followed so the result is reproducible,
+  and the choice is called out in the PR summary for the release author.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Draft and apply the changelog delta
+
+- [ ] 1.1 Enumerate merged PRs not yet credited in the 0.6.7 block
+- [ ] 1.2 Resolve credited authors with the Supersede Credit Rule
+- [ ] 1.3 Categorize and write the bullets into the existing sections
+
+### Phase 2: Verify and ship
+
+- [ ] 2.1 Verify the diff is additive and complete
+- [ ] 2.2 Run the docs-only gate, open the PR, review and label

--- a/.ai/runs/2026-08-01-changelog-0.6.7-tail.md
+++ b/.ai/runs/2026-08-01-changelog-0.6.7-tail.md
@@ -76,11 +76,11 @@ release across two sections and misrepresent what `v0.6.7` will contain when it 
 
 ### Phase 1: Draft and apply the changelog delta
 
-- [ ] 1.1 Enumerate merged PRs not yet credited in the 0.6.7 block
-- [ ] 1.2 Resolve credited authors with the Supersede Credit Rule
-- [ ] 1.3 Categorize and write the bullets into the existing sections
+- [x] 1.1 Enumerate merged PRs not yet credited in the 0.6.7 block — ea4f9413e
+- [x] 1.2 Resolve credited authors with the Supersede Credit Rule — ea4f9413e
+- [x] 1.3 Categorize and write the bullets into the existing sections — ea4f9413e
 
 ### Phase 2: Verify and ship
 
-- [ ] 2.1 Verify the diff is additive and complete
+- [x] 2.1 Verify the diff is additive and complete — ea4f9413e
 - [ ] 2.2 Run the docs-only gate, open the PR, review and label

--- a/.ai/runs/2026-08-01-changelog-0.6.7-tail.md
+++ b/.ai/runs/2026-08-01-changelog-0.6.7-tail.md
@@ -72,6 +72,8 @@ release across two sections and misrepresent what `v0.6.7` will contain when it 
 
 ## Progress
 
+PR: #4783
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Draft and apply the changelog delta
@@ -83,4 +85,4 @@ release across two sections and misrepresent what `v0.6.7` will contain when it 
 ### Phase 2: Verify and ship
 
 - [x] 2.1 Verify the diff is additive and complete — ea4f9413e
-- [ ] 2.2 Run the docs-only gate, open the PR, review and label
+- [x] 2.2 Run the docs-only gate, open the PR, review and label

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 
-# 0.6.7 (2026-07-30)
+# 0.6.7 (2026-08-01)
 
 ## Highlights
 <!-- TODO: Highlights — auto-update-changelog leaves this blank for the human author to fill in. -->
 
 ## ✨ Features
+- ✨ Add 'partner-request' to allowed labels in community labels. (#4730) *(@MStaniaszek1998)*
+- ✨ Enable community PR label commands. (#4726) *(@MStaniaszek1998)*
 - ✨ Implementation of WMS (warehouse management). (#4566) *(@patzick)*
 - ✨ Cache organization switcher responses (#2907). (#4538) *(@hubert-madej-softiq)*
+- ✨ Make the standalone harness pass on Claude Sonnet. (#4529) *(@pkarw)*
 - ✨ Add initialValues prop to CreateDealForm (supersedes #3729). (#4485) *(@jakubsobczak-syhi, via @pkarw)*
 - ✨ Cache role lists safely (supersedes #3143). (#4480) *(@adeptofvoltron, via @pkarw)*
 - ✨ Honor custom-field priority and declaration order (supersedes #4417). (#4466) *(@wojciechszyjka, via @pkarw)*
@@ -21,7 +24,9 @@
 - ✨ DataTable interactive column resize + width persistence (#1835). (#3774) *(@zielivia)*
 
 ## 🔒 Security
+- 🔒 Gate /label on the certified partner registry (develop mirror of #4761). (#4762) *(@MStaniaszek1998)*
 - 🔒 Reject prototype keys in getNestedValue field paths (#3823). (#4517) *(@Marynat)*
+- 🔒 Enforce cumulative capture ceiling (#4487). (#4508) *(@wojciechszyjka)*
 - 🔒 Bump the postcss resolution off the vulnerable 8.5.15 (#4499). (#4500) *(@wojciechszyjka)*
 - 🔒 Run a daily dependency audit and stop caching the audit result (#4479). (#4497) *(@wojciechszyjka)*
 - 🔒 Guard bounded bcrypt candidate loop invariant (#3812). (#4469) *(@DarrenStasiakDev4You)*
@@ -31,7 +36,14 @@
 - 🔒 Remove raw acceptance-token fallback in public quote endpoints (#2929). (#2997) *(@adeptofvoltron)*
 
 ## 🐛 Fixes
+- 🐛 Use nil UUID sentinel instead of string in leave-requests filters. (#4766) *(@mikoajp)*
+- 🔧 Grant community label workflow PR access. (#4753) *(@MStaniaszek1998)*
+- 🔧 Enforce standalone spec phase gates. (#4752) *(@pkarw)*
+- 🔧 Warn when an injection table references a widget nothing declares. (#4710) *(@lchrusciel)*
+- 🔐 Never return an unencrypted index document (#4677). (#4686) *(@wojciechszyjka)*
+- 🌍 Make the usage scanner see multiline t() calls (#4666). (#4684) *(@wojciechszyjka)*
 - 📦 Preapprove @open-mercato past yarn's minimum release age gate. (#4644) *(@patzick)*
+- 🌍 Define the phone custom-field translation keys (#4607). (#4608) *(@wojciechszyjka)*
 - 🔄 Stop reindex batches from silently dropping records (supersedes #4593). (#4598) *(@jtomaszewski, via @pkarw)*
 - 🔐 Fail closed on unresolved tenant scope in read routes. (#4590) *(@tomaszscigalacshark)*
 - 🔧 Surface swallowed Next.js dev startup errors, retry cold starts. (#4567) *(@patzick)*
@@ -43,6 +55,7 @@
 - 🔧 Give the AGENTS.md budget chain sort an explicit comparator. (#4527) *(@wojciechszyjka)*
 - 🔐 Tenant-scope custom entity mutations (supersedes #4134). (#4511) *(@haxiorz, via @pkarw)*
 - 🔧 Invalidate trigger cache on customize and reset-to-code (#4425). (#4509) *(@wojciechszyjka)*
+- 🔧 Log command-interceptor registry import failures. (#4505) *(@wojciechszyjka)*
 - 🔧 Restore ESLint coverage and keep audit green (supersedes #4496). (#4501) *(@wojciechszyjka, via @pkarw)*
 - 🔐 Backfill poisoned customer_entity_id links (#4473). (#4494) *(@wojciechszyjka)*
 - 🔐 Harden rate-limit proxy trust (#4041) (supersedes #4074). (#4490) *(@haxiorz, via @pkarw)*
@@ -53,12 +66,14 @@
 - 🔐 Return 400 for malformed uuid list filters (#3819). (#4468) *(@DarrenStasiakDev4You)*
 - 🐛 Restore request bodies from runtime registry (supersedes #4410). (#4467) *(@wojciechszyjka, via @pkarw)*
 - 🐛 Register code-defined workflow triggers with the trigger engine (supersedes #4443). (#4463) *(@wojciechszyjka, via @pkarw)*
+- 🐛 Activity configuration — edit-time validation, editable JSON, working timeouts (supersedes #4449). (#4460) *(@wojciechszyjka, via @pkarw)*
 - 📦 Scaffolded apps run their own tooling (supersedes #4454). (#4456) *(@wojciechszyjka, via @pkarw)*
 - 🌍 Complete Polish translations and drop duplicated integrations keys (#2077). (#4452) *(@wojciechszyjka)*
 - 🖼️ Library interaction fixes — input focus and download-cell click. (#4450) *(@wojciechszyjka)*
 - 🌍 Translate the remaining Polish CRM strings (#2077, #4380). (#4446) *(@wojciechszyjka)*
 - 🔧 Malformed ?ids= no longer returns the full list. (#4444) *(@wojciechszyjka)*
 - 🔧 Load command interceptors in the CLI/queue-worker bootstrap. (#4414) *(@wojciechszyjka)*
+- 🐛 Stop useGroupOrder render loop when hosts recreate group ids every render (#4386). (#4411) *(@wojciechszyjka)*
 - 🐛 Apply overrides.widgets.dashboard to the server-side widget catalog (#4377). (#4408) *(@wojciechszyjka)*
 - 🔧 Restore standalone optimistic locking DI (supersedes #4209). (#4395) *(@migace, via @pkarw)*
 - 🐛 CustomFieldValuesList honors listVisible and formats values by kind. (#4388) *(@wojciechszyjka)*
@@ -136,6 +151,9 @@
 - 🧪 Stub DNS in the redirect-hop tests so develop is green again (#4515). (#4516) *(@wojciechszyjka)*
 
 ## 📝 Specs & Documentation
+- 📝 Standalone harness canonical UI and i18n acceptance. (#4743) *(@pkarw)*
+- 📝 Add configuration decision guide (supersedes #4549). (#4741) *(@jtomaszewski, via @pkarw)*
+- 📝 AST-first code generation for the remaining string emitters (#1637). (#4636) *(@wojciechszyjka)*
 - 📝 Publish Enterprise License Agreement Terms v2.2. (#4610) *(@matgren)*
 - 📝 Fit the root AGENTS.md into Codex's 32 KiB instruction budget (#4484). (#4506) *(@wojciechszyjka)*
 - 📝 Note that finishing the self-QA exception needs `triage` permission (#4478). (#4498) *(@wojciechszyjka)*
@@ -175,6 +193,8 @@
 - @zielivia
 - @piotrchabros
 - @pat-lewczuk
+- @lchrusciel
+- @mikoajp
 
 ---
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-01-changelog-0.6.7-tail.md
Status: complete

## 🎯 Goal

Complete the unreleased `# 0.6.7` block in `CHANGELOG.md` so it reflects everything that is actually on `develop`. The previous changelog run (#4674) recorded 134 pull requests merged between 2026-07-17 and the snapshot it took on 2026-07-30. Eighteen more have merged since — including eight that landed on 2026-07-30 *after* that run had already enumerated its window — and none of them were recorded anywhere.

`0.6.7` has **not** been released: the newest tag is `v0.6.6` and `package.json` still reads `0.6.6`. The block is therefore still the open release section, so this PR **extends it in place** instead of opening a `0.6.8` heading. Cutting a new heading for two days of work would split a single release across two sections and misrepresent what `v0.6.7` contains when it is tagged.

## What Changed

- **`CHANGELOG.md`** — 20 added lines and one changed line inside the existing `# 0.6.7` block. Nothing else in the file moves; the `0.6.6` block and every earlier release are untouched, and the `<!-- TODO: Highlights -->` marker stays for the human release author.
  - **Heading date** moved from `2026-07-30` to `2026-08-01` to match the widened window.
  - **✨ Features — 3 entries** (#4730, #4726, #4529).
  - **🔒 Security — 2 entries** (#4762, #4508).
  - **🐛 Fixes — 10 entries** (#4766, #4753, #4752, #4710, #4686, #4684, #4608, #4505, #4460, #4411).
  - **📝 Specs & Documentation — 3 entries** (#4743, #4741, #4636).
  - **👥 Contributors — 2 new handles** (`@lchrusciel`, `@mikoajp`); every other author in the delta was already credited in the block.
- **`.ai/runs/2026-08-01-changelog-0.6.7-tail.md`** — the execution plan for this run, with its Progress checklist.

### Credit resolution (Supersede Credit Rule)

Two of the 18 pull requests were carried forward by a reviewer, so the merged PR's author is not the person who did the work. Both were resolved through Path A (`Supersedes #N` in the body) confirmed by Path B (`Credit: original implementation by @user`), with the original author read back from the superseded PR rather than inferred:

| Merged PR | Merged by | Supersedes | Credited to |
|---|---|---|---|
| #4460 | @pkarw | #4449 | **@wojciechszyjka**, via @pkarw |
| #4741 | @pkarw | #4549 | **@jtomaszewski**, via @pkarw |

The remaining 16 fall through to the merged PR's own author. #4674 — the previous run of `om-auto-update-changelog` — is deliberately excluded from the delta, since a changelog PR does not appear in its own changelog.

Worth flagging for whoever tags the release: **#4725 is not in this entry.** It supersedes @wojciechszyjka's #4507 and would credit `@wojciechszyjka, via @pkarw`, but it is still **open**, so it belongs to the next changelog window, not this one.

### Categorization note

Section assignment follows the skill's documented derivation order — labels first, conventional-commit prefix second. That puts the community-label CI work in three different sections: #4726 carries the `feature` label (→ Features), #4762 carries `security` (→ Security) and #4753 carries `bug` (→ Fixes). The result is reproducible rather than hand-curated; if the release author would rather see those four grouped under a `🚀 CI/CD & Infrastructure` heading, that is a one-line regroup.

## 🧪 Tests

- **Docs-only change — no code, no locale files, no generated artifacts.** `CHANGELOG.md` is not read by any build, test, or lint step in `validation.commands` (`build:packages`, `generate`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`), so none of those commands can observe this diff. Per the docs-only gate, verification is mechanical instead:
  - Every one of the 18 delta PR numbers appears **exactly once** in the block.
  - The block now credits **152 unique PR numbers** (134 previously recorded + 18 new) with **zero duplicates**.
  - All 134 previously-credited numbers are still present and undisturbed.
  - Every section is still in descending PR-number order: Features 17, Security 10, Fixes 95, Improvements 13, Testing 1, Specs & Documentation 15.
  - `git diff --stat` confirms the scope: `CHANGELOG.md | 21 insertions(+), 1 deletion(-)`, the single deletion being the heading date.

## 💥 Breaking Changes

- None. Documentation only; no contract surface, schema, API, or public export is touched.

## 📋 Progress

See the Progress section in the tracking plan.
