### PR TITLE
fix(checkout): scope transaction expiry per organization

### DIFF
--- a/packages/checkout/src/modules/checkout/__tests__/setup-schedules.test.ts
+++ b/packages/checkout/src/modules/checkout/__tests__/setup-schedules.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, jest } from '@jest/globals'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import type { AwilixContainer } from 'awilix'
+import type { InitSetupContext } from '@open-mercato/shared/modules/setup'
+import { CHECKOUT_EXPIRY_QUEUE } from '../workers/transaction-expiry.worker'
+
+const ensureCheckoutFieldsetsAndDefinitions = jest.fn(async (..._args: unknown[]) => undefined)
+
+jest.mock('../seed/customFields', () => ({
+  ensureCheckoutFieldsetsAndDefinitions: (...args: unknown[]) => ensureCheckoutFieldsetsAndDefinitions(...args),
+}))
+
+type ScheduleRegistration = {
+  id: string
+  organizationId: string
+  tenantId: string
+  scopeType: string
+  targetQueue: string
+}
+
+function createSetupContext(options: {
+  tenantId?: string
+  organizationId?: string
+  hasScheduler?: boolean
+  register?: (registration: ScheduleRegistration) => Promise<void>
+}) {
+  const register = jest.fn(options.register ?? (async () => undefined))
+  const resolve = jest.fn((name: string) => {
+    if (name === 'schedulerService') return { register }
+    throw new Error(`[internal] Missing dependency: ${name}`)
+  })
+  const container = {
+    hasRegistration: jest.fn(() => options.hasScheduler ?? true),
+    resolve,
+  }
+  const context: InitSetupContext = {
+    tenantId: options.tenantId ?? 'tenant-1',
+    organizationId: options.organizationId ?? 'organization-1',
+    em: {} as EntityManager,
+    container: container as unknown as AwilixContainer,
+  }
+  return { context, register, resolve }
+}
+
+async function seedDefaults(context: InitSetupContext): Promise<void> {
+  const { setup } = await import('../setup')
+  if (!setup.seedDefaults) throw new Error('[internal] Checkout seedDefaults hook is missing')
+  await setup.seedDefaults(context)
+}
+
+describe('checkout setup schedules', () => {
+  it('registers one organization-scoped transaction-expiry schedule', async () => {
+    const { context, register } = createSetupContext({})
+
+    await seedDefaults(context)
+
+    expect(register).toHaveBeenCalledWith(expect.objectContaining({
+      organizationId: 'organization-1',
+      tenantId: 'tenant-1',
+      scopeType: 'organization',
+      targetQueue: CHECKOUT_EXPIRY_QUEUE,
+    }))
+  })
+
+  it('uses stable IDs that remain distinct across organizations in one tenant', async () => {
+    const first = createSetupContext({ organizationId: 'organization-1' })
+    const second = createSetupContext({ organizationId: 'organization-2' })
+    const repeated = createSetupContext({ organizationId: 'organization-1' })
+
+    await seedDefaults(first.context)
+    await seedDefaults(second.context)
+    await seedDefaults(repeated.context)
+
+    const firstId = first.register.mock.calls[0][0].id
+    const secondId = second.register.mock.calls[0][0].id
+    const repeatedId = repeated.register.mock.calls[0][0].id
+    expect(firstId).not.toBe(secondId)
+    expect(repeatedId).toBe(firstId)
+  })
+
+  it('skips schedule registration when the optional scheduler module is absent', async () => {
+    const { context, register, resolve } = createSetupContext({ hasScheduler: false })
+
+    await seedDefaults(context)
+
+    expect(register).not.toHaveBeenCalled()
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
+  it('propagates scheduler registration failures', async () => {
+    const { context } = createSetupContext({
+      register: async () => {
+        throw new Error('[internal] scheduler unavailable')
+      },
+    })
+
+    await expect(seedDefaults(context)).rejects.toThrow('[internal] scheduler unavailable')
+  })
+})

--- a/packages/checkout/src/modules/checkout/setup.ts
+++ b/packages/checkout/src/modules/checkout/setup.ts
@@ -1,16 +1,15 @@
 import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
-import crypto from 'node:crypto'
+import { createHash } from 'node:crypto'
 import { ensureCheckoutFieldsetsAndDefinitions } from './seed/customFields'
 import { seedCheckoutExamples } from './seed/examples'
 import { CHECKOUT_EXPIRY_QUEUE } from './workers/transaction-expiry.worker'
 export { DEFAULT_CHECKOUT_CUSTOMER_FIELDS } from './lib/defaults'
 
 function stableUuidFromString(input: string): string {
-  const bytes = crypto.createHash('sha256').update(input).digest().subarray(0, 16)
-  // RFC4122: set version (5) and variant (10xx)
+  const bytes = createHash('sha256').update(input).digest().subarray(0, 16)
   bytes[6] = (bytes[6] & 0x0f) | 0x50
   bytes[8] = (bytes[8] & 0x3f) | 0x80
-  const hex = Buffer.from(bytes).toString('hex') // 32 hex chars
+  const hex = Buffer.from(bytes).toString('hex')
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`
 }
 
@@ -42,29 +41,25 @@ export const setup: ModuleSetupConfig = {
     })
 
     const cradle = ctx.container as { hasRegistration?: (name: string) => boolean }
-    if (typeof cradle.hasRegistration === 'function' && cradle.hasRegistration('schedulerService')) {
-      try {
-        const schedulerService = ctx.container.resolve('schedulerService') as SchedulerServiceLike
-        await schedulerService.register({
-          id: stableUuidFromString(`checkout:transaction-expiry:${ctx.tenantId}`),
-          name: 'Checkout transaction expiry',
-          description: 'Marks stale checkout transactions as expired and runs usage limit updates.',
-          scopeType: 'organization',
-          organizationId: ctx.organizationId,
-          tenantId: ctx.tenantId,
-          scheduleType: 'interval',
-          scheduleValue: '10m',
-          timezone: 'UTC',
-          targetType: 'queue',
-          targetQueue: CHECKOUT_EXPIRY_QUEUE,
-          sourceType: 'module',
-          sourceModule: 'checkout',
-          isEnabled: true,
-        })
-      } catch {
-        // Scheduler may not be installed in this deployment; ignore.
-      }
-    }
+    if (typeof cradle.hasRegistration !== 'function' || !cradle.hasRegistration('schedulerService')) return
+
+    const schedulerService = ctx.container.resolve('schedulerService') as SchedulerServiceLike
+    await schedulerService.register({
+      id: stableUuidFromString(`checkout:transaction-expiry:${ctx.tenantId}:${ctx.organizationId}`),
+      name: 'Checkout transaction expiry',
+      description: 'Marks stale checkout transactions as expired and runs usage limit updates.',
+      scopeType: 'organization',
+      organizationId: ctx.organizationId,
+      tenantId: ctx.tenantId,
+      scheduleType: 'interval',
+      scheduleValue: '10m',
+      timezone: 'UTC',
+      targetType: 'queue',
+      targetQueue: CHECKOUT_EXPIRY_QUEUE,
+      sourceType: 'module',
+      sourceModule: 'checkout',
+      isEnabled: true,
+    })
   },
 
   defaultRoleFeatures: {

--- a/packages/checkout/src/modules/checkout/setup.ts
+++ b/packages/checkout/src/modules/checkout/setup.ts
@@ -1,7 +1,38 @@
 import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
+import crypto from 'node:crypto'
 import { ensureCheckoutFieldsetsAndDefinitions } from './seed/customFields'
 import { seedCheckoutExamples } from './seed/examples'
+import { CHECKOUT_EXPIRY_QUEUE } from './workers/transaction-expiry.worker'
 export { DEFAULT_CHECKOUT_CUSTOMER_FIELDS } from './lib/defaults'
+
+function stableUuidFromString(input: string): string {
+  const bytes = crypto.createHash('sha256').update(input).digest().subarray(0, 16)
+  // RFC4122: set version (5) and variant (10xx)
+  bytes[6] = (bytes[6] & 0x0f) | 0x50
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Buffer.from(bytes).toString('hex') // 32 hex chars
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`
+}
+
+type SchedulerServiceLike = {
+  register: (registration: {
+    id: string
+    name: string
+    description?: string
+    scopeType: 'organization'
+    organizationId: string
+    tenantId: string
+    scheduleType: 'cron' | 'interval'
+    scheduleValue: string
+    timezone?: string
+    targetType: 'queue'
+    targetQueue: string
+    targetPayload?: Record<string, unknown>
+    sourceType: 'module'
+    sourceModule: string
+    isEnabled?: boolean
+  }) => Promise<void>
+}
 
 export const setup: ModuleSetupConfig = {
   async seedDefaults(ctx) {
@@ -9,6 +40,31 @@ export const setup: ModuleSetupConfig = {
       tenantId: ctx.tenantId,
       organizationId: ctx.organizationId,
     })
+
+    const cradle = ctx.container as { hasRegistration?: (name: string) => boolean }
+    if (typeof cradle.hasRegistration === 'function' && cradle.hasRegistration('schedulerService')) {
+      try {
+        const schedulerService = ctx.container.resolve('schedulerService') as SchedulerServiceLike
+        await schedulerService.register({
+          id: stableUuidFromString(`checkout:transaction-expiry:${ctx.tenantId}`),
+          name: 'Checkout transaction expiry',
+          description: 'Marks stale checkout transactions as expired and runs usage limit updates.',
+          scopeType: 'organization',
+          organizationId: ctx.organizationId,
+          tenantId: ctx.tenantId,
+          scheduleType: 'interval',
+          scheduleValue: '10m',
+          timezone: 'UTC',
+          targetType: 'queue',
+          targetQueue: CHECKOUT_EXPIRY_QUEUE,
+          sourceType: 'module',
+          sourceModule: 'checkout',
+          isEnabled: true,
+        })
+      } catch {
+        // Scheduler may not be installed in this deployment; ignore.
+      }
+    }
   },
 
   defaultRoleFeatures: {

--- a/packages/checkout/src/modules/checkout/workers/__tests__/transaction-expiry.worker.test.ts
+++ b/packages/checkout/src/modules/checkout/workers/__tests__/transaction-expiry.worker.test.ts
@@ -1,0 +1,111 @@
+import { CheckoutTransaction } from '../../data/entities'
+
+const findWithDecryption = jest.fn()
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => findWithDecryption(...args),
+}))
+
+describe('checkout transaction-expiry worker', () => {
+  const mockCommandBus = {
+    execute: jest.fn().mockResolvedValue({ ok: true }),
+  }
+
+  const mockEm = {
+    fork: () => mockEm,
+  }
+
+  const mockResolve = jest.fn((name: string) => {
+    if (name === 'em') return mockEm
+    if (name === 'commandBus') return mockCommandBus
+    throw new Error(`Missing dependency: ${name}`)
+  })
+
+  const mockContext = {
+    resolve: mockResolve,
+    jobId: 'job-1',
+    attemptNumber: 1,
+  } as any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('throws an error if tenantId or organizationId is missing', async () => {
+    const { default: handle } = await import('../transaction-expiry.worker')
+
+    await expect(
+      handle(
+        {
+          payload: { batchSize: 10 } as any,
+        } as any,
+        mockContext,
+      ),
+    ).rejects.toThrow('tenantId and organizationId are required in CheckoutExpiryJob')
+
+    expect(findWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('queries only transactions matching the payload tenantId and organizationId and passes decryption scope', async () => {
+    const { default: handle } = await import('../transaction-expiry.worker')
+
+    const mockTransactions = [
+      {
+        id: 'txn-1',
+        organizationId: 'org-123',
+        tenantId: 'tenant-456',
+      },
+      {
+        id: 'txn-2',
+        organizationId: 'org-123',
+        tenantId: 'tenant-456',
+      },
+    ]
+
+    findWithDecryption.mockResolvedValueOnce(mockTransactions)
+
+    await handle(
+      {
+        payload: {
+          batchSize: 50,
+          tenantId: 'tenant-456',
+          organizationId: 'org-123',
+        },
+      } as any,
+      mockContext,
+    )
+
+    // Verify findWithDecryption was called with org and tenant scoping
+    expect(findWithDecryption).toHaveBeenCalledWith(
+      mockEm,
+      CheckoutTransaction,
+      expect.objectContaining({
+        status: 'processing',
+        tenantId: 'tenant-456',
+        organizationId: 'org-123',
+      }),
+      expect.objectContaining({
+        limit: 50,
+      }),
+      {
+        tenantId: 'tenant-456',
+        organizationId: 'org-123',
+      },
+    )
+
+    // Verify command bus executes updateStatus for each transaction with context
+    expect(mockCommandBus.execute).toHaveBeenCalledTimes(2)
+    expect(mockCommandBus.execute).toHaveBeenNthCalledWith(
+      1,
+      'checkout.transaction.updateStatus',
+      expect.objectContaining({
+        input: {
+          id: 'txn-1',
+          status: 'expired',
+          paymentStatus: 'expired',
+          organizationId: 'org-123',
+          tenantId: 'tenant-456',
+        },
+      }),
+    )
+  })
+})

--- a/packages/checkout/src/modules/checkout/workers/__tests__/transaction-expiry.worker.test.ts
+++ b/packages/checkout/src/modules/checkout/workers/__tests__/transaction-expiry.worker.test.ts
@@ -1,4 +1,7 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+import type { JobContext, QueuedJob } from '@open-mercato/queue'
 import { CheckoutTransaction } from '../../data/entities'
+import type { CheckoutExpiryJob } from '../transaction-expiry.worker'
 
 const findWithDecryption = jest.fn()
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
@@ -10,21 +13,31 @@ describe('checkout transaction-expiry worker', () => {
     execute: jest.fn().mockResolvedValue({ ok: true }),
   }
 
-  const mockEm = {
+  type MockEntityManager = {
+    fork: () => MockEntityManager
+  }
+
+  const mockEm: MockEntityManager = {
     fork: () => mockEm,
   }
 
-  const mockResolve = jest.fn((name: string) => {
-    if (name === 'em') return mockEm
-    if (name === 'commandBus') return mockCommandBus
-    throw new Error(`Missing dependency: ${name}`)
-  })
+  const resolve = <ResolvedValue = unknown>(name: string): ResolvedValue => {
+    if (name === 'em') return mockEm as ResolvedValue
+    if (name === 'commandBus') return mockCommandBus as ResolvedValue
+    throw new Error(`[internal] Missing dependency: ${name}`)
+  }
 
-  const mockContext = {
-    resolve: mockResolve,
+  const mockContext: JobContext & { resolve: typeof resolve } = {
+    resolve,
     jobId: 'job-1',
     attemptNumber: 1,
-  } as any
+    queueName: 'checkout-transaction-expiry',
+  }
+
+  const baseJob = {
+    id: 'job-1',
+    createdAt: '2026-08-01T00:00:00.000Z',
+  }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -36,11 +49,12 @@ describe('checkout transaction-expiry worker', () => {
     await expect(
       handle(
         {
-          payload: { batchSize: 10 } as any,
-        } as any,
+          ...baseJob,
+          payload: { batchSize: 10 },
+        } as unknown as QueuedJob<CheckoutExpiryJob>,
         mockContext,
       ),
-    ).rejects.toThrow('tenantId and organizationId are required in CheckoutExpiryJob')
+    ).rejects.toThrow('[internal] tenantId and organizationId are required in CheckoutExpiryJob')
 
     expect(findWithDecryption).not.toHaveBeenCalled()
   })
@@ -65,16 +79,16 @@ describe('checkout transaction-expiry worker', () => {
 
     await handle(
       {
+        ...baseJob,
         payload: {
           batchSize: 50,
           tenantId: 'tenant-456',
           organizationId: 'org-123',
         },
-      } as any,
+      } satisfies QueuedJob<CheckoutExpiryJob>,
       mockContext,
     )
 
-    // Verify findWithDecryption was called with org and tenant scoping
     expect(findWithDecryption).toHaveBeenCalledWith(
       mockEm,
       CheckoutTransaction,
@@ -92,7 +106,6 @@ describe('checkout transaction-expiry worker', () => {
       },
     )
 
-    // Verify command bus executes updateStatus for each transaction with context
     expect(mockCommandBus.execute).toHaveBeenCalledTimes(2)
     expect(mockCommandBus.execute).toHaveBeenNthCalledWith(
       1,

--- a/packages/checkout/src/modules/checkout/workers/transaction-expiry.worker.ts
+++ b/packages/checkout/src/modules/checkout/workers/transaction-expiry.worker.ts
@@ -35,7 +35,7 @@ export default async function handle(job: QueuedJob<CheckoutExpiryJob>, ctx: Han
   const cutoff = new Date(Date.now() - EXPIRY_TIMEOUT_MS)
 
   if (!job.payload?.tenantId || !job.payload?.organizationId) {
-    throw new Error('tenantId and organizationId are required in CheckoutExpiryJob')
+    throw new Error('[internal] tenantId and organizationId are required in CheckoutExpiryJob')
   }
 
   const { tenantId, organizationId } = job.payload

--- a/packages/checkout/src/modules/checkout/workers/transaction-expiry.worker.ts
+++ b/packages/checkout/src/modules/checkout/workers/transaction-expiry.worker.ts
@@ -14,6 +14,8 @@ const EXPIRY_TIMEOUT_MS = 2 * 60 * 60 * 1000 // 2 hours
 
 export type CheckoutExpiryJob = {
   batchSize?: number
+  tenantId: string
+  organizationId: string
 }
 
 export const metadata: WorkerMeta = {
@@ -32,14 +34,23 @@ export default async function handle(job: QueuedJob<CheckoutExpiryJob>, ctx: Han
   const batchSize = job.payload?.batchSize ?? 100
   const cutoff = new Date(Date.now() - EXPIRY_TIMEOUT_MS)
 
+  if (!job.payload?.tenantId || !job.payload?.organizationId) {
+    throw new Error('tenantId and organizationId are required in CheckoutExpiryJob')
+  }
+
+  const { tenantId, organizationId } = job.payload
+
   const staleTransactions = await findWithDecryption(
     em,
     CheckoutTransaction,
     {
       status: 'processing',
       createdAt: { $lt: cutoff },
+      tenantId,
+      organizationId,
     },
     { limit: batchSize, orderBy: { createdAt: 'ASC' } },
+    { tenantId, organizationId },
   )
 
   for (const transaction of staleTransactions) {


### PR DESCRIPTION
Supersedes #4775

Credit: original implementation by @Pallavikumarimdb. This follow-up PR carries that work forward with the requested fixes so it can merge without waiting on the original fork branch.

## Included work

- Original tenant/organization scoping fix from #4775
- Organization-scoped scheduler registration for transaction expiry
- Stable schedule IDs that remain distinct across organizations in one tenant
- Registration failures that surface instead of silently disabling expiry processing
- Typed worker tests plus setup regression coverage for scope, idempotence, optional scheduler absence, and failure propagation

## Validation

- `yarn workspace @open-mercato/checkout test --runInBand --no-cache` — 18 suites, 86 tests passed
- `yarn workspace @open-mercato/checkout typecheck` — passed
- `yarn workspace @open-mercato/checkout build` — passed
- app module generation — passed

The branch was re-reviewed after autofix and is intended to be merge-ready. The full workspace wrappers were not reproducible in the isolated reviewer worktree because Turbo child processes hit host write/quota errors; GitHub CI is the authoritative follow-up signal for this pushed head.

Fixes #4698
