### PR TITLE
docs(webhooks): correct the retry window and flag the unenforced rate limit

### DIFF
--- a/apps/docs/docs/framework/webhooks/overview.mdx
+++ b/apps/docs/docs/framework/webhooks/overview.mdx
@@ -20,7 +20,7 @@ When any module emits a domain event (e.g., `customers.person.created`, `sales.o
 2. Matches each event against registered webhook subscriptions (supports wildcards like `customers.*`)
 3. Enqueues delivery jobs to a dedicated `webhook-deliveries` queue
 4. A delivery worker signs the payload per Standard Webhooks spec and delivers it
-5. On failure, retries with exponential backoff (up to 10 attempts over ~24 hours)
+5. On failure, retries with exponential backoff (up to 10 attempts over ~8.5 minutes by default)
 
 ```
   Module emits event → Event Bus → Webhook Dispatcher → Delivery Queue → HTTP POST
@@ -146,18 +146,34 @@ Use the official [Standard Webhooks libraries](https://github.com/standard-webho
 
 ## Retry Behavior
 
-Failed deliveries are retried with exponential backoff:
+Failed deliveries are retried with exponential backoff. The delay before attempt *n* is
+`1s × 2^(n-2)` plus up to 1s of jitter (`calculateNextRetry` in `lib/delivery.ts`):
 
-| Attempt | Delay |
-|---------|-------|
-| 1 | Immediate |
-| 2 | ~5 seconds |
-| 3 | ~5 minutes |
-| 4 | ~30 minutes |
-| 5 | ~2 hours |
-| 6 | ~5 hours |
-| 7 | ~10 hours |
-| 8-10 | ~14-24 hours |
+| Attempt | Delay before it |
+|---------|-----------------|
+| 1 | immediate |
+| 2 | ~1 second |
+| 3 | ~2 seconds |
+| 4 | ~4 seconds |
+| 5 | ~8 seconds |
+| 6 | ~16 seconds |
+| 7 | ~32 seconds |
+| 8 | ~1 minute |
+| 9 | ~2 minutes |
+| 10 | ~4 minutes |
+
+**Total window**: with the default `maxRetries` of 10, a delivery exhausts its attempts about
+**8.5 minutes** after the first one — not hours. Retries stop once `attemptNumber` reaches
+`maxRetries`, so the last delay is the one before the final attempt. In general the window is
+`2^(maxRetries - 1) - 1` seconds, so raising `maxRetries` grows it geometrically: 15 gives ~4.5 hours,
+17 gives ~18 hours.
+
+:::warning
+Size your alerting against this window, not against a multi-hour assumption. A receiver that is down
+for more than ~9 minutes will exhaust every attempt for events emitted during the outage. If you need
+longer durability, raise `maxRetries` on the webhook or consume from the dead-letter path rather than
+relying on the default.
+:::
 
 **Non-retryable responses**: HTTP 4xx (except 408 and 429) are not retried.
 
@@ -212,7 +228,7 @@ interface WebhookEndpointAdapter {
 ```
 
 Inbound webhooks are:
-- **Rate limited** per endpoint
+- **Rate limit per endpoint** is configurable and persisted, but is **not enforced yet** — the delivery worker ignores `rateLimitPerMinute`. Throttle at the receiver until it is wired up.
 - **Deduplicated** by message ID
 - Processed via **fire-and-forget** (return 200 immediately, emit event for async processing)
 

--- a/packages/webhooks/src/modules/webhooks/i18n/de.json
+++ b/packages/webhooks/src/modules/webhooks/i18n/de.json
@@ -80,7 +80,7 @@
   "webhooks.form.name": "Name",
   "webhooks.form.namePlaceholder": "My Webhook",
   "webhooks.form.rateLimitPerMinute": "Rate Limit Per Minute",
-  "webhooks.form.rateLimitPerMinuteHint": "Maximum deliveries per minute for this endpoint (0 means unlimited).",
+  "webhooks.form.rateLimitPerMinuteHint": "Maximum deliveries per minute for this endpoint (0 means unlimited). Stored for future use — the delivery worker does not enforce it yet.",
   "webhooks.form.secret": "Signing Secret",
   "webhooks.form.secretCopied": "Secret copied to clipboard.",
   "webhooks.form.secretCopy": "Copy Secret",

--- a/packages/webhooks/src/modules/webhooks/i18n/en.json
+++ b/packages/webhooks/src/modules/webhooks/i18n/en.json
@@ -80,7 +80,7 @@
   "webhooks.form.name": "Name",
   "webhooks.form.namePlaceholder": "My Webhook",
   "webhooks.form.rateLimitPerMinute": "Rate Limit Per Minute",
-  "webhooks.form.rateLimitPerMinuteHint": "Maximum deliveries per minute for this endpoint (0 means unlimited).",
+  "webhooks.form.rateLimitPerMinuteHint": "Maximum deliveries per minute for this endpoint (0 means unlimited). Stored for future use — the delivery worker does not enforce it yet.",
   "webhooks.form.secret": "Signing Secret",
   "webhooks.form.secretCopied": "Secret copied to clipboard.",
   "webhooks.form.secretCopy": "Copy Secret",

--- a/packages/webhooks/src/modules/webhooks/i18n/es.json
+++ b/packages/webhooks/src/modules/webhooks/i18n/es.json
@@ -80,7 +80,7 @@
   "webhooks.form.name": "Name",
   "webhooks.form.namePlaceholder": "My Webhook",
   "webhooks.form.rateLimitPerMinute": "Rate Limit Per Minute",
-  "webhooks.form.rateLimitPerMinuteHint": "Maximum deliveries per minute for this endpoint (0 means unlimited).",
+  "webhooks.form.rateLimitPerMinuteHint": "Maximum deliveries per minute for this endpoint (0 means unlimited). Stored for future use — the delivery worker does not enforce it yet.",
   "webhooks.form.secret": "Signing Secret",
   "webhooks.form.secretCopied": "Secret copied to clipboard.",
   "webhooks.form.secretCopy": "Copy Secret",

--- a/packages/webhooks/src/modules/webhooks/i18n/pl.json
+++ b/packages/webhooks/src/modules/webhooks/i18n/pl.json
@@ -80,7 +80,7 @@
   "webhooks.form.name": "Nazwa",
   "webhooks.form.namePlaceholder": "Mój webhook",
   "webhooks.form.rateLimitPerMinute": "Limit na minutę",
-  "webhooks.form.rateLimitPerMinuteHint": "Maksymalna liczba dostaw na minutę dla tego endpointu (0 oznacza brak limitu).",
+  "webhooks.form.rateLimitPerMinuteHint": "Maksymalna liczba dostaw na minutę dla tego endpointu (0 oznacza brak limitu). Wartość jest zapisywana, ale nie jest jeszcze wymuszana przy dostarczaniu.",
   "webhooks.form.secret": "Sekret podpisujący",
   "webhooks.form.secretCopied": "Skopiowano sekret do schowka.",
   "webhooks.form.secretCopy": "Kopiuj sekret",


### PR DESCRIPTION
Two places where the webhooks docs and UI describe behaviour the code does not have. Documentation and one form hint only — no behaviour change.

## 1. The retry window is ~8.5 minutes, not ~24 hours

The published table claimed:

| Attempt | Delay (documented) |
|---|---|
| 4 | ~30 minutes |
| 5 | ~2 hours |
| 8-10 | ~14-24 hours |

The code (`lib/delivery.ts:410-414`):

```ts
function calculateNextRetry(attemptNumber: number): Date {
  const baseDelayMs = 1000
  const jitterMs = Math.floor(Math.random() * 1000)
  const delayMs = baseDelayMs * Math.pow(2, Math.max(attemptNumber - 1, 0)) + jitterMs
  return new Date(Date.now() + delayMs)
}
```

`handleFailedDelivery` (`:325`) retries while `attemptNumber < maxRetries`, and `maxRetries` defaults to 10 (`data/entities.ts:47`). So delays land after attempts 1-9 — 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s — summing to **511s ≈ 8.5 minutes**, with the largest single gap ~4 minutes.

The table now matches the code, gives the general form (`2^(maxRetries - 1) - 1` seconds, so 15 → ~4.5h and 17 → ~18h), and adds a warning to size alerting against ~9 minutes.

**Why it's worth a PR:** this is the number operators plan incident response around. Believing a receiver can be down for hours when it actually has nine minutes is the difference between a replayed backlog and permanent data loss.

## 2. `rateLimitPerMinute` is not enforced

The field is validated, persisted, returned by the API (`api/helpers.ts:118`) and rendered on the detail page (`backend/webhooks/[id]/page.tsx:579`) — but nothing in `lib/` or `workers/` reads it. There is no rate-limit path in the delivery worker at all.

The overview listed "**Rate limited** per endpoint" as a shipped capability, and the form hint read "Maximum deliveries per minute for this endpoint (0 means unlimited)" — both implying enforcement. Both now state it is stored but not yet enforced, so operators throttle at the receiver rather than trusting a knob that does nothing.

Hint updated across all four locales; `yarn i18n:check-sync` reports all files in sync.

## Not included

Deliberately left for maintainer decisions rather than guessed at: enforcing the rate limit, scheduling the `integrations` log-pruner worker (nothing enqueues it today, so `integration_logs` grows unbounded), and per-attempt delivery history. Happy to file those as issues or implement whichever direction you prefer.

## Provenance

Found while integrating a downstream application with Open Mercato's webhook and integration surfaces, and verified against `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)