### PR TITLE
docs(queue): describe what the local strategy actually does with exhausted jobs

### DIFF
--- a/packages/queue/src/strategies/local.ts
+++ b/packages/queue/src/strategies/local.ts
@@ -49,9 +49,14 @@ const fsp = fs.promises
  * - Jobs are processed sequentially (concurrency option is for logging/compatibility only)
  * - Not suitable for production or multi-process environments
  *
- * Failed jobs are retried up to `DEFAULT_MAX_ATTEMPTS` times with exponential
- * backoff and moved to a dead-letter store once attempts are exhausted (see the
- * retry handling in `process()` below).
+ * Failed jobs are retried up to `DEFAULT_MAX_ATTEMPTS` times with exponential backoff.
+ * There is **no dead-letter store**: once attempts are exhausted the job is removed from
+ * `queue.json` and only counted in `state.failedCount`, so the payload is lost and the
+ * failure survives solely as an error log line. Anything that must not be dropped needs
+ * its own durable record before enqueueing, or the `async` strategy.
+ *
+ * `DEFAULT_MAX_ATTEMPTS` is a module constant, not a per-job option — callers cannot
+ * request a different attempt count. See the retry handling in `process()` below.
  *
  * All file I/O is asynchronous (`fs.promises.*`) so queue operations do not
  * block the Node.js event loop. A per-queue promise chain serializes
@@ -262,7 +267,7 @@ export function createLocalQueue<T = unknown>(
           failed++
           lastJobId = job.id
           if (attemptNumber >= DEFAULT_MAX_ATTEMPTS) {
-            logger.error('Job exhausted all attempts, moving to dead letter', { jobId: job.id, maxAttempts: DEFAULT_MAX_ATTEMPTS })
+            logger.error('Job exhausted all attempts; dropping it (no dead-letter store)', { jobId: job.id, maxAttempts: DEFAULT_MAX_ATTEMPTS })
             deadJobIds.add(job.id)
           } else {
             const backoffMs = RETRY_BACKOFF_BASE_MS * Math.pow(2, attemptNumber - 1)

--- a/packages/queue/src/strategies/local.ts
+++ b/packages/queue/src/strategies/local.ts
@@ -50,13 +50,17 @@ const fsp = fs.promises
  * - Not suitable for production or multi-process environments
  *
  * Failed jobs are retried up to `DEFAULT_MAX_ATTEMPTS` times with exponential backoff.
- * There is **no dead-letter store**: once attempts are exhausted the job is removed from
- * `queue.json` and only counted in `state.failedCount`, so the payload is lost and the
- * failure survives solely as an error log line. Anything that must not be dropped needs
- * its own durable record before enqueueing, or the `async` strategy.
+ * **This strategy keeps no failed-job store**: once attempts are exhausted the job is
+ * removed from `queue.json` and only counted in `state.failedCount`, so the payload is
+ * lost and the failure survives solely as an error log line. The `async` strategy does
+ * retain them — it enqueues with `removeOnFail: 1000`, so the most recent 1000 failures
+ * stay inspectable — which is another reason not to run `local` where losing a job
+ * matters. Anything that must not be dropped needs its own durable record before
+ * enqueueing, or the `async` strategy.
  *
  * `DEFAULT_MAX_ATTEMPTS` is a module constant, not a per-job option — callers cannot
- * request a different attempt count. See the retry handling in `process()` below.
+ * request a different attempt count. (`async` likewise hard-codes `attempts: 3`.)
+ * See the retry handling in `process()` below.
  *
  * All file I/O is asynchronous (`fs.promises.*`) so queue operations do not
  * block the Node.js event loop. A per-queue promise chain serializes


### PR DESCRIPTION
The local queue strategy's module docstring promised something that strategy does not do. Documentation and one log message only — no behaviour change.

## The promise

```
 * Failed jobs are retried up to `DEFAULT_MAX_ATTEMPTS` times with exponential
 * backoff and moved to a dead-letter store once attempts are exhausted (see the
 * retry handling in `process()` below).
```

## The reality for `local`

In `process()` (`local.ts:264-291`):

- the exhausted job's id goes into `deadJobIds`
- `deadJobIds` is then used to **filter the job out** of `queue.json` (`:284`)
- `state.failedCount` is incremented (`:291`)

The payload is gone. The only surviving detail is an error log line — and its wording, `'Job exhausted all attempts, moving to dead letter'`, repeated the same promise. Both are corrected here.

## Correction to the first revision of this description

The first version of this PR body claimed no failed-job store exists anywhere in `packages/queue`. **That was too broad, and I'm correcting it rather than leaving it.** The `async` strategy enqueues with `removeOnFail: 1000` (`async.ts:160`), so the most recent 1000 failures stay inspectable in BullMQ's failed set. It is specifically `local` that retains nothing.

The docstring now says exactly that, and names async's retention as the concrete alternative — which makes the "don't run `local` where losing a job matters" point sharper than a blanket statement did. Second commit on this branch carries that correction.

## Also recorded

- **`DEFAULT_MAX_ATTEMPTS` is a module constant** (`:36`, value 3), not a per-job option — callers cannot request a different attempt count. `async` hard-codes `attempts: 3` too (`async.ts:161`), so this limitation applies to both backends.

## Why it's worth fixing

This docstring is what a module author reads when deciding whether the local strategy is safe for their job. It read as at-least-once delivery with a safety net. It is at-most-three-attempts with silent loss — a reasonable design for a dev-only backend, but only if it says so.

Not proposing the store itself here; if you'd like a real dead-letter path for `local`, or per-job attempt configuration across both backends, say which shape you want and I'll follow up.

Queue suite 54 passing, typecheck clean.

## Provenance

Found while integrating a downstream application with Open Mercato, and verified against `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
