### PR TITLE
fix(customers): exclude closure_outcome-closed deals from the deals summary pipeline (#4697)

### DIFF
--- a/.ai/runs/2026-08-01-deals-summary-closure-outcome.md
+++ b/.ai/runs/2026-08-01-deals-summary-closure-outcome.md
@@ -1,0 +1,108 @@
+# Execution plan — deals-summary-closure-outcome
+
+Engine: om-auto-fix-issue (bug route: om-verify-in-repo → om-root-cause → om-fix → om-open-pr → om-auto-review-pr)
+Base branch: develop
+Branch: fix/issue-4697-deals-summary-closure-outcome
+Issue: #4697
+
+## Goal
+
+Make `GET /api/customers/deals/summary` classify every deal exactly once. A deal closed by writing
+`closure_outcome` alone — which the CRUD API explicitly permits — must leave the open-pipeline
+figures instead of being reported as active pipeline and as won inside the same response.
+
+## Context
+
+`customer_deals` carries two independent closure signals. `status` is a lenient text column fed by a
+per-tenant dictionary, and `closure_outcome` is a nullable `won` / `lost` enum. The supported writers
+do not agree on which one they set: the closure UI writes both, the AI stage tool writes `status`
+only, and `dealUpdateSchema` accepts `closureOutcome` on its own — `commands/deals.ts:717` assigns
+that column without ever deriving `status` from it.
+
+The summary route already reads both columns in its won/lost queries
+(`(status = 'win' OR closure_outcome = 'won')`), but its open-deal queries read `status` alone
+through the `OPEN_STATUSES` allowlist. A deal closed through `closureOutcome` therefore satisfies
+both predicates at once: it is summed into `pipelineValue`, counted in `activeDeals`, and
+simultaneously counted in `wonThisQuarter`. The same deal also disagrees with the
+`dashboards.analytics.pipelineSummary` widget, which since #4683 filters `closureOutcome IS NULL` in
+its default *Open deals only* scope — so the card and the chart report different numbers for the same
+tenant and period.
+
+## Scope
+
+- `packages/core/src/modules/customers/api/deals/summary/route.ts` — the open-deal predicate only.
+- Its unit test file and the `TC-CRM-082` integration spec.
+
+## Non-goals
+
+- No change to the `status IN ('open','in_progress')` allowlist itself. Whether it should become a
+  denylist (mirroring the widget and the reasoning in #4621/#4629) is a product decision raised for
+  the maintainer in the PR description, not taken here.
+- No refactor of the route onto `customers/lib/dealStatus.ts`. That library classifies a JS-side
+  status string; these are raw SQL predicates, and pulling one into the other is a separate change.
+- No change to the won/lost queries, the win-rate series, or the widget.
+
+## Implementation plan
+
+### Phase 1: Correct the predicate
+
+- **Step 1.1** — Introduce one shared open-deal SQL fragment next to `openPlaceholders`:
+  `status IN (?,?) AND closure_outcome IS NULL`, documenting why it must be `IS NULL` and not a `!=`
+  comparison (the column is nullable, so `closure_outcome != 'won'` evaluates to NULL for every
+  genuinely open deal and would empty the pipeline rather than trim it).
+- **Step 1.2** — Apply it to the three allowlist sites: the pipeline/stage aggregation that also
+  carries the owner rollup, the quarter-over-quarter inflow delta, and the need-attention stuck
+  intersection.
+- **Step 1.3** — Apply the same guard to the fourth open-deal query, the overdue lookup that forms
+  the other half of `needAttention`, so the whole card uses one definition of "open".
+
+### Phase 2: Lock the behavior down
+
+- **Step 2.1** — Unit regression test in the route's existing mocked-SQL harness: assert every
+  open-deal query requires `closure_outcome IS NULL`, keeps its status allowlist, and uses no
+  NULL-swallowing inequality; assert the won query still reads either column. Verify the test fails
+  against the pre-fix route and passes after.
+- **Step 2.2** — Integration case in `TC-CRM-082`: seed an open deal, confirm it raises
+  `activeDeals`, close it with `PUT { id, closureOutcome: 'won' }`, confirm the read-back still shows
+  `status = 'open'`, then assert the deal has left `activeDeals` and `pipelineValue` and is counted
+  once in `wonThisQuarter`.
+
+### Phase 3: Ship
+
+- **Step 3.1** — Run the full validation gate from `.ai/agentic.config.json`.
+- **Step 3.2** — Open the PR against `develop`, put the allowlist question to the maintainer in the
+  description, run the review pass, and report the label set the account cannot apply.
+
+## Risks
+
+- **Wrong NULL semantics.** The obvious spelling `closure_outcome != 'won'` silently drops every open
+  deal because the column is NULL for all of them. Mitigated by using `IS NULL`, by a unit assertion
+  that rejects `!=` / `<>` on that column, and by an inline comment at the definition site.
+- **Over-trimming the pipeline.** A tenant whose deals carry a stale `closure_outcome` alongside an
+  open status would see the pipeline shrink after this change. That is the intended correction — such
+  a deal is already being counted as won — and the integration test pins the expected direction.
+- **Scope creep into the allowlist question.** Changing `status IN (...)` to a denylist in the same
+  PR would alter which deals the cards see for tenants with custom dictionaries. Deliberately left to
+  the maintainer.
+
+## Progress
+
+PR: (pending — filled in when the PR is opened)
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Correct the predicate
+
+- [x] 1.1 Introduce the shared open-deal SQL fragment with the NULL-semantics rationale
+- [x] 1.2 Apply it to the pipeline/stage aggregation, inflow delta and stuck intersection
+- [x] 1.3 Apply the same guard to the overdue half of need-attention
+
+### Phase 2: Lock the behavior down
+
+- [x] 2.1 Unit regression test over the open-deal query shapes (fails pre-fix, passes post-fix)
+- [x] 2.2 Integration case for a deal closed through `closure_outcome` alone
+
+### Phase 3: Ship
+
+- [ ] 3.1 Run the full validation gate
+- [ ] 3.2 Open the PR, raise the allowlist question, review and report labels

--- a/.ai/runs/2026-08-01-deals-summary-closure-outcome.md
+++ b/.ai/runs/2026-08-01-deals-summary-closure-outcome.md
@@ -87,7 +87,7 @@ tenant and period.
 
 ## Progress
 
-PR: (pending — filled in when the PR is opened)
+PR: #4819
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
@@ -104,5 +104,6 @@ PR: (pending — filled in when the PR is opened)
 
 ### Phase 3: Ship
 
-- [ ] 3.1 Run the full validation gate
-- [ ] 3.2 Open the PR, raise the allowlist question, review and report labels
+- [x] 3.1 Run the full validation gate — 82deeaf81 (green except three pre-existing/environmental
+      `yarn test` clusters, each reproduced independently of this change; detailed in the PR body)
+- [x] 3.2 Open the PR, raise the allowlist question, review and report labels — #4819

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-082.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-082.spec.ts
@@ -20,10 +20,12 @@ import { randomUUID } from 'node:crypto';
  *   quarter-over-quarter deltas, a per-stage open-pipeline breakdown, top owners, and a
  *   6-month win-rate series. All money is converted to the tenant base currency where rates
  *   are available; partial conversions are disclosed via `convertedAll` / `missingRateCurrencies`.
- * - `activeDeals.value` / `pipelineValue.value` aggregate OPEN deals (status ∈ {open, in_progress}).
+ * - `activeDeals.value` / `pipelineValue.value` aggregate OPEN deals (status ∈ {open, in_progress}
+ *   AND closure_outcome IS NULL — a recorded closure outcome closes a deal on its own).
  * - `wonThisQuarter` counts deals (status='win' OR closure_outcome='won') whose `updated_at` falls
  *   in the current quarter — a freshly-created `win` deal qualifies (updated_at = now).
- * - `needAttention` = open + overdue (expected_close_at < today) ∪ stuck deals.
+ * - `needAttention` = open + overdue (expected_close_at < today) ∪ stuck deals, both sides using
+ *   the same open-deal predicate.
  * - Requires auth: an unauthenticated GET returns 401.
  *
  * The summary aggregates ALL org deals, so demo/seeded deals are present in the totals. This test
@@ -324,6 +326,99 @@ test.describe('TC-CRM-082: Deals KPI summary endpoint', () => {
       ).toBe(before.pipelineValue.value);
     } finally {
       await deleteEntityIfExists(request, token, '/api/customers/deals', foreignDealId);
+    }
+  });
+
+  // Regression guard for #4697. `dealUpdateSchema` accepts `closureOutcome` on its own and the
+  // update command writes only the column it was given, so a deal can end up with
+  // `status = 'open'` and `closure_outcome = 'won'` at once — the shape any importer or
+  // integration that closes deals through the API produces. Before the fix the summary route's
+  // open-deal predicate read `status` alone, so that single deal was counted as active pipeline
+  // AND as won inside one response. The route now requires `closure_outcome IS NULL` on every
+  // open-deal query, so closing a deal this way must move its value out of `pipelineValue` and
+  // its head out of `activeDeals`, exactly as a `status` flip does.
+  test('drops a deal closed through closure_outcome alone from the pipeline and active-deal cards', async ({ request }) => {
+    test.slow();
+
+    const stamp = Date.now();
+    const DEAL_VALUE = 210_000; // large and unmistakable, so any residue in the totals shows up.
+
+    let token: string | null = null;
+    let dealId: string | null = null;
+
+    try {
+      token = await getAuthToken(request, 'admin');
+      const scope = getTokenScope(token);
+
+      const before = await fetchSummary(request, token);
+      assertSummaryShape(before);
+      const seedCurrency = before.baseCurrencyCode ?? undefined;
+
+      dealId = await createDealFixture(request, token, {
+        title: `TC-CRM-082 Closure-only ${stamp}`,
+        status: 'open',
+        valueAmount: DEAL_VALUE,
+        valueCurrency: seedCurrency,
+        ownerUserId: scope.userId,
+      });
+
+      // The deal is open: it must be visible in both active-deal cards first, otherwise the
+      // "it disappears after closing" assertion below would pass vacuously.
+      const whileOpen = await fetchSummary(request, token);
+      assertSummaryShape(whileOpen);
+      expect(
+        whileOpen.activeDeals.value - before.activeDeals.value,
+        'the freshly seeded open deal should raise activeDeals by exactly 1',
+      ).toBe(1);
+
+      // Close it the way the CRUD API permits: `closureOutcome` only, `status` untouched.
+      const closeResponse = await apiRequest(request, 'PUT', '/api/customers/deals', {
+        token,
+        data: { id: dealId, closureOutcome: 'won' },
+      });
+      expect(closeResponse.status(), 'PUT with closureOutcome alone should be accepted').toBe(200);
+
+      // Confirm the premise of the regression: the write left `status` alone. If a future change
+      // makes the API derive `status` from `closureOutcome`, this assertion is the signal to
+      // revisit the test — the KPI assertions below hold under either behavior.
+      const readBack = await apiRequest(request, 'GET', `/api/customers/deals?id=${encodeURIComponent(dealId)}`, { token });
+      expect(readBack.status()).toBe(200);
+      const readBackBody = await readJsonSafe<{ items?: Array<{ id: string; status?: string; closureOutcome?: string | null }> }>(readBack);
+      const closedRow = readBackBody?.items?.find((entry) => entry.id === dealId);
+      expect(closedRow, 'the closed deal should still be readable').toBeTruthy();
+      expect(closedRow?.status, 'closing via closureOutcome must not move status').toBe('open');
+
+      const afterClose = await fetchSummary(request, token);
+      assertSummaryShape(afterClose);
+
+      // The deal is closed, so both active-deal cards must return to their baseline …
+      expect(
+        afterClose.activeDeals.value,
+        'a deal closed through closure_outcome must leave the active-deal count',
+      ).toBe(before.activeDeals.value);
+
+      // … and it must be counted as won exactly once, never as both at the same time.
+      expect(
+        afterClose.wonThisQuarter.dealsClosed - before.wonThisQuarter.dealsClosed,
+        'the closed deal should be counted once in wonThisQuarter',
+      ).toBe(1);
+
+      // Money assertions are only deterministic when a base currency exists and the seed used it.
+      if (before.baseCurrencyCode) {
+        const pipelineDelta = afterClose.pipelineValue.value - before.pipelineValue.value;
+        expect(
+          Math.abs(pipelineDelta),
+          `pipelineValue should return to its baseline after the deal is closed (got delta ${pipelineDelta})`,
+        ).toBeLessThanOrEqual(1);
+
+        const wonDelta = afterClose.wonThisQuarter.value - before.wonThisQuarter.value;
+        expect(
+          Math.abs(wonDelta - DEAL_VALUE),
+          `wonThisQuarter should increase by ~${DEAL_VALUE} (got delta ${wonDelta})`,
+        ).toBeLessThanOrEqual(1);
+      }
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/deals', dealId);
     }
   });
 });

--- a/packages/core/src/modules/customers/api/deals/summary/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/deals/summary/__tests__/route.test.ts
@@ -322,4 +322,61 @@ describe('customers deals summary route', () => {
     // Only the open stuck deal counts; the terminal stuck deal is filtered out by the intersection.
     expect(body.activeDeals.needAttention).toBe(1)
   })
+
+  // A deal closed through `closureOutcome` alone keeps `status = 'open'` (the CRUD API accepts the
+  // column on its own), so an open predicate that reads only `status` counts it as active pipeline
+  // while the won queries — which read both columns — also count it as won. Every open-deal query
+  // must therefore require `closure_outcome IS NULL`, and it must be `IS NULL` rather than a `!=`
+  // comparison: the column is nullable, so `closure_outcome != 'won'` evaluates to NULL for every
+  // genuinely open deal and would empty the pipeline instead of trimming it.
+  it('requires a NULL closure_outcome in every open-deal query so a closure_outcome-only deal leaves the pipeline', async () => {
+    fetchStuckDealIdsMock.mockResolvedValue([stuckDealId])
+
+    executeMock
+      // 1) base currency
+      .mockResolvedValueOnce([{ code: 'USD' }])
+      // 2) open pipeline rows
+      .mockResolvedValueOnce([])
+      // 3) inflow
+      .mockResolvedValueOnce([])
+      // 4) won
+      .mockResolvedValueOnce([])
+      // 5) win/loss
+      .mockResolvedValueOnce([{ current_won: '0', current_lost: '0', previous_won: '0', previous_lost: '0' }])
+      // 6) series
+      .mockResolvedValueOnce([])
+      // 7) overdue
+      .mockResolvedValueOnce([])
+      // 8) open intersection for the stuck ids
+      .mockResolvedValueOnce([])
+
+    const response = await GET(new Request('http://localhost/api/customers/deals/summary'))
+    expect(response.status).toBe(200)
+
+    const sqlOf = (callIndex: number): string =>
+      String(executeMock.mock.calls[callIndex][0]).replace(/\s+/g, ' ')
+
+    // The open-deal queries behind pipelineValue, its stage breakdown, activeDeals and the
+    // need-attention stuck intersection: open status allowlist AND no recorded closure outcome.
+    const openDealQueries = {
+      'open pipeline aggregation': sqlOf(1),
+      'open inflow delta': sqlOf(2),
+      'need-attention stuck intersection': sqlOf(7),
+    }
+    for (const [label, sql] of Object.entries(openDealQueries)) {
+      expect({ label, keepsStatusAllowlist: sql.includes('status IN (?,?)') }).toEqual({ label, keepsStatusAllowlist: true })
+      expect({ label, excludesClosureOutcome: sql.includes('closure_outcome IS NULL') }).toEqual({ label, excludesClosureOutcome: true })
+      // A `!=` / `<>` comparison on a nullable column evaluates to NULL for every open deal and
+      // would empty the pipeline instead of trimming it.
+      expect({ label, usesNullSwallowingInequality: /closure_outcome\s*(!=|<>)/.test(sql) })
+        .toEqual({ label, usesNullSwallowingInequality: false })
+    }
+
+    // The other half of need-attention: overdue open deals.
+    expect(sqlOf(6)).toContain("status = 'open' AND closure_outcome IS NULL")
+
+    // Unchanged counterpart: the won query still treats either column as authoritative, which is
+    // what made the contradiction visible in the first place.
+    expect(sqlOf(3)).toContain("(status = 'win' OR closure_outcome = 'won')")
+  })
 })

--- a/packages/core/src/modules/customers/api/deals/summary/route.ts
+++ b/packages/core/src/modules/customers/api/deals/summary/route.ts
@@ -196,6 +196,17 @@ export async function GET(req: Request) {
   const scopeWhere = `tenant_id = ? AND organization_id IN (${orgPlaceholders}) AND deleted_at IS NULL`
   const scopeValues: Array<string | number | null> = [effectiveTenantId, ...orgFilterIds]
   const openPlaceholders = OPEN_STATUSES.map(() => '?').join(',')
+  // A deal is closed when EITHER `status` OR `closure_outcome` says so. The CRUD API accepts
+  // `closureOutcome` on its own (`data/validators.ts`), so a deal can hold `status = 'open'` and
+  // `closure_outcome = 'won'` at the same time. The won/lost queries below already read both
+  // columns, so the open predicate must read both too — otherwise one deal comes back as active
+  // pipeline AND won inside a single response.
+  //
+  // `IS NULL` rather than `!= 'won'`: `closure_outcome` is nullable and every open deal holds NULL
+  // there, so a `!=` comparison evaluates to NULL and would drop every open deal instead of the
+  // closed ones. This matches the `closureOutcome IS NULL` filter the dashboards pipeline-summary
+  // widget applies, so the card and the chart count the same deals.
+  const openDealsWhere = `status IN (${openPlaceholders}) AND closure_outcome IS NULL`
 
   // 1) Open pipeline: per (stage, currency) sums + open-deal owner per row, so we can
   //    derive pipeline value (per stage + converted total) and the open owner set in one pass.
@@ -207,7 +218,7 @@ export async function GET(req: Request) {
         COUNT(*) AS count,
         owner_user_id
       FROM customer_deals
-      WHERE ${scopeWhere} AND status IN (${openPlaceholders})
+      WHERE ${scopeWhere} AND ${openDealsWhere}
       GROUP BY pipeline_stage, UPPER(COALESCE(value_currency, '')), owner_user_id`,
     [...scopeValues, ...OPEN_STATUSES],
   )
@@ -221,7 +232,7 @@ export async function GET(req: Request) {
         COALESCE(SUM(value_amount) FILTER (WHERE created_at >= ? AND created_at < ?), 0) AS previous_total,
         COUNT(*) FILTER (WHERE created_at >= ? AND created_at < ?) AS previous_count
       FROM customer_deals
-      WHERE ${scopeWhere} AND status IN (${openPlaceholders})
+      WHERE ${scopeWhere} AND ${openDealsWhere}
       GROUP BY UPPER(COALESCE(value_currency, ''))`,
     [
       currentQuarter.start.toISOString(), currentQuarter.end.toISOString(),
@@ -283,9 +294,12 @@ export async function GET(req: Request) {
   )
 
   // Overdue open deals (id set) + stuck deals (id set) → union count for "need attention".
+  // "Need attention" is a slice of the active-deal card, so it carries the same `closure_outcome`
+  // guard as the pipeline queries: a deal closed through `closure_outcome` alone must not be
+  // reported as needing attention while it is also being counted as won.
   const overdueRows: Array<{ id: string }> = await connection.execute<Array<{ id: string }>>(
     `SELECT id FROM customer_deals
-      WHERE ${scopeWhere} AND status = 'open' AND expected_close_at IS NOT NULL AND expected_close_at < CURRENT_DATE`,
+      WHERE ${scopeWhere} AND status = 'open' AND closure_outcome IS NULL AND expected_close_at IS NOT NULL AND expected_close_at < CURRENT_DATE`,
     [...scopeValues],
   )
   // `fetchStuckDealIds` is single-org; run it for every org in scope so multi-org callers don't
@@ -298,15 +312,15 @@ export async function GET(req: Request) {
   for (const list of stuckIdLists) for (const id of list) stuckIdSet.add(id)
 
   // The stuck-deal query does not filter status, so a stuck id can be a won/lost/closed deal.
-  // "Need attention" is an active-deal metric — intersect with the open (OPEN_STATUSES) set so
-  // terminal deals never inflate the count.
+  // "Need attention" is an active-deal metric — intersect with the open set (open status AND no
+  // recorded closure outcome) so terminal deals never inflate the count.
   let openStuckIds: string[] = []
   if (stuckIdSet.size > 0) {
     const stuckIdValues = Array.from(stuckIdSet)
     const stuckPlaceholders = stuckIdValues.map(() => '?').join(',')
     const openStuckRows: Array<{ id: string }> = await connection.execute<Array<{ id: string }>>(
       `SELECT id FROM customer_deals
-        WHERE ${scopeWhere} AND status IN (${openPlaceholders}) AND id IN (${stuckPlaceholders})`,
+        WHERE ${scopeWhere} AND ${openDealsWhere} AND id IN (${stuckPlaceholders})`,
       [...scopeValues, ...OPEN_STATUSES, ...stuckIdValues],
     )
     openStuckIds = openStuckRows.map((row) => row.id)


### PR DESCRIPTION
Closes #4697
Tracking plan: .ai/runs/2026-08-01-deals-summary-closure-outcome.md
Status: complete

## 🎯 Goal

Make `GET /api/customers/deals/summary` classify each deal exactly once. A deal closed by writing `closure_outcome` alone — which the CRUD API explicitly permits — now leaves the open-pipeline figures instead of being reported as active pipeline *and* as won inside the same response, so the *Pipeline value* / *Active deals* cards stop contradicting the *Won this quarter* card and the `dashboards.analytics.pipelineSummary` chart.

## 🔍 Problem

`customer_deals` carries two independent closure signals and the supported writers do not agree on which one they set: the closure UI writes both `status` and `closure_outcome`, the AI stage tool writes `status` only, and `dealUpdateSchema` accepts `closureOutcome` on its own. A deal closed through the CRUD API therefore ends up with `status = 'open'` and `closure_outcome = 'won'` at the same time.

The summary route already read both columns in its won/lost queries (`status = 'win' OR closure_outcome = 'won'`), but its open-deal queries read `status` alone. As #4697 reports, one `GET /api/customers/deals/summary` then returned the same deal in `wonThisQuarter` **and** inside `pipelineValue` / `activeDeals` — and disagreed with the pipeline-summary widget, which has filtered `closureOutcome IS NULL` in its default *Open deals only* scope since #4683.

## 🔍 Root Cause

`summary/route.ts` built its open-deal predicate from the `OPEN_STATUSES` allowlist only — `status IN ('open','in_progress')` — and never consulted `closure_outcome`. The predicate was inlined at each call site, so there was no single place where the two-column definition of "closed" could be applied. `commands/deals.ts` assigns `closureOutcome` without deriving `status` from it, so nothing upstream repaired the mismatch before it reached the query.

## What Changed

- **`packages/core/src/modules/customers/api/deals/summary/route.ts`** — the four open-deal queries now share one documented SQL fragment, `status IN (?,?) AND closure_outcome IS NULL`:
  - the pipeline/stage aggregation that also produces the owner rollup (feeds `pipelineValue`, its `stages` breakdown, `activeDeals.value`, `activeDeals.owners`),
  - the quarter-over-quarter inflow query behind `pipelineValue.delta`,
  - the stuck-deal intersection behind `activeDeals.needAttention`,
  - and the overdue lookup, which is the other half of `needAttention` — included so the whole card uses one definition of "open" rather than two.

  The guard is spelled `IS NULL` rather than `!= 'won'` on purpose, and the code says why: `closure_outcome` is nullable and every genuinely open deal holds NULL there, so an inequality would evaluate to NULL and empty the pipeline instead of trimming it. This is the same reasoning #4683 documented on the widget side, which is what makes the card and the chart agree.

- **No change** to the won/lost queries, the win-rate series, the widget, or the `status IN ('open','in_progress')` allowlist itself — see the open question below.

## 🧪 Tests

- Full gate from `.ai/agentic.config.json`, run locally in order: `build:packages` ✅, `generate` ✅ (no tracked drift), `build:packages` ✅, `i18n:check-sync` ✅, `i18n:check-usage` ✅, `typecheck` ✅, `test` ❌ (see below), `build:app` ✅.
- `yarn workspace @open-mercato/core test` — **8722 passed / 3 failed, 1129 of 1130 suites**. The three failures are all in `src/modules/sales/api/__tests__/documents.routes.test.ts` (sales order create route returns 400 where the test expects 201) and are **pre-existing**: I reproduced them with all three of my files reverted to `upstream/develop`, and they touch a module this PR does not.
- The other two `yarn test` failures in the monorepo run are likewise unrelated to this change: `create-mercato-app`'s module-facts build test failed under turbo's parallel run but passes **426/0** when the workspace is run on its own (`node build.mjs` succeeds standalone — a build race, not a defect), and `open-mercato-docs`' search-index test needs `apps/docs/build/search-index.json`, which only a docs production build produces.
- `packages/core/src/modules/customers/api/deals/summary/__tests__/route.test.ts` — **10 passed**.
- **New unit regression** in `api/deals/summary/__tests__/route.test.ts`: asserts every open-deal query keeps its status allowlist, requires `closure_outcome IS NULL`, and uses no NULL-swallowing `!=` / `<>` on that column, while the won query still reads either column. Verified against the pre-fix route: the test **fails** without this change (`excludesClosureOutcome: false` on the open pipeline aggregation) and passes with it.
- **New integration case** in `__integration__/TC-CRM-082.spec.ts`: seeds an open deal, confirms it raises `activeDeals`, closes it with `PUT { id, closureOutcome: 'won' }`, confirms the read-back still shows `status = 'open'` (the exact condition from the issue), then asserts the deal has left `activeDeals` and `pipelineValue` and is counted once in `wonThisQuarter`. The spec's contract header was updated to state the two-column open predicate.

## 💥 Breaking Changes

None. The response shape is unchanged. The figures change only where they were already wrong: a tenant holding deals with an open `status` and a recorded `closure_outcome` will see `pipelineValue` / `activeDeals` drop by exactly those deals — the same deals that were simultaneously being counted as won.

## ❓ Open question for a maintainer — should the status allowlist stay?

The issue asks this explicitly and I deliberately did **not** decide it here.

The route keeps an **allowlist**, `status IN ('open','in_progress')`, while the pipeline-summary widget uses a **denylist** (`status NOT IN {win, won, loose, lost, closed}` plus `closureOutcome IS NULL`). With this PR both sides agree on the `closure_outcome` dimension, but they still disagree on the `status` dimension: `customer_deals.status` is a lenient text column fed by the per-tenant `deal_status` dictionary, so a tenant whose vocabulary carries an active status outside `('open','in_progress')` — say `negotiation` — has those deals invisible to the *Pipeline value* and *Active deals* cards while the chart counts them. That is the mirror image of the denylist reasoning in #4621/#4629 and of the "an unknown status counts as OPEN" rule that `customers/lib/dealStatus.ts` already encodes.

Switching the route to the denylist would align the two surfaces completely, but it changes which deals the cards see for any tenant with a custom dictionary, so it is a product call rather than a bug fix. Happy to follow up either way:

1. **Keep the allowlist** — conservative, cards only ever count statuses the platform knows.
2. **Move to the denylist / `isOpenDealStatus`** — matches the widget and the shared vocabulary, unknown statuses count as open.

## 🏷️ Labels — needed from a maintainer

My account has `read` without `triage`, so I cannot apply labels (`AddLabelsToLabelable` returns a permissions error). Requested set:

- `bug` — a single deal was returned classified two ways at once, so the KPI cards reported figures that could not all be true.
- `priority-medium` — it corrupts revenue reporting people act on, but only for deals closed through the `closure_outcome`-only path rather than the normal closure flow.
- `risk-low` — a predicate correction inside one already-identified read route, shipped with unit and integration coverage; no schema, no write path, no response-shape change.
- `review` — ready for code review.
- `skip-qa` or `needs-qa` — a maintainer's call. The change touches no UI-rendering file (no `.tsx` outside tests, nothing under `packages/ui/src/`), leaves the database structure and API surface unchanged, breaks no `BACKWARD_COMPATIBILITY.md` contract, and ships automated tests for the changed behavior, so it meets the automated-verification exemption for `skip-qa`; it does move numbers on two visible KPI cards, so `needs-qa` is equally defensible if you want eyes on them.
