### PR TITLE
fix(auth): keep example sidebar group last by default

### DIFF
--- a/.ai/runs/2026-08-01-example-sidebar-order.md
+++ b/.ai/runs/2026-08-01-example-sidebar-order.md
@@ -50,8 +50,8 @@ Source doc: `.ai/specs/2026-07-30-nav-group-order-override-domain.md`
 
 ### Phase 2: Regression coverage and documentation
 
-- [ ] 2.1 Add synchronized app/template regression coverage
-- [ ] 2.2 Record the corrected integration-fixture boundary in the source spec
+- [x] 2.1 Add synchronized app/template regression coverage — 994e21945
+- [x] 2.2 Record the corrected integration-fixture boundary in the source spec — fdaa1ca8a
 
 ### Phase 3: Verification and review
 

--- a/.ai/runs/2026-08-01-example-sidebar-order.md
+++ b/.ai/runs/2026-08-01-example-sidebar-order.md
@@ -46,7 +46,7 @@ Source doc: `.ai/specs/2026-07-30-nav-group-order-override-domain.md`
 
 ### Phase 1: Runtime boundary
 
-- [ ] 1.1 Gate the applied Example nav override to integration-test runtimes
+- [x] 1.1 Gate the applied Example nav override to integration-test runtimes — 9b4c4e5c4
 
 ### Phase 2: Regression coverage and documentation
 

--- a/.ai/runs/2026-08-01-example-sidebar-order.md
+++ b/.ai/runs/2026-08-01-example-sidebar-order.md
@@ -1,0 +1,58 @@
+# Restore the Example Sidebar Group to the End
+
+## Goal
+
+Restore the Example module's sidebar group to its historical tail position in normal monorepo and standalone-app runtimes without weakening the new app-level navigation ordering override.
+
+Source doc: `.ai/specs/2026-07-30-nav-group-order-override-domain.md`
+
+## Scope
+
+- Correct the app configuration that enabled `example.nav.group` as a live ordering override solely to support integration coverage.
+- Keep the real-bootstrap integration proof active only inside the existing ephemeral integration-test runtime.
+- Mirror the correction in the create-app template and add a regression contract that prevents the test fixture from leaking into default app behavior again.
+- Update the existing navigation-ordering spec to record the corrected fixture boundary.
+
+## Non-goals
+
+- Do not change `overrides.nav.groupOrder` prepend semantics or the shipped `defaultGroupOrder`.
+- Do not change role or per-user sidebar preferences, persistence, APIs, or the customization editor.
+- Do not add a new environment variable or alter navigation for apps that deliberately configure their own group ordering.
+
+## Implementation Plan
+
+### Phase 1: Runtime boundary
+
+- Gate the applied Example-module nav override behind the existing `OM_INTEGRATION_TEST` runtime flag in both the monorepo app and the standalone template, while leaving the copyable override example intact.
+
+### Phase 2: Regression coverage and documentation
+
+- Add a create-app contract test that checks the monorepo/template Example entries remain synchronized and that their applied nav override is explicitly test-only.
+- Update the existing nav-ordering spec's integration-coverage explanation and changelog with the root-cause correction.
+
+### Phase 3: Verification and review
+
+- Run focused tests for the changed app/template contract, the configured validation gate, and the authoritative PR review/autofix workflow before marking the run complete.
+
+## Risks
+
+- The integration server must continue receiving `OM_INTEGRATION_TEST=true`; the existing ephemeral runner already sets it for both reusable and fresh runtimes, and the route-level integration test retains coverage of the enabled path.
+- A source-contract test can become brittle if the Example entry is substantially reorganized; it intentionally scopes extraction to that entry and validates behavior-bearing syntax rather than the entire modules file.
+- Users with saved role or personal ordering remain unaffected because those preferences already have higher precedence than app defaults.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Runtime boundary
+
+- [ ] 1.1 Gate the applied Example nav override to integration-test runtimes
+
+### Phase 2: Regression coverage and documentation
+
+- [ ] 2.1 Add synchronized app/template regression coverage
+- [ ] 2.2 Record the corrected integration-fixture boundary in the source spec
+
+### Phase 3: Verification and review
+
+- [ ] 3.1 Complete the validation gate and authoritative PR review

--- a/.ai/specs/2026-07-30-nav-group-order-override-domain.md
+++ b/.ai/specs/2026-07-30-nav-group-order-override-domain.md
@@ -175,9 +175,10 @@ Override plumbing (`packages/shared`):
 
 Route-level (`packages/core/src/modules/auth/__integration__/TC-AUTH-NAV-OVERRIDE-001.spec.ts`) —
 proves a real declaration survives a real bootstrap, following the pattern already used for the
-API-route domain (`TC-UMES-022`), where the example app applies a genuine override so a test can
-observe it. `apps/mercato/src/modules.ts` therefore applies `nav: { groupOrder: ['example.nav.group'] }`
-on the `example` entry:
+API-route domain (`TC-UMES-022`). The example app applies a genuine
+`nav: { groupOrder: ['example.nav.group'] }` override only when the ephemeral runner's existing
+`OM_INTEGRATION_TEST` flag is enabled. This keeps the test path real without turning the fixture into
+the default sidebar policy for normal monorepo development or newly scaffolded standalone apps:
 
 - the app-declared group leads the sidebar, outranking `customers.nav.group` (first in the shipped list)
 - a personal sidebar preference still wins over the app default, and clearing it falls back to the
@@ -256,6 +257,10 @@ No migration is required, and no existing installation changes behaviour.
   identical to the previous implementation. Verified empirically rather than by inspection: the ordering
   test suite was run against the *unmodified* implementation, where the no-override and empty-override
   cases pass unchanged and only the override-specific cases fail.
+- **The repository's applied integration fixture is test-only.** Both the monorepo app and create-app
+  template guard the Example module's `nav.groupOrder` declaration with `OM_INTEGRATION_TEST`. Normal
+  development and production runtimes therefore exercise the no-override path unless an app owner
+  deliberately configures an ordering override.
 - **One narrow behaviour does change, intentionally.** An app that had already written `overrides.nav`
   was previously ignored with a "domain not yet wired" warning, and now takes effect. That is the point
   of wiring the domain; such an app was relying on a documented no-op.
@@ -282,3 +287,9 @@ No migration is required, and no existing installation changes behaviour.
   domain in the umbrella spec's status table (phase 19), `packages/shared/AGENTS.md`, the overrides
   docs page, and the `moduleOverrideExamples` catalogue in both the app and the create-app template.
   Added `TC-AUTH-NAV-OVERRIDE-001` for route-level proof through a real bootstrap.
+
+- 2026-08-01: Corrected the route-level fixture boundary after the applied Example override made the
+  Example group lead every normal monorepo and classic standalone sidebar. The declaration is now
+  active only under the integration runner's existing `OM_INTEGRATION_TEST` flag, with a create-app
+  regression contract keeping the monorepo and template entries synchronized. The override feature,
+  precedence, and integration assertion remain unchanged.

--- a/apps/mercato/src/modules.ts
+++ b/apps/mercato/src/modules.ts
@@ -127,11 +127,11 @@ export const enabledModules: ModuleEntry[] = [
     id: 'example',
     from: '@app',
     overrides: {
-      // Applied (not just catalogued) so integration coverage can prove a real nav override survives
-      // bootstrap, mirroring how the override-probe route below is proven by TC-UMES-022.
-      nav: {
-        groupOrder: ['example.nav.group'],
-      },
+      // Keep the real-bootstrap nav override probe isolated from normal app behavior. The integration
+      // runner sets OM_INTEGRATION_TEST, while development and production keep Example at the tail.
+      nav: parseBooleanWithDefault(process.env.OM_INTEGRATION_TEST, false)
+        ? { groupOrder: ['example.nav.group'] }
+        : undefined,
       routes: {
         api: {
           'GET /api/example/override-probe': {

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-NAV-OVERRIDE-001.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-NAV-OVERRIDE-001.spec.ts
@@ -12,7 +12,7 @@ import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixt
  * through a real bootstrap. This does, following the same pattern the repository already uses for the
  * API-route domain (`TC-UMES-022`, where the example app applies a real override so a test can prove
  * it): `apps/mercato/src/modules.ts` applies `nav: { groupOrder: ['example.nav.group'] }` to the
- * `example` entry.
+ * `example` entry only under `OM_INTEGRATION_TEST`, which the ephemeral runner sets for the app.
  *
  * Verified-against-source contract:
  * - `overrides.nav.groupOrder` prepends group ids ahead of the built-in `defaultGroupOrder`

--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -129,6 +129,18 @@ function makeTempDir(): string {
   return dir
 }
 
+function extractExampleModuleEntry(content: string): string {
+  const startMarker = "  {\n    id: 'example',"
+  const endMarker = "\n  { id: 'ratelimit_probe'"
+  const start = content.indexOf(startMarker)
+  const end = content.indexOf(endMarker, start)
+
+  assert.notEqual(start, -1, 'expected the Example module entry')
+  assert.notEqual(end, -1, 'expected the module entry after Example')
+
+  return content.slice(start, end)
+}
+
 test('applyStarterPreset: classic is a no-op', () => {
   const dir = makeTempDir()
   try {
@@ -199,4 +211,21 @@ test('template baseline modules keep example enabled for classic', () => {
   assert.ok(content.includes("id: 'example'"))
   assert.ok(content.includes("enabledModules.some((entry) => entry.id === 'example')"))
   assert.ok(content.includes("enabledModules.push({ id: 'example_customers_sync', from: '@app' })"))
+})
+
+test('template and monorepo keep the applied Example nav override integration-only', () => {
+  const templateContent = readFileSync(join(__dirname, '..', '..', 'template', 'src', 'modules.ts'), 'utf-8')
+  const monorepoContent = readFileSync(join(__dirname, '..', '..', '..', '..', 'apps', 'mercato', 'src', 'modules.ts'), 'utf-8')
+  const templateEntry = extractExampleModuleEntry(templateContent)
+  const monorepoEntry = extractExampleModuleEntry(monorepoContent)
+
+  assert.equal(templateEntry, monorepoEntry)
+
+  for (const entry of [templateEntry, monorepoEntry]) {
+    assert.match(
+      entry,
+      /nav:\s*parseBooleanWithDefault\(process\.env\.OM_INTEGRATION_TEST, false\)\s*\?\s*\{ groupOrder: \['example\.nav\.group'\] \}\s*:\s*undefined/,
+    )
+    assert.doesNotMatch(entry, /nav:\s*\{\s*groupOrder:/)
+  }
 })

--- a/packages/create-app/template/src/modules.ts
+++ b/packages/create-app/template/src/modules.ts
@@ -127,11 +127,11 @@ export const enabledModules: ModuleEntry[] = [
     id: 'example',
     from: '@app',
     overrides: {
-      // Applied (not just catalogued) so integration coverage can prove a real nav override survives
-      // bootstrap, mirroring how the override-probe route below is proven by TC-UMES-022.
-      nav: {
-        groupOrder: ['example.nav.group'],
-      },
+      // Keep the real-bootstrap nav override probe isolated from normal app behavior. The integration
+      // runner sets OM_INTEGRATION_TEST, while development and production keep Example at the tail.
+      nav: parseBooleanWithDefault(process.env.OM_INTEGRATION_TEST, false)
+        ? { groupOrder: ['example.nav.group'] }
+        : undefined,
       routes: {
         api: {
           'GET /api/example/override-probe': {


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-01-example-sidebar-order.md
Source doc: .ai/specs/2026-07-30-nav-group-order-override-domain.md
Status: in-progress

## 🎯 Goal
- Restore the Example module's sidebar group to its historical end position in normal monorepo and standalone-app runtimes while preserving real-bootstrap coverage of app-level nav ordering overrides.
- The regression came from an integration fixture being applied as default app policy, not from the ordering resolver itself.

## What Changed
- `apps/mercato/src/modules.ts` now applies the Example nav ordering probe only when the existing ephemeral-test flag `OM_INTEGRATION_TEST` is enabled.
- `packages/create-app/template/src/modules.ts` mirrors the same boundary so newly scaffolded classic apps do not promote Example to the top.
- `packages/create-app/src/lib/apply-starter-preset.test.ts` locks the app/template entries together and rejects an unconditional applied nav override.
- The source spec and route-level integration commentary now document that the real-bootstrap fixture is test-only.

## 🧪 Tests
- Focused changed-surface checks passed: create-app 11/11, sidebar ordering 7/7, and app unit tests 182/182.
- Clean CI passed lint, package builds, generation, app build, typecheck, i18n, selected integration coverage, and CodeQL.
- The full test job is blocked by three deterministic failures in `packages/core/src/modules/sales/api/__tests__/documents.routes.test.ts` (8721 other tests passed). Those Sales files are identical to `origin/develop`, and the focused file reproduces the same failures locally because its fixtures omit line items now required by the base branch.
- This PR intentionally does not widen into an unrelated Sales repair; it remains a draft until the base-branch failure is corrected and the gate can rerun green.

## 💥 Breaking Changes
- None. The additive `overrides.nav.groupOrder` contract and its precedence are unchanged; only the repository's accidental default fixture is constrained to tests.

## 📋 Progress
See the Progress section in the tracking plan.
