### PR TITLE
fix(customers): stabilize calendar date range hydration

### DIFF
--- a/.ai/runs/2026-08-01-calendar-toolbar-hydration-error.md
+++ b/.ai/runs/2026-08-01-calendar-toolbar-hydration-error.md
@@ -1,0 +1,48 @@
+# Calendar Toolbar Hydration Error
+
+## Goal
+
+Prevent the CRM calendar toolbar from producing byte-different server and client date-range labels when their `Intl` implementations use different invisible spacing characters.
+
+Source doc: `.ai/specs/2026-06-11-crm-calendar.md`
+
+## Scope
+
+- Add regression coverage for locale-aware calendar labels whose visible text is identical but whose `Intl` output contains environment-dependent Unicode spacing.
+- Canonicalize invisible spacing in the shared calendar date/time formatting helper while preserving localized month names, clock formats, visible punctuation, and the existing fallback path.
+- Verify the focused customers-calendar tests and the repository's configured validation gate.
+
+## Non-goals
+
+- Do not change locale detection, timezone behavior, calendar range calculations, or the toolbar component contract.
+- Do not redesign the visible date/time formats or touch unrelated calendar surfaces.
+- Do not add dependencies, API changes, schema changes, or migrations.
+
+## Implementation Plan
+
+### Phase 1: Deterministic localized labels
+
+1. Add regression coverage that rejects hydration-unstable Unicode spacing in date and time labels.
+2. Canonicalize invisible `Intl` spacing without changing the visible localized output or fallback behavior.
+
+### Phase 2: Verification
+
+1. Run focused calendar formatter tests and the complete configured validation gate, then review the final diff for compatibility and scope.
+
+## Risks
+
+- Unicode normalization could accidentally alter meaningful visible punctuation. Mitigation: normalize only known space variants and keep locale-specific words, ordering, punctuation, and hour cycles untouched.
+- Different runtimes may vary beyond whitespace. The attached React diff shows visually identical range text, so this run deliberately addresses the proven invisible-character mismatch and leaves broader format redesign out of scope.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Deterministic localized labels
+
+- [ ] 1.1 Add regression coverage that rejects hydration-unstable Unicode spacing in date and time labels.
+- [ ] 1.2 Canonicalize invisible `Intl` spacing without changing the visible localized output or fallback behavior.
+
+### Phase 2: Verification
+
+- [ ] 2.1 Run focused calendar formatter tests and the complete configured validation gate, then review the final diff for compatibility and scope.

--- a/.ai/runs/2026-08-01-calendar-toolbar-hydration-error.md
+++ b/.ai/runs/2026-08-01-calendar-toolbar-hydration-error.md
@@ -40,8 +40,8 @@ Source doc: `.ai/specs/2026-06-11-crm-calendar.md`
 
 ### Phase 1: Deterministic localized labels
 
-- [ ] 1.1 Add regression coverage that rejects hydration-unstable Unicode spacing in date and time labels.
-- [ ] 1.2 Canonicalize invisible `Intl` spacing without changing the visible localized output or fallback behavior.
+- [x] 1.1 Add regression coverage that rejects hydration-unstable Unicode spacing in date and time labels. — 439bd7d1f5
+- [x] 1.2 Canonicalize invisible `Intl` spacing without changing the visible localized output or fallback behavior. — 439bd7d1f5
 
 ### Phase 2: Verification
 

--- a/.ai/runs/2026-08-01-calendar-toolbar-hydration-error.md
+++ b/.ai/runs/2026-08-01-calendar-toolbar-hydration-error.md
@@ -33,6 +33,7 @@ Source doc: `.ai/specs/2026-06-11-crm-calendar.md`
 
 - Unicode normalization could accidentally alter meaningful visible punctuation. Mitigation: normalize only known space variants and keep locale-specific words, ordering, punctuation, and hour cycles untouched.
 - Different runtimes may vary beyond whitespace. The attached React diff shows visually identical range text, so this run deliberately addresses the proven invisible-character mismatch and leaves broader format redesign out of scope.
+- Verification is blocked by an unrelated base failure in `packages/core/src/modules/sales/api/__tests__/documents.routes.test.ts`: the clean CI runner and local no-cache suite both report three payment-ledger compatibility assertions receiving HTTP 400 instead of 201. Fixing sales behavior is outside this calendar-only plan; resume step 2.1 after the base suite is repaired.
 
 ## Progress
 

--- a/packages/core/src/modules/customers/lib/calendar/__tests__/format.test.ts
+++ b/packages/core/src/modules/customers/lib/calendar/__tests__/format.test.ts
@@ -3,8 +3,12 @@ import { formatDateLabel, formatDateRangeLabel, formatTimeRangeLabel } from '../
 const JUN_15 = new Date(2026, 5, 15)
 const JUN_21 = new Date(2026, 5, 21)
 const JUN_28 = new Date(2026, 5, 28)
+const JUL_27 = new Date(2026, 6, 27)
+const AUG_2 = new Date(2026, 7, 2)
 const AT_14 = new Date(2026, 5, 28, 14, 0)
 const AT_15 = new Date(2026, 5, 28, 15, 0)
+
+const HYDRATION_UNSTABLE_SPACING = /[\u00a0\u2007\u2009\u202f]/
 
 describe('formatDateRangeLabel', () => {
   it('localizes the month name for Polish instead of falling back to English', () => {
@@ -22,6 +26,13 @@ describe('formatDateRangeLabel', () => {
     expect(formatDateRangeLabel('pl', JUN_15, JUN_21)).not.toBe(
       formatDateRangeLabel('en', JUN_15, JUN_21),
     )
+  })
+
+  it('uses hydration-stable spacing around the localized range', () => {
+    const label = formatDateRangeLabel('en', JUL_27, AUG_2)
+
+    expect(label).toBe('Jul 27 – Aug 2, 2026')
+    expect(label).not.toMatch(HYDRATION_UNSTABLE_SPACING)
   })
 })
 
@@ -55,5 +66,12 @@ describe('formatTimeRangeLabel', () => {
     expect(formatTimeRangeLabel('pl', AT_14, AT_15)).not.toBe(
       formatTimeRangeLabel('en', AT_14, AT_15),
     )
+  })
+
+  it('uses hydration-stable spacing around the localized range', () => {
+    const label = formatTimeRangeLabel('en', AT_14, AT_15)
+
+    expect(label).toBe('2:00 – 3:00 PM')
+    expect(label).not.toMatch(HYDRATION_UNSTABLE_SPACING)
   })
 })

--- a/packages/core/src/modules/customers/lib/calendar/format.ts
+++ b/packages/core/src/modules/customers/lib/calendar/format.ts
@@ -2,6 +2,12 @@ const DATE_OPTIONS: Intl.DateTimeFormatOptions = { day: 'numeric', month: 'short
 
 const TIME_OPTIONS: Intl.DateTimeFormatOptions = { hour: 'numeric', minute: '2-digit' }
 
+const NON_CANONICAL_INTL_SPACING = /[\u00a0\u2007\u2009\u202f]/g
+
+function normalizeIntlSpacing(value: string): string {
+  return value.replace(NON_CANONICAL_INTL_SPACING, ' ')
+}
+
 export function formatDateLabel(locale: string, date: Date): string {
   return new Intl.DateTimeFormat(locale, DATE_OPTIONS).format(date)
 }
@@ -9,17 +15,17 @@ export function formatDateLabel(locale: string, date: Date): string {
 export function formatDateRangeLabel(locale: string, from: Date, to: Date): string {
   const formatter = new Intl.DateTimeFormat(locale, DATE_OPTIONS)
   try {
-    return formatter.formatRange(from, to)
+    return normalizeIntlSpacing(formatter.formatRange(from, to))
   } catch {
-    return `${formatter.format(from)} – ${formatter.format(to)}`
+    return normalizeIntlSpacing(`${formatter.format(from)} – ${formatter.format(to)}`)
   }
 }
 
 export function formatTimeRangeLabel(locale: string, start: Date, end: Date): string {
   const formatter = new Intl.DateTimeFormat(locale, TIME_OPTIONS)
   try {
-    return formatter.formatRange(start, end)
+    return normalizeIntlSpacing(formatter.formatRange(start, end))
   } catch {
-    return `${formatter.format(start)} – ${formatter.format(end)}`
+    return normalizeIntlSpacing(`${formatter.format(start)} – ${formatter.format(end)}`)
   }
 }


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-01-calendar-toolbar-hydration-error.md
Source doc: .ai/specs/2026-06-11-crm-calendar.md
Status: in-progress

## 🎯 Goal
- Prevent the CRM calendar toolbar from hydrating with byte-different server and client labels when their `Intl` implementations use different invisible Unicode spacing.

## What Changed
- Canonicalized non-breaking, figure, thin, and narrow no-break spaces produced by `Intl.DateTimeFormat.formatRange()` in the shared customers-calendar formatter.
- Preserved localized month names, clock formats, punctuation, date calculations, and the existing fallback behavior.
- Added exact-output regression coverage for cross-month date ranges and English time ranges, including assertions that hydration-unstable spacing is absent.

## 🧪 Tests
- Focused calendar formatter suite: 10 tests passed.
- Package builds, module generation, i18n synchronization/usage checks, sequential workspace typechecks, docs build/test, and the production application build passed using the local runner.
- The clean GitHub runner passed package builds, generation, the second package build, i18n checks, typechecking, and the production app build. Its test gate passed 1,131 of 1,132 core suites (8,727 of 8,730 tests); three unrelated sales payment-ledger compatibility assertions fail on the base state, so this run remains in progress under the mandatory-gate policy.

## 💥 Breaking Changes
- None. No exported signatures, routes, response shapes, event IDs, schemas, migrations, or generated contracts changed.

## 📋 Progress
See the Progress section in the tracking plan.
