### PR TITLE
fix(app): prevent root layout script render warning

### DIFF
--- a/.ai/runs/2026-08-01-root-layout-script-render-warning.md
+++ b/.ai/runs/2026-08-01-root-layout-script-render-warning.md
@@ -1,0 +1,54 @@
+# Root Layout Script Render Warning
+
+## Goal
+
+Remove the React development-console error caused by rendering the theme initializer as a raw `<script>` while preserving the initializer's pre-hydration behavior in both the monorepo app and generated standalone apps.
+
+## Scope
+
+- Add focused regression coverage for the root layout's theme initializer.
+- Replace the raw script element with Next.js's supported `Script` component using the `beforeInteractive` strategy.
+- Keep `apps/mercato/src/app/layout.tsx` and `packages/create-app/template/src/app/layout.tsx` behaviorally aligned.
+- Run the configured validation gate and the authoritative PR review/autofix pass.
+
+## Non-goals
+
+- Do not change theme selection semantics, storage keys, or dark-mode styling.
+- Do not refactor `AppProviders` or other app-shell responsibilities.
+- Do not change dependencies, routes, public contracts, or generated artifacts.
+
+## Implementation Plan
+
+### Phase 1: Regression coverage
+
+1. Add a layout regression assertion that requires the theme initializer to use Next.js `Script` with stable identity and pre-interactive execution.
+
+### Phase 2: Minimal repair
+
+1. Migrate the mirrored root layouts from a raw script element to `next/script` without changing the initializer body.
+
+### Phase 3: Verification and delivery
+
+1. Run targeted coverage, the full configured validation gate, and the authoritative PR review/autofix workflow; publish the results and UI evidence on the PR.
+
+## Risks
+
+- Changing script placement or strategy could allow a light-theme flash before hydration; the fix therefore retains `beforeInteractive` execution and the existing initializer body.
+- Updating only the monorepo app would leave newly scaffolded apps broken; both layout copies are changed and reviewed together.
+- No matching feature specification exists because this is a narrow regression fix rather than a new capability.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Regression coverage
+
+- [ ] 1.1 Add a layout regression assertion that requires the theme initializer to use Next.js `Script` with stable identity and pre-interactive execution.
+
+### Phase 2: Minimal repair
+
+- [ ] 2.1 Migrate the mirrored root layouts from a raw script element to `next/script` without changing the initializer body.
+
+### Phase 3: Verification and delivery
+
+- [ ] 3.1 Run targeted coverage, the full configured validation gate, and the authoritative PR review/autofix workflow; publish the results and UI evidence on the PR.

--- a/.ai/runs/2026-08-01-root-layout-script-render-warning.md
+++ b/.ai/runs/2026-08-01-root-layout-script-render-warning.md
@@ -36,8 +36,11 @@ Remove the React development-console error caused by rendering the theme initial
 - Changing script placement or strategy could allow a light-theme flash before hydration; the fix therefore retains `beforeInteractive` execution and the existing initializer body.
 - Updating only the monorepo app would leave newly scaffolded apps broken; both layout copies are changed and reviewed together.
 - No matching feature specification exists because this is a narrow regression fix rather than a new capability.
+- The full gate is externally blocked by repository-wide baseline issue [#4824](https://github.com/open-mercato/open-mercato/issues/4824): an unchanged sales payment-ledger test and integration case omit newly required order lines. Expanding this app-shell PR into the sales module requires maintainer approval.
 
 ## Progress
+
+PR: #4825
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 

--- a/.ai/runs/2026-08-01-root-layout-script-render-warning.md
+++ b/.ai/runs/2026-08-01-root-layout-script-render-warning.md
@@ -43,7 +43,7 @@ Remove the React development-console error caused by rendering the theme initial
 
 ### Phase 1: Regression coverage
 
-- [ ] 1.1 Add a layout regression assertion that requires the theme initializer to use Next.js `Script` with stable identity and pre-interactive execution.
+- [x] 1.1 Add a layout regression assertion that requires the theme initializer to use Next.js `Script` with stable identity and pre-interactive execution. — c021c32af
 
 ### Phase 2: Minimal repair
 

--- a/.ai/runs/2026-08-01-root-layout-script-render-warning.md
+++ b/.ai/runs/2026-08-01-root-layout-script-render-warning.md
@@ -47,7 +47,7 @@ Remove the React development-console error caused by rendering the theme initial
 
 ### Phase 2: Minimal repair
 
-- [ ] 2.1 Migrate the mirrored root layouts from a raw script element to `next/script` without changing the initializer body.
+- [x] 2.1 Migrate the mirrored root layouts from a raw script element to `next/script` without changing the initializer body. — b676c7a7c
 
 ### Phase 3: Verification and delivery
 

--- a/apps/mercato/src/app/layout.tsx
+++ b/apps/mercato/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import './globals.css'
 import '@/lib/i18n/register-dictionary-loader'
 import { AppProviders } from '@/components/AppProviders'
@@ -26,25 +27,20 @@ export default async function RootLayout({
   const noticeBarsEnabled = process.env.OM_INTEGRATION_TEST !== 'true'
   return (
     <html lang={locale} suppressHydrationWarning>
-      <head>
-        <script
-          key="om-theme-init"
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                try {
-                  var stored = localStorage.getItem('om-theme');
-                  var theme = stored === 'dark' ? 'dark'
-                    : stored === 'light' ? 'light'
-                    : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-                  if (theme === 'dark') document.documentElement.classList.add('dark');
-                } catch (e) {}
-              })();
-            `,
-          }}
-        />
-      </head>
       <body className="antialiased" suppressHydrationWarning data-gramm="false">
+        <Script id="om-theme-init" strategy="beforeInteractive">
+          {`
+            (function() {
+              try {
+                var stored = localStorage.getItem('om-theme');
+                var theme = stored === 'dark' ? 'dark'
+                  : stored === 'light' ? 'light'
+                  : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                if (theme === 'dark') document.documentElement.classList.add('dark');
+              } catch (e) {}
+            })();
+          `}
+        </Script>
         <AppProviders locale={locale} dict={dict} localeLocked={localeLocked} demoModeEnabled={demoModeEnabled} noticeBarsEnabled={noticeBarsEnabled}>
           {children}
         </AppProviders>

--- a/packages/create-app/src/lib/root-layout-theme-script.test.ts
+++ b/packages/create-app/src/lib/root-layout-theme-script.test.ts
@@ -16,7 +16,7 @@ test('root layouts use a pre-interactive Next.js script for theme initialization
     const source = fs.readFileSync(rootLayoutPath, 'utf8')
 
     assert.match(source, /import Script from ['"]next\/script['"]/, rootLayoutPath)
-    assert.doesNotMatch(source, /<script(?:\s|>)/, rootLayoutPath)
+    assert.equal(source.includes('<script'), false, rootLayoutPath)
     assert.match(
       source,
       /<Script\s+id="om-theme-init"\s+strategy="beforeInteractive">/,

--- a/packages/create-app/src/lib/root-layout-theme-script.test.ts
+++ b/packages/create-app/src/lib/root-layout-theme-script.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = path.resolve(currentDirectory, '..', '..', '..', '..')
+const rootLayoutPaths = [
+  path.join(repositoryRoot, 'apps', 'mercato', 'src', 'app', 'layout.tsx'),
+  path.join(repositoryRoot, 'packages', 'create-app', 'template', 'src', 'app', 'layout.tsx'),
+]
+
+test('root layouts use a pre-interactive Next.js script for theme initialization', () => {
+  for (const rootLayoutPath of rootLayoutPaths) {
+    const source = fs.readFileSync(rootLayoutPath, 'utf8')
+
+    assert.match(source, /import Script from ['"]next\/script['"]/, rootLayoutPath)
+    assert.doesNotMatch(source, /<script(?:\s|>)/, rootLayoutPath)
+    assert.match(
+      source,
+      /<Script\s+id="om-theme-init"\s+strategy="beforeInteractive">/,
+      rootLayoutPath,
+    )
+    assert.match(source, /localStorage\.getItem\(['"]om-theme['"]\)/, rootLayoutPath)
+  }
+})

--- a/packages/create-app/template/src/app/layout.tsx
+++ b/packages/create-app/template/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import './globals.css'
 import '@/lib/i18n/register-dictionary-loader'
 import { AppProviders } from '@/components/AppProviders'
@@ -26,25 +27,20 @@ export default async function RootLayout({
   const noticeBarsEnabled = process.env.OM_INTEGRATION_TEST !== 'true'
   return (
     <html lang={locale} suppressHydrationWarning>
-      <head>
-        <script
-          key="om-theme-init"
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                try {
-                  var stored = localStorage.getItem('om-theme');
-                  var theme = stored === 'dark' ? 'dark'
-                    : stored === 'light' ? 'light'
-                    : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-                  if (theme === 'dark') document.documentElement.classList.add('dark');
-                } catch (e) {}
-              })();
-            `,
-          }}
-        />
-      </head>
       <body className="antialiased" suppressHydrationWarning data-gramm="false">
+        <Script id="om-theme-init" strategy="beforeInteractive">
+          {`
+            (function() {
+              try {
+                var stored = localStorage.getItem('om-theme');
+                var theme = stored === 'dark' ? 'dark'
+                  : stored === 'light' ? 'light'
+                  : window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                if (theme === 'dark') document.documentElement.classList.add('dark');
+              } catch (e) {}
+            })();
+          `}
+        </Script>
         <AppProviders locale={locale} dict={dict} localeLocked={localeLocked} demoModeEnabled={demoModeEnabled} noticeBarsEnabled={noticeBarsEnabled}>
           {children}
         </AppProviders>


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-01-root-layout-script-render-warning.md
Status: in-progress

## 🎯 Goal

Remove the React development-console error caused by rendering the theme initializer as a raw script while preserving its pre-hydration behavior in monorepo and standalone apps.

## What Changed

- Render the static theme initializer through Next.js `Script` with `strategy="beforeInteractive"` in the monorepo app root layout.
- Mirror the app-shell repair in the create-app template so new standalone apps inherit the fix.
- Add a focused parity regression test that rejects raw root-layout script elements and verifies the stable theme initializer contract.

## 🧪 Tests

- Focused root-layout regression test: pass.
- Package builds, generation, i18n sync/usage, typecheck, and app build: pass locally.
- Workspace test gate: 1,131/1,132 core suites pass; the unchanged base-branch sales payment-ledger compatibility suite has three failures. GitHub CI reproduced the same repository-wide baseline failure, tracked by #4824.
- CodeQL review surfaced one test-only regexp finding; it was resolved in one autonomous autofix iteration, and refreshed CodeQL reports no changed-code alerts.

## ⛔ Blocker

- Repository-wide baseline issue #4824 keeps the required test gate red and also affects `TC-SALES-040`. The app-shell fix does not touch sales. Per the repository's scope rules, adding the unrelated sales fixture repair to this PR requires maintainer approval.

## 💥 Breaking Changes

- None. The initializer logic, storage key, and pre-hydration execution timing are preserved.

## 📋 Progress

See the Progress section in the tracking plan.
