### PR TITLE
fix(ci): classify create-app cross-package guards

### DIFF
--- a/scripts/repo-wide-guards.mjs
+++ b/scripts/repo-wide-guards.mjs
@@ -173,6 +173,14 @@ export const REPO_WIDE_GUARDS = [
  */
 export const CROSS_PACKAGE_EXCEPTIONS = [
   {
+    path: 'packages/create-app/src/lib/apply-starter-preset.test.ts',
+    reason: 'Already unfiltered — the "Check create-app template parity" CI step runs the whole create-mercato-app suite (#3779).',
+  },
+  {
+    path: 'packages/create-app/src/lib/root-layout-theme-script.test.ts',
+    reason: 'Already unfiltered — covered by the same create-app parity step (#3779).',
+  },
+  {
     path: 'packages/create-app/src/lib/template-dependency-drift.test.ts',
     reason: 'Already unfiltered — the "Check create-app template parity" CI step runs the whole create-mercato-app suite (#3779).',
   },


### PR DESCRIPTION
## Summary

- classify the two newly detected create-app cross-package tests
- document that both already run in the unconditional create-app parity job
- restore the root script phase on develop

## Validation

- `yarn test:scripts` — 376/376 passed
- `yarn test:repo-wide-guards` — 20 test files passed
- `yarn workspace create-mercato-app test` — 429 passed, 5 platform skips
- `yarn build:app` — passed

No UI, database, or API contract changes.