### PR TITLE
fix(ui): apply meta.hidden to columns that arrive after the first render

### DIFF
--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -1733,19 +1733,31 @@ export function DataTable<T>({
     })
   }, [table, mergedColumns])
 
-  const initialVisibilityApplied = React.useRef(Boolean(mergedInitialSettings?.columnVisibility))
+  // Columns carrying `meta.hidden` must start hidden. This used to run once, guarded by a
+  // boolean ref -- but custom-field definitions arrive asynchronously, so on the first render
+  // there are no `cf_*` columns yet: the loop found nothing, and the guard was raised anyway.
+  // Once the definitions landed the effect never ran again, leaving fields declared with
+  // `listVisible: false` visible in the table.
+  // The symptom looked random because it depended on cache state: a hard page load showed the
+  // hidden columns, while client-side navigation (definitions already cached) did not.
+  // Tracking the set of columns already auto-hidden fixes the race and keeps the original
+  // intent: each column is auto-hidden exactly once, so a column the user re-enables is not
+  // force-hidden again on a later pass. A stored perspective still wins outright.
+  const autoHiddenApplied = React.useRef<Set<string>>(new Set())
   React.useEffect(() => {
-    if (initialVisibilityApplied.current) return
+    if (mergedInitialSettings?.columnVisibility) return
     const hidden: VisibilityState = {}
     table.getAllLeafColumns().forEach((column) => {
       const hiddenMeta = (column.columnDef as any)?.meta?.hidden
-      if (hiddenMeta) hidden[column.id] = false
+      if (hiddenMeta && !autoHiddenApplied.current.has(column.id)) {
+        hidden[column.id] = false
+        autoHiddenApplied.current.add(column.id)
+      }
     })
     if (Object.keys(hidden).length) {
       setColumnVisibility((prev) => ({ ...hidden, ...prev }))
     }
-    initialVisibilityApplied.current = true
-  }, [table, mergedColumns])
+  }, [table, mergedColumns, mergedInitialSettings])
 
   const getCurrentSettings = React.useCallback((): PerspectiveSettings => {
     const visibility: Record<string, boolean> = {}

--- a/packages/ui/src/backend/__tests__/DataTable.metaHiddenRace.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.metaHiddenRace.test.tsx
@@ -1,0 +1,72 @@
+/** @jest-environment jsdom */
+import * as React from 'react'
+import { DataTable } from '../DataTable'
+import type { ColumnDef } from '@tanstack/react-table'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { render, screen, waitFor } from '@testing-library/react'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+}))
+
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false }),
+}))
+
+type Row = { id: string; name: string }
+
+const BASE_COLUMNS: ColumnDef<Row>[] = [{ accessorKey: 'name', header: 'Name' }]
+
+// Columns that arrive on a later render, the way custom-field columns do: their
+// definitions are fetched asynchronously, so they are absent from the first pass.
+const LATE_COLUMNS: ColumnDef<Row>[] = [
+  ...BASE_COLUMNS,
+  { accessorKey: 'cf_hidden_one', header: 'Hidden One', meta: { hidden: true } },
+  { accessorKey: 'cf_visible_one', header: 'Visible One' },
+]
+
+function renderTable(columns: ColumnDef<Row>[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <I18nProvider locale="en" dict={{}}>
+        <DataTable columns={columns} data={[{ id: '1', name: 'Row' }]} />
+      </I18nProvider>
+    </QueryClientProvider>,
+  )
+}
+
+describe('DataTable — meta.hidden applies to columns that arrive late', () => {
+  it('hides a meta.hidden column added after the first render', async () => {
+    // Regression: auto-hiding used to run once behind a boolean ref. Custom-field
+    // definitions load asynchronously, so the first pass saw no `cf_*` columns at all,
+    // found nothing to hide, and still raised the guard — leaving fields declared with
+    // `listVisible: false` permanently visible after a hard page load.
+    const { rerender } = renderTable(BASE_COLUMNS)
+    await waitFor(() => expect(screen.getByText('Name')).toBeTruthy())
+
+    rerender(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <I18nProvider locale="en" dict={{}}>
+          <DataTable columns={LATE_COLUMNS} data={[{ id: '1', name: 'Row' }]} />
+        </I18nProvider>
+      </QueryClientProvider>,
+    )
+
+    // The late column opting into `meta.hidden` must not reach the header row...
+    await waitFor(() => expect(screen.queryByText('Hidden One')).toBeNull())
+    // ...while a late column without that flag stays visible, so the fix cannot be
+    // mistaken for "late columns are dropped".
+    expect(screen.queryByText('Visible One')).toBeTruthy()
+  })
+
+  it('hides a meta.hidden column that is present from the very first render', async () => {
+    // Guards the original behaviour the boolean ref was written for.
+    renderTable(LATE_COLUMNS)
+    await waitFor(() => expect(screen.getByText('Visible One')).toBeTruthy())
+    expect(screen.queryByText('Hidden One')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

Columns declaring `meta.hidden` are supposed to start hidden. They don't, if they arrive after the first render.

The auto-hide effect in `DataTable` runs once, guarded by a boolean ref. Custom-field columns are built from definitions fetched asynchronously, so on the first render there are no `cf_*` columns at all: the loop finds nothing to hide, and the guard is raised anyway. Once the definitions land, the effect never runs again — leaving fields declared with `listVisible: false` visible in the table.

## Why it looks random

The symptom depends on cache state, which makes it hard to reproduce on demand:

| entering the same list | columns | deprecated ones visible |
|---|---|---|
| hard page load (definitions fetched from scratch) | 32 | 8 |
| client-side navigation (definitions already cached) | 19 | 0 |

Same code, same data, same session. On client-side navigation the definitions are already in the query cache, so the columns exist on the first render and the effect works as intended.

## Fix

Track the set of columns already auto-hidden instead of a single boolean.

Each column is auto-hidden exactly once, so a column the user re-enables is not force-hidden again on a later pass — that was the reason for the original guard. A stored perspective still wins outright via the early return.

## Test

Adds `DataTable.metaHiddenRace.test.tsx` covering both orders: a `meta.hidden` column present from the first render, and one arriving on a later render. Without the fix the late-arrival case fails while the other passes, so the test pins the regression rather than the behaviour that already worked.

All 9 existing DataTable suites (40 tests) stay green.
