### PR TITLE
docs(specs): complete source-linked module extension contracts

### DIFF
--- a/.ai/specs/2026-08-02-module-facts-exact-override-targets.md
+++ b/.ai/specs/2026-08-02-module-facts-exact-override-targets.md
@@ -63,11 +63,21 @@ Conceptual documentation cannot enumerate changing module-specific keys safely. 
 - Serializing DI runtime values or executing registries.
 - Adding runtime UI/API/database surfaces.
 
-## Data Model
+## Proposed Solution
+
+Project exact module-specific targets from the runtime override schema and normalized owned facts through one exhaustive adapter registry. Each target carries a structured path, the applicable runtime mode, a shared fact reference, and portable provenance. Unsupported dynamic entries produce per-module diagnostics; they never become guessed targets or non-module keys at the generated document root.
+
+## Data Models
 
 Add an optional module-specific collection:
 
 ```ts
+type ModuleOverrideMode = 'disable-replace' | 'replace' | 'additive'
+
+type ModuleOverrideTargetNote =
+  | 'safe-metadata-only'
+  | 'page-middleware-not-mutation-guard'
+
 type ModuleOverrideTarget = {
   id: string
   domain: ModuleOverrideDomain
@@ -81,6 +91,7 @@ type ModuleOverrideTarget = {
 
 type ModuleFactsJsonEntry = ExistingModuleFactsJsonEntry & {
   overrideTargets?: ModuleOverrideTarget[]
+  overrideTargetDiagnostics?: ModuleOverrideTargetDiagnostic[]
 }
 ```
 
@@ -92,13 +103,13 @@ Definitions:
 - `modes` reference the supported operations already established by the framework extension-point catalog.
 - `factRef` points to the module-owned fact being overridden.
 - `source` points to the registry, convention file, or defining entry used by runtime normalization.
-- `notes` is a closed enum for facts such as `safe-metadata-only`, `page-middleware-not-mutation-guard`, or `framework-only`; it is not free-form prose.
+- `notes` is the closed `ModuleOverrideTargetNote` enum; it is not free-form prose. Framework-only settings are never emitted as module targets.
 
-`id` is deterministically derived from `moduleId + domain + path`. `path` rather than a concatenated display string is the lossless authority.
+`id` is deterministically derived from the JSON-serialized tuple `[moduleId, domain, path]`, so segment boundaries cannot collide. `path` rather than a concatenated display string is the lossless authority.
 
 For a keyed-record domain, `key` must equal the terminal key-bearing `path` segment after runtime normalization; it is repeated only as a convenience for consumers that do not render paths. For singleton or structured domains whose terminal path identifies a property rather than a lookup key, omit `key`. A contract test asserts this invariant for every adapter.
 
-Add a deterministic generator diagnostic collection using the existing module-facts diagnostics envelope (or, if none is exported, an additive `diagnostics` array on the generated document root):
+Add a deterministic per-module diagnostic collection through `ModuleFactsJsonEntry.overrideTargetDiagnostics`. Reuse the existing module-facts diagnostic renderer where practical, but never add a non-module key or diagnostics array at the generated document root:
 
 ```ts
 type ModuleOverrideTargetDiagnostic = {
@@ -110,7 +121,7 @@ type ModuleOverrideTargetDiagnostic = {
 }
 ```
 
-Diagnostics sort by `moduleId`, `domain`, `code`, then path/source. They contain no source snippets or runtime values. Release validation fails for missing adapter/domain coverage; per-module dynamic-key diagnostics remain visible and explicitly prevent a fabricated target.
+Diagnostics sort by `moduleId`, `domain`, `code`, then path/source. They contain no source snippets or runtime values. Release validation fails for missing adapter/domain coverage; per-module dynamic-key diagnostics remain visible and explicitly prevent a fabricated target. A compatibility test asserts that every root key still identifies a selected module and that a legacy root record remains readable unchanged.
 
 ## Framework and Module Responsibilities
 
@@ -148,14 +159,14 @@ The implementation audits the runtime unified override type/parser and covers ev
 | `ai.extensions` and AI file overrides | extension/override ID and full nested path |
 | `routes.api` | uppercase method plus normalized `/api/...` route key |
 | `routes.pages` | backend/frontend application route path |
-| `eventSubscribers` | subscriber registry ID |
+| `events.subscribers` | subscriber registry ID |
 | `workers` | worker registry ID/name |
 | `widgets.injection` | injection spot/contribution key shape accepted by runtime |
 | `widgets.components` | replaceable component ID plus supported replace/wrap/props path |
 | `widgets.dashboard` | dashboard widget ID |
 | `notifications.types` | notification type ID |
 | `notifications.handlers` | handler ID |
-| `apiInterceptors` | exact interceptor contribution key/target identity |
+| `interceptors` | exact interceptor contribution key/target identity |
 | `commandInterceptors` | exact command interceptor key/target identity |
 | `enrichers` | exact response/query enricher key where runtime supports override |
 | `guards` | backend/frontend page route middleware identity only |
@@ -165,7 +176,7 @@ The implementation audits the runtime unified override type/parser and covers ev
 | `di` | Awilix registration token |
 | `encryption` | entity/config key accepted by the override resolver |
 
-This table is an audit seed, not a second runtime schema. Implementation must derive the final list from the current unified override types/parser and fail a coverage test when a new domain is added without a target extractor or explicit `framework-only` classification.
+This table is an audit seed, not a second runtime schema. Implementation must derive the final list from the current unified override types/parser and fail a coverage test when a new domain is added without a target extractor or explicit `framework-only` classification. Every emitted target's top-level `domain` must be a member of the runtime `ModuleOverrideDomain` union; nested segments such as `subscribers` live only in `path`.
 
 ## Exact-Key Rules
 
@@ -201,7 +212,7 @@ This table is an audit seed, not a second runtime schema. Implementation must de
 - When topology activation facts exist, link `factRef` or a supplemental reference to them; absence of the topology sibling must not prevent the override target from representing a valid registry entry.
 - Wildcard target semantics do not change the override entry's own exact registry key.
 
-## Discovery Architecture
+## Architecture
 
 Build override targets from a registry of domain adapters tied to the unified override schema:
 
@@ -243,6 +254,10 @@ Render paths as copyable code, but generate them from structured `path` data. Ma
 - Never translate a mutation guard into `overrides.guards`.
 - Escalate only to the named source when the fact cannot answer one exact remaining detail.
 - Prefer the smallest safe override and preserve module ownership/optional coupling.
+
+## API Contracts
+
+No HTTP API is added or changed. Generated JSON gains only the optional per-module `overrideTargets` and `overrideTargetDiagnostics` fields, and generated Markdown gains one additive section. The root record remains `Record<moduleId, ModuleFactsJsonEntry>` with no synthetic framework or diagnostics key.
 
 ## Backward Compatibility
 
@@ -335,7 +350,7 @@ At least one failure-first case must make a plausible domain-only answer incorre
 - Facts survive package packing and a fresh standalone scaffold.
 - Focused tests, generation, configured validation, `harness:validate --all`, and full `harness:release` pass.
 
-## Risks
+## Risks & Impact Review
 
 ### Generated key disagrees with runtime normalization
 
@@ -363,6 +378,17 @@ At least one failure-first case must make a plausible domain-only answer incorre
 
 ## Final Compliance Report — 2026-08-02
 
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md` (root)
+- `.ai/specs/AGENTS.md`
+- `packages/cli/AGENTS.md`
+- `packages/create-app/AGENTS.md`
+- `packages/shared/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+
 | Rule source | Requirement | Status | Evidence in this spec |
 |---|---|---|---|
 | Root `AGENTS.md` | Preserve public override contracts and avoid unsafe mutation bypass. | Compliant | Facts mirror runtime only; no new domains or behavior. |
@@ -372,7 +398,22 @@ At least one failure-first case must make a plausible domain-only answer incorre
 | Root security rules | Never expose DI values/secrets. | Compliant | DI facts and tests are metadata-only. |
 | Spec cohesion | One independently deployable capability. | Compliant | This spec owns only exact unified override target facts. |
 
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|---|---|---|
+| Domain names match runtime | Pass | Top-level domains derive from `ModuleOverrideDomain`; nested names live in structured paths. |
+| Keys and paths round-trip | Pass | The terminal-key invariant and runtime resolver tests cover keyed domains. |
+| Diagnostics preserve root compatibility | Pass | Diagnostics are optional per-module fields, never root keys. |
+| Framework-only settings remain separate | Pass | `nav.groupOrder` stays in framework facts and cannot become a module target. |
+
+### Non-Compliant Items
+
 No non-compliant item or required human confirmation was identified.
+
+### Verdict
+
+**Fully compliant:** approved after the provenance prerequisite as the implementation specification for exact unified override targets.
 
 ## Changelog
 
@@ -380,6 +421,7 @@ No non-compliant item or required human confirmation was identified.
 
 - Split module-specific exact override targets from general provenance and extension topology.
 - Defined exhaustive domain adapters, exact structured paths, page/mutation guard separation, and standalone exact-key proof.
+- Aligned domain names with `ModuleOverrideDomain` and constrained diagnostics to per-module entries.
 
 ## Review — 2026-08-02
 

--- a/.ai/specs/2026-08-02-module-facts-exact-override-targets.md
+++ b/.ai/specs/2026-08-02-module-facts-exact-override-targets.md
@@ -1,0 +1,391 @@
+# Module Facts Exact Unified Override Targets
+
+- **Status:** Proposed — implementation-ready
+- **Date:** 2026-08-02
+- **Parent:** [Complete Source-Linked Module Extension Contracts](2026-08-02-module-facts-extension-surface-completeness.md)
+- **Depends on:** [Source Provenance and Contract Inventory](2026-08-02-module-facts-source-provenance-and-contract-inventory.md)
+- **Related:** [Bound Extension Activation and Incoming Contribution Index](2026-08-02-module-facts-extension-activation-and-incoming-index.md)
+- **Scope:** exact module-specific unified override facts, framework catalog correlation, Markdown/guidance, and standalone harness case `OMH-089`
+
+## TLDR
+
+Keep the framework extension-point catalog as the authority for supported override domains and merge/replace modes, then add the missing module-specific layer: every selected module fact sheet lists each exact key that can be used in `modules.ts`, its domain, mode, referenced fact, and defining source.
+
+The implementation must distinguish similarly named but different contracts. In particular, `overrides.guards` targets backend/frontend page route middleware; `data/guards.ts` mutation guards are not override entries in that domain. The standalone harness must reject domain-only answers and prove representative exact keys, including a safe DI override.
+
+## Resolved assumptions (autonomous defaults)
+
+| # | Question | Applied default | Rationale | Confirm? |
+|---|---|---|---|---|
+| Q1 | Duplicate framework domain prose in each module? | No. Reference framework facts for modes and emit only concrete module targets. | Keeps one authority for override semantics. | ok |
+| Q2 | Include only currently populated domains? | Emit exact targets for every domain the selected module actually exposes; keep the framework domain catalog complete separately. | Empty domains should not produce invented keys. | ok |
+| Q3 | Treat mutation guards as `overrides.guards`? | No. Only page route middleware maps to that domain unless a future dedicated mutation-guard override contract is approved. | The runtime types are distinct despite the shared word “guard.” | ok |
+| Q4 | Can exact keys be inferred from filenames alone? | Only when the runtime override resolver uses that same normalized convention; otherwise bind to the actual registry/parser. | Facts must match accepted runtime keys exactly. | ok |
+
+No assumption needs human confirmation.
+
+## Overview
+
+PR #4810 added framework-level UMES facts and standalone guidance for extension modes. It can tell an agent that API routes, pages, workers, subscribers, widgets, notifications, DI, ACL, setup, encryption, and other domains are overrideable. It does not consistently tell the agent the exact key for a particular installed module entry.
+
+The gap matters because override keys are domain-specific. API routes use a method plus normalized `/api/...` path, pages use application route paths, DI uses container tokens, event subscribers and workers use registry identities, and nested domains such as widgets or AI contain their own keyed registries. Guessing a key produces a silent no-op or replaces the wrong entry.
+
+The existing standalone case `OMH-089` promises exact keys across override domains. The current facts can satisfy only some domains directly, so the evaluation can reward plausible domain-level advice instead of an executable override.
+
+## Problem Statement
+
+Developers and agents lack one deterministic answer to:
+
+- Which exact property/key under `modules.<moduleId>.overrides` targets this installed contract?
+- Does the domain replace, merge, wrap, disable, or apply another supported mode?
+- Which generated fact proves the target exists?
+- Where is the target registered or discovered in source?
+- Is a “guard” a page route middleware override or an unrelated mutation guard?
+- Are module-specific keys present after packaging a standalone app?
+
+Conceptual documentation cannot enumerate changing module-specific keys safely. The generated module facts must provide them.
+
+## Goals
+
+- Emit every exact unified override target exposed by each selected module.
+- Correlate each target to the framework domain/mode fact, module fact, and source.
+- Match runtime normalization and nested override shapes exactly.
+- Clearly separate unsupported similarly named registries.
+- Keep framework-wide domains out of fake module entries.
+- Make standalone evaluations require executable exact-key answers.
+
+## Non-Goals
+
+- Adding new unified override domains or changing override runtime behavior.
+- Making mutation guards overrideable through `overrides.guards`.
+- Replacing the framework extension-point catalog.
+- Describing active cross-module contribution bindings; use the topology sibling spec.
+- Serializing DI runtime values or executing registries.
+- Adding runtime UI/API/database surfaces.
+
+## Data Model
+
+Add an optional module-specific collection:
+
+```ts
+type ModuleOverrideTarget = {
+  id: string
+  domain: ModuleOverrideDomain
+  key?: string
+  path: string[]
+  modes: ModuleOverrideMode[]
+  factRef: ModuleFactRef
+  source: ModuleFactSourceRef
+  notes?: ModuleOverrideTargetNote[]
+}
+
+type ModuleFactsJsonEntry = ExistingModuleFactsJsonEntry & {
+  overrideTargets?: ModuleOverrideTarget[]
+}
+```
+
+Definitions:
+
+- `domain` is the exact top-level domain accepted by the unified override schema.
+- `key` is the runtime lookup key when the domain is a keyed record.
+- `path` is the complete property path below `overrides`, preserving nested registries such as `['widgets', 'injection', spotId]`.
+- `modes` reference the supported operations already established by the framework extension-point catalog.
+- `factRef` points to the module-owned fact being overridden.
+- `source` points to the registry, convention file, or defining entry used by runtime normalization.
+- `notes` is a closed enum for facts such as `safe-metadata-only`, `page-middleware-not-mutation-guard`, or `framework-only`; it is not free-form prose.
+
+`id` is deterministically derived from `moduleId + domain + path`. `path` rather than a concatenated display string is the lossless authority.
+
+For a keyed-record domain, `key` must equal the terminal key-bearing `path` segment after runtime normalization; it is repeated only as a convenience for consumers that do not render paths. For singleton or structured domains whose terminal path identifies a property rather than a lookup key, omit `key`. A contract test asserts this invariant for every adapter.
+
+Add a deterministic generator diagnostic collection using the existing module-facts diagnostics envelope (or, if none is exported, an additive `diagnostics` array on the generated document root):
+
+```ts
+type ModuleOverrideTargetDiagnostic = {
+  code: 'missing-owned-fact' | 'missing-source' | 'unsupported-dynamic-key' | 'unknown-framework-domain'
+  moduleId: string
+  domain: ModuleOverrideDomain
+  candidatePath?: string[]
+  source?: ModuleFactSourceRef
+}
+```
+
+Diagnostics sort by `moduleId`, `domain`, `code`, then path/source. They contain no source snippets or runtime values. Release validation fails for missing adapter/domain coverage; per-module dynamic-key diagnostics remain visible and explicitly prevent a fabricated target.
+
+## Framework and Module Responsibilities
+
+### Framework catalog
+
+`framework-extension-points.md` / its JSON source continues to define:
+
+- available override domains;
+- supported modes and value shapes;
+- merge/replace/disable semantics;
+- global restrictions and security rules;
+- framework-only settings such as `nav.groupOrder`.
+
+Do not create a synthetic framework module merely to attach global keys.
+
+### Module fact sheet
+
+Each module emits only targets it actually exposes after selected-module resolution. A target must correlate to:
+
+1. a runtime override parser/registry entry;
+2. a module-owned fact from the provenance prerequisite;
+3. an applicable framework domain/mode definition;
+4. a portable defining source.
+
+If one of these cannot be proven, emit a diagnostic rather than an invented target.
+
+## Required Domain Coverage
+
+The implementation audits the runtime unified override type/parser and covers every currently supported nested domain. The expected inventory includes:
+
+| Domain/path family | Exact target identity |
+|---|---|
+| `ai.agents` | agent ID |
+| `ai.tools` | tool ID/name used by the resolver |
+| `ai.extensions` and AI file overrides | extension/override ID and full nested path |
+| `routes.api` | uppercase method plus normalized `/api/...` route key |
+| `routes.pages` | backend/frontend application route path |
+| `eventSubscribers` | subscriber registry ID |
+| `workers` | worker registry ID/name |
+| `widgets.injection` | injection spot/contribution key shape accepted by runtime |
+| `widgets.components` | replaceable component ID plus supported replace/wrap/props path |
+| `widgets.dashboard` | dashboard widget ID |
+| `notifications.types` | notification type ID |
+| `notifications.handlers` | handler ID |
+| `apiInterceptors` | exact interceptor contribution key/target identity |
+| `commandInterceptors` | exact command interceptor key/target identity |
+| `enrichers` | exact response/query enricher key where runtime supports override |
+| `guards` | backend/frontend page route middleware identity only |
+| `cli` | CLI command ID/name |
+| `setup` | supported setup hook/profile override path |
+| `acl` | ACL feature ID |
+| `di` | Awilix registration token |
+| `encryption` | entity/config key accepted by the override resolver |
+
+This table is an audit seed, not a second runtime schema. Implementation must derive the final list from the current unified override types/parser and fail a coverage test when a new domain is added without a target extractor or explicit `framework-only` classification.
+
+## Exact-Key Rules
+
+### API routes
+
+- Use the runtime's canonical uppercase method and normalized route path.
+- Record one target per supported method.
+- Do not infer methods absent from the route metadata.
+- Include the route fact/source and framework modes.
+
+### Pages and guards
+
+- Page targets use the exact application path accepted by the page override resolver.
+- `guards` targets backend/frontend `PageRouteMiddleware` convention entries.
+- Add the closed note `page-middleware-not-mutation-guard` to the domain description or affected targets.
+- `data/guards.ts` mutation guards may remain extension contribution/activation facts but cannot appear under `overrideTargets` with domain `guards`.
+
+### DI
+
+- Use the exact registration token, correlated to the rich DI fact.
+- Include registration kind to let guidance choose a safe compatible override.
+- Never include the original `asValue` payload, constructed service, or factory/class body.
+- Harness modifications must use a benign, isolated test token/provider and restore/clean the fixture.
+
+### Nested widgets and AI
+
+- Preserve the nested path expected by runtime; do not flatten keys ambiguously.
+- Correlate replacement, wrapper, props, injection, dashboard, agent, tool, extension, and file-override facts to their distinct paths and supported modes.
+
+### Interceptors, enrichers, subscribers, and workers
+
+- Use the registered contribution/entry ID actually consumed by the override resolver.
+- When topology activation facts exist, link `factRef` or a supplemental reference to them; absence of the topology sibling must not prevent the override target from representing a valid registry entry.
+- Wildcard target semantics do not change the override entry's own exact registry key.
+
+## Discovery Architecture
+
+Build override targets from a registry of domain adapters tied to the unified override schema:
+
+```ts
+type OverrideTargetAdapter = {
+  domain: ModuleOverrideDomain
+  collect(moduleFacts: ModuleFactsJsonEntry): ModuleOverrideTarget[]
+  frameworkOnly?: boolean
+}
+```
+
+Requirements:
+
+- Adapter coverage is checked against the actual top-level/nested override schema.
+- Adapters consume normalized owned facts; they do not rescan source independently unless the runtime key is unavailable in those facts.
+- Any necessary rescan uses the same parser/normalizer as runtime and the provenance generator.
+- The framework catalog and module target generation share domain identifiers and mode enums.
+- Output sorts by domain, then path segments, then source.
+
+## Markdown and Guidance
+
+### Module Markdown
+
+Add an **Exact override targets** section with columns:
+
+- domain;
+- exact `modules.<moduleId>.overrides...` path/key;
+- supported modes;
+- referenced fact;
+- source.
+
+Render paths as copyable code, but generate them from structured `path` data. Mark global/framework-only domains only in the framework document, not in module sheets.
+
+### Standalone guidance
+
+- Start from the user's target fact and follow its `overrideTargets` reference.
+- Require an exact module ID, domain path, and key before proposing code.
+- Consult framework facts for value shape/mode semantics.
+- Never translate a mutation guard into `overrides.guards`.
+- Escalate only to the named source when the fact cannot answer one exact remaining detail.
+- Prefer the smallest safe override and preserve module ownership/optional coupling.
+
+## Backward Compatibility
+
+- `overrideTargets` is optional and additive.
+- Existing `frameworkExtensionPoints`, module facts, and UMES rows keep their shape and semantics.
+- No current runtime override path/key/mode changes.
+- Exact IDs/paths published by the new facts become stable according to the underlying runtime contract.
+- Existing Markdown headings remain; the new section is additive.
+- If implementation discovers that current docs name a key the runtime does not accept, correct the docs with an upgrade note; do not silently change runtime behavior under this spec.
+
+No HTTP, DB, event emission, ACL runtime, or UI contract changes are introduced.
+
+## Implementation Plan
+
+### Phase 1 — Runtime schema audit and shared types
+
+- Enumerate every nested unified override domain and supported mode from the actual parser/types.
+- Add shared domain/path/mode types and `overrideTargets` to module facts.
+- Add a coverage test requiring an adapter or explicit framework-only classification for every domain.
+
+### Phase 2 — Target adapters
+
+- Implement adapters for routes/pages, subscribers/workers, widgets, notifications, AI, interceptors/enrichers, CLI, setup, ACL, DI, encryption, and page middleware guards.
+- Correlate every entry to owned facts and portable source references.
+- Add negative correlation diagnostics and mutation-guard/page-guard separation tests.
+
+### Phase 3 — Markdown and facts-first routing
+
+- Render copyable exact paths/keys with modes, fact refs, and source links.
+- Update standalone system-extension guidance to require the exact target and framework mode before code generation.
+- Keep conceptual guides free of module-specific key lists.
+
+### Phase 4 — Harness and release proof
+
+- Invoke `om-refresh-standalone-harness <from> <to>`.
+- Strengthen `OMH-089` so domain-only or plausible guessed answers fail.
+- Add representative exact-key cases across all domain families, including a safe DI override and the page/mutation guard distinction.
+- Validate packed artifacts in a fresh Verdaccio scaffold and run the full release gate.
+
+## Test Plan
+
+### Generator tests
+
+- One golden target for every adapter/domain family.
+- Coverage failure when a runtime override domain has neither an adapter nor `framework-only` classification.
+- API method/path normalization and page-path exactness.
+- Nested widget and AI path round-trip without flattening loss.
+- Exact DI token and registration-kind correlation without values.
+- Page middleware appears under `guards`; mutation guard never does.
+- Missing fact/source correlation yields a deterministic diagnostic, not a guessed key.
+- Repeated generation produces byte-identical JSON/Markdown.
+
+### Runtime contract tests
+
+For representative entries, feed the generated `domain + path + key` into the same resolver/validator used by `modules.ts` and assert it selects the intended entry. Include negative tests for:
+
+- lowercased or missing API methods;
+- UI filesystem paths instead of application route paths;
+- flattened nested keys;
+- mutation guard IDs under page `guards`;
+- unknown DI tokens;
+- framework-only `nav.groupOrder` attached to a module target.
+
+### Standalone harness
+
+`OMH-089` and related cases must require:
+
+| Case | Required answer evidence |
+|---|---|
+| API route override | Module ID, exact `METHOD /api/path`, supported mode, fact/source. |
+| Page override | Exact application route and mode, not filesystem path. |
+| Page guard | Correct middleware target and explicit distinction from mutation guards. |
+| Worker/subscriber | Exact registry key and source. |
+| Widget/AI nested override | Complete path segments and correct mode. |
+| DI override | Exact benign token, registration kind, safe replacement shape, no original value. |
+| Framework-only setting | Correctly sourced from framework facts, with no fake module key. |
+
+At least one failure-first case must make a plausible domain-only answer incorrect. Run `harness:validate --all`, then `harness:release` against a freshly packed and scaffolded app.
+
+## Acceptance Criteria
+
+- Every runtime unified override domain has a tested adapter or explicit framework-only classification.
+- Every actual selected-module override entry has an exact domain/path/key, modes, fact reference, and portable source.
+- Generated targets round-trip through the runtime resolver for representative domain families.
+- `overrides.guards` contains only page route middleware targets; mutation guards never appear there.
+- DI facts expose all exact tokens safely without runtime values or bodies.
+- Framework-only settings remain only in framework facts.
+- Existing facts and runtime override behavior remain unchanged.
+- `OMH-089` fails domain-only/guessed answers and passes executable exact-key answers.
+- Facts survive package packing and a fresh standalone scaffold.
+- Focused tests, generation, configured validation, `harness:validate --all`, and full `harness:release` pass.
+
+## Risks
+
+### Generated key disagrees with runtime normalization
+
+- **Severity:** High
+- **Mitigation:** Adapter inputs come from normalized owned facts and keys round-trip through the runtime resolver.
+- **Residual risk:** A highly dynamic third-party registry may require a diagnostic/source escalation rather than a target.
+
+### Guard terminology causes unsafe overrides
+
+- **Severity:** High
+- **Mitigation:** Separate facts, closed note, negative tests, and harness case explicitly distinguish page and mutation guards.
+- **Residual risk:** External prose may retain the ambiguous term; generated facts remain authoritative.
+
+### DI override exposes or destabilizes values
+
+- **Severity:** High
+- **Mitigation:** Metadata-only schema and benign isolated harness fixtures.
+- **Residual risk:** Consumers can still choose an incompatible implementation; registration kind and framework semantics reduce the chance.
+
+### Adapter list drifts from runtime domains
+
+- **Severity:** High
+- **Mitigation:** Exhaustive coverage test against the runtime schema.
+- **Residual risk:** Runtime types that are not introspectable may need a shared declarative domain registry in a separately reviewed refactor.
+
+## Final Compliance Report — 2026-08-02
+
+| Rule source | Requirement | Status | Evidence in this spec |
+|---|---|---|---|
+| Root `AGENTS.md` | Preserve public override contracts and avoid unsafe mutation bypass. | Compliant | Facts mirror runtime only; no new domains or behavior. |
+| `BACKWARD_COMPATIBILITY.md` | Keep override keys/modes and generated fields stable. | Compliant | Additive target catalog; runtime keys unchanged. |
+| `packages/cli/AGENTS.md` | Deterministic facts and source correlation. | Compliant | Structured paths, adapter coverage, sorting, resolver round-trip. |
+| `packages/create-app/AGENTS.md` | Standalone exact-key guidance must match packaged runtime. | Compliant | Strengthened OMH-089 and fresh release proof. |
+| Root security rules | Never expose DI values/secrets. | Compliant | DI facts and tests are metadata-only. |
+| Spec cohesion | One independently deployable capability. | Compliant | This spec owns only exact unified override target facts. |
+
+No non-compliant item or required human confirmation was identified.
+
+## Changelog
+
+### 2026-08-02
+
+- Split module-specific exact override targets from general provenance and extension topology.
+- Defined exhaustive domain adapters, exact structured paths, page/mutation guard separation, and standalone exact-key proof.
+
+## Review — 2026-08-02
+
+- **Fresh-context scope verdict:** KEEP after defining `key`/`path` invariants and deterministic diagnostic storage.
+- **Security:** Passed with metadata-only DI and no runtime execution.
+- **Performance:** Passed; adapters consume existing normalized facts.
+- **Compatibility:** Passed; generated target facts are additive and runtime behavior is unchanged.
+- **Scope:** Cohesive; framework semantics and topology remain linked dependencies.
+- **Verdict:** Ready for implementation after the provenance prerequisite.

--- a/.ai/specs/2026-08-02-module-facts-extension-activation-and-incoming-index.md
+++ b/.ai/specs/2026-08-02-module-facts-extension-activation-and-incoming-index.md
@@ -60,13 +60,36 @@ Without those answers, standalone guidance can produce code that compiles but is
 - Introducing direct ORM relationships or runtime dependencies between modules.
 - Adding a UI graph, API, database schema, or module activation behavior.
 
-## Data Model
+## Proposed Solution
+
+Extend the existing `ModuleExtensionSurfaceFacts` entry with an authoritative activation layer, a compact target-owned incoming index, and one contributor-owned resolution summary per target. Reuse the provenance prerequisite's `ModuleFactSourceRef`/`ModuleFactRef` and the existing UMES contribution discriminant so the new topology is a correlation view over established facts rather than a parallel contribution catalog.
+
+## Data Models
 
 ### Activation facts
 
 Add an optional additive collection under the existing extension-surface model:
 
 ```ts
+type ModuleExtensionContributionKind = ModuleExtensionContributionFact['kind']
+
+type ModuleExtensionActivationKind =
+  | 'crud-response-enricher'
+  | 'query-enricher'
+  | 'mutation-guard'
+  | 'api-interceptor-bridge'
+  | 'command-interceptor-bridge'
+  | 'widget-injection-consumer'
+  | 'component-extension-consumer'
+  | 'dashboard-host-consumer'
+
+type ModuleExtensionTargetRef = {
+  kind: 'module' | 'entity' | 'api-route' | 'command' | 'widget-spot' | 'component' | 'event' | 'notification' | 'wildcard'
+  id: string
+  moduleId?: string
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
+}
+
 type ModuleExtensionActivation = {
   id: string
   kind: ModuleExtensionActivationKind
@@ -77,12 +100,14 @@ type ModuleExtensionActivation = {
   bridge?: ModuleFactRef
 }
 
-type ModuleExtensionSurfaces = ExistingModuleExtensionSurfaces & {
+type ModuleExtensionSurfaceFactsAdditions = {
   activations?: ModuleExtensionActivation[]
   incoming?: ModuleIncomingExtensionRef[]
   contributionResolutions?: ModuleContributionResolution[]
 }
 ```
+
+Add `ModuleExtensionSurfaceFactsAdditions` to the existing exported `ModuleExtensionSurfaceFacts` shape; do not introduce a second extension-surface property or rename the public type.
 
 An activation means the selected module's runtime path will query, invoke, merge, or render the named contribution family. `id` must be stable and derived from the host kind and exact normalized runtime identity, not from filesystem order.
 
@@ -147,7 +172,9 @@ Use existing UMES target/fact reference primitives wherever possible. Extend the
 
 Entity names alone are insufficient when two routes or command surfaces activate different extension families.
 
-## Authoritative Activation Rules
+## Architecture
+
+### Authoritative Activation Rules
 
 ### CRUD routes and enrichers
 
@@ -178,7 +205,7 @@ Entity names alone are insufficient when two routes or command surfaces activate
 
 Modules that do not use a factory may expose an activation through a supported static bridge declaration. The bridge must be an existing runtime convention or a separately approved additive contract; this implementation must not invent a facts-only manifest that runtime ignores.
 
-## Correlation Algorithm
+### Correlation Algorithm
 
 1. Extract selected module-owned facts and source provenance.
 2. Extract existing hosts, contributions, and new activation facts without changing their runtime meaning.
@@ -199,6 +226,10 @@ Resolution rules:
 - `unresolved`: the target should be concrete but no selected host/capability can resolve it.
 
 Generation diagnostics must distinguish `optional-target-missing` from `unresolved`; optional integrations are not build failures.
+
+## API Contracts
+
+No HTTP API is added or changed. The only published output changes are optional fields on each module's existing `ModuleFactsJsonEntry.extensionSurfaces`; the top-level `module-facts.json` record and every existing extension-surface field retain their current shape and meaning.
 
 ## Backward Compatibility
 
@@ -313,7 +344,7 @@ Run focused package tests, `yarn generate`, the configured validation subset, `h
 - Standalone guidance refuses unsupported activation claims and finds already-installed contributors facts-first.
 - Fresh standalone package/scaffold and full harness release gates pass.
 
-## Risks
+## Risks & Impact Review
 
 ### False activation from static parsing
 
@@ -341,6 +372,17 @@ Run focused package tests, `yarn generate`, the configured validation subset, `h
 
 ## Final Compliance Report — 2026-08-02
 
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md` (root)
+- `.ai/specs/AGENTS.md`
+- `packages/cli/AGENTS.md`
+- `packages/create-app/AGENTS.md`
+- `packages/shared/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+
 | Rule source | Requirement | Status | Evidence in this spec |
 |---|---|---|---|
 | Root `AGENTS.md` | No direct cross-module ORM relationship; preserve optional integration. | Compliant | Correlation is generated documentation with explicit optional states. |
@@ -349,7 +391,22 @@ Run focused package tests, `yarn generate`, the configured validation subset, `h
 | `packages/create-app/AGENTS.md` | Standalone guidance and packaging stay aligned. | Compliant | Refresh skill, failure-first cases, and fresh release gate. |
 | Spec cohesion | One independently deployable capability. | Compliant | This spec owns only extension topology and bidirectional correlation. |
 
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|---|---|---|
+| Activation identities match target identities | Pass | The shared target reference distinguishes route methods and all supported host kinds. |
+| Incoming rows point to source-owned contributions | Pass | Incoming facts remain compact and never duplicate contribution behavior. |
+| Resolution cardinality is defined | Pass | One target can resolve to multiple activation IDs with deterministic ordering. |
+| Optional-module behavior remains decoupled | Pass | Missing optional targets are contributor-owned non-error outcomes. |
+
+### Non-Compliant Items
+
 No non-compliant item or required human confirmation was identified.
+
+### Verdict
+
+**Fully compliant:** approved after the provenance prerequisite as the implementation specification for authoritative bidirectional extension topology.
 
 ## Changelog
 
@@ -357,6 +414,7 @@ No non-compliant item or required human confirmation was identified.
 
 - Split authoritative activation and incoming topology from owned fact provenance and exact override targets.
 - Preserved all legacy host/contribution facts while defining source-linked bindings and target-side references.
+- Defined the shared target, activation, and contribution-kind identities used by the additive topology fields.
 
 ## Review — 2026-08-02
 

--- a/.ai/specs/2026-08-02-module-facts-extension-activation-and-incoming-index.md
+++ b/.ai/specs/2026-08-02-module-facts-extension-activation-and-incoming-index.md
@@ -1,0 +1,368 @@
+# Module Facts Bound Extension Activation and Incoming Contribution Index
+
+- **Status:** Proposed — implementation-ready
+- **Date:** 2026-08-02
+- **Parent:** [Complete Source-Linked Module Extension Contracts](2026-08-02-module-facts-extension-surface-completeness.md)
+- **Depends on:** [Source Provenance and Contract Inventory](2026-08-02-module-facts-source-provenance-and-contract-inventory.md)
+- **Scope:** `packages/cli` UMES correlation, module-facts/Markdown topology, route/entity activation proof, and standalone harness routing
+
+## TLDR
+
+Distinguish “this entity could host an extension” from “this route or entity actually activates that extension,” and make existing contributions discoverable from both directions. Preserve all published `extensionSurfaces.hosts` and source-owned contribution rows, add an authoritative `activations` layer derived from real call sites, and add compact incoming references to the target module's fact sheet.
+
+This prevents agents from recommending enrichers, guards, interceptors, or widgets merely because a broad host capability exists, while letting a target-module investigation see which optional modules already extend it.
+
+## Resolved assumptions (autonomous defaults)
+
+| # | Question | Applied default | Rationale | Confirm? |
+|---|---|---|---|---|
+| Q1 | Replace broad host rows with only active hosts? | No. Preserve host rows and add authoritative activations. | Published host arrays and IDs are stable contracts. | ok |
+| Q2 | Duplicate full contributions on target modules? | No. Store compact incoming references; retain the full fact on the contributor. | Avoids drift and excessive generated context. | ok |
+| Q3 | May inferred naming count as activation? | No. Require a real CRUD-factory option, bridge, registry, or other supported runtime call site. | A plausible target is not proof that runtime invokes the extension. | ok |
+| Q4 | How are optional or missing target modules represented? | Keep the source-owned contribution and mark its resolution state deterministically. | Optional integrations must remain module-decoupled and inspectable. | ok |
+
+No assumption needs human confirmation.
+
+## Overview
+
+PR #4810 introduced `extensionSurfaces.hosts` and `extensionSurfaces.contributions`. The contribution facts are valuable: enrichers and interceptors already include targets, phases, behavior metadata, and source paths. The host extractor, however, can advertise generic entity capabilities based on entity presence rather than actual route activation. That makes the catalog useful for discovery but not sufficient for deterministic implementation guidance.
+
+The catalog is also primarily source-oriented. A contributor module shows what it sends elsewhere, but the target module's sheet does not compactly show which installed modules already contribute to it. Developers investigating a host therefore need a repository-wide search or must inspect every other module's fact sheet.
+
+## Problem Statement
+
+The generated catalog currently cannot reliably answer:
+
+- Is response enrichment actually enabled on this route, or does the module merely own an entity with a compatible name?
+- Which interceptor bridge invokes this contribution and for which phase/method/path?
+- Which mutation guard applies to this concrete entity mutation surface?
+- Which installed optional modules already extend this host module, entity, route, spot, or component?
+- Is an unresolved contribution intentionally optional, a wildcard target, or a broken reference?
+- Which source call site proves the attachment?
+
+Without those answers, standalone guidance can produce code that compiles but is never invoked.
+
+## Goals
+
+- Add authoritative, source-linked activation facts based on real runtime call sites.
+- Keep capability/host discovery separate from activation proof.
+- Correlate outgoing contributions into compact target-owned incoming indexes.
+- Preserve optional-module decoupling, wildcard semantics, and duplicate-module selection.
+- Make Markdown and standalone guidance require activation proof for route/entity-bound recommendations.
+- Prove bidirectional topology in a fresh standalone harness.
+
+## Non-Goals
+
+- Removing or redefining existing host/contribution facts.
+- Adding missing owned-contract provenance; that is the prerequisite spec.
+- Publishing exact unified override keys; that is the override-target sibling spec.
+- Executing module registries or resolving DI at generation time.
+- Introducing direct ORM relationships or runtime dependencies between modules.
+- Adding a UI graph, API, database schema, or module activation behavior.
+
+## Data Model
+
+### Activation facts
+
+Add an optional additive collection under the existing extension-surface model:
+
+```ts
+type ModuleExtensionActivation = {
+  id: string
+  kind: ModuleExtensionActivationKind
+  host: ModuleExtensionTargetRef
+  contributionKinds: ModuleExtensionContributionKind[]
+  phases?: string[]
+  source: ModuleFactSourceRef
+  bridge?: ModuleFactRef
+}
+
+type ModuleExtensionSurfaces = ExistingModuleExtensionSurfaces & {
+  activations?: ModuleExtensionActivation[]
+  incoming?: ModuleIncomingExtensionRef[]
+  contributionResolutions?: ModuleContributionResolution[]
+}
+```
+
+An activation means the selected module's runtime path will query, invoke, merge, or render the named contribution family. `id` must be stable and derived from the host kind and exact normalized runtime identity, not from filesystem order.
+
+Initial activation kinds include:
+
+- CRUD response enricher activation;
+- query enricher activation;
+- mutation guard activation;
+- API interceptor bridge activation;
+- command interceptor bridge activation;
+- widget injection spot consumption;
+- component replacement/wrapper/props consumption;
+- dashboard or other registered host consumption already represented by UMES.
+
+The implementation may use narrower discriminated unions where metadata differs, but every fact needs an exact host reference and proof source.
+
+This initial set is closed by an extractor-adapter registry. Its coverage test compares the registry against the existing UMES host capability and contribution-kind enums: every route/entity-bound kind must have an activation adapter or an explicit tested `capability-only` classification. Adding a UMES kind therefore fails CI until its activation behavior is classified. The initial adapters are CRUD response/query enrichment, mutation-guard bridges, API-interceptor bridges, command-interceptor bridges, injection-spot consumers, replaceable-component consumers, and dashboard-host consumers.
+
+### Incoming references
+
+Add compact references after all selected module facts are extracted:
+
+```ts
+type ModuleIncomingExtensionRef = {
+  contributionId: string
+  contributionKind: ModuleExtensionContributionKind
+  contributorModuleId: string
+  target: ModuleExtensionTargetRef
+  activationId?: string
+  resolution: 'bound' | 'capability-only' | 'optional-target-missing' | 'wildcard' | 'unresolved'
+  source: ModuleFactSourceRef
+}
+```
+
+The incoming row points to the full contribution fact in the contributor module. It must not duplicate behavior metadata such as timeouts, caching, or payload transforms.
+
+Contributor-owned resolution is recorded separately for every contribution, including states for which no target sheet can own an incoming row:
+
+```ts
+type ModuleContributionResolution = {
+  contributionId: string
+  target: ModuleExtensionTargetRef
+  resolution: 'bound' | 'capability-only' | 'optional-target-missing' | 'wildcard' | 'unresolved'
+  activationIds: string[]
+}
+```
+
+This array is the authoritative location for optional-missing, wildcard, and unresolved outcomes. It also gives the contributor a complete resolution summary without modifying the existing contribution union.
+
+### Target identity
+
+Use existing UMES target/fact reference primitives wherever possible. Extend them additively only when a runtime identity cannot be represented. Exact target identities must distinguish, as applicable:
+
+- module;
+- entity;
+- API route plus method;
+- command ID;
+- widget spot;
+- component ID;
+- event or notification ID;
+- explicit wildcard target.
+
+Entity names alone are insufficient when two routes or command surfaces activate different extension families.
+
+## Authoritative Activation Rules
+
+### CRUD routes and enrichers
+
+- Derive response/query enricher activation from the actual `makeCrudRoute` options or the shared normalized CRUD-route descriptor.
+- Record whether list, detail, or both paths activate the family when the factory makes that distinction.
+- Bind the exact route/entity fact and the source line containing the option or bridge.
+- An entity declaration without the activation option remains a capability/host fact only.
+
+### Mutation guards
+
+- Bind only when a mutation route or command calls the supported mutation-guard bridge for the exact entity/action.
+- Do not treat page route middleware as mutation guards.
+- Do not infer activation from the existence of `data/guards.ts` alone.
+
+### API and command interceptors
+
+- Bind API interceptor contributions to the concrete interceptor bridge and normalized method/path/phase set.
+- Bind command interceptors to the command bus/bridge and exact command/phase set.
+- Preserve wildcard targets explicitly; never expand them into a guessed list during generation.
+
+### Widgets and component extension
+
+- Bind injection contributions to host spots actually consumed through the supported widget/injection helpers.
+- Bind component replacement/wrapper/props contributions to registered replaceable component IDs.
+- If an existing host fact already proves consumption, activation may reference it rather than duplicate fields.
+
+### Explicit bridges
+
+Modules that do not use a factory may expose an activation through a supported static bridge declaration. The bridge must be an existing runtime convention or a separately approved additive contract; this implementation must not invent a facts-only manifest that runtime ignores.
+
+## Correlation Algorithm
+
+1. Extract selected module-owned facts and source provenance.
+2. Extract existing hosts, contributions, and new activation facts without changing their runtime meaning.
+3. Build indexes by normalized module/fact/target identity.
+4. For each contribution, resolve its target against selected modules and activations.
+5. Append one compact incoming reference to the target module for each matching activation. When only a compatible legacy host exists, append one capability-only row with no `activationId`.
+6. Append one contributor-owned resolution row per contribution target. Keep optional-missing, wildcard, and unresolved states there; add them to `incoming` only when a concrete target owner exists.
+7. Sort and deduplicate deterministically.
+
+An incoming row's deduplication identity is `contributorModuleId + contributionId + normalized target + (activationId ?? resolution)`. One contribution matching two activations therefore emits two incoming rows and one contributor-owned resolution row whose sorted `activationIds` contains both IDs.
+
+Resolution rules:
+
+- `bound`: an authoritative activation accepts the contribution kind and target.
+- `capability-only`: a compatible legacy host exists, but no activation proves runtime use.
+- `optional-target-missing`: the contribution targets an optional module not selected in this build.
+- `wildcard`: the target is intentionally wildcarded and cannot be assigned to one host.
+- `unresolved`: the target should be concrete but no selected host/capability can resolve it.
+
+Generation diagnostics must distinguish `optional-target-missing` from `unresolved`; optional integrations are not build failures.
+
+## Backward Compatibility
+
+- Keep every current `extensionSurfaces.hosts` and `extensionSurfaces.contributions` item and field unchanged.
+- Do not change stable host/contribution IDs or reinterpret their semantics.
+- Add `activations` and `incoming` as optional properties; current generators emit deterministic arrays according to existing empty-section conventions.
+- Keep source-owned contribution facts authoritative.
+- Append Markdown sections/columns without renaming current headings.
+- Guidance changes may say a host is “available” from the legacy row, but must require a bound activation before claiming runtime invocation.
+
+No HTTP, database, event, ACL, widget, or DI runtime contract changes are introduced.
+
+## Markdown and Guidance
+
+### Module fact sheet
+
+Render three explicitly distinct concepts:
+
+1. **Available extension hosts** — existing capability rows.
+2. **Active extension bindings** — exact host/call-site proof with source links.
+3. **Incoming installed contributions** — contributor module, kind, target, resolution, activation link, and source link.
+
+Do not merge capability-only and bound rows under an ambiguous “supports” label.
+
+### Standalone system-extension guidance
+
+- Route entity/route extension recommendations through `activations`, not broad hosts.
+- Use `incoming` to detect an already-installed contributor before proposing a duplicate.
+- Inspect the full contributor fact by `contributorModuleId + contributionId` when behavior details are needed.
+- Escalate to the named activation/contribution source only if the generated fact lacks one exact detail.
+- Explain optional-missing and wildcard states without recommending direct cross-module ORM coupling.
+
+## Implementation Plan
+
+### Phase 1 — Activation schema and extraction
+
+- Add optional activation types and stable identity helpers.
+- Reuse source references from the prerequisite spec.
+- Extract CRUD, guard, interceptor, widget, and component activations from real normalized call sites.
+- Add negative fixtures proving entity presence alone does not activate a family.
+
+### Phase 2 — Cross-module incoming correlation
+
+- Build post-selection correlation indexes.
+- Resolve exact, optional, wildcard, capability-only, and broken targets.
+- Emit compact incoming rows and contributor-owned resolution rows while preserving source ownership.
+- Add deterministic duplicate-selection and contribution-deduplication tests.
+
+### Phase 3 — Markdown and diagnostics
+
+- Render separate capability, activation, and incoming sections with source links.
+- Add generator diagnostics for unresolved concrete targets without failing valid optional integrations.
+- Measure JSON/Markdown growth on the largest selected host.
+
+### Phase 4 — Standalone harness
+
+- Invoke `om-refresh-standalone-harness <from> <to>`.
+- Update facts-first routing and case metadata.
+- Add failure-first cases where a broad host exists but activation is absent.
+- Add an installed optional contributor fixture and a missing-optional-target fixture.
+- Run fresh Verdaccio scaffold validation and full release proof.
+
+## Test Plan
+
+### Focused generator tests
+
+- CRUD route with response/query enricher activation.
+- Same entity without factory activation yields capability-only, never bound.
+- Mutation guard bridge is distinct from page middleware.
+- API and command interceptor phases bind to exact host identities.
+- Widget spot and replaceable component consumption bind correctly.
+- Source link points to the activation call site.
+- Exact, wildcard, optional missing, unresolved, and duplicate-provider resolution.
+- One contribution matching two activations emits two incoming rows with the documented identities and one sorted resolution summary.
+- Existing hosts/contributions golden fixture is unchanged.
+
+### Cross-module fixtures
+
+Use at least:
+
+- one core host plus one installed optional contributor;
+- two contributors targeting the same host;
+- one contributor targeting two valid activations;
+- one optional contributor whose target module is absent;
+- one intentionally malformed concrete target;
+- one wildcard interceptor.
+
+Assert both the contributor's full outgoing fact and the host's compact incoming reference.
+
+### Standalone cases
+
+| Case | Expected behavior |
+|---|---|
+| Capability without activation | Agent refuses to claim the extension will run and cites the missing activation. |
+| Bound enricher | Agent identifies exact host, activation source, and contributor fact. |
+| Existing incoming contribution | Agent finds the installed extension from the host sheet and avoids duplication. |
+| Optional target absent | Agent preserves decoupling and explains the non-error state. |
+| Wildcard interceptor | Agent reports wildcard semantics without fabricating individual hosts. |
+
+Run focused package tests, `yarn generate`, the configured validation subset, `harness:validate --all`, and `harness:release` in a freshly scaffolded app.
+
+## Acceptance Criteria
+
+- No broad entity/route capability is described as active without a source-linked activation fact.
+- Every adapter-registry bridge produces a deterministic activation with an exact host identity, and every UMES route/entity-bound kind has an adapter or tested capability-only classification.
+- Every concrete installed contribution has a correct target-owned incoming reference or a tested resolution state.
+- Every contribution target has a contributor-owned resolution row, including optional-missing, wildcard, and unresolved outcomes.
+- Full contribution behavior remains source-owned and is not duplicated into the incoming index.
+- Optional missing modules and wildcards remain valid and do not create forbidden direct dependencies.
+- Existing host/contribution arrays and stable IDs remain unchanged.
+- Markdown clearly separates capability, activation, and incoming topology and includes portable links.
+- Standalone guidance refuses unsupported activation claims and finds already-installed contributors facts-first.
+- Fresh standalone package/scaffold and full harness release gates pass.
+
+## Risks
+
+### False activation from static parsing
+
+- **Severity:** High
+- **Mitigation:** Require recognized runtime factory/bridge call sites and negative fixtures.
+- **Residual risk:** Highly dynamic custom routes may remain capability-only and require source inspection.
+
+### Cross-module correlation creates coupling
+
+- **Severity:** High
+- **Mitigation:** Correlation is generated documentation only; runtime ownership and optional selection remain unchanged.
+- **Residual risk:** Consumers may misread incoming facts as hard dependencies; resolution labels and guidance must prevent this.
+
+### Duplicate or excessive topology
+
+- **Severity:** Medium
+- **Mitigation:** Compact references, stable tuple deduplication, source-owned full facts, and byte-budget measurements.
+- **Residual risk:** Wildcard-heavy ecosystems may still need filtered loading later.
+
+### Legacy consumers interpret new rows incorrectly
+
+- **Severity:** Medium
+- **Mitigation:** Add optional sibling arrays and retain old semantics/headings.
+- **Residual risk:** Exact-object consumers may need release notes despite additive JSON.
+
+## Final Compliance Report — 2026-08-02
+
+| Rule source | Requirement | Status | Evidence in this spec |
+|---|---|---|---|
+| Root `AGENTS.md` | No direct cross-module ORM relationship; preserve optional integration. | Compliant | Correlation is generated documentation with explicit optional states. |
+| `BACKWARD_COMPATIBILITY.md` | Preserve stable generated hosts/contributions and IDs. | Compliant | Existing arrays remain unchanged; activations/incoming are additive. |
+| `packages/cli/AGENTS.md` | Deterministic static generation. | Compliant | Exact call-site extraction, stable sorting, and parity fixtures. |
+| `packages/create-app/AGENTS.md` | Standalone guidance and packaging stay aligned. | Compliant | Refresh skill, failure-first cases, and fresh release gate. |
+| Spec cohesion | One independently deployable capability. | Compliant | This spec owns only extension topology and bidirectional correlation. |
+
+No non-compliant item or required human confirmation was identified.
+
+## Changelog
+
+### 2026-08-02
+
+- Split authoritative activation and incoming topology from owned fact provenance and exact override targets.
+- Preserved all legacy host/contribution facts while defining source-linked bindings and target-side references.
+
+## Review — 2026-08-02
+
+- **Fresh-context scope verdict:** KEEP after defining contributor-owned resolution storage, multi-activation cardinality, and the closed bridge-adapter coverage rule.
+- **Security:** Passed; only static contract identifiers and paths are emitted.
+- **Performance:** Passed with compact references and byte-budget evidence.
+- **Compatibility:** Passed; legacy arrays and IDs are preserved.
+- **Scope:** Cohesive; owned inventory and override syntax are explicit dependencies/non-goals.
+- **Verdict:** Ready for implementation after the provenance prerequisite.

--- a/.ai/specs/2026-08-02-module-facts-extension-surface-completeness.md
+++ b/.ai/specs/2026-08-02-module-facts-extension-surface-completeness.md
@@ -1,0 +1,210 @@
+# Complete Source-Linked Module Extension Contracts — Spec Suite Index
+
+- **Status:** Proposed umbrella index — design only, not directly implementable
+- **Date:** 2026-08-02
+- **Scope:** OSS developer tooling; `packages/cli`, `packages/shared`, package module contracts, and the `packages/create-app` standalone agent harness
+- **Source:** merged PR [#4810](https://github.com/open-mercato/open-mercato/pull/4810) and its [UMES catalog spec](2026-08-01-module-extension-point-catalog.md)
+- **Related:** [Module Fact-Sheets](2026-06-27-ts-morph-module-fact-sheets.md), [Standalone AI Development Harness](2026-07-24-standalone-ai-development-harness.md), `BACKWARD_COMPATIBILITY.md`
+
+## 📝 TLDR
+
+The audit confirms that backend/frontend pages are already generated with source links, and that response/query enrichers plus API/command interceptors are already emitted as UMES contributions. The missing work is deeper: most public/overrideable module contracts lack uniform provenance, active extension bindings are over-generalized and not indexed from the host side, and the standalone override guide promises exact module keys that generated facts do not comprehensively expose.
+
+Those are three independently shippable capabilities, so this index routes implementation into three cohesive specs:
+
+1. [Source Provenance and Contract Inventory](2026-08-02-module-facts-source-provenance-and-contract-inventory.md)
+2. [Bound Extension Activation and Incoming Contribution Index](2026-08-02-module-facts-extension-activation-and-incoming-index.md)
+3. [Exact Unified Override Targets](2026-08-02-module-facts-exact-override-targets.md)
+
+Together they answer: **“What can this installed module expose, accept, replace, extend, or depend on; which exact stable key do I use; and where is the defining source?”** Each child spec has its own implementation plan, compatibility boundary, tests, harness refresh, and release proof. This index must never be passed directly to an implementation workflow.
+
+## Resolved assumptions (autonomous defaults)
+
+| # | Question | Applied default | Rationale | Confirm? |
+|---|---|---|---|---|
+| Q1 | Cover only missing UMES/override facts, or every public and auto-discovered module contract an app can extend, replace, target, or depend on? | Cover the complete public/auto-discovered contract boundary, excluding ordinary internal support files. | The request asks to document everything extensible within modules; partial facts keep agents guessing. | ok |
+| Q2 | Replace existing scalar JSON arrays with source-linked objects, or preserve them? | Preserve every legacy shape and add provenance/indexes additively. | Generated fact shapes are STABLE under `BACKWARD_COMPATIBILITY.md`. | ok |
+| Q3 | Keep contributions only on their contributor module, or also index them on the host owner? | Keep the full source-owned fact and add a compact host-owned incoming reference. | One target module sheet must expose what already extends it without duplicating definitions. | ok |
+| Q4 | Does complete DI documentation include `asValue` registrations? | Include `asFunction`, `asClass`, `asValue`, and supported aliases with safe registration metadata. | Every published DI key is stable and replaceable; classification prevents hiding value/entity registrations. | ok |
+| Q5 | Ship one umbrella implementation or split independently usable capabilities? | Split into the three child specs above and keep this file as a non-implementable index. | A fresh-context scope review found that provenance/inventory, extension topology, and override targets each function independently. | ok |
+
+No assumption needs human confirmation.
+
+## 📝 Audit Summary
+
+### Already implemented
+
+| Surface | Current state | Source |
+|---|---|---|
+| Backend/frontend pages | Route path plus portable `sourcePath`. | [`extractModulePages`](../../packages/cli/src/lib/generators/module-facts.ts) |
+| API routes | Methods, per-method auth, and source path. | [`extractApiRoutes`](../../packages/cli/src/lib/generators/module-facts.ts) |
+| CLI commands | Legacy `cli: string[]` plus source-linked `cliCommands`. | [`extractCli`](../../packages/cli/src/lib/generators/module-facts.ts) |
+| AI tools and agents | Exact ID/name and source path. | [`extractAiTools` / `extractAiAgents`](../../packages/cli/src/lib/generators/module-facts.ts) |
+| Response/query enrichers | Outgoing contributions with target, activation metadata, timeout/fallback/cache posture, and source. | [`extractEnrichers`](../../packages/cli/src/lib/generators/module-extension-facts.ts) |
+| API/command interceptors | Outgoing contributions with target, phases, and source. | [`extractApiInterceptors` / `extractCommandInterceptors`](../../packages/cli/src/lib/generators/module-extension-facts.ts) |
+| Entity extensions, mutation guards, subscribers, browser reactions, component overrides, and selected specialized registries | Outgoing extension contributions. | [`extractModuleExtensionFacts`](../../packages/cli/src/lib/generators/module-extension-facts.ts) |
+
+The child specs extend and correlate these surfaces; they do not create duplicate catalogs.
+
+### Live repository baseline — 2026-08-02
+
+A non-test scan found **70 package module roots / 60 unique module IDs** on `origin/develop`; duplicate IDs continue through existing provider selection.
+
+| Contract family | Roots | Gap owner |
+|---|---:|---|
+| Backend / frontend pages | 39 / 9 | Spec 1 adds metadata/provenance; Spec 3 adds exact override keys. |
+| Backend / frontend page middleware | 1 / 1 | Spec 1 inventories; Spec 3 maps the `guards` override domain. |
+| API routes | 47 | Spec 1 completes provenance; Spec 2 binds activation; Spec 3 adds method keys. |
+| Domain commands | 19 | Spec 1 emits source-linked facts. |
+| Subscribers / workers | 23 / 19 | Spec 1 aligns recursive facts; Spec 3 maps override keys. |
+| DI | 41 | Spec 1 emits complete safe registrations; Spec 3 maps safe overrides. |
+| Setup / encryption | 48 / 15 | Spec 1 inventories capabilities; Spec 3 maps exact override shapes/keys. |
+| Custom entities / entity extensions | 13 / 6 | Spec 1 completes ownership; Spec 2 correlates incoming extensions. |
+| Enrichers / mutation guards | 9 / 2 | Spec 2 binds real route/entity activation and incoming refs; Spec 3 maps supported override domains. |
+| API / command interceptors | 6 / 2 | Spec 2 binds host bridges; Spec 3 maps exact contribution keys. |
+| Notifications / handlers | 17 / 2 | Spec 1 completes provenance; Spec 3 maps exact keys. |
+| Search / vector | 11 / 2 | Spec 1 completes provenance/specialist facts. |
+| Integration manifests / generator plugins | 7 / 2 | Spec 1 completes singular/array/bundle/plugin facts. |
+| Dashboard widgets / injection tables / component overrides | 4 / 24 / 3 | Spec 2 adds incoming/source views; Spec 3 maps override keys. |
+
+Counts are audit evidence, not hard-coded acceptance criteria. Tests derive the live selected module set.
+
+## Research — comparable contract catalogs
+
+- [VS Code contribution points](https://code.visualstudio.com/api/references/contribution-points) demonstrate stable machine-readable contribution kinds and IDs. Open Mercato keeps executable convention sources as authority rather than adding a hand-maintained manifest.
+- [Backstage extension blueprints](https://backstage.io/docs/frontend-system/architecture/extension-blueprints/) and [extension overrides](https://backstage.io/docs/frontend-system/architecture/extension-overrides/) separate attachment identity, typed data, additive inputs, and replacement. The child specs preserve those distinctions without replacing UMES.
+- [Backstage plugin modules](https://backstage.io/docs/backend-system/architecture/modules/) distinguish host-owned extension points from module-owned contributions. Spec 2 adopts that bidirectional view while preserving optional-module ownership.
+- [NestJS custom providers](https://docs.nestjs.com/fundamentals/custom-providers) distinguishes provider token from class/value/factory registration. Spec 1 applies that safe metadata boundary to Awilix facts.
+
+## Suite Boundaries
+
+### Shared goals
+
+- Every public, auto-discovered, targetable, or overrideable module contract is deterministic and source-linked.
+- Runtime registries and generated facts reuse one normalized discovery interpretation.
+- Legacy module-facts JSON fields and Markdown headings remain compatible.
+- Facts never include source bodies, runtime values, secrets, credentials, tenant/user/customer data, or absolute local paths.
+- Standalone evaluations fail when exact facts are missing and use installed source only for one named unresolved detail.
+
+### Shared non-goals
+
+- No runtime Platform Map UI/API, database migration, product UI, cache behavior, or registry execution change.
+- No rename/cleanup of existing IDs, paths, tokens, or convention files.
+- No inventory of arbitrary internal helpers.
+- No module-specific exact keys duplicated into conceptual guides.
+- No hand-editing generated artifacts.
+
+### Dependency order
+
+```text
+Spec 1: provenance + owned contract facts + packaging
+           │
+           ├──────────────┐
+           ▼              ▼
+Spec 2: bound topology   Spec 3: exact overrides
+           │              ▲
+           └──────────────┘
+        Spec 3 consumes topology refs where applicable
+```
+
+- Spec 1 ships first because Specs 2 and 3 reuse its portable source/fact references.
+- Spec 2 may ship independently after Spec 1.
+- Spec 3 depends on Spec 1 and consumes Spec 2 activation/incoming references when present; it must still work with empty topology sections.
+- Every child implementation invokes `om-refresh-standalone-harness` for its own committed local range and runs its own fresh-scaffold release gate.
+
+## Cross-Suite Compatibility Contract
+
+- The top-level `module-facts.json` remains `Record<moduleId, ModuleFactsJsonEntry>`.
+- New exported properties are optional; current generators emit deterministic empty values.
+- Existing arrays/objects keep their current types and required fields.
+- Existing Markdown headings remain; new sections and appended source columns are additive.
+- Existing `extensionSurfaces.hosts` rows are not removed or reclassified in this suite. Spec 2 adds an authoritative activation layer and guidance requires an activation for route-bound use.
+- Framework facts remain in `framework-extension-points.md`; no fake framework module key is added.
+- Exact fact IDs/source/override keys become STABLE/FROZEN according to their underlying contract after publication.
+
+## Suite-Level Risks
+
+### Partial rollout ambiguity
+
+- **Scenario:** Guidance expects an incoming/override fact before its child spec ships.
+- **Severity:** High
+- **Affected area:** Standalone routing and implementation correctness.
+- **Mitigation:** Each child updates only its owned guidance/cases, gates facts by optional fields, and passes a fresh scaffold independently.
+- **Residual risk:** During staggered releases, older scaffolds keep their older facts and require version-stamped source escalation.
+
+### Contract/context growth
+
+- **Scenario:** Combined facts exceed harness context budgets.
+- **Severity:** Medium
+- **Affected area:** Standalone one-shot performance.
+- **Mitigation:** Source/fact references instead of bodies/duplication, per-child byte measurements, compact incoming refs, and largest-module budget guards.
+- **Residual risk:** Highly extensible modules may eventually require targeted section loading.
+
+### Generated compatibility drift
+
+- **Scenario:** A child changes a legacy key or runtime registry while refactoring readers.
+- **Severity:** High
+- **Affected area:** Third-party consumers and module activation.
+- **Mitigation:** Each child owns BC fixtures and runtime-output parity before publishing new facts.
+- **Residual risk:** Undocumented exact-object consumers may reject additive keys and need release-note guidance.
+
+## Final Compliance Report — 2026-08-02
+
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md` (root)
+- `.ai/specs/AGENTS.md`
+- `packages/cli/AGENTS.md`
+- `packages/create-app/AGENTS.md`
+- `packages/core/AGENTS.md`
+- `packages/shared/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+- `.ai/skills/om-refresh-standalone-harness/SKILL.md` and references
+- `packages/create-app/agentic/shared/ai/skills/om-system-extension/SKILL.md` and references
+
+### Compliance Matrix
+
+| Rule source | Rule | Status | Notes |
+|---|---|---|---|
+| Spec checklist | One independently deployable capability per implementation spec. | Compliant | Fresh-context SPLIT verdict applied; this file is an index and three child specs own implementation. |
+| Root + CLI | Deterministic generated output from module source. | Compliant | Child specs require shared normalized readers and parity tests. |
+| Root + BC | Preserve generated-file contracts and public IDs. | Compliant | Shared compatibility boundary is additive and forbids host-row removal. |
+| Create-app | Keep standalone guidance aligned with generator behavior. | Compliant | Each child owns its packaging/guidance/harness/release gate. |
+| Root security | Exclude secrets and scoped user data. | Compliant | Only static contract IDs/metadata/provenance are allowed. |
+| Root UI/data rules | UI, schema, locking, and migrations. | N/A | This suite is generated developer tooling with no runtime UI/data mutation. |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|---|---|---|
+| Scope maps to implementation plans | Pass | Implementation lives only in child specs. |
+| Dependencies are acyclic | Pass | Spec 1 precedes Specs 2/3; Spec 3 optionally consumes Spec 2 refs. |
+| Compatibility is consistent | Pass | All children inherit the additive suite boundary. |
+| Harness ownership is clear | Pass | Each child refreshes only its own facts/behavior range. |
+
+### Non-Compliant Items
+
+None identified.
+
+### Verdict
+
+**Umbrella index approved:** do not implement this file directly; implement the three child specs in dependency order.
+
+## Changelog
+
+### 2026-08-02
+
+- Audited PR #4810, its spec, baseline facts, runtime module discovery, unified overrides, and standalone harness promises.
+- Confirmed pages and enrichers/interceptors already exist and isolated the actual provenance, topology, and exact-key gaps.
+- Applied the required fresh-context SPLIT verdict by replacing one umbrella implementation plan with this index and three cohesive child specs.
+
+### Review — 2026-08-02
+
+- **Reviewer:** Agent author plus required fresh-context scope reviewer.
+- **Security:** Passed.
+- **Performance:** Passed with child-spec evidence gates.
+- **Cache:** N/A.
+- **Commands:** N/A for the index.
+- **Risks:** Passed.
+- **Scope cohesion:** SPLIT applied; each child is independently deployable.
+- **Verdict:** Index approved; child specs are the implementation inputs.

--- a/.ai/specs/2026-08-02-module-facts-extension-surface-completeness.md
+++ b/.ai/specs/2026-08-02-module-facts-extension-surface-completeness.md
@@ -115,6 +115,7 @@ Spec 2: bound topology   Spec 3: exact overrides
 ## Cross-Suite Compatibility Contract
 
 - The top-level `module-facts.json` remains `Record<moduleId, ModuleFactsJsonEntry>`.
+- Generator diagnostics remain optional fields on the owning module entry (or a separate sibling artifact); no synthetic framework/diagnostics key is added to the root module record.
 - New exported properties are optional; current generators emit deterministic empty values.
 - Existing arrays/objects keep their current types and required fields.
 - Existing Markdown headings remain; new sections and appended source columns are additive.

--- a/.ai/specs/2026-08-02-module-facts-source-provenance-and-contract-inventory.md
+++ b/.ai/specs/2026-08-02-module-facts-source-provenance-and-contract-inventory.md
@@ -1,0 +1,324 @@
+# Module Facts Source Provenance and Contract Inventory
+
+- **Status:** Proposed — implementation-ready
+- **Date:** 2026-08-02
+- **Parent:** [Complete Source-Linked Module Extension Contracts](2026-08-02-module-facts-extension-surface-completeness.md)
+- **Depends on:** merged PR [#4810](https://github.com/open-mercato/open-mercato/pull/4810)
+- **Scope:** `packages/cli` module-facts generation and Markdown, module discovery readers, generated-file compatibility, and `packages/create-app` standalone harness packaging
+
+## TLDR
+
+Make the generated module fact sheet the deterministic, source-linked inventory of every public or auto-discovered contract owned by an installed module. Preserve all existing JSON shapes, add portable provenance alongside them, and fill the currently absent contract families: commands, recursive subscribers and workers, page middleware, setup, encryption, complete DI registrations, custom-entity ownership, vector search, integrations, AI extensions, and generator plugins.
+
+This spec does not decide whether another module actively attaches to those contracts and does not define unified override keys. Those are the responsibilities of the sibling topology and override-target specs.
+
+## Resolved assumptions (autonomous defaults)
+
+| # | Question | Applied default | Rationale | Confirm? |
+|---|---|---|---|---|
+| Q1 | Which files qualify for inventory? | Public, auto-discovered, targetable, replaceable, or dependency-bearing module contracts only. | Arbitrary internal helpers are not extension contracts and would make facts noisy. | ok |
+| Q2 | May source-linked objects replace legacy scalar arrays? | No. Keep legacy fields byte-compatible and add optional provenance/index fields. | Published generated schemas are stable contract surfaces. | ok |
+| Q3 | What DI registrations are visible? | Functions, classes, values, and supported aliases, with static metadata only. | Every registered token can affect extension behavior, but runtime values may be sensitive. | ok |
+| Q4 | Should runtime and fact discovery be separate parsers? | No. Extract or reuse a normalized reader shared with runtime discovery wherever practical. | Parallel parsers drift and produce misleading documentation. | ok |
+
+No assumption needs human confirmation.
+
+## Overview
+
+PR #4810 added the Unified Module Extension Surface (UMES) catalog and correlated many outgoing contributions. The pre-existing module-facts generator already covers pages, API routes, CLI commands, AI tools, and AI agents with source paths. Other sections remain scalar-only, omit their existing source metadata in Markdown, or are absent despite being discovered by runtime conventions.
+
+The repository audit on 2026-08-02 found 70 package module roots representing 60 selected module IDs. Among those roots were 41 DI registries, 48 setup files, 19 workers, 23 subscriber roots, 19 command roots, 15 encryption declarations, 13 custom-entity declarations, 7 integration manifests, and 2 generator plugins. Counts are evidence only; implementation tests must discover the current selected module set rather than freeze these numbers.
+
+## Problem Statement
+
+An app developer or coding agent cannot answer all of these questions from generated facts alone:
+
+- Where is this entity, event, ACL feature, DI token, search declaration, notification, or setup hook defined?
+- Which commands, workers, middleware, encryption declarations, integration bundles, and generator plugins does the module own?
+- Is a DI token registered as a class, factory, value, or alias, and with which safe lifetime/injection mode?
+- Does the fact describe what runtime actually discovers, including nested subscriber directories?
+- Will the same facts be present after publishing and installing a standalone app package?
+
+The fallback is broad source search. That is slow, non-deterministic, and sometimes impossible in the installed package because the relevant source was not packaged.
+
+## Goals
+
+- Give every owned contract fact a stable portable reference to its defining source.
+- Cover the complete public and auto-discovered module contract boundary.
+- Preserve current `ModuleFacts` and Markdown consumers additively.
+- Reuse runtime discovery semantics instead of implementing approximations.
+- Keep output deterministic across local monorepo and installed standalone contexts.
+- Prove facts-first routing and source escalation in the standalone harness.
+
+## Non-Goals
+
+- Active extension bindings or host-side incoming contribution indexes.
+- Exact keys accepted by `modules.ts` unified overrides.
+- Executing modules, resolving DI containers, importing runtime values, or evaluating registrations.
+- Cataloging private helpers, React components that are not discovery surfaces, or arbitrary exports.
+- Adding a runtime API, Platform Map UI, persistence, migrations, or telemetry.
+- Renaming existing IDs, filenames, or convention paths.
+
+## Contract Boundary
+
+### Provenance primitive
+
+Add an exported optional provenance model in the shared module-facts contract:
+
+```ts
+export type ModuleFactSourceRef = {
+  sourcePath: string
+  exportName?: string
+  line?: number
+}
+```
+
+`sourcePath` uses the existing canonical representation: a POSIX-normalized portable installed-source path that includes the `sourceRoot` prefix (for example `node_modules/@open-mercato/core/src/modules/customers/acl.ts`). It is not a second path relative to `sourceRoot`, and it must never be an absolute workstation path. Markdown renders that exact portable path as a link from the generated document. `line` is optional because AST recovery can fail after transforms; consumers must use the path and exported symbol as the stable identity.
+
+Add a deterministic provenance index without replacing legacy fields:
+
+```ts
+export type ModuleFactSourceEntry = {
+  kind: ModuleFactSourceKind
+  id: string
+  source: ModuleFactSourceRef
+}
+
+export type ModuleFactsJsonEntry = ExistingModuleFactsJsonEntry & {
+  factSources?: ModuleFactSourceEntry[]
+  ownedContracts?: ModuleOwnedContracts
+}
+```
+
+`kind + id` is unique inside one module. When multiple declarations claim the same identity, select one canonical source using the same convention/provider precedence as runtime discovery and emit a deterministic duplicate-source diagnostic for the rejected declarations. Entries sort first by `kind`, then `id`; `sourcePath` is only a final deterministic tie-breaker while assembling candidates. Existing source-bearing rich fields remain unchanged.
+
+### Owned contract families
+
+`ownedContracts` adds source-linked facts only where a richer established field does not already exist. The concrete types may be split by file, but the public JSON shape must cover:
+
+| Family | Required safe fields | Authoritative convention |
+|---|---|---|
+| Module metadata | module ID, version/metadata flags, required module IDs, ejectable state, source | `index.ts` / `module.ts` exports used by module selection |
+| Domain commands | command ID, source | recursive `commands/*.ts` discovery |
+| Subscribers | subscriber ID or stable generated identity, event patterns when statically declared, source | the same recursive subscriber scanner used at runtime |
+| Workers | worker ID, queue/name metadata when static, source | the runtime worker scanner |
+| Page middleware | surface (`backend` or `frontend`), middleware ID or export, source | `backend/middleware.ts`, `frontend/middleware.ts` |
+| Setup | present hooks, exported default-role/profile identifiers when static, source | `setup.ts` recognized exports |
+| Encryption | entity IDs and declared encrypted fields only when statically safe, source | `encryption.ts` |
+| DI registrations | token, registration kind, provider symbol if static, lifetime, injection mode, source | `di.ts` registration map |
+| Custom entities/fields | owned entity or field-set ID and source | `ce.ts`, custom-field DSL convention files |
+| Search/vector | indexed entity or provider ID, search kind, source | `search.ts`, `vector-search.ts` and current runtime readers |
+| Integrations | integration IDs, bundle membership, manifest kind, source | singular/array/bundle manifest conventions |
+| AI extensions | extension ID, file override target if declared, source | AI extension and override convention files |
+| Generator plugins | plugin ID/name and source | generator plugin convention files |
+
+Existing rich page, route, CLI, tool, and agent facts remain authoritative. Their source references are also added to `factSources` so consumers can use one uniform provenance lookup.
+
+### Safe page metadata
+
+The current page facts already contain route path and source. Add only statically declared metadata that affects extensibility or access:
+
+- auth/customer-auth requirement presence;
+- feature/customer-feature identifiers;
+- navigation visibility/group/order identifiers when declared;
+- page context or extension spot identifiers exposed by metadata.
+
+Do not serialize executable guards, translation results, React nodes, or arbitrary metadata values. Exact unified override page keys belong to the override-target sibling spec.
+
+### Complete DI facts
+
+The current `diTokens: string[]` must remain. Add rich registration facts covering all supported Awilix registration forms:
+
+```ts
+type ModuleDiRegistrationFact = {
+  token: string
+  registrationKind: 'function' | 'class' | 'value' | 'alias'
+  providerSymbol?: string
+  lifetime?: 'singleton' | 'scoped' | 'transient'
+  injectionMode?: 'classic' | 'proxy'
+  source: ModuleFactSourceRef
+}
+```
+
+Requirements:
+
+- Recognize `asFunction`, `asClass`, `asValue`, and the alias form supported by the repository's Awilix version and DI DSL.
+- Resolve static object spreads and local constants only through the same bounded AST utilities used by module-facts generation.
+- Record `providerSymbol` only when it is a local/static identifier.
+- Never import or execute `di.ts` to inspect it.
+- Never serialize the value passed to `asValue`, factory/class bodies, credentials, configuration payloads, or inferred runtime types.
+- Keep `diTokens` derived from the normalized rich facts plus any legacy fallback so no current token disappears.
+
+## Architecture
+
+### One normalized discovery path
+
+For each convention family:
+
+1. Locate the runtime scanner or parser.
+2. Extract a pure normalized reader when the runtime code currently mixes filesystem discovery with registration.
+3. Have runtime registration and module-facts generation consume that reader, or add parity fixtures when sharing would introduce a runtime/package dependency cycle.
+4. Transform normalized facts into the additive JSON and Markdown models.
+
+The generator must not import module code. All extraction remains static and side-effect free.
+
+### Deterministic generation
+
+- Select duplicate module IDs with the existing provider-selection rules.
+- Normalize separators to `/`.
+- Sort every emitted collection by its stable identity.
+- Deduplicate identical candidates, then select one canonical source per `kind + id` using runtime convention/provider precedence; report non-identical rejected declarations deterministically.
+- Emit empty optional arrays consistently according to the existing generator convention.
+- Keep Markdown relative links valid from the generated output directory.
+
+### Markdown rendering
+
+Update the module Markdown sheet so that:
+
+- existing source-bearing rows actually render clickable source links;
+- scalar sections gain a `Source` column through `factSources` or `ownedContracts`;
+- missing optional metadata renders as `—`, never guessed text;
+- source links use repository-relative paths and optional line anchors supported by the renderer;
+- sections with no facts retain current empty/omission behavior.
+
+## API and Generated-File Compatibility
+
+No HTTP API changes are introduced. Generated-file changes are additive:
+
+- preserve the top-level `Record<moduleId, ModuleFactsJsonEntry>` shape;
+- preserve all existing properties, types, and required fields;
+- add only optional exported properties in the shared type;
+- keep existing Markdown headings and append columns/sections;
+- version any standalone prompt schema marker that depends on the new facts;
+- document the additions in `UPGRADE_NOTES.md` if the implementation changes a published import or generated contract expectation.
+
+## Implementation Plan
+
+### Phase 1 — Contract and provenance
+
+- Add `ModuleFactSourceRef`, source kinds, `factSources`, and `ownedContracts` types in the current shared module-facts contract.
+- Add compatibility fixtures that load a pre-change JSON sample with the new reader.
+- Centralize stable IDs, path normalization, sorting, and deduplication.
+
+### Phase 2 — Existing fact provenance
+
+- Correlate source references for entities, events, ACL features, DI tokens, search/vector declarations, notifications, CLI, pages, routes, AI tools/agents, and current extension facts.
+- Render the already-available UMES contribution sources in Markdown.
+- Add safe page metadata.
+
+### Phase 3 — Missing owned families
+
+- Add domain commands, recursive subscribers, workers, page middleware, setup, encryption, rich DI, custom-entity/field ownership, vector, integration arrays/bundles, AI extensions/file overrides, and generator plugins.
+- Align each reader with runtime discovery and add parity fixtures.
+- Run `yarn generate` after changing auto-discovery inputs or generated registries.
+
+### Phase 4 — Standalone packaging and harness
+
+- Invoke `om-refresh-standalone-harness <from> <to>` for the implementation range.
+- Ensure the create-app package includes every reader/template/source file required to generate the facts after packing.
+- Update the system-extension guidance to treat the fact sheet as authoritative and source as escalation for one unresolved named detail.
+- Add/refresh facts-only cases for provenance and each newly represented contract family.
+- Add a deliberate failure-first fixture where the fact is absent, so a plausible source-only answer fails.
+
+## Test Plan
+
+### Unit and contract tests
+
+- Golden JSON and Markdown output for every contract family.
+- Legacy fixture compatibility: no existing field disappears or changes type.
+- Cross-platform path normalization and deterministic ordering.
+- No absolute path, source body, function body, runtime value, secret-like key/value, tenant ID, user ID, or customer ID appears.
+- DI fixtures for function, class, value, alias, lifetime, injection mode, spread, and unresolved dynamic registration.
+- Recursive nested subscriber and worker fixtures match runtime discovery.
+- Integration-array/bundle and generator-plugin fixtures cover all supported declaration shapes.
+- Duplicate module ID selection matches runtime provider selection.
+- Duplicate declarations of one `kind + id` select the runtime-authoritative source and emit deterministic rejected-source diagnostics.
+
+### Runtime parity tests
+
+For each shared or parallel reader, use one fixture tree to compare:
+
+- files runtime discovery would register;
+- files/facts the generator reports;
+- stable IDs and source paths after selection.
+
+Dynamic declarations that cannot be resolved statically must produce an explicit diagnostic or partial fact, never a fabricated value.
+
+### Standalone harness cases
+
+| Case | Required proof |
+|---|---|
+| Facts provenance | Agent cites the exact generated fact and portable source path without broad search. |
+| DI classification | Agent distinguishes a value token from factory/class registration and does not reveal its value. |
+| Worker/subscriber discovery | Nested contract is present and points to the runtime-discovered source. |
+| Setup/encryption safety | Agent reports only hook/entity/field identifiers allowed by the schema. |
+| Installed packaging | Fresh Verdaccio scaffold contains and generates the same fact families. |
+
+Run `harness:validate --all`, then the full `harness:release` gate after package build/publish/scaffold. The release proof must come from a fresh app, not the monorepo checkout.
+
+## Acceptance Criteria
+
+- Every selected module's public/auto-discovered owned contract is either represented or explicitly classified out of scope by a tested rule.
+- Every represented fact has a portable source reference, including current UMES contributions in Markdown.
+- Pages keep their existing path/source behavior and gain only safe static metadata.
+- `diTokens` remains compatible while rich DI facts cover function, class, value, and alias registrations safely.
+- Runtime and generated discovery agree for recursive and specialized convention families.
+- JSON/Markdown output is deterministic on repeated generation.
+- No generated output leaks executable bodies, runtime values, credentials, scoped data, or absolute paths.
+- The facts and required sources survive package packing and a fresh standalone scaffold.
+- Focused tests, `yarn generate`, the configured validation subset, `harness:validate --all`, and `harness:release` pass.
+
+## Risks
+
+### Static analysis overclaims dynamic declarations
+
+- **Severity:** High
+- **Mitigation:** Emit only statically proven fields, preserve unresolved diagnostics, and compare against runtime fixture discovery.
+- **Residual risk:** Third-party modules with computed registries may expose only a partial fact and require source escalation.
+
+### Facts expose sensitive DI values
+
+- **Severity:** High
+- **Mitigation:** Schema excludes values and bodies; security tests reject secret-like content and absolute paths.
+- **Residual risk:** A token name itself may reveal architecture, which is already part of the published DI contract.
+
+### Generated context grows too large
+
+- **Severity:** Medium
+- **Mitigation:** Central provenance index, references instead of source snippets, stable deduplication, and byte-budget assertions for the largest module.
+- **Residual risk:** Large third-party modules may need targeted section loading later.
+
+### Runtime/parser drift
+
+- **Severity:** High
+- **Mitigation:** Shared normalized readers or mandatory parity fixtures for every family.
+- **Residual risk:** Runtime conventions added without updating the reader; CI coverage must make this visible.
+
+## Final Compliance Report — 2026-08-02
+
+| Rule source | Requirement | Status | Evidence in this spec |
+|---|---|---|---|
+| Root `AGENTS.md` | Preserve generated contract surfaces. | Compliant | Additive JSON/Markdown boundary and legacy fixtures. |
+| `BACKWARD_COMPATIBILITY.md` | Do not remove stable fields/imports. | Compliant | No existing field is replaced; new properties are optional. |
+| `packages/cli/AGENTS.md` | Deterministic, static generation and runtime-aligned discovery. | Compliant | Normalized readers, sorting, and parity tests. |
+| `packages/create-app/AGENTS.md` | Keep standalone packaged artifacts aligned. | Compliant | Pack, fresh-scaffold, validation, and release gates. |
+| Root security rules | Do not expose secrets or scoped data. | Compliant | Explicit safe schema and negative tests. |
+| Spec cohesion | One independently deployable capability. | Compliant | This spec owns only source-linked owned contract inventory. |
+
+No non-compliant item or required human confirmation was identified.
+
+## Changelog
+
+### 2026-08-02
+
+- Split source provenance and owned contract inventory from extension topology and override-key work.
+- Specified additive source references, complete safe DI classification, runtime discovery parity, and standalone package/harness proof.
+
+## Review — 2026-08-02
+
+- **Fresh-context scope verdict:** KEEP after canonicalizing portable source paths and duplicate-source selection.
+- **Security:** Passed with value/body/path exclusion requirements.
+- **Performance:** Passed with deterministic deduplication and byte-budget evidence.
+- **Compatibility:** Passed as an additive generated-contract change.
+- **Scope:** Cohesive; topology and override targets are explicit sibling specs.
+- **Verdict:** Ready for implementation after parent suite approval.

--- a/.ai/specs/2026-08-02-module-facts-source-provenance-and-contract-inventory.md
+++ b/.ai/specs/2026-08-02-module-facts-source-provenance-and-contract-inventory.md
@@ -8,7 +8,7 @@
 
 ## TLDR
 
-Make the generated module fact sheet the deterministic, source-linked inventory of every public or auto-discovered contract owned by an installed module. Preserve all existing JSON shapes, add portable provenance alongside them, and fill the currently absent contract families: commands, recursive subscribers and workers, page middleware, setup, encryption, complete DI registrations, custom-entity ownership, vector search, integrations, AI extensions, and generator plugins.
+Make the generated module fact sheet the deterministic, source-linked inventory of every public or auto-discovered contract owned by an installed module. Preserve all existing JSON shapes, add portable provenance alongside them, fill the currently absent command/worker/middleware/setup/encryption/rich-DI/custom-entity/AI-extension/generator-plugin families, and close recursive-subscriber plus vector/integration coverage gaps in the established rich contribution facts.
 
 This spec does not decide whether another module actively attaches to those contracts and does not define unified override keys. Those are the responsibilities of the sibling topology and override-target specs.
 
@@ -59,9 +59,13 @@ The fallback is broad source search. That is slow, non-deterministic, and someti
 - Adding a runtime API, Platform Map UI, persistence, migrations, or telemetry.
 - Renaming existing IDs, filenames, or convention paths.
 
-## Contract Boundary
+## Proposed Solution
 
-### Provenance primitive
+Extend the existing module-facts entry additively with one shared provenance/reference vocabulary and source-linked owned-contract facts only for families that have no richer established representation. Existing rich facts remain authoritative and receive provenance-index entries; they are not copied into a second payload. Runtime discovery and fact generation must consume the same normalized reader, or prove parity with one shared fixture where package boundaries prevent code reuse.
+
+## Data Models
+
+### Provenance and reference primitives
 
 Add an exported optional provenance model in the shared module-facts contract:
 
@@ -71,6 +75,64 @@ export type ModuleFactSourceRef = {
   exportName?: string
   line?: number
 }
+
+export type ModuleFactRef = {
+  factSection: string
+  factKey: string
+}
+
+export type ModuleFactSourceKind =
+  | 'module-metadata'
+  | 'entity'
+  | 'event'
+  | 'acl-feature'
+  | 'api-route'
+  | 'di-registration'
+  | 'search'
+  | 'vector'
+  | 'notification'
+  | 'cli-command'
+  | 'backend-page'
+  | 'frontend-page'
+  | 'ai-tool'
+  | 'ai-agent'
+  | 'ai-extension'
+  | 'command'
+  | 'subscriber'
+  | 'worker'
+  | 'page-middleware'
+  | 'setup'
+  | 'encryption'
+  | 'custom-entity'
+  | 'integration'
+  | 'generator-plugin'
+  | 'extension-host'
+  | 'extension-contribution'
+
+export type ModuleOwnedContractKind =
+  | 'module-metadata'
+  | 'command'
+  | 'worker'
+  | 'page-middleware'
+  | 'setup'
+  | 'encryption'
+  | 'di-registration'
+  | 'custom-entity'
+  | 'ai-extension'
+  | 'generator-plugin'
+
+export type ModuleFactSafeScalar = string | number | boolean | null
+
+export type ModuleOwnedContractFact = {
+  kind: ModuleOwnedContractKind
+  id: string
+  source: ModuleFactSourceRef
+  metadata?: Record<string, ModuleFactSafeScalar | ModuleFactSafeScalar[]>
+}
+
+export type ModuleOwnedContracts = Partial<
+  Record<ModuleOwnedContractKind, ModuleOwnedContractFact[]>
+>
 ```
 
 `sourcePath` uses the existing canonical representation: a POSIX-normalized portable installed-source path that includes the `sourceRoot` prefix (for example `node_modules/@open-mercato/core/src/modules/customers/acl.ts`). It is not a second path relative to `sourceRoot`, and it must never be an absolute workstation path. Markdown renders that exact portable path as a link from the generated document. `line` is optional because AST recovery can fail after transforms; consumers must use the path and exported symbol as the stable identity.
@@ -87,6 +149,14 @@ export type ModuleFactSourceEntry = {
 export type ModuleFactsJsonEntry = ExistingModuleFactsJsonEntry & {
   factSources?: ModuleFactSourceEntry[]
   ownedContracts?: ModuleOwnedContracts
+  factDiagnostics?: ModuleFactDiagnostic[]
+}
+
+export type ModuleFactDiagnostic = {
+  code: 'duplicate-source' | 'unresolved-static-contract'
+  kind: ModuleFactSourceKind
+  id: string
+  source?: ModuleFactSourceRef
 }
 ```
 
@@ -94,23 +164,24 @@ export type ModuleFactsJsonEntry = ExistingModuleFactsJsonEntry & {
 
 ### Owned contract families
 
-`ownedContracts` adds source-linked facts only where a richer established field does not already exist. The concrete types may be split by file, but the public JSON shape must cover:
+`ownedContracts` adds source-linked facts only where a richer established field does not already exist. Established rich facts are referenced through `factSources` and `ModuleFactRef`; they are never copied into `ownedContracts`. The concrete family types may be narrower discriminated unions in implementation, but the public JSON projection must follow this ownership table:
 
-| Family | Required safe fields | Authoritative convention |
-|---|---|---|
-| Module metadata | module ID, version/metadata flags, required module IDs, ejectable state, source | `index.ts` / `module.ts` exports used by module selection |
-| Domain commands | command ID, source | recursive `commands/*.ts` discovery |
-| Subscribers | subscriber ID or stable generated identity, event patterns when statically declared, source | the same recursive subscriber scanner used at runtime |
-| Workers | worker ID, queue/name metadata when static, source | the runtime worker scanner |
-| Page middleware | surface (`backend` or `frontend`), middleware ID or export, source | `backend/middleware.ts`, `frontend/middleware.ts` |
-| Setup | present hooks, exported default-role/profile identifiers when static, source | `setup.ts` recognized exports |
-| Encryption | entity IDs and declared encrypted fields only when statically safe, source | `encryption.ts` |
-| DI registrations | token, registration kind, provider symbol if static, lifetime, injection mode, source | `di.ts` registration map |
-| Custom entities/fields | owned entity or field-set ID and source | `ce.ts`, custom-field DSL convention files |
-| Search/vector | indexed entity or provider ID, search kind, source | `search.ts`, `vector-search.ts` and current runtime readers |
-| Integrations | integration IDs, bundle membership, manifest kind, source | singular/array/bundle manifest conventions |
-| AI extensions | extension ID, file override target if declared, source | AI extension and override convention files |
-| Generator plugins | plugin ID/name and source | generator plugin convention files |
+| Family | Projection | Required safe fields | Authoritative convention |
+|---|---|---|---|
+| Module metadata | New `ownedContracts` fact | module ID, version/metadata flags, required module IDs, ejectable state, source | `index.ts` metadata used by module selection |
+| Domain commands | New `ownedContracts` fact | command ID, source | recursive `commands/*.ts` discovery |
+| Subscribers | Reuse `extensionSurfaces.contributions[kind=subscriber]`; add `factSources` entry and make its reader recursively match runtime | subscriber ID, event patterns when statically declared, source | the same recursive subscriber scanner used at runtime |
+| Workers | New `ownedContracts` fact | worker ID, queue/name metadata when static, source | the runtime worker scanner |
+| Page middleware | New `ownedContracts` fact | surface (`backend` or `frontend`), middleware ID or export, source | `backend/middleware.ts`, `frontend/middleware.ts` |
+| Setup | New `ownedContracts` fact | present hooks, exported default-role/profile identifiers when static, source | `setup.ts` recognized exports |
+| Encryption | New `ownedContracts` fact | entity IDs and declared encrypted fields only when statically safe, source | `encryption.ts` |
+| DI registrations | New `ownedContracts` fact; keep legacy `diTokens` | token, registration kind, provider symbol if static, lifetime, injection mode, source | `di.ts` registration map |
+| Custom entities/fields | New `ownedContracts` fact | owned entity or field-set ID and source | `ce.ts`, custom-field DSL convention files |
+| Search/vector | Reuse `searchEntities` plus `extensionSurfaces.contributions[kind=specialized-registry]`; add `factSources` entries | indexed entity or provider ID, search kind, source | `search.ts`, `vector.ts`, and current runtime readers |
+| Integrations | Reuse `extensionSurfaces.contributions[kind=specialized-registry]`; add `factSources` entries and complete its array/bundle reader | integration IDs, bundle membership, manifest kind, source | `integration.ts` singular/array/bundle exports |
+| AI tools/agents | Reuse existing rich facts and specialized-registry contributions; add `factSources` entries | stable ID/name and source | `ai-tools.ts`, `ai-agents.ts` |
+| AI extensions/file overrides | New `ownedContracts` fact only when no established rich field represents the export | extension ID, file override target if declared, source | AI extension and override convention files |
+| Generator plugins | New `ownedContracts` fact | plugin ID/name and source | `generators.ts` `generatorPlugins` export |
 
 Existing rich page, route, CLI, tool, and agent facts remain authoritative. Their source references are also added to `factSources` so consumers can use one uniform provenance lookup.
 
@@ -181,7 +252,7 @@ Update the module Markdown sheet so that:
 - source links use repository-relative paths and optional line anchors supported by the renderer;
 - sections with no facts retain current empty/omission behavior.
 
-## API and Generated-File Compatibility
+## API Contracts
 
 No HTTP API changes are introduced. Generated-file changes are additive:
 
@@ -208,7 +279,8 @@ No HTTP API changes are introduced. Generated-file changes are additive:
 
 ### Phase 3 — Missing owned families
 
-- Add domain commands, recursive subscribers, workers, page middleware, setup, encryption, rich DI, custom-entity/field ownership, vector, integration arrays/bundles, AI extensions/file overrides, and generator plugins.
+- Add new owned facts for domain commands, workers, page middleware, setup, encryption, rich DI, custom-entity/field ownership, AI extensions/file overrides, and generator plugins.
+- Extend the established subscriber and specialized-registry readers for recursive subscribers, vector facts, and integration arrays/bundles; reference those rich facts instead of duplicating their payloads in `ownedContracts`.
 - Align each reader with runtime discovery and add parity fixtures.
 - Run `yarn generate` after changing auto-discovery inputs or generated registries.
 
@@ -233,6 +305,8 @@ No HTTP API changes are introduced. Generated-file changes are additive:
 - Integration-array/bundle and generator-plugin fixtures cover all supported declaration shapes.
 - Duplicate module ID selection matches runtime provider selection.
 - Duplicate declarations of one `kind + id` select the runtime-authoritative source and emit deterministic rejected-source diagnostics.
+- Established subscriber, search, vector, integration, tool, and agent facts gain `factSources` references without duplicating their payloads in `ownedContracts`.
+- Every top-level `module-facts.json` key still resolves to a selected module ID; diagnostics remain inside the owning module entry.
 
 ### Runtime parity tests
 
@@ -268,7 +342,7 @@ Run `harness:validate --all`, then the full `harness:release` gate after package
 - The facts and required sources survive package packing and a fresh standalone scaffold.
 - Focused tests, `yarn generate`, the configured validation subset, `harness:validate --all`, and `harness:release` pass.
 
-## Risks
+## Risks & Impact Review
 
 ### Static analysis overclaims dynamic declarations
 
@@ -296,6 +370,17 @@ Run `harness:validate --all`, then the full `harness:release` gate after package
 
 ## Final Compliance Report — 2026-08-02
 
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md` (root)
+- `.ai/specs/AGENTS.md`
+- `packages/cli/AGENTS.md`
+- `packages/create-app/AGENTS.md`
+- `packages/shared/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+
 | Rule source | Requirement | Status | Evidence in this spec |
 |---|---|---|---|
 | Root `AGENTS.md` | Preserve generated contract surfaces. | Compliant | Additive JSON/Markdown boundary and legacy fixtures. |
@@ -305,7 +390,22 @@ Run `harness:validate --all`, then the full `harness:release` gate after package
 | Root security rules | Do not expose secrets or scoped data. | Compliant | Explicit safe schema and negative tests. |
 | Spec cohesion | One independently deployable capability. | Compliant | This spec owns only source-linked owned contract inventory. |
 
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|---|---|---|
+| Data models match generated contracts | Pass | New fields are optional per-module fields; the root module record is unchanged. |
+| Existing rich facts remain authoritative | Pass | The projection table references subscriber/search/vector/integration/AI facts instead of duplicating them. |
+| Risks cover extraction and packaging | Pass | Static overclaiming, sensitive metadata, context growth, and reader drift are covered. |
+| Test plan covers every new family | Pass | Unit, parity, compatibility, and fresh standalone release gates are specified. |
+
+### Non-Compliant Items
+
 No non-compliant item or required human confirmation was identified.
+
+### Verdict
+
+**Fully compliant:** approved as the prerequisite implementation specification for source-linked owned contract inventory.
 
 ## Changelog
 
@@ -313,6 +413,7 @@ No non-compliant item or required human confirmation was identified.
 
 - Split source provenance and owned contract inventory from extension topology and override-key work.
 - Specified additive source references, complete safe DI classification, runtime discovery parity, and standalone package/harness proof.
+- Kept established rich extension/search/AI facts authoritative and made root-record compatibility an explicit regression gate.
 
 ## Review — 2026-08-02
 


### PR DESCRIPTION
Source doc: .ai/specs/2026-08-02-module-facts-extension-surface-completeness.md
Status: complete

## 🎯 Goal

Audit merged PR #4810 and specify the remaining deterministic module facts needed to document every public or auto-discovered extension contract, with portable source links and standalone-harness proof.

## What Changed

- Added a non-implementable suite index that records the repository audit and dependency order.
- Added an implementation-ready source provenance and owned-contract inventory spec, including complete safe DI facts.
- Added an implementation-ready active extension topology spec with real call-site activations and target-owned incoming references.
- Added an implementation-ready exact unified override-target spec, including page-middleware versus mutation-guard separation.
- Connected every child spec to packaged standalone facts, failure-first evaluations, fresh Verdaccio scaffolds, and the full harness release gate.

## Audit Outcome

Backend and frontend pages already expose paths and source links. Enrichers plus API and command interceptors already exist as outgoing UMES contributions. The missing contracts are uniform provenance, several owned discovery families, authoritative activation rather than broad capability inference, target-side incoming indexes, and exact per-module override keys.

## Evidence

Text-only specification. Mockups and current-app screenshots were skipped because this change defines developer tooling and generated documentation, with no user-facing rendered surface.

## 💥 Breaking Changes

None — design only. Existing generated JSON fields, Markdown headings, host rows, contribution rows, IDs, and runtime override behavior are preserved additively.