### PR TITLE
security(sync_excel): bound multipart upload parsing (#4831)

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1060,3 +1060,5 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: Complete document preparation before entering an encryption-only guard. When encryption throws, log and rethrow or skip the write explicitly; never return the pre-encryption payload. Keep regression coverage at the final persistence boundary so a helper-level fix cannot mask a plaintext write.
 
 **Applies to**: index projections, search/vector payloads, export staging, and every write path that conditionally encrypts a prepared document.
+
+- 2026-08-02 · verification: sandboxed macOS rejected Homebrew Node dylibs and a fresh docs search index was absent → use the bundled Node runtime and build docs before retrying the full gate.

--- a/packages/core/src/modules/sync_excel/api/upload/__tests__/route.test.ts
+++ b/packages/core/src/modules/sync_excel/api/upload/__tests__/route.test.ts
@@ -1,20 +1,19 @@
 /** @jest-environment node */
 
 const mockGetAuthFromRequest = jest.fn()
-const mockIsMultipartRequestWithinUploadLimit = jest.fn()
-const mockResolveDefaultAttachmentMaxUploadBytes = jest.fn()
 const mockResolveSyncExcelConcreteScope = jest.fn()
+const mockCreateSyncExcelUploadAttachment = jest.fn()
+const mockEntityManager = {
+  create: jest.fn((_entity: unknown, payload: Record<string, unknown>) => payload),
+  persist: jest.fn(),
+  flush: jest.fn(),
+}
 const mockContainer = {
-  resolve: jest.fn(),
+  resolve: jest.fn(() => mockEntityManager),
 }
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
-}))
-
-jest.mock('../../../../attachments/lib/upload-limits', () => ({
-  isMultipartRequestWithinUploadLimit: jest.fn((contentLength: string | null) => mockIsMultipartRequestWithinUploadLimit(contentLength)),
-  resolveDefaultAttachmentMaxUploadBytes: jest.fn(() => mockResolveDefaultAttachmentMaxUploadBytes()),
 }))
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
@@ -23,6 +22,10 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 
 jest.mock('../../../lib/scope', () => ({
   resolveSyncExcelConcreteScope: jest.fn((params: unknown) => mockResolveSyncExcelConcreteScope(params)),
+}))
+
+jest.mock('../../../lib/upload-storage', () => ({
+  createSyncExcelUploadAttachment: jest.fn((params: unknown) => mockCreateSyncExcelUploadAttachment(params)),
 }))
 
 type RouteModule = typeof import('../route')
@@ -34,15 +37,17 @@ beforeAll(async () => {
 })
 
 describe('sync_excel upload route limits', () => {
+  const maxUploadEnv = 'OM_ATTACHMENT_MAX_UPLOAD_MB'
+  const originalMaxUploadMb = process.env[maxUploadEnv]
+
   beforeEach(() => {
     jest.clearAllMocks()
+    delete process.env[maxUploadEnv]
     mockGetAuthFromRequest.mockResolvedValue({
       sub: 'user-1',
       tenantId: '22222222-2222-4222-8222-222222222222',
       orgId: '33333333-3333-4333-8333-333333333333',
     })
-    mockIsMultipartRequestWithinUploadLimit.mockReturnValue(true)
-    mockResolveDefaultAttachmentMaxUploadBytes.mockReturnValue(5)
     mockResolveSyncExcelConcreteScope.mockResolvedValue({
       ok: true,
       scope: {
@@ -50,6 +55,13 @@ describe('sync_excel upload route limits', () => {
         tenantId: '22222222-2222-4222-8222-222222222222',
       },
     })
+    mockCreateSyncExcelUploadAttachment.mockResolvedValue({ id: 'attachment-1' })
+    mockEntityManager.flush.mockResolvedValue(undefined)
+  })
+
+  afterAll(() => {
+    if (originalMaxUploadMb === undefined) delete process.env[maxUploadEnv]
+    else process.env[maxUploadEnv] = originalMaxUploadMb
   })
 
   it('rejects All organizations scope before parsing form data', async () => {
@@ -71,13 +83,13 @@ describe('sync_excel upload route limits', () => {
   })
 
   it('rejects multipart payloads over the content-length guard before parsing form data', async () => {
-    mockIsMultipartRequestWithinUploadLimit.mockReturnValueOnce(false)
+    process.env[maxUploadEnv] = '0.000001'
 
     const response = await postHandler(new Request('http://localhost/api/sync_excel/upload', {
       method: 'POST',
       headers: {
         'content-type': 'multipart/form-data; boundary=too-large',
-        'content-length': '100000',
+        'content-length': String(2 * 1024 * 1024),
       },
       body: '--too-large--',
     }))
@@ -86,7 +98,34 @@ describe('sync_excel upload route limits', () => {
     await expect(response.json()).resolves.toEqual({ error: 'CSV upload exceeds the maximum upload size.' })
   })
 
+  it.each([null, 'invalid', '1'])(
+    'rejects an oversized streamed multipart body when content-length is %p',
+    async (contentLength) => {
+      process.env[maxUploadEnv] = '0.000001'
+      const boundary = 'sync-excel-upload-limit'
+      const body = new TextEncoder().encode([
+        `--${boundary}\r\n`,
+        'Content-Disposition: form-data; name="metadata"\r\n\r\n',
+        'x'.repeat(1024 * 1024),
+        `\r\n--${boundary}--\r\n`,
+      ].join(''))
+      const headers = new Headers({ 'content-type': `multipart/form-data; boundary=${boundary}` })
+      if (contentLength !== null) headers.set('content-length', contentLength)
+
+      const response = await postHandler(new Request('http://localhost/api/sync_excel/upload', {
+        method: 'POST',
+        headers,
+        body,
+      }))
+
+      expect(response.status).toBe(413)
+      await expect(response.json()).resolves.toEqual({ error: 'CSV upload exceeds the maximum upload size.' })
+      expect(mockCreateSyncExcelUploadAttachment).not.toHaveBeenCalled()
+    },
+  )
+
   it('rejects CSV files larger than the attachment upload limit before reading the buffer', async () => {
+    process.env[maxUploadEnv] = String(5 / (1024 * 1024))
     const formData = new FormData()
     formData.set('entityType', 'customers.person')
     formData.set('file', new File([Buffer.from('123456')], 'leads.csv', { type: 'text/csv' }))
@@ -98,6 +137,28 @@ describe('sync_excel upload route limits', () => {
 
     expect(response.status).toBe(413)
     await expect(response.json()).resolves.toEqual({ error: 'CSV upload exceeds the maximum upload size.' })
-    expect(mockResolveDefaultAttachmentMaxUploadBytes).toHaveBeenCalled()
+  })
+
+  it('accepts a valid CSV exactly at the configured file-size limit', async () => {
+    const maxUploadBytes = 128
+    process.env[maxUploadEnv] = String(maxUploadBytes / (1024 * 1024))
+    const header = 'firstName\n'
+    const csv = Buffer.from(`${header}${'x'.repeat(maxUploadBytes - Buffer.byteLength(header))}`)
+    const formData = new FormData()
+    formData.set('entityType', 'customers.person')
+    formData.set('file', new File([csv], 'leads.csv', { type: 'text/csv' }))
+
+    const response = await postHandler(new Request('http://localhost/api/sync_excel/upload', {
+      method: 'POST',
+      body: formData,
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      filename: 'leads.csv',
+      fileSize: maxUploadBytes,
+      entityType: 'customers.person',
+    })
+    expect(mockCreateSyncExcelUploadAttachment).toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/sync_excel/api/upload/route.ts
+++ b/packages/core/src/modules/sync_excel/api/upload/route.ts
@@ -10,7 +10,12 @@ import { buildSuggestedMapping } from '../../lib/mapping'
 import { parseCsvPreview } from '../../lib/parser'
 import { createSyncExcelUploadAttachment } from '../../lib/upload-storage'
 import { resolveSyncExcelConcreteScope } from '../../lib/scope'
-import { isMultipartRequestWithinUploadLimit, resolveDefaultAttachmentMaxUploadBytes } from '../../../attachments/lib/upload-limits'
+import {
+  isMultipartRequestWithinUploadLimit,
+  isMultipartUploadLimitError,
+  parseMultipartFormDataWithinUploadLimit,
+  resolveDefaultAttachmentMaxUploadBytes,
+} from '../../../attachments/lib/upload-limits'
 
 export const metadata = {
   POST: { requireAuth: true, requireFeatures: ['sync_excel.run'] },
@@ -67,7 +72,15 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: 'CSV upload exceeds the maximum upload size.' }, { status: 413 })
   }
 
-  const formData = await request.formData()
+  let formData: FormData
+  try {
+    formData = await parseMultipartFormDataWithinUploadLimit(request)
+  } catch (error) {
+    if (isMultipartUploadLimitError(error)) {
+      return NextResponse.json({ error: 'CSV upload exceeds the maximum upload size.' }, { status: 413 })
+    }
+    throw error
+  }
   const parsedPayload = multipartSchema.safeParse({
     entityType: typeof formData.get('entityType') === 'string' ? formData.get('entityType') : undefined,
   })


### PR DESCRIPTION
Closes #4831

## 🎯 Goal
- Bound multipart parsing for `POST /api/sync_excel/upload` before the form body is materialized.

## 🔍 Problem
The sync-excel upload route performed only a `Content-Length` preflight before calling raw `request.formData()`. Missing, invalid, or dishonest lengths could therefore allow an oversized multipart body, including non-file fields, to be fully materialized before the later file-size check.

## 🔍 Root Cause
The route did not use the shared bounded streaming multipart parser already used by the canonical attachments upload route. Its header-only preflight cannot enforce the total request budget when the declared length is absent or untrustworthy.

## What Changed
- Parse sync-excel uploads with `parseMultipartFormDataWithinUploadLimit`.
- Map bounded-parser limit failures to the route's existing `413` response.
- Preserve authentication, tenant and organization scoping, CSV validation, configured file limits, status codes, and response shapes.
- Add focused coverage for missing, invalid, and dishonest content lengths, oversized non-file fields, and a valid boundary-sized CSV.
- Record the sandboxed verification-runtime workaround in `.ai/lessons.md`.

## 🧪 Tests
- Focused route suite: demonstrated the expected red failure before the product fix, then passed 7/7.
- `yarn build:packages` — passed.
- `yarn generate` — passed.
- Second `yarn build:packages` — passed.
- `yarn i18n:check-sync` — passed.
- `yarn i18n:check-usage` — passed with advisory unused-key output.
- `yarn typecheck` — passed.
- `yarn test` — passed, 24/24 workspaces.
- `yarn build:app` — passed.
- Scoped ESLint for the changed route and test — passed.

## 💥 Breaking Changes
- None. The existing API URL, request semantics, status codes, response schema, authentication, and scope behavior are preserved.
