### PR TITLE
fix(payment-gateways): restore claim diagnostics (#4862)

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1060,3 +1060,5 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: Complete document preparation before entering an encryption-only guard. When encryption throws, log and rethrow or skip the write explicitly; never return the pre-encryption payload. Keep regression coverage at the final persistence boundary so a helper-level fix cannot mask a plaintext write.
 
 **Applies to**: index projections, search/vector payloads, export staging, and every write path that conditionally encrypts a prepared document.
+
+- 2026-08-02 · create-app test gate: macOS containment can block dynamically linked Homebrew Node through `libuv` and cascade into false timeouts → prepend the bundled self-contained Node runtime to `PATH`.

--- a/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.idempotency.test.ts
+++ b/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.idempotency.test.ts
@@ -11,9 +11,19 @@ import {
 import { createPaymentGatewayService } from '../gateway-service'
 import { buildPaymentSessionOperationKey } from '../session-idempotency'
 
+const mockLoggerWarn = jest.fn()
+
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findOneWithDecryption: jest.fn(),
   findWithDecryption: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/logger', () => ({
+  createLogger: () => ({
+    child: () => ({
+      warn: (...args: unknown[]) => mockLoggerWarn(...args),
+    }),
+  }),
 }))
 
 type AnyRecord = Record<string, any>
@@ -159,6 +169,7 @@ describe('payment gateway service session idempotency (#4035)', () => {
   beforeEach(() => {
     clearGatewayAdapters()
     ;(findOneWithDecryption as jest.Mock).mockReset()
+    mockLoggerWarn.mockReset()
   })
 
   afterEach(() => {
@@ -217,6 +228,54 @@ describe('payment gateway service session idempotency (#4035)', () => {
     expect(createSession.mock.calls[0]?.[0].idempotencyKey).toBe(operationKey)
     expect(recoveryResult.session.sessionId).toBe('provider-session-1')
     expect(em._transactions.size).toBe(1)
+  })
+
+  it('warns when claim release fails and rethrows the original provider error', async () => {
+    const { service, em, createSession } = buildService()
+    const providerError = new Error('provider unavailable')
+    const releaseError = new Error('claim release failed')
+    const originalNativeUpdate = em.nativeUpdate.bind(em)
+    createSession.mockRejectedValueOnce(providerError)
+    em.nativeUpdate = async (cls: unknown, where: AnyRecord, data: AnyRecord) => {
+      const isClaimRelease = data.claimToken === null && data.claimedAt === null
+      if (isClaimRelease) throw releaseError
+      return originalNativeUpdate(cls, where, data)
+    }
+
+    await expect(service.createPaymentSession(buildInput('checkout-submit-key-0006'))).rejects.toBe(providerError)
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'Failed to release payment session initialization claim',
+      expect.objectContaining({
+        claimId: expect.any(String),
+        providerKey: PROVIDER_KEY,
+        err: releaseError,
+      }),
+    )
+  })
+
+  it('marks the missing completed-session transaction invariant as internal', async () => {
+    const { service, em } = buildService()
+    const input = buildInput('checkout-submit-key-0007')
+    const operationKey = buildPaymentSessionOperationKey({
+      idempotencyKey: input.idempotencyKey,
+      paymentId: input.paymentId,
+      providerKey: input.providerKey,
+      scope: { organizationId: input.organizationId, tenantId: input.tenantId },
+    })
+    const completedClaim = {
+      id: randomUUID(),
+      operationKey,
+      providerKey: input.providerKey,
+      organizationId: input.organizationId,
+      tenantId: input.tenantId,
+      gatewayTransactionId: randomUUID(),
+      claimToken: null,
+    }
+    em._claims.set(claimKey(completedClaim), completedClaim)
+
+    await expect(service.createPaymentSession(input)).rejects.toThrow(
+      '[internal] Completed payment session is missing its gateway transaction',
+    )
   })
 
   it('survives a heartbeat refresh failure during the provider call without rejecting', async () => {

--- a/packages/core/src/modules/payment_gateways/lib/gateway-service.ts
+++ b/packages/core/src/modules/payment_gateways/lib/gateway-service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import {
   getGatewayAdapter,
   type CreateSessionInput,
@@ -48,6 +49,7 @@ import {
 
 const PAYMENT_SESSION_CLAIM_STALE_MS = 30_000
 const PAYMENT_SESSION_WAIT_INTERVAL_MS = 25
+const logger = createLogger('payment_gateways').child({ component: 'gateway-service' })
 
 function assertManualActionAllowed(action: ManualGatewayAction, transaction: GatewayTransaction): void {
   const current = transaction.unifiedStatus as UnifiedPaymentStatus
@@ -469,7 +471,7 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
             scope,
           )
           if (!transaction) {
-            throw new Error('Completed payment session is missing its gateway transaction')
+            throw new Error('[internal] Completed payment session is missing its gateway transaction')
           }
           return { transaction, session: restoreSession(transaction) }
         }
@@ -490,7 +492,15 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
         try {
           session = await adapter.createSession({ ...sessionInput, idempotencyKey: operationKey })
         } catch (error) {
-          await releasePaymentSessionInitialization(em, ownership, scope).catch(() => undefined)
+          try {
+            await releasePaymentSessionInitialization(em, ownership, scope)
+          } catch (releaseError) {
+            logger.warn('Failed to release payment session initialization claim', {
+              claimId: ownership.id,
+              providerKey: input.providerKey,
+              err: releaseError,
+            })
+          }
           throw error
         } finally {
           await stopHeartbeat()


### PR DESCRIPTION
Closes #4862

## 🎯 Goal
- Recover payment-session claim diagnostics lost when superseded PR #4062 was replaced.

## 🔍 Problem
A failed provider session creation attempted to release its initialization claim, but any release failure was silently swallowed. That left operators without the diagnostics needed to explain a retained claim, while the missing completed-session transaction invariant was not marked as an internal error.

## 🔍 Root Cause
The provider-error path used `releasePaymentSessionInitialization(...).catch(() => undefined)`, discarding the cleanup error before rethrowing the provider error. The adjacent completed-session invariant predated the repository's `[internal]` error-prefix convention.

## What Changed
- added a scoped `payment_gateways` logger for the gateway service
- log claim-release failures with safe claim ID, provider key, and caught error context
- preserve and rethrow the original provider error unchanged
- mark the missing completed-session transaction invariant with `[internal]`
- add regression tests for both diagnostic paths
- record the macOS contained-test runner workaround encountered during verification

## 🧪 Tests
- focused payment-gateway idempotency suite: red before the fix, then 6/6 passing
- `yarn build:packages` — passed before and after generation
- `yarn generate` — passed
- `yarn i18n:check-sync` — passed
- `yarn i18n:check-usage` — passed
- `yarn typecheck` — passed, 21/21 tasks
- `yarn test` — passed, 24/24 package tasks
- `yarn build:app` — passed
- scoped ESLint and `yarn logger:check-console:ci` — passed
- fresh-context adversarial review — passed with 0 blockers
- `yarn template:sync` still reports 29 pre-existing app/template differences on current `develop`; this branch changes no app/template paths

## 💥 Breaking Changes
- None. No API, database, event, DI, schema, or public import contract changed.
