### PR TITLE
fix(payment_gateways): define session claim retention (#4861)

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1060,3 +1060,11 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: Complete document preparation before entering an encryption-only guard. When encryption throws, log and rethrow or skip the write explicitly; never return the pre-encryption payload. Keep regression coverage at the final persistence boundary so a helper-level fix cannot mask a plaintext write.
 
 **Applies to**: index projections, search/vector payloads, export staging, and every write path that conditionally encrypts a prepared document.
+
+## Run macOS sandbox harness gates with a self-contained Node runtime
+
+**Context**: The standalone agent-harness tests launch nested processes inside a macOS sandbox. A Homebrew Node binary can depend on dynamic libraries under `/opt/homebrew`, which the nested sandbox does not allow the process to load.
+
+**Rule**: When harness tests fail broadly with `dyld` or blocked Node-library errors, put the workspace's self-contained Node runtime first on `PATH` and rerun the complete gate. Do not diagnose the resulting cascade as product failures until the runtime can start inside the sandbox.
+
+**Applies to**: `create-mercato-app` agent-harness tests and validation gates that execute them on macOS.

--- a/.ai/specs/implemented/2026-03-19-checkout-pay-links.md
+++ b/.ai/specs/implemented/2026-03-19-checkout-pay-links.md
@@ -1273,7 +1273,7 @@ Customer visits /pay/[slug]
   (render inline)                      (frontend redirects)
 ```
 
-Keyed session creation is single-flight across concurrent processes. The payment-gateway service derives a tenant-scoped operation key, atomically claims a short lease before network I/O, renews that lease while the owner is alive, and persists the winning `GatewayTransaction` on the coordination record. Followers wait for and reuse that completed transaction without imposing a shorter timeout than the provider call. A stale lease can be reclaimed after 30 seconds without a heartbeat; token-checked completion prevents the old owner from publishing a second local transaction. Provider adapters receive the same optional operation key for native idempotency (Stripe passes it as the PaymentIntent request idempotency key). Unkeyed callers preserve the pre-existing behavior.
+Keyed session creation is single-flight across concurrent processes. The payment-gateway service derives a tenant-scoped operation key, atomically claims a short lease before network I/O, renews that lease while the owner is alive, and persists the winning `GatewayTransaction` on the coordination record. Followers wait for and reuse that completed transaction without imposing a shorter timeout than the provider call. A stale lease can be reclaimed after 30 seconds without a heartbeat; token-checked completion prevents the old owner from publishing a second local transaction. Provider adapters receive the same optional operation key for native idempotency (Stripe passes it as the PaymentIntent request idempotency key). Successful replay is supported for 24 hours from finalization, measured by the coordination row's `updated_at`. A tenant-scoped daily worker deletes one bounded batch of completed rows (`gateway_transaction_id IS NOT NULL`) whose finalization timestamp is strictly older than that window and queues a continuation when the batch fills; incomplete, released, and active claims are never retention-pruned. New organizations receive the schedule through `seedDefaults`, while an idempotent `payment_gateways.register-session-initialization-prune` upgrade action registers it for existing organizations. The daily cadence can retain completed rows beyond 24 hours, but replay after the supported window is best-effort until cleanup runs. Unkeyed callers preserve the pre-existing behavior.
 
 ### Gateway Event Processing
 
@@ -1863,6 +1863,7 @@ Preferred doc locations:
 | TC-CHKT-031 | Pay page section wrapper/replacement handle can customize summary/help area without changing payment integrity | UMES component replacement test |
 | TC-CHKT-032 | Checkout emits webhook-ready customer-data/session-start lifecycle events only after commit | Submit flow with webhook subscriber spy |
 | TC-CHKT-033 | External webhook subscription can receive checkout success/failure automation events with stable identifiers and no secrets | `webhooks` module subscribed to `checkout.transaction.**` |
+| TC-PGWY-024 | Completed payment-session claims remain replayable through 24 hours and become cleanup-eligible only after expiry; incomplete and cross-organization rows survive | Database-backed tenant-scoped retention worker coverage around the strict replay cutoff |
 | TC-CHKT-034 | Required terms/privacy consent blocks submit when unchecked | `POST /api/checkout/pay/:slug/submit` → 422 |
 | TC-CHKT-035 | Terms/privacy links open popup with sanitized markdown content and accepted proof is stored on transaction | Public pay page + transaction detail |
 
@@ -1947,6 +1948,7 @@ Phase A keeps core changes minimal, but it does introduce one **additive** contr
 - **Gateway descriptor surface**: new additive service/API only; no existing fields or routes are removed or renamed
 - **API routes**: additive only; checkout introduces new `/api/checkout/*` endpoints
 - **Database schema**: additive only; checkout introduces its checkout-owned tables/columns and `payment_gateways` adds the internal `gateway_session_initializations` coordination table
+- **Retention**: completed `gateway_session_initializations` rows have a documented 24-hour replay guarantee and are deleted only after expiry by an additive tenant-scoped queue worker and schedule; an idempotent upgrade action registers the schedule for existing organizations, and no entity or migration change is required
 - **Widget spots**: additive only; checkout adds new UMES spots and checkout-owned widgets
 
 Optional future enhancements to generic payment-source correlation in `payment_gateways` must be specified separately and follow the full deprecation / BC process if they alter existing contracts.
@@ -2048,3 +2050,6 @@ None identified.
 
 ### 2026-07-09
 - Hardened keyed payment-session creation with tenant-scoped single-flight claims, stale-lease recovery, persisted transaction reuse, and provider-native Stripe idempotency (#4035)
+
+### 2026-08-02
+- Defined the 24-hour payment-session replay window and added tenant-scoped cleanup for expired completed initialization claims (#4861)

--- a/packages/core/src/modules/configs/lib/__tests__/upgrade-actions.test.ts
+++ b/packages/core/src/modules/configs/lib/__tests__/upgrade-actions.test.ts
@@ -143,3 +143,30 @@ describe('interaction-statuses seed upgrade action', () => {
     expect(typeof action?.run).toBe('function')
   })
 })
+
+describe('payment-session initialization prune upgrade action', () => {
+  it('registers the retention schedule for an existing tenant organization', async () => {
+    const action = upgradeActions.find(
+      (candidate) => candidate.id === 'payment_gateways.register-session-initialization-prune',
+    )
+    const register = jest.fn().mockResolvedValue(undefined)
+    const container = {
+      hasRegistration: (name: string) => name === 'schedulerService',
+      resolve: jest.fn(() => ({ register })),
+    }
+
+    expect(action?.version).toBe('0.6.6')
+    await action?.run({
+      container: container as never,
+      em: {} as never,
+      tenantId: '10000000-0000-4000-8000-000000000001',
+      organizationId: '20000000-0000-4000-8000-000000000001',
+    })
+
+    expect(register).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: '10000000-0000-4000-8000-000000000001',
+      organizationId: '20000000-0000-4000-8000-000000000001',
+      targetQueue: 'payment-gateway-session-initialization-prune',
+    }))
+  })
+})

--- a/packages/core/src/modules/configs/lib/upgrade-actions.ts
+++ b/packages/core/src/modules/configs/lib/upgrade-actions.ts
@@ -91,6 +91,20 @@ export const upgradeActions: UpgradeActionDefinition[] = [
       }
     },
   },
+  {
+    id: 'payment_gateways.register-session-initialization-prune',
+    version: '0.6.6',
+    messageKey: 'payment_gateways.upgradeActions.sessionInitializationPrune.message',
+    ctaKey: 'payment_gateways.upgradeActions.sessionInitializationPrune.cta',
+    successKey: 'payment_gateways.upgradeActions.sessionInitializationPrune.success',
+    loadingKey: 'payment_gateways.upgradeActions.sessionInitializationPrune.loading',
+    run: async ({ container, tenantId, organizationId }) => {
+      const { registerSessionInitializationPruneSchedule } = await import(
+        '@open-mercato/core/modules/payment_gateways/setup'
+      )
+      await registerSessionInitializationPruneSchedule(container, { tenantId, organizationId })
+    },
+  },
 ]
 
 export function actionsUpToVersion(version: string): UpgradeActionDefinition[] {

--- a/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-024.spec.ts
+++ b/packages/core/src/modules/payment_gateways/__integration__/TC-PGWY-024.spec.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from 'node:crypto'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { expect, test } from '@playwright/test'
+import type { Client } from 'pg'
+import { withClient } from '@open-mercato/core/modules/core/__integration__/helpers/dbFixtures'
+import {
+  PAYMENT_SESSION_REPLAY_WINDOW_MS,
+  pruneCompletedPaymentSessionInitializations,
+} from '@open-mercato/core/modules/payment_gateways/lib/session-idempotency'
+
+type ClaimFixture = {
+  id: string
+  operationKey: string
+  tenantId: string
+  organizationId: string
+  updatedAt: Date
+  gatewayTransactionId: string | null
+  claimToken?: string | null
+  claimedAt?: Date | null
+}
+
+function makeEntityManager(client: Client): EntityManager {
+  return {
+    getConnection: () => ({
+      execute: async (sql: string, params: unknown[]) => {
+        let position = 0
+        const pgSql = sql.replace(/\?/g, () => `$${++position}`)
+        const result = await client.query(pgSql, params)
+        return { affectedRows: result.rowCount ?? 0 }
+      },
+    }),
+  } as unknown as EntityManager
+}
+
+async function insertClaim(client: Client, fixture: ClaimFixture): Promise<void> {
+  await client.query(
+    `insert into gateway_session_initializations
+      (id, operation_key, provider_key, claim_token, claimed_at, gateway_transaction_id,
+       organization_id, tenant_id, created_at, updated_at)
+     values ($1, $2, 'tc-pgwy-024', $3, $4, $5, $6, $7, $8, $8)`,
+    [
+      fixture.id,
+      fixture.operationKey,
+      fixture.claimToken ?? null,
+      fixture.claimedAt ?? null,
+      fixture.gatewayTransactionId,
+      fixture.organizationId,
+      fixture.tenantId,
+      fixture.updatedAt,
+    ],
+  )
+}
+
+test.describe('TC-PGWY-024: payment-session initialization retention', () => {
+  test('prunes only completed scoped claims strictly beyond the replay window', async () => {
+    const scope = { tenantId: randomUUID(), organizationId: randomUUID() }
+    const now = new Date('2026-08-02T12:00:00.000Z')
+    const cutoff = new Date(now.getTime() - PAYMENT_SESSION_REPLAY_WINDOW_MS)
+    const otherOrganizationId = randomUUID()
+    const fixtures: ClaimFixture[] = [
+      {
+        id: randomUUID(),
+        operationKey: `expired-completed-${randomUUID()}`,
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        updatedAt: new Date(cutoff.getTime() - 1),
+        gatewayTransactionId: randomUUID(),
+      },
+      {
+        id: randomUUID(),
+        operationKey: `boundary-completed-${randomUUID()}`,
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        updatedAt: cutoff,
+        gatewayTransactionId: randomUUID(),
+      },
+      {
+        id: randomUUID(),
+        operationKey: `inside-completed-${randomUUID()}`,
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        updatedAt: new Date(cutoff.getTime() + 1),
+        gatewayTransactionId: randomUUID(),
+      },
+      {
+        id: randomUUID(),
+        operationKey: `old-active-${randomUUID()}`,
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        updatedAt: new Date(cutoff.getTime() - 1),
+        gatewayTransactionId: null,
+        claimToken: randomUUID(),
+        claimedAt: new Date(cutoff.getTime() - 1),
+      },
+      {
+        id: randomUUID(),
+        operationKey: `old-released-${randomUUID()}`,
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        updatedAt: new Date(cutoff.getTime() - 1),
+        gatewayTransactionId: null,
+      },
+      {
+        id: randomUUID(),
+        operationKey: `other-scope-${randomUUID()}`,
+        tenantId: scope.tenantId,
+        organizationId: otherOrganizationId,
+        updatedAt: new Date(cutoff.getTime() - 1),
+        gatewayTransactionId: randomUUID(),
+      },
+    ]
+
+    await withClient(async (client) => {
+      try {
+        for (const fixture of fixtures) await insertClaim(client, fixture)
+
+        const deleted = await pruneCompletedPaymentSessionInitializations(
+          makeEntityManager(client),
+          scope,
+          { now, batchSize: 100 },
+        )
+        const remaining = await client.query<{ id: string }>(
+          'select id from gateway_session_initializations where id = any($1::uuid[])',
+          [fixtures.map((fixture) => fixture.id)],
+        )
+        const remainingIds = new Set(remaining.rows.map((row) => row.id))
+
+        expect(deleted).toBe(1)
+        expect(remainingIds.has(fixtures[0].id)).toBe(false)
+        for (const fixture of fixtures.slice(1)) expect(remainingIds.has(fixture.id)).toBe(true)
+      } finally {
+        await client.query(
+          'delete from gateway_session_initializations where id = any($1::uuid[])',
+          [fixtures.map((fixture) => fixture.id)],
+        )
+      }
+    })
+  })
+})

--- a/packages/core/src/modules/payment_gateways/__tests__/session-initialization-prune.test.ts
+++ b/packages/core/src/modules/payment_gateways/__tests__/session-initialization-prune.test.ts
@@ -1,0 +1,111 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+
+const mockEnqueue = jest.fn()
+
+jest.mock('@open-mercato/queue', () => ({
+  createModuleQueue: jest.fn(() => ({ enqueue: mockEnqueue })),
+}))
+
+import {
+  PAYMENT_SESSION_INITIALIZATION_PRUNE_BATCH_SIZE,
+  PAYMENT_SESSION_REPLAY_WINDOW_MS,
+  pruneCompletedPaymentSessionInitializations,
+} from '../lib/session-idempotency'
+import handle, { metadata } from '../workers/session-initialization-prune'
+
+const TENANT_ID = '10000000-0000-4000-8000-000000000001'
+const ORGANIZATION_ID = '20000000-0000-4000-8000-000000000001'
+
+type ExecuteResult = { affectedRows?: number; rowCount?: number }
+type ExecuteSpy = jest.Mock<Promise<ExecuteResult>>
+
+function makeEmStub(execute: ExecuteSpy): EntityManager {
+  return {
+    getConnection: () => ({ execute }),
+  } as unknown as EntityManager
+}
+
+describe('payment session initialization retention (#4861)', () => {
+  beforeEach(() => {
+    mockEnqueue.mockReset()
+  })
+
+  it('retains completed claims through the 24-hour boundary and scopes cleanup eligibility', async () => {
+    const execute: ExecuteSpy = jest.fn().mockResolvedValue({ affectedRows: 0 })
+    const now = new Date('2026-08-02T12:00:00.000Z')
+
+    const deleted = await pruneCompletedPaymentSessionInitializations(
+      makeEmStub(execute),
+      { tenantId: TENANT_ID, organizationId: ORGANIZATION_ID },
+      { now, batchSize: 100 },
+    )
+
+    expect(deleted).toBe(0)
+    expect(PAYMENT_SESSION_REPLAY_WINDOW_MS).toBe(24 * 60 * 60 * 1000)
+    expect(execute).toHaveBeenCalledTimes(1)
+
+    const [sql, params, mode] = execute.mock.calls[0] as [string, unknown[], string]
+    const normalizedSql = sql.replace(/\s+/g, ' ').trim()
+    expect(normalizedSql).toContain('gateway_transaction_id is not null')
+    expect(normalizedSql).toContain('tenant_id = ?')
+    expect(normalizedSql).toContain('organization_id = ?')
+    expect(normalizedSql).toContain('updated_at < ?')
+    expect(normalizedSql).not.toContain('updated_at <= ?')
+    expect(params).toEqual([
+      TENANT_ID,
+      ORGANIZATION_ID,
+      new Date('2026-08-01T12:00:00.000Z'),
+      100,
+    ])
+    expect(mode).toBe('run')
+  })
+
+  it('deletes at most one bounded batch per invocation', async () => {
+    const execute: ExecuteSpy = jest.fn().mockResolvedValue({ affectedRows: 2 })
+
+    const deleted = await pruneCompletedPaymentSessionInitializations(
+      makeEmStub(execute),
+      { tenantId: TENANT_ID, organizationId: ORGANIZATION_ID },
+      { now: new Date('2026-08-02T12:00:00.000Z'), batchSize: 2 },
+    )
+
+    expect(deleted).toBe(2)
+    expect(execute).toHaveBeenCalledTimes(1)
+  })
+
+  it('queues a continuation after a full worker batch', async () => {
+    const execute: ExecuteSpy = jest.fn().mockResolvedValue({
+      affectedRows: PAYMENT_SESSION_INITIALIZATION_PRUNE_BATCH_SIZE,
+    })
+    const em = makeEmStub(execute) as EntityManager & { fork: () => EntityManager }
+    em.fork = () => em
+    const resolve = jest.fn(() => em)
+
+    await handle(
+      { payload: { tenantId: TENANT_ID, organizationId: ORGANIZATION_ID } } as never,
+      { resolve } as never,
+    )
+
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(mockEnqueue).toHaveBeenCalledWith(
+      { tenantId: TENANT_ID, organizationId: ORGANIZATION_ID },
+      { delayMs: 1_000 },
+    )
+  })
+
+  it('fails closed when the scheduled job has no complete tenant scope', async () => {
+    const resolve = jest.fn()
+
+    await handle({ payload: { tenantId: TENANT_ID } } as never, { resolve } as never)
+
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
+  it('uses a single-flight queue worker contract', () => {
+    expect(metadata).toEqual({
+      queue: 'payment-gateway-session-initialization-prune',
+      id: 'payment_gateways:session-initialization-prune',
+      concurrency: 1,
+    })
+  })
+})

--- a/packages/core/src/modules/payment_gateways/__tests__/setup-schedules.test.ts
+++ b/packages/core/src/modules/payment_gateways/__tests__/setup-schedules.test.ts
@@ -1,0 +1,64 @@
+import { setup } from '../setup'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+const TENANT_ID = '10000000-0000-4000-8000-000000000001'
+const ORGANIZATION_ID = '20000000-0000-4000-8000-000000000001'
+
+function makeContainer(hasScheduler = true) {
+  const register = jest.fn().mockResolvedValue(undefined)
+  const resolve = jest.fn((name: string) => {
+    if (name !== 'schedulerService') throw new Error(`unexpected registration: ${name}`)
+    return { register }
+  })
+  return {
+    register,
+    resolve,
+    container: {
+      hasRegistration: (name: string) => hasScheduler && name === 'schedulerService',
+      resolve,
+    },
+  }
+}
+
+describe('payment_gateways setup schedules', () => {
+  it('registers a stable organization-scoped daily retention schedule', async () => {
+    const { container, register } = makeContainer()
+    const context = { container, tenantId: TENANT_ID, organizationId: ORGANIZATION_ID } as never
+
+    await setup.seedDefaults?.(context)
+    await setup.seedDefaults?.(context)
+
+    expect(register).toHaveBeenCalledTimes(2)
+    const first = register.mock.calls[0]?.[0] as Record<string, unknown>
+    const second = register.mock.calls[1]?.[0] as Record<string, unknown>
+    expect(first.id).toBe(second.id)
+    expect(UUID_RE.test(first.id as string)).toBe(true)
+    expect(first).toMatchObject({
+      scopeType: 'organization',
+      tenantId: TENANT_ID,
+      organizationId: ORGANIZATION_ID,
+      scheduleType: 'interval',
+      scheduleValue: '24h',
+      timezone: 'UTC',
+      targetType: 'queue',
+      targetQueue: 'payment-gateway-session-initialization-prune',
+      targetPayload: { tenantId: TENANT_ID, organizationId: ORGANIZATION_ID },
+      sourceType: 'module',
+      sourceModule: 'payment_gateways',
+      isEnabled: true,
+    })
+  })
+
+  it('keeps tenant setup working when the optional scheduler is unavailable', async () => {
+    const { container, register, resolve } = makeContainer(false)
+
+    await setup.seedDefaults?.({
+      container,
+      tenantId: TENANT_ID,
+      organizationId: ORGANIZATION_ID,
+    } as never)
+
+    expect(resolve).not.toHaveBeenCalled()
+    expect(register).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/payment_gateways/i18n/de.json
+++ b/packages/core/src/modules/payment_gateways/i18n/de.json
@@ -79,5 +79,9 @@
   "payment_gateways.transactions.success.capture": "Payment erfasst",
   "payment_gateways.transactions.success.refreshStatus": "Der Transaktionsstatus wurde aktualisiert",
   "payment_gateways.transactions.tableTitle": "Transaktionen",
-  "payment_gateways.transactions.title": "Zahlungstransaktionen"
+  "payment_gateways.transactions.title": "Zahlungstransaktionen",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.cta": "Bereinigung der Ansprüche planen",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.loading": "Bereinigung der Ansprüche wird geplant…",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.message": "Registrieren Sie den täglichen Bereinigungsplan, der abgeschlossene Zahlungssitzungsansprüche nach ihrem 24-stündigen Wiederholungsfenster entfernt.",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.success": "Die Bereinigung der Zahlungssitzungsansprüche ist geplant."
 }

--- a/packages/core/src/modules/payment_gateways/i18n/en.json
+++ b/packages/core/src/modules/payment_gateways/i18n/en.json
@@ -79,5 +79,9 @@
   "payment_gateways.transactions.success.capture": "Payment captured",
   "payment_gateways.transactions.success.refreshStatus": "Transaction status refreshed",
   "payment_gateways.transactions.tableTitle": "Transactions",
-  "payment_gateways.transactions.title": "Payment Transactions"
+  "payment_gateways.transactions.title": "Payment Transactions",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.cta": "Schedule claim cleanup",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.loading": "Scheduling claim cleanup…",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.message": "Register the daily cleanup schedule that removes completed payment-session claims after their 24-hour replay window.",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.success": "Payment-session claim cleanup is scheduled."
 }

--- a/packages/core/src/modules/payment_gateways/i18n/es.json
+++ b/packages/core/src/modules/payment_gateways/i18n/es.json
@@ -79,5 +79,9 @@
   "payment_gateways.transactions.success.capture": "Pago capturado",
   "payment_gateways.transactions.success.refreshStatus": "El estado de la transaccion se actualizo",
   "payment_gateways.transactions.tableTitle": "Transacciones",
-  "payment_gateways.transactions.title": "Transacciones de pago"
+  "payment_gateways.transactions.title": "Transacciones de pago",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.cta": "Programar limpieza de reclamaciones",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.loading": "Programando limpieza de reclamaciones…",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.message": "Registra la limpieza diaria que elimina las reclamaciones de sesiones de pago completadas después de su ventana de repetición de 24 horas.",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.success": "La limpieza de reclamaciones de sesiones de pago está programada."
 }

--- a/packages/core/src/modules/payment_gateways/i18n/pl.json
+++ b/packages/core/src/modules/payment_gateways/i18n/pl.json
@@ -79,5 +79,9 @@
   "payment_gateways.transactions.success.capture": "Płatność została przechwycona",
   "payment_gateways.transactions.success.refreshStatus": "Status transakcji odświeżony",
   "payment_gateways.transactions.tableTitle": "Transakcje",
-  "payment_gateways.transactions.title": "Transakcje płatności"
+  "payment_gateways.transactions.title": "Transakcje płatności",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.cta": "Zaplanuj czyszczenie roszczeń",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.loading": "Planowanie czyszczenia roszczeń…",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.message": "Zarejestruj codzienny harmonogram usuwający zakończone roszczenia inicjalizacji sesji płatności po 24-godzinnym oknie ponowienia.",
+  "payment_gateways.upgradeActions.sessionInitializationPrune.success": "Czyszczenie roszczeń inicjalizacji sesji płatności zostało zaplanowane."
 }

--- a/packages/core/src/modules/payment_gateways/lib/session-idempotency.ts
+++ b/packages/core/src/modules/payment_gateways/lib/session-idempotency.ts
@@ -6,6 +6,11 @@ import { GatewaySessionInitialization } from '../data/entities'
 
 type Scope = { organizationId: string; tenantId: string }
 
+export const PAYMENT_SESSION_REPLAY_WINDOW_MS = 24 * 60 * 60 * 1000
+export const PAYMENT_SESSION_INITIALIZATION_PRUNE_QUEUE =
+  'payment-gateway-session-initialization-prune'
+export const PAYMENT_SESSION_INITIALIZATION_PRUNE_BATCH_SIZE = 1_000
+
 export type OwnedPaymentSessionInitialization = {
   id: string
   claimToken: string
@@ -139,4 +144,35 @@ export async function refreshPaymentSessionInitialization(
     { claimedAt, updatedAt: claimedAt },
   )
   return refreshedRows > 0
+}
+
+export async function pruneCompletedPaymentSessionInitializations(
+  em: EntityManager,
+  scope: Scope,
+  options: { now?: Date; batchSize?: number } = {},
+): Promise<number> {
+  const now = options.now ?? new Date()
+  const batchSize = options.batchSize ?? PAYMENT_SESSION_INITIALIZATION_PRUNE_BATCH_SIZE
+  if (!Number.isInteger(batchSize) || batchSize < 1) {
+    throw new Error('[internal] Payment-session initialization prune batch size must be a positive integer')
+  }
+  const cutoff = new Date(now.getTime() - PAYMENT_SESSION_REPLAY_WINDOW_MS)
+  const connection = em.getConnection()
+  const result = await connection.execute(
+    `
+    delete from gateway_session_initializations
+    where id in (
+      select id from gateway_session_initializations
+      where tenant_id = ?
+        and organization_id = ?
+        and gateway_transaction_id is not null
+        and updated_at < ?
+      order by updated_at asc
+      limit ?
+    )
+    `,
+    [scope.tenantId, scope.organizationId, cutoff, batchSize],
+    'run',
+  ) as { affectedRows?: number; rowCount?: number } | undefined
+  return result?.affectedRows ?? result?.rowCount ?? 0
 }

--- a/packages/core/src/modules/payment_gateways/setup.ts
+++ b/packages/core/src/modules/payment_gateways/setup.ts
@@ -1,10 +1,72 @@
+import { createHash } from 'node:crypto'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
+import { PAYMENT_SESSION_INITIALIZATION_PRUNE_QUEUE } from './lib/session-idempotency'
+
+type SchedulerServiceLike = {
+  register: (registration: Record<string, unknown>) => Promise<void>
+}
+
+const logger = createLogger('payment_gateways')
+
+function stableScheduleUuid(stableKey: string): string {
+  const hex = createHash('sha256').update(stableKey).digest('hex')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`
+}
+
+export async function registerSessionInitializationPruneSchedule(
+  container: import('awilix').AwilixContainer | undefined,
+  scope: { tenantId: string; organizationId: string },
+): Promise<boolean> {
+  if (!container) return false
+  const cradle = container as { hasRegistration?: (name: string) => boolean }
+  if (typeof cradle.hasRegistration !== 'function' || !cradle.hasRegistration('schedulerService')) {
+    return false
+  }
+
+  const schedulerService = container.resolve('schedulerService') as SchedulerServiceLike
+  await schedulerService.register({
+    id: stableScheduleUuid(
+      `payment_gateways:session-initialization-prune:${scope.tenantId}:${scope.organizationId}`,
+    ),
+    name: 'Payment-session initialization prune',
+    description: 'Delete completed payment-session initialization claims after the 24-hour replay window.',
+    scopeType: 'organization',
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    scheduleType: 'interval',
+    scheduleValue: '24h',
+    timezone: 'UTC',
+    targetType: 'queue',
+    targetQueue: PAYMENT_SESSION_INITIALIZATION_PRUNE_QUEUE,
+    targetPayload: scope,
+    sourceType: 'module',
+    sourceModule: 'payment_gateways',
+    isEnabled: true,
+  })
+  return true
+}
+
+async function ensureSessionInitializationPruneSchedule(
+  container: import('awilix').AwilixContainer | undefined,
+  scope: { tenantId: string; organizationId: string },
+): Promise<void> {
+  try {
+    await registerSessionInitializationPruneSchedule(container, scope)
+  } catch (error) {
+    logger.warn('Failed to register payment-session initialization prune schedule', { err: error })
+  }
+}
 
 export const setup: ModuleSetupConfig = {
   defaultRoleFeatures: {
     superadmin: ['payment_gateways.*'],
     admin: ['payment_gateways.*'],
     employee: ['payment_gateways.view'],
+  },
+
+  async seedDefaults({ container, tenantId, organizationId }) {
+    await ensureSessionInitializationPruneSchedule(container, { tenantId, organizationId })
   },
 }
 

--- a/packages/core/src/modules/payment_gateways/workers/session-initialization-prune.ts
+++ b/packages/core/src/modules/payment_gateways/workers/session-initialization-prune.ts
@@ -1,0 +1,58 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { createModuleQueue, type JobContext, type QueuedJob, type WorkerMeta } from '@open-mercato/queue'
+import { createLogger } from '@open-mercato/shared/lib/logger'
+import {
+  PAYMENT_SESSION_INITIALIZATION_PRUNE_QUEUE,
+  PAYMENT_SESSION_INITIALIZATION_PRUNE_BATCH_SIZE,
+  pruneCompletedPaymentSessionInitializations,
+} from '../lib/session-idempotency'
+
+type PrunePayload = {
+  tenantId?: string
+  organizationId?: string
+}
+
+type HandlerContext = JobContext & {
+  resolve: <T = unknown>(name: string) => T
+}
+
+const logger = createLogger('payment_gateways')
+const continuationQueue = createModuleQueue<PrunePayload>(
+  PAYMENT_SESSION_INITIALIZATION_PRUNE_QUEUE,
+  { concurrency: 1 },
+)
+
+export const metadata: WorkerMeta = {
+  queue: PAYMENT_SESSION_INITIALIZATION_PRUNE_QUEUE,
+  id: 'payment_gateways:session-initialization-prune',
+  concurrency: 1,
+}
+
+export default async function handle(
+  job: QueuedJob<PrunePayload>,
+  ctx: HandlerContext,
+): Promise<void> {
+  const tenantId = job.payload?.tenantId
+  const organizationId = job.payload?.organizationId
+  if (!tenantId || !organizationId) {
+    logger.warn('Skipping payment-session initialization prune without tenant scope')
+    return
+  }
+
+  const em = ctx.resolve<EntityManager>('em').fork()
+  const deleted = await pruneCompletedPaymentSessionInitializations(
+    em,
+    { tenantId, organizationId },
+    { batchSize: PAYMENT_SESSION_INITIALIZATION_PRUNE_BATCH_SIZE },
+  )
+  if (deleted > 0) {
+    logger.info('Pruned completed payment-session initialization claims', {
+      deleted,
+      tenantId,
+      organizationId,
+    })
+  }
+  if (deleted === PAYMENT_SESSION_INITIALIZATION_PRUNE_BATCH_SIZE) {
+    await continuationQueue.enqueue({ tenantId, organizationId }, { delayMs: 1_000 })
+  }
+}


### PR DESCRIPTION
Closes #4861

## 🎯 Goal

- Define and enforce a bounded retention policy for completed payment-session initialization claims.

## 🔍 Problem

Completed `gateway_session_initializations` claims were retained indefinitely, causing unbounded growth while their replay behavior had no documented support window.

## 🔍 Root Cause

The idempotency coordination flow created, completed, and replayed claims but provided no scoped deletion worker or schedule. Cleanup also needed to distinguish completed rows from active, released, or incomplete claims and preserve tenant/organization isolation.

## What Changed

- Defined a 24-hour replay guarantee from finalization (`updated_at`).
- Added a tenant/organization-scoped worker that deletes one bounded batch of completed expired claims and queues continuation work when full.
- Registered daily schedules for new organizations and a versioned upgrade action for existing organizations.
- Added localized upgrade-action copy and updated the governing checkout specification.
- Added focused unit, setup, upgrade, and PostgreSQL-backed cutoff/state/scope coverage.

## 🧪 Tests

- `yarn test` — 24/24 package tasks; core 1,142 suites and 8,823 tests.
- Focused payment-gateway/config tests — 4 suites and 29 tests.
- `yarn mercato test:integration TC-PGWY-024 --no-screenshots` — passed on a freshly migrated isolated PostgreSQL database.
- Core typecheck, scoped ESLint, i18n sync/usage, generation, package build, and app build passed.
- `template:sync` still reports 29 pre-existing unrelated template drift files; none are part of this PR.

## 💥 Breaking Changes

- None. The worker, schedule, upgrade action, locales, and tests are additive; no API shape or database schema changes.