### PR TITLE
refactor(storage_s3): localize route error responses (#4830)

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1060,3 +1060,5 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: Complete document preparation before entering an encryption-only guard. When encryption throws, log and rethrow or skip the write explicitly; never return the pre-encryption payload. Keep regression coverage at the final persistence boundary so a helper-level fix cannot mask a plaintext write.
 
 **Applies to**: index projections, search/vector payloads, export staging, and every write path that conditionally encrypts a prepared document.
+
+- 2026-08-03 · validation: when create-app harness tests fail because their macOS sandbox blocks Homebrew Node's external `libuv`, record the environment blocker explicitly and never report the full gate as passing.

--- a/packages/storage-s3/package.json
+++ b/packages/storage-s3/package.json
@@ -37,6 +37,7 @@
       ],
       "default": "./dist/*/*/*.js"
     },
+    "./modules/storage_s3/i18n/*.json": "./src/modules/storage_s3/i18n/*.json",
     "./*/*/*/*": {
       "types": [
         "./src/*/*/*/*.ts",

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/i18nPackageExports.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/i18nPackageExports.test.ts
@@ -1,0 +1,13 @@
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+
+const packageRequire = createRequire(__filename)
+
+describe('storage_s3 locale package exports', () => {
+  it.each(['en', 'de', 'es', 'pl'] as const)('resolves the %s locale through the package export map', (locale) => {
+    const localePath = packageRequire.resolve(`@open-mercato/storage-s3/modules/storage_s3/i18n/${locale}.json`)
+    const translations = JSON.parse(readFileSync(localePath, 'utf8')) as Record<string, unknown>
+
+    expect(translations['storage_s3.errors.unauthorized']).toEqual(expect.any(String))
+  })
+})

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/s3ListRoute.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/s3ListRoute.test.ts
@@ -9,6 +9,12 @@ jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: async () => ({ tenantId, orgId, sub: null }),
 }))
 
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (key: string) => `translated:${key}`,
+  }),
+}))
+
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: async () => ({
     resolve: (token: string) => {
@@ -69,7 +75,7 @@ describe('storage_s3 list route tenant scoping', () => {
 
     expect(response.status).toBe(403)
     await expect(response.json()).resolves.toEqual({
-      error: 'Access denied: prefix is not scoped to this tenant.',
+      error: 'translated:storage_s3.errors.prefixAccessDenied',
     })
     expect(listObjectsMock).not.toHaveBeenCalled()
   })

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts
@@ -5,6 +5,12 @@ jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
 }))
 
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (key: string) => `translated:${key}`,
+  }),
+}))
+
 const mockResolveCredentials = jest.fn()
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => ({
@@ -93,7 +99,24 @@ describe('storage_s3 standalone route key scope', () => {
     }))
 
     expect(response.status).toBe(403)
+    await expect(response.json()).resolves.toEqual({
+      error: 'translated:storage_s3.errors.keyAccessDenied',
+    })
     expect(mockGetSignedUrl).not.toHaveBeenCalled()
+  })
+
+  it('localizes invalid delete payload errors', async () => {
+    const response = await DELETE(new Request('http://example.test/api/storage-providers/s3/delete', {
+      method: 'DELETE',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'translated:storage_s3.errors.invalidPayload',
+    })
+    expect(mockDelete).not.toHaveBeenCalled()
   })
 
   it('deletes shared namespace objects for an authorized storage manager', async () => {
@@ -116,6 +139,9 @@ describe('storage_s3 standalone route key scope', () => {
       )
 
       expect(response.status).toBe(403)
+      await expect(response.json()).resolves.toEqual({
+        error: 'translated:storage_s3.errors.keyAccessDenied',
+      })
     }
     expect(mockRead).not.toHaveBeenCalled()
   })

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/upload.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/upload.test.ts
@@ -5,6 +5,12 @@ jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
 }))
 
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (key: string) => `translated:${key}`,
+  }),
+}))
+
 const mockResolveCredentials = jest.fn()
 const mockCreateRequestContainer = jest.fn(async () => ({
   resolve: () => ({ resolve: mockResolveCredentials }),
@@ -62,7 +68,9 @@ describe('storage_s3 direct upload route', () => {
     const response = await POST(request)
 
     expect(response.status).toBe(413)
-    await expect(response.json()).resolves.toEqual({ error: 'Attachment exceeds the maximum upload size.' })
+    await expect(response.json()).resolves.toEqual({
+      error: 'translated:storage_s3.errors.maxUploadSize',
+    })
     expect(mockCreateRequestContainer).not.toHaveBeenCalled()
     expect(mockPutObject).not.toHaveBeenCalled()
   })

--- a/packages/storage-s3/src/modules/storage_s3/api/delete/storage-providers/s3/delete.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/delete/storage-providers/s3/delete.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { isS3KeyAddressableByScope } from '../../../../lib/key-scope'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 
@@ -26,24 +27,25 @@ async function resolveDriver(tenantId: string, orgId: string): Promise<S3Storage
 }
 
 export async function DELETE(req: Request) {
+  const { t } = await resolveTranslations()
   const auth = await getAuthFromRequest(req)
   if (!auth?.tenantId || !auth.orgId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return NextResponse.json({ error: t('storage_s3.errors.unauthorized', 'Unauthorized') }, { status: 401 })
   }
 
   const json = await req.json().catch(() => null)
   const parsed = requestSchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.invalidPayload', 'Invalid payload') }, { status: 400 })
   }
 
   if (!isS3KeyAddressableByScope(parsed.data.key, auth.orgId, auth.tenantId)) {
-    return NextResponse.json({ error: 'Access denied: key is not scoped to this tenant.' }, { status: 403 })
+    return NextResponse.json({ error: t('storage_s3.errors.keyAccessDenied', 'Access denied: key is not scoped to this tenant.') }, { status: 403 })
   }
 
   const driver = await resolveDriver(auth.tenantId, auth.orgId)
   if (!driver) {
-    return NextResponse.json({ error: 'S3 integration is not configured.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.integrationNotConfigured', 'S3 integration is not configured.') }, { status: 400 })
   }
 
   await driver.delete('', parsed.data.key)

--- a/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import {
   buildAttachmentContentDisposition,
   canRenderInlineAttachment,
@@ -27,23 +28,24 @@ async function resolveDriver(tenantId: string, orgId: string): Promise<S3Storage
 }
 
 export async function GET(req: Request) {
+  const { t } = await resolveTranslations()
   const auth = await getAuthFromRequest(req)
   if (!auth?.tenantId || !auth.orgId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return NextResponse.json({ error: t('storage_s3.errors.unauthorized', 'Unauthorized') }, { status: 401 })
   }
 
   const key = new URL(req.url).searchParams.get('key')
   if (!key) {
-    return NextResponse.json({ error: 'key query param is required' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.keyRequired', 'key query param is required') }, { status: 400 })
   }
 
   if (!isS3KeyAddressableByScope(key, auth.orgId, auth.tenantId)) {
-    return NextResponse.json({ error: 'Access denied: key is not scoped to this tenant.' }, { status: 403 })
+    return NextResponse.json({ error: t('storage_s3.errors.keyAccessDenied', 'Access denied: key is not scoped to this tenant.') }, { status: 403 })
   }
 
   const driver = await resolveDriver(auth.tenantId, auth.orgId)
   if (!driver) {
-    return NextResponse.json({ error: 'S3 integration is not configured.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.integrationNotConfigured', 'S3 integration is not configured.') }, { status: 400 })
   }
 
   let buffer: Buffer
@@ -53,7 +55,7 @@ export async function GET(req: Request) {
     buffer = result.buffer
     contentType = result.contentType
   } catch {
-    return NextResponse.json({ error: 'File not found' }, { status: 404 })
+    return NextResponse.json({ error: t('storage_s3.errors.fileNotFound', 'File not found') }, { status: 404 })
   }
 
   const fileName = sanitizeUploadedFileName(key.split('/').pop() || 'download')

--- a/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/list.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/list.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 
 export const metadata = {
@@ -71,29 +72,30 @@ function resolveTenantScopedPrefix(prefix: string, tenantId: string, orgId: stri
 }
 
 export async function GET(req: Request) {
+  const { t } = await resolveTranslations()
   const auth = await getAuthFromRequest(req)
   if (!auth?.tenantId || !auth.orgId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return NextResponse.json({ error: t('storage_s3.errors.unauthorized', 'Unauthorized') }, { status: 401 })
   }
 
   const params = Object.fromEntries(new URL(req.url).searchParams.entries())
   const parsed = querySchema.safeParse(params)
   if (!parsed.success) {
-    return NextResponse.json({ error: 'Invalid query parameters' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.invalidQuery', 'Invalid query parameters') }, { status: 400 })
   }
 
   // Always scope list operations to the tenant namespace to prevent cross-tenant enumeration.
   const effectivePrefix = resolveTenantScopedPrefix(parsed.data.prefix, auth.tenantId, auth.orgId)
   if (effectivePrefix === null) {
     return NextResponse.json(
-      { error: 'Access denied: prefix is not scoped to this tenant.' },
+      { error: t('storage_s3.errors.prefixAccessDenied', 'Access denied: prefix is not scoped to this tenant.') },
       { status: 403 },
     )
   }
 
   const driver = await resolveDriver(auth.tenantId, auth.orgId)
   if (!driver) {
-    return NextResponse.json({ error: 'S3 integration is not configured.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.integrationNotConfigured', 'S3 integration is not configured.') }, { status: 400 })
   }
 
   const result = await driver.listObjects(

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/signed-url.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/signed-url.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { isS3KeyAddressableByScope, isS3KeyScopedToTenant } from '../../../../lib/key-scope'
 import { S3StorageDriver } from '../../../../lib/s3-driver'
 
@@ -34,15 +35,16 @@ async function resolveDriver(tenantId: string, orgId: string): Promise<S3Storage
 }
 
 export async function POST(req: Request) {
+  const { t } = await resolveTranslations()
   const auth = await getAuthFromRequest(req)
   if (!auth?.tenantId || !auth.orgId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return NextResponse.json({ error: t('storage_s3.errors.unauthorized', 'Unauthorized') }, { status: 401 })
   }
 
   const json = await req.json().catch(() => null)
   const parsed = requestSchema.safeParse(json)
   if (!parsed.success) {
-    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.invalidPayload', 'Invalid payload') }, { status: 400 })
   }
 
   const { key, operation, expiresIn, contentType } = parsed.data
@@ -50,12 +52,12 @@ export async function POST(req: Request) {
     ? isS3KeyAddressableByScope(key, auth.orgId, auth.tenantId)
     : isS3KeyScopedToTenant(key, auth.orgId, auth.tenantId)
   if (!canAccessKey) {
-    return NextResponse.json({ error: 'Access denied: key is not scoped to this tenant.' }, { status: 403 })
+    return NextResponse.json({ error: t('storage_s3.errors.keyAccessDenied', 'Access denied: key is not scoped to this tenant.') }, { status: 403 })
   }
 
   const driver = await resolveDriver(auth.tenantId, auth.orgId)
   if (!driver) {
-    return NextResponse.json({ error: 'S3 integration is not configured.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.integrationNotConfigured', 'S3 integration is not configured.') }, { status: 400 })
   }
 
   const url = await driver.getSignedUrl(key, operation, expiresIn, contentType)

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import {
   detectAttachmentMimeType,
   hasDangerousExecutableExtension,
@@ -70,18 +71,19 @@ async function readTenantStorageUsageBytes(
 }
 
 export async function POST(req: Request) {
+  const { t } = await resolveTranslations()
   const auth = await getAuthFromRequest(req)
   if (!auth?.tenantId || !auth.orgId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    return NextResponse.json({ error: t('storage_s3.errors.unauthorized', 'Unauthorized') }, { status: 401 })
   }
 
   if (!isMultipartRequestWithinUploadLimit(req.headers.get('content-length'))) {
-    return NextResponse.json({ error: 'Attachment exceeds the maximum upload size.' }, { status: 413 })
+    return NextResponse.json({ error: t('storage_s3.errors.maxUploadSize', 'Attachment exceeds the maximum upload size.') }, { status: 413 })
   }
 
   const contentType = req.headers.get('content-type') ?? ''
   if (!contentType.includes('multipart/form-data')) {
-    return NextResponse.json({ error: 'Expected multipart/form-data' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.multipartRequired', 'Expected multipart/form-data') }, { status: 400 })
   }
 
   let form: FormData
@@ -89,48 +91,48 @@ export async function POST(req: Request) {
     form = await parseMultipartFormDataWithinUploadLimit(req)
   } catch (error) {
     if (isMultipartUploadLimitError(error)) {
-      return NextResponse.json({ error: 'Attachment exceeds the maximum upload size.' }, { status: 413 })
+      return NextResponse.json({ error: t('storage_s3.errors.maxUploadSize', 'Attachment exceeds the maximum upload size.') }, { status: 413 })
     }
     throw error
   }
   const file = form.get('file') as File | null
   if (!file) {
-    return NextResponse.json({ error: 'file field is required' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.fileRequired', 'file field is required') }, { status: 400 })
   }
 
   const keyOverride = form.get('key') ? String(form.get('key')) : null
 
   if (keyOverride !== null && !isS3KeyScopedToTenant(keyOverride, auth.orgId, auth.tenantId)) {
     return NextResponse.json(
-      { error: 'Access denied: key override is not scoped to this tenant.' },
+      { error: t('storage_s3.errors.keyOverrideAccessDenied', 'Access denied: key override is not scoped to this tenant.') },
       { status: 403 },
     )
   }
 
   if (hasDangerousExecutableExtension(file.name)) {
-    return NextResponse.json({ error: 'Executable file types are not allowed as attachments.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.dangerousExecutable', 'Executable file types are not allowed as attachments.') }, { status: 400 })
   }
 
   const effectiveMaxBytes = resolveAttachmentMaxBytes()
   if (file.size > effectiveMaxBytes) {
-    return NextResponse.json({ error: 'Attachment exceeds the maximum upload size.' }, { status: 413 })
+    return NextResponse.json({ error: t('storage_s3.errors.maxUploadSize', 'Attachment exceeds the maximum upload size.') }, { status: 413 })
   }
 
   const driver = await resolveDriver(auth.tenantId, auth.orgId)
   if (!driver) {
-    return NextResponse.json({ error: 'S3 integration is not configured.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.integrationNotConfigured', 'S3 integration is not configured.') }, { status: 400 })
   }
 
   const buffer = Buffer.from(await file.arrayBuffer())
   const safeName = sanitizeFileName(file.name)
   const trustedMimeType = detectAttachmentMimeType(buffer, safeName, file.type || null)
   if (isActiveContentAttachment(buffer, safeName, trustedMimeType)) {
-    return NextResponse.json({ error: 'Active content uploads are not allowed.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.activeContentBlocked', 'Active content uploads are not allowed.') }, { status: 400 })
   }
 
   const tenantUsageBytes = await readTenantStorageUsageBytes(driver, auth.tenantId, auth.orgId)
   if (willExceedAttachmentTenantQuota(tenantUsageBytes, buffer.length)) {
-    return NextResponse.json({ error: 'Attachment storage quota exceeded for this tenant.' }, { status: 413 })
+    return NextResponse.json({ error: t('storage_s3.errors.quotaExceeded', 'Attachment storage quota exceeded for this tenant.') }, { status: 413 })
   }
 
   const key =

--- a/packages/storage-s3/src/modules/storage_s3/i18n/de.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/de.json
@@ -1,0 +1,17 @@
+{
+  "storage_s3.errors.activeContentBlocked": "Das Hochladen aktiver Inhalte ist nicht erlaubt.",
+  "storage_s3.errors.dangerousExecutable": "Ausführbare Dateitypen sind als Anhänge nicht erlaubt.",
+  "storage_s3.errors.fileNotFound": "Datei nicht gefunden",
+  "storage_s3.errors.fileRequired": "Das Feld „file“ ist erforderlich",
+  "storage_s3.errors.integrationNotConfigured": "Die S3-Integration ist nicht konfiguriert.",
+  "storage_s3.errors.invalidPayload": "Ungültige Anfragedaten",
+  "storage_s3.errors.invalidQuery": "Ungültige Abfrageparameter",
+  "storage_s3.errors.keyAccessDenied": "Zugriff verweigert: Der Schlüssel ist nicht auf diesen Tenant beschränkt.",
+  "storage_s3.errors.keyOverrideAccessDenied": "Zugriff verweigert: Die Schlüsselüberschreibung ist nicht auf diesen Tenant beschränkt.",
+  "storage_s3.errors.keyRequired": "Der Abfrageparameter „key“ ist erforderlich",
+  "storage_s3.errors.maxUploadSize": "Der Anhang überschreitet die maximal zulässige Upload-Größe.",
+  "storage_s3.errors.multipartRequired": "multipart/form-data wurde erwartet",
+  "storage_s3.errors.prefixAccessDenied": "Zugriff verweigert: Das Präfix ist nicht auf diesen Tenant beschränkt.",
+  "storage_s3.errors.quotaExceeded": "Das Speicherlimit für Anhänge dieses Tenants wurde überschritten.",
+  "storage_s3.errors.unauthorized": "Nicht autorisiert"
+}

--- a/packages/storage-s3/src/modules/storage_s3/i18n/en.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/en.json
@@ -1,0 +1,17 @@
+{
+  "storage_s3.errors.activeContentBlocked": "Active content uploads are not allowed.",
+  "storage_s3.errors.dangerousExecutable": "Executable file types are not allowed as attachments.",
+  "storage_s3.errors.fileNotFound": "File not found",
+  "storage_s3.errors.fileRequired": "file field is required",
+  "storage_s3.errors.integrationNotConfigured": "S3 integration is not configured.",
+  "storage_s3.errors.invalidPayload": "Invalid payload",
+  "storage_s3.errors.invalidQuery": "Invalid query parameters",
+  "storage_s3.errors.keyAccessDenied": "Access denied: key is not scoped to this tenant.",
+  "storage_s3.errors.keyOverrideAccessDenied": "Access denied: key override is not scoped to this tenant.",
+  "storage_s3.errors.keyRequired": "key query param is required",
+  "storage_s3.errors.maxUploadSize": "Attachment exceeds the maximum upload size.",
+  "storage_s3.errors.multipartRequired": "Expected multipart/form-data",
+  "storage_s3.errors.prefixAccessDenied": "Access denied: prefix is not scoped to this tenant.",
+  "storage_s3.errors.quotaExceeded": "Attachment storage quota exceeded for this tenant.",
+  "storage_s3.errors.unauthorized": "Unauthorized"
+}

--- a/packages/storage-s3/src/modules/storage_s3/i18n/es.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/es.json
@@ -1,0 +1,17 @@
+{
+  "storage_s3.errors.activeContentBlocked": "No se permite la carga de contenido activo.",
+  "storage_s3.errors.dangerousExecutable": "No se permiten archivos ejecutables como adjuntos.",
+  "storage_s3.errors.fileNotFound": "Archivo no encontrado",
+  "storage_s3.errors.fileRequired": "El campo file es obligatorio",
+  "storage_s3.errors.integrationNotConfigured": "La integración de S3 no está configurada.",
+  "storage_s3.errors.invalidPayload": "Contenido de solicitud no válido",
+  "storage_s3.errors.invalidQuery": "Parámetros de consulta no válidos",
+  "storage_s3.errors.keyAccessDenied": "Acceso denegado: la clave no está limitada a este tenant.",
+  "storage_s3.errors.keyOverrideAccessDenied": "Acceso denegado: la sobrescritura de la clave no está limitada a este tenant.",
+  "storage_s3.errors.keyRequired": "Se requiere el parámetro de consulta key",
+  "storage_s3.errors.maxUploadSize": "El archivo adjunto supera el tamaño máximo de carga permitido.",
+  "storage_s3.errors.multipartRequired": "Se esperaba multipart/form-data",
+  "storage_s3.errors.prefixAccessDenied": "Acceso denegado: el prefijo no está limitado a este tenant.",
+  "storage_s3.errors.quotaExceeded": "Se superó la cuota de almacenamiento de adjuntos para este tenant.",
+  "storage_s3.errors.unauthorized": "No autorizado"
+}

--- a/packages/storage-s3/src/modules/storage_s3/i18n/pl.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/pl.json
@@ -1,0 +1,17 @@
+{
+  "storage_s3.errors.activeContentBlocked": "Przesyłanie treści aktywnych nie jest dozwolone.",
+  "storage_s3.errors.dangerousExecutable": "Pliki wykonywalne nie są dozwolone jako załączniki.",
+  "storage_s3.errors.fileNotFound": "Nie znaleziono pliku",
+  "storage_s3.errors.fileRequired": "Pole file jest wymagane",
+  "storage_s3.errors.integrationNotConfigured": "Integracja S3 nie jest skonfigurowana.",
+  "storage_s3.errors.invalidPayload": "Nieprawidłowe dane żądania",
+  "storage_s3.errors.invalidQuery": "Nieprawidłowe parametry zapytania",
+  "storage_s3.errors.keyAccessDenied": "Odmowa dostępu: klucz nie jest ograniczony do tego tenantu.",
+  "storage_s3.errors.keyOverrideAccessDenied": "Odmowa dostępu: nadpisany klucz nie jest ograniczony do tego tenantu.",
+  "storage_s3.errors.keyRequired": "Wymagany jest parametr zapytania key",
+  "storage_s3.errors.maxUploadSize": "Załącznik przekracza maksymalny dopuszczalny rozmiar przesyłania.",
+  "storage_s3.errors.multipartRequired": "Oczekiwano multipart/form-data",
+  "storage_s3.errors.prefixAccessDenied": "Odmowa dostępu: prefiks nie jest ograniczony do tego tenantu.",
+  "storage_s3.errors.quotaExceeded": "Przekroczono limit miejsca na załączniki dla tego tenantu.",
+  "storage_s3.errors.unauthorized": "Brak autoryzacji"
+}


### PR DESCRIPTION
Closes #4830

## 🎯 Goal
- Localize every user-facing error returned by the five `storage_s3` route handlers.

## 🔍 Problem
The storage_s3 list, download, delete, upload, and signed-URL handlers returned hardcoded English errors and the package provided no discoverable locale resources.

## 🔍 Root Cause
The handlers bypassed the server translation resolver, and the storage-s3 package export map did not expose locale JSON for generated package-specifier imports.

## What Changed
- Added `en`, `de`, `es`, and `pl` locale resources for all storage_s3 route errors.
- Routed all five handlers through server-side `resolveTranslations()` while preserving URLs, methods, status codes, and `{ error: string }` response shapes.
- Exposed storage_s3 locale JSON through the package export map.
- Added focused route-localization and package-export regression coverage.

## 🧪 Tests
- `corepack yarn workspace @open-mercato/storage-s3 test --runInBand` — 12 suites, 103 tests passed.
- `corepack yarn workspace @open-mercato/storage-s3 typecheck` — passed.
- Scoped ESLint — passed.
- `corepack yarn build:packages` → `corepack yarn generate` → `corepack yarn build:packages` — passed.
- i18n sync, usage, hardcoded-string, and locale-value checks — passed.
- Repository typecheck and production app build — passed.
- Repository-wide `corepack yarn test` could not complete cleanly in this macOS environment because create-app harness subprocesses sandbox Homebrew Node without its external `libuv` path; the changed package suite passes and CI is expected to provide the clean-environment verdict.
- `corepack yarn template:sync` reports 29 pre-existing app/template drifts outside this package and was not auto-fixed into this focused PR.

## 💥 Breaking Changes
- None. Existing route URLs, methods, status codes, and response shapes are unchanged; the package export addition is additive.
