### PR TITLE
fix(customers): restore activity dialog cancel exits

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1060,3 +1060,11 @@ Centralize shared command utilities like undo extraction in `packages/shared/src
 **Rule**: Complete document preparation before entering an encryption-only guard. When encryption throws, log and rethrow or skip the write explicitly; never return the pre-encryption payload. Keep regression coverage at the final persistence boundary so a helper-level fix cannot mask a plaintext write.
 
 **Applies to**: index projections, search/vector payloads, export staging, and every write path that conditionally encrypts a prepared document.
+
+## Portaled confirmations must stay inside their parent dialog's React tree
+
+**Context**: A native confirmation dialog was portaled to `document.body` from beside a Radix dialog's content, so real pointer events were classified as outside interactions and Escape was intercepted before the native cancel event.
+
+**Rule**: Render portaled confirmations as React children of the owning `DialogContent`, and handle Escape before the parent overlay's document-capture dismissal when the confirmation owns the active modal interaction.
+
+**Applies to**: nested native dialogs, Radix `DismissableLayer`, and any portaled confirmation shown from an open modal.

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-056.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-056.spec.ts
@@ -7,10 +7,11 @@ import {
 } from '@open-mercato/core/helpers/integration/crmFixtures'
 
 /**
- * TC-CRM-056: Confirm-dialog stability — Discard prompt reopens after Keep
- * editing/X (#1804) and Company Name with JSON-like content does not crash
- * the page with a `useInsertionEffect must not schedule updates` warning
- * (#1810).
+ * TC-CRM-056: Confirm-dialog stability — Discard prompt supports real pointer
+ * and keyboard cancellation inside the Schedule Activity Radix modal (#4822),
+ * reopens after cancellation (#1804), and Company Name with JSON-like content
+ * does not crash the page with a `useInsertionEffect must not schedule updates`
+ * warning (#1810).
  *
  * Spec: .ai/specs/2026-05-06-crm-fixes-3.md (Cluster A — Step 6).
  *
@@ -31,7 +32,7 @@ import {
  * in one path does not starve the other under a shared Playwright timeout.
  */
 test.describe('TC-CRM-056: Confirm-dialog stability (#1804, #1810)', () => {
-  test('Schedule Activity discard prompt reopens after Keep editing (#1804)', async ({ page, request }) => {
+  test('Schedule Activity discard prompt has non-destructive pointer and keyboard exits (#4822)', async ({ page, request }) => {
     test.slow()
     test.setTimeout(120_000)
 
@@ -109,22 +110,9 @@ test.describe('TC-CRM-056: Confirm-dialog stability (#1804, #1810)', () => {
       const discardDialog = page.locator('dialog[role="alertdialog"][open]')
       await expect(discardDialog).toHaveCount(1, { timeout: 10_000 })
 
-      // Click "Keep editing" to dismiss the discard prompt without losing
-      // the unsaved title. Before the fix the second confirm() never reopened.
-      // The native <dialog> sits in the top-layer; Playwright's standard
-      // click + force-click both intermittently fail to register here.
-      // Calling `.click()` from inside the page evaluates element.click()
-      // on the focused button which always fires the React click handler
-      // (this is the same path the user takes when pressing Space/Enter
-      // on the focused "Keep editing" button).
-      await page.evaluate(() => {
-        const dialog = document.querySelector('dialog[role="alertdialog"][open]')
-        if (!dialog) throw new Error('Discard dialog not present in DOM')
-        const buttons = Array.from(dialog.querySelectorAll('button')) as HTMLButtonElement[]
-        const target = buttons.find((btn) => /keep editing/i.test(btn.textContent ?? ''))
-        if (!target) throw new Error('"Keep editing" button not found inside discard dialog')
-        target.click()
-      })
+      // Use a real Playwright pointer sequence. A programmatic element.click()
+      // omits pointerdown, which previously hid the nested-modal regression.
+      await discardDialog.getByRole('button', { name: /Keep editing/i }).click()
       // Wait for the dialog's `open` attribute to be removed.
       await expect(page.locator('dialog[role="alertdialog"][open]')).toHaveCount(0, { timeout: 10_000 })
 
@@ -138,15 +126,26 @@ test.describe('TC-CRM-056: Confirm-dialog stability (#1804, #1810)', () => {
       const discardDialog2 = page.locator('dialog[role="alertdialog"][open]')
       await expect(discardDialog2).toHaveCount(1, { timeout: 10_000 })
 
-      // Confirm the discard this time. The schedule dialog MUST close.
-      await page.evaluate(() => {
-        const dialog = document.querySelector('dialog[role="alertdialog"][open]')
-        if (!dialog) throw new Error('Second discard dialog not present in DOM')
-        const buttons = Array.from(dialog.querySelectorAll('button')) as HTMLButtonElement[]
-        const target = buttons.find((btn) => /^discard$/i.test((btn.textContent ?? '').trim()))
-        if (!target) throw new Error('"Discard" button not found inside discard dialog')
-        target.click()
-      })
+      // The alert-dialog X is also a non-destructive exit and must preserve
+      // the underlying form values.
+      await discardDialog2.getByRole('button', { name: /^Close$/i }).click()
+      await expect(page.locator('dialog[role="alertdialog"][open]')).toHaveCount(0, { timeout: 10_000 })
+      await expect(titleInput).toHaveValue(titleStub)
+
+      // Escape follows the same cancel path and must keep the activity editor
+      // open with the unsaved title intact.
+      await dialogCancelButton.click()
+      const discardDialog3 = page.locator('dialog[role="alertdialog"][open]')
+      await expect(discardDialog3).toHaveCount(1, { timeout: 10_000 })
+      await page.keyboard.press('Escape')
+      await expect(page.locator('dialog[role="alertdialog"][open]')).toHaveCount(0, { timeout: 10_000 })
+      await expect(titleInput).toHaveValue(titleStub)
+
+      // Discard remains the only destructive exit and closes the scheduler.
+      await dialogCancelButton.click()
+      const discardDialog4 = page.locator('dialog[role="alertdialog"][open]')
+      await expect(discardDialog4).toHaveCount(1, { timeout: 10_000 })
+      await discardDialog4.getByRole('button', { name: /^Discard$/i }).click()
 
       // The Schedule Activity dialog should be unmounted.
       await expect(scheduleDialog).toBeHidden({ timeout: 10_000 })

--- a/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/ScheduleActivityDialog.tsx
@@ -207,6 +207,7 @@ export function ScheduleActivityDialog({
   const initialSnapshotRef = React.useRef<string | null>(null)
   const snapshotOpenKeyRef = React.useRef<string | null>(null)
   const snapshotSettleCountRef = React.useRef(0)
+  const closeConfirmPendingRef = React.useRef(false)
   const openKey = open ? `${editData?.id ?? 'new'}` : null
   React.useEffect(() => {
     if (!open) {
@@ -232,21 +233,27 @@ export function ScheduleActivityDialog({
   }, [formSnapshot])
 
   const guardedClose = React.useCallback(async () => {
+    if (closeConfirmPendingRef.current) return
     if (!isDirty()) {
       onClose()
       return
     }
-    const ok = await confirm({
-      title: t('customers.schedule.discardConfirm.title', 'Discard unsaved changes?'),
-      description: t(
-        'customers.schedule.discardConfirm.description',
-        'You have unsaved edits in this activity. Save them first or continue to discard them.',
-      ),
-      confirmText: t('customers.schedule.discardConfirm.confirm', 'Discard'),
-      cancelText: t('customers.schedule.discardConfirm.cancel', 'Keep editing'),
-      variant: 'destructive',
-    })
-    if (ok) onClose()
+    closeConfirmPendingRef.current = true
+    try {
+      const ok = await confirm({
+        title: t('customers.schedule.discardConfirm.title', 'Discard unsaved changes?'),
+        description: t(
+          'customers.schedule.discardConfirm.description',
+          'You have unsaved edits in this activity. Save them first or continue to discard them.',
+        ),
+        confirmText: t('customers.schedule.discardConfirm.confirm', 'Discard'),
+        cancelText: t('customers.schedule.discardConfirm.cancel', 'Keep editing'),
+        variant: 'destructive',
+      })
+      if (ok) onClose()
+    } finally {
+      closeConfirmPendingRef.current = false
+    }
   }, [confirm, isDirty, onClose, t])
 
   const mutationContextId = React.useMemo(
@@ -468,8 +475,12 @@ export function ScheduleActivityDialog({
 
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) void guardedClose() }}>
-      {ConfirmDialogElement}
-      <DialogContent className="flex max-h-[90vh] flex-col overflow-hidden border-border p-0 shadow-xl sm:max-w-[760px] sm:rounded-xl [&>[data-dialog-close]]:hidden" onKeyDown={handleKeyDown} aria-describedby={undefined}>
+      <DialogContent
+        className="flex max-h-[90vh] flex-col overflow-hidden border-border p-0 shadow-xl sm:max-w-[760px] sm:rounded-xl [&>[data-dialog-close]]:hidden"
+        onKeyDown={handleKeyDown}
+        aria-describedby={undefined}
+      >
+        {ConfirmDialogElement}
         <VisuallyHidden>
           <DialogTitle>{isEditing ? t('customers.schedule.editTitle', 'Edit activity') : t(chrome.titleKey, chrome.titleFallback)}</DialogTitle>
         </VisuallyHidden>

--- a/packages/ui/src/backend/confirm-dialog/ConfirmDialog.tsx
+++ b/packages/ui/src/backend/confirm-dialog/ConfirmDialog.tsx
@@ -136,6 +136,21 @@ export function ConfirmDialog({
     return () => dialog.removeEventListener("cancel", handleCancel);
   }, [loading, requestClose]);
 
+  React.useEffect(() => {
+    if (!open) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (!(event.target instanceof Node) || !dialogRef.current?.contains(event.target)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (!loading) requestClose();
+    };
+
+    window.addEventListener("keydown", handleEscape, true);
+    return () => window.removeEventListener("keydown", handleEscape, true);
+  }, [loading, open, requestClose]);
+
   // Handle backdrop click
   const handleBackdropClick = (e: React.MouseEvent<HTMLDialogElement>) => {
     // Only close if clicking directly on the dialog (backdrop), not its children

--- a/packages/ui/src/backend/confirm-dialog/__tests__/ConfirmDialog.test.tsx
+++ b/packages/ui/src/backend/confirm-dialog/__tests__/ConfirmDialog.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import * as React from 'react'
-import { screen } from '@testing-library/react'
+import { fireEvent, screen, within } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { ConfirmDialog } from '../ConfirmDialog'
 
@@ -59,5 +59,37 @@ describe('ConfirmDialog', () => {
     const dialog = screen.getByRole('alertdialog')
     expect(container.contains(dialog)).toBe(false)
     expect(dialog.parentElement).toBe(document.body)
+  })
+
+  it('closes only the confirmation that owns an Escape event', () => {
+    const firstOpenChange = jest.fn()
+    const secondOpenChange = jest.fn()
+
+    renderWithProviders(
+      <>
+        <ConfirmDialog
+          open
+          onOpenChange={firstOpenChange}
+          onConfirm={() => undefined}
+          title="First confirmation"
+          confirmText="Confirm first"
+          cancelText="Cancel first"
+        />
+        <ConfirmDialog
+          open
+          onOpenChange={secondOpenChange}
+          onConfirm={() => undefined}
+          title="Second confirmation"
+          confirmText="Confirm second"
+          cancelText="Cancel second"
+        />
+      </>,
+    )
+
+    const secondDialog = screen.getByRole('alertdialog', { name: 'Second confirmation' })
+    fireEvent.keyDown(within(secondDialog).getByRole('button', { name: 'Cancel second' }), { key: 'Escape' })
+
+    expect(firstOpenChange).not.toHaveBeenCalled()
+    expect(secondOpenChange).toHaveBeenCalledWith(false)
   })
 })


### PR DESCRIPTION
## Summary

Restore non-destructive exits from the unsaved-changes confirmation in the CRM activity scheduler. Real pointer and Escape interactions no longer re-enter the parent Radix dialog or immediately reopen the discard prompt.

## Changes

- render the portaled confirmation as a React child of the owning `DialogContent` so Radix classifies its pointer events as internal
- guard the scheduler close flow against duplicate in-flight confirmations
- capture Escape before the parent overlay and scope it to the confirmation that owns the keyboard event
- cover Keep editing, alert X, Escape, Discard, and concurrent confirmation ownership with regression tests

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:** N/A

## Testing

- `yarn build:packages`
- `yarn generate`
- `yarn build:packages`
- `yarn i18n:check-sync`
- `yarn i18n:check-usage` (passes; existing unused-key advisory only)
- `yarn typecheck`
- `yarn build:app`
- `yarn workspace @open-mercato/core test` (8,815 passed)
- `yarn workspace @open-mercato/ui test` (1,731 passed before the reviewer correction; focused shared suites 7/7 after it)
- `npx playwright test --config .ai/qa/tests/playwright.config.ts packages/core/src/modules/customers/__integration__/TC-CRM-056.spec.ts --retries=0` (2 passed)
- focused `#4822` Playwright regression after final review correction (1 passed)
- scoped ESLint (0 errors; 2 pre-existing hook warnings)

Local gate notes:

- the repository-wide `yarn test` run stops in unrelated `create-mercato-app` macOS sandbox tests because child Homebrew Node processes cannot load `/opt/homebrew/opt/libuv/lib/libuv.1.dylib`; the affected core/UI suites pass independently
- `yarn template:sync` reports 29 existing app-template drift files outside this change

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: this customer-facing UI fix carries `needs-qa`.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

Fixes #4822
