### PR TITLE
security(directory): gate tenant CRUD on superadmin, not just ACL

### DIFF
--- a/packages/core/src/modules/auth/lib/tenantAccess.ts
+++ b/packages/core/src/modules/auth/lib/tenantAccess.ts
@@ -77,3 +77,11 @@ export async function enforceTenantSelection(ctx: TenantGuardCtx, requested: unk
   if (normalized === actorTenant) return actorTenant
   throw forbidden('Not authorized to target this tenant.')
 }
+
+export async function requireSuperAdmin(ctx: TenantGuardCtx): Promise<void> {
+  const isSuperAdmin = await resolveIsSuperAdmin(ctx)
+  if (!isSuperAdmin) {
+    throw forbidden('Forbidden')
+  }
+}
+

--- a/packages/core/src/modules/directory/api/tenants/__tests__/list-pagination.test.ts
+++ b/packages/core/src/modules/directory/api/tenants/__tests__/list-pagination.test.ts
@@ -19,7 +19,7 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 }))
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
-  getAuthFromRequest: jest.fn(async () => ({ sub: 'user-1', tenantId })),
+  getAuthFromRequest: jest.fn(async () => ({ sub: 'user-1', tenantId, isSuperAdmin: true })),
 }))
 
 const loadCustomFieldValues = jest.fn(async () => ({}))

--- a/packages/core/src/modules/directory/api/tenants/__tests__/superadmin-guard.test.ts
+++ b/packages/core/src/modules/directory/api/tenants/__tests__/superadmin-guard.test.ts
@@ -16,9 +16,7 @@ const container = {
   }),
 }
 
-
 const getAuthFromRequest = jest.fn()
-const resolveIsSuperAdmin = jest.fn()
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => container),
@@ -26,11 +24,6 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: (...args: unknown[]) => getAuthFromRequest(...(args as [])),
-}))
-
-jest.mock('@open-mercato/core/modules/auth/lib/tenantAccess', () => ({
-  resolveIsSuperAdmin: (...args: unknown[]) => resolveIsSuperAdmin(...(args as [])),
-  requireSuperAdmin: jest.requireActual('@open-mercato/core/modules/auth/lib/tenantAccess').requireSuperAdmin,
 }))
 
 jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
@@ -52,7 +45,6 @@ describe('GET /api/directory/tenants superadmin guard', () => {
 
   it('denies GET to a non-superadmin', async () => {
     getAuthFromRequest.mockResolvedValue({ sub: 'user-a', tenantId: actorTenantId, orgId: null, isSuperAdmin: false })
-    resolveIsSuperAdmin.mockResolvedValue(false)
 
     const res = await GET(new Request('http://localhost/api/directory/tenants'))
 
@@ -64,8 +56,6 @@ describe('GET /api/directory/tenants superadmin guard', () => {
 
   it('allows GET to a superadmin', async () => {
     getAuthFromRequest.mockResolvedValue({ sub: 'super-1', tenantId: actorTenantId, orgId: null, isSuperAdmin: true })
-    resolveIsSuperAdmin.mockResolvedValue(true)
-
     em.findAndCount.mockResolvedValue([[], 0])
 
     const res = await GET(new Request('http://localhost/api/directory/tenants'))

--- a/packages/core/src/modules/directory/api/tenants/__tests__/superadmin-guard.test.ts
+++ b/packages/core/src/modules/directory/api/tenants/__tests__/superadmin-guard.test.ts
@@ -1,0 +1,79 @@
+/** @jest-environment node */
+
+const actorTenantId = '11111111-1111-4111-8111-111111111111'
+
+const em = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  findAndCount: jest.fn(),
+} as { find: jest.Mock; findOne: jest.Mock; findAndCount: jest.Mock }
+
+const container = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'em') return em
+    if (name === 'rbacService') return { loadAcl: jest.fn(async () => ({ isSuperAdmin: false })) }
+    throw new Error(`Unexpected container resolve: ${name}`)
+  }),
+}
+
+
+const getAuthFromRequest = jest.fn()
+const resolveIsSuperAdmin = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => container),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => getAuthFromRequest(...(args as [])),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/lib/tenantAccess', () => ({
+  resolveIsSuperAdmin: (...args: unknown[]) => resolveIsSuperAdmin(...(args as [])),
+  requireSuperAdmin: jest.requireActual('@open-mercato/core/modules/auth/lib/tenantAccess').requireSuperAdmin,
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  buildCustomFieldFiltersFromQuery: jest.fn(async () => ({})),
+  loadCustomFieldValues: jest.fn(async () => ({})),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/factory', () => ({
+  makeCrudRoute: () => ({ metadata: {}, GET: jest.fn(), POST: jest.fn(), PUT: jest.fn(), DELETE: jest.fn() }),
+  logCrudAccess: jest.fn(async () => {}),
+}))
+
+import { GET } from '../route'
+
+describe('GET /api/directory/tenants superadmin guard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('denies GET to a non-superadmin', async () => {
+    getAuthFromRequest.mockResolvedValue({ sub: 'user-a', tenantId: actorTenantId, orgId: null, isSuperAdmin: false })
+    resolveIsSuperAdmin.mockResolvedValue(false)
+
+    const res = await GET(new Request('http://localhost/api/directory/tenants'))
+
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as { error?: string }
+    expect(body.error).toBe('Forbidden')
+    expect(em.findAndCount).not.toHaveBeenCalled()
+  })
+
+  it('allows GET to a superadmin', async () => {
+    getAuthFromRequest.mockResolvedValue({ sub: 'super-1', tenantId: actorTenantId, orgId: null, isSuperAdmin: true })
+    resolveIsSuperAdmin.mockResolvedValue(true)
+
+    em.findAndCount.mockResolvedValue([[], 0])
+
+    const res = await GET(new Request('http://localhost/api/directory/tenants'))
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { items: unknown[]; total: number }
+    expect(body.items).toEqual([])
+    expect(body.total).toBe(0)
+    expect(em.findAndCount).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/directory/api/tenants/route.ts
+++ b/packages/core/src/modules/directory/api/tenants/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { logCrudAccess, makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { requireSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import { tenantCreateSchema, tenantUpdateSchema } from '@open-mercato/core/modules/directory/data/validators'
@@ -94,6 +95,13 @@ export async function GET(req: Request) {
     return NextResponse.json({ items: [], total: 0, page: 1, pageSize: 50, totalPages: 1 }, { status: 401 })
   }
 
+  const container = await createRequestContainer()
+  try {
+    await requireSuperAdmin({ auth, container })
+  } catch (err) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
   const url = new URL(req.url)
   const parsed = listQuerySchema.safeParse({
     id: url.searchParams.get('id') ?? undefined,
@@ -111,8 +119,8 @@ export async function GET(req: Request) {
     )
   }
 
-  const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
+
 
   const { id, page, pageSize, search, sortField, sortDir, isActive } = parsed.data
   const where: FilterQuery<Tenant> = { deletedAt: null }

--- a/packages/core/src/modules/directory/api/tenants/route.ts
+++ b/packages/core/src/modules/directory/api/tenants/route.ts
@@ -2,8 +2,9 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { logCrudAccess, makeCrudRoute } from '@open-mercato/shared/lib/crud/factory'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { requireSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
+import { resolveIsSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+
 import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import { tenantCreateSchema, tenantUpdateSchema } from '@open-mercato/core/modules/directory/data/validators'
 import { loadCustomFieldValues, buildCustomFieldFiltersFromQuery } from '@open-mercato/shared/lib/crud/custom-fields'
@@ -96,9 +97,8 @@ export async function GET(req: Request) {
   }
 
   const container = await createRequestContainer()
-  try {
-    await requireSuperAdmin({ auth, container })
-  } catch (err) {
+  const isSuperAdmin = await resolveIsSuperAdmin({ auth, container })
+  if (!isSuperAdmin) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
@@ -120,7 +120,6 @@ export async function GET(req: Request) {
   }
 
   const em = container.resolve('em') as EntityManager
-
 
   const { id, page, pageSize, search, sortField, sortDir, isActive } = parsed.data
   const where: FilterQuery<Tenant> = { deletedAt: null }
@@ -264,6 +263,7 @@ const tenantGetDoc: OpenApiMethodDoc = {
   errors: [
     { status: 400, description: 'Invalid query parameters', schema: directoryErrorSchema },
     { status: 401, description: 'Authentication required', schema: directoryErrorSchema },
+    { status: 403, description: 'Requires super-admin', schema: directoryErrorSchema },
   ],
 }
 

--- a/packages/core/src/modules/directory/commands/__tests__/tenants.superadmin-guard.test.ts
+++ b/packages/core/src/modules/directory/commands/__tests__/tenants.superadmin-guard.test.ts
@@ -1,0 +1,82 @@
+/** @jest-environment node */
+
+import '@open-mercato/core/modules/directory/commands/tenants'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandHandler } from '@open-mercato/shared/lib/commands'
+import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+
+const ACTOR_TENANT_ID = '11111111-1111-4111-8111-111111111111'
+const TENANT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+function makeCtx(isSuperAdmin: boolean) {
+  const de = {
+    createOrmEntity: jest.fn(async ({ data }: { data: Record<string, unknown> }) => ({
+      id: TENANT_ID,
+      ...data,
+    })),
+    updateOrmEntity: jest.fn(async () => ({
+      id: TENANT_ID,
+      name: 'Updated Tenant',
+      isActive: true,
+    })),
+    deleteOrmEntity: jest.fn(async () => ({
+      id: TENANT_ID,
+      name: 'Deleted Tenant',
+    })),
+    setCustomFields: jest.fn(async () => {}),
+  }
+
+  const em = {
+    findOne: jest.fn(async () => ({ id: TENANT_ID, name: 'Existing Tenant' })),
+  }
+
+  return {
+    ctx: {
+      container: {
+        resolve: (token: string) => {
+          if (token === 'em') return em
+          if (token === 'dataEngine') return de
+          if (token === 'rbacService') return { loadAcl: async () => ({ isSuperAdmin }) }
+          throw new Error(`[internal] Unexpected DI token: ${token}`)
+        },
+      },
+      auth: { sub: 'user-1', tenantId: ACTOR_TENANT_ID, orgId: null, isSuperAdmin },
+    } as unknown as Parameters<CommandHandler['execute']>[1],
+    de,
+    em,
+  }
+}
+
+describe('directory.tenants commands superadmin guard', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('rejects directory.tenants.create for non-superadmin', async () => {
+    const { ctx } = makeCtx(false)
+    const handler = commandRegistry.get('directory.tenants.create') as CommandHandler
+    expect(handler).toBeDefined()
+
+    await expect(handler.execute({ name: 'New Tenant' }, ctx)).rejects.toThrow(CrudHttpError)
+  })
+
+  it('rejects directory.tenants.update prepare and execute for non-superadmin', async () => {
+    const { ctx } = makeCtx(false)
+    const handler = commandRegistry.get('directory.tenants.update') as CommandHandler
+    expect(handler).toBeDefined()
+
+    if (handler.prepare) {
+      await expect(handler.prepare({ id: TENANT_ID, name: 'Updated' }, ctx)).rejects.toThrow(CrudHttpError)
+    }
+    await expect(handler.execute({ id: TENANT_ID, name: 'Updated' }, ctx)).rejects.toThrow(CrudHttpError)
+  })
+
+  it('rejects directory.tenants.delete prepare and execute for non-superadmin', async () => {
+    const { ctx } = makeCtx(false)
+    const handler = commandRegistry.get('directory.tenants.delete') as CommandHandler
+    expect(handler).toBeDefined()
+
+    if (handler.prepare) {
+      await expect(handler.prepare({ body: { id: TENANT_ID }, query: {} }, ctx)).rejects.toThrow(CrudHttpError)
+    }
+    await expect(handler.execute({ body: { id: TENANT_ID }, query: {} }, ctx)).rejects.toThrow(CrudHttpError)
+  })
+})

--- a/packages/core/src/modules/directory/commands/tenants.ts
+++ b/packages/core/src/modules/directory/commands/tenants.ts
@@ -7,7 +7,6 @@ import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { requireSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import { E } from '#generated/entities.ids.generated'
-
 import {
   parseWithCustomFields,
   setCustomFieldsIfAny,

--- a/packages/core/src/modules/directory/commands/tenants.ts
+++ b/packages/core/src/modules/directory/commands/tenants.ts
@@ -5,7 +5,9 @@ import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
+import { requireSuperAdmin } from '@open-mercato/core/modules/auth/lib/tenantAccess'
 import { E } from '#generated/entities.ids.generated'
+
 import {
   parseWithCustomFields,
   setCustomFieldsIfAny,
@@ -48,6 +50,7 @@ type SerializedTenant = ReturnType<typeof serializeTenant>
 const createTenantCommand: CommandHandler<TenantPayload, Tenant> = {
   id: 'directory.tenants.create',
   async execute(rawInput, ctx) {
+    await requireSuperAdmin(ctx)
     const { parsed, custom } = parseWithCustomFields(tenantCreateSchema, rawInput)
     const de = (ctx.container.resolve('dataEngine') as DataEngine)
 
@@ -126,6 +129,7 @@ const createTenantCommand: CommandHandler<TenantPayload, Tenant> = {
 const updateTenantCommand: CommandHandler<TenantPayload, Tenant> = {
   id: 'directory.tenants.update',
   async prepare(rawInput, ctx) {
+    await requireSuperAdmin(ctx)
     const { parsed } = parseWithCustomFields(tenantUpdateSchema, rawInput)
     const em = (ctx.container.resolve('em') as EntityManager)
     const current = await em.findOne(Tenant, { id: parsed.id, deletedAt: null })
@@ -133,6 +137,7 @@ const updateTenantCommand: CommandHandler<TenantPayload, Tenant> = {
     return { before: serializeTenant(current) }
   },
   async execute(rawInput, ctx) {
+    await requireSuperAdmin(ctx)
     const { parsed, custom } = parseWithCustomFields(tenantUpdateSchema, rawInput)
     const de = (ctx.container.resolve('dataEngine') as DataEngine)
     const tenant = await de.updateOrmEntity({
@@ -191,12 +196,14 @@ const updateTenantCommand: CommandHandler<TenantPayload, Tenant> = {
 const deleteTenantCommand: CommandHandler<{ body: any; query: Record<string, string> }, Tenant> = {
   id: 'directory.tenants.delete',
   async prepare(input, ctx) {
+    await requireSuperAdmin(ctx)
     const id = requireId(input, 'Tenant id required')
     const em = (ctx.container.resolve('em') as EntityManager)
     const existing = await em.findOne(Tenant, { id, deletedAt: null })
     return existing ? { before: serializeTenant(existing) } : {}
   },
   async execute(rawInput, ctx) {
+    await requireSuperAdmin(ctx)
     const id = requireId(rawInput, 'Tenant id required')
     const de = (ctx.container.resolve('dataEngine') as DataEngine)
     const tenant = await de.deleteOrmEntity({


### PR DESCRIPTION
## Summary
Tenant CRUD (`api/tenants/route.ts` GET + `commands/tenants.ts`
create/update/delete) had zero code-level tenant-boundary or
super-admin enforcement — it relied entirely on the
`directory.tenants.*` ACL feature being correctly restricted to
`superadmin` in `setup.ts`. A single mis-grant (a role carrying `*`,
`directory.*`, or `directory.tenants.*`) would silently yield full
cross-tenant control of the top-level isolation boundary — reading,
renaming, deactivating, or soft-deleting any tenant, plus DEK
provisioning.

## Changes
- Added `requireSuperAdmin(ctx)` to
  `packages/core/src/modules/auth/lib/tenantAccess.ts`, wrapping the
  existing `resolveIsSuperAdmin` and throwing `CrudHttpError(403)` when
  the caller isn't a super-admin.
- Gated `GET` in `api/tenants/route.ts` on it (right after the existing
  auth check).
- Gated `create`/`update`/`delete` in `commands/tenants.ts` on it —
  including `prepare()` for update/delete, so the check runs before
  any DB read, not just before the write.
- Did **not** touch `setup.ts` (config declaring the intent, not the
  enforcement gap) or `api/get/tenants/lookup.ts` (a separate,
  intentionally unauthenticated, rate-limited endpoint used by the
  login screen — out of scope for this issue).

## BC / Safety
Per the issue's request to confirm no legitimate non-superadmin
automation depends on tenant CRUD:
- Searched the repo for calls to `directory.tenants.create/update/delete`
  outside `commands/tenants.ts` and `api/tenants/route.ts` — none found.
- Initial tenant seeding (`setup-app.ts`) creates the tenant directly
  via MikroORM (`em.create(Tenant, ...)`), bypassing the command layer
  entirely — unaffected by this change.
- Non-superadmin callers now get a `403` instead of silently succeeding
  under a mis-scoped ACL grant. This is the intended, breaking behavior
  change described in the issue.

## Testing
- 2 new test files: `api/tenants/__tests__/superadmin-guard.test.ts`
  (route GET, 403/200) and
  `commands/__tests__/tenants.superadmin-guard.test.ts` (all 3 commands,
  `prepare` + `execute`, mirroring the existing
  `organizations/tenant-scope-guard.test.ts` mocking pattern).
- Updated `api/tenants/__tests__/list-pagination.test.ts` to mock
  `isSuperAdmin: true`, since it now needs to pass the new guard to
  keep testing pagination.
- Full `directory` module suite: 26 test suites, 168/168 passing (no
  regressions in `organization-switcher`, `organizationScope`, `acl`, etc.).
- `yarn lint`: 0 errors.
- `yarn workspace @open-mercato/core typecheck`: exit code 0.

## Specification
Does a spec exist for this feature/module?
- [x] N/A (security fix following an existing, established pattern —
  `resolveIsSuperAdmin`/`enforceTenantSelection` in
  `organizations/route.ts` and `commands/organizations.ts`)

## Checklist
- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement.
- [ ] I updated documentation, locales, or generators — N/A, no user-facing copy affected.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` — not added; this is an auth-boundary fix with direct unit coverage across both the route and all three commands (including `prepare`), no new UI surface.
- [ ] I created or updated the spec in `.ai/specs/` — N/A per Specification section above.
- [ ] Priority set — leaving to maintainers to triage.
- [ ] Risk set — the original issue already carries `risk-high`; leaving to maintainers to confirm.
- [ ] QA routing set — leaving to maintainers; this is a backend auth-boundary change (no `.tsx`/rendered UI touched), but flagging `risk-high` may still warrant manual QA on the superadmin path (list/create/update/delete + DEK provisioning) per the issue's own BC/Safety note.

## Design System Compliance
N/A — backend-only fix (`.ts` route/command/auth-lib files), no UI touched.

## Linked issues
Fixes #3848