### PR TITLE
fix(payment-gateways): sanitize session API errors

### DIFF
--- a/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
+++ b/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
@@ -42,6 +42,8 @@ Prevent internal payment-session failures from leaking through the sessions API 
 
 ## Progress
 
+PR: #4898
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Safe payment-session error mapping

--- a/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
+++ b/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
@@ -45,8 +45,8 @@ Prevent internal payment-session failures from leaking through the sessions API 
 
 ### Phase 1: Safe payment-session error mapping
 
-- [ ] 1.1 Route missing-adapter failures through a typed HTTP error and sanitize unexpected 502 responses
-- [ ] 1.2 Add focused service and route regression tests
+- [x] 1.1 Route missing-adapter failures through a typed HTTP error and sanitize unexpected 502 responses — c88ca2ac9f
+- [x] 1.2 Add focused service and route regression tests — c88ca2ac9f
 
 ### Phase 2: Test robustness and validation
 

--- a/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
+++ b/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
@@ -54,4 +54,4 @@ PR: #4898
 ### Phase 2: Test robustness and validation
 
 - [x] 2.1 Expand the idempotency suite logger mock — 88cf0de486
-- [ ] 2.2 Run the configured validation and compatibility review
+- [x] 2.2 Run the configured validation and compatibility review — 00b82a66f

--- a/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
+++ b/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
@@ -38,6 +38,7 @@ Prevent internal payment-session failures from leaking through the sessions API 
 
 - Some clients may have read raw provider error text from the 502 `error` field. The field and status remain stable, but the value becomes intentionally generic to prevent internal information disclosure.
 - The typed 422 mapping must preserve the existing unsupported-provider behavior without relying on message substring matching.
+- The configured validation gate is blocked on current `develop` by 21 unrelated missing i18n keys and unrelated app/docs test fixture failures; branch-specific tests, builds, generation, typecheck, and the app production build pass.
 
 ## Progress
 
@@ -50,5 +51,5 @@ Prevent internal payment-session failures from leaking through the sessions API 
 
 ### Phase 2: Test robustness and validation
 
-- [ ] 2.1 Expand the idempotency suite logger mock
+- [x] 2.1 Expand the idempotency suite logger mock — 88cf0de486
 - [ ] 2.2 Run the configured validation and compatibility review

--- a/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
+++ b/.ai/runs/2026-08-03-payment-gateway-safe-errors.md
@@ -1,0 +1,54 @@
+# Payment Gateway Safe Error Follow-up
+
+## Overview
+
+Follow up on the non-blocking review feedback from superseded PR #4870 and merged replacement PR #4894.
+
+## Goal
+
+Prevent internal payment-session failures from leaking through the sessions API while preserving a useful 422 response for unsupported gateway providers and strengthening the affected logger test mock.
+
+## Scope
+
+- Map missing gateway adapters through the existing typed HTTP error contract.
+- Return a generic 502 response for unexpected payment-session failures.
+- Add route and service regression coverage for the safe mappings.
+- Broaden the payment-gateway idempotency test logger mock to cover the logger facade methods used by the module.
+
+## Non-goals
+
+- Change the payment-session API route, method, or response shape.
+- Change provider execution, idempotency, claim, or transaction behavior.
+- Localize all existing payment-gateway API messages.
+- Modify database, event, DI, or public import contracts.
+
+## Implementation Plan
+
+### Phase 1: Safe payment-session error mapping
+
+1. Route missing-adapter failures through `CrudHttpError` and map unexpected session errors to a generic 502 body.
+2. Add focused service and route regression tests covering the typed 422 and generic 502 behavior.
+
+### Phase 2: Test robustness and validation
+
+1. Expand the idempotency suite's logger mock with no-op `debug`, `info`, and `error` methods.
+2. Run focused module validation followed by the configured repository gate and review the final diff for compatibility and security concerns.
+
+## Risks
+
+- Some clients may have read raw provider error text from the 502 `error` field. The field and status remain stable, but the value becomes intentionally generic to prevent internal information disclosure.
+- The typed 422 mapping must preserve the existing unsupported-provider behavior without relying on message substring matching.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Safe payment-session error mapping
+
+- [ ] 1.1 Route missing-adapter failures through a typed HTTP error and sanitize unexpected 502 responses
+- [ ] 1.2 Add focused service and route regression tests
+
+### Phase 2: Test robustness and validation
+
+- [ ] 2.1 Expand the idempotency suite logger mock
+- [ ] 2.2 Run the configured validation and compatibility review

--- a/packages/core/src/modules/payment_gateways/api/__tests__/guarded-routes.test.ts
+++ b/packages/core/src/modules/payment_gateways/api/__tests__/guarded-routes.test.ts
@@ -2,7 +2,7 @@
 
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
-import { conflict } from '@open-mercato/shared/lib/crud/errors'
+import { conflict, CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import {
   runPaymentGatewayMutationGuardAfterSuccess,
   runPaymentGatewayMutationGuards,
@@ -108,6 +108,28 @@ describe('payment gateway write routes wire the mutation guard lifecycle', () =>
         error: 'Payment session amount 1 does not match the amount due for order o-1',
       })
       expect(runPaymentGatewayMutationGuardAfterSuccess).not.toHaveBeenCalled()
+    })
+
+    it('preserves a typed missing-adapter response as 422', async () => {
+      service.createPaymentSession.mockRejectedValue(
+        new CrudHttpError(422, { error: 'No gateway adapter registered for provider: missing' }),
+      )
+
+      const response = await createSession(buildRequest(body))
+
+      expect(response.status).toBe(422)
+      expect(await response.json()).toEqual({ error: 'No gateway adapter registered for provider: missing' })
+    })
+
+    it('does not expose unexpected internal errors in a 502 response', async () => {
+      service.createPaymentSession.mockRejectedValue(
+        new Error('[internal] Completed payment session is missing its gateway transaction'),
+      )
+
+      const response = await createSession(buildRequest(body))
+
+      expect(response.status).toBe(502)
+      expect(await response.json()).toEqual({ error: 'Failed to create payment session' })
     })
   })
 

--- a/packages/core/src/modules/payment_gateways/api/sessions/route.ts
+++ b/packages/core/src/modules/payment_gateways/api/sessions/route.ts
@@ -102,9 +102,7 @@ export async function POST(req: Request) {
     if (isCrudHttpError(err)) {
       return NextResponse.json(err.body, { status: err.status })
     }
-    const message = err instanceof Error ? err.message : 'Failed to create payment session'
-    const status = message.includes('No gateway adapter') ? 422 : 502
-    return NextResponse.json({ error: message }, { status })
+    return NextResponse.json({ error: 'Failed to create payment session' }, { status: 502 })
   }
 }
 

--- a/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.idempotency.test.ts
+++ b/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.idempotency.test.ts
@@ -21,7 +21,10 @@ jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
 jest.mock('@open-mercato/shared/lib/logger', () => ({
   createLogger: () => ({
     child: () => ({
+      debug: jest.fn(),
+      info: jest.fn(),
       warn: (...args: unknown[]) => mockLoggerWarn(...args),
+      error: jest.fn(),
     }),
   }),
 }))

--- a/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.idempotency.test.ts
+++ b/packages/core/src/modules/payment_gateways/lib/__tests__/gateway-service.idempotency.test.ts
@@ -176,6 +176,18 @@ describe('payment gateway service session idempotency (#4035)', () => {
     clearGatewayAdapters()
   })
 
+  it('maps a missing gateway adapter to a typed 422 error', async () => {
+    const service = createPaymentGatewayService({
+      em: makeMockEm(),
+      integrationCredentialsService: { resolve: jest.fn(async () => ({})) } as never,
+    })
+
+    await expect(service.createPaymentSession(buildInput('checkout-submit-key-0000'))).rejects.toMatchObject({
+      status: 422,
+      body: { error: `No gateway adapter registered for provider: ${PROVIDER_KEY}` },
+    })
+  })
+
   it('single-flights concurrent keyed calls and reuses the completed provider session', async () => {
     const { service, gate, firstCallStarted, createSession } = buildService()
     const input = buildInput('checkout-submit-key-0001')

--- a/packages/core/src/modules/payment_gateways/lib/gateway-service.ts
+++ b/packages/core/src/modules/payment_gateways/lib/gateway-service.ts
@@ -18,7 +18,7 @@ import {
 import type { CredentialsService } from '../../integrations/lib/credentials-service'
 import type { IntegrationStateService } from '../../integrations/lib/state-service'
 import type { IntegrationLogService } from '../../integrations/lib/log-service'
-import { conflict } from '@open-mercato/shared/lib/crud/errors'
+import { conflict, CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { GatewayPaymentOperation, GatewaySessionInitialization, GatewayTransaction } from '../data/entities'
 import { canApplyManualAction, isValidTransition, type ManualGatewayAction } from './status-machine'
 import { emitPaymentGatewayEvent } from '../events'
@@ -191,11 +191,10 @@ export function createPaymentGatewayService(deps: PaymentGatewayServiceDeps) {
       : undefined
     const adapter = getGatewayAdapter(providerKey, selectedVersion)
     if (!adapter) {
-      throw new Error(
-        selectedVersion
-          ? `No gateway adapter registered for provider: ${providerKey} (version: ${selectedVersion})`
-          : `No gateway adapter registered for provider: ${providerKey}`,
-      )
+      const message = selectedVersion
+        ? `No gateway adapter registered for provider: ${providerKey} (version: ${selectedVersion})`
+        : `No gateway adapter registered for provider: ${providerKey}`
+      throw new CrudHttpError(422, { error: message })
     }
     const credentials = await integrationCredentialsService.resolve(integrationId, scope) ?? {}
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-03-payment-gateway-safe-errors.md
Status: in-progress

## Goal
- Address the remaining non-blocking review feedback from #4870 / #4894 by preventing internal payment-session errors from reaching API clients and completing the logger test mock.

## What Changed
- map missing gateway adapters through the existing typed 422 HTTP error path instead of message substring matching
- return a generic 502 body for unexpected payment-session failures so internal invariant and provider messages are not disclosed
- add service and route regression tests for the typed 422 and sanitized 502 paths
- add no-op `debug`, `info`, and `error` methods to the idempotency suite logger mock

## Tests
- focused payment-gateway route and idempotency suites: 22/22 passed
- payment-gateway idempotency suite after logger-mock hardening: 7/7 passed
- scoped ESLint, `git diff --check`, and `yarn logger:check-console:ci` passed
- `yarn build:packages`, `yarn generate`, the required second `yarn build:packages`, `yarn i18n:check-sync`, `yarn typecheck`, and `yarn build:app` passed
- `yarn i18n:check-usage` is blocked by 21 missing keys in unrelated schedule/design-system files on current `develop`
- `yarn test` is blocked by unrelated app storage-route bootstrap failures and a missing docs search-index build artifact on current `develop`
- `yarn template:sync` passed

## Breaking Changes
- None. The payment-session route, method, response fields, and documented statuses are unchanged; unexpected 502 error text is intentionally sanitized.

## Progress
See the Progress section in the tracking plan. The implementation is complete; the run remains in progress until the current base-branch validation blockers clear.
