### PR TITLE
fix(customer_accounts): isolate invitation route tests

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-person-link.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/__tests__/users-invite-person-link.test.ts
@@ -13,6 +13,7 @@ const mockEmit = jest.fn(async () => undefined)
 const mockIsOwnedCompanyEntity = jest.fn()
 const mockIsOwnedPersonEntity = jest.fn()
 const mockResolveOwnedCompanyForPerson = jest.fn()
+const mockSendCustomerInvitationEmail = jest.fn(async () => undefined)
 
 jest.mock('@open-mercato/core/modules/customer_accounts/lib/rateLimiter', () => ({
   checkAuthRateLimit: (...args: unknown[]) => mockCheckAuthRateLimit(...args),
@@ -45,6 +46,10 @@ jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerEntityOwners
   isOwnedCompanyEntity: (...args: unknown[]) => mockIsOwnedCompanyEntity(...args),
   isOwnedPersonEntity: (...args: unknown[]) => mockIsOwnedPersonEntity(...args),
   resolveOwnedCompanyForPerson: (...args: unknown[]) => mockResolveOwnedCompanyForPerson(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/invitationEmail', () => ({
+  sendCustomerInvitationEmail: (...args: unknown[]) => mockSendCustomerInvitationEmail(...args),
 }))
 
 const tenantId = '22222222-2222-4222-8222-222222222222'


### PR DESCRIPTION
## Summary

- mock `sendCustomerInvitationEmail` in the person-link invitation route test
- keep the route test isolated from real email delivery
- restore the full customer-accounts test gate after #3598 added email delivery to the route

## Root cause

PR #3598 began invoking the invitation email sender on successful admin invitations. The existing person-link route test mocked the invitation service but not the new email side effect, so all seven success-path cases reached the real sender and returned HTTP 502 instead of the expected 201.

This follow-up changes test setup only; production behavior is unchanged.

## Validation

- `yarn workspace @open-mercato/core test --runInBand`: 1,163 suites, 8,981 tests passed
- six focused invitation/acceptance suites: 43 tests passed
- `yarn typecheck`: 21 tasks passed
- `yarn test`: the changed core package passed, but the monorepo run stopped on five unrelated failures in `apps/mercato/src/__tests__/storage-s3-routes.test.ts`; that suite independently reproduces on current `develop` because the global module registry is not initialized

Follow-up to #3598.