### PR TITLE
fix(crud): pass request query to DELETE before-interceptors

### DIFF
--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -991,6 +991,85 @@ describe('CRUD Factory', () => {
     const body = await res.json()
     expect(body._interceptor).toEqual({ ok: true, count: 1 })
   })
+
+  // The command DELETE path used to hand before-interceptors the body only, so a
+  // guard reading `?id=` saw nothing to object to and the delete went through
+  // with a 200 (issue #4842).
+  it('DELETE command route passes the query id to interceptor before hooks', async () => {
+    const lockedId = '123e4567-e89b-12d3-a456-426614174010'
+    const seenQueries: Array<Record<string, unknown> | undefined> = []
+    registerApiInterceptors([
+      {
+        moduleId: 'example',
+        interceptors: [
+          {
+            id: 'example.block-locked-delete',
+            targetRoute: 'example/todos/command',
+            methods: ['DELETE'],
+            async before(request) {
+              seenQueries.push(request.query)
+              const queryId = request.query?.id
+              if (typeof queryId === 'string' && queryId === lockedId) {
+                return { ok: false, statusCode: 409, message: 'Record is locked' }
+              }
+              return { ok: true }
+            },
+          },
+        ],
+      },
+    ])
+    const commandRoute = makeCrudRoute({
+      metadata: { DELETE: { requireAuth: true } },
+      orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+      indexer: { entityType: 'example.todo' },
+      actions: {
+        delete: {
+          commandId: 'example.todo.delete',
+          schema: z.any(),
+          response: () => ({ ok: true }),
+        },
+      },
+    })
+
+    const res = await commandRoute.DELETE(new Request(`http://x/api/example/todos/command?id=${lockedId}`, {
+      method: 'DELETE',
+      body: JSON.stringify({}),
+      headers: { 'content-type': 'application/json' },
+    }))
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toMatchObject({ error: 'Record is locked' })
+    expect(seenQueries).toEqual([{ id: lockedId }])
+    expect(commandBus.execute).not.toHaveBeenCalled()
+  })
+
+  it('DELETE route passes the whole query string to interceptor before hooks', async () => {
+    const created = em.create(Todo, { title: 'Z', organizationId: defaultOrganizationId, tenantId: defaultTenantId }) as Rec
+    created.id = '123e4567-e89b-12d3-a456-426614174011'
+    await em.persist(created).flush()
+    let seenQuery: Record<string, unknown> | undefined
+    registerApiInterceptors([
+      {
+        moduleId: 'example',
+        interceptors: [
+          {
+            id: 'example.capture-delete-query',
+            targetRoute: 'example/todos',
+            methods: ['DELETE'],
+            async before(request) {
+              seenQuery = request.query
+              return { ok: true }
+            },
+          },
+        ],
+      },
+    ])
+
+    const res = await route.DELETE(new Request(`http://x/api/example/todos?id=${created.id}&reason=cleanup`, { method: 'DELETE' }))
+
+    expect(res.status).toBe(200)
+    expect(seenQuery).toEqual({ id: created.id, reason: 'cleanup' })
+  })
 })
 
 describe('CRUD Factory — optimistic-lock auto-registration', () => {

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -2775,6 +2775,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
           request,
           method: 'DELETE',
           body: interceptorInput,
+          query: raw.query,
         })
         if (beforeInterceptors.errorResponse) return beforeInterceptors.errorResponse
         interceptorRequestPayload = beforeInterceptors.requestPayload
@@ -2899,7 +2900,7 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
         request,
         method: 'DELETE',
         body: idFrom === 'query' ? undefined : ({ id } as Record<string, unknown>),
-        query: idFrom === 'query' ? ({ id } as Record<string, unknown>) : undefined,
+        query: idFrom === 'query' ? Object.fromEntries(url.searchParams.entries()) : undefined,
       })
       if (beforeInterceptors.errorResponse) return beforeInterceptors.errorResponse
       interceptorRequestPayload = beforeInterceptors.requestPayload


### PR DESCRIPTION
Fixes #4842

`makeCrudRoute` has two delete paths, and neither gave before-interceptors the request's query string:

- The **command path** (routes declaring `actions.delete`) called `applyInterceptorsBefore` with the parsed **body only**, while the UI sends the record id as `?id=`. An interceptor that guards deletions by loading the record by id therefore received no id, found nothing to object to, and returned "allow" — the delete went through with a 200.
- The **plain path** passed a synthetic `{ id }` object instead of the actual query parameters, so any other query param an interceptor relied on was invisible.

Any deployment using before-interceptors as an authorisation or integrity gate on delete had the same hole: `PUT` and bulk `POST` were correctly rejected with 409 while `DELETE ?id=…` silently succeeded.

## Included work
- Command delete path forwards the parsed query (`raw.query`) to `applyInterceptorsBefore`
- Plain delete path forwards the real query parameters (`Object.fromEntries(url.searchParams.entries())`) instead of a synthetic `{ id }`
- Two regression tests in `packages/shared/src/lib/crud/__tests__/crud-factory.test.ts`: a command-path interceptor that blocks a locked record now returns 409 and never reaches the command bus, and the plain path receives the whole query string (`{ id, reason }`)

The change is strictly additive with respect to the interceptor contract — an interceptor that already read `query.id` on the plain path keeps receiving it, and the command path gains a `query` it previously never got. No API route, response shape, or database structure changes.

Both tests were confirmed to fail without the fix and pass with it.

## Validation
Run locally (Node 24), full gate from `.ai/agentic.config.json`:

- `yarn build:packages`: passed (both stages, 21/21 tasks)
- `yarn generate`: passed
- `yarn i18n:check-sync`: passed
- `yarn i18n:check-usage`: 21 missing keys reported — all pre-existing in `ScheduleToolbar.tsx` and `design_system/gallery/entries/*.tsx`, untouched by this PR (this branch changes exactly two files)
- `yarn typecheck`: passed (21/21)
- `yarn test`: `@open-mercato/shared` 1723/1723 passed, including the new regression tests. Remaining failures are pre-existing and were reproduced identically on a clean tree with this diff stashed: `@open-mercato/app` storage_s3 routes (5, test-harness bootstrap "Modules not registered"), `@open-mercato/core` (15, locale-dependent currency/KPI formatting + invite link), `@open-mercato/ui` `formatCurrency` (1, locale-dependent), `@open-mercato/cli` `dev-env-reload` (1, `fs.watch` timing), `create-mercato-app` (live-Claude harness tests requiring network)
- `yarn build:app`: passed

Required CI is the authoritative environment check.
