### PR TITLE
fix(workflows): abort synchronous activities when their timeout elapses

### DIFF
--- a/.ai/runs/2026-08-02-workflow-timeout-abort.md
+++ b/.ai/runs/2026-08-02-workflow-timeout-abort.md
@@ -42,10 +42,12 @@ makes that PR conflict.
 - [x] Add a regression test proving a synchronous webhook receives an aborted signal
       when its timeout elapses
 - [x] Run the validation gate
-- [ ] Open the replacement PR superseding #4502 with credit to the original authors
+- [x] Open the replacement PR superseding #4502 with credit to the original authors
 
 ## Progress
 
+- **2026-08-03** — Rebuilt the carry-forward on the latest `develop`, applied the
+  structured-logging CI autofix, and opened replacement PR #4918 superseding #4854.
 - **2026-08-02** — Isolated the residual delta, applied the abort wiring on top of
   `develop`, kept the single regression test from #4502 and dropped the tests that
   cover behavior `develop` already ships.

--- a/.ai/runs/2026-08-02-workflow-timeout-abort.md
+++ b/.ai/runs/2026-08-02-workflow-timeout-abort.md
@@ -1,0 +1,51 @@
+# Abort synchronous workflow activities when their timeout wins
+
+Carry-forward of the one behavior left over from #4502 (itself a carry-forward of
+#4495) after #4460 landed the rest of the #4424 timeout fix on `develop`.
+
+## Context
+
+`#4424` reported that per-activity timeouts were unreachable: the editor wrote
+`timeoutMs`, the definition schema accepted only `timeout`, and the executor read
+`timeoutMs`. Two independent carry-forward PRs fixed it:
+
+- **#4460 — merged 2026-07-30.** Landed the schema/editor/executor alignment plus
+  `resolveActivityTimeoutMs()`, which normalizes the deprecated `timeout` string.
+  Issue #4424 was closed by it.
+- **#4502 — still open, conflicting.** Carries the same fix a second time, so it now
+  conflicts with `develop` on `validators.ts`, `TransitionsEditor.tsx` and
+  `activity-executor.ts`. Its head branch lives in the upstream repository, which
+  this account cannot push to, so the conflicts cannot be resolved in place.
+
+Exactly one behavior in #4502 is **not** on `develop`: when an activity timeout wins
+the `Promise.race` in `executeWithTimeout()`, the in-flight HTTP request is left
+running. `executeCallApi()` and `executeCallWebhook()` already accept an
+`AbortSignal` and forward it to `fetch`, but nothing ever creates or passes one — so
+a timed-out `CALL_API` / `CALL_WEBHOOK` keeps its request alive while the retry loop
+issues the next attempt, and the remote endpoint can observe the same side effect
+several times.
+
+## Scope
+
+Wire the missing signal and nothing else. The duplicate `timeoutMs` plumbing from
+#4502 is deliberately dropped — `develop` already has it, and re-landing it is what
+makes that PR conflict.
+
+## Tasks
+
+- [x] Confirm `#4460` merged and `#4424` closed, and diff `#4502` against `develop`
+      to isolate the residual behavior
+- [x] Create an `AbortController` in `executeWithTimeout()` and abort it in the
+      timeout callback
+- [x] Thread the signal through `executeActivityByType()` into `executeCallApi()`
+      and `executeCallWebhook()`
+- [x] Add a regression test proving a synchronous webhook receives an aborted signal
+      when its timeout elapses
+- [x] Run the validation gate
+- [ ] Open the replacement PR superseding #4502 with credit to the original authors
+
+## Progress
+
+- **2026-08-02** — Isolated the residual delta, applied the abort wiring on top of
+  `develop`, kept the single regression test from #4502 and dropped the tests that
+  cover behavior `develop` already ships.

--- a/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users-invite.ts
@@ -16,6 +16,9 @@ import {
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
 import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 import { sendCustomerInvitationEmail } from '@open-mercato/core/modules/customer_accounts/lib/invitationEmail'
+import { createLogger } from '@open-mercato/shared/lib/logger'
+
+const logger = createLogger('customer_accounts').child({ component: 'admin-users-invite' })
 
 export const metadata = {}
 
@@ -121,11 +124,11 @@ export async function POST(req: Request) {
       rawToken,
     })
   } catch (error) {
-    console.error('[customer_accounts.admin.users-invite] invitation email failed', error)
+    logger.error('Invitation email failed', { err: error })
     try {
       await customerInvitationService.rollbackInvitation(invitation, rollbackState)
     } catch (rollbackError) {
-      console.error('[customer_accounts.admin.users-invite] invitation rollback failed', rollbackError)
+      logger.error('Invitation rollback failed', { err: rollbackError })
     }
     return NextResponse.json({ ok: false, error: 'Invitation email could not be sent' }, { status: 502 })
   }

--- a/packages/core/src/modules/customer_accounts/api/portal/users-invite.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/users-invite.ts
@@ -17,6 +17,9 @@ import {
 } from '@open-mercato/core/modules/customer_accounts/lib/rateLimiter'
 import { readNormalizedEmailFromJsonRequest } from '@open-mercato/core/modules/customer_accounts/lib/rateLimitIdentifier'
 import { sendCustomerInvitationEmail } from '@open-mercato/core/modules/customer_accounts/lib/invitationEmail'
+import { createLogger } from '@open-mercato/shared/lib/logger'
+
+const logger = createLogger('customer_accounts').child({ component: 'portal-users-invite' })
 
 export const metadata: { path?: string; requireAuth?: boolean } = { requireAuth: false }
 
@@ -110,11 +113,11 @@ export async function POST(req: Request) {
       rawToken,
     })
   } catch (error) {
-    console.error('[customer_accounts.portal.users-invite] invitation email failed', error)
+    logger.error('Invitation email failed', { err: error })
     try {
       await customerInvitationService.rollbackInvitation(invitation, rollbackState)
     } catch (rollbackError) {
-      console.error('[customer_accounts.portal.users-invite] invitation rollback failed', rollbackError)
+      logger.error('Invitation rollback failed', { err: rollbackError })
     }
     return NextResponse.json({ ok: false, error: 'Invitation email could not be sent' }, { status: 502 })
   }

--- a/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
@@ -1597,6 +1597,52 @@ describe('Activity Executor (Unit Tests)', () => {
       expect(result.success).toBe(false)
       expect(result.error).toContain('timeout after 50ms')
     })
+
+    test('should abort an in-flight synchronous webhook when its timeout elapses', async () => {
+      const originalAllowPrivate = process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+      process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = 'true'
+      let capturedSignal: AbortSignal | undefined
+
+      ;(global.fetch as jest.Mock).mockImplementation(
+        (_url: string, init?: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            capturedSignal = init?.signal ?? undefined
+            capturedSignal?.addEventListener('abort', () => {
+              reject(new DOMException('The operation was aborted', 'AbortError'))
+            })
+          })
+      )
+
+      const activity: ActivityDefinition = {
+        activityId: 'activity-timeout-webhook',
+        activityName: 'Slow webhook',
+        activityType: 'CALL_WEBHOOK',
+        config: {
+          url: 'http://127.0.0.1/webhook',
+          method: 'POST',
+        },
+        timeoutMs: 10,
+      }
+
+      try {
+        const result = await activityExecutor.executeActivity(
+          mockEm,
+          mockContainer,
+          activity,
+          mockContext
+        )
+
+        expect(result.success).toBe(false)
+        expect(result.error).toContain('timeout after 10ms')
+        expect(capturedSignal?.aborted).toBe(true)
+      } finally {
+        if (originalAllowPrivate === undefined) {
+          delete process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS
+        } else {
+          process.env.OM_WORKFLOWS_ALLOW_PRIVATE_URLS = originalAllowPrivate
+        }
+      }
+    })
   })
 
   // ============================================================================

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -371,7 +371,7 @@ export async function executeActivity(
       const timeoutMs = resolveActivityTimeoutMs(activity)
       const result = timeoutMs
         ? await executeWithTimeout(
-            () => executeActivityByType(em, container, activity, context),
+            (signal) => executeActivityByType(em, container, activity, context, signal),
             timeoutMs
           )
         : await executeActivityByType(em, container, activity, context)
@@ -511,7 +511,8 @@ async function executeActivityByType(
   em: EntityManager,
   container: AwilixContainer,
   activity: ActivityDefinition,
-  context: ActivityContext
+  context: ActivityContext,
+  signal?: AbortSignal
 ): Promise<any> {
   // Interpolate config variables from context (including workflow metadata)
   const interpolatedConfig = interpolateVariables(activity.config, context.workflowContext, context.workflowInstance)
@@ -521,7 +522,7 @@ async function executeActivityByType(
       return await executeSendEmail(interpolatedConfig, context, container)
 
     case 'CALL_API':
-      return await executeCallApi(em, interpolatedConfig, context, container)
+      return await executeCallApi(em, interpolatedConfig, context, container, signal)
 
     case 'EMIT_EVENT':
       return await executeEmitEvent(interpolatedConfig, context, container)
@@ -530,7 +531,7 @@ async function executeActivityByType(
       return await executeUpdateEntity(em, interpolatedConfig, context, container)
 
     case 'CALL_WEBHOOK':
-      return await executeCallWebhook(interpolatedConfig, context)
+      return await executeCallWebhook(interpolatedConfig, context, { signal })
 
     case 'EXECUTE_FUNCTION':
       return await executeFunction(interpolatedConfig, context, container)
@@ -1456,19 +1457,21 @@ function sleep(ms: number): Promise<void> {
  * Execute a promise with timeout
  */
 async function executeWithTimeout<T>(
-  executor: () => Promise<T>,
+  executor: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number
 ): Promise<T> {
   let timeoutId: NodeJS.Timeout
+  const abortController = new AbortController()
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutId = setTimeout(() => {
+      abortController.abort()
       reject(new Error(`Activity execution timeout after ${timeoutMs}ms`))
     }, timeoutMs)
   })
 
   try {
-    return await Promise.race([executor(), timeoutPromise])
+    return await Promise.race([executor(abortController.signal), timeoutPromise])
   } finally {
     clearTimeout(timeoutId!)
   }


### PR DESCRIPTION
Supersedes #4854 (which supersedes #4502)

Credit: original implementation by @wojciechszyjka, carrying forward the workflow timeout-abort fix co-authored with @pkarw. This replacement preserves that work on the latest `develop` and includes the requested autofix so CI can run cleanly.

## Included work

- Original workflow timeout cancellation changes from #4854
- Original regression test proving a timed-out synchronous webhook receives an aborted signal
- Autofix for the current `logger:check-console:ci` failure: migrate the admin and portal invitation error paths to `createLogger`
- Clean branch rebuilt directly on the latest `develop`

## Validation

Runner: local (no compose `app` container running).

- `yarn workspace @open-mercato/app generate` — pass
- `yarn workspace @open-mercato/core build` — pass
- `yarn workspace @open-mercato/core typecheck` — pass
- Focused core tests (workflow executor, CALL_API, admin/portal invitation routes) — 139/139 pass
- `yarn logger:check-console:ci` — pass
- Changed-file ESLint — pass
- `yarn template:sync` — pass
- `git diff --check origin/develop...HEAD` — pass

## Re-review

The combined diff was re-reviewed after autofix against correctness, security, tenant scoping, test coverage, and `BACKWARD_COMPATIBILITY.md`. No blocker, major, medium, or low findings remain. This carry-forward is intended to be merge-ready once GitHub checks and independent review pass.
