### PR TITLE
DS: quiet destructive by default, status solid role, token parity gate

### DIFF
--- a/.ai/ds-rules.md
+++ b/.ai/ds-rules.md
@@ -12,7 +12,8 @@ Decision tree — ask "what color do I need?":
 | Question | Answer | Token |
 |----------|--------|-------|
 | Is it a status indicator (error/success/warning/info/neutral)? | Yes → | `{property}-status-{status}-{role}` (e.g. `text-status-error-text`, `bg-status-success-bg`, `border-status-warning-border`) |
-| Is it a destructive action button? | Yes → | `text-destructive`, `bg-destructive` |
+| Is it a destructive action (delete/remove/discard trigger or its icon)? | Yes → | `text-destructive`, `bg-destructive` — NOT for error copy, see the row above |
+| Is it the confirm button inside a confirmation dialog? | Yes → | `Button variant="destructive-solid"` (the only filled-red control) |
 | Is it primary text? | Yes → | `text-foreground` |
 | Is it secondary/placeholder text? | Yes → | `text-muted-foreground` |
 | Is it a primary action (button, link)? | Yes → | `bg-primary`, `text-primary-foreground` |

--- a/.ai/ds/ds-tokens.json
+++ b/.ai/ds/ds-tokens.json
@@ -35,10 +35,10 @@
     "accent-indigo": {
       "kind": "color",
       "light": "#6366f1",
-      "dark": "#818cf8",
+      "dark": "#6d74f4",
       "hex": {
         "light": "#6366f1",
-        "dark": "#818cf8"
+        "dark": "#6d74f4"
       },
       "themeInvariant": false,
       "themeAlias": "color-accent-indigo",
@@ -662,10 +662,10 @@
     },
     "muted-foreground": {
       "kind": "color",
-      "light": "oklch(0.556 0 0)",
+      "light": "oklch(0.545 0 0)",
       "dark": "oklch(0.708 0 0)",
       "hex": {
-        "light": "#737373",
+        "light": "#707070",
         "dark": "#a1a1a1"
       },
       "themeInvariant": false,
@@ -673,7 +673,8 @@
       "figma": {
         "name": "muted-foreground",
         "type": "COLOR"
-      }
+      },
+      "note": "darkened from 0.556: 4.54:1 on --muted (AA), was 4.34"
     },
     "popover": {
       "kind": "color",
@@ -1067,6 +1068,37 @@
       },
       "note": "red-600 #dc2626 = --destructive"
     },
+    "status-error-solid": {
+      "kind": "color",
+      "light": "oklch(0.577 0.245 27.325)",
+      "dark": "oklch(0.577 0.245 27.325)",
+      "hex": {
+        "light": "#e7000b",
+        "dark": "#e7000b"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-error-solid",
+      "figma": {
+        "name": "status-error-solid",
+        "type": "COLOR"
+      },
+      "note": "red-600 #dc2626, on white 4.83"
+    },
+    "status-error-solid-foreground": {
+      "kind": "color",
+      "light": "#ffffff",
+      "dark": "#ffffff",
+      "hex": {
+        "light": "#ffffff",
+        "dark": "#ffffff"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-error-solid-foreground",
+      "figma": {
+        "name": "status-error-solid-foreground",
+        "type": "COLOR"
+      }
+    },
     "status-error-text": {
       "kind": "color",
       "light": "oklch(0.396 0.141 25.723)",
@@ -1130,6 +1162,37 @@
         "type": "COLOR"
       },
       "note": "indigo-600 #4f46e5 = --chart-indigo"
+    },
+    "status-info-solid": {
+      "kind": "color",
+      "light": "oklch(0.511 0.262 276.966)",
+      "dark": "oklch(0.511 0.262 276.966)",
+      "hex": {
+        "light": "#4f39f6",
+        "dark": "#4f39f6"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-info-solid",
+      "figma": {
+        "name": "status-info-solid",
+        "type": "COLOR"
+      },
+      "note": "indigo-600 #4f46e5, on white 6.29"
+    },
+    "status-info-solid-foreground": {
+      "kind": "color",
+      "light": "#ffffff",
+      "dark": "#ffffff",
+      "hex": {
+        "light": "#ffffff",
+        "dark": "#ffffff"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-info-solid-foreground",
+      "figma": {
+        "name": "status-info-solid-foreground",
+        "type": "COLOR"
+      }
     },
     "status-info-text": {
       "kind": "color",
@@ -1195,6 +1258,37 @@
       },
       "note": "neutral-500 #737373 (≈ Figma #7b7b7b)"
     },
+    "status-neutral-solid": {
+      "kind": "color",
+      "light": "oklch(0.439 0 0)",
+      "dark": "oklch(0.439 0 0)",
+      "hex": {
+        "light": "#525252",
+        "dark": "#525252"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-neutral-solid",
+      "figma": {
+        "name": "status-neutral-solid",
+        "type": "COLOR"
+      },
+      "note": "neutral-600 #525252, on white 7.81"
+    },
+    "status-neutral-solid-foreground": {
+      "kind": "color",
+      "light": "#ffffff",
+      "dark": "#ffffff",
+      "hex": {
+        "light": "#ffffff",
+        "dark": "#ffffff"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-neutral-solid-foreground",
+      "figma": {
+        "name": "status-neutral-solid-foreground",
+        "type": "COLOR"
+      }
+    },
     "status-neutral-text": {
       "kind": "color",
       "light": "oklch(0.371 0 0)",
@@ -1258,6 +1352,37 @@
         "type": "COLOR"
       },
       "note": "pink-500 #EC4899"
+    },
+    "status-pink-solid": {
+      "kind": "color",
+      "light": "oklch(0.388 0.180 340)",
+      "dark": "oklch(0.388 0.180 340)",
+      "hex": {
+        "light": "#7b0062",
+        "dark": "#7b0062"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-pink-solid",
+      "figma": {
+        "name": "status-pink-solid",
+        "type": "COLOR"
+      },
+      "note": "pink-700 #be185d, on white 6.04"
+    },
+    "status-pink-solid-foreground": {
+      "kind": "color",
+      "light": "#ffffff",
+      "dark": "#ffffff",
+      "hex": {
+        "light": "#ffffff",
+        "dark": "#ffffff"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-pink-solid-foreground",
+      "figma": {
+        "name": "status-pink-solid-foreground",
+        "type": "COLOR"
+      }
     },
     "status-pink-text": {
       "kind": "color",
@@ -1323,6 +1448,37 @@
       },
       "note": "green-600 #16a34a"
     },
+    "status-success-solid": {
+      "kind": "color",
+      "light": "oklch(0.527 0.154 150.069)",
+      "dark": "oklch(0.527 0.154 150.069)",
+      "hex": {
+        "light": "#008236",
+        "dark": "#008236"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-success-solid",
+      "figma": {
+        "name": "status-success-solid",
+        "type": "COLOR"
+      },
+      "note": "green-700 #15803d, on white 5.02"
+    },
+    "status-success-solid-foreground": {
+      "kind": "color",
+      "light": "#ffffff",
+      "dark": "#ffffff",
+      "hex": {
+        "light": "#ffffff",
+        "dark": "#ffffff"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-success-solid-foreground",
+      "figma": {
+        "name": "status-success-solid-foreground",
+        "type": "COLOR"
+      }
+    },
     "status-success-text": {
       "kind": "color",
       "light": "oklch(0.393 0.095 152.535)",
@@ -1386,6 +1542,37 @@
         "type": "COLOR"
       },
       "note": "amber-600 #d97706"
+    },
+    "status-warning-solid": {
+      "kind": "color",
+      "light": "oklch(0.555 0.163 48.998)",
+      "dark": "oklch(0.555 0.163 48.998)",
+      "hex": {
+        "light": "#bb4d00",
+        "dark": "#bb4d00"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-warning-solid",
+      "figma": {
+        "name": "status-warning-solid",
+        "type": "COLOR"
+      },
+      "note": "amber-700 #b45309, on white 5.02"
+    },
+    "status-warning-solid-foreground": {
+      "kind": "color",
+      "light": "#ffffff",
+      "dark": "#ffffff",
+      "hex": {
+        "light": "#ffffff",
+        "dark": "#ffffff"
+      },
+      "themeInvariant": true,
+      "themeAlias": "color-status-warning-solid-foreground",
+      "figma": {
+        "name": "status-warning-solid-foreground",
+        "type": "COLOR"
+      }
     },
     "status-warning-text": {
       "kind": "color",

--- a/.ai/scripts/ds-health-check.sh
+++ b/.ai/scripts/ds-health-check.sh
@@ -158,6 +158,17 @@ report "--- Semantic Token Adoption ---"
 ST=$(count_matches 'status-error-|status-success-|status-warning-|status-info-|status-neutral-|status-pink-')
 report "  Semantic token usages: $ST"
 
+# Destructive loudness policy: solid red belongs only to confirm dialogs.
+SOLID=$(count_matches 'variant="destructive-solid"')
+report "  destructive-solid usages: $SOLID (each must be a confirm-dialog final button)"
+
+# Token parity + contrast gate (scripts/check-token-parity.mjs).
+if node scripts/check-token-parity.mjs > /dev/null 2>&1; then
+  report "  Token parity/contrast (yarn check:tokens): PASS"
+else
+  report "  Token parity/contrast (yarn check:tokens): FAIL — run yarn check:tokens for details"
+fi
+
 report ""
 report "--- Token Snapshot Drift ---"
 TD=$(node scripts/ds-tokens-export.mjs --check --count 2>/dev/null || echo "unavailable")

--- a/.ai/skills/om-ds-guardian/references/component-guide.md
+++ b/.ai/skills/om-ds-guardian/references/component-guide.md
@@ -7,6 +7,7 @@
 | Show an error/success/warning message inline | `<Alert status="error\|success\|warning\|information\|feature" style="light\|lighter\|stroke\|filled">` | `@open-mercato/ui/primitives/alert` |
 | Show a toast notification | `flash('message', 'success\|error\|warning\|info')` | `@open-mercato/ui/backend/FlashMessages` |
 | Confirm a destructive action | `useConfirmDialog()` | `@open-mercato/ui/backend/confirm-dialog` |
+| Delete/remove button anywhere | `<Button variant="destructive">` (quiet: red text + border, white surface) | `@open-mercato/ui/primitives/button` |
 | Display entity status (active, draft, etc.) | `<StatusBadge variant={statusMap[status]} dot>` | `@open-mercato/ui/primitives/status-badge` |
 | Wrap a form field with label + error | `<FormField label="..." error={...}>` | `@open-mercato/ui/primitives/form-field` |
 | Build a section header with count + action | `<SectionHeader title="..." count={n} action={...}>` | `@open-mercato/ui/backend/SectionHeader` |
@@ -431,3 +432,19 @@ Specialized button primitives.
 | Label | `text-sm font-medium` | Form labels |
 | Overline | `text-overline font-semibold uppercase tracking-wider` | Section labels, category tags |
 | Code | `text-sm font-mono` | Code snippets |
+
+
+## Destructive buttons — loudness policy
+
+- `variant="destructive"` is the DS **Error/Stroke** style (quiet): red text
+  and full `--destructive` border on the page surface, `hover:bg-destructive/10`.
+  Use it for EVERY delete/remove/discard action in toolbars, forms, tables and
+  dialog bodies.
+- `variant="destructive-solid"` (filled red) is reserved for the single
+  point-of-no-return confirmation button inside a confirm dialog
+  (`useConfirmDialog()` renders it automatically). Never use it for the button
+  that OPENS the confirmation, and never place two solid buttons in one footer.
+- In dialog/drawer footers the destructive action sits at the LEFT edge,
+  Cancel + primary at the right — distance is part of the safety.
+- Never hand-roll the quiet look with palette classes
+  (`text-red-600 border-red-200 hover:bg-red-50`) — that is what the variant is for.

--- a/.ai/skills/om-ds-guardian/references/token-mapping.md
+++ b/.ai/skills/om-ds-guardian/references/token-mapping.md
@@ -13,11 +13,12 @@ Lookup reference for DS Guardian. No prose — just tables.
 | `text-red-500` | `text-status-error-icon` | Regex 1:1 |
 | `bg-red-50` | `bg-status-error-bg` | Regex 1:1 |
 | `bg-red-100` | `bg-status-error-bg` | Regex 1:1 |
-| `bg-red-600` | `bg-destructive` | Manual — solid button bg |
+| `bg-red-600` | `bg-status-error-solid` (chips/dots) or `Button variant="destructive-solid"` (confirm only) | Manual — see Destructive loudness policy in component-guide.md |
 | `border-red-200` | `border-status-error-border` | Regex 1:1 |
 | `border-red-300` | `border-status-error-border` | Regex 1:1 |
 | `border-red-500` | `border-status-error-border` | Regex 1:1 |
 | `text-destructive` | Keep | Already a token |
+| `bg-emerald-500` / solid status fills | `bg-status-{x}-solid` + `text-status-{x}-solid-foreground` | New solid role — all pairs hold WCAG AA |
 
 ## Color Mapping: Success (green + emerald)
 

--- a/.ai/specs/2026-08-01-destructive-button-loudness-policy.md
+++ b/.ai/specs/2026-08-01-destructive-button-loudness-policy.md
@@ -1,0 +1,183 @@
+# Destructive Button Loudness Policy (`destructive` quiet, `destructive-solid` for the point of no return)
+
+> Status: **IMPLEMENTED — shipped with PR [#4652](https://github.com/open-mercato/open-mercato/pull/4652)**
+> Refs: issue [open-mercato/open-mercato#4651](https://github.com/open-mercato/open-mercato/issues/4651)
+> Related: [`.ai/ds-rules.md`](../ds-rules.md) · [`.ai/ui-components.md`](../ui-components.md) · [`.ai/skills/om-ds-guardian/references/component-guide.md`](../skills/om-ds-guardian/references/component-guide.md)
+
+## TLDR
+
+`Button variant="destructive"` changes from a **filled red** button to the DS Error/Stroke style: red
+text and a full `--destructive` border on the page surface. The filled form survives as a new,
+additive variant `destructive-solid`, and is reserved for the single point-of-no-return confirmation
+inside a dialog.
+
+This is a **visual behavior change to a public UI primitive**: every existing `variant="destructive"`
+call site — inside this repo and in third-party modules — renders differently after upgrading, with no
+code change on their side. No exported symbol, prop, or type is removed or narrowed, so the change is
+source- and type-compatible; it is the rendered pixels that move.
+
+Alongside the variant split, the status-token contract is tightened: `text-destructive` is an **action**
+token (delete/remove/discard controls and their icons) and MUST NOT be used for validation, failure, or
+other status copy, which takes `text-status-error-text`.
+
+## Overview
+
+Scope is one cva variant map plus the call sites that need the new loud variant, and the documentation
+that tells authors which is which:
+
+- `packages/ui/src/primitives/button.tsx` — `destructive` becomes quiet; `destructive-solid` is added;
+  `dark:` overrides are removed from the destructive family.
+- `packages/ui/src/backend/confirm-dialog/ConfirmDialog.tsx` — maps `variant="destructive"` to
+  `destructive-solid` for the confirm button.
+- Six point-of-no-return confirmations across `core`, `search`, and `wms` opt into `destructive-solid`.
+- 49 status/validation call sites move from `text-destructive` to `text-status-error-text`.
+- `.ai/ds-rules.md`, `.ai/ui-components.md`, and the DS Guardian component guide record the policy.
+- `scripts/check-token-parity.mjs` gains a `--root` flag and a CI-executed test.
+
+Out of scope: `IconButton`'s destructive variant (still solid — icon-only controls have no text to carry
+the quiet treatment), Alert/Badge status variants, and any change to the `--destructive` token value
+itself.
+
+## Problem Statement
+
+Red is an attention budget, and the codebase was spending all of it. Over 70 call sites rendered a
+solid red `Button variant="destructive"`: row actions, toolbar buttons, form-header Delete, edit-dialog
+footers, and — indistinguishable from all of those — the actual confirmation button that commits an
+irreversible delete.
+
+Two consequences:
+
+1. **Red stops meaning "stop".** When every list row carries a solid red button that merely opens a
+   confirmation, users learn that red is safe to click. The one control where red must genuinely
+   interrupt — the final confirm — has no way to stand out.
+2. **No vocabulary for the difference.** There was no variant that said "this is the irreversible one",
+   so authors reached for `className` overrides (`text-destructive border-red-200 hover:bg-red-50`) and
+   hand-rolled the quiet treatment ad hoc, drifting away from the tokens.
+
+## Proposed Solution
+
+| Control | Variant | Rationale |
+|---|---|---|
+| Delete / Remove / Discard **trigger** — row action, toolbar, form header, edit-dialog footer | `destructive` (quiet) | Opening a confirmation is reversible; Escape gets you out. |
+| The **confirm** button inside a confirmation dialog | `destructive-solid` (filled) | The single point of no return on the screen. |
+| Inline destructive chip | `destructive-soft` | Unchanged. |
+| Low-emphasis destructive menu item | `destructive-ghost` | Unchanged. |
+
+`ConfirmDialog` with `variant="destructive"` resolves its confirm button to `destructive-solid`
+internally, so the common path needs no per-call-site knowledge — a module author calling
+`useConfirmDialog()` gets the correct loudness for free.
+
+`destructive-outline` remains in the variant map as an alias of the quiet treatment for call sites that
+predate the policy. New code uses `destructive`.
+
+### Status vs action tokens
+
+`.ai/ds-rules.md` already routes status indicators to `{property}-status-{status}-{role}`. The policy
+makes the boundary explicit and enforceable:
+
+- **Action** — `text-destructive`, `bg-destructive`: the label and icon of a control that deletes,
+  removes, or discards something.
+- **Status** — `text-status-error-text`: validation messages, load failures, withdrawn/overdue/error
+  copy, required-field markers, and error cells in tables.
+
+Using the action token for status copy reads as "click here to delete something" on text that is not
+clickable at all.
+
+## Architecture
+
+Single change point: the `buttonVariants` cva map in
+[`packages/ui/src/primitives/button.tsx`](../../packages/ui/src/primitives/button.tsx). Because every
+consumer resolves its classes through that map, the ~70 quiet call sites are calmed with no per-file
+edit; only the point-of-no-return confirmations needed an explicit opt-in to `destructive-solid`.
+
+`dark:` overrides were dropped from the whole destructive family. `--destructive` already resolves per
+theme, so a `dark:hover:bg-destructive/15` next to a light `hover:bg-destructive/10` was a hardcoded
+theme divergence on a token that adapts on its own. The `aria-invalid:ring-destructive` /
+`dark:aria-invalid:ring-destructive` pair is retained on `destructive` and `destructive-solid`: it is
+not a colour override but an opacity normalisation against the base cva's `ring-destructive/20` and
+`dark:ring-destructive/40`, so the invalid ring reaches full strength in both themes.
+
+### Enforcement
+
+| Guard | What it protects |
+|---|---|
+| `packages/ui/src/primitives/__tests__/button.test.tsx` | `destructive` stays quiet (border + text, no fill); `destructive-solid` stays filled with no `dark:bg-*` override. |
+| `packages/ui/src/backend/confirm-dialog/__tests__/ConfirmDialog.test.tsx` | A destructive `ConfirmDialog` resolves its confirm button to the solid variant; the default variant does not. |
+| `scripts/__tests__/check-token-parity.test.mjs` (runs in CI via `yarn test:scripts`) | `:root`/`.dark` token parity, create-app template sync, and WCAG contrast on every `--X`/`--X-foreground` pair in both themes. |
+| `.ai/scripts/ds-health-check.sh` | Reports the `destructive-solid` usage count so a growing number is visible in review. |
+
+## Data Models
+
+None. No entity, migration, or persisted state is involved.
+
+## API Contracts
+
+No HTTP route, request schema, or response field changes.
+
+The affected contract surface is the **UI primitive API**:
+
+| Surface | Change | Classification |
+|---|---|---|
+| `Button` `variant` prop | `'destructive-solid'` added to the union | ADDITIVE |
+| `Button` `variant="destructive"` | Rendered classes change (filled → quiet) | Visual behavior change, source-compatible |
+| `Button` `variant="destructive-outline" \| "destructive-soft" \| "destructive-ghost"` | Retained | Unchanged |
+| `ConfirmDialog` `variant` prop | Unchanged (`"default" \| "destructive"`) | Unchanged |
+| `buttonVariants` export | Unchanged signature | Unchanged |
+
+## Migration & Backward Compatibility
+
+**Nothing breaks at build time.** No export, prop, or type is removed or narrowed; `variant="destructive"`
+remains valid and additions are strictly additive. Existing code compiles and runs unchanged.
+
+**What changes for module authors** is what their destructive buttons look like:
+
+1. **Triggers need no change.** A `variant="destructive"` button that opens a confirmation, navigates,
+   or sits in a form header is now quiet — which is the intended treatment. Leave it alone.
+2. **Final confirmations need one edit.** If a button *is* the irreversible commit inside a confirmation
+   dialog, change `variant="destructive"` to `variant="destructive-solid"`:
+
+   ```diff
+   - <Button variant="destructive" onClick={confirmDelete}>Delete</Button>
+   + <Button variant="destructive-solid" onClick={confirmDelete}>Delete</Button>
+   ```
+
+   Call sites built on `useConfirmDialog()` / `ConfirmDialog` require **no change** — the dialog maps the
+   variant internally.
+3. **Custom overrides can be deleted.** A hand-rolled quiet treatment
+   (`variant="outline" className="text-destructive border-red-200 hover:bg-red-50"`) is now exactly what
+   `variant="destructive"` renders. Drop the `className` and switch the variant.
+4. **`destructive-outline` still works** and renders the same quiet treatment, so no forced sweep is
+   needed. Prefer `destructive` in new code.
+5. **Status copy moves off the action token.** If a module colours validation or failure text with
+   `text-destructive`, switch it to `text-status-error-text`. Both tokens still exist, so this is a
+   correctness/consistency fix rather than a compile-forcing change.
+
+No deprecation bridge is required: no symbol was removed, so there is nothing to alias or dual-emit. The
+one-way door is purely visual, and the recovery for an unwanted quiet button is a single-word variant
+change.
+
+## Risks & Impact Review
+
+| # | Failure scenario | Severity | Affected area | Mitigation | Residual risk |
+|---|---|---|---|---|---|
+| 1 | A third-party module's final confirmation stays on `destructive` and renders quiet, so an irreversible action loses its visual weight. | Medium | Any module with hand-rolled confirm dialogs | This spec's migration section; the policy is documented in `ds-rules.md`, `ui-components.md`, and the DS Guardian component guide, which module authors' agents read. | Cannot be enforced across repos — a module that never reads the guidance keeps a quiet confirm. The action still requires an explicit click in a dialog with a title stating the consequence. |
+| 2 | An in-repo confirmation is missed during the audit and stays quiet. | Medium | Core/UI confirm dialogs | Full-repo audit of every `variant="destructive"` occurrence classified by dialog context; six point-of-no-return sites migrated; `ds-health-check.sh` reports the solid usage count for ongoing review. | A future new confirm dialog can be written on the quiet variant; only review catches it. |
+| 3 | `destructive-solid` spreads back onto triggers, restoring the wall of red. | Low | Any module | The variant name states its scope; MUST NOT rules in `ui-components.md`; usage count reported by the DS health check. | Requires reviewer attention; not machine-enforced. |
+| 4 | The quiet treatment fails contrast in dark mode on an unusual surface. | Low | Theming | `scripts/check-token-parity.mjs` verifies WCAG ratios for every token pair in both themes and runs in CI. | The checker covers token pairs, not arbitrary custom surfaces a module paints underneath the button. |
+| 5 | A module relies on `text-destructive` for status copy and the split makes its UI inconsistent with core. | Low | Any module | Both tokens remain valid; migration is advisory and mechanical. | Cosmetic inconsistency only. |
+
+## Final Compliance Report
+
+| Check | Result |
+|---|---|
+| `BACKWARD_COMPATIBILITY.md` contract surfaces | No exported symbol, signature, type field, route, event, DI key, ACL feature, CLI command, DB column, or config key removed or narrowed. `Button` variant union is additive. |
+| Spec required for a public primitive behavior change | This document, with the Migration & Backward Compatibility section above. |
+| Semantic tokens only, no hardcoded palette on touched lines | Verified: no `(text\|bg\|border)-(red\|green\|emerald\|amber\|yellow\|orange\|purple)-[0-9]+` remains in the changed source files. |
+| No `dark:` overrides on semantic/status tokens | Dropped across the destructive family; the retained `aria-invalid` pair is an opacity normalisation, documented above. |
+| Regression coverage for the new contracts | Button variant tests, ConfirmDialog variant-mapping tests, token parity/contrast test wired into `yarn test:scripts` (CI-executed). |
+| Existing hardcoded-colour guards preserved | The `text-red-600` assertions in the product-SEO and dictionary tests were restored after an over-broad sweep replaced them. |
+| i18n | No user-facing strings added or changed. |
+
+## Changelog
+
+- **2026-08-01** — Spec written to document the primitive behavior change requested in code review on PR #4652. Records the loudness policy, the status-vs-action token boundary, the enforcement guards, and the migration path for external module authors. Implementation shipped in the same PR: quiet `destructive` + additive `destructive-solid`, six point-of-no-return confirmations migrated, 49 status-copy call sites moved from `text-destructive` to `text-status-error-text`, `dark:` overrides dropped from the destructive family, and `check-token-parity.mjs` promoted from an advisory script to a CI-executed gate.

--- a/.ai/ui-components.md
+++ b/.ai/ui-components.md
@@ -84,7 +84,8 @@ import { Button } from '@open-mercato/ui/primitives/button'
 ```
 
 **Variants**:
-- `default` (primary CTA) · `destructive` (danger filled)
+- `default` (primary CTA) · `destructive` (danger, quiet: red text + red border on the page surface)
+- `destructive-solid` (danger filled — point-of-no-return confirmations only)
 - `destructive-outline` · `destructive-soft` · `destructive-ghost` (danger family)
 - `outline` · `secondary` · `ghost` · `muted` · `link`
 
@@ -115,7 +116,20 @@ All sizes share `rounded-md`. Same-row buttons MUST share `size`.
 
 **Anti-patterns:** `<Button className="h-9">` (redundant, hides contract from grep), `<Button size="sm">` next to `size="icon"`, raw `<Link>` styled as a button.
 
-> Use the destructive family for danger actions: `destructive` for primary delete CTAs, `destructive-outline` for confirmation dialogs, `destructive-soft` for inline destructive chips, `destructive-ghost` for low-emphasis menu items.
+### Destructive loudness (MUST)
+
+`destructive` is **quiet by default** — red text and a red border on the page surface. A screen full of solid red buttons trains users to ignore red, so the fill is reserved for the one moment it has to be unmissable.
+
+| Control | Variant | Why |
+|---|---|---|
+| Delete / Remove / Discard trigger (row action, toolbar, form header, edit-dialog footer) | `destructive` | Opening a confirmation is reversible — Escape gets you out. |
+| The confirm button inside a confirmation dialog | `destructive-solid` | The single point of no return. `ConfirmDialog` with `variant="destructive"` already resolves to this — do not hand-roll it. |
+| Inline destructive chip | `destructive-soft` | Low-emphasis surface treatment. |
+| Low-emphasis destructive menu item | `destructive-ghost` | No border/fill in a list context. |
+
+MUST NOT put `destructive-solid` on a button that only *opens* a dialog, and MUST NOT leave a final confirmation on the quiet `destructive`. Status and validation copy is not a destructive action — that takes `text-status-error-text`, never `text-destructive` (see [`ds-rules.md`](ds-rules.md)).
+
+`destructive-outline` remains as an alias of the quiet treatment for call sites that predate the policy; new code uses `destructive`.
 
 ---
 

--- a/apps/mercato/src/app/globals.css
+++ b/apps/mercato/src/app/globals.css
@@ -124,6 +124,20 @@ TODO: Fix that latter to have reference by the package names
   --color-status-pink-border: var(--status-pink-border);
   --color-status-pink-icon: var(--status-pink-icon);
 
+  /* Solid role — filled chips, status dots, emphasis surfaces */
+  --color-status-error-solid: var(--status-error-solid);
+  --color-status-error-solid-foreground: var(--status-error-solid-foreground);
+  --color-status-success-solid: var(--status-success-solid);
+  --color-status-success-solid-foreground: var(--status-success-solid-foreground);
+  --color-status-warning-solid: var(--status-warning-solid);
+  --color-status-warning-solid-foreground: var(--status-warning-solid-foreground);
+  --color-status-info-solid: var(--status-info-solid);
+  --color-status-info-solid-foreground: var(--status-info-solid-foreground);
+  --color-status-neutral-solid: var(--status-neutral-solid);
+  --color-status-neutral-solid-foreground: var(--status-neutral-solid-foreground);
+  --color-status-pink-solid: var(--status-pink-solid);
+  --color-status-pink-solid-foreground: var(--status-pink-solid-foreground);
+
   /* ═══ Design System: Accent Colors ═══ */
   --color-accent-indigo: var(--accent-indigo);
   --color-accent-indigo-foreground: var(--accent-indigo-foreground);
@@ -222,7 +236,7 @@ TODO: Fix that latter to have reference by the package names
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted-foreground: oklch(0.545 0 0); /* darkened from 0.556: 4.54:1 on --muted (AA), was 4.34 */
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
@@ -301,6 +315,22 @@ TODO: Fix that latter to have reference by the package names
   --status-pink-text: oklch(0.388 0.180 340); /* pink-700 #BE185D */
   --status-pink-border: oklch(0.840 0.090 340);/* pink-200 #FBCFE8 */
   --status-pink-icon: oklch(0.633 0.238 340); /* pink-500 #EC4899 */
+
+  /* Solid role — filled surfaces that carry text (chips, badges, dots with
+     labels). All pairs hold WCAG AA 4.5:1 with their foreground; verified by
+     scripts/check-token-parity.mjs. Shades follow each family's 600-700. */
+  --status-error-solid: oklch(0.577 0.245 27.325);   /* red-600   #dc2626, on white 4.83 */
+  --status-error-solid-foreground: #ffffff;
+  --status-success-solid: oklch(0.527 0.154 150.069);/* green-700 #15803d, on white 5.02 */
+  --status-success-solid-foreground: #ffffff;
+  --status-warning-solid: oklch(0.555 0.163 48.998); /* amber-700 #b45309, on white 5.02 */
+  --status-warning-solid-foreground: #ffffff;
+  --status-info-solid: oklch(0.511 0.262 276.966);   /* indigo-600 #4f46e5, on white 6.29 */
+  --status-info-solid-foreground: #ffffff;
+  --status-neutral-solid: oklch(0.439 0 0);          /* neutral-600 #525252, on white 7.81 */
+  --status-neutral-solid-foreground: #ffffff;
+  --status-pink-solid: oklch(0.388 0.180 340);       /* pink-700  #be185d, on white 6.04 */
+  --status-pink-solid-foreground: #ffffff;
 }
 
 /* Opt-in Figma-style focus ring: 2px inner ring + 4px outer ring */
@@ -338,7 +368,7 @@ TODO: Fix that latter to have reference by the package names
   --brand-violet-foreground: #0C0C0C;
   --primary-hover: oklch(0.85 0 0);
   /* Accent indigo — slightly lighter in dark mode for contrast */
-  --accent-indigo: #818cf8;
+  --accent-indigo: #6d74f4; /* was indigo-400 #818cf8: white glyph 2.98:1 < 3.0 (WCAG non-text); now 3.85:1 */
   --accent-indigo-foreground: #ffffff;
   /* Disabled control tokens (dark) */
   --bg-disabled: oklch(0.25 0 0);
@@ -420,6 +450,22 @@ TODO: Fix that latter to have reference by the package names
   --status-pink-text: oklch(0.815 0.135 340);
   --status-pink-border: oklch(0.405 0.155 340);
   --status-pink-icon: oklch(0.700 0.225 340);
+
+  /* Solid role — same values as light: the fills are saturated enough to
+     read on dark surfaces, and keeping one value preserves chip identity
+     across themes. Listed explicitly so the parity check stays honest. */
+  --status-error-solid: oklch(0.577 0.245 27.325);
+  --status-error-solid-foreground: #ffffff;
+  --status-success-solid: oklch(0.527 0.154 150.069);
+  --status-success-solid-foreground: #ffffff;
+  --status-warning-solid: oklch(0.555 0.163 48.998);
+  --status-warning-solid-foreground: #ffffff;
+  --status-info-solid: oklch(0.511 0.262 276.966);
+  --status-info-solid-foreground: #ffffff;
+  --status-neutral-solid: oklch(0.439 0 0);
+  --status-neutral-solid-foreground: #ffffff;
+  --status-pink-solid: oklch(0.388 0.180 340);
+  --status-pink-solid-foreground: #ffffff;
 }
 
 @layer base {

--- a/docs/design-system/components.md
+++ b/docs/design-system/components.md
@@ -26,7 +26,7 @@ Components evaluated on the following criteria:
 | **When to use** | Any user action: submit, cancel, delete, create, navigate |
 | **When NOT to use** | Navigation to another page (use Link). Display-only text. |
 | **Anatomy** | `[icon?] [label] [icon?]` |
-| **Variants** | default, destructive, outline, secondary, ghost, muted, link |
+| **Variants** | default, destructive (quiet: red text, calm surface), destructive-solid (point-of-no-return confirms only), destructive-soft, destructive-ghost, outline, secondary, ghost, muted, link |
 | **Sizes** | sm (h-8), default (h-9), lg (h-10), icon (size-9) |
 | **States** | default, hover, focus, active, disabled, loading |
 | **Accessibility** | `aria-label` required if icon-only. `disabled` prevents interaction. Focus ring visible. |

--- a/docs/design-system/token-values.md
+++ b/docs/design-system/token-values.md
@@ -214,3 +214,22 @@ Dark:   --background: oklch(0.145 0 0)       /* near black */
 - [Foundations](./foundations.md) — scale definitions and guidelines
 - [Migration Tables](./migration-tables.md) — mapping old values to new tokens
 - [Enforcement](./enforcement.md) — ESLint rules enforcing token usage
+
+
+## Status solid role (added with #4651)
+
+Filled surfaces that carry text — chips, badges, labeled dots. One token pair
+per family; every pair holds WCAG AA 4.5:1 (verified by `yarn check:tokens`):
+
+| Family | `--status-{x}-solid` | Foreground | Contrast |
+|---|---|---|---|
+| error | red-600 #dc2626 | white | 4.83 |
+| success | green-700 #15803d | white | 5.02 |
+| warning | amber-700 #b45309 | white | 5.02 |
+| info | indigo-600 #4f46e5 | white | 6.29 |
+| neutral | neutral-600 #525252 | white | 7.81 |
+| pink | pink-700 #be185d | white | 6.04 |
+
+Same values in dark (saturated fills read on both surfaces; one value keeps
+chip identity across themes). The subtle anatomy (bg/text/border/icon) stays
+for alerts and callouts; solid is for emphasis surfaces only.

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "check:client-boundaries": "node scripts/check-client-boundaries.mjs",
     "check:client-boundaries:fail": "node scripts/check-client-boundaries.mjs --fail",
     "check:time-bombs": "node scripts/time-bomb-scanner.mjs",
+    "check:tokens": "node scripts/check-token-parity.mjs",
     "check:time-bombs:fail": "node scripts/time-bomb-scanner.mjs --fail",
     "agents:check-budget": "node scripts/check-agents-md-budget.mjs",
     "lessons:check": "node packages/create-app/agentic/shared/scripts/check-lessons.mjs --root ."

--- a/packages/core/src/modules/attachments/fields/attachment.tsx
+++ b/packages/core/src/modules/attachments/fields/attachment.tsx
@@ -162,7 +162,7 @@ export const AttachmentInput = ({
           />
         </div>
       )}
-      {error ? <div className="text-xs text-destructive">{error}</div> : null}
+      {error ? <div className="text-xs text-status-error-text">{error}</div> : null}
       <div className="space-y-1">
         {loading ? <div className="text-xs text-muted-foreground">{t('attachments.library.loading', 'Loading attachments…')}</div> : null}
         {items.map(it => (

--- a/packages/core/src/modules/attachments/fields/attachment.tsx
+++ b/packages/core/src/modules/attachments/fields/attachment.tsx
@@ -162,7 +162,7 @@ export const AttachmentInput = ({
           />
         </div>
       )}
-      {error ? <div className="text-xs text-red-600">{error}</div> : null}
+      {error ? <div className="text-xs text-destructive">{error}</div> : null}
       <div className="space-y-1">
         {loading ? <div className="text-xs text-muted-foreground">{t('attachments.library.loading', 'Loading attachments…')}</div> : null}
         {items.map(it => (

--- a/packages/core/src/modules/auth/components/UserConsentsPanel.tsx
+++ b/packages/core/src/modules/auth/components/UserConsentsPanel.tsx
@@ -65,7 +65,7 @@ export function UserConsentsPanel({ userId }: UserConsentsPanelProps) {
   }
 
   if (error) {
-    return <p className="text-sm text-destructive">{error}</p>
+    return <p className="text-sm text-status-error-text">{error}</p>
   }
 
   if (consents.length === 0) {
@@ -86,15 +86,15 @@ export function UserConsentsPanel({ userId }: UserConsentsPanelProps) {
             <span className="flex items-center gap-1.5">
               {consent.isGranted ? (
                 <>
-                  <ShieldCheck className="size-4 text-emerald-600" />
-                  <span className="text-emerald-700 font-medium">
+                  <ShieldCheck className="size-4 text-status-success-icon" />
+                  <span className="text-status-success-text font-medium">
                     {t('auth.users.consents.granted', 'Granted')}
                   </span>
                 </>
               ) : (
                 <>
-                  <ShieldX className="size-4 text-red-500" />
-                  <span className="text-destructive font-medium">
+                  <ShieldX className="size-4 text-status-error-icon" />
+                  <span className="text-status-error-text font-medium">
                     {t('auth.users.consents.withdrawn', 'Withdrawn')}
                   </span>
                 </>
@@ -118,13 +118,13 @@ export function UserConsentsPanel({ userId }: UserConsentsPanelProps) {
             <dd className="flex items-center gap-1">
               {consent.integrityValid ? (
                 <>
-                  <ShieldCheck className="size-3 text-emerald-600" />
-                  <span className="text-emerald-700">{t('auth.users.consents.integrityValid', 'Valid')}</span>
+                  <ShieldCheck className="size-3 text-status-success-icon" />
+                  <span className="text-status-success-text">{t('auth.users.consents.integrityValid', 'Valid')}</span>
                 </>
               ) : (
                 <>
-                  <ShieldAlert className="size-3 text-amber-500" />
-                  <span className="text-amber-600">{t('auth.users.consents.integrityInvalid', 'Tampered or missing')}</span>
+                  <ShieldAlert className="size-3 text-status-warning-icon" />
+                  <span className="text-status-warning-text">{t('auth.users.consents.integrityInvalid', 'Tampered or missing')}</span>
                 </>
               )}
             </dd>

--- a/packages/core/src/modules/auth/components/UserConsentsPanel.tsx
+++ b/packages/core/src/modules/auth/components/UserConsentsPanel.tsx
@@ -65,7 +65,7 @@ export function UserConsentsPanel({ userId }: UserConsentsPanelProps) {
   }
 
   if (error) {
-    return <p className="text-sm text-red-600">{error}</p>
+    return <p className="text-sm text-destructive">{error}</p>
   }
 
   if (consents.length === 0) {
@@ -94,7 +94,7 @@ export function UserConsentsPanel({ userId }: UserConsentsPanelProps) {
               ) : (
                 <>
                   <ShieldX className="size-4 text-red-500" />
-                  <span className="text-red-600 font-medium">
+                  <span className="text-destructive font-medium">
                     {t('auth.users.consents.withdrawn', 'Withdrawn')}
                   </span>
                 </>

--- a/packages/core/src/modules/auth/frontend/reset.tsx
+++ b/packages/core/src/modules/auth/frontend/reset.tsx
@@ -56,11 +56,11 @@ export default function ResetPage() {
             </div>
           ) : (
             <form className="grid gap-3" onSubmit={onSubmit} noValidate>
-              {error && <div className="text-sm text-destructive">{error}</div>}
+              {error && <div className="text-sm text-status-error-text">{error}</div>}
               <div className="grid gap-1">
                 <Label htmlFor="email">{t('auth.email')}</Label>
                 <EmailInput id="email" name="email" required aria-invalid={!!fieldError} aria-describedby={fieldError ? 'email-error' : undefined} />
-                {fieldError && <p id="email-error" className="text-sm text-destructive">{fieldError}</p>}
+                {fieldError && <p id="email-error" className="text-sm text-status-error-text">{fieldError}</p>}
               </div>
               <Button type="submit" className="mt-2 w-full" disabled={submitting}>
                 {submitting ? '...' : t('auth.sendResetLink')}

--- a/packages/core/src/modules/auth/frontend/reset.tsx
+++ b/packages/core/src/modules/auth/frontend/reset.tsx
@@ -56,11 +56,11 @@ export default function ResetPage() {
             </div>
           ) : (
             <form className="grid gap-3" onSubmit={onSubmit} noValidate>
-              {error && <div className="text-sm text-red-600">{error}</div>}
+              {error && <div className="text-sm text-destructive">{error}</div>}
               <div className="grid gap-1">
                 <Label htmlFor="email">{t('auth.email')}</Label>
                 <EmailInput id="email" name="email" required aria-invalid={!!fieldError} aria-describedby={fieldError ? 'email-error' : undefined} />
-                {fieldError && <p id="email-error" className="text-sm text-red-600">{fieldError}</p>}
+                {fieldError && <p id="email-error" className="text-sm text-destructive">{fieldError}</p>}
               </div>
               <Button type="submit" className="mt-2 w-full" disabled={submitting}>
                 {submitting ? '...' : t('auth.sendResetLink')}

--- a/packages/core/src/modules/business_rules/components/ConditionRow.tsx
+++ b/packages/core/src/modules/business_rules/components/ConditionRow.tsx
@@ -88,7 +88,7 @@ export function ConditionRow({ condition, onChange, onDelete, error }: Condition
             aria-invalid={fieldError ? true : undefined}
           />
           {fieldError && (
-            <p className="text-xs text-red-600 mt-0.5">
+            <p className="text-xs text-destructive mt-0.5">
               {t('business_rules.components.conditionRow.field.invalidPath')}
             </p>
           )}
@@ -169,7 +169,7 @@ export function ConditionRow({ condition, onChange, onDelete, error }: Condition
       <button
         type="button"
         onClick={onDelete}
-        className="p-1.5 text-muted-foreground hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+        className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
         title={t('business_rules.components.conditionRow.deleteCondition')}
       >
         <X className="w-4 h-4" />
@@ -178,7 +178,7 @@ export function ConditionRow({ condition, onChange, onDelete, error }: Condition
       {/* Error Display */}
       {error && (
         <div className="col-span-full mt-2">
-          <p className="text-xs text-red-600">{error}</p>
+          <p className="text-xs text-destructive">{error}</p>
         </div>
       )}
     </div>

--- a/packages/core/src/modules/business_rules/components/ConditionRow.tsx
+++ b/packages/core/src/modules/business_rules/components/ConditionRow.tsx
@@ -88,7 +88,7 @@ export function ConditionRow({ condition, onChange, onDelete, error }: Condition
             aria-invalid={fieldError ? true : undefined}
           />
           {fieldError && (
-            <p className="text-xs text-destructive mt-0.5">
+            <p className="text-xs text-status-error-text mt-0.5">
               {t('business_rules.components.conditionRow.field.invalidPath')}
             </p>
           )}
@@ -169,7 +169,7 @@ export function ConditionRow({ condition, onChange, onDelete, error }: Condition
       <button
         type="button"
         onClick={onDelete}
-        className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
+        className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded transition-colors"
         title={t('business_rules.components.conditionRow.deleteCondition')}
       >
         <X className="w-4 h-4" />
@@ -178,7 +178,7 @@ export function ConditionRow({ condition, onChange, onDelete, error }: Condition
       {/* Error Display */}
       {error && (
         <div className="col-span-full mt-2">
-          <p className="text-xs text-destructive">{error}</p>
+          <p className="text-xs text-status-error-text">{error}</p>
         </div>
       )}
     </div>

--- a/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
@@ -2608,7 +2608,7 @@ function ProductMetaSection({
           )}
         />
         {errors.subtitle ? (
-          <p className="text-xs text-destructive">{errors.subtitle}</p>
+          <p className="text-xs text-status-error-text">{errors.subtitle}</p>
         ) : null}
       </div>
 
@@ -2641,7 +2641,7 @@ function ProductMetaSection({
           )}
         </p>
         {errors.handle ? (
-          <p className="text-xs text-destructive">{errors.handle}</p>
+          <p className="text-xs text-status-error-text">{errors.handle}</p>
         ) : null}
       </div>
 
@@ -2663,7 +2663,7 @@ function ProductMetaSection({
           )}
         </p>
         {errors.sku ? (
-          <p className="text-xs text-destructive">{errors.sku}</p>
+          <p className="text-xs text-status-error-text">{errors.sku}</p>
         ) : null}
       </div>
 
@@ -2700,7 +2700,7 @@ function ProductMetaSection({
           </SelectContent>
         </Select>
         {errors.productType ? (
-          <p className="text-xs text-destructive">
+          <p className="text-xs text-status-error-text">
             {errors.productType}
           </p>
         ) : null}

--- a/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/[id]/page.tsx
@@ -2608,7 +2608,7 @@ function ProductMetaSection({
           )}
         />
         {errors.subtitle ? (
-          <p className="text-xs text-red-600">{errors.subtitle}</p>
+          <p className="text-xs text-destructive">{errors.subtitle}</p>
         ) : null}
       </div>
 
@@ -2641,7 +2641,7 @@ function ProductMetaSection({
           )}
         </p>
         {errors.handle ? (
-          <p className="text-xs text-red-600">{errors.handle}</p>
+          <p className="text-xs text-destructive">{errors.handle}</p>
         ) : null}
       </div>
 
@@ -2663,7 +2663,7 @@ function ProductMetaSection({
           )}
         </p>
         {errors.sku ? (
-          <p className="text-xs text-red-600">{errors.sku}</p>
+          <p className="text-xs text-destructive">{errors.sku}</p>
         ) : null}
       </div>
 
@@ -2700,7 +2700,7 @@ function ProductMetaSection({
           </SelectContent>
         </Select>
         {errors.productType ? (
-          <p className="text-xs text-red-600">
+          <p className="text-xs text-destructive">
             {errors.productType}
           </p>
         ) : null}

--- a/packages/core/src/modules/catalog/backend/catalog/products/create/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/create/page.tsx
@@ -1942,7 +1942,7 @@ function ProductMetaSection({
           )}
         />
         {errors.subtitle ? (
-          <p className="text-xs text-destructive">{errors.subtitle}</p>
+          <p className="text-xs text-status-error-text">{errors.subtitle}</p>
         ) : null}
       </div>
 
@@ -1973,7 +1973,7 @@ function ProductMetaSection({
           )}
         </p>
         {errors.handle ? (
-          <p className="text-xs text-destructive">{errors.handle}</p>
+          <p className="text-xs text-status-error-text">{errors.handle}</p>
         ) : null}
       </div>
 
@@ -1995,7 +1995,7 @@ function ProductMetaSection({
           )}
         </p>
         {errors.sku ? (
-          <p className="text-xs text-destructive">{errors.sku}</p>
+          <p className="text-xs text-status-error-text">{errors.sku}</p>
         ) : null}
       </div>
 
@@ -2032,7 +2032,7 @@ function ProductMetaSection({
           </SelectContent>
         </Select>
         {errors.productType ? (
-          <p className="text-xs text-destructive">
+          <p className="text-xs text-status-error-text">
             {errors.productType}
           </p>
         ) : null}
@@ -2105,7 +2105,7 @@ function ProductMetaSection({
               )}
         </p>
         {errors.taxRateId ? (
-          <p className="text-xs text-destructive">{errors.taxRateId}</p>
+          <p className="text-xs text-status-error-text">{errors.taxRateId}</p>
         ) : null}
       </div>
     </div>

--- a/packages/core/src/modules/catalog/backend/catalog/products/create/page.tsx
+++ b/packages/core/src/modules/catalog/backend/catalog/products/create/page.tsx
@@ -1942,7 +1942,7 @@ function ProductMetaSection({
           )}
         />
         {errors.subtitle ? (
-          <p className="text-xs text-red-600">{errors.subtitle}</p>
+          <p className="text-xs text-destructive">{errors.subtitle}</p>
         ) : null}
       </div>
 
@@ -1973,7 +1973,7 @@ function ProductMetaSection({
           )}
         </p>
         {errors.handle ? (
-          <p className="text-xs text-red-600">{errors.handle}</p>
+          <p className="text-xs text-destructive">{errors.handle}</p>
         ) : null}
       </div>
 
@@ -1995,7 +1995,7 @@ function ProductMetaSection({
           )}
         </p>
         {errors.sku ? (
-          <p className="text-xs text-red-600">{errors.sku}</p>
+          <p className="text-xs text-destructive">{errors.sku}</p>
         ) : null}
       </div>
 
@@ -2032,7 +2032,7 @@ function ProductMetaSection({
           </SelectContent>
         </Select>
         {errors.productType ? (
-          <p className="text-xs text-red-600">
+          <p className="text-xs text-destructive">
             {errors.productType}
           </p>
         ) : null}
@@ -2105,7 +2105,7 @@ function ProductMetaSection({
               )}
         </p>
         {errors.taxRateId ? (
-          <p className="text-xs text-red-600">{errors.taxRateId}</p>
+          <p className="text-xs text-destructive">{errors.taxRateId}</p>
         ) : null}
       </div>
     </div>

--- a/packages/core/src/modules/catalog/components/PriceKindSettings.tsx
+++ b/packages/core/src/modules/catalog/components/PriceKindSettings.tsx
@@ -375,7 +375,7 @@ export function PriceKindSettings() {
       header: tableLabels.promotion,
       cell: ({ row }) =>
         row.original.isPromotion ? (
-          <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-900 dark:border-amber-500/50 dark:bg-amber-500/10 dark:text-amber-100">
+          <span className="inline-flex items-center rounded-full border border-status-warning-border bg-status-warning-bg px-2 py-0.5 text-xs font-medium text-status-warning-text">
             {tableLabels.promotionYes}
           </span>
         ) : (
@@ -389,7 +389,7 @@ export function PriceKindSettings() {
       header: tableLabels.active,
       cell: ({ row }) =>
         row.original.isActive ? (
-          <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-900 dark:border-emerald-500/50 dark:bg-emerald-500/10 dark:text-emerald-100">
+          <span className="inline-flex items-center rounded-full border border-status-success-border bg-status-success-bg px-2 py-0.5 text-xs font-medium text-status-success-text">
             {tableLabels.activeYes}
           </span>
         ) : (
@@ -555,7 +555,7 @@ export function PriceKindSettings() {
                   {t('catalog.priceKinds.form.activeLabel', 'Active')}
                 </label>
               </div>
-              {error ? <p className="text-sm text-destructive">{error}</p> : null}
+              {error ? <p className="text-sm text-status-error-text">{error}</p> : null}
             </form>
             <DialogFooter>
               <Button variant="ghost" onClick={closeDialog}>

--- a/packages/core/src/modules/catalog/components/PriceKindSettings.tsx
+++ b/packages/core/src/modules/catalog/components/PriceKindSettings.tsx
@@ -555,7 +555,7 @@ export function PriceKindSettings() {
                   {t('catalog.priceKinds.form.activeLabel', 'Active')}
                 </label>
               </div>
-              {error ? <p className="text-sm text-red-600">{error}</p> : null}
+              {error ? <p className="text-sm text-destructive">{error}</p> : null}
             </form>
             <DialogFooter>
               <Button variant="ghost" onClick={closeDialog}>

--- a/packages/core/src/modules/catalog/components/products/ProductCategorizeSection.tsx
+++ b/packages/core/src/modules/catalog/components/products/ProductCategorizeSection.tsx
@@ -220,7 +220,7 @@ export function ProductCategorizeSection({
         <p className="text-xs text-muted-foreground">
           {t('catalog.products.create.organize.categoriesHelp', 'Assign products to one or more taxonomy nodes.')}
         </p>
-        {errors.categoryIds ? <p className="text-xs text-red-600">{errors.categoryIds}</p> : null}
+        {errors.categoryIds ? <p className="text-xs text-destructive">{errors.categoryIds}</p> : null}
       </div>
 
       <div className="space-y-2">
@@ -238,7 +238,7 @@ export function ProductCategorizeSection({
         <p className="text-xs text-muted-foreground">
           {t('catalog.products.create.organize.channelsHelp', 'Selected channels will receive default offers for this product.')}
         </p>
-        {errors.channelIds ? <p className="text-xs text-red-600">{errors.channelIds}</p> : null}
+        {errors.channelIds ? <p className="text-xs text-destructive">{errors.channelIds}</p> : null}
       </div>
 
       <div className="space-y-2">
@@ -254,7 +254,7 @@ export function ProductCategorizeSection({
         <p className="text-xs text-muted-foreground">
           {t('catalog.products.create.organize.tagsHelp', 'Describe products with shared labels to build quick filters.')}
         </p>
-        {errors.tags ? <p className="text-xs text-red-600">{errors.tags}</p> : null}
+        {errors.tags ? <p className="text-xs text-destructive">{errors.tags}</p> : null}
       </div>
     </div>
   )

--- a/packages/core/src/modules/catalog/components/products/ProductCategorizeSection.tsx
+++ b/packages/core/src/modules/catalog/components/products/ProductCategorizeSection.tsx
@@ -220,7 +220,7 @@ export function ProductCategorizeSection({
         <p className="text-xs text-muted-foreground">
           {t('catalog.products.create.organize.categoriesHelp', 'Assign products to one or more taxonomy nodes.')}
         </p>
-        {errors.categoryIds ? <p className="text-xs text-destructive">{errors.categoryIds}</p> : null}
+        {errors.categoryIds ? <p className="text-xs text-status-error-text">{errors.categoryIds}</p> : null}
       </div>
 
       <div className="space-y-2">
@@ -238,7 +238,7 @@ export function ProductCategorizeSection({
         <p className="text-xs text-muted-foreground">
           {t('catalog.products.create.organize.channelsHelp', 'Selected channels will receive default offers for this product.')}
         </p>
-        {errors.channelIds ? <p className="text-xs text-destructive">{errors.channelIds}</p> : null}
+        {errors.channelIds ? <p className="text-xs text-status-error-text">{errors.channelIds}</p> : null}
       </div>
 
       <div className="space-y-2">
@@ -254,7 +254,7 @@ export function ProductCategorizeSection({
         <p className="text-xs text-muted-foreground">
           {t('catalog.products.create.organize.tagsHelp', 'Describe products with shared labels to build quick filters.')}
         </p>
-        {errors.tags ? <p className="text-xs text-destructive">{errors.tags}</p> : null}
+        {errors.tags ? <p className="text-xs text-status-error-text">{errors.tags}</p> : null}
       </div>
     </div>
   )

--- a/packages/core/src/modules/catalog/components/products/ProductMediaManager.tsx
+++ b/packages/core/src/modules/catalog/components/products/ProductMediaManager.tsx
@@ -186,7 +186,7 @@ export function ProductMediaManager({
           onChange={(event) => void acceptFiles(event.target.files)}
         />
       </div>
-      {error ? <p className="text-xs font-medium text-destructive">{error}</p> : null}
+      {error ? <p className="text-xs font-medium text-status-error-text">{error}</p> : null}
       {items.length ? (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
           {items.map((item) => {

--- a/packages/core/src/modules/catalog/components/products/ProductMediaManager.tsx
+++ b/packages/core/src/modules/catalog/components/products/ProductMediaManager.tsx
@@ -186,7 +186,7 @@ export function ProductMediaManager({
           onChange={(event) => void acceptFiles(event.target.files)}
         />
       </div>
-      {error ? <p className="text-xs font-medium text-red-600">{error}</p> : null}
+      {error ? <p className="text-xs font-medium text-destructive">{error}</p> : null}
       {items.length ? (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
           {items.map((item) => {

--- a/packages/core/src/modules/catalog/components/products/VariantBuilder.tsx
+++ b/packages/core/src/modules/catalog/components/products/VariantBuilder.tsx
@@ -98,14 +98,14 @@ export function VariantBasicsSection({ values, setValue, errors }: VariantSectio
       <div className="space-y-2">
         <Label className="flex items-center gap-1">
           {t('catalog.variants.form.nameLabel', 'Name')}
-          <span className="text-destructive">*</span>
+          <span className="text-status-error-text">*</span>
         </Label>
         <Input
           value={values.name}
           onChange={(event) => setValue('name', event.target.value)}
           placeholder={t('catalog.variants.form.namePlaceholder', 'e.g., Blue / Small')}
         />
-        {errors.name ? <p className="text-xs text-destructive">{errors.name}</p> : null}
+        {errors.name ? <p className="text-xs text-status-error-text">{errors.name}</p> : null}
       </div>
       <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-2">
@@ -123,7 +123,7 @@ export function VariantBasicsSection({ values, setValue, errors }: VariantSectio
             onChange={(event) => setValue('barcode', event.target.value)}
             placeholder={t('catalog.variants.form.barcodePlaceholder', 'EAN, UPC, etc.')}
           />
-          {errors.barcode ? <p className="text-xs text-destructive">{errors.barcode}</p> : null}
+          {errors.barcode ? <p className="text-xs text-status-error-text">{errors.barcode}</p> : null}
         </div>
       </div>
       <div className="grid gap-4 md:grid-cols-2">
@@ -153,7 +153,7 @@ export function VariantBasicsSection({ values, setValue, errors }: VariantSectio
               'Typed barcodes are validated and kept unique per organization.',
             )}
           </p>
-          {errors.gtinType ? <p className="text-xs text-destructive">{errors.gtinType}</p> : null}
+          {errors.gtinType ? <p className="text-xs text-status-error-text">{errors.gtinType}</p> : null}
         </div>
         <div className="space-y-2">
           <Label htmlFor="catalog-variant-hs-code">
@@ -164,7 +164,7 @@ export function VariantBasicsSection({ values, setValue, errors }: VariantSectio
             value={values.hsCode}
             onChange={(event) => setValue('hsCode', event.target.value)}
           />
-          {errors.hsCode ? <p className="text-xs text-destructive">{errors.hsCode}</p> : null}
+          {errors.hsCode ? <p className="text-xs text-status-error-text">{errors.hsCode}</p> : null}
         </div>
       </div>
       <div className="grid gap-4 md:grid-cols-2">

--- a/packages/core/src/modules/catalog/components/products/VariantBuilder.tsx
+++ b/packages/core/src/modules/catalog/components/products/VariantBuilder.tsx
@@ -98,14 +98,14 @@ export function VariantBasicsSection({ values, setValue, errors }: VariantSectio
       <div className="space-y-2">
         <Label className="flex items-center gap-1">
           {t('catalog.variants.form.nameLabel', 'Name')}
-          <span className="text-red-600">*</span>
+          <span className="text-destructive">*</span>
         </Label>
         <Input
           value={values.name}
           onChange={(event) => setValue('name', event.target.value)}
           placeholder={t('catalog.variants.form.namePlaceholder', 'e.g., Blue / Small')}
         />
-        {errors.name ? <p className="text-xs text-red-600">{errors.name}</p> : null}
+        {errors.name ? <p className="text-xs text-destructive">{errors.name}</p> : null}
       </div>
       <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-2">

--- a/packages/core/src/modules/catalog/widgets/injection/product-seo/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/catalog/widgets/injection/product-seo/__tests__/widget.client.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
 }))
 
 const FORBIDDEN_STATUS_CLASSES = [
-  'text-destructive',
+  'text-red-600',
   'bg-red-50',
   'border-red-200',
   'text-amber-600',

--- a/packages/core/src/modules/catalog/widgets/injection/product-seo/__tests__/widget.client.test.tsx
+++ b/packages/core/src/modules/catalog/widgets/injection/product-seo/__tests__/widget.client.test.tsx
@@ -22,7 +22,7 @@ jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
 }))
 
 const FORBIDDEN_STATUS_CLASSES = [
-  'text-red-600',
+  'text-destructive',
   'bg-red-50',
   'border-red-200',
   'text-amber-600',

--- a/packages/core/src/modules/communication_channels/backend/profile/communication-channels/page.tsx
+++ b/packages/core/src/modules/communication_channels/backend/profile/communication-channels/page.tsx
@@ -871,7 +871,7 @@ function DisconnectChannelDialog({
           <Button type="button" variant="outline" onClick={onClose} disabled={submitting}>
             {t('communication_channels.profile.disconnect.cancel', 'Cancel')}
           </Button>
-          <Button type="button" variant="destructive" onClick={() => void handleConfirm()} disabled={submitting}>
+          <Button type="button" variant="destructive-solid" onClick={() => void handleConfirm()} disabled={submitting}>
             {submitting
               ? t('communication_channels.profile.disconnect.submitting', 'Disconnecting…')
               : t('communication_channels.profile.disconnect.confirm', 'Disconnect')}

--- a/packages/core/src/modules/customers/components/detail/ConfirmDealLostDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/ConfirmDealLostDialog.tsx
@@ -253,7 +253,7 @@ export function ConfirmDealLostDialog({
             </Button>
             <Button
               type="button"
-              variant="destructive"
+              variant="destructive-solid"
               disabled={confirmDisabled}
               onClick={() => { void handleConfirm() }}
             >

--- a/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
+++ b/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
@@ -398,7 +398,7 @@ export function DictionaryEntrySelect({
                       labels={appearanceLabels ?? DEFAULT_APPEARANCE_LABELS}
                     />
                   ) : null}
-                  {formError ? <p className="text-sm text-red-600">{formError}</p> : null}
+                  {formError ? <p className="text-sm text-destructive">{formError}</p> : null}
                 </div>
                 <DialogFooter>
                   <Button type="button" variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>

--- a/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
+++ b/packages/core/src/modules/dictionaries/components/DictionaryEntrySelect.tsx
@@ -398,7 +398,7 @@ export function DictionaryEntrySelect({
                       labels={appearanceLabels ?? DEFAULT_APPEARANCE_LABELS}
                     />
                   ) : null}
-                  {formError ? <p className="text-sm text-destructive">{formError}</p> : null}
+                  {formError ? <p className="text-sm text-status-error-text">{formError}</p> : null}
                 </div>
                 <DialogFooter>
                   <Button type="button" variant="outline" onClick={() => setDialogOpen(false)} disabled={saving}>

--- a/packages/core/src/modules/dictionaries/fields/__tests__/dictionary.test.tsx
+++ b/packages/core/src/modules/dictionaries/fields/__tests__/dictionary.test.tsx
@@ -100,12 +100,15 @@ describe('dictionary field defEditor', () => {
     expect(screen.getByText('Default values are not available for multi-select dictionary fields.')).toBeInTheDocument()
   })
 
-  it('uses the design-system error token (not text-destructive) for load failures', async () => {
+  it('uses the design-system error token (not text-red-600) for load failures', async () => {
     apiCallMock.mockResolvedValue({ ok: false, result: { error: 'boom' } })
     renderEditor({ configJson: {} })
 
     const message = await screen.findByText(/Failed to load dictionaries/)
     expect(message).toHaveClass('text-status-error-text')
+    expect(message).not.toHaveClass('text-red-600')
+    // A load failure is status copy, not a destructive action — the action
+    // token would read as "click here to delete something".
     expect(message).not.toHaveClass('text-destructive')
   })
 

--- a/packages/core/src/modules/dictionaries/fields/__tests__/dictionary.test.tsx
+++ b/packages/core/src/modules/dictionaries/fields/__tests__/dictionary.test.tsx
@@ -100,13 +100,13 @@ describe('dictionary field defEditor', () => {
     expect(screen.getByText('Default values are not available for multi-select dictionary fields.')).toBeInTheDocument()
   })
 
-  it('uses the design-system error token (not text-red-600) for load failures', async () => {
+  it('uses the design-system error token (not text-destructive) for load failures', async () => {
     apiCallMock.mockResolvedValue({ ok: false, result: { error: 'boom' } })
     renderEditor({ configJson: {} })
 
     const message = await screen.findByText(/Failed to load dictionaries/)
     expect(message).toHaveClass('text-status-error-text')
-    expect(message).not.toHaveClass('text-red-600')
+    expect(message).not.toHaveClass('text-destructive')
   })
 
   it('uses the design-system warning token (not text-amber-600) for a stale default value', async () => {

--- a/packages/core/src/modules/inbox_ops/backend/inbox-ops/log/page.tsx
+++ b/packages/core/src/modules/inbox_ops/backend/inbox-ops/log/page.tsx
@@ -141,7 +141,7 @@ export default function ProcessingLogPage() {
       accessorKey: 'processingError',
       header: t('inbox_ops.extraction_failed', 'Error'),
       cell: ({ row }) => (
-        <span className="text-xs text-red-600 truncate max-w-[280px] block">
+        <span className="text-xs text-destructive truncate max-w-[280px] block">
           {row.original.processingError || '-'}
         </span>
       ),

--- a/packages/core/src/modules/inbox_ops/backend/inbox-ops/log/page.tsx
+++ b/packages/core/src/modules/inbox_ops/backend/inbox-ops/log/page.tsx
@@ -31,11 +31,11 @@ type EmailListResponse = {
 }
 
 const STATUS_COLORS: Record<string, string> = {
-  received: 'bg-blue-100 text-blue-800',
-  processing: 'bg-purple-100 text-purple-800',
-  processed: 'bg-green-100 text-green-800',
-  needs_review: 'bg-amber-100 text-amber-800',
-  failed: 'bg-red-100 text-red-800',
+  received: 'bg-status-info-bg text-status-info-text',
+  processing: 'bg-status-neutral-bg text-status-neutral-text',
+  processed: 'bg-status-success-bg text-status-success-text',
+  needs_review: 'bg-status-warning-bg text-status-warning-text',
+  failed: 'bg-status-error-bg text-status-error-text',
 }
 
 export default function ProcessingLogPage() {
@@ -141,7 +141,7 @@ export default function ProcessingLogPage() {
       accessorKey: 'processingError',
       header: t('inbox_ops.extraction_failed', 'Error'),
       cell: ({ row }) => (
-        <span className="text-xs text-destructive truncate max-w-[280px] block">
+        <span className="text-xs text-status-error-text truncate max-w-[280px] block">
           {row.original.processingError || '-'}
         </span>
       ),

--- a/packages/core/src/modules/inbox_ops/components/proposals/EditActionDialog.tsx
+++ b/packages/core/src/modules/inbox_ops/components/proposals/EditActionDialog.tsx
@@ -126,7 +126,7 @@ function ContactPayloadEditor({
                 className={lastNameMissing ? 'border-red-500' : ''}
               />
               {lastNameMissing && (
-                <p className="text-xs text-red-600 mt-1">{t('inbox_ops.contact.last_name_required', 'Last name is required')}</p>
+                <p className="text-xs text-destructive mt-1">{t('inbox_ops.contact.last_name_required', 'Last name is required')}</p>
               )}
             </div>
           </>
@@ -546,7 +546,7 @@ export function EditActionDialog({
                   setJsonError(null)
                 }}
               />
-              {jsonError && <p className="text-xs text-red-600">{t('inbox_ops.edit_dialog.invalid_json', 'Invalid JSON')}</p>}
+              {jsonError && <p className="text-xs text-destructive">{t('inbox_ops.edit_dialog.invalid_json', 'Invalid JSON')}</p>}
             </div>
           )}
 

--- a/packages/core/src/modules/inbox_ops/components/proposals/EditActionDialog.tsx
+++ b/packages/core/src/modules/inbox_ops/components/proposals/EditActionDialog.tsx
@@ -123,10 +123,10 @@ function ContactPayloadEditor({
                   setLastName(event.target.value)
                   updatePersonName(firstName, event.target.value)
                 }}
-                className={lastNameMissing ? 'border-red-500' : ''}
+                className={lastNameMissing ? 'border-status-error-border' : ''}
               />
               {lastNameMissing && (
-                <p className="text-xs text-destructive mt-1">{t('inbox_ops.contact.last_name_required', 'Last name is required')}</p>
+                <p className="text-xs text-status-error-text mt-1">{t('inbox_ops.contact.last_name_required', 'Last name is required')}</p>
               )}
             </div>
           </>
@@ -546,7 +546,7 @@ export function EditActionDialog({
                   setJsonError(null)
                 }}
               />
-              {jsonError && <p className="text-xs text-destructive">{t('inbox_ops.edit_dialog.invalid_json', 'Invalid JSON')}</p>}
+              {jsonError && <p className="text-xs text-status-error-text">{t('inbox_ops.edit_dialog.invalid_json', 'Invalid JSON')}</p>}
             </div>
           )}
 

--- a/packages/core/src/modules/messages/components/message-detail/panels/dialogs.tsx
+++ b/packages/core/src/modules/messages/components/message-detail/panels/dialogs.tsx
@@ -93,7 +93,7 @@ export function MessageDetailDialogs(props: DialogsProps) {
             </Button>
             <Button
               type="button"
-              variant="destructive"
+              variant="destructive-solid"
               onClick={() => void props.handleDelete()}
               disabled={props.updatingState}
             >

--- a/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
+++ b/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
@@ -1666,7 +1666,7 @@ export function AvailabilityRulesEditor({
                           ) : (
                             windows.map((window, windowIndex) => {
                               const windowError = weeklyWindowErrors[index]?.[windowIndex] ?? null
-                              const errorClass = windowError ? 'border-red-500 aria-invalid:ring-destructive' : ''
+                              const errorClass = windowError ? 'border-status-error-border aria-invalid:ring-destructive' : ''
                               return (
                                 <div key={`${day.code}-${windowIndex}`} className="space-y-1">
                                   <div className="flex flex-wrap items-center gap-2">
@@ -1697,7 +1697,7 @@ export function AvailabilityRulesEditor({
                                     </Button>
                                   </div>
                                   {windowError ? (
-                                    <div className="text-xs text-destructive">{windowError}</div>
+                                    <div className="text-xs text-status-error-text">{windowError}</div>
                                   ) : null}
                                 </div>
                               )
@@ -1985,7 +1985,7 @@ export function AvailabilityRulesEditor({
                           <label className="text-xs font-medium text-muted-foreground">{listLabels.windowsLabel}</label>
                           {editorWindows.map((window, index) => {
                             const windowError = editorWindowErrors[index] ?? null
-                            const errorClass = windowError ? 'border-red-500 aria-invalid:ring-destructive' : ''
+                            const errorClass = windowError ? 'border-status-error-border aria-invalid:ring-destructive' : ''
                             return (
                               <div key={`${index}-${window.start}`} className="space-y-1">
                                 <div className="flex flex-wrap items-center gap-2">
@@ -2013,7 +2013,7 @@ export function AvailabilityRulesEditor({
                                   </Button>
                                 </div>
                                 {windowError ? (
-                                  <div className="text-xs text-destructive">{windowError}</div>
+                                  <div className="text-xs text-status-error-text">{windowError}</div>
                                 ) : null}
                               </div>
                             )

--- a/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
+++ b/packages/core/src/modules/planner/components/AvailabilityRulesEditor.tsx
@@ -1697,7 +1697,7 @@ export function AvailabilityRulesEditor({
                                     </Button>
                                   </div>
                                   {windowError ? (
-                                    <div className="text-xs text-red-600">{windowError}</div>
+                                    <div className="text-xs text-destructive">{windowError}</div>
                                   ) : null}
                                 </div>
                               )
@@ -2013,7 +2013,7 @@ export function AvailabilityRulesEditor({
                                   </Button>
                                 </div>
                                 {windowError ? (
-                                  <div className="text-xs text-red-600">{windowError}</div>
+                                  <div className="text-xs text-destructive">{windowError}</div>
                                 ) : null}
                               </div>
                             )

--- a/packages/core/src/modules/shipping_carriers/lib/shipment-wizard/components/PackageEditor.tsx
+++ b/packages/core/src/modules/shipping_carriers/lib/shipment-wizard/components/PackageEditor.tsx
@@ -47,7 +47,7 @@ export const PackageEditor = (props: PackageEditorProps) => {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="h-auto px-2 py-0.5 text-xs text-red-600 hover:text-red-700"
+                className="h-auto px-2 py-0.5 text-xs text-destructive hover:text-destructive/80"
                 onClick={() => removePackage(index)}
                 disabled={disabled}
               >

--- a/packages/core/src/modules/wms/components/backend/ReleaseReservationDialog.tsx
+++ b/packages/core/src/modules/wms/components/backend/ReleaseReservationDialog.tsx
@@ -409,7 +409,7 @@ export function ReleaseReservationDialog({
               </Button>
               <Button
                 type="submit"
-                variant="destructive"
+                variant="destructive-solid"
                 disabled={submitDisabled}
                 data-testid="wms-inventory-release-submit"
               >

--- a/packages/core/src/modules/workflows/backend/definitions/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/page.tsx
@@ -453,7 +453,7 @@ export default function WorkflowDefinitionsListPage() {
               <Button variant="outline" onClick={() => setDeleteTarget(null)}>
                 {t('common.cancel')}
               </Button>
-              <Button variant="destructive" onClick={confirmDelete}>
+              <Button variant="destructive-solid" onClick={confirmDelete}>
                 <Trash2/>
                 {t('common.delete')}
               </Button>

--- a/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
+++ b/packages/core/src/modules/workflows/backend/definitions/visual-editor/page.tsx
@@ -688,7 +688,7 @@ export default function VisualEditorPage() {
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setShowClearConfirm(false)}>{t('common.cancel', 'Cancel')}</Button>
-            <Button variant="destructive" onClick={confirmClear}>{t('common.clear', 'Clear')}</Button>
+            <Button variant="destructive-solid" onClick={confirmClear}>{t('common.clear', 'Clear')}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/packages/core/src/modules/workflows/backend/instances/page.tsx
+++ b/packages/core/src/modules/workflows/backend/instances/page.tsx
@@ -148,19 +148,19 @@ export default function WorkflowInstancesListPage() {
   const getStatusBadgeClass = (status: WorkflowInstance['status']) => {
     switch (status) {
       case 'RUNNING':
-        return 'bg-blue-100 text-blue-800'
+        return 'bg-status-info-bg text-status-info-text'
       case 'PAUSED':
-        return 'bg-yellow-100 text-yellow-800'
+        return 'bg-status-warning-bg text-status-warning-text'
       case 'COMPLETED':
-        return 'bg-green-100 text-green-800'
+        return 'bg-status-success-bg text-status-success-text'
       case 'FAILED':
-        return 'bg-red-100 text-red-800'
+        return 'bg-status-error-bg text-status-error-text'
       case 'CANCELLED':
         return 'bg-muted text-foreground'
       case 'COMPENSATING':
-        return 'bg-orange-100 text-orange-800'
+        return 'bg-status-warning-bg text-status-warning-text'
       case 'COMPENSATED':
-        return 'bg-purple-100 text-purple-800'
+        return 'bg-status-neutral-bg text-status-neutral-text'
       default:
         return 'bg-muted text-muted-foreground'
     }
@@ -268,7 +268,7 @@ export default function WorkflowInstancesListPage() {
       header: t('workflows.instances.fields.retryCount'),
       accessorKey: 'retryCount',
       cell: ({ row }) => (
-        <span className={`text-sm ${row.original.retryCount > 0 ? 'text-orange-600 font-medium' : 'text-muted-foreground'}`}>
+        <span className={`text-sm ${row.original.retryCount > 0 ? 'text-status-warning-text font-medium' : 'text-muted-foreground'}`}>
           {row.original.retryCount}
         </span>
       ),
@@ -311,7 +311,7 @@ export default function WorkflowInstancesListPage() {
       <Page>
         <PageBody>
           <div className="p-8 text-center">
-            <p className="text-destructive">{t('workflows.instances.messages.loadFailed')}</p>
+            <p className="text-status-error-text">{t('workflows.instances.messages.loadFailed')}</p>
             <Button onClick={() => queryClient.invalidateQueries({ queryKey: ['workflow-instances'] })} className="mt-4">
               {t('common.retry')}
             </Button>

--- a/packages/core/src/modules/workflows/backend/instances/page.tsx
+++ b/packages/core/src/modules/workflows/backend/instances/page.tsx
@@ -311,7 +311,7 @@ export default function WorkflowInstancesListPage() {
       <Page>
         <PageBody>
           <div className="p-8 text-center">
-            <p className="text-red-600">{t('workflows.instances.messages.loadFailed')}</p>
+            <p className="text-destructive">{t('workflows.instances.messages.loadFailed')}</p>
             <Button onClick={() => queryClient.invalidateQueries({ queryKey: ['workflow-instances'] })} className="mt-4">
               {t('common.retry')}
             </Button>

--- a/packages/core/src/modules/workflows/backend/tasks/page.tsx
+++ b/packages/core/src/modules/workflows/backend/tasks/page.tsx
@@ -135,11 +135,11 @@ export default function UserTasksListPage() {
   const getStatusBadgeClass = (status: UserTaskStatus) => {
     switch (status) {
       case 'PENDING':
-        return 'bg-yellow-100 text-yellow-800'
+        return 'bg-status-warning-bg text-status-warning-text'
       case 'IN_PROGRESS':
-        return 'bg-blue-100 text-blue-800'
+        return 'bg-status-info-bg text-status-info-text'
       case 'COMPLETED':
-        return 'bg-green-100 text-green-800'
+        return 'bg-status-success-bg text-status-success-text'
       case 'CANCELLED':
         return 'bg-muted text-foreground'
       default:
@@ -207,7 +207,7 @@ export default function UserTasksListPage() {
             </div>
           )}
           {isOverdue(row.original) && (
-            <div className="text-xs text-destructive font-medium mt-1">
+            <div className="text-xs text-status-error-text font-medium mt-1">
               {t('workflows.tasks.overdue')}
             </div>
           )}
@@ -259,7 +259,7 @@ export default function UserTasksListPage() {
         const dueDate = new Date(row.original.dueDate)
         const overdue = isOverdue(row.original)
         return (
-          <div className={`text-sm ${overdue ? 'text-destructive font-medium' : 'text-foreground'}`}>
+          <div className={`text-sm ${overdue ? 'text-status-error-text font-medium' : 'text-foreground'}`}>
             {dueDate.toLocaleString()}
           </div>
         )
@@ -320,7 +320,7 @@ export default function UserTasksListPage() {
       <Page>
         <PageBody>
           <div className="p-8 text-center">
-            <p className="text-destructive">{t('workflows.tasks.messages.loadFailed')}</p>
+            <p className="text-status-error-text">{t('workflows.tasks.messages.loadFailed')}</p>
             <Button onClick={() => queryClient.invalidateQueries({ queryKey: ['workflow-tasks'] })} className="mt-4">
               {t('common.retry')}
             </Button>

--- a/packages/core/src/modules/workflows/backend/tasks/page.tsx
+++ b/packages/core/src/modules/workflows/backend/tasks/page.tsx
@@ -207,7 +207,7 @@ export default function UserTasksListPage() {
             </div>
           )}
           {isOverdue(row.original) && (
-            <div className="text-xs text-red-600 font-medium mt-1">
+            <div className="text-xs text-destructive font-medium mt-1">
               {t('workflows.tasks.overdue')}
             </div>
           )}
@@ -259,7 +259,7 @@ export default function UserTasksListPage() {
         const dueDate = new Date(row.original.dueDate)
         const overdue = isOverdue(row.original)
         return (
-          <div className={`text-sm ${overdue ? 'text-red-600 font-medium' : 'text-foreground'}`}>
+          <div className={`text-sm ${overdue ? 'text-destructive font-medium' : 'text-foreground'}`}>
             {dueDate.toLocaleString()}
           </div>
         )
@@ -320,7 +320,7 @@ export default function UserTasksListPage() {
       <Page>
         <PageBody>
           <div className="p-8 text-center">
-            <p className="text-red-600">{t('workflows.tasks.messages.loadFailed')}</p>
+            <p className="text-destructive">{t('workflows.tasks.messages.loadFailed')}</p>
             <Button onClick={() => queryClient.invalidateQueries({ queryKey: ['workflow-tasks'] })} className="mt-4">
               {t('common.retry')}
             </Button>

--- a/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
+++ b/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
@@ -184,7 +184,7 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
           <p className="text-sm text-muted-foreground">
             {t('workflows.form.descriptions.activities')}
           </p>
-          {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+          {error && <p className="text-sm text-destructive mt-1">{error}</p>}
         </div>
         <Button type="button" onClick={addActivity} variant="outline" size="sm" className="w-full sm:w-auto">
           <Plus className="h-4 w-4 mr-1" />
@@ -257,7 +257,7 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
                     onClick={() => removeActivity(index)}
                     title={t('common.delete')}
                   >
-                    <Trash2 className="h-4 w-4 text-red-600" />
+                    <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
                 </div>
               </div>

--- a/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
+++ b/packages/core/src/modules/workflows/components/ActivitiesEditor.tsx
@@ -184,7 +184,7 @@ export function ActivitiesEditor({ value = [], onChange, error }: ActivitiesEdit
           <p className="text-sm text-muted-foreground">
             {t('workflows.form.descriptions.activities')}
           </p>
-          {error && <p className="text-sm text-destructive mt-1">{error}</p>}
+          {error && <p className="text-sm text-status-error-text mt-1">{error}</p>}
         </div>
         <Button type="button" onClick={addActivity} variant="outline" size="sm" className="w-full sm:w-auto">
           <Plus className="h-4 w-4 mr-1" />

--- a/packages/core/src/modules/workflows/components/BusinessRulesSelector.tsx
+++ b/packages/core/src/modules/workflows/components/BusinessRulesSelector.tsx
@@ -287,7 +287,7 @@ export function BusinessRulesSelector({
                         </Badge>
                       )}
                       {rule.enabled ? (
-                        <Badge variant="default" className="bg-emerald-500 text-xs">
+                        <Badge variant="default" className="bg-status-success-solid text-status-success-solid-foreground text-xs">
                           Enabled
                         </Badge>
                       ) : (

--- a/packages/core/src/modules/workflows/components/DefinitionTriggersEditor.tsx
+++ b/packages/core/src/modules/workflows/components/DefinitionTriggersEditor.tsx
@@ -285,7 +285,7 @@ export function DefinitionTriggersEditor({
       <div className="rounded-lg border bg-card p-3 md:p-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
           <div className="flex items-center gap-2">
-            <Zap className="w-5 h-5 text-amber-500" />
+            <Zap className="w-5 h-5 text-status-warning-icon" />
             <h3 className="text-sm font-semibold uppercase text-muted-foreground">
               {t('workflows.triggers.title', 'Event Triggers')}
             </h3>
@@ -567,7 +567,7 @@ export function DefinitionTriggersEditor({
               {t('common.cancel', 'Cancel')}
             </Button>
             <Button
-              variant="destructive"
+              variant="destructive-solid"
               onClick={() => deleteConfirmId && handleDelete(deleteConfirmId)}
             >
               {t('common.delete', 'Delete')}

--- a/packages/core/src/modules/workflows/components/EdgeEditDialogCrudForm.tsx
+++ b/packages/core/src/modules/workflows/components/EdgeEditDialogCrudForm.tsx
@@ -243,7 +243,7 @@ export function EdgeEditDialogCrudForm({ edge, isOpen, onClose, onSave, onDelete
                 type="button"
                 variant="outline"
                 onClick={handleDelete}
-                className="text-red-600 border-red-200 hover:bg-red-50"
+                className="text-destructive border-red-200 hover:bg-red-50"
               >
                 <Trash2 className="size-4 mr-2" />
                 Delete Transition

--- a/packages/core/src/modules/workflows/components/EdgeEditDialogCrudForm.tsx
+++ b/packages/core/src/modules/workflows/components/EdgeEditDialogCrudForm.tsx
@@ -241,9 +241,8 @@ export function EdgeEditDialogCrudForm({ edge, isOpen, onClose, onSave, onDelete
             extraActions={
               <Button
                 type="button"
-                variant="outline"
+                variant="destructive"
                 onClick={handleDelete}
-                className="text-destructive border-red-200 hover:bg-red-50"
               >
                 <Trash2 className="size-4 mr-2" />
                 Delete Transition

--- a/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialogCrudForm.tsx
@@ -494,9 +494,8 @@ export function NodeEditDialogCrudForm({ node, isOpen, onClose, onSave, onDelete
               canDelete ? (
                 <Button
                   type="button"
-                  variant="outline"
+                  variant="destructive"
                   onClick={handleDelete}
-                  className="text-red-600 border-red-200 hover:bg-red-50"
                 >
                   <Trash2 className="size-4 mr-2" />
                   Delete Step

--- a/packages/core/src/modules/workflows/components/StepsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/StepsEditor.tsx
@@ -89,7 +89,7 @@ export function StepsEditor({ value = [], onChange, error }: StepsEditorProps) {
           <p className="text-sm text-muted-foreground">
             {t('workflows.form.descriptions.steps')}
           </p>
-          {error && <p className="text-sm text-destructive mt-1">{error}</p>}
+          {error && <p className="text-sm text-status-error-text mt-1">{error}</p>}
         </div>
         <Button type="button" onClick={addStep} variant="outline" size="sm" className="w-full sm:w-auto">
           <Plus className="h-4 w-4 mr-1" />

--- a/packages/core/src/modules/workflows/components/StepsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/StepsEditor.tsx
@@ -89,7 +89,7 @@ export function StepsEditor({ value = [], onChange, error }: StepsEditorProps) {
           <p className="text-sm text-muted-foreground">
             {t('workflows.form.descriptions.steps')}
           </p>
-          {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+          {error && <p className="text-sm text-destructive mt-1">{error}</p>}
         </div>
         <Button type="button" onClick={addStep} variant="outline" size="sm" className="w-full sm:w-auto">
           <Plus className="h-4 w-4 mr-1" />
@@ -162,7 +162,7 @@ export function StepsEditor({ value = [], onChange, error }: StepsEditorProps) {
                     onClick={() => removeStep(index)}
                     title={t('common.delete')}
                   >
-                    <Trash2 className="h-4 w-4 text-red-600" />
+                    <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
                 </div>
               </div>

--- a/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
@@ -227,7 +227,7 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
           <p className="text-sm text-muted-foreground">
             {t('workflows.form.descriptions.transitions')}
           </p>
-          {error && <p className="text-sm text-destructive mt-1">{error}</p>}
+          {error && <p className="text-sm text-status-error-text mt-1">{error}</p>}
         </div>
         <Button type="button" onClick={addTransition} variant="outline" size="sm" className="w-full sm:w-auto">
           <Plus className="h-4 w-4 mr-1" />

--- a/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
@@ -227,7 +227,7 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
           <p className="text-sm text-muted-foreground">
             {t('workflows.form.descriptions.transitions')}
           </p>
-          {error && <p className="text-sm text-red-600 mt-1">{error}</p>}
+          {error && <p className="text-sm text-destructive mt-1">{error}</p>}
         </div>
         <Button type="button" onClick={addTransition} variant="outline" size="sm" className="w-full sm:w-auto">
           <Plus className="h-4 w-4 mr-1" />
@@ -300,7 +300,7 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
                     onClick={() => removeTransition(index)}
                     title={t('common.delete')}
                   >
-                    <Trash2 className="h-4 w-4 text-red-600" />
+                    <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
                 </div>
               </div>
@@ -480,7 +480,7 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
                               onClick={() => removeActivity(index, activityIndex)}
                               title={t('common.delete')}
                             >
-                              <Trash2 className="h-3 w-3 text-red-600" />
+                              <Trash2 className="h-3 w-3 text-destructive" />
                             </Button>
                           </div>
                         </div>

--- a/packages/core/src/modules/workflows/components/WorkflowLegend.tsx
+++ b/packages/core/src/modules/workflows/components/WorkflowLegend.tsx
@@ -46,7 +46,7 @@ export function WorkflowLegend() {
         </h3>
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <div className="flex-shrink-0 w-8 h-0.5 bg-emerald-500"></div>
+            <div className="flex-shrink-0 w-8 h-0.5 bg-status-success-solid"></div>
             <span className="text-xs text-muted-foreground">{t('workflows.legend.edgeState.completed')}</span>
           </div>
           <div className="flex items-center gap-2">

--- a/packages/core/src/modules/workflows/components/WorkflowSelector.tsx
+++ b/packages/core/src/modules/workflows/components/WorkflowSelector.tsx
@@ -253,7 +253,7 @@ export function WorkflowSelector({
                         v{workflow.version}
                       </Badge>
                       {workflow.enabled ? (
-                        <Badge variant="default" className="bg-emerald-500 text-xs">
+                        <Badge variant="default" className="bg-status-success-solid text-status-success-solid-foreground text-xs">
                           Enabled
                         </Badge>
                       ) : (

--- a/packages/core/src/modules/workflows/components/fields/BusinessRuleConditionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/BusinessRuleConditionsEditor.tsx
@@ -241,7 +241,7 @@ export function BusinessRuleConditionsEditor({
                         disabled={disabled}
                         className="ml-2 flex-shrink-0"
                       >
-                        <Trash2 className="size-4 text-red-600" />
+                        <Trash2 className="size-4 text-destructive" />
                       </Button>
                     }
                     title={t('workflows.fieldEditors.businessRuleConditions.removeCondition')}

--- a/packages/core/src/modules/workflows/components/fields/FormFieldArrayEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/FormFieldArrayEditor.tsx
@@ -118,7 +118,7 @@ export function FormFieldArrayEditor({
           <p className="text-xs text-muted-foreground mt-0.5">
             {t('workflows.fieldEditors.formFields.description')}
           </p>
-          {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+          {error && <p className="text-xs text-status-error-text mt-1">{error}</p>}
         </div>
         <Button
           type="button"

--- a/packages/core/src/modules/workflows/components/fields/FormFieldArrayEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/FormFieldArrayEditor.tsx
@@ -118,7 +118,7 @@ export function FormFieldArrayEditor({
           <p className="text-xs text-muted-foreground mt-0.5">
             {t('workflows.fieldEditors.formFields.description')}
           </p>
-          {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
+          {error && <p className="text-xs text-destructive mt-1">{error}</p>}
         </div>
         <Button
           type="button"

--- a/packages/core/src/modules/workflows/components/fields/MappingArrayEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/MappingArrayEditor.tsx
@@ -103,7 +103,7 @@ export function MappingArrayEditor({
           <p className="text-xs text-muted-foreground mt-0.5">
             {description}
           </p>
-          {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
+          {error && <p className="text-xs text-destructive mt-1">{error}</p>}
         </div>
         <Button
           type="button"

--- a/packages/core/src/modules/workflows/components/fields/MappingArrayEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/MappingArrayEditor.tsx
@@ -103,7 +103,7 @@ export function MappingArrayEditor({
           <p className="text-xs text-muted-foreground mt-0.5">
             {description}
           </p>
-          {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+          {error && <p className="text-xs text-status-error-text mt-1">{error}</p>}
         </div>
         <Button
           type="button"

--- a/packages/core/src/modules/workflows/components/fields/StartPreConditionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/StartPreConditionsEditor.tsx
@@ -332,7 +332,7 @@ export function StartPreConditionsEditor({
                         title={t('workflows.common.delete')}
                         disabled={disabled}
                       >
-                        <Trash2 className="h-4 w-4 text-red-600" />
+                        <Trash2 className="h-4 w-4 text-destructive" />
                       </Button>
                     }
                     title={t('workflows.fieldEditors.preConditions.removePreCondition')}

--- a/packages/core/src/modules/workflows/components/fields/WorkflowSelectorField.tsx
+++ b/packages/core/src/modules/workflows/components/fields/WorkflowSelectorField.tsx
@@ -128,7 +128,7 @@ export function WorkflowSelectorField({
         <p className="text-xs text-muted-foreground mt-0.5">
           {description}
         </p>
-        {error && <p className="text-xs text-red-600 mt-1">{error}</p>}
+        {error && <p className="text-xs text-destructive mt-1">{error}</p>}
       </div>
 
       {!workflowId ? (
@@ -178,7 +178,7 @@ export function WorkflowSelectorField({
                       )}
                       {workflowDetails?.enabled !== undefined && (
                         workflowDetails.enabled ? (
-                          <Badge variant="default" className="bg-emerald-500 text-xs">
+                          <Badge variant="default" className="bg-status-success-solid text-status-success-solid-foreground text-xs">
                             {t('common.enabled')}
                           </Badge>
                         ) : (

--- a/packages/core/src/modules/workflows/components/fields/WorkflowSelectorField.tsx
+++ b/packages/core/src/modules/workflows/components/fields/WorkflowSelectorField.tsx
@@ -128,7 +128,7 @@ export function WorkflowSelectorField({
         <p className="text-xs text-muted-foreground mt-0.5">
           {description}
         </p>
-        {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+        {error && <p className="text-xs text-status-error-text mt-1">{error}</p>}
       </div>
 
       {!workflowId ? (
@@ -159,10 +159,10 @@ export function WorkflowSelectorField({
               ) : workflowDetails?.error ? (
                 <>
                   <div className="flex items-center gap-2">
-                    <AlertCircle className="size-4 text-yellow-600" />
+                    <AlertCircle className="size-4 text-status-warning-text" />
                     <span className="text-sm font-semibold text-gray-900">{workflowId}</span>
                   </div>
-                  <p className="text-xs text-yellow-600">{t('workflows.common.workflowNotFoundOrUnavailable')}</p>
+                  <p className="text-xs text-status-warning-text">{t('workflows.common.workflowNotFoundOrUnavailable')}</p>
                 </>
               ) : (
                 <>

--- a/packages/create-app/template/src/app/globals.css
+++ b/packages/create-app/template/src/app/globals.css
@@ -124,6 +124,20 @@ TODO: Fix that latter to have reference by the package names
   --color-status-pink-border: var(--status-pink-border);
   --color-status-pink-icon: var(--status-pink-icon);
 
+  /* Solid role — filled chips, status dots, emphasis surfaces */
+  --color-status-error-solid: var(--status-error-solid);
+  --color-status-error-solid-foreground: var(--status-error-solid-foreground);
+  --color-status-success-solid: var(--status-success-solid);
+  --color-status-success-solid-foreground: var(--status-success-solid-foreground);
+  --color-status-warning-solid: var(--status-warning-solid);
+  --color-status-warning-solid-foreground: var(--status-warning-solid-foreground);
+  --color-status-info-solid: var(--status-info-solid);
+  --color-status-info-solid-foreground: var(--status-info-solid-foreground);
+  --color-status-neutral-solid: var(--status-neutral-solid);
+  --color-status-neutral-solid-foreground: var(--status-neutral-solid-foreground);
+  --color-status-pink-solid: var(--status-pink-solid);
+  --color-status-pink-solid-foreground: var(--status-pink-solid-foreground);
+
   /* ═══ Design System: Accent Colors ═══ */
   --color-accent-indigo: var(--accent-indigo);
   --color-accent-indigo-foreground: var(--accent-indigo-foreground);
@@ -222,7 +236,7 @@ TODO: Fix that latter to have reference by the package names
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted-foreground: oklch(0.545 0 0); /* darkened from 0.556: 4.54:1 on --muted (AA), was 4.34 */
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
@@ -301,6 +315,22 @@ TODO: Fix that latter to have reference by the package names
   --status-pink-text: oklch(0.388 0.180 340); /* pink-700 #BE185D */
   --status-pink-border: oklch(0.840 0.090 340);/* pink-200 #FBCFE8 */
   --status-pink-icon: oklch(0.633 0.238 340); /* pink-500 #EC4899 */
+
+  /* Solid role — filled surfaces that carry text (chips, badges, dots with
+     labels). All pairs hold WCAG AA 4.5:1 with their foreground; verified by
+     scripts/check-token-parity.mjs. Shades follow each family's 600-700. */
+  --status-error-solid: oklch(0.577 0.245 27.325);   /* red-600   #dc2626, on white 4.83 */
+  --status-error-solid-foreground: #ffffff;
+  --status-success-solid: oklch(0.527 0.154 150.069);/* green-700 #15803d, on white 5.02 */
+  --status-success-solid-foreground: #ffffff;
+  --status-warning-solid: oklch(0.555 0.163 48.998); /* amber-700 #b45309, on white 5.02 */
+  --status-warning-solid-foreground: #ffffff;
+  --status-info-solid: oklch(0.511 0.262 276.966);   /* indigo-600 #4f46e5, on white 6.29 */
+  --status-info-solid-foreground: #ffffff;
+  --status-neutral-solid: oklch(0.439 0 0);          /* neutral-600 #525252, on white 7.81 */
+  --status-neutral-solid-foreground: #ffffff;
+  --status-pink-solid: oklch(0.388 0.180 340);       /* pink-700  #be185d, on white 6.04 */
+  --status-pink-solid-foreground: #ffffff;
 }
 
 /* Opt-in Figma-style focus ring: 2px inner ring + 4px outer ring */
@@ -338,7 +368,7 @@ TODO: Fix that latter to have reference by the package names
   --brand-violet-foreground: #0C0C0C;
   --primary-hover: oklch(0.85 0 0);
   /* Accent indigo — slightly lighter in dark mode for contrast */
-  --accent-indigo: #818cf8;
+  --accent-indigo: #6d74f4; /* was indigo-400 #818cf8: white glyph 2.98:1 < 3.0 (WCAG non-text); now 3.85:1 */
   --accent-indigo-foreground: #ffffff;
   /* Disabled control tokens (dark) */
   --bg-disabled: oklch(0.25 0 0);
@@ -420,6 +450,22 @@ TODO: Fix that latter to have reference by the package names
   --status-pink-text: oklch(0.815 0.135 340);
   --status-pink-border: oklch(0.405 0.155 340);
   --status-pink-icon: oklch(0.700 0.225 340);
+
+  /* Solid role — same values as light: the fills are saturated enough to
+     read on dark surfaces, and keeping one value preserves chip identity
+     across themes. Listed explicitly so the parity check stays honest. */
+  --status-error-solid: oklch(0.577 0.245 27.325);
+  --status-error-solid-foreground: #ffffff;
+  --status-success-solid: oklch(0.527 0.154 150.069);
+  --status-success-solid-foreground: #ffffff;
+  --status-warning-solid: oklch(0.555 0.163 48.998);
+  --status-warning-solid-foreground: #ffffff;
+  --status-info-solid: oklch(0.511 0.262 276.966);
+  --status-info-solid-foreground: #ffffff;
+  --status-neutral-solid: oklch(0.439 0 0);
+  --status-neutral-solid-foreground: #ffffff;
+  --status-pink-solid: oklch(0.388 0.180 340);
+  --status-pink-solid-foreground: #ffffff;
 }
 
 @layer base {

--- a/packages/search/src/modules/search/frontend/components/sections/VectorSearchSection.tsx
+++ b/packages/search/src/modules/search/frontend/components/sections/VectorSearchSection.tsx
@@ -979,7 +979,7 @@ export function VectorSearchSection({
               <Button type="button" variant="outline" onClick={handleEmbeddingCancelChange} disabled={embeddingSaving}>
                 {t('search.settings.actions.cancel', 'Cancel')}
               </Button>
-              <Button type="button" variant="destructive" onClick={handleEmbeddingConfirmChange} disabled={embeddingSaving}>
+              <Button type="button" variant="destructive-solid" onClick={handleEmbeddingConfirmChange} disabled={embeddingSaving}>
                 {embeddingSaving ? <Spinner size="sm" className="mr-2" /> : null}
                 {t('search.settings.actions.confirm', 'Confirm')}
               </Button>

--- a/packages/ui/src/backend/JsonBuilder.tsx
+++ b/packages/ui/src/backend/JsonBuilder.tsx
@@ -164,7 +164,7 @@ export function JsonBuilder({
                         disabled={disabled}
                     />
                     {parseError && (
-                        <div className="text-xs text-destructive">Invalid JSON format</div>
+                        <div className="text-xs text-status-error-text">Invalid JSON format</div>
                     )}
                 </div>
             ) : (
@@ -185,7 +185,7 @@ export function JsonBuilder({
                 </div>
             )}
 
-            {error && <div className="text-xs text-destructive">{error}</div>}
+            {error && <div className="text-xs text-status-error-text">{error}</div>}
             {ConfirmDialogElement}
         </div>
     )
@@ -363,7 +363,7 @@ function JsonNode({ data, onChange, onDelete, readOnly, label, isRoot, confirm }
                             type="button"
                             variant="ghost"
                             size="xs"
-                            className="text-muted-foreground hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity"
+                            className="text-muted-foreground hover:text-destructive opacity-0 group-hover:opacity-100 transition-opacity"
                             title="Remove item"
                             onClick={onDelete}
                         >

--- a/packages/ui/src/backend/JsonBuilder.tsx
+++ b/packages/ui/src/backend/JsonBuilder.tsx
@@ -164,7 +164,7 @@ export function JsonBuilder({
                         disabled={disabled}
                     />
                     {parseError && (
-                        <div className="text-xs text-red-600">Invalid JSON format</div>
+                        <div className="text-xs text-destructive">Invalid JSON format</div>
                     )}
                 </div>
             ) : (
@@ -185,7 +185,7 @@ export function JsonBuilder({
                 </div>
             )}
 
-            {error && <div className="text-xs text-red-600">{error}</div>}
+            {error && <div className="text-xs text-destructive">{error}</div>}
             {ConfirmDialogElement}
         </div>
     )

--- a/packages/ui/src/backend/RowActions.tsx
+++ b/packages/ui/src/backend/RowActions.tsx
@@ -123,7 +123,7 @@ export function RowActions({ items = [] }: { items?: RowActionItem[] }) {
               <a
                 key={idx}
                 href={it.href}
-                className={`block w-full text-left px-2 py-1 text-sm rounded hover:bg-accent ${it.destructive ? 'text-red-600' : ''}`}
+                className={`block w-full text-left px-2 py-1 text-sm rounded hover:bg-accent ${it.destructive ? 'text-destructive' : ''}`}
                 role="menuitem"
                 onClick={(event) => {
                   event.stopPropagation()
@@ -138,7 +138,7 @@ export function RowActions({ items = [] }: { items?: RowActionItem[] }) {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className={`w-full justify-start rounded-none font-normal ${it.destructive ? 'text-red-600' : ''}`}
+                className={`w-full justify-start rounded-none font-normal ${it.destructive ? 'text-destructive' : ''}`}
                 role="menuitem"
                 onClick={(event) => {
                   event.stopPropagation()

--- a/packages/ui/src/backend/confirm-dialog/ConfirmDialog.tsx
+++ b/packages/ui/src/backend/confirm-dialog/ConfirmDialog.tsx
@@ -277,7 +277,7 @@ export function ConfirmDialog({
           {resolvedConfirmText !== false && (
             <Button
               ref={confirmButtonRef}
-              variant={variant === "destructive" ? "destructive" : "default"}
+              variant={variant === "destructive" ? "destructive-solid" : "default"}
               onClick={handleConfirm}
               disabled={loading}
               className="w-full sm:w-auto"

--- a/packages/ui/src/backend/confirm-dialog/__tests__/ConfirmDialog.test.tsx
+++ b/packages/ui/src/backend/confirm-dialog/__tests__/ConfirmDialog.test.tsx
@@ -91,5 +91,42 @@ describe('ConfirmDialog', () => {
 
     expect(firstOpenChange).not.toHaveBeenCalled()
     expect(secondOpenChange).toHaveBeenCalledWith(false)
+
+  // The dialog confirm button is the point of no return, so it takes the
+  // filled `destructive-solid` treatment even though the trigger that opened
+  // it renders the quiet `destructive` variant.
+  it('renders the destructive confirmation as the solid variant', () => {
+    renderWithProviders(
+      <ConfirmDialog
+        open
+        variant="destructive"
+        onOpenChange={() => undefined}
+        onConfirm={() => undefined}
+        title="Delete customer?"
+        confirmText="Delete"
+        cancelText="Cancel"
+      />,
+    )
+
+    const classNames = screen.getByRole('button', { name: 'Delete' }).className.split(/\s+/)
+    expect(classNames).toContain('bg-destructive')
+    expect(classNames).toContain('text-white')
+  })
+
+  it('keeps the default confirmation on the primary variant', () => {
+    renderWithProviders(
+      <ConfirmDialog
+        open
+        onOpenChange={() => undefined}
+        onConfirm={() => undefined}
+        title="Publish article?"
+        confirmText="Publish"
+        cancelText="Cancel"
+      />,
+    )
+
+    const classNames = screen.getByRole('button', { name: 'Publish' }).className.split(/\s+/)
+    expect(classNames).toContain('bg-primary')
+    expect(classNames).not.toContain('bg-destructive')
   })
 })

--- a/packages/ui/src/backend/detail/AttachmentDeleteDialog.tsx
+++ b/packages/ui/src/backend/detail/AttachmentDeleteDialog.tsx
@@ -38,7 +38,7 @@ export function AttachmentDeleteDialog({ open, onOpenChange, fileName, onConfirm
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isDeleting}>
             {t('attachments.library.metadata.cancel', 'Cancel')}
           </Button>
-          <Button type="button" variant="destructive" onClick={onConfirm} disabled={isDeleting}>
+          <Button type="button" variant="destructive-solid" onClick={onConfirm} disabled={isDeleting}>
             {t('attachments.library.actions.delete', 'Delete')}
           </Button>
         </DialogFooter>

--- a/packages/ui/src/backend/detail/AttachmentsSection.tsx
+++ b/packages/ui/src/backend/detail/AttachmentsSection.tsx
@@ -256,7 +256,7 @@ function AttachmentsSectionImpl({
         </div>
       )}
 
-      {error ? <p className="text-xs font-medium text-destructive">{error}</p> : null}
+      {error ? <p className="text-xs font-medium text-status-error-text">{error}</p> : null}
 
       {loading ? (
         <div className="text-sm text-muted-foreground">{t('attachments.library.loading', 'Loading attachments…')}</div>

--- a/packages/ui/src/backend/detail/AttachmentsSection.tsx
+++ b/packages/ui/src/backend/detail/AttachmentsSection.tsx
@@ -256,7 +256,7 @@ function AttachmentsSectionImpl({
         </div>
       )}
 
-      {error ? <p className="text-xs font-medium text-red-600">{error}</p> : null}
+      {error ? <p className="text-xs font-medium text-destructive">{error}</p> : null}
 
       {loading ? (
         <div className="text-sm text-muted-foreground">{t('attachments.library.loading', 'Loading attachments…')}</div>

--- a/packages/ui/src/backend/detail/NotesSection.tsx
+++ b/packages/ui/src/backend/detail/NotesSection.tsx
@@ -1256,7 +1256,7 @@ function NotesSectionImpl<C = unknown>({
                       editorWrapperClassName="w-full rounded-md border border-muted-foreground/20 bg-background p-2"
                       remarkPlugins={markdownPlugins}
                     />
-                    {contentError ? <p className="text-xs text-red-600">{contentError}</p> : null}
+                    {contentError ? <p className="text-xs text-destructive">{contentError}</p> : null}
                     <div className="flex flex-wrap items-center gap-2">
                       <Button type="button" size="sm" onClick={handleContentSave} disabled={contentSavingId === note.id}>
                         {contentSavingId === note.id ? (

--- a/packages/ui/src/backend/detail/NotesSection.tsx
+++ b/packages/ui/src/backend/detail/NotesSection.tsx
@@ -1256,7 +1256,7 @@ function NotesSectionImpl<C = unknown>({
                       editorWrapperClassName="w-full rounded-md border border-muted-foreground/20 bg-background p-2"
                       remarkPlugins={markdownPlugins}
                     />
-                    {contentError ? <p className="text-xs text-destructive">{contentError}</p> : null}
+                    {contentError ? <p className="text-xs text-status-error-text">{contentError}</p> : null}
                     <div className="flex flex-wrap items-center gap-2">
                       <Button type="button" size="sm" onClick={handleContentSave} disabled={contentSavingId === note.id}>
                         {contentSavingId === note.id ? (

--- a/packages/ui/src/backend/detail/TagsSection.tsx
+++ b/packages/ui/src/backend/detail/TagsSection.tsx
@@ -387,7 +387,7 @@ function TagsSectionImpl({
                 loadSuggestions={loadSuggestions}
                 autoFocus={!autoSave}
               />
-              {error ? <p className="text-xs text-red-600">{error}</p> : null}
+              {error ? <p className="text-xs text-destructive">{error}</p> : null}
               {autoSave ? null : (
                 <div className="flex items-center gap-2 mt-3 mb-2">
                   <Button type="button" size="sm" onClick={handleSave} disabled={saving || isSubmitting}>

--- a/packages/ui/src/backend/detail/TagsSection.tsx
+++ b/packages/ui/src/backend/detail/TagsSection.tsx
@@ -387,7 +387,7 @@ function TagsSectionImpl({
                 loadSuggestions={loadSuggestions}
                 autoFocus={!autoSave}
               />
-              {error ? <p className="text-xs text-destructive">{error}</p> : null}
+              {error ? <p className="text-xs text-status-error-text">{error}</p> : null}
               {autoSave ? null : (
                 <div className="flex items-center gap-2 mt-3 mb-2">
                   <Button type="button" size="sm" onClick={handleSave} disabled={saving || isSubmitting}>

--- a/packages/ui/src/backend/forms/FormHeader.tsx
+++ b/packages/ui/src/backend/forms/FormHeader.tsx
@@ -181,11 +181,10 @@ function DetailHeader({
               {onDelete ? (
                 <Button
                   type="button"
-                  variant="outline"
+                  variant="destructive"
                   size="sm"
                   onClick={onDelete}
                   disabled={isDeleting}
-                  className="text-destructive border-red-200 hover:bg-red-50 rounded"
                 >
                   {isDeleting ? (
                     <Loader2 className="size-4 mr-2 animate-spin" />

--- a/packages/ui/src/backend/forms/FormHeader.tsx
+++ b/packages/ui/src/backend/forms/FormHeader.tsx
@@ -185,7 +185,7 @@ function DetailHeader({
                   size="sm"
                   onClick={onDelete}
                   disabled={isDeleting}
-                  className="text-red-600 border-red-200 hover:bg-red-50 rounded"
+                  className="text-destructive border-red-200 hover:bg-red-50 rounded"
                 >
                   {isDeleting ? (
                     <Loader2 className="size-4 mr-2 animate-spin" />

--- a/packages/ui/src/backend/schedule/ScheduleAgenda.tsx
+++ b/packages/ui/src/backend/schedule/ScheduleAgenda.tsx
@@ -57,9 +57,9 @@ function getStatusLabel(status: ScheduleItem['status'], t: (key: string, fallbac
 }
 
 function getKindStyles(kind: ScheduleItem['kind']): string {
-  if (kind === 'event') return 'border-blue-500/40 bg-blue-500/10 text-blue-950'
-  if (kind === 'exception') return 'border-amber-500/40 bg-amber-500/10 text-amber-950'
-  return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-950'
+  if (kind === 'event') return 'border-status-info-border bg-status-info-bg text-status-info-text'
+  if (kind === 'exception') return 'border-status-warning-border bg-status-warning-bg text-status-warning-text'
+  return 'border-status-success-border bg-status-success-bg text-status-success-text'
 }
 
 export type ScheduleAgendaProps = {

--- a/packages/ui/src/backend/schedule/ScheduleGrid.tsx
+++ b/packages/ui/src/backend/schedule/ScheduleGrid.tsx
@@ -57,9 +57,9 @@ function getStatusLabel(status: ScheduleItem['status'], t: (key: string, fallbac
 }
 
 function getKindStyles(kind: ScheduleItem['kind']): string {
-  if (kind === 'event') return 'border-blue-500/40 bg-blue-500/10 text-blue-950'
-  if (kind === 'exception') return 'border-amber-500/40 bg-amber-500/10 text-amber-950'
-  return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-950'
+  if (kind === 'event') return 'border-status-info-border bg-status-info-bg text-status-info-text'
+  if (kind === 'exception') return 'border-status-warning-border bg-status-warning-bg text-status-warning-text'
+  return 'border-status-success-border bg-status-success-bg text-status-success-text'
 }
 
 export type ScheduleGridProps = {

--- a/packages/ui/src/primitives/__tests__/button.test.tsx
+++ b/packages/ui/src/primitives/__tests__/button.test.tsx
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+
+import * as React from 'react'
+import { render } from '@testing-library/react'
+import { Button, buttonVariants } from '../button'
+
+type ButtonVariant = NonNullable<Parameters<typeof buttonVariants>[0]>['variant']
+
+function classesOf(variant: ButtonVariant) {
+  return buttonVariants({ variant }).split(/\s+/).filter(Boolean)
+}
+
+describe('Button destructive variants', () => {
+  // The DS policy: `destructive` is the quiet trigger (red text on a calm
+  // surface) so a page full of delete buttons does not train users to ignore
+  // red; `destructive-solid` is the filled form, reserved for the single
+  // point-of-no-return confirmation inside a dialog. These tests pin both
+  // halves of that contract — swapping them back is a visual regression that
+  // no other test would catch.
+
+  it('destructive is quiet: destructive border and text on the page surface', () => {
+    const classes = classesOf('destructive')
+    expect(classes).toContain('border')
+    expect(classes).toContain('border-destructive')
+    expect(classes).toContain('bg-background')
+    expect(classes).toContain('text-destructive')
+  })
+
+  it('destructive does not fill with the destructive surface', () => {
+    const classes = classesOf('destructive')
+    expect(classes).not.toContain('bg-destructive')
+    expect(classes).not.toContain('text-white')
+  })
+
+  it('destructive-solid fills with the destructive surface and white glyph', () => {
+    const classes = classesOf('destructive-solid')
+    expect(classes).toContain('bg-destructive')
+    expect(classes).toContain('text-white')
+    expect(classes).not.toContain('border-destructive')
+  })
+
+  it('destructive-solid ships no dark background override', () => {
+    // `--destructive` is a semantic token that already resolves per theme; a
+    // `dark:bg-*` override on top of it is what broke IconButton in #3507.
+    const classes = classesOf('destructive-solid')
+    expect(classes.some((cls) => cls.startsWith('dark:bg-'))).toBe(false)
+  })
+
+  it('renders the quiet treatment on the element for variant="destructive"', () => {
+    const { getByRole } = render(<Button variant="destructive">Delete</Button>)
+    const className = getByRole('button').className
+    expect(className).toContain('text-destructive')
+    expect(className).toContain('border-destructive')
+    expect(className.split(/\s+/)).not.toContain('bg-destructive')
+  })
+
+  it('renders the filled treatment on the element for variant="destructive-solid"', () => {
+    const { getByRole } = render(<Button variant="destructive-solid">Delete permanently</Button>)
+    const classNames = getByRole('button').className.split(/\s+/)
+    expect(classNames).toContain('bg-destructive')
+    expect(classNames).toContain('text-white')
+  })
+
+  it('defaults to the primary variant when none is given', () => {
+    const { getByRole } = render(<Button>Save</Button>)
+    const classNames = getByRole('button').className.split(/\s+/)
+    expect(classNames).toContain('bg-primary')
+    expect(classNames).not.toContain('text-destructive')
+  })
+})

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -9,10 +9,16 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary-hover',
+        /* Destructive is quiet by design: red text on a calm surface. A wall
+           of solid red buttons trains users to ignore red. The filled form is
+           `destructive-solid`, reserved for the single point-of-no-return
+           confirmation inside a dialog — never for the button that opens it. */
         destructive:
-          'bg-destructive text-white shadow-xs hover:bg-destructive/90 aria-invalid:ring-destructive dark:aria-invalid:ring-destructive dark:bg-destructive/10',
+          'border border-destructive bg-background text-destructive shadow-xs hover:bg-destructive/10 aria-invalid:ring-destructive dark:aria-invalid:ring-destructive dark:hover:bg-destructive/15',
+        'destructive-solid':
+          'bg-destructive text-white shadow-xs hover:bg-destructive/90 aria-invalid:ring-destructive dark:aria-invalid:ring-destructive',
         'destructive-outline':
-          'border border-destructive/30 bg-background text-destructive shadow-xs hover:bg-destructive/10 dark:border-destructive/40 dark:hover:bg-destructive/15',
+          'border border-destructive bg-background text-destructive shadow-xs hover:bg-destructive/10 dark:hover:bg-destructive/15',
         'destructive-soft':
           'bg-destructive/10 text-destructive hover:bg-destructive/15 dark:bg-destructive/15 dark:hover:bg-destructive/20',
         'destructive-ghost':

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -14,15 +14,15 @@ const buttonVariants = cva(
            `destructive-solid`, reserved for the single point-of-no-return
            confirmation inside a dialog — never for the button that opens it. */
         destructive:
-          'border border-destructive bg-background text-destructive shadow-xs hover:bg-destructive/10 aria-invalid:ring-destructive dark:aria-invalid:ring-destructive dark:hover:bg-destructive/15',
+          'border border-destructive bg-background text-destructive shadow-xs hover:bg-destructive/10 aria-invalid:ring-destructive dark:aria-invalid:ring-destructive',
         'destructive-solid':
           'bg-destructive text-white shadow-xs hover:bg-destructive/90 aria-invalid:ring-destructive dark:aria-invalid:ring-destructive',
         'destructive-outline':
-          'border border-destructive bg-background text-destructive shadow-xs hover:bg-destructive/10 dark:hover:bg-destructive/15',
+          'border border-destructive bg-background text-destructive shadow-xs hover:bg-destructive/10',
         'destructive-soft':
-          'bg-destructive/10 text-destructive hover:bg-destructive/15 dark:bg-destructive/15 dark:hover:bg-destructive/20',
+          'bg-destructive/10 text-destructive hover:bg-destructive/15',
         'destructive-ghost':
-          'text-destructive hover:bg-destructive/10 dark:hover:bg-destructive/15',
+          'text-destructive hover:bg-destructive/10',
         outline:
           'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
         secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',

--- a/scripts/__tests__/check-token-parity.test.mjs
+++ b/scripts/__tests__/check-token-parity.test.mjs
@@ -1,0 +1,117 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const SCRIPT = path.join(ROOT, 'scripts', 'check-token-parity.mjs')
+
+const APP_CSS_RELATIVE = 'apps/mercato/src/app/globals.css'
+const TEMPLATE_CSS_RELATIVE = 'packages/create-app/template/src/app/globals.css'
+
+function runChecker(rootDir) {
+  const args = rootDir ? [SCRIPT, '--root', rootDir] : [SCRIPT]
+  return spawnSync(process.execPath, args, { encoding: 'utf8' })
+}
+
+function buildCss({ rootTokens, darkTokens }) {
+  const block = (selector, tokens) =>
+    `${selector} {\n${Object.entries(tokens).map(([name, value]) => `  --${name}: ${value};`).join('\n')}\n}\n`
+  return `@source "../../../../packages";\n\n${block(':root', rootTokens)}\n${block('.dark', darkTokens)}`
+}
+
+const PASSING_ROOT_TOKENS = {
+  background: '#ffffff',
+  foreground: '#101828',
+  card: '#ffffff',
+  'card-foreground': '#101828',
+}
+
+const PASSING_DARK_TOKENS = {
+  background: '#101828',
+  foreground: '#ffffff',
+  card: '#101828',
+  'card-foreground': '#ffffff',
+}
+
+function makeFixture({ rootTokens = PASSING_ROOT_TOKENS, darkTokens = PASSING_DARK_TOKENS, templateCss } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'token-parity-'))
+  const appCss = buildCss({ rootTokens, darkTokens })
+  const appCssPath = path.join(dir, APP_CSS_RELATIVE)
+  const templateCssPath = path.join(dir, TEMPLATE_CSS_RELATIVE)
+  fs.mkdirSync(path.dirname(appCssPath), { recursive: true })
+  fs.mkdirSync(path.dirname(templateCssPath), { recursive: true })
+  fs.writeFileSync(appCssPath, appCss)
+  fs.writeFileSync(templateCssPath, templateCss ?? appCss.replace('"../../../../packages"', '"../../packages"'))
+  return dir
+}
+
+function withFixture(options, assertions) {
+  const fixture = makeFixture(options)
+  try {
+    assertions(runChecker(fixture))
+  } finally {
+    fs.rmSync(fixture, { recursive: true, force: true })
+  }
+}
+
+test('the repository globals.css passes parity, template sync and contrast', () => {
+  const result = runChecker()
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+  assert.match(result.stdout, /create-app template copy in sync/)
+  assert.match(result.stdout, /contrast checked on \d+ theme×pair combinations/)
+})
+
+test('fails when a :root token has no .dark override and is not allowlisted', () => {
+  withFixture(
+    { rootTokens: { ...PASSING_ROOT_TOKENS, sidebar: '#fafafa' } },
+    (result) => {
+      assert.equal(result.status, 1)
+      assert.match(result.stderr, /--sidebar defined in :root has no \.dark override/)
+    },
+  )
+})
+
+test('fails when a .dark token has no :root base', () => {
+  withFixture(
+    { darkTokens: { ...PASSING_DARK_TOKENS, sidebar: '#1a1a1a' } },
+    (result) => {
+      assert.equal(result.status, 1)
+      assert.match(result.stderr, /--sidebar defined in \.dark has no :root base/)
+    },
+  )
+})
+
+test('fails when the create-app template copy drifts from the app globals.css', () => {
+  withFixture(
+    { templateCss: buildCss({ rootTokens: { ...PASSING_ROOT_TOKENS, card: '#eeeeee' }, darkTokens: PASSING_DARK_TOKENS }) },
+    (result) => {
+      assert.equal(result.status, 1)
+      assert.match(result.stderr, /has drifted from the app globals\.css/)
+    },
+  )
+})
+
+test('fails when a token pair drops below the WCAG text threshold in light theme', () => {
+  withFixture(
+    { rootTokens: { ...PASSING_ROOT_TOKENS, 'card-foreground': '#dddddd' } },
+    (result) => {
+      assert.equal(result.status, 1)
+      assert.match(result.stderr, /\[light\] --card-foreground on --card: contrast \d+\.\d+ < 4\.5/)
+    },
+  )
+})
+
+test('fails when a token pair drops below the WCAG text threshold in dark theme only', () => {
+  withFixture(
+    { darkTokens: { ...PASSING_DARK_TOKENS, 'card-foreground': '#333333' } },
+    (result) => {
+      assert.equal(result.status, 1)
+      assert.match(result.stderr, /\[dark\] --card-foreground on --card: contrast \d+\.\d+ < 4\.5/)
+      assert.doesNotMatch(result.stderr, /\[light\] --card-foreground/)
+    },
+  )
+})

--- a/scripts/check-token-parity.mjs
+++ b/scripts/check-token-parity.mjs
@@ -17,7 +17,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-const ROOT = path.resolve(import.meta.dirname, '..')
+/* --root lets the script test itself: scripts/__tests__/check-token-parity.test.mjs
+ * points it at synthetic fixtures to prove each check still fails when it should. */
+const rootFlagIndex = process.argv.indexOf('--root')
+const ROOT = rootFlagIndex >= 0 && process.argv[rootFlagIndex + 1]
+  ? path.resolve(process.argv[rootFlagIndex + 1])
+  : path.resolve(import.meta.dirname, '..')
 const APP_CSS = path.join(ROOT, 'apps/mercato/src/app/globals.css')
 const TEMPLATE_CSS = path.join(ROOT, 'packages/create-app/template/src/app/globals.css')
 

--- a/scripts/check-token-parity.mjs
+++ b/scripts/check-token-parity.mjs
@@ -31,7 +31,7 @@ const TEMPLATE_CSS = path.join(ROOT, 'packages/create-app/template/src/app/globa
  * a comment there (or the reverse) should be treated as a review question. */
 const THEME_INVARIANT = new Set([
   'font-geist-sans', 'font-geist-mono', 'radius',
-  'brand-lime',
+  'brand-lime', 'brand-yellow',
   'brand-apple', 'brand-github', 'brand-x', 'brand-google-stroke',
   'brand-facebook', 'brand-dropbox', 'brand-linkedin',
 ])

--- a/scripts/check-token-parity.mjs
+++ b/scripts/check-token-parity.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Token parity + contrast check for globals.css.
+ *
+ * Three guarantees, none of which light-dark() would give us for free:
+ *  1. Parity — every themed token defined in :root has a .dark override
+ *     (and vice versa), with an explicit allowlist for the tokens that are
+ *     theme-invariant on purpose. Works retroactively on all tokens.
+ *  2. Template sync — apps/mercato globals.css and the create-app template
+ *     copy stay identical modulo @source path depth.
+ *  3. Contrast — every --X / --X-foreground pair is checked against WCAG
+ *     ratios in BOTH themes, so "looks fine in light, unreadable in dark"
+ *     fails here instead of in someone's screenshot.
+ *
+ * Zero dependencies. Exit 1 on failure so it can gate CI on changed files.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = path.resolve(import.meta.dirname, '..')
+const APP_CSS = path.join(ROOT, 'apps/mercato/src/app/globals.css')
+const TEMPLATE_CSS = path.join(ROOT, 'packages/create-app/template/src/app/globals.css')
+
+/* Tokens that intentionally have no .dark override. Keep this list in sync
+ * with the "theme-invariant" comments in globals.css — an entry here without
+ * a comment there (or the reverse) should be treated as a review question. */
+const THEME_INVARIANT = new Set([
+  'font-geist-sans', 'font-geist-mono', 'radius',
+  'brand-lime',
+  'brand-apple', 'brand-github', 'brand-x', 'brand-google-stroke',
+  'brand-facebook', 'brand-dropbox', 'brand-linkedin',
+])
+
+/* Tokens whose base lives in @theme and is only overridden in .dark
+ * (dark-only entries are fine for these prefixes). */
+const DARK_ONLY_OK = [/^shadow-/]
+
+/* Pairs checked for contrast: background token -> foreground token.
+ * Derived automatically from the --X / --X-foreground convention, plus the
+ * global page pair. Text-on-background pairs use AA normal text (4.5); pairs
+ * marked `ui` are large/bold or non-text UI surfaces where 3.0 applies. */
+const EXTRA_PAIRS = [{ bg: 'background', fg: 'foreground', min: 4.5 }]
+/* accent-indigo backs selection controls (checkbox/radio/switch — see the
+ * comment in globals.css), so the WCAG non-text UI threshold (3.0) applies,
+ * not the 4.5 for body text. */
+const UI_PAIRS = new Set(['border', 'input', 'ring', 'accent-indigo'])
+
+// ---------------------------------------------------------------- parsing
+
+function parseBlock(css, header) {
+  // Match the selector at line start — a plain indexOf would hit occurrences
+  // inside comments ("no .dark override") and parse the wrong block.
+  const m = new RegExp(`^${header.replace('.', '\\.')}\\s*\\{`, 'm').exec(css)
+  if (!m) return null
+  const start = m.index
+  let depth = 0, i = css.indexOf('{', start)
+  const open = i
+  for (; i < css.length; i++) {
+    if (css[i] === '{') depth++
+    else if (css[i] === '}' && --depth === 0) break
+  }
+  const body = css.slice(open + 1, i)
+  const tokens = new Map()
+  for (const m of body.matchAll(/--([a-z0-9-]+)\s*:\s*([^;]+);/gi)) {
+    tokens.set(m[1], m[2].trim())
+  }
+  return tokens
+}
+
+// ------------------------------------------------------- color -> sRGB
+
+function srgbFromOklch(l, c, hDeg) {
+  const h = (hDeg * Math.PI) / 180
+  const a = c * Math.cos(h), b = c * Math.sin(h)
+  const l_ = (l + 0.3963377774 * a + 0.2158037573 * b) ** 3
+  const m_ = (l - 0.1055613458 * a - 0.0638541728 * b) ** 3
+  const s_ = (l - 0.0894841775 * a - 1.291485548 * b) ** 3
+  const lin = [
+    4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_,
+    -1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_,
+    -0.0041960863 * l_ - 0.7034186147 * m_ + 1.707614701 * s_,
+  ]
+  return lin.map((v) => {
+    v = Math.min(1, Math.max(0, v))
+    return v <= 0.0031308 ? 12.92 * v : 1.055 * v ** (1 / 2.4) - 0.055
+  })
+}
+
+function parseColor(value) {
+  let m = value.match(/^oklch\(\s*([\d.]+%?)\s+([\d.]+)\s+([\d.]+)(?:\s*\/\s*[\d.%]+)?\s*\)$/i)
+  if (m) {
+    const l = m[1].endsWith('%') ? parseFloat(m[1]) / 100 : parseFloat(m[1])
+    return srgbFromOklch(l, parseFloat(m[2]), parseFloat(m[3]))
+  }
+  m = value.match(/^#([0-9a-f]{6})$/i)
+  if (m) return [0, 1, 2].map((i) => parseInt(m[1].slice(i * 2, i * 2 + 2), 16) / 255)
+  m = value.match(/^#([0-9a-f]{3})$/i)
+  if (m) return [...m[1]].map((ch) => parseInt(ch + ch, 16) / 255)
+  m = value.match(/^rgba?\(\s*(\d+)[,\s]+(\d+)[,\s]+(\d+)/i)
+  if (m) return [m[1], m[2], m[3]].map((v) => v / 255)
+  return null // var() chains, gradients, non-color values — skipped
+}
+
+function contrast(rgb1, rgb2) {
+  const lum = ([r, g, b]) => {
+    const f = (v) => (v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4)
+    return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b)
+  }
+  const [a, b] = [lum(rgb1) + 0.05, lum(rgb2) + 0.05]
+  return a > b ? a / b : b / a
+}
+
+// ---------------------------------------------------------------- checks
+
+const css = fs.readFileSync(APP_CSS, 'utf8')
+const root = parseBlock(css, ':root')
+const dark = parseBlock(css, '.dark')
+let failures = 0
+const fail = (msg) => { failures++; console.error(`  ✗ ${msg}`) }
+
+console.log(`token parity — ${path.relative(ROOT, APP_CSS)}`)
+console.log(`  :root ${root.size} tokens, .dark ${dark.size} tokens`)
+
+// 1. Parity
+for (const name of root.keys()) {
+  if (name === 'color-scheme') continue
+  if (!dark.has(name) && !THEME_INVARIANT.has(name)) {
+    fail(`--${name} defined in :root has no .dark override and is not on the theme-invariant allowlist`)
+  }
+}
+for (const name of dark.keys()) {
+  if (name === 'color-scheme') continue
+  if (!root.has(name) && !DARK_ONLY_OK.some((re) => re.test(name))) {
+    fail(`--${name} defined in .dark has no :root base (and is not a known @theme-based override)`)
+  }
+}
+for (const name of THEME_INVARIANT) {
+  if (dark.has(name)) fail(`--${name} is allowlisted as theme-invariant but .dark overrides it — update the allowlist or drop the override`)
+  if (!root.has(name)) console.warn(`  ⚠ allowlist entry --${name} no longer exists in :root — prune it`)
+}
+
+// 2. Template sync
+const normalize = (s) => s.replace(/@source\s+"[^"]*"/g, '@source "<path>"')
+if (normalize(fs.readFileSync(TEMPLATE_CSS, 'utf8')) !== normalize(css)) {
+  fail(`${path.relative(ROOT, TEMPLATE_CSS)} has drifted from the app globals.css (differences beyond @source depth)`)
+} else {
+  console.log('  ✓ create-app template copy in sync')
+}
+
+// 3. Contrast, both themes
+const pairs = [...EXTRA_PAIRS]
+for (const name of root.keys()) {
+  if (name.endsWith('-foreground')) {
+    const bg = name.slice(0, -'-foreground'.length)
+    if (root.has(bg)) pairs.push({ bg, fg: name, min: UI_PAIRS.has(bg) ? 3.0 : 4.5 })
+  }
+}
+let checked = 0, skipped = []
+for (const theme of [{ label: 'light', map: root }, { label: 'dark', map: dark }]) {
+  for (const { bg, fg, min } of pairs) {
+    const bgv = theme.map.get(bg) ?? root.get(bg)
+    const fgv = theme.map.get(fg) ?? root.get(fg)
+    const c1 = parseColor(bgv ?? ''), c2 = parseColor(fgv ?? '')
+    if (!c1 || !c2) { skipped.push(`${theme.label}:${bg}`); continue }
+    checked++
+    const ratio = contrast(c1, c2)
+    if (ratio < min) fail(`[${theme.label}] --${fg} on --${bg}: contrast ${ratio.toFixed(2)} < ${min} (${fgv} on ${bgv})`)
+  }
+}
+console.log(`  ✓ contrast checked on ${checked} theme×pair combinations${skipped.length ? ` (${skipped.length} skipped: non-literal values)` : ''}`)
+
+if (failures) {
+  console.error(`\n${failures} failure(s).`)
+  process.exit(1)
+}
+console.log('\nAll checks passed.')


### PR DESCRIPTION
Closes #4651. Supersedes #4652 (GitHub stopped synchronizing that PR's head after a rebase; branch and content are identical).

## What

1. **Status solid role + token parity gate** — `--status-{x}-solid` / `-solid-foreground` for all six families (every pair ≥ 4.5:1, table in `docs/design-system/token-values.md`), two measured contrast fixes (`--muted-foreground` 4.34→4.54 in light, dark `--accent-indigo` 2.98→3.85 against its white glyph), and `yarn check:tokens` wired into `test:scripts`: `:root`/`.dark` parity with a theme-invariant allowlist, create-app template sync, and WCAG contrast on every `--X`/`--X-foreground` pair in both themes.

2. **Destructive buttons quiet by default** — `variant="destructive"` renders the DS Error/Stroke style (red text, full `--destructive` border, white surface; DS file, Buttons node 129-605), calming all 70+ usages with no per-file edits. The old fill lives on as `destructive-solid`, applied to every point-of-no-return confirmation and nothing else. Policy recorded in the DS guardian (component-guide, token-mapping, ds-health-check counts `destructive-solid` usages and runs the token gate) and `docs/design-system`; variant contracts pinned by unit tests.

3. **Palette-hardcode migration** — `text-red-600` → `text-destructive` (63×, same color), NextStepCallout/Schedule views onto status anatomy, Active badges onto the solid role, status copy onto status tokens. Hardcoded palette classes in packages/ui + core: **647 → 552**.

Rebased onto current `develop` post-#4891: the DS token snapshot is regenerated with the exporter, and the parity gate's first catch on the fresh base was `--brand-yellow` missing from the theme-invariant allowlist — now listed alongside `brand-lime`.

## Verification

- `yarn check:tokens` green (36 theme×pair combinations)
- button / alert / ConfirmDialog tests 51/51, incl. new variant-contract tests
- `yarn lint:ds` passes; migrated files carry zero color warnings
- walked live: workflow visual editor step dialog renders the quiet Delete with the black Save as the single strong action