### PR TITLE
test(app): mock i18n in the app-level storage_s3 route suite (#4926)

### DIFF
--- a/.ai/runs/2026-08-04-storage-s3-route-tests-i18n-mock.md
+++ b/.ai/runs/2026-08-04-storage-s3-route-tests-i18n-mock.md
@@ -1,0 +1,64 @@
+# Fix red `test` job on develop — app-level storage_s3 route suite misses the i18n mock
+
+- **Issue:** [#4926](https://github.com/open-mercato/open-mercato/issues/4926)
+- **Branch:** `fix/issue-4926-storage-s3-route-tests-i18n`
+- **Base:** `develop` (`upstream/develop` @ `a575bebce`)
+- **Skill:** `om-auto-fix-issue` (bug route)
+
+## 🎯 Goal
+
+Bring the unit `test` job on `develop` back to green. Since #4887 (`c95ff214e`) merged,
+`apps/mercato/src/__tests__/storage-s3-routes.test.ts` fails all five of its cases, so every open PR
+against `develop` inherits a red `test` job and a skipped `merge-coverage` regardless of its own diff.
+
+## 🔍 Problem and root cause
+
+#4887 replaced the hard-coded error strings in the `storage_s3` routes with `resolveTranslations()`.
+`resolveTranslations()` loads the locale dictionary through `getModules()`, which throws
+`[Bootstrap] Modules not registered. Call registerModules() at bootstrap.` whenever the module registry
+has not been populated.
+
+The PR updated the tests that live next to the routes — `packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts`
+already mocks `@open-mercato/shared/lib/i18n/server`, so it stayed green. What it missed is the app-level
+consumer suite, which imports the real `download`/`upload` handlers but mocks only
+`@open-mercato/shared/lib/auth/server`, `@open-mercato/shared/lib/di/container` and the S3 driver. Nothing
+registers modules and nothing mocks i18n, so the very first line of each handler throws before any
+assertion runs.
+
+This class of breakage is invisible to the package's own tests by construction: the package suite mocks i18n,
+so localizing a route never surfaces the app-level consumer that does not.
+
+## Approach
+
+Test-side only; no production change is warranted. Add the i18n mock to the app-level suite, following the
+pattern the sibling app suite `apps/mercato/src/__tests__/extract-tenant-candidate.test.ts` already uses
+(`t: (key, fallback) => fallback ?? key`). That keeps the existing assertions on the user-facing English
+messages meaningful instead of degrading them into assertions on translation keys.
+
+To make the change a real regression guard rather than a plain unbreak, the mocked `t` is a `jest.fn` and two
+error-path cases additionally assert that the route asked for the expected translation key — so silently
+reverting #4887's localization would fail the suite again.
+
+## 📋 Progress
+
+- [x] Reproduce the failure on `upstream/develop` (`yarn workspace @open-mercato/app test --testPathPatterns storage-s3-routes` → 5 failed / 5 total)
+- [x] Confirm the root cause against `download.ts` / `upload.ts` and the package-level suite
+- [x] Audit the other `apps/mercato/src/__tests__/*` suites that import real route modules
+- [x] Add the i18n mock and the translation-key assertions to `apps/mercato/src/__tests__/storage-s3-routes.test.ts`
+- [x] Re-run the suite (5 passed / 5 total)
+- [x] Run the full validation gate
+- [x] Open the PR and request labels from a maintainer
+
+## Audit of sibling app suites
+
+Only three suites under `apps/mercato/src/__tests__/` import real route modules, and the other two are
+already immune:
+
+- `extract-tenant-candidate.test.ts` — mocks `@open-mercato/shared/lib/i18n/server` directly.
+- `api-authorization.test.ts` — mocks `@open-mercato/shared/modules/registry`, so `getModules()` resolves.
+- `storage-s3-routes.test.ts` — the one fixed here.
+
+## Notes
+
+- The account running this work has `read` permission on `open-mercato/open-mercato`, so assignee and label
+  mutations return 403. The claim and the label request are posted as comments instead.

--- a/apps/mercato/src/__tests__/storage-s3-routes.test.ts
+++ b/apps/mercato/src/__tests__/storage-s3-routes.test.ts
@@ -5,9 +5,16 @@ const putObjectMock = jest.fn()
 const getBucketMock = jest.fn(() => 'test-bucket')
 const listObjectsMock = jest.fn()
 const readMock = jest.fn()
+const translateMock = jest.fn((key: string, fallback?: string) => fallback ?? key)
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: (...args: unknown[]) => getAuthFromRequestMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    t: (key: string, fallback?: string) => translateMock(key, fallback),
+  }),
 }))
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
@@ -56,6 +63,7 @@ describe('storage_s3 upload/download routes', () => {
 
     expect(response.status).toBe(400)
     await expect(response.json()).resolves.toEqual({ error: 'Active content uploads are not allowed.' })
+    expect(translateMock).toHaveBeenCalledWith('storage_s3.errors.activeContentBlocked', expect.any(String))
     expect(putObjectMock).not.toHaveBeenCalled()
   })
 
@@ -100,6 +108,7 @@ describe('storage_s3 upload/download routes', () => {
 
     expect(response.status).toBe(413)
     await expect(response.json()).resolves.toEqual({ error: 'Attachment storage quota exceeded for this tenant.' })
+    expect(translateMock).toHaveBeenCalledWith('storage_s3.errors.quotaExceeded', expect.any(String))
     expect(putObjectMock).not.toHaveBeenCalled()
   })
 


### PR DESCRIPTION
Closes #4926
Tracking plan: .ai/runs/2026-08-04-storage-s3-route-tests-i18n-mock.md
Status: complete

## 🎯 Goal

Bring the unit `test` job on `develop` back to green. Since #4887 (`c95ff214e`, 2026-08-03) merged, every open PR against `develop` inherits a red `test` job — and therefore a skipped `merge-coverage` — no matter what its own diff touches.

## 🔍 Problem

`apps/mercato/src/__tests__/storage-s3-routes.test.ts` fails all 5 of its cases on the base branch itself with:

```
[Bootstrap] Modules not registered. Call registerModules() at bootstrap.
  at getModules (packages/shared/src/lib/modules/registry.ts:68:11)
  at loadDictionary (packages/shared/src/lib/i18n/server.ts:64:29)
  at resolveTranslations (packages/shared/src/lib/i18n/server.ts:75:16)
  at GET (packages/storage-s3/src/modules/storage_s3/api/get/storage-providers/s3/download.ts:31:17)
```

Reproduced locally on `develop` @ `a575bebce` with `yarn workspace @open-mercato/app test --testPathPatterns storage-s3-routes` → **Tests: 5 failed, 5 total**.

## 🔍 Root Cause

#4887 replaced the storage_s3 routes' hard-coded error strings with `resolveTranslations()`. That helper loads the locale dictionary through `getModules()`, which throws whenever the module registry has not been populated — and nothing populates it in a plain unit test.

The PR correctly updated the tests that live next to the routes: `packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts` already mocks `@open-mercato/shared/lib/i18n/server`, so it stayed green. What it missed is the **app-level consumer suite**, which imports the real `download`/`upload` handlers but mocks only `@open-mercato/shared/lib/auth/server`, `@open-mercato/shared/lib/di/container` and the S3 driver. `const { t } = await resolveTranslations()` is the first line of both handlers, so it threw before any assertion could run.

This class of breakage is invisible to a package's own tests by construction — the package suite mocks i18n, so localizing a route never surfaces an app-level consumer that does not.

## What Changed

- `apps/mercato/src/__tests__/storage-s3-routes.test.ts` — added a `jest.mock` for `@open-mercato/shared/lib/i18n/server`, following the pattern the sibling app suite `apps/mercato/src/__tests__/extract-tenant-candidate.test.ts` already uses: `t: (key, fallback) => fallback ?? key`. Returning the route's own fallback rather than a `translated:<key>` sentinel means the five existing assertions keep asserting the real user-facing message instead of degrading into assertions on translation keys.
- Same file — the mocked `t` is a `jest.fn` (`translateMock`), and the two error-path cases now additionally assert the translation key the route asked for (`storage_s3.errors.activeContentBlocked`, `storage_s3.errors.quotaExceeded`). Without this the suite would pass again just as happily if someone reverted #4887 and hard-coded the strings back; with it, the localization contract is locked in.
- No production code changed — this is entirely a test-side fix, as the issue diagnosed.

### Audit of the other app-level suites

The issue asked whether other `apps/mercato/src/__tests__/*` suites import routes that have since acquired `resolveTranslations()`. Only three suites there import real route modules, and the other two are already immune:

| Suite | Status |
|---|---|
| `extract-tenant-candidate.test.ts` | Already mocks `@open-mercato/shared/lib/i18n/server` directly. |
| `api-authorization.test.ts` | Already mocks `@open-mercato/shared/modules/registry`, so `getModules()` resolves. |
| `storage-s3-routes.test.ts` | The one fixed here. |

## 🧪 Tests

Full configured validation gate, run locally (no compose `app` container was running, so local mode):

| Command | Result |
|---|---|
| `yarn build:packages` | ✅ 21/21 tasks |
| `yarn generate` | ✅ 430 API paths, 91 artifacts refreshed |
| `yarn build:packages` (second pass) | ✅ 21/21 tasks |
| `yarn i18n:check-sync` | ✅ all 4 locales in sync |
| `yarn i18n:check-usage` | ⚠️ pre-existing failure — see below |
| `yarn typecheck` | ✅ |
| `yarn test` | ⚠️ one pre-existing local flake — see below |
| `yarn build:app` | ✅ |

- **Target suite:** `yarn workspace @open-mercato/app test --testPathPatterns storage-s3-routes` → **5 failed / 5 total** before, **5 passed / 5 total** after.
- **Whole app workspace:** `@open-mercato/app` → **38 suites passed, 182 tests passed**, including `PASS src/__tests__/storage-s3-routes.test.ts`.
- **`yarn i18n:check-usage`** reports 21 missing keys, all of them in `packages/ui/src/backend/schedule/ScheduleToolbar.tsx` and `packages/core/src/modules/design_system/gallery/entries/*`. None are in `apps/mercato` or `storage_s3`, and this PR touches neither file, so the failure is pre-existing on `develop` and out of scope here.
- **`yarn test`** was green in every workspace except one suite in `@open-mercato/enterprise`, which died with `A jest worker process (pid=…) was terminated by another process: signal=SIGSEGV` — a worker crash under full parallel load, with `Tests: 473 passed, 473 total` and zero assertion failures in that workspace. Re-running it on its own (`yarn workspace @open-mercato/enterprise test --testPathPatterns "record_locks/api"`) gives **3 suites passed / 11 tests passed**, confirming it is a local resource flake and not a regression from this change.

## 💥 Breaking Changes

None. No production code, public contract, database schema, or API surface is touched — the diff is a single test file plus the tracking plan.

## 🏷️ Labels

This account only has `read` permission on the repository, so GitHub rejects both `addLabelsToLabelable` and `replaceActorsForAssignable` with a 403. **A maintainer needs to apply the label set**, which for this PR should be:

- 🐛 `bug` — it removes a defect (a red required job on the base branch), even though the change itself is test-side.
- 🔍 `review` — the PR is ready and in the review pipeline state.
- ⏫ `priority-high` — `develop` is red for everyone, so every open PR inherits a failing `test` job and a skipped `merge-coverage` until this lands.
- 🟢 `risk-low` — one test file; no production code path, contract, or schema is affected.
- ⏭️ `skip-qa` — per the automated-verification exemption: no `.tsx` outside tests, nothing under `packages/ui/src/` or `**/components/**`, database structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract touched, and the changed behavior is covered by automated tests in this same PR.

## 📋 Progress

See the Progress section in the tracking plan.
