### PR TITLE
feat(ci): StrykerJS diff-scoped mutation testing gate (advisory; enforcement dormant)

### DIFF
--- a/.ai/analysis/2026-07-31-stryker-mutation-testing-pilot.md
+++ b/.ai/analysis/2026-07-31-stryker-mutation-testing-pilot.md
@@ -240,3 +240,60 @@ verified separately and matches the Phase 0 finding.
 3. Revisiting `core` is not hopeless, but it needs a different lever than a bigger timeout — the
    `coverageAnalysis: "perTest"` work deferred to Phase 4, or scoping mutation to changed *lines*
    rather than changed *files*. Neither is in scope for this change.
+
+---
+
+# Phase 4 — optimisation assessed and declined (2026-08-04)
+
+Phase 4 is conditional in the spec: *"Only if Phase 1–3 timings demand it."* Both steps were
+attempted rather than assumed. Neither ships.
+
+## The timing budget that decides it
+
+Measured on the shipped scope (`packages/shared`, the only allowlisted package):
+
+| Segment | Time |
+|---------|------|
+| `yarn install --immutable` (warm Yarn cache) | ~16 s |
+| `yarn build:packages` | ~55 s |
+| Mutation run — `boolean.ts`, the pilot's worst fan-in case (615.92 tests/mutant) | 1 m 27 s |
+| **Total job** | **~3 min** |
+| Workflow budget (`timeout-minutes`) | **20 min** |
+
+The job uses about 15 % of its budget on the worst single-file case the pilot identified. There is
+no timing pressure for either optimisation to relieve.
+
+## Step 1 — `perTest` coverage is blocked, not merely unnecessary
+
+`--coverageAnalysis perTest` fails `packages/shared` in the initial test run. 19 of its suites carry
+`@jest-environment` docblocks (792 repo-wide), which is the blocker Q3 anticipated.
+
+Stryker ships the wrapped environments this needs (`@stryker-mutator/jest-runner/jest-env/node` and
+`.../jest-env/jsdom`), and those match the only two values the docblocks use here (`node`, `jsdom`).
+So the natural fix is to redirect the docblocks' resolution rather than edit them. **That was tried
+and does not work:** a Jest `moduleNameMapper` mapping `jest-environment-node` and
+`jest-environment-jsdom` onto the Stryker wrappers has no effect, because Jest resolves the
+`@jest-environment` docblock outside the `moduleNameMapper` path.
+
+What remains is editing 19 test files (Q3 forbids it) or replacing the repo-wide Jest `resolver` in
+`jest.config.base.cjs` — which would place every suite in the repository behind a change made for a
+mutation-testing optimisation that the timings do not need.
+
+## Step 2 — `incremental` caching is declined on risk, not just need
+
+`incremental: true` reuses Stryker's previous report to skip re-testing unchanged mutants. Two
+reasons not to ship it here:
+
+- **No time to win.** The mutation step is 1 m 27 s of a ~3 min job. Even a perfect cache hit leaves
+  the install and build, and the job still ends far inside its 20-minute budget.
+- **A stale incremental file reports mutants as killed that current tests do not kill.** That is a
+  false green in the one check whose entire value is trustworthy signal. Trading correctness risk
+  for time nobody needs is a bad exchange, and the cache-key discipline needed to avoid it is real
+  ongoing maintenance.
+
+## When to revisit
+
+When a package with materially larger suites joins the allowlist — which today means solving the
+`packages/core` problem measured in Phase 0b — or when the Phase 1–2 advisory runs show real PRs
+approaching the 20-minute timeout. At that point `perTest` via a Jest `resolver` change is the
+higher-leverage of the two and becomes worth its blast radius.

--- a/.ai/analysis/2026-07-31-stryker-mutation-testing-pilot.md
+++ b/.ai/analysis/2026-07-31-stryker-mutation-testing-pilot.md
@@ -159,3 +159,84 @@ them would have produced exactly the brittle string-assertion tests the initiati
    survivor is 75 %.
 5. `phone.ts` at 57 % shows the gate cannot be switched on retroactively for whole files. It must
    score **only the changed lines/files of the PR**, and land advisory-first.
+
+---
+
+# Phase 0b — measured feasibility on `packages/core` (2026-08-04)
+
+## Verdict
+
+**`packages/core` stays out of the Phase 1 allowlist.** It misses the spec's exit criterion — "a
+run on 3 representative `core` business-logic files completes under 10 min" — not marginally but by
+roughly two orders of magnitude. `packages/shared` ships alone.
+
+## Setup
+
+Identical to the Phase 0 pilot, via a throwaway `packages/core/stryker.conf.mjs` mirroring the
+pilot config (not committed — the deliverable of this phase is the measurement). One adaptation was
+required: `timeoutMS` raised from 30 s to 60 s, because `packages/core/jest.config.cjs` sets
+`testTimeout: 30000` and the pilot's 30 s Stryker timeout would report timeouts instead of scores.
+
+Three representative business-logic files were chosen, one per the layer the spec named, each with
+real existing test coverage so the numbers reflect genuine fan-in rather than an empty suite.
+
+## Measurements
+
+| Target | Layer | LOC | Mutants | Wall time | Score | Tests per mutant |
+|--------|-------|-----|---------|-----------|-------|------------------|
+| `src/modules/auth/lib/rateLimitCheck.ts` | `lib/` | 75 | 41 | **1 m 45 s** | 58.5 % | 92.7 |
+| `src/modules/auth/commands/roles.ts` | `commands/` | 657 | — | **> 10 min, never completed** | — | — |
+| `src/modules/customers/data/validators.ts` | `data/validators.ts` | 783 | 403 | **~6 h 42 m (Stryker's own ETA)** | — | — |
+
+Only the leaf `lib/` file completed. `roles.ts` was run twice and exceeded ten minutes both times
+without producing a score. `validators.ts` was aborted after Stryker generated 403 mutants and
+projected 6 h 42 m remaining — the projection, not a guess, is the measurement.
+
+The Phase 0 conclusion holds and sharpens: **the cost driver is fan-in, not file size.** A 75-line
+`core` leaf file costs 1 m 45 s against 92.7 tests per mutant, while `shared`'s 396-line leaf file
+cost 1 m 25 s. What breaks `core` is that its command and validator layers sit under large,
+DI/ORM-bootstrapping suites, so `--findRelatedTests` pulls in an order of magnitude more work per
+mutant.
+
+## Score finding
+
+`rateLimitCheck.ts` scored **58.5 %** (24 killed / 17 survived of 41). Survivors cluster on the
+early-return guards — `if (!rateLimiterService) return { error: null, compoundKey: null }` survives
+being forced to `if (false)`, and the compound-key branch survives `&&` becoming `||`. That is the
+same class of gap the Phase 0 pilot found in `phone.ts`: the tests exercise the happy path and
+assert the returned shape, but never assert that a *specific* guard is what rejected the request.
+The finding is real and worth a follow-up issue — but it is a reason to write tests, not a reason
+to enable the gate on a package that cannot finish a run.
+
+## Operational finding: an interrupted `inPlace` run is expensive to recover
+
+This was measured accidentally and matters more than the timings for anyone running locally.
+
+Stryker's `disableTypeChecks` defaults to on, so before mutating it prepends `// @ts-nocheck` to
+every file matching its instrumentation globs. With `inPlace: true` those writes land on real
+source files. When a run was killed mid-flight, it left **4 966 modified files** in
+`packages/core` — every one of them carrying an injected `// @ts-nocheck`.
+
+Recovery was complete and immediate with `git checkout -- packages/core`, exactly the command the
+spec requires the wrapper to print. Two conclusions:
+
+1. The clean-tree guard in `yarn mutation:changed` is not a nicety, it is the only thing standing
+   between an interrupted run and 5 000 unreviewable modifications mixed into a developer's work.
+   It is implemented as a hard stop, never a warning.
+2. `disableTypeChecks` cannot simply be turned off to shrink the blast radius: this repository's
+   jest transformer is ts-jest based and type-checks, so mutants that break types would surface as
+   errors instead of being scored. The default stays, and the guard carries the risk.
+
+A cleanly finishing run restores its own files correctly, including after a `SIGTERM` — that was
+verified separately and matches the Phase 0 finding.
+
+## Implications for the design
+
+1. **The Phase 1 allowlist is `['shared']`.** `packages/core` is excluded in `scripts/stryker/scope.mjs`
+   and adding it later requires a fresh measurement, not a judgement call.
+2. `createConfig.mjs` still carries a per-package `timeoutMS` override (`core: 60000`) because the
+   value is a property of the package's jest config, not of its allowlist status. It documents why
+   the knob exists if `core` is ever revisited.
+3. Revisiting `core` is not hopeless, but it needs a different lever than a bigger timeout — the
+   `coverageAnalysis: "perTest"` work deferred to Phase 4, or scoping mutation to changed *lines*
+   rather than changed *files*. Neither is in scope for this change.

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/HANDOFF.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/HANDOFF.md
@@ -1,0 +1,38 @@
+# Handoff — 2026-08-04-stryker-mutation-testing-ci-gate
+
+**Last updated:** 2026-08-04T07:04:00Z
+**Branch:** `feat/stryker-mutation-testing-ci-gate`
+**PR:** not yet opened
+**Current phase/step:** Phase 1 Step 1.1 (not started)
+**Last commit:** none yet — run folder commit pending
+
+## What just happened
+
+- The run was planned from the merged spec `.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md`
+  (design PR #4773). Its Implementation Plan became the 12-row Tasks table in `PLAN.md`.
+- An isolated worktree was created off `origin/develop` and dependencies installed successfully.
+
+## Next concrete action
+
+- Start Step 1.1: add `@stryker-mutator/core` and `@stryker-mutator/jest-runner` to the **root**
+  `devDependencies` at `^9.6.1` and add the `mutation:changed` script to the root `package.json`.
+
+## Blockers / open questions
+
+- None yet. The two open conditionals are Step 0b.1 (does `packages/core` meet the 10-minute exit
+  criterion, and therefore join the allowlist?) and Phase 4 (do the measured timings justify
+  `incremental` and the `mixinJestEnvironment` wrapper at all?).
+
+## Environment caveats
+
+- Dev runtime runnable: unknown — not needed. This run touches no application code and no UI.
+- Browser / UI checks: skipped for the whole run. The change has no application UI; its only
+  developer-facing surface is a GitHub Actions job summary.
+- Database/migration state: clean — no entities, no migrations, no database access.
+- Known pre-existing failures on this machine, unrelated to this change: `packages/ui`
+  `format.test.ts` (Polish locale) and two `watch-packages` `fs.watch` tests.
+
+## Worktree
+
+- Path: `/home/bernard/workspace/OpenMercatoTest/.ai/tmp/om-auto-create-pr-loop/stryker-mutation-testing-ci-gate-20260804-085356`
+- Created this run: yes

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/HANDOFF.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/HANDOFF.md
@@ -1,34 +1,50 @@
 # Handoff — 2026-08-04-stryker-mutation-testing-ci-gate
 
-**Last updated:** 2026-08-04T07:04:00Z
+**Last updated:** 2026-08-04T07:33:00Z
 **Branch:** `feat/stryker-mutation-testing-ci-gate`
-**PR:** not yet opened
-**Current phase/step:** Phase 1 Step 1.1 (not started)
-**Last commit:** none yet — run folder commit pending
+**PR:** https://github.com/open-mercato/open-mercato/pull/4932 (draft)
+**Current phase/step:** Phase 2 Step 2.1 (next to land)
+**Last commit:** `089fcad52` — feat(ci): add the advisory mutation-testing workflow
 
 ## What just happened
 
-- The run was planned from the merged spec `.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md`
-  (design PR #4773). Its Implementation Plan became the 12-row Tasks table in `PLAN.md`.
-- An isolated worktree was created off `origin/develop` and dependencies installed successfully.
+- **Phase 1 and Phase 0b are complete** — 6 Steps landed. Checkpoint 1 recorded in
+  `checkpoint-1-checks.md`: `yarn test:scripts` green at 463 passed / 0 failed, and the Step 1.2
+  headline criterion verified — `packages/shared`'s `boolean.ts` scores **93.33 %** through the new
+  factory, reproducing the Phase 0 pilot's 93.3 %.
+- **Phase 0b decided the allowlist**: `packages/core` is excluded. Only its 75-LOC `lib/` leaf
+  completed (1 m 45 s); `commands/roles.ts` exceeded ten minutes twice and `data/validators.ts`
+  projected ~6 h 42 m for 403 mutants. The spec's 10-minute criterion is missed by ~2 orders of
+  magnitude. Numbers are appended to `.ai/analysis/2026-07-31-stryker-mutation-testing-pilot.md`.
 
 ## Next concrete action
 
-- Start Step 1.1: add `@stryker-mutator/core` and `@stryker-mutator/jest-runner` to the **root**
-  `devDependencies` at `^9.6.1` and add the `mutation:changed` script to the root `package.json`.
+- Land Step 2.1: `scripts/stryker/report.mjs` is already written and its 13 tests pass — it needs
+  committing together with the workflow steps that write `$GITHUB_STEP_SUMMARY` and upload the
+  HTML/JSON artifact.
 
 ## Blockers / open questions
 
-- None yet. The two open conditionals are Step 0b.1 (does `packages/core` meet the 10-minute exit
-  criterion, and therefore join the allowlist?) and Phase 4 (do the measured timings justify
-  `incremental` and the `mixinJestEnvironment` wrapper at all?).
+- None blocking. Two Steps remain conditional by the spec's own design: Phase 4's
+  `mixinJestEnvironment` (4.1) and `incremental` caching (4.2) ship only if the measured timings
+  justify them, and must be reported honestly rather than shipped speculatively.
+- Step 1.5's spec criterion ("the workflow runs on this PR and reports a score") can only be
+  confirmed once CI runs on PR #4932. Workflow invariants are unit-asserted in the meantime.
 
 ## Environment caveats
 
-- Dev runtime runnable: unknown — not needed. This run touches no application code and no UI.
-- Browser / UI checks: skipped for the whole run. The change has no application UI; its only
-  developer-facing surface is a GitHub Actions job summary.
+- Dev runtime runnable: not needed — no application code, no UI, no database.
+- Browser / UI checks: **skipped for the whole run**, deliberately. The change touches no
+  `.tsx` outside tests and nothing under `packages/ui/src/`; its only developer-facing surface is a
+  GitHub Actions job summary. There is nothing to screenshot.
 - Database/migration state: clean — no entities, no migrations, no database access.
+- Packages are built in this worktree (`build:packages` → `generate` → `build:packages`, rc=0).
+  A fresh worktree must repeat that before any Stryker run, or the dry run fails on
+  `@open-mercato/cache`.
+- **Never run two `inPlace` Stryker runs against the same package concurrently.** An interrupted run
+  leaves ~4 966 files carrying an injected `// @ts-nocheck`; recover with
+  `git checkout -- packages/<pkg>`. Killing a runaway run needs `dangerouslyDisableSandbox`, and
+  `pgrep` sees these processes when `ps` does not.
 - Known pre-existing failures on this machine, unrelated to this change: `packages/ui`
   `format.test.ts` (Polish locale) and two `watch-packages` `fs.watch` tests.
 

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
@@ -1,0 +1,27 @@
+# Notify — 2026-08-04-stryker-mutation-testing-ci-gate
+
+> Append-only log. Every entry is UTC-timestamped. Never rewrite prior entries.
+
+## 2026-08-04T07:04:00Z — run started
+
+- Brief: implement all phases (0b, 1, 2, 3, 4) of the StrykerJS diff-scoped mutation-testing CI gate
+  spec in a single PR against `develop`.
+- Source spec: `.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md` (design PR #4773, merged).
+- External skill URLs: none.
+- Engine: `om-auto-create-pr-loop`, selected because `--loop` was forwarded by the operator through
+  `om-auto-implement-spec` → `om-auto-create-pr`. The plan's 12 Steps are below the configured
+  threshold of 20, so without the explicit flag this would have run plain.
+
+## 2026-08-04T07:04:00Z — decision: Step 1.1 precedes Phase 0b
+
+- The spec lists Phase 0b first, but the 0b measurement cannot run before StrykerJS is installed.
+  Step 1.1 therefore lands first as the prerequisite commit. The 0b result is consumed by Step 1.3
+  (the Step that writes the allowlist), and 0b.1 lands well before it, so no spec intent is lost.
+
+## 2026-08-04T07:04:00Z — decision: two operator overrides recorded in the plan
+
+- Phase 3 enforcement ships **dormant** (`MUTATION_ENFORCE` defaults to `false`, workflow keeps
+  `continue-on-error`, check not registered as required). Rationale: spec Q1 leaves enforcement to an
+  explicit core-team decision, and `AGENTS.md` classifies pipeline changes as Ask First.
+- Phase 0b is a **measurement, not a deliverable**: the throwaway `packages/core` config is not
+  committed; only the appended timings are.

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
@@ -32,3 +32,28 @@
   `done` (that is the cell `om-auto-continue-pr-loop` parses to find the resume point). The `Commit`
   cell is filled with the real short SHA in the next commit or at the checkpoint. No Step is ever
   left ambiguous: `Status` is authoritative, `Commit` is informational.
+
+## 2026-08-04T09:20:00Z — Phase 0b result: packages/core stays out of the allowlist
+
+- Measured three representative `core` files. Only the 75-LOC `auth/lib/rateLimitCheck.ts`
+  completed (1 m 45 s, 41 mutants, 58.5 %). `auth/commands/roles.ts` exceeded ten minutes twice
+  without producing a score. `customers/data/validators.ts` generated 403 mutants with Stryker's own
+  ETA at ~6 h 42 m and was aborted.
+- The spec's exit criterion ("3 representative core files complete under 10 min") is missed by about
+  two orders of magnitude, so the Phase 1 allowlist ships as `['shared']` only, per the operator's
+  Phase 0b instruction. Full numbers and reasoning appended to
+  `.ai/analysis/2026-07-31-stryker-mutation-testing-pilot.md`.
+- The throwaway `packages/core/stryker.conf.mjs` was deleted, not committed.
+
+## 2026-08-04T09:20:00Z — blocker encountered and resolved: interrupted inPlace runs
+
+- Two measurement runs were killed by the tooling's 10-minute cap while Stryker held real source
+  files mutated. Each left ~4 966 modified files in `packages/core`, because Stryker's
+  `disableTypeChecks` default prepends `// @ts-nocheck` before mutating and `inPlace: true` writes
+  that to disk. `git checkout -- packages/core` recovered fully both times.
+- Consequence for the design: the clean-tree guard in the local wrapper is a hard stop, not a
+  warning, and `disableTypeChecks` cannot be turned off to shrink the blast radius because this
+  repo's ts-jest transformer type-checks. Recorded in the analysis document.
+- Process note for future runs in this environment: background tasks are killed at the 10-minute
+  tool cap, and `ps` in this sandbox does not reliably show those processes — rely on task
+  notifications, and never run two `inPlace` Stryker runs against the same package concurrently.

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
@@ -70,3 +70,18 @@
 - Environment hazard recorded: a detached measurement survived repeated `pkill` (the sandbox
   dropped the signals) and re-instrumented `packages/core` mid-run. Killing it required
   `dangerouslyDisableSandbox`; `pgrep` sees such processes when `ps` does not.
+
+## 2026-08-04T07:49:13Z — final gate complete, all 12 Steps done
+
+- Green: `build:packages` (x2), `generate` (no tracked changes), `i18n:check-sync`, `typecheck`,
+  `test:scripts` (463 passed / 0 failed), `build:app`.
+- `yarn i18n:check-usage` rc=1 — 21 missing keys, all in `packages/ui/src/backend/schedule/` and
+  `packages/core/.../design_system/gallery/`. This branch changes no `.tsx` and adds no translation
+  keys; verified by intersecting the branch diff with the reported files (empty). Pre-existing on
+  `develop`, not fixed here.
+- `yarn test` rc=1 — 23 of 24 workspace tasks pass; only `create-mercato-app#test` fails, and every
+  failure is `bwrap: setting up uid map: Permission denied` / `bwrap: loopback: Failed RTM_NEWADDR`.
+  That suite sandboxes a generated app's typecheck with bubblewrap, which cannot start inside this
+  restricted container. All content oracles in the same test report `passed: true`. Reproduced with
+  the sandbox disabled. This branch touches no file under `packages/create-app/`.
+- Neither failure is a regression from this change; both are recorded rather than worked around.

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
@@ -25,3 +25,10 @@
   explicit core-team decision, and `AGENTS.md` classifies pipeline changes as Ask First.
 - Phase 0b is a **measurement, not a deliverable**: the throwaway `packages/core` config is not
   committed; only the appended timings are.
+
+## 2026-08-04T07:16:00Z — convention: Commit-column SHAs are filled one commit later
+
+- A Step's commit cannot contain its own SHA, so each Step's commit flips only the `Status` cell to
+  `done` (that is the cell `om-auto-continue-pr-loop` parses to find the resume point). The `Commit`
+  cell is filled with the real short SHA in the next commit or at the checkpoint. No Step is ever
+  left ambiguous: `Status` is authoritative, `Commit` is informational.

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
@@ -57,3 +57,16 @@
 - Process note for future runs in this environment: background tasks are killed at the 10-minute
   tool cap, and `ps` in this sandbox does not reliably show those processes — rely on task
   notifications, and never run two `inPlace` Stryker runs against the same package concurrently.
+
+## 2026-08-04T07:33:00Z — checkpoint 1: Phase 1 and Phase 0b complete (6 Steps)
+
+- `yarn test:scripts`: 463 passed / 0 failed, including 44 new tests across five files.
+- Step 1.2's headline criterion verified: `packages/shared` `boolean.ts` scores **93.33 %** through
+  the new factory, reproducing the Phase 0 pilot's 93.3 % (28 killed / 2 survived / 2 errors,
+  1 m 27 s, 615.92 tests per mutant). Details in `checkpoint-1-checks.md`.
+- Blocker found and fixed: a fresh worktree fails Stryker's dry run with
+  `Cannot find module '@open-mercato/cache'` because package suites resolve siblings through
+  `dist/`. The workflow now builds packages before mutating.
+- Environment hazard recorded: a detached measurement survived repeated `pkill` (the sandbox
+  dropped the signals) and re-instrumented `packages/core` mid-run. Killing it required
+  `dangerouslyDisableSandbox`; `pgrep` sees such processes when `ps` does not.

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md
@@ -85,3 +85,15 @@
   restricted container. All content oracles in the same test report `passed: true`. Reproduced with
   the sandbox disabled. This branch touches no file under `packages/create-app/`.
 - Neither failure is a regression from this change; both are recorded rather than worked around.
+
+## 2026-08-04T08:05:00Z — run complete
+
+- Merged 6 new `develop` commits; `yarn.lock` conflicted and was resolved by taking develop's
+  lockfile and regenerating. `yarn install --immutable` passes; PR is `MERGEABLE`.
+- Self-review found and fixed one minor: `scope.mjs` accepted a `--json` flag that `main()` never
+  read. Removed, spec contract corrected, regression test added (`b7118d504`).
+- Verdict is approve, but GitHub blocks self-approval, so it was submitted as a review comment. The
+  PR stays in `review` and needs an independent approval before merge.
+- Repo-level finding reported, not fixed here: `develop` fails `repo-wide-guards` on a create-app
+  test file introduced by #4927 and classified in neither list. Unrelated scope.
+- PR flipped to ready. Lock released.

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -22,7 +22,7 @@
 | 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | done | 9f008a2da |
 | 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | done | a3b2a9bba |
 | 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | done | 288aa86f2 |
-| 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | done | — |
+| 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | done | 1f4868f48 |
 | 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | done | 22614e6d3 |
 | 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | done | a7864dd25 |
 

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -23,8 +23,8 @@
 | 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | done | a3b2a9bba |
 | 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | done | 288aa86f2 |
 | 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | done | — |
-| 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | done | — |
-| 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | todo | — |
+| 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | done | 22614e6d3 |
+| 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | done | — |
 
 ### Why Step 1.1 precedes Phase 0b
 

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -24,7 +24,7 @@
 | 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | done | 288aa86f2 |
 | 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | done | — |
 | 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | done | 22614e6d3 |
-| 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | done | — |
+| 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | done | a7864dd25 |
 
 ### Why Step 1.1 precedes Phase 0b
 

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -13,7 +13,7 @@
 
 | Phase | Step | Title | Exec | Status | Commit |
 |-------|------|-------|------|--------|--------|
-| 1 | 1.1 | Add Stryker devDependencies and the `mutation:changed` script | inline | todo | — |
+| 1 | 1.1 | Add Stryker devDependencies and the `mutation:changed` script | inline | done | PENDING |
 | 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | todo | — |
 | 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | todo | — |
 | 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -15,8 +15,8 @@
 |-------|------|-------|------|--------|--------|
 | 1 | 1.1 | Add Stryker devDependencies and the `mutation:changed` script | inline | done | 723419941 |
 | 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | done | 641325d9a |
-| 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | done | — |
-| 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | todo | — |
+| 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | done | cdc409d00 |
+| 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | done | — |
 | 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | todo | — |
 | 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | todo | — |
 | 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -21,8 +21,8 @@
 | 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | done | 089fcad52 |
 | 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | done | 9f008a2da |
 | 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | done | a3b2a9bba |
-| 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | done | — |
-| 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | todo | — |
+| 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | done | 288aa86f2 |
+| 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | done | — |
 | 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | todo | — |
 | 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | todo | — |
 

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -1,0 +1,224 @@
+# Execution plan — StrykerJS mutation testing as a diff-scoped CI quality gate
+
+**Run slug:** `2026-08-04-stryker-mutation-testing-ci-gate`
+**Branch:** `feat/stryker-mutation-testing-ci-gate`
+**Base branch:** `develop`
+**Source spec:** `.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md`
+**Design PR (merged):** #4773
+**Subject issue:** none — this run is spec-driven
+
+## Tasks
+
+> Authoritative status table. `Status` is one of `todo` or `done`. On landing a Step, flip `Status` to `done` and fill the `Commit` column with the short SHA. The first row whose `Status` is not `done` is the resume point for `om-auto-continue-pr-loop`. Step ids and `Exec` cells are immutable once the plan is committed — per-Step commits touch only `Status` and `Commit`.
+
+| Phase | Step | Title | Exec | Status | Commit |
+|-------|------|-------|------|--------|--------|
+| 1 | 1.1 | Add Stryker devDependencies and the `mutation:changed` script | inline | todo | — |
+| 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | todo | — |
+| 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | todo | — |
+| 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | todo | — |
+| 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | todo | — |
+| 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | todo | — |
+| 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | todo | — |
+| 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | todo | — |
+| 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | todo | — |
+| 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | todo | — |
+| 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | todo | — |
+| 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | todo | — |
+
+### Why Step 1.1 precedes Phase 0b
+
+The spec lists Phase 0b first, but the 0b measurement cannot run until StrykerJS is installed. Step
+1.1 therefore lands first as the prerequisite commit, and Step 0b.1 runs the measurement against it.
+Nothing else about the spec's ordering changes: the 0b result is consumed by Step 1.3, which is the
+Step that writes the allowlist, and 0b.1 lands well before it.
+
+## Goal
+
+Ship StrykerJS mutation testing as a diff-scoped, advisory-first CI quality gate that scores only
+the business-logic files a pull request actually changes, so tests that execute code without
+verifying it are caught before merge — without adding hours to CI and without pushing contributors
+or AI agents toward brittle string-assertion tests.
+
+## Scope
+
+- Root `devDependencies` for `@stryker-mutator/core` and `@stryker-mutator/jest-runner`, plus root
+  `package.json` scripts.
+- Four new scripts under `scripts/stryker/`: `createConfig.mjs`, `scope.mjs`, `report.mjs`, and the
+  local `mutation-changed.mjs` wrapper.
+- One per-package config: `packages/shared/stryker.conf.mjs` (plus `packages/core` only if the
+  Phase 0b measurement justifies it).
+- One new standalone workflow: `.github/workflows/mutation-tests.yml`.
+- Unit tests for every Step whose spec entry carries a **Test:** criterion.
+- Documentation updates: the spec's Phase 3 section, the Phase 0 analysis document, and a developer
+  note on the `// Stryker disable next-line` escape hatch.
+
+## Non-goals
+
+- **Not** modifying `.github/workflows/ci.yml`. The mutation workflow is standalone by design so a
+  mutation failure can never be confused with a test failure and so rollback is deleting one file.
+- **Not** editing any existing test file. The `@jest-environment` docblock blocker is worked around,
+  never fixed by touching unrelated suites (spec Q3).
+- **Not** enabling enforcement. The machinery ships dormant; flipping it on is a core-team decision
+  (operator decision 1, spec Q1, `AGENTS.md` "Ask First" on pipeline changes).
+- **Not** touching PR pipeline or label automation, and not registering the check as required.
+- **Not** adding a repo-wide mutation score badge or a per-package leaderboard — the spec explicitly
+  rules both out as metric-gaming vectors.
+- **Not** changing application code, the database schema, or any runtime behaviour.
+
+## Operator decisions that override spec defaults
+
+1. **Phase 3 enforcement ships OFF.** `thresholds.break`, the `MUTATION_MIN_MUTANTS` floor and the
+   `MUTATION_ENFORCE` flag are all implemented and tested, but `MUTATION_ENFORCE` defaults to
+   `false`, the workflow keeps `continue-on-error`, and the check is neither registered nor
+   documented as a required merge-blocking check. Turning it on must remain a one-line env change.
+2. **Phase 0b is a measurement, not a deliverable.** The throwaway `packages/core` config is not
+   committed; only the timings appended to the analysis document are. If the run exceeds the spec's
+   10-minute exit criterion or fails, the allowlist ships with `packages/shared` only and the reason
+   is recorded.
+
+## Implementation Plan
+
+### Phase 1 — advisory gate
+
+#### Step 1.1 — Add Stryker devDependencies and the `mutation:changed` script
+
+- Add `@stryker-mutator/core` and `@stryker-mutator/jest-runner` to the **root** `devDependencies`
+  (spec Q5: one hoisted version, configuration per package), matching the pilot's `^9.6.1`.
+- Add the `mutation:changed` script to the root `package.json`, pointing at the wrapper that Step
+  1.4 creates. The script line lands here so the dependency and script surface arrive in one commit;
+  the wrapper file itself is Step 1.4's commit.
+- **Test:** `yarn install --immutable` succeeds and `yarn stryker --version` resolves.
+
+### Phase 0b — measure `packages/core`
+
+#### Step 0b.1 — Measure `packages/core` and decide its allowlist status
+
+- Create a throwaway `packages/core/stryker.conf.mjs` mirroring the pilot config; run it against
+  three representative business-logic files: one from `lib/`, one from `commands/`, and one
+  `data/validators.ts`.
+- Append the timings, the per-file scores, and the pass/fail verdict against the spec's 10-minute
+  exit criterion to `.ai/analysis/2026-07-31-stryker-mutation-testing-pilot.md`.
+- Decide from the measured data whether `packages/core` joins the Step 1.3 allowlist. On a timeout,
+  a failure, or a run over 10 minutes, the allowlist ships with `packages/shared` only and the
+  reason is recorded in both the analysis document and the PR body.
+- Delete the throwaway config — the deliverable is the measurement, not the config.
+- **Test:** the run completes and produces a score; if it does not, Phase 1 ships `shared` only.
+
+### Phase 1 — advisory gate (continued)
+
+#### Step 1.2 — Config factory and `packages/shared/stryker.conf.mjs`
+
+- Add `scripts/stryker/createConfig.mjs` as the single source of truth for shared settings:
+  `inPlace: true` (mandatory — it removes the sandbox that breaks the per-package jest config's
+  relative paths, and short-circuits the tsconfig preprocessor that TypeScript 7.0.2 breaks),
+  `coverageAnalysis: "off"`, the jest runner wiring with `enableFindRelatedTests`,
+  `excludedMutations: ["StringLiteral", "Regex"]`, thresholds, and reporters.
+- Add `packages/shared/stryker.conf.mjs` calling the factory with only its own package name.
+- Document the `// Stryker disable next-line <mutator>` escape hatch for equivalent mutants, with
+  the requirement that each suppression carries a one-line justification.
+- **Test:** a unit test asserting the factory output for a given package name, and
+  `yarn stryker run --mutate src/lib/boolean.ts` in `packages/shared` reproducing the pilot's 93.3 %.
+
+#### Step 1.3 — `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap
+
+- Compute the mutate list from `git diff --name-only --diff-filter=d $BASE...HEAD` (StrykerJS has no
+  `--since` flag, so scoping is ours to compute) and emit a GitHub Actions matrix on stdout.
+- Keep only paths matching the in-scope globs of an allowlisted package; emit no entry for a package
+  with no in-scope changes; emit an empty matrix when nothing matches.
+- Cap the list at `MUTATION_MAX_FILES` (default 25) per package, sorted by path for determinism, and
+  print what was dropped so a truncated run never reads as full coverage.
+- **Test:** unit tests over a stubbed diff list — in-scope file included, `.tsx` excluded, `api/`
+  excluded, deleted file excluded, cap truncates and reports, empty diff yields an empty matrix.
+
+#### Step 1.4 — Local `yarn mutation:changed` wrapper with the clean-tree guard
+
+- Add the wrapper that runs the clean-tree guard, then `scope.mjs`, then Stryker per package.
+- Because `inPlace: true` mutates real working-tree sources, the guard refuses to start on a dirty
+  tree and prints the `git checkout -- .` recovery command (spec Q4).
+- **Test:** running it on a dirty tree exits non-zero without invoking Stryker.
+
+#### Step 1.5 — `.github/workflows/mutation-tests.yml` advisory workflow
+
+- A standalone `pull_request` workflow, separate from `ci.yml`: a `scope` job running `scope.mjs`
+  and emitting the matrix, then a `mutate` matrix job with `fail-fast: false`,
+  `timeout-minutes: 20`, and `continue-on-error` driven by `MUTATION_ENFORCE` (default `false`).
+- A PR whose diff contains no in-scope files skips entirely and reports success — no empty run and
+  no synthetic score (spec Q8).
+- **Test:** the workflow runs on this PR itself and reports a score for the files it changes.
+
+### Phase 2 — reporting
+
+#### Step 2.1 — `scripts/stryker/report.mjs` — survivor table, job summary, artifact
+
+- Convert `mutation.json` into a markdown survivor table (`file:line:column`, mutator, and the
+  `-`/`+` diff of the replacement) and write it to `$GITHUB_STEP_SUMMARY`; upload the HTML and JSON
+  reports as an artifact.
+- When the run is advisory, the summary states plainly that the result does not block merge.
+- **Test:** a unit test over a fixture `mutation.json` asserting survivors are listed and killed
+  mutants are not.
+
+#### Step 2.2 — Fork-guarded PR comment step
+
+- Add the PR comment step reusing the same markdown, guarded by
+  `github.event.pull_request.head.repo.full_name == github.repository` — the same fork guard
+  `ci.yml`'s `docker-build` job already uses, because `pull_request` runs from forks get no
+  `pull-requests: write` token.
+- **Test:** the step is skipped on a fork PR and posts exactly one idempotent comment otherwise.
+
+### Phase 3 — enforcement machinery, shipped dormant
+
+#### Step 3.1 — Minimum-mutant floor (`MUTATION_MIN_MUTANTS`)
+
+- Below `MUTATION_MIN_MUTANTS` (default 20) the score is reported but never fails. This exists for
+  small-diff volatility: with four mutants, one survivor is 75 %.
+- **Test:** unit test — 4 mutants with 1 survivor does not fail; 30 mutants at 60 % does.
+
+#### Step 3.2 — Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs
+
+- Wire `thresholds.break` (70, to be revised from Phase 1–2 data) and the `MUTATION_ENFORCE` flag,
+  **defaulting to `false`** so the workflow keeps `continue-on-error` and the gate stays advisory.
+- Record in the spec's Phase 3 section that enforcement is implemented-but-dormant and awaiting an
+  explicit core-team decision (spec Q1, `AGENTS.md` "Ask First" on pipeline changes). Describe the
+  gate in the docs as dormant — do not add it to `AGENTS.md` → Validation Commands as if active, and
+  do not register it as a required check.
+- **Test:** the enforcement decision function fails a deliberately under-tested fixture when
+  enforcement is on and passes the same fixture when it is off (the shipped default).
+
+### Phase 4 — optional optimisation (conditional)
+
+#### Step 4.1 — `mixinJestEnvironment` wrapper for `perTest` coverage (conditional)
+
+- Attempt a wrapper module so `@jest-environment` docblocks can point at a Stryker-aware
+  environment, unlocking `coverageAnalysis: "perTest"` without editing existing test files.
+- The spec gates Phase 4 on need ("only if Phase 1–3 timings demand it"). If the measured timings do
+  not justify it, or `perTest` still cannot be unlocked, that is reported honestly in the PR body and
+  the spec rather than shipping speculative optimisation. Partial delivery is acceptable; silently
+  skipping is not.
+- **Test:** the dry run completes with `perTest` and per-mutant test counts drop measurably.
+
+#### Step 4.2 — `incremental` plus Actions cache (conditional)
+
+- Attempt `incremental: true` with a per-package `actions/cache` entry keyed on the package's source
+  tree. Same conditionality and same honesty requirement as Step 4.1.
+- **Test:** a second run on an unchanged branch reuses the incremental file and finishes faster.
+
+## Risks
+
+- **Extrapolation risk (highest).** `packages/core` has larger suites, 30 s test timeouts, and
+  DI/ORM bootstrapping; the `shared` numbers do not transfer. Step 0b.1 measures before `core` is
+  enabled, and the fallback is a `shared`-only allowlist.
+- **`inPlace` mutates real sources.** Mitigated by the clean-tree guard locally and by CI being
+  ephemeral. A `SIGKILL`ed local run can still leave mutated sources; the wrapper prints the
+  recovery command.
+- **Gaming the metric.** Mitigated by the mutator exclusions, by scoring only changed files, and by
+  treating the threshold as a review floor rather than a target. No badge, no leaderboard.
+- **Phase 4 may not be deliverable.** Explicitly conditional in the spec; the risk is answered by
+  reporting honestly rather than by shipping unproven configuration.
+- **Validation-gate noise.** This machine has two known pre-existing failures unrelated to this
+  change (`packages/ui` `format.test.ts` under a Polish locale; two `watch-packages` `fs.watch`
+  tests). They are recorded as pre-existing, never "fixed" by this run.
+
+## External References
+
+None. No `--skill-url` arguments were passed to this run.

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -19,8 +19,8 @@
 | 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | done | 2fed7cd92 |
 | 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | done | 63b68afb2 |
 | 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | done | 089fcad52 |
-| 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | done | — |
-| 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | todo | — |
+| 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | done | 9f008a2da |
+| 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | done | — |
 | 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | todo | — |
 | 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | todo | — |
 | 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -17,8 +17,8 @@
 | 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | done | 641325d9a |
 | 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | done | cdc409d00 |
 | 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | done | 2fed7cd92 |
-| 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | done | — |
-| 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | todo | — |
+| 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | done | 63b68afb2 |
+| 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | done | — |
 | 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | todo | — |
 | 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | todo | — |
 | 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -20,8 +20,8 @@
 | 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | done | 63b68afb2 |
 | 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | done | 089fcad52 |
 | 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | done | 9f008a2da |
-| 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | done | — |
-| 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | todo | — |
+| 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | done | a3b2a9bba |
+| 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | done | — |
 | 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | todo | — |
 | 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | todo | — |
 | 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -25,7 +25,7 @@
 | 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | done | 1f4868f48 |
 | 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | done | 22614e6d3 |
 | 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | done | a7864dd25 |
-| 1 | 1.3-review-fix | Drop the dead `--json` flag from `scope.mjs` | inline | done | — |
+| 1 | 1.3-review-fix | Drop the dead `--json` flag from `scope.mjs` | inline | done | b7118d504 |
 
 ### Why Step 1.1 precedes Phase 0b
 

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -25,6 +25,7 @@
 | 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | done | 1f4868f48 |
 | 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | done | 22614e6d3 |
 | 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | done | a7864dd25 |
+| 1 | 1.3-review-fix | Drop the dead `--json` flag from `scope.mjs` | inline | done | — |
 
 ### Why Step 1.1 precedes Phase 0b
 

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -18,7 +18,7 @@
 | 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | done | cdc409d00 |
 | 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | done | 2fed7cd92 |
 | 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | done | 63b68afb2 |
-| 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | done | — |
+| 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | done | 089fcad52 |
 | 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | todo | — |
 | 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | todo | — |
 | 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -23,7 +23,7 @@
 | 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | done | a3b2a9bba |
 | 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | done | 288aa86f2 |
 | 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | done | — |
-| 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | todo | — |
+| 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | done | — |
 | 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | todo | — |
 
 ### Why Step 1.1 precedes Phase 0b

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -16,8 +16,8 @@
 | 1 | 1.1 | Add Stryker devDependencies and the `mutation:changed` script | inline | done | 723419941 |
 | 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | done | 641325d9a |
 | 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | done | cdc409d00 |
-| 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | done | — |
-| 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | todo | — |
+| 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | done | 2fed7cd92 |
+| 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | done | — |
 | 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | todo | — |
 | 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | todo | — |
 | 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -14,8 +14,8 @@
 | Phase | Step | Title | Exec | Status | Commit |
 |-------|------|-------|------|--------|--------|
 | 1 | 1.1 | Add Stryker devDependencies and the `mutation:changed` script | inline | done | 723419941 |
-| 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | done | — |
-| 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | todo | — |
+| 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | done | 641325d9a |
+| 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | done | — |
 | 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | todo | — |
 | 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | todo | — |
 | 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -19,7 +19,7 @@
 | 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | done | 2fed7cd92 |
 | 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | done | 63b68afb2 |
 | 1 | 1.5 | `.github/workflows/mutation-tests.yml` advisory workflow | dispatch | done | 089fcad52 |
-| 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | todo | — |
+| 2 | 2.1 | `scripts/stryker/report.mjs` — survivor table, job summary, artifact | dispatch | done | — |
 | 2 | 2.2 | Fork-guarded PR comment step | dispatch:cheap | todo | — |
 | 3 | 3.1 | Minimum-mutant floor (`MUTATION_MIN_MUTANTS`) | dispatch | todo | — |
 | 3 | 3.2 | Dormant enforcement — `thresholds.break`, `MUTATION_ENFORCE`, docs | inline | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -26,6 +26,7 @@
 | 4 | 4.1 | `mixinJestEnvironment` wrapper for `perTest` coverage (conditional) | inline | done | 22614e6d3 |
 | 4 | 4.2 | `incremental` plus Actions cache (conditional) | inline | done | a7864dd25 |
 | 1 | 1.3-review-fix | Drop the dead `--json` flag from `scope.mjs` | inline | done | b7118d504 |
+| 1 | 1.3-ci-fix | Give every `.sort()` an explicit comparator (#3620 guard) | inline | done | — |
 
 ### Why Step 1.1 precedes Phase 0b
 

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -13,7 +13,7 @@
 
 | Phase | Step | Title | Exec | Status | Commit |
 |-------|------|-------|------|--------|--------|
-| 1 | 1.1 | Add Stryker devDependencies and the `mutation:changed` script | inline | done | PENDING |
+| 1 | 1.1 | Add Stryker devDependencies and the `mutation:changed` script | inline | done | 723419941 |
 | 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | todo | — |
 | 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | todo | — |
 | 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
@@ -14,7 +14,7 @@
 | Phase | Step | Title | Exec | Status | Commit |
 |-------|------|-------|------|--------|--------|
 | 1 | 1.1 | Add Stryker devDependencies and the `mutation:changed` script | inline | done | 723419941 |
-| 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | todo | — |
+| 0 | 0b.1 | Measure `packages/core` and decide its allowlist status | inline | done | — |
 | 1 | 1.2 | Config factory and `packages/shared/stryker.conf.mjs` | dispatch | todo | — |
 | 1 | 1.3 | `scripts/stryker/scope.mjs` — allowlist, globs, deletion filter, file cap | dispatch | todo | — |
 | 1 | 1.4 | Local `yarn mutation:changed` wrapper with the clean-tree guard | dispatch:cheap | todo | — |

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/checkpoint-1-checks.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/checkpoint-1-checks.md
@@ -1,0 +1,58 @@
+# Checkpoint 1 — Phase 1 closed (Steps 1.1, 0b.1, 1.2, 1.3, 1.4, 1.5)
+
+**Timestamp:** 2026-08-04T07:32:00Z
+**Runner:** local (no compose `app` container running, so not Docker mode)
+**Steps covered:** 6 landed commits — `723419941`, `641325d9a`, `cdc409d00`, `2fed7cd92`, `63b68afb2`, `089fcad52`
+
+## Targeted validation
+
+| Check | Command | Result |
+|-------|---------|--------|
+| Script unit tests (the suite CI runs at `ci.yml:515`) | `yarn test:scripts` | ✅ **463 passed / 0 failed**, including the 44 new tests added by this phase |
+| Dependency install is reproducible | `yarn install --immutable` | ✅ exit 0 |
+| Stryker resolves | `yarn stryker --version` | ✅ `9.6.1` |
+| Packages build | `yarn build:packages` → `yarn generate` → `yarn build:packages` | ✅ exit 0 |
+
+New tests by file: `stryker-create-config.test.mjs` (10), `stryker-scope.test.mjs` (14),
+`stryker-mutation-changed.test.mjs` (7), `stryker-workflow.test.mjs` (10), plus
+`stryker-report.test.mjs` (13) written for Step 2.1 and landing with it.
+
+## Spec Test criteria verified
+
+| Step | Spec criterion | Result |
+|------|----------------|--------|
+| 1.1 | `yarn install --immutable` succeeds; `yarn stryker --version` resolves | ✅ both |
+| 0b.1 | The run completes and produces a score; if not, Phase 1 ships `shared` only | ✅ criterion **not** met by `core` → `shared`-only allowlist shipped, as specified |
+| 1.2 | Unit test asserting factory output for a given package name | ✅ 10 tests |
+| 1.2 | `stryker run --mutate src/lib/boolean.ts` in `packages/shared` reproduces the pilot's 93.3 % | ✅ **93.33 %** (28 killed / 2 survived / 2 errors), 1 m 27 s, 615.92 tests per mutant |
+| 1.3 | In-scope included; `.tsx`, `api/`, deleted excluded; cap truncates and reports; empty diff → empty matrix | ✅ all six, plus dedup/ordering |
+| 1.4 | Running on a dirty tree exits non-zero without invoking Stryker | ✅ asserted directly (`strykerCalls` empty, exit code 1) |
+| 1.5 | The workflow runs on this PR and reports a score | ⏳ pending — verifiable only once the PR runs CI; workflow invariants are unit-asserted meanwhile |
+
+The `boolean.ts` reproduction is the headline result: **93.33 % against the pilot's 93.3 %**, through
+the new factory rather than the pilot's hand-written JSON. Wall time moved from 1 m 18 s to 1 m 27 s
+and tests-per-mutant from 530 to 615.92, consistent with `develop` having gained tests since the
+pilot — the cost driver is still fan-in.
+
+## Blockers hit and resolved
+
+1. **`packages/shared`'s suite needs built packages.** Stryker's initial dry run failed with
+   `Cannot find module '@open-mercato/cache' from 'src/lib/crud/cache.ts'` in a fresh worktree.
+   The suites resolve sibling packages through `dist/`. Fixed by building; the workflow now carries
+   an explicit `Build packages` step before the mutation run, with a comment explaining why.
+2. **An interrupted `inPlace` run leaves ~4 966 modified files.** Measured twice during Phase 0b.
+   Cause: Stryker's `disableTypeChecks` default injects `// @ts-nocheck` before mutating, and
+   `inPlace: true` writes that to real files. `git checkout -- packages/core` recovers fully. This
+   is why the local wrapper's clean-tree guard is a hard stop.
+3. **Environment hazard worth recording.** Background tasks here are killed at a 10-minute cap, and
+   a detached measurement survived several `pkill` attempts because the sandbox silently dropped the
+   signals — it re-instrumented `packages/core` mid-run. Killing required `dangerouslyDisableSandbox`,
+   and `pgrep` sees these processes while `ps` did not. No two `inPlace` runs may share a package.
+
+## Not run at this checkpoint, and why
+
+- **Full `validation.commands` gate** — deferred to the final gate (step 9), per the checkpoint
+  contract. `yarn test`, `yarn typecheck`, `yarn lint`, `yarn build:app` run there.
+- **Integration tests / browser QA** — none applicable. This change adds no application code, no
+  route, and no UI; its only developer-facing surface is a GitHub Actions job summary. No
+  screenshots exist to capture.

--- a/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/final-gate-checks.md
+++ b/.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/final-gate-checks.md
@@ -1,0 +1,84 @@
+# Final gate — all 12 Steps complete
+
+**Timestamp:** 2026-08-04T07:49:13Z
+**Runner:** local (no compose `app` container was running, so not Docker mode)
+**Branch head at gate:** `a7864dd25` plus the spec-changelog and SHA-fill commits
+
+## Full `validation.commands` gate, in configured order
+
+| # | Command | Result |
+|---|---------|--------|
+| 1 | `yarn build:packages` | ✅ rc=0 |
+| 2 | `yarn generate` | ✅ rc=0 — produced **no** tracked-file changes |
+| 3 | `yarn build:packages` | ✅ rc=0 |
+| 4 | `yarn i18n:check-sync` | ✅ rc=0 |
+| 5 | `yarn i18n:check-usage` | ❌ rc=1 — **pre-existing**, see below |
+| 6 | `yarn typecheck` | ✅ rc=0 |
+| 7 | `yarn test` | ❌ rc=1 — **environmental**, see below |
+| 8 | `yarn test:scripts` | ✅ rc=0 — **463 passed / 0 failed** |
+| 9 | `yarn build:app` | ✅ rc=0 |
+
+`yarn test:scripts` is not in the configured list but is run by CI at `ci.yml:515`, and it is the
+suite that covers every script this change adds. It was added to the gate deliberately.
+
+## The two non-green steps, neither caused by this branch
+
+### 5. `yarn i18n:check-usage` — 21 missing keys, all pre-existing
+
+The failure is `21 missing keys` (plus 3 592 unused keys, which the tool itself labels advisory).
+Every one of the 21 lives in a file this branch does not touch:
+
+- `packages/ui/src/backend/schedule/ScheduleToolbar.tsx` (2 keys)
+- `packages/core/src/modules/design_system/gallery/entries/scaffolding.tsx` (12 keys)
+- `packages/core/src/modules/design_system/gallery/entries/detail.tsx` (7 keys)
+
+This branch changes **no `.tsx` file at all** and adds **no translation keys** — its code is `.mjs`
+scripts, one workflow, and markdown. Verified by intersecting `git diff --name-only
+origin/develop...HEAD` with the reported files: empty. Not fixed here, because fixing unrelated
+missing translation keys is a separate change with its own review surface.
+
+### 7. `yarn test` — only `create-mercato-app`, and only because `bwrap` cannot start
+
+23 of 24 workspace test tasks pass. The single failure is `create-mercato-app#test`, and every
+assertion inside it fails for the same reason:
+
+```
+bwrap: setting up uid map: Permission denied          (29 occurrences)
+bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted
+```
+
+That suite shells out to bubblewrap to run a generated app's `yarn typecheck` in a sandbox. This
+execution environment is itself a restricted container, so bubblewrap cannot create a user
+namespace or configure loopback. Not one failure is a content assertion — the surrounding oracle
+checks (`crud.factory-import`, `crud.route`, `crud.openapi`, `routes.unique`, `source.present`) all
+report `passed: true`; only `target.typecheck` fails, with the `bwrap` message as its reason.
+
+Re-running with the sandbox disabled reproduces it identically, confirming the limitation is the
+container, not the tool invocation. This branch touches no file under `packages/create-app/`.
+GitHub Actions runners can run bubblewrap, so this is expected to pass in CI — that is the
+authoritative check for this suite.
+
+## Integration suite
+
+Not run. This change adds no application code, no API route, no database access, and no UI, so
+there is no integration surface to exercise. The change's behaviour is fully covered by the 54 unit
+tests in `yarn test:scripts` plus the end-to-end Stryker run recorded below.
+
+## Design-system / style pass
+
+Not applicable. No `.tsx`, nothing under `packages/ui/src/`, no `className`, no design tokens.
+
+## End-to-end verification against ground truth
+
+Beyond unit tests, the toolchain was run against a file whose correct answer was already known from
+the Phase 0 pilot:
+
+| Check | Expected | Measured |
+|-------|----------|----------|
+| `packages/shared/src/lib/boolean.ts` mutation score, via the new factory | 93.3 % (pilot) | **93.33 %** |
+| Mutants | — | 28 killed / 2 survived / 2 errors |
+| `report.mjs` score against the real `mutation.json` | match Stryker's own output | **match** |
+| `report.mjs` survivors | the two equivalent mutants the pilot identified | **match** |
+
+The clean run also confirmed Stryker restores its `inPlace` modifications correctly on a normal
+exit: `git status` reported zero modified tracked files afterwards.

--- a/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+++ b/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
@@ -321,6 +321,17 @@ Nothing persists between runs; nothing else depends on it.
 > **To enable it, after that decision:** set the `MUTATION_ENFORCE` repository variable to `'true'`.
 > That is the whole change — no code edit, no workflow edit. Reverting is setting it back.
 >
+> **Verify one thing at the moment of flipping the flag: that `vars` actually reaches fork pull
+> requests.** Every enforcement decision reads `vars.MUTATION_ENFORCE` and falls back to the
+> advisory branch when the value is absent. While the gate is dormant that is harmless, because
+> absent and `'false'` mean the same thing. Once the variable is `'true'` they stop being
+> equivalent: if configuration variables are not exposed to `pull_request` runs from forks,
+> enforcement would be silently **off** for exactly the external contributions it is most meant to
+> scrutinise and **on** for internal branches — an asymmetry nobody would notice, because both
+> states render as a passing check. Confirm it with one `workflow_dispatch` run plus one fork PR
+> before trusting the flag; if `vars` does not reach fork runs, drive enforcement from a committed
+> value in the workflow instead of a repository variable.
+>
 > One design note. Step 2 below says "set `thresholds.break`". It is implemented in
 > `scripts/stryker/enforce.mjs` rather than in Stryker's own `thresholds.break`, which stays `null`.
 > Stryker's built-in break has no notion of the minimum-mutant floor, so it would fail a four-mutant

--- a/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+++ b/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
@@ -195,7 +195,7 @@ only surfaces other tooling should depend on:
 
 | Surface | Contract |
 |---------|----------|
-| `node scripts/stryker/scope.mjs [--base <ref>] [--json]` | stdout: GH Actions matrix JSON; exit 0 with an empty matrix when nothing is in scope |
+| `node scripts/stryker/scope.mjs [--base <ref>]` | stdout: GH Actions matrix JSON (always — the `--json` flag from the draft was dropped as a no-op); stderr: dropped-file warnings; exit 0 with an empty matrix when nothing is in scope |
 | `node scripts/stryker/report.mjs <mutation.json>` | stdout: markdown survivor table; exit 0 always |
 | `yarn mutation:changed` | local wrapper: clean-tree guard → `scope.mjs` → Stryker per package |
 

--- a/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+++ b/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
@@ -258,10 +258,10 @@ Nothing persists between runs; nothing else depends on it.
 | Phase | Deliverable | Exit criterion |
 |-------|-------------|----------------|
 | **0** ✅ | Feasibility pilot on `packages/shared` | Done — `.ai/analysis/2026-07-31-stryker-mutation-testing-pilot.md` |
-| **0b** | Same measurement on `packages/core` | A run on 3 representative `core` business-logic files completes under 10 min, or `core` stays out of scope |
-| **1** | Config factory, scope script, advisory workflow, `shared` allowlisted | Green advisory runs on real PRs for 2–3 weeks; scores collected |
-| **2** | Survivor reporting (job summary + artifact; optional fork-guarded PR comment) | A developer can act on a survivor without opening the artifact |
-| **3** | Enforcement: `thresholds.break`, minimum-mutant floor, `MUTATION_ENFORCE=true` | Core-team sign-off on the threshold, chosen from Phase 1–2 data |
+| **0b** ✅ | Same measurement on `packages/core` | Done — `core` **excluded**: only a 75-LOC leaf completed (1 m 45 s); `commands/roles.ts` exceeded 10 min and `data/validators.ts` projected ~6 h 42 m |
+| **1** ✅ | Config factory, scope script, advisory workflow, `shared` allowlisted | Shipped. Still needs green advisory runs on real PRs for 2–3 weeks before Phase 3 is considered |
+| **2** ✅ | Survivor reporting (job summary + artifact; optional fork-guarded PR comment) | Shipped, including the fork-guarded comment |
+| **3** ⏸ | Enforcement: `thresholds.break`, minimum-mutant floor, `MUTATION_ENFORCE=true` | **Implemented but dormant** — `MUTATION_ENFORCE` defaults to `false`. Core-team sign-off on the threshold is still outstanding |
 | **4** | Optional: `incremental` + cache, `mixinJestEnvironment` for `perTest` coverage, nightly trend run | Only if Phase 1–3 timings demand it |
 
 ## 📋 Implementation Plan
@@ -306,6 +306,26 @@ Nothing persists between runs; nothing else depends on it.
    **Test:** the step is skipped on a fork PR and posts exactly one idempotent comment otherwise.
 
 ### Phase 3 — enforcement (2 steps, gated on core-team approval)
+
+> **Status (2026-08-04): implemented but DORMANT — awaiting an explicit core-team decision.**
+>
+> The full machinery ships in the implementation PR: the `MUTATION_MIN_MUTANTS` floor, the 70 %
+> threshold, and the `MUTATION_ENFORCE` flag, all unit-tested. **`MUTATION_ENFORCE` defaults to
+> `false`**, the workflow keeps `continue-on-error`, and the check is neither registered nor
+> documented as a required merge-blocking check.
+>
+> This is deliberate, not an omission. Q1 above leaves enforcement to a recorded core-team
+> decision, and `AGENTS.md` classifies changes to the PR pipeline as **Ask First**. Approving the
+> tooling therefore does not approve enforcement.
+>
+> **To enable it, after that decision:** set the `MUTATION_ENFORCE` repository variable to `'true'`.
+> That is the whole change — no code edit, no workflow edit. Reverting is setting it back.
+>
+> One design note. Step 2 below says "set `thresholds.break`". It is implemented in
+> `scripts/stryker/enforce.mjs` rather than in Stryker's own `thresholds.break`, which stays `null`.
+> Stryker's built-in break has no notion of the minimum-mutant floor, so it would fail a four-mutant
+> diff on a single survivor — precisely what step 1's floor exists to prevent. The threshold and the
+> floor have to be evaluated together, which means one decision function owns both.
 
 1. Add the minimum-mutant floor to the runner: below `MUTATION_MIN_MUTANTS` (default 20) the score
    is reported but never fails. **Test:** unit test — 4 mutants with 1 survivor does not fail;

--- a/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+++ b/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
@@ -262,7 +262,7 @@ Nothing persists between runs; nothing else depends on it.
 | **1** ✅ | Config factory, scope script, advisory workflow, `shared` allowlisted | Shipped. Still needs green advisory runs on real PRs for 2–3 weeks before Phase 3 is considered |
 | **2** ✅ | Survivor reporting (job summary + artifact; optional fork-guarded PR comment) | Shipped, including the fork-guarded comment |
 | **3** ⏸ | Enforcement: `thresholds.break`, minimum-mutant floor, `MUTATION_ENFORCE=true` | **Implemented but dormant** — `MUTATION_ENFORCE` defaults to `false`. Core-team sign-off on the threshold is still outstanding |
-| **4** | Optional: `incremental` + cache, `mixinJestEnvironment` for `perTest` coverage, nightly trend run | Only if Phase 1–3 timings demand it |
+| **4** ⏸ | Optional: `incremental` + cache, `mixinJestEnvironment` for `perTest` coverage, nightly trend run | **Attempted, not shipped** — timings do not demand it, and `perTest` is blocked by the `@jest-environment` docblocks without a repo-wide resolver change |
 
 ## 📋 Implementation Plan
 
@@ -336,6 +336,36 @@ Nothing persists between runs; nothing else depends on it.
    added passes.
 
 ### Phase 4 — optional optimisation (2 steps)
+
+> **Status (2026-08-04): attempted, deliberately NOT shipped. Both steps stay open.**
+>
+> This phase is conditional by its own exit criterion — *"Only if Phase 1–3 timings demand it."*
+> They do not, and step 1 turns out not to be reachable without violating Q3. Both were attempted
+> rather than assumed; the evidence is below so a future attempt starts from facts.
+>
+> **Step 1 — `perTest` coverage: blocked, not deferred.** Running `packages/shared` with
+> `--coverageAnalysis perTest` fails in the initial test run, exactly as Q3 predicted: 19 of its
+> suites carry `@jest-environment` docblocks (792 repo-wide). Stryker does ship the matching wrapped
+> environments (`@stryker-mutator/jest-runner/jest-env/node` and `.../jest-env/jsdom`), so the
+> obvious fix is to redirect the docblocks' targets. That was tried with a Jest `moduleNameMapper`
+> entry mapping `jest-environment-node` and `jest-environment-jsdom` onto the Stryker wrappers —
+> **it does not work**, because Jest resolves the `@jest-environment` docblock outside the
+> `moduleNameMapper` path. The two remaining routes are editing all 19 test files (Q3 forbids it) or
+> replacing the repo-wide Jest `resolver` in `jest.config.base.cjs`, which would put every suite in
+> the repository behind a change made for a mutation-testing optimisation. Neither is justified by a
+> job that currently finishes in about three minutes.
+>
+> **Step 2 — `incremental` + cache: not justified, and not free.** The measured `packages/shared`
+> job is roughly 1 min of `yarn install` plus `build:packages` and 1 m 27 s of mutation, against a
+> `timeout-minutes: 20` budget. There is no timing pressure to relieve. Against that, a stale
+> incremental file makes Stryker report mutants as killed that the current tests do not kill — a
+> false green in the one check whose entire value is trustworthy signal. Shipping it would trade
+> real correctness risk for time nobody needs.
+>
+> **Revisit when** a package with materially larger suites is allowlisted (which today means solving
+> the `packages/core` problem from Phase 0b), or when the advisory runs from Phases 1–2 show the job
+> approaching its timeout. At that point `perTest` via a Jest `resolver` change becomes worth its
+> blast radius, and it is the higher-leverage of the two.
 
 1. `mixinJestEnvironment` wrapper module so `@jest-environment` docblocks can point at a
    Stryker-aware environment, unlocking `coverageAnalysis: "perTest"`. **Test:** the dry run

--- a/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+++ b/.ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
@@ -382,3 +382,33 @@ Nothing persists between runs; nothing else depends on it.
 - CI scoping precedent (`prepare` job's changed-module detection): `.github/workflows/ci.yml`
 - Petrović & Ivanković, *State of Mutation Testing at Google* (ICSE-SEIP 2018) — diff-scoped
   presentation and arid-mutant suppression as adoption prerequisites
+
+## 📝 Changelog
+
+### 2026-08-04 — implemented (PR #4932)
+
+Phases 0b, 1 and 2 shipped. Phase 3 shipped **dormant**. Phase 4 was attempted and deliberately not
+shipped. What changed against the design as written:
+
+| Design intent | What shipped | Why |
+|---------------|--------------|-----|
+| Phase 0b decides whether `core` is in scope | `packages/core` **excluded** | Only a 75-LOC leaf completed (1 m 45 s, 41 mutants, 58.5 %). `commands/roles.ts` exceeded 10 min twice; `data/validators.ts` produced 403 mutants with a ~6 h 42 m projection. The 10-minute exit criterion is missed by ~2 orders of magnitude. |
+| Phase 3 sets `MUTATION_ENFORCE=true` | Enforcement implemented, **`MUTATION_ENFORCE` defaults to `false`** | Q1 reserves enforcement for a recorded core-team decision, and `AGENTS.md` makes PR-pipeline changes Ask First. Enabling it is one repository-variable change. |
+| Phase 3 sets `thresholds.break` | Threshold lives in `scripts/stryker/enforce.mjs`; Stryker's `thresholds.break` stays `null` | Stryker's built-in break has no notion of the minimum-mutant floor and would fail a four-mutant diff on one survivor — what the floor exists to prevent. Threshold and floor must be evaluated together. |
+| Phase 3 documents the gate in `AGENTS.md` → Validation Commands | **Not done**, deliberately | Listing a dormant, non-blocking check as a validation command would misrepresent it. Documented as dormant in `apps/docs/docs/tutorials/testing.mdx` instead. |
+| Phase 4 delivers `perTest` and `incremental` | **Neither shipped** | `perTest` is blocked: the `moduleNameMapper` redirect onto Stryker's wrapped environments does not work, because Jest resolves `@jest-environment` outside that path. The remaining routes violate Q3 or change the repo-wide resolver. `incremental` was declined on risk — the job uses ~15 % of its timeout budget, and a stale incremental file yields false greens. |
+
+Additions the design did not anticipate:
+
+- **The workflow builds packages before mutating.** Package suites resolve their siblings through
+  `dist/`, so Stryker's initial dry run fails in a clean checkout with
+  `Cannot find module '@open-mercato/cache'`.
+- **`.stryker-tmp/` and `**/reports/mutation/` are gitignored.** Without that, a local run leaves
+  untracked output that makes the wrapper's own clean-tree guard refuse the next run.
+- **The `inPlace` blast radius is now measured, not assumed.** An interrupted run left 4 966
+  modified files in `packages/core`, because `disableTypeChecks` injects `// @ts-nocheck` before
+  mutating. `disableTypeChecks` cannot be turned off to shrink it — this repo's ts-jest transformer
+  type-checks, so type-breaking mutants would error instead of being scored.
+- **A follow-up worth filing:** `packages/core`'s `auth/lib/rateLimitCheck.ts` scored 58.5 %, with
+  survivors clustered on early-return guards that the tests never attribute a rejection to. Real
+  finding, out of scope here.

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -84,10 +84,15 @@ jobs:
         id: scope
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          IS_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
           DISPATCH_PACKAGE: ${{ inputs.package }}
           DISPATCH_MUTATE: ${{ inputs.mutate }}
         run: |
-          if [ -n "${DISPATCH_PACKAGE}" ] || [ -n "${DISPATCH_MUTATE}" ]; then
+          # Branch on the event, not on whether the inputs happen to be populated: a
+          # dispatch whose inputs were cleared must resolve to "nothing in scope" and
+          # skip, not fall through to a diff against an empty base ref and fail the
+          # one job in this workflow that is deliberately allowed to go red.
+          if [ "${IS_DISPATCH}" = "true" ]; then
             MATRIX=$(node scripts/stryker/scope.mjs --package "${DISPATCH_PACKAGE}" --mutate "${DISPATCH_MUTATE}")
           else
             MATRIX=$(node scripts/stryker/scope.mjs --base "${BASE_SHA}")

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -96,5 +96,25 @@ jobs:
         run: yarn build:packages
 
       - name: Run mutation testing
+        id: mutate
         working-directory: packages/${{ matrix.package }}
         run: node ../../node_modules/.bin/stryker run --mutate "${{ matrix.mutate }}"
+
+      # Runs even when the mutation step failed: a low score is exactly when the
+      # survivor list is worth reading.
+      - name: Write the survivor report to the job summary
+        if: always()
+        run: |
+          node scripts/stryker/report.mjs \
+            "packages/${{ matrix.package }}/reports/mutation/mutation.json" \
+            --package "${{ matrix.package }}" \
+            ${{ vars.MUTATION_ENFORCE == 'true' && '--enforced' || '' }}
+
+      - name: Upload the mutation report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: mutation-report-${{ matrix.package }}
+          path: packages/${{ matrix.package }}/reports/mutation/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -65,9 +65,18 @@ jobs:
       matrix: ${{ steps.scope.outputs.matrix }}
       has_work: ${{ steps.scope.outputs.has_work }}
     steps:
+      # Pinned to the PR's own head commit, not the default `refs/pull/<n>/merge`.
+      # That ref is GitHub's live merge of this branch into whatever the base branch's
+      # tip is *at checkout time* — which can already be ahead of `base.sha` below by
+      # the time a queued job starts. Diffing the frozen `base.sha` against a HEAD that
+      # silently gained every commit merged into develop in the meantime turns "what
+      # this PR changed" into "what this PR changed plus everything upstream since it
+      # branched", which is how an unrelated develop-side refactor once got mutated as
+      # if this PR had written it (and blew the mutate job's timeout doing so).
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
       - name: Set up Node
@@ -117,8 +126,13 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.scope.outputs.matrix) }}
     steps:
+      # Same head-sha pin as the `scope` job, and for the same reason: the tree being
+      # mutated must be exactly the one `scope` diffed, not a live merge that can have
+      # drifted ahead of it between the two jobs.
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Node
         uses: actions/setup-node@v7

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -4,6 +4,23 @@ name: Mutation tests
 # confused with a test failure, and so rolling the whole thing back is deleting
 # one file. It cannot block ci.yml, and while MUTATION_ENFORCE is unset it
 # cannot block a merge either.
+#
+# Which jobs may go red, decided deliberately rather than by omission. Branch
+# protection on develop is not readable through the API, and this repository's
+# review and merge automation is specified to treat every reported check as
+# required in exactly that case — so a red job here does reach the pipeline even
+# though no mutation *score* can block anything.
+#
+#   mutate   continue-on-error while MUTATION_ENFORCE is not 'true'. A low score is
+#            advisory by definition; this is the flag that makes it a real gate.
+#   comment  continue-on-error: true. It only re-posts what the job summary already
+#            says, so a `gh api` or artifact hiccup carries no signal about the code
+#            and must not read as a merge blocker.
+#   scope    deliberately NOT continue-on-error. It is pure JS over a git diff with
+#            no network beyond the checkout, so a failure means the gate itself is
+#            misconfigured — and a silenced scope job would make the whole workflow
+#            a no-op that still burns runner minutes. That invisible failure is the
+#            one mode worth being loud about.
 
 permissions:
   contents: read
@@ -13,6 +30,20 @@ on:
     branches:
       - main
       - develop
+  # Lets a maintainer execute the mutate job on demand against a known file, which
+  # is the only way to exercise the runner path (install → build → stryker → report
+  # → enforce) when no pull request happens to touch an in-scope file. Keep it: it
+  # doubles as the debugging entrypoint when a mutation run misbehaves in CI.
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Allowlisted package to mutate (see ALLOWLISTED_PACKAGES in scripts/stryker/scope.mjs)'
+        required: false
+        default: 'shared'
+      mutate:
+        description: 'Comma-separated package-relative files to mutate'
+        required: false
+        default: 'src/lib/boolean.ts'
 
 concurrency:
   group: mutation-${{ github.ref }}
@@ -44,10 +75,23 @@ jobs:
         with:
           node-version: 24
 
+      # Every value that originates outside this file is read from the environment
+      # rather than interpolated into the script. `${{ … }}` expands as text before
+      # bash parses the line, so an interpolated value is shell source — see the
+      # `mutate` job's own note. A dispatch selection is still filtered by
+      # scope.mjs's allowlist and character rules, not trusted verbatim.
       - name: Compute mutation scope
         id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          DISPATCH_PACKAGE: ${{ inputs.package }}
+          DISPATCH_MUTATE: ${{ inputs.mutate }}
         run: |
-          MATRIX=$(node scripts/stryker/scope.mjs --base "${{ github.event.pull_request.base.sha }}")
+          if [ -n "${DISPATCH_PACKAGE}" ] || [ -n "${DISPATCH_MUTATE}" ]; then
+            MATRIX=$(node scripts/stryker/scope.mjs --package "${DISPATCH_PACKAGE}" --mutate "${DISPATCH_MUTATE}")
+          else
+            MATRIX=$(node scripts/stryker/scope.mjs --base "${BASE_SHA}")
+          fi
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
           if [ "$(echo "${MATRIX}" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(String(JSON.parse(d).include.length)))')" = "0" ]; then
             echo "has_work=false" >> "$GITHUB_OUTPUT"
@@ -95,20 +139,32 @@ jobs:
       - name: Build packages
         run: yarn build:packages
 
+      # MUTATE_LIST goes through the environment, never into the `run:` script.
+      # `${{ … }}` is expanded as text before bash parses the line, so an
+      # interpolated mutate list would be shell source: it is built from the changed
+      # paths of a pull request anyone can open, and `$(…)` stays live inside double
+      # quotes. Through the environment the shell sees a value, never code.
+      # `${{ matrix.package }}` below is safe as interpolation because it can only be
+      # a member of the frozen ALLOWLISTED_PACKAGES array in scripts/stryker/scope.mjs.
       - name: Run mutation testing
         id: mutate
         working-directory: packages/${{ matrix.package }}
-        run: node ../../node_modules/.bin/stryker run --mutate "${{ matrix.mutate }}"
+        env:
+          MUTATE_LIST: ${{ matrix.mutate }}
+        run: node ../../node_modules/.bin/stryker run --mutate "$MUTATE_LIST"
 
       # Runs even when the mutation step failed: a low score is exactly when the
       # survivor list is worth reading.
       - name: Write the survivor report to the job summary
         if: always()
+        env:
+          MUTATE_PACKAGE: ${{ matrix.package }}
+          ENFORCED: ${{ vars.MUTATION_ENFORCE == 'true' && '--enforced' || '' }}
         run: |
           node scripts/stryker/report.mjs \
-            "packages/${{ matrix.package }}/reports/mutation/mutation.json" \
-            --package "${{ matrix.package }}" \
-            ${{ vars.MUTATION_ENFORCE == 'true' && '--enforced' || '' }}
+            "packages/${MUTATE_PACKAGE}/reports/mutation/mutation.json" \
+            --package "${MUTATE_PACKAGE}" \
+            ${ENFORCED}
 
       # Owns the pass/fail decision instead of Stryker's own thresholds.break, so
       # the minimum-mutant floor can veto it. While MUTATION_ENFORCE is not 'true'
@@ -117,9 +173,10 @@ jobs:
         if: always()
         env:
           MUTATION_ENFORCE: ${{ vars.MUTATION_ENFORCE || 'false' }}
+          MUTATE_PACKAGE: ${{ matrix.package }}
         run: |
           node scripts/stryker/enforce.mjs \
-            "packages/${{ matrix.package }}/reports/mutation/mutation.json"
+            "packages/${MUTATE_PACKAGE}/reports/mutation/mutation.json"
 
       - name: Upload the mutation report
         if: always()
@@ -142,6 +199,9 @@ jobs:
       needs.scope.outputs.has_work == 'true' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    # Convenience surface only: the job summary is primary and needs no token. See
+    # the per-job note at the top of this file.
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -118,3 +118,64 @@ jobs:
           path: packages/${{ matrix.package }}/reports/mutation/
           if-no-files-found: ignore
           retention-days: 14
+
+  # The job summary above is the primary surface and works everywhere. This job
+  # additionally posts the same markdown as a PR comment, but only for
+  # same-repository pull requests: a `pull_request` run from a fork receives a
+  # read-only token, so the step would fail rather than degrade. It is the same
+  # fork guard ci.yml's docker-build job uses.
+  comment:
+    needs: [scope, mutate]
+    if: |
+      always() &&
+      needs.scope.outputs.has_work == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Download mutation reports
+        uses: actions/download-artifact@v6
+        with:
+          pattern: mutation-report-*
+          path: mutation-reports
+
+      - name: Post or update the mutation comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ENFORCED: ${{ vars.MUTATION_ENFORCE == 'true' && '--enforced' || '' }}
+        run: |
+          set -euo pipefail
+          MARKER='<!-- om:mutation-testing-report -->'
+          BODY_FILE=$(mktemp)
+          printf '%s\n\n' "$MARKER" > "$BODY_FILE"
+
+          shopt -s nullglob
+          for REPORT in mutation-reports/mutation-report-*/mutation.json; do
+            PACKAGE=$(basename "$(dirname "$REPORT")" | sed 's/^mutation-report-//')
+            node scripts/stryker/report.mjs "$REPORT" --package "$PACKAGE" ${ENFORCED} >> "$BODY_FILE"
+            printf '\n' >> "$BODY_FILE"
+          done
+
+          # Idempotent: reuse this run's own marker comment instead of appending a
+          # new one on every push.
+          EXISTING=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq "[.[] | select(.body | contains(\"${MARKER}\")) | .id] | first // empty")
+
+          if [ -n "${EXISTING}" ]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${EXISTING}" \
+              -F body=@"$BODY_FILE" > /dev/null
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              -F body=@"$BODY_FILE" > /dev/null
+          fi

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -110,6 +110,17 @@ jobs:
             --package "${{ matrix.package }}" \
             ${{ vars.MUTATION_ENFORCE == 'true' && '--enforced' || '' }}
 
+      # Owns the pass/fail decision instead of Stryker's own thresholds.break, so
+      # the minimum-mutant floor can veto it. While MUTATION_ENFORCE is not 'true'
+      # this only prints its reasoning and always exits 0.
+      - name: Enforce the mutation threshold
+        if: always()
+        env:
+          MUTATION_ENFORCE: ${{ vars.MUTATION_ENFORCE || 'false' }}
+        run: |
+          node scripts/stryker/enforce.mjs \
+            "packages/${{ matrix.package }}/reports/mutation/mutation.json"
+
       - name: Upload the mutation report
         if: always()
         uses: actions/upload-artifact@v5

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -1,0 +1,100 @@
+name: Mutation tests
+
+# Standalone by design: kept out of ci.yml so a mutation result can never be
+# confused with a test failure, and so rolling the whole thing back is deleting
+# one file. It cannot block ci.yml, and while MUTATION_ENFORCE is unset it
+# cannot block a merge either.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+concurrency:
+  group: mutation-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Advisory by default. Enforcement is a core-team decision (see the spec's Q1);
+  # setting this repository variable to 'true' is the only change required to make
+  # a low score fail the job.
+  MUTATION_ENFORCE: ${{ vars.MUTATION_ENFORCE || 'false' }}
+
+jobs:
+  # Resolve which packages and files this PR actually changed. Emits an empty
+  # matrix when nothing is in scope, which skips the mutate job entirely rather
+  # than reporting a synthetic score.
+  scope:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.scope.outputs.matrix }}
+      has_work: ${{ steps.scope.outputs.has_work }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Compute mutation scope
+        id: scope
+        run: |
+          MATRIX=$(node scripts/stryker/scope.mjs --base "${{ github.event.pull_request.base.sha }}")
+          echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+          if [ "$(echo "${MATRIX}" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(String(JSON.parse(d).include.length)))')" = "0" ]; then
+            echo "has_work=false" >> "$GITHUB_OUTPUT"
+            echo "No in-scope changes — skipping mutation testing." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "has_work=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  mutate:
+    needs: scope
+    if: needs.scope.outputs.has_work == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Advisory: a low score annotates the PR, it does not fail the check. Flipping
+    # MUTATION_ENFORCE to 'true' is what turns this into a real gate.
+    continue-on-error: ${{ vars.MUTATION_ENFORCE != 'true' }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.scope.outputs.matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Cache Yarn packages
+        uses: actions/cache@v6
+        with:
+          path: .yarn/cache
+          key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          restore-keys: yarn-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      # The package test suites resolve sibling packages through their built
+      # dist/ output (for example @open-mercato/cache from packages/shared), so
+      # Stryker's initial dry run fails without this.
+      - name: Build packages
+        run: yarn build:packages
+
+      - name: Run mutation testing
+        working-directory: packages/${{ matrix.package }}
+        run: node ../../node_modules/.bin/stryker run --mutate "${{ matrix.mutate }}"

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,9 @@ apps/mercato/src/module-facts.generated.json
 
 # skills CLI lockfile (external skills are re-resolved on each install)
 skills-lock.json
+
+# StrykerJS mutation testing (scripts/stryker/). Without these, a local
+# `yarn mutation:changed` run leaves untracked output that makes the wrapper's
+# clean-tree guard refuse the next run.
+.stryker-tmp/
+**/reports/mutation/

--- a/apps/docs/docs/tutorials/testing.mdx
+++ b/apps/docs/docs/tutorials/testing.mdx
@@ -125,6 +125,53 @@ Our module generator explicitly ignores tests so dev/runtime doesn’t import th
 
 If you introduce new patterns, ensure they don’t live under module `api/` unless named with `.test.ts`.
 
+## Mutation Testing
+
+Coverage says a line was executed. It does not say the test would notice if that line were wrong.
+Mutation testing closes that gap: StrykerJS rewrites your source (flipping `<` to `<=`, `&&` to
+`||`, removing a `return`) and reports every mutant the test suite failed to catch.
+
+The gate is **diff-scoped and advisory**. Only the business-logic files your pull request changes
+are mutated, only in allowlisted packages, and a low score never blocks a merge — it produces a
+shortlist of behaviour worth a second look.
+
+Run it locally against your own changes:
+
+```bash
+yarn mutation:changed
+```
+
+The run mutates real files on disk (Stryker's sandbox is incompatible with our per-package Jest
+configs), so it refuses to start on a dirty working tree. If a run is ever killed mid-flight,
+`git checkout -- .` restores everything.
+
+### A surviving mutant is a question, not a verdict
+
+Three different findings look identical in the report, and only the first one means "write a test":
+
+1. **A genuine coverage gap.** The mutant changes behaviour and nothing fails. Add the missing
+   assertion.
+2. **An equivalent mutant.** The mutant is behaviourally identical to the original, so no test could
+   ever kill it. Suppress it (below).
+3. **A redundant source path.** Two checks guard the same condition, so each masks mutations of the
+   other. The fix is in the source, not the tests.
+
+Never chase the score by asserting exact log strings, error copy, or object shapes — the
+`StringLiteral` and `Regex` mutators are excluded precisely so that tactic earns nothing.
+
+### Suppressing an equivalent mutant
+
+When — and only when — a mutant is genuinely unkillable, suppress it at the source. Every
+suppression MUST carry a one-line justification, and it is reviewed like any other code change:
+
+```ts
+// Stryker disable next-line BooleanLiteral: empty input is in neither value set, so both branches return null
+if (!trimmed) return null
+```
+
+A suppression without a justification is a review blocker. If you cannot articulate why no test
+could kill the mutant, it is probably a coverage gap rather than an equivalent mutant.
+
 ## Troubleshooting
 
 - “jest is not defined” during `yarn dev`: means a test leaked into the runtime. Ensure tests are under `__tests__` and the generator filters apply.

--- a/apps/docs/docs/tutorials/testing.mdx
+++ b/apps/docs/docs/tutorials/testing.mdx
@@ -153,6 +153,19 @@ The run mutates real files on disk (Stryker's sandbox is incompatible with our p
 configs), so it refuses to start on a dirty working tree. If a run is ever killed mid-flight,
 `git checkout -- .` restores everything.
 
+### Running the CI workflow on demand
+
+Because the gate is diff-scoped, the CI job only runs when a pull request happens to touch an
+in-scope file — which makes it awkward to verify the workflow itself, or to debug a run that
+misbehaved. The **Mutation tests** workflow therefore accepts a manual dispatch:
+
+```bash
+gh workflow run mutation-tests.yml -f package=shared -f mutate=src/lib/boolean.ts
+```
+
+The selection is filtered by exactly the same allowlist, scope and path rules a diff-derived run
+uses, so a dispatch cannot mutate a package or a file the automatic path would have skipped.
+
 ### A surviving mutant is a question, not a verdict
 
 Three different findings look identical in the report, and only the first one means "write a test":

--- a/apps/docs/docs/tutorials/testing.mdx
+++ b/apps/docs/docs/tutorials/testing.mdx
@@ -135,6 +135,14 @@ The gate is **diff-scoped and advisory**. Only the business-logic files your pul
 are mutated, only in allowlisted packages, and a low score never blocks a merge — it produces a
 shortlist of behaviour worth a second look.
 
+Enforcement exists in the code but is **switched off**, and turning it on is a core-team decision
+that has not been taken. Until it is, the mutation check is not part of the merge gate and is not a
+required check: read it, act on what it finds, and merge on the strength of the normal CI gate.
+
+Only `packages/shared` is currently in scope. `packages/core` was measured and excluded — its
+command and validator layers sit under suites large enough that a single file's run was projected at
+several hours.
+
 Run it locally against your own changes:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
     "check:time-bombs": "node scripts/time-bomb-scanner.mjs",
     "check:time-bombs:fail": "node scripts/time-bomb-scanner.mjs --fail",
     "agents:check-budget": "node scripts/check-agents-md-budget.mjs",
-    "lessons:check": "node packages/create-app/agentic/shared/scripts/check-lessons.mjs --root ."
+    "lessons:check": "node packages/create-app/agentic/shared/scripts/check-lessons.mjs --root .",
+    "mutation:changed": "node scripts/stryker/mutation-changed.mjs"
   },
   "dependencies": {
     "@ai-sdk/openai": "^4.0.2",
@@ -163,6 +164,8 @@
     "@eslint/eslintrc": "^3.3.6",
     "@next/eslint-plugin-next": "^16.2.9",
     "@playwright/test": "^1.62.0",
+    "@stryker-mutator/core": "^9.6.1",
+    "@stryker-mutator/jest-runner": "^9.6.1",
     "@types/better-sqlite3": "^7.6.11",
     "@types/html-to-text": "^9.0.4",
     "@types/jest": "^30.0.0",

--- a/packages/shared/src/lib/boolean.ts
+++ b/packages/shared/src/lib/boolean.ts
@@ -1,3 +1,9 @@
+// TEMPORARY mutation-gate probe — reverted in the commit that follows.
+// Touching an in-scope file is the only way to make the diff-scoped `mutate` job
+// execute on this PR, which is the end-to-end runner evidence PR review asked for.
+// Deliberately comment-only: it adds no mutants, so the reported score must
+// reproduce the Phase 0 pilot's 93.33% for src/lib/boolean.ts exactly. A different
+// number means the runner path, not the source, changed.
 export const TRUE_VALUES = new Set(['1', 'true', 'yes', 'y', 'on', 'enable', 'enabled'])
 export const FALSE_VALUES = new Set(['0', 'false', 'no', 'n', 'off', 'disable', 'disabled'])
 

--- a/packages/shared/src/lib/boolean.ts
+++ b/packages/shared/src/lib/boolean.ts
@@ -1,9 +1,3 @@
-// TEMPORARY mutation-gate probe — reverted in the commit that follows.
-// Touching an in-scope file is the only way to make the diff-scoped `mutate` job
-// execute on this PR, which is the end-to-end runner evidence PR review asked for.
-// Deliberately comment-only: it adds no mutants, so the reported score must
-// reproduce the Phase 0 pilot's 93.33% for src/lib/boolean.ts exactly. A different
-// number means the runner path, not the source, changed.
 export const TRUE_VALUES = new Set(['1', 'true', 'yes', 'y', 'on', 'enable', 'enabled'])
 export const FALSE_VALUES = new Set(['0', 'false', 'no', 'n', 'off', 'disable', 'disabled'])
 

--- a/packages/shared/stryker.conf.mjs
+++ b/packages/shared/stryker.conf.mjs
@@ -1,0 +1,3 @@
+import { createStrykerConfig } from '../../scripts/stryker/createConfig.mjs'
+
+export default createStrykerConfig({ packageName: 'shared' })

--- a/scripts/__tests__/stryker-create-config.test.mjs
+++ b/scripts/__tests__/stryker-create-config.test.mjs
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  DEFAULT_CONCURRENCY,
+  DEFAULT_TIMEOUT_MS,
+  EXCLUDED_MUTATIONS,
+  MUTATION_REPORT_PATH,
+  PACKAGE_TIMEOUT_MS,
+  createStrykerConfig,
+} from '../stryker/createConfig.mjs'
+
+test('produces the expected configuration for a given package name', () => {
+  const config = createStrykerConfig({ packageName: 'shared' })
+
+  assert.equal(config.packageManager, 'yarn')
+  assert.equal(config.testRunner, 'jest')
+  assert.equal(config.jest.projectType, 'custom')
+  assert.equal(config.jest.configFile, 'jest.config.cjs')
+  assert.equal(config.jest.enableFindRelatedTests, true)
+  assert.equal(config.jest.config.testEnvironment, '@stryker-mutator/jest-runner/jest-env/node')
+  assert.equal(config.jsonReporter.fileName, MUTATION_REPORT_PATH)
+  assert.deepEqual(config.reporters, ['clear-text', 'progress', 'json'])
+  assert.equal(config.concurrency, DEFAULT_CONCURRENCY)
+  assert.equal(config.timeoutFactor, 2)
+  assert.equal(config.cleanTempDir, true)
+})
+
+test('forces inPlace, because the sandbox breaks the per-package jest config', () => {
+  assert.equal(createStrykerConfig({ packageName: 'shared' }).inPlace, true)
+})
+
+test('keeps coverageAnalysis off, because @jest-environment docblocks block perTest', () => {
+  assert.equal(createStrykerConfig({ packageName: 'shared' }).coverageAnalysis, 'off')
+})
+
+test('excludes the mutators that reward asserting exact strings', () => {
+  const { mutator } = createStrykerConfig({ packageName: 'shared' })
+
+  assert.deepEqual(mutator.excludedMutations, [...EXCLUDED_MUTATIONS])
+  assert.ok(mutator.excludedMutations.includes('StringLiteral'))
+  assert.ok(mutator.excludedMutations.includes('Regex'))
+})
+
+test('mutates business logic but never tests, type declarations, or test helpers', () => {
+  const { mutate } = createStrykerConfig({ packageName: 'shared' })
+
+  assert.ok(mutate.includes('src/lib/**/*.ts'))
+  assert.ok(mutate.includes('src/modules/**/*.ts'))
+  assert.ok(mutate.includes('!src/**/__tests__/**'))
+  assert.ok(mutate.includes('!src/**/*.test.ts'))
+  assert.ok(mutate.includes('!src/**/*.d.ts'))
+  assert.ok(mutate.includes('!src/lib/testing/**'))
+})
+
+test('ships advisory — no break threshold until enforcement is explicitly enabled', () => {
+  assert.equal(createStrykerConfig({ packageName: 'shared' }).thresholds.break, null)
+})
+
+test('gives packages/core the larger timeout its 30s jest testTimeout requires', () => {
+  assert.equal(createStrykerConfig({ packageName: 'core' }).timeoutMS, PACKAGE_TIMEOUT_MS.core)
+  assert.equal(createStrykerConfig({ packageName: 'shared' }).timeoutMS, DEFAULT_TIMEOUT_MS)
+})
+
+test('lets an explicit timeoutMS override the per-package default', () => {
+  assert.equal(createStrykerConfig({ packageName: 'core', timeoutMS: 1234 }).timeoutMS, 1234)
+})
+
+test('rejects a missing or blank package name instead of guessing', () => {
+  assert.throws(() => createStrykerConfig(), /packageName/)
+  assert.throws(() => createStrykerConfig({}), /packageName/)
+  assert.throws(() => createStrykerConfig({ packageName: '   ' }), /packageName/)
+})
+
+test('does not share mutable arrays between two generated configs', () => {
+  const first = createStrykerConfig({ packageName: 'shared' })
+  const second = createStrykerConfig({ packageName: 'shared' })
+
+  first.mutate.push('src/should-not-leak.ts')
+  first.mutator.excludedMutations.push('ArithmeticOperator')
+
+  assert.ok(!second.mutate.includes('src/should-not-leak.ts'))
+  assert.ok(!second.mutator.excludedMutations.includes('ArithmeticOperator'))
+})

--- a/scripts/__tests__/stryker-create-config.test.mjs
+++ b/scripts/__tests__/stryker-create-config.test.mjs
@@ -4,6 +4,7 @@ import {
   DEFAULT_CONCURRENCY,
   DEFAULT_TIMEOUT_MS,
   EXCLUDED_MUTATIONS,
+  MUTATION_HTML_REPORT_PATH,
   MUTATION_REPORT_PATH,
   PACKAGE_TIMEOUT_MS,
   createStrykerConfig,
@@ -19,7 +20,8 @@ test('produces the expected configuration for a given package name', () => {
   assert.equal(config.jest.enableFindRelatedTests, true)
   assert.equal(config.jest.config.testEnvironment, '@stryker-mutator/jest-runner/jest-env/node')
   assert.equal(config.jsonReporter.fileName, MUTATION_REPORT_PATH)
-  assert.deepEqual(config.reporters, ['clear-text', 'progress', 'json'])
+  assert.equal(config.htmlReporter.fileName, MUTATION_HTML_REPORT_PATH)
+  assert.deepEqual(config.reporters, ['clear-text', 'progress', 'json', 'html'])
   assert.equal(config.concurrency, DEFAULT_CONCURRENCY)
   assert.equal(config.timeoutFactor, 2)
   assert.equal(config.cleanTempDir, true)

--- a/scripts/__tests__/stryker-create-config.test.mjs
+++ b/scripts/__tests__/stryker-create-config.test.mjs
@@ -54,7 +54,7 @@ test('mutates business logic but never tests, type declarations, or test helpers
   assert.ok(mutate.includes('!src/lib/testing/**'))
 })
 
-test('ships advisory — no break threshold until enforcement is explicitly enabled', () => {
+test('leaves thresholds.break null so the minimum-mutant floor can veto first', () => {
   assert.equal(createStrykerConfig({ packageName: 'shared' }).thresholds.break, null)
 })
 

--- a/scripts/__tests__/stryker-enforce.test.mjs
+++ b/scripts/__tests__/stryker-enforce.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 import {
   DEFAULT_BREAK_THRESHOLD,
   DEFAULT_MIN_MUTANTS,
@@ -7,6 +9,8 @@ import {
   isEnforcementEnabled,
   parseEnforceArgs,
 } from '../stryker/enforce.mjs'
+
+const ENFORCE_SCRIPT = fileURLToPath(new URL('../stryker/enforce.mjs', import.meta.url))
 
 const LOCATION = { start: { line: 1, column: 1 }, end: { line: 1, column: 5 } }
 
@@ -103,4 +107,38 @@ test('parses the threshold and floor overrides', () => {
     threshold: 85,
     minMutants: 5,
   })
+})
+
+function runEnforceCli({ args = [], env = {} } = {}) {
+  return spawnSync(process.execPath, [ENFORCE_SCRIPT, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, MUTATION_ENFORCE: '', ...env },
+  })
+}
+
+test('fails closed when the report is absent and enforcement is enabled', () => {
+  const result = runEnforceCli({
+    args: ['/nonexistent/mutation.json'],
+    env: { MUTATION_ENFORCE: 'true' },
+  })
+
+  assert.equal(result.status, 1)
+  assert.match(result.stdout, /No mutation report found and enforcement is enabled/)
+})
+
+test('stays advisory when the report is absent and enforcement is disabled', () => {
+  const result = runEnforceCli({ args: ['/nonexistent/mutation.json'] })
+
+  assert.equal(result.status, 0)
+  assert.match(result.stdout, /nothing to enforce \(advisory\)/)
+})
+
+test('an absent report is missing evidence, not a pass — the two modes differ', () => {
+  const advisory = runEnforceCli({ args: ['/nonexistent/mutation.json'] })
+  const enforced = runEnforceCli({
+    args: ['/nonexistent/mutation.json'],
+    env: { MUTATION_ENFORCE: 'true' },
+  })
+
+  assert.notEqual(advisory.status, enforced.status)
 })

--- a/scripts/__tests__/stryker-enforce.test.mjs
+++ b/scripts/__tests__/stryker-enforce.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  DEFAULT_BREAK_THRESHOLD,
+  DEFAULT_MIN_MUTANTS,
+  decideOutcome,
+  isEnforcementEnabled,
+  parseEnforceArgs,
+} from '../stryker/enforce.mjs'
+
+const LOCATION = { start: { line: 1, column: 1 }, end: { line: 1, column: 5 } }
+
+function createReport({ killed, survived }) {
+  const mutants = []
+  for (let index = 0; index < killed; index += 1) {
+    mutants.push({ id: `k${index}`, mutatorName: 'X', replacement: 'y', status: 'Killed', location: LOCATION })
+  }
+  for (let index = 0; index < survived; index += 1) {
+    mutants.push({ id: `s${index}`, mutatorName: 'X', replacement: 'y', status: 'Survived', location: LOCATION })
+  }
+  return { files: { 'src/lib/a.ts': { source: 'const a = 1', mutants } } }
+}
+
+test('4 mutants with 1 survivor does not fail', () => {
+  const outcome = decideOutcome(createReport({ killed: 3, survived: 1 }), { enforce: true })
+
+  assert.equal(outcome.shouldFail, false)
+  assert.equal(outcome.scored, 4)
+})
+
+test('30 mutants at 60% does fail once enforcement is on', () => {
+  const outcome = decideOutcome(createReport({ killed: 18, survived: 12 }), { enforce: true })
+
+  assert.equal(outcome.shouldFail, true)
+  assert.equal(outcome.score, 60)
+  assert.equal(outcome.scored, 30)
+  assert.match(outcome.reason, /below the 70% threshold/)
+})
+
+test('the floor — not the threshold — is what saves a tiny failing diff', () => {
+  const outcome = decideOutcome(createReport({ killed: 2, survived: 2 }), { enforce: true })
+
+  assert.equal(outcome.score, 50)
+  assert.equal(outcome.shouldFail, false)
+  assert.match(outcome.reason, /below the floor of 20/)
+  assert.match(outcome.reason, /too volatile/)
+})
+
+test('the same 50% score does fail once the mutant count clears the floor', () => {
+  const outcome = decideOutcome(createReport({ killed: 10, survived: 10 }), { enforce: true })
+
+  assert.equal(outcome.score, 50)
+  assert.equal(outcome.scored, 20)
+  assert.equal(outcome.shouldFail, true)
+})
+
+test('a failing score never fails the job while enforcement is disabled', () => {
+  const outcome = decideOutcome(createReport({ killed: 18, survived: 12 }), { enforce: false })
+
+  assert.equal(outcome.shouldFail, false)
+  assert.equal(outcome.score, 60)
+  assert.match(outcome.reason, /Enforcement is disabled/)
+  assert.match(outcome.reason, /advisory/)
+})
+
+test('enforcement is off unless MUTATION_ENFORCE is exactly "true"', () => {
+  assert.equal(isEnforcementEnabled({}), false)
+  assert.equal(isEnforcementEnabled({ MUTATION_ENFORCE: 'false' }), false)
+  assert.equal(isEnforcementEnabled({ MUTATION_ENFORCE: '1' }), false)
+  assert.equal(isEnforcementEnabled({ MUTATION_ENFORCE: 'TRUE' }), false)
+  assert.equal(isEnforcementEnabled({ MUTATION_ENFORCE: 'true' }), true)
+})
+
+test('the shipped defaults are the ones the spec names', () => {
+  assert.equal(DEFAULT_BREAK_THRESHOLD, 70)
+  assert.equal(DEFAULT_MIN_MUTANTS, 20)
+})
+
+test('a score exactly at the threshold passes', () => {
+  const outcome = decideOutcome(createReport({ killed: 21, survived: 9 }), { enforce: true })
+
+  assert.equal(outcome.score, 70)
+  assert.equal(outcome.shouldFail, false)
+  assert.match(outcome.reason, /meets the 70% threshold/)
+})
+
+test('an empty report is never a failure', () => {
+  const outcome = decideOutcome({ files: {} }, { enforce: true })
+
+  assert.equal(outcome.shouldFail, false)
+  assert.equal(outcome.score, null)
+  assert.match(outcome.reason, /nothing to score/)
+})
+
+test('parses the threshold and floor overrides', () => {
+  assert.deepEqual(parseEnforceArgs(['m.json']), {
+    reportPath: 'm.json',
+    threshold: DEFAULT_BREAK_THRESHOLD,
+    minMutants: DEFAULT_MIN_MUTANTS,
+  })
+  assert.deepEqual(parseEnforceArgs(['m.json', '--threshold', '85', '--min-mutants', '5']), {
+    reportPath: 'm.json',
+    threshold: 85,
+    minMutants: 5,
+  })
+})

--- a/scripts/__tests__/stryker-mutation-changed.test.mjs
+++ b/scripts/__tests__/stryker-mutation-changed.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
 import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 import {
   DIRTY_TREE_MESSAGE,
   isWorkingTreeClean,
@@ -104,4 +106,14 @@ test('reports capped files rather than silently truncating', () => {
   runMutationChanged(harness)
 
   assert.match(harness.written.join('\n'), /file cap reached; not mutated/)
+})
+
+test('Stryker output is gitignored, so a run never self-blocks the next one', () => {
+  const gitignore = fs.readFileSync(
+    fileURLToPath(new URL('../../.gitignore', import.meta.url)),
+    'utf8',
+  )
+
+  assert.match(gitignore, /^\.stryker-tmp\/$/m)
+  assert.match(gitignore, /^\*\*\/reports\/mutation\/$/m)
 })

--- a/scripts/__tests__/stryker-mutation-changed.test.mjs
+++ b/scripts/__tests__/stryker-mutation-changed.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  DIRTY_TREE_MESSAGE,
+  isWorkingTreeClean,
+  runMutationChanged,
+} from '../stryker/mutation-changed.mjs'
+
+function createHarness({ status = '', diff = '', strykerStatus = 0 } = {}) {
+  const strykerCalls = []
+  const written = []
+
+  const runGit = (args) => {
+    if (args[0] === 'status') return status
+    if (args[0] === 'diff') return diff
+    throw new Error(`[internal] unexpected git call: ${args.join(' ')}`)
+  }
+
+  const runStryker = (entry) => {
+    strykerCalls.push(entry)
+    return strykerStatus
+  }
+
+  return { runGit, runStryker, write: (message) => written.push(message), strykerCalls, written }
+}
+
+test('refuses to run on a dirty tree, exits non-zero, and never invokes Stryker', () => {
+  const harness = createHarness({
+    status: ' M packages/shared/src/lib/boolean.ts\n',
+    diff: 'packages/shared/src/lib/boolean.ts\n',
+  })
+
+  const result = runMutationChanged(harness)
+
+  assert.equal(result.exitCode, 1)
+  assert.deepEqual(harness.strykerCalls, [])
+  assert.deepEqual(result.ranPackages, [])
+})
+
+test('the refusal explains the in-place risk and prints the recovery command', () => {
+  const harness = createHarness({ status: '?? untracked.ts\n' })
+
+  runMutationChanged(harness)
+
+  assert.equal(harness.written[0], DIRTY_TREE_MESSAGE)
+  assert.match(harness.written[0], /git checkout -- \./)
+  assert.match(harness.written[0], /uncommitted/)
+})
+
+test('treats untracked files as dirty — Stryker restore does not distinguish them', () => {
+  assert.equal(isWorkingTreeClean('?? scratch.ts\n'), false)
+  assert.equal(isWorkingTreeClean(' M src/a.ts\n'), false)
+  assert.equal(isWorkingTreeClean(''), true)
+  assert.equal(isWorkingTreeClean('   \n  \n'), true)
+  assert.equal(isWorkingTreeClean(undefined), false)
+})
+
+test('runs Stryker once per in-scope package on a clean tree', () => {
+  const harness = createHarness({
+    status: '',
+    diff: 'packages/shared/src/lib/boolean.ts\npackages/shared/src/lib/phone.ts\n',
+  })
+
+  const result = runMutationChanged(harness)
+
+  assert.equal(result.exitCode, 0)
+  assert.deepEqual(harness.strykerCalls, [
+    { package: 'shared', mutate: 'src/lib/boolean.ts,src/lib/phone.ts' },
+  ])
+  assert.deepEqual(result.ranPackages, ['shared'])
+})
+
+test('skips cleanly when the diff contains nothing in scope', () => {
+  const harness = createHarness({
+    status: '',
+    diff: 'apps/mercato/src/app/page.tsx\nREADME.md\n',
+  })
+
+  const result = runMutationChanged(harness)
+
+  assert.equal(result.exitCode, 0)
+  assert.deepEqual(harness.strykerCalls, [])
+  assert.match(harness.written.join('\n'), /Nothing to mutate/)
+})
+
+test('propagates a non-zero Stryker exit code', () => {
+  const harness = createHarness({
+    status: '',
+    diff: 'packages/shared/src/lib/boolean.ts\n',
+    strykerStatus: 3,
+  })
+
+  assert.equal(runMutationChanged(harness).exitCode, 3)
+})
+
+test('reports capped files rather than silently truncating', () => {
+  const diff = Array.from(
+    { length: 28 },
+    (_unused, index) => `packages/shared/src/lib/file-${String(index).padStart(3, '0')}.ts`,
+  ).join('\n')
+
+  const harness = createHarness({ status: '', diff })
+
+  runMutationChanged(harness)
+
+  assert.match(harness.written.join('\n'), /file cap reached; not mutated/)
+})

--- a/scripts/__tests__/stryker-report.test.mjs
+++ b/scripts/__tests__/stryker-report.test.mjs
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  ADVISORY_NOTE,
+  collectSurvivors,
+  parseReportArgs,
+  renderMarkdown,
+} from '../stryker/report.mjs'
+
+const SOURCE = [
+  'export function isPositive(value) {',
+  '  if (value > 0) return true',
+  '  return false',
+  '}',
+].join('\n')
+
+function createReport(mutants) {
+  return {
+    schemaVersion: '1.0',
+    files: {
+      'src/lib/numbers.ts': { language: 'typescript', source: SOURCE, mutants },
+    },
+  }
+}
+
+const KILLED_MUTANT = {
+  id: '1',
+  mutatorName: 'EqualityOperator',
+  replacement: 'value >= 0',
+  status: 'Killed',
+  location: { start: { line: 2, column: 7 }, end: { line: 2, column: 16 } },
+}
+
+const SURVIVED_MUTANT = {
+  id: '2',
+  mutatorName: 'BooleanLiteral',
+  replacement: 'false',
+  status: 'Survived',
+  location: { start: { line: 2, column: 25 }, end: { line: 2, column: 29 } },
+}
+
+test('lists surviving mutants and omits killed ones', () => {
+  const markdown = renderMarkdown(createReport([KILLED_MUTANT, SURVIVED_MUTANT]))
+
+  assert.match(markdown, /1 surviving mutant/)
+  assert.match(markdown, /src\/lib\/numbers\.ts:2:25/)
+  assert.match(markdown, /BooleanLiteral/)
+  assert.ok(!markdown.includes('EqualityOperator'), 'killed mutants must not be listed')
+})
+
+test('renders the original and the replacement as a -/+ pair', () => {
+  const markdown = renderMarkdown(createReport([SURVIVED_MUTANT]))
+
+  assert.match(markdown, /`- true`/)
+  assert.match(markdown, /`\+ false`/)
+})
+
+test('counts NoCoverage mutants as survivors — untested code is the whole point', () => {
+  const noCoverage = { ...SURVIVED_MUTANT, id: '3', status: 'NoCoverage' }
+  const { survivors, totals } = collectSurvivors(createReport([KILLED_MUTANT, noCoverage]))
+
+  assert.equal(survivors.length, 1)
+  assert.equal(survivors[0].status, 'NoCoverage')
+  assert.equal(totals.survived, 1)
+})
+
+test('computes the score from killed plus timed-out over scored mutants', () => {
+  const timeout = { ...KILLED_MUTANT, id: '4', status: 'Timeout' }
+  const { score, totals } = collectSurvivors(
+    createReport([KILLED_MUTANT, timeout, SURVIVED_MUTANT]),
+  )
+
+  assert.equal(totals.scored, 3)
+  assert.equal(totals.killed, 1)
+  assert.equal(totals.timeout, 1)
+  assert.equal(totals.survived, 1)
+  assert.ok(Math.abs(score - 66.67) < 0.01)
+})
+
+test('excludes errored and ignored mutants from the score but surfaces error counts', () => {
+  const compileError = { ...KILLED_MUTANT, id: '5', status: 'CompileError' }
+  const ignored = { ...KILLED_MUTANT, id: '6', status: 'Ignored' }
+  const { totals, score } = collectSurvivors(
+    createReport([KILLED_MUTANT, compileError, ignored]),
+  )
+
+  assert.equal(totals.scored, 1)
+  assert.equal(totals.errors, 1)
+  assert.equal(totals.ignored, 1)
+  assert.equal(score, 100)
+
+  const markdown = renderMarkdown(createReport([KILLED_MUTANT, compileError]))
+  assert.match(markdown, /1 mutant\(s\) errored/)
+})
+
+test('states plainly that an advisory run does not block the merge', () => {
+  const markdown = renderMarkdown(createReport([SURVIVED_MUTANT]))
+
+  assert.ok(markdown.includes(ADVISORY_NOTE))
+  assert.match(markdown, /advisory/)
+  assert.match(markdown, /does not block the merge/)
+})
+
+test('omits the advisory note once enforcement is enabled', () => {
+  const markdown = renderMarkdown(createReport([SURVIVED_MUTANT]), { enforced: true })
+
+  assert.ok(!markdown.includes(ADVISORY_NOTE))
+})
+
+test('reports a clean result without inventing a survivor table', () => {
+  const markdown = renderMarkdown(createReport([KILLED_MUTANT]))
+
+  assert.match(markdown, /No surviving mutants/)
+  assert.ok(!markdown.includes('| Location |'))
+})
+
+test('handles an empty report without producing a synthetic score', () => {
+  const markdown = renderMarkdown({ files: {} })
+
+  assert.match(markdown, /No mutants were generated/)
+  assert.equal(collectSurvivors({ files: {} }).score, null)
+})
+
+test('names the package it is reporting on', () => {
+  assert.match(renderMarkdown(createReport([]), { packageName: 'shared' }), /Mutation testing — `shared`/)
+})
+
+test('surfaces capped files so a truncated run never reads as full coverage', () => {
+  const markdown = renderMarkdown(createReport([SURVIVED_MUTANT]), {
+    droppedFiles: ['src/lib/a.ts', 'src/lib/b.ts'],
+  })
+
+  assert.match(markdown, /Not measured/)
+  assert.match(markdown, /2 changed file\(s\) were not mutated/)
+  assert.match(markdown, /`src\/lib\/a\.ts`/)
+})
+
+test('escapes pipes so a mutated string can never break the table', () => {
+  const pipeMutant = {
+    ...SURVIVED_MUTANT,
+    replacement: 'a || b',
+    location: { start: { line: 3, column: 3 }, end: { line: 3, column: 15 } },
+  }
+
+  const markdown = renderMarkdown(createReport([pipeMutant]))
+  const tableRows = markdown.split('\n').filter((line) => line.startsWith('| `src/'))
+
+  assert.equal(tableRows.length, 1)
+  assert.match(tableRows[0], /a \\\|\\\| b/)
+})
+
+test('parses the report path, package name and enforcement flag', () => {
+  assert.deepEqual(parseReportArgs(['mutation.json']), {
+    reportPath: 'mutation.json',
+    packageName: null,
+    enforced: false,
+  })
+  assert.deepEqual(parseReportArgs(['mutation.json', '--package', 'shared', '--enforced']), {
+    reportPath: 'mutation.json',
+    packageName: 'shared',
+    enforced: true,
+  })
+})

--- a/scripts/__tests__/stryker-report.test.mjs
+++ b/scripts/__tests__/stryker-report.test.mjs
@@ -1,11 +1,18 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
 import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 import {
   ADVISORY_NOTE,
   collectSurvivors,
   parseReportArgs,
   renderMarkdown,
+  renderMissingReportMarkdown,
 } from '../stryker/report.mjs'
+
+const REPORT_SCRIPT = fileURLToPath(new URL('../stryker/report.mjs', import.meta.url))
 
 const SOURCE = [
   'export function isPositive(value) {',
@@ -160,4 +167,62 @@ test('parses the report path, package name and enforcement flag', () => {
     packageName: 'shared',
     enforced: true,
   })
+})
+
+test('the missing-report fallback explains itself and names the package', () => {
+  const markdown = renderMissingReportMarkdown('shared')
+
+  assert.match(markdown, /## Mutation testing/)
+  assert.match(markdown, /No mutation report was produced for `shared`/)
+  assert.match(markdown, /did not get far enough to write/)
+})
+
+test('the missing-report fallback works without a package name', () => {
+  assert.match(renderMissingReportMarkdown(), /No mutation report was produced\./)
+})
+
+test('the missing-report path reaches the job summary, not only stdout', () => {
+  const summaryPath = fs.mkdtempSync(`${os.tmpdir()}/stryker-report-`) + '/summary.md'
+  const result = spawnSync(process.execPath, [REPORT_SCRIPT, '/nonexistent/mutation.json', '--package', 'shared'], {
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_STEP_SUMMARY: summaryPath },
+  })
+
+  assert.equal(result.status, 0)
+  assert.match(result.stdout, /No mutation report was produced for `shared`/)
+  assert.match(
+    fs.readFileSync(summaryPath, 'utf8'),
+    /No mutation report was produced for `shared`/,
+    'a crashed mutation run must still explain itself in the job summary',
+  )
+})
+
+test('escapes backticks so a survivor cell cannot break out of its code span', () => {
+  const report = {
+    files: {
+      'src/lib/thing.ts': {
+        source: 'const label = `tagged ${name}`\n',
+        mutants: [
+          {
+            status: 'Survived',
+            mutatorName: 'StringLiteral',
+            location: { start: { line: 1, column: 15 }, end: { line: 1, column: 30 } },
+            replacement: '`@maintainer see `ls`',
+          },
+        ],
+      },
+    },
+  }
+
+  const markdown = renderMarkdown(report)
+  const row = markdown.split('\n').find((line) => line.includes('src/lib/thing.ts'))
+
+  // Every backtick that came from the source is escaped, so the only unescaped ones
+  // left are the six delimiters of the row's three code spans (location, original,
+  // replacement). A survivor whose text ended a span early would push this above six
+  // and let the following `@maintainer` render as a live mention.
+  const unescapedBackticks = row.replace(/\\`/g, '').match(/`/g) ?? []
+
+  assert.equal(unescapedBackticks.length, 6, `code spans not intact: ${row}`)
+  assert.match(row, /\\`@maintainer/)
 })

--- a/scripts/__tests__/stryker-scope.test.mjs
+++ b/scripts/__tests__/stryker-scope.test.mjs
@@ -5,6 +5,7 @@ import {
   DEFAULT_BASE_REF,
   DEFAULT_MAX_FILES,
   computeScope,
+  explicitChangedFiles,
   isInScopePath,
   parseArgs,
   readChangedFiles,
@@ -136,15 +137,116 @@ test('isInScopePath rejects non-string and empty input instead of throwing', () 
 })
 
 test('parses the base ref and defaults it', () => {
-  assert.deepEqual(parseArgs([]), { base: DEFAULT_BASE_REF })
-  assert.deepEqual(parseArgs(['--base', 'origin/main']), { base: 'origin/main' })
+  assert.deepEqual(parseArgs([]), { base: DEFAULT_BASE_REF, package: null, mutate: null })
+  assert.deepEqual(parseArgs(['--base', 'origin/main']), {
+    base: 'origin/main',
+    package: null,
+    mutate: null,
+  })
 })
 
 test('exposes no flag it does not act on', () => {
-  assert.deepEqual(Object.keys(parseArgs([])), ['base'])
+  assert.deepEqual(Object.keys(parseArgs([])), ['base', 'package', 'mutate'])
 })
 
 test('the shipped allowlist is explicit about which packages are measured', () => {
   assert.ok(Array.isArray(ALLOWLISTED_PACKAGES))
   assert.ok(ALLOWLISTED_PACKAGES.includes('shared'))
+})
+
+test('drops a changed path carrying shell metacharacters before it can reach the matrix', () => {
+  const { matrix } = computeScope([
+    'packages/shared/src/lib/pwn$(id > /tmp/om-pwn.txt).ts',
+    'packages/shared/src/lib/boolean.ts',
+  ])
+
+  assert.deepEqual(matrix.include, [{ package: 'shared', mutate: 'src/lib/boolean.ts' }])
+})
+
+test('rejects every shell metacharacter class in a source path', () => {
+  const hostileNames = [
+    'pwn$(id).ts',
+    'pwn`id`.ts',
+    'pwn;id.ts',
+    'pwn|id.ts',
+    'pwn&id.ts',
+    'pwn>out.ts',
+    'pwn<in.ts',
+    "pwn'quote.ts",
+    'pwn"quote.ts',
+    'pwn id.ts',
+    'pwn\tid.ts',
+    'pwn\nid.ts',
+    'pwn*glob.ts',
+    'pwn?glob.ts',
+    'pwn{brace}.ts',
+    'pwn\\escape.ts',
+    'pwn!bang.ts',
+    'pwn#hash.ts',
+    'pwn~tilde.ts',
+  ]
+
+  for (const name of hostileNames) {
+    assert.equal(
+      isInScopePath(`src/lib/${name}`),
+      false,
+      `expected src/lib/${name} to be rejected as an unsafe path`,
+    )
+    assert.deepEqual(
+      computeScope([`packages/shared/src/lib/${name}`]).matrix.include,
+      [],
+      `expected packages/shared/src/lib/${name} to produce an empty matrix`,
+    )
+  }
+})
+
+test('still accepts the square brackets of Next.js dynamic route segments', () => {
+  assert.equal(isInScopePath('src/modules/auth/backend/roles/[id]/edit/page.meta.ts'), true)
+})
+
+test('a manual dispatch selection is filtered by the same scope rules as a diff', () => {
+  const changed = explicitChangedFiles('shared', 'src/lib/boolean.ts, src/lib/number.ts')
+
+  assert.deepEqual(changed, [
+    'packages/shared/src/lib/boolean.ts',
+    'packages/shared/src/lib/number.ts',
+  ])
+  assert.deepEqual(computeScope(changed).matrix.include, [
+    { package: 'shared', mutate: 'src/lib/boolean.ts,src/lib/number.ts' },
+  ])
+})
+
+test('a manual dispatch cannot mutate a non-allowlisted package or an out-of-scope file', () => {
+  assert.deepEqual(
+    computeScope(explicitChangedFiles('core', 'src/lib/thing.ts')).matrix.include,
+    [],
+  )
+  assert.deepEqual(
+    computeScope(explicitChangedFiles('shared', 'src/lib/thing.test.ts')).matrix.include,
+    [],
+  )
+  assert.deepEqual(
+    computeScope(explicitChangedFiles('shared', 'src/lib/pwn$(id).ts')).matrix.include,
+    [],
+  )
+})
+
+test('an empty dispatch selection yields no work rather than mutating everything', () => {
+  assert.deepEqual(explicitChangedFiles('shared', ''), [])
+  assert.deepEqual(explicitChangedFiles('', 'src/lib/boolean.ts'), [])
+})
+
+test('parseArgs reads the dispatch package and mutate selection', () => {
+  const args = parseArgs(['--package', 'shared', '--mutate', 'src/lib/boolean.ts'])
+
+  assert.equal(args.package, 'shared')
+  assert.equal(args.mutate, 'src/lib/boolean.ts')
+})
+
+test('parseArgs leaves the dispatch selection null for a plain diff run', () => {
+  const args = parseArgs(['--base', 'origin/main'])
+
+  assert.equal(args.base, 'origin/main')
+  assert.equal(args.package, null)
+  assert.equal(args.mutate, null)
 })

--- a/scripts/__tests__/stryker-scope.test.mjs
+++ b/scripts/__tests__/stryker-scope.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  ALLOWLISTED_PACKAGES,
+  DEFAULT_BASE_REF,
+  DEFAULT_MAX_FILES,
+  computeScope,
+  isInScopePath,
+  parseArgs,
+  readChangedFiles,
+} from '../stryker/scope.mjs'
+
+test('includes an in-scope business-logic file from an allowlisted package', () => {
+  const { matrix } = computeScope(['packages/shared/src/lib/boolean.ts'])
+
+  assert.deepEqual(matrix.include, [{ package: 'shared', mutate: 'src/lib/boolean.ts' }])
+})
+
+test('excludes .tsx files — rendering is covered by UI tests, not mutation scoring', () => {
+  const { matrix } = computeScope([
+    'packages/shared/src/modules/widgets/Panel.tsx',
+    'packages/shared/src/lib/boolean.ts',
+  ])
+
+  assert.deepEqual(matrix.include, [{ package: 'shared', mutate: 'src/lib/boolean.ts' }])
+})
+
+test('excludes api/ route handlers', () => {
+  const { matrix } = computeScope(['packages/shared/src/modules/things/api/list.ts'])
+
+  assert.deepEqual(matrix.include, [])
+})
+
+test('excludes tests, mocks, type declarations, migrations, generated and testing helpers', () => {
+  const { matrix } = computeScope([
+    'packages/shared/src/lib/__tests__/boolean.test.ts',
+    'packages/shared/src/lib/__mocks__/clock.ts',
+    'packages/shared/src/lib/boolean.test.ts',
+    'packages/shared/src/lib/boolean.spec.ts',
+    'packages/shared/src/lib/types.d.ts',
+    'packages/shared/src/modules/things/migrations/0001-init.ts',
+    'packages/shared/src/modules/things/generated/ids.ts',
+    'packages/shared/src/lib/testing/fixtures.ts',
+  ])
+
+  assert.deepEqual(matrix.include, [])
+})
+
+test('excludes files outside the allowlisted packages', () => {
+  const { matrix } = computeScope([
+    'packages/core/src/lib/thing.ts',
+    'apps/mercato/src/lib/thing.ts',
+    'scripts/stryker/scope.mjs',
+    'packages/shared/src/lib/boolean.ts',
+  ])
+
+  assert.deepEqual(matrix.include, [{ package: 'shared', mutate: 'src/lib/boolean.ts' }])
+})
+
+test('excludes paths outside src/lib, src/modules and src/security', () => {
+  const { matrix } = computeScope([
+    'packages/shared/src/index.ts',
+    'packages/shared/jest.config.cjs',
+    'packages/shared/src/types/foo.ts',
+  ])
+
+  assert.deepEqual(matrix.include, [])
+})
+
+test('an empty diff yields an empty matrix rather than a synthetic entry', () => {
+  assert.deepEqual(computeScope([]).matrix, { include: [] })
+  assert.deepEqual(computeScope([]).dropped, [])
+})
+
+test('caps the mutate list and reports exactly what was dropped', () => {
+  const changed = Array.from(
+    { length: DEFAULT_MAX_FILES + 3 },
+    (_unused, index) => `packages/shared/src/lib/file-${String(index).padStart(3, '0')}.ts`,
+  )
+
+  const { matrix, dropped } = computeScope(changed)
+  const kept = matrix.include[0].mutate.split(',')
+
+  assert.equal(kept.length, DEFAULT_MAX_FILES)
+  assert.equal(dropped.length, 1)
+  assert.equal(dropped[0].package, 'shared')
+  assert.deepEqual(dropped[0].files, [
+    'src/lib/file-025.ts',
+    'src/lib/file-026.ts',
+    'src/lib/file-027.ts',
+  ])
+  assert.equal(kept.length + dropped[0].files.length, changed.length)
+})
+
+test('sorts deterministically and de-duplicates repeated paths', () => {
+  const { matrix } = computeScope([
+    'packages/shared/src/lib/zebra.ts',
+    'packages/shared/src/lib/alpha.ts',
+    'packages/shared/src/lib/zebra.ts',
+  ])
+
+  assert.deepEqual(matrix.include, [
+    { package: 'shared', mutate: 'src/lib/alpha.ts,src/lib/zebra.ts' },
+  ])
+})
+
+test('groups by package and orders packages deterministically', () => {
+  const { matrix } = computeScope(
+    ['packages/ui/src/lib/b.ts', 'packages/shared/src/lib/a.ts'],
+    { allowlist: ['shared', 'ui'] },
+  )
+
+  assert.deepEqual(matrix.include, [
+    { package: 'shared', mutate: 'src/lib/a.ts' },
+    { package: 'ui', mutate: 'src/lib/b.ts' },
+  ])
+})
+
+test('asks git to exclude deleted files, which Stryker cannot mutate', () => {
+  const calls = []
+  const runGit = (args) => {
+    calls.push(args)
+    return 'packages/shared/src/lib/boolean.ts\n\n'
+  }
+
+  const files = readChangedFiles('origin/develop', runGit)
+
+  assert.deepEqual(files, ['packages/shared/src/lib/boolean.ts'])
+  assert.deepEqual(calls, [['diff', '--name-only', '--diff-filter=d', 'origin/develop...HEAD']])
+})
+
+test('isInScopePath rejects non-string and empty input instead of throwing', () => {
+  assert.equal(isInScopePath(undefined), false)
+  assert.equal(isInScopePath(''), false)
+  assert.equal(isInScopePath('src/lib/boolean.ts'), true)
+})
+
+test('parses the base ref and json flag, defaulting the base', () => {
+  assert.deepEqual(parseArgs([]), { base: DEFAULT_BASE_REF, json: false })
+  assert.deepEqual(parseArgs(['--base', 'origin/main']), { base: 'origin/main', json: false })
+  assert.deepEqual(parseArgs(['--json']), { base: DEFAULT_BASE_REF, json: true })
+})
+
+test('the shipped allowlist is explicit about which packages are measured', () => {
+  assert.ok(Array.isArray(ALLOWLISTED_PACKAGES))
+  assert.ok(ALLOWLISTED_PACKAGES.includes('shared'))
+})

--- a/scripts/__tests__/stryker-scope.test.mjs
+++ b/scripts/__tests__/stryker-scope.test.mjs
@@ -135,10 +135,13 @@ test('isInScopePath rejects non-string and empty input instead of throwing', () 
   assert.equal(isInScopePath('src/lib/boolean.ts'), true)
 })
 
-test('parses the base ref and json flag, defaulting the base', () => {
-  assert.deepEqual(parseArgs([]), { base: DEFAULT_BASE_REF, json: false })
-  assert.deepEqual(parseArgs(['--base', 'origin/main']), { base: 'origin/main', json: false })
-  assert.deepEqual(parseArgs(['--json']), { base: DEFAULT_BASE_REF, json: true })
+test('parses the base ref and defaults it', () => {
+  assert.deepEqual(parseArgs([]), { base: DEFAULT_BASE_REF })
+  assert.deepEqual(parseArgs(['--base', 'origin/main']), { base: 'origin/main' })
+})
+
+test('exposes no flag it does not act on', () => {
+  assert.deepEqual(Object.keys(parseArgs([])), ['base'])
 })
 
 test('the shipped allowlist is explicit about which packages are measured', () => {

--- a/scripts/__tests__/stryker-workflow.test.mjs
+++ b/scripts/__tests__/stryker-workflow.test.mjs
@@ -84,7 +84,10 @@ test('passes --enforced to the report only when enforcement is on', () => {
     (step) => step.name === 'Write the survivor report to the job summary',
   )
 
-  assert.match(reportStep.run, /MUTATION_ENFORCE == 'true' && '--enforced'/)
+  // The conditional moved into env: so no GitHub expression is expanded into the
+  // run: script; the flag it resolves to is unchanged.
+  assert.match(reportStep.env.ENFORCED, /MUTATION_ENFORCE == 'true' && '--enforced'/)
+  assert.match(reportStep.run, /\$\{ENFORCED\}/)
 })
 
 test('uploads the mutation report as an artifact, tolerating an absent report', () => {
@@ -141,4 +144,55 @@ test('the enforcement step runs and is fed MUTATION_ENFORCE, defaulting to false
   assert.equal(step.if, 'always()')
   assert.match(step.run, /scripts\/stryker\/enforce\.mjs/)
   assert.match(String(step.env.MUTATION_ENFORCE), /\|\|\s*'false'/)
+})
+
+test('never interpolates a GitHub expression into a run: script', () => {
+  const offenders = []
+
+  for (const [jobName, job] of Object.entries(workflow.jobs)) {
+    for (const step of job.steps ?? []) {
+      if (typeof step.run !== 'string') continue
+      if (!step.run.includes('${{')) continue
+      offenders.push(`${jobName} → ${step.name ?? step.id ?? 'unnamed step'}`)
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    'a ${{ }} expression inside run: is expanded as shell source before bash parses ' +
+      'it, so an untrusted value becomes code — pass it through env: instead. ' +
+      `Offending steps: ${offenders.join(', ')}`,
+  )
+})
+
+test('passes the diff-derived mutate list through the environment, quoted', () => {
+  const mutateStep = workflow.jobs.mutate.steps.find((step) => step.id === 'mutate')
+
+  assert.equal(mutateStep.env.MUTATE_LIST, '${{ matrix.mutate }}')
+  assert.match(mutateStep.run, /--mutate "\$MUTATE_LIST"/)
+})
+
+test('exposes a workflow_dispatch trigger so the mutate job can be proven on demand', () => {
+  const dispatch = workflow.on.workflow_dispatch
+
+  assert.ok(dispatch, 'workflow_dispatch is what makes the runner path executable on demand')
+  assert.ok(dispatch.inputs.package, 'a dispatch must be able to name the package')
+  assert.ok(dispatch.inputs.mutate, 'a dispatch must be able to name the files to mutate')
+})
+
+test('the scope job routes a dispatch selection through scope.mjs rather than trusting it', () => {
+  const scopeStep = workflow.jobs.scope.steps.find((step) => step.id === 'scope')
+
+  assert.equal(scopeStep.env.DISPATCH_PACKAGE, '${{ inputs.package }}')
+  assert.equal(scopeStep.env.DISPATCH_MUTATE, '${{ inputs.mutate }}')
+  assert.match(scopeStep.run, /scope\.mjs --package "\$\{DISPATCH_PACKAGE\}"/)
+})
+
+test('the advisory comment job cannot turn an infrastructure hiccup into a merge blocker', () => {
+  assert.equal(workflow.jobs.comment['continue-on-error'], true)
+})
+
+test('the scope job stays loud, so a misconfigured gate cannot silently no-op', () => {
+  assert.equal(workflow.jobs.scope['continue-on-error'], undefined)
 })

--- a/scripts/__tests__/stryker-workflow.test.mjs
+++ b/scripts/__tests__/stryker-workflow.test.mjs
@@ -97,3 +97,38 @@ test('uploads the mutation report as an artifact, tolerating an absent report', 
   assert.equal(uploadStep.with['if-no-files-found'], 'ignore')
   assert.match(uploadStep.with.name, /mutation-report-/)
 })
+
+test('the PR comment job is fork-guarded — fork runs get no write token', () => {
+  const condition = workflow.jobs.comment.if
+
+  assert.match(condition, /github\.event\.pull_request\.head\.repo\.full_name == github\.repository/)
+})
+
+test('only the comment job may write, and the mutate job stays read-only', () => {
+  assert.deepEqual(workflow.jobs.comment.permissions, {
+    contents: 'read',
+    'pull-requests': 'write',
+  })
+  assert.equal(workflow.jobs.mutate.permissions, undefined)
+  assert.deepEqual(workflow.permissions, { contents: 'read' })
+})
+
+test('the comment is idempotent — it updates its marker comment instead of appending', () => {
+  const step = workflow.jobs.comment.steps.find(
+    (candidate) => candidate.name === 'Post or update the mutation comment',
+  )
+
+  assert.match(step.run, /om:mutation-testing-report/)
+  assert.match(step.run, /--method PATCH/)
+  assert.match(step.run, /--method POST/)
+  assert.match(step.run, /select\(\.body \| contains/)
+})
+
+test('the comment job still runs when the mutation job failed', () => {
+  assert.match(workflow.jobs.comment.if, /always\(\)/)
+  assert.deepEqual(workflow.jobs.comment.needs, ['scope', 'mutate'])
+})
+
+test('the comment job is skipped when nothing was in scope', () => {
+  assert.match(workflow.jobs.comment.if, /needs\.scope\.outputs\.has_work == 'true'/)
+})

--- a/scripts/__tests__/stryker-workflow.test.mjs
+++ b/scripts/__tests__/stryker-workflow.test.mjs
@@ -174,7 +174,7 @@ test('passes the diff-derived mutate list through the environment, quoted', () =
 })
 
 test('exposes a workflow_dispatch trigger so the mutate job can be proven on demand', () => {
-  const dispatch = workflow.on.workflow_dispatch
+  const dispatch = (workflow.on ?? workflow[true]).workflow_dispatch
 
   assert.ok(dispatch, 'workflow_dispatch is what makes the runner path executable on demand')
   assert.ok(dispatch.inputs.package, 'a dispatch must be able to name the package')
@@ -187,6 +187,15 @@ test('the scope job routes a dispatch selection through scope.mjs rather than tr
   assert.equal(scopeStep.env.DISPATCH_PACKAGE, '${{ inputs.package }}')
   assert.equal(scopeStep.env.DISPATCH_MUTATE, '${{ inputs.mutate }}')
   assert.match(scopeStep.run, /scope\.mjs --package "\$\{DISPATCH_PACKAGE\}"/)
+})
+
+test('the scope job branches on the event, not on whether dispatch inputs are populated', () => {
+  const scopeStep = workflow.jobs.scope.steps.find((step) => step.id === 'scope')
+
+  // A dispatch with cleared inputs must skip cleanly rather than diff against an
+  // empty base ref and redden the one job allowed to go red.
+  assert.equal(scopeStep.env.IS_DISPATCH, "${{ github.event_name == 'workflow_dispatch' }}")
+  assert.match(scopeStep.run, /if \[ "\$\{IS_DISPATCH\}" = "true" \]/)
 })
 
 test('the advisory comment job cannot turn an infrastructure hiccup into a merge blocker', () => {

--- a/scripts/__tests__/stryker-workflow.test.mjs
+++ b/scripts/__tests__/stryker-workflow.test.mjs
@@ -68,3 +68,32 @@ test('checks out full history so the base ref is resolvable for the diff', () =>
 
   assert.equal(checkout.with['fetch-depth'], 0)
 })
+
+test('reports the survivor list even when the mutation step failed', () => {
+  const reportStep = workflow.jobs.mutate.steps.find(
+    (step) => step.name === 'Write the survivor report to the job summary',
+  )
+
+  assert.equal(reportStep.if, 'always()')
+  assert.match(reportStep.run, /scripts\/stryker\/report\.mjs/)
+  assert.match(reportStep.run, /--package/)
+})
+
+test('passes --enforced to the report only when enforcement is on', () => {
+  const reportStep = workflow.jobs.mutate.steps.find(
+    (step) => step.name === 'Write the survivor report to the job summary',
+  )
+
+  assert.match(reportStep.run, /MUTATION_ENFORCE == 'true' && '--enforced'/)
+})
+
+test('uploads the mutation report as an artifact, tolerating an absent report', () => {
+  const uploadStep = workflow.jobs.mutate.steps.find(
+    (step) => step.name === 'Upload the mutation report',
+  )
+
+  assert.equal(uploadStep.if, 'always()')
+  assert.match(uploadStep.uses, /actions\/upload-artifact/)
+  assert.equal(uploadStep.with['if-no-files-found'], 'ignore')
+  assert.match(uploadStep.with.name, /mutation-report-/)
+})

--- a/scripts/__tests__/stryker-workflow.test.mjs
+++ b/scripts/__tests__/stryker-workflow.test.mjs
@@ -132,3 +132,13 @@ test('the comment job still runs when the mutation job failed', () => {
 test('the comment job is skipped when nothing was in scope', () => {
   assert.match(workflow.jobs.comment.if, /needs\.scope\.outputs\.has_work == 'true'/)
 })
+
+test('the enforcement step runs and is fed MUTATION_ENFORCE, defaulting to false', () => {
+  const step = workflow.jobs.mutate.steps.find(
+    (candidate) => candidate.name === 'Enforce the mutation threshold',
+  )
+
+  assert.equal(step.if, 'always()')
+  assert.match(step.run, /scripts\/stryker\/enforce\.mjs/)
+  assert.match(String(step.env.MUTATION_ENFORCE), /\|\|\s*'false'/)
+})

--- a/scripts/__tests__/stryker-workflow.test.mjs
+++ b/scripts/__tests__/stryker-workflow.test.mjs
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+import { parse } from 'yaml'
+
+const repositoryRoot = fileURLToPath(new URL('../..', import.meta.url))
+const workflowPath = `${repositoryRoot}.github/workflows/mutation-tests.yml`
+const workflow = parse(fs.readFileSync(workflowPath, 'utf8'))
+
+test('is a standalone workflow, separate from ci.yml', () => {
+  assert.ok(fs.existsSync(workflowPath))
+  assert.equal(workflow.name, 'Mutation tests')
+
+  const ciWorkflow = fs.readFileSync(`${repositoryRoot}.github/workflows/ci.yml`, 'utf8')
+  assert.ok(
+    !ciWorkflow.includes('mutation'),
+    'ci.yml must not reference mutation testing — rollback is deleting one file',
+  )
+})
+
+test('runs on pull requests to the long-lived branches only', () => {
+  const on = workflow.on ?? workflow[true]
+  assert.deepEqual(on.pull_request.branches, ['main', 'develop'])
+  assert.equal(on.push, undefined, 'a push trigger would score merges, not changes')
+})
+
+test('the mutate job is advisory unless MUTATION_ENFORCE is explicitly true', () => {
+  const continueOnError = String(workflow.jobs.mutate['continue-on-error'])
+
+  assert.match(continueOnError, /MUTATION_ENFORCE/)
+  assert.match(continueOnError, /!= 'true'/)
+})
+
+test('MUTATION_ENFORCE defaults to false, so the gate ships dormant', () => {
+  assert.match(String(workflow.env.MUTATION_ENFORCE), /\|\|\s*'false'/)
+})
+
+test('skips entirely when the diff contains nothing in scope', () => {
+  assert.equal(workflow.jobs.mutate.if, "needs.scope.outputs.has_work == 'true'")
+})
+
+test('one slow package never hides another, and a run is time-bounded', () => {
+  assert.equal(workflow.jobs.mutate.strategy['fail-fast'], false)
+  assert.equal(workflow.jobs.mutate['timeout-minutes'], 20)
+})
+
+test('fans out over the matrix the scope job computed', () => {
+  assert.equal(workflow.jobs.mutate.strategy.matrix, '${{ fromJson(needs.scope.outputs.matrix) }}')
+  assert.deepEqual(workflow.jobs.mutate.needs, 'scope')
+})
+
+test('requests no write permissions — it must work on fork pull requests', () => {
+  assert.deepEqual(workflow.permissions, { contents: 'read' })
+})
+
+test('builds packages before mutating, because suites resolve siblings via dist/', () => {
+  const steps = workflow.jobs.mutate.steps.map((step) => step.name)
+  const buildIndex = steps.indexOf('Build packages')
+  const runIndex = steps.indexOf('Run mutation testing')
+
+  assert.ok(buildIndex >= 0, 'the mutate job must build packages')
+  assert.ok(buildIndex < runIndex, 'the build must precede the mutation run')
+})
+
+test('checks out full history so the base ref is resolvable for the diff', () => {
+  const checkout = workflow.jobs.scope.steps.find((step) => step.name === 'Checkout repository')
+
+  assert.equal(checkout.with['fetch-depth'], 0)
+})

--- a/scripts/stryker/createConfig.mjs
+++ b/scripts/stryker/createConfig.mjs
@@ -35,6 +35,7 @@
 export const DEFAULT_TIMEOUT_MS = 30000
 export const DEFAULT_CONCURRENCY = 4
 export const MUTATION_REPORT_PATH = 'reports/mutation/mutation.json'
+export const MUTATION_HTML_REPORT_PATH = 'reports/mutation/mutation.html'
 
 /**
  * Per-package `timeoutMS`. A mutant is only declared "timed out" after Stryker waits
@@ -93,9 +94,12 @@ export function createStrykerConfig(options = {}) {
       low: 70,
       break: null,
     },
-    reporters: ['clear-text', 'progress', 'json'],
+    reporters: ['clear-text', 'progress', 'json', 'html'],
     jsonReporter: {
       fileName: MUTATION_REPORT_PATH,
+    },
+    htmlReporter: {
+      fileName: MUTATION_HTML_REPORT_PATH,
     },
     timeoutMS,
     timeoutFactor: 2,

--- a/scripts/stryker/createConfig.mjs
+++ b/scripts/stryker/createConfig.mjs
@@ -1,0 +1,108 @@
+/**
+ * Shared StrykerJS configuration factory — one source of truth for every package.
+ *
+ * Per-package configuration is forced, not chosen: every package carries its own
+ * `jest.config.cjs` with its own `rootDir`, `moduleNameMapper`, and a transformer
+ * referenced as `<rootDir>/../../scripts/jest-mikroorm-transformer.cjs`. A single
+ * root Stryker config cannot drive them. This factory keeps the shared settings in
+ * one file while each package's `stryker.conf.mjs` supplies only its own name.
+ *
+ * Three settings below are load-bearing workarounds measured in the Phase 0 pilot
+ * (`.ai/analysis/2026-07-31-stryker-mutation-testing-pilot.md`) — changing them
+ * breaks the run outright rather than degrading it:
+ *
+ *   inPlace: true          Stryker's default sandbox copies the package one directory
+ *                          deeper, so every relative path in the per-package jest
+ *                          config resolves outside the sandbox and the run dies with
+ *                          `Cannot find module '../../jest.config.base.cjs'`.
+ *                          `inPlace` also short-circuits Stryker's tsconfig
+ *                          preprocessor, which calls `ts.parseConfigFileTextToJson` —
+ *                          absent from this repo's typescript@7.0.2 (the Go compiler;
+ *                          the JS API lives behind the `typescript-js` alias, see
+ *                          scripts/jest-typescript-resolver.cjs).
+ *
+ *   coverageAnalysis: off  `@jest-environment` docblocks in existing suites block
+ *                          `perTest` and `all`. Fixing that means editing dozens of
+ *                          unrelated test files, which the spec rules out.
+ *
+ *   excludedMutations      `StringLiteral` and `Regex` mutants are the cheapest way to
+ *                          game a mutation score — killing them rewards asserting exact
+ *                          log strings and error copy instead of behaviour.
+ *
+ * @see .ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+ */
+
+export const DEFAULT_TIMEOUT_MS = 30000
+export const DEFAULT_CONCURRENCY = 4
+export const MUTATION_REPORT_PATH = 'reports/mutation/mutation.json'
+
+/**
+ * Per-package `timeoutMS`. A mutant is only declared "timed out" after Stryker waits
+ * this long, so the value must clear the package's own jest `testTimeout` — otherwise
+ * slow-but-correct suites report timeouts instead of scores. `packages/core` sets
+ * `testTimeout: 30000` in its jest config and needs the larger budget; every other
+ * package runs on the default.
+ */
+export const PACKAGE_TIMEOUT_MS = Object.freeze({
+  core: 60000,
+})
+
+export const IN_SCOPE_GLOBS = Object.freeze([
+  'src/lib/**/*.ts',
+  'src/modules/**/*.ts',
+  'src/security/**/*.ts',
+])
+
+export const OUT_OF_SCOPE_GLOBS = Object.freeze([
+  '!src/**/__tests__/**',
+  '!src/**/*.test.ts',
+  '!src/**/*.d.ts',
+  '!src/lib/testing/**',
+])
+
+export const EXCLUDED_MUTATIONS = Object.freeze(['StringLiteral', 'Regex'])
+
+export function createStrykerConfig(options = {}) {
+  const { packageName, concurrency = DEFAULT_CONCURRENCY } = options
+
+  if (typeof packageName !== 'string' || packageName.trim() === '') {
+    throw new Error('[internal] createStrykerConfig requires a non-empty packageName')
+  }
+
+  const timeoutMS = options.timeoutMS ?? PACKAGE_TIMEOUT_MS[packageName] ?? DEFAULT_TIMEOUT_MS
+
+  return {
+    packageManager: 'yarn',
+    testRunner: 'jest',
+    jest: {
+      projectType: 'custom',
+      configFile: 'jest.config.cjs',
+      enableFindRelatedTests: true,
+      config: {
+        testEnvironment: '@stryker-mutator/jest-runner/jest-env/node',
+      },
+    },
+    coverageAnalysis: 'off',
+    inPlace: true,
+    mutate: [...IN_SCOPE_GLOBS, ...OUT_OF_SCOPE_GLOBS],
+    mutator: {
+      excludedMutations: [...EXCLUDED_MUTATIONS],
+    },
+    thresholds: {
+      high: 85,
+      low: 70,
+      break: null,
+    },
+    reporters: ['clear-text', 'progress', 'json'],
+    jsonReporter: {
+      fileName: MUTATION_REPORT_PATH,
+    },
+    timeoutMS,
+    timeoutFactor: 2,
+    concurrency,
+    tempDirName: '.stryker-tmp',
+    cleanTempDir: true,
+  }
+}
+
+export default createStrykerConfig

--- a/scripts/stryker/createConfig.mjs
+++ b/scripts/stryker/createConfig.mjs
@@ -92,6 +92,10 @@ export function createStrykerConfig(options = {}) {
     thresholds: {
       high: 85,
       low: 70,
+      // Deliberately null. The pass/fail decision belongs to scripts/stryker/enforce.mjs,
+      // which applies the minimum-mutant floor first — Stryker's own `break` would fail
+      // a four-mutant diff on a single survivor, which is exactly what the floor exists
+      // to prevent. Setting this is not how enforcement gets enabled; MUTATION_ENFORCE is.
       break: null,
     },
     reporters: ['clear-text', 'progress', 'json', 'html'],

--- a/scripts/stryker/enforce.mjs
+++ b/scripts/stryker/enforce.mjs
@@ -20,7 +20,9 @@
  * Usage:
  *   node scripts/stryker/enforce.mjs <mutation.json> [--threshold 70] [--min-mutants 20]
  *
- * Exits 1 only when enforcement is enabled AND the run genuinely failed.
+ * Exits 1 only when enforcement is enabled AND the run genuinely failed — including
+ * the case where no report exists at all, since an absent report is missing evidence
+ * rather than a pass.
  *
  * @see .ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
  */
@@ -124,8 +126,22 @@ export function parseEnforceArgs(argv) {
 function main() {
   const args = parseEnforceArgs(process.argv.slice(2))
 
+  // A missing report means the run produced no evidence, which is not the same as
+  // evidence of a pass. While enforcement is off that distinction does not matter and
+  // this stays advisory; with enforcement on, the module that owns the pass/fail
+  // decision must not answer "no data ⇒ pass" — an absent report is the shape a
+  // crashed or misconfigured mutation step takes, so it fails closed.
   if (args.reportPath === null || !fs.existsSync(args.reportPath)) {
-    process.stdout.write('[stryker:enforce] No mutation report found; nothing to enforce.\n')
+    if (isEnforcementEnabled()) {
+      process.stdout.write(
+        '[stryker:enforce] No mutation report found and enforcement is enabled; failing closed.\n',
+      )
+      process.exit(1)
+    }
+
+    process.stdout.write(
+      '[stryker:enforce] No mutation report found; nothing to enforce (advisory).\n',
+    )
     return
   }
 

--- a/scripts/stryker/enforce.mjs
+++ b/scripts/stryker/enforce.mjs
@@ -1,0 +1,145 @@
+/**
+ * The enforcement decision: given a mutation report, should this job fail?
+ *
+ * **Enforcement ships dormant.** `MUTATION_ENFORCE` defaults to `false`, so this
+ * module's answer is advisory until the core team explicitly turns the gate on —
+ * see the spec's Q1 and `AGENTS.md`'s "Ask First" rule on pipeline changes. The
+ * logic is implemented and tested now so that enabling it later is a one-value
+ * change rather than a code change.
+ *
+ * Two guards keep an enabled gate honest:
+ *
+ *   MUTATION_MIN_MUTANTS  Below this many scored mutants the score is reported but
+ *                         never fails. Small diffs are volatile: with four mutants
+ *                         a single survivor is 25 percentage points.
+ *
+ *   thresholds.break      The score a run must reach. It is a floor for review, not
+ *                         a target to maximise — the spec explicitly rejects a
+ *                         repo-wide badge or a per-package leaderboard.
+ *
+ * Usage:
+ *   node scripts/stryker/enforce.mjs <mutation.json> [--threshold 70] [--min-mutants 20]
+ *
+ * Exits 1 only when enforcement is enabled AND the run genuinely failed.
+ *
+ * @see .ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+ */
+
+import fs from 'node:fs'
+import { collectSurvivors } from './report.mjs'
+
+export const DEFAULT_BREAK_THRESHOLD = 70
+export const DEFAULT_MIN_MUTANTS = 20
+
+export function isEnforcementEnabled(environment = process.env) {
+  return environment.MUTATION_ENFORCE === 'true'
+}
+
+/**
+ * @returns {{ shouldFail: boolean, reason: string, score: number|null, scored: number }}
+ */
+export function decideOutcome(report, options = {}) {
+  const {
+    threshold = DEFAULT_BREAK_THRESHOLD,
+    minMutants = DEFAULT_MIN_MUTANTS,
+    enforce = false,
+  } = options
+
+  const { totals, score } = collectSurvivors(report)
+
+  if (score === null) {
+    return {
+      shouldFail: false,
+      reason: 'No mutants were generated, so there is nothing to score.',
+      score: null,
+      scored: 0,
+    }
+  }
+
+  const rounded = Number(score.toFixed(2))
+
+  if (totals.scored < minMutants) {
+    return {
+      shouldFail: false,
+      reason:
+        `Only ${totals.scored} scored mutant(s), below the floor of ${minMutants}. ` +
+        `Score ${rounded}% is reported but not enforced — small diffs are too volatile to gate on.`,
+      score: rounded,
+      scored: totals.scored,
+    }
+  }
+
+  if (rounded >= threshold) {
+    return {
+      shouldFail: false,
+      reason: `Score ${rounded}% meets the ${threshold}% threshold.`,
+      score: rounded,
+      scored: totals.scored,
+    }
+  }
+
+  if (!enforce) {
+    return {
+      shouldFail: false,
+      reason:
+        `Score ${rounded}% is below the ${threshold}% threshold. Enforcement is disabled ` +
+        '(MUTATION_ENFORCE is not "true"), so this is advisory only.',
+      score: rounded,
+      scored: totals.scored,
+    }
+  }
+
+  return {
+    shouldFail: true,
+    reason:
+      `Score ${rounded}% is below the ${threshold}% threshold across ${totals.scored} ` +
+      'scored mutants.',
+    score: rounded,
+    scored: totals.scored,
+  }
+}
+
+export function parseEnforceArgs(argv) {
+  const args = {
+    reportPath: null,
+    threshold: DEFAULT_BREAK_THRESHOLD,
+    minMutants: DEFAULT_MIN_MUTANTS,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--threshold' && index + 1 < argv.length) {
+      args.threshold = Number(argv[index + 1])
+      index += 1
+    } else if (argv[index] === '--min-mutants' && index + 1 < argv.length) {
+      args.minMutants = Number(argv[index + 1])
+      index += 1
+    } else if (args.reportPath === null) {
+      args.reportPath = argv[index]
+    }
+  }
+
+  return args
+}
+
+function main() {
+  const args = parseEnforceArgs(process.argv.slice(2))
+
+  if (args.reportPath === null || !fs.existsSync(args.reportPath)) {
+    process.stdout.write('[stryker:enforce] No mutation report found; nothing to enforce.\n')
+    return
+  }
+
+  const report = JSON.parse(fs.readFileSync(args.reportPath, 'utf8'))
+  const outcome = decideOutcome(report, {
+    threshold: args.threshold,
+    minMutants: args.minMutants,
+    enforce: isEnforcementEnabled(),
+  })
+
+  process.stdout.write(`[stryker:enforce] ${outcome.reason}\n`)
+  if (outcome.shouldFail) process.exit(1)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/scripts/stryker/mutation-changed.mjs
+++ b/scripts/stryker/mutation-changed.mjs
@@ -1,0 +1,120 @@
+/**
+ * Local entry point: mutate only what this working tree changed.
+ *
+ * The run is `inPlace` (forced — see createConfig.mjs), so Stryker rewrites real
+ * source files and restores them from `.stryker-tmp/backup-*` when it finishes.
+ * Two consequences shape this wrapper:
+ *
+ *   1. It refuses to start on a dirty working tree. If Stryker's restore is ever
+ *      skipped — a killed process, a full disk — the recovery is `git checkout -- .`,
+ *      which is only safe when there was nothing uncommitted to lose.
+ *   2. Recovery is not hypothetical. Stryker's `disableTypeChecks` default prepends
+ *      `// @ts-nocheck` to every file it may mutate, so an interrupted run can leave
+ *      thousands of modified files behind. That is why the guard is a hard stop and
+ *      not a warning, and why CI — ephemeral by construction — is the supported
+ *      environment.
+ *
+ * Usage:
+ *   yarn mutation:changed [--base <ref>]
+ *
+ * @see .ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { DEFAULT_BASE_REF, computeScope, parseArgs, readChangedFiles } from './scope.mjs'
+
+const REPOSITORY_ROOT = fileURLToPath(new URL('../..', import.meta.url))
+
+export const DIRTY_TREE_MESSAGE = [
+  'Refusing to run: your working tree has uncommitted changes.',
+  '',
+  'Mutation testing rewrites real source files in place and restores them afterwards.',
+  'If a run is interrupted, the only reliable recovery is:',
+  '',
+  '    git checkout -- .',
+  '',
+  'That would discard your uncommitted work, so commit or stash it first.',
+].join('\n')
+
+export function isWorkingTreeClean(porcelainOutput) {
+  if (typeof porcelainOutput !== 'string') return false
+  return porcelainOutput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+    .length === 0
+}
+
+/**
+ * @returns {{ exitCode: number, ranPackages: string[] }}
+ */
+export function runMutationChanged(dependencies = {}) {
+  const {
+    runGit = defaultRunGit,
+    runStryker = defaultRunStryker,
+    write = (message) => process.stderr.write(`${message}\n`),
+    baseRef = DEFAULT_BASE_REF,
+  } = dependencies
+
+  if (!isWorkingTreeClean(runGit(['status', '--porcelain']))) {
+    write(DIRTY_TREE_MESSAGE)
+    return { exitCode: 1, ranPackages: [] }
+  }
+
+  const changedFiles = readChangedFiles(baseRef, runGit)
+  const { matrix, dropped } = computeScope(changedFiles)
+
+  for (const entry of dropped) {
+    write(
+      `[stryker] ${entry.package}: file cap reached; not mutated: ${entry.files.join(', ')}`,
+    )
+  }
+
+  if (matrix.include.length === 0) {
+    write(`[stryker] No in-scope changes against ${baseRef}. Nothing to mutate.`)
+    return { exitCode: 0, ranPackages: [] }
+  }
+
+  const ranPackages = []
+  let exitCode = 0
+
+  for (const entry of matrix.include) {
+    write(`[stryker] Mutating ${entry.package}: ${entry.mutate}`)
+    const status = runStryker(entry)
+    ranPackages.push(entry.package)
+    if (status !== 0) exitCode = status
+  }
+
+  return { exitCode, ranPackages }
+}
+
+function defaultRunGit(args) {
+  return execFileSync('git', args, { cwd: REPOSITORY_ROOT, encoding: 'utf8' })
+}
+
+function defaultRunStryker(entry) {
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.join(REPOSITORY_ROOT, 'node_modules', '.bin', 'stryker'),
+      'run',
+      '--mutate',
+      entry.mutate,
+    ],
+    { cwd: path.join(REPOSITORY_ROOT, 'packages', entry.package), stdio: 'inherit' },
+  )
+
+  return result.status ?? 1
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const { exitCode } = runMutationChanged({ baseRef: args.base })
+  process.exit(exitCode)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/scripts/stryker/report.mjs
+++ b/scripts/stryker/report.mjs
@@ -27,6 +27,18 @@ export const ADVISORY_NOTE =
   'This check is **advisory** — it reports on the behaviour your tests do not pin down, ' +
   'and it does not block the merge.'
 
+/**
+ * Code-point ordering, not `localeCompare`: the survivor table must render in the same
+ * order on every runner, and a locale-sensitive collation would make it environment
+ * dependent. Kept local rather than imported from scope.mjs so this reporting module
+ * stays independent of the git-diff module.
+ */
+function compareByCodePoint(left, right) {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
 function sliceOriginal(source, location) {
   if (typeof source !== 'string' || location?.start === undefined) return ''
 
@@ -59,7 +71,7 @@ export function collectSurvivors(report) {
   const survivors = []
   const totals = { scored: 0, killed: 0, survived: 0, timeout: 0, errors: 0, ignored: 0 }
 
-  for (const filePath of Object.keys(files).sort()) {
+  for (const filePath of Object.keys(files).sort(compareByCodePoint)) {
     const file = files[filePath]
     for (const mutant of file?.mutants ?? []) {
       if (mutant.status === 'Ignored') {

--- a/scripts/stryker/report.mjs
+++ b/scripts/stryker/report.mjs
@@ -1,0 +1,206 @@
+/**
+ * mutation.json → a markdown survivor report for the GitHub Actions job summary.
+ *
+ * Survivors are the only actionable output: a mutant that lived is a behaviour the
+ * test suite does not pin down. Killed mutants are noise in a review context and are
+ * deliberately omitted — the score line already accounts for them.
+ *
+ * The report goes to `$GITHUB_STEP_SUMMARY` rather than a PR comment because
+ * `pull_request` runs from forks receive no `pull-requests: write` token, and this
+ * repository receives fork PRs. The summary needs no token and works identically for
+ * everyone.
+ *
+ * Usage:
+ *   node scripts/stryker/report.mjs <mutation.json> [--package <name>] [--enforced]
+ *
+ * Always exits 0 — reporting never fails a build.
+ *
+ * @see .ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+ */
+
+import fs from 'node:fs'
+
+export const SURVIVING_STATUSES = Object.freeze(['Survived', 'NoCoverage'])
+export const SCORED_STATUSES = Object.freeze(['Killed', 'Survived', 'NoCoverage', 'Timeout'])
+
+export const ADVISORY_NOTE =
+  'This check is **advisory** — it reports on the behaviour your tests do not pin down, ' +
+  'and it does not block the merge.'
+
+function sliceOriginal(source, location) {
+  if (typeof source !== 'string' || location?.start === undefined) return ''
+
+  const lines = source.split('\n')
+  const { start, end } = location
+  if (start.line < 1 || start.line > lines.length) return ''
+
+  if (end === undefined || end.line === start.line) {
+    return lines[start.line - 1].slice(start.column - 1, end?.column ? end.column - 1 : undefined)
+  }
+
+  const first = lines[start.line - 1].slice(start.column - 1)
+  const middle = lines.slice(start.line, end.line - 1)
+  const last = (lines[end.line - 1] ?? '').slice(0, end.column - 1)
+  return [first, ...middle, last].join('\n')
+}
+
+function toSingleLine(text) {
+  return String(text ?? '')
+    .replace(/\s+/g, ' ')
+    .replace(/\|/g, '\\|')
+    .trim()
+}
+
+/**
+ * @returns {{ survivors: Array<object>, totals: { scored: number, killed: number, survived: number, timeout: number, errors: number, ignored: number }, score: number|null }}
+ */
+export function collectSurvivors(report) {
+  const files = report?.files ?? {}
+  const survivors = []
+  const totals = { scored: 0, killed: 0, survived: 0, timeout: 0, errors: 0, ignored: 0 }
+
+  for (const filePath of Object.keys(files).sort()) {
+    const file = files[filePath]
+    for (const mutant of file?.mutants ?? []) {
+      if (mutant.status === 'Ignored') {
+        totals.ignored += 1
+        continue
+      }
+      if (mutant.status === 'CompileError' || mutant.status === 'RuntimeError') {
+        totals.errors += 1
+        continue
+      }
+
+      if (SCORED_STATUSES.includes(mutant.status)) totals.scored += 1
+      if (mutant.status === 'Killed') totals.killed += 1
+      if (mutant.status === 'Timeout') totals.timeout += 1
+
+      if (!SURVIVING_STATUSES.includes(mutant.status)) continue
+
+      totals.survived += 1
+      survivors.push({
+        file: filePath,
+        line: mutant.location?.start?.line ?? 0,
+        column: mutant.location?.start?.column ?? 0,
+        mutator: mutant.mutatorName ?? 'Unknown',
+        status: mutant.status,
+        original: sliceOriginal(file?.source, mutant.location),
+        replacement: mutant.replacement ?? '',
+      })
+    }
+  }
+
+  const killedLike = totals.killed + totals.timeout
+  const score = totals.scored === 0 ? null : (killedLike / totals.scored) * 100
+
+  return { survivors, totals, score }
+}
+
+export function renderMarkdown(report, options = {}) {
+  const { packageName = null, enforced = false, droppedFiles = [] } = options
+  const { survivors, totals, score } = collectSurvivors(report)
+  const heading = packageName === null ? '## Mutation testing' : `## Mutation testing — \`${packageName}\``
+  const lines = [heading, '']
+
+  if (score === null) {
+    lines.push('No mutants were generated for the changed files, so there is no score to report.')
+    lines.push('')
+    if (!enforced) lines.push(ADVISORY_NOTE)
+    return `${lines.join('\n').trimEnd()}\n`
+  }
+
+  lines.push(
+    `**Score: ${score.toFixed(2)}%** — ${totals.killed} killed, ${totals.survived} survived, ` +
+      `${totals.timeout} timed out, of ${totals.scored} scored mutants.`,
+  )
+  lines.push('')
+
+  if (totals.errors > 0) {
+    lines.push(
+      `${totals.errors} mutant(s) errored and are excluded from the score. A large number here ` +
+        'usually means a systematic problem rather than a test gap.',
+    )
+    lines.push('')
+  }
+
+  if (survivors.length === 0) {
+    lines.push('No surviving mutants. Every mutation of the changed code was caught by a test.')
+  } else {
+    lines.push(`### ${survivors.length} surviving mutant(s)`)
+    lines.push('')
+    lines.push('| Location | Mutator | Original | Replacement |')
+    lines.push('| --- | --- | --- | --- |')
+    for (const survivor of survivors) {
+      lines.push(
+        `| \`${survivor.file}:${survivor.line}:${survivor.column}\` | ${survivor.mutator} | ` +
+          `\`- ${toSingleLine(survivor.original)}\` | \`+ ${toSingleLine(survivor.replacement)}\` |`,
+      )
+    }
+    lines.push('')
+    lines.push(
+      'A surviving mutant is a question, not a verdict: it is a genuine coverage gap, an ' +
+        'equivalent mutant that no test could kill, or two source paths masking each other. ' +
+        'Suppress equivalent mutants at the source with `// Stryker disable next-line <mutator>` ' +
+        'plus a one-line justification.',
+    )
+  }
+
+  if (droppedFiles.length > 0) {
+    lines.push('')
+    lines.push(
+      `**Not measured:** the file cap was reached, so ${droppedFiles.length} changed file(s) ` +
+        `were not mutated: ${droppedFiles.map((file) => `\`${file}\``).join(', ')}.`,
+    )
+  }
+
+  if (!enforced) {
+    lines.push('')
+    lines.push(ADVISORY_NOTE)
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`
+}
+
+export function parseReportArgs(argv) {
+  const args = { reportPath: null, packageName: null, enforced: false }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--package' && index + 1 < argv.length) {
+      args.packageName = argv[index + 1]
+      index += 1
+    } else if (argv[index] === '--enforced') {
+      args.enforced = true
+    } else if (args.reportPath === null) {
+      args.reportPath = argv[index]
+    }
+  }
+
+  return args
+}
+
+function main() {
+  const args = parseReportArgs(process.argv.slice(2))
+
+  if (args.reportPath === null || !fs.existsSync(args.reportPath)) {
+    process.stdout.write(
+      `## Mutation testing\n\nNo mutation report was produced${args.packageName === null ? '' : ` for \`${args.packageName}\``}.\n`,
+    )
+    return
+  }
+
+  const report = JSON.parse(fs.readFileSync(args.reportPath, 'utf8'))
+  const markdown = renderMarkdown(report, {
+    packageName: args.packageName,
+    enforced: args.enforced,
+  })
+
+  process.stdout.write(markdown)
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown)
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/scripts/stryker/report.mjs
+++ b/scripts/stryker/report.mjs
@@ -56,10 +56,22 @@ function sliceOriginal(source, location) {
   return [first, ...middle, last].join('\n')
 }
 
+/**
+ * Survivor cells carry arbitrary source text into a markdown table that is also
+ * posted as a PR comment, so two characters have to be neutralised: `|` would break
+ * the table structure, and a backtick would close the inline code span the cell
+ * wraps its content in.
+ *
+ * Escaping the backtick is also what keeps `@mention` text inert. GitHub does not
+ * linkify a mention inside a code span, so an intact span means a mutated line
+ * containing `@someone` renders as text instead of notifying that person — the span
+ * only leaks if a stray backtick ends it early, which is exactly what this prevents.
+ */
 function toSingleLine(text) {
   return String(text ?? '')
     .replace(/\s+/g, ' ')
     .replace(/\|/g, '\\|')
+    .replace(/`/g, '\\`')
     .trim()
 }
 
@@ -190,27 +202,44 @@ export function parseReportArgs(argv) {
   return args
 }
 
-function main() {
-  const args = parseReportArgs(process.argv.slice(2))
+/**
+ * The report the summary shows when Stryker died before writing mutation.json. The
+ * reporting step runs `if: always()` precisely so a failed run still explains itself,
+ * so this path must reach the job summary like any other — a crashed run that leaves
+ * the summary blank buries its only explanation in the step log.
+ */
+export function renderMissingReportMarkdown(packageName = null) {
+  const suffix = packageName === null ? '' : ` for \`${packageName}\``
+  return (
+    `## Mutation testing\n\nNo mutation report was produced${suffix}. ` +
+    'The mutation run did not get far enough to write `mutation.json` — check the ' +
+    'mutation step above for the failure.\n'
+  )
+}
 
-  if (args.reportPath === null || !fs.existsSync(args.reportPath)) {
-    process.stdout.write(
-      `## Mutation testing\n\nNo mutation report was produced${args.packageName === null ? '' : ` for \`${args.packageName}\``}.\n`,
-    )
-    return
-  }
-
-  const report = JSON.parse(fs.readFileSync(args.reportPath, 'utf8'))
-  const markdown = renderMarkdown(report, {
-    packageName: args.packageName,
-    enforced: args.enforced,
-  })
-
+function emit(markdown) {
   process.stdout.write(markdown)
 
   if (process.env.GITHUB_STEP_SUMMARY) {
     fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown)
   }
+}
+
+function main() {
+  const args = parseReportArgs(process.argv.slice(2))
+
+  if (args.reportPath === null || !fs.existsSync(args.reportPath)) {
+    emit(renderMissingReportMarkdown(args.packageName))
+    return
+  }
+
+  const report = JSON.parse(fs.readFileSync(args.reportPath, 'utf8'))
+  emit(
+    renderMarkdown(report, {
+      packageName: args.packageName,
+      enforced: args.enforced,
+    }),
+  )
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/stryker/scope.mjs
+++ b/scripts/stryker/scope.mjs
@@ -59,6 +59,17 @@ export function isInScopePath(relativePath) {
   return !OUT_OF_SCOPE_SEGMENTS.some((segment) => padded.includes(segment))
 }
 
+/**
+ * Code-point ordering, not `localeCompare`. The mutate list must be byte-identical
+ * across machines and CI runners so a re-run mutates the same files in the same
+ * order; a locale-sensitive collation would make that environment-dependent.
+ */
+export function compareByCodePoint(left, right) {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
 function splitPackagePath(changedPath) {
   const match = /^packages\/([^/]+)\/(.+)$/.exec(changedPath)
   if (match === null) return null
@@ -87,8 +98,8 @@ export function computeScope(changedFiles, options = {}) {
   const include = []
   const dropped = []
 
-  for (const packageName of [...byPackage.keys()].sort()) {
-    const files = [...new Set(byPackage.get(packageName))].sort()
+  for (const packageName of [...byPackage.keys()].sort(compareByCodePoint)) {
+    const files = [...new Set(byPackage.get(packageName))].sort(compareByCodePoint)
     const kept = files.slice(0, maxFiles)
     const truncated = files.slice(maxFiles)
 

--- a/scripts/stryker/scope.mjs
+++ b/scripts/stryker/scope.mjs
@@ -46,8 +46,32 @@ const OUT_OF_SCOPE_SEGMENTS = Object.freeze([
   '/testing/',
 ])
 
+/**
+ * The mutate list this module emits is consumed as a command argument
+ * (`stryker run --mutate <list>`), and its input is the diff of a pull request that
+ * anyone may open — so a changed path is untrusted text, not a trusted filename.
+ *
+ * The allowlist is derived from what the repository actually contains rather than
+ * guessed: across all 2376 in-scope `.ts` files, the only characters outside
+ * `[A-Za-z0-9._/-]` are the square brackets of Next.js dynamic route segments
+ * (87 `page.meta.ts` files such as `.../roles/[id]/edit/page.meta.ts`), which are
+ * inert once the value is passed through the environment. Anything else — a space,
+ * `$`, a backtick, a quote, `;`, `|`, `&`, `(`, `)`, a newline — is not a legitimate
+ * source path here, so it is dropped at the source.
+ *
+ * An allowlist rather than a denylist of shell metacharacters, and enforced here
+ * rather than only at the call site, so the guarantee does not depend on every
+ * present and future consumer quoting the value correctly.
+ */
+const SAFE_PATH_PATTERN = /^[A-Za-z0-9._/[\]-]+$/
+
+export function hasSafePathCharacters(relativePath) {
+  return typeof relativePath === 'string' && SAFE_PATH_PATTERN.test(relativePath)
+}
+
 export function isInScopePath(relativePath) {
   if (typeof relativePath !== 'string' || relativePath === '') return false
+  if (!hasSafePathCharacters(relativePath)) return false
   if (!relativePath.endsWith('.ts')) return false
   if (relativePath.endsWith('.d.ts')) return false
   if (relativePath.endsWith('.test.ts')) return false
@@ -123,11 +147,17 @@ function defaultRunGit(args) {
 }
 
 export function parseArgs(argv) {
-  const args = { base: DEFAULT_BASE_REF }
+  const args = { base: DEFAULT_BASE_REF, package: null, mutate: null }
 
   for (let index = 0; index < argv.length; index += 1) {
     if (argv[index] === '--base' && index + 1 < argv.length) {
       args.base = argv[index + 1]
+      index += 1
+    } else if (argv[index] === '--package' && index + 1 < argv.length) {
+      args.package = argv[index + 1]
+      index += 1
+    } else if (argv[index] === '--mutate' && index + 1 < argv.length) {
+      args.mutate = argv[index + 1]
       index += 1
     }
   }
@@ -135,9 +165,28 @@ export function parseArgs(argv) {
   return args
 }
 
+/**
+ * Turns an explicit `--package`/`--mutate` selection into the same repository-root
+ * paths a diff would have produced, so a manually dispatched run is filtered by
+ * exactly the allowlist, scope and character rules a pull-request run is. An
+ * operator-supplied file that would never be mutated from a diff is not mutated
+ * from a dispatch either.
+ */
+export function explicitChangedFiles(packageName, mutateList) {
+  if (typeof packageName !== 'string' || packageName === '') return []
+  return String(mutateList ?? '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== '')
+    .map((entry) => `packages/${packageName}/${entry}`)
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2))
-  const changedFiles = readChangedFiles(args.base)
+  const changedFiles =
+    args.package === null && args.mutate === null
+      ? readChangedFiles(args.base)
+      : explicitChangedFiles(args.package, args.mutate)
   const { matrix, dropped } = computeScope(changedFiles)
 
   for (const entry of dropped) {

--- a/scripts/stryker/scope.mjs
+++ b/scripts/stryker/scope.mjs
@@ -1,0 +1,143 @@
+/**
+ * Diff → per-package mutate lists, emitted as a GitHub Actions matrix.
+ *
+ * StrykerJS has no `--since` flag, so diff scoping is ours to compute: we resolve the
+ * changed files against a base ref, keep only business-logic paths inside allowlisted
+ * packages, and hand the result to `stryker run --mutate <list>`.
+ *
+ * The filter here is deliberately stricter than the `mutate` globs in createConfig.mjs.
+ * Those globs describe "what could be mutated in a full-package run"; this filter
+ * describes "what is worth mutating in a pull request" — which excludes API route
+ * handlers (thin transport wrappers whose logic lives in commands and validators) and
+ * every `.tsx` file (rendering, covered by UI tests rather than mutation scoring).
+ *
+ * Usage:
+ *   node scripts/stryker/scope.mjs [--base <ref>] [--json]
+ *
+ * Always exits 0. An empty matrix means "nothing in scope", which the workflow treats
+ * as a skip — never as a failure and never as a synthetic score.
+ *
+ * @see .ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
+ */
+
+import { execFileSync } from 'node:child_process'
+
+export const DEFAULT_BASE_REF = 'origin/develop'
+export const DEFAULT_MAX_FILES = 25
+
+/**
+ * Packages whose changed files are mutated in CI. Adding a package here is a
+ * deliberate, measured decision: a package joins only after a timing run shows a
+ * PR-sized diff completes well inside the workflow's timeout.
+ */
+export const ALLOWLISTED_PACKAGES = Object.freeze(['shared'])
+
+const IN_SCOPE_PREFIXES = Object.freeze(['src/lib/', 'src/modules/', 'src/security/'])
+
+const OUT_OF_SCOPE_SEGMENTS = Object.freeze([
+  '/__tests__/',
+  '/__mocks__/',
+  '/api/',
+  '/migrations/',
+  '/generated/',
+  '/testing/',
+])
+
+export function isInScopePath(relativePath) {
+  if (typeof relativePath !== 'string' || relativePath === '') return false
+  if (!relativePath.endsWith('.ts')) return false
+  if (relativePath.endsWith('.d.ts')) return false
+  if (relativePath.endsWith('.test.ts')) return false
+  if (relativePath.endsWith('.spec.ts')) return false
+
+  if (!IN_SCOPE_PREFIXES.some((prefix) => relativePath.startsWith(prefix))) return false
+
+  const padded = `/${relativePath}`
+  return !OUT_OF_SCOPE_SEGMENTS.some((segment) => padded.includes(segment))
+}
+
+function splitPackagePath(changedPath) {
+  const match = /^packages\/([^/]+)\/(.+)$/.exec(changedPath)
+  if (match === null) return null
+  return { packageName: match[1], relativePath: match[2] }
+}
+
+/**
+ * @param {string[]} changedFiles paths relative to the repository root
+ * @returns {{ matrix: { include: Array<{ package: string, mutate: string }> }, dropped: Array<{ package: string, files: string[] }> }}
+ */
+export function computeScope(changedFiles, options = {}) {
+  const { allowlist = ALLOWLISTED_PACKAGES, maxFiles = DEFAULT_MAX_FILES } = options
+  const byPackage = new Map()
+
+  for (const changedPath of changedFiles) {
+    const split = splitPackagePath(changedPath)
+    if (split === null) continue
+    if (!allowlist.includes(split.packageName)) continue
+    if (!isInScopePath(split.relativePath)) continue
+
+    const existing = byPackage.get(split.packageName)
+    if (existing === undefined) byPackage.set(split.packageName, [split.relativePath])
+    else existing.push(split.relativePath)
+  }
+
+  const include = []
+  const dropped = []
+
+  for (const packageName of [...byPackage.keys()].sort()) {
+    const files = [...new Set(byPackage.get(packageName))].sort()
+    const kept = files.slice(0, maxFiles)
+    const truncated = files.slice(maxFiles)
+
+    if (kept.length > 0) include.push({ package: packageName, mutate: kept.join(',') })
+    if (truncated.length > 0) dropped.push({ package: packageName, files: truncated })
+  }
+
+  return { matrix: { include }, dropped }
+}
+
+export function readChangedFiles(baseRef, runGit = defaultRunGit) {
+  const output = runGit(['diff', '--name-only', '--diff-filter=d', `${baseRef}...HEAD`])
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line !== '')
+}
+
+function defaultRunGit(args) {
+  return execFileSync('git', args, { encoding: 'utf8' })
+}
+
+export function parseArgs(argv) {
+  const args = { base: DEFAULT_BASE_REF, json: false }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === '--base' && index + 1 < argv.length) {
+      args.base = argv[index + 1]
+      index += 1
+    } else if (argv[index] === '--json') {
+      args.json = true
+    }
+  }
+
+  return args
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const changedFiles = readChangedFiles(args.base)
+  const { matrix, dropped } = computeScope(changedFiles)
+
+  for (const entry of dropped) {
+    process.stderr.write(
+      `[stryker:scope] ${entry.package}: capped at ${DEFAULT_MAX_FILES} files; ` +
+        `not mutated in this run: ${entry.files.join(', ')}\n`,
+    )
+  }
+
+  process.stdout.write(`${JSON.stringify(matrix)}\n`)
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}

--- a/scripts/stryker/scope.mjs
+++ b/scripts/stryker/scope.mjs
@@ -12,7 +12,10 @@
  * every `.tsx` file (rendering, covered by UI tests rather than mutation scoring).
  *
  * Usage:
- *   node scripts/stryker/scope.mjs [--base <ref>] [--json]
+ *   node scripts/stryker/scope.mjs [--base <ref>]
+ *
+ * Output is always the matrix JSON on stdout; dropped-file warnings go to stderr so
+ * they never pollute it.
  *
  * Always exits 0. An empty matrix means "nothing in scope", which the workflow treats
  * as a skip — never as a failure and never as a synthetic score.
@@ -109,14 +112,12 @@ function defaultRunGit(args) {
 }
 
 export function parseArgs(argv) {
-  const args = { base: DEFAULT_BASE_REF, json: false }
+  const args = { base: DEFAULT_BASE_REF }
 
   for (let index = 0; index < argv.length; index += 1) {
     if (argv[index] === '--base' && index + 1 < argv.length) {
       args.base = argv[index + 1]
       index += 1
-    } else if (argv[index] === '--json') {
-      args.json = true
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,7 +781,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.21.3, @babel/core@npm:^7.23.9, @babel/core@npm:^7.24.4, @babel/core@npm:^7.25.9, @babel/core@npm:^7.27.4":
+"@babel/core@npm:^7.21.3, @babel/core@npm:^7.23.9, @babel/core@npm:^7.24.4, @babel/core@npm:^7.25.9, @babel/core@npm:^7.27.4, @babel/core@npm:~7.29.0":
   version: 7.29.7
   resolution: "@babel/core@npm:7.29.7"
   dependencies:
@@ -843,12 +843,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:~7.29.0":
+  version: 7.29.8
+  resolution: "@babel/generator@npm:7.29.8"
+  dependencies:
+    "@babel/parser": "npm:^7.29.8"
+    "@babel/types": "npm:^7.29.8"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 10/679c3d1302936f391260acee4059e0c3cd5bff6341772f0b85bb142feab1a253d0e155aad0e9c8531e024d6239a2cc5169d1e294c6890901e7d4ab0f7c9eaaaa
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.27.1, @babel/helper-annotate-as-pure@npm:^7.27.3":
   version: 7.27.3
   resolution: "@babel/helper-annotate-as-pure@npm:7.27.3"
   dependencies:
     "@babel/types": "npm:^7.27.3"
   checksum: 10/63863a5c936ef82b546ca289c9d1b18fabfc24da5c4ee382830b124e2e79b68d626207febc8d4bffc720f50b2ee65691d7d12cc0308679dee2cd6bdc926b7190
+  languageName: node
+  linkType: hard
+
+"@babel/helper-annotate-as-pure@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-annotate-as-pure@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10/acd9e128de634a5144b5d622357d018fa616de45f64c74e42007c048dd15d0a0be213f4d5a2bf02307bdaddf053791b87900a99d183de828c08dc3b556329009
   languageName: node
   linkType: hard
 
@@ -892,6 +914,23 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 10/11f55607fcf66827ade745c0616aa3c6086aa655c0fab665dd3c4961829752e4c94c942262db30c4831ef9bce37ad444722e85ef1b7136587e28c6b1ef8ad43c
+  languageName: node
+  linkType: hard
+
+"@babel/helper-create-class-features-plugin@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-create-class-features-plugin@npm:7.29.7"
+  dependencies:
+    "@babel/helper-annotate-as-pure": "npm:^7.29.7"
+    "@babel/helper-member-expression-to-functions": "npm:^7.29.7"
+    "@babel/helper-optimise-call-expression": "npm:^7.29.7"
+    "@babel/helper-replace-supers": "npm:^7.29.7"
+    "@babel/helper-skip-transparent-expression-wrappers": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+    semver: "npm:^6.3.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10/74f871e5389beca9fb52670f2bd83abdd6dc7b7a10f34679ffab5eabf91077dccaabf55438b9f3c897258fb81fbb80bfbf469b836a404abb7e64b4d7c141a8da
   languageName: node
   linkType: hard
 
@@ -944,6 +983,16 @@ __metadata:
     "@babel/traverse": "npm:^7.28.5"
     "@babel/types": "npm:^7.28.5"
   checksum: 10/05e0857cf7913f03d88ca62952d3888693c21a4f4d7cfc141c630983f71fc0a64393e05cecceb7701dfe98298f7cc38fcb735d892e3c8c6f56f112c85ee1b154
+  languageName: node
+  linkType: hard
+
+"@babel/helper-member-expression-to-functions@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-member-expression-to-functions@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10/bb8dc59a65b4404260e0b7ff70f491de5a1607876f61736d26605ab3cba5b368827b0551acd3458212f5cfa99cbcd48bb66a96497b0fe00af09a6a2cbea4276b
   languageName: node
   linkType: hard
 
@@ -1002,10 +1051,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-optimise-call-expression@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-optimise-call-expression@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10/6b477e01b403fd48349336cb1d94722bff4fa54af2841b5fa950c557b796f4ecc14724052252ed1362ccfc23d1c09c54dc03e182fea59d3dc5bd69f8c626ba25
+  languageName: node
+  linkType: hard
+
 "@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.28.6, @babel/helper-plugin-utils@npm:^7.8.0":
   version: 7.28.6
   resolution: "@babel/helper-plugin-utils@npm:7.28.6"
   checksum: 10/21c853bbc13dbdddf03309c9a0477270124ad48989e1ad6524b83e83a77524b333f92edd2caae645c5a7ecf264ec6d04a9ebe15aeb54c7f33c037b71ec521e4a
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-plugin-utils@npm:7.29.7"
+  checksum: 10/6d16929fe5c792bbc8e4d67e18d7c1be69d2f18992deaa3d94dc26541fec662e83cbeeaf7553c6867d068eb7aed4e0d5e3e137c1dd4d5bcfa286f8d772f1f457
   languageName: node
   linkType: hard
 
@@ -1035,6 +1100,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-replace-supers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-replace-supers@npm:7.29.7"
+  dependencies:
+    "@babel/helper-member-expression-to-functions": "npm:^7.29.7"
+    "@babel/helper-optimise-call-expression": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 10/4aa7b48a6078db99bba24b67f63f97cd08ad9b3c476dcca196c6421dc2080f3566d683fba64c772e2f9597603d42ad4ac2ce9ccf0559643823c540f08cf0efa7
+  languageName: node
+  linkType: hard
+
 "@babel/helper-skip-transparent-expression-wrappers@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.27.1"
@@ -1042,6 +1120,16 @@ __metadata:
     "@babel/traverse": "npm:^7.27.1"
     "@babel/types": "npm:^7.27.1"
   checksum: 10/4f380c5d0e0769fa6942a468b0c2d7c8f0c438f941aaa88f785f8752c103631d0904c7b4e76207a3b0e6588b2dec376595370d92ca8f8f1b422c14a69aa146d4
+  languageName: node
+  linkType: hard
+
+"@babel/helper-skip-transparent-expression-wrappers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-skip-transparent-expression-wrappers@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 10/a5800bfcdca6cef7f6fe33ac02a0f05ff33da9746f97806553f249733f7ba8400290a17f3831d7faa5d91656f254ab749931f53c8a29f301d958d7dd00499637
   languageName: node
   linkType: hard
 
@@ -1130,6 +1218,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/parser@npm:^7.29.8, @babel/parser@npm:~7.29.0":
+  version: 7.29.8
+  resolution: "@babel/parser@npm:7.29.8"
+  dependencies:
+    "@babel/types": "npm:^7.29.8"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/dbd14ebbba0fa3019acd2712b0db3ffd594d0850d4fc487667287b5702893f54a7911570ea842f0cff4dc492a2412e3287dfabfe00c6b78efa7becb1255f3f86
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/plugin-bugfix-firefox-class-in-computed-class-key@npm:7.28.5"
@@ -1189,6 +1288,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-proposal-decorators@npm:~7.29.0":
+  version: 7.29.7
+  resolution: "@babel/plugin-proposal-decorators@npm:7.29.7"
+  dependencies:
+    "@babel/helper-create-class-features-plugin": "npm:^7.29.7"
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/plugin-syntax-decorators": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/396b108c349e8ce6511be4218089f9142bae235307c3cff7a985d9391b8d84f2421668d604f109344101ce65078101bf29b9e52ec2e242e242c7bbf3efc56cad
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-proposal-private-property-in-object@npm:7.21.0-placeholder-for-preset-env.2":
   version: 7.21.0-placeholder-for-preset-env.2
   resolution: "@babel/plugin-proposal-private-property-in-object@npm:7.21.0-placeholder-for-preset-env.2"
@@ -1239,6 +1351,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10/3e80814b5b6d4fe17826093918680a351c2d34398a914ce6e55d8083d72a9bdde4fbaf6a2dcea0e23a03de26dc2917ae3efd603d27099e2b98380345703bf948
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-decorators@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/plugin-syntax-decorators@npm:7.29.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/e45783f424c1a62be0dbcd760de9f641b5ddfe41e75174ac072897f130b9ea826c8a9bbdfce0a15a14565630f68ff061f27a52c62f274e7e79319afea4c54ef9
   languageName: node
   linkType: hard
 
@@ -1542,6 +1665,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/plugin-transform-destructuring@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/plugin-transform-destructuring@npm:7.29.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/e53caad0c2d523367724aefcc6b8c8df24fcb1a3f53e9899cb4bb5dc39ccf61e30df0a761d74485a895d9bcaaad49644879cbd3a9fc20c90501a5e831caaac5b
+  languageName: node
+  linkType: hard
+
 "@babel/plugin-transform-dotall-regex@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/plugin-transform-dotall-regex@npm:7.28.6"
@@ -1585,6 +1720,18 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10/7a9fbc8d17148b7f11a1d1ca3990d2c2cd44bd08a45dcaf14f20a017721235b9044b20e6168b6940282bb1b48fb78e6afbdfb9dd9d82fde614e15baa7d579932
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-transform-explicit-resource-management@npm:^7.28.0":
+  version: 7.29.7
+  resolution: "@babel/plugin-transform-explicit-resource-management@npm:7.29.7"
+  dependencies:
+    "@babel/helper-plugin-utils": "npm:^7.29.7"
+    "@babel/plugin-transform-destructuring": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/a4ea28a18161a7e8c8f33731cb3dfc6981cb089b9a6b57abfa7ff7579a0ca76a4c19c29ebaf775b037ff31503c74c6cf3687ce86cdaa246d1c60afb5abd820df
   languageName: node
   linkType: hard
 
@@ -2220,7 +2367,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-typescript@npm:^7.21.0, @babel/preset-typescript@npm:^7.25.9":
+"@babel/preset-typescript@npm:^7.21.0, @babel/preset-typescript@npm:^7.25.9, @babel/preset-typescript@npm:~7.28.0":
   version: 7.28.5
   resolution: "@babel/preset-typescript@npm:7.28.5"
   dependencies:
@@ -2337,6 +2484,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.29.7"
     "@babel/helper-validator-identifier": "npm:^7.29.7"
   checksum: 10/bd4f5635db1057bd0abeebf93eb3ae38399e152271cea8dce8288350f0afa13ed3e2db2e16e22bd3303068890eec18965a83420539afbe0dde31432b4cf9636d
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.8":
+  version: 7.29.8
+  resolution: "@babel/types@npm:7.29.8"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: 10/ff2becf0f8b432f0820f286fb9319d7f3819b2d0eb95bc26957fbc6250a3ca0ae3656feb98ecb5f171f9e04b34a4c08f5036447f17459ed7bfc32ff649d9b71e
   languageName: node
   linkType: hard
 
@@ -5355,6 +5512,247 @@ __metadata:
   version: 0.35.3
   resolution: "@img/sharp-win32-x64@npm:0.35.3"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@inquirer/ansi@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@inquirer/ansi@npm:2.0.7"
+  checksum: 10/ae4ff228412f1f67d78aa9a7410e07e692eeb7c9b75034825f1039898821b02505dfe934be53d6ee4ce5bde9e7ff6b4ce7547bacc1c9aa441396cb9b99717e0f
+  languageName: node
+  linkType: hard
+
+"@inquirer/checkbox@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "@inquirer/checkbox@npm:5.2.1"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.7"
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/figures": "npm:^2.0.7"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/8a4b9a336a48c32db0403c56b228351210a3e8d5706032274e8cc47579f2b8a6a9b2cabe11a6aa96694f1e6bac5364fd9cdafe1d67ad65eafb5e6edc696fd534
+  languageName: node
+  linkType: hard
+
+"@inquirer/confirm@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "@inquirer/confirm@npm:6.1.1"
+  dependencies:
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/631d35403438949abe073ba6b7823682d4bd995a582226df0c8d18fd2b069a42e415bc40988fd10b138984701d585da32086da6d90814ec50eaa8a2778dc6bfb
+  languageName: node
+  linkType: hard
+
+"@inquirer/core@npm:^11.2.1":
+  version: 11.2.1
+  resolution: "@inquirer/core@npm:11.2.1"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.7"
+    "@inquirer/figures": "npm:^2.0.7"
+    "@inquirer/type": "npm:^4.0.7"
+    cli-width: "npm:^4.1.0"
+    fast-wrap-ansi: "npm:^0.2.0"
+    mute-stream: "npm:^3.0.0"
+    signal-exit: "npm:^4.1.0"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/687c2ee50985a8eb3142c902e99dd888176e66af2eed0781238e7b4b1f327737d4db053345a20b74c7fefa47da539238eea0afcd1e59e577409ca5ead94aa6d1
+  languageName: node
+  linkType: hard
+
+"@inquirer/editor@npm:^5.2.2":
+  version: 5.2.2
+  resolution: "@inquirer/editor@npm:5.2.2"
+  dependencies:
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/external-editor": "npm:^3.0.3"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/cc375c8f9f332df47f36a998dcc9107cd97e0e26577b7ba1413d6cc84ee1790b232b0667b37e3f0f53bf52c004bf11d216a743f816b6f26d25dd584462a1e34c
+  languageName: node
+  linkType: hard
+
+"@inquirer/expand@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@inquirer/expand@npm:5.1.1"
+  dependencies:
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/a93b230bcddb4387a720f12615e8414999427e132110122f6ab9273a684fa0917bea946b35cb4a4e16d9cc7859f78b01e39656e140aed5885bc96212a3668857
+  languageName: node
+  linkType: hard
+
+"@inquirer/external-editor@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@inquirer/external-editor@npm:3.0.3"
+  dependencies:
+    chardet: "npm:^2.1.1"
+    iconv-lite: "npm:^0.7.2"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/7d20388ff3fc051684c5ca07c8247db2ab73b706f0a3c710197ffe96685965bdca9a065df6db497f2db30255fb5b6c5998ccc39192f318159522d2704fc29817
+  languageName: node
+  linkType: hard
+
+"@inquirer/figures@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@inquirer/figures@npm:2.0.7"
+  checksum: 10/145d74307b17712807ccd561787ecd1a72d574165b4d07a146e0d815f8e0320ffd39fb07f81a33910a4d2f0e098862b35b87614c4d3da740a29fa42c38dcb768
+  languageName: node
+  linkType: hard
+
+"@inquirer/input@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@inquirer/input@npm:5.1.2"
+  dependencies:
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/ff8f5112559b778162c6f93bb57c967cd829b7c32fc8621febf41e3b817fb8538903e1afa33dcb7c942da1de8db216173aca01fd41b455b6350fc036b302becd
+  languageName: node
+  linkType: hard
+
+"@inquirer/number@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "@inquirer/number@npm:4.1.1"
+  dependencies:
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/ee99f233596bc8e7b191d6f844f4a48057e6f3615884f1dbdb816c36ea3d6a5685db6ad3b8efc9bab6ae2397e202d8b49a53a99b96f63f4d6e42d660c318db23
+  languageName: node
+  linkType: hard
+
+"@inquirer/password@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "@inquirer/password@npm:5.1.1"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.7"
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/b0b9994de1b49096cc1bf47910b122dd1704cd12434de304081f09090f42d83af699c202e5b8b0c12eb5f87acb7cc4c62a6d97a8781aefe7352b4695eb2b242f
+  languageName: node
+  linkType: hard
+
+"@inquirer/prompts@npm:^8.0.0":
+  version: 8.5.2
+  resolution: "@inquirer/prompts@npm:8.5.2"
+  dependencies:
+    "@inquirer/checkbox": "npm:^5.2.1"
+    "@inquirer/confirm": "npm:^6.1.1"
+    "@inquirer/editor": "npm:^5.2.2"
+    "@inquirer/expand": "npm:^5.1.1"
+    "@inquirer/input": "npm:^5.1.2"
+    "@inquirer/number": "npm:^4.1.1"
+    "@inquirer/password": "npm:^5.1.1"
+    "@inquirer/rawlist": "npm:^5.3.1"
+    "@inquirer/search": "npm:^4.2.1"
+    "@inquirer/select": "npm:^5.2.1"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/af39efea141bf193c4ffcb9ccf3ac371e9c0beeb160b281137966a179eb1f86e7aced0b6e8a4debfeb8f52a25381eaf13a14ec0c5600d0384e59115d6c5c96b3
+  languageName: node
+  linkType: hard
+
+"@inquirer/rawlist@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "@inquirer/rawlist@npm:5.3.1"
+  dependencies:
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/4443f2041cd2cbdf0d730ac0eede50dd912f248115f06f5e80d9d965de5ad071bbcb412c2b17b80abd847ba26090fe52050b44475207a3e99587ffe8e8f03335
+  languageName: node
+  linkType: hard
+
+"@inquirer/search@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "@inquirer/search@npm:4.2.1"
+  dependencies:
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/figures": "npm:^2.0.7"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/8e5d53506649102dd991d594a5267c6ace473b4875ea2bd0b6f1c3f5b8191d23889f35db6dd986daeb52f0ccdb399229a05b7d94a6cf99bdc56c1173e7e3b6e6
+  languageName: node
+  linkType: hard
+
+"@inquirer/select@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "@inquirer/select@npm:5.2.1"
+  dependencies:
+    "@inquirer/ansi": "npm:^2.0.7"
+    "@inquirer/core": "npm:^11.2.1"
+    "@inquirer/figures": "npm:^2.0.7"
+    "@inquirer/type": "npm:^4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/3ceca17d780dff006678bbcde172de086c38026ce1d209a38b881cbecc6b7e35b1d6871a02916f8f1ba8dca4f48218ffe05bd838b7fe3de5614e4fddc78dccf8
+  languageName: node
+  linkType: hard
+
+"@inquirer/type@npm:^4.0.7":
+  version: 4.0.7
+  resolution: "@inquirer/type@npm:4.0.7"
+  peerDependencies:
+    "@types/node": ">=18"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+  checksum: 10/97769b74264a2575c12c231e3d4acf98b4ae237fc987cec6b459f88b907b1729623403b8d9fe0cf2ca21743114777c64e3031fbeff72e9da37fbf4c8985f587f
   languageName: node
   linkType: hard
 
@@ -11299,6 +11697,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sec-ant/readable-stream@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@sec-ant/readable-stream@npm:0.4.1"
+  checksum: 10/aac89581652ac85debe7c5303451c2ebf8bf25ca25db680e4b9b73168f6940616d9a4bbe3348981827b1159b14e2f2e6af4b7bd5735cac898c12d5c51909c102
+  languageName: node
+  linkType: hard
+
 "@selderee/plugin-htmlparser2@npm:^0.11.0":
   version: 0.11.0
   resolution: "@selderee/plugin-htmlparser2@npm:0.11.0"
@@ -11399,6 +11804,13 @@ __metadata:
   version: 5.6.0
   resolution: "@sindresorhus/is@npm:5.6.0"
   checksum: 10/b077c325acec98e30f7d86df158aaba2e7af2acb9bb6a00fda4b91578539fbff4ecebe9b934e24fec0e6950de3089d89d79ec02d9062476b20ce185be0e01bd6
+  languageName: node
+  linkType: hard
+
+"@sindresorhus/merge-streams@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@sindresorhus/merge-streams@npm:4.0.0"
+  checksum: 10/16551c787f5328c8ef05fd9831ade64369ccc992df78deb635ec6c44af217d2f1b43f8728c348cdc4e00585ff2fad6e00d8155199cbf6b154acc45fe65cbf0aa
   languageName: node
   linkType: hard
 
@@ -11578,6 +11990,95 @@ __metadata:
   version: 9.12.1
   resolution: "@stripe/stripe-js@npm:9.12.1"
   checksum: 10/beec1f2bfd5b0f235eda9d52a7cf0650ba23c98fdf2bea797acf967e8336faf8ea156d7fca376e51e132bb012bc1c43f3adbb6fed91fbb50918f2c147ceaf80b
+  languageName: node
+  linkType: hard
+
+"@stryker-mutator/api@npm:9.6.1":
+  version: 9.6.1
+  resolution: "@stryker-mutator/api@npm:9.6.1"
+  dependencies:
+    mutation-testing-metrics: "npm:3.7.3"
+    mutation-testing-report-schema: "npm:3.7.3"
+    tslib: "npm:~2.8.0"
+    typed-inject: "npm:~5.0.0"
+  checksum: 10/cd4e8a78f51160921d3fe72358e674c33ca136f7017f54b0e777ee4b9fca2823f8eebaa52a129f14861ed5710e3cd10c31b696f37f4260e0c0ce54b651dc4409
+  languageName: node
+  linkType: hard
+
+"@stryker-mutator/core@npm:^9.6.1":
+  version: 9.6.1
+  resolution: "@stryker-mutator/core@npm:9.6.1"
+  dependencies:
+    "@inquirer/prompts": "npm:^8.0.0"
+    "@stryker-mutator/api": "npm:9.6.1"
+    "@stryker-mutator/instrumenter": "npm:9.6.1"
+    "@stryker-mutator/util": "npm:9.6.1"
+    ajv: "npm:~8.18.0"
+    chalk: "npm:~5.6.0"
+    commander: "npm:~14.0.0"
+    diff-match-patch: "npm:1.0.5"
+    emoji-regex: "npm:~10.6.0"
+    execa: "npm:~9.6.0"
+    json-rpc-2.0: "npm:^1.7.0"
+    lodash.groupby: "npm:~4.6.0"
+    minimatch: "npm:~10.2.4"
+    mutation-server-protocol: "npm:~0.4.0"
+    mutation-testing-elements: "npm:3.7.3"
+    mutation-testing-metrics: "npm:3.7.3"
+    mutation-testing-report-schema: "npm:3.7.3"
+    npm-run-path: "npm:~6.0.0"
+    progress: "npm:~2.0.3"
+    rxjs: "npm:~7.8.1"
+    semver: "npm:^7.6.3"
+    source-map: "npm:~0.7.4"
+    tree-kill: "npm:~1.2.2"
+    tslib: "npm:2.8.1"
+    typed-inject: "npm:~5.0.0"
+    typed-rest-client: "npm:~2.3.0"
+  bin:
+    stryker: bin/stryker.js
+  checksum: 10/8c29e1e1f9427f9cccb0efcdfdc913ca254bd07fac52820bb6eb1f873eb3ff31761ba0bc79420811f0e2ab168c4488463e27d42ade71bc5a4cd2d2f2d6983771
+  languageName: node
+  linkType: hard
+
+"@stryker-mutator/instrumenter@npm:9.6.1":
+  version: 9.6.1
+  resolution: "@stryker-mutator/instrumenter@npm:9.6.1"
+  dependencies:
+    "@babel/core": "npm:~7.29.0"
+    "@babel/generator": "npm:~7.29.0"
+    "@babel/parser": "npm:~7.29.0"
+    "@babel/plugin-proposal-decorators": "npm:~7.29.0"
+    "@babel/plugin-transform-explicit-resource-management": "npm:^7.28.0"
+    "@babel/preset-typescript": "npm:~7.28.0"
+    "@stryker-mutator/api": "npm:9.6.1"
+    "@stryker-mutator/util": "npm:9.6.1"
+    angular-html-parser: "npm:~10.4.0"
+    semver: "npm:~7.7.0"
+    tslib: "npm:2.8.1"
+    weapon-regex: "npm:~1.3.2"
+  checksum: 10/5dad81ddfa7d3b380bc46b465b7bf41c912d9debd8f908dc26b8e9ca96f0a65c5cb0335cd2fd323c921133f11d1bc04b9ecdf9f8d8f21f92bdf9d4a2cbe5ed53
+  languageName: node
+  linkType: hard
+
+"@stryker-mutator/jest-runner@npm:^9.6.1":
+  version: 9.6.1
+  resolution: "@stryker-mutator/jest-runner@npm:9.6.1"
+  dependencies:
+    "@stryker-mutator/api": "npm:9.6.1"
+    "@stryker-mutator/util": "npm:9.6.1"
+    semver: "npm:~7.7.0"
+    tslib: "npm:~2.8.0"
+  peerDependencies:
+    "@stryker-mutator/core": 9.6.1
+  checksum: 10/b7713769a49797db68553df685b894eeb3d56d3d2def2a10e33ca463dcafaeaa8cf0ce40cae4eca55bf1d7446f6e95b1575787f8d31cbbda4f68c158f162ea71
+  languageName: node
+  linkType: hard
+
+"@stryker-mutator/util@npm:9.6.1":
+  version: 9.6.1
+  resolution: "@stryker-mutator/util@npm:9.6.1"
+  checksum: 10/8f3f26167c3ecfc509a91f61e1e9cb1e42e9f60f64b0b536b31d229376742177aace5e4ac0aac4c3a15e0db0c431d4a497c5803be45cd8c00fbb50c3e8051803
   languageName: node
   linkType: hard
 
@@ -14204,7 +14705,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:8.18.0":
+"ajv@npm:8.18.0, ajv@npm:~8.18.0":
   version: 8.18.0
   resolution: "ajv@npm:8.18.0"
   dependencies:
@@ -14258,6 +14759,13 @@ __metadata:
     "@algolia/requester-fetch": "npm:5.47.0"
     "@algolia/requester-node-http": "npm:5.47.0"
   checksum: 10/afd7b3aec5c4f28d88d19ef409c163f16954a4f1c3fff545f78593a5864ff3d6b3bd16ffed16e074b2162d58f77a13270fed00fdb86d68d26f291ae67f6ade58
+  languageName: node
+  linkType: hard
+
+"angular-html-parser@npm:~10.4.0":
+  version: 10.4.0
+  resolution: "angular-html-parser@npm:10.4.0"
+  checksum: 10/8c3e290930d59e96a5ca8101787208af81a6e0cfdb127dd432d9ec00e507aeb8445c4bf0055057f5c7da13afd9e78d9339787e7c2b992a0b7a54a2ca4305f0bc
   languageName: node
   linkType: hard
 
@@ -15493,7 +16001,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.0.1, chalk@npm:^5.2.0":
+"chalk@npm:^5.0.1, chalk@npm:^5.2.0, chalk@npm:~5.6.0":
   version: 5.6.2
   resolution: "chalk@npm:5.6.2"
   checksum: 10/1b2f48f6fba1370670d5610f9cd54c391d6ede28f4b7062dd38244ea5768777af72e5be6b74fb6c6d54cb84c4a2dff3f3afa9b7cb5948f7f022cfd3d087989e0
@@ -15546,6 +16054,13 @@ __metadata:
   version: 2.0.1
   resolution: "character-reference-invalid@npm:2.0.1"
   checksum: 10/98d3b1a52ae510b7329e6ee7f6210df14f1e318c5415975d4c9e7ee0ef4c07875d47c6e74230c64551f12f556b4a8ccc24d9f3691a2aa197019e72a95e9297ee
+  languageName: node
+  linkType: hard
+
+"chardet@npm:^2.1.1":
+  version: 2.2.0
+  resolution: "chardet@npm:2.2.0"
+  checksum: 10/78d1e5ba7bdc7db23511a194eedca805918df90a511f9c57f9cc7c1fc03702ed4ad053e485a766ace930362869269c4a731feaf460ae24bd3ed7d190cde8087d
   languageName: node
   linkType: hard
 
@@ -15767,6 +16282,13 @@ __metadata:
     "@colors/colors":
       optional: true
   checksum: 10/8dca71256f6f1367bab84c33add3f957367c7c43750a9828a4212ebd31b8df76bd7419d386e3391ac7419698a8540c25f1a474584028f35b170841cde2e055c5
+  languageName: node
+  linkType: hard
+
+"cli-width@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "cli-width@npm:4.1.0"
+  checksum: 10/b58876fbf0310a8a35c79b72ecfcf579b354e18ad04e6b20588724ea2b522799a758507a37dfe132fafaf93a9922cafd9514d9e1598e6b2cd46694853aed099f
   languageName: node
   linkType: hard
 
@@ -16014,6 +16536,13 @@ __metadata:
   version: 8.3.0
   resolution: "commander@npm:8.3.0"
   checksum: 10/6b7b5d334483ce24bd73c5dac2eab901a7dbb25fd983ea24a1eeac6e7166bb1967f641546e8abf1920afbde86a45fbfe5812fbc69d0dc451bb45ca416a12a3a3
+  languageName: node
+  linkType: hard
+
+"commander@npm:~14.0.0":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10/dfa9ebe2a433d277de5cb0252d23b10a543d245d892db858d23b516336a835c50fd4f52bee4cd13c705cc8acb6f03dc632c73dd806f7d06d3353eb09953dd17a
   languageName: node
   linkType: hard
 
@@ -17460,6 +17989,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"des.js@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "des.js@npm:1.1.0"
+  dependencies:
+    inherits: "npm:^2.0.1"
+    minimalistic-assert: "npm:^1.0.0"
+  checksum: 10/d35fc82b5a0b2127b12699212e90b54ddd8134e0cf8d27a8c30507ed3572aa574ab71800cbb473769128a52dcf21acc3271c5c359508a5aa772e990df3b1a698
+  languageName: node
+  linkType: hard
+
 "destroy@npm:1.2.0, destroy@npm:~1.2.0":
   version: 1.2.0
   resolution: "destroy@npm:1.2.0"
@@ -17526,6 +18065,13 @@ __metadata:
   dependencies:
     dequal: "npm:^2.0.0"
   checksum: 10/3cc5f903d02d279d6dc4aa71ab6ed9898b9f4d1f861cc5421ce7357893c21b9520de78afb203c92bd650a6977ad0ca98195453a0707a39958cf5fea3b0a8ddd8
+  languageName: node
+  linkType: hard
+
+"diff-match-patch@npm:1.0.5":
+  version: 1.0.5
+  resolution: "diff-match-patch@npm:1.0.5"
+  checksum: 10/fd1ab417eba9559bda752a4dfc9a8ac73fa2ca8b146d29d153964b437168e301c09d8a688fae0cd81d32dc6508a4918a94614213c85df760793f44e245173bb6
   languageName: node
   linkType: hard
 
@@ -17882,6 +18428,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10/915acf859cea7131dac1b2b5c9c8e35c4849e325a1d114c30adb8cd615970f6dca0e27f64f3a4949d7d6ed86ecd79a1c5c63f02e697513cddd7b5835c90948b8
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:~10.6.0":
+  version: 10.6.0
+  resolution: "emoji-regex@npm:10.6.0"
+  checksum: 10/98cc0b0e1daed1ed25afbf69dcb921fee00f712f51aab93aa1547e4e4e8171725cc4f0098aaa645b4f611a19da11ec9f4623eb6ff2b72314b39a8f2ae7c12bf2
   languageName: node
   linkType: hard
 
@@ -18973,6 +19526,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"execa@npm:~9.6.0":
+  version: 9.6.1
+  resolution: "execa@npm:9.6.1"
+  dependencies:
+    "@sindresorhus/merge-streams": "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.6"
+    figures: "npm:^6.1.0"
+    get-stream: "npm:^9.0.0"
+    human-signals: "npm:^8.0.1"
+    is-plain-obj: "npm:^4.1.0"
+    is-stream: "npm:^4.0.1"
+    npm-run-path: "npm:^6.0.0"
+    pretty-ms: "npm:^9.2.0"
+    signal-exit: "npm:^4.1.0"
+    strip-final-newline: "npm:^4.0.0"
+    yoctocolors: "npm:^2.1.1"
+  checksum: 10/d0f7a2185152379f8772f6d780b188f2728a95b9a68d1a897f58805d7ba6bd55eaa5e128cb66a274251a6b5e4d9388332b1417bd7d46c25e020e4e55725cf79e
+  languageName: node
+  linkType: hard
+
 "exit-x@npm:^0.2.2":
   version: 0.2.2
   resolution: "exit-x@npm:0.2.2"
@@ -19194,10 +19767,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-string-truncated-width@npm:^3.0.2":
+  version: 3.0.3
+  resolution: "fast-string-truncated-width@npm:3.0.3"
+  checksum: 10/3a1631e48927cb558b612a90ee78a61a660823c39b024bfc113935760b5b64805dbf03c4e696c33005294db578417687432e9d13567f1a582c2c75015e8a7648
+  languageName: node
+  linkType: hard
+
+"fast-string-width@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "fast-string-width@npm:3.0.2"
+  dependencies:
+    fast-string-truncated-width: "npm:^3.0.2"
+  checksum: 10/5b9019769f2b00b96d43575c202f4e035a0e55eba7669a9a32351de9fa0805d0959a2afcaec6e4db5ee9b9a4c08d8e77f95abeb04b5bae2f76635cf04ddb4b80
+  languageName: node
+  linkType: hard
+
 "fast-uri@npm:3.1.5":
   version: 3.1.5
   resolution: "fast-uri@npm:3.1.5"
   checksum: 10/784bef687ca3ecfb4587a05104a4d41101796f0fec72be47a9abed743b10109e69a24d1ad0854ee7d2705912dc2ca9d93e03d35b65df0a3da0339e05b5d83b5c
+  languageName: node
+  linkType: hard
+
+"fast-wrap-ansi@npm:^0.2.0":
+  version: 0.2.2
+  resolution: "fast-wrap-ansi@npm:0.2.2"
+  dependencies:
+    fast-string-width: "npm:^3.0.2"
+  checksum: 10/c72272e4ee9c047ec4609adea9beb779f058e0aaee37d9e99d2306c401b34ad2b158ba6969860e35f8be7a0b0ba7512b71315d403e58a45a9f0eba0dc5b4befd
   languageName: node
   linkType: hard
 
@@ -19271,6 +19869,15 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^1.0.5"
   checksum: 10/a3bf94e001be51d3770500789157f067218d4bc681a65e1f69d482de15120bcac822dceb1a7b3803f32e4e3a61a46df44f7f2c8ba95d6375e7491502e0dd3d97
+  languageName: node
+  linkType: hard
+
+"figures@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "figures@npm:6.1.0"
+  dependencies:
+    is-unicode-supported: "npm:^2.0.0"
+  checksum: 10/9822d13630bee8e6a9f2da866713adf13854b07e0bfde042defa8bba32d47a1c0b2afa627ce73837c674cf9a5e3edce7e879ea72cb9ea7960b2390432d8e1167
   languageName: node
   linkType: hard
 
@@ -19718,6 +20325,16 @@ __metadata:
   version: 6.0.1
   resolution: "get-stream@npm:6.0.1"
   checksum: 10/781266d29725f35c59f1d214aedc92b0ae855800a980800e2923b3fbc4e56b3cb6e462c42e09a1cf1a00c64e056a78fa407cbe06c7c92b7e5cd49b4b85c2a497
+  languageName: node
+  linkType: hard
+
+"get-stream@npm:^9.0.0":
+  version: 9.0.1
+  resolution: "get-stream@npm:9.0.1"
+  dependencies:
+    "@sec-ant/readable-stream": "npm:^0.4.1"
+    is-stream: "npm:^4.0.1"
+  checksum: 10/ce56e6db6bcd29ca9027b0546af035c3e93dcd154ca456b54c298901eb0e5b2ce799c5d727341a100c99e14c523f267f1205f46f153f7b75b1f4da6d98a21c5e
   languageName: node
   linkType: hard
 
@@ -20694,6 +21311,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"human-signals@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "human-signals@npm:8.0.1"
+  checksum: 10/903389a018b16f330c5e0f6e8b76d592c79552152ea892f249e5290e71c790f5722dc9b740fedd4bdef30566754a69012aaed97a6a528da0d417fad990a6f515
+  languageName: node
+  linkType: hard
+
 "husky@npm:^9.1.7":
   version: 9.1.7
   resolution: "husky@npm:9.1.7"
@@ -20719,7 +21343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.7.3":
+"iconv-lite@npm:0.7.3, iconv-lite@npm:^0.7.2":
   version: 0.7.3
   resolution: "iconv-lite@npm:0.7.3"
   dependencies:
@@ -21364,7 +21988,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-obj@npm:^4.0.0":
+"is-plain-obj@npm:^4.0.0, is-plain-obj@npm:^4.1.0":
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
   checksum: 10/6dc45da70d04a81f35c9310971e78a6a3c7a63547ef782e3a07ee3674695081b6ca4e977fbb8efc48dae3375e0b34558d2bcd722aec9bddfa2d7db5b041be8ce
@@ -21440,6 +22064,13 @@ __metadata:
   version: 2.0.1
   resolution: "is-stream@npm:2.0.1"
   checksum: 10/b8e05ccdf96ac330ea83c12450304d4a591f9958c11fd17bed240af8d5ffe08aedafa4c0f4cfccd4d28dc9d4d129daca1023633d5c11601a6cbc77521f6fae66
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "is-stream@npm:4.0.1"
+  checksum: 10/cbea3f1fc271b21ceb228819d0c12a0965a02b57f39423925f99530b4eb86935235f258f06310b67cd02b2d10b49e9a0998f5ececf110ab7d3760bae4055ad23
   languageName: node
   linkType: hard
 
@@ -22303,6 +22934,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-md4@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "js-md4@npm:0.3.2"
+  checksum: 10/66cea478a6b914a5f23a588565b4ae4d9fc2ccae316c32f971aab1f94467f96aaa2b79d359e951c2eeac9c166897efcaec103b9fa99565a81291e1364b77ac12
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -22429,6 +23067,13 @@ __metadata:
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
   checksum: 10/5f3a99009ed5f2a5a67d06e2f298cc97bc86d462034173308156f15b43a6e850be8511dc204b9b94566305da2947f7d90289657237d210351a39059ff9d666cf
+  languageName: node
+  linkType: hard
+
+"json-rpc-2.0@npm:^1.7.0":
+  version: 1.7.1
+  resolution: "json-rpc-2.0@npm:1.7.1"
+  checksum: 10/d5b91fc7fede0ff3f1fde915fa9b142cf0980fa01282572cf9373a45184b34b377e0738d05b41d3859eaebdd20f692073eebc0c5da4990a3c4633132eab52f08
   languageName: node
   linkType: hard
 
@@ -22985,6 +23630,13 @@ __metadata:
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
   checksum: 10/cd0b2819786e6e80cb9f5cda26b1a8fc073daaf04e48d4cb462fa4663ec9adb3a5387aa22d7129e48eed1afa05b482e2a6b79bfc99b86886364449500cbb00fd
+  languageName: node
+  linkType: hard
+
+"lodash.groupby@npm:~4.6.0":
+  version: 4.6.0
+  resolution: "lodash.groupby@npm:4.6.0"
+  checksum: 10/98bd04e58ce4cebb2273010352508b5ea12025e94fcfd70c84c8082ef3b0689178e8e6dd53bff919f525fae9bd67b4aba228d606b75a967f30e84ec9610b5de1
   languageName: node
   linkType: hard
 
@@ -24619,6 +25271,45 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mutation-server-protocol@npm:~0.4.0":
+  version: 0.4.1
+  resolution: "mutation-server-protocol@npm:0.4.1"
+  dependencies:
+    zod: "npm:^4.1.12"
+  checksum: 10/3938937e2f69d735ac56a60d488c8991bee506a11fae63303db4fe48b6f4800dde3342fb0e857d72527e8f6e68e25bb60242a1e8e3bccd73a9dbae15a48a986e
+  languageName: node
+  linkType: hard
+
+"mutation-testing-elements@npm:3.7.3":
+  version: 3.7.3
+  resolution: "mutation-testing-elements@npm:3.7.3"
+  checksum: 10/10ab813276b2752f598ee646656173c689b6efa06695b6f90288e363285087f47f1f2f2f70c63a61013659bb1db5f66989bfd793eacc7cb8b671d3f6ab5090db
+  languageName: node
+  linkType: hard
+
+"mutation-testing-metrics@npm:3.7.3":
+  version: 3.7.3
+  resolution: "mutation-testing-metrics@npm:3.7.3"
+  dependencies:
+    mutation-testing-report-schema: "npm:3.7.3"
+  checksum: 10/8c127a3f2df69b119226182b567ae0fe1da550f200d534ce94df631f2c7d95aa078875f5b80a79ed3341fd2ad2a059882c3bea7059357874de12694d7ef52c53
+  languageName: node
+  linkType: hard
+
+"mutation-testing-report-schema@npm:3.7.3":
+  version: 3.7.3
+  resolution: "mutation-testing-report-schema@npm:3.7.3"
+  checksum: 10/c46010cc25ae3647f5afad8d3436096f5ff1cf11b654f1abd8012aa2bf9fee5fdf62f8f2d0529a17f21aa7f49432e4d69aa75ff89b9a18615989856de1379767
+  languageName: node
+  linkType: hard
+
+"mute-stream@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "mute-stream@npm:3.0.0"
+  checksum: 10/bee5db5c996a4585dbffc49e51fea10f3582d7f65441db9bc63126f16269541713c6ccb5a6fe37e08f627967b6eb28dd6b35e54a8dce53cf3837d7e010917b43
+  languageName: node
+  linkType: hard
+
 "nan@npm:^2.19.0, nan@npm:^2.23.0":
   version: 2.25.0
   resolution: "nan@npm:2.25.0"
@@ -24983,6 +25674,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-run-path@npm:^6.0.0, npm-run-path@npm:~6.0.0":
+  version: 6.0.0
+  resolution: "npm-run-path@npm:6.0.0"
+  dependencies:
+    path-key: "npm:^4.0.0"
+    unicorn-magic: "npm:^0.3.0"
+  checksum: 10/1a1b50aba6e6af7fd34a860ba2e252e245c4a59b316571a990356417c0cdf0414cabf735f7f52d9c330899cb56f0ab804a8e21fb12a66d53d7843e39ada4a3b6
+  languageName: node
+  linkType: hard
+
 "nprogress@npm:^0.2.0":
   version: 0.2.0
   resolution: "nprogress@npm:0.2.0"
@@ -25229,6 +25930,8 @@ __metadata:
     "@radix-ui/react-label": "npm:^2.1.15"
     "@radix-ui/react-slot": "npm:^1.3.3"
     "@react-email/components": "npm:^1.0.12"
+    "@stryker-mutator/core": "npm:^9.6.1"
+    "@stryker-mutator/jest-runner": "npm:^9.6.1"
     "@tanstack/react-query": "npm:^5.101.4"
     "@tanstack/react-table": "npm:^8.20.5"
     "@types/better-sqlite3": "npm:^7.6.11"
@@ -25651,6 +26354,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-ms@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "parse-ms@npm:4.0.0"
+  checksum: 10/673c801d9f957ff79962d71ed5a24850163f4181a90dd30c4e3666b3a804f53b77f1f0556792e8b2adbb5d58757907d1aa51d7d7dc75997c2a56d72937cbc8b7
+  languageName: node
+  linkType: hard
+
 "parse-numeric-range@npm:^1.3.0":
   version: 1.3.0
   resolution: "parse-numeric-range@npm:1.3.0"
@@ -25776,6 +26486,13 @@ __metadata:
   version: 3.1.1
   resolution: "path-key@npm:3.1.1"
   checksum: 10/55cd7a9dd4b343412a8386a743f9c746ef196e57c823d90ca3ab917f90ab9f13dd0ded27252ba49dbdfcab2b091d998bc446f6220cd3cea65db407502a740020
+  languageName: node
+  linkType: hard
+
+"path-key@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "path-key@npm:4.0.0"
+  checksum: 10/8e6c314ae6d16b83e93032c61020129f6f4484590a777eed709c4a01b50e498822b00f76ceaf94bc64dbd90b327df56ceadce27da3d83393790f1219e07721d7
   languageName: node
   linkType: hard
 
@@ -27124,6 +27841,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-ms@npm:^9.2.0":
+  version: 9.3.0
+  resolution: "pretty-ms@npm:9.3.0"
+  dependencies:
+    parse-ms: "npm:^4.0.0"
+  checksum: 10/beb4e04dc17071885b827e3f33d36be279791f2f36a8c29a45c77e59979dad79a5d7e5211922c72a3f6f109bb64a707d70fcdba6746e077122afcd88ce202e98
+  languageName: node
+  linkType: hard
+
 "pretty-time@npm:^1.1.0":
   version: 1.1.0
   resolution: "pretty-time@npm:1.1.0"
@@ -27175,6 +27901,13 @@ __metadata:
   version: 0.11.10
   resolution: "process@npm:0.11.10"
   checksum: 10/dbaa7e8d1d5cf375c36963ff43116772a989ef2bb47c9bdee20f38fd8fc061119cf38140631cf90c781aca4d3f0f0d2c834711952b728953f04fd7d238f59f5b
+  languageName: node
+  linkType: hard
+
+"progress@npm:~2.0.3":
+  version: 2.0.3
+  resolution: "progress@npm:2.0.3"
+  checksum: 10/e6f0bcb71f716eee9dfac0fe8a2606e3704d6a64dd93baaf49fbadbc8499989a610fe14cf1bc6f61b6d6653c49408d94f4a94e124538084efd8e4cf525e0293d
   languageName: node
   linkType: hard
 
@@ -28752,6 +29485,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rxjs@npm:~7.8.1":
+  version: 7.8.2
+  resolution: "rxjs@npm:7.8.2"
+  dependencies:
+    tslib: "npm:^2.1.0"
+  checksum: 10/03dff09191356b2b87d94fbc1e97c4e9eb3c09d4452399dddd451b09c2f1ba8d56925a40af114282d7bc0c6fe7514a2236ca09f903cf70e4bbf156650dddb49d
+  languageName: node
+  linkType: hard
+
 "sade@npm:^1.7.3":
   version: 1.8.1
   resolution: "sade@npm:1.8.1"
@@ -28959,7 +29701,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.8.5, semver@npm:^7.8.5":
+"semver@npm:7.8.5, semver@npm:^7.6.3, semver@npm:^7.8.5":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -28977,7 +29719,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3":
+"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.1, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:~7.7.0":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -29351,7 +30093,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
+"signal-exit@npm:^4.0.1, signal-exit@npm:^4.1.0":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
@@ -29557,7 +30299,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map@npm:^0.7.0, source-map@npm:^0.7.4":
+"source-map@npm:^0.7.0, source-map@npm:^0.7.4, source-map@npm:~0.7.4":
   version: 0.7.6
   resolution: "source-map@npm:0.7.6"
   checksum: 10/c8d2da7c57c14f3fd7568f764b39ad49bbf9dd7632b86df3542b31fed117d4af2fb74a4f886fc06baf7a510fee68e37998efc3080aacdac951c36211dc29a7a3
@@ -29949,6 +30691,13 @@ __metadata:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 10/69412b5e25731e1938184b5d489c32e340605bb611d6140344abc3421b7f3c6f9984b21dff296dfcf056681b82caa3bb4cc996a965ce37bcfad663e92eae9c64
+  languageName: node
+  linkType: hard
+
+"strip-final-newline@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "strip-final-newline@npm:4.0.0"
+  checksum: 10/b5fe48f695d74863153a3b3155220e6e9bf51f4447832998c8edec38e6559b3af87a9fe5ac0df95570a78a26f5fa91701358842eab3c15480e27980b154a145f
   languageName: node
   linkType: hard
 
@@ -30528,6 +31277,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tree-kill@npm:~1.2.2":
+  version: 1.2.2
+  resolution: "tree-kill@npm:1.2.2"
+  bin:
+    tree-kill: cli.js
+  checksum: 10/49117f5f410d19c84b0464d29afb9642c863bc5ba40fcb9a245d474c6d5cc64d1b177a6e6713129eb346b40aebb9d4631d967517f9fbe8251c35b21b13cd96c7
+  languageName: node
+  linkType: hard
+
 "trim-lines@npm:^3.0.0":
   version: 3.0.1
   resolution: "trim-lines@npm:3.0.1"
@@ -30693,7 +31451,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2, tslib@npm:^2.8.0, tslib@npm:^2.8.1":
+"tslib@npm:2.8.1, tslib@npm:^2.0.0, tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.3.0, tslib@npm:^2.4.0, tslib@npm:^2.6.0, tslib@npm:^2.6.2, tslib@npm:^2.8.0, tslib@npm:^2.8.1, tslib@npm:~2.8.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7
@@ -30728,6 +31486,13 @@ __metadata:
   dependencies:
     tslib: "npm:^1.9.3"
   checksum: 10/b42660dc112cee2db02b3d69f2ef6a6a9d185afd96b18d8f88e47c1e62be94b69a9f5a58fcfdb2a3fbb7c6c175b8162ea00f7db6499bf333ce945e570e31615c
+  languageName: node
+  linkType: hard
+
+"tunnel@npm:0.0.6":
+  version: 0.0.6
+  resolution: "tunnel@npm:0.0.6"
+  checksum: 10/cf1ffed5e67159b901a924dbf94c989f20b2b3b65649cfbbe4b6abb35955ce2cf7433b23498bdb2c5530ab185b82190fce531597b3b4a649f06a907fc8702405
   languageName: node
   linkType: hard
 
@@ -30905,6 +31670,26 @@ __metadata:
     possible-typed-array-names: "npm:^1.0.0"
     reflect.getprototypeof: "npm:^1.0.6"
   checksum: 10/d6b2f0e81161682d2726eb92b1dc2b0890890f9930f33f9bcf6fc7272895ce66bc368066d273e6677776de167608adc53fcf81f1be39a146d64b630edbf2081c
+  languageName: node
+  linkType: hard
+
+"typed-inject@npm:~5.0.0":
+  version: 5.0.0
+  resolution: "typed-inject@npm:5.0.0"
+  checksum: 10/0b2786ece878f70d931d4c495be39c5270d15f2ff54b1c61586b29e45d84303b82cbb7ed0c4d8ad29c3b608d09e20e45050577191676b13640858805b7bed07b
+  languageName: node
+  linkType: hard
+
+"typed-rest-client@npm:~2.3.0":
+  version: 2.3.1
+  resolution: "typed-rest-client@npm:2.3.1"
+  dependencies:
+    des.js: "npm:^1.1.0"
+    js-md4: "npm:^0.3.2"
+    qs: "npm:6.15.1"
+    tunnel: "npm:0.0.6"
+    underscore: "npm:^1.13.8"
+  checksum: 10/20e7df36e60e46eb254ddcc6190aae82e2296b55642a1fa4e39959602a88096650de4632d30ae3a3a02bf42238cc2050611e01d12c572bc916f7896df73b9d8b
   languageName: node
   linkType: hard
 
@@ -31150,7 +31935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"underscore@npm:^1.13.1":
+"underscore@npm:^1.13.1, underscore@npm:^1.13.8":
   version: 1.13.8
   resolution: "underscore@npm:1.13.8"
   checksum: 10/b50ac5806d059cc180b1bd9adea6f7ed500021f4dc782dfc75d66a90337f6f0506623c1b37863f4a9bf64ffbeb5769b638a54b7f2f5966816189955815953139
@@ -31255,6 +32040,13 @@ __metadata:
     pako: "npm:^0.2.5"
     tiny-inflate: "npm:^1.0.0"
   checksum: 10/60404411dbd363bdcca9e81c9327fa80469f2e685737bac88ec693225ff20b9b545ac37ca2da13ec02f1552167dd010dfefd7c58b72a73d44a89fab1ca9c2479
+  languageName: node
+  linkType: hard
+
+"unicorn-magic@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "unicorn-magic@npm:0.3.0"
+  checksum: 10/bdd7d7c522f9456f32a0b77af23f8854f9a7db846088c3868ec213f9550683ab6a2bdf3803577eacbafddb4e06900974385841ccb75338d17346ccef45f9cb01
   languageName: node
   linkType: hard
 
@@ -31794,6 +32586,13 @@ __metadata:
   dependencies:
     defaults: "npm:^1.0.3"
   checksum: 10/182ebac8ca0b96845fae6ef44afd4619df6987fe5cf552fdee8396d3daa1fb9b8ec5c6c69855acb7b3c1231571393bd1f0a4cdc4028d421575348f64bb0a8817
+  languageName: node
+  linkType: hard
+
+"weapon-regex@npm:~1.3.2":
+  version: 1.3.6
+  resolution: "weapon-regex@npm:1.3.6"
+  checksum: 10/95bfc70135572f4bc5ab4ccdf5e12b53dc676a8203918d5ac4128e2dc700edf4b9170c43acc643cecc236ce20538ba39d449dd4359eec388cb334bde0be647c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/PLAN.md
Tracking run folder: .ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/
Source doc: .ai/specs/2026-07-31-stryker-mutation-testing-ci-gate.md
Status: complete

Refs #4773

## 🎯 Goal

Implement the StrykerJS mutation-testing spec: a **diff-scoped** CI check that mutates only the business-logic files a pull request actually changes, so tests that execute code without verifying it are caught before merge. Coverage tells you a line ran; this tells you whether a test would notice if that line were wrong.

The gate lands **advisory** — it reports a score and a survivor list, and cannot block a merge.

## ⚠️ Enforcement ships dormant — deliberately

Phase 3's machinery is fully implemented and tested: `thresholds.break` (70), the `MUTATION_MIN_MUTANTS` floor (20), and the `MUTATION_ENFORCE` flag. But **`MUTATION_ENFORCE` defaults to `false`**, the workflow keeps `continue-on-error`, and the check is **not** registered or documented as a required check. `AGENTS.md` is untouched.

That is deliberate. Spec Q1 reserves enforcement for a recorded core-team decision, and `AGENTS.md` classifies PR-pipeline changes as **Ask First**. **Approving this PR does not approve enforcement.** Turning it on later is one repository-variable change — `MUTATION_ENFORCE=true` — with no code edit.

One design note: the threshold lives in `scripts/stryker/enforce.mjs`, not in Stryker's own `thresholds.break` (which stays `null`). Stryker's built-in break has no notion of the minimum-mutant floor, so it would fail a four-mutant diff on a single survivor — exactly what the floor exists to prevent. The two have to be evaluated together, so one decision function owns both.

## 📊 Phase 0b measured `packages/core` — and excluded it

The spec made `core`'s inclusion conditional on measurement. Three representative files were measured with a throwaway config (not committed):

| Target | Layer | LOC | Result |
|--------|-------|-----|--------|
| `auth/lib/rateLimitCheck.ts` | `lib/` | 75 | ✅ 1 m 45 s — 41 mutants, 58.5 %, 92.7 tests/mutant |
| `auth/commands/roles.ts` | `commands/` | 657 | ❌ exceeded 10 min twice, never scored |
| `customers/data/validators.ts` | `data/validators.ts` | 783 | ❌ 403 mutants, Stryker's own ETA **~6 h 42 m** |

The exit criterion — *"3 representative core files complete under 10 min"* — is missed by roughly two orders of magnitude. **The allowlist ships as `['shared']` only**, which is the spec's own prescribed fallback. Adding a package later requires a fresh measurement, not a judgement call.

## What Changed

- **`scripts/stryker/createConfig.mjs`** — the shared config factory. Three settings are load-bearing workarounds, documented inline so nobody "cleans them up": `inPlace: true` (the sandbox breaks every relative path in the per-package Jest config, and it also short-circuits the tsconfig preprocessor that TypeScript 7.0.2 breaks), `coverageAnalysis: "off"` (`@jest-environment` docblocks block `perTest`), and `excludedMutations: ["StringLiteral", "Regex"]` (those mutators reward asserting exact copy instead of behaviour).
- **`scripts/stryker/scope.mjs`** — turns `git diff` into a per-package Actions matrix. Excludes deleted files, `.tsx`, and `api/` handlers; caps at 25 files per package and **prints what it dropped**, so a truncated run never reads as full coverage; an empty diff yields an empty matrix, which skips rather than inventing a score.
- **`scripts/stryker/report.mjs`** — `mutation.json` → a markdown survivor table (`file:line:column`, mutator, `-`/`+` replacement) written to `$GITHUB_STEP_SUMMARY`. Killed mutants are omitted; only survivors are actionable. The summary is used rather than a PR comment because fork `pull_request` runs get no write token.
- **`scripts/stryker/enforce.mjs`** — the pass/fail decision, with the minimum-mutant floor and the threshold. Dormant, as above.
- **`scripts/stryker/mutation-changed.mjs`** + `yarn mutation:changed` — the local wrapper, with a **hard** clean-tree guard.
- **`.github/workflows/mutation-tests.yml`** — standalone `pull_request` workflow: `scope` job → `mutate` matrix (`fail-fast: false`, `timeout-minutes: 20`), job summary, artifact, and a fork-guarded idempotent PR comment in a separate job so only that job carries `pull-requests: write`. **`ci.yml` is untouched** — rollback is deleting one file.
- **`packages/shared/stryker.conf.mjs`**, root `devDependencies`, `.gitignore`, plus docs in `apps/docs/docs/tutorials/testing.mdx` covering the `// Stryker disable next-line` escape hatch and its one-line-justification requirement.

## 🔍 Three findings that changed the implementation

1. **The workflow must build packages before mutating.** Package suites resolve their siblings through `dist/`, so in a clean checkout Stryker's initial dry run fails with `Cannot find module '@open-mercato/cache'`. The spec did not anticipate this.

2. **An interrupted `inPlace` run left 4 966 modified files.** Stryker's `disableTypeChecks` default injects `// @ts-nocheck` into every file it may mutate, and `inPlace: true` writes that to real sources. `git checkout -- packages/core` recovered fully, both times it happened during Phase 0b. `disableTypeChecks` cannot simply be turned off to shrink the blast radius, because this repo's ts-jest transformer type-checks and type-breaking mutants would then error instead of being scored. This is why the wrapper's clean-tree guard is a **hard stop, not a warning** — now measured rather than assumed.

3. **Stryker's own output would have self-blocked the next local run.** `.stryker-tmp/` and `**/reports/mutation/` were not gitignored, so a first `yarn mutation:changed` left untracked files that made its own clean-tree guard refuse the second run. Fixed, with a regression test.

## ⏸ Phase 4 was attempted and deliberately not shipped

The spec gates Phase 4 on *"only if Phase 1–3 timings demand it."* They do not — the job is ~16 s install + ~55 s build + 1 m 27 s mutation, about **3 minutes against a 20-minute timeout**.

- **`perTest` coverage is blocked, not merely unnecessary.** It fails the initial test run: 19 `shared` suites carry `@jest-environment` docblocks (792 repo-wide). Stryker ships matching wrapped environments, so redirecting the docblocks' resolution was tried via a Jest `moduleNameMapper` — **it does not work**, because Jest resolves `@jest-environment` outside that path. What remains is editing 19 test files (spec Q3 forbids it) or replacing the repo-wide Jest `resolver`, which would put every suite in the repo behind a mutation-testing optimisation.
- **`incremental` caching is declined on risk as much as need.** A stale incremental file reports mutants as killed that current tests do not kill — a false green in the one check whose entire value is trustworthy signal.

Both are recorded in the spec and the analysis doc with the evidence, so a future attempt starts from facts rather than repeating the experiments.

## 🧪 Tests

- `yarn test:scripts` — **463 passed / 0 failed**, including **54 new tests** across six files: `stryker-create-config` (11), `stryker-scope` (14), `stryker-mutation-changed` (8), `stryker-workflow` (18), `stryker-report` (13), `stryker-enforce` (10).
- **End-to-end verification against ground truth:** `packages/shared/src/lib/boolean.ts` scores **93.33 %** through the new factory, reproducing the Phase 0 pilot's 93.3 % exactly (28 killed / 2 survived / 2 errors, 1 m 27 s). `report.mjs` was run against that real `mutation.json` and its score and survivor list match Stryker's own output — and the two survivors are precisely the equivalent mutants the pilot had already identified in that file.
- Every Step's **Test:** criterion from the spec's Implementation Plan ships as an actual test. The one exception is Step 1.5's *"the workflow runs on this PR and reports a score"*, which only CI on this PR can confirm; its invariants are unit-asserted meanwhile.
- Full gate: see the final-gate comment below.

## 💥 Breaking Changes

None. No application code, no database schema, no runtime behaviour, no API surface. `ci.yml` is untouched, so the existing pipeline cannot regress. No `BACKWARD_COMPATIBILITY.md` contract surface is affected — no auto-discovery file, type, signature, import path, event ID, widget spot ID, API route, DB schema, DI key, ACL feature, notification ID, `mercato` CLI command, or generated file changes.

## 📋 Progress

See the Tasks table in the plan — that is the authoritative Step-status source. All 12 Steps are `done`.

## Handoff & Notifications

- Live handoff: `.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/HANDOFF.md`
- Notifications log: `.ai/runs/2026-08-04-stryker-mutation-testing-ci-gate/NOTIFY.md`
