### PR TITLE
fix(scheduler,shared): address review findings on #4364 (warning + docs + tests)

### DIFF
--- a/.ai/runs/2026-08-04-pr-4364-review-followups.md
+++ b/.ai/runs/2026-08-04-pr-4364-review-followups.md
@@ -1,0 +1,67 @@
+# PR #4364 — review follow-ups (om-auto-fix-pr)
+
+**Subject PR:** open-mercato/open-mercato#4364 — `fix(scheduler,shared): stop idle-in-transaction reaps crashing the scheduler daemon`
+**Driver:** `om-auto-fix-pr 4364`
+**Follow-up issue:** #4934 (lease-based claim)
+
+## 🎯 Goal
+
+Drive #4364 to merge-ready by resolving the two `changes-requested` reviews on it
+(@wojciechszyjka 2026-07-26, @patzick 2026-08-03) without touching the crash fix
+itself. The PR author's branch lives in the upstream repository and this account
+has read-only access to it, so the work is delivered as a small PR **targeting
+that branch** instead of pushed onto it.
+
+## 📋 Progress
+
+- [x] Claim #4364 (comment only — assignee and `in-progress` label return HTTP 403 for a read-only account)
+- [x] Merge the current `main` into the PR head so review and validation judge the real merge result
+- [x] Major finding — restore an honest guarantee: startup warning + documentation for the lost cross-process exclusion
+- [x] Minor finding — class docstring and the three scheduler docs pages no longer claim advisory-lock single-instance safety
+- [x] Minor finding — `heldKeys` records the one-instance-per-process invariant it relies on
+- [x] Nit — client-level pg error message made state-neutral (an idle reap logs through both handlers)
+- [x] Nit — the never-removed client-level listener documented as a deliberate last-resort sink
+- [x] Test gaps — startup warning, different keys do not block each other, key released when the claim transaction itself rejects
+- [x] Validation gate (local runner): all eight configured commands green
+- [x] Follow-up issue for the deferred lease implementation (#4934)
+- [x] Open the delivery PR against `dokploy-runtime-error-fix`
+- [ ] Author merges the delivery PR; #4364 re-reviewed and labels normalized by a maintainer
+
+## Decisions
+
+**Major finding — option 2, not option 1.** @patzick offered two resolutions: a
+lease-based claim that advances `next_run_at` inside the claim transaction
+(behavior-preserving, restores real cross-process exclusion), or a startup
+warning plus documentation with the lease tracked as a follow-up — explicitly
+stating "I would accept that as a resolution". This run took the second route
+because #4364 is a `priority-high` production hotfix for a crash-loop: changing
+when the scheduler advances `next_run_at` alters the claim/retry path of every
+schedule and deserves its own PR and its own review, not a rider on a hotfix.
+The deferred half is tracked in #4934 with the reviewer's exact proposal quoted.
+
+**Docs beyond the review's ask.** The review named
+`apps/docs/docs/framework/scheduler/overview.mdx`. Two further pages made the
+same now-false promise — `user-guide/scheduler.mdx` ("Uses PostgreSQL advisory
+locks for safety") and `cli/scheduler.mdx` ("Lock Strategy: PostgreSQL advisory
+locks") — so both were corrected in the same pass rather than left to contradict
+the code.
+
+**Delivery shape.** The base-first step was performed as a *validation* step
+only: `main` was merged into a scratch branch and the whole gate ran against that
+merged state, so the fixes are proven against the current base. The delivery PR
+itself is the two fix commits cherry-picked onto the untouched PR head, so its
+diff is nine files instead of the ~1100 a merge commit would have dragged in.
+Updating #4364 against `main` is one "Update branch" click for the author and
+does not need to ride along here. An earlier delivery PR that did carry the merge
+commit was closed for exactly this reason.
+
+## Validation
+
+Local runner (no compose `app` container running). Every command in
+`.ai/agentic.config.json` → `validation.commands`, in order, against the merged
+state: `yarn build:packages`, `yarn generate`, `yarn build:packages`,
+`yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`,
+`yarn build:app` — all green. `yarn test` ran 23/23 turbo tasks; the scheduler
+and shared suites relevant to this change are 37 and 12 tests respectively.
+`i18n:check-usage` reports 2 missing keys and 3819 unused keys as advisory
+pre-existing findings unrelated to this diff (it touches no locale files).

--- a/apps/docs/docs/cli/scheduler.mdx
+++ b/apps/docs/docs/cli/scheduler.mdx
@@ -223,7 +223,7 @@ Starting scheduler in LOCAL mode...
 
 Configuration:
 - Poll Interval: 30000ms
-- Lock Strategy: PostgreSQL advisory locks
+- Lock Strategy: in-process (single instance only)
 - Execution: Direct (queue/command)
 
 Database connected

--- a/apps/docs/docs/framework/scheduler/overview.mdx
+++ b/apps/docs/docs/framework/scheduler/overview.mdx
@@ -64,7 +64,8 @@ import {
 ```typescript
 class LocalSchedulerService {
   // Polls database every 30s (configurable via SCHEDULER_POLL_INTERVAL_MS)
-  // Uses PostgreSQL advisory locks for single-instance safety
+  // Prevents duplicate execution in-process; the PostgreSQL advisory lock
+  // only serialises the claim, not the run
   // Enqueues to target queues or executes commands directly
   async start(): Promise<void>
   async stop(): Promise<void>
@@ -80,6 +81,23 @@ class LocalSchedulerService {
 - ~30 second timing accuracy
 - Single instance only
 - No execution history UI
+
+:::warning Run exactly one process with `QUEUE_STRATEGY=local`
+
+The local strategy provides **no cross-process protection**. Duplicate prevention is
+in-process only: the PostgreSQL advisory lock is released as soon as the short claim
+transaction commits (holding it across the whole run would pin a connection
+idle-in-transaction and get it reaped), and `nextRunAt` is advanced only after the
+target has run. A second process polling the same database therefore sees the schedule
+as still due and executes it too — the same job is enqueued twice, or the same command
+runs twice.
+
+Two entry points start this engine: `mercato scheduler start` and
+`mercato worker --with-scheduler`. Running both, or overlapping containers during a
+rolling redeploy, double-fires every schedule due in that window. Use
+`QUEUE_STRATEGY=async` when more than one instance may run.
+
+:::
 
 #### Async Strategy (`QUEUE_STRATEGY=async`)
 

--- a/apps/docs/docs/user-guide/scheduler.mdx
+++ b/apps/docs/docs/user-guide/scheduler.mdx
@@ -105,7 +105,7 @@ The scheduler supports two execution strategies:
 **Environment:** `QUEUE_STRATEGY=local` (default)
 
 - Polls the database every 30 seconds for due schedules
-- Uses PostgreSQL advisory locks for safety
+- Prevents duplicate execution within the process only — run exactly one scheduler process, or a second one will execute the same due schedule
 - No Redis required
 - Best for development and single-instance deployments
 

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
@@ -158,5 +158,40 @@ describe('LocalLockStrategy', () => {
       const fn = jest.fn(async () => 'ok')
       await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
     })
+
+    it('should release the key when the claim transaction itself rejects', async () => {
+      ;(mockConnection.execute as any).mockRejectedValueOnce(new Error('Database connection failed'))
+      ;(mockConnection.execute as any).mockResolvedValueOnce([{ acquired: true }])
+
+      await expect(strategy.runWithLock('test-key', async () => 'ok')).resolves.toEqual({ acquired: false })
+
+      const fn = jest.fn(async () => 'ok')
+      await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not let a held key block a different key', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      let releaseFirst: () => void = () => {}
+      const firstDone = new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      })
+      const firstRun = strategy.runWithLock('key-a', async () => {
+        await firstDone
+        return 'first'
+      })
+      await Promise.resolve()
+
+      const secondFn = jest.fn(async () => 'second')
+      await expect(strategy.runWithLock('key-b', secondFn)).resolves.toEqual({
+        acquired: true,
+        result: 'second',
+      })
+      expect(secondFn).toHaveBeenCalledTimes(1)
+
+      releaseFirst()
+      await expect(firstRun).resolves.toEqual({ acquired: true, result: 'first' })
+    })
   })
 })

--- a/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
@@ -4,9 +4,24 @@ import { createLogger } from '@open-mercato/shared/lib/logger'
 const logger = createLogger('scheduler').child({ component: 'local' })
 
 /**
- * PostgreSQL advisory lock strategy for single-instance or local development
+ * Mutual-exclusion strategy for single-instance or local development.
+ *
+ * Exclusion for the duration of the guarded run is IN-PROCESS (`heldKeys`).
+ * The PostgreSQL advisory lock only serialises concurrent *claims* — it is
+ * transaction-scoped and released as soon as the short claim transaction
+ * commits, before the guarded function runs. It therefore does NOT protect
+ * against two processes executing the same key concurrently; that matches the
+ * documented single-instance contract of the local scheduler strategy, and
+ * `LocalSchedulerService.start()` warns about it at startup.
  */
 export class LocalLockStrategy {
+  // Process-local by construction, so it only guards a single strategy
+  // instance. Invariant relied upon: exactly one LocalLockStrategy exists per
+  // process, because the only construction site is LocalSchedulerService
+  // (an Awilix singleton) and only the CLI entry points start the polling
+  // engine. A caller that resolves a second container would silently get an
+  // independent guard — see the single-instance warning in
+  // LocalSchedulerService.start().
   private heldKeys = new Set<string>()
 
   constructor(private em: () => EntityManager) {}

--- a/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
+++ b/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
@@ -113,6 +113,16 @@ describe('LocalSchedulerService', () => {
       expect(loggerInfo).toHaveBeenCalledWith('Polling engine started')
     })
 
+    it('should warn that the local strategy has no cross-process protection', async () => {
+      mockForkedEm.find.mockResolvedValue([])
+
+      await service.start()
+
+      expect(loggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('no cross-process protection'),
+      )
+    })
+
     it('should run initial poll immediately', async () => {
       mockForkedEm.find.mockResolvedValue([])
 

--- a/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
@@ -28,14 +28,19 @@ export interface LocalSchedulerConfig {
  * 
  * Features:
  * - PostgreSQL polling (configurable interval, default 30s)
- * - PostgreSQL advisory locks for duplicate prevention
+ * - In-process duplicate prevention across overlapping poll ticks
  * - Supports both queue and command targets
  * - Emits the same events as async strategy
  * - Updates nextRunAt after execution
- * 
+ *
  * Limitations:
  * - Polling delay (up to configured interval)
- * - Single instance only (no distributed locking across instances)
+ * - Single instance only (no distributed locking across instances). Duplicate
+ *   prevention is in-process only: the advisory lock serialises the claim, not
+ *   the execution, and nextRunAt is advanced only after the target has run, so
+ *   two processes polling the same database will both execute a due schedule.
+ *   Run exactly one process with QUEUE_STRATEGY=local, or use the async
+ *   strategy, which locks across instances.
  * - Higher database load than async strategy
  * 
  * Set QUEUE_STRATEGY=local to use this service.
@@ -65,6 +70,9 @@ export class LocalSchedulerService {
 
     this.isRunning = true
     logger.info('Starting polling engine', { pollIntervalMs: this.config.pollIntervalMs })
+    logger.warn(
+      'Local scheduler strategy provides no cross-process protection: duplicate prevention is in-process only, so a second process polling the same database will execute the same due schedule. Run exactly one process with QUEUE_STRATEGY=local, or use the async strategy for distributed locking.',
+    )
 
     // Run initial poll immediately
     await this.poll()

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -97,13 +97,20 @@ type PoolLike = {
 // polling engine exited unexpectedly with exit code 1"). Swallow both: the pool
 // discards the dead client, and any in-flight transaction still fails normally
 // on its next query/commit against the dead connection.
+// The per-client listener is deliberately attached once on 'connect' and never
+// removed: it is a last-resort sink whose only job is to guarantee the 'error'
+// event always has a listener, in every client state. It is not error handling
+// and must not be "cleaned up" — removing it reintroduces the process crash.
+// A reaped IDLE client therefore logs twice (once here, once via the pool-level
+// handler that pg-pool's own idle listener re-emits); the pool-level line is the
+// one that identifies the client as idle.
 export function attachPoolErrorHandlers(pool: PoolLike): void {
   pool.on('error', (err: unknown) => {
     logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
   })
   pool.on('connect', (client) => {
     client.on('error', (err: unknown) => {
-      logger.warn('Checked-out pg client error (connection reaped/terminated)', { err })
+      logger.warn('pg client error (connection reaped/terminated)', { err })
     })
   })
 }


### PR DESCRIPTION
Refs #4364
Tracking plan: .ai/runs/2026-08-04-pr-4364-review-followups.md
Status: complete

## 🎯 Goal

Resolve the two `changes-requested` reviews on #4364 so the crash fix can merge, without touching the crash fix itself. **This PR targets `dokploy-runtime-error-fix`, not `main`** — merging it lands the review fixes inside #4364 and keeps @MStaniaszek1998 as the author of the work.

## 🔍 Problem

#4364 correctly shortens the lifetime of the advisory lock in `LocalLockStrategy` so the scheduler's connection is no longer pinned idle-in-transaction and reaped with `FATAL 25P03`. The review found that the change also, silently, removes a guarantee the long-held lock was incidentally providing: cross-process exclusion of schedule execution. Since `nextRunAt` is advanced only *after* the target has run, a second process polling the same database still sees the schedule as due and executes it too.

## 🔍 Root Cause

The advisory lock is transaction-scoped. Once the claim transaction commits before `fn()` runs, nothing serialises the execution across processes — the remaining `heldKeys` guard is process-local by construction. Nothing in the code, the docs, or the PR description told an operator that the safety net was gone.

## What Changed

- `packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts` — `start()` now emits an explicit startup warning that the local strategy has no cross-process protection and that exactly one process must run with `QUEUE_STRATEGY=local`. The class docstring spells out why (the lock serialises the claim, `nextRunAt` advances only after execution).
- `packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts` — the class docstring no longer claims the advisory lock provides single-instance safety; `heldKeys` records the one-instance-per-process invariant it depends on (single construction site, Awilix singleton, CLI-only entry points).
- `apps/docs/docs/framework/scheduler/overview.mdx` — a warning admonition describing the real guarantee, naming both entry points that start the engine (`mercato scheduler start`, `mercato worker --with-scheduler`) and the rolling-redeploy overlap.
- `apps/docs/docs/user-guide/scheduler.mdx` and `apps/docs/docs/cli/scheduler.mdx` — the same now-false "advisory locks for safety" claim corrected in both.
- `packages/shared/src/lib/db/mikro.ts` — the client-level pg error message is state-neutral (an idle reap fires both handlers, so the old "Checked-out" wording mislabelled idle connections), and the never-removed listener is documented as a deliberate last-resort sink so it is not "cleaned up" later.

## 🧪 Tests

- Full configured gate, local runner, run against this branch **merged with the current `main`** (so the result is judged against the real base, even though the delivered commits sit on the untouched PR head): `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test` (23/23 turbo tasks, `@open-mercato/core` alone 8255 tests passing), `yarn build:app` — all green.
- `localSchedulerService.test.ts` — `start()` emits the single-instance warning, so the guard cannot be silently deleted later.
- `localLockStrategy.test.ts` — a held key does not block a different key (pins that `heldKeys` is per-schedule, not an accidental global mutex serialising the whole due backlog).
- `localLockStrategy.test.ts` — the key is released when the claim transaction itself rejects, making the early `return { acquired: false }` path's `finally` coverage explicit.

## 💥 Breaking Changes

None. No exported symbol, signature, route, event, CLI flag, or column changes. The one behavioral addition is a `warn`-level log line at scheduler startup.

## 📝 What this PR deliberately does not do

@patzick's Major offered two resolutions: a lease-based claim (advance `next_run_at` inside the claim transaction) or the warning-plus-documentation route with the lease deferred — the latter explicitly accepted, provided the warning and docs ship in *this* PR. This PR takes the second route, because changing when the scheduler advances `next_run_at` alters the claim/retry path of every schedule and should not ride along on a `priority-high` production hotfix. The lease is tracked in #4934 with the reviewer's proposal quoted verbatim.
