### PR TITLE
fix(shared): register the app-level DI hook in worker/CLI bootstrap

### DIFF
--- a/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
+++ b/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
@@ -91,6 +91,8 @@ Document the worker/CLI app-DI wiring in the IoC container docs and the shared p
 
 ## Progress
 
+PR: #4937
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Worker/CLI app-DI wiring

--- a/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
+++ b/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
@@ -1,0 +1,110 @@
+# Register the app-level DI hook in worker/CLI bootstrap (`@/di` ERR_MODULE_NOT_FOUND spam)
+
+- **Branch:** `fix/app-di-registrar-worker-cli-bootstrap`
+- **Base:** `develop`
+- **Skill:** `om-auto-create-pr`
+
+## 🎯 Goal
+
+Make the app's `src/di.ts` registrations run in worker/CLI/scheduler processes the same way they run in the
+Next.js runtime, and stop the per-job `Cannot find package '@/di'` module-resolution failure that the missing
+wiring produces.
+
+## 🔍 Problem and root cause
+
+Reported symptom — `yarn dev` prints this once per queue job/scheduler tick:
+
+```
+DEBUG [shared:di] App-level DI override module (@/di) not resolvable; skipping
+Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@/di' imported from
+  packages/shared/dist/lib/di/container.js
+```
+
+Chain:
+
+1. The Next.js runtime boots through `apps/mercato/src/bootstrap.ts`, which passes
+   `{ appDiRegistrar: registerAppDi }` (from `@/di`) into `createBootstrap`. `createBootstrap` calls
+   `registerAppDiRegistrar(...)`, so the web process has the app DI hook wired explicitly and never
+   dynamic-imports `@/di`.
+2. Worker, scheduler and CLI processes boot through `packages/cli/src/bin.ts` →
+   `bootstrapFromAppRoot()` in `packages/shared/src/lib/bootstrap/dynamicLoader.ts`, which calls
+   `createBootstrap(data)` **with no options**. `registerAppDiRegistrar()` is therefore never called there.
+3. Consequently `getAppDiRegistrar()` in `packages/shared/src/lib/di/container.ts` returns `null` for every
+   request container in those processes, and the legacy compatibility fallback `await import('@/di')` runs.
+   Those processes are plain Node ESM importing `packages/shared/dist/**`, where the `@/*` tsconfig alias does
+   not exist — so the import throws `ERR_MODULE_NOT_FOUND`, is caught, and is logged with its stack on
+   **every** container creation (one per job).
+
+Impact is not only log noise: the app's `src/di.ts` `register()` never runs in worker/CLI/scheduler
+processes, so app-level DI overrides and the `application.bootstrap.*` lifecycle events are silently missing
+there — the same "registry silently no-ops in workers only" failure class as #4327 (command interceptors)
+and #4491.
+
+A second, latent defect sits in the same path: `createCliBundlePlugins`' `@/` alias plugin maps `@/x` to
+`<appRoot>/x`, while the app tsconfig maps `@/*` → `./src/*` and only `@/.mercato/*` → `./.mercato/*`. Today
+only `@/.mercato/...` specifiers reach it, so it happens to work; anything else (including `@/…` imports
+inside `src/di.ts`) would mis-resolve.
+
+## Approach
+
+1. Load the app's `src/di.ts` in the dynamic (worker/CLI) bootstrap path and hand its `register` export to
+   `createBootstrap(data, { appDiRegistrar })`, mirroring what the app bootstrap already does. Absent file =
+   supported case (debug log, `null`); present-but-broken = error log, bootstrap continues.
+2. Parameterize `compileAndImport` with an explicit app root and output path — its current
+   `dirname(dirname(dirname(tsPath)))` derivation only holds for `<appRoot>/.mercato/generated/*.ts` — and
+   emit the compiled app-DI module into the gitignored `.mercato/generated/` directory instead of next to
+   `src/di.ts`.
+3. Fix the `@/` alias plugin to mirror the tsconfig mapping (`@/.mercato/*` → app root, `@/*` → `<appRoot>/src`),
+   the same two-tier resolution `packages/cli/src/lib/generators/openapi.ts` already implements.
+4. Memoize the legacy `@/di` fallback outcome per process in `container.ts`, so an unresolvable `@/di` costs
+   one failed resolution per process instead of one per request container.
+
+## Non-goals
+
+- Removing the `@/di` dynamic-import fallback (kept for apps that have not adopted explicit wiring).
+- Changing how the Next.js runtime wires app DI.
+- Touching `external/official-modules` or any generated file by hand.
+
+## Risks
+
+- Enabling the app DI registrar in worker/CLI processes means `apps/mercato/src/di.ts` now runs there, which
+  emits `application.bootstrap.started/completed` once per worker process. That is the intended semantics of
+  an app-level DI hook, but it is new behavior for those processes.
+- `compileAndImport` signature change must stay backward compatible (options object with defaults preserving
+  today's derivation) — it is module-private, but its cache-metadata format is depended on by existing tests.
+- The alias-plugin change must keep existing `@/.mercato/*` resolution byte-identical.
+
+## 📋 Implementation Plan
+
+### Phase 1: Worker/CLI app-DI wiring
+
+Parameterize `compileAndImport`, load `src/di.ts`, pass it to `createBootstrap`, fix the `@/` alias plugin,
+and cover all of it with regression tests.
+
+### Phase 2: Fallback memoization
+
+Make the legacy `@/di` dynamic import at most once per process, with a test.
+
+### Phase 3: Docs
+
+Document the worker/CLI app-DI wiring in the IoC container docs and the shared package AGENTS.md row.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Worker/CLI app-DI wiring
+
+- [ ] 1.1 Parameterize `compileAndImport` with explicit app root and output path
+- [ ] 1.2 Mirror the tsconfig `@/*` mapping in the CLI bundle alias plugin
+- [ ] 1.3 Load `src/di.ts` and pass `appDiRegistrar` from `bootstrapFromAppRoot`
+- [ ] 1.4 Regression tests for the dynamic-loader app-DI path
+
+### Phase 2: Fallback memoization
+
+- [ ] 2.1 Memoize the unresolvable `@/di` fallback per process
+- [ ] 2.2 Test that the fallback import is attempted at most once
+
+### Phase 3: Docs
+
+- [ ] 3.1 Document worker/CLI app-DI wiring (IoC docs + shared AGENTS.md)

--- a/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
+++ b/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
@@ -102,8 +102,8 @@ Document the worker/CLI app-DI wiring in the IoC container docs and the shared p
 
 ### Phase 2: Fallback memoization
 
-- [ ] 2.1 Memoize the unresolvable `@/di` fallback per process
-- [ ] 2.2 Test that the fallback import is attempted at most once
+- [x] 2.1 Memoize the unresolvable `@/di` fallback per process — 76003595e
+- [x] 2.2 Test that the fallback import is attempted at most once — 76003595e
 
 ### Phase 3: Docs
 

--- a/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
+++ b/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
@@ -107,4 +107,4 @@ Document the worker/CLI app-DI wiring in the IoC container docs and the shared p
 
 ### Phase 3: Docs
 
-- [ ] 3.1 Document worker/CLI app-DI wiring (IoC docs + shared AGENTS.md)
+- [x] 3.1 Document worker/CLI app-DI wiring (IoC docs + shared AGENTS.md) — ca83ed203

--- a/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
+++ b/.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md
@@ -95,10 +95,10 @@ Document the worker/CLI app-DI wiring in the IoC container docs and the shared p
 
 ### Phase 1: Worker/CLI app-DI wiring
 
-- [ ] 1.1 Parameterize `compileAndImport` with explicit app root and output path
-- [ ] 1.2 Mirror the tsconfig `@/*` mapping in the CLI bundle alias plugin
-- [ ] 1.3 Load `src/di.ts` and pass `appDiRegistrar` from `bootstrapFromAppRoot`
-- [ ] 1.4 Regression tests for the dynamic-loader app-DI path
+- [x] 1.1 Parameterize `compileAndImport` with explicit app root and output path — 6a5ec9a56
+- [x] 1.2 Mirror the tsconfig `@/*` mapping in the CLI bundle alias plugin — 6a5ec9a56
+- [x] 1.3 Load `src/di.ts` and pass `appDiRegistrar` from `bootstrapFromAppRoot` — 6a5ec9a56
+- [x] 1.4 Regression tests for the dynamic-loader app-DI path — 6a5ec9a56
 
 ### Phase 2: Fallback memoization
 

--- a/apps/docs/docs/framework/ioc/container.mdx
+++ b/apps/docs/docs/framework/ioc/container.mdx
@@ -54,6 +54,8 @@ export const bootstrap = createBootstrap(data, {
 
 Explicit wiring keeps the app alias in the app's bundler context, so scaffolded apps do not rely on package code resolving `@/di` on their behalf. A package-level dynamic-import fallback remains only for compatibility with older app bootstraps. The registrar runs for each request container after core and module registrars; inline `modules.ts` DI overrides remain the final mutation tier.
 
+Worker, scheduler and CLI processes never load `src/bootstrap.ts` — they bootstrap through `bootstrapFromAppRoot()`, which compiles `src/di.ts` from the app root and wires the same `appDiRegistrar`. So one `register()` covers every process. An app without `src/di.ts` is the supported case; a `src/di.ts` that fails to compile or exports no `register` is logged at error level and skipped rather than taking the process down.
+
 ## Best practices
 
 - **Naming** – use descriptive keys (`organizationInvitationService`). Keep module-specific prefixes to avoid collisions.

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -44,7 +44,7 @@ yarn workspace @open-mercato/shared build
 | `custom-fields/` | When handling custom field payloads | `@open-mercato/shared/lib/custom-fields` |
 | `data/` | When you need `DataEngine` or `QueryEngine` types | `@open-mercato/shared/lib/data/engine` |
 | `db/` | When resolving the ORM/connection-pool config (`resolvePoolConfig`, pool/timeout env knobs) | `@open-mercato/shared/lib/db/mikro` |
-| `di/` | When setting up dependency injection (Awilix) | `@open-mercato/shared/lib/di` |
+| `di/` | When setting up dependency injection (Awilix). The app-level hook (`src/di.ts` → `register`) is wired explicitly in BOTH bootstrap paths — `src/bootstrap.ts` for the Next.js runtime, `bootstrapFromAppRoot()` for worker/scheduler/CLI processes. Never rely on the legacy `import('@/di')` fallback: the alias does not exist outside the app bundler | `@open-mercato/shared/lib/di` |
 | `encryption/` | When querying encrypted entities (MUST use instead of raw `em.find`) | `@open-mercato/shared/lib/encryption/find` |
 | `i18n/` | When translating strings — `useT()` client-side, `resolveTranslations()` server-side | `@open-mercato/shared/lib/i18n/context` or `/server` |
 | `indexers/` | When building query index helpers | `@open-mercato/shared/lib/indexers` |

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.aliasResolver.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.aliasResolver.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ *
+ * The CLI bundle's `@/` alias must mirror what the app tsconfig maps, because the dynamic
+ * bootstrap path compiles app sources (`src/di.ts`) and generated registries that import app
+ * modules through the alias. The tsconfig maps `@/.mercato/*` to the app root and every other
+ * `@/*` to the app's `src/` directory; resolving everything against the app root silently sends
+ * `@/lib/x` to a path that does not exist.
+ */
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { createCliBundlePlugins } from '../dynamicLoader'
+
+async function bundleWithCliPlugins(appRoot: string, entry: string): Promise<string> {
+  const esbuild = await import('esbuild')
+  const outfile = path.join(appRoot, 'bundle.mjs')
+  await esbuild.build({
+    entryPoints: [entry],
+    outfile,
+    absWorkingDir: appRoot,
+    bundle: true,
+    format: 'esm',
+    platform: 'node',
+    target: 'node18',
+    plugins: createCliBundlePlugins(appRoot),
+  })
+  return fs.readFileSync(outfile, 'utf8')
+}
+
+describe('createCliBundlePlugins — @/ alias resolution', () => {
+  let appRoot: string
+
+  beforeEach(() => {
+    appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-alias-resolver-'))
+    fs.mkdirSync(path.join(appRoot, 'src', 'lib'), { recursive: true })
+    fs.mkdirSync(path.join(appRoot, 'src', 'modules', 'demo'), { recursive: true })
+    fs.mkdirSync(path.join(appRoot, '.mercato', 'generated'), { recursive: true })
+
+    fs.writeFileSync(
+      path.join(appRoot, 'src', 'lib', 'marker.ts'),
+      "export const srcLibMarker = 'resolved-from-src-lib'\n",
+    )
+    fs.writeFileSync(
+      path.join(appRoot, 'src', 'modules', 'demo', 'index.ts'),
+      "export const srcModuleMarker = 'resolved-from-src-module-index'\n",
+    )
+    fs.writeFileSync(
+      path.join(appRoot, '.mercato', 'generated', 'registry.generated.ts'),
+      "export const generatedMarker = 'resolved-from-generated'\n",
+    )
+  })
+
+  afterEach(() => {
+    fs.rmSync(appRoot, { recursive: true, force: true })
+  })
+
+  it('resolves @/* against the app src directory and @/.mercato/* against the app root', async () => {
+    const entry = path.join(appRoot, '.mercato', 'generated', 'entry.ts')
+    fs.writeFileSync(
+      entry,
+      [
+        "import { srcLibMarker } from '@/lib/marker'",
+        "import { srcModuleMarker } from '@/modules/demo'",
+        "import { generatedMarker } from '@/.mercato/generated/registry.generated'",
+        'export const markers = [srcLibMarker, srcModuleMarker, generatedMarker]',
+        '',
+      ].join('\n'),
+    )
+
+    const output = await bundleWithCliPlugins(appRoot, entry)
+
+    expect(output).toContain('resolved-from-src-lib')
+    expect(output).toContain('resolved-from-src-module-index')
+    expect(output).toContain('resolved-from-generated')
+  })
+
+  it('prefers an app-root match when the specifier has no src counterpart', async () => {
+    fs.writeFileSync(
+      path.join(appRoot, 'root-only.ts'),
+      "export const rootOnlyMarker = 'resolved-from-app-root'\n",
+    )
+    const entry = path.join(appRoot, '.mercato', 'generated', 'entry.ts')
+    fs.writeFileSync(
+      entry,
+      [
+        "import { rootOnlyMarker } from '@/root-only'",
+        'export const markers = [rootOnlyMarker]',
+        '',
+      ].join('\n'),
+    )
+
+    const output = await bundleWithCliPlugins(appRoot, entry)
+
+    expect(output).toContain('resolved-from-app-root')
+  })
+})

--- a/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.appDi.test.ts
+++ b/packages/shared/src/lib/bootstrap/__tests__/dynamicLoader.appDi.test.ts
@@ -1,0 +1,211 @@
+/**
+ * @jest-environment node
+ *
+ * Regression guard: the worker/CLI/scheduler bootstrap path (bootstrapFromAppRoot) must register
+ * the app-level DI hook (`src/di.ts`) the same way the Next.js runtime does through its own
+ * `src/bootstrap.ts`. Without it, `getAppDiRegistrar()` stays null in those processes, so the app's
+ * registrations silently never run there and every request container falls back to a doomed
+ * `import('@/di')` — the `@/` alias does not exist in a plain Node ESM process, so it throws
+ * ERR_MODULE_NOT_FOUND once per created container (once per queued job).
+ *
+ * Like the #4327 guard next to it, this test authors both the `.ts` sources and fresh compiled
+ * `.mjs` siblings so compileAndImport takes its cache path and never invokes esbuild. The `.mjs`
+ * stubs use module.exports because Jest's CJS runtime handles the dynamic import().
+ *
+ * `bootstrapFromAppRoot` reaches the factory through `import('./factory.js')`, a specifier with no
+ * on-disk counterpart under Jest's CJS resolver, so it is mocked virtually.
+ */
+jest.mock('../../logger', () => {
+  const logger = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: () => logger,
+  }
+  return { createLogger: () => logger }
+})
+
+const createBootstrapMock = jest.fn(() => () => {})
+
+jest.mock(
+  '../factory.js',
+  () => ({
+    createBootstrap: (...args: unknown[]) => createBootstrapMock(...(args as [])),
+    waitForAsyncRegistration: async () => {},
+  }),
+  { virtual: true },
+)
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import crypto from 'node:crypto'
+import { createLogger } from '../../logger'
+import { bootstrapFromAppRoot } from '../dynamicLoader'
+
+const mockedLogger = createLogger('shared') as unknown as {
+  debug: jest.Mock
+  error: jest.Mock
+}
+
+const APP_DI_CALL_COUNTER_KEY = '__omTestAppDiRegisterCalls__'
+
+const GENERATED_MODULES: Record<string, { ts: string; compiled: string }> = {
+  'entities.ids.generated': { ts: 'export const E = {}', compiled: 'module.exports = { E: {} }' },
+  'modules.cli.generated': { ts: 'export const modules = []', compiled: 'module.exports = { modules: [] }' },
+  'entities.generated': { ts: 'export const entities = []', compiled: 'module.exports = { entities: [] }' },
+  'di.generated': { ts: 'export const diRegistrars = []', compiled: 'module.exports = { diRegistrars: [] }' },
+}
+
+const APP_TSCONFIG = JSON.stringify({
+  compilerOptions: {
+    experimentalDecorators: true,
+    emitDecoratorMetadata: true,
+    useDefineForClassFields: false,
+    target: 'ES2022',
+  },
+})
+
+const APP_DI_TS = 'export function register() {}'
+
+const APP_DI_COMPILED = [
+  'module.exports = {',
+  '  register: () => {',
+  `    globalThis['${APP_DI_CALL_COUNTER_KEY}'] = (globalThis['${APP_DI_CALL_COUNTER_KEY}'] ?? 0) + 1`,
+  '  },',
+  '}',
+].join('\n')
+
+function hash(content: string): string {
+  return crypto.createHash('sha256').update(content).digest('hex')
+}
+
+function writeCompiledPair(
+  appRoot: string,
+  sourcePath: string,
+  compiledPath: string,
+  source: { ts: string; compiled: string },
+) {
+  fs.writeFileSync(sourcePath, source.ts)
+  fs.writeFileSync(compiledPath, source.compiled)
+  const sourceRelativePath = path.relative(appRoot, sourcePath).split(path.sep).join('/')
+  fs.writeFileSync(`${compiledPath}.cache.json`, JSON.stringify({
+    version: 4,
+    inputHash: hash(JSON.stringify({
+      version: 4,
+      sourceHash: hash(source.ts),
+      tsconfigHashes: {
+        'tsconfig.json': hash(APP_TSCONFIG),
+      },
+    })),
+    outputHash: hash(source.compiled),
+    dependencies: {
+      [sourceRelativePath]: hash(source.ts),
+    },
+  }))
+}
+
+const createdAppRoots: string[] = []
+
+function createAppRoot(appDi: { ts: string; compiled: string } | null): string {
+  const appRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'om-bootstrap-app-di-'))
+  const generatedDir = path.join(appRoot, '.mercato', 'generated')
+  fs.mkdirSync(generatedDir, { recursive: true })
+  fs.writeFileSync(path.join(appRoot, 'tsconfig.json'), APP_TSCONFIG)
+
+  for (const [baseName, source] of Object.entries(GENERATED_MODULES)) {
+    writeCompiledPair(
+      appRoot,
+      path.join(generatedDir, `${baseName}.ts`),
+      path.join(generatedDir, `${baseName}.mjs`),
+      source,
+    )
+  }
+
+  if (appDi) {
+    fs.mkdirSync(path.join(appRoot, 'src'), { recursive: true })
+    writeCompiledPair(
+      appRoot,
+      path.join(appRoot, 'src', 'di.ts'),
+      path.join(generatedDir, 'app-di.compiled.mjs'),
+      appDi,
+    )
+  }
+
+  createdAppRoots.push(appRoot)
+  return appRoot
+}
+
+function appDiRegistrarArgument(): unknown {
+  const [, options] = createBootstrapMock.mock.calls[0] as unknown as [unknown, Record<string, unknown>]
+  return options?.appDiRegistrar
+}
+
+describe('bootstrapFromAppRoot — app-level DI reaches worker/CLI processes', () => {
+  afterAll(() => {
+    for (const root of createdAppRoots) {
+      fs.rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  beforeEach(() => {
+    createBootstrapMock.mockClear()
+    mockedLogger.debug.mockClear()
+    mockedLogger.error.mockClear()
+    delete (globalThis as Record<string, unknown>)[APP_DI_CALL_COUNTER_KEY]
+  })
+
+  it('passes the app DI register() from src/di.ts to createBootstrap', async () => {
+    const appRoot = createAppRoot({ ts: APP_DI_TS, compiled: APP_DI_COMPILED })
+
+    await bootstrapFromAppRoot(appRoot)
+
+    const registrar = appDiRegistrarArgument()
+    expect(typeof registrar).toBe('function')
+
+    await (registrar as (container: unknown) => unknown)({})
+    expect((globalThis as Record<string, unknown>)[APP_DI_CALL_COUNTER_KEY]).toBe(1)
+    expect(mockedLogger.error).not.toHaveBeenCalled()
+  })
+
+  it('bootstraps without an app DI registrar when src/di.ts is absent', async () => {
+    const appRoot = createAppRoot(null)
+
+    await bootstrapFromAppRoot(appRoot)
+
+    expect(createBootstrapMock).toHaveBeenCalledTimes(1)
+    expect(appDiRegistrarArgument()).toBeUndefined()
+    expect(mockedLogger.error).not.toHaveBeenCalled()
+  })
+
+  it('reports an error and keeps bootstrapping when src/di.ts fails to load', async () => {
+    const appRoot = createAppRoot({
+      ts: APP_DI_TS,
+      compiled: "throw new Error('src/di.ts is broken')",
+    })
+
+    await bootstrapFromAppRoot(appRoot)
+
+    expect(createBootstrapMock).toHaveBeenCalledTimes(1)
+    expect(appDiRegistrarArgument()).toBeUndefined()
+    expect(mockedLogger.error).toHaveBeenCalledTimes(1)
+    const [message, fields] = mockedLogger.error.mock.calls[0] as [string, Record<string, unknown>]
+    expect(message).toContain('Failed to load the app-level DI module')
+    expect((fields.err as Error).message).toContain('src/di.ts is broken')
+  })
+
+  it('reports an error and keeps bootstrapping when src/di.ts exports no register()', async () => {
+    const appRoot = createAppRoot({
+      ts: APP_DI_TS,
+      compiled: 'module.exports = {}',
+    })
+
+    await bootstrapFromAppRoot(appRoot)
+
+    expect(createBootstrapMock).toHaveBeenCalledTimes(1)
+    expect(appDiRegistrarArgument()).toBeUndefined()
+    expect(mockedLogger.error).toHaveBeenCalledTimes(1)
+    expect(mockedLogger.error.mock.calls[0][0]).toContain('exports no register()')
+  })
+})

--- a/packages/shared/src/lib/bootstrap/dynamicLoader.ts
+++ b/packages/shared/src/lib/bootstrap/dynamicLoader.ts
@@ -1,4 +1,5 @@
 import type { BootstrapData } from './types'
+import type { AppDiRegistrar } from '../di/container'
 import { findAppRoot, type AppRoot } from './appResolver'
 import { registerEntityIds } from '../encryption/entityIds'
 import { createLogger } from '../logger'
@@ -41,22 +42,29 @@ class GeneratedFileNotFoundError extends Error {
  * list, which would silently reintroduce #4623.
  */
 export function createCliBundlePlugins(appRoot: string): import('esbuild').Plugin[] {
-  // Plugin to resolve @/ alias to app root (works for @app modules)
+  // Plugin to resolve the @/ alias the way the app tsconfig maps it:
+  // `@/.mercato/*` to the app root, every other `@/*` to the app's src/ directory.
   const aliasPlugin: import('esbuild').Plugin = {
     name: 'alias-resolver',
     setup(build) {
-      // Resolve @/ alias to app root
       build.onResolve({ filter: /^@\// }, (args) => {
-        const resolved = path.join(appRoot, args.path.slice(2))
-        // Try with .ts extension if base path doesn't exist
-        if (!fs.existsSync(resolved) && fs.existsSync(resolved + '.ts')) {
-          return { path: resolved + '.ts' }
+        const rest = args.path.slice('@/'.length)
+        const bases = rest.startsWith('.mercato/')
+          ? [path.join(appRoot, rest)]
+          : [path.join(appRoot, 'src', rest), path.join(appRoot, rest)]
+        for (const base of bases) {
+          if (fs.existsSync(base) && fs.statSync(base).isFile()) {
+            return { path: base }
+          }
+          for (const suffix of ['.ts', '.tsx', '/index.ts', '/index.tsx']) {
+            if (fs.existsSync(base + suffix)) {
+              return { path: base + suffix }
+            }
+          }
         }
-        // Also check for /index.ts if it's a directory
-        if (fs.existsSync(resolved) && fs.statSync(resolved).isDirectory() && fs.existsSync(path.join(resolved, 'index.ts'))) {
-          return { path: path.join(resolved, 'index.ts') }
-        }
-        return { path: resolved }
+        // Nothing matched — hand esbuild the literal mapping so it reports the
+        // missing file against the path the app author actually wrote.
+        return { path: path.join(appRoot, rest) }
       })
     },
   }
@@ -297,13 +305,32 @@ function cacheIsValid(
 }
 
 /**
+ * Options for `compileAndImport`.
+ *
+ * Both paths default to the generated-registry layout (`<appRoot>/.mercato/generated/<file>.ts`
+ * compiled to a `.mjs` sibling). Sources that live elsewhere in the app — `src/di.ts` — MUST pass
+ * both explicitly: the default app root is derived by walking three directories up from the source,
+ * which only holds inside `.mercato/generated`.
+ */
+type CompileAndImportOptions = {
+  appRoot?: string
+  outFile?: string
+  allowRecovery?: boolean
+}
+
+/**
  * Compile a TypeScript file to JavaScript using esbuild bundler.
  * This bundles the file and all its dependencies, handling JSON imports properly.
- * The compiled file is written next to the source file with a .mjs extension.
+ * The compiled file is written next to the source file with a .mjs extension unless
+ * `outFile` says otherwise.
  */
-async function compileAndImport(tsPath: string, allowRecovery: boolean = true): Promise<Record<string, unknown>> {
-  const jsPath = tsPath.replace(/\.ts$/, '.mjs')
-  const appRoot = path.dirname(path.dirname(path.dirname(tsPath)))
+async function compileAndImport(
+  tsPath: string,
+  options: CompileAndImportOptions = {},
+): Promise<Record<string, unknown>> {
+  const allowRecovery = options.allowRecovery ?? true
+  const jsPath = options.outFile ?? tsPath.replace(/\.ts$/, '.mjs')
+  const appRoot = options.appRoot ?? path.dirname(path.dirname(path.dirname(tsPath)))
   const appTsconfig = path.join(appRoot, 'tsconfig.json')
   const metadataPath = cacheMetadataPath(jsPath)
 
@@ -322,6 +349,7 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
   const needsCompile = !cacheIsValid(appRoot, jsPath, metadataPath, expectedInputHash)
 
   if (needsCompile) {
+    fs.mkdirSync(path.dirname(jsPath), { recursive: true })
     // Dynamically import esbuild only when needed
     const esbuild = await import('esbuild')
 
@@ -367,7 +395,7 @@ async function compileAndImport(tsPath: string, allowRecovery: boolean = true): 
       throw error
     }
 
-    return compileAndImport(tsPath, false)
+    return compileAndImport(tsPath, { ...options, allowRecovery: false })
   }
 }
 
@@ -405,20 +433,7 @@ async function loadOptionalGeneratedModule(
   }
 }
 
-/**
- * Dynamically load bootstrap data from a resolved app directory.
- *
- * IMPORTANT: This only works in unbundled contexts (CLI, tsx).
- * Do NOT use this in Next.js bundled code - use static imports instead.
- *
- * For CLI context, we skip loading modules.generated.ts which has Next.js dependencies.
- * CLI commands are discovered separately via the CLI module system.
- *
- * @param appRoot - Optional explicit app root path. If not provided, will search from cwd.
- * @returns The loaded bootstrap data
- * @throws Error if app root cannot be found or generated files are missing
- */
-export async function loadBootstrapData(appRoot?: string): Promise<BootstrapData> {
+function resolveAppRootOrThrow(appRoot?: string): AppRoot {
   const resolved: AppRoot | null = appRoot
     ? {
         generatedDir: path.join(appRoot, '.mercato', 'generated'),
@@ -434,6 +449,68 @@ export async function loadBootstrapData(appRoot?: string): Promise<BootstrapData
         'or run "yarn mercato generate" first to create the generated files.',
     )
   }
+
+  return resolved
+}
+
+/**
+ * Load the app-level DI registrar (`src/di.ts`) for the dynamic bootstrap path.
+ *
+ * The Next.js runtime imports `@/di` statically from its own `src/bootstrap.ts` and hands the
+ * registrar to `createBootstrap`. Worker, scheduler and CLI processes bootstrap through
+ * `bootstrapFromAppRoot` instead, where the `@/` alias does not exist — so without this the app's
+ * DI registrations silently never ran there, and every request container paid a failed
+ * `import('@/di')` resolution (the compatibility fallback in `lib/di/container.ts`).
+ *
+ * An absent `src/di.ts` is the supported case and resolves to `null` quietly. A file that exists
+ * but cannot be compiled, imported, or does not export `register` is reported at error level and
+ * still resolves to `null`, so a broken app DI module degrades the same way a broken generated
+ * registry does (#4327, #4491) instead of taking the whole process down.
+ */
+async function loadAppDiRegistrar(appDir: string): Promise<AppDiRegistrar | null> {
+  const tsPath = path.join(appDir, 'src', 'di.ts')
+  if (!fs.existsSync(tsPath)) {
+    logger.debug('App-level DI module not present, skipping its registrations', { filePath: tsPath })
+    return null
+  }
+
+  try {
+    const appDiModule = await compileAndImport(tsPath, {
+      appRoot: appDir,
+      outFile: path.join(appDir, '.mercato', 'generated', 'app-di.compiled.mjs'),
+    })
+    const register = appDiModule.register
+    if (typeof register !== 'function') {
+      logger.error('App-level DI module exports no register(); its registrations are skipped', {
+        filePath: tsPath,
+      })
+      return null
+    }
+    return register as AppDiRegistrar
+  } catch (error) {
+    logger.error('Failed to load the app-level DI module; its registrations are skipped', {
+      filePath: tsPath,
+      err: error,
+    })
+    return null
+  }
+}
+
+/**
+ * Dynamically load bootstrap data from a resolved app directory.
+ *
+ * IMPORTANT: This only works in unbundled contexts (CLI, tsx).
+ * Do NOT use this in Next.js bundled code - use static imports instead.
+ *
+ * For CLI context, we skip loading modules.generated.ts which has Next.js dependencies.
+ * CLI commands are discovered separately via the CLI module system.
+ *
+ * @param appRoot - Optional explicit app root path. If not provided, will search from cwd.
+ * @returns The loaded bootstrap data
+ * @throws Error if app root cannot be found or generated files are missing
+ */
+export async function loadBootstrapData(appRoot?: string): Promise<BootstrapData> {
+  const resolved = resolveAppRootOrThrow(appRoot)
 
   const { generatedDir } = resolved
 
@@ -506,8 +583,10 @@ export async function loadBootstrapData(appRoot?: string): Promise<BootstrapData
  */
 export async function bootstrapFromAppRoot(appRoot?: string): Promise<BootstrapData> {
   const { createBootstrap, waitForAsyncRegistration } = await import('./factory.js')
-  const data = await loadBootstrapData(appRoot)
-  const bootstrap = createBootstrap(data)
+  const resolved = resolveAppRootOrThrow(appRoot)
+  const data = await loadBootstrapData(resolved.appDir)
+  const appDiRegistrar = await loadAppDiRegistrar(resolved.appDir)
+  const bootstrap = createBootstrap(data, appDiRegistrar ? { appDiRegistrar } : {})
   bootstrap()
   // In CLI context, wait for async registrations (UI widgets, search configs, etc.)
   await waitForAsyncRegistration()

--- a/packages/shared/src/lib/di/__tests__/container-app-di-absent.test.ts
+++ b/packages/shared/src/lib/di/__tests__/container-app-di-absent.test.ts
@@ -84,9 +84,10 @@ jest.mock(
 )
 
 const mockWarn = jest.fn()
+const mockDebug = jest.fn()
 jest.mock('../../logger', () => ({
   createLogger: () => ({
-    debug: jest.fn(),
+    debug: (...args: unknown[]) => mockDebug(...args),
     info: jest.fn(),
     warn: (...args: unknown[]) => mockWarn(...args),
     error: jest.fn(),
@@ -107,6 +108,7 @@ describe('app-level DI override hook when @/di is absent', () => {
     registerAppDiRegistrar(null)
     registerDiRegistrars([])
     mockWarn.mockClear()
+    mockDebug.mockClear()
   })
 
   it('creates the container without warning', async () => {
@@ -115,6 +117,20 @@ describe('app-level DI override hook when @/di is absent', () => {
     expect(firstContainer).toBeDefined()
     expect(secondContainer).toBeDefined()
     expect(mockWarn).not.toHaveBeenCalled()
+  })
+
+  // Worker and CLI processes create one request container per job against built package
+  // output, where the app's `@/` alias does not exist. Retrying the doomed import per
+  // container repeats a failed module resolution — and its log line — once per job.
+  it('stops retrying the unresolvable @/di import after the first container', async () => {
+    await createRequestContainer()
+    await createRequestContainer()
+    await createRequestContainer()
+
+    const unresolvableLogs = mockDebug.mock.calls.filter(
+      ([message]) => message === 'App-level DI override module (@/di) not resolvable; skipping',
+    )
+    expect(unresolvableLogs).toHaveLength(1)
   })
 
   it('warns once when @/di fails because a nested app alias is missing', async () => {

--- a/packages/shared/src/lib/di/container.ts
+++ b/packages/shared/src/lib/di/container.ts
@@ -26,6 +26,11 @@ const GLOBAL_KEY = '__openMercatoDiRegistrars__'
 const APP_DI_REGISTRAR_KEY = '__openMercatoAppDiRegistrar__'
 const APP_DI_LOAD_WARNING_KEY = '__openMercatoAppDiLoadWarningEmitted__'
 const APP_DI_REGISTER_WARNING_KEY = '__openMercatoAppDiRegisterWarningEmitted__'
+// Set once the legacy `@/di` fallback proves the specifier is unresolvable in this process.
+// Worker/CLI processes run against built package output where the app's `@/` alias does not
+// exist, so retrying the import per request container only repeats a failed module resolution
+// (and its log line) once per job.
+const APP_DI_MODULE_UNRESOLVABLE_KEY = '__openMercatoAppDiModuleUnresolvable__'
 // Phase 5 — process-scoped bootstrap cache. The cache/event-bus/encryption
 // services bootstrap() creates are inherently process-scoped (they hold
 // state across requests). Caching them on globalThis after the first
@@ -120,6 +125,9 @@ export function registerDiRegistrars(registrars: DiRegistrar[]) {
   // Force re-bootstrap on HMR — module subscribers may have changed.
   ;(globalThis as any)[BOOTSTRAP_CACHE_KEY] = null
   ;(globalThis as any)[ENCRYPTION_ENABLED_KEY] = undefined
+  // An app that gains a src/di.ts mid-session reloads through here, so the negative
+  // resolution result must not outlive the reload.
+  ;(globalThis as Record<string, unknown>)[APP_DI_MODULE_UNRESOLVABLE_KEY] = undefined
 }
 
 export function getDiRegistrars(): DiRegistrar[] {
@@ -145,6 +153,15 @@ export function resetBootstrapCache(): void {
   ;(globalThis as any)[ENCRYPTION_ENABLED_KEY] = undefined
   ;(globalThis as Record<string, unknown>)[APP_DI_LOAD_WARNING_KEY] = undefined
   ;(globalThis as Record<string, unknown>)[APP_DI_REGISTER_WARNING_KEY] = undefined
+  ;(globalThis as Record<string, unknown>)[APP_DI_MODULE_UNRESOLVABLE_KEY] = undefined
+}
+
+function isAppDiModuleUnresolvable(): boolean {
+  return (globalThis as Record<string, unknown>)[APP_DI_MODULE_UNRESOLVABLE_KEY] === true
+}
+
+function markAppDiModuleUnresolvable(): void {
+  ;(globalThis as Record<string, unknown>)[APP_DI_MODULE_UNRESOLVABLE_KEY] = true
 }
 
 function isAppDiModuleNotFound(error: unknown): boolean {
@@ -267,7 +284,7 @@ export async function createRequestContainer(): Promise<AppContainer> {
     } catch (error) {
       logger.error('App-level DI registrar failed', { err: error })
     }
-  } else {
+  } else if (!isAppDiModuleUnresolvable()) {
     // Backward-compatible fallback for apps that have not adopted explicit wiring.
     try {
       // @ts-ignore - @/di only exists in app context, not in packages
@@ -286,6 +303,7 @@ export async function createRequestContainer(): Promise<AppContainer> {
       }
     } catch (err) {
       if (isAppDiModuleNotFound(err)) {
+        markAppDiModuleUnresolvable()
         logger.debug('App-level DI override module (@/di) not resolvable; skipping', { err })
       } else {
         warnAppDiFailureOnce(


### PR DESCRIPTION
## Summary

`src/di.ts` — the app-level DI hook — only ever ran in the Next.js runtime. Worker, scheduler and CLI processes bootstrap through a different path that never wired it, so app-level DI registrations were silently missing there, and every request container in those processes paid a failed `import('@/di')` module resolution.

Symptom reported from `yarn dev`, once per queue job / scheduler tick:

```
DEBUG [shared:di] App-level DI override module (@/di) not resolvable; skipping
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@/di' imported from
  packages/shared/dist/lib/di/container.js
```

## Root cause

1. `apps/mercato/src/bootstrap.ts` passes `{ appDiRegistrar: registerAppDi }` into `createBootstrap`, so the web process wires the hook explicitly and never dynamic-imports `@/di`.
2. Worker/scheduler/CLI processes boot via `packages/cli/src/bin.ts` → `bootstrapFromAppRoot()`, which called `createBootstrap(data)` **with no options** — `registerAppDiRegistrar()` was never called there.
3. So `getAppDiRegistrar()` returned `null` for every request container in those processes and the legacy compatibility fallback `await import('@/di')` ran. Those processes are plain Node ESM importing `packages/shared/dist/**`, where the `@/*` tsconfig alias does not exist — the import threw, was caught, and was logged with its stack on **every** container creation.

Impact beyond the noise: app-level DI overrides and the `application.bootstrap.*` lifecycle events never ran in worker/CLI processes. Same "registry silently no-ops in workers only" failure class as #4327 (command interceptors) and #4491.

## Changes

- **`bootstrapFromAppRoot` now loads `src/di.ts`** and hands its `register` to `createBootstrap`, mirroring the app bootstrap. Absent `src/di.ts` stays the supported case (debug log); a file that exists but fails to compile/import, or exports no `register`, is reported at error level and skipped rather than taking the process down.
- **`compileAndImport` takes an explicit app root and output path.** Its previous `dirname×3` derivation only holds inside `.mercato/generated`. The compiled app-DI bundle lands in the gitignored `.mercato/generated/`, not next to the app source.
- **The CLI bundle's `@/` alias now mirrors the app tsconfig** (`@/.mercato/*` → app root, `@/*` → `<appRoot>/src`), matching the two-tier resolution `packages/cli/src/lib/generators/openapi.ts` already implements. Previously everything resolved against the app root, so any non-`.mercato` `@/` specifier mis-resolved.
- **The legacy `@/di` fallback is memoized per process**, so an unresolvable alias costs one failed resolution instead of one per job. Cleared by `resetBootstrapCache()` and `registerDiRegistrars()` so an app that gains a `src/di.ts` during an HMR reload is still picked up.

The `@/di` dynamic-import fallback is retained for apps that have not adopted explicit wiring.

## Verification

Full configured gate, local runner, all green:

| Command | Result |
|---|---|
| `yarn build:packages` | ✅ 21/21 |
| `yarn generate` | ✅ no generated drift |
| `yarn build:packages` | ✅ 21/21 |
| `yarn i18n:check-sync` | ✅ 4 locales in sync |
| `yarn i18n:check-usage` | ✅ advisory only |
| `yarn typecheck` | ✅ 21/21 |
| `yarn test` | ✅ 24/24 |
| `yarn build:app` | ✅ |

Each new test was verified **red before green**:

- `dynamicLoader.appDi.test.ts` — 3 of 4 cases fail on pre-fix code.
- `dynamicLoader.aliasResolver.test.ts` — the `@/lib/*` case fails on pre-fix code.
- `container-app-di-absent.test.ts` — asserts 1 resolution attempt across 3 containers; pre-fix code makes 3.

End-to-end: booting `bootstrapFromAppRoot(apps/mercato)` in a real Node ESM process against built `dist` now resolves the registrar as a `function` (was `undefined`), and the compiled artifact lands gitignored at `apps/mercato/.mercato/generated/app-di.compiled.mjs`.

## Behavioral change

`apps/mercato/src/di.ts` now runs in worker/CLI processes, so `application.bootstrap.started/completed` are emitted there. The only subscriber is `system_status_overlays:application-bootstrap-enterprise-warning` — ephemeral, `globalThis`-guarded to log once per process, no DB writes or queue fan-out. Its `bootstrap(container)` call is guarded by `if (!container.registrations?.eventBus)`, and `createRequestContainer` runs core bootstrap before the app registrar, so there is no double-bootstrap.

## Backward compatibility

- No exported signature changed. `compileAndImport` is module-private (`dynamicLoader` is deliberately excluded from the bootstrap barrel); all call sites updated, and the new options default to the previous behavior.
- `BACKWARD_COMPATIBILITY.md` §14: no generated export name changed, `BootstrapData` required fields untouched. The new `app-di.compiled.mjs` is a compile-cache sibling like the existing `*.generated.mjs`/`.cache.json` pairs.
- §1 (`di.ts` → `register(container)`): consumed with exactly that signature — this PR starts *honoring* the contract in more processes rather than changing it.
- The legacy `@/di` fallback is preserved; only its retry is memoized.

## Follow-up (not in this PR)

`packages/ai-assistant/.../generated-registry-loader.ts` `rewriteGeneratedAliasImportsForRuntime` still maps `@/x` → `<appRoot>/x`, the same tsconfig mismatch fixed here for the CLI bundle. It is latent today (the AI generated registries emit only `@/.mercato/...` and `../../src/...`), so it is left out to keep this PR's blast radius tight.

Tracking plan: `.ai/runs/2026-08-04-app-di-registrar-worker-cli-bootstrap.md`
Status: complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)
