### PR TITLE
fix(ui,dev): reject aborted API reads and stop browser logs unfolding dev output

### DIFF
--- a/apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs
+++ b/apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs
@@ -16,6 +16,10 @@ import {
   isIgnorableSchedulerLogLine,
   isIgnorableSearchWarningLine,
   isInteractivePromptHintLine,
+  isBrowserForwardedLogLine,
+  isNonRuntimeFailureLine,
+  isStackFrameLine,
+  isStructuredNonErrorLogLine,
   isStatelessRuntimeNoiseLine,
   shouldIgnoreSplashPassthroughLine,
   stripStructuredLogPrefix,
@@ -197,6 +201,29 @@ test('isStatelessRuntimeNoiseLine combines all single-line ignore predicates', (
   assert.equal(isStatelessRuntimeNoiseLine('Error: real failure'), false)
   assert.equal(isStatelessRuntimeNoiseLine(''), false)
   assert.equal(isStatelessRuntimeNoiseLine(null), false)
+})
+
+test('browser-forwarded client logs are not runtime failures', () => {
+  const browserWarning = '[browser] [customers] failed to load interactions component=ActivitiesDayStrip Error: Missing response payload (200)'
+
+  assert.equal(isBrowserForwardedLogLine(browserWarning), true)
+  assert.equal(isBrowserForwardedLogLine('09:47:25.952 WARN  [browser] [customers] failed to load interactions'), true)
+  assert.equal(isBrowserForwardedLogLine('[server] Next.js dev server failed to boot'), false)
+
+  assert.equal(isNonRuntimeFailureLine(browserWarning), true)
+})
+
+test('stack frames and non-error structured log lines are not runtime failures', () => {
+  assert.equal(isStackFrameLine('    at readApiResultOrThrow (http://localhost:3000/_next/static/chunks/app.js:1678:15)'), true)
+  assert.equal(isStackFrameLine('at async ActivitiesDayStrip.useEffect (http://localhost:3000/_next/static/chunks/detail.js:6460:41)'), true)
+  assert.equal(isStackFrameLine('attach failed'), false)
+
+  assert.equal(isStructuredNonErrorLogLine('09:47:25.952 WARN  [ai_assistant] Tool registration failed toolName=search_query'), true)
+  assert.equal(isStructuredNonErrorLogLine('09:47:25.952 INFO  [ai_assistant:tools] Registered module-contributed AI tools toolCount=67'), true)
+  assert.equal(isStructuredNonErrorLogLine('09:47:25.952 ERROR [sales] Order sync failed orderId=42'), false)
+
+  assert.equal(isNonRuntimeFailureLine('09:47:25.952 ERROR [sales] Order sync failed orderId=42'), false)
+  assert.equal(isNonRuntimeFailureLine('⨯ Error: Cannot find module "next/dist/server"'), false)
 })
 
 test('createRuntimeNoiseFilter ignores empty, stateless noise, and multi-line search warning blocks', () => {

--- a/apps/mercato/scripts/dev-runtime-log-policy.mjs
+++ b/apps/mercato/scripts/dev-runtime-log-policy.mjs
@@ -8,6 +8,39 @@ export function stripStructuredLogPrefix(line) {
   return line.replace(STRUCTURED_PRETTY_LOG_PREFIX, '')
 }
 
+// Client console output forwarded by the browser log bridge. It describes the
+// page, not the dev runtime, so a handled client-side warning must never latch
+// the runtime failure state or force the compact view open.
+const BROWSER_FORWARDED_LOG_PREFIX = '[browser]'
+const STACK_FRAME_PATTERN = /^at\s+\S/
+const STRUCTURED_PRETTY_NON_ERROR_PREFIX = /^\d{2}:\d{2}:\d{2}\.\d{3}\s+(?:DEBUG|INFO|WARN)\s+/
+
+export function isBrowserForwardedLogLine(line) {
+  if (typeof line !== 'string') return false
+  return stripStructuredLogPrefix(line.trim()).startsWith(BROWSER_FORWARDED_LOG_PREFIX)
+}
+
+// Stack frames only ever follow a header line, and that header is what decides
+// whether the block is a failure. Frames matched on their own text produce false
+// positives, because module paths and function names routinely contain "failed".
+export function isStackFrameLine(line) {
+  if (typeof line !== 'string') return false
+  return STACK_FRAME_PATTERN.test(line.trim())
+}
+
+// The structured logger already encodes severity; trust the level over a
+// substring match on the message.
+export function isStructuredNonErrorLogLine(line) {
+  if (typeof line !== 'string') return false
+  return STRUCTURED_PRETTY_NON_ERROR_PREFIX.test(line.trim())
+}
+
+export function isNonRuntimeFailureLine(line) {
+  return isBrowserForwardedLogLine(line)
+    || isStackFrameLine(line)
+    || isStructuredNonErrorLogLine(line)
+}
+
 const KMS_VAULT_FALLBACK_MESSAGE_PATTERN = /^\[shared:kms\] (?:Vault (?:read|write) (?:error|failed)\b|Vault write CAS conflict\b|No tenant DEK found in Vault\b|Failed to store tenant DEK in Vault\b)/
 
 export function isIgnorableDerivedKeyWarningLine(line) {

--- a/apps/mercato/scripts/dev.mjs
+++ b/apps/mercato/scripts/dev.mjs
@@ -7,6 +7,7 @@ import {
   createRuntimeFailureLatch,
   createRuntimeNoiseFilter,
   formatChildExitStatus,
+  isNonRuntimeFailureLine,
   isStatelessRuntimeNoiseLine,
   resolveChildExitCode,
   resolveUnexpectedExitCode,
@@ -597,7 +598,7 @@ function looksLikeWarningLine(line) {
 }
 
 function looksLikeFailure(line) {
-  if (isStatelessRuntimeNoiseLine(line) || looksLikeWarningLine(line)) return false
+  if (isStatelessRuntimeNoiseLine(line) || looksLikeWarningLine(line) || isNonRuntimeFailureLine(line)) return false
 
   return /^error\b/i.test(line)
     || /^Error:/i.test(line)

--- a/packages/core/src/modules/customers/components/detail/ActivitiesDayStrip.tsx
+++ b/packages/core/src/modules/customers/components/detail/ActivitiesDayStrip.tsx
@@ -245,9 +245,8 @@ export function ActivitiesDayStrip({ entityId, selectedDate, onSelectDate, refre
         )
         setFetchedEvents(Array.isArray(payload?.items) ? payload.items : [])
       } catch (err) {
-        if ((err as { name?: string } | null)?.name !== 'AbortError') {
-          logger.warn('failed to load interactions', { component: 'ActivitiesDayStrip', err })
-        }
+        if ((err as { name?: string } | null)?.name === 'AbortError') return
+        logger.warn('failed to load interactions', { component: 'ActivitiesDayStrip', err })
         setFetchedEvents([])
       }
     })()

--- a/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesDayStrip.abort.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ActivitiesDayStrip.abort.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, screen } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import { ActivitiesDayStrip } from '../ActivitiesDayStrip'
+import type { InteractionSummary } from '../types'
+
+const readApiResultOrThrowMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+}))
+
+const loggerWarnMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/logger', () => ({
+  createLogger: () => ({
+    warn: (...args: unknown[]) => loggerWarnMock(...args),
+    info: jest.fn(),
+    debug: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+  }),
+}))
+
+function makeScheduledActivity(scheduledAt: Date): InteractionSummary {
+  return {
+    id: 'act-1',
+    interactionType: 'meeting',
+    title: 'Q2 review meeting',
+    body: null,
+    status: 'planned',
+    scheduledAt: scheduledAt.toISOString(),
+    occurredAt: null,
+    priority: null,
+    authorUserId: null,
+    ownerUserId: null,
+    appearanceIcon: null,
+    appearanceColor: null,
+    source: null,
+    entityId: 'entity-1',
+    dealId: null,
+    organizationId: null,
+    tenantId: null,
+    authorName: null,
+    authorEmail: null,
+    dealTitle: null,
+    customValues: null,
+    duration: 25,
+    createdAt: scheduledAt.toISOString(),
+    updatedAt: scheduledAt.toISOString(),
+  }
+}
+
+function createAbortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+describe('ActivitiesDayStrip — aborted refreshes', () => {
+  const selectedDate = (() => {
+    const date = new Date()
+    date.setHours(10, 0, 0, 0)
+    return date
+  })()
+
+  beforeEach(() => {
+    readApiResultOrThrowMock.mockReset()
+    loggerWarnMock.mockReset()
+  })
+
+  async function renderWithLoadedEvent() {
+    readApiResultOrThrowMock.mockResolvedValueOnce({ items: [makeScheduledActivity(selectedDate)] })
+    const view = renderWithProviders(
+      <ActivitiesDayStrip entityId="person-1" selectedDate={selectedDate} onSelectDate={() => {}} refreshKey={0} />,
+    )
+    await screen.findByText(/1 event/)
+    return view
+  }
+
+  function queueDeferredReload() {
+    let rejectReload: (reason: unknown) => void = () => {}
+    readApiResultOrThrowMock.mockImplementationOnce(
+      () => new Promise((_resolve, reject) => { rejectReload = reject }),
+    )
+    return (reason: unknown) => rejectReload(reason)
+  }
+
+  it('keeps the loaded events and stays quiet when a refresh is aborted', async () => {
+    const { rerender } = await renderWithLoadedEvent()
+    const failReload = queueDeferredReload()
+
+    rerender(
+      <ActivitiesDayStrip entityId="person-1" selectedDate={selectedDate} onSelectDate={() => {}} refreshKey={1} />,
+    )
+    await act(async () => { failReload(createAbortError()) })
+
+    expect(screen.getByText(/1 event/)).toBeInTheDocument()
+    expect(loggerWarnMock).not.toHaveBeenCalled()
+  })
+
+  it('clears the events and reports the failure on a real load error', async () => {
+    const { rerender } = await renderWithLoadedEvent()
+    const failReload = queueDeferredReload()
+
+    rerender(
+      <ActivitiesDayStrip entityId="person-1" selectedDate={selectedDate} onSelectDate={() => {}} refreshKey={1} />,
+    )
+    await act(async () => { failReload(new Error('[internal] boom')) })
+
+    expect(screen.queryByText(/1 event/)).toBeNull()
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/create-app/template/scripts/dev-runtime-log-policy.mjs
+++ b/packages/create-app/template/scripts/dev-runtime-log-policy.mjs
@@ -8,6 +8,39 @@ export function stripStructuredLogPrefix(line) {
   return line.replace(STRUCTURED_PRETTY_LOG_PREFIX, '')
 }
 
+// Client console output forwarded by the browser log bridge. It describes the
+// page, not the dev runtime, so a handled client-side warning must never latch
+// the runtime failure state or force the compact view open.
+const BROWSER_FORWARDED_LOG_PREFIX = '[browser]'
+const STACK_FRAME_PATTERN = /^at\s+\S/
+const STRUCTURED_PRETTY_NON_ERROR_PREFIX = /^\d{2}:\d{2}:\d{2}\.\d{3}\s+(?:DEBUG|INFO|WARN)\s+/
+
+export function isBrowserForwardedLogLine(line) {
+  if (typeof line !== 'string') return false
+  return stripStructuredLogPrefix(line.trim()).startsWith(BROWSER_FORWARDED_LOG_PREFIX)
+}
+
+// Stack frames only ever follow a header line, and that header is what decides
+// whether the block is a failure. Frames matched on their own text produce false
+// positives, because module paths and function names routinely contain "failed".
+export function isStackFrameLine(line) {
+  if (typeof line !== 'string') return false
+  return STACK_FRAME_PATTERN.test(line.trim())
+}
+
+// The structured logger already encodes severity; trust the level over a
+// substring match on the message.
+export function isStructuredNonErrorLogLine(line) {
+  if (typeof line !== 'string') return false
+  return STRUCTURED_PRETTY_NON_ERROR_PREFIX.test(line.trim())
+}
+
+export function isNonRuntimeFailureLine(line) {
+  return isBrowserForwardedLogLine(line)
+    || isStackFrameLine(line)
+    || isStructuredNonErrorLogLine(line)
+}
+
 const KMS_VAULT_FALLBACK_MESSAGE_PATTERN = /^\[shared:kms\] (?:Vault (?:read|write) (?:error|failed)\b|Vault write CAS conflict\b|No tenant DEK found in Vault\b|Failed to store tenant DEK in Vault\b)/
 
 export function isIgnorableDerivedKeyWarningLine(line) {

--- a/packages/create-app/template/scripts/dev-runtime.mjs
+++ b/packages/create-app/template/scripts/dev-runtime.mjs
@@ -7,6 +7,7 @@ import {
   createRuntimeFailureLatch,
   createRuntimeNoiseFilter,
   formatChildExitStatus,
+  isNonRuntimeFailureLine,
   isStatelessRuntimeNoiseLine,
   resolveChildExitCode,
   resolveUnexpectedExitCode,
@@ -597,7 +598,7 @@ function looksLikeWarningLine(line) {
 }
 
 function looksLikeFailure(line) {
-  if (isStatelessRuntimeNoiseLine(line) || looksLikeWarningLine(line)) return false
+  if (isStatelessRuntimeNoiseLine(line) || looksLikeWarningLine(line) || isNonRuntimeFailureLine(line)) return false
 
   return /^error\b/i.test(line)
     || /^Error:/i.test(line)

--- a/packages/ui/src/backend/utils/__tests__/apiCall.test.ts
+++ b/packages/ui/src/backend/utils/__tests__/apiCall.test.ts
@@ -107,3 +107,64 @@ describe('readApiResultOrThrow', () => {
     expect(result).toBeNull()
   })
 })
+
+describe('aborted requests', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  function createAbortedBodyResponse(): Response {
+    const abortError = new Error('The operation was aborted.')
+    abortError.name = 'AbortError'
+    const response = {
+      ok: true,
+      status: 200,
+      headers: new Map<string, string>(),
+      text: jest.fn(async () => { throw abortError }),
+      clone: () => response,
+    } as unknown as Response
+    return response
+  }
+
+  it('rejects with AbortError instead of reporting an empty payload', async () => {
+    ;(apiFetch as jest.Mock).mockResolvedValue(createAbortedBodyResponse())
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      readApiResultOrThrow('/api/interactions', { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('does not mask a genuinely empty payload when the request was not aborted', async () => {
+    ;(apiFetch as jest.Mock).mockResolvedValue(createMockResponse('', { status: 200 }))
+    const controller = new AbortController()
+
+    await expect(
+      readApiResultOrThrow('/api/interactions', { signal: controller.signal }),
+    ).rejects.toThrow('Missing response payload (200)')
+  })
+
+  it('keeps the caller-provided fallback when one is configured', async () => {
+    ;(apiFetch as jest.Mock).mockResolvedValue(createAbortedBodyResponse())
+    const controller = new AbortController()
+    controller.abort()
+
+    const call = await apiCall<{ items: string[] }>(
+      '/api/interactions',
+      { signal: controller.signal },
+      { fallback: { items: [] } },
+    )
+    expect(call.result).toEqual({ items: [] })
+  })
+
+  it('propagates AbortError raised by a custom parser', async () => {
+    ;(apiFetch as jest.Mock).mockResolvedValue(createMockResponse('{}', { status: 200 }))
+    const abortError = new Error('The operation was aborted.')
+    abortError.name = 'AbortError'
+
+    await expect(
+      apiCall('/api/interactions', undefined, { parse: async () => { throw abortError } }),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+  })
+})

--- a/packages/ui/src/backend/utils/apiCall.ts
+++ b/packages/ui/src/backend/utils/apiCall.ts
@@ -19,6 +19,27 @@ export type ApiCallResult<TReturn> = {
 
 const scopedRequestHeaders = createScopedHeaderStack()
 
+function isAbortError(error: unknown): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && (error as { name?: unknown }).name === 'AbortError'
+}
+
+function createAbortError(): Error {
+  if (typeof DOMException === 'function') {
+    return new DOMException('[internal] The operation was aborted.', 'AbortError')
+  }
+  const error = new Error('[internal] The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+function resolveAbortSignal(input: RequestInfo | URL, init?: RequestInit): AbortSignal | null {
+  if (init?.signal) return init.signal
+  if (typeof Request !== 'undefined' && input instanceof Request) return input.signal ?? null
+  return null
+}
+
 function mergeHeaders(base: HeadersInit | undefined, extra: Record<string, string>): HeadersInit {
   if (!base) return extra
   if (typeof Headers !== 'undefined' && base instanceof Headers) {
@@ -63,8 +84,15 @@ export async function apiCall<TReturn = Record<string, unknown>>(
       : response
     if (parser) result = await parser(source)
     else result = await readJsonSafe<TReturn>(source, fallback)
-  } catch {
+  } catch (err) {
+    if (isAbortError(err)) throw err
     result = fallback
+  }
+  // `readJsonSafe` swallows the abort that cancels an in-flight body read, so a
+  // request aborted after its response headers arrived would otherwise look like
+  // a successful call that returned an empty payload.
+  if (result == null && resolveAbortSignal(input, init)?.aborted) {
+    throw createAbortError()
   }
   return {
     ok: response.ok,


### PR DESCRIPTION
## What happened

While running `yarn dev` in compact mode, the raw-log view unfolded itself with:

```
❌ App runtime emitted raw output
```

The line that triggered it was a **forwarded browser warning**, not a runtime failure:

```
[browser] [customers] failed to load interactions component=ActivitiesDayStrip Error: Missing response payload (200)
    at readApiResultOrThrow (…)
    at async ActivitiesDayStrip.useEffect (…)
```

Two independent bugs, both fixed here at the root cause.

## 1. Aborted API reads were reported as empty payloads

`apiCall` reads the body through `readJsonSafe`, which catches everything internally and returns the fallback. When an `AbortController` fires **after** the response headers arrive but **before** the body is read (the normal case for a React effect cleanup that re-runs on a dependency change), the abort was swallowed and the call resolved as `{ ok: true, status: 200, result: null }`. `readApiResultOrThrow` then threw `Missing response payload (200)`.

Consequence: every caller's `if (err.name !== 'AbortError')` guard was defeated — a routine, correct cancellation surfaced as a load failure, was logged as a warning, and (per the second bug) broke the dev runner's compact output.

`packages/ui/src/backend/utils/apiCall.ts` now rejects with a real `AbortError` when the request was aborted and no payload could be read, and re-throws an `AbortError` raised by a custom `parse`. An explicitly configured `fallback` still wins, and a genuinely empty 200 on a non-aborted request still reports `Missing response payload (200)`.

**Blast radius:** behavior changes only on the abort path, and only for callers that pass a `signal`. Those already have to handle rejections, because `apiFetch` rejects on the far more common pre-response abort. Signature and types are unchanged.

`ActivitiesDayStrip` additionally cleared its already-loaded events on abort; it now only resets on a real failure, matching `ActivitiesCard`.

## 2. The dev runner treated any line containing "failed" as a runtime failure

`looksLikeFailure` in the compact dev runner substring-matches `/\bfailed\b/i` anywhere in a line. A forwarded client-side warning latched the runtime failure state, published a splash error, and force-revealed the last 200 buffered lines.

The heuristic now defers to severity and origin. These can no longer latch a failure:

- `[browser] …` lines — forwarded client console output describes the page, not the runtime
- stack frames (`at …`) — the header line above them already decides whether the block is a failure
- structured log lines at `DEBUG`/`INFO`/`WARN` — the logger already encodes severity

`ERROR`-level structured lines, `⨯ …`, bare `Error:` lines and crash output still latch exactly as before. Browser lines fall through to `ignore`, the same treatment server-side `WARN`s already get; they remain in the raw buffer and in `.mercato/logs/*-app-raw.log`, one `[d]` keypress away.

Mirrored into the create-app template (`scripts/dev-runtime.mjs`, `scripts/dev-runtime-log-policy.mjs`), which is byte-identical to the app copy by contract.

## Tests

- `packages/ui/.../__tests__/apiCall.test.ts` — aborted body read rejects with `AbortError`; non-aborted empty payload still reports `Missing response payload (200)`; configured fallback still returned; `AbortError` from a custom parser propagates
- `packages/core/.../__tests__/ActivitiesDayStrip.abort.test.tsx` — an aborted refresh keeps the loaded events and logs nothing; a real error clears them and warns
- `apps/mercato/scripts/__tests__/dev-runtime-log-policy.test.mjs` — browser lines, stack frames and non-ERROR structured lines are not failures; `ERROR` lines and `⨯` crashes still are

Both new regression tests were verified to fail against the pre-fix code.

## Validation

Ran locally (no compose container running → local runner): `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app` — all pass.

`yarn test:scripts` has one failure, `no test that audits other packages is left unclassified`, flagging `packages/create-app/src/lib/standalone-portal-email-env-guard.test.ts` and `packages/telemetry/src/__tests__/default-unloaded.test.ts`. Verified pre-existing: it fails identically on a clean `develop` tree with these changes stashed. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
