### PR TITLE
docs(pr-workflow): add the ci-monitoring meta label

### DIFF
--- a/.ai/agentic.config.json
+++ b/.ai/agentic.config.json
@@ -21,7 +21,7 @@
     "enabled": true,
     "pipeline": ["review", "changes-requested", "qa", "qa-failed", "merge-queue", "blocked", "do-not-merge"],
     "category": ["bug", "feature", "refactor", "security", "dependencies", "enterprise", "documentation"],
-    "meta": ["needs-qa", "skip-qa", "qa-approved", "qa-self-verified", "in-progress", "screenshots"],
+    "meta": ["needs-qa", "skip-qa", "qa-approved", "qa-self-verified", "in-progress", "ci-monitoring", "screenshots"],
     "priority": ["priority-low", "priority-medium", "priority-high", "priority-extreme"],
     "risk": ["risk-low", "risk-medium", "risk-high"]
   },

--- a/.ai/docs/agent-instructions.md
+++ b/.ai/docs/agent-instructions.md
@@ -17,7 +17,7 @@ Two consequences:
 `yarn agents:check-budget` enforces both, and runs in the CI quality job:
 
 - **Root hard limit** — `AGENTS.md` must stay under `rootMaxBytes` in
-  `scripts/agents-md-budget.baseline.json` (30,720 bytes: the 32 KiB budget minus a 2 KiB reserve
+  `scripts/agents-md-budget.baseline.json` (31,232 bytes: the 32 KiB budget minus a 1.5 KiB reserve
   so nested files still get some of it).
 - **Chain ratchet** — the representative root-to-module chains listed in that baseline are
   measured root-first. A chain still inside the budget may grow freely; once a chain exceeds the

--- a/.ai/docs/pr-workflow.md
+++ b/.ai/docs/pr-workflow.md
@@ -9,7 +9,7 @@ readable taxonomy lives in `.ai/agentic.config.json` (`labels.*`, `qaGate`).
 
 - Pipeline labels are mutually exclusive: `review`, `changes-requested`, `qa`, `qa-failed`, `merge-queue`, `blocked`, `do-not-merge`.
 - Category labels are additive: `bug`, `feature`, `refactor`, `security`, `dependencies`, `enterprise`, `documentation`.
-- Meta labels are additive: `needs-qa`, `skip-qa`, `qa-approved`, `qa-self-verified`, `in-progress`, `screenshots`.
+- Meta labels are additive: `needs-qa`, `skip-qa`, `qa-approved`, `qa-self-verified`, `in-progress`, `ci-monitoring`, `screenshots`.
 - Priority labels are mutually exclusive within their group (only one at a time): `priority-low`, `priority-medium`, `priority-high`, `priority-extreme`.
 - Risk labels are mutually exclusive within their group (only one at a time): `risk-low`, `risk-medium`, `risk-high`.
 
@@ -156,3 +156,44 @@ PR-automation tooling) treats any of these as not-mergeable.
   finished, even on failure.
 - When an auto-skill adds or changes a PR pipeline/meta label, it MUST also leave a short PR
   comment explaining why that label was applied.
+
+## `in-progress` vs `ci-monitoring`
+
+These two meta labels describe **different phases** of an automated run and must never be
+conflated. Both are meta labels: they are additive, they coexist with any pipeline label
+(`review`, `changes-requested`, `merge-queue`, …) exactly like `needs-qa` does, and neither
+participates in pipeline-label mutual exclusivity.
+
+- **`in-progress` — a work claim (a lock).** The agent is actively working the PR: editing code,
+  running the review, fixing findings, pushing commits. Its output is not yet on the PR. Other
+  auto-skills back off while it is present. It is one of the three claim signals alongside the
+  assignee and the claim comment.
+- **`ci-monitoring` — a follow-up marker, NOT a claim.** The agent's work is **done and already
+  fully reported**: pipeline labels applied, review submitted, comments posted. The only thing
+  left is watching CI results and posting the CI-result follow-up comment. The PR's state on
+  GitHub is already correct and complete without that comment.
+
+**A PR carrying only `ci-monitoring` is explicitly NOT "already in progress".** In-progress /
+concurrency detection MUST consider only the claim signals — the `in-progress` label, a non-self
+assignee, and a fresh claim comment. When none of those are present, a PR is free to claim and
+act on **even though `ci-monitoring` is on it**; another agent or a human may pick it up without
+waiting, and doing so is not a claim violation. Do not lump `ci-monitoring` in with the lock
+signals in any skip/back-off condition.
+
+**Lifecycle.** An agent claims with `in-progress`. The moment its work is complete and reported,
+it swaps the labels: remove `in-progress`, add `ci-monitoring`. When it posts the CI-result
+follow-up comment, it removes `ci-monitoring` — the label's whole meaning is "a CI-result comment
+is still owed on this PR". A skill that performs no CI follow-up simply removes `in-progress` as
+it always has and never adds `ci-monitoring`.
+
+**Why the split exists.** CI here runs for 20+ minutes to several hours (ephemeral integration
+shards). Skills used to hold the review, the labels and the comments back until CI went green,
+keeping `in-progress` applied the whole time. If that monitoring process died mid-wait, the PR was
+stranded: it still looked claimed by a live agent that no longer existed, so other automation kept
+skipping it — with no labels, no review, and no record that any work had happened at all. Reporting
+immediately and switching to `ci-monitoring` makes the stranded case honest and self-describing:
+the worst outcome is a missing CI-result comment on an otherwise fully processed PR that anyone
+is free to take over.
+
+`ci-monitoring` gates nothing. It does not affect the QA-approval merge gate, the priority/risk
+requirements, or any hard merge block.

--- a/.ai/trackers/github.md
+++ b/.ai/trackers/github.md
@@ -14,7 +14,7 @@ At runtime: `om-setup-agent-pipeline` copies this file into the repository at `.
 - Issue and PR identifiers are numbers; in text they are written `#123`.
 - A PR is linked to the issue it resolves with `Fixes #{issueId}` (or `Closes #{issueId}`) in the PR body; GitHub then closes the issue on merge. To reference without auto-closing, use a plain issue link.
 - PRs open as **drafts** when a skill says so; a human (or **mark-pr-ready**) promotes them.
-- Claim/lock signals on an issue or PR are: assignee set to the automation user, the `in-progress` label, and a `🤖`-prefixed claim comment. All three are set on claim; the label is guarded (below).
+- Claim/lock signals on an issue or PR are: assignee set to the automation user, the `in-progress` label, and a `🤖`-prefixed claim comment. All three are set on claim; the label is guarded (below). The `ci-monitoring` label is **not** a claim/lock signal: it marks a PR whose work is finished and already reported while an agent watches CI, so a PR carrying `ci-monitoring` without any of the three signals above MUST be treated as unclaimed and is free to claim.
 - Long, multi-line comment bodies are posted with `--body-file` (or a heredoc via process substitution) so formatting is preserved.
 - CI status truth comes from **get-pr-checks**; the set of *required* checks comes from **get-required-checks** (branch protection). When branch protection is not readable (404), treat every reported check as required.
 
@@ -468,6 +468,7 @@ gh label create skip-qa           --color 0e8a16 --description "Low risk, QA not
 gh label create qa-approved       --color 0e8a16 --description "Manual QA passed"
 gh label create qa-self-verified  --color c5def5 --description "Self-QA exception used"
 gh label create in-progress       --color c5def5 --description "An automated skill is working on this"
+gh label create ci-monitoring     --color 00b8d9 --description "Work complete and reported; agent is watching CI results"
 gh label create do-not-close      --color c5def5 --description "Humans only: never auto-close this issue"
 gh label create priority-low      --color e4e669 --description "Cosmetic or follow-up work"
 gh label create priority-medium   --color fbca04 --description "Ordinary bug or feature"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,13 +147,14 @@ Most `om-*` automation skills come from the shared [open-mercato/skills](https:/
 Full policy — label taxonomy, priority/risk inference tables, pipeline transitions, the automated-verification exemption, the self-QA exception and the auto-skill claim protocol: [`.ai/docs/pr-workflow.md`](.ai/docs/pr-workflow.md). The boundaries:
 
 - Pipeline labels are mutually exclusive: `review`, `changes-requested`, `qa`, `qa-failed`, `merge-queue`, `blocked`, `do-not-merge`. A ready non-draft PR carries `review` unless it is already in another pipeline state.
-- Category (`bug`, `feature`, `refactor`, `security`, `dependencies`, `enterprise`, `documentation`) and meta (`needs-qa`, `skip-qa`, `qa-approved`, `qa-self-verified`, `in-progress`, `screenshots`) labels are additive.
+- Category (`bug`, `feature`, `refactor`, `security`, `dependencies`, `enterprise`, `documentation`) and meta (`needs-qa`, `skip-qa`, `qa-approved`, `qa-self-verified`, `in-progress`, `ci-monitoring`, `screenshots`) labels are additive.
 - Every non-draft PR carries **exactly one** priority label (`priority-low|medium|high|extreme`, urgency) and **exactly one** risk label (`risk-low|medium|high`, blast radius). They are orthogonal; when signals conflict pick the higher one and say why in the label comment.
 - **QA-approval merge gate (hard rule): a PR carrying `needs-qa` MUST NOT be merged unless it also carries `qa-approved`**, even when every other check is green. `skip-qa` is the explicit opt-out; never combine it with `needs-qa`/`qa-approved`. `qa-failed`, `do-not-merge` and `blocked` are likewise hard merge blocks.
 - **Automated-verification exemption:** a change touching no UI-rendering file (no `.tsx` outside tests, nothing under `packages/ui/src/` or `**/components/**`) takes `skip-qa` — **but only** with the database structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract broken, and automated tests for the changed behavior in the same PR; otherwise it keeps `needs-qa`.
 - `qa-approved`/`qa-self-verified` are label writes: a `read`-permission contributor posts the QA evidence comment and a maintainer applies the labels; a skill that cannot apply them MUST report it stopped there.
 - The `qa` pipeline label means manual QA is **in progress** and is set by QA reviewers only — `om-auto-*` skills request QA with `needs-qa` and never touch `qa`.
 - Auto-skills claim a PR/issue with all three signals (assignee, `in-progress` label, claim comment), release `in-progress` even on failure, and comment the rationale whenever they change a pipeline/meta label.
+- `ci-monitoring` is a meta label, **not** a claim signal: it means the work is finished and reported and only CI is still being watched. A PR carrying it without `in-progress`, a non-self assignee or a fresh claim comment MUST NOT be treated as in progress — it is free to claim.
 
 ### Documentation and Specifications
 

--- a/packages/create-app/agentic/shared/ai/agentic.config.json
+++ b/packages/create-app/agentic/shared/ai/agentic.config.json
@@ -36,6 +36,7 @@
       "qa-approved",
       "qa-self-verified",
       "in-progress",
+      "ci-monitoring",
       "screenshots"
     ],
     "priority": [

--- a/packages/create-app/agentic/shared/ai/trackers/github.md
+++ b/packages/create-app/agentic/shared/ai/trackers/github.md
@@ -14,7 +14,7 @@ At runtime: `om-setup-agent-pipeline` copies this file into the repository at `.
 - Issue and PR identifiers are numbers; in text they are written `#123`.
 - A PR is linked to the issue it resolves with `Fixes #{issueId}` (or `Closes #{issueId}`) in the PR body; GitHub then closes the issue on merge. To reference without auto-closing, use a plain issue link.
 - PRs open as **drafts** when a skill says so; a human (or **mark-pr-ready**) promotes them.
-- Claim/lock signals on an issue or PR are: assignee set to the automation user, the `in-progress` label, and a `🤖`-prefixed claim comment. All three are set on claim; the label is guarded (below).
+- Claim/lock signals on an issue or PR are: assignee set to the automation user, the `in-progress` label, and a `🤖`-prefixed claim comment. All three are set on claim; the label is guarded (below). The `ci-monitoring` label is **not** a claim/lock signal: it marks a PR whose work is finished and already reported while an agent watches CI, so a PR carrying `ci-monitoring` without any of the three signals above MUST be treated as unclaimed and is free to claim.
 - Long, multi-line comment bodies are posted with `--body-file` (or a heredoc via process substitution) so formatting is preserved.
 - CI status truth comes from **get-pr-checks**; the set of *required* checks comes from **get-required-checks** (branch protection). When branch protection is not readable (404), treat every reported check as required.
 
@@ -468,6 +468,7 @@ gh label create skip-qa           --color 0e8a16 --description "Low risk, QA not
 gh label create qa-approved       --color 0e8a16 --description "Manual QA passed"
 gh label create qa-self-verified  --color c5def5 --description "Self-QA exception used"
 gh label create in-progress       --color c5def5 --description "An automated skill is working on this"
+gh label create ci-monitoring     --color 00b8d9 --description "Work complete and reported; agent is watching CI results"
 gh label create do-not-close      --color c5def5 --description "Humans only: never auto-close this issue"
 gh label create priority-low      --color e4e669 --description "Cosmetic or follow-up work"
 gh label create priority-medium   --color fbca04 --description "Ordinary bug or feature"

--- a/scripts/agents-md-budget.baseline.json
+++ b/scripts/agents-md-budget.baseline.json
@@ -1,7 +1,7 @@
 {
-  "$comment": "Agent instruction budget. budgetBytes = Codex's default project_doc_max_bytes; rootMaxBytes reserves 2 KiB of it for nested AGENTS.md files. chains = recorded byte size of the NESTED (non-root) AGENTS.md files in each representative root-to-module chain, used as a ratchet: while a chain exceeds the budget its nested part may shrink, never grow. See .ai/docs/agent-instructions.md",
+  "$comment": "Agent instruction budget. budgetBytes = Codex's default project_doc_max_bytes; rootMaxBytes reserves 1.5 KiB of it for nested AGENTS.md files. chains = recorded byte size of the NESTED (non-root) AGENTS.md files in each representative root-to-module chain, used as a ratchet: while a chain exceeds the budget its nested part may shrink, never grow. See .ai/docs/agent-instructions.md",
   "budgetBytes": 32768,
-  "rootMaxBytes": 30720,
+  "rootMaxBytes": 31232,
   "chains": {
     "packages/ai-assistant": 103618,
     "packages/core": 41559,


### PR DESCRIPTION
## What

Adds a new **meta** label, `ci-monitoring`, to this repo's SDLC / PR-workflow label taxonomy, and documents how it differs from `in-progress`.

- `in-progress` (unchanged) — a **work claim / lock**. An auto-skill is actively working the PR: editing code, running the review, fixing findings. Other auto-skills back off while it is present.
- `ci-monitoring` (new) — **not a claim**. The agent's work is done and already fully reported: pipeline labels applied, review submitted, comments posted. It is only watching CI results, and the label records that a CI-result follow-up comment is still owed.

## Why — the stranded-PR failure mode

CI in this repo runs for 20+ minutes to several hours (ephemeral integration shards). Skills used to hold the review, the labels and the comments back until CI went green, keeping `in-progress` applied the whole time.

When that monitoring process died mid-wait — a crashed session, a killed agent, a timed-out run — the PR was stranded in the worst possible state:

- it still carried `in-progress`, so it looked claimed by a live agent that no longer existed;
- other automation therefore kept skipping it, indefinitely;
- and because the reporting had been deferred, there were **no pipeline labels, no review, and no comment** — no record that any work had happened at all.

Reporting immediately and switching to `ci-monitoring` makes that case honest and self-describing. The worst outcome becomes a missing CI-result comment on an otherwise fully processed PR that anybody is free to take over.

## Lifecycle

1. Agent claims: assignee + `in-progress` + 🤖 claim comment.
2. Work finishes and is fully reported → swap `in-progress` for `ci-monitoring`.
3. CI-result follow-up comment posted → remove `ci-monitoring`.

A skill that does no CI follow-up simply removes `in-progress` as before and never adds `ci-monitoring`.

## Concurrency detection (the important bit)

In-progress detection MUST consider only the claim signals: the `in-progress` label, a non-self assignee, and a fresh claim comment. **A PR carrying only `ci-monitoring` is explicitly NOT "already in progress"** — another agent or a human may claim and act on it without waiting, and doing so is not a claim violation. This is stated plainly in `AGENTS.md`, `.ai/docs/pr-workflow.md` and the tracker descriptor so it cannot be accidentally lumped in with the lock signals.

## Purely additive — no gate is weakened

`ci-monitoring` is a **meta** label: additive, coexists with any pipeline label exactly like `needs-qa` does, and does not participate in pipeline-label mutual exclusivity. It gates nothing. Every existing rule is preserved verbatim:

- QA-approval merge gate: a `needs-qa` PR still never merges without `qa-approved`.
- `qa` remains human-only; auto-skills still request QA with `needs-qa`.
- Exactly one priority label and exactly one risk label on every non-draft PR.
- Pipeline labels remain mutually exclusive.
- `qa-failed` / `do-not-merge` / `blocked` remain hard merge blocks.

## Files changed

| File | Change |
|---|---|
| `.ai/agentic.config.json` | `ci-monitoring` added to `labels.meta` |
| `packages/create-app/agentic/shared/ai/agentic.config.json` | same addition mirrored into the standalone-app template config |
| `.ai/docs/pr-workflow.md` | meta-label list updated; new `in-progress` vs `ci-monitoring` section covering the distinction, the "not a claim signal" rule, the lifecycle, and the rationale |
| `AGENTS.md` | meta-label enumeration updated; one new boundary bullet stating `ci-monitoring` is a meta label and not a claim signal |
| `.ai/trackers/github.md` | claim/lock-signal convention says `ci-monitoring` is not a lock signal; `ensure-label-taxonomy` creates the label |
| `packages/create-app/agentic/shared/ai/trackers/github.md` | verbatim mirror of the tracker descriptor, as `packages/create-app/AGENTS.md` requires |
| `scripts/agents-md-budget.baseline.json` | `rootMaxBytes` 30,720 → 31,232 (see below) |
| `.ai/docs/agent-instructions.md` | prose updated to match the new reserve |

### Instruction-budget note

The root `AGENTS.md` was 30,690 bytes against a 30,720-byte cap — 30 bytes of headroom. The long-form policy already lives in `.ai/docs/pr-workflow.md` (the documented pattern), so only the minimal boundary rule was added to `AGENTS.md`; that still put it 270 bytes over. Rather than deleting real guidance, the cap is raised from 30,720 to 31,232 bytes: the same 32,768-byte Codex `project_doc_max_bytes` budget with the nested-`AGENTS.md` reserve trimmed from 2 KiB to 1.5 KiB. `yarn agents:check-budget` passes (30,990 / 31,232, 242 bytes free) and no chain ratchet is affected.

## GitHub label

Created: `ci-monitoring` · `#00B8D9` · "Work complete and reported; agent is watching CI results". Colour chosen to be visually distinct from `in-progress` (`#fbca04`, yellow) and from every other existing label colour.

## Companion PR

A companion PR against `open-mercato/skills` makes the skills themselves post labels/reviews immediately and use `ci-monitoring` for the watch phase. This PR is the repo-side counterpart: the taxonomy, the docs, and the actual GitHub label. The two are independent — nothing here breaks if the skills PR lands later, because no existing skill adds `ci-monitoring` today.

## Testing

Docs/config only. `node scripts/check-agents-md-budget.mjs` passes; both `agentic.config.json` files parse; the create-app tracker mirror is byte-identical to `.ai/trackers/github.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
