### PR TITLE
fix(crud): terminate fetch-all pagination loops on short pages, fail closed at the page ceiling (#4552 Phase 1)

### DIFF
--- a/.ai/specs/2026-07-27-list-count-strategies.md
+++ b/.ai/specs/2026-07-27-list-count-strategies.md
@@ -627,7 +627,7 @@ None blocking. One deferred item: integration tests are specified but not shippe
 
 ## Changelog
 
-### 2026-08-04 — Phase 1 implemented
+### 2026-08-04 — Phase 1 implemented ([#4942](https://github.com/open-mercato/open-mercato/pull/4942))
 
 All six loops now terminate on a short page with a fail-closed page ceiling that throws (`[internal]`-prefixed), per §Short-page termination. `total`/`totalPages` are no longer loop bounds anywhere in the converted set. Line references as implemented:
 

--- a/.ai/specs/2026-07-27-list-count-strategies.md
+++ b/.ai/specs/2026-07-27-list-count-strategies.md
@@ -386,7 +386,7 @@ Communication requirements, which are not optional even though the default is:
 
 ## Implementation Plan
 
-### Phase 1 — Short-page termination *(independently correct; no cap yet)*
+### Phase 1 — Short-page termination *(independently correct; no cap yet)* — **Implemented 2026-08-04**
 
 1. Convert the CRUD export loop, `packages/shared/src/lib/crud/factory.ts:1787-1807` (`while (exportItems.length < total)` at `:1792`), to short-page termination with a fail-closed page ceiling.
 2. Convert the custom-entity records export loop, `packages/core/src/modules/entities/api/records.ts:357-371` (`while (exportItems.length < total)` at `:360`), identically.
@@ -626,6 +626,26 @@ None blocking. One deferred item: integration tests are specified but not shippe
 **Fully compliant** — ready for implementation.
 
 ## Changelog
+
+### 2026-08-04 — Phase 1 implemented
+
+All six loops now terminate on a short page with a fail-closed page ceiling that throws (`[internal]`-prefixed), per §Short-page termination. `total`/`totalPages` are no longer loop bounds anywhere in the converted set. Line references as implemented:
+
+- CRUD export loop — `packages/shared/src/lib/crud/factory.ts` (`EXPORT_MAX_PAGES = 1000`); loop gate is now "first page came back full", not `total > exportItems.length`.
+- Custom-entity records export — `packages/core/src/modules/entities/api/records.ts` (`EXPORT_MAX_PAGES = 1000`).
+- `findMatchingEntityIdsWithQueryEngine` — `packages/core/src/modules/customers/api/utils.ts`; the latent infinite loop (`Set` size vs duplicate-inflated `total`) is gone. Signature unchanged (`Promise<string[]>`); the three callers' `!== null` checks are a pre-existing dead branch left as-is.
+- `fetchFilteredProductIds` — `packages/core/src/modules/catalog/widgets/injection/product-bulk-delete/widget.ts`; previously had no ceiling and no empty-page break.
+- `loadLegacyActivities` — extracted from `MiniWeekCalendar.tsx` into `packages/core/src/modules/customers/components/detail/legacyActivities.ts` (`loadLegacyActivitiesInRange`) so the loop is unit-testable; the domain date-range break is preserved.
+- `phoneDuplicates.ts` — `total`-derived early exit replaced with a short-page check; the deliberate `MAX_PAGES = 3` best-effort bound stays (hint feature, partial acceptable by design).
+
+Regression coverage (per step 7): `crud-factory.test.ts` (export loop ×3), `records.export.test.ts` (×3), customers `utils.test.ts` (×4, incl. the duplicate-ids infinite-loop repro), `product-bulk-delete/__tests__/widget.test.ts` (×3), `legacyActivities.test.ts` (×4), `phoneDuplicates.test.ts` (updated to short-page fixtures, +2).
+
+**Adjacent sites found during implementation — to fold into Phases 2–3** (all consume `total`/`totalPages` as truth but are not termination hazards, so they were out of Phase 1 scope):
+
+- WMS `inventoryMutationLoaders.ts` loops (`while (page <= totalPages && page <= N)`, N ∈ {10, 20, 50}) — already hard-bounded, but under a capped total they under-enumerate silently; the location total-on-hand loop **sums `quantity_on_hand` across pages into a user-visible number**.
+- `hasMore: offset + … < total` computations in `workflows/api/{tasks,instances,instances/[id]/events,definitions}/route.ts` and `dictionaries/api/[dictionaryId]/entries/route.ts` — a capped total flips `hasMore` to false early. Phase 2 must convert these to `items.length === limit` (or thread `totalIsCapped`).
+- UI "load more" guards comparing against `totalPages`/`total`: `packages/ui/src/backend/detail/AttachmentsSection.tsx`, customers `LinkedEntitiesField.tsx`, `ParticipantsField.tsx`, `DealsSection.tsx`, `AssignRoleDialog.tsx` — a capped total hides the button early (labelling-class, Phase 3).
+- `loadCanonicalInteractions` in `MiniWeekCalendar.tsx` — cursor-driven (cap-immune) but fully unbounded; `useCalendarItems.ts` (`MAX_WINDOW_ITEMS` + `truncated` flag) is the in-repo precedent if it is ever bounded.
 
 ### 2026-07-28 — Review revision
 

--- a/packages/core/src/modules/catalog/widgets/injection/product-bulk-delete/__tests__/widget.test.ts
+++ b/packages/core/src/modules/catalog/widgets/injection/product-bulk-delete/__tests__/widget.test.ts
@@ -1,0 +1,94 @@
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  fetchCrudList: jest.fn(),
+}))
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: jest.fn(),
+}))
+
+import widget from '../widget'
+import { fetchCrudList } from '@open-mercato/ui/backend/utils/crud'
+import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockedFetchCrudList = fetchCrudList as jest.MockedFunction<typeof fetchCrudList>
+const mockedApiCall = apiCall as jest.MockedFunction<typeof apiCall>
+
+const PAGE_SIZE = 100
+
+const bulkDeleteFiltered = widget.bulkActions?.find(
+  (action) => action.id === 'catalog.products.bulk-delete-filtered',
+)
+
+const makeItems = (count: number, offset = 0) =>
+  Array.from({ length: count }, (_, index) => ({ id: `product-${offset + index}` }))
+
+const listPayload = (items: Array<{ id: string }>, totalPages: number) => ({
+  items,
+  total: items.length,
+  page: 1,
+  pageSize: PAGE_SIZE,
+  totalPages,
+})
+
+const context = {
+  confirm: jest.fn(async () => true),
+  translate: (_key: string, fallback: string) => fallback,
+}
+
+describe('catalog product-bulk-delete widget - filtered id enumeration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockedApiCall.mockResolvedValue({
+      ok: true,
+      status: 200,
+      result: { ok: true, progressJobId: 'job-1' },
+      response: {} as Response,
+      cacheStatus: null,
+    })
+  })
+
+  it('exists on the widget', () => {
+    expect(bulkDeleteFiltered).toBeDefined()
+  })
+
+  it('enumerates every page even when totalPages under-reports the result set', async () => {
+    mockedFetchCrudList
+      .mockResolvedValueOnce(listPayload(makeItems(PAGE_SIZE), 1))
+      .mockResolvedValueOnce(listPayload(makeItems(PAGE_SIZE, PAGE_SIZE), 1))
+      .mockResolvedValueOnce(listPayload(makeItems(5, PAGE_SIZE * 2), 1))
+
+    const result = await bulkDeleteFiltered!.onExecute([], context)
+
+    expect(result).toMatchObject({ ok: true, progressJobId: 'job-1' })
+    expect(mockedFetchCrudList).toHaveBeenCalledTimes(3)
+    const deleteCall = mockedApiCall.mock.calls[0]
+    const body = JSON.parse((deleteCall[1] as RequestInit).body as string)
+    expect(body.ids).toHaveLength(PAGE_SIZE * 2 + 5)
+    expect(body.scope).toBe('filtered')
+  })
+
+  it('terminates on a short final page', async () => {
+    mockedFetchCrudList.mockResolvedValueOnce(listPayload(makeItems(3), 50))
+
+    const result = await bulkDeleteFiltered!.onExecute([], context)
+
+    expect(result).toMatchObject({ ok: true })
+    expect(mockedFetchCrudList).toHaveBeenCalledTimes(1)
+    const body = JSON.parse((mockedApiCall.mock.calls[0][1] as RequestInit).body as string)
+    expect(body.ids).toHaveLength(3)
+  })
+
+  it('throws at the page ceiling rather than deleting a partial set', async () => {
+    let offset = 0
+    mockedFetchCrudList.mockImplementation(async () => {
+      const items = makeItems(PAGE_SIZE, offset)
+      offset += PAGE_SIZE
+      return listPayload(items, 10_000)
+    })
+
+    await expect(bulkDeleteFiltered!.onExecute([], context)).rejects.toThrow(
+      /refusing to bulk-delete a partial set/,
+    )
+    expect(mockedFetchCrudList).toHaveBeenCalledTimes(1000)
+    expect(mockedApiCall).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/catalog/widgets/injection/product-bulk-delete/widget.ts
+++ b/packages/core/src/modules/catalog/widgets/injection/product-bulk-delete/widget.ts
@@ -8,6 +8,9 @@ type ProductRow = {
   id: string
 }
 
+const FILTERED_IDS_PAGE_SIZE = 100
+const FILTERED_IDS_MAX_PAGES = 1000
+
 type BulkActionContext = {
   confirm?: (options?: {
     title?: string
@@ -32,7 +35,7 @@ function readRowId(row: unknown): string | null {
 }
 
 function buildListParams(context: BulkActionContext): Record<string, string> {
-  const params: Record<string, string> = { pageSize: '100' }
+  const params: Record<string, string> = { pageSize: String(FILTERED_IDS_PAGE_SIZE) }
   const injectionContext = context.injectionContext
   const search = typeof injectionContext?.search === 'string' ? injectionContext.search.trim() : ''
   if (search) params.search = search
@@ -106,19 +109,26 @@ async function fetchFilteredProductIds(context: BulkActionContext): Promise<stri
   const baseParams = buildListParams(context)
   const productIds = new Set<string>()
   let page = 1
-  let totalPages = 1
 
-  while (page <= totalPages) {
+  // Short-page termination: server-reported `totalPages` is a display value, not a loop
+  // bound — it can under-report (capped counts) or drift mid-enumeration. Fail closed at
+  // the page ceiling: a partial id set would turn "delete all filtered" into "delete the
+  // first N" with no signal to the user.
+  for (;;) {
     const payload = await fetchCrudList<ProductRow>('catalog/products', {
       ...baseParams,
       page,
     })
-    for (const item of payload.items) {
+    const items = Array.isArray(payload.items) ? payload.items : []
+    for (const item of items) {
       if (typeof item?.id === 'string' && item.id.length > 0) {
         productIds.add(item.id)
       }
     }
-    totalPages = typeof payload.totalPages === 'number' && payload.totalPages > 0 ? payload.totalPages : 1
+    if (items.length < FILTERED_IDS_PAGE_SIZE) break
+    if (page >= FILTERED_IDS_MAX_PAGES) {
+      throw new Error(`[internal] filtered product enumeration exceeded ${FILTERED_IDS_MAX_PAGES} pages; refusing to bulk-delete a partial set`)
+    }
     page += 1
   }
 

--- a/packages/core/src/modules/customers/api/__tests__/utils.test.ts
+++ b/packages/core/src/modules/customers/api/__tests__/utils.test.ts
@@ -1,4 +1,8 @@
-import { withScopedPayload, findMatchingEntityIdsBySearchTokensAcrossSources } from '../utils'
+import {
+  withScopedPayload,
+  findMatchingEntityIdsBySearchTokensAcrossSources,
+  findMatchingEntityIdsWithQueryEngine,
+} from '../utils'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 
 const translate = (key: string, fallback?: string) => fallback ?? key
@@ -204,5 +208,89 @@ describe('customers api utils - findMatchingEntityIdsBySearchTokensAcrossSources
     })
 
     expect(maxInFlight).toBe(2)
+  })
+})
+
+describe('customers api utils - findMatchingEntityIdsWithQueryEngine', () => {
+  const PAGE_SIZE = 100
+
+  function makeRows(count: number, offset = 0): Array<{ id: string }> {
+    return Array.from({ length: count }, (_, index) => ({ id: `id-${offset + index}` }))
+  }
+
+  function createCtxWithQueryEngine(pages: Array<Array<{ id: string }>>, total: number) {
+    const calls: number[] = []
+    const qe = {
+      async query(_entity: string, opts: { page?: { page?: number } }) {
+        const page = opts.page?.page ?? 1
+        calls.push(page)
+        return { items: pages[page - 1] ?? [], total }
+      },
+    }
+    const ctx = {
+      auth: { tenantId: 'tenant-1' },
+      selectedOrganizationId: 'org-1',
+      container: { resolve: (key: string) => (key === 'queryEngine' ? qe : undefined) },
+    } as any
+    return { ctx, calls }
+  }
+
+  it('enumerates every page even when total under-reports the result set', async () => {
+    const pages = [makeRows(PAGE_SIZE), makeRows(PAGE_SIZE, PAGE_SIZE), makeRows(10, PAGE_SIZE * 2)]
+    const { ctx, calls } = createCtxWithQueryEngine(pages, 5)
+
+    const ids = await findMatchingEntityIdsWithQueryEngine({
+      ctx,
+      entityId: 'customers:customer_entity' as any,
+      filters: {},
+    })
+
+    expect(ids).toHaveLength(PAGE_SIZE * 2 + 10)
+    expect(calls).toEqual([1, 2, 3])
+  })
+
+  it('terminates on a short final page instead of trusting an inflated total', async () => {
+    const pages = [makeRows(PAGE_SIZE), makeRows(3, PAGE_SIZE)]
+    const { ctx, calls } = createCtxWithQueryEngine(pages, 10_000)
+
+    const ids = await findMatchingEntityIdsWithQueryEngine({
+      ctx,
+      entityId: 'customers:customer_entity' as any,
+      filters: {},
+    })
+
+    expect(ids).toHaveLength(PAGE_SIZE + 3)
+    expect(calls).toEqual([1, 2])
+  })
+
+  it('terminates when pages repeat duplicate ids (previously an infinite loop)', async () => {
+    // Old shape looped `while (ids.size < total)`: duplicates keep the Set's size below
+    // an inflated total forever, so only an empty page could stop it. Full pages of the
+    // same 100 ids now stop at the page ceiling by throwing instead of spinning.
+    const repeated = makeRows(PAGE_SIZE)
+    const pages = Array.from({ length: 2000 }, () => repeated)
+    const { ctx, calls } = createCtxWithQueryEngine(pages, PAGE_SIZE * 2000)
+
+    await expect(
+      findMatchingEntityIdsWithQueryEngine({
+        ctx,
+        entityId: 'customers:customer_entity' as any,
+        filters: {},
+      }),
+    ).rejects.toThrow(/exceeded 1000 pages/)
+    expect(calls).toHaveLength(1000)
+  })
+
+  it('throws at the page ceiling rather than returning a partial id set', async () => {
+    const pages = Array.from({ length: 2000 }, (_, index) => makeRows(PAGE_SIZE, index * PAGE_SIZE))
+    const { ctx } = createCtxWithQueryEngine(pages, PAGE_SIZE * 2000)
+
+    await expect(
+      findMatchingEntityIdsWithQueryEngine({
+        ctx,
+        entityId: 'customers:customer_entity' as any,
+        filters: {},
+      }),
+    ).rejects.toThrow(/refusing to return a partial id set/)
   })
 })

--- a/packages/core/src/modules/customers/api/utils.ts
+++ b/packages/core/src/modules/customers/api/utils.ts
@@ -280,10 +280,14 @@ export async function findMatchingEntityIdsWithQueryEngine({
   const qe = ctx.container.resolve('queryEngine') as QueryEngine
   const ids = new Set<string>()
   const pageSize = 100
+  const maxPages = 1000
   let page = 1
-  let total = 0
 
-  do {
+  // Short-page termination: `total` is a display value, not a loop bound. The previous
+  // `while (ids.size < total)` could spin forever — `ids` is a Set, so duplicate ids across
+  // pages keep its size permanently below an inflated `total`. Fail closed at the page
+  // ceiling: a partial id set fed into advanced filtering would silently drop matches.
+  for (;;) {
     const result = await qe.query(entityId, {
       fields: ['id'],
       filters,
@@ -296,16 +300,19 @@ export async function findMatchingEntityIdsWithQueryEngine({
       joins,
     })
 
-    total = result.total ?? 0
-    for (const item of result.items ?? []) {
+    const items = result.items ?? []
+    for (const item of items) {
       const id = item && typeof item === 'object' ? (item as Record<string, unknown>).id : null
       if (typeof id === 'string' && id.length > 0) {
         ids.add(id)
       }
     }
-    if (!result.items?.length) break
+    if (items.length < pageSize) break
+    if (page >= maxPages) {
+      throw new Error(`[internal] advanced-filter id resolution exceeded ${maxPages} pages; refusing to return a partial id set`)
+    }
     page += 1
-  } while (ids.size < total)
+  }
 
   return Array.from(ids)
 }

--- a/packages/core/src/modules/customers/components/detail/MiniWeekCalendar.tsx
+++ b/packages/core/src/modules/customers/components/detail/MiniWeekCalendar.tsx
@@ -7,7 +7,8 @@ import { useT } from '@open-mercato/shared/lib/i18n/context'
 import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
-import type { InteractionSummary, ActivitySummary } from './types'
+import type { InteractionSummary } from './types'
+import { loadLegacyActivitiesInRange } from './legacyActivities'
 
 interface MiniWeekCalendarProps {
   entityId: string
@@ -132,61 +133,6 @@ export function MiniWeekCalendar({ entityId, useCanonicalInteractions = true, re
       return items.filter(isWithinRange)
     }
 
-    async function loadLegacyActivities(): Promise<InteractionSummary[]> {
-      const items: InteractionSummary[] = []
-      let page = 1
-      let totalPages = 1
-      do {
-        const payload = await readApiResultOrThrow<{
-          items?: ActivitySummary[]
-          totalPages?: number
-        }>(
-          `/api/customers/activities?entityId=${encodeURIComponent(entityId)}&page=${page}&pageSize=100&sortField=occurredAt&sortDir=desc`,
-          { signal: controller.signal },
-        )
-        const pageItems = Array.isArray(payload?.items) ? payload.items : []
-        const mappedItems: InteractionSummary[] = pageItems.map((activity) => ({
-          id: activity.id,
-          interactionType: activity.activityType,
-          title: activity.subject ?? null,
-          body: activity.body ?? null,
-          status: 'done',
-          scheduledAt: null,
-          occurredAt: activity.occurredAt ?? null,
-          priority: null,
-          authorUserId: activity.authorUserId ?? null,
-          ownerUserId: null,
-          appearanceIcon: activity.appearanceIcon ?? null,
-          appearanceColor: activity.appearanceColor ?? null,
-          source: 'legacy-activity',
-          entityId: activity.entityId ?? null,
-          dealId: activity.dealId ?? null,
-          organizationId: null,
-          tenantId: null,
-          authorName: activity.authorName ?? null,
-          authorEmail: activity.authorEmail ?? null,
-          dealTitle: activity.dealTitle ?? null,
-          customValues: null,
-          createdAt: activity.createdAt,
-          updatedAt: activity.createdAt,
-        }))
-        items.push(...mappedItems.filter(isWithinRange))
-        totalPages = typeof payload?.totalPages === 'number' ? payload.totalPages : totalPages
-        if (!pageItems.length) break
-        const oldestPageTimestamp = pageItems.reduce<number>((oldest, activity) => {
-          const rawDate = activity.occurredAt ?? activity.createdAt
-          const timestamp = rawDate ? new Date(rawDate).getTime() : Number.NaN
-          if (!Number.isFinite(timestamp)) return oldest
-          return Math.min(oldest, timestamp)
-        }, Number.POSITIVE_INFINITY)
-        if (Number.isFinite(oldestPageTimestamp) && oldestPageTimestamp < rangeStart.getTime()) {
-          break
-        }
-        page += 1
-      } while (page <= totalPages)
-      return items
-    }
-
     void (async () => {
       try {
         const canonicalItems = await loadCanonicalInteractions()
@@ -194,7 +140,12 @@ export function MiniWeekCalendar({ entityId, useCanonicalInteractions = true, re
           setEvents(canonicalItems)
           return
         }
-        const legacyItems = await loadLegacyActivities()
+        const legacyItems = await loadLegacyActivitiesInRange({
+          entityId,
+          rangeStart,
+          isWithinRange,
+          signal: controller.signal,
+        })
         const seen = new Set<string>()
         const merged: InteractionSummary[] = []
         for (const item of [...canonicalItems, ...legacyItems]) {

--- a/packages/core/src/modules/customers/components/detail/__tests__/legacyActivities.test.ts
+++ b/packages/core/src/modules/customers/components/detail/__tests__/legacyActivities.test.ts
@@ -1,0 +1,80 @@
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  readApiResultOrThrow: jest.fn(),
+}))
+
+import { loadLegacyActivitiesInRange, LEGACY_ACTIVITIES_PAGE_SIZE } from '../legacyActivities'
+import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+
+const mockedRead = readApiResultOrThrow as jest.MockedFunction<typeof readApiResultOrThrow>
+
+const IN_RANGE_DATE = '2026-08-03T12:00:00.000Z'
+const OUT_OF_RANGE_DATE = '2026-07-01T12:00:00.000Z'
+const RANGE_START = new Date('2026-08-01T00:00:00.000Z')
+
+const makeActivities = (count: number, offset = 0, occurredAt = IN_RANGE_DATE) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `activity-${offset + index}`,
+    activityType: 'note',
+    occurredAt,
+    createdAt: occurredAt,
+  }))
+
+const loadOptions = {
+  entityId: 'entity-1',
+  rangeStart: RANGE_START,
+  isWithinRange: () => true,
+}
+
+describe('customers detail - loadLegacyActivitiesInRange', () => {
+  beforeEach(() => {
+    mockedRead.mockReset()
+  })
+
+  it('enumerates every page even when totalPages under-reports the result set', async () => {
+    mockedRead
+      .mockResolvedValueOnce({ items: makeActivities(LEGACY_ACTIVITIES_PAGE_SIZE), totalPages: 1 })
+      .mockResolvedValueOnce({
+        items: makeActivities(4, LEGACY_ACTIVITIES_PAGE_SIZE),
+        totalPages: 1,
+      })
+
+    const items = await loadLegacyActivitiesInRange(loadOptions)
+
+    expect(items).toHaveLength(LEGACY_ACTIVITIES_PAGE_SIZE + 4)
+    expect(mockedRead).toHaveBeenCalledTimes(2)
+  })
+
+  it('terminates on a short final page instead of trusting an inflated totalPages', async () => {
+    mockedRead.mockResolvedValueOnce({ items: makeActivities(2), totalPages: 500 })
+
+    const items = await loadLegacyActivitiesInRange(loadOptions)
+
+    expect(items).toHaveLength(2)
+    expect(mockedRead).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops once a full page scans past the requested range start', async () => {
+    mockedRead.mockResolvedValueOnce({
+      items: makeActivities(LEGACY_ACTIVITIES_PAGE_SIZE, 0, OUT_OF_RANGE_DATE),
+      totalPages: 500,
+    })
+
+    await loadLegacyActivitiesInRange(loadOptions)
+
+    expect(mockedRead).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws at the page ceiling rather than returning a partial set', async () => {
+    let offset = 0
+    mockedRead.mockImplementation(async () => {
+      const items = makeActivities(LEGACY_ACTIVITIES_PAGE_SIZE, offset)
+      offset += LEGACY_ACTIVITIES_PAGE_SIZE
+      return { items, totalPages: 10_000 }
+    })
+
+    await expect(loadLegacyActivitiesInRange(loadOptions)).rejects.toThrow(
+      /refusing to render a partial set/,
+    )
+    expect(mockedRead).toHaveBeenCalledTimes(1000)
+  })
+})

--- a/packages/core/src/modules/customers/components/detail/legacyActivities.ts
+++ b/packages/core/src/modules/customers/components/detail/legacyActivities.ts
@@ -1,0 +1,79 @@
+import { readApiResultOrThrow } from '@open-mercato/ui/backend/utils/apiCall'
+import type { ActivitySummary, InteractionSummary } from './types'
+
+export const LEGACY_ACTIVITIES_PAGE_SIZE = 100
+export const LEGACY_ACTIVITIES_MAX_PAGES = 1000
+
+function mapActivityToInteraction(activity: ActivitySummary): InteractionSummary {
+  return {
+    id: activity.id,
+    interactionType: activity.activityType,
+    title: activity.subject ?? null,
+    body: activity.body ?? null,
+    status: 'done',
+    scheduledAt: null,
+    occurredAt: activity.occurredAt ?? null,
+    priority: null,
+    authorUserId: activity.authorUserId ?? null,
+    ownerUserId: null,
+    appearanceIcon: activity.appearanceIcon ?? null,
+    appearanceColor: activity.appearanceColor ?? null,
+    source: 'legacy-activity',
+    entityId: activity.entityId ?? null,
+    dealId: activity.dealId ?? null,
+    organizationId: null,
+    tenantId: null,
+    authorName: activity.authorName ?? null,
+    authorEmail: activity.authorEmail ?? null,
+    dealTitle: activity.dealTitle ?? null,
+    customValues: null,
+    createdAt: activity.createdAt,
+    updatedAt: activity.createdAt,
+  }
+}
+
+export async function loadLegacyActivitiesInRange({
+  entityId,
+  rangeStart,
+  isWithinRange,
+  signal,
+}: {
+  entityId: string
+  rangeStart: Date
+  isWithinRange: (item: InteractionSummary) => boolean
+  signal?: AbortSignal
+}): Promise<InteractionSummary[]> {
+  const items: InteractionSummary[] = []
+  let page = 1
+  // Short-page termination: server-reported `totalPages` is a display value, not a loop
+  // bound — it can under-report (capped counts) or drift mid-enumeration. Pages are sorted
+  // by `occurredAt` desc, so the scan also stops once a page reaches past the requested
+  // range. Fail closed at the page ceiling rather than rendering a partial week silently.
+  for (;;) {
+    const payload = await readApiResultOrThrow<{
+      items?: ActivitySummary[]
+      totalPages?: number
+    }>(
+      `/api/customers/activities?entityId=${encodeURIComponent(entityId)}&page=${page}&pageSize=${LEGACY_ACTIVITIES_PAGE_SIZE}&sortField=occurredAt&sortDir=desc`,
+      { signal },
+    )
+    const pageItems = Array.isArray(payload?.items) ? payload.items : []
+    items.push(...pageItems.map(mapActivityToInteraction).filter(isWithinRange))
+    if (!pageItems.length) break
+    const oldestPageTimestamp = pageItems.reduce<number>((oldest, activity) => {
+      const rawDate = activity.occurredAt ?? activity.createdAt
+      const timestamp = rawDate ? new Date(rawDate).getTime() : Number.NaN
+      if (!Number.isFinite(timestamp)) return oldest
+      return Math.min(oldest, timestamp)
+    }, Number.POSITIVE_INFINITY)
+    if (Number.isFinite(oldestPageTimestamp) && oldestPageTimestamp < rangeStart.getTime()) {
+      break
+    }
+    if (pageItems.length < LEGACY_ACTIVITIES_PAGE_SIZE) break
+    if (page >= LEGACY_ACTIVITIES_MAX_PAGES) {
+      throw new Error(`[internal] legacy activity enumeration exceeded ${LEGACY_ACTIVITIES_MAX_PAGES} pages; refusing to render a partial set`)
+    }
+    page += 1
+  }
+  return items
+}

--- a/packages/core/src/modules/customers/utils/__tests__/phoneDuplicates.test.ts
+++ b/packages/core/src/modules/customers/utils/__tests__/phoneDuplicates.test.ts
@@ -17,6 +17,15 @@ const createResponse = (payload: unknown, ok = true) => {
   }
 }
 
+const PAGE_SIZE = 50
+
+const fillerPeople = (count: number, offset = 0) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `filler-${offset + index}`,
+    display_name: `Filler ${offset + index}`,
+    primary_phone: `+1 555 000-${String(offset + index).padStart(4, '0')}`,
+  }))
+
 describe('customers utils - phone duplicate lookup', () => {
   beforeEach(() => {
     mockedApiCall.mockReset()
@@ -54,8 +63,8 @@ describe('customers utils - phone duplicate lookup', () => {
         createResponse({
           items: [
             { id: 'current', display_name: 'Keep', primary_phone: '+1 555 123-4567' },
+            ...fillerPeople(PAGE_SIZE - 1),
           ],
-          total: 120,
         })
       )
       .mockResolvedValueOnce(
@@ -63,10 +72,9 @@ describe('customers utils - phone duplicate lookup', () => {
           items: [
             { id: 'duplicate', display_name: 'Grace Hopper', primary_phone: '+1 555 123-4567' },
           ],
-          total: 120,
         })
       )
-      .mockResolvedValue(createResponse({ items: [], total: 120 }))
+      .mockResolvedValue(createResponse({ items: [] }))
 
     const result = await lookupPhoneDuplicate('+1 555 123-4567', { recordId: 'current' })
     expect(result).toEqual({
@@ -85,14 +93,49 @@ describe('customers utils - phone duplicate lookup', () => {
           items: [
             { id: 'c1', display_name: 'Incomplete', primary_phone: '+1 555 000-0000' },
             { id: 'c2', display_name: null, primary_phone: '+1 555 123-4567' },
+            ...fillerPeople(PAGE_SIZE - 2),
           ],
-          total: 200,
         })
       )
-      .mockResolvedValue(createResponse({ items: [], total: 200 }))
+      .mockResolvedValue(createResponse({ items: fillerPeople(PAGE_SIZE, PAGE_SIZE) }))
 
     const result = await lookupPhoneDuplicate('+1 555 999-9999')
     expect(result).toBeNull()
+    expect(mockedApiCall).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops on a short page without consulting total', async () => {
+    mockedApiCall.mockResolvedValueOnce(
+      createResponse({
+        items: fillerPeople(3),
+        total: 10_000,
+      })
+    )
+
+    const result = await lookupPhoneDuplicate('+1 555 999-9999')
+    expect(result).toBeNull()
+    expect(mockedApiCall).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps scanning full pages up to MAX_PAGES even when total under-reports', async () => {
+    mockedApiCall
+      .mockResolvedValueOnce(createResponse({ items: fillerPeople(PAGE_SIZE), total: 1 }))
+      .mockResolvedValueOnce(createResponse({ items: fillerPeople(PAGE_SIZE, PAGE_SIZE), total: 1 }))
+      .mockResolvedValueOnce(
+        createResponse({
+          items: [
+            { id: 'duplicate', display_name: 'Grace Hopper', primary_phone: '+1 555 123-4567' },
+          ],
+          total: 1,
+        })
+      )
+
+    const result = await lookupPhoneDuplicate('+1 555 123-4567')
+    expect(result).toEqual({
+      id: 'duplicate',
+      label: 'Grace Hopper',
+      href: '/backend/customers/people/duplicate',
+    })
     expect(mockedApiCall).toHaveBeenCalledTimes(3)
   })
 })

--- a/packages/core/src/modules/customers/utils/phoneDuplicates.ts
+++ b/packages/core/src/modules/customers/utils/phoneDuplicates.ts
@@ -22,7 +22,7 @@ export async function lookupPhoneDuplicate(
   for (let page = 1; page <= MAX_PAGES; page += 1) {
     try {
       const url = `/api/customers/people?hasPhone=true&page=${page}&pageSize=${PAGE_SIZE}&sortField=createdAt&sortDir=desc`
-      const call = await apiCall<{ items?: unknown[]; total?: number }>(url)
+      const call = await apiCall<{ items?: unknown[] }>(url)
       if (!call.ok) continue
       const payload = call.result ?? {}
       const items = Array.isArray(payload?.items) ? payload.items : []
@@ -45,8 +45,11 @@ export async function lookupPhoneDuplicate(
           }
         }
       }
-      const total = typeof payload?.total === 'number' ? payload.total : null
-      if (total !== null && page * PAGE_SIZE >= total) {
+      // Short-page termination: a page shorter than requested is the end of the result
+      // set. `total` is a display value and may under-report (capped counts), so it is
+      // no longer consulted. MAX_PAGES stays as the deliberate best-effort bound — this
+      // is a duplicate hint, not an exhaustive check.
+      if (items.length < PAGE_SIZE) {
         break
       }
     } catch {

--- a/packages/core/src/modules/entities/api/__tests__/records.export.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/records.export.test.ts
@@ -1,0 +1,72 @@
+/** @jest-environment node */
+import { GET } from '@open-mercato/core/modules/entities/api/records'
+
+const EXPORT_PAGE_SIZE = 1000
+
+const makeItems = (count: number, offset = 0) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `rec-${offset + index}`,
+    cf_title: `Title ${offset + index}`,
+  }))
+
+const mockQE = {
+  query: jest.fn(),
+}
+
+const mockEm = {
+  findOne: jest.fn(async () => ({ id: 'ce-1', entityId: 'example:custom' })),
+}
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => ({ resolve: (k: string) => (k === 'queryEngine' ? mockQE : mockEm) }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({ getAuthFromRequest: () => ({ orgId: 'org', tenantId: 't1', roles: ['admin'] }) }))
+
+function queueQueryPages(pages: Array<Array<Record<string, unknown>>>, total: number) {
+  mockQE.query.mockImplementation(async (_entityId: string, opts: { page?: { page?: number } }) => {
+    const page = opts.page?.page ?? 1
+    return { items: pages[page - 1] ?? [], total, page, pageSize: EXPORT_PAGE_SIZE }
+  })
+}
+
+async function csvRowCount(res: Response): Promise<number> {
+  const body = await res.text()
+  return body.trim().split('\n').length - 1
+}
+
+describe('GET /api/entities/records export loop', () => {
+  beforeEach(() => { jest.clearAllMocks() })
+
+  it('exports every row even when total under-reports the result set', async () => {
+    queueQueryPages(
+      [makeItems(EXPORT_PAGE_SIZE), makeItems(EXPORT_PAGE_SIZE, EXPORT_PAGE_SIZE), makeItems(7, EXPORT_PAGE_SIZE * 2)],
+      5,
+    )
+    const res = await GET(new Request('http://x/api/entities/records?entityId=example:custom&format=csv'))
+    expect(res.status).toBe(200)
+    expect(await csvRowCount(res)).toBe(EXPORT_PAGE_SIZE * 2 + 7)
+    expect(mockQE.query).toHaveBeenCalledTimes(3)
+  })
+
+  it('terminates on a short final page instead of trusting an inflated total', async () => {
+    queueQueryPages([makeItems(3)], 10_000)
+    const res = await GET(new Request('http://x/api/entities/records?entityId=example:custom&format=csv'))
+    expect(res.status).toBe(200)
+    expect(await csvRowCount(res)).toBe(3)
+    expect(mockQE.query).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed at the page ceiling rather than serializing a partial export', async () => {
+    const fullPage = makeItems(EXPORT_PAGE_SIZE)
+    mockQE.query.mockImplementation(async () => ({
+      items: fullPage,
+      total: EXPORT_PAGE_SIZE,
+      page: 1,
+      pageSize: EXPORT_PAGE_SIZE,
+    }))
+    const res = await GET(new Request('http://x/api/entities/records?entityId=example:custom&format=csv'))
+    expect(res.status).toBe(500)
+    expect(mockQE.query).toHaveBeenCalledTimes(1000)
+  })
+})

--- a/packages/core/src/modules/entities/api/records.ts
+++ b/packages/core/src/modules/entities/api/records.ts
@@ -120,6 +120,7 @@ export const metadata = {
 }
 
 const DEFAULT_EXPORT_PAGE_SIZE = 1000
+const EXPORT_MAX_PAGES = 1000
 
 const listRecordsQuerySchema = z
   .object({
@@ -330,10 +331,14 @@ export async function GET(req: Request) {
     }
 
     if (requestedExport) {
-      let exportItems: any[] = exportFullRequested ? [...fullPageItems] : [...viewPageItems]
-      if (total > exportItems.length) {
+      const exportItems: any[] = exportFullRequested ? [...fullPageItems] : [...viewPageItems]
+      // Short-page termination: `total` is a display value, not a loop bound — it can
+      // under-report (capped counts) or drift while rows are inserted/deleted mid-export.
+      // Keep fetching while pages come back full; fail closed at the page ceiling rather
+      // than serializing a partial export.
+      if (rawItems.length >= pageSize) {
         let nextPage = 2
-        while (exportItems.length < total) {
+        for (;;) {
           const nextRes = await qe.query(entityId as any, {
             ...qopts,
             page: { page: nextPage, pageSize },
@@ -344,7 +349,10 @@ export async function GET(req: Request) {
           const nextFullItems = nextRawItems.map(mapFullRow)
           const nextBatch = exportFullRequested ? nextFullItems : nextViewItems
           exportItems.push(...nextBatch)
-          if (nextBatch.length < pageSize) break
+          if (nextRawItems.length < pageSize) break
+          if (nextPage >= EXPORT_MAX_PAGES) {
+            throw new Error(`[internal] export exceeded ${EXPORT_MAX_PAGES} pages; refusing to return a partial export`)
+          }
           nextPage += 1
         }
       }

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -539,6 +539,59 @@ describe('CRUD Factory', () => {
     })
   })
 
+  describe('export loop termination', () => {
+    const EXPORT_PAGE_SIZE = 1000
+
+    afterEach(() => {
+      queryEngine.query.mockImplementation(async (_entityId: any, _q: any) => ({ items: [{ id: 'id-1', title: 'A', is_done: false, organization_id: defaultOrganizationId, tenant_id: defaultTenantId }], total: 1 }))
+    })
+
+    const makeItems = (count: number, offset = 0) =>
+      Array.from({ length: count }, (_, index) => ({
+        id: `id-${offset + index}`,
+        title: `Todo ${offset + index}`,
+        is_done: false,
+        organization_id: defaultOrganizationId,
+        tenant_id: defaultTenantId,
+      }))
+
+    const queuePages = (pages: Array<Array<Record<string, unknown>>>, total: number) => {
+      queryEngine.query.mockImplementation(async (_entityId: any, q: any) => {
+        const page = q?.page?.page ?? 1
+        return { items: pages[page - 1] ?? [], total }
+      })
+    }
+
+    it('GET export enumerates every page even when total under-reports the result set', async () => {
+      queuePages(
+        [makeItems(EXPORT_PAGE_SIZE), makeItems(EXPORT_PAGE_SIZE, EXPORT_PAGE_SIZE), makeItems(5, EXPORT_PAGE_SIZE * 2)],
+        3,
+      )
+      const res = await route.GET(new Request('http://x/api/example/todos?format=json'))
+      expect(res.status).toBe(200)
+      const parsed = JSON.parse(await res.text())
+      expect(parsed).toHaveLength(EXPORT_PAGE_SIZE * 2 + 5)
+      expect(queryEngine.query).toHaveBeenCalledTimes(3)
+    })
+
+    it('GET export terminates on a short final page instead of trusting an inflated total', async () => {
+      queuePages([makeItems(4)], 10_000)
+      const res = await route.GET(new Request('http://x/api/example/todos?format=json'))
+      expect(res.status).toBe(200)
+      const parsed = JSON.parse(await res.text())
+      expect(parsed).toHaveLength(4)
+      expect(queryEngine.query).toHaveBeenCalledTimes(1)
+    })
+
+    it('GET export fails closed at the page ceiling rather than serializing a partial export', async () => {
+      const fullPage = makeItems(EXPORT_PAGE_SIZE)
+      queryEngine.query.mockImplementation(async () => ({ items: fullPage, total: EXPORT_PAGE_SIZE }))
+      const res = await route.GET(new Request('http://x/api/example/todos?format=json'))
+      expect(res.status).toBe(500)
+      expect(queryEngine.query).toHaveBeenCalledTimes(1000)
+    })
+  })
+
   it('POST creates entity, saves custom fields, emits created event', async () => {
     const res = await route.POST(new Request('http://x/api/example/todos', { method: 'POST', body: JSON.stringify({ title: 'B', is_done: true, cf_priority: 3 }), headers: { 'content-type': 'application/json' } }))
     expect(res.status).toBe(201)

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -252,6 +252,7 @@ const DEFAULT_EXPORT_FORMATS: CrudExportFormat[] = ['csv', 'json', 'xml', 'markd
 const DEFAULT_EXPORT_BATCH_SIZE = 1000
 const MIN_EXPORT_BATCH_SIZE = 100
 const MAX_EXPORT_BATCH_SIZE = 10000
+const EXPORT_MAX_PAGES = 1000
 
 type ColumnResolver = {
   field: string
@@ -1806,13 +1807,17 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
           const initialExportItems = exportFullRequested
             ? rawItems.map(normalizeFullRecordForExport)
             : transformedItems
-          let exportItems = [...initialExportItems]
-          if (total > exportItems.length) {
-            const exportPageSizeNumber = typeof page.pageSize === 'number' ? page.pageSize : exportPageSize
+          const exportItems = [...initialExportItems]
+          const exportPageSizeNumber = typeof page.pageSize === 'number' ? page.pageSize : exportPageSize
+          // Short-page termination: `total` is a display value, not a loop bound — it can
+          // under-report (capped counts) or drift while rows are inserted/deleted mid-export.
+          // Keep fetching while pages come back full; fail closed at the page ceiling rather
+          // than serializing a partial export.
+          if (rawItems.length >= exportPageSizeNumber) {
             const queryBase: any = { ...queryOpts }
             delete queryBase.page
             let nextPage = 2
-            while (exportItems.length < total) {
+            for (;;) {
               profiler.mark('export_next_page_request', { page: nextPage })
               const nextRes = await qe.query(opts.list.entityId as any, {
                 ...queryBase,
@@ -1827,7 +1832,10 @@ export function makeCrudRoute<TCreate = any, TUpdate = any, TList = any>(opts: C
                 ? nextItemsRaw.map(normalizeFullRecordForExport)
                 : nextTransformed
               exportItems.push(...nextExportItems)
-              if (nextExportItems.length < exportPageSizeNumber) break
+              if (nextItemsRaw.length < exportPageSizeNumber) break
+              if (nextPage >= EXPORT_MAX_PAGES) {
+                throw new Error(`[internal] export exceeded ${EXPORT_MAX_PAGES} pages; refusing to return a partial export`)
+              }
               nextPage += 1
             }
           }


### PR DESCRIPTION
## Summary

Phase 1 of the capped-list-count spec merged in #4552 (`.ai/specs/2026-07-27-list-count-strategies.md`). Six fetch-all pagination loops used a server-reported `total`/`totalPages` as their loop bound. That is wrong today (a count-terminated loop misbehaves when rows are inserted or deleted mid-loop; one of the six could already spin **forever**), and it becomes silent data loss the moment Phase 2 makes `total` a bounded floor (`OM_LIST_COUNT_CAP`).

Every converted loop now uses one shape, per the spec's §Short-page termination (in-repo reference: `TenantSelect.tsx`): collect until a page comes back shorter than requested, and **fail closed** — throw an `[internal]`-prefixed error — at a hard page ceiling instead of returning a partial export or a partial id set.

## Changes

- `packages/shared/src/lib/crud/factory.ts` — CRUD CSV/XLSX/JSON export loop: loop gate is now "first page came back full" instead of `total > exportItems.length`; `EXPORT_MAX_PAGES = 1000` throws rather than truncating.
- `packages/core/src/modules/entities/api/records.ts` — custom-entity records export loop: identical treatment.
- `packages/core/src/modules/customers/api/utils.ts` — `findMatchingEntityIdsWithQueryEngine`: **fixes a latent infinite loop.** `ids` is a `Set`, so duplicate ids across pages kept `ids.size` permanently below an inflated `total`; the only escape was an empty page. Signature unchanged; feeds the advanced filters on `customers/api/{deals,people,companies}`.
- `packages/core/src/modules/catalog/widgets/injection/product-bulk-delete/widget.ts` — `fetchFilteredProductIds`: previously had **no** page ceiling and **no** empty-page break; a partial id set would turn "delete all filtered" into "delete the first N" with no signal.
- `packages/core/src/modules/customers/components/detail/MiniWeekCalendar.tsx` — legacy-activities loop extracted to `legacyActivities.ts` (`loadLegacyActivitiesInRange`) so it is unit-testable; the domain date-range break is preserved.
- `packages/core/src/modules/customers/utils/phoneDuplicates.ts` — `total`-derived early exit replaced with a short-page check; the deliberate `MAX_PAGES = 3` best-effort bound stays (duplicate *hint*, partial acceptable by design).
- Spec updated: Phase 1 marked implemented, changelog entry with as-implemented references, plus adjacent `total`-consuming sites found during implementation recorded for Phases 2–3 (WMS `inventoryMutationLoaders` bounded loops, `hasMore` computations in workflows/dictionaries routes, UI "load more" guards, the unbounded cursor loop in `MiniWeekCalendar`).

No behaviour change for consistent result sets: the converted loops fetch the same pages and return the same data; they just no longer trust the count.

## Specification

**Does a spec exist for this feature/module?**
- [x] Yes

**Spec file path:**
`.ai/specs/2026-07-27-list-count-strategies.md` (Implementation Plan → Phase 1; changelog entry added)

## Testing

Per spec Phase 1 step 7, every converted loop has regression tests asserting: full enumeration when `total` deliberately under-reports, termination on a short final page, and a **throwing** (not truncating) page ceiling:

- `packages/shared/src/lib/crud/__tests__/crud-factory.test.ts` — export loop ×3
- `packages/core/src/modules/entities/api/__tests__/records.export.test.ts` — new, ×3
- `packages/core/src/modules/customers/api/__tests__/utils.test.ts` — ×4, incl. the duplicate-ids infinite-loop repro (hangs against the old loop, passes now)
- `packages/core/src/modules/catalog/widgets/injection/product-bulk-delete/__tests__/widget.test.ts` — new, ×3 (ceiling test asserts the bulk-delete POST is never issued)
- `packages/core/src/modules/customers/components/detail/__tests__/legacyActivities.test.ts` — new, ×4
- `packages/core/src/modules/customers/utils/__tests__/phoneDuplicates.test.ts` — fixtures updated to short-page semantics, +2 cases

Commands (local, all green): `yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn lint`, `yarn test` (24/24 turbo tasks; `@open-mercato/core` 1170 suites / 9037 tests).

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. — spec updated; no locale/generator surface changes (ceiling throws are `[internal]`-prefixed per the i18n opt-out convention)
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — not required here: no API contract, schema, or UI-surface change; the behavior change (loop termination) is fully covered by the unit regression suites above. The spec's integration matrix is tied to the Phase 2 cap and ships with it.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label. — proposing `priority-medium` (see label comment)
- [ ] Risk set: this PR carries exactly one `risk-*` label. — proposing `risk-medium` (see label comment)
- [ ] QA routing set — proposing `needs-qa`: the diff touches `.tsx` under `components/` (`MiniWeekCalendar`), so the automated-verification exemption does not apply.

### Design System Compliance

N/A — no UI rendering change; `MiniWeekCalendar.tsx` only swaps an inline fetch loop for the extracted helper.

- [x] No hardcoded status colors — none added
- [x] No arbitrary text sizes — none added
- [x] Empty state — unchanged
- [x] Loading state — unchanged
- [x] `aria-label` — no new buttons
- [x] Uses existing DS components — no new components

## Linked issues

Implements Phase 1 of #4552 (spec). Related: #2227 (count-distinct optimization), #4618 (list-views-at-scale RFC — its WS5 builds on this).