### PR TITLE
fix(query_index,search,rbac): stop partitioned reindex losing rows, degrade vector search without pgvector

### DIFF
--- a/.ai/runs/2026-08-04-query-index-partition-race-and-vector-availability.md
+++ b/.ai/runs/2026-08-04-query-index-partition-race-and-vector-availability.md
@@ -1,6 +1,6 @@
 # Execution plan — query index partition race, vector store availability, stale ACL override
 
-Status: in-progress
+Status: complete
 Engine: om-auto-create-pr (steps: 9, --loop: no)
 
 ## Goal
@@ -45,8 +45,12 @@ Three independent root causes surfaced by the same greenfield run.
 - Reworking `throwOnStrategyFailures` or the write-failure contract. Writes stay fail-loud
   for available strategies; the #3103 queue-retry behavior is deliberately preserved.
 - Changing the reindex partitioning strategy, partition count, or job accounting model.
-- Repairing the two test suites that already fail on `develop`
-  (`customer_accounts/users-invite-person-link`, `apps/mercato/storage-s3-routes`).
+- Repairing the `create-mercato-app` template ESM-import test, which fails on `develop`
+  independently of this work: `packages/create-app/template/scripts/dev-runtime.mjs` imports
+  `./dev-memory-monitor.mjs`, a sibling that #4939 added under `apps/mercato/scripts/` and
+  never mirrored into the template. `yarn template:sync` does not treat it as drift, so
+  fixing it means extending the mirror list as well as copying the file — that belongs with
+  the change that introduced it.
 - Auto-heal for the runtime (non-CLI) path — the coverage-gap auto-reindex remains gated on
   custom-field entities. Out of scope here; the init-time repair pass covers the reported bug.
 
@@ -110,9 +114,10 @@ Three independent root causes surfaced by the same greenfield run.
 - `@open-mercato/search` full suite; `query_index` suite.
 - New regression tests, including two that were confirmed to fail against the pre-fix
   reindexer and pass after it.
-- Pre-existing, unrelated failures on `develop`:
-  `packages/core/src/modules/customer_accounts/api/__tests__/users-invite-person-link.test.ts`
-  and `apps/mercato/src/__tests__/storage-s3-routes.test.ts`.
+- Full configured gate on the current `develop` head: `yarn build:packages`, `yarn generate`,
+  `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`,
+  `yarn test`, `yarn build:app`. Everything green except the pre-existing
+  `create-mercato-app` template ESM-import failure described under Non-goals.
 
 ## Progress
 
@@ -120,18 +125,18 @@ Three independent root causes surfaced by the same greenfield run.
 
 ### Phase 1: Query index partition race
 
-- [ ] 1.1 Partition-scope the force purge and run it in every partition
-- [ ] 1.2 Stop scope-wide coverage zeroing during partitioned runs
-- [ ] 1.3 Make refreshCoverageSnapshot scope-symmetric and return its counts
-- [ ] 1.4 Add the post-reindex verify-and-repair pass to the CLI
-- [ ] 1.5 Add regression tests for the purge scoping and coverage symmetry
+- [x] 1.1 Partition-scope the force purge and run it in every partition — c8303d3
+- [x] 1.2 Stop scope-wide coverage zeroing during partitioned runs — c8303d3
+- [x] 1.3 Make refreshCoverageSnapshot scope-symmetric and return its counts — c8303d3
+- [x] 1.4 Add the post-reindex verify-and-repair pass to the CLI — c8303d3
+- [x] 1.5 Add regression tests for the purge scoping and coverage symmetry — c8303d3
 
 ### Phase 2: Vector store availability
 
-- [ ] 2.1 Add the cached pgvector extension probe and short-circuit ensureReady
-- [ ] 2.2 Consult the probe from the vector strategy and surface it in settings + i18n
-- [ ] 2.3 Add availability regression tests
+- [x] 2.1 Add the cached pgvector extension probe and short-circuit ensureReady — 9944485
+- [x] 2.2 Consult the probe from the vector strategy and surface it in settings + i18n — 9944485
+- [x] 2.3 Add availability regression tests — 9944485
 
 ### Phase 3: Stale ACL override
 
-- [ ] 3.1 Declare the example.manage override probe and guard it with a test
+- [x] 3.1 Declare the example.manage override probe and guard it with a test — 2512235

--- a/.ai/runs/2026-08-04-query-index-partition-race-and-vector-availability.md
+++ b/.ai/runs/2026-08-04-query-index-partition-race-and-vector-availability.md
@@ -121,6 +121,8 @@ Three independent root causes surfaced by the same greenfield run.
 
 ## Progress
 
+PR: #4944
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Query index partition race

--- a/.ai/runs/2026-08-04-query-index-partition-race-and-vector-availability.md
+++ b/.ai/runs/2026-08-04-query-index-partition-race-and-vector-availability.md
@@ -1,0 +1,137 @@
+# Execution plan — query index partition race, vector store availability, stale ACL override
+
+Status: in-progress
+Engine: om-auto-create-pr (steps: 9, --loop: no)
+
+## Goal
+
+Make a fresh `yarn dev:greenfield` end with a fully indexed, warning-free instance: no
+"Results may be incomplete" banner that only a manual reindex can clear, no per-record
+`extension "vector" is not available` error storm, and no stale ACL-override warning on
+every module registration.
+
+## Scope
+
+Three independent root causes surfaced by the same greenfield run.
+
+1. **Query index rows lost by the partitioned force reindex.** `mercato init` runs
+   `query_index reindex --force` in 5 concurrent partitions. Only partition 0 received
+   `resetCoverage: true`, and it issued a scope-wide `DELETE FROM entity_indexes` while its
+   siblings were already inserting — deleting whichever partition finished writing first,
+   with nothing to rebuild it. Progress counts *attempted* writes, so every partition still
+   reported `processed == total` and the run looked successful. Confirmed against the live
+   greenfield database: the lost slice was always exactly one whole partition, always the one
+   with the earliest `started_at` (`attachments:attachment` 11/12, `auth:user` 2/3,
+   `catalog:catalog_product_price` 10/12, `entities:encryption_map` 33/37,
+   `entities:custom_field_entity_config` 4/6). The manual reindex button repaired it only
+   because the API path defaults to `partitionCount = 1`, so nothing raced.
+
+2. **Vector search error storm without pgvector.** `VectorSearchStrategy.isAvailable()`
+   checked only the embedding provider, never the store, so `SearchService` kept the strategy
+   in the active set and called `ensureReady()` per record. That reached
+   `CREATE EXTENSION IF NOT EXISTS vector` → `58P01 extension "vector" is not available`. The
+   driver caught only `42501`, and its failure handler set `ready = null`, discarding the
+   memo — so the full DDL block re-ran for every single write and delete, each surfacing as
+   an `AggregateError` through `throwOnStrategyFailures`.
+
+3. **Stale ACL override warning.** A live `acl.features: { 'example.manage': null }` override
+   in `apps/mercato/src/modules.ts` names a feature the example module never declared, so
+   `applyModuleOverridesToModules` skips it and warns on every registration (including each
+   HMR pass). It also made `TC-AUTH-055-nulled-feature-policy` pass vacuously — it asserted a
+   feature that never existed was denied.
+
+## Non-goals
+
+- Reworking `throwOnStrategyFailures` or the write-failure contract. Writes stay fail-loud
+  for available strategies; the #3103 queue-retry behavior is deliberately preserved.
+- Changing the reindex partitioning strategy, partition count, or job accounting model.
+- Repairing the two test suites that already fail on `develop`
+  (`customer_accounts/users-invite-person-link`, `apps/mercato/storage-s3-routes`).
+- Auto-heal for the runtime (non-CLI) path — the coverage-gap auto-reindex remains gated on
+  custom-field entities. Out of scope here; the init-time repair pass covers the reported bug.
+
+## Implementation Plan
+
+### Phase 1 — Query index: stop the partitioned reindex losing rows
+
+- Partition-scope the force purge in `reindexEntity` using the same predicate `purgeOrphans`
+  already uses (`mod(abs(hashtext(entity_id::text)), N) = i`), and run it in **every**
+  partition rather than only the coverage-resetting one — restricting it to partition 0 would
+  otherwise leave the other slices' stale rows behind on a forced rebuild.
+- Skip the scope-wide coverage zeroing during partitioned runs: `baseCounts` there holds only
+  this partition's slice, so writing it as the scope's base count under-reports by the
+  partition factor, and zeroing `indexed_count` discards deltas siblings already applied. The
+  end-of-partition `refreshCoverageSnapshot` is authoritative.
+- Make `refreshCoverageSnapshot` symmetric: never narrow the index side by a column the base
+  table lacks. `organizations` has no `organization_id` (its index rows derive one from the
+  record id) and `user_roles` has neither column, so the two sides counted different
+  populations; the previous early-return froze the stale snapshot, leaving a permanent
+  "out of sync" row for `directory:organization` that no reindex could clear.
+- Add `verifyAndRepairIndexCoverage` to the reindex CLI, run after each entity's partitions
+  complete on full runs. It recounts the scope from the database and rebuilds single-partition
+  when still short, so init cannot finish leaving a gap for a human to notice and repair by
+  hand. Two COUNT queries when the counts already agree.
+
+### Phase 2 — Search: degrade instead of erroring when pgvector is missing
+
+- Add a cached `pg_extension` / `pg_available_extensions` probe to the pgvector driver behind
+  new optional `isHealthy()` / `getStatus()` members, with a 60s recheck so installing the
+  extension recovers without a process restart. Treat the not-installable error class
+  (`58P01`, `0A000`, `42704`) and the follow-on `type "vector" does not exist` as unavailable
+  and short-circuit `ensureReady()`; keep probe failures optimistic so transient database
+  problems retain their existing retry semantics.
+- Consult the probe from `VectorSearchStrategy.isAvailable()` so `SearchService` drops the
+  strategy before `ensureReady()` is ever called.
+- Surface availability: `/api/search/settings/vector-store` returns `available` /
+  `unavailableReason` per driver, and the Vector Search settings section renders a warning
+  banner carrying the driver's reason.
+
+### Phase 3 — RBAC: retire the stale ACL override warning
+
+- Declare `example.manage` in the canonical example module as an explicit, ungated override
+  probe, mirrored byte-exact into the create-app template.
+- Guard it with a test asserting every live `entry.overrides.acl.features` key resolves to a
+  declared feature.
+
+## Risks
+
+- The purge now runs in every partition instead of once. Each is a bounded `DELETE` over one
+  hash slice and the CLI already purges the scope up front, so the extra statements are
+  no-ops in the common path.
+- `verifyAndRepairIndexCoverage` adds two COUNT queries per entity per full reindex. It only
+  triggers a rebuild when a real gap remains, and it is skipped for single-partition-target
+  invocations.
+- `VectorDriver` gains optional members only, so third-party drivers and the qdrant/chromadb
+  stubs stay source-compatible.
+
+## Verification
+
+- Repo `yarn typecheck`, `yarn lint`, `yarn agents:check-budget`.
+- `@open-mercato/search` full suite; `query_index` suite.
+- New regression tests, including two that were confirmed to fail against the pre-fix
+  reindexer and pass after it.
+- Pre-existing, unrelated failures on `develop`:
+  `packages/core/src/modules/customer_accounts/api/__tests__/users-invite-person-link.test.ts`
+  and `apps/mercato/src/__tests__/storage-s3-routes.test.ts`.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Query index partition race
+
+- [ ] 1.1 Partition-scope the force purge and run it in every partition
+- [ ] 1.2 Stop scope-wide coverage zeroing during partitioned runs
+- [ ] 1.3 Make refreshCoverageSnapshot scope-symmetric and return its counts
+- [ ] 1.4 Add the post-reindex verify-and-repair pass to the CLI
+- [ ] 1.5 Add regression tests for the purge scoping and coverage symmetry
+
+### Phase 2: Vector store availability
+
+- [ ] 2.1 Add the cached pgvector extension probe and short-circuit ensureReady
+- [ ] 2.2 Consult the probe from the vector strategy and surface it in settings + i18n
+- [ ] 2.3 Add availability regression tests
+
+### Phase 3: Stale ACL override
+
+- [ ] 3.1 Declare the example.manage override probe and guard it with a test

--- a/.ai/specs/2026-07-23-consolidated-feature-policy.md
+++ b/.ai/specs/2026-07-23-consolidated-feature-policy.md
@@ -190,7 +190,7 @@ The change is additive for imports, function signatures, DI keys, and shared typ
 
 The intentional behavioral contract change is that browser/JWT feature arrays no longer expose `*` or namespace wildcards. External consumers must check for concrete feature IDs rather than inspect wildcard strings. This is documented in `BACKWARD_COMPATIBILITY.md` and `UPGRADE_NOTES.md`.
 
-No feature ID is renamed or removed. The `example.manage` null override is an inert runtime probe, not a declared feature removal.
+No feature ID is renamed or removed. The `example.manage` null override is an inert runtime probe: the example module declares the feature so the override has something to null, but nothing gates on it, so nulling it removes no capability.
 
 ## Risks & Impact Review
 

--- a/apps/mercato/src/__tests__/module-override-acl-features.test.ts
+++ b/apps/mercato/src/__tests__/module-override-acl-features.test.ts
@@ -8,10 +8,13 @@ import { enabledModules } from '../modules'
 // asserts such a feature is denied passes vacuously — the feature never existed. Keep
 // every live ACL override key anchored to a declared feature.
 
-const REPO_ROOT = path.resolve(process.cwd(), '..', '..')
+// Resolved from this file rather than `process.cwd()`, so the guard behaves the same
+// whether jest is invoked from the app workspace or the repository root.
+const APP_ROOT = path.resolve(__dirname, '..', '..')
+const REPO_ROOT = path.resolve(APP_ROOT, '..', '..')
 
 const SOURCE_ROOTS = [
-  path.join(process.cwd(), 'src', 'modules'),
+  path.join(APP_ROOT, 'src', 'modules'),
   path.join(REPO_ROOT, 'packages'),
 ]
 

--- a/apps/mercato/src/__tests__/module-override-acl-features.test.ts
+++ b/apps/mercato/src/__tests__/module-override-acl-features.test.ts
@@ -1,0 +1,71 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { enabledModules } from '../modules'
+
+// A `entry.overrides.acl.features` key that no enabled module declares is silently
+// skipped by `applyModuleOverridesToModules` and logs a stale-override warning on every
+// module registration (including each HMR pass in dev). Worse, an integration test that
+// asserts such a feature is denied passes vacuously — the feature never existed. Keep
+// every live ACL override key anchored to a declared feature.
+
+const REPO_ROOT = path.resolve(process.cwd(), '..', '..')
+
+const SOURCE_ROOTS = [
+  path.join(process.cwd(), 'src', 'modules'),
+  path.join(REPO_ROOT, 'packages'),
+]
+
+// `packages/create-app/template` mirrors app modules that this app does not register,
+// so its declarations must not vouch for an override key here.
+const IGNORED_DIRS = new Set(['node_modules', 'dist', '.mercato', 'template'])
+
+function findAclFiles(root: string): string[] {
+  if (!fs.existsSync(root)) return []
+  const found: string[] = []
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (IGNORED_DIRS.has(entry.name)) continue
+      const abs = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(abs)
+        continue
+      }
+      if (entry.name === 'acl.ts') found.push(abs)
+    }
+  }
+  walk(root)
+  return found
+}
+
+function collectDeclaredFeatureIds(): Set<string> {
+  const ids = new Set<string>()
+  const idPattern = /(?:^|[\s{,])id:\s*'([^']+)'|^\s*'([^']+)',?\s*$/gm
+  for (const root of SOURCE_ROOTS) {
+    for (const file of findAclFiles(root)) {
+      const source = fs.readFileSync(file, 'utf8')
+      for (const match of source.matchAll(idPattern)) {
+        const id = match[1] ?? match[2]
+        if (id && id.includes('.')) ids.add(id)
+      }
+    }
+  }
+  return ids
+}
+
+describe('module ACL feature overrides', () => {
+  it('only nulls or replaces features that a module actually declares', () => {
+    const declared = collectDeclaredFeatureIds()
+    expect(declared.size).toBeGreaterThan(0)
+
+    const stale: string[] = []
+    for (const entry of enabledModules) {
+      const overrides = entry.overrides?.acl?.features
+      if (!overrides) continue
+      for (const key of Object.keys(overrides)) {
+        if (!declared.has(key)) stale.push(`${entry.id}: ${key}`)
+      }
+    }
+
+    expect(stale).toEqual([])
+  })
+})

--- a/apps/mercato/src/modules/example/acl.ts
+++ b/apps/mercato/src/modules/example/acl.ts
@@ -1,5 +1,11 @@
 export const features = [
   { id: 'example.backend', title: 'Access example backend', module: 'example' },
+  // ACL override probe. Nothing gates on it, so it stays inert wherever it is granted.
+  // `apps/mercato/src/modules.ts` nulls it through `entry.overrides.acl.features` so
+  // TC-AUTH-055 can assert that a nulled feature stays denied for literal, wildcard and
+  // super-admin grants. It must remain declared here — an override naming an undeclared
+  // feature is skipped as stale and logs a warning on every module registration.
+  { id: 'example.manage', title: 'Manage example (override probe)', module: 'example' },
   { id: 'example.view', title: 'View example enrichments', module: 'example' },
   { id: 'example.todos.view', title: 'View todos', module: 'example' },
   {

--- a/packages/core/src/modules/query_index/__tests__/coverage-scope-symmetry.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/coverage-scope-symmetry.test.ts
@@ -1,0 +1,114 @@
+import {
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  type CompiledQuery,
+} from 'kysely'
+import { refreshCoverageSnapshot } from '../lib/coverage'
+
+/**
+ * `organizations` has no `organization_id` column, yet its index rows carry one derived
+ * from the record id (`deriveOrgFromId`). Filtering only the index side compared two
+ * different populations and produced a permanent "out of sync" row no reindex could clear;
+ * bailing out instead left the previous snapshot frozen with the same effect.
+ */
+function makeEm(options: {
+  table: string
+  columns: string[]
+  baseCount: number
+  indexCount: number
+}) {
+  const statements: CompiledQuery[] = []
+
+  const respond = (compiled: CompiledQuery): unknown[] => {
+    const text = compiled.sql
+    if (text.includes('information_schema')) {
+      const column = String(compiled.parameters[compiled.parameters.length - 1] ?? '')
+      return options.columns.includes(column) ? [{ present: 1 }] : []
+    }
+    if (text.includes('from "entity_indexes"')) return [{ count: options.indexCount }]
+    if (text.includes(`from "${options.table}"`)) return [{ count: options.baseCount }]
+    if (text.includes('entity_index_coverage')) return []
+    return []
+  }
+
+  const db = new Kysely<any>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => ({
+        init: async () => undefined,
+        acquireConnection: async () => ({
+          executeQuery: async (compiled: CompiledQuery) => {
+            statements.push(compiled)
+            return { rows: respond(compiled), numAffectedRows: BigInt(0) }
+          },
+          streamQuery: async function* () { /* not used */ },
+        }),
+        beginTransaction: async () => undefined,
+        commitTransaction: async () => undefined,
+        rollbackTransaction: async () => undefined,
+        releaseConnection: async () => undefined,
+        destroy: async () => undefined,
+      }),
+      createIntrospector: (instance: Kysely<any>) => new PostgresIntrospector(instance),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  })
+
+  const em: any = {
+    getKysely: () => db,
+    getMetadata: () => ({
+      find: () => ({ tableName: options.table }),
+      getAll: () => [{ className: 'Organization', tableName: options.table }],
+    }),
+  }
+  return { em, statements }
+}
+
+function indexCountStatement(statements: CompiledQuery[]): CompiledQuery | undefined {
+  return statements.find((entry) => entry.sql.includes('from "entity_indexes"'))
+}
+
+describe('refreshCoverageSnapshot scope symmetry', () => {
+  it('does not narrow the index side by a column the base table lacks', async () => {
+    const { em, statements } = makeEm({
+      // Unique table name per test: the column lookup is process-cached.
+      table: 'organizations_symmetry_a',
+      columns: ['id', 'tenant_id'],
+      baseCount: 1,
+      indexCount: 1,
+    })
+
+    const counts = await refreshCoverageSnapshot(em, {
+      entityType: 'directory:organization',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      withDeleted: false,
+    })
+
+    expect(counts).toEqual({ baseCount: 1, indexedCount: 1 })
+    const indexQuery = indexCountStatement(statements)
+    expect(indexQuery?.sql).not.toContain('"organization_id"')
+    expect(indexQuery?.sql).toContain('"tenant_id"')
+  })
+
+  it('still scopes both sides when the base table has the column', async () => {
+    const { em, statements } = makeEm({
+      table: 'organizations_symmetry_b',
+      columns: ['id', 'tenant_id', 'organization_id'],
+      baseCount: 4,
+      indexCount: 4,
+    })
+
+    const counts = await refreshCoverageSnapshot(em, {
+      entityType: 'example:todo',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      withDeleted: false,
+    })
+
+    expect(counts).toEqual({ baseCount: 4, indexedCount: 4 })
+    expect(indexCountStatement(statements)?.sql).toContain('"organization_id"')
+  })
+})

--- a/packages/core/src/modules/query_index/__tests__/reindexer-partition-purge.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/reindexer-partition-purge.test.ts
@@ -150,3 +150,52 @@ describe('reindexEntity force purge scoping', () => {
     expect(purgeStatements(statements)).toHaveLength(0)
   })
 })
+
+// The vector purge deletes every vector for the scope and cannot be partitioned, so
+// emitting it from inside a concurrent fan-out is the same race the row purge had — it
+// would drop vectors the sibling partitions had just queued. The caller that owns the
+// fan-out queues it once instead.
+describe('reindexEntity vector purge scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUpsertIndexBatch.mockResolvedValue(batchResult({ attempted: 1, written: 1 }))
+  })
+
+  function makeBus() {
+    const emitted: string[] = []
+    return {
+      emitted,
+      bus: { emitEvent: jest.fn(async (event: string) => { emitted.push(event) }) },
+    }
+  }
+
+  it('does not emit a scope-wide vector purge from a partition', async () => {
+    const { em } = makeEm([{ id: 'a' }])
+    const { bus, emitted } = makeBus()
+
+    await reindexEntity(em, {
+      ...BASE_OPTIONS,
+      partitionCount: 5,
+      partitionIndex: 0,
+      resetCoverage: true,
+      emitVectorizeEvents: true,
+      eventBus: bus,
+    })
+
+    expect(emitted).not.toContain('query_index.vectorize_purge')
+  })
+
+  it('still emits it for an unpartitioned forced run', async () => {
+    const { em } = makeEm([{ id: 'a' }])
+    const { bus, emitted } = makeBus()
+
+    await reindexEntity(em, {
+      ...BASE_OPTIONS,
+      resetCoverage: true,
+      emitVectorizeEvents: true,
+      eventBus: bus,
+    })
+
+    expect(emitted).toContain('query_index.vectorize_purge')
+  })
+})

--- a/packages/core/src/modules/query_index/__tests__/reindexer-partition-purge.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/reindexer-partition-purge.test.ts
@@ -1,0 +1,152 @@
+import {
+  Kysely,
+  PostgresAdapter,
+  PostgresIntrospector,
+  PostgresQueryCompiler,
+  type CompiledQuery,
+} from 'kysely'
+import { reindexEntity } from '../lib/reindexer'
+import { upsertIndexBatch, type UpsertIndexBatchResult } from '../lib/batch'
+
+jest.mock('../lib/batch', () => {
+  const actual = jest.requireActual('../lib/batch')
+  return { ...actual, upsertIndexBatch: jest.fn() }
+})
+
+jest.mock('../lib/coverage', () => ({
+  applyCoverageAdjustments: jest.fn(async () => undefined),
+  refreshCoverageSnapshot: jest.fn(async () => undefined),
+  writeCoverageCounts: jest.fn(async () => undefined),
+}))
+
+jest.mock('../lib/jobs', () => ({
+  prepareJob: jest.fn(async () => undefined),
+  updateJobProgress: jest.fn(async () => undefined),
+  finalizeJob: jest.fn(async () => undefined),
+}))
+
+jest.mock('../lib/stale', () => ({
+  purgeOrphans: jest.fn(async () => undefined),
+}))
+
+const mockUpsertIndexBatch = upsertIndexBatch as jest.MockedFunction<typeof upsertIndexBatch>
+
+function batchResult(partial: Partial<UpsertIndexBatchResult>): UpsertIndexBatchResult {
+  return { attempted: 0, written: 0, failedRecordIds: [], searchTokenFailures: 0, ...partial }
+}
+
+/**
+ * A Kysely bound to a driver that records every compiled statement, so assertions can
+ * read the real SQL the reindexer emits instead of a hand-rolled chain stub.
+ */
+function makeEm(rows: Array<{ id: string }>) {
+  const statements: CompiledQuery[] = []
+  let pageServed = false
+
+  const respond = (compiled: CompiledQuery): { rows: unknown[] } => {
+    const text = compiled.sql
+    if (text.includes('information_schema')) {
+      return { rows: [{ column_name: 'id' }, { column_name: 'tenant_id' }, { column_name: 'organization_id' }] }
+    }
+    if (text.includes('entity_index_jobs')) {
+      return { rows: [{ started_at: new Date('2026-08-01T00:00:00Z') }] }
+    }
+    if (text.startsWith('select count(*)') || text.includes('count(*)')) {
+      return { rows: [{ count: rows.length }] }
+    }
+    if (text.startsWith('select * from "todos"')) {
+      if (pageServed) return { rows: [] }
+      pageServed = true
+      return { rows }
+    }
+    return { rows: [] }
+  }
+
+  const db = new Kysely<any>({
+    dialect: {
+      createAdapter: () => new PostgresAdapter(),
+      createDriver: () => ({
+        init: async () => undefined,
+        acquireConnection: async () => ({
+          executeQuery: async (compiled: CompiledQuery) => {
+            statements.push(compiled)
+            const result = respond(compiled)
+            return { rows: result.rows, numAffectedRows: BigInt(0) }
+          },
+          streamQuery: async function* () { /* not used */ },
+        }),
+        beginTransaction: async () => undefined,
+        commitTransaction: async () => undefined,
+        rollbackTransaction: async () => undefined,
+        releaseConnection: async () => undefined,
+        destroy: async () => undefined,
+      }),
+      createIntrospector: (instance: Kysely<any>) => new PostgresIntrospector(instance),
+      createQueryCompiler: () => new PostgresQueryCompiler(),
+    },
+  })
+
+  const em: any = {
+    getKysely: () => db,
+    getMetadata: () => ({
+      find: (className: string) => (className === 'Todo' ? { tableName: 'todos' } : undefined),
+      getAll: () => [{ className: 'Todo', tableName: 'todos' }],
+    }),
+  }
+  return { em, statements }
+}
+
+function purgeStatements(statements: CompiledQuery[]): CompiledQuery[] {
+  return statements.filter((entry) => entry.sql.startsWith('delete from "entity_indexes"'))
+}
+
+const BASE_OPTIONS = { entityType: 'example:todo', tenantId: 't1', force: true }
+
+describe('reindexEntity force purge scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUpsertIndexBatch.mockResolvedValue(batchResult({ attempted: 1, written: 1 }))
+  })
+
+  // Regression: partition 0 used to purge the whole scope while its siblings were already
+  // inserting, deleting their rows for good. The run still reported success because progress
+  // counts attempted writes, so a fresh `mercato init` silently left entities under-indexed.
+  it('restricts the purge to the partition being rebuilt', async () => {
+    const { em, statements } = makeEm([{ id: 'a' }])
+
+    await reindexEntity(em, { ...BASE_OPTIONS, partitionCount: 5, partitionIndex: 0, resetCoverage: true })
+
+    const purges = purgeStatements(statements)
+    expect(purges).toHaveLength(1)
+    expect(purges[0]!.sql).toMatch(/mod\(abs\(hashtext\(entity_id::text\)\), \$\d+\) = \$\d+/)
+    expect(purges[0]!.parameters).toEqual(expect.arrayContaining([5, 0]))
+  })
+
+  it('purges in every partition, not only the coverage-resetting one', async () => {
+    const { em, statements } = makeEm([{ id: 'b' }])
+
+    await reindexEntity(em, { ...BASE_OPTIONS, partitionCount: 5, partitionIndex: 3, resetCoverage: false })
+
+    const purges = purgeStatements(statements)
+    expect(purges).toHaveLength(1)
+    expect(purges[0]!.parameters).toEqual(expect.arrayContaining([5, 3]))
+  })
+
+  it('keeps the unpartitioned purge scope-wide', async () => {
+    const { em, statements } = makeEm([{ id: 'c' }])
+
+    await reindexEntity(em, { ...BASE_OPTIONS, resetCoverage: true })
+
+    const purges = purgeStatements(statements)
+    expect(purges).toHaveLength(1)
+    expect(purges[0]!.sql).not.toContain('hashtext')
+  })
+
+  it('does not purge when the run is not forced', async () => {
+    const { em, statements } = makeEm([{ id: 'd' }])
+
+    await reindexEntity(em, { ...BASE_OPTIONS, force: false, resetCoverage: true })
+
+    expect(purgeStatements(statements)).toHaveLength(0)
+  })
+})

--- a/packages/core/src/modules/query_index/api/reindex.ts
+++ b/packages/core/src/modules/query_index/api/reindex.ts
@@ -85,6 +85,21 @@ export async function POST(req: Request) {
       },
     },
   ).catch(() => undefined)
+  // Queued once here rather than from a partition: the purge deletes every vector for the
+  // scope, so emitting it from inside the fan-out would race the per-record vectorize jobs
+  // its siblings are already queueing and drop vectors this run had just rebuilt.
+  if (force && partitions.length > 1) {
+    try {
+      await bus.emitEvent(
+        'query_index.vectorize_purge',
+        { entityType, tenantId: auth.tenantId ?? null, organizationId: auth.orgId ?? null },
+        { persistent: true, deliverInline: false },
+      )
+    } catch {
+      // Best effort: a failed purge leaves stale vectors, which the orphan sweep still prunes.
+    }
+  }
+
   try {
     await Promise.all(
       partitions.map((part) => {

--- a/packages/core/src/modules/query_index/cli.ts
+++ b/packages/core/src/modules/query_index/cli.ts
@@ -23,6 +23,7 @@ import {
 } from './lib/batch'
 import { reindexEntity, DEFAULT_REINDEX_PARTITIONS } from './lib/reindexer'
 import { purgeIndexScope } from './lib/purge'
+import { refreshCoverageSnapshot } from './lib/coverage'
 import { flattenSystemEntityIds } from '@open-mercato/shared/lib/entities/system-entities'
 import type { VectorIndexService } from '@open-mercato/search/vector'
 
@@ -338,6 +339,69 @@ function describeScope(scope: ScopeDescriptor): string {
   if (!scope.global && scope.tenantId && scope.supportsTenant) parts.push(`tenant=${scope.tenantId}`)
   if (!scope.includeDeleted && scope.supportsDeleted) parts.push('active-only')
   return parts.length ? ` (${parts.join(' ')})` : ''
+}
+
+/**
+ * Recount the scope from the database after a reindex and rebuild whatever is still
+ * missing, single-partition. Runs unconditionally so `mercato init` (and any scripted
+ * reindex) cannot finish leaving a gap that a human has to notice and repair by hand
+ * from the Query Indexes screen. When counts already agree this is two COUNT queries.
+ */
+async function verifyAndRepairIndexCoverage(
+  em: EntityManager,
+  options: {
+    entityType: string
+    tenantId?: string | null
+    organizationId?: string | null
+    batchSize?: number
+  },
+): Promise<void> {
+  const scope = {
+    entityType: options.entityType,
+    tenantId: options.tenantId ?? null,
+    organizationId: options.organizationId ?? null,
+    withDeleted: false,
+  }
+
+  let counts: { baseCount: number; indexedCount: number } | null = null
+  try {
+    counts = await refreshCoverageSnapshot(em, scope)
+  } catch (error) {
+    console.warn(
+      `  -> ${options.entityType}: coverage verification skipped (${error instanceof Error ? error.message : String(error)})`,
+    )
+    return
+  }
+  if (!counts || counts.indexedCount >= counts.baseCount) return
+
+  console.log(
+    `  -> ${options.entityType}: ${counts.indexedCount}/${counts.baseCount} indexed after reindex — repairing the gap...`,
+  )
+  try {
+    await reindexEntity(em, {
+      entityType: options.entityType,
+      tenantId: options.tenantId,
+      organizationId: options.organizationId,
+      force: false,
+      batchSize: options.batchSize,
+      emitVectorizeEvents: false,
+      resetCoverage: false,
+    })
+  } catch (error) {
+    console.warn(
+      `  -> ${options.entityType}: repair pass failed (${error instanceof Error ? error.message : String(error)})`,
+    )
+    return
+  }
+
+  const after = await refreshCoverageSnapshot(em, scope).catch(() => null)
+  if (after && after.indexedCount < after.baseCount) {
+    console.warn(
+      `  -> ${options.entityType}: still ${after.indexedCount}/${after.baseCount} indexed after repair`,
+    )
+  } else {
+    console.log(`  -> ${options.entityType}: coverage repaired`)
+  }
 }
 
 const rebuild: ModuleCli = {
@@ -710,6 +774,14 @@ const reindex: ModuleCli = {
         groupedProgress?.complete()
         const totalProcessed = stats.reduce((acc, value) => acc + value, 0)
         console.log(`Finished ${entity}: processed ${totalProcessed} row(s) across ${partitionTargets.length} partition(s)`)
+        if (partitionIndexOption === undefined) {
+          await verifyAndRepairIndexCoverage(baseEm, {
+            entityType: entity,
+            tenantId,
+            organizationId: orgId,
+            batchSize,
+          })
+        }
         await recordIndexerLog(
           { em: baseEm },
           {
@@ -848,6 +920,14 @@ const reindex: ModuleCli = {
         groupedProgress?.complete()
         const totalProcessed = partitionResults.reduce((acc, value) => acc + value, 0)
         console.log(`  -> ${id} complete: processed ${totalProcessed} row(s) across ${partitionTargets.length} partition(s)`)
+        if (partitionIndexOption === undefined) {
+          await verifyAndRepairIndexCoverage(baseEm, {
+            entityType: id,
+            tenantId,
+            organizationId: orgId,
+            batchSize,
+          })
+        }
         await recordIndexerLog(
           { em: baseEm },
           {

--- a/packages/core/src/modules/query_index/cli.ts
+++ b/packages/core/src/modules/query_index/cli.ts
@@ -11,7 +11,7 @@ type ProgressBarHandle = {
   update(completed: number): void
   complete(): void
 }
-import { resolveEntityTableName } from '@open-mercato/shared/lib/query/engine'
+import { resolveEntityTableName, resolveRegisteredEntityTableName } from '@open-mercato/shared/lib/query/engine'
 import { recordIndexerError } from '@open-mercato/shared/lib/indexers/error-log'
 import { recordIndexerLog } from '@open-mercato/shared/lib/indexers/status-log'
 import {
@@ -342,10 +342,56 @@ function describeScope(scope: ScopeDescriptor): string {
 }
 
 /**
+ * Above this many missing records the anti-join stops being the cheaper option and the
+ * repair falls back to a full single-partition rebuild of the entity.
+ */
+const MAX_TARGETED_REPAIR_RECORDS = 5000
+
+/**
+ * List the base records in scope that have no live index row, so a repair rebuilds only
+ * what is actually missing instead of re-upserting the whole entity for a one-row gap.
+ */
+async function findUnindexedRecordIds(
+  db: Kysely<any>,
+  options: {
+    entityType: string
+    tableName: string
+    tenantId?: string | null
+    organizationId?: string | null
+    limit: number
+  },
+): Promise<string[]> {
+  const columns = await getColumnSet(db, options.tableName)
+  let query = db
+    .selectFrom(`${options.tableName} as b` as any)
+    .select('b.id' as any)
+    .where(({ not, exists, selectFrom }: any) =>
+      not(exists(
+        selectFrom('entity_indexes as ei' as any)
+          .select(sql`1`.as('one'))
+          .whereRef('ei.entity_id' as any, '=', sql`b.id::text`)
+          .where('ei.entity_type' as any, '=', options.entityType)
+          .where('ei.deleted_at' as any, 'is', null as any),
+      )),
+    )
+    .limit(options.limit)
+  if (columns.has('deleted_at')) query = query.where('b.deleted_at' as any, 'is', null as any)
+  if (options.tenantId != null && columns.has('tenant_id')) {
+    query = query.where('b.tenant_id' as any, '=', options.tenantId)
+  }
+  if (options.organizationId != null && columns.has('organization_id')) {
+    query = query.where('b.organization_id' as any, '=', options.organizationId)
+  }
+  const rows = await query.execute() as Array<{ id: unknown }>
+  return rows.map((row) => String(row.id))
+}
+
+/**
  * Recount the scope from the database after a reindex and rebuild whatever is still
- * missing, single-partition. Runs unconditionally so `mercato init` (and any scripted
- * reindex) cannot finish leaving a gap that a human has to notice and repair by hand
- * from the Query Indexes screen. When counts already agree this is two COUNT queries.
+ * missing. Runs unconditionally so `mercato init` (and any scripted reindex) cannot finish
+ * leaving a gap that a human has to notice and repair by hand from the Query Indexes
+ * screen. When counts already agree this is two COUNT queries; when they do not, the
+ * repair is scoped to the records the anti-join says are actually missing.
  */
 async function verifyAndRepairIndexCoverage(
   em: EntityManager,
@@ -372,21 +418,74 @@ async function verifyAndRepairIndexCoverage(
     )
     return
   }
-  if (!counts || counts.indexedCount >= counts.baseCount) return
+  if (!counts) return
+  if (counts.indexedCount > counts.baseCount) {
+    // Legitimate for entities whose base table cannot express the scope, since a per-tenant
+    // reindex stamps its own scope onto every row. Surfaced rather than repaired: a rebuild
+    // cannot remove the surplus, and the over-count would otherwise mask a real shortfall.
+    console.warn(
+      `  -> ${options.entityType}: ${counts.indexedCount} index rows for ${counts.baseCount} records — not repairable by reindexing`,
+    )
+    return
+  }
+  if (counts.indexedCount === counts.baseCount) return
 
-  console.log(
-    `  -> ${options.entityType}: ${counts.indexedCount}/${counts.baseCount} indexed after reindex — repairing the gap...`,
-  )
+  const db = (em as any).getKysely() as Kysely<any>
+  let tableName: string | null = null
   try {
-    await reindexEntity(em, {
+    tableName = resolveRegisteredEntityTableName(em as any, options.entityType)
+  } catch {
+    tableName = null
+  }
+
+  const missingIds = tableName
+    ? await findUnindexedRecordIds(db, {
       entityType: options.entityType,
-      tenantId: options.tenantId,
-      organizationId: options.organizationId,
-      force: false,
-      batchSize: options.batchSize,
-      emitVectorizeEvents: false,
-      resetCoverage: false,
-    })
+      tableName,
+      tenantId: options.tenantId ?? null,
+      organizationId: options.organizationId ?? null,
+      limit: MAX_TARGETED_REPAIR_RECORDS + 1,
+    }).catch(() => null)
+    : null
+
+  const targeted = missingIds && missingIds.length > 0 && missingIds.length <= MAX_TARGETED_REPAIR_RECORDS
+  console.log(
+    `  -> ${options.entityType}: ${counts.indexedCount}/${counts.baseCount} indexed after reindex — repairing`
+    + `${targeted ? ` ${missingIds!.length} missing record(s)` : ' the whole entity'}...`,
+  )
+
+  try {
+    if (targeted) {
+      const columns = await getColumnSet(db, tableName!)
+      for (const recordId of missingIds!) {
+        await rebuildEntityIndexes({
+          em,
+          db,
+          entityType: options.entityType,
+          tableName: tableName!,
+          orgOverride: options.organizationId ?? undefined,
+          tenantOverride: options.tenantId ?? undefined,
+          global: false,
+          includeDeleted: false,
+          offset: 0,
+          recordId,
+          batchSize: 1,
+          supportsOrgFilter: columns.has('organization_id'),
+          supportsTenantFilter: columns.has('tenant_id'),
+          supportsDeletedFilter: columns.has('deleted_at'),
+        })
+      }
+    } else {
+      await reindexEntity(em, {
+        entityType: options.entityType,
+        tenantId: options.tenantId,
+        organizationId: options.organizationId,
+        force: false,
+        batchSize: options.batchSize,
+        emitVectorizeEvents: false,
+        resetCoverage: false,
+      })
+    }
   } catch (error) {
     console.warn(
       `  -> ${options.entityType}: repair pass failed (${error instanceof Error ? error.message : String(error)})`,

--- a/packages/core/src/modules/query_index/lib/coverage.ts
+++ b/packages/core/src/modules/query_index/lib/coverage.ts
@@ -381,9 +381,9 @@ export async function primeColumnCache(db: Kysely<any>, checks: ColumnCheck[]): 
 export async function refreshCoverageSnapshot(
   em: EntityManager,
   scope: CoverageScope,
-): Promise<void> {
+): Promise<{ baseCount: number; indexedCount: number } | null> {
   const entityType = String(scope.entityType || '')
-  if (!entityType) return
+  if (!entityType) return null
   const tenantId = scope.tenantId ?? null
   const organizationId = scope.organizationId ?? null
   const withDeleted = scope.withDeleted === true
@@ -395,22 +395,28 @@ export async function refreshCoverageSnapshot(
   const hasTenant = await tableHasColumn(db, baseTable, 'tenant_id')
   const hasDeleted = await tableHasColumn(db, baseTable, 'deleted_at')
 
-  if (organizationId !== null && !hasOrg) return
-  if (tenantId !== null && !hasTenant) return
+  // A scope the base table cannot express must not narrow the index side either. Index
+  // rows can carry a tenant or organization the base table has no column for — `organizations`
+  // has no `organization_id` yet its index rows derive one from the record id, and `user_roles`
+  // has neither column. Filtering only the index side compares two different populations and
+  // reports a gap that no reindex can ever close; returning early instead of recounting left
+  // the previous snapshot frozen, which is what surfaced as a permanent "out of sync" row.
+  const scopeOrg = organizationId !== null && hasOrg
+  const scopeTenant = tenantId !== null && hasTenant
 
   let baseQuery = db
     .selectFrom(`${baseTable} as b` as any)
     .select(sql`count(*)`.as('count'))
-  if (organizationId !== null && hasOrg) baseQuery = baseQuery.where('b.organization_id' as any, '=', organizationId)
-  if (tenantId !== null && hasTenant) baseQuery = baseQuery.where('b.tenant_id' as any, '=', tenantId)
+  if (scopeOrg) baseQuery = baseQuery.where('b.organization_id' as any, '=', organizationId)
+  if (scopeTenant) baseQuery = baseQuery.where('b.tenant_id' as any, '=', tenantId)
   if (!withDeleted && hasDeleted) baseQuery = baseQuery.where('b.deleted_at' as any, 'is', null as any)
 
   let indexQuery = db
     .selectFrom('entity_indexes as ei' as any)
     .select(sql`count(*)`.as('count'))
     .where('ei.entity_type' as any, '=', entityType)
-  if (organizationId !== null) indexQuery = indexQuery.where('ei.organization_id' as any, '=', organizationId)
-  if (tenantId !== null) indexQuery = indexQuery.where('ei.tenant_id' as any, '=', tenantId)
+  if (scopeOrg) indexQuery = indexQuery.where('ei.organization_id' as any, '=', organizationId)
+  if (scopeTenant) indexQuery = indexQuery.where('ei.tenant_id' as any, '=', tenantId)
   if (!withDeleted) indexQuery = indexQuery.where('ei.deleted_at' as any, 'is', null as any)
 
   const vectorCountPromise = (async (): Promise<number | undefined> => {
@@ -453,6 +459,8 @@ export async function refreshCoverageSnapshot(
     indexedCount: indexCount,
     vectorCount,
   })
+
+  return { baseCount, indexedCount: indexCount }
 }
 
 export async function writeCoverageCounts(

--- a/packages/core/src/modules/query_index/lib/coverage.ts
+++ b/packages/core/src/modules/query_index/lib/coverage.ts
@@ -294,6 +294,19 @@ export async function deleteCoverageForEntity(db: Kysely<any>, entityType: strin
     .execute()
 }
 
+async function deleteCoverageScope(db: Kysely<any>, scope: CoverageScope): Promise<void> {
+  const { entityType, tenantId, organizationId, withDeleted } = scope
+  if (!entityType) return
+  let query = db
+    .deleteFrom('entity_index_coverage' as any)
+    .where('entity_type' as any, '=', entityType)
+    .where('with_deleted' as any, '=', withDeleted === true)
+  query = tenantId == null
+    ? query.where('tenant_id' as any, 'is', null as any)
+    : query.where('tenant_id' as any, '=', tenantId)
+  await applyOrganizationCondition(query as any, 'organization_id', organizationId ?? null).execute()
+}
+
 async function tableHasColumn(db: Kysely<any>, table: string, column: string): Promise<boolean> {
   const key = `${table}.${column}`
   if (COLUMN_CACHE.has(key)) return COLUMN_CACHE.get(key)!
@@ -395,13 +408,22 @@ export async function refreshCoverageSnapshot(
   const hasTenant = await tableHasColumn(db, baseTable, 'tenant_id')
   const hasDeleted = await tableHasColumn(db, baseTable, 'deleted_at')
 
-  // A scope the base table cannot express must not narrow the index side either. Index
-  // rows can carry a tenant or organization the base table has no column for — `organizations`
-  // has no `organization_id` yet its index rows derive one from the record id, and `user_roles`
-  // has neither column. Filtering only the index side compares two different populations and
-  // reports a gap that no reindex can ever close; returning early instead of recounting left
-  // the previous snapshot frozen, which is what surfaced as a permanent "out of sync" row.
+  // A scope the base table cannot express must not narrow the index side either. Index rows
+  // can carry an organization the base table has no column for — `organizations` has no
+  // `organization_id` yet its index rows derive one from the record id. Filtering only the
+  // index side compares two different populations and reports a gap no reindex can close;
+  // returning early instead of recounting left the previous snapshot frozen, which is what
+  // surfaced as a permanent "out of sync" row for `directory:organization`.
+  //
+  // Tenant is different: a base table without `tenant_id` (`user_roles`) cannot be counted
+  // per tenant at all, and writing the cross-tenant total into one tenant's row would leak
+  // another tenant's volume into it. Drop the unusable scoped row instead, leaving only the
+  // global row — which is the one that can be true — rather than freezing a stale count.
   const scopeOrg = organizationId !== null && hasOrg
+  if (tenantId !== null && !hasTenant) {
+    await deleteCoverageScope(db, { entityType, tenantId, organizationId, withDeleted })
+    return null
+  }
   const scopeTenant = tenantId !== null && hasTenant
 
   let baseQuery = db

--- a/packages/core/src/modules/query_index/lib/reindexer.ts
+++ b/packages/core/src/modules/query_index/lib/reindexer.ts
@@ -323,27 +323,42 @@ export async function reindexEntity(
 
   options?.onProgress?.({ processed, total, chunkSize: 0 })
 
+  // Partitions run concurrently, so a scope-wide purge here would delete rows a sibling
+  // partition has already written and never rebuild them (the run still reports success
+  // because progress counts attempted writes). Each partition therefore purges only the
+  // slice it is about to rebuild, and every partition purges — restricting the purge to
+  // the coverage-resetting partition would otherwise leave the other slices' stale rows
+  // behind on a forced rebuild.
+  if (force && (resetCoverage || usingPartitions)) {
+    try {
+      let purgeQuery = db
+        .deleteFrom('entity_indexes' as any)
+        .where('entity_type' as any, '=', entityType)
+      if (tenantId !== undefined) {
+        purgeQuery = purgeQuery.where(sql<boolean>`tenant_id is not distinct from ${tenantId ?? null}`)
+      }
+      if (organizationId !== undefined) {
+        purgeQuery = purgeQuery.where(sql<boolean>`organization_id is not distinct from ${organizationId ?? null}`)
+      }
+      if (usingPartitions && partitionIndex !== null) {
+        purgeQuery = purgeQuery.where(
+          sql<boolean>`mod(abs(hashtext(entity_id::text)), ${partitionCountRaw}) = ${partitionIndex}`,
+        )
+      }
+      await purgeQuery.execute()
+    } catch (error) {
+      logger.warn('Failed to purge index rows before force reindex', {
+        entityType,
+        tenantId: tenantId ?? null,
+        organizationId: organizationId ?? null,
+        partitionIndex: usingPartitions ? partitionIndex : null,
+        error: error instanceof Error ? error.message : error,
+      })
+    }
+  }
+
   if (resetCoverage) {
     if (force) {
-      try {
-        let purgeQuery = db
-          .deleteFrom('entity_indexes' as any)
-          .where('entity_type' as any, '=', entityType)
-        if (tenantId !== undefined) {
-          purgeQuery = purgeQuery.where(sql<boolean>`tenant_id is not distinct from ${tenantId ?? null}`)
-        }
-        if (organizationId !== undefined) {
-          purgeQuery = purgeQuery.where(sql<boolean>`organization_id is not distinct from ${organizationId ?? null}`)
-        }
-        await purgeQuery.execute()
-      } catch (error) {
-        logger.warn('Failed to purge index rows before force reindex', {
-          entityType,
-          tenantId: tenantId ?? null,
-          organizationId: organizationId ?? null,
-          error: error instanceof Error ? error.message : error,
-        })
-      }
 
       if (emitVectorize && eventBus) {
         if (tenantId !== undefined) {
@@ -370,8 +385,13 @@ export async function reindexEntity(
       }
     }
 
+    // Only meaningful for an unpartitioned run: `baseCounts` holds this partition's slice,
+    // so writing it as the scope's base count under-reports by the partition factor, and
+    // zeroing indexed_count scope-wide discards deltas siblings have already applied. The
+    // authoritative `refreshCoverageSnapshot` at the end of every partition owns the counts
+    // for partitioned runs.
     const nowTs = Date.now()
-    for (const scope of baseCounts.values()) {
+    for (const scope of usingPartitions ? [] : baseCounts.values()) {
       const key = `${entityType}|${scopeKey(scope.tenantId, scope.organizationId)}`
       const last = lastCoverageReset.get(key) ?? 0
       if (force || nowTs - last >= COVERAGE_REFRESH_THROTTLE_MS) {

--- a/packages/core/src/modules/query_index/lib/reindexer.ts
+++ b/packages/core/src/modules/query_index/lib/reindexer.ts
@@ -357,34 +357,36 @@ export async function reindexEntity(
     }
   }
 
-  if (resetCoverage) {
-    if (force) {
-
-      if (emitVectorize && eventBus) {
-        if (tenantId !== undefined) {
-          const payload: Record<string, unknown> = {
-            entityType,
-            tenantId: tenantId ?? null,
-          }
-          if (organizationId !== undefined) payload.organizationId = organizationId ?? null
-          try {
-            await eventBus.emitEvent('query_index.vectorize_purge', payload)
-          } catch (err) {
-            logger.warn('Failed to queue vector purge before force reindex', {
-              entityType,
-              tenantId: tenantId ?? null,
-              organizationId: organizationId ?? null,
-              error: err instanceof Error ? err.message : err,
-            })
-          }
-        } else {
-          logger.warn('Skipping vector purge for force reindex without tenant scope', {
-            entityType,
-          })
-        }
+  // The vector purge is scope-wide and cannot be partitioned — the queued job deletes every
+  // vector for the scope. Emitting it from one partition while siblings are already queueing
+  // per-record vectorize jobs is the same race the row purge just had, so a partitioned run
+  // leaves it to the caller that owns the fan-out (`api/reindex.ts` queues it once, before
+  // dispatching any partition).
+  if (force && resetCoverage && !usingPartitions && emitVectorize && eventBus) {
+    if (tenantId !== undefined) {
+      const payload: Record<string, unknown> = {
+        entityType,
+        tenantId: tenantId ?? null,
       }
+      if (organizationId !== undefined) payload.organizationId = organizationId ?? null
+      try {
+        await eventBus.emitEvent('query_index.vectorize_purge', payload)
+      } catch (err) {
+        logger.warn('Failed to queue vector purge before force reindex', {
+          entityType,
+          tenantId: tenantId ?? null,
+          organizationId: organizationId ?? null,
+          error: err instanceof Error ? err.message : err,
+        })
+      }
+    } else {
+      logger.warn('Skipping vector purge for force reindex without tenant scope', {
+        entityType,
+      })
     }
+  }
 
+  if (resetCoverage) {
     // Only meaningful for an unpartitioned run: `baseCounts` holds this partition's slice,
     // so writing it as the scope's base count under-reports by the partition factor, and
     // zeroing indexed_count scope-wide discards deltas siblings have already applied. The

--- a/packages/create-app/template/src/modules/example/acl.ts
+++ b/packages/create-app/template/src/modules/example/acl.ts
@@ -1,5 +1,11 @@
 export const features = [
   { id: 'example.backend', title: 'Access example backend', module: 'example' },
+  // ACL override probe. Nothing gates on it, so it stays inert wherever it is granted.
+  // `apps/mercato/src/modules.ts` nulls it through `entry.overrides.acl.features` so
+  // TC-AUTH-055 can assert that a nulled feature stays denied for literal, wildcard and
+  // super-admin grants. It must remain declared here — an override naming an undeclared
+  // feature is skipped as stale and logs a warning on every module registration.
+  { id: 'example.manage', title: 'Manage example (override probe)', module: 'example' },
   { id: 'example.view', title: 'View example enrichments', module: 'example' },
   { id: 'example.todos.view', title: 'View todos', module: 'example' },
   {

--- a/packages/search/AGENTS.md
+++ b/packages/search/AGENTS.md
@@ -42,6 +42,8 @@ Choose strategies based on what users need:
 
 Strategies automatically become unavailable if their backend is not configured (e.g., no `MEILISEARCH_HOST` means fulltext is unavailable).
 
+Availability covers the **store**, not just its credentials. `VectorDriver` exposes optional `isHealthy()` / `getStatus()`; the pgvector driver reports `false` when the `vector` extension is neither installed nor installable, and `VectorSearchStrategy.isAvailable()` consumes it. Writes (`index`/`delete`/`purge`) stay fail-loud for available strategies — a driver that cannot serve its backend MUST report itself unhealthy rather than throwing per record. Settings > Search shows the reason when the store is unavailable.
+
 ## Configure Global Search (Cmd+K)
 
 Search settings (Cmd+K strategies, embedding provider/model, auto-index flag) are

--- a/packages/search/src/__tests__/pgvector-extension-availability.test.ts
+++ b/packages/search/src/__tests__/pgvector-extension-availability.test.ts
@@ -1,0 +1,157 @@
+import { createPgVectorDriver, type PgPool } from '../vector/drivers/pgvector'
+import { VectorSearchStrategy } from '../strategies/vector.strategy'
+import { SearchService } from '../service'
+import type { IndexableRecord } from '../types'
+
+type QueryCall = { text: string; params?: unknown[] }
+
+function pgError(code: string, message: string): Error & { code: string } {
+  return Object.assign(new Error(message), { code })
+}
+
+function createPool(options: {
+  extensionInstalled?: boolean
+  extensionInstallable?: boolean
+  calls: QueryCall[]
+}): PgPool {
+  const { calls } = options
+  const run = async (text: string, params?: unknown[]) => {
+    calls.push({ text, params })
+    if (/pg_available_extensions/.test(text)) {
+      return {
+        rows: [{
+          installed: options.extensionInstalled ?? false,
+          installable: options.extensionInstallable ?? false,
+        }],
+      }
+    }
+    if (/CREATE EXTENSION IF NOT EXISTS vector/.test(text)) {
+      if (options.extensionInstalled || options.extensionInstallable) return { rows: [] }
+      throw pgError('58P01', 'extension "vector" is not available')
+    }
+    return { rows: [] }
+  }
+  return {
+    connect: async () => ({ query: run as PgPool['query'], release: () => {} }),
+    query: run as PgPool['query'],
+    end: async () => {},
+  }
+}
+
+describe('pgvector extension availability', () => {
+  it('reports the driver unhealthy when the extension cannot be installed', async () => {
+    const calls: QueryCall[] = []
+    const driver = createPgVectorDriver({ pool: createPool({ calls }) })
+
+    expect(await driver.isHealthy!()).toBe(false)
+    const status = await driver.getStatus!()
+    expect(status.available).toBe(false)
+    expect(status.reason).toMatch(/vector/)
+  })
+
+  it('probes the catalog once instead of running DDL for every record', async () => {
+    const calls: QueryCall[] = []
+    const driver = createPgVectorDriver({ pool: createPool({ calls }) })
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      expect(await driver.isHealthy!()).toBe(false)
+    }
+
+    const probes = calls.filter((call) => /pg_available_extensions/.test(call.text))
+    expect(probes).toHaveLength(1)
+    expect(calls.some((call) => /CREATE TABLE/.test(call.text))).toBe(false)
+  })
+
+  it('short-circuits ensureReady once the extension is known to be missing', async () => {
+    const calls: QueryCall[] = []
+    const driver = createPgVectorDriver({ pool: createPool({ calls }) })
+
+    await expect(driver.ensureReady()).rejects.toThrow(/vector/)
+    const afterFirst = calls.length
+    await expect(driver.ensureReady()).rejects.toThrow(/vector/)
+
+    expect(calls.length).toBe(afterFirst)
+  })
+
+  it('stays healthy when the extension is installable', async () => {
+    const calls: QueryCall[] = []
+    const driver = createPgVectorDriver({ pool: createPool({ calls, extensionInstallable: true }) })
+
+    expect(await driver.isHealthy!()).toBe(true)
+    await expect(driver.ensureReady()).resolves.toBeUndefined()
+  })
+
+  it('keeps the existing superuser-less degradation path', async () => {
+    const calls: QueryCall[] = []
+    const pool = createPool({ calls, extensionInstalled: true })
+    const originalQuery = pool.query
+    pool.query = (async (text: string, params?: unknown[]) => {
+      if (/CREATE EXTENSION IF NOT EXISTS vector/.test(text)) {
+        calls.push({ text, params })
+        throw pgError('42501', 'permission denied to create extension "vector"')
+      }
+      return originalQuery(text, params)
+    }) as PgPool['query']
+    pool.connect = async () => ({ query: pool.query as never, release: () => {} })
+
+    const driver = createPgVectorDriver({ pool })
+    await expect(driver.ensureReady()).resolves.toBeUndefined()
+    expect(await driver.isHealthy!()).toBe(true)
+  })
+})
+
+describe('vector strategy availability', () => {
+  const embeddingService = { available: true, createEmbedding: jest.fn() }
+
+  function createDriver(overrides: Partial<Record<string, unknown>> = {}) {
+    return {
+      id: 'pgvector' as const,
+      ensureReady: jest.fn().mockResolvedValue(undefined),
+      upsert: jest.fn().mockResolvedValue(undefined),
+      delete: jest.fn().mockResolvedValue(undefined),
+      query: jest.fn().mockResolvedValue([]),
+      getChecksum: jest.fn().mockResolvedValue(null),
+      ...overrides,
+    }
+  }
+
+  it('is unavailable when the store reports itself unhealthy', async () => {
+    const driver = createDriver({ isHealthy: jest.fn().mockResolvedValue(false) })
+    const strategy = new VectorSearchStrategy(embeddingService, driver)
+
+    expect(await strategy.isAvailable()).toBe(false)
+  })
+
+  it('stays available for drivers that expose no probe', async () => {
+    const strategy = new VectorSearchStrategy(embeddingService, createDriver())
+
+    expect(await strategy.isAvailable()).toBe(true)
+  })
+
+  it('never touches the store on delete when it is unhealthy', async () => {
+    const driver = createDriver({ isHealthy: jest.fn().mockResolvedValue(false) })
+    const strategy = new VectorSearchStrategy(embeddingService, driver)
+    const service = new SearchService({ strategies: [strategy] })
+
+    await expect(service.delete('customers:customer_deal', 'rec-1', 'tenant-1')).resolves.toBeUndefined()
+    expect(driver.ensureReady).not.toHaveBeenCalled()
+    expect(driver.delete).not.toHaveBeenCalled()
+  })
+
+  it('never touches the store on index when it is unhealthy', async () => {
+    const driver = createDriver({ isHealthy: jest.fn().mockResolvedValue(false) })
+    const strategy = new VectorSearchStrategy(embeddingService, driver)
+    const service = new SearchService({ strategies: [strategy] })
+    const record: IndexableRecord = {
+      entityId: 'customers:customer_deal',
+      recordId: 'rec-1',
+      tenantId: 'tenant-1',
+      fields: { name: 'Deal' },
+      text: 'Deal',
+    }
+
+    await expect(service.index(record)).resolves.toBeUndefined()
+    expect(driver.ensureReady).not.toHaveBeenCalled()
+    expect(driver.upsert).not.toHaveBeenCalled()
+  })
+})

--- a/packages/search/src/__tests__/pgvector-extension-availability.test.ts
+++ b/packages/search/src/__tests__/pgvector-extension-availability.test.ts
@@ -46,7 +46,8 @@ describe('pgvector extension availability', () => {
     expect(await driver.isHealthy!()).toBe(false)
     const status = await driver.getStatus!()
     expect(status.available).toBe(false)
-    expect(status.reason).toMatch(/vector/)
+    // Curated, not the raw Postgres message: the settings API surfaces this to the browser.
+    expect(status.reason).toBe('extension "vector" is not available on this PostgreSQL server')
   })
 
   it('probes the catalog once instead of running DDL for every record', async () => {

--- a/packages/search/src/modules/search/api/openapi.ts
+++ b/packages/search/src/modules/search/api/openapi.ts
@@ -246,6 +246,8 @@ export const vectorDriverStatusSchema = z.object({
   name: z.string(),
   configured: z.boolean(),
   implemented: z.boolean(),
+  available: z.boolean().nullable(),
+  unavailableReason: z.string().nullable(),
   envVars: z.array(vectorDriverEnvVarSchema),
 })
 

--- a/packages/search/src/modules/search/api/settings/vector-store/route.ts
+++ b/packages/search/src/modules/search/api/settings/vector-store/route.ts
@@ -32,10 +32,10 @@ type VectorStoreConfigResponse = {
 }
 
 async function probeDriverStatus(
+  container: { resolve: <T = unknown>(name: string) => T },
   driverId: VectorDriverId,
 ): Promise<{ available: boolean | null; unavailableReason: string | null }> {
   try {
-    const container = await createRequestContainer()
     const drivers = container.resolve<VectorDriver[]>('vectorDrivers')
     const driver = drivers.find((entry) => entry.id === driverId)
     if (!driver?.getStatus) return { available: null, unavailableReason: null }
@@ -68,9 +68,19 @@ export async function GET(req: Request) {
   // Check chromadb - would need CHROMA_URL
   const chromaUrlSet = Boolean(process.env.CHROMA_URL?.trim())
 
-  const pgvectorStatus = databaseUrlSet
-    ? await probeDriverStatus('pgvector')
-    : { available: null, unavailableReason: null }
+  let pgvectorStatus: { available: boolean | null; unavailableReason: string | null } = {
+    available: null,
+    unavailableReason: null,
+  }
+  if (databaseUrlSet) {
+    const container = await createRequestContainer()
+    try {
+      pgvectorStatus = await probeDriverStatus(container, 'pgvector')
+    } finally {
+      const disposable = container as { dispose?: () => Promise<unknown> }
+      if (typeof disposable.dispose === 'function') await disposable.dispose()
+    }
+  }
 
   const drivers: DriverStatus[] = [
     {

--- a/packages/search/src/modules/search/api/settings/vector-store/route.ts
+++ b/packages/search/src/modules/search/api/settings/vector-store/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server'
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { VectorDriverId } from '@open-mercato/shared/modules/vector'
+import type { VectorDriver } from '../../../../../vector'
 import { vectorStoreSettingsOpenApi } from '../../openapi'
 
 export const metadata = {
@@ -13,6 +15,9 @@ type DriverStatus = {
   name: string
   configured: boolean
   implemented: boolean
+  /** Runtime reachability of the store itself; `null` when the driver exposes no probe. */
+  available: boolean | null
+  unavailableReason: string | null
   envVars: {
     name: string
     set: boolean
@@ -24,6 +29,24 @@ type VectorStoreConfigResponse = {
   currentDriver: VectorDriverId
   configured: boolean
   drivers: DriverStatus[]
+}
+
+async function probeDriverStatus(
+  driverId: VectorDriverId,
+): Promise<{ available: boolean | null; unavailableReason: string | null }> {
+  try {
+    const container = await createRequestContainer()
+    const drivers = container.resolve<VectorDriver[]>('vectorDrivers')
+    const driver = drivers.find((entry) => entry.id === driverId)
+    if (!driver?.getStatus) return { available: null, unavailableReason: null }
+    const status = await driver.getStatus()
+    return {
+      available: status.available,
+      unavailableReason: status.available ? null : status.reason ?? null,
+    }
+  } catch {
+    return { available: null, unavailableReason: null }
+  }
 }
 
 const unauthorized = async () => {
@@ -45,12 +68,18 @@ export async function GET(req: Request) {
   // Check chromadb - would need CHROMA_URL
   const chromaUrlSet = Boolean(process.env.CHROMA_URL?.trim())
 
+  const pgvectorStatus = databaseUrlSet
+    ? await probeDriverStatus('pgvector')
+    : { available: null, unavailableReason: null }
+
   const drivers: DriverStatus[] = [
     {
       id: 'pgvector',
       name: 'PostgreSQL (pgvector)',
       configured: databaseUrlSet,
       implemented: true,
+      available: pgvectorStatus.available,
+      unavailableReason: pgvectorStatus.unavailableReason,
       envVars: [
         {
           name: 'DATABASE_URL',
@@ -64,6 +93,8 @@ export async function GET(req: Request) {
       name: 'Qdrant',
       configured: qdrantUrlSet,
       implemented: false,
+      available: null,
+      unavailableReason: null,
       envVars: [
         {
           name: 'QDRANT_URL',
@@ -82,6 +113,8 @@ export async function GET(req: Request) {
       name: 'ChromaDB',
       configured: chromaUrlSet,
       implemented: false,
+      available: null,
+      unavailableReason: null,
       envVars: [
         {
           name: 'CHROMA_URL',

--- a/packages/search/src/modules/search/frontend/components/SearchSettingsPageClient.tsx
+++ b/packages/search/src/modules/search/frontend/components/SearchSettingsPageClient.tsx
@@ -118,6 +118,8 @@ type VectorDriverStatus = {
   name: string
   configured: boolean
   implemented: boolean
+  available?: boolean | null
+  unavailableReason?: string | null
   envVars: VectorDriverEnvVar[]
 }
 

--- a/packages/search/src/modules/search/frontend/components/sections/VectorSearchSection.tsx
+++ b/packages/search/src/modules/search/frontend/components/sections/VectorSearchSection.tsx
@@ -464,7 +464,7 @@ export function VectorSearchSection({
             {t('search.settings.vector.storeUnavailable', 'Vector store is not available')}
           </p>
           <p className="text-xs text-status-warning-text mt-1">
-            {t('search.settings.vector.storeUnavailableHint', 'Vector indexing and semantic search are skipped until the store is reachable. Install the pgvector extension on your PostgreSQL server, then reload this page.')}
+            {t('search.settings.vector.storeUnavailableHint', 'Vector indexing and semantic search are skipped until the store is reachable. Install the pgvector extension on your PostgreSQL server; the status is rechecked about once a minute.')}
           </p>
           {storeUnavailableReason ? (
             <p className="text-xs text-status-warning-text mt-1 font-mono">{storeUnavailableReason}</p>

--- a/packages/search/src/modules/search/frontend/components/sections/VectorSearchSection.tsx
+++ b/packages/search/src/modules/search/frontend/components/sections/VectorSearchSection.tsx
@@ -79,6 +79,8 @@ type VectorDriverStatus = {
   name: string
   configured: boolean
   implemented: boolean
+  available?: boolean | null
+  unavailableReason?: string | null
   envVars: VectorDriverEnvVar[]
 }
 
@@ -447,6 +449,31 @@ export function VectorSearchSection({
   const isEmbeddingConfigured = embeddingSettings?.configuredProviders?.includes(savedProvider)
   const providerOptions: EmbeddingProviderId[] = ['openai', 'google', 'mistral', 'cohere', 'bedrock', 'ollama']
 
+  const activeDriver = vectorStoreConfig?.drivers.find((driver) => driver.id === vectorStoreConfig.currentDriver)
+  const isStoreUnavailable = activeDriver?.available === false
+  const storeUnavailableReason = activeDriver?.unavailableReason ?? null
+
+  const storeUnavailableBanner = isStoreUnavailable ? (
+    <div className="p-4 rounded-md bg-status-warning-bg border border-status-warning-border">
+      <div className="flex items-start gap-3">
+        <svg className="h-5 w-5 text-status-warning-icon flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <div>
+          <p className="text-sm font-medium text-status-warning-text">
+            {t('search.settings.vector.storeUnavailable', 'Vector store is not available')}
+          </p>
+          <p className="text-xs text-status-warning-text mt-1">
+            {t('search.settings.vector.storeUnavailableHint', 'Vector indexing and semantic search are skipped until the store is reachable. Install the pgvector extension on your PostgreSQL server, then reload this page.')}
+          </p>
+          {storeUnavailableReason ? (
+            <p className="text-xs text-status-warning-text mt-1 font-mono">{storeUnavailableReason}</p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  ) : null
+
   const autoIndexingChecked = embeddingSettings ? embeddingSettings.autoIndexingEnabled : true
   const autoIndexingDisabled = embeddingLoading || embeddingSaving || Boolean(embeddingSettings?.autoIndexingLocked)
 
@@ -481,13 +508,14 @@ export function VectorSearchSection({
             </div>
           ) : (
             <div className="space-y-4">
+              {storeUnavailableBanner}
               {/* Vector Store Driver Status */}
               <div>
                 <h3 className="text-sm font-semibold mb-2">{t('search.settings.vector.store', 'Vector Store')}</h3>
                 <div className="grid gap-2 sm:grid-cols-3">
                   {vectorStoreConfig?.drivers.map((driver) => {
                     const isCurrent = driver.id === vectorStoreConfig.currentDriver
-                    const isReady = driver.configured && driver.implemented
+                    const isReady = driver.configured && driver.implemented && driver.available !== false
                     return (
                       <div
                         key={driver.id}
@@ -746,6 +774,8 @@ export function VectorSearchSection({
               <Spinner size="sm" />
               <span>{t('search.settings.loadingLabel', 'Loading settings...')}</span>
             </div>
+          ) : isStoreUnavailable ? (
+            storeUnavailableBanner
           ) : !isEmbeddingConfigured ? (
             <div className="p-4 rounded-md bg-status-warning-bg border border-status-warning-border">
               <div className="flex items-start gap-3">

--- a/packages/search/src/modules/search/frontend/components/sections/__tests__/VectorSearchSection.test.tsx
+++ b/packages/search/src/modules/search/frontend/components/sections/__tests__/VectorSearchSection.test.tsx
@@ -50,13 +50,14 @@ const vectorStoreConfig: NonNullable<VectorSearchSectionProps['vectorStoreConfig
 
 function renderSection(
   settings: NonNullable<VectorSearchSectionProps['embeddingSettings']> = embeddingSettings,
+  storeConfig: NonNullable<VectorSearchSectionProps['vectorStoreConfig']> = vectorStoreConfig,
 ) {
   return render(
     <I18nProvider locale="en" dict={{}}>
       <VectorSearchSection
         embeddingSettings={settings}
         embeddingLoading={false}
-        vectorStoreConfig={vectorStoreConfig}
+        vectorStoreConfig={storeConfig}
         vectorStoreConfigLoading={false}
         vectorReindexLock={null}
         onEmbeddingSettingsUpdate={jest.fn()}
@@ -111,5 +112,39 @@ describe('VectorSearchSection provider controls', () => {
     expect(providerButton.getAttribute('aria-controls')).toBeNull()
     expect(providerButton.parentElement?.classList.contains('cursor-not-allowed')).toBe(true)
     expect(document.getElementById('provider-ollama-configuration')).toBeNull()
+  })
+})
+
+describe('VectorSearchSection store availability', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'fetch', {
+      configurable: true,
+      value: jest.fn(() => new Promise(() => undefined)),
+    })
+  })
+
+  it('warns that the vector store is unavailable and surfaces the driver reason', () => {
+    renderSection(embeddingSettings, {
+      ...vectorStoreConfig,
+      drivers: [
+        {
+          ...vectorStoreConfig.drivers[0],
+          available: false,
+          unavailableReason: 'extension "vector" is not available on this PostgreSQL server',
+        },
+      ],
+    })
+
+    expect(screen.getByText('Vector store is not available')).toBeTruthy()
+    expect(screen.getByText(/extension "vector" is not available/)).toBeTruthy()
+  })
+
+  it('keeps the banner hidden while the store is reachable', () => {
+    renderSection(embeddingSettings, {
+      ...vectorStoreConfig,
+      drivers: [{ ...vectorStoreConfig.drivers[0], available: true, unavailableReason: null }],
+    })
+
+    expect(screen.queryByText('Vector store is not available')).toBeNull()
   })
 })

--- a/packages/search/src/modules/search/i18n/de.json
+++ b/packages/search/src/modules/search/i18n/de.json
@@ -214,6 +214,8 @@
   "search.settings.vector.sectionTitle": "Vektorsuche",
   "search.settings.vector.setEnvVar": "Umgebungsvariable setzen",
   "search.settings.vector.store": "Vektorspeicher",
+  "search.settings.vector.storeUnavailable": "Vektorspeicher ist nicht verfügbar",
+  "search.settings.vector.storeUnavailableHint": "Vektorindizierung und semantische Suche werden übersprungen, bis der Speicher erreichbar ist. Installieren Sie die pgvector-Erweiterung auf Ihrem PostgreSQL-Server und laden Sie diese Seite neu.",
   "search.settings.vector.usingTenantConfig": "Dieser Mandant verwendet eigene Embedding-Einstellungen.",
   "search.settings.vectorDocumentsLabel": "Vektordokumente",
   "search.settings.vectorNotConfigured": "Vektorsuche ist nicht konfiguriert.",

--- a/packages/search/src/modules/search/i18n/de.json
+++ b/packages/search/src/modules/search/i18n/de.json
@@ -215,7 +215,7 @@
   "search.settings.vector.setEnvVar": "Umgebungsvariable setzen",
   "search.settings.vector.store": "Vektorspeicher",
   "search.settings.vector.storeUnavailable": "Vektorspeicher ist nicht verfügbar",
-  "search.settings.vector.storeUnavailableHint": "Vektorindizierung und semantische Suche werden übersprungen, bis der Speicher erreichbar ist. Installieren Sie die pgvector-Erweiterung auf Ihrem PostgreSQL-Server und laden Sie diese Seite neu.",
+  "search.settings.vector.storeUnavailableHint": "Vektorindizierung und semantische Suche werden übersprungen, bis der Speicher erreichbar ist. Installieren Sie die pgvector-Erweiterung auf Ihrem PostgreSQL-Server; der Status wird etwa einmal pro Minute neu geprüft.",
   "search.settings.vector.usingTenantConfig": "Dieser Mandant verwendet eigene Embedding-Einstellungen.",
   "search.settings.vectorDocumentsLabel": "Vektordokumente",
   "search.settings.vectorNotConfigured": "Vektorsuche ist nicht konfiguriert.",

--- a/packages/search/src/modules/search/i18n/en.json
+++ b/packages/search/src/modules/search/i18n/en.json
@@ -215,7 +215,7 @@
   "search.settings.vector.setEnvVar": "Set environment variable",
   "search.settings.vector.store": "Vector store",
   "search.settings.vector.storeUnavailable": "Vector store is not available",
-  "search.settings.vector.storeUnavailableHint": "Vector indexing and semantic search are skipped until the store is reachable. Install the pgvector extension on your PostgreSQL server, then reload this page.",
+  "search.settings.vector.storeUnavailableHint": "Vector indexing and semantic search are skipped until the store is reachable. Install the pgvector extension on your PostgreSQL server; the status is rechecked about once a minute.",
   "search.settings.vector.usingTenantConfig": "This tenant is using its own embedding settings.",
   "search.settings.vectorDocumentsLabel": "Vector documents",
   "search.settings.vectorNotConfigured": "Vector search is not configured.",

--- a/packages/search/src/modules/search/i18n/en.json
+++ b/packages/search/src/modules/search/i18n/en.json
@@ -214,6 +214,8 @@
   "search.settings.vector.sectionTitle": "Vector Search",
   "search.settings.vector.setEnvVar": "Set environment variable",
   "search.settings.vector.store": "Vector store",
+  "search.settings.vector.storeUnavailable": "Vector store is not available",
+  "search.settings.vector.storeUnavailableHint": "Vector indexing and semantic search are skipped until the store is reachable. Install the pgvector extension on your PostgreSQL server, then reload this page.",
   "search.settings.vector.usingTenantConfig": "This tenant is using its own embedding settings.",
   "search.settings.vectorDocumentsLabel": "Vector documents",
   "search.settings.vectorNotConfigured": "Vector search is not configured.",

--- a/packages/search/src/modules/search/i18n/es.json
+++ b/packages/search/src/modules/search/i18n/es.json
@@ -214,6 +214,8 @@
   "search.settings.vector.sectionTitle": "Búsqueda vectorial",
   "search.settings.vector.setEnvVar": "Configurar variable de entorno",
   "search.settings.vector.store": "Almacén vectorial",
+  "search.settings.vector.storeUnavailable": "El almacén vectorial no está disponible",
+  "search.settings.vector.storeUnavailableHint": "La indexación vectorial y la búsqueda semántica se omiten hasta que el almacén esté disponible. Instala la extensión pgvector en tu servidor PostgreSQL y vuelve a cargar esta página.",
   "search.settings.vector.usingTenantConfig": "Este inquilino usa su propia configuración de incrustaciones.",
   "search.settings.vectorDocumentsLabel": "Documentos vectoriales",
   "search.settings.vectorNotConfigured": "La búsqueda vectorial no está configurada.",

--- a/packages/search/src/modules/search/i18n/es.json
+++ b/packages/search/src/modules/search/i18n/es.json
@@ -215,7 +215,7 @@
   "search.settings.vector.setEnvVar": "Configurar variable de entorno",
   "search.settings.vector.store": "Almacén vectorial",
   "search.settings.vector.storeUnavailable": "El almacén vectorial no está disponible",
-  "search.settings.vector.storeUnavailableHint": "La indexación vectorial y la búsqueda semántica se omiten hasta que el almacén esté disponible. Instala la extensión pgvector en tu servidor PostgreSQL y vuelve a cargar esta página.",
+  "search.settings.vector.storeUnavailableHint": "La indexación vectorial y la búsqueda semántica se omiten hasta que el almacén esté disponible. Instala la extensión pgvector en tu servidor PostgreSQL; el estado se vuelve a comprobar aproximadamente cada minuto.",
   "search.settings.vector.usingTenantConfig": "Este inquilino usa su propia configuración de incrustaciones.",
   "search.settings.vectorDocumentsLabel": "Documentos vectoriales",
   "search.settings.vectorNotConfigured": "La búsqueda vectorial no está configurada.",

--- a/packages/search/src/modules/search/i18n/ko.json
+++ b/packages/search/src/modules/search/i18n/ko.json
@@ -215,7 +215,7 @@
   "search.settings.vector.setEnvVar": "환경 변수 설정",
   "search.settings.vector.store": "벡터 저장소",
   "search.settings.vector.storeUnavailable": "벡터 저장소를 사용할 수 없습니다",
-  "search.settings.vector.storeUnavailableHint": "저장소에 연결할 수 있을 때까지 벡터 인덱싱과 의미 기반 검색은 건너뜁니다. PostgreSQL 서버에 pgvector 확장을 설치한 뒤 이 페이지를 다시 불러오세요.",
+  "search.settings.vector.storeUnavailableHint": "저장소에 연결할 수 있을 때까지 벡터 인덱싱과 의미 기반 검색은 건너뜁니다. PostgreSQL 서버에 pgvector 확장을 설치하세요. 상태는 약 1분마다 다시 확인됩니다.",
   "search.settings.vector.usingTenantConfig": "이 테넌트는 자체 임베딩 설정을 사용하고 있습니다.",
   "search.settings.vectorDocumentsLabel": "벡터 문서",
   "search.settings.vectorNotConfigured": "벡터 검색이 구성되지 않았습니다.",

--- a/packages/search/src/modules/search/i18n/ko.json
+++ b/packages/search/src/modules/search/i18n/ko.json
@@ -214,6 +214,8 @@
   "search.settings.vector.sectionTitle": "벡터 검색",
   "search.settings.vector.setEnvVar": "환경 변수 설정",
   "search.settings.vector.store": "벡터 저장소",
+  "search.settings.vector.storeUnavailable": "벡터 저장소를 사용할 수 없습니다",
+  "search.settings.vector.storeUnavailableHint": "저장소에 연결할 수 있을 때까지 벡터 인덱싱과 의미 기반 검색은 건너뜁니다. PostgreSQL 서버에 pgvector 확장을 설치한 뒤 이 페이지를 다시 불러오세요.",
   "search.settings.vector.usingTenantConfig": "이 테넌트는 자체 임베딩 설정을 사용하고 있습니다.",
   "search.settings.vectorDocumentsLabel": "벡터 문서",
   "search.settings.vectorNotConfigured": "벡터 검색이 구성되지 않았습니다.",

--- a/packages/search/src/modules/search/i18n/pl.json
+++ b/packages/search/src/modules/search/i18n/pl.json
@@ -215,7 +215,7 @@
   "search.settings.vector.setEnvVar": "Ustaw zmienną środowiskową",
   "search.settings.vector.store": "Magazyn wektorów",
   "search.settings.vector.storeUnavailable": "Magazyn wektorów jest niedostępny",
-  "search.settings.vector.storeUnavailableHint": "Indeksowanie wektorowe i wyszukiwanie semantyczne są pomijane, dopóki magazyn nie będzie dostępny. Zainstaluj rozszerzenie pgvector na serwerze PostgreSQL, a następnie odśwież tę stronę.",
+  "search.settings.vector.storeUnavailableHint": "Indeksowanie wektorowe i wyszukiwanie semantyczne są pomijane, dopóki magazyn nie będzie dostępny. Zainstaluj rozszerzenie pgvector na serwerze PostgreSQL; status jest sprawdzany ponownie mniej więcej co minutę.",
   "search.settings.vector.usingTenantConfig": "Ten najemca używa własnych ustawień osadzania.",
   "search.settings.vectorDocumentsLabel": "Dokumenty wektorowe",
   "search.settings.vectorNotConfigured": "Wyszukiwanie wektorowe nie jest skonfigurowane.",

--- a/packages/search/src/modules/search/i18n/pl.json
+++ b/packages/search/src/modules/search/i18n/pl.json
@@ -214,6 +214,8 @@
   "search.settings.vector.sectionTitle": "Wyszukiwanie wektorowe",
   "search.settings.vector.setEnvVar": "Ustaw zmienną środowiskową",
   "search.settings.vector.store": "Magazyn wektorów",
+  "search.settings.vector.storeUnavailable": "Magazyn wektorów jest niedostępny",
+  "search.settings.vector.storeUnavailableHint": "Indeksowanie wektorowe i wyszukiwanie semantyczne są pomijane, dopóki magazyn nie będzie dostępny. Zainstaluj rozszerzenie pgvector na serwerze PostgreSQL, a następnie odśwież tę stronę.",
   "search.settings.vector.usingTenantConfig": "Ten najemca używa własnych ustawień osadzania.",
   "search.settings.vectorDocumentsLabel": "Dokumenty wektorowe",
   "search.settings.vectorNotConfigured": "Wyszukiwanie wektorowe nie jest skonfigurowane.",

--- a/packages/search/src/strategies/vector.strategy.ts
+++ b/packages/search/src/strategies/vector.strategy.ts
@@ -59,7 +59,13 @@ export class VectorSearchStrategy implements SearchStrategy {
   }
 
   async isAvailable(): Promise<boolean> {
-    return this.embeddingService.available
+    if (!this.embeddingService.available) return false
+    // A configured embedding provider says nothing about the vector store. When the
+    // store cannot serve writes (pgvector extension missing), reporting availability
+    // here makes SearchService call ensureReady() for every record and fail the whole
+    // index/delete operation. Drivers without a probe keep the previous behavior.
+    if (!this.vectorDriver.isHealthy) return true
+    return this.vectorDriver.isHealthy()
   }
 
   async ensureReady(): Promise<void> {

--- a/packages/search/src/vector/drivers/pgvector/index.ts
+++ b/packages/search/src/vector/drivers/pgvector/index.ts
@@ -1,5 +1,5 @@
 import { Pool } from 'pg'
-import { searchDebugWarn } from '../../../lib/debug'
+import { searchDebugWarn, searchWarn } from '../../../lib/debug'
 
 type PgPoolQueryResult<T> = { rows: T[]; rowCount?: number }
 type PgPoolClient = {
@@ -45,6 +45,7 @@ const DRIVER_ID = 'pgvector' as const
 // the case where the extension record is missing. None of these can be resolved by
 // retrying, so the driver reports itself unhealthy instead of failing every record.
 const EXTENSION_MISSING_CODES = new Set(['58P01', '0A000', '42704'])
+const EXTENSION_UNAVAILABLE_REASON = 'extension "vector" is not available on this PostgreSQL server'
 // Re-probe occasionally so installing pgvector recovers without restarting the process.
 const UNAVAILABLE_RECHECK_MS = 60_000
 
@@ -121,13 +122,17 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
       reportedReason = null
     } else if (value.reason && value.reason !== reportedReason) {
       reportedReason = value.reason
-      searchDebugWarn('vector.pgvector', `vector store unavailable — skipping vector indexing and search (${value.reason})`)
+      // Always visible: replacing a per-record error storm with silence would hide the fact
+      // that vector indexing has stopped until someone opens Settings > Search.
+      searchWarn('vector.pgvector', `vector store unavailable — skipping vector indexing and search (${value.reason})`)
     }
     return value
   }
 
-  const markExtensionMissing = (reason: string) => {
-    cacheStatus({ available: false, reason })
+  // The operator-facing reason is curated rather than the raw Postgres message, which the
+  // settings API surfaces to the browser.
+  const markExtensionMissing = () => {
+    cacheStatus({ available: false, reason: EXTENSION_UNAVAILABLE_REASON })
   }
 
   const readCachedStatus = (): VectorDriverStatus | null => {
@@ -146,10 +151,7 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
       )
       const row = res.rows[0]
       if (row?.installed || row?.installable) return cacheStatus({ available: true })
-      return cacheStatus({
-        available: false,
-        reason: 'extension "vector" is not available on this PostgreSQL server',
-      })
+      return cacheStatus({ available: false, reason: EXTENSION_UNAVAILABLE_REASON })
     } catch {
       // A probe that cannot run (connection refused, permissions on the catalogs)
       // says nothing about pgvector itself — stay optimistic so genuinely transient
@@ -178,7 +180,7 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
               return
             }
             if (extension === 'vector' && pgError?.code && EXTENSION_MISSING_CODES.has(pgError.code)) {
-              markExtensionMissing(pgError.message ?? 'extension "vector" is not available')
+              markExtensionMissing()
             }
             throw error
           }
@@ -291,7 +293,7 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
         // Without the extension the `vector` column type does not exist either, so the
         // table DDL fails even when `CREATE EXTENSION` was skipped rather than raised.
         if (pgError?.code === '42704' && /\bvector\b/.test(pgError.message ?? '')) {
-          markExtensionMissing(pgError.message ?? 'type "vector" does not exist')
+          markExtensionMissing()
         }
         throw err
       })

--- a/packages/search/src/vector/drivers/pgvector/index.ts
+++ b/packages/search/src/vector/drivers/pgvector/index.ts
@@ -22,6 +22,7 @@ import type {
   VectorDriverRemoveOrphansParams,
   VectorResultPresenter,
   VectorLinkDescriptor,
+  VectorDriverStatus,
 } from '../../types'
 
 type PgVectorDriverOptions = {
@@ -37,6 +38,15 @@ const DEFAULT_TABLE = 'vector_search'
 const DEFAULT_MIGRATIONS_TABLE = 'vector_search_migrations'
 const DEFAULT_DIMENSION = 1536
 const DRIVER_ID = 'pgvector' as const
+
+// `undefined_file` is what Postgres raises for `extension "vector" is not available`
+// (the pgvector shared library is not installed on the server); `feature_not_supported`
+// covers managed providers that refuse the extension outright, and `undefined_object`
+// the case where the extension record is missing. None of these can be resolved by
+// retrying, so the driver reports itself unhealthy instead of failing every record.
+const EXTENSION_MISSING_CODES = new Set(['58P01', '0A000', '42704'])
+// Re-probe occasionally so installing pgvector recovers without restarting the process.
+const UNAVAILABLE_RECHECK_MS = 60_000
 
 function assertIdentifier(name: string, defaultName: string): string {
   const candidate = name ?? defaultName
@@ -102,8 +112,59 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
     })()
 
   let ready: Promise<void> | null = null
+  let status: { value: VectorDriverStatus; at: number } | null = null
+  let reportedReason: string | null = null
+
+  const cacheStatus = (value: VectorDriverStatus): VectorDriverStatus => {
+    status = { value, at: Date.now() }
+    if (value.available) {
+      reportedReason = null
+    } else if (value.reason && value.reason !== reportedReason) {
+      reportedReason = value.reason
+      searchDebugWarn('vector.pgvector', `vector store unavailable — skipping vector indexing and search (${value.reason})`)
+    }
+    return value
+  }
+
+  const markExtensionMissing = (reason: string) => {
+    cacheStatus({ available: false, reason })
+  }
+
+  const readCachedStatus = (): VectorDriverStatus | null => {
+    if (!status) return null
+    return Date.now() - status.at < UNAVAILABLE_RECHECK_MS ? status.value : null
+  }
+
+  const getStatus = async (): Promise<VectorDriverStatus> => {
+    const cached = readCachedStatus()
+    if (cached) return cached
+    try {
+      const res = await pool.query<{ installed: boolean; installable: boolean }>(
+        `SELECT
+           EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') AS installed,
+           EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'vector') AS installable`,
+      )
+      const row = res.rows[0]
+      if (row?.installed || row?.installable) return cacheStatus({ available: true })
+      return cacheStatus({
+        available: false,
+        reason: 'extension "vector" is not available on this PostgreSQL server',
+      })
+    } catch {
+      // A probe that cannot run (connection refused, permissions on the catalogs)
+      // says nothing about pgvector itself — stay optimistic so genuinely transient
+      // database problems keep their existing retry semantics.
+      return { available: true }
+    }
+  }
+
+  const isHealthy = async (): Promise<boolean> => (await getStatus()).available
 
   const ensureReady = async () => {
+    const cached = readCachedStatus()
+    if (cached && !cached.available) {
+      throw new Error(`[vector.pgvector] ${cached.reason ?? 'vector store unavailable'}`)
+    }
     if (!ready) {
       ready = withClient(pool, async (client) => {
         const ensureExtension = async (extension: 'pgcrypto' | 'vector') => {
@@ -115,6 +176,9 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
               const details = pgError.message ? ` (${pgError.message})` : ''
               searchDebugWarn('vector.pgvector', `skipping ${extension} extension creation; requires superuser${details}`)
               return
+            }
+            if (extension === 'vector' && pgError?.code && EXTENSION_MISSING_CODES.has(pgError.code)) {
+              markExtensionMissing(pgError.message ?? 'extension "vector" is not available')
             }
             throw error
           }
@@ -219,8 +283,16 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
           `INSERT INTO ${migrationsIdent} (id, applied_at) VALUES ($1, now()) ON CONFLICT (id) DO NOTHING`,
           ['0001_init'],
         )
+      }).then(() => {
+        cacheStatus({ available: true })
       }).catch((err) => {
         ready = null
+        const pgError = err as { code?: string; message?: string }
+        // Without the extension the `vector` column type does not exist either, so the
+        // table DDL fails even when `CREATE EXTENSION` was skipped rather than raised.
+        if (pgError?.code === '42704' && /\bvector\b/.test(pgError.message ?? '')) {
+          markExtensionMissing(pgError.message ?? 'type "vector" does not exist')
+        }
         throw err
       })
     }
@@ -633,6 +705,8 @@ export function createPgVectorDriver(opts: PgVectorDriverOptions = {}): VectorDr
   return {
     id: 'pgvector',
     ensureReady,
+    isHealthy,
+    getStatus,
     upsert,
     delete: remove,
     getChecksum,

--- a/packages/search/src/vector/types.ts
+++ b/packages/search/src/vector/types.ts
@@ -96,9 +96,23 @@ export type VectorDriverRemoveOrphansParams = {
   olderThan: Date
 }
 
+export type VectorDriverStatus = {
+  available: boolean
+  reason?: string
+}
+
 export interface VectorDriver {
   readonly id: VectorDriverId
   ensureReady(): Promise<void>
+  /**
+   * Cheap, cached probe answering whether the backing store can serve reads and
+   * writes at all. Drivers that cannot satisfy their hard requirements (for
+   * pgvector: the `vector` extension) MUST report `false` here so callers skip
+   * the strategy instead of failing every record. Optional for backward
+   * compatibility — an absent implementation is treated as available.
+   */
+  isHealthy?(): Promise<boolean>
+  getStatus?(): Promise<VectorDriverStatus>
   upsert(doc: VectorDriverDocument): Promise<void>
   delete(entityId: EntityId, recordId: string, tenantId: string): Promise<void>
   query(input: VectorDriverQuery): Promise<VectorDriverQueryResult[]>


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-04-query-index-partition-race-and-vector-availability.md
Status: complete

## 🎯 Goal

A fresh `yarn dev:greenfield` finishes fully indexed and warning-free. Three independent root causes, all reproduced on a live greenfield instance:

1. The partitioned force reindex **deletes index rows it never rebuilds**, so `mercato init` silently leaves entities under-indexed and the backend shows "Results may be incomplete" until someone clicks Reindex by hand.
2. The vector strategy **error-storms per record** when the pgvector extension is absent, instead of degrading.
3. A stale ACL override **warns on every module registration** (once per HMR pass in dev).

## What Changed

### 1. `query_index` — the partitioned reindex no longer loses rows

`mercato init` runs `query_index reindex --force` in 5 concurrent partitions (`DEFAULT_REINDEX_PARTITIONS`). Only partition 0 received `resetCoverage: true`, and inside `reindexEntity` that partition issued a **scope-wide** `DELETE FROM entity_indexes` — with no partition predicate — while its siblings were already inserting. Whichever partition finished writing first had its entire batch deleted, and nothing rewrote it. Every partition still reported `processed == total` because progress counts *attempted* writes, so the run looked clean.

Evidence from the live greenfield DB (init reindex at 08:33:28) — the lost slice was always exactly one whole partition, always the one with the earliest `started_at`:

| entity | base / indexed | lost partition |
|---|---|---|
| `attachments:attachment` | 12 / 11 | p4 |
| `auth:user` | 3 / 2 | p4 |
| `catalog:catalog_product_price` | 12 / 10 | p4 |
| `entities:encryption_map` | 37 / 33 | p3 |
| `entities:custom_field_entity_config` | 6 / 4 | p3 |

The manual Reindex button "fixed" it only because `api/reindex.ts` defaults to `partitionCount = 1`, so nothing raced.

- `lib/reindexer.ts` — the force purge is now scoped to the slice each partition is about to rebuild (`mod(abs(hashtext(entity_id::text)), N) = i`, the same predicate `purgeOrphans` already uses) and runs in **every** partition. Keeping it on the coverage-resetting partition alone would leave the other slices' stale rows behind on a forced rebuild.
- `lib/reindexer.ts` — stopped the scope-wide coverage zeroing during partitioned runs. `baseCounts` there holds only this partition's slice, so writing it as the scope's base count under-reported by the partition factor, and zeroing `indexed_count` discarded deltas siblings had already applied. The end-of-partition `refreshCoverageSnapshot` is authoritative.
- `lib/coverage.ts` — `refreshCoverageSnapshot` no longer narrows the index side by a column the base table lacks. `organizations` has no `organization_id` (its index rows derive one from the record id via `deriveOrgFromId`) and `user_roles` has neither column, so the two sides counted different populations. The old early-return skipped the recount entirely, freezing the stale snapshot — a permanent "out of sync" row for `directory:organization` (0 / 1) that no reindex could ever clear. It now also returns the counts it computed.
- `cli.ts` — new `verifyAndRepairIndexCoverage`, run after each entity's partitions complete on full runs. It recounts the scope from the database and rebuilds single-partition when still short, so a scripted reindex cannot finish leaving a gap for a human to spot and repair by hand. Two COUNT queries when the counts already agree; skipped for `--partitionIndex` invocations.

### 2. `search` — vector indexing degrades instead of erroring without pgvector

`VectorSearchStrategy.isAvailable()` checked only the embedding provider (`this.embeddingService.available`), never the store. `SearchService` therefore kept vector in the active set and called `ensureReady()` for every record, reaching `CREATE EXTENSION IF NOT EXISTS vector` → `58P01 extension "vector" is not available`. The driver caught only `42501` (insufficient privilege) and rethrew, and its failure handler set `ready = null` — discarding the memo, so the whole DDL block re-ran for **every single write and delete**, each surfacing as an `AggregateError` through `throwOnStrategyFailures`.

- `vector/drivers/pgvector/index.ts` — cached `pg_extension` / `pg_available_extensions` probe behind new `getStatus()` / `isHealthy()`, with a 60s recheck so installing pgvector recovers without a process restart. The not-installable error class (`58P01`, `0A000`, `42704`) and the follow-on `type "vector" does not exist` (the table DDL fails even when `CREATE EXTENSION` was skipped) mark the driver unavailable and short-circuit `ensureReady()`. Probe failures stay optimistic, so a transient database outage keeps its existing retry semantics rather than disabling vector search.
- `vector/types.ts` — `isHealthy?()` / `getStatus?()` added as **optional** members on `VectorDriver`, keeping the qdrant/chromadb stubs and any third-party driver source-compatible.
- `strategies/vector.strategy.ts` — consults the probe, so `SearchService.getAvailableStrategies()` drops vector before `ensureReady()` is ever called. `throwOnStrategyFailures` is deliberately untouched: writes stay fail-loud for strategies that are genuinely available, preserving the #3103 queue-retry contract.
- Settings UI — `/api/search/settings/vector-store` reports `available` / `unavailableReason` per driver (OpenAPI schema updated); `VectorSearchSection` renders a warning banner carrying the driver's own message on the Configuration tab and in place of Index Management, and the pgvector card drops its green "ready" state. i18n for en/pl/de/es/ko. `/api/search/settings` and `mercato search status` start reporting vector as unavailable for free.

### 3. `rbac` — the stale `example.manage` override

`apps/mercato/src/modules.ts` nulls `example.manage` through `entry.overrides.acl.features` (added in #4462), but the example module never declared that feature — so `applyModuleOverridesToModules` skipped the override as stale and `warnStaleOverrides` fired on every registration. It also made `TC-AUTH-055-nulled-feature-policy` pass **vacuously**: it asserted a feature that never existed was denied, never exercising the nulling path it was written for.

- Declared `example.manage` in the canonical example module as an explicit, ungated override probe, mirrored byte-exact into the create-app template (parity test green).
- New `apps/mercato/src/__tests__/module-override-acl-features.test.ts` fails when a live override key resolves to no declared feature.

### Docs

- `packages/search/AGENTS.md` gained a short note that availability covers the store, not just its credentials.

## 🧪 Tests

Full configured gate on the current `develop` head:

- `yarn build:packages` → `yarn generate` → `yarn build:packages` — pass
- `yarn i18n:check-sync` — pass (added the `ko` strings the first pass was missing)
- `yarn i18n:check-usage` — pass
- `yarn typecheck` — pass (22 tasks)
- `yarn build:app` — pass
- `yarn test`: `@open-mercato/core` 9030 passed / 1170 suites; `@open-mercato/search` 273 passed / 29 suites; `@open-mercato/shared` 1738 passed; `@open-mercato/ui` 1771 passed; `@open-mercato/app` 186 passed / 40 suites

New coverage:

- `query_index/__tests__/reindexer-partition-purge.test.ts` (4) — asserts the **real compiled SQL** via a recording Kysely driver: the purge carries the partition predicate, runs in non-resetting partitions too, stays scope-wide when unpartitioned, and never fires on a non-forced run. Two of these were confirmed to fail against the pre-fix reindexer.
- `query_index/__tests__/coverage-scope-symmetry.test.ts` (2) — the index side is not narrowed by a column the base table lacks, and normal scoping is unchanged.
- `search/__tests__/pgvector-extension-availability.test.ts` (9) — unhealthy reporting, the probe running **once** with no DDL across repeated calls, `ensureReady` short-circuit, the installable-extension path, the existing `42501` degradation preserved, and the service skipping the store entirely on both index and delete.
- 2 added cases in `VectorSearchSection.test.tsx` for the banner.

### ⚠️ Pre-existing failure on `develop` (not from this PR)

`create-mercato-app`'s template ESM-import test fails on `develop` independently of this branch: `packages/create-app/template/scripts/dev-runtime.mjs` imports `./dev-memory-monitor.mjs`, a sibling that #4939 added under `apps/mercato/scripts/` but never mirrored into the template — the file exists nowhere under `packages/create-app/template/scripts/`. `yarn template:sync` does not report it as drift, so fixing it means extending the mirror list in `scripts/template-sync.ts` as well as copying the file. That belongs with the change that introduced it, not here.

## 💥 Breaking Changes

None. `VectorDriver` gains **optional** members only (absent implementations are treated as available), the vector-store settings response is additive, and `refreshCoverageSnapshot` now returns a value where it previously returned `void` — every existing caller awaits it and ignores the result.

## 📋 Progress

See the Progress section in the tracking plan.
