### PR TITLE
fix(ci): register the telemetry default-unloaded guard in the repo-wide enumeration

### DIFF
--- a/.ai/runs/2026-08-04-telemetry-repo-wide-guard.md
+++ b/.ai/runs/2026-08-04-telemetry-repo-wide-guard.md
@@ -76,4 +76,29 @@ classification. Adding a second test asserting the same enumeration would duplic
 ### Phase 1: Classify the guard
 
 - [x] 1.1 Add the telemetry workspace group to REPO_WIDE_GUARDS — 678541426
-- [ ] 1.2 Verify with the guard contract test, the guard runner and the validation gate
+- [x] 1.2 Verify with the guard contract test, the guard runner and the validation gate — 678541426
+
+## Validation gate (runner: local — no compose `app` container up)
+
+| Command | Result |
+|---|---|
+| `yarn build:packages` | ✅ 22/22 |
+| `yarn generate` | ✅ clean tree, no unrelated migrations |
+| `yarn build:packages` (rebuild) | ✅ 22/22 |
+| `yarn i18n:check-sync` | ✅ all in sync |
+| `yarn i18n:check-usage` | ✅ advisory only |
+| `yarn typecheck` | ✅ 22/22 |
+| `yarn test` | ⚠️ one pre-existing base failure, see below |
+| `yarn build:app` | ✅ 1/1 |
+| `node --test scripts/__tests__/repo-wide-guards.test.mjs` | ✅ 14/14 (was 13/14 before this change) |
+| `yarn test:repo-wide-guards` | ✅ all guards pass, 24 test files, telemetry now among them |
+
+`yarn test` fails only on `create-mercato-app`'s
+`every local ESM import in template scripts resolves inside the template`: the template's
+`scripts/dev-runtime.mjs:15` imports `./dev-memory-monitor.mjs`, which exists nowhere in the
+repository. Reproduced on a pristine `upstream/develop` checkout with none of this branch's content —
+it is base breakage from #4867, filed as **#4948**, and untouched by this diff. Run in isolation the
+rest of that suite is green (450 tests, 444 pass, that one fail). A second create-app failure seen
+during the first sweep (`build emits customers facts … (T5)`, `node build.mjs` exiting non-zero)
+did **not** reproduce once nothing else was running — it was local memory pressure from a concurrent
+`yarn build:app`, and `node build.mjs` completes cleanly on its own.

--- a/.ai/runs/2026-08-04-telemetry-repo-wide-guard.md
+++ b/.ai/runs/2026-08-04-telemetry-repo-wide-guard.md
@@ -1,0 +1,79 @@
+# Execution plan — register the telemetry default-unloaded guard
+
+Fixes #4946.
+
+## Goal
+
+Make `scripts/__tests__/repo-wide-guards.test.mjs` pass again on `develop` and on every PR by
+classifying `packages/telemetry/src/__tests__/default-unloaded.test.ts` in `REPO_WIDE_GUARDS`.
+
+## Context
+
+`packages/telemetry` landed with #4475 (`e76f4b8cb`, 2026-08-04 09:56Z). Its
+`default-unloaded.test.ts` asserts host wiring across eight files that live outside the telemetry
+package:
+
+```
+apps/mercato/src/instrumentation.ts
+apps/mercato/src/app/api/[...slug]/route.ts
+packages/create-app/template/src/instrumentation.ts
+packages/create-app/template/src/app/api/[...slug]/route.ts
+packages/cli/src/bin.ts
+packages/queue/src/tracing.ts
+packages/queue/src/strategies/async.ts
+packages/queue/src/worker/runner.ts
+```
+
+`scripts/repo-wide-guards.mjs` is the single enumeration of such cross-package audits, and its own
+test fails any test that reaches outside its package without being classified. The classification
+entry was not added alongside the new package, so the guard test now fails on a pristine `develop`
+checkout — and, because `ci.yml` runs the repo-wide guards unconditionally, on every PR that merges
+the current base.
+
+## Scope
+
+One entry in `REPO_WIDE_GUARDS` in `scripts/repo-wide-guards.mjs`, declaring the telemetry workspace
+and its guard test.
+
+`REPO_WIDE_GUARDS` rather than `CROSS_PACKAGE_EXCEPTIONS` is the correct side of the fork: the test
+must run on every PR precisely because a change to `packages/queue` or `apps/mercato` would otherwise
+have this assertion filtered away by turbo — which is the failure mode the enumeration exists to
+prevent (#4527, #4534).
+
+## Non-goals
+
+- No change to the telemetry package, its test, or any runtime host it scans.
+- No change to the guard runner's mechanics, the CI workflow, or the enumeration's shape.
+- No sweep for other unclassified tests beyond the one the guard currently reports.
+
+## Risks
+
+Low. The change is data in an enumeration; the guard test is the executable contract for it and moves
+from red to green. The one behavioural consequence is intended: `packages/telemetry`'s guard test now
+runs on every PR (~one extra jest run inside an already-batched step, seconds).
+
+## Implementation Plan
+
+### Phase 1: Classify the guard
+
+- Step 1.1 — Add the `@open-mercato/telemetry` workspace group to `REPO_WIDE_GUARDS` with
+  `src/__tests__/default-unloaded.test.ts` and a `scans` description naming the hosts it reads.
+- Step 1.2 — Verify with the repository's own contract test
+  (`node --test scripts/__tests__/repo-wide-guards.test.mjs`) plus the guard runner
+  (`yarn test:repo-wide-guards`), then run the configured validation gate.
+
+## Regression coverage
+
+No new test is written, deliberately: `scripts/__tests__/repo-wide-guards.test.mjs` **is** the
+regression test for this change. It fails on the current `develop` for exactly this file and passes
+once the entry exists, and it will fail again the next time a cross-package test is added without a
+classification. Adding a second test asserting the same enumeration would duplicate it.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Classify the guard
+
+- [ ] 1.1 Add the telemetry workspace group to REPO_WIDE_GUARDS
+- [ ] 1.2 Verify with the guard contract test, the guard runner and the validation gate

--- a/.ai/runs/2026-08-04-telemetry-repo-wide-guard.md
+++ b/.ai/runs/2026-08-04-telemetry-repo-wide-guard.md
@@ -75,5 +75,5 @@ classification. Adding a second test asserting the same enumeration would duplic
 
 ### Phase 1: Classify the guard
 
-- [ ] 1.1 Add the telemetry workspace group to REPO_WIDE_GUARDS
+- [x] 1.1 Add the telemetry workspace group to REPO_WIDE_GUARDS — 678541426
 - [ ] 1.2 Verify with the guard contract test, the guard runner and the validation gate

--- a/.ai/runs/2026-08-04-telemetry-repo-wide-guard.md
+++ b/.ai/runs/2026-08-04-telemetry-repo-wide-guard.md
@@ -71,6 +71,8 @@ classification. Adding a second test asserting the same enumeration would duplic
 
 ## Progress
 
+PR: #4947
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Classify the guard

--- a/scripts/repo-wide-guards.mjs
+++ b/scripts/repo-wide-guards.mjs
@@ -148,6 +148,17 @@ export const REPO_WIDE_GUARDS = [
     ],
   },
   {
+    workspace: '@open-mercato/telemetry',
+    workspaceDir: 'packages/telemetry',
+    jestConfig: 'jest.config.cjs',
+    tests: [
+      {
+        path: 'src/__tests__/default-unloaded.test.ts',
+        scans: 'apps/mercato, packages/create-app/template, packages/cli and packages/queue runtime hosts — telemetry stays unloaded unless a backend is configured (#4475)',
+      },
+    ],
+  },
+  {
     workspace: '@open-mercato/ui',
     workspaceDir: 'packages/ui',
     jestConfig: 'jest.config.cjs',


### PR DESCRIPTION
Closes #4946
Tracking plan: .ai/runs/2026-08-04-telemetry-repo-wide-guard.md
Status: complete

## 🎯 Goal
- `scripts/__tests__/repo-wide-guards.test.mjs` fails on a pristine `develop` checkout because `packages/telemetry/src/__tests__/default-unloaded.test.ts` reads files outside its own package but is classified in neither `REPO_WIDE_GUARDS` nor `CROSS_PACKAGE_EXCEPTIONS`. `ci.yml` runs the repo-wide guards unconditionally, so this turns the `test` job red on `develop` and on every PR that merges the current base. This registers the missing entry.

## What Changed
- `scripts/repo-wide-guards.mjs` — one new workspace group in `REPO_WIDE_GUARDS` for `@open-mercato/telemetry`, listing `src/__tests__/default-unloaded.test.ts` with a `scans` line naming the hosts it reads. Nothing else in the file, the runner, the workflow or the telemetry package changes.
- `REPO_WIDE_GUARDS` rather than `CROSS_PACKAGE_EXCEPTIONS` is the correct side of the fork: the test asserts telemetry host wiring across `apps/mercato/src/instrumentation.ts`, `apps/mercato/src/app/api/[...slug]/route.ts`, both `packages/create-app/template` equivalents, `packages/cli/src/bin.ts`, `packages/queue/src/tracing.ts`, `packages/queue/src/strategies/async.ts` and `packages/queue/src/worker/runner.ts`. A PR touching `packages/queue` or `apps/mercato` selects no owning package for this test, so turbo would filter away exactly the assertion the enumeration exists to keep running (#4527, #4534).
- The test arrived with #4475 (`e76f4b8cb`, today 09:56Z) without its classification entry.

## 🧪 Tests
- `node --test scripts/__tests__/repo-wide-guards.test.mjs` — **14 passed / 0 failed** (13/14 with 1 failure before this change). This test *is* the regression coverage: it fails today for exactly this file, passes with the entry, and will fail again the next time a cross-package test is added unclassified. A second test asserting the same enumeration would only duplicate it.
- `yarn test:repo-wide-guards` — all guards pass across 24 test files; `@open-mercato/telemetry — 1 repo-wide guard(s)` now appears in the run with 17 passing tests.
- Full gate (runner: local): `build:packages` ✅ 22/22 · `generate` ✅ clean tree · `build:packages` rebuild ✅ · `i18n:check-sync` ✅ · `i18n:check-usage` ✅ advisory · `typecheck` ✅ 22/22 · `build:app` ✅ 1/1.
- `yarn test` ⚠️ — fails only on `create-mercato-app`'s `every local ESM import in template scripts resolves inside the template`, because the template's `scripts/dev-runtime.mjs:15` imports a `./dev-memory-monitor.mjs` that exists nowhere in the repo. Reproduced on a pristine `upstream/develop` checkout with none of this branch's content: **base breakage from #4867, filed as #4948**, and untouched by this diff. In isolation the rest of that suite is green (450 tests, 444 pass).

## 💥 Breaking Changes
- None. The change is one entry in a data enumeration. The single intended behavioural consequence is that `packages/telemetry`'s guard test now runs on every PR — one extra jest invocation inside an already-batched step, seconds.

## 📋 Progress
See the Progress section in the tracking plan.
