### PR TITLE
fix(sales): persist customFields supplied on order and quote create

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-041-document-create-custom-fields.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-041-document-create-custom-fields.spec.ts
@@ -1,0 +1,139 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { expectId, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import { deleteSalesEntityIfExists } from '@open-mercato/core/helpers/integration/salesFixtures'
+
+/**
+ * TC-SALES-041 — custom fields supplied on document create are persisted.
+ *
+ * The create route folds `cf_*` body keys into `customFields` before handing the
+ * payload to `sales.orders.create` / `sales.quotes.create`. Those create schemas
+ * used to omit the key, so zod stripped it and the values silently vanished —
+ * callers had to create, then immediately update, for a custom field to stick.
+ */
+
+const DEFINITIONS = '/api/entities/definitions'
+const ORDERS = '/api/sales/orders'
+const QUOTES = '/api/sales/quotes'
+
+type CreateResponse = { id?: string }
+type DocumentRecord = Record<string, unknown> & { id?: string }
+type ListResponse = { items?: DocumentRecord[] }
+
+async function createDefinition(
+  request: APIRequestContext,
+  token: string,
+  entityId: string,
+  key: string,
+  label: string,
+): Promise<void> {
+  const response = await apiRequest(request, 'POST', DEFINITIONS, {
+    token,
+    data: { entityId, key, kind: 'text', label, formEditable: true, listVisible: true },
+  })
+  expect(response.ok(), `custom field definition create failed (${response.status()})`).toBeTruthy()
+}
+
+async function deleteDefinition(
+  request: APIRequestContext,
+  token: string,
+  entityId: string,
+  key: string,
+): Promise<void> {
+  await apiRequest(
+    request,
+    'DELETE',
+    `${DEFINITIONS}?entityId=${encodeURIComponent(entityId)}&key=${encodeURIComponent(key)}`,
+    { token },
+  ).catch(() => {})
+}
+
+async function readDocument(
+  request: APIRequestContext,
+  token: string,
+  path: string,
+  id: string,
+): Promise<DocumentRecord | undefined> {
+  const response = await apiRequest(request, 'GET', `${path}?id=${encodeURIComponent(id)}`, {
+    token,
+  })
+  expect(response.status(), 'created document should be readable').toBe(200)
+  const body = await readJsonSafe<ListResponse>(response)
+  return body?.items?.find((item) => item.id === id)
+}
+
+const seedLine = {
+  currencyCode: 'USD',
+  quantity: 1,
+  name: 'QA seed line',
+  unitPriceNet: 0,
+  unitPriceGross: 0,
+}
+
+test.describe('TC-SALES-041: custom fields on sales document create', () => {
+  test('order create persists cf_ values without a follow-up update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const key = `sales_create_cf_${stamp}`
+    const value = `FS-${stamp}/2026`
+    let orderId: string | null = null
+    let definitionCreated = false
+
+    try {
+      await createDefinition(request, token, 'sales:sales_order', key, `Order CF ${stamp}`)
+      definitionCreated = true
+
+      const createResponse = await apiRequest(request, 'POST', ORDERS, {
+        token,
+        data: { currencyCode: 'USD', lines: [seedLine], [`cf_${key}`]: value },
+      })
+      const createBody = await readJsonSafe<CreateResponse>(createResponse)
+
+      expect(createResponse.status(), 'order create should succeed').toBe(201)
+      orderId = expectId(createBody?.id, 'order create response should contain an id')
+
+      const order = await readDocument(request, token, ORDERS, orderId)
+      expect(order, 'created order should appear in the filtered list').toBeDefined()
+      expect(
+        (order as Record<string, unknown>)[`cf_${key}`],
+        'custom field supplied on create should be persisted',
+      ).toBe(value)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, ORDERS, orderId)
+      if (definitionCreated) await deleteDefinition(request, token, 'sales:sales_order', key)
+    }
+  })
+
+  test('quote create persists cf_ values without a follow-up update', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const stamp = Date.now()
+    const key = `sales_create_cf_q_${stamp}`
+    const value = `QT-${stamp}/2026`
+    let quoteId: string | null = null
+    let definitionCreated = false
+
+    try {
+      await createDefinition(request, token, 'sales:sales_quote', key, `Quote CF ${stamp}`)
+      definitionCreated = true
+
+      const createResponse = await apiRequest(request, 'POST', QUOTES, {
+        token,
+        data: { currencyCode: 'USD', lines: [seedLine], [`cf_${key}`]: value },
+      })
+      const createBody = await readJsonSafe<CreateResponse>(createResponse)
+
+      expect(createResponse.status(), 'quote create should succeed').toBe(201)
+      quoteId = expectId(createBody?.id, 'quote create response should contain an id')
+
+      const quote = await readDocument(request, token, QUOTES, quoteId)
+      expect(quote, 'created quote should appear in the filtered list').toBeDefined()
+      expect(
+        (quote as Record<string, unknown>)[`cf_${key}`],
+        'custom field supplied on create should be persisted',
+      ).toBe(value)
+    } finally {
+      await deleteSalesEntityIfExists(request, token, QUOTES, quoteId)
+      if (definitionCreated) await deleteDefinition(request, token, 'sales:sales_quote', key)
+    }
+  })
+})

--- a/packages/core/src/modules/sales/commands/__tests__/documents.create-custom-fields.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/documents.create-custom-fields.test.ts
@@ -1,0 +1,250 @@
+/** @jest-environment node */
+
+import { asValue, createContainer, InjectionMode } from 'awilix'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands/types'
+import { orderCreateSchema, quoteCreateSchema } from '../../data/validators'
+import { DefaultSalesCalculationService } from '../../services/salesCalculationService'
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    sales: {
+      sales_order: 'sales.sales_order',
+      sales_order_line: 'sales.sales_order_line',
+      sales_order_adjustment: 'sales.sales_order_adjustment',
+      sales_quote: 'sales.sales_quote',
+      sales_quote_line: 'sales.sales_quote_line',
+      sales_quote_adjustment: 'sales.sales_quote_adjustment',
+    },
+  },
+}))
+
+jest.mock('@open-mercato/shared/lib/logger', () => {
+  const logger = {
+    debug: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    child: jest.fn(),
+  }
+  logger.child.mockReturnValue(logger)
+  return { createLogger: () => logger }
+})
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn(async () => ({})),
+}))
+
+jest.mock('@open-mercato/core/modules/entities/lib/helpers', () => ({
+  setRecordCustomFields: jest.fn(async () => undefined),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+  findOneWithDecryption: jest.fn(async () => null),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  emitCrudSideEffects: jest.fn(async () => undefined),
+}))
+
+jest.mock('@open-mercato/core/modules/notifications/lib/notificationService', () => ({
+  resolveNotificationService: () => ({ createForFeature: jest.fn(async () => undefined) }),
+}))
+
+const { setRecordCustomFields } = jest.requireMock(
+  '@open-mercato/core/modules/entities/lib/helpers',
+) as { setRecordCustomFields: jest.Mock }
+
+const { emitCrudSideEffects } = jest.requireMock('@open-mercato/shared/lib/commands/helpers') as {
+  emitCrudSideEffects: jest.Mock
+}
+
+const TEST_TENANT_ID = 'aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa'
+const TEST_ORG_ID = 'bbbbbbbb-bbbb-4bbb-abbb-bbbbbbbbbbbb'
+
+function buildHarness() {
+  let inTransaction = false
+  let em: Record<string, unknown>
+  em = {
+    fork: () => em,
+    create: (_entity: unknown, data: Record<string, unknown>) => ({ ...data }),
+    persist: () => undefined,
+    find: async () => [],
+    findOne: async () => null,
+    nativeDelete: async () => 0,
+    remove: jest.fn(),
+    flush: async () => undefined,
+    isInTransaction: () => inTransaction,
+    begin: async () => {
+      inTransaction = true
+    },
+    commit: async () => {
+      inTransaction = false
+    },
+    rollback: async () => {
+      inTransaction = false
+    },
+    getReference: (_entity: unknown, id: unknown) => ({ id }),
+  }
+
+  const container = createContainer({ injectionMode: InjectionMode.PROXY })
+  container.register({
+    em: asValue(em),
+    dataEngine: asValue({}),
+    eventBus: asValue({ emit: async () => undefined, emitEvent: async () => undefined }),
+    salesCalculationService: asValue(new DefaultSalesCalculationService(null)),
+    salesDocumentNumberGenerator: asValue({ generate: async () => ({ number: 'DOC-1' }) }),
+  })
+
+  const ctx: CommandRuntimeContext = {
+    container,
+    auth: null,
+    organizationScope: null,
+    selectedOrganizationId: TEST_ORG_ID,
+    organizationIds: [TEST_ORG_ID],
+  }
+
+  return { ctx }
+}
+
+const line = {
+  name: 'Item',
+  currencyCode: 'USD',
+  quantity: 1,
+  unitPriceNet: 100,
+  unitPriceGross: 100,
+  taxRate: 0,
+  discountAmount: 0,
+  discountPercent: 0,
+}
+
+function buildInput(extra: Record<string, unknown> = {}) {
+  return {
+    organizationId: TEST_ORG_ID,
+    tenantId: TEST_TENANT_ID,
+    currencyCode: 'USD',
+    lines: [line],
+    ...extra,
+  }
+}
+
+function customFieldWritesFor(entityId: string) {
+  return setRecordCustomFields.mock.calls
+    .map(([, options]) => options as Record<string, unknown>)
+    .filter((options) => options.entityId === entityId)
+}
+
+describe('order/quote create schemas — customFields (GSM-296)', () => {
+  it('keeps customFields on orderCreateSchema instead of stripping it', () => {
+    const parsed = orderCreateSchema.parse(
+      buildInput({ customFields: { subiekt_doc_id: '42', customer_name: 'Acme' } }),
+    )
+
+    expect(parsed.customFields).toEqual({ subiekt_doc_id: '42', customer_name: 'Acme' })
+  })
+
+  it('keeps customFields on quoteCreateSchema instead of stripping it', () => {
+    const parsed = quoteCreateSchema.parse(buildInput({ customFields: { source: 'import' } }))
+
+    expect(parsed.customFields).toEqual({ source: 'import' })
+  })
+})
+
+describe('sales document create commands — customFields (GSM-296)', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../documents')
+  })
+
+  beforeEach(() => {
+    setRecordCustomFields.mockClear()
+    emitCrudSideEffects.mockClear()
+  })
+
+  function getHandler(id: string) {
+    const handler = commandRegistry.get<unknown, { orderId?: string; quoteId?: string }>(id)
+    expect(handler).toBeTruthy()
+    return handler!
+  }
+
+  it('persists customFields supplied to sales.orders.create', async () => {
+    const { ctx } = buildHarness()
+
+    const result = await getHandler('sales.orders.create').execute(
+      buildInput({ customFields: { subiekt_doc_id: 'FS-1/2026', payment_status: 'paid' } }) as never,
+      ctx,
+    )
+
+    const writes = customFieldWritesFor('sales.sales_order')
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toEqual({
+      entityId: 'sales.sales_order',
+      recordId: result.orderId,
+      organizationId: TEST_ORG_ID,
+      tenantId: TEST_TENANT_ID,
+      values: { subiekt_doc_id: 'FS-1/2026', payment_status: 'paid' },
+    })
+  })
+
+  it('persists customFields supplied to sales.quotes.create', async () => {
+    const { ctx } = buildHarness()
+
+    const result = await getHandler('sales.quotes.create').execute(
+      buildInput({ customFields: { source: 'import' } }) as never,
+      ctx,
+    )
+
+    const writes = customFieldWritesFor('sales.sales_quote')
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toMatchObject({
+      recordId: result.quoteId,
+      organizationId: TEST_ORG_ID,
+      tenantId: TEST_TENANT_ID,
+      values: { source: 'import' },
+    })
+  })
+
+  it('writes custom fields before the create side effects refresh the query index', async () => {
+    const { ctx } = buildHarness()
+    const order: string[] = []
+    setRecordCustomFields.mockImplementationOnce(async () => {
+      order.push('custom-fields')
+    })
+    emitCrudSideEffects.mockImplementationOnce(async () => {
+      order.push('side-effects')
+    })
+
+    await getHandler('sales.orders.create').execute(
+      buildInput({ customFields: { subiekt_doc_id: 'FS-2/2026' } }) as never,
+      ctx,
+    )
+
+    expect(order).toEqual(['custom-fields', 'side-effects'])
+  })
+
+  it('skips the custom field write when the caller supplies none', async () => {
+    const { ctx } = buildHarness()
+
+    await getHandler('sales.orders.create').execute(buildInput() as never, ctx)
+
+    expect(customFieldWritesFor('sales.sales_order')).toHaveLength(0)
+  })
+
+  it('skips the custom field write for an empty customFields object', async () => {
+    const { ctx } = buildHarness()
+
+    await getHandler('sales.orders.create').execute(
+      buildInput({ customFields: {} }) as never,
+      ctx,
+    )
+
+    expect(customFieldWritesFor('sales.sales_order')).toHaveLength(0)
+  })
+})

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -665,6 +665,41 @@ function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
+/**
+ * Persists document-level custom fields supplied on a create input.
+ *
+ * Order and quote creates used to accept `customFields` at the HTTP boundary
+ * (`splitCustomFieldPayload` folds `cf_*` keys into it) and then drop the values
+ * on the floor, because the create schemas never declared the key and the
+ * handlers never wrote it — only updates did. Callers therefore had to create,
+ * then immediately update, to get custom fields to stick.
+ */
+async function setDocumentCustomFieldsIfSupplied(
+  em: EntityManager,
+  params: {
+    entityId: string;
+    recordId: string;
+    organizationId: string;
+    tenantId: string;
+    customFields: unknown;
+  },
+): Promise<void> {
+  const { customFields } = params;
+  if (customFields === undefined || customFields === null) return;
+  const values =
+    typeof customFields === "object" && !Array.isArray(customFields)
+      ? (customFields as Record<string, unknown>)
+      : {};
+  if (!Object.keys(values).length) return;
+  await setRecordCustomFields(em, {
+    entityId: params.entityId,
+    recordId: params.recordId,
+    organizationId: params.organizationId,
+    tenantId: params.tenantId,
+    values: normalizeCustomFieldValues(values),
+  });
+}
+
 async function resolveCustomerSnapshot(
   em: EntityManager,
   organizationId: string,
@@ -4782,6 +4817,13 @@ const createQuoteCommand: CommandHandler<
             tenantId: quote.tenantId,
             tagIds: parsed.tags,
           });
+          await setDocumentCustomFieldsIfSupplied(em, {
+            entityId: E.sales.sales_quote,
+            recordId: quote.id,
+            organizationId: quote.organizationId,
+            tenantId: quote.tenantId,
+            customFields: parsed.customFields,
+          });
         },
       ],
       { transaction: true },
@@ -5803,6 +5845,13 @@ const createOrderCommand: CommandHandler<
             organizationId: order.organizationId,
             tenantId: order.tenantId,
             tagIds: parsed.tags,
+          });
+          await setDocumentCustomFieldsIfSupplied(em, {
+            entityId: E.sales.sales_order,
+            recordId: order.id,
+            organizationId: order.organizationId,
+            tenantId: order.tenantId,
+            customFields: parsed.customFields,
           });
         },
       ],

--- a/packages/core/src/modules/sales/data/validators.ts
+++ b/packages/core/src/modules/sales/data/validators.ts
@@ -717,6 +717,7 @@ export const orderCreateSchema = scoped.extend({
   paymentMethodSnapshot: jsonRecord.optional(),
   metadata,
   customFieldSetId: uuid().optional(),
+  customFields: z.record(z.string(), z.unknown()).optional(),
   lines: z
     .array(orderLineCreateSchema.omit({ organizationId: true, tenantId: true, orderId: true }), {
       error: SALES_ORDER_LINES_REQUIRED_MESSAGE_KEY,
@@ -761,6 +762,7 @@ export const quoteCreateSchema = scoped.extend({
   paymentMethodSnapshot: jsonRecord.optional(),
   metadata,
   customFieldSetId: uuid().optional(),
+  customFields: z.record(z.string(), z.unknown()).optional(),
   lines: z
     .array(quoteLineCreateSchema.omit({ organizationId: true, tenantId: true, quoteId: true }))
     .optional(),


### PR DESCRIPTION
## Summary

`sales.orders.create` and `sales.quotes.create` silently discard `customFields`. The create route already folds `cf_*` body keys into a `customFields` key (`api/documents/factory.ts:479`) and hands the payload to `orderCreateSchema` / `quoteCreateSchema` — neither of which declares the key, so zod strips it. On top of that, the create handlers have no custom-field write path at all; only the update path writes them (`documents.ts:1354`).

Net effect: custom fields set at create time vanish with no error, no warning and no log. Callers have to create, then immediately update, for a value to stick — and anything that only ever creates a record (bulk imports, external syncs) ends up with permanently empty custom fields. This was found in production data on an integration that imports orders from an external ERP; every never-updated order had empty custom-field columns.

The document header is the **only** create schema in `data/validators.ts` missing this key. `lineSharedSchema` (shared by both order and quote line creates) declares `customFieldSetId` and `customFields` adjacently at lines 390–391, and `orderAdjustmentCreateSchema`, `quoteAdjustmentCreateSchema`, `shipmentCreateSchema` and `paymentCreateSchema` all declare it too. Order lines get their custom fields written on create (`documents.ts:3162`); the order itself does not. This PR removes that outlier.

## Changes

- `data/validators.ts` — declare `customFields` on `orderCreateSchema` and `quoteCreateSchema`, matching the sibling create schemas in the same file.
- `commands/documents.ts` — add `setDocumentCustomFieldsIfSupplied`, called from both create commands **inside the existing `withAtomicFlush` transaction phase**, so a later failure in the same phase can't leave custom fields committed against a rolled-back document. It runs before `emitCrudSideEffects`, so the per-record query-index refresh picks the values up rather than leaving the index stale.
- No-ops when the caller supplies nothing or an empty object, so existing create payloads are byte-for-byte unaffected.

Both halves were required — the schema gap was only half the bug, since the handlers had no write path either.

**Backward compatibility:** additive only. A new *optional* request field on a create schema; no DB schema change, no response-shape change, no removed or renamed surface. Under `BACKWARD_COMPATIBILITY.md` this is an ADDITIVE-ONLY change to the API-route contract surface and needs no deprecation bridge. Two behaviours fall out for free: passing `customFields: {...}` directly (not just `cf_*`) now works on create, and the audit snapshot captures the created values so create-undo/redo handles them.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — bug fix restoring documented behaviour, no architectural change.

## Testing

Runner: local (no compose `app` container running for this workspace).

- `packages/core/src/modules/sales/commands/__tests__/documents.create-custom-fields.test.ts` — 7 new unit cases: schema retention for both document kinds, persistence with correct entity/record/scope for orders and quotes, ordering (custom fields written before side effects), and two negative cases (absent / empty object → no write). **Verified non-vacuous:** 5 of the 7 fail on the unpatched tree; the 2 negative cases correctly pass either way.
- `packages/core/src/modules/sales/__integration__/TC-SALES-041-document-create-custom-fields.spec.ts` — new Playwright integration coverage over the real API surface: creates a custom-field definition via `POST /api/entities/definitions`, creates an order (and a quote) via `POST /api/sales/orders` with a `cf_<key>` body key, reads back and asserts the value persisted without a follow-up update. Self-contained: creates its own fixtures and deletes both the document and the definition in `finally`. **Both tests passed** against a real app + Postgres via `yarn test:integration:ephemeral --filter TC-SALES-041`.

Full validation gate from `.ai/agentic.config.json`, all run after rebasing onto current `develop`:

| Command | Result |
|---|---|
| `yarn build:packages` | pass |
| `yarn generate` | pass |
| `yarn i18n:check-sync` | pass — all locales in sync |
| `yarn i18n:check-usage` | pass (advisory unused-key count unchanged by this PR) |
| `yarn typecheck` | pass — 22/22 |
| `yarn workspace @open-mercato/core test` | pass — 1169 suites / 9048 tests |
| `yarn workspace @open-mercato/shared test` | pass — 167 suites / 1740 tests |
| `yarn build:app` | pass |
| `yarn test:integration:ephemeral --filter TC-SALES-041` | pass — 2/2 |

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). <!-- left for the PR author to tick personally -->
- [x] I updated documentation, locales, or generators if the change requires it. — none required: the OpenAPI spec derives from `createSchema` (`api/documents/factory.ts:633`) so the new field documents itself, and no user-facing strings were added.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests — placed in the module's `__integration__/` folder per `.ai/qa/AGENTS.md`, which reserves `.ai/qa/tests/` for shared Playwright config and forbids executable specs there.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — not applicable, see Specification above.
- [x] Priority set: `priority-medium` — silent data loss, but with a known caller-side workaround (create-then-update).
- [x] Risk set: `risk-low` — additive optional schema field plus a guarded write inside an existing transaction; no DB or response-shape change, and a no-op for payloads that don't supply the field.
- [x] QA routing set: `needs-qa`. This change does not qualify for the automated-verification exemption in `AGENTS.md` — it alters the API surface (a newly accepted request field) and has a manually exercisable UI path: define a custom field on `sales:sales_order`, fill it on the order create form, and confirm it persists without a second save.

### Design System Compliance

N/A — this PR touches no UI-rendering files (no `.tsx`, nothing under `packages/ui/src/` or `**/components/**`). The four changed files are two command/validator modules and two test files, so every box in this section is inapplicable rather than satisfied; leaving them unticked to avoid implying otherwise.

## Linked issues

None — reported from downstream production usage rather than an existing issue.
