### PR TITLE
refactor(ci): make the guard manifest the single enumeration for the repo-wide audit step (#4770)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,21 +539,16 @@ jobs:
         # other packages, apps/ or scripts/. The turbo filter selects packages, not paths, so
         # a PR touching only scripts/ selects no package and those audits never run — the
         # violation then lands on develop and the post-merge unfiltered `yarn test` goes red
-        # for everyone (#4527). Run them unconditionally so they fail their own PR.
+        # for everyone (#4527). Run them unconditionally so they fail their own PR — do not
+        # move this step behind an `if:`, or the silent skip comes straight back.
         #
-        # Enumerated today (full list with per-test reasons: scripts/repo-wide-guards.mjs,
-        # kept honest by scripts/__tests__/repo-wide-guards.test.mjs):
-        #   @open-mercato/core   — explicit-sort-comparators, alert-duplicate-icon-coverage,
-        #                          auth-onboarding-feedback-ds-tokens, license-metadata-consistency,
-        #                          types-dependency-classification, optimistic-lock-ui-coverage-workspace,
-        #                          optimistic-lock-command-coverage, modules/crud-indexer-config
-        #   @open-mercato/cli    — module-facts.bc-guard, module-facts.customers.fixture,
-        #                          module-facts.auth-source, module-facts.extension-hosts,
-        #                          example-public-route-safety, disabled-example-module,
-        #                          release-notes-retired
-        #   @open-mercato/shared — db/escapeLikePattern
-        #   @open-mercato/ui     — primitives/zindex-overlay
-        #   @open-mercato/app    — components/starter-chrome-ds, components/StartPageContent
+        # The guards are enumerated in exactly one place: REPO_WIDE_GUARDS in
+        # scripts/repo-wide-guards.mjs, where each entry carries the reason it is repo-wide.
+        # Print the current set with `yarn test:repo-wide-guards --list`. This comment does
+        # not repeat it: a second copy went stale the first time a guard was added (#4770),
+        # and a stale list in CI config is worse than none because the next reader trusts it.
+        # scripts/__tests__/repo-wide-guards.test.mjs fails if the enumeration reappears here.
+        #
         # Not here because they already run unfiltered: the create-app parity guards (step
         # above), `yarn agents:check-budget`, `yarn test:scripts`. All guards are static file
         # scans — the whole set is ~10 s, so it stays on the common PR path.

--- a/scripts/__tests__/repo-wide-guards.test.mjs
+++ b/scripts/__tests__/repo-wide-guards.test.mjs
@@ -33,6 +33,17 @@ function readWorkflowStep(name) {
   return step
 }
 
+function readWorkflowStepComment(name) {
+  const step = readWorkflowStep(name)
+  if (!step) return null
+
+  return step.filter((line) => line.trim().startsWith('#')).join('\n')
+}
+
+function guardStem(guardPath) {
+  return path.basename(guardPath).replace(/\.test\.[cm]?[jt]sx?$/, '')
+}
+
 test('every enumerated repo-wide guard file exists', () => {
   for (const guardPath of listGuardPaths()) {
     assert.ok(
@@ -100,6 +111,40 @@ test('ci.yml runs the repo-wide guards unconditionally', () => {
   assert.ok(
     !step.some((line) => /^\s+if:/.test(line)),
     'The step must stay unconditional — a conditional step reintroduces the silent skip it exists to prevent.',
+  )
+})
+
+test('ci.yml points at the guard manifest instead of carrying its own copy', () => {
+  const comment = readWorkflowStepComment(STEP_NAME)
+  assert.ok(comment, `ci.yml has no "${STEP_NAME}" step, so there is nothing documenting why the guards run unfiltered.`)
+
+  assert.match(
+    comment,
+    /scripts\/repo-wide-guards\.mjs/,
+    'The step comment must point the reader at the manifest that enumerates the guards, or removing the inline list leaves no way to find out what the step covers.',
+  )
+  assert.match(
+    comment,
+    /yarn test:repo-wide-guards --list/,
+    'The step comment must name the command that prints the current enumeration on demand — that is what makes one source of truth usable from the workflow file.',
+  )
+  assert.match(
+    comment,
+    /turbo/i,
+    'The step comment must keep explaining why the step is unconditional (the turbo filter selects packages, not paths), or the next reader "optimises" it behind an `if:` and reintroduces the silent skip it exists to prevent.',
+  )
+})
+
+test('ci.yml does not re-copy the guard enumeration it cannot keep in sync', () => {
+  const comment = readWorkflowStepComment(STEP_NAME)
+  const copied = listGuardPaths()
+    .map(guardStem)
+    .filter((stem) => comment.includes(stem))
+
+  assert.deepEqual(
+    copied,
+    [],
+    `The ci.yml step comment names individual guards again. REPO_WIDE_GUARDS in scripts/repo-wide-guards.mjs is the single enumeration; a copy in the workflow comment drifts the first time a guard is added, and nothing in CI catches it — which is exactly how the previous list ended up advertising 19 guards while 24 ran (#4770). Point at the manifest and \`yarn test:repo-wide-guards --list\` instead of naming these:\n${copied.join('\n')}`,
   )
 })
 

--- a/scripts/__tests__/repo-wide-guards.test.mjs
+++ b/scripts/__tests__/repo-wide-guards.test.mjs
@@ -137,6 +137,8 @@ test('ci.yml points at the guard manifest instead of carrying its own copy', () 
 
 test('ci.yml does not re-copy the guard enumeration it cannot keep in sync', () => {
   const comment = readWorkflowStepComment(STEP_NAME)
+  assert.ok(comment, `ci.yml has no "${STEP_NAME}" step, so there is no comment to check for a copied enumeration.`)
+
   const copied = listGuardPaths()
     .map(guardStem)
     .filter((stem) => comment.includes(stem))

--- a/scripts/repo-wide-guards.mjs
+++ b/scripts/repo-wide-guards.mjs
@@ -179,6 +179,10 @@ export const REPO_WIDE_GUARDS = [
     jestConfig: 'jest.config.cjs',
     tests: [
       {
+        path: 'src/__tests__/module-override-acl-features.test.ts',
+        scans: 'apps/mercato/src/modules plus every packages/ acl.ts — module override keys anchored to declared ACL features (#4462)',
+      },
+      {
         path: 'src/components/__tests__/starter-chrome-ds.test.ts',
         scans: 'apps/mercato and packages/create-app/template components — DS status tokens in starter chrome',
       },


### PR DESCRIPTION
Closes #4770

## 🎯 Goal

`.github/workflows/ci.yml` no longer carries its own copy of the repo-wide guard enumeration. `REPO_WIDE_GUARDS` in `scripts/repo-wide-guards.mjs` becomes the single source of truth, the workflow comment points at it, and a new test stops the copy from growing back.

## 🔍 Problem

#4687 made CI run the repo-wide audit guards unfiltered on every PR, and documented them twice: authoritatively in `scripts/repo-wide-guards.mjs`, and again as a hand-maintained list inside the workflow step's comment. The self-review on that PR flagged the duplication as a drift hazard, which is what #4770 tracks.

The drift was not hypothetical — it had **already happened five times** by the time this fix was written. The comment advertised 19 guards while the manifest ran 24. Missing from the comment were:

- `packages/core/src/__tests__/feature-policy-authorization-coverage.test.ts`
- `packages/core/src/modules/design_system/gallery/__tests__/gallery-coverage.test.ts`
- the entire `@open-mercato/content` group (`legal-entity.test.tsx`)
- the entire `@open-mercato/telemetry` group (`default-unloaded.test.ts`, added by d6ef3324d / #4947)
- `packages/ui/src/backend/icons/__tests__/lucideRegistryGenerator.test.ts`

A stale list in CI config is worse than no list, because the next reader trusts it.

## 🔍 Root Cause

Two sources of truth, only one of them enforced. `scripts/__tests__/repo-wide-guards.test.mjs` asserted that the step exists and stays unconditional, but never compared the comment against `REPO_WIDE_GUARDS`. Nothing in CI could notice the comment going stale, so every guard added since #4687 silently widened the gap.

## What Changed

- **`.github/workflows/ci.yml`** — the 11-line guard enumeration in the `Run repo-wide audit guards (always, unfiltered)` step is replaced by a pointer at `scripts/repo-wide-guards.mjs` plus `yarn test:repo-wide-guards --list`, which prints the current set on demand. This is the first of the two routes the issue offers, and the one the original reviewer preferred. The comment keeps its explanation of *why* the step is unconditional (the turbo filter selects packages, not paths) and now says so explicitly — "do not move this step behind an `if:`" — so the rationale survives the list's removal.
- **`scripts/__tests__/repo-wide-guards.test.mjs`** — two new tests. `ci.yml points at the guard manifest instead of carrying its own copy` asserts the comment names the manifest, names the `--list` command, and still explains the turbo-filter rationale. `ci.yml does not re-copy the guard enumeration it cannot keep in sync` derives each guard's filename stem from `REPO_WIDE_GUARDS` and fails if any of them reappears in the step comment — so re-adding the list is now a CI failure rather than a silent liability.

### Unrelated drive-by, needed to get this PR green

- **`scripts/repo-wide-guards.mjs`** — classifies `apps/mercato/src/__tests__/module-override-acl-features.test.ts` in the `@open-mercato/app` group. This is **not** part of #4770. That test arrived with b304dd6c8 (#4944, merged a couple of hours before this PR was opened) and reads every `packages/*/**/acl.ts`, so the existing `no test that audits other packages is left unclassified` guard rejects it. It fails on the current tip of `develop` independently of this change, which means it would also have failed here and made this PR look broken. It is a one-entry manifest addition, the guard passes in 1.5 s, and leaving it would have blocked the actual fix — but reviewers should read it as a separate concern.

## 🧪 Tests

- `yarn test:scripts` (run as `node --test scripts/__tests__/*.test.mjs apps/mercato/scripts/__tests__/*.test.mjs`) — **429 passed, 0 failed, 430 total**. On the unmodified tip of `develop` the same command reports 1 failure (the unclassified-guard drive-by above).
- `scripts/__tests__/repo-wide-guards.test.mjs` on its own — **16 passed, 0 failed** (14 pre-existing plus the 2 added here).
- Regression proof: with the new tests in place but `ci.yml` reverted to its enumerated form, `ci.yml does not re-copy the guard enumeration it cannot keep in sync` fails and names the copied guards. It passes only once the enumeration is gone, so the test is not vacuous.
- `node scripts/repo-wide-guards.mjs --list` — prints 25 guards and 10 documented exceptions, confirming the command the comment now points readers at actually works.
- `apps/mercato` jest, `src/__tests__/module-override-acl-features.test.ts` — 1 passed in 1.5 s, confirming the newly enumerated guard is green and cheap enough for the unfiltered PR path.
- Not run: `yarn build:packages`, `yarn typecheck`, `yarn build:app`, `yarn test`. This PR changes a YAML comment and two `.mjs` files under `scripts/`; none of it is TypeScript, none of it is compiled, and no package source is touched. `.github/workflows/ci.yml` was parsed with the `yaml` package to confirm it is still valid (8 jobs), and both `.mjs` files pass `node --check`.

## 💥 Breaking Changes

- None. No public contract, database structure, API surface or module code is touched. The set of guards CI executes is unchanged except for the one addition described above, which makes an already-merged test run unfiltered rather than changing any guard's behavior.
