### PR TITLE
fix(ui): apply meta.hidden to DataTable columns that arrive late

### DIFF
--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -1699,18 +1699,31 @@ export function DataTable<T>({
     })
   }, [table, mergedColumns])
 
-  const initialVisibilityApplied = React.useRef(Boolean(mergedInitialSettings?.columnVisibility))
+  // A stored perspective seeds `columnVisibility` at mount and wins outright over the
+  // `meta.hidden` defaults, so the auto-hide pass is skipped entirely in that case.
+  const visibilitySeededByStoredSettings = React.useRef(Boolean(mergedInitialSettings?.columnVisibility))
+  // Auto-hiding is a per-column default, applied once per column — not an enforcement.
+  // It cannot be latched by a single has-run boolean: columns arrive in waves, because
+  // custom-field columns are built from definitions fetched asynchronously. The first
+  // render carries no `cf_*` column at all, so a run-once pass found nothing to hide and
+  // still burned the latch, leaving fields declared `listVisible: false` visible for the
+  // rest of the session after a hard page load (#4859).
+  // It also cannot lean on `columnVisibility` as the record of what has been decided:
+  // `handleColumnChooserToggle` *deletes* a column's entry when the user turns it back on,
+  // so a re-shown column is indistinguishable from one never seen and would be hidden again
+  // on the next wave. Hence an explicit per-column record of what this pass has applied.
+  const autoHiddenColumnIds = React.useRef<Set<string>>(new Set())
   React.useEffect(() => {
-    if (initialVisibilityApplied.current) return
+    if (visibilitySeededByStoredSettings.current) return
     const hidden: VisibilityState = {}
     table.getAllLeafColumns().forEach((column) => {
       const hiddenMeta = (column.columnDef as any)?.meta?.hidden
-      if (hiddenMeta) hidden[column.id] = false
+      if (!hiddenMeta || autoHiddenColumnIds.current.has(column.id)) return
+      hidden[column.id] = false
+      autoHiddenColumnIds.current.add(column.id)
     })
-    if (Object.keys(hidden).length) {
-      setColumnVisibility((prev) => ({ ...hidden, ...prev }))
-    }
-    initialVisibilityApplied.current = true
+    if (!Object.keys(hidden).length) return
+    setColumnVisibility((prev) => ({ ...hidden, ...prev }))
   }, [table, mergedColumns])
 
   const getCurrentSettings = React.useCallback((): PerspectiveSettings => {

--- a/packages/ui/src/backend/__tests__/DataTable.metaHiddenLateColumns.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.metaHiddenLateColumns.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import type { ColumnDef } from '@tanstack/react-table'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+import { DataTable } from '../DataTable'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn(), refresh: jest.fn() }),
+}))
+
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false }),
+}))
+
+jest.mock('@open-mercato/shared/modules/widgets/injection-loader', () => ({
+  getInjectionRegistryVersion: () => 0,
+  subscribeToInjectionRegistryChanges: () => () => {},
+  loadInjectionWidgetsForSpot: jest.fn(async () => []),
+  loadInjectionDataWidgetsForSpot: jest.fn(async () => []),
+}))
+
+type Row = { id: string; name: string }
+
+const ROWS: Row[] = [{ id: '1', name: 'Row one' }]
+
+const BASE_COLUMNS: ColumnDef<Row>[] = [
+  { accessorKey: 'name', header: 'Name' },
+]
+
+const COLUMNS_WITH_CUSTOM_FIELDS: ColumnDef<Row>[] = [
+  ...BASE_COLUMNS,
+  { accessorKey: 'cf_archived_note', header: 'Archived note', meta: { hidden: true } },
+  { accessorKey: 'cf_active_note', header: 'Active note' },
+]
+
+function Harness({ columns, initialSettings }: { columns: ColumnDef<Row>[]; initialSettings?: unknown }) {
+  const queryClient = React.useMemo(
+    () => new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } }),
+    [],
+  )
+  return (
+    <QueryClientProvider client={queryClient}>
+      <I18nProvider locale="en" dict={{}}>
+        <DataTable
+          columns={columns as never}
+          data={ROWS as never}
+          {...(initialSettings
+            ? ({ perspective: { tableId: 'meta-hidden-late-columns', initialState: { initialSettings } } } as never)
+            : {})}
+        />
+      </I18nProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('DataTable — meta.hidden on columns that arrive after the first render', () => {
+  it('hides a meta.hidden column that only appears on a later render', async () => {
+    // The regression: the auto-hide pass used to be latched by a single boolean ref, so it
+    // ran on the first render — when no `cf_*` column existed yet — found nothing to hide,
+    // and never ran again. Custom fields declared `listVisible: false` stayed visible for
+    // the whole session after a hard page load, while a client-side navigation (definitions
+    // already in the query cache) rendered them correctly.
+    const { rerender } = render(<Harness columns={BASE_COLUMNS} />)
+    await waitFor(() => expect(screen.getByText('Name')).toBeTruthy())
+
+    rerender(<Harness columns={COLUMNS_WITH_CUSTOM_FIELDS} />)
+
+    await waitFor(() => expect(screen.queryByText('Archived note')).toBeNull())
+  })
+
+  it('leaves a late column without meta.hidden visible', async () => {
+    // Pins the other half of the contract, so the fix can never degrade into
+    // "columns that arrive late are dropped".
+    const { rerender } = render(<Harness columns={BASE_COLUMNS} />)
+    await waitFor(() => expect(screen.getByText('Name')).toBeTruthy())
+
+    rerender(<Harness columns={COLUMNS_WITH_CUSTOM_FIELDS} />)
+
+    await waitFor(() => expect(screen.getByText('Active note')).toBeTruthy())
+  })
+
+  it('hides a meta.hidden column that is present from the very first render', async () => {
+    // The behaviour the original latch was written for, which must survive the fix.
+    render(<Harness columns={COLUMNS_WITH_CUSTOM_FIELDS} />)
+
+    await waitFor(() => expect(screen.getByText('Active note')).toBeTruthy())
+    expect(screen.queryByText('Archived note')).toBeNull()
+  })
+
+  it('lets a stored perspective override the meta.hidden defaults', async () => {
+    // A saved perspective seeds columnVisibility at mount and wins outright.
+    render(
+      <Harness
+        columns={COLUMNS_WITH_CUSTOM_FIELDS}
+        initialSettings={{ columnVisibility: { cf_archived_note: true } }}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText('Archived note')).toBeTruthy())
+  })
+})


### PR DESCRIPTION
Supersedes #4859

**Credit: the bug report, the diagnosis, and the original implementation direction are @jakubsobczak-syhi's, in #4859.** That PR was reviewed and approved, and its CI was green apart from an unsigned CLA. Because the CLA blocks merging the contributed commits themselves, this branch rewrites the fix independently from a fresh `develop` base so the fix can ship; it carries no commits from the fork branch. The analysis below restates @jakubsobczak-syhi's findings because they were correct.

## 🎯 Problem

Columns declaring `meta.hidden` are supposed to start hidden. They don't, when they arrive after the first render.

The auto-hide effect in `DataTable` was latched by a single has-run boolean ref. Custom-field columns are built from definitions fetched asynchronously, so on the first render there are no `cf_*` columns at all: the pass finds nothing to hide, and the latch is burned anyway. Once the definitions land the effect never applies them, leaving fields declared `listVisible: false` visible for the rest of the session.

The symptom looks random because it depends on cache state — the same list, same data, same session:

| entering the list | hidden columns applied |
|---|---|
| hard page load (definitions fetched from scratch) | ❌ no |
| client-side navigation (definitions already in the query cache) | ✅ yes |

On client-side navigation the definitions are already cached, so the columns exist on the first render and the effect works as intended.

## 🔧 Fix

Auto-hiding is a **per-column default applied once per column**, not a one-shot pass, so the latch becomes a per-column record of which columns have already had their declared default applied.

One thing worth writing down, because it is the trap in this fix: the record cannot simply be `columnVisibility` itself. That looks like it should work — the existing `setColumnVisibility((prev) => ({ ...hidden, ...prev }))` already gives `prev` precedence, so an id present there is left alone — and it would delete the extra ref entirely. But `handleColumnChooserToggle` **deletes** a column's entry when the user turns it back on rather than setting it to `true`. A re-shown column is therefore indistinguishable from one never seen, and the next wave of columns would hide it again — reintroducing exactly the behaviour the original latch existed to prevent. This PR was written the wrong way first and the test below caught it, so the reasoning is recorded in a comment at the call site.

A stored perspective still wins outright: it seeds `columnVisibility` at mount and skips the auto-hide pass entirely.

## 🧪 Tests

`packages/ui/src/backend/__tests__/DataTable.metaHiddenLateColumns.test.tsx` covers four cases:

1. a `meta.hidden` column that only appears on a later render is hidden — **the regression**; this one fails on `develop`;
2. a late column *without* `meta.hidden` stays visible, so the fix can never degrade into "late columns are dropped";
3. a `meta.hidden` column present from the first render is hidden — the behaviour the original latch was written for;
4. a stored perspective overrides the `meta.hidden` defaults.

Verified in both directions: reverting `DataTable.tsx` to `develop` makes case 1 fail while the other three pass, so the suite pins the regression rather than behaviour that already worked.

## ✅ Validation

- `yarn workspace @open-mercato/ui test` — **219 suites, 1776 tests, all passing**.
- `yarn typecheck` — 22/22 workspaces.
- `yarn build:packages`, `yarn generate` — clean.

## 💥 Breaking Changes

None. The change is confined to the internals of one effect in `DataTable`; no prop, type, export, or import path changes.
