### PR TITLE
fix(entities): stop relation options 500ing on unresolvable entity ids (#4949)

### DIFF
--- a/packages/core/src/modules/entities/api/__tests__/relations.options.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/relations.options.test.ts
@@ -10,7 +10,26 @@ const mockQE = {
   })),
 }
 
-const mockEm = {}
+// Entity ids the fake ORM metadata knows about, keyed by the class name the
+// resolver derives from the id's entity segment.
+const registeredTables: Record<string, string> = {
+  CustomerEntity: 'customer_entities',
+}
+
+const mockEm = {
+  // Custom (doc-storage) entities: registered rows make an id queryable.
+  findOne: jest.fn(async (_entity: unknown, where: { entityId?: string }) => (
+    typeof where?.entityId === 'string' && where.entityId.startsWith('virtual:')
+      ? { labelField: null }
+      : null
+  )),
+  getMetadata: () => ({
+    find: (className: string) => (
+      registeredTables[className] ? { tableName: registeredTables[className] } : undefined
+    ),
+    getAll: () => Object.values(registeredTables).map((tableName) => ({ tableName })),
+  }),
+}
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: async () => ({ resolve: (key: string) => (key === 'queryEngine' ? mockQE : mockEm) }),
@@ -97,6 +116,39 @@ describe('GET /api/entities/relations/options', () => {
         page: { page: 1, pageSize: 200 },
       }),
     )
+  })
+
+  // #4949: a relation custom field whose `relatedEntityId` was never filled in sent
+  // `entityId=p:0`; the query engine guessed a table name for it and Postgres raised
+  // `relation "0s" does not exist`, surfacing as a 500 on every render of the section.
+  it.each([
+    ['a half-configured placeholder id', 'p:0'],
+    ['a well-formed id no entity backs', 'nosuch:thing'],
+    ['an id without a module segment', 'person'],
+  ])('answers with an empty option list for %s', async (_label, entityId) => {
+    const req = new Request(
+      `http://x/api/entities/relations/options?entityId=${encodeURIComponent(entityId)}`,
+    )
+
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ items: [] })
+    expect(mockQE.query).not.toHaveBeenCalled()
+  })
+
+  it('still queries a registered ORM entity that has no custom entity row', async () => {
+    mockQE.query.mockResolvedValueOnce({ items: [] })
+
+    const req = new Request(
+      'http://x/api/entities/relations/options?entityId=customers:customer_entity&labelField=title',
+    )
+
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    expect(mockEm.findOne).toHaveBeenCalled()
+    expect(mockQE.query).toHaveBeenCalledWith('customers:customer_entity', expect.any(Object))
   })
 
   it('defaults to pageSize 50 when no ids are provided', async () => {

--- a/packages/core/src/modules/entities/api/relations/options.ts
+++ b/packages/core/src/modules/entities/api/relations/options.ts
@@ -8,12 +8,16 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { resolveRegisteredEntityTableName } from '@open-mercato/shared/lib/query/engine'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['entities.definitions.view'] },
 }
 
 const ALLOWED_ROUTE_CONTEXT_FIELDS = new Set(['kind', 'entity_id', 'product_id'])
+
+const logger = createLogger('entities')
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
@@ -44,17 +48,27 @@ export async function GET(req: Request) {
   const qe = container.resolve('queryEngine') as QueryEngine
   const em = container.resolve('em') as EntityManager
 
-  if (!labelField) {
-    const cfg = await em.findOne(CustomEntity, {
-      entityId,
-      $and: [
-        { $or: [ { organizationId: auth.orgId ?? undefined as any }, { organizationId: null } ] },
-        { $or: [ { tenantId: auth.tenantId ?? undefined as any }, { tenantId: null } ] },
-      ],
-      isActive: true,
-    })
-    labelField = (cfg?.labelField as string | undefined) || ''
+  const customEntity = await em.findOne(CustomEntity, {
+    entityId,
+    $and: [
+      { $or: [ { organizationId: auth.orgId ?? undefined as any }, { organizationId: null } ] },
+      { $or: [ { tenantId: auth.tenantId ?? undefined as any }, { tenantId: null } ] },
+    ],
+    isActive: true,
+  })
+
+  // A relation field can point at an entity that does not exist — most often a half-configured
+  // `relatedEntityId` that was never filled in (#4949 reported `entityId=p:0`). The query engine
+  // falls back to a pluralized table-name guess for ids it cannot resolve, so such a lookup used
+  // to reach Postgres as `select ... from "0s"` and escape this handler as an unhandled 500 on
+  // every render of the section holding the field. Resolve the id first and answer with an empty
+  // option list instead, mirroring the empty-`entityId` contract above.
+  if (!customEntity && resolveRegisteredEntityTableName(em, entityId) === null) {
+    logger.warn('Relation options requested for an unresolvable entity id', { entityId })
+    return NextResponse.json({ items: [] })
   }
+
+  if (!labelField) labelField = (customEntity?.labelField as string | undefined) || ''
   if (!labelField) {
     const candidates = ['name', 'title', 'code', 'email']
     const table = tableNameFromEntityId(entityId)
@@ -122,7 +136,7 @@ export const openApi: OpenApiRouteDoc = {
   methods: {
     GET: {
       summary: 'List relation options',
-      description: 'Returns up to 200 option entries for populating relation dropdowns, automatically resolving label fields when omitted.',
+      description: 'Returns up to 200 option entries for populating relation dropdowns, automatically resolving label fields when omitted. An entityId that matches neither an active custom entity nor a registered ORM entity yields an empty option list.',
       query: relationOptionsQuerySchema,
       responses: [
         {


### PR DESCRIPTION
Closes #4949

## 🎯 Goal
Expanding the "Moje role" section on a CRM person's detail page no longer fires failing requests: the relation-options endpoint that backed a misconfigured relation field returned `500 Internal Server Error` on every render, and now answers with an empty option list instead.

## 🔍 Problem
`GET /api/entities/relations/options?entityId=p:0` returned a 500 every time the person detail page rendered the section holding a relation custom field (twice per expand), for any person record. `p:0` is not a real entity id — it is a `relatedEntityId` that was never properly filled in on a relation custom-field definition.

## 🔍 Root Cause
The route passed the caller-supplied `entityId` straight into the query engine without ever checking that the entity exists. For an id it cannot resolve, `resolveEntityTableName` deliberately falls back to a pluralized table-name *guess* (`p:0` → `0s`), the hybrid engine sees that the guessed table does not exist and delegates to `BasicQueryEngine`, which builds `select ... from "0s"`. Postgres then raises `relation "0s" does not exist`, and because the handler has no validation for this case the error escaped as an unhandled 500. Any well-formed-but-unknown id (`nosuch:thing`) or id without a module segment (`person`) failed the same way.

## What Changed
- `packages/core/src/modules/entities/api/relations/options.ts`: the active `CustomEntity` config lookup now always runs (it was previously conditional on `labelField` being absent) and doubles as an existence signal. When the id matches neither an active custom entity nor a registered ORM entity — resolved with `resolveRegisteredEntityTableName`, the helper already used at security-sensitive call sites precisely so arbitrary caller-chosen tables are never read — the route logs a warning naming the offending id and returns `{ items: [] }` with a 200, mirroring the existing empty-`entityId` contract. Label-field resolution is unchanged for every id that does resolve.
- The route's OpenAPI description now documents the empty-option-list behaviour for unresolvable entity ids.

A stricter `400` was considered and rejected: a relation field pointing at a missing entity legitimately has no options, the client already renders raw ids when the lookup yields nothing, and the reported symptom is precisely that the section should load without errors. The `logger.warn` keeps the misconfiguration visible to operators rather than silently swallowing it.

## 🧪 Tests
- `packages/core/src/modules/entities/api/__tests__/relations.options.test.ts` — four new cases: three parameterised unresolvable ids (`p:0` from the report, the well-formed-but-unknown `nosuch:thing`, and the module-less `person`) assert a 200 with an empty item list and that the query engine is never reached, plus one case pinning that a registered ORM entity with no custom-entity row still queries normally. The existing `em` test double gained `findOne` and `getMetadata` so it models the two resolution paths.
- `yarn workspace @open-mercato/core test` — 8260 passed / 1084 suites, on the `main` base this PR targets.
- `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn typecheck`, `yarn i18n:check-sync`, `yarn build:app` — all pass.
- `yarn i18n:check-usage` reports 2 missing keys, both `ui.customFields.phone.defaultCountry*` referenced from `packages/ui/src/backend/fields/phone.tsx`. That file is untouched by this diff; the failure is pre-existing on `main`.
- `yarn test` (full monorepo) hit a jest worker `SIGSEGV` on this machine — in `gateway-stripe` on one run and in `ui` on the next, with **zero** assertion failures either time. Both packages pass green when run on their own (`gateway-stripe` 33/33, `ui` 1682/1682), so this is a local worker crash rather than a repository failure; CI is the authority here.

## 💥 Breaking Changes
- None for any supported entity id. Ids backed by an active custom entity or by registered ORM metadata resolve and query exactly as before; only ids that previously crashed the request now return an empty list.
- One deliberate narrowing worth naming: an id that resolved *only* through `resolveEntityTableName`'s pluralized-guess fallback — no ORM registration and no `custom_entities` row, but a table that happens to match the guess — is now refused with an empty list. That path already logged a "could not resolve entity via ORM metadata" warning and is exactly the arbitrary-table read `resolveRegisteredEntityTableName` exists to prevent, so refusing it is intended rather than incidental.

## Follow-up worth considering
The underlying misconfiguration — a relation custom-field definition whose `relatedEntityId` points at nothing — is still accepted by the field-definitions editor. Validating that id against the known entity list at save time would stop the bad config from being created in the first place; that is deliberately out of scope here.


