### PR TITLE
fix(query): compare doc-backed fields to null with IS NULL (#4841)

### DIFF
--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -1298,8 +1298,10 @@ describe('doc-field null equality (issue #4841)', () => {
       )
       .filter((serialized: string) => serialized.includes('->>'))
 
-  // `started_at` / `ended_at` are absent from the base table, so the running-timer
-  // filter shape resolves against entity_indexes.doc instead of a real column.
+  // The synthetic base table declares neither `started_at` nor `ended_at`, so both
+  // filters resolve against entity_indexes.doc instead of a real column — this
+  // covers the doc path only; entities with physical timestamp columns take the
+  // already-null-safe base-column path.
   const runFilters = async (filters: Record<string, unknown>) => {
     const db = createFakeKysely({
       baseTable: 'todos',
@@ -1327,7 +1329,7 @@ describe('doc-field null equality (issue #4841)', () => {
     return serializeWheres(db, 'todos')
   }
 
-  test('the running-timer filter shape compiles to null-safe doc predicates', async () => {
+  test('doc-backed null filters compile to null-safe doc predicates', async () => {
     const predicates = await runFilters({ started_at: { $ne: null }, ended_at: null })
 
     expect(predicates.length).toBeGreaterThan(0)

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -1349,6 +1349,43 @@ describe('doc-field null equality (issue #4841)', () => {
     expect(predicates.join('\n')).not.toContain('is null')
   })
 
+  // Boundary pin: entities whose filtered fields ARE physical columns (like
+  // staff_time_entries.started_at/ended_at) never reach the doc builders — the
+  // base-column path emits the null-safe predicates on its own.
+  test('physical-column null filters take the base-column path, not the doc path', async () => {
+    const db = createFakeKysely({
+      baseTable: 'todos',
+      hasIndexAny: true,
+      baseCount: 5,
+      indexCount: 5,
+      columns: [
+        { table_name: 'todos', column_name: 'id' },
+        { table_name: 'todos', column_name: 'tenant_id' },
+        { table_name: 'todos', column_name: 'organization_id' },
+        { table_name: 'todos', column_name: 'deleted_at' },
+        { table_name: 'todos', column_name: 'started_at' },
+        { table_name: 'todos', column_name: 'ended_at' },
+      ],
+    })
+    const em = buildEm(db)
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => null)
+
+    await engine.query('example:todo', {
+      fields: ['id'],
+      organizationId: 'org1',
+      tenantId: 't1',
+      filters: { started_at: { $ne: null }, ended_at: null },
+    })
+
+    expect(serializeWheres(db, 'todos')).toHaveLength(0)
+    const columnWheres = (db._chains as ChainLog[])
+      .filter((chain) => chain.table === 'todos')
+      .flatMap((chain) => chain.wheres as any[])
+    expect(columnWheres).toContainEqual(['b.started_at', 'is not', null])
+    expect(columnWheres).toContainEqual(['b.ended_at', 'is', null])
+  })
+
   // Custom-field values are doc-backed too, so the cf: filter builders need the
   // same null handling — an unset cf must be findable with `$eq: null`.
   const runCfFilters = async (filters: Record<string, unknown>) => {

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -1285,3 +1285,65 @@ describe('HybridQueryEngine custom-entity classification (#2939)', () => {
     })
   })
 })
+
+describe('doc-field null equality (issue #4841)', () => {
+  const serializeWheres = (db: any, table: string): string[] =>
+    (db._chains as ChainLog[])
+      .filter((chain) => chain.table === table)
+      .flatMap((chain) => chain.wheres as any[])
+      .map((entry: any) =>
+        JSON.stringify(entry, (_key, inner) =>
+          inner && typeof inner.toOperationNode === 'function' ? inner.toOperationNode() : inner,
+        ),
+      )
+      .filter((serialized: string) => serialized.includes('->>'))
+
+  // `started_at` / `ended_at` are absent from the base table, so the running-timer
+  // filter shape resolves against entity_indexes.doc instead of a real column.
+  const runFilters = async (filters: Record<string, unknown>) => {
+    const db = createFakeKysely({
+      baseTable: 'todos',
+      hasIndexAny: true,
+      baseCount: 5,
+      indexCount: 5,
+      columns: [
+        { table_name: 'todos', column_name: 'id' },
+        { table_name: 'todos', column_name: 'tenant_id' },
+        { table_name: 'todos', column_name: 'organization_id' },
+        { table_name: 'todos', column_name: 'deleted_at' },
+      ],
+    })
+    const em = buildEm(db)
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => null)
+
+    await engine.query('example:todo', {
+      fields: ['id'],
+      organizationId: 'org1',
+      tenantId: 't1',
+      filters,
+    })
+
+    return serializeWheres(db, 'todos')
+  }
+
+  test('the running-timer filter shape compiles to null-safe doc predicates', async () => {
+    const predicates = await runFilters({ started_at: { $ne: null }, ended_at: null })
+
+    expect(predicates.length).toBeGreaterThan(0)
+    const combined = predicates.join('\n')
+    // `(doc ->> 'ended_at') = NULL` and `<> NULL` are never TRUE, which silently
+    // emptied the active-timer lookup instead of narrowing it.
+    expect(combined).toContain('is null')
+    expect(combined).toContain('is not null')
+    expect(combined).not.toContain('<>')
+    expect(predicates.some((sql: string) => / = /.test(sql))).toBe(false)
+  })
+
+  test('non-null doc comparisons keep using the equality operators', async () => {
+    const predicates = await runFilters({ ended_at: '2026-01-01' })
+
+    expect(predicates.some((sql: string) => / = /.test(sql))).toBe(true)
+    expect(predicates.join('\n')).not.toContain('is null')
+  })
+})

--- a/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/hybrid-engine.test.ts
@@ -1346,4 +1346,53 @@ describe('doc-field null equality (issue #4841)', () => {
     expect(predicates.some((sql: string) => / = /.test(sql))).toBe(true)
     expect(predicates.join('\n')).not.toContain('is null')
   })
+
+  // Custom-field values are doc-backed too, so the cf: filter builders need the
+  // same null handling — an unset cf must be findable with `$eq: null`.
+  const runCfFilters = async (filters: Record<string, unknown>) => {
+    const db = createFakeKysely({
+      baseTable: 'todos',
+      hasIndexAny: true,
+      baseCount: 5,
+      indexCount: 5,
+    })
+    const em = buildEm(db)
+    const fallback = { query: jest.fn() }
+    const engine = new HybridQueryEngine(em, fallback as any, () => null)
+
+    await engine.query('example:todo', {
+      fields: ['id', 'cf:priority'],
+      includeCustomFields: true,
+      organizationId: 'org1',
+      tenantId: 't1',
+      filters,
+    })
+
+    return (db._chains as ChainLog[])
+      .flatMap((chain) => chain.wheres as any[])
+      .map((entry: any) =>
+        JSON.stringify(entry, (_key, inner) =>
+          inner && typeof inner.toOperationNode === 'function' ? inner.toOperationNode() : inner,
+        ),
+      )
+      .filter((serialized: string) => serialized.includes('->>'))
+  }
+
+  test('an unset custom field is matched with is null rather than = null', async () => {
+    const predicates = await runCfFilters({ 'cf:priority': null })
+
+    expect(predicates.length).toBeGreaterThan(0)
+    const combined = predicates.join('\n')
+    expect(combined).toContain('is null')
+    // `@> '[null]'::jsonb` cannot match an absent value, so the eq-null branch
+    // must not fall back to the array-contains form.
+    expect(combined).not.toContain('@>')
+  })
+
+  test('a set custom field is matched with is not null rather than <> null', async () => {
+    const predicates = await runCfFilters({ 'cf:priority': { $ne: null } })
+
+    expect(predicates.join('\n')).toContain('is not null')
+    expect(predicates.join('\n')).not.toContain('<>')
+  })
 })

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -1589,9 +1589,13 @@ export class HybridQueryEngine implements QueryEngine {
     }
     switch (op) {
       case 'eq':
-        return q.where(sql<boolean>`${textExpr} = ${value}`)
+        return value === null
+          ? q.where(sql<boolean>`${textExpr} is null`)
+          : q.where(sql<boolean>`${textExpr} = ${value}`)
       case 'ne':
-        return q.where(sql<boolean>`${textExpr} <> ${value}`)
+        return value === null
+          ? q.where(sql<boolean>`${textExpr} is not null`)
+          : q.where(sql<boolean>`${textExpr} <> ${value}`)
       case 'in': {
         const vals = this.toArray(value)
         return q.where(sql<boolean>`${textExpr} in (${sql.join(vals.map((v) => sql`${v}`), sql`, `)})`)
@@ -1709,8 +1713,8 @@ export class HybridQueryEngine implements QueryEngine {
   ): any {
     const textExpr = sql<string | null>`(${sql.ref(alias + '.doc')} ->> ${key})`
     switch (op) {
-      case 'eq': return sql<boolean>`${textExpr} = ${value}`
-      case 'ne': return sql<boolean>`${textExpr} <> ${value}`
+      case 'eq': return value === null ? sql<boolean>`${textExpr} is null` : sql<boolean>`${textExpr} = ${value}`
+      case 'ne': return value === null ? sql<boolean>`${textExpr} is not null` : sql<boolean>`${textExpr} <> ${value}`
       case 'gt':
       case 'gte':
       case 'lt':

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -1388,11 +1388,12 @@ export class HybridQueryEngine implements QueryEngine {
       case 'eq':
         // An unset custom field has no array element to contain, so the
         // arrContains branch cannot match it — compare the text value only.
-        if (value === null) return builder.where(sql<boolean>`${textExpr} is null`)
-        return builder.where((eb: any) => eb.or([
-          sql<boolean>`${textExpr} = ${value}`,
-          arrContains(value),
-        ]))
+        return value === null
+          ? builder.where(sql<boolean>`${textExpr} is null`)
+          : builder.where((eb: any) => eb.or([
+              sql<boolean>`${textExpr} = ${value}`,
+              arrContains(value),
+            ]))
       case 'ne':
         return value === null
           ? builder.where(sql<boolean>`${textExpr} is not null`)
@@ -1524,11 +1525,12 @@ export class HybridQueryEngine implements QueryEngine {
       case 'eq':
         // An unset custom field has no array element to contain, so the
         // arrContains branch cannot match it — compare the text value only.
-        if (value === null) return q.where(sql<boolean>`${textExpr} is null`)
-        return q.where((eb: any) => eb.or([
-          sql<boolean>`${textExpr} = ${value}`,
-          arrContains(value),
-        ]))
+        return value === null
+          ? q.where(sql<boolean>`${textExpr} is null`)
+          : q.where((eb: any) => eb.or([
+              sql<boolean>`${textExpr} = ${value}`,
+              arrContains(value),
+            ]))
       case 'ne':
         return value === null
           ? q.where(sql<boolean>`${textExpr} is not null`)

--- a/packages/core/src/modules/query_index/lib/engine.ts
+++ b/packages/core/src/modules/query_index/lib/engine.ts
@@ -1386,12 +1386,17 @@ export class HybridQueryEngine implements QueryEngine {
 
     switch (op) {
       case 'eq':
+        // An unset custom field has no array element to contain, so the
+        // arrContains branch cannot match it — compare the text value only.
+        if (value === null) return builder.where(sql<boolean>`${textExpr} is null`)
         return builder.where((eb: any) => eb.or([
           sql<boolean>`${textExpr} = ${value}`,
           arrContains(value),
         ]))
       case 'ne':
-        return builder.where(sql<boolean>`${textExpr} <> ${value}`)
+        return value === null
+          ? builder.where(sql<boolean>`${textExpr} is not null`)
+          : builder.where(sql<boolean>`${textExpr} <> ${value}`)
       case 'in': {
         const values = this.toArray(value)
         return builder.where((eb: any) => eb.or(
@@ -1517,12 +1522,17 @@ export class HybridQueryEngine implements QueryEngine {
     }
     switch (op) {
       case 'eq':
+        // An unset custom field has no array element to contain, so the
+        // arrContains branch cannot match it — compare the text value only.
+        if (value === null) return q.where(sql<boolean>`${textExpr} is null`)
         return q.where((eb: any) => eb.or([
           sql<boolean>`${textExpr} = ${value}`,
           arrContains(value),
         ]))
       case 'ne':
-        return q.where(sql<boolean>`${textExpr} <> ${value}`)
+        return value === null
+          ? q.where(sql<boolean>`${textExpr} is not null`)
+          : q.where(sql<boolean>`${textExpr} <> ${value}`)
       case 'in': {
         const vals = this.toArray(value)
         return q.where((eb: any) => eb.or(

--- a/packages/core/src/modules/staff/lib/timesheets/__tests__/timeEntryListFilters.test.ts
+++ b/packages/core/src/modules/staff/lib/timesheets/__tests__/timeEntryListFilters.test.ts
@@ -1,3 +1,4 @@
+import { normalizeFilters } from '@open-mercato/shared/lib/query/join-utils'
 import { buildTimeEntryListFilters } from '../timeEntryListFilters'
 
 describe('buildTimeEntryListFilters — running filter (issue #3717)', () => {
@@ -36,5 +37,20 @@ describe('buildTimeEntryListFilters — running filter (issue #3717)', () => {
   it('parses id lists and ignores blank entries', () => {
     const filters = buildTimeEntryListFilters({ ids: 'a, ,b' })
     expect(filters.id).toEqual({ $in: ['a', 'b'] })
+  })
+})
+
+describe('buildTimeEntryListFilters — query-engine normalization (issue #4841)', () => {
+  it('normalizes the running lookup to null-comparison clauses the engine must honor', () => {
+    const clauses = normalizeFilters(buildTimeEntryListFilters({ running: 'true' }))
+
+    // The bare `ended_at: null` must survive as an `eq` against null rather than
+    // being dropped — a dropped clause would silently widen the running lookup.
+    expect(clauses).toEqual(
+      expect.arrayContaining([
+        { field: 'started_at', op: 'ne', value: null },
+        { field: 'ended_at', op: 'eq', value: null },
+      ]),
+    )
   })
 })

--- a/packages/shared/src/lib/query/__tests__/engine.scope-and-or.test.ts
+++ b/packages/shared/src/lib/query/__tests__/engine.scope-and-or.test.ts
@@ -282,6 +282,73 @@ describe('BasicQueryEngine — null equality', () => {
   })
 })
 
+describe('BasicQueryEngine — doc-field null equality (issue #4841)', () => {
+  function serializeNode(value: any): string {
+    return JSON.stringify(value, (_key, inner) =>
+      inner && typeof inner.toOperationNode === 'function' ? inner.toOperationNode() : inner,
+    )
+  }
+
+  // The doc-backed predicates land inside the entity_indexes EXISTS sub-builder;
+  // pick out the one that reads the JSONB doc (`doc ->> 'field'`).
+  function docPredicates(fakeDb: any, table: string): string[] {
+    const baseCall = fakeDb._calls.find((b: any) => b._ops.table === table)
+    expect(baseCall).toBeTruthy()
+    const existsEntries = (baseCall._ops.wheres as any[]).filter(
+      (where: any) => Array.isArray(where) && where[0] === 'exists',
+    )
+    expect(existsEntries.length).toBeGreaterThan(0)
+    return existsEntries
+      .flatMap((entry: any) => (entry[1]?._ops?.wheres ?? []) as any[])
+      .map((where: any) => serializeNode(where))
+      .filter((serialized: string) => serialized.includes('->>'))
+  }
+
+  async function runDocFilter(filters: Record<string, unknown>) {
+    const fakeDb = createFakeKysely({
+      scheduled_jobs: [],
+      // `ended_at` is deliberately absent, so the field resolves to the
+      // entity_indexes doc rather than to a base column.
+      'information_schema.columns': [
+        { table_name: 'scheduled_jobs', column_name: 'id' },
+      ],
+      'information_schema.tables': [{ table_name: 'entity_indexes' }],
+    })
+    const engine = new BasicQueryEngine({} as any, () => fakeDb as any)
+    await engine.query('scheduler:scheduled_job', {
+      tenantId: 't1',
+      fields: ['id'],
+      omitAutomaticTenantOrgScope: true,
+      filters,
+    })
+    return docPredicates(fakeDb, 'scheduled_jobs')
+  }
+
+  test('$eq null on a doc field compiles to "is null", never "= null"', async () => {
+    const predicates = await runDocFilter({ ended_at: { $eq: null } })
+
+    expect(predicates.length).toBeGreaterThan(0)
+    expect(predicates.some((sql: string) => sql.includes('is null'))).toBe(true)
+    // `(doc ->> 'ended_at') = NULL` is never TRUE in SQL, so it silently
+    // returns zero rows instead of matching unset values.
+    expect(predicates.some((sql: string) => / = /.test(sql))).toBe(false)
+  })
+
+  test('bare null on a doc field compiles to "is null"', async () => {
+    const predicates = await runDocFilter({ ended_at: null })
+
+    expect(predicates.some((sql: string) => sql.includes('is null'))).toBe(true)
+    expect(predicates.some((sql: string) => / = /.test(sql))).toBe(false)
+  })
+
+  test('$ne null on a doc field compiles to "is not null", never "<> null"', async () => {
+    const predicates = await runDocFilter({ started_at: { $ne: null } })
+
+    expect(predicates.some((sql: string) => sql.includes('is not null'))).toBe(true)
+    expect(predicates.some((sql: string) => sql.includes('<>'))).toBe(false)
+  })
+})
+
 describe('BasicQueryEngine — omitAutomaticTenantOrgScope', () => {
   test('skips automatic tenant and organization guards when flag is set', async () => {
     const fakeDb = createFakeKysely({

--- a/packages/shared/src/lib/query/engine.ts
+++ b/packages/shared/src/lib/query/engine.ts
@@ -1351,9 +1351,15 @@ export class BasicQueryEngine implements QueryEngine {
       const textExpr = sql<string | null>`(${sql.ref(`${alias}.doc`)} ->> ${opts.field})`
       switch (opts.op) {
         case 'eq':
-          sub = sub.where(sql<boolean>`${textExpr} = ${opts.value}`); break
+          sub = opts.value === null
+            ? sub.where(sql<boolean>`${textExpr} is null`)
+            : sub.where(sql<boolean>`${textExpr} = ${opts.value}`)
+          break
         case 'ne':
-          sub = sub.where(sql<boolean>`${textExpr} <> ${opts.value}`); break
+          sub = opts.value === null
+            ? sub.where(sql<boolean>`${textExpr} is not null`)
+            : sub.where(sql<boolean>`${textExpr} <> ${opts.value}`)
+          break
         case 'gt':
         case 'gte':
         case 'lt':


### PR DESCRIPTION
## 🎯 Goal

Refs #4841 — this PR fixes a **latent null-safety defect in the doc-backed filter builders**, found while investigating that issue. It deliberately does **not** close #4841: review established empirically that for `staff:staff_time_entry` the filters at fault resolve to physical base columns (`started_at` / `ended_at` on `staff_time_entries`), and that base-column path was already null-safe before this change — so the reported `running=true → total: 0` symptom has a different, still-open root cause. The issue stays open with the narrowed search space recorded on it.

## 🔍 Root cause (of the defect this PR fixes)

While tracing #4841: `buildTimeEntryListFilters` maps `running=true` to `{ started_at: { $ne: null }, ended_at: null }`, and `compileToDnf` normalizes the bare `null` into `op: 'eq', value: null`.

The JSONB doc-path filter builders interpolated the value straight into SQL for `eq` and `ne`:

```sql
(doc ->> 'ended_at')   =  NULL   -- never TRUE
(doc ->> 'started_at') <> NULL   -- never TRUE
```

Under SQL three-valued logic neither predicate is ever `TRUE`, so **any** `$eq: null` / `$ne: null` filter on a field that is not a physical base column matched zero rows — indistinguishable from a genuine empty result. The base-column builders (`applyColumnFilter`, `buildColumnFilterExpression`) already branched on null correctly, and so did the `exists` operator in the very same `switch` statements — which makes the omission a clear oversight rather than a deliberate choice.

## 🔧 Change

Five sites now branch on `value === null` to `is null` / `is not null`, mirroring the base-column path:

- `packages/shared/src/lib/query/engine.ts` — `BasicQueryEngine.buildIndexDocOpExpression`
- `packages/core/src/modules/query_index/lib/engine.ts` — `applyIndexDocFilterFromAlias`
- `packages/core/src/modules/query_index/lib/engine.ts` — `buildIndexDocFilterExpression`
- `packages/core/src/modules/query_index/lib/engine.ts` — `applyCfFilterAcrossSources` (custom-field `eq`/`ne`)
- `packages/core/src/modules/query_index/lib/engine.ts` — `applyCfFilterFromAlias` (custom-field `eq`/`ne`)

For the custom-field `eq` branches, `eq null` compares the text value only — an unset custom field has no array element for the `@>` arrContains branch to match. Non-null comparisons keep using `=` / `<>` unchanged. No signature, response shape, route, or schema change.

## 🧪 Tests

Regression tests written **before** each fix and confirmed red:

- `engine.scope-and-or.test.ts` — doc-backed `$eq: null`, bare `null`, and `$ne: null` compile to `is null` / `is not null` and never to `= null` / `<> null`
- `hybrid-engine.test.ts` — doc-backed null filters compile to null-safe doc predicates, **plus a guard** that non-null doc comparisons still use `=` (catches over-correction), plus custom-field `eq null` / `ne null` coverage pinning that the `@>` branch is dropped for null
- `timeEntryListFilters.test.ts` — pins that `normalizeFilters` turns the route's bare `ended_at: null` into `eq null`, so the route contract is covered end to end

Non-vacuous: reverting the two production files turns the new tests red (verified independently by review).

## ⚠️ Issue linkage — resolved by review

An earlier revision opened with `Fixes #4841` and asked reviewers to treat the endpoint behavior as needing QA confirmation. Review resolved that question conclusively: `resolveBaseColumn` returns `started_at` / `ended_at` for `staff_time_entries` because they are physical `timestamptz` columns, so the running-timer query takes `buildColumnFilterExpression` — null-safe long before this PR. The reporter's symptom therefore cannot be caused by the defect fixed here, and the linkage was downgraded to `Refs`. What is now known and recorded on #4841: both the base-column path and the doc path are null-safe after this PR, so the remaining cause of the reported symptom lies elsewhere (not in null comparison).

## 💥 Breaking changes

None to any contract surface. There is one intended behavior change: doc-backed `$eq: null` / `$ne: null` filters previously returned nothing and now return the correct rows — any caller that depended on the always-empty result will start seeing matches. Note `(doc ->> 'x') IS NULL` matches both an absent key and a JSON `null`, which is the intended "not set" semantics and consistent with the adjacent `exists: false` behavior.

## Security impact

None. The change alters only null-comparison SQL for doc-backed filters; values remain bound parameters (no new interpolation), and no tenant/organization scoping, auth, or ACL logic is touched. The null branches emit literal SQL keywords with no user-controlled input.
