### PR TITLE
fix(directory): emit null index scope for the global Tenant entity (#4906)

### DIFF
--- a/packages/core/src/modules/directory/commands/__tests__/tenants.global-index-scope.test.ts
+++ b/packages/core/src/modules/directory/commands/__tests__/tenants.global-index-scope.test.ts
@@ -1,0 +1,181 @@
+/** @jest-environment node */
+
+// Regression for #4906: Tenant is a global entity — the `tenants` table has neither a
+// tenant_id nor an organization_id column — so the query index resolves its source scope
+// as `{ kind: 'global' }` and rejects any index event whose payload does not carry both
+// scope ids as explicit nulls. The tenant commands used to emit `tenantId: <the tenant's
+// own id>`, which made every create/update/delete record a QueryIndexScopeError. We assert
+// the emitted identifiers here AND replay them through the real scope resolver, so the
+// invariant is pinned against the actual consumer instead of a restated literal.
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/commands/helpers')
+  return {
+    ...actual,
+    emitCrudSideEffects: jest.fn(async () => {}),
+  }
+})
+
+import '@open-mercato/core/modules/directory/commands/tenants'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import { emitCrudSideEffects } from '@open-mercato/shared/lib/commands/helpers'
+import type { CommandHandler } from '@open-mercato/shared/lib/commands'
+import type { CommandUndoLogEntry } from '@open-mercato/shared/lib/commands/types'
+import { Tenant } from '@open-mercato/core/modules/directory/data/entities'
+import {
+  resolveQueryIndexRecordScope,
+  type QueryIndexScope,
+} from '@open-mercato/core/modules/query_index/lib/subscriber-scope'
+
+const TENANT_ID = '33333333-3333-4333-8333-333333333333'
+const ACTOR_TENANT_ID = '11111111-1111-4111-8111-111111111111'
+
+const emitCrudSideEffectsMock = emitCrudSideEffects as jest.MockedFunction<typeof emitCrudSideEffects>
+
+function makeTenant(overrides: Partial<Tenant> = {}): Tenant {
+  return {
+    id: TENANT_ID,
+    name: 'Acme',
+    isActive: true,
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    deletedAt: null,
+    ...overrides,
+  } as Tenant
+}
+
+function makeEm() {
+  const em = {
+    findOne: jest.fn(async () => null),
+    create: jest.fn((_entity: unknown, data: Record<string, unknown>) => ({ ...data })),
+    persist: jest.fn(),
+    flush: jest.fn(async () => {}),
+    fork: jest.fn(() => em),
+  }
+  return em
+}
+
+function makeDataEngine() {
+  return {
+    createOrmEntity: jest.fn(async ({ data }: { data: Record<string, unknown> }) => makeTenant(data as Partial<Tenant>)),
+    updateOrmEntity: jest.fn(async ({ apply }: { apply: (entity: Tenant) => void }) => {
+      const tenant = makeTenant()
+      apply(tenant)
+      return tenant
+    }),
+    deleteOrmEntity: jest.fn(async () => makeTenant({ deletedAt: new Date('2026-01-03T00:00:00.000Z') })),
+    setCustomFields: jest.fn(async () => {}),
+  }
+}
+
+function makeCtx(em: ReturnType<typeof makeEm>, de: ReturnType<typeof makeDataEngine>) {
+  return {
+    container: {
+      resolve: (token: string) => {
+        if (token === 'em') return em
+        if (token === 'dataEngine') return de
+        if (token === 'kmsService') return { isHealthy: () => false }
+        throw new Error(`[internal] Unexpected DI token: ${token}`)
+      },
+    },
+    auth: { sub: 'user-1', tenantId: ACTOR_TENANT_ID, orgId: null, isSuperAdmin: true },
+  } as unknown as Parameters<CommandHandler['execute']>[1]
+}
+
+/**
+ * The query-index subscriber copies the emitted identifiers straight into the
+ * `query_index.upsert_one` / `delete_one` payload, so feeding them back through the
+ * resolver reproduces exactly what blew up in #4906.
+ */
+function resolveScopeForEmittedIdentifiers(identifiers: {
+  organizationId: string | null
+  tenantId: string | null
+}): QueryIndexScope {
+  return resolveQueryIndexRecordScope({
+    payloadOrganizationId: identifiers.organizationId,
+    payloadTenantId: identifiers.tenantId,
+    hasPayloadOrganizationId: true,
+    hasPayloadTenantId: true,
+    sourceScope: { kind: 'global' },
+  })
+}
+
+function lastEmittedIdentifiers() {
+  expect(emitCrudSideEffectsMock).toHaveBeenCalledTimes(1)
+  const call = emitCrudSideEffectsMock.mock.calls[0][0] as {
+    identifiers: { id: string; organizationId: string | null; tenantId: string | null }
+  }
+  return call.identifiers
+}
+
+describe('directory tenant commands — global query-index scope (#4906)', () => {
+  afterEach(() => jest.clearAllMocks())
+
+  it('emits a null tenant scope when creating a tenant', async () => {
+    const de = makeDataEngine()
+    const handler = commandRegistry.get('directory.tenants.create') as CommandHandler
+    expect(handler).toBeDefined()
+
+    await handler.execute({ name: 'Acme' }, makeCtx(makeEm(), de))
+
+    const identifiers = lastEmittedIdentifiers()
+    expect(identifiers).toEqual({ id: TENANT_ID, organizationId: null, tenantId: null })
+    expect(resolveScopeForEmittedIdentifiers(identifiers)).toEqual({ organizationId: null, tenantId: null })
+  })
+
+  it('emits a null tenant scope when updating a tenant', async () => {
+    const de = makeDataEngine()
+    const handler = commandRegistry.get('directory.tenants.update') as CommandHandler
+
+    await handler.execute({ id: TENANT_ID, name: 'Acme Renamed' }, makeCtx(makeEm(), de))
+
+    const identifiers = lastEmittedIdentifiers()
+    expect(identifiers).toEqual({ id: TENANT_ID, organizationId: null, tenantId: null })
+    expect(resolveScopeForEmittedIdentifiers(identifiers)).toEqual({ organizationId: null, tenantId: null })
+  })
+
+  it('emits a null tenant scope when deleting a tenant', async () => {
+    const de = makeDataEngine()
+    const handler = commandRegistry.get('directory.tenants.delete') as CommandHandler
+
+    await handler.execute({ body: { id: TENANT_ID }, query: {} }, makeCtx(makeEm(), de))
+
+    const identifiers = lastEmittedIdentifiers()
+    expect(identifiers).toEqual({ id: TENANT_ID, organizationId: null, tenantId: null })
+    expect(resolveScopeForEmittedIdentifiers(identifiers)).toEqual({ organizationId: null, tenantId: null })
+  })
+
+  it('emits a null tenant scope when redoing a tenant creation', async () => {
+    const de = makeDataEngine()
+    const handler = commandRegistry.get('directory.tenants.create') as CommandHandler
+    expect(handler.redo).toBeDefined()
+
+    const logEntry = {
+      resourceId: TENANT_ID,
+      payload: {
+        undo: {
+          after: {
+            id: TENANT_ID,
+            name: 'Acme',
+            isActive: true,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-02T00:00:00.000Z',
+            deletedAt: null,
+          },
+        },
+      },
+    } as unknown as CommandUndoLogEntry
+
+    await handler.redo!({ input: {}, ctx: makeCtx(makeEm(), de), logEntry })
+
+    const identifiers = lastEmittedIdentifiers()
+    expect(identifiers).toEqual({ id: TENANT_ID, organizationId: null, tenantId: null })
+    expect(resolveScopeForEmittedIdentifiers(identifiers)).toEqual({ organizationId: null, tenantId: null })
+  })
+
+  it('still rejects a tenant-scoped payload for the global Tenant entity', () => {
+    expect(() =>
+      resolveScopeForEmittedIdentifiers({ organizationId: null, tenantId: TENANT_ID }),
+    ).toThrow(/global entity/)
+  })
+})

--- a/packages/core/src/modules/directory/commands/tenants.ts
+++ b/packages/core/src/modules/directory/commands/tenants.ts
@@ -87,7 +87,7 @@ const createTenantCommand: CommandHandler<TenantPayload, Tenant> = {
     const identifiers = {
       id: String(tenant.id),
       organizationId: null,
-      tenantId: String(tenant.id),
+      tenantId: null,
     }
 
     await emitCrudSideEffects({
@@ -119,9 +119,6 @@ const createTenantCommand: CommandHandler<TenantPayload, Tenant> = {
     buildResult: (entity) => entity,
     events: tenantCrudEvents,
     indexer: tenantCrudIndexer,
-    afterRestore: ({ entity }) => {
-      Reflect.set(entity, 'tenantId', String(entity.id))
-    },
   }),
 }
 
@@ -162,7 +159,7 @@ const updateTenantCommand: CommandHandler<TenantPayload, Tenant> = {
     const identifiers = {
       id: String(tenant.id),
       organizationId: null,
-      tenantId: String(tenant.id),
+      tenantId: null,
     }
 
     await emitCrudSideEffects({
@@ -216,7 +213,7 @@ const deleteTenantCommand: CommandHandler<{ body: any; query: Record<string, str
     const identifiers = {
       id: String(id),
       organizationId: null,
-      tenantId: String(id),
+      tenantId: null,
     }
 
     await emitCrudSideEffects({


### PR DESCRIPTION
Closes #4906

## 🎯 Goal
Creating or editing a tenant in the admin panel no longer records a `QueryIndexScopeError` for every write, and tenant records reach the query index instead of being rejected by it.

## 🔍 Problem
Every tenant create/update/delete saved correctly, but the background query-index job that follows the write immediately failed with `QueryIndexScopeError`, so each admin action left a recorded indexer error in the logs and left the tenant unindexed.

## 🔍 Root Cause
`Tenant` is a global entity — the `tenants` table has neither a `tenant_id` nor an `organization_id` column, and the CRUD route declares `orgField: null, tenantField: null`. Because of that, `resolveQueryIndexSourceMetadata` finds no scope columns and `loadQueryIndexRowScope` classifies the source as `{ kind: 'global' }`. For a global source, `resolveQueryIndexRecordScope` (`packages/core/src/modules/query_index/lib/subscriber-scope.ts:119`) requires the event payload to carry **both** scope ids as explicit `null` and throws otherwise. All three tenant commands built their side-effect `identifiers` with `tenantId: String(tenant.id)` — the tenant's own id — and the create command's redo hook forced the same value back onto the restored row via `afterRestore`, from which `makeCreateRedo` derives its identifiers. `markOrmEntityChange` forwards those identifiers verbatim into the `query_index.upsert_one` / `query_index.delete_one` payload, so the subscriber rejected every tenant write while the write itself committed.

## What Changed
- `packages/core/src/modules/directory/commands/tenants.ts` — the `create`, `update` and `delete` commands now emit `identifiers.tenantId: null` (matching the `organizationId: null` that was already correct), so the payload satisfies the global-entity contract the query-index subscriber enforces.
- Same file — dropped the create command's redo `afterRestore` hook that did `Reflect.set(entity, 'tenantId', String(entity.id))`. `Tenant` has no mapped `tenantId` property, so `makeCreateRedo`'s `entity.tenantId ?? null` now naturally yields `null` and a redone tenant creation indexes cleanly too.
- Audit logging is deliberately untouched: `buildLog` still records `tenantId: ctx.auth?.tenantId`, which is the *actor's* tenant for the audit trail — a different concern from the indexed record's scope.

## 🧪 Tests
- New `packages/core/src/modules/directory/commands/__tests__/tenants.global-index-scope.test.ts` — 5 cases. Create, update, delete and redo each assert the emitted identifiers are `{ id, organizationId: null, tenantId: null }` **and** replay those identifiers through the real `resolveQueryIndexRecordScope` against `{ kind: 'global' }`, so the invariant is pinned against the actual consumer rather than a restated literal. A fifth negative-control case proves a tenant-scoped payload still throws, so the guard itself is not weakened.
- Regression proven: with the production change stashed, 4 of the 5 cases fail; with it applied, all 5 pass.
- `yarn workspace @open-mercato/core test src/modules/directory/` — 27 suites / 173 tests passed.
- Full validation gate run locally (no Docker app container was up): `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn build:app` all passed.
- Two gate commands fail identically on a clean `develop` checkout with these changes stashed, so they are pre-existing and not caused by this PR: `yarn i18n:check-sync` (3 missing `attachments` keys in `ko.json`) and `yarn test` (`apps/mercato` `storage-s3-routes.test.ts` → "rejects uploads that exceed tenant quota"). Three further core suites (`dashboards/formatters`, `CompanyKpiBar.dealStatus`, `DealsKpiStrip`) fail only on this machine's Polish default locale — they expect `"1.0M"` and receive `"1,0 mln"` — and the docs `search-index` test needs a docs build absent from a fresh worktree.

## 💥 Breaking Changes
- None to any documented contract: no API route, response shape, DB schema, event id or exported signature changes.
- Behavioral note for third-party modules: the `directory.tenant.created` / `.updated` / `.deleted` events now carry `tenantId: null` instead of the tenant's own id. No in-repo subscriber reads that field, and the tenant id is still available as the payload's `id`, but an external subscriber keying off `tenantId` for these three events should read `id` instead.
