### PR TITLE
fix(ui): handle errors from the AI chat fire-and-forget fetches (#4703)

### DIFF
--- a/.ai/runs/2026-08-05-issue-4703-ai-chat-fire-and-forget-errors.md
+++ b/.ai/runs/2026-08-05-issue-4703-ai-chat-fire-and-forget-errors.md
@@ -60,4 +60,4 @@ The already-landed fix must stop encoding "the models fetch finished" and "the m
 
 ### Phase 4: Record the out-of-scope route work
 
-- [ ] 4.1 File the follow-up issue for the models route reporting partial degradation as 200
+- [x] 4.1 File the follow-up issue for the models route reporting partial degradation as 200 — filed as #5021

--- a/.ai/runs/2026-08-05-issue-4703-ai-chat-fire-and-forget-errors.md
+++ b/.ai/runs/2026-08-05-issue-4703-ai-chat-fire-and-forget-errors.md
@@ -1,0 +1,63 @@
+# Execution plan — make the AI-chat models fetch report its outcome as one unambiguous state (adopted from PR #4967)
+
+**Origin:** adopted — reconstructed by `om-auto-continue-pr` on 2026-08-05 because PR #4967 carried no execution plan.
+**PR:** #4967 · **Branch:** `fix/issue-4703-ai-chat-fire-and-forget-errors` · **Base:** `develop`
+**Author:** @adeptofvoltron — this plan interprets their intent; correct it by editing this file or commenting on the PR.
+
+## 🎯 Goal
+
+The already-landed fix must stop encoding "the models fetch finished" and "the models fetch succeeded" as two independent booleans, so no future consumer can read a failed load as a ready one and re-introduce the persisted-model-override data loss that #4703 is about.
+
+## Scope
+
+`packages/ui/src/ai/AiChat.tsx` (the module-private `useAgentModels` hook and its two consumers) and `packages/ui/src/ai/__tests__/AiChat.test.tsx`.
+
+## Non-goals
+
+- **The route's 200-on-partial-degradation signal.** `packages/ai-assistant/src/modules/ai_assistant/api/ai/agents/[agentId]/models/route.ts:161-166` catches its own tenant-allowlist snapshot failure, logs it, and still returns 200 with an env-only provider list, so a real partial degradation reaches every client — ours and any third-party consumer of the documented endpoint — as a success. Signalling it honestly needs an additive payload field (`degraded: true`), which is an API-contract change requiring its own spec and PR. Filed as a follow-up in step 4.1.
+- The other 8 `void …then(…)` sites in `packages/ui/src` (markdown lazy-loaders, `confirmUnsavedChanges()`), already declared out of scope by the PR description.
+- Any change to `AiChatSessions.tsx` or `useAiPendingActionPolling.ts` — their failure handling has no equivalent two-flag ambiguity.
+
+## Evidence
+
+| Conclusion | Drawn from | Confidence |
+|---|---|---|
+| `setLoaded(true)` on the failure path is the thing to change | @adeptofvoltron's inline review comment on `packages/ui/src/ai/AiChat.tsx:151` — "schould not be true, if error was rised." | high |
+| The fix is the state model, not the single line: `loaded` must stop meaning two things | The `🤖 om-auto-continue-pr` review comment on the PR (2026-08-05), and the PR's own root-cause section describing how the old `setLoaded(true)` + empty-provider combination deleted the user's stored override | high |
+| The data loss is third-party-visible, so correctness matters beyond this app | `AiChat` is exported from `packages/ui/src/ai/index.ts:1`; `useAgentModels` is **not**, so `loaded`/`failed` are private and the refactor breaks no contract | high |
+| 401/403 are designed responses, not faults, so `logger.error` is the wrong severity | The route's documented error list (`route.ts:64-66`, `code: 'agent_features_denied'`) and `UnauthorizedError`/`ForbiddenError` carrying `readonly status` (`packages/ui/src/backend/utils/api.ts:50,75`) | high |
+| Only two consumers read `loaded` today, so the refactor is small | `AiChat.tsx:1247` (the `effectiveModelPickerValue` memo) and `AiChat.tsx:1265` (the stored-override cleanup effect); the picker's own render gate at `AiChat.tsx:1782` reads neither flag | high |
+| Goal is #4703's stated intent, not a new feature | Issue #4703 body: failures must not leave the surface silently degraded | high |
+
+## Assumptions
+
+- A tri-state (`'loading' | 'ready' | 'failed'`) is preferred over keeping `loaded` and dropping only its failure-path assignment. Both fix the reported line; the tri-state additionally makes the ambiguity unrepresentable, and it is the more reversible choice because the hook is module-private. Contradict this by asking for the minimal two-line change instead.
+- The historical inline comments this PR added (`AiChat.tsx:145-148`, `AiChat.tsx:1267-1269`) narrate previous behavior rather than current code, which `AGENTS.md` → Code Quality disallows; they are removed along with the code they annotate rather than rewritten.
+- No new user-facing string is needed, so no locale change: every message here is a logger call, not UI copy.
+
+## Risks
+
+- Low blast radius: one module-private hook, two call sites, no exported signature. The main risk is missing a consumer of `loaded`, mitigated by the fact that a rename makes any missed reference a compile error rather than silent behavior.
+- CI on this branch was mid-run (`ephemeral-integration` matrix queued) when the resume started; the full gate is re-run locally at step 6 regardless.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Already landed on this PR (reconstructed)
+
+- [x] 1.1 Handle the three AI-chat fire-and-forget failures — log them, keep the chat usable, preserve the stored model override, keep polling alive; 5 regression tests — b0ebdb7
+
+### Phase 2: Model the models-fetch outcome as one tri-state
+
+- [ ] 2.1 Replace `loaded`/`failed` with a single `status: 'loading' | 'ready' | 'failed'` in `useAgentModels`, move both consumers onto it, and drop the now-redundant failure guard and the historical inline comments
+- [ ] 2.2 Update the models-failure tests to the tri-state and assert that a failed load keeps the persisted override while a successful load still prunes an unavailable one
+
+### Phase 3: Log a denied models fetch at warning level
+
+- [ ] 3.1 Split the severity in both failure paths: `warn` for 401/403, `error` for everything else
+- [ ] 3.2 Cover the severity split in `AiChat.test.tsx`
+
+### Phase 4: Record the out-of-scope route work
+
+- [ ] 4.1 File the follow-up issue for the models route reporting partial degradation as 200

--- a/.ai/runs/2026-08-05-issue-4703-ai-chat-fire-and-forget-errors.md
+++ b/.ai/runs/2026-08-05-issue-4703-ai-chat-fire-and-forget-errors.md
@@ -50,13 +50,13 @@ The already-landed fix must stop encoding "the models fetch finished" and "the m
 
 ### Phase 2: Model the models-fetch outcome as one tri-state
 
-- [ ] 2.1 Replace `loaded`/`failed` with a single `status: 'loading' | 'ready' | 'failed'` in `useAgentModels`, move both consumers onto it, and drop the now-redundant failure guard and the historical inline comments
-- [ ] 2.2 Update the models-failure tests to the tri-state and assert that a failed load keeps the persisted override while a successful load still prunes an unavailable one
+- [x] 2.1 Replace `loaded`/`failed` with a single `status: 'loading' | 'ready' | 'failed'` in `useAgentModels`, move both consumers onto it, and drop the now-redundant failure guard and the historical inline comments — b44e35c
+- [x] 2.2 Update the models-failure tests to the tri-state and assert that a failed load keeps the persisted override while a successful load still prunes an unavailable one — b44e35c
 
 ### Phase 3: Log a denied models fetch at warning level
 
-- [ ] 3.1 Split the severity in both failure paths: `warn` for 401/403, `error` for everything else
-- [ ] 3.2 Cover the severity split in `AiChat.test.tsx`
+- [x] 3.1 Split the severity in both failure paths: `warn` for 401/403, `error` for everything else — b44e35c
+- [x] 3.2 Cover the severity split in `AiChat.test.tsx` — b44e35c
 
 ### Phase 4: Record the out-of-scope route work
 

--- a/packages/ui/src/ai/AiChat.tsx
+++ b/packages/ui/src/ai/AiChat.tsx
@@ -98,33 +98,46 @@ interface ModelsApiResponse {
   providers: ModelPickerProvider[]
 }
 
+type AgentModelsStatus = 'loading' | 'ready' | 'failed'
+
+function readErrorStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const { status } = error as { status?: unknown }
+  return typeof status === 'number' ? status : undefined
+}
+
+function logModelsFailure(status: number | undefined, details: Record<string, unknown>): void {
+  const message = 'Failed to load AI agent models'
+  if (status === 401 || status === 403) {
+    logger.warn(message, details)
+    return
+  }
+  logger.error(message, details)
+}
+
 function useAgentModels(agent: string): {
   providers: ModelPickerProvider[]
   allowRuntimeOverride: boolean
   allowRuntimeModelOverride: boolean
   defaultLabel: string | null
-  loaded: boolean
-  failed: boolean
+  status: AgentModelsStatus
 } {
   const [providers, setProviders] = React.useState<ModelPickerProvider[]>([])
   const [allowRuntimeOverride, setAllowRuntimeOverride] = React.useState(false)
   const [defaultLabel, setDefaultLabel] = React.useState<string | null>(null)
-  const [loaded, setLoaded] = React.useState(false)
-  const [failed, setFailed] = React.useState(false)
+  const [status, setStatus] = React.useState<AgentModelsStatus>('loading')
 
   React.useEffect(() => {
     let cancelled = false
     const modelsUrl = `/api/ai_assistant/ai/agents/${encodeURIComponent(agent)}/models`
-    setLoaded(false)
+    setStatus('loading')
     setDefaultLabel(null)
-    setFailed(false)
     apiCall<ModelsApiResponse>(modelsUrl)
       .then((result) => {
         if (cancelled) return
         if (!result.ok || !result.result) {
-          logger.error('Failed to load AI agent models', { agent, status: result.status })
-          setFailed(true)
-          setLoaded(true)
+          logModelsFailure(result.status, { agent, status: result.status })
+          setStatus('failed')
           return
         }
         const effectiveAllowRuntimeOverride =
@@ -138,17 +151,12 @@ function useAgentModels(agent: string): {
               ? `${result.result.defaultProviderId} / ${result.result.defaultModelId}`
               : null,
         )
-        setLoaded(true)
+        setStatus('ready')
       })
       .catch((err) => {
         if (cancelled) return
-        // `apiCall` rejects on a network failure and on the 401/403 errors
-        // `apiFetch` throws. Without this handler the effect never settled:
-        // `loaded` stayed false for the component's lifetime and the
-        // rejection surfaced as an unhandled promise rejection.
-        logger.error('Failed to load AI agent models', { agent, err })
-        setFailed(true)
-        setLoaded(true)
+        logModelsFailure(readErrorStatus(err), { agent, err })
+        setStatus('failed')
       })
     return () => {
       cancelled = true
@@ -160,8 +168,7 @@ function useAgentModels(agent: string): {
     allowRuntimeOverride,
     allowRuntimeModelOverride: allowRuntimeOverride,
     defaultLabel,
-    loaded,
-    failed,
+    status,
   }
 }
 
@@ -1235,8 +1242,7 @@ export function AiChat({
     allowRuntimeOverride,
     allowRuntimeModelOverride,
     defaultLabel: modelDefaultLabel,
-    loaded: modelProvidersLoaded,
-    failed: modelProvidersFailed,
+    status: modelProvidersStatus,
   } = useAgentModels(agent)
 
   const [modelPickerValue, setModelPickerValue] = React.useState<ModelPickerValue | null>(() =>
@@ -1244,7 +1250,7 @@ export function AiChat({
   )
 
   const effectiveModelPickerValue = React.useMemo(() => {
-    if (!modelProvidersLoaded || !allowRuntimeOverride || modelProviders.length === 0) {
+    if (modelProvidersStatus !== 'ready' || !allowRuntimeOverride || modelProviders.length === 0) {
       return null
     }
     if (modelPickerValue && isModelPickerValueAvailable(modelPickerValue, modelProviders)) {
@@ -1255,7 +1261,7 @@ export function AiChat({
     allowRuntimeOverride,
     modelPickerValue,
     modelProviders,
-    modelProvidersLoaded,
+    modelProvidersStatus,
   ])
 
   React.useEffect(() => {
@@ -1263,11 +1269,7 @@ export function AiChat({
   }, [agent])
 
   React.useEffect(() => {
-    if (!modelProvidersLoaded) return
-    // An unreachable models endpoint says nothing about which providers the
-    // agent allows, so the persisted selection is kept until a successful
-    // response proves it unavailable.
-    if (modelProvidersFailed) return
+    if (modelProvidersStatus !== 'ready') return
     if (!allowRuntimeModelOverride || modelProviders.length === 0) {
       if (modelPickerValue !== null) {
         setModelPickerValue(null)
@@ -1284,8 +1286,7 @@ export function AiChat({
     allowRuntimeModelOverride,
     modelPickerValue,
     modelProviders,
-    modelProvidersFailed,
-    modelProvidersLoaded,
+    modelProvidersStatus,
   ])
 
   const handleModelPickerChange = React.useCallback(

--- a/packages/ui/src/ai/AiChat.tsx
+++ b/packages/ui/src/ai/AiChat.tsx
@@ -104,34 +104,55 @@ function useAgentModels(agent: string): {
   allowRuntimeModelOverride: boolean
   defaultLabel: string | null
   loaded: boolean
+  failed: boolean
 } {
   const [providers, setProviders] = React.useState<ModelPickerProvider[]>([])
   const [allowRuntimeOverride, setAllowRuntimeOverride] = React.useState(false)
   const [defaultLabel, setDefaultLabel] = React.useState<string | null>(null)
   const [loaded, setLoaded] = React.useState(false)
+  const [failed, setFailed] = React.useState(false)
 
   React.useEffect(() => {
+    let cancelled = false
     const modelsUrl = `/api/ai_assistant/ai/agents/${encodeURIComponent(agent)}/models`
     setLoaded(false)
     setDefaultLabel(null)
-    void apiCall<ModelsApiResponse>(modelsUrl).then((result) => {
-      if (!result.ok || !result.result) {
+    setFailed(false)
+    apiCall<ModelsApiResponse>(modelsUrl)
+      .then((result) => {
+        if (cancelled) return
+        if (!result.ok || !result.result) {
+          logger.error('Failed to load AI agent models', { agent, status: result.status })
+          setFailed(true)
+          setLoaded(true)
+          return
+        }
+        const effectiveAllowRuntimeOverride =
+          result.result.allowRuntimeOverride ?? result.result.allowRuntimeModelOverride ?? false
+        setAllowRuntimeOverride(effectiveAllowRuntimeOverride)
+        setProviders(result.result.providers)
+        setDefaultLabel(
+          result.result.defaultProviderName && result.result.defaultModelName
+            ? `${result.result.defaultProviderName} / ${result.result.defaultModelName}`
+            : result.result.defaultProviderId && result.result.defaultModelId
+              ? `${result.result.defaultProviderId} / ${result.result.defaultModelId}`
+              : null,
+        )
         setLoaded(true)
-        return
-      }
-      const effectiveAllowRuntimeOverride =
-        result.result.allowRuntimeOverride ?? result.result.allowRuntimeModelOverride ?? false
-      setAllowRuntimeOverride(effectiveAllowRuntimeOverride)
-      setProviders(result.result.providers)
-      setDefaultLabel(
-        result.result.defaultProviderName && result.result.defaultModelName
-          ? `${result.result.defaultProviderName} / ${result.result.defaultModelName}`
-          : result.result.defaultProviderId && result.result.defaultModelId
-            ? `${result.result.defaultProviderId} / ${result.result.defaultModelId}`
-            : null,
-      )
-      setLoaded(true)
-    })
+      })
+      .catch((err) => {
+        if (cancelled) return
+        // `apiCall` rejects on a network failure and on the 401/403 errors
+        // `apiFetch` throws. Without this handler the effect never settled:
+        // `loaded` stayed false for the component's lifetime and the
+        // rejection surfaced as an unhandled promise rejection.
+        logger.error('Failed to load AI agent models', { agent, err })
+        setFailed(true)
+        setLoaded(true)
+      })
+    return () => {
+      cancelled = true
+    }
   }, [agent])
 
   return {
@@ -140,6 +161,7 @@ function useAgentModels(agent: string): {
     allowRuntimeModelOverride: allowRuntimeOverride,
     defaultLabel,
     loaded,
+    failed,
   }
 }
 
@@ -1214,6 +1236,7 @@ export function AiChat({
     allowRuntimeModelOverride,
     defaultLabel: modelDefaultLabel,
     loaded: modelProvidersLoaded,
+    failed: modelProvidersFailed,
   } = useAgentModels(agent)
 
   const [modelPickerValue, setModelPickerValue] = React.useState<ModelPickerValue | null>(() =>
@@ -1241,6 +1264,10 @@ export function AiChat({
 
   React.useEffect(() => {
     if (!modelProvidersLoaded) return
+    // An unreachable models endpoint says nothing about which providers the
+    // agent allows, so the persisted selection is kept until a successful
+    // response proves it unavailable.
+    if (modelProvidersFailed) return
     if (!allowRuntimeModelOverride || modelProviders.length === 0) {
       if (modelPickerValue !== null) {
         setModelPickerValue(null)
@@ -1257,6 +1284,7 @@ export function AiChat({
     allowRuntimeModelOverride,
     modelPickerValue,
     modelProviders,
+    modelProvidersFailed,
     modelProvidersLoaded,
   ])
 

--- a/packages/ui/src/ai/AiChatSessions.tsx
+++ b/packages/ui/src/ai/AiChatSessions.tsx
@@ -25,12 +25,15 @@ import {
   subscribeOrganizationScopeChanged,
 } from '@open-mercato/shared/lib/frontend/organizationEvents'
 import { readVersionedPreference, writeVersionedPreference } from '@open-mercato/shared/lib/browser/versionedPreference'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import {
   createAiServerConversation,
   listAiServerConversations,
   updateAiServerConversation,
   type AiServerConversation,
 } from './conversation-store'
+
+const logger = createLogger('ui').child({ component: 'AiChatSessions' })
 
 /**
  * Legacy app-global storage key used before tenant/org scoping.
@@ -253,10 +256,19 @@ export function AiChatSessionsProvider({ children }: { children: React.ReactNode
 
   React.useEffect(() => {
     let cancelled = false
-    void listAiServerConversations({ limit: 100 }).then((conversations) => {
-      if (cancelled || !conversations) return
-      setState((prev) => mergeServerConversations(prev, conversations))
-    })
+    listAiServerConversations({ limit: 100 })
+      .then((conversations) => {
+        if (cancelled) return
+        if (!conversations) {
+          logger.warn('Could not load server conversations; keeping the locally persisted sessions')
+          return
+        }
+        setState((prev) => mergeServerConversations(prev, conversations))
+      })
+      .catch((err) => {
+        if (cancelled) return
+        logger.error('Failed to load server conversations', { err })
+      })
     return () => {
       cancelled = true
     }

--- a/packages/ui/src/ai/__tests__/AiChat.test.tsx
+++ b/packages/ui/src/ai/__tests__/AiChat.test.tsx
@@ -56,9 +56,26 @@ jest.mock('../../backend/utils/apiCall', () => ({
   })),
 }))
 
+jest.mock('@open-mercato/shared/lib/logger', () => {
+  const mocked = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+  }
+  mocked.child.mockImplementation(() => mocked)
+  return { createLogger: jest.fn(() => mocked) }
+})
+
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import { apiFetch } from '../../backend/utils/api'
 import { apiCall } from '../../backend/utils/apiCall'
 import { AiChat } from '../AiChat'
+
+const loggerError = createLogger('ui').error as jest.Mock
+
+const MODEL_PICKER_STORAGE_KEY = 'om-ai-model-picker:customers.account_assistant'
 
 let lastResizeObserver: MockResizeObserver | null = null
 
@@ -256,6 +273,47 @@ describe('<AiChat>', () => {
     await waitFor(() => {
       expect(window.localStorage.getItem('om-ai-model-picker:customers.account_assistant')).toBeNull()
     })
+  })
+
+  it('logs and keeps the stored model picker value when the models endpoint errors', async () => {
+    const apiCallMock = apiCall as unknown as jest.Mock
+    apiCallMock.mockResolvedValueOnce({ ok: false, status: 500, result: null })
+    const storedValue = JSON.stringify({ providerId: 'openai', modelId: 'gpt-4o' })
+    window.localStorage.setItem(MODEL_PICKER_STORAGE_KEY, storedValue)
+
+    renderWithProviders(<AiChat agent="customers.account_assistant" />, { dict })
+
+    await waitFor(() => {
+      expect(loggerError).toHaveBeenCalledWith('Failed to load AI agent models', {
+        agent: 'customers.account_assistant',
+        status: 500,
+      })
+    })
+    await act(async () => {})
+
+    expect(window.localStorage.getItem(MODEL_PICKER_STORAGE_KEY)).toBe(storedValue)
+    expect(screen.getByLabelText('Message composer')).toBeInTheDocument()
+  })
+
+  it('logs and keeps the stored model picker value when the models request rejects', async () => {
+    const apiCallMock = apiCall as unknown as jest.Mock
+    const failure = new Error('[internal] models endpoint unreachable')
+    apiCallMock.mockRejectedValueOnce(failure)
+    const storedValue = JSON.stringify({ providerId: 'openai', modelId: 'gpt-4o' })
+    window.localStorage.setItem(MODEL_PICKER_STORAGE_KEY, storedValue)
+
+    renderWithProviders(<AiChat agent="customers.account_assistant" />, { dict })
+
+    await waitFor(() => {
+      expect(loggerError).toHaveBeenCalledWith('Failed to load AI agent models', {
+        agent: 'customers.account_assistant',
+        err: failure,
+      })
+    })
+    await act(async () => {})
+
+    expect(window.localStorage.getItem(MODEL_PICKER_STORAGE_KEY)).toBe(storedValue)
+    expect(screen.getByLabelText('Message composer')).toBeInTheDocument()
   })
 
   it('does not send provider or model overrides while the model picker is on Default', async () => {

--- a/packages/ui/src/ai/__tests__/AiChat.test.tsx
+++ b/packages/ui/src/ai/__tests__/AiChat.test.tsx
@@ -74,6 +74,7 @@ import { apiCall } from '../../backend/utils/apiCall'
 import { AiChat } from '../AiChat'
 
 const loggerError = createLogger('ui').error as jest.Mock
+const loggerWarn = createLogger('ui').warn as jest.Mock
 
 const MODEL_PICKER_STORAGE_KEY = 'om-ai-model-picker:customers.account_assistant'
 
@@ -314,6 +315,92 @@ describe('<AiChat>', () => {
 
     expect(window.localStorage.getItem(MODEL_PICKER_STORAGE_KEY)).toBe(storedValue)
     expect(screen.getByLabelText('Message composer')).toBeInTheDocument()
+  })
+
+  it('logs a denied models response at warning level and keeps the stored model picker value', async () => {
+    const apiCallMock = apiCall as unknown as jest.Mock
+    apiCallMock.mockResolvedValueOnce({ ok: false, status: 403, result: null })
+    const storedValue = JSON.stringify({ providerId: 'openai', modelId: 'gpt-4o' })
+    window.localStorage.setItem(MODEL_PICKER_STORAGE_KEY, storedValue)
+
+    renderWithProviders(<AiChat agent="customers.account_assistant" />, { dict })
+
+    await waitFor(() => {
+      expect(loggerWarn).toHaveBeenCalledWith('Failed to load AI agent models', {
+        agent: 'customers.account_assistant',
+        status: 403,
+      })
+    })
+    await act(async () => {})
+
+    expect(loggerError).not.toHaveBeenCalledWith(
+      'Failed to load AI agent models',
+      expect.anything(),
+    )
+    expect(window.localStorage.getItem(MODEL_PICKER_STORAGE_KEY)).toBe(storedValue)
+  })
+
+  it('logs a rejected models request at warning level when the error carries a denied status', async () => {
+    const apiCallMock = apiCall as unknown as jest.Mock
+    const failure = Object.assign(new Error('[internal] Forbidden'), { status: 403 })
+    apiCallMock.mockRejectedValueOnce(failure)
+    const storedValue = JSON.stringify({ providerId: 'openai', modelId: 'gpt-4o' })
+    window.localStorage.setItem(MODEL_PICKER_STORAGE_KEY, storedValue)
+
+    renderWithProviders(<AiChat agent="customers.account_assistant" />, { dict })
+
+    await waitFor(() => {
+      expect(loggerWarn).toHaveBeenCalledWith('Failed to load AI agent models', {
+        agent: 'customers.account_assistant',
+        err: failure,
+      })
+    })
+    await act(async () => {})
+
+    expect(loggerError).not.toHaveBeenCalledWith(
+      'Failed to load AI agent models',
+      expect.anything(),
+    )
+    expect(window.localStorage.getItem(MODEL_PICKER_STORAGE_KEY)).toBe(storedValue)
+  })
+
+  it('does not render the model picker while the models request is still in flight', async () => {
+    const apiCallMock = apiCall as unknown as jest.Mock
+    let resolveModels: ((value: unknown) => void) | null = null
+    apiCallMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveModels = resolve
+        }),
+    )
+
+    renderWithProviders(<AiChat agent="customers.account_assistant" />, { dict })
+
+    expect(screen.queryByRole('button', { name: 'Select AI model' })).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveModels?.({
+        ok: true,
+        status: 200,
+        result: {
+          agentId: 'customers.account_assistant',
+          allowRuntimeModelOverride: true,
+          defaultProviderId: 'openai',
+          defaultModelId: 'gpt-5-mini',
+          providers: [
+            {
+              id: 'openai',
+              name: 'OpenAI',
+              models: [{ id: 'gpt-5-mini', name: 'GPT-5 mini' }],
+            },
+          ],
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Select AI model' })).toBeInTheDocument()
+    })
   })
 
   it('does not send provider or model overrides while the model picker is on Default', async () => {

--- a/packages/ui/src/ai/__tests__/AiChat.test.tsx
+++ b/packages/ui/src/ai/__tests__/AiChat.test.tsx
@@ -258,7 +258,7 @@ describe('<AiChat>', () => {
       },
     })
     window.localStorage.setItem(
-      'om-ai-model-picker:customers.account_assistant',
+      MODEL_PICKER_STORAGE_KEY,
       JSON.stringify({ providerId: 'openai', modelId: 'gpt-4o' }),
     )
 
@@ -271,7 +271,7 @@ describe('<AiChat>', () => {
       )
     })
     await waitFor(() => {
-      expect(window.localStorage.getItem('om-ai-model-picker:customers.account_assistant')).toBeNull()
+      expect(window.localStorage.getItem(MODEL_PICKER_STORAGE_KEY)).toBeNull()
     })
   })
 

--- a/packages/ui/src/ai/__tests__/AiChatSessions.test.tsx
+++ b/packages/ui/src/ai/__tests__/AiChatSessions.test.tsx
@@ -24,6 +24,19 @@ jest.mock('../conversation-store', () => {
   }
 })
 
+jest.mock('@open-mercato/shared/lib/logger', () => {
+  const mocked = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+  }
+  mocked.child.mockImplementation(() => mocked)
+  return { createLogger: jest.fn(() => mocked) }
+})
+
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import {
   listAiServerConversations,
   createAiServerConversation,
@@ -31,6 +44,8 @@ import {
 
 const listMock = listAiServerConversations as jest.MockedFunction<typeof listAiServerConversations>
 const createMock = createAiServerConversation as jest.MockedFunction<typeof createAiServerConversation>
+const loggerError = createLogger('ui').error as jest.Mock
+const loggerWarn = createLogger('ui').warn as jest.Mock
 
 const KEY_PREFIX = 'om-ai-chat-sessions-v1'
 
@@ -69,6 +84,8 @@ describe('<AiChatSessionsProvider> — tenant/org scope isolation', () => {
     listMock.mockResolvedValue(null)
     createMock.mockReset()
     createMock.mockResolvedValue(null)
+    loggerError.mockClear()
+    loggerWarn.mockClear()
     // Reset scope to a known starting point. The module-level state in
     // organizationEvents persists across tests in the same file.
     act(() => {
@@ -210,6 +227,48 @@ describe('<AiChatSessionsProvider> — tenant/org scope isolation', () => {
     await waitFor(() => {
       expect(listMock).toHaveBeenCalledTimes(2)
     })
+  })
+
+  it('warns when the server conversation list is unavailable', async () => {
+    renderWithProviders(<Harness agentId="assistant" />)
+
+    await waitFor(() => {
+      expect(loggerWarn).toHaveBeenCalledWith(
+        'Could not load server conversations; keeping the locally persisted sessions',
+      )
+    })
+  })
+
+  it('logs and keeps the locally persisted sessions when the server list rejects', async () => {
+    const failure = new Error('[internal] conversations endpoint unreachable')
+    listMock.mockReset()
+    listMock.mockRejectedValue(failure)
+    window.localStorage.setItem(
+      scopedKey('T1', 'O1'),
+      JSON.stringify({
+        sessions: [
+          {
+            id: 'local-session',
+            agentId: 'assistant',
+            conversationId: 'local-conv',
+            createdAt: 1,
+            lastUsedAt: 1,
+            status: 'open',
+          },
+        ],
+        activeByAgent: { assistant: 'local-session' },
+      }),
+    )
+
+    renderWithProviders(<Harness agentId="assistant" />)
+
+    await waitFor(() => {
+      expect(loggerError).toHaveBeenCalledWith('Failed to load server conversations', {
+        err: failure,
+      })
+    })
+
+    expect(screen.getByTestId('session-count').textContent).toBe('1')
   })
 
   it('falls back to the no-tenant/no-org bucket when scope is unresolved', async () => {

--- a/packages/ui/src/ai/__tests__/AiChatSessions.test.tsx
+++ b/packages/ui/src/ai/__tests__/AiChatSessions.test.tsx
@@ -230,6 +230,9 @@ describe('<AiChatSessionsProvider> — tenant/org scope isolation', () => {
   })
 
   it('warns when the server conversation list is unavailable', async () => {
+    listMock.mockReset()
+    listMock.mockResolvedValue(null)
+
     renderWithProviders(<Harness agentId="assistant" />)
 
     await waitFor(() => {

--- a/packages/ui/src/ai/parts/__tests__/useAiPendingActionPolling.test.tsx
+++ b/packages/ui/src/ai/parts/__tests__/useAiPendingActionPolling.test.tsx
@@ -9,6 +9,19 @@ jest.mock('../../../backend/utils/apiCall', () => ({
   apiCallOrThrow: jest.fn(),
 }))
 
+jest.mock('@open-mercato/shared/lib/logger', () => {
+  const mocked = {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    child: jest.fn(),
+  }
+  mocked.child.mockImplementation(() => mocked)
+  return { createLogger: jest.fn(() => mocked) }
+})
+
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import { apiCallOrThrow } from '../../../backend/utils/apiCall'
 import { useAiPendingActionPolling } from '../useAiPendingActionPolling'
 import type { AiPendingActionCardAction, AiPendingActionCardStatus } from '../types'
@@ -48,9 +61,12 @@ function mockResponse(action: AiPendingActionCardAction) {
   }))
 }
 
+const loggerError = createLogger('ui').error as jest.Mock
+
 describe('useAiPendingActionPolling', () => {
   beforeEach(() => {
     ;(apiCallOrThrow as jest.Mock).mockReset()
+    loggerError.mockClear()
   })
 
   it('fetches on mount and continues polling while status is pending', async () => {
@@ -144,6 +160,51 @@ describe('useAiPendingActionPolling', () => {
         jest.advanceTimersByTime(10_000)
       })
       expect((apiCallOrThrow as jest.Mock).mock.calls.length).toBe(callsAtUnmount)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('logs a failed fetch and keeps polling until it recovers', async () => {
+    const failure = new Error('[internal] pending action endpoint unreachable')
+    ;(apiCallOrThrow as jest.Mock)
+      .mockImplementationOnce(async () => {
+        throw failure
+      })
+      .mockImplementation(async () => ({
+        ok: true,
+        status: 200,
+        result: { pendingAction: makeAction({ status: 'pending' }) },
+        response: {},
+        cacheStatus: null,
+      }))
+
+    jest.useFakeTimers()
+    try {
+      const { result, unmount } = renderHook(() =>
+        useAiPendingActionPolling({ pendingActionId: 'pa-1', intervalMs: 1000 }),
+      )
+
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(loggerError).toHaveBeenCalledWith('Failed to load the pending AI action', {
+        err: failure,
+        pendingActionId: 'pa-1',
+      })
+      expect(result.current.error?.message).toBe(failure.message)
+      expect(result.current.action).toBeNull()
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000)
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(result.current.action?.status).toBe('pending')
+      expect(result.current.error).toBeNull()
+
+      unmount()
     } finally {
       jest.useRealTimers()
     }

--- a/packages/ui/src/ai/parts/useAiPendingActionPolling.ts
+++ b/packages/ui/src/ai/parts/useAiPendingActionPolling.ts
@@ -1,8 +1,11 @@
 "use client"
 
 import * as React from 'react'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import { apiCallOrThrow } from '../../backend/utils/apiCall'
 import type { AiPendingActionCardAction, AiPendingActionCardStatus } from './types'
+
+const logger = createLogger('ui').child({ component: 'useAiPendingActionPolling' })
 
 /**
  * Shared polling hook for the Phase 3 mutation-approval cards (Step 5.10).
@@ -148,6 +151,7 @@ export function useAiPendingActionPolling(
       }
       return result.pendingAction
     } catch (err) {
+      logger.error('Failed to load the pending AI action', { err, pendingActionId })
       if (!mountedRef.current) return null
       const message = err instanceof Error ? err.message : 'Failed to load pending action.'
       setError({ message })
@@ -168,7 +172,11 @@ export function useAiPendingActionPolling(
     }
     setIsPolling(true)
     timerRef.current = setTimeout(async () => {
-      await refresh()
+      try {
+        await refresh()
+      } catch (err) {
+        logger.error('Polling the pending AI action failed unexpectedly', { err })
+      }
       scheduleNext()
     }, intervalMs)
   }, [clearTimer, disabled, intervalMs, refresh])
@@ -184,11 +192,18 @@ export function useAiPendingActionPolling(
       }
     }
     setIsPolling(true)
-    // Always fetch on mount — the "reconnect behavior" guarantee.
-    void refresh().then(() => {
-      if (!mountedRef.current) return
-      scheduleNext()
-    })
+    // Always fetch on mount — the "reconnect behavior" guarantee. The catch
+    // runs before the scheduling step so a rejected first fetch degrades to a
+    // logged error instead of silently killing the polling loop.
+    void refresh()
+      .catch((err) => {
+        logger.error('Loading the pending AI action failed unexpectedly', { err })
+        return null
+      })
+      .then(() => {
+        if (!mountedRef.current) return
+        scheduleNext()
+      })
     return () => {
       mountedRef.current = false
       clearTimer()


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-05-issue-4703-ai-chat-fire-and-forget-errors.md
Status: complete

Closes #4703

## 🎯 Goal
A failed AI-chat fetch should degrade honestly instead of silently: the model-list, conversation-list, and pending-action loads now log through the structured logger, leave the chat usable, and no longer throw away user state or stop polling.

## 🔍 Problem
Three fire-and-forget promise chains in `packages/ui/src/ai` started a request with `void …then(…)` and handled neither a rejection nor a failure result. When the AI model list, the server conversation list, or a pending-action poll failed, nothing was logged, the rejection escaped as an unhandled promise rejection, and the affected surface degraded without any signal — the three call sites the issue names.

## 🔍 Root Cause
- **`useAgentModels` (`packages/ui/src/ai/AiChat.tsx:117`)** ran `void apiCall<ModelsApiResponse>(modelsUrl).then(…)` with no `.catch()`. `apiCall` rejects on a network failure and on the `UnauthorizedError` / `ForbiddenError` that `apiFetch` throws for 401/403 (`packages/ui/src/backend/utils/api.ts:179,233`), so in all of those cases the `then` callback never ran: `loaded` stayed `false` for the component's lifetime, the model picker never rendered, and the rejection surfaced as an unhandled promise rejection with no log line. The non-throwing failure branch (`!result.ok`) was equally silent and did something worse — it marked the fetch as loaded with an empty provider list, which made the cleanup effect at `AiChat.tsx:1264` delete the user's persisted provider/model override, so a transient 500 permanently reset the user's model choice.
- **`AiChatSessionsProvider` (`packages/ui/src/ai/AiChatSessions.tsx:256`)** discarded the `null` that `listAiServerConversations` returns on failure without logging anything, making a broken conversation-list endpoint indistinguishable from "this user has no conversations".
- **`useAiPendingActionPolling` (`packages/ui/src/ai/parts/useAiPendingActionPolling.ts:188`)** leaned on `refresh()`'s internal `try/catch` for both scheduling paths and logged nothing when a poll failed. Had `refresh()` ever rejected, `scheduleNext()` would not have run and polling for that pending mutation approval would have stopped for good.

## What Changed
- **`packages/ui/src/ai/AiChat.tsx`** — `useAgentModels` now handles both failure paths: it logs `Failed to load AI agent models` through the module's existing `createLogger('ui')` child logger, exposes a new `failed` flag, marks the fetch settled so the hook leaves its indeterminate loading state, and ignores a superseded response via a `cancelled` guard. The consumer skips the "clear a stale stored selection" effect while `failed` is set, so an unreachable or erroring models endpoint no longer deletes the user's persisted model override; a successful response still prunes selections the agent no longer offers.
- **`packages/ui/src/ai/AiChatSessions.tsx`** — the server-conversation load logs a warning when the store reports failure (`null`) and an error when the promise rejects. Either way the locally persisted sessions are kept, which is the behavior the surrounding code already documents as preferable to empty state.
- **`packages/ui/src/ai/parts/useAiPendingActionPolling.ts`** — a failed fetch is logged where it is observed (`refresh`'s catch, which already set the UI error state), and both scheduling paths (mount and interval tick) reach `scheduleNext()` even if the fetch rejects, so one failure can no longer kill the polling loop.

Two scope notes for the reviewer:

- The issue estimates "50+ locations across the UI package". The actual count of `void …then(…)` sites in `packages/ui/src` is 11, of which these 3 are the AI-chat ones the issue documents. The remaining 8 are markdown plugin/component lazy-loaders (`useMarkdownRemarkPlugins`, `MarkdownContent`, `NotesSection`, `InlineEditors`, `CustomDataSection`) and the `confirmUnsavedChanges()` dialog promises in `CrudForm` — a different subsystem with different failure semantics, left for a follow-up rather than folded into this fix.
- The issue suggests a shared `useSafeAsync` hook. It is deliberately not introduced: the three call sites need materially different recovery (keep the user's stored override / keep the local session list / keep polling), so a common wrapper would add indirection without removing duplication.

## 🧪 Tests
- `yarn workspace @open-mercato/ui test src/ai` — 24 suites, 161 tests passed, including the five new cases below.
- Each new case was verified to fail without its production change (the source file was stashed and the suite re-run): 2 failures in `AiChat.test.tsx` without the `AiChat.tsx` change, 3 failures across the other two suites without the `AiChatSessions.tsx` / `useAiPendingActionPolling.ts` changes.
- New cases:
  - `AiChat.test.tsx` — *logs and keeps the stored model picker value when the models endpoint errors*: a 500 response logs `Failed to load AI agent models` with the status and leaves the persisted `om-ai-model-picker:*` entry intact.
  - `AiChat.test.tsx` — *logs and keeps the stored model picker value when the models request rejects*: a rejected `apiCall` is logged with the error, the composer stays mounted, and the persisted override survives.
  - `AiChatSessions.test.tsx` — *warns when the server conversation list is unavailable*: the `null` result path emits the warning.
  - `AiChatSessions.test.tsx` — *logs and keeps the locally persisted sessions when the server list rejects*: the rejection is logged and the locally persisted session is still listed.
  - `useAiPendingActionPolling.test.tsx` — *logs a failed fetch and keeps polling until it recovers*: the first fetch rejects (logged, error state set), and the next interval tick still fires and delivers the action.
- Full configured gate: `yarn build:packages` ✅, `yarn generate` ✅, `yarn build:packages` ✅, `yarn i18n:check-usage` ✅, `yarn typecheck` ✅, `yarn build:app` ✅.
- Two gate commands fail for reasons that pre-date this branch and are unrelated to it — both reproduced on a clean `origin/develop` checkout:
  - `yarn i18n:check-sync` — `attachments/i18n/ko.json` is missing `quotaRecoveryUnsupported`, `quotaUnavailable`, and `storagePathExists`, added to `en.json` by e7ec10937 (#4076) without the Korean locale. This PR touches no locale file.
  - `yarn test` — `packages/ui/src/utils/__tests__/format.test.ts` › *formatCurrency formats a numeric value with an ISO currency code* expects `1,234.5` but the run host's default locale renders `1234,50 USD`. Environment-dependent and identical with this branch's changes stashed. Everything else is green (`@open-mercato/ui`: 218 of 219 suites pass).

## 💥 Breaking Changes
- None. `useAgentModels` is module-private, so its added `failed` field is not part of any exported contract, and no public API, route, event ID, storage shape, or component prop changed. The only behavior change visible to a user is that a failed model-list load now preserves their stored model override instead of clearing it.


