### PR TITLE
fix(checkout): expose completionCount so TC-CHKT-043 can actually assert it

### DIFF
--- a/packages/checkout/src/modules/checkout/__integration__/TC-CHKT-043-concurrent-status-update.spec.ts
+++ b/packages/checkout/src/modules/checkout/__integration__/TC-CHKT-043-concurrent-status-update.spec.ts
@@ -96,8 +96,10 @@ test.describe('TC-CHKT-043 (concurrency): Two-contender race — only one update
       // 2. completionCount must be exactly 1 — the terminal state must have
       //    been applied exactly once, not zero or twice.
       const updatedLinkResponse = await apiRequest(request, 'GET', `/api/checkout/links/${encodeURIComponent(link.id)}`, { token })
-      const updatedLinkBody = await readJsonSafe<{ link?: { completionCount?: number } }>(updatedLinkResponse)
-      expect(updatedLinkBody?.link?.completionCount).toBe(1)
+      // The detail route spreads the serialized link at the top level; there is
+      // no `link` wrapper. Reading one made this assertion compare undefined to 1.
+      const updatedLinkBody = await readJsonSafe<{ completionCount?: number }>(updatedLinkResponse)
+      expect(updatedLinkBody?.completionCount).toBe(1)
 
       // 3. The stored transaction must have a gatewayTransactionId from the webhook.
       const storedTransaction = await readCheckoutTransaction(request, token!, transactionId)

--- a/packages/checkout/src/modules/checkout/commands/links.ts
+++ b/packages/checkout/src/modules/checkout/commands/links.ts
@@ -520,5 +520,9 @@ registerCommand(updateLinkCommand)
 registerCommand(deleteLinkCommand)
 
 export function serializeLinkRecord(record: CheckoutLink) {
-  return serializeTemplateOrLink(record)
+  // completionCount is link-only state (templates have no completions), so it is
+  // added here rather than in the shared template/link serializer. It is the
+  // observable proof that a terminal transaction was applied exactly once, which
+  // TC-CHKT-043 asserts and could not previously read from any API.
+  return { ...serializeTemplateOrLink(record), completionCount: record.completionCount ?? 0 }
 }


### PR DESCRIPTION
Fixes the `ephemeral-integration` failure on `develop` — the second of the two jobs failing in run [30928965307](https://github.com/open-mercato/open-mercato/actions/runs/30928965307).

## It was not a concurrency flake

That is what it looked like — a two-contender race test failing in CI. The assertion detail says otherwise:

```
expect(received).toBe(expected)
Expected: 1
Received: undefined
```

`undefined`, not `0` or `2`. A lost or doubled increment would produce a number. And it failed **identically on retry #1**, so it was deterministic, not timing-dependent.

## Root cause: two independent mistakes that cancelled into a plausible-looking failure

1. The test read `body.link.completionCount`, but `GET /api/checkout/links/{id}` **spreads the serialized link at the top level** — there is no `link` wrapper.
2. `serializeTemplateOrLink` **never emitted `completionCount` at all**, so even the correct property path would have read `undefined`.

## The part worth flagging

This means the invariant the test exists for — *the terminal state is applied exactly once, not zero or twice* — **was never actually being verified**. It asserted `undefined === 1` and would have failed for any concurrency outcome whatsoever, correct or not.

That matters because this test was the DB-backed proof requested during #4814's review, on a money path. The CAS itself is still covered by unit tests, but the single-winner guarantee was not being checked end to end as believed.

## Fix

- `serializeLinkRecord` now emits `completionCount`. Added there rather than in the shared template/link serializer, because completions are link-only state and templates have no meaningful value for it.
- The test reads the top-level property.

Fixing only the property path would have left the assertion reading a field the API does not return, so both sides were necessary.

## Validation

`yarn workspace @open-mercato/checkout test` — 23 suites, 140 tests, all passing. `yarn build:packages`, `yarn generate`, `yarn typecheck` (all workspaces) pass.

The integration test itself needs the ephemeral environment, so its real verification is this PR's own `ephemeral-integration` run.

## Additive API change

`completionCount` is a new field on the checkout-link detail and list responses. Additive only — no field removed, renamed or retyped.
