### PR TITLE
refactor(storage_s3): localize the remaining route error responses (#4830)

### DIFF
--- a/.ai/runs/2026-08-05-storage-s3-route-i18n.md
+++ b/.ai/runs/2026-08-05-storage-s3-route-i18n.md
@@ -1,0 +1,113 @@
+# Execution plan — localize the remaining storage_s3 route error responses
+
+Closes #4830. Consolidates #4997 (closed) into this PR.
+
+## Goal
+
+Every user-facing error the `storage_s3` routes return goes through `t()` instead of a hardcoded
+English literal, and the package carries its own regression guard so the next rewrite of these paths
+fails in the package that owns them.
+
+## Context
+
+#4887 (issue #4830) localized the `storage_s3` route errors. #4076 (`e7ec10937`, *make storage quota
+admission atomic*) then rewrote the quota-admission path in both POST routes and added
+`api/put/storage-providers/s3/signed-upload/[token].ts`. The rewrite kept the
+`const { t } = await resolveTranslations()` binding both POST files already held but stopped calling
+it, and the new PUT route never had translation plumbing at all. So this is a regression, not a
+missing feature — which is why the guards below matter more than the string edits.
+
+The same shape has now landed three times: #4926, #4995 and #5000.
+
+### What changed underneath this branch
+
+**#5001 (`61001cf9a`, merged 2026-08-05T09:50Z) landed first** and localized the three quota
+responses in `upload.ts` (`quota_exceeded`, `quota_target_exists`, the accounting-unavailable 500)
+plus the legacy non-atomic path. `develop`'s `test` job is green again, so the "unblock a red base
+branch" framing this branch was cut with is **no longer true** — that half of the work is delivered.
+
+#5001 named its keys `storage_s3.errors.quotaTargetExists` and `storage_s3.errors.quotaUnavailable`.
+This branch had named the same message `quotaAccountingUnavailable`. The rebase adopts **develop's**
+name rather than renaming a merged surface, because resolving the conflict hunks by keeping the branch
+side leaves both names alive — five keys for three messages, two pairs with byte-identical English
+values — and neither checker flags that: `i18n:check-sync` sees the same key set in all five locales,
+`i18n:check-usage` downgrades unused keys to an advisory warning and exits `0`. On #4997's narrower
+diff `en.json` auto-merged outright, so the duplicate pair would not even have surfaced as a conflict
+to think about; on this diff all five locale files conflict, which makes the trap visible but no less
+real.
+
+## Scope
+
+Post-rebase, the remaining work is:
+
+- `api/post/storage-providers/s3/signed-url.ts` — four error responses (missing quota service 500,
+  `quota_exceeded` 413, `quota_target_exists` 409, reservation-failure 500). Still fully hardcoded on
+  `develop`.
+- `api/post/storage-providers/s3/upload.ts` — the persist-failure 500. Still hardcoded on `develop`;
+  #5001 did not touch it.
+- `api/put/storage-providers/s3/signed-upload/[token].ts` — all ten responses, plus the
+  `resolveTranslations` import. Never localized. The `UploadBodyTooLargeError` branch also stops
+  echoing an internal exception message to an unauthenticated caller and returns
+  `reservedSizeExceeded` like its two sibling size checks.
+- Five genuinely new locale keys in all five locales: `persistFailed`, `readFailed`,
+  `reservedSizeExceeded`, `uploadTokenInvalid`, `uploadTokenRequired`. `quotaTargetExists` and
+  `quotaUnavailable` come from `develop` via #5001 and are reused as-is.
+- `[internal]` markers on the two diagnostic-only `throw` messages, per root `AGENTS.md`.
+- Package-level regression guards (see below).
+- `__tests__/i18nPackageExports.test.ts` — the export-map check covered `en/de/es/pl` but not `ko`,
+  which the repo gained in #4912.
+
+## Non-goals
+
+- The quota-admission logic itself. #4076's atomic reservation behaviour is untouched; only the
+  strings it returns change.
+- The `storage_s3` health-check strings and integration-credential field labels — integration-config
+  metadata, not route error responses, and outside #4830's acceptance criteria.
+- `packages/core/src/modules/attachments/api/route.ts:519`, which has the identical hardcoded
+  `Failed to persist attachment.` from the same #4076-era work. Same regression class, different
+  module — worth a follow-up issue, not an absorption here.
+
+## Regression guards
+
+Two layers, both inside `packages/storage-s3` so an author rewriting this package gets a local signal:
+
+1. **Static, in `__tests__/routeErrorLocalization.test.ts`** — walks every `.ts` file under `api/`
+   recursively, so it also covers routes that do not exist yet: no route returns a hardcoded
+   user-facing `error: '…'` literal; every `storage_s3.errors.*` key a route uses exists in all five
+   locales; every inline English fallback is byte-identical to `en.json`; every thrown `Error`
+   message carries `[internal]`.
+2. **Behavioral, in `__tests__/s3Routes.test.ts` and `__tests__/upload.test.ts`** — carried over from
+   #4997 and extended from one branch to all of them. The package suite mocks `resolveTranslations`
+   as ``t: (key) => `translated:${key}` ``, so a localized body reads `translated:<key>` while a
+   hardcoded string does not. Covered: all four `signed-url.ts` quota branches, and `upload.ts`'s
+   persist-failure plus its three quota branches (the ones #5001 localized, which had no
+   package-level guard either).
+
+## Progress
+
+- [x] Read the #4997 review in full and carry its findings over
+- [x] Rebase onto current `develop` (`d1ce9999e`, post-#5001)
+- [x] Resolve `i18n/{de,es,ko,pl}.json` by taking `develop`'s values and adding only new keys — #5001
+      re-worded `quotaExceeded` in all four, and a "take ours" resolution would have reverted it
+- [x] Adopt `develop`'s key names (`quotaUnavailable`, `quotaTargetExists`); no synonym pair survives
+- [x] Verify every locale diff against `origin/develop` is additions only
+- [x] Route `signed-url.ts`, `upload.ts` persist-failure and all of `[token].ts` through `t()`
+- [x] Carry the #4997 package-level guard over and extend it to every localized response
+- [x] Rewrite this plan and the PR body — the "develop is red" premise is stale
+- [x] Full validation gate on the rebased tree
+
+## Verification
+
+CI green on the pre-#5001 head is not evidence: those runs have a merge base that no longer exists.
+The gate below was re-run locally on the rebased tree.
+
+```
+yarn build:packages
+yarn generate
+yarn build:packages
+yarn i18n:check-sync
+yarn i18n:check-usage
+yarn typecheck
+yarn test
+yarn build:app
+```

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/i18nPackageExports.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/i18nPackageExports.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs'
 const packageRequire = createRequire(__filename)
 
 describe('storage_s3 locale package exports', () => {
-  it.each(['en', 'de', 'es', 'pl'] as const)('resolves the %s locale through the package export map', (locale) => {
+  it.each(['en', 'de', 'es', 'ko', 'pl'] as const)('resolves the %s locale through the package export map', (locale) => {
     const localePath = packageRequire.resolve(`@open-mercato/storage-s3/modules/storage_s3/i18n/${locale}.json`)
     const translations = JSON.parse(readFileSync(localePath, 'utf8')) as Record<string, unknown>
 

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/routeErrorLocalization.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/routeErrorLocalization.test.ts
@@ -1,0 +1,111 @@
+/** @jest-environment node */
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    t: (key: string) => `translated:${key}`,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => ({ resolve: () => null })),
+}))
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const LOCALES = ['en', 'de', 'es', 'ko', 'pl'] as const
+
+const apiDir = path.join(__dirname, '..', 'api')
+const i18nDir = path.join(__dirname, '..', 'i18n')
+
+function routeFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) return routeFiles(full)
+    return full.endsWith('.ts') ? [full] : []
+  })
+}
+
+function localeDictionary(locale: string): Record<string, string> {
+  return JSON.parse(readFileSync(path.join(i18nDir, `${locale}.json`), 'utf8')) as Record<string, string>
+}
+
+const sources = routeFiles(apiDir).map((file) => ({
+  file: path.relative(apiDir, file),
+  source: readFileSync(file, 'utf8'),
+}))
+
+const dictionaries = Object.fromEntries(LOCALES.map((locale) => [locale, localeDictionary(locale)]))
+
+describe('storage_s3 route error localization (#4830)', () => {
+  const usages = sources.flatMap(({ file, source }) =>
+    [...source.matchAll(/t\('(storage_s3\.errors\.[a-zA-Z]+)', '([^']*)'\)/g)].map((match) => ({
+      file,
+      key: match[1],
+      fallback: match[2],
+    })),
+  )
+
+  it('uses translation keys in every route that reports an error', () => {
+    expect(usages.length).toBeGreaterThan(0)
+  })
+
+  it('ships every key the routes use in all five supported locales', () => {
+    const missing = usages.flatMap(({ key }) =>
+      LOCALES.filter((locale) => dictionaries[locale][key] === undefined).map((locale) => `${locale}:${key}`),
+    )
+    expect(missing).toEqual([])
+  })
+
+  it('keeps each inline English fallback identical to en.json', () => {
+    const drifted = usages
+      .filter(({ key, fallback }) => dictionaries.en[key] !== fallback)
+      .map(({ file, key }) => `${file}:${key}`)
+    expect(drifted).toEqual([])
+  })
+
+  it('never returns a hardcoded user-facing error string from a route response', () => {
+    // #4076 added the atomic quota-admission paths on top of an already localized
+    // module and reintroduced hardcoded English, which is how this issue came back.
+    const hardcoded = sources.flatMap(({ file, source }) =>
+      [...source.matchAll(/error: '([^']+)'/g)].map((match) => `${file}: ${match[1]}`),
+    )
+    expect(hardcoded).toEqual([])
+  })
+
+  it('marks diagnostic-only thrown errors with the [internal] opt-out marker', () => {
+    const unmarked = sources.flatMap(({ file, source }) =>
+      [...source.matchAll(/throw new \w*Error\('([^']+)'\)/g)]
+        .map((match) => match[1])
+        .filter((message) => !message.startsWith('[internal] '))
+        .map((message) => `${file}: ${message}`),
+    )
+    expect(unmarked).toEqual([])
+  })
+
+  it('returns the translated string, not the English literal, when the upload token is missing', async () => {
+    const { PUT } = await import('../api/put/storage-providers/s3/signed-upload/[token]')
+    const response = await PUT(
+      new Request('http://localhost/api/storage-providers/s3/signed-upload/', { method: 'PUT' }),
+      { params: { token: '  ' } },
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({
+      error: 'translated:storage_s3.errors.uploadTokenRequired',
+    })
+  })
+
+  it('returns the translated string when the quota service is not registered', async () => {
+    const { PUT } = await import('../api/put/storage-providers/s3/signed-upload/[token]')
+    const response = await PUT(
+      new Request('http://localhost/api/storage-providers/s3/signed-upload/tok', { method: 'PUT' }),
+      { params: { token: 'tok' } },
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'translated:storage_s3.errors.quotaUnavailable',
+    })
+  })
+})

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts
@@ -12,11 +12,24 @@ jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
 }))
 
 const mockResolveCredentials = jest.fn()
+const mockReserve = jest.fn()
+const mockReconcileStandaloneObjects = jest.fn()
+let quotaServiceRegistered = false
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(async () => ({
     resolve: (name: string) => {
       if (name === 'integrationCredentialsService') {
         return { resolve: mockResolveCredentials }
+      }
+      if (quotaServiceRegistered && name === 'attachmentQuotaService') {
+        return {
+          reserve: (...args: unknown[]) => mockReserve(...args),
+          reconcileStandaloneObjects: (...args: unknown[]) => mockReconcileStandaloneObjects(...args),
+          release: jest.fn(),
+        }
+      }
+      if (quotaServiceRegistered && name === 'storageS3QuotaRecoveryScheduler') {
+        return jest.fn()
       }
       throw new Error(`Unexpected dependency: ${name}`)
     },
@@ -26,11 +39,13 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
 const mockRead = jest.fn()
 const mockDelete = jest.fn()
 const mockGetSignedUrl = jest.fn()
+const mockListObjects = jest.fn()
 jest.mock('../lib/s3-driver', () => ({
   S3StorageDriver: jest.fn().mockImplementation(() => ({
     read: (...args: unknown[]) => mockRead(...args),
     delete: (...args: unknown[]) => mockDelete(...args),
     getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
+    listObjects: (...args: unknown[]) => mockListObjects(...args),
   })),
 }))
 
@@ -58,6 +73,11 @@ describe('storage_s3 standalone route key scope', () => {
     mockRead.mockReset()
     mockDelete.mockReset()
     mockGetSignedUrl.mockReset()
+    mockReserve.mockReset()
+    mockReconcileStandaloneObjects.mockReset()
+    mockReconcileStandaloneObjects.mockResolvedValue(undefined)
+    mockListObjects.mockResolvedValue({ files: [], truncated: false })
+    quotaServiceRegistered = false
   })
 
   it('downloads shared namespace objects for an authorized storage manager', async () => {
@@ -103,6 +123,65 @@ describe('storage_s3 standalone route key scope', () => {
       error: 'translated:storage_s3.errors.keyAccessDenied',
     })
     expect(mockGetSignedUrl).not.toHaveBeenCalled()
+  })
+
+  // Regression guards for the quota-admission responses #4076 shipped unlocalized
+  // (#4926, #4995, #5000 — the same shape three times). This suite mocks
+  // `resolveTranslations`, so a localized body reads `translated:<key>` while a
+  // hardcoded English string does not, which is what lets the guard live next to
+  // the route instead of only in the app-level consumer suite one layer up.
+  describe('signed upload URL quota-admission responses', () => {
+    const OWN_KEY = 'docs/org_org-1/tenant_tenant-1/mine.txt'
+
+    function uploadRequest(): Request {
+      return jsonRequest({ key: OWN_KEY, operation: 'upload', expiresIn: 600 })
+    }
+
+    it('localizes the missing quota service response', async () => {
+      const response = await POST(uploadRequest())
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({
+        error: 'translated:storage_s3.errors.quotaUnavailable',
+      })
+      expect(mockReserve).not.toHaveBeenCalled()
+    })
+
+    it('localizes the exceeded tenant quota response', async () => {
+      quotaServiceRegistered = true
+      mockReserve.mockRejectedValueOnce(Object.assign(new Error('quota'), { code: 'quota_exceeded' }))
+
+      const response = await POST(uploadRequest())
+
+      expect(response.status).toBe(413)
+      await expect(response.json()).resolves.toEqual({
+        error: 'translated:storage_s3.errors.quotaExceeded',
+      })
+    })
+
+    it('localizes the existing target key response', async () => {
+      quotaServiceRegistered = true
+      mockReserve.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'quota_target_exists' }))
+
+      const response = await POST(uploadRequest())
+
+      expect(response.status).toBe(409)
+      await expect(response.json()).resolves.toEqual({
+        error: 'translated:storage_s3.errors.quotaTargetExists',
+      })
+    })
+
+    it('localizes the reservation failure response', async () => {
+      quotaServiceRegistered = true
+      mockReserve.mockRejectedValueOnce(new Error('reservation backend down'))
+
+      const response = await POST(uploadRequest())
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({
+        error: 'translated:storage_s3.errors.quotaUnavailable',
+      })
+    })
   })
 
   it('localizes invalid delete payload errors', async () => {

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/upload.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/upload.test.ts
@@ -12,9 +12,21 @@ jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
 }))
 
 const mockResolveCredentials = jest.fn()
+const mockReserve = jest.fn()
+const mockReconcileStandaloneObjects = jest.fn()
+const mockRelease = jest.fn()
+let quotaServiceRegistered = false
 const mockCreateRequestContainer = jest.fn(async () => ({
   resolve: (key: string) => {
     if (key === 'integrationCredentialsService') return { resolve: mockResolveCredentials }
+    if (quotaServiceRegistered && key === 'attachmentQuotaService') {
+      return {
+        reserve: (...args: unknown[]) => mockReserve(...args),
+        reconcileStandaloneObjects: (...args: unknown[]) => mockReconcileStandaloneObjects(...args),
+        release: (...args: unknown[]) => mockRelease(...args),
+      }
+    }
+    if (quotaServiceRegistered && key === 'storageS3QuotaRecoveryScheduler') return jest.fn()
     throw new Error(`Unexpected dependency: ${key}`)
   },
 }))
@@ -43,6 +55,8 @@ describe('storage_s3 direct upload route', () => {
     mockResolveCredentials.mockResolvedValue({ bucket: 'test-bucket', region: 'eu-central-1' })
     mockListObjects.mockResolvedValue({ files: [], truncated: false })
     mockPutObject.mockResolvedValue(undefined)
+    mockReconcileStandaloneObjects.mockResolvedValue(undefined)
+    quotaServiceRegistered = false
     delete process.env.OM_ATTACHMENT_MAX_UPLOAD_MB
   })
 
@@ -89,5 +103,64 @@ describe('storage_s3 direct upload route', () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toMatchObject({ bucket: 'test-bucket', size: 4 })
     expect(mockPutObject).toHaveBeenCalledTimes(1)
+  })
+
+  // Regression guards for the quota-admission responses #4076 shipped unlocalized
+  // (#4926, #4995, #5000). The suite mocks `resolveTranslations`, so a localized
+  // body reads `translated:<key>` while a hardcoded English string does not.
+  describe('quota-admission error responses', () => {
+    function uploadRequest(): Request {
+      const form = new FormData()
+      form.set('file', new File([new TextEncoder().encode('safe')], 'safe.txt', { type: 'text/plain' }))
+      return new Request('http://example.test/api/storage-providers/s3/upload', { method: 'POST', body: form })
+    }
+
+    it('localizes the persist failure response', async () => {
+      mockPutObject.mockRejectedValueOnce(new Error('s3 unreachable'))
+
+      const response = await POST(uploadRequest())
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({
+        error: 'translated:storage_s3.errors.persistFailed',
+      })
+    })
+
+    it('localizes the exceeded tenant quota response', async () => {
+      quotaServiceRegistered = true
+      mockReserve.mockRejectedValueOnce(Object.assign(new Error('quota'), { code: 'quota_exceeded' }))
+
+      const response = await POST(uploadRequest())
+
+      expect(response.status).toBe(413)
+      await expect(response.json()).resolves.toEqual({
+        error: 'translated:storage_s3.errors.quotaExceeded',
+      })
+      expect(mockPutObject).not.toHaveBeenCalled()
+    })
+
+    it('localizes the existing target key response', async () => {
+      quotaServiceRegistered = true
+      mockReserve.mockRejectedValueOnce(Object.assign(new Error('exists'), { code: 'quota_target_exists' }))
+
+      const response = await POST(uploadRequest())
+
+      expect(response.status).toBe(409)
+      await expect(response.json()).resolves.toEqual({
+        error: 'translated:storage_s3.errors.quotaTargetExists',
+      })
+    })
+
+    it('localizes the reservation failure response', async () => {
+      quotaServiceRegistered = true
+      mockReserve.mockRejectedValueOnce(new Error('reservation backend down'))
+
+      const response = await POST(uploadRequest())
+
+      expect(response.status).toBe(500)
+      await expect(response.json()).resolves.toEqual({
+        error: 'translated:storage_s3.errors.quotaUnavailable',
+      })
+    })
   })
 })

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/signed-url.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/signed-url.ts
@@ -85,7 +85,7 @@ export async function POST(req: Request) {
       // Fail closed below when the attachments quota service is not registered.
     }
     if (!attachmentQuotaService) {
-      return NextResponse.json({ error: 'Storage quota accounting is unavailable.' }, { status: 500 })
+      return NextResponse.json({ error: t('storage_s3.errors.quotaUnavailable', 'Storage quota accounting is unavailable.') }, { status: 500 })
     }
     const compatibilityToken = randomBytes(32).toString('base64url')
     const reservedBytes = size ?? resolveAttachmentMaxBytes()
@@ -107,7 +107,7 @@ export async function POST(req: Request) {
         uploadTokenHash: createHash('sha256').update(compatibilityToken).digest('hex'),
         ttlMs: expiresIn * 1000,
       })
-      if (!recoveryScheduler) throw new Error('Storage quota recovery is unavailable.')
+      if (!recoveryScheduler) throw new Error('[internal] Storage quota recovery is unavailable.')
       await recoveryScheduler({
         reservationId: reservation.id,
         tenantId: auth.tenantId,
@@ -121,12 +121,12 @@ export async function POST(req: Request) {
       }
       const code = (error as { code?: unknown })?.code
       if (code === 'quota_exceeded') {
-        return NextResponse.json({ error: 'Attachment storage quota exceeded for this tenant.' }, { status: 413 })
+        return NextResponse.json({ error: t('storage_s3.errors.quotaExceeded', 'Attachment storage quota exceeded for this tenant.') }, { status: 413 })
       }
       if (code === 'quota_target_exists') {
-        return NextResponse.json({ error: 'The target storage key already exists.' }, { status: 409 })
+        return NextResponse.json({ error: t('storage_s3.errors.quotaTargetExists', 'The target storage key already exists.') }, { status: 409 })
       }
-      return NextResponse.json({ error: 'Storage quota accounting is unavailable.' }, { status: 500 })
+      return NextResponse.json({ error: t('storage_s3.errors.quotaUnavailable', 'Storage quota accounting is unavailable.') }, { status: 500 })
     }
   }
 

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
@@ -168,7 +168,7 @@ export async function POST(req: Request) {
         storageDriver: 's3',
         storagePath: key,
       })
-      if (!recoveryScheduler) throw new Error('Storage quota recovery is unavailable.')
+      if (!recoveryScheduler) throw new Error('[internal] Storage quota recovery is unavailable.')
       await recoveryScheduler({
         reservationId: reservation.id,
         tenantId: auth.tenantId,
@@ -211,7 +211,7 @@ export async function POST(req: Request) {
         // Retain the reservation when object absence cannot be proven.
       }
     }
-    return NextResponse.json({ error: 'Failed to persist attachment.' }, { status: 500 })
+    return NextResponse.json({ error: t('storage_s3.errors.persistFailed', 'Failed to persist attachment.') }, { status: 500 })
   }
 
   return NextResponse.json({

--- a/packages/storage-s3/src/modules/storage_s3/api/put/storage-providers/s3/signed-upload/[token].ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/put/storage-providers/s3/signed-upload/[token].ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import {
   detectAttachmentMimeType,
   hasDangerousExecutableExtension,
@@ -33,7 +34,7 @@ async function readBoundedBody(req: Request, maxBytes: number): Promise<Buffer> 
       totalBytes += value.byteLength
       if (totalBytes > maxBytes) {
         await reader.cancel()
-        throw new UploadBodyTooLargeError('Attachment exceeds the reserved upload size.')
+        throw new UploadBodyTooLargeError('[internal] Attachment exceeds the reserved upload size.')
       }
       chunks.push(Buffer.from(value))
     }
@@ -44,9 +45,10 @@ async function readBoundedBody(req: Request, maxBytes: number): Promise<Buffer> 
 }
 
 export async function PUT(req: Request, ctx: RouteContext) {
+  const { t } = await resolveTranslations()
   const params = ctx.params instanceof Promise ? await ctx.params : ctx.params
   const token = params?.token?.trim()
-  if (!token) return NextResponse.json({ error: 'Upload token is required.' }, { status: 400 })
+  if (!token) return NextResponse.json({ error: t('storage_s3.errors.uploadTokenRequired', 'Upload token is required.') }, { status: 400 })
 
   const { resolve } = await createRequestContainer()
   let quotaService: AttachmentQuotaService | null = null
@@ -55,19 +57,19 @@ export async function PUT(req: Request, ctx: RouteContext) {
   } catch {
     // Fail closed below when the attachments quota service is not registered.
   }
-  if (!quotaService) return NextResponse.json({ error: 'Storage quota accounting is unavailable.' }, { status: 500 })
+  if (!quotaService) return NextResponse.json({ error: t('storage_s3.errors.quotaUnavailable', 'Storage quota accounting is unavailable.') }, { status: 500 })
 
   const tokenHash = createHash('sha256').update(token).digest('hex')
   const reservation = await quotaService.claimPendingByUploadTokenHash(tokenHash)
   if (!reservation || reservation.source !== 'storage_s3_signed') {
-    return NextResponse.json({ error: 'Upload token is invalid or expired.' }, { status: 410 })
+    return NextResponse.json({ error: t('storage_s3.errors.uploadTokenInvalid', 'Upload token is invalid or expired.') }, { status: 410 })
   }
 
   const declaredLengthHeader = req.headers.get('content-length')
   const declaredLength = declaredLengthHeader == null ? null : Number(declaredLengthHeader)
   if (declaredLength !== null && Number.isFinite(declaredLength) && declaredLength > reservation.reservedBytes) {
     await quotaService.release(reservation.id, reservation.leaseToken).catch(() => {})
-    return NextResponse.json({ error: 'Attachment exceeds the reserved upload size.' }, { status: 413 })
+    return NextResponse.json({ error: t('storage_s3.errors.reservedSizeExceeded', 'Attachment exceeds the reserved upload size.') }, { status: 413 })
   }
   let buffer: Buffer
   try {
@@ -75,23 +77,23 @@ export async function PUT(req: Request, ctx: RouteContext) {
   } catch (error) {
     await quotaService.release(reservation.id, reservation.leaseToken).catch(() => {})
     if (error instanceof UploadBodyTooLargeError) {
-      return NextResponse.json({ error: error.message }, { status: 413 })
+      return NextResponse.json({ error: t('storage_s3.errors.reservedSizeExceeded', 'Attachment exceeds the reserved upload size.') }, { status: 413 })
     }
-    return NextResponse.json({ error: 'Failed to read attachment.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.readFailed', 'Failed to read attachment.') }, { status: 400 })
   }
   if (buffer.length > reservation.reservedBytes) {
     await quotaService.release(reservation.id, reservation.leaseToken).catch(() => {})
-    return NextResponse.json({ error: 'Attachment exceeds the reserved upload size.' }, { status: 413 })
+    return NextResponse.json({ error: t('storage_s3.errors.reservedSizeExceeded', 'Attachment exceeds the reserved upload size.') }, { status: 413 })
   }
   const fileName = path.posix.basename(reservation.storagePath)
   if (hasDangerousExecutableExtension(fileName)) {
     await quotaService.release(reservation.id, reservation.leaseToken).catch(() => {})
-    return NextResponse.json({ error: 'Executable file types are not allowed as attachments.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.dangerousExecutable', 'Executable file types are not allowed as attachments.') }, { status: 400 })
   }
   const contentType = detectAttachmentMimeType(buffer, fileName, req.headers.get('content-type'))
   if (isActiveContentAttachment(buffer, fileName, contentType)) {
     await quotaService.release(reservation.id, reservation.leaseToken).catch(() => {})
-    return NextResponse.json({ error: 'Active content uploads are not allowed.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.activeContentBlocked', 'Active content uploads are not allowed.') }, { status: 400 })
   }
 
   const credentialsService = resolve('integrationCredentialsService') as {
@@ -103,7 +105,7 @@ export async function PUT(req: Request, ctx: RouteContext) {
   })
   if (!credentials) {
     await quotaService.release(reservation.id, reservation.leaseToken).catch(() => {})
-    return NextResponse.json({ error: 'S3 integration is not configured.' }, { status: 400 })
+    return NextResponse.json({ error: t('storage_s3.errors.integrationNotConfigured', 'S3 integration is not configured.') }, { status: 400 })
   }
 
   const driver = new S3StorageDriver({
@@ -127,7 +129,7 @@ export async function PUT(req: Request, ctx: RouteContext) {
         // Retain the reservation when object absence cannot be proven.
       }
     }
-    return NextResponse.json({ error: 'Failed to persist attachment.' }, { status: 500 })
+    return NextResponse.json({ error: t('storage_s3.errors.persistFailed', 'Failed to persist attachment.') }, { status: 500 })
   }
 }
 

--- a/packages/storage-s3/src/modules/storage_s3/i18n/de.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/de.json
@@ -11,9 +11,14 @@
   "storage_s3.errors.keyRequired": "Der Abfrageparameter „key“ ist erforderlich",
   "storage_s3.errors.maxUploadSize": "Der Anhang überschreitet die maximal zulässige Upload-Größe.",
   "storage_s3.errors.multipartRequired": "multipart/form-data wurde erwartet",
+  "storage_s3.errors.persistFailed": "Der Anhang konnte nicht gespeichert werden.",
   "storage_s3.errors.prefixAccessDenied": "Zugriff verweigert: Das Präfix ist nicht auf diesen Tenant beschränkt.",
   "storage_s3.errors.quotaExceeded": "Das Speicherkontingent für Anhänge dieses Mandanten ist erschöpft.",
   "storage_s3.errors.quotaTargetExists": "Der Ziel-Speicherschlüssel existiert bereits.",
   "storage_s3.errors.quotaUnavailable": "Die Kontingentabrechnung des Speichers ist nicht verfügbar.",
-  "storage_s3.errors.unauthorized": "Nicht autorisiert"
+  "storage_s3.errors.readFailed": "Der Anhang konnte nicht gelesen werden.",
+  "storage_s3.errors.reservedSizeExceeded": "Der Anhang überschreitet die reservierte Upload-Größe.",
+  "storage_s3.errors.unauthorized": "Nicht autorisiert",
+  "storage_s3.errors.uploadTokenInvalid": "Das Upload-Token ist ungültig oder abgelaufen.",
+  "storage_s3.errors.uploadTokenRequired": "Ein Upload-Token ist erforderlich."
 }

--- a/packages/storage-s3/src/modules/storage_s3/i18n/en.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/en.json
@@ -11,9 +11,14 @@
   "storage_s3.errors.keyRequired": "key query param is required",
   "storage_s3.errors.maxUploadSize": "Attachment exceeds the maximum upload size.",
   "storage_s3.errors.multipartRequired": "Expected multipart/form-data",
+  "storage_s3.errors.persistFailed": "Failed to persist attachment.",
   "storage_s3.errors.prefixAccessDenied": "Access denied: prefix is not scoped to this tenant.",
   "storage_s3.errors.quotaExceeded": "Attachment storage quota exceeded for this tenant.",
   "storage_s3.errors.quotaTargetExists": "The target storage key already exists.",
   "storage_s3.errors.quotaUnavailable": "Storage quota accounting is unavailable.",
-  "storage_s3.errors.unauthorized": "Unauthorized"
+  "storage_s3.errors.readFailed": "Failed to read attachment.",
+  "storage_s3.errors.reservedSizeExceeded": "Attachment exceeds the reserved upload size.",
+  "storage_s3.errors.unauthorized": "Unauthorized",
+  "storage_s3.errors.uploadTokenInvalid": "Upload token is invalid or expired.",
+  "storage_s3.errors.uploadTokenRequired": "Upload token is required."
 }

--- a/packages/storage-s3/src/modules/storage_s3/i18n/es.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/es.json
@@ -11,9 +11,14 @@
   "storage_s3.errors.keyRequired": "Se requiere el parámetro de consulta key",
   "storage_s3.errors.maxUploadSize": "El archivo adjunto supera el tamaño máximo de carga permitido.",
   "storage_s3.errors.multipartRequired": "Se esperaba multipart/form-data",
+  "storage_s3.errors.persistFailed": "No se pudo guardar el archivo adjunto.",
   "storage_s3.errors.prefixAccessDenied": "Acceso denegado: el prefijo no está limitado a este tenant.",
   "storage_s3.errors.quotaExceeded": "Se superó la cuota de almacenamiento de adjuntos para este inquilino.",
   "storage_s3.errors.quotaTargetExists": "La clave de almacenamiento de destino ya existe.",
   "storage_s3.errors.quotaUnavailable": "La contabilidad de la cuota de almacenamiento no está disponible.",
-  "storage_s3.errors.unauthorized": "No autorizado"
+  "storage_s3.errors.readFailed": "No se pudo leer el archivo adjunto.",
+  "storage_s3.errors.reservedSizeExceeded": "El archivo adjunto supera el tamaño de carga reservado.",
+  "storage_s3.errors.unauthorized": "No autorizado",
+  "storage_s3.errors.uploadTokenInvalid": "El token de carga no es válido o ha caducado.",
+  "storage_s3.errors.uploadTokenRequired": "Se requiere un token de carga."
 }

--- a/packages/storage-s3/src/modules/storage_s3/i18n/ko.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/ko.json
@@ -11,9 +11,14 @@
   "storage_s3.errors.keyRequired": "주요 쿼리 매개변수가 필요합니다.",
   "storage_s3.errors.maxUploadSize": "첨부파일이 최대 업로드 크기를 초과합니다.",
   "storage_s3.errors.multipartRequired": "예상되는 멀티파트/양식 데이터",
+  "storage_s3.errors.persistFailed": "첨부파일을 저장하지 못했습니다.",
   "storage_s3.errors.prefixAccessDenied": "액세스 거부됨: 접두사의 범위가 이 테넌트로 지정되지 않았습니다.",
   "storage_s3.errors.quotaExceeded": "이 테넌트의 첨부 파일 저장 용량 한도를 초과했습니다.",
   "storage_s3.errors.quotaTargetExists": "대상 저장 키가 이미 존재합니다.",
   "storage_s3.errors.quotaUnavailable": "저장 용량 정산을 사용할 수 없습니다.",
-  "storage_s3.errors.unauthorized": "승인되지 않은"
+  "storage_s3.errors.readFailed": "첨부파일을 읽지 못했습니다.",
+  "storage_s3.errors.reservedSizeExceeded": "첨부파일이 예약된 업로드 크기를 초과합니다.",
+  "storage_s3.errors.unauthorized": "승인되지 않은",
+  "storage_s3.errors.uploadTokenInvalid": "업로드 토큰이 유효하지 않거나 만료되었습니다.",
+  "storage_s3.errors.uploadTokenRequired": "업로드 토큰이 필요합니다."
 }

--- a/packages/storage-s3/src/modules/storage_s3/i18n/pl.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/pl.json
@@ -11,9 +11,14 @@
   "storage_s3.errors.keyRequired": "Wymagany jest parametr zapytania key",
   "storage_s3.errors.maxUploadSize": "Załącznik przekracza maksymalny dopuszczalny rozmiar przesyłania.",
   "storage_s3.errors.multipartRequired": "Oczekiwano multipart/form-data",
+  "storage_s3.errors.persistFailed": "Nie udało się zapisać załącznika.",
   "storage_s3.errors.prefixAccessDenied": "Odmowa dostępu: prefiks nie jest ograniczony do tego tenantu.",
   "storage_s3.errors.quotaExceeded": "Przekroczono limit przestrzeni na załączniki dla tego najemcy.",
   "storage_s3.errors.quotaTargetExists": "Docelowy klucz w magazynie już istnieje.",
   "storage_s3.errors.quotaUnavailable": "Rozliczanie limitu magazynu jest niedostępne.",
-  "storage_s3.errors.unauthorized": "Brak autoryzacji"
+  "storage_s3.errors.readFailed": "Nie udało się odczytać załącznika.",
+  "storage_s3.errors.reservedSizeExceeded": "Załącznik przekracza zarezerwowany rozmiar przesyłania.",
+  "storage_s3.errors.unauthorized": "Brak autoryzacji",
+  "storage_s3.errors.uploadTokenInvalid": "Token przesyłania jest nieprawidłowy lub wygasł.",
+  "storage_s3.errors.uploadTokenRequired": "Token przesyłania jest wymagany."
 }


### PR DESCRIPTION
Closes #4830
Tracking plan: .ai/runs/2026-08-05-storage-s3-route-i18n.md
Status: complete

Consolidates #4997, which is closed in favour of this PR.

## 🎯 Goal

Every user-facing error the `storage_s3` routes return goes through `t()` instead of a hardcoded English literal, so a Polish, German, Spanish or Korean operator no longer gets an English string when an upload is rejected — and the package carries its own regression guard, so the next rewrite of these paths fails in the package that owns them.

## 🔍 Problem

Issue #4830 was filed as a module-wide i18n gap, but the module had moved since. #4887 localized the `storage_s3` route errors and `list.ts`, `download.ts` and `delete.ts` have routed through `resolveTranslations()` ever since. What stayed hardcoded is everything added **after** that: the atomic quota-admission branches in `upload.ts` and `signed-url.ts` (#4076 / #4043) and the entire `signed-upload/[token].ts` route, which never imported `resolveTranslations` at all.

So this is a **regression, not a missing feature**: new response paths were written on top of an already localized module and reverted to English literals. The same shape has now landed three times — #4926, #4995, #5000 — which is why the guards matter more here than the string edits.

### What changed underneath this branch

The original version of this PR also claimed to unblock a red `test` job on `develop`. **That premise is stale.** #5001 (`61001cf9a`, merged 2026-08-05T09:50Z, by @zielivia) landed first and localized the three quota responses in `upload.ts` plus the legacy non-atomic path. `develop` is green, and that half of the work is delivered — credit where it is due.

What is left, and what this PR now actually delivers, is the unduplicated remainder plus the guards.

## What Changed

- **`api/post/storage-providers/s3/signed-url.ts`** — four error responses (missing quota service 500, `quota_exceeded` 413, `quota_target_exists` 409, reservation-failure 500). Still fully hardcoded on `develop`; #5001 did not touch this file.
- **`api/post/storage-providers/s3/upload.ts`** — the persist-failure 500 (`Failed to persist attachment.`), the one response in this file #5001 left behind.
- **`api/put/storage-providers/s3/signed-upload/[token].ts`** — imports `resolveTranslations`, resolves `t` once at the top of `PUT`, routes all ten error responses through it. The `UploadBodyTooLargeError` branch no longer leaks `error.message` into the response body; it returns the `reservedSizeExceeded` key like its two sibling size checks. This route is the scope #4997 deliberately excluded.
- **`i18n/{en,pl,de,es,ko}.json`** — five new keys in all five locales: `persistFailed`, `readFailed`, `reservedSizeExceeded`, `uploadTokenInvalid`, `uploadTokenRequired`. **`quotaTargetExists` and `quotaUnavailable` are reused from `develop` as #5001 named them** — see below.
- **Diagnostic-only throws** carry the `[internal]` marker root `AGENTS.md` requires, so `yarn i18n:check-hardcoded` treats them as deliberately opted out.
- **`__tests__/i18nPackageExports.test.ts`** — the export-map check covered `en/de/es/pl` but not `ko`, which the repo gained in #4912.

HTTP statuses and the `{ error: string }` response shape are untouched throughout — this is a presentation-layer change only.

### Key-name reconciliation (the part the gate does not catch)

This branch and #5001 named the same message differently: `quotaAccountingUnavailable` here, `quotaUnavailable` on `develop`. The hazard @pkarw flagged on #4997 applies here too — resolving each conflict hunk by keeping the branch side produces a file where *both* names survive, which is five keys for three messages with two byte-identical English pairs, and **nothing in the gate stops it**: `i18n:check-sync` sees the same key set in all five locales and passes, `i18n:check-usage` downgrades unused keys to an advisory warning and exits `0`.

(On #4997's narrower diff `en.json` auto-merged outright, so the duplicate pair would not even have surfaced as a conflict to think about. On this branch's diff all five locale files conflict — which makes the trap more visible, not less real.)

The rebase therefore **adopts `develop`'s names** rather than renaming a merged surface. Verified: `yarn i18n:check-usage` reports zero unused `storage_s3.errors.*` keys, and each locale carries 22 keys against the 22 distinct keys the routes reference.

The four conflicted locale files were resolved by taking `develop`'s side and adding only the genuinely new keys on top — #5001 also **re-worded** `quotaExceeded` in `de`, `es`, `ko` and `pl` (`pl.json`: "…limit miejsca na załączniki dla tego tenantu." → "…limit przestrzeni na załączniki dla tego najemcy."), and a "take ours" resolution would have silently reverted four translations that shipped hours earlier. Each resolved locale was diffed against `origin/develop` to confirm the only changes are additions.

## 🧪 Tests

Two layers of guard, both inside `packages/storage-s3` so an author rewriting this package gets a local signal:

- **`__tests__/routeErrorLocalization.test.ts` (new, static)** — walks every `.ts` file under `api/` recursively, so it extends to routes that do not exist yet: no route returns a hardcoded user-facing `error: '…'` literal; every `storage_s3.errors.*` key a route uses exists in all five locales; every inline English fallback is byte-identical to `en.json`; every thrown `Error` carries `[internal]`. Plus two behavioral cases driving the real `PUT` handler.
- **`__tests__/s3Routes.test.ts` and `__tests__/upload.test.ts` (behavioral)** — carried over from #4997 and **extended from one branch to all of them**, per @pkarw's review. The suite mocks `resolveTranslations` as `` t: (key) => `translated:${key}` ``, so a localized body reads `translated:<key>` while a hardcoded string does not. Covered: all four `signed-url.ts` quota branches (including the reservation-failure catch, a different branch from the missing-service early return despite returning the same key), and `upload.ts`'s persist-failure plus its three quota branches — the ones #5001 localized, which had no package-level guard either.

**Verified the guards bite.** Restoring `develop`'s `upload.ts` and `signed-url.ts` under the new tests fails exactly seven cases: the four `signed-url` branches, `upload.ts`'s persist-failure, and both static guards. The three `upload.ts` quota cases keep passing, because #5001 already localized them — they are forward guards, not regression proofs.

**Full gate, local runner (no compose `app` container running), on the rebased tree.** CI green on the pre-rebase head is *not* evidence — those runs have a merge base of `c11a64ce0`, which predates #5001 and describes a tree that no longer exists.

- `yarn build:packages` ✅ · `yarn generate` ✅ (no drift) · `yarn build:packages` ✅
- `yarn i18n:check-sync` ✅ all five locales in sync · `yarn i18n:check-usage` ✅ (advisory; zero unused `storage_s3.errors.*`)
- `yarn typecheck` ✅ · `yarn lint` ✅ (0 errors) · `yarn test` ✅ · `yarn build:app` ✅
- `@open-mercato/storage-s3` — **15 suites / 128 tests green** (was 15/120 before the added cases).

## 💥 Breaking Changes

None. No route path, HTTP method, status code or response shape changed — `{ error: string }` is preserved everywhere, and each `t(key, fallback)` call keeps the previous English text as its fallback, so an untranslated deployment renders byte-identical strings. The five added locale keys are additive and no key that shipped in #5001 is renamed or removed, so cross-locale parity and any downstream override keep working.

The only behavioral difference is that `[token].ts` no longer echoes an internal exception message to an unauthenticated caller (`metadata.PUT.requireAuth = false`), which is a fail-closed improvement returning the same English text through `reservedSizeExceeded`.

## 📋 Not in this PR

`packages/core/src/modules/attachments/api/route.ts:519` returns a hardcoded `{ error: 'Failed to persist attachment.' }` while its own siblings route through `t('attachments.errors.*', …)`. Same regression class from the same #4076-era work, different module — spotted by @pat-lewczuk in review, worth a follow-up issue rather than an absorption here. The `storage_s3` health-check strings and integration-credential field labels are integration-config metadata, not route error responses, and outside #4830's acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
