### PR TITLE
fix(sales): render line description in the admin items table

### DIFF
--- a/packages/core/src/modules/sales/components/documents/ItemsSection.tsx
+++ b/packages/core/src/modules/sales/components/documents/ItemsSection.tsx
@@ -239,6 +239,10 @@ export function SalesDocumentItemsSection({
                     typeof (item.catalog_snapshot as Record<string, unknown>).name === "string"
                   ? (item.catalog_snapshot as Record<string, unknown>).name as string
                   : null;
+            const description =
+              typeof item.description === "string" && item.description.trim()
+                ? item.description
+                : null;
             const quantity = normalizeNumber(item.quantity, 0);
             const uomFields = getUomFields(item);
             const quantityUnit = canonicalizeUnitCode(uomFields.quantityUnit);
@@ -303,6 +307,7 @@ export function SalesDocumentItemsSection({
             const record: SalesLineRecord = {
               id,
               name,
+              description,
               productId:
                 typeof item.product_id === "string" ? item.product_id : null,
               productVariantId:
@@ -723,6 +728,14 @@ export function SalesDocumentItemsSection({
                           {showProductSku ? (
                             <div className="text-xs text-muted-foreground truncate">
                               {showProductSku}
+                            </div>
+                          ) : null}
+                          {item.description ? (
+                            <div
+                              className="text-xs text-muted-foreground line-clamp-2"
+                              title={item.description}
+                            >
+                              {item.description}
                             </div>
                           ) : null}
                         </div>

--- a/packages/core/src/modules/sales/components/documents/__tests__/ItemsSection.description.test.tsx
+++ b/packages/core/src/modules/sales/components/documents/__tests__/ItemsSection.description.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { SalesDocumentItemsSection } from '../ItemsSection'
+
+const mockApiCall = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: any[]) => mockApiCall(...args),
+  withScopedApiRequestHeaders: async (_headers: unknown, operation: () => Promise<unknown>) => operation(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: () => ({}),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  deleteCrud: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  normalizeCrudServerError: (err: unknown) => err,
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  LoadingMessage: () => null,
+  TabEmptyState: () => null,
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: jest.fn().mockResolvedValue(true),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useInjectionDataWidgets', () => ({
+  useInjectionDataWidgets: () => ({ widgets: [] }),
+}))
+
+jest.mock('../LineItemDialog', () => ({
+  LineItemDialog: () => null,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (_key: string, fallback?: string) => fallback ?? _key,
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeDetail: () => ({ organizationId: 'org-1', tenantId: 'tenant-1' }),
+}))
+
+jest.mock(
+  '@open-mercato/core/modules/dictionaries/components/dictionaryAppearance',
+  () => ({
+    DictionaryValue: () => null,
+    createDictionaryMap: () => ({}),
+    normalizeDictionaryEntries: () => [],
+  }),
+)
+
+function lineResponse(description: unknown) {
+  return {
+    ok: true,
+    result: {
+      items: [
+        {
+          id: '11111111-1111-1111-1111-111111111111',
+          order_id: '22222222-2222-2222-2222-222222222222',
+          name: 'Widget',
+          description,
+          quantity: 2,
+          unit_price_net: 10,
+          unit_price_gross: 12.3,
+          tax_rate: 23,
+          total_net_amount: 20,
+          total_gross_amount: 24.6,
+          currency_code: 'PLN',
+        },
+      ],
+    },
+  }
+}
+
+function renderSection() {
+  return render(
+    <SalesDocumentItemsSection
+      documentId="22222222-2222-2222-2222-222222222222"
+      kind="order"
+      currencyCode="PLN"
+    />,
+  )
+}
+
+describe('SalesDocumentItemsSection line description', () => {
+  beforeEach(() => {
+    mockApiCall.mockReset()
+  })
+
+  it('renders the line description under the product name', async () => {
+    mockApiCall.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/sales/order-lines')) return lineResponse('Cut to 120 cm, drilled')
+      return { ok: true, result: { items: [] } }
+    })
+
+    renderSection()
+
+    await waitFor(() => expect(screen.getByText('Widget')).toBeInTheDocument())
+    expect(screen.getByText('Cut to 120 cm, drilled')).toBeInTheDocument()
+  })
+
+  it('renders no sub-line when the line has no description', async () => {
+    mockApiCall.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/sales/order-lines')) return lineResponse(null)
+      return { ok: true, result: { items: [] } }
+    })
+
+    const { container } = renderSection()
+
+    await waitFor(() => expect(screen.getByText('Widget')).toBeInTheDocument())
+    expect(container.querySelector('tbody .min-w-0')?.childElementCount).toBe(1)
+  })
+
+  it('ignores a whitespace-only description', async () => {
+    mockApiCall.mockImplementation(async (url: string) => {
+      if (url.startsWith('/api/sales/order-lines')) return lineResponse('   ')
+      return { ok: true, result: { items: [] } }
+    })
+
+    const { container } = renderSection()
+
+    await waitFor(() => expect(screen.getByText('Widget')).toBeInTheDocument())
+    expect(container.querySelector('tbody .min-w-0')?.childElementCount).toBe(1)
+  })
+})

--- a/packages/core/src/modules/sales/components/documents/lineItemTypes.ts
+++ b/packages/core/src/modules/sales/components/documents/lineItemTypes.ts
@@ -3,6 +3,7 @@ import type { SalesLineUomSnapshot } from '../../lib/types'
 export type SalesLineRecord = {
   id: string
   name: string | null
+  description?: string | null
   productId: string | null
   productVariantId: string | null
   quantity: number


### PR DESCRIPTION
## Summary

The sales line `description` field renders on the **customer-facing** quote page but nowhere in the **backoffice**. The customer sees the line description; the operator doesn't.

`description` is already a first-class column on order/quote lines — it has an ORM column, the create/update validators accept it, and the line list API already projects it (`packages/core/src/modules/sales/lib/makeSalesLineRoute.ts`, `F.description` in `list.fields`). So the value is already sitting in the payload `ItemsSection` receives; it was simply never read.

Core renders it here, and only here:

```tsx
// packages/core/src/modules/sales/frontend/quote/[token]/page.tsx:160
{line.description ? <p className="text-sm text-muted-foreground">{line.description}</p> : null}
```

This was found while integrating an ERP (Subiekt GT) into Open Mercato, at a scale of ~1.42M orders / ~4.14M order lines. Imported lines routinely carry per-line descriptions ("cut to 120 cm", "drilled") that the warehouse needs off the document — and the admin simply never showed them.

The fix applies the same muted sub-line treatment in the admin items table, in the product cell right where `variantLabel` / `productSku` already render. It is **self-hiding**: it renders only when the field is set, so no existing tenant's screen changes.

## Changes

- `components/documents/lineItemTypes.ts` — `SalesLineRecord` gains an **optional** `description?: string | null`. Optional rather than required, so the exported type stays additive per `BACKWARD_COMPATIBILITY.md` and no existing constructor of the type breaks.
- `components/documents/ItemsSection.tsx` — map `item.description` off the list response, treating blank / whitespace-only values as absent; render it in the product cell as a muted sub-line (`text-xs text-muted-foreground`), clamped to two lines with the full text in `title=` so long ERP descriptions don't distort row height.
- `components/documents/__tests__/ItemsSection.description.test.tsx` — new.

No new locale keys (the field is tenant data, not chrome), no generator inputs touched, no DB schema change, no API surface change, and no `BACKWARD_COMPATIBILITY.md` contract surface modified.

Editing `description` from `LineItemDialog` is deliberately **out of scope** — that pulls in recalculation interplay and dialog layout decisions, and isn't needed to unblock read-side visibility for imported orders.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->
N/A — 14-line display-only fix that surfaces an existing, already-projected field. Happy to write one if maintainers would rather this go through the spec flow.

## Testing

New unit suite `packages/core/src/modules/sales/components/documents/__tests__/ItemsSection.description.test.tsx`:

- renders the description sub-line under the product name;
- renders no extra sub-line when `description` is `null`;
- ignores a whitespace-only description.

I verified the first case **fails** when the render block is removed, so it's a real guard rather than a tautology.

Commands run locally (local runner, no compose `app` container):

| Command | Result |
|---|---|
| `yarn build:packages` | pass (22/22) |
| `yarn generate` | pass |
| `yarn i18n:check-sync` | pass — all translation files in sync |
| `yarn i18n:check-usage` | advisory only (3624 pre-existing unused keys, unchanged) |
| `yarn typecheck` | pass (22/22, clean) |
| `yarn test` | 1 pre-existing failure, unrelated — see below |
| `yarn workspace @open-mercato/core test src/modules/sales` | pass — 77 suites / 529 tests |

**Pre-existing failure, not introduced here:** `apps/mercato/src/__tests__/storage-s3-routes.test.ts` → `rejects uploads that exceed tenant quota` (asserts `translateMock` was called with `storage_s3.errors.quotaExceeded`; 0 calls). I reproduced it on a clean checkout of `develop` at `c11a64ce0` **without** this commit — identical failure. This branch touches only three files under `packages/core/src/modules/sales/components/documents/`.

Branch is rebased onto `develop` at `c11a64ce0`, so all of the above ran against the current base rather than an older one.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. — verified none required: no new user-facing strings, no generator inputs touched, `yarn i18n:check-sync` clean.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — documenting why: this is a display-only render of a field the line list API already projects and already covers. The visible behaviour (renders / self-hides / ignores blank) is fully covered by the new jsdom suite, and a Playwright case would need bespoke ERP-shaped line fixtures for no additional signal beyond what the unit suite asserts. Glad to add one to `.ai/qa/tests/` if maintainers prefer.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — not applicable; see the Specification section above.
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes — and for changes with no manually exercisable UI surface that leave the database structure and API surface unchanged, preserve `BACKWARD_COMPATIBILITY.md` contracts, and ship automated tests for the behavior they change — otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified` — without `triage` permission, post the evidence and ask a maintainer to apply those two labels). See `.github/QA-DEPLOYMENT.md` and `AGENTS.md` → PR Workflow for the authoritative rules.

> The three label boxes above are **unticked because I only have `read` permission on this repository** and cannot apply labels. A separate comment on this PR proposes the intended `priority-*`, `risk-*`, category and QA labels with rationale, for a maintainer to apply.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop) — `ItemsSection` already renders `TabEmptyState`; unchanged here
- [x] Loading state handled for async pages — `ItemsSection` already renders `LoadingMessage`; unchanged here
- [ ] `aria-label` on all icon-only buttons (`<IconButton>`) — N/A, this change adds no interactive elements
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements — reuses the exact markup pattern of the adjacent `variantLabel` / `productSku` sub-lines

## Linked issues

No existing upstream issue found for this (searched open issues for order/quote line description). Happy to file one if you'd rather track it that way.

Context for maintainers: this came out of a review of the order-line surface that turned up two other items, deliberately **not** bundled here — order lines defaulting to sort by random `id` (v4 UUID) instead of the already-sort-mapped `line_number`, which reshuffles the on-screen line order after every delete-and-reinsert ERP sync; and line-level discount being computed into the totals block but invisible and un-enterable on the row. The first is a small config change I can send as its own PR; the second probably wants a spec first. Say the word and I'll open either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
