### PR TITLE
fix(storage_s3): relocalize the quota-admission error responses (#4995)

### DIFF
--- a/.ai/runs/2026-08-05-storage-s3-quota-i18n.md
+++ b/.ai/runs/2026-08-05-storage-s3-quota-i18n.md
@@ -1,0 +1,75 @@
+# Execution plan — relocalize the S3 quota-admission error responses
+
+Fixes #4995.
+
+## Goal
+
+Turn the `test` job green on `develop` and stop the tenant attachment-quota errors reaching operators
+in untranslated English.
+
+## Context
+
+#4887 (issue #4830) localized every error response in the `storage_s3` routes, replacing hardcoded
+English with `t('storage_s3.errors.<key>', …)`, and `apps/mercato/src/__tests__/storage-s3-routes.test.ts`
+was extended to assert the localization.
+
+#4076 (`e7ec10937`, *make storage quota admission atomic*) then rewrote the quota-admission path in
+both POST routes. The rewrite kept the `const { t } = await resolveTranslations()` both files already
+held, but stopped calling it — every error response it emits is a hardcoded English literal again.
+
+The result: `rejects uploads that exceed tenant quota` fails on a pristine `develop`, so every open PR
+inherits a red `test` job regardless of its own diff, and a genuinely broken suite becomes
+indistinguishable from inherited breakage.
+
+`git log -L` attributes all of it to `e7ec10937`:
+
+- `upload.ts` lines 185, 188, 190, 195, 226
+- `signed-url.ts` lines 88, 124, 127, 129
+- `signed-upload/[token].ts` — the whole file, new in that commit, 11 strings
+
+## Scope
+
+The eight strings in the two POST routes, plus the three locale keys they need. Both files already
+resolve `t`, so this is a mechanical change with no new plumbing.
+
+## Non-goals
+
+- `api/put/storage-providers/s3/signed-upload/[token].ts`. New in #4076, declared `requireAuth: false`
+  (it authenticates by signed token), and carrying no translation plumbing. Adding locale resolution to
+  an unauthenticated route is a behavioural change that should be reviewed on its own, not folded into
+  a CI-unblocking fix.
+- The quota-admission logic itself. #4076's atomic reservation behaviour is untouched; only the strings
+  it returns change.
+
+## Progress
+
+- [x] Confirm the failure reproduces on the current `develop` (`c11a64ce0`)
+- [x] Attribute every hardcoded string with `git log -L`
+- [x] Route the four `upload.ts` responses through `t()`
+- [x] Route the four `signed-url.ts` responses through `t()`
+- [x] Add `keyAlreadyExists`, `quotaAccountingUnavailable`, `persistFailed` to en/pl/es/de/ko
+      (`quotaExceeded` already existed — #4076 orphaned it)
+- [x] Add a package-level regression test so the guard sits next to the route
+- [x] Validation gate
+
+## Why the guard moved
+
+This is the second time this shape has landed — #4926 was the same class of breakage from #4887. The
+package's own suite mocks `resolveTranslations`, so a route losing its localization stays green there
+and only the app-level consumer suite notices, one layer away from the code being changed. The new test
+in `__tests__/s3Routes.test.ts` asserts the `translated:<key>` marker on the quota-accounting branch, so
+the next rewrite of this path fails in the package that owns it.
+
+## Verification
+
+```
+yarn build:packages
+yarn generate
+yarn build:packages
+yarn i18n:check-sync
+yarn i18n:check-usage
+yarn typecheck
+yarn build:app
+yarn workspace @open-mercato/storage-s3 test   # 14 suites / 113 tests
+yarn workspace @open-mercato/app test          # the previously red suite
+```

--- a/packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts
+++ b/packages/storage-s3/src/modules/storage_s3/__tests__/s3Routes.test.ts
@@ -105,6 +105,23 @@ describe('storage_s3 standalone route key scope', () => {
     expect(mockGetSignedUrl).not.toHaveBeenCalled()
   })
 
+  // Regression guard for the quota-admission responses #4076 shipped unlocalized
+  // (#4995). This suite mocks `resolveTranslations`, so a localized body reads
+  // `translated:<key>` while a hardcoded English string does not — which is what
+  // lets the guard live next to the route instead of only in the app-level suite.
+  it('localizes the quota-accounting failure on signed upload URLs', async () => {
+    const response = await POST(jsonRequest({
+      key: 'docs/org_org-1/tenant_tenant-1/mine.txt',
+      operation: 'upload',
+      expiresIn: 600,
+    }))
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'translated:storage_s3.errors.quotaAccountingUnavailable',
+    })
+  })
+
   it('localizes invalid delete payload errors', async () => {
     const response = await DELETE(new Request('http://example.test/api/storage-providers/s3/delete', {
       method: 'DELETE',

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/signed-url.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/signed-url.ts
@@ -85,7 +85,10 @@ export async function POST(req: Request) {
       // Fail closed below when the attachments quota service is not registered.
     }
     if (!attachmentQuotaService) {
-      return NextResponse.json({ error: 'Storage quota accounting is unavailable.' }, { status: 500 })
+      return NextResponse.json(
+        { error: t('storage_s3.errors.quotaAccountingUnavailable', 'Storage quota accounting is unavailable.') },
+        { status: 500 },
+      )
     }
     const compatibilityToken = randomBytes(32).toString('base64url')
     const reservedBytes = size ?? resolveAttachmentMaxBytes()
@@ -121,12 +124,21 @@ export async function POST(req: Request) {
       }
       const code = (error as { code?: unknown })?.code
       if (code === 'quota_exceeded') {
-        return NextResponse.json({ error: 'Attachment storage quota exceeded for this tenant.' }, { status: 413 })
+        return NextResponse.json(
+          { error: t('storage_s3.errors.quotaExceeded', 'Attachment storage quota exceeded for this tenant.') },
+          { status: 413 },
+        )
       }
       if (code === 'quota_target_exists') {
-        return NextResponse.json({ error: 'The target storage key already exists.' }, { status: 409 })
+        return NextResponse.json(
+          { error: t('storage_s3.errors.keyAlreadyExists', 'The target storage key already exists.') },
+          { status: 409 },
+        )
       }
-      return NextResponse.json({ error: 'Storage quota accounting is unavailable.' }, { status: 500 })
+      return NextResponse.json(
+        { error: t('storage_s3.errors.quotaAccountingUnavailable', 'Storage quota accounting is unavailable.') },
+        { status: 500 },
+      )
     }
   }
 

--- a/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
+++ b/packages/storage-s3/src/modules/storage_s3/api/post/storage-providers/s3/upload.ts
@@ -182,17 +182,29 @@ export async function POST(req: Request) {
       }
       const code = (error as { code?: unknown })?.code
       if (code === 'quota_exceeded') {
-        return NextResponse.json({ error: 'Attachment storage quota exceeded for this tenant.' }, { status: 413 })
+        return NextResponse.json(
+          { error: t('storage_s3.errors.quotaExceeded', 'Attachment storage quota exceeded for this tenant.') },
+          { status: 413 },
+        )
       }
       if (code === 'quota_target_exists') {
-        return NextResponse.json({ error: 'The target storage key already exists.' }, { status: 409 })
+        return NextResponse.json(
+          { error: t('storage_s3.errors.keyAlreadyExists', 'The target storage key already exists.') },
+          { status: 409 },
+        )
       }
-      return NextResponse.json({ error: 'Storage quota accounting is unavailable.' }, { status: 500 })
+      return NextResponse.json(
+        { error: t('storage_s3.errors.quotaAccountingUnavailable', 'Storage quota accounting is unavailable.') },
+        { status: 500 },
+      )
     }
   } else {
     const tenantUsageBytes = await readTenantStorageUsageBytes(driver, auth.tenantId, auth.orgId)
     if (willExceedAttachmentTenantQuota(tenantUsageBytes, buffer.length)) {
-      return NextResponse.json({ error: 'Attachment storage quota exceeded for this tenant.' }, { status: 413 })
+      return NextResponse.json(
+        { error: t('storage_s3.errors.quotaExceeded', 'Attachment storage quota exceeded for this tenant.') },
+        { status: 413 },
+      )
     }
   }
 
@@ -211,7 +223,10 @@ export async function POST(req: Request) {
         // Retain the reservation when object absence cannot be proven.
       }
     }
-    return NextResponse.json({ error: 'Failed to persist attachment.' }, { status: 500 })
+    return NextResponse.json(
+      { error: t('storage_s3.errors.persistFailed', 'Failed to persist attachment.') },
+      { status: 500 },
+    )
   }
 
   return NextResponse.json({

--- a/packages/storage-s3/src/modules/storage_s3/i18n/de.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/de.json
@@ -7,11 +7,14 @@
   "storage_s3.errors.invalidPayload": "Ungültige Anfragedaten",
   "storage_s3.errors.invalidQuery": "Ungültige Abfrageparameter",
   "storage_s3.errors.keyAccessDenied": "Zugriff verweigert: Der Schlüssel ist nicht auf diesen Tenant beschränkt.",
+  "storage_s3.errors.keyAlreadyExists": "Der Ziel-Speicherschlüssel existiert bereits.",
   "storage_s3.errors.keyOverrideAccessDenied": "Zugriff verweigert: Die Schlüsselüberschreibung ist nicht auf diesen Tenant beschränkt.",
   "storage_s3.errors.keyRequired": "Der Abfrageparameter „key“ ist erforderlich",
   "storage_s3.errors.maxUploadSize": "Der Anhang überschreitet die maximal zulässige Upload-Größe.",
   "storage_s3.errors.multipartRequired": "multipart/form-data wurde erwartet",
+  "storage_s3.errors.persistFailed": "Der Anhang konnte nicht gespeichert werden.",
   "storage_s3.errors.prefixAccessDenied": "Zugriff verweigert: Das Präfix ist nicht auf diesen Tenant beschränkt.",
+  "storage_s3.errors.quotaAccountingUnavailable": "Die Speicherkontingent-Verwaltung ist nicht verfügbar.",
   "storage_s3.errors.quotaExceeded": "Das Speicherlimit für Anhänge dieses Tenants wurde überschritten.",
   "storage_s3.errors.unauthorized": "Nicht autorisiert"
 }

--- a/packages/storage-s3/src/modules/storage_s3/i18n/en.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/en.json
@@ -7,11 +7,14 @@
   "storage_s3.errors.invalidPayload": "Invalid payload",
   "storage_s3.errors.invalidQuery": "Invalid query parameters",
   "storage_s3.errors.keyAccessDenied": "Access denied: key is not scoped to this tenant.",
+  "storage_s3.errors.keyAlreadyExists": "The target storage key already exists.",
   "storage_s3.errors.keyOverrideAccessDenied": "Access denied: key override is not scoped to this tenant.",
   "storage_s3.errors.keyRequired": "key query param is required",
   "storage_s3.errors.maxUploadSize": "Attachment exceeds the maximum upload size.",
   "storage_s3.errors.multipartRequired": "Expected multipart/form-data",
+  "storage_s3.errors.persistFailed": "Failed to persist attachment.",
   "storage_s3.errors.prefixAccessDenied": "Access denied: prefix is not scoped to this tenant.",
+  "storage_s3.errors.quotaAccountingUnavailable": "Storage quota accounting is unavailable.",
   "storage_s3.errors.quotaExceeded": "Attachment storage quota exceeded for this tenant.",
   "storage_s3.errors.unauthorized": "Unauthorized"
 }

--- a/packages/storage-s3/src/modules/storage_s3/i18n/es.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/es.json
@@ -7,11 +7,14 @@
   "storage_s3.errors.invalidPayload": "Contenido de solicitud no válido",
   "storage_s3.errors.invalidQuery": "Parámetros de consulta no válidos",
   "storage_s3.errors.keyAccessDenied": "Acceso denegado: la clave no está limitada a este tenant.",
+  "storage_s3.errors.keyAlreadyExists": "La clave de almacenamiento de destino ya existe.",
   "storage_s3.errors.keyOverrideAccessDenied": "Acceso denegado: la sobrescritura de la clave no está limitada a este tenant.",
   "storage_s3.errors.keyRequired": "Se requiere el parámetro de consulta key",
   "storage_s3.errors.maxUploadSize": "El archivo adjunto supera el tamaño máximo de carga permitido.",
   "storage_s3.errors.multipartRequired": "Se esperaba multipart/form-data",
+  "storage_s3.errors.persistFailed": "No se pudo guardar el archivo adjunto.",
   "storage_s3.errors.prefixAccessDenied": "Acceso denegado: el prefijo no está limitado a este tenant.",
+  "storage_s3.errors.quotaAccountingUnavailable": "La contabilidad de la cuota de almacenamiento no está disponible.",
   "storage_s3.errors.quotaExceeded": "Se superó la cuota de almacenamiento de adjuntos para este tenant.",
   "storage_s3.errors.unauthorized": "No autorizado"
 }

--- a/packages/storage-s3/src/modules/storage_s3/i18n/ko.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/ko.json
@@ -7,11 +7,14 @@
   "storage_s3.errors.invalidPayload": "잘못된 페이로드",
   "storage_s3.errors.invalidQuery": "잘못된 쿼리 매개변수",
   "storage_s3.errors.keyAccessDenied": "액세스 거부됨: 키 범위가 이 테넌트로 지정되지 않았습니다.",
+  "storage_s3.errors.keyAlreadyExists": "대상 스토리지 키가 이미 존재합니다.",
   "storage_s3.errors.keyOverrideAccessDenied": "액세스 거부됨: 키 재정의 범위가 이 테넌트로 지정되지 않았습니다.",
   "storage_s3.errors.keyRequired": "주요 쿼리 매개변수가 필요합니다.",
   "storage_s3.errors.maxUploadSize": "첨부파일이 최대 업로드 크기를 초과합니다.",
   "storage_s3.errors.multipartRequired": "예상되는 멀티파트/양식 데이터",
+  "storage_s3.errors.persistFailed": "첨부 파일을 저장하지 못했습니다.",
   "storage_s3.errors.prefixAccessDenied": "액세스 거부됨: 접두사의 범위가 이 테넌트로 지정되지 않았습니다.",
+  "storage_s3.errors.quotaAccountingUnavailable": "저장 공간 할당량 계산을 사용할 수 없습니다.",
   "storage_s3.errors.quotaExceeded": "이 테넌트에 대한 첨부 파일 저장소 할당량이 초과되었습니다.",
   "storage_s3.errors.unauthorized": "승인되지 않은"
 }

--- a/packages/storage-s3/src/modules/storage_s3/i18n/pl.json
+++ b/packages/storage-s3/src/modules/storage_s3/i18n/pl.json
@@ -7,11 +7,14 @@
   "storage_s3.errors.invalidPayload": "Nieprawidłowe dane żądania",
   "storage_s3.errors.invalidQuery": "Nieprawidłowe parametry zapytania",
   "storage_s3.errors.keyAccessDenied": "Odmowa dostępu: klucz nie jest ograniczony do tego tenantu.",
+  "storage_s3.errors.keyAlreadyExists": "Docelowy klucz w magazynie już istnieje.",
   "storage_s3.errors.keyOverrideAccessDenied": "Odmowa dostępu: nadpisany klucz nie jest ograniczony do tego tenantu.",
   "storage_s3.errors.keyRequired": "Wymagany jest parametr zapytania key",
   "storage_s3.errors.maxUploadSize": "Załącznik przekracza maksymalny dopuszczalny rozmiar przesyłania.",
   "storage_s3.errors.multipartRequired": "Oczekiwano multipart/form-data",
+  "storage_s3.errors.persistFailed": "Nie udało się zapisać załącznika.",
   "storage_s3.errors.prefixAccessDenied": "Odmowa dostępu: prefiks nie jest ograniczony do tego tenantu.",
+  "storage_s3.errors.quotaAccountingUnavailable": "Rozliczanie limitu miejsca jest niedostępne.",
   "storage_s3.errors.quotaExceeded": "Przekroczono limit miejsca na załączniki dla tego tenantu.",
   "storage_s3.errors.unauthorized": "Brak autoryzacji"
 }


### PR DESCRIPTION
Closes #4995
Tracking plan: .ai/runs/2026-08-05-storage-s3-quota-i18n.md
Status: complete

## 🎯 Goal

Turn the `test` job green on `develop` — it is currently red on a pristine checkout, so every open PR inherits a failing job regardless of its own diff — and stop the tenant attachment-quota errors reaching operators in untranslated English.

## 🔍 Problem

`apps/mercato/src/__tests__/storage-s3-routes.test.ts` › *rejects uploads that exceed tenant quota* fails on `develop` (`c11a64ce0`):

```
Expected: "storage_s3.errors.quotaExceeded", Any<String>
Number of calls: 0
```

The route answers `413` with the right body — it just never calls the translator. A red base job is worse than it looks: it makes a genuinely failing suite indistinguishable from inherited breakage, which is exactly how a real regression slips through review.

## 🔍 Root Cause

#4887 (issue #4830) localized every error response in the `storage_s3` routes and added the assertion above. #4076 (`e7ec10937`, *make storage quota admission atomic*) then rewrote the quota-admission path in both POST routes. The rewrite **kept** the `const { t } = await resolveTranslations()` that both files already held from #4887, but stopped using it — every error response it emits is a hardcoded English literal again.

`git log -L` attributes all of it to that one commit:

| File | Lines | What |
|---|---|---|
| `api/post/storage-providers/s3/upload.ts` | 185, 188, 190, 195, 226 | quota exceeded, target key exists, quota accounting unavailable, quota exceeded (legacy non-atomic path), persist failed |
| `api/post/storage-providers/s3/signed-url.ts` | 88, 124, 127, 129 | quota accounting unavailable ×2, quota exceeded, target key exists |
| `api/put/storage-providers/s3/signed-upload/[token].ts` | whole file | new route from the same commit, 11 strings, never localized |

Only `upload.ts:195` has an assertion behind it, which is why exactly one of the nine showed up as a red test.

## What Changed

- **`upload.ts` and `signed-url.ts`** — the eight error responses go back through `t()`, matching their neighbours in the same files (which #4887 localized and #4076 left alone). No new plumbing: both files already resolve `t` at the top of the handler. The quota-admission *logic* from #4076 is untouched; only the strings it returns change.
- **`i18n/{en,pl,es,de,ko}.json`** — three new keys: `keyAlreadyExists`, `quotaAccountingUnavailable`, `persistFailed`. `quotaExceeded` already existed in all five locales — #4076 orphaned it rather than removing it, so this PR just puts it back in use.
- **`__tests__/s3Routes.test.ts`** — a regression assertion for the quota-accounting branch.

### Why the new test lives in the package suite

This is the **second** time this shape has landed: #4926 was the same class of breakage caused by #4887. The reason it keeps happening is structural — the package's own suite mocks `resolveTranslations`, so a route losing its localization stays green there, and only the app-level consumer suite one layer up notices. An author rewriting `packages/storage-s3` has no local signal.

The suite mocks the translator as `t: (key) => \`translated:${key}\``, so a localized body reads `translated:storage_s3.errors.…` while a hardcoded string does not. The new test drives the signed-upload path with no quota service registered and asserts that marker — so the next rewrite of this path fails in the package that owns it.

## 🧪 Tests

Full gate, local runner (no compose `app` container running):

- `yarn build:packages` ✅ · `yarn generate` ✅ (no drift) · `yarn build:packages` ✅
- `yarn i18n:check-sync` ✅ all five locales in sync · `yarn i18n:check-usage` ✅ advisory only
- `yarn typecheck` ✅ · `yarn build:app` ✅
- `yarn workspace @open-mercato/storage-s3 test` — **14 suites / 113 tests green**, including the new assertion
- `yarn workspace @open-mercato/app test` — **40 suites / 186 tests green**. This is the job that matters: on `develop` it is 1 failed / 185 passed.

The new test fails without the production change (the body reads the hardcoded English string instead of the `translated:` marker) and passes with it.

## 💥 Breaking Changes

None. The response shape (`{ error: string }`) and every status code are unchanged. For an English client the text is byte-identical, because each `t()` call passes the previous literal as its fallback. Non-English tenants now get the message in their locale, which is the behaviour #4887 shipped and #4076 reverted by accident.

## 📋 Not in this PR

`api/put/storage-providers/s3/signed-upload/[token].ts` keeps its 11 hardcoded strings. That route is new in #4076, is declared `requireAuth: false` (it authenticates by signed token), and has no translation plumbing at all. Adding locale resolution to an unauthenticated route is a behavioural change that deserves its own review rather than riding along in a fix whose job is to unblock CI. It is called out in #4995 and is worth a follow-up issue.

See the Progress section in the tracking plan.
