### PR TITLE
docs(github): add Full Stack House to the certified partner registry

### DIFF
--- a/.github/certified-partners.yml
+++ b/.github/certified-partners.yml
@@ -25,6 +25,8 @@ partners:
     contributors: [adeptofvoltron, lbajsarowicz]
   - company: Freight Tech
     contributors: [fto-aubergine, karolina-fto]
+  - company: Full Stack House
+    contributors: [kamwro, maxidragon, jtomaszewski, patrykbojczuk, KubaBir, frshy]
   - company: GoNextStage
     contributors: [truongx, mat-kruk]
   - company: Itrix
@@ -34,7 +36,7 @@ partners:
   - company: Omdyo
     contributors: [zielivia, haxiorz]
   - company: 8lines
-    contributors: [jtomaszewski, RadnoK, KamilGrocholski, patrykbojczuk, KubaBir, frshy]
+    contributors: [RadnoK]
   - company: Evojam
     contributors: [marcinwadon, abankowski]
   - company: Idego


### PR DESCRIPTION
Registers **Full Stack House** as a certified partner in `.github/certified-partners.yml` with `kamwro` and `maxidragon`, and moves `jtomaszewski`, `patrykbojczuk`, `KubaBir` and `frshy` over from 8lines (which keeps `RadnoK`). Also drops `KamilGrocholski` from the registry entirely.

Registry-only change — it affects who may run `/label partner-request` via `.github/workflows/community-labels.yml`. I ran that workflow's own registry parser against the edited file: all six Full Stack House logins and `RadnoK` resolve, `KamilGrocholski` no longer does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)