### PR TITLE
fix(release): split release into prepare/publish, stop pushing to main

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,161 @@
+name: Release Prepare
+
+# Stage 1 of a release: bump versions on a branch and open a PR.
+# `main` is a protected branch, so the version commit must land through review —
+# the Release workflow then publishes whatever version main already holds.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type for the release PR'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      resume:
+        description: 'Recover a release that already published to npm (skips the "not on npm yet" and tag guards)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  prepare:
+    name: Prepare release PR
+    runs-on: ubuntu-latest
+    # Only allow release preparation from main branch
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump ${{ inputs.bump }} version
+        id: bump
+        run: |
+          VERSION=$(./scripts/bump-version.sh "${{ inputs.bump }}")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # Both guards are skipped in resume mode: recovering a release that already
+      # published means npm is deliberately ahead of git, and the bump PR is how
+      # git catches up
+      - name: Verify the target version is not published yet
+        if: ${{ !inputs.resume }}
+        run: ./scripts/check-version-unpublished.sh "${{ steps.bump.outputs.version }}"
+
+      - name: Verify the release tag does not exist
+        if: ${{ !inputs.resume }}
+        run: |
+          TAG="v${{ steps.bump.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists on origin"
+            exit 1
+          fi
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          BRANCH="release/v$VERSION"
+
+          git switch -c "$BRANCH"
+          # Only tracked manifests change here; nothing is built, so -u cannot pick up artifacts
+          git add -u
+          if git diff --cached --quiet; then
+            echo "::error::No version changes to release"
+            exit 1
+          fi
+
+          git commit -m "chore: release v$VERSION"
+          git push origin "$BRANCH"
+
+          if [ "${{ inputs.resume }}" = "true" ]; then
+            BODY="**Recovery** release preparation for **v$VERSION**."
+            BODY="$BODY"$'\n\n'"\`$VERSION\` is already published on npm — this PR brings the repository back in sync."
+            BODY="$BODY"$'\n\n'"- Bumps every public package and the root manifest to \`$VERSION\`"
+            BODY="$BODY"$'\n'"- No build or publish happens here"
+          else
+            BODY="Automated release preparation for **v$VERSION**."
+            BODY="$BODY"$'\n\n'"- Bumps every public package and the root manifest to \`$VERSION\`"
+            BODY="$BODY"$'\n'"- No build or publish happens here"
+          fi
+
+          if ./scripts/changelog-section.sh "$VERSION" > /dev/null 2>&1; then
+            BODY="$BODY"$'\n'"- \`CHANGELOG.md\` already has a \`$VERSION\` entry ✅"
+          else
+            BODY="$BODY"$'\n'"- ⚠️ \`CHANGELOG.md\` has **no \`$VERSION\` entry yet** — add one before releasing, or the Release workflow will stop at its changelog gate"
+            echo "::warning::CHANGELOG.md has no entry for $VERSION; the Release workflow will fail until one is added"
+          fi
+
+          if [ "${{ inputs.resume }}" = "true" ]; then
+            BODY="$BODY"$'\n\n'"After this PR is merged, run the **Release** workflow on \`main\` **with \`resume: true\`**. It will tag \`v$VERSION\`, skip the packages already on npm, and create the GitHub Release from the \`$VERSION\` \`CHANGELOG.md\` section."
+          else
+            BODY="$BODY"$'\n\n'"After this PR is merged, run the **Release** workflow on \`main\` to build, tag \`v$VERSION\`, publish to npm and create the GitHub Release. The release notes are built from the \`$VERSION\` \`CHANGELOG.md\` section."
+          fi
+
+          COMPARE_URL="${{ github.server_url }}/${{ github.repository }}/compare/main...$BRANCH?expand=1"
+
+          # `gh pr create` needs "Allow GitHub Actions to create and approve pull requests"
+          # (Settings → Actions → General). The branch is already pushed either way, so a
+          # blocked token degrades to a one-click compare link instead of failing the run.
+          if PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: release v$VERSION" \
+            --body "$BODY" 2>"$RUNNER_TEMP/pr-error.txt"); then
+            echo "Opened $PR_URL"
+
+            gh pr edit "$PR_URL" --add-label skip-qa --add-label priority-high --add-label risk-medium || \
+              echo "::warning::Could not apply labels to $PR_URL"
+
+            {
+              echo "### Release v$VERSION prepared"
+              echo ""
+              echo "Pull request: $PR_URL"
+              echo ""
+              echo "Merge it, then run the **Release** workflow on \`main\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat "$RUNNER_TEMP/pr-error.txt"
+            echo "::warning::Could not open the pull request automatically; branch $BRANCH is pushed and ready"
+
+            {
+              echo "### Release v$VERSION prepared — PR needs a manual click"
+              echo ""
+              echo "Branch \`$BRANCH\` is pushed. Open the pull request against \`main\`:"
+              echo ""
+              echo "**[Create the release PR]($COMPARE_URL)**"
+              echo ""
+              echo "To let this workflow open it automatically, enable"
+              echo "_Settings → Actions → General → Workflow permissions →"
+              echo "\"Allow GitHub Actions to create and approve pull requests\"_."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,20 @@
 name: Release
 
+# Stage 2 of a release: publish the version already committed on main.
+# The version bump lands through the Release Prepare workflow's PR, so this
+# workflow never pushes to the protected main branch — it only pushes a tag.
+#
+# Ordering matters: every reversible step (checks, build, tag) runs before the
+# irreversible one (npm publish), so a failure never leaves npm ahead of git.
+
 on:
   workflow_dispatch:
     inputs:
-      bump:
-        description: 'Version bump type (`existing` uses root package.json as-is)'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-          - existing
+      resume:
+        description: 'Resume a partially published release (skips the "not on npm yet" guard)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -57,79 +60,146 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Configure git
+      - name: Resolve release version
+        id: version
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          VERSION=$(jq -r '.version' package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION from $(git rev-parse --short HEAD)"
 
-      - name: Release ${{ inputs.bump }}
-        id: release
+      - name: Verify version alignment
+        run: ./scripts/check-version-alignment.sh --reference package.json
+
+      - name: Verify the version is not published yet
+        if: ${{ !inputs.resume }}
+        run: ./scripts/check-version-unpublished.sh "${{ steps.version.outputs.version }}"
+
+      - name: Extract changelog entry
+        # Gates the release: a version with no CHANGELOG.md section fails here,
+        # before anything is built, tagged or published
         run: |
-          ./scripts/release-${{ inputs.bump }}.sh 2>&1 | tee release-output.txt
+          ./scripts/changelog-section.sh "${{ steps.version.outputs.version }}" \
+            > "$RUNNER_TEMP/changelog-section.md"
+          echo "Changelog entry: $(wc -c < "$RUNNER_TEMP/changelog-section.md") bytes"
 
-          if [ "${{ inputs.bump }}" = "existing" ]; then
-            NEW_VERSION=$(jq -r '.version' package.json)
-          else
-            NEW_VERSION=$(jq -r '.version' packages/shared/package.json)
-          fi
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-
-          # Build packages list from package.json files
-          PACKAGES_JSON=$(find packages -name package.json -not -path "*/node_modules/*" -exec cat {} \; | \
-            jq -s '[.[] | select(.private != true) | {name: .name, version: .version}]')
-
-          echo "packages_json<<EOF" >> $GITHUB_OUTPUT
-          echo "$PACKAGES_JSON" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Commit version changes
+      - name: Build packages
+        # `shell: bash` adds `-o pipefail`, so a failure upstream of `tee` still fails the step
+        shell: bash
         run: |
-          if [ "${{ inputs.bump }}" = "existing" ]; then
-            echo "Existing release mode uses committed versions as-is; skipping version commit"
-            exit 0
-          fi
-
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No release changes to commit"
-            exit 0
-          fi
-
-          git commit -m "chore: release v${{ steps.release.outputs.version }}"
-          git push
+          {
+            yarn build:packages
+            yarn generate
+            yarn build:packages
+          } 2>&1 | tee "$RUNNER_TEMP/release-output.txt"
 
       - name: Create git tag
+        # Runs before publishing: a tag is cheap to delete, an npm version is not
         run: |
-          git tag "v${{ steps.release.outputs.version }}"
-          git push origin "v${{ steps.release.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin; leaving it untouched"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Publish packages to npm
+        id: release
+        shell: bash
+        run: |
+          ./scripts/publish-packages.sh 2>&1 | tee -a "$RUNNER_TEMP/release-output.txt"
+
+          PACKAGES_JSON=$(find packages -maxdepth 2 -name package.json -not -path "*/node_modules/*" -exec cat {} \; | \
+            jq -s '[.[] | select(.private != true) | {name: .name, version: .version}]')
+
+          {
+            echo "packages_json<<PACKAGES_EOF"
+            echo "$PACKAGES_JSON"
+            echo "PACKAGES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload release log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-log
+          path: ${{ runner.temp }}/release-output.txt
+          if-no-files-found: ignore
 
       - name: Create GitHub Release
         uses: actions/github-script@v8
         with:
           script: |
-            const packages = ${{ steps.release.outputs.packages_json }};
-            const version = '${{ steps.release.outputs.version }}';
+            const fs = require('fs');
+            const path = require('path');
 
-            let releaseNotes = '## Published Packages\n\n';
-            releaseNotes += '| Package | Version |\n|---------|---------|';
-            for (const pkg of packages) {
-              releaseNotes += `\n| \`${pkg.name}\` | \`${pkg.version}\` |`;
+            const packages = ${{ steps.release.outputs.packages_json }};
+            const version = '${{ steps.version.outputs.version }}';
+            const tag = `v${version}`;
+
+            // Read from disk rather than interpolating: changelog prose contains
+            // backticks, quotes and newlines that would break an inline expression
+            const changelog = fs.readFileSync(
+              path.join(process.env.RUNNER_TEMP, 'changelog-section.md'),
+              'utf8',
+            ).trim();
+
+            let packageNotes = '## Published Packages\n\n';
+            packageNotes += '| Package | Version |\n|---------|---------|';
+            for (const pkg of packages.sort((a, b) => a.name.localeCompare(b.name))) {
+              packageNotes += `\n| \`${pkg.name}\` | \`${pkg.version}\` |`;
             }
 
-            releaseNotes += '\n\n### Install\n\n```bash\n';
-            releaseNotes += 'npm install @open-mercato/shared@' + version + '\n';
-            releaseNotes += '# or\n';
-            releaseNotes += 'yarn add @open-mercato/shared@' + version + '\n';
-            releaseNotes += '```';
+            const CHANGELOG_URL = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${tag}/CHANGELOG.md`;
+            // GitHub rejects release bodies over 125,000 characters
+            const BODY_LIMIT = 125000;
+            const budget = BODY_LIMIT - packageNotes.length - 500;
+
+            let changelogSection = changelog;
+            if (changelogSection.length > budget) {
+              changelogSection = changelogSection.slice(0, budget) +
+                `\n\n_Changelog truncated — [read the full entry](${CHANGELOG_URL})._`;
+              core.warning(`Changelog entry for ${tag} exceeded the release body limit and was truncated`);
+            }
+
+            const releaseNotes = `${changelogSection}\n\n---\n\n${packageNotes}\n\n[Full changelog](${CHANGELOG_URL})`;
+
+            let existing = null;
+            try {
+              const found = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              existing = found.data;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            // Resuming a partial release refreshes the notes instead of failing
+            if (existing) {
+              await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: existing.id,
+                name: tag,
+                body: releaseNotes,
+              });
+              console.log(`Updated existing release ${tag}`);
+              return;
+            }
 
             await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `v${version}`,
-              name: `v${version}`,
+              tag_name: tag,
+              name: tag,
               body: releaseNotes,
               draft: false,
               prerelease: false
             });
 
-            console.log(`Created release v${version}`);
+            console.log(`Created release ${tag}`);

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build
 # misc
 .DS_Store
 *.pem
+/release-output.txt
 
 # Exception: Allow public CA certificates for SSL verification
 !certs/*.pem

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Guide shorthand: `<pkg>` = `packages/<pkg>/AGENTS.md` (so `core` = `packages/cor
 | **Spec & PR Automation** | |
 | Spec lifecycle (pre-implement → implement → write/update), code review, DS review | `.agents/skills/{om-spec-writing,om-code-review}/SKILL.md` + `.ai/skills/{om-pre-implement-spec,om-implement-spec,om-ds-guardian}/SKILL.md` + `.ai/specs/AGENTS.md` + `.ai/ds-rules.md` |
 | PR/issue automation (one-shot auto-PR, resumable loop variants, review/merge-buddy, post-merge sync, changelog, UI QA). **Default for one-off bug fixes / small features:** `om-auto-create-pr` | `.agents/skills/{om-auto-create-pr,om-auto-continue-pr,om-auto-create-pr-loop,om-auto-continue-pr-loop,om-auto-review-pr,om-auto-qa-pr,om-merge-buddy,om-review-prs,om-close-fixed-issues,om-auto-update-changelog,om-prepare-issue}/SKILL.md` |
+| Cutting a release (version bump PR, tag, npm publish, release notes) | [`CONTRIBUTING.md`](CONTRIBUTING.md) → Releasing |
 | **Agent harness itself** | |
 | Editing this file or a package `AGENTS.md`; the instruction budget and boundary labels | [`.ai/docs/agent-instructions.md`](.ai/docs/agent-instructions.md) + `scripts/check-agents-md-budget.mjs` (`yarn agents:check-budget`) |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,75 @@ PRs do not publish npm canary packages automatically. Maintainers can publish pk
 
 The legacy npm canary snapshot path is still available for comparison by dispatching the `NPM Snapshot Preview` workflow manually with the PR number on a trusted same-repository PR branch. That workflow publishes real npm canary packages and runs standalone app integration against the exact snapshot, so use it only when pkg.pr.new previews are not enough evidence. Both preview workflows are restricted to same-repository PR branches.
 
+## Releasing
+
+Two channels ship packages to npm:
+
+- **Snapshots** — every push to `develop` runs `Develop Snapshot Release`, publishing under the `develop` dist-tag. Fully automatic; nothing to do.
+- **Stable releases** — a maintainer-driven two-stage flow off `main`, described below.
+
+Stable releases are split across two workflows on purpose. `main` is protected, so a workflow cannot push a version bump to it directly; the bump lands through a normal PR, and the publishing workflow only ever pushes a tag.
+
+### Stage 0 — land the changelog
+
+Add the `# <version> (YYYY-MM-DD)` section to [`CHANGELOG.md`](CHANGELOG.md) and merge it to `main`. The release workflow reads its GitHub Release notes from this section and **fails without it**, so this comes first. The `om-auto-update-changelog` skill drafts the entry.
+
+### Stage 1 — `Release Prepare`
+
+Dispatch **Release Prepare** from the Actions tab with a `patch`, `minor` or `major` bump:
+
+```bash
+gh workflow run release-prepare.yml --ref main -f bump=patch
+```
+
+It bumps every public package plus the root manifest, pushes `release/v<version>`, and opens a PR against `main`. It publishes nothing. The PR body confirms whether the changelog entry exists. Review and merge it as usual.
+
+> Opening the PR automatically requires _Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"_. Without it the branch is still pushed and the job summary links straight to the compare page — one click instead of zero.
+
+### Stage 2 — `Release`
+
+With the bump on `main`, dispatch **Release**:
+
+```bash
+gh workflow run release.yml --ref main
+```
+
+The job requires approval from the `production` environment, then runs in a deliberate order — every reversible step before the irreversible one:
+
+1. **Preflight** — version alignment across packages, the version is not already on npm, and the changelog section exists. Nothing has happened yet if any of these fail.
+2. **Build** — `build:packages`, `generate`, `build:packages`.
+3. **Tag** — pushes `v<version>`. A tag is cheap to delete; an npm version is not.
+4. **Publish** — `publish-packages.sh` with npm provenance, skipping anything already published.
+5. **GitHub Release** — notes built from the changelog section plus the published-package table.
+
+### Resuming a failed release
+
+If publishing fails partway, packages are already on npm and cannot be republished — npm is ahead of git, and the repository has to catch up. Both stages take the same `resume` flag for this, which relaxes the guards that would otherwise refuse an already-published version.
+
+If the version bump never landed on `main`, run the whole flow again with `resume: true`:
+
+```bash
+gh workflow run release-prepare.yml --ref main -f bump=patch -f resume=true
+# merge the recovery PR, then
+gh workflow run release.yml --ref main -f resume=true
+```
+
+If the bump is already on `main` and only publishing failed, just the second command is needed.
+
+In resume mode, `Release Prepare` skips the "not on npm yet" and "tag does not exist" checks and marks the PR as a recovery; `Release` skips the same npm preflight, skips packages that already published, reuses the existing tag, and refreshes the release notes instead of failing.
+
+> `resume` disables the guard that prevents double-publishing. Use it only when a run died *after* npm publish — on a normal release it removes a check you want.
+
+### Local equivalents
+
+`yarn release:{patch,minor,major}` bump, build and publish from a working copy; `yarn release:existing` publishes the version already in the root `package.json`. None of them tag or push — prefer the workflows. Useful for inspection:
+
+```bash
+yarn release:bump patch                 # bump manifests only, no build or publish
+yarn release:check-unpublished 0.6.8    # is this version already on npm?
+./scripts/changelog-section.sh 0.6.8    # preview the release notes body
+```
+
 ## Helpful Resources
 
 - 📚 Documentation: [docs.openmercato.com](https://docs.openmercato.com/)

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "release:patch": "./scripts/release-patch.sh",
     "release:minor": "./scripts/release-minor.sh",
     "release:major": "./scripts/release-major.sh",
+    "release:bump": "./scripts/bump-version.sh",
+    "release:check-unpublished": "./scripts/check-version-unpublished.sh",
     "i18n:check-sync": "tsx scripts/i18n-check-sync.ts",
     "i18n:check-usage": "tsx scripts/i18n-check-usage.ts",
     "i18n:check-hardcoded": "tsx scripts/i18n-check-hardcoded.ts",

--- a/scripts/__tests__/release-workflow.test.mjs
+++ b/scripts/__tests__/release-workflow.test.mjs
@@ -3,27 +3,126 @@ import fs from 'node:fs'
 import path from 'node:path'
 import test from 'node:test'
 
-const workflowPath = path.resolve('.github/workflows/release.yml')
+const releasePath = path.resolve('.github/workflows/release.yml')
+const preparePath = path.resolve('.github/workflows/release-prepare.yml')
 
-function extractNamedRunStep(workflow, stepName) {
-  const marker = `- name: ${stepName}`
-  const start = workflow.indexOf(marker)
-  assert.notEqual(start, -1, `Expected workflow to contain step "${stepName}"`)
-
-  const nextStep = workflow.indexOf('\n      - name:', start + marker.length)
-  return workflow.slice(start, nextStep === -1 ? undefined : nextStep)
+function stepIndex(workflow, stepName) {
+  const index = workflow.indexOf(`- name: ${stepName}`)
+  assert.notEqual(index, -1, `Expected workflow to contain step "${stepName}"`)
+  return index
 }
 
-test('release existing mode skips committing version changes', () => {
-  const workflow = fs.readFileSync(workflowPath, 'utf8')
-  const commitStep = extractNamedRunStep(workflow, 'Commit version changes')
+test('release workflow never pushes to the protected main branch', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
 
-  const existingGuardIndex = commitStep.indexOf('if [ "${{ inputs.bump }}" = "existing" ]; then')
-  const gitAddIndex = commitStep.indexOf('git add -A')
+  assert.doesNotMatch(workflow, /git commit/, 'Release must not create commits on main')
+  assert.doesNotMatch(workflow, /^\s+git push\s*$/m, 'Release must not push branches')
+  assert.match(workflow, /git push origin "\$TAG"/, 'Release must push only the release tag')
+})
 
-  assert.notEqual(existingGuardIndex, -1, 'Commit step should guard existing releases')
-  assert.notEqual(gitAddIndex, -1, 'Commit step should keep staging version changes for bump releases')
-  assert.ok(existingGuardIndex < gitAddIndex, 'Existing release guard must run before staging files')
-  assert.match(commitStep, /Existing release mode uses committed versions as-is; skipping version commit/)
-  assert.match(commitStep, /exit 0/)
+test('release workflow tags before publishing to npm', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  assert.ok(
+    stepIndex(workflow, 'Create git tag') < stepIndex(workflow, 'Publish packages to npm'),
+    'Tagging is reversible and must happen before the irreversible npm publish',
+  )
+})
+
+test('release workflow guards against republishing an existing version', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  const guardIndex = stepIndex(workflow, 'Verify the version is not published yet')
+  assert.ok(
+    guardIndex < stepIndex(workflow, 'Build packages'),
+    'The npm version guard must run before any build or publish work',
+  )
+  assert.match(workflow, /check-version-unpublished\.sh/)
+})
+
+test('release workflow keeps its log out of the working tree', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  assert.doesNotMatch(
+    workflow,
+    /tee -?a? ?"?release-output\.txt/,
+    'The release log must be written outside the repository so it can never be committed',
+  )
+  assert.match(workflow, /\$RUNNER_TEMP\/release-output\.txt/)
+})
+
+test('release workflow pipes through a pipefail shell', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  for (const [, block] of workflow.matchAll(/- name: [^\n]+\n((?:\s{8}[^\n]*\n)+)/g)) {
+    if (!block.includes('| tee')) continue
+    assert.match(block, /shell: bash/, 'Steps piping into tee must opt into pipefail via `shell: bash`')
+  }
+})
+
+test('release workflow gates on a changelog entry before publishing', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  const extractIndex = stepIndex(workflow, 'Extract changelog entry')
+  assert.ok(
+    extractIndex < stepIndex(workflow, 'Build packages'),
+    'A missing changelog entry must fail before anything is built or published',
+  )
+  assert.match(workflow, /changelog-section\.sh/)
+})
+
+test('release notes embed the changelog section from disk', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  assert.match(
+    workflow,
+    /readFileSync\(\s*\n?\s*path\.join\(process\.env\.RUNNER_TEMP, 'changelog-section\.md'\)/,
+    'Changelog prose must be read from disk, never interpolated into the script',
+  )
+  assert.match(workflow, /BODY_LIMIT = 125000/, 'Release bodies must respect the GitHub size limit')
+  assert.match(workflow, /updateRelease/, 'Re-running a release should refresh notes, not fail')
+})
+
+test('release prepare workflow opens a PR instead of pushing to main', () => {
+  const workflow = fs.readFileSync(preparePath, 'utf8')
+
+  assert.match(workflow, /gh pr create/, 'Version bumps must land through a pull request')
+  assert.match(workflow, /git push origin "\$BRANCH"/, 'Prepare must push the release branch only')
+  assert.doesNotMatch(workflow, /git push origin main/)
+  assert.doesNotMatch(workflow, /git add -A/, 'Staging must stay scoped to tracked manifest changes')
+})
+
+test('release prepare targets main explicitly', () => {
+  const workflow = fs.readFileSync(preparePath, 'utf8')
+
+  assert.match(workflow, /--base main \\/, 'The PR base must be pinned to main, not the repo default')
+  assert.match(workflow, /--head "\$BRANCH"/)
+  assert.match(workflow, /compare\/main\.\.\.\$BRANCH/, 'The fallback compare link must also target main')
+})
+
+test('both release stages share the same resume escape hatch', () => {
+  const release = fs.readFileSync(releasePath, 'utf8')
+  const prepare = fs.readFileSync(preparePath, 'utf8')
+
+  for (const [name, workflow] of [['release', release], ['release-prepare', prepare]]) {
+    assert.match(workflow, /resume:\n\s+description:/, `${name} must expose a resume input`)
+    assert.match(workflow, /if: \$\{\{ !inputs\.resume \}\}/, `${name} must gate a guard on resume`)
+  }
+
+  // Recovery means npm is deliberately ahead of git, so neither the npm guard nor the
+  // tag guard should block the catch-up bump PR
+  const gatedGuards = prepare.match(/if: \$\{\{ !inputs\.resume \}\}/g) ?? []
+  assert.equal(gatedGuards.length, 2, 'Prepare must skip both the npm and tag guards when resuming')
+})
+
+test('release prepare survives a token that cannot open PRs', () => {
+  const workflow = fs.readFileSync(preparePath, 'utf8')
+
+  assert.match(workflow, /if PR_URL=\$\(gh pr create/, 'PR creation must be a conditional, not a hard failure')
+  assert.match(workflow, /GITHUB_STEP_SUMMARY/, 'Both branches must report where the release stands')
+  assert.match(
+    workflow,
+    /Allow GitHub Actions to create and approve pull requests/,
+    'The fallback must name the setting that unblocks automatic PR creation',
+  )
 })

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Bump the monorepo version across all public packages and the root manifest.
+# Does not build, publish, commit or tag — see scripts/release-*.sh for those.
+# Usage: ./scripts/bump-version.sh <patch|minor|major>
+set -euo pipefail
+
+BUMP="${1:-}"
+case "$BUMP" in
+  patch|minor|major) ;;
+  *)
+    echo "Usage: ./scripts/bump-version.sh <patch|minor|major>"
+    exit 1
+    ;;
+esac
+
+echo "==> Checking version alignment across packages..." >&2
+./scripts/check-version-alignment.sh >&2
+
+echo "==> Bumping $BUMP version..." >&2
+yarn workspaces foreach -A --no-private version "$BUMP" >&2
+
+NEW_VERSION=$(jq -r '.version' packages/shared/package.json)
+
+echo "==> Syncing root package.json to $NEW_VERSION..." >&2
+jq --arg version "$NEW_VERSION" '.version = $version' package.json > package.json.bump
+mv package.json.bump package.json
+
+echo "==> Verifying alignment against root package.json..." >&2
+./scripts/check-version-alignment.sh --reference package.json >&2
+
+echo "$NEW_VERSION"

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Print the CHANGELOG.md section for a release version, without its `# <version> (<date>)`
+# heading — the GitHub Release is already titled with the version.
+# Exits 1 when the version has no changelog entry, so a release can fail before publishing.
+# Usage: ./scripts/changelog-section.sh [version] [--changelog <path>]
+set -euo pipefail
+
+VERSION=""
+CHANGELOG="CHANGELOG.md"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --changelog) CHANGELOG="$2"; shift 2 ;;
+    --help|-h)
+      echo "Usage: ./scripts/changelog-section.sh [version] [--changelog <path>]"
+      exit 0
+      ;;
+    *)
+      if [ -n "$VERSION" ]; then
+        echo "Unexpected argument: $1" >&2
+        exit 1
+      fi
+      VERSION="$1"
+      shift
+      ;;
+  esac
+done
+
+VERSION="${VERSION:-$(jq -r '.version' package.json)}"
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "ERROR: $CHANGELOG not found" >&2
+  exit 1
+fi
+
+# `index(...) == 1` keeps the match literal, so dots in the version are not treated as regex
+SECTION=$(awk -v heading="# $VERSION (" '
+  index($0, "# ") == 1 {
+    if (found) exit
+    if (index($0, heading) == 1) { found = 1; next }
+  }
+  found { print }
+' "$CHANGELOG")
+
+# Trim leading blank lines, then the section separator and trailing blank lines
+SECTION=$(printf '%s\n' "$SECTION" | sed -e '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba')
+if [ "$(printf '%s\n' "$SECTION" | tail -n 1)" = "---" ]; then
+  SECTION=$(printf '%s\n' "$SECTION" | sed '$d')
+  SECTION=$(printf '%s\n' "$SECTION" | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba')
+fi
+
+if [ -z "$SECTION" ]; then
+  echo "ERROR: no changelog entry for version $VERSION in $CHANGELOG" >&2
+  echo "Add a '# $VERSION (YYYY-MM-DD)' section before releasing." >&2
+  exit 1
+fi
+
+printf '%s\n' "$SECTION"

--- a/scripts/check-version-unpublished.sh
+++ b/scripts/check-version-unpublished.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Fail when the release version is already on npm for any public package.
+# Publishing is irreversible, so this runs before any release side effect.
+# Usage: ./scripts/check-version-unpublished.sh [version]
+set -euo pipefail
+
+VERSION="${1:-$(jq -r '.version' package.json)}"
+
+PACKAGE_NAMES=$(find packages -maxdepth 2 -name package.json -not -path "*/node_modules/*" -print0 \
+  | xargs -0 jq -r 'select(.private != true) | .name')
+
+if [ -z "$PACKAGE_NAMES" ]; then
+  echo "ERROR: no public packages found to check"
+  exit 1
+fi
+
+ALREADY_PUBLISHED=$(echo "$PACKAGE_NAMES" | xargs -P 8 -I{} \
+  sh -c 'npm view "{}@'"$VERSION"'" version > /dev/null 2>&1 && echo "{}"' || true)
+
+if [ -n "$ALREADY_PUBLISHED" ]; then
+  echo "ERROR: version $VERSION is already published on npm for:"
+  echo "$ALREADY_PUBLISHED" | sed 's/^/  - /'
+  echo "Bump to a new version before releasing; npm versions cannot be republished."
+  echo "To resume a partially published release on purpose, re-run the workflow with resume=true."
+  exit 1
+fi
+
+echo "Version $VERSION is not published yet on any public package."

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -34,6 +34,11 @@ for pkg_dir in $PACKAGES; do
   PKG_VERSION=$(jq -r '.version' "$PKG_PATH/package.json" 2>/dev/null)
   PKG_REPOSITORY_URL=$(jq -r '.repository.url // empty' "$PKG_PATH/package.json" 2>/dev/null)
 
+  if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+    echo "  Skipping $PKG_NAME@$PKG_VERSION (already published)"
+    continue
+  fi
+
   echo "  Publishing $PKG_NAME@$PKG_VERSION..."
   cd "$PKG_PATH"
 

--- a/scripts/release-existing.sh
+++ b/scripts/release-existing.sh
@@ -15,6 +15,9 @@ echo "==> Checking version alignment across packages against root package.json..
 RELEASE_VERSION=$(jq -r '.version' package.json)
 echo "==> Releasing existing version ${RELEASE_VERSION}..."
 
+echo "==> Verifying the target version is not published yet..."
+./scripts/check-version-unpublished.sh "$RELEASE_VERSION"
+
 echo "==> Building packages..."
 yarn build:packages
 

--- a/scripts/release-major.sh
+++ b/scripts/release-major.sh
@@ -9,11 +9,11 @@ else
   echo "==> Skipping template sync in CI"
 fi
 
-echo "==> Checking version alignment across packages..."
-./scripts/check-version-alignment.sh
+echo "==> Bumping major version (packages + root manifest)..."
+./scripts/bump-version.sh major > /dev/null
 
-echo "==> Bumping major version..."
-yarn workspaces foreach -A --no-private version major
+echo "==> Verifying the target version is not published yet..."
+./scripts/check-version-unpublished.sh
 
 echo "==> Building packages..."
 yarn build:packages

--- a/scripts/release-minor.sh
+++ b/scripts/release-minor.sh
@@ -9,11 +9,11 @@ else
   echo "==> Skipping template sync in CI"
 fi
 
-echo "==> Checking version alignment across packages..."
-./scripts/check-version-alignment.sh
+echo "==> Bumping minor version (packages + root manifest)..."
+./scripts/bump-version.sh minor > /dev/null
 
-echo "==> Bumping minor version..."
-yarn workspaces foreach -A --no-private version minor
+echo "==> Verifying the target version is not published yet..."
+./scripts/check-version-unpublished.sh
 
 echo "==> Building packages..."
 yarn build:packages

--- a/scripts/release-patch.sh
+++ b/scripts/release-patch.sh
@@ -9,11 +9,11 @@ else
   echo "==> Skipping template sync in CI"
 fi
 
-echo "==> Checking version alignment across packages..."
-./scripts/check-version-alignment.sh
+echo "==> Bumping patch version (packages + root manifest)..."
+./scripts/bump-version.sh patch > /dev/null
 
-echo "==> Bumping patch version..."
-yarn workspaces foreach -A --no-private version patch
+echo "==> Verifying the target version is not published yet..."
+./scripts/check-version-unpublished.sh
 
 echo "==> Building packages..."
 yarn build:packages


### PR DESCRIPTION
## Summary

The `Release` workflow published every package to npm and *then* tried to push the version bump to `main` — a protected branch, so the push was rejected and npm was left ahead of git with no tag and no GitHub Release. This hit v0.6.6 and v0.6.7 identically (3 of the last 5 release runs failed) and required manual repair each time. The flow is now split in two: `Release Prepare` bumps versions and opens a PR, while `Release` publishes what `main` already holds and pushes only a tag. Every reversible step (preflight, build, tag) now runs before the irreversible npm publish, so a failure can never again leave npm ahead of git.

## Changes

- **`release-prepare.yml` (new)** — bumps versions, pushes `release/vX.Y.Z`, opens a PR against `main`; publishes nothing. Degrades to a one-click compare link when Actions is not permitted to create PRs.
- **`release.yml` (rewritten)** — order is now verify → changelog → build → tag → publish → GitHub Release. Never commits or pushes to `main`.
- **Release notes** — built from the matching `CHANGELOG.md` section (read from disk, not interpolated) plus the published-package table; a missing entry fails the run before anything is built.
- **`resume` input on both stages** — recovers a release that already published: skips the "not on npm yet" and tag guards, skips already-published packages, refreshes existing release notes.
- **New scripts** — `bump-version.sh` (bump-only, also syncs the root manifest, which previously drifted behind), `changelog-section.sh`, `check-version-unpublished.sh`; `publish-packages.sh` now skips already-published versions.
- **Bug fixes** — release log moved to `$RUNNER_TEMP` (it was written into the repo and swept into the commit by `git add -A`, adding ~18k lines); `shell: bash` added so `| tee` pipelines get `pipefail` instead of masking failures.
- **Docs** — new `CONTRIBUTING.md` → Releasing section documenting both stages, recovery, and local equivalents; `AGENTS.md` router row pointing at it.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (CI/release-automation fix, no module surface)

**Spec file path:**
N/A — related historical context in `.ai/runs/2026-05-07-release-existing-no-version-push.md`

## Testing

- `yarn test:scripts` — **357/357 pass**; `release-workflow.test.mjs` grew from 1 test to 11, covering no-push-to-main, tag-before-publish, the changelog gate, log-outside-tree, `pipefail`, `--base main`, the PR-creation fallback, and `resume` parity across both stages.
- `yarn agents:check-budget` — exits 0 (`AGENTS.md` at 30,526 / 30,720 bytes).
- Both workflows parsed with `js-yaml`; all shell scripts pass `bash -n`; the `Open release PR` step body extracted and syntax-checked.
- `bump-version.sh` run locally against a manifest backup: emitted `0.6.7`, synced the root manifest, produced a clean one-line diff, then restored.
- `check-version-unpublished.sh` verified both ways against the live registry — correctly flags all 21 packages at `0.6.7`, passes for `0.6.8`.
- Release body rendered end-to-end for v0.6.7: 19,254 chars, well under GitHub's 125,000 limit.

## Checklist

- [ ] This pull request targets `develop`. — **targets `main` intentionally**: this is release-pipeline repair, which `CONTRIBUTING.md` scopes to `main`, and the workflows only run from `main`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — N/A: no runtime surface; covered by the workflow regression tests above.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A per Specification section.
- [x] Priority set: `priority-high`.
- [x] Risk set: `risk-medium`.
- [x] QA routing set: `skip-qa` — no `.tsx` outside tests, nothing under `packages/ui/src/`, database structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract affected, and automated tests for the changed behaviour ship in this PR.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI changes
- [x] No arbitrary text sizes — N/A, no UI changes
- [x] Empty state handled for list/data pages — N/A, no UI changes
- [x] Loading state handled for async pages — N/A, no UI changes
- [x] `aria-label` on all icon-only buttons — N/A, no UI changes
- [x] Uses existing DS components — N/A, no UI changes

## Linked issues

None.

## Note for reviewers

`Release`'s `bump` input is removed — it now takes only `resume`, and bumping moves to `Release Prepare`. Nothing in the repo dispatches it with `bump`, but it changes the manual dispatch you may be used to.

Two repository settings are worth flipping alongside this (neither blocks the merge):
1. *Settings → Actions → General* → "Allow GitHub Actions to create and approve pull requests" is **off**, so `Release Prepare` falls back to a compare link instead of opening the PR itself.
2. The `production` environment has **no protection rules**, so the approval gate `release.yml` claims in its comments does not currently exist.
