### PR TITLE
test(catalog,customers): stabilize TC-CAT-035 and TC-CRM-085 against the UI they assert

### DIFF
--- a/packages/core/src/modules/catalog/__integration__/TC-CAT-035.spec.ts
+++ b/packages/core/src/modules/catalog/__integration__/TC-CAT-035.spec.ts
@@ -16,6 +16,7 @@ import { login } from '@open-mercato/core/modules/core/__integration__/helpers/a
  */
 test.describe('TC-CAT-035: Product SEO Helper i18n save-block', () => {
   test('blocks a short-title save with a Polish SEO helper message', async ({ page }) => {
+    test.setTimeout(120_000)
     const baseUrl = process.env.BASE_URL || 'http://localhost:3000'
 
     // Log in first (default English chrome), then pin the locale to Polish so the
@@ -28,18 +29,27 @@ test.describe('TC-CAT-035: Product SEO Helper i18n save-block', () => {
     ])
 
     await page.goto('/backend/catalog/products/create', { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('backend-chrome-ready')).toHaveAttribute('data-ready', 'true', {
+      timeout: 30_000,
+    })
 
     // A too-short title (< 10 chars) with an otherwise-valid long description, so
     // exactly one SEO issue (title) drives the localized validation.
-    await page.getByPlaceholder('np. Letnie trampki').fill('Buty')
-    await page
-      .getByPlaceholder('Opisz produkt...')
-      .fill('To jest wystarczająco długi opis produktu dla dobrego SEO i walidacji.')
+    const titleInput = page.getByPlaceholder('np. Letnie trampki')
+    const descriptionInput = page.getByPlaceholder('Opisz produkt...')
+    const titleTooShortScore = page.getByText('Za krótki', { exact: true }).first()
 
     // Wait (web-first, no arbitrary timeout) until the SEO helper has processed the
     // short title — its title score flips to "Za krótki" — before saving, so the
-    // block runs against the settled form state.
-    await expect(page.getByText('Za krótki', { exact: true }).first()).toBeVisible()
+    // block runs against the settled form state. The fills are retried inside the
+    // poll because the product form is a client component: under CI load a fill()
+    // that lands before it hydrates only writes the DOM value, which the controlled
+    // input discards on mount, leaving the helper with an empty title forever.
+    await expect(async () => {
+      await titleInput.fill('Buty')
+      await descriptionInput.fill('To jest wystarczająco długi opis produktu dla dobrego SEO i walidacji.')
+      await expect(titleTooShortScore).toBeVisible({ timeout: 3_000 })
+    }).toPass({ timeout: 45_000, intervals: [500, 1_000, 2_000] })
 
     await page.getByRole('button', { name: 'Utwórz produkt' }).first().click()
 

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-085.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-085.spec.ts
@@ -162,6 +162,10 @@ test.describe('TC-CRM-085: deals map view tab (UI)', () => {
 
       // Mobile: the located panel is height-capped (max-h-[60vh]) so its card list scrolls within a
       // bounded region instead of stacking the full set above the map; the cap is lifted at lg.
+      // Resizing the viewport resizes the Leaflet canvas, which re-centers the map and re-runs the
+      // located-deals query; while that query is in flight DealsMapView renders LoadingMessage in
+      // place of the panel, so a single evaluate() snapshot can land on the unmounted window and
+      // read 'MISSING'. Poll the read instead of sampling it once.
       const readPanelMaxHeight = () =>
         page.evaluate(() => {
           const node = Array.from(document.querySelectorAll('div')).find(
@@ -169,12 +173,17 @@ test.describe('TC-CRM-085: deals map view tab (UI)', () => {
           );
           return node ? getComputedStyle(node).maxHeight : 'MISSING';
         });
+      const POLL_PANEL = { timeout: 15_000, intervals: [250, 500, 1_000] };
       await page.setViewportSize({ width: 375, height: 812 });
-      const mobileMaxHeight = await readPanelMaxHeight();
-      expect(mobileMaxHeight, 'panel height-cap element is present').not.toBe('MISSING');
-      expect(mobileMaxHeight, 'panel is height-capped on mobile (scrollable region)').not.toBe('none');
+      await expect(async () => {
+        const mobileMaxHeight = await readPanelMaxHeight();
+        expect(mobileMaxHeight, 'panel height-cap element is present').not.toBe('MISSING');
+        expect(mobileMaxHeight, 'panel is height-capped on mobile (scrollable region)').not.toBe('none');
+      }).toPass(POLL_PANEL);
       await page.setViewportSize({ width: 1280, height: 900 });
-      expect(await readPanelMaxHeight(), 'panel height-cap is lifted at lg (lg:max-h-none)').toBe('none');
+      await expect(async () => {
+        expect(await readPanelMaxHeight(), 'panel height-cap is lifted at lg (lg:max-h-none)').toBe('none');
+      }).toPass(POLL_PANEL);
     } finally {
       await deleteEntityIfExists(request, token, DEALS_PATH, dealId);
       await deleteEntityByBody(request, token, PIPELINE_STAGES_PATH, stageId);


### PR DESCRIPTION
## Why

Opened from the `/om-auto-review-pr --autofix` pass on #4840 (the `develop` → `main` pre-release promotion). #4840's head **is** `develop`, so nothing is committed to it directly — the CI fixes land here and reach the promotion through `develop`.

Three checks were red on the `develop` matrix. One of them fixed itself while this ran; the other two are here.

| Failure | Lane | Status |
|---|---|---|
| `storage-s3-routes.test.ts` › quota i18n | `test` | ✅ already fixed on `develop` by #5001 (`61001cf9a`, 09:50Z) — nothing to do |
| `TC-CRM-085` › located panel height cap | `ephemeral-integration (8/15)` — hard fail | fixed here |
| `TC-CAT-035` › Polish SEO save-block | `Standalone App Integration Tests` — hard fail; **also flaky in `ephemeral-integration`** (passed on retry in the same run) | fixed here |

Both are test bugs, not product regressions. Neither product behaviour under test is broken and no assertion is relaxed.

## TC-CRM-085 — reading a panel that is legitimately unmounted

The spec reads the located panel's height cap with a single `page.evaluate()` immediately after `setViewportSize()`:

```ts
await page.setViewportSize({ width: 375, height: 812 });
const mobileMaxHeight = await readPanelMaxHeight();   // ← one shot
```

Resizing the viewport resizes the Leaflet canvas, which re-centers the map and re-runs the located-deals query. While that query is in flight `DealsMapView` renders `LoadingMessage` **instead of** `DealsLocationPanel` (`DealsMapView.tsx:612`), so the `max-h-[60vh]` node is genuinely absent and the read returns `'MISSING'`.

The CI artifacts show the race directly: the first attempt failed on the *mobile* read (line 174), the retry got past that one and failed on the *lg* read (line 177) — same test, different assertion, which is the signature of a timing window rather than a broken cap.

Fix: poll both reads with `toPass()`. The cap is still required present and non-`none` on mobile, and still required `none` at `lg`.

## TC-CAT-035 — filling a form that has not hydrated

The spec fills the product title straight after `goto(..., { waitUntil: 'domcontentloaded' })`. Under CI load that `fill()` can land before the create form hydrates: it writes the DOM value only, the controlled input discards it on mount, and the injected SEO helper is left with an empty title **permanently**. Its title score then stays `Brak` and never flips to `Za krótki`, so the web-first wait on line 42 cannot resolve and the test dies on its 20s timeout — exactly the observed failure (`element(s) not found`, full timeout consumed).

Fix, matching the pattern already used in `TC-AI-MERCHANDISING-008`: wait for `backend-chrome-ready`, then retry the fills inside a `toPass()` until the helper reacts. Test timeout raised to 120s to fit the retry budget.

## Still blocking #4840 (not fixed here — needs a maintainer call)

#4840 is `CONFLICTING` against `main`. `main` has **9 commits** `develop` does not, five of them PRs that never came back: **#5007, #4968, #4957, #4364, #4917**. Reconciling means back-merging `main` into `develop`, which conflicts in exactly 2 files (`packages/core/src/modules/auth/frontend/login.tsx` and `packages/core/src/modules/customers/__integration__/TC-CRM-086.spec.ts`, both from #4917).

That back-merge is deliberately **not** in this PR: it only clears #4840 if it lands as a real **merge commit** recording `main` as a parent (the way `8be6177d5` did). This repo squash-merges, and squashing the back-merge would flatten that parent away and let the same conflict re-form on the next release cut. It needs its own PR merged with "Create a merge commit", or a direct maintainer back-merge.

## Validation

Validation source: **GitHub checks** (this repo's checks-first extension) — runs `30980642508` / `30980642517` on `c11a64ce0` and `30928965307` on `e4727b568`, read via `--log`, plus the diff of `61001cf9a` for the storage-s3 lane. Locally: `tsc -p packages/core/tsconfig.json` over the two edited specs — clean (the 30 remaining errors are pre-existing `#generated` gaps in an ungenerated worktree, none in these files).

The specs themselves are Playwright integration tests; the CI matrix on this PR is the real verification.

Refs #4840

🤖 Generated with [Claude Code](https://claude.com/claude-code)