### PR TITLE
fix(workflows): accept a plain millisecond timeout from the activity editor

### DIFF
--- a/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
@@ -25,7 +25,7 @@ import {useT} from '@open-mercato/shared/lib/i18n/context'
 import {useDialogKeyHandler} from '@open-mercato/ui/hooks/useDialogKeyHandler'
 import {useConfirmDialog} from '@open-mercato/ui/backend/confirm-dialog'
 import {isFutureIsoDateString, isValidDurationString} from '../data/validators'
-import {toTimeoutMs} from '../lib/duration'
+import {millisecondTimeoutInputValue, millisecondTimeoutPatch} from '../lib/activityTimeoutFields'
 
 export interface NodeEditDialogProps {
   node: Node | null
@@ -1024,10 +1024,10 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
                                   <Input
                                     type="text"
                                     size="sm"
-                                    value={activity.timeoutMs ?? toTimeoutMs(activity.timeout) ?? ''}
+                                    value={millisecondTimeoutInputValue(activity)}
                                     onChange={(e) => {
                                       const updated = [...stepActivities]
-                                      updated[index].timeoutMs = e.target.value ? parseInt(e.target.value) : undefined
+                                      updated[index] = { ...updated[index], ...millisecondTimeoutPatch(e.target.value) }
                                       setStepActivities(updated)
                                     }}
                                     placeholder={t('workflows.form.placeholders.timeoutMs')}

--- a/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
+++ b/packages/core/src/modules/workflows/components/NodeEditDialog.tsx
@@ -25,6 +25,7 @@ import {useT} from '@open-mercato/shared/lib/i18n/context'
 import {useDialogKeyHandler} from '@open-mercato/ui/hooks/useDialogKeyHandler'
 import {useConfirmDialog} from '@open-mercato/ui/backend/confirm-dialog'
 import {isFutureIsoDateString, isValidDurationString} from '../data/validators'
+import {toTimeoutMs} from '../lib/duration'
 
 export interface NodeEditDialogProps {
   node: Node | null
@@ -1023,7 +1024,7 @@ export function NodeEditDialog({ node, isOpen, onClose, onSave, onDelete }: Node
                                   <Input
                                     type="text"
                                     size="sm"
-                                    value={activity.timeoutMs || ''}
+                                    value={activity.timeoutMs ?? toTimeoutMs(activity.timeout) ?? ''}
                                     onChange={(e) => {
                                       const updated = [...stepActivities]
                                       updated[index].timeoutMs = e.target.value ? parseInt(e.target.value) : undefined

--- a/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
@@ -14,6 +14,7 @@ import {
 import { Textarea } from '@open-mercato/ui/primitives/textarea'
 import { Trash2, Plus, ChevronUp, ChevronDown } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { toTimeoutMs } from '../lib/duration'
 
 interface Activity {
   activityId: string
@@ -31,6 +32,8 @@ interface Activity {
   // as an ISO 8601 string, so saving a timeout from this editor failed
   // validation outright (#4424).
   timeoutMs?: number
+  /** @deprecated Use `timeoutMs`. Written by the CrudForm activity editor as a duration or millisecond string. */
+  timeout?: string
   compensation?: Record<string, any>
 }
 
@@ -513,7 +516,7 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
                             <Input
                               id={`activity-${index}-${activityIndex}-timeout`}
                               type="number"
-                              value={activity.timeoutMs || ''}
+                              value={activity.timeoutMs ?? toTimeoutMs(activity.timeout) ?? ''}
                               onChange={(e) => updateActivity(index, activityIndex, 'timeoutMs', e.target.value ? parseInt(e.target.value) : undefined)}
                               placeholder="30000"
                               className="mt-1 text-xs h-8"

--- a/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
+++ b/packages/core/src/modules/workflows/components/TransitionsEditor.tsx
@@ -14,7 +14,7 @@ import {
 import { Textarea } from '@open-mercato/ui/primitives/textarea'
 import { Trash2, Plus, ChevronUp, ChevronDown } from 'lucide-react'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
-import { toTimeoutMs } from '../lib/duration'
+import { millisecondTimeoutInputValue, millisecondTimeoutPatch } from '../lib/activityTimeoutFields'
 
 interface Activity {
   activityId: string
@@ -178,12 +178,16 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
     onChange(updated)
   }
 
-  const updateActivity = (transitionIndex: number, activityIndex: number, field: keyof Activity, fieldValue: any) => {
+  const patchActivity = (transitionIndex: number, activityIndex: number, patch: Partial<Activity>) => {
     const updated = [...value]
     const activities = [...(updated[transitionIndex].activities || [])]
-    activities[activityIndex] = { ...activities[activityIndex], [field]: fieldValue }
+    activities[activityIndex] = { ...activities[activityIndex], ...patch }
     updated[transitionIndex] = { ...updated[transitionIndex], activities }
     onChange(updated)
+  }
+
+  const updateActivity = (transitionIndex: number, activityIndex: number, field: keyof Activity, fieldValue: any) => {
+    patchActivity(transitionIndex, activityIndex, { [field]: fieldValue })
   }
 
   const updateRetryPolicy = (transitionIndex: number, activityIndex: number, field: string, fieldValue: any) => {
@@ -516,8 +520,8 @@ export function TransitionsEditor({ value = [], onChange, steps = [], error }: T
                             <Input
                               id={`activity-${index}-${activityIndex}-timeout`}
                               type="number"
-                              value={activity.timeoutMs ?? toTimeoutMs(activity.timeout) ?? ''}
-                              onChange={(e) => updateActivity(index, activityIndex, 'timeoutMs', e.target.value ? parseInt(e.target.value) : undefined)}
+                              value={millisecondTimeoutInputValue(activity)}
+                              onChange={(e) => patchActivity(index, activityIndex, millisecondTimeoutPatch(e.target.value))}
                               placeholder="30000"
                               className="mt-1 text-xs h-8"
                             />

--- a/packages/core/src/modules/workflows/components/__tests__/ActivityArrayEditor.timeout.test.tsx
+++ b/packages/core/src/modules/workflows/components/__tests__/ActivityArrayEditor.timeout.test.tsx
@@ -1,0 +1,77 @@
+/** @jest-environment jsdom */
+
+/**
+ * The timeout box in this editor displays the activity's effective timeout,
+ * which may come from either field. It must therefore write both, or an edit
+ * made here is discarded at run time in favour of a stale `timeoutMs`.
+ */
+import * as React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { resolveActivityTimeoutMs } from '../../lib/activityTimeoutFields'
+import { ActivityArrayEditor, type Activity } from '../fields/ActivityArrayEditor'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : key),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({ confirm: jest.fn().mockResolvedValue(true), ConfirmDialogElement: null }),
+}))
+
+jest.mock('@open-mercato/ui/backend/JsonBuilder', () => ({
+  JsonBuilder: () => <div data-testid="json-builder" />,
+}))
+
+function renderEditor(activity: Activity) {
+  const setValue = jest.fn()
+  const { container } = render(
+    <ActivityArrayEditor id="activities" value={[activity]} setValue={setValue} />,
+  )
+  fireEvent.click(screen.getByRole('button', { name: /Call API/ }))
+  const input = container.querySelector<HTMLInputElement>('#activities-0-timeout')
+  if (!input) throw new Error('[internal] timeout input not rendered')
+  return { input, setValue }
+}
+
+const baseActivity: Activity = {
+  activityId: 'call_api_1',
+  activityName: 'Call API',
+  activityType: 'CALL_API',
+  config: { endpoint: '/api/x' },
+}
+
+function lastActivity(setValue: jest.Mock): Activity {
+  const [activities] = setValue.mock.calls[setValue.mock.calls.length - 1] as [Activity[]]
+  return activities[0]
+}
+
+describe('ActivityArrayEditor timeout binding', () => {
+  it('shows the canonical timeout of an activity written by a visual editor', () => {
+    const { input } = renderEditor({ ...baseActivity, timeoutMs: 5000 })
+    expect(input.value).toBe('5000')
+  })
+
+  it('applies an edit to the timeout the executor resolves', () => {
+    const { input, setValue } = renderEditor({ ...baseActivity, timeoutMs: 5000 })
+
+    fireEvent.change(input, { target: { value: '60000' } })
+
+    expect(resolveActivityTimeoutMs(lastActivity(setValue))).toBe(60000)
+  })
+
+  it('clears the timeout when the box is emptied', () => {
+    const { input, setValue } = renderEditor({ ...baseActivity, timeoutMs: 5000, timeout: '5000' })
+
+    fireEvent.change(input, { target: { value: '' } })
+
+    expect(resolveActivityTimeoutMs(lastActivity(setValue))).toBeUndefined()
+  })
+
+  it('resolves a duration string typed into the box', () => {
+    const { input, setValue } = renderEditor(baseActivity)
+
+    fireEvent.change(input, { target: { value: 'PT30S' } })
+
+    expect(resolveActivityTimeoutMs(lastActivity(setValue))).toBe(30000)
+  })
+})

--- a/packages/core/src/modules/workflows/components/__tests__/TransitionsEditor.timeout.test.tsx
+++ b/packages/core/src/modules/workflows/components/__tests__/TransitionsEditor.timeout.test.tsx
@@ -1,0 +1,73 @@
+/** @jest-environment jsdom */
+
+/**
+ * This editor's timeout box is millisecond-only, but it displays a legacy
+ * `timeout` string normalized to milliseconds. It must therefore drop that
+ * alias when it writes, or clearing the box leaves the old timeout in force.
+ */
+import * as React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import { resolveActivityTimeoutMs } from '../../lib/activityTimeoutFields'
+import { TransitionsEditor } from '../TransitionsEditor'
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useT: () => (key: string, fallback?: string) => (typeof fallback === 'string' ? fallback : key),
+}))
+
+type ActivityFields = { timeout?: string; timeoutMs?: number }
+
+function renderEditor(activity: ActivityFields) {
+  const onChange = jest.fn()
+  const transitions = [
+    {
+      transitionId: 'transition_1',
+      transitionName: 'Approve',
+      fromStepId: 'start',
+      toStepId: 'end',
+      trigger: 'AUTOMATIC',
+      activities: [
+        {
+          activityId: 'call_api_1',
+          activityName: 'Call API',
+          activityType: 'CALL_API',
+          config: { endpoint: '/api/x' },
+          ...activity,
+        },
+      ],
+    },
+  ]
+  const { container } = render(<TransitionsEditor value={transitions} onChange={onChange} />)
+  const input = container.querySelector<HTMLInputElement>('#activity-0-0-timeout')
+  if (!input) throw new Error('[internal] timeout input not rendered')
+  return { input, onChange }
+}
+
+function lastActivity(onChange: jest.Mock): ActivityFields {
+  const [transitions] = onChange.mock.calls[onChange.mock.calls.length - 1] as [
+    Array<{ activities: ActivityFields[] }>,
+  ]
+  return transitions[0].activities[0]
+}
+
+describe('TransitionsEditor timeout binding', () => {
+  it('shows a legacy duration alias normalized to milliseconds', () => {
+    const { input } = renderEditor({ timeout: 'PT30S' })
+    expect(input.value).toBe('30000')
+  })
+
+  it('clears the timeout when the box is emptied on a legacy activity', () => {
+    const { input, onChange } = renderEditor({ timeout: 'PT30S' })
+
+    fireEvent.change(input, { target: { value: '' } })
+
+    expect(resolveActivityTimeoutMs(lastActivity(onChange))).toBeUndefined()
+  })
+
+  it('replaces a legacy alias with the edited value', () => {
+    const { input, onChange } = renderEditor({ timeout: 'PT30S' })
+
+    fireEvent.change(input, { target: { value: '45000' } })
+
+    expect(resolveActivityTimeoutMs(lastActivity(onChange))).toBe(45000)
+  })
+})

--- a/packages/core/src/modules/workflows/components/fields/ActivityArrayEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/ActivityArrayEditor.tsx
@@ -251,7 +251,7 @@ export function ActivityArrayEditor({ id, value = [], error, setValue, disabled 
                       <Input
                         id={`${id}-${index}-timeout`}
                         type="text"
-                        value={activity.timeout || ''}
+                        value={activity.timeout || (activity.timeoutMs != null ? String(activity.timeoutMs) : '')}
                         onChange={(e) => updateActivity(index, 'timeout', e.target.value)}
                         placeholder={t('workflows.fieldEditors.activities.timeoutPlaceholder')}
                         className="text-xs"

--- a/packages/core/src/modules/workflows/components/fields/ActivityArrayEditor.tsx
+++ b/packages/core/src/modules/workflows/components/fields/ActivityArrayEditor.tsx
@@ -17,6 +17,7 @@ import { ChevronDown, Plus, Trash2 } from 'lucide-react'
 import { JsonBuilder } from '@open-mercato/ui/backend/JsonBuilder'
 import type { CrudCustomFieldRenderProps } from '@open-mercato/ui/backend/CrudForm'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { durationTimeoutInputValue, durationTimeoutPatch } from '../../lib/activityTimeoutFields'
 
 /**
  * Activity definition structure
@@ -111,10 +112,14 @@ export function ActivityArrayEditor({ id, value = [], error, setValue, disabled 
     setExpandedIndices(newExpanded)
   }
 
-  const updateActivity = (index: number, field: keyof Activity, fieldValue: any) => {
+  const patchActivity = (index: number, patch: Partial<Activity>) => {
     const updated = [...activities]
-    updated[index] = { ...updated[index], [field]: fieldValue }
+    updated[index] = { ...updated[index], ...patch }
     setValue(updated)
+  }
+
+  const updateActivity = (index: number, field: keyof Activity, fieldValue: any) => {
+    patchActivity(index, { [field]: fieldValue })
   }
 
   const updateRetryPolicy = (index: number, field: string, fieldValue: any) => {
@@ -251,8 +256,8 @@ export function ActivityArrayEditor({ id, value = [], error, setValue, disabled 
                       <Input
                         id={`${id}-${index}-timeout`}
                         type="text"
-                        value={activity.timeout || (activity.timeoutMs != null ? String(activity.timeoutMs) : '')}
-                        onChange={(e) => updateActivity(index, 'timeout', e.target.value)}
+                        value={durationTimeoutInputValue(activity)}
+                        onChange={(e) => patchActivity(index, durationTimeoutPatch(e.target.value))}
                         placeholder={t('workflows.fieldEditors.activities.timeoutPlaceholder')}
                         className="text-xs"
                         disabled={disabled}

--- a/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activity-executor.test.ts
@@ -2577,3 +2577,32 @@ describe('Activity Executor (Unit Tests)', () => {
     })
   })
 })
+
+describe('resolveActivityTimeoutMs', () => {
+  const resolve = activityExecutor.resolveActivityTimeoutMs
+
+  test('prefers the canonical timeoutMs over the deprecated alias', () => {
+    expect(resolve({ timeoutMs: 5000, timeout: 'PT30S' })).toBe(5000)
+  })
+
+  test('reads a plain millisecond string from the deprecated alias', () => {
+    expect(resolve({ timeout: '30000' })).toBe(30000)
+  })
+
+  test('reads a duration string from the deprecated alias', () => {
+    expect(resolve({ timeout: 'PT30S' })).toBe(30 * 1000)
+    expect(resolve({ timeout: '5m' })).toBe(5 * 60 * 1000)
+  })
+
+  test('falls back to the alias when timeoutMs is not a usable value', () => {
+    expect(resolve({ timeoutMs: 0, timeout: '30000' })).toBe(30000)
+  })
+
+  test('ignores a malformed alias rather than throwing mid-execution', () => {
+    expect(resolve({ timeout: 'not-a-duration' })).toBeUndefined()
+  })
+
+  test('returns undefined when no timeout is configured', () => {
+    expect(resolve({})).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/workflows/lib/__tests__/activityTimeoutFields.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/activityTimeoutFields.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment node
+ *
+ * The timeout inputs bind two fields — canonical `timeoutMs` and the deprecated
+ * `timeout` alias — so a patch that writes only one of them leaves the box
+ * showing a value the executor will not use. These cases pin the round-trip:
+ * whatever the input displays after an edit is what `resolveActivityTimeoutMs`
+ * resolves, and the resulting activity still validates.
+ */
+import { activityDefinitionSchema } from '../../data/validators'
+import {
+  durationTimeoutInputValue,
+  durationTimeoutPatch,
+  millisecondTimeoutInputValue,
+  millisecondTimeoutPatch,
+  resolveActivityTimeoutMs,
+} from '../activityTimeoutFields'
+
+const baseActivity = {
+  activityId: 'call_api_1',
+  activityName: 'Call API',
+  activityType: 'CALL_API' as const,
+  config: { endpoint: '/api/x' },
+}
+
+describe('durationTimeoutInputValue', () => {
+  it('prefers the raw alias text so a duration string stays readable', () => {
+    expect(durationTimeoutInputValue({ timeout: 'PT30S' })).toBe('PT30S')
+    expect(durationTimeoutInputValue({ timeout: 'PT30S', timeoutMs: 30000 })).toBe('PT30S')
+  })
+
+  it('falls back to the canonical field for an activity written by a visual editor', () => {
+    expect(durationTimeoutInputValue({ timeoutMs: 5000 })).toBe('5000')
+  })
+
+  it('shows nothing when no timeout is configured', () => {
+    expect(durationTimeoutInputValue({})).toBe('')
+    expect(durationTimeoutInputValue({ timeout: '' })).toBe('')
+  })
+})
+
+describe('millisecondTimeoutInputValue', () => {
+  it('prefers the canonical field', () => {
+    expect(millisecondTimeoutInputValue({ timeoutMs: 5000 })).toBe(5000)
+    expect(millisecondTimeoutInputValue({ timeoutMs: 5000, timeout: 'PT30S' })).toBe(5000)
+  })
+
+  it('normalizes a legacy alias to milliseconds', () => {
+    expect(millisecondTimeoutInputValue({ timeout: 'PT30S' })).toBe(30000)
+    expect(millisecondTimeoutInputValue({ timeout: '30000' })).toBe(30000)
+  })
+
+  it('shows nothing for an absent or unusable timeout', () => {
+    expect(millisecondTimeoutInputValue({})).toBe('')
+    expect(millisecondTimeoutInputValue({ timeout: 'not-a-duration' })).toBe('')
+  })
+})
+
+describe('durationTimeoutPatch', () => {
+  it('writes both fields so the canonical one reflects what was typed', () => {
+    expect(durationTimeoutPatch('60000')).toEqual({ timeout: '60000', timeoutMs: 60000 })
+    expect(durationTimeoutPatch('PT30S')).toEqual({ timeout: 'PT30S', timeoutMs: 30000 })
+  })
+
+  it('keeps unparseable text visible while clearing the canonical field', () => {
+    expect(durationTimeoutPatch('PT')).toEqual({ timeout: 'PT', timeoutMs: undefined })
+  })
+
+  it('clears both fields when the box is emptied', () => {
+    expect(durationTimeoutPatch('')).toEqual({ timeout: undefined, timeoutMs: undefined })
+  })
+})
+
+describe('millisecondTimeoutPatch', () => {
+  it('writes the canonical field and drops the deprecated alias', () => {
+    expect(millisecondTimeoutPatch('60000')).toEqual({ timeout: undefined, timeoutMs: 60000 })
+  })
+
+  it('clears both fields when the box is emptied', () => {
+    expect(millisecondTimeoutPatch('')).toEqual({ timeout: undefined, timeoutMs: undefined })
+  })
+
+  it('never writes a value the definition schema would reject', () => {
+    expect(millisecondTimeoutPatch('0').timeoutMs).toBeUndefined()
+    expect(millisecondTimeoutPatch('-5').timeoutMs).toBeUndefined()
+    expect(millisecondTimeoutPatch('1.5').timeoutMs).toBeUndefined()
+  })
+})
+
+describe('editor round-trip resolves to the value the box shows', () => {
+  it('applies an edit made in the duration editor to an activity a visual editor wrote', () => {
+    const stored = { ...baseActivity, timeoutMs: 5000 }
+    expect(durationTimeoutInputValue(stored)).toBe('5000')
+
+    const edited = { ...stored, ...durationTimeoutPatch('60000') }
+
+    expect(resolveActivityTimeoutMs(edited)).toBe(60000)
+    expect(activityDefinitionSchema.safeParse(edited).success).toBe(true)
+  })
+
+  it('clears a legacy alias when the millisecond editor box is emptied', () => {
+    const stored = { ...baseActivity, timeout: 'PT30S' }
+    expect(millisecondTimeoutInputValue(stored)).toBe(30000)
+
+    const cleared = { ...stored, ...millisecondTimeoutPatch('') }
+
+    expect(resolveActivityTimeoutMs(cleared)).toBeUndefined()
+    expect(millisecondTimeoutInputValue(cleared)).toBe('')
+    expect(activityDefinitionSchema.safeParse(cleared).success).toBe(true)
+  })
+
+  it('replaces a legacy alias when the millisecond editor sets a new value', () => {
+    const stored = { ...baseActivity, timeout: 'PT30S' }
+
+    const edited = { ...stored, ...millisecondTimeoutPatch('45000') }
+
+    expect(resolveActivityTimeoutMs(edited)).toBe(45000)
+    expect(edited.timeout).toBeUndefined()
+  })
+})

--- a/packages/core/src/modules/workflows/lib/__tests__/duration.test.ts
+++ b/packages/core/src/modules/workflows/lib/__tests__/duration.test.ts
@@ -1,4 +1,4 @@
-import { parseDuration } from '../duration'
+import { parseDuration, toTimeoutMs } from '../duration'
 
 describe('parseDuration', () => {
   describe('ISO 8601 format', () => {
@@ -65,6 +65,66 @@ describe('parseDuration', () => {
 
     test('throws on random text', () => {
       expect(() => parseDuration('abc')).toThrow('Invalid duration format')
+    })
+  })
+})
+
+describe('toTimeoutMs', () => {
+  describe('millisecond strings', () => {
+    test('"30000" → 30000 (the value the activity editor placeholder asks for)', () => {
+      expect(toTimeoutMs('30000')).toBe(30000)
+    })
+
+    test('surrounding whitespace is tolerated', () => {
+      expect(toTimeoutMs('  30000  ')).toBe(30000)
+    })
+
+    test('"0" is not a usable timeout', () => {
+      expect(toTimeoutMs('0')).toBeUndefined()
+    })
+  })
+
+  describe('duration strings', () => {
+    test('PT30S → 30 seconds', () => {
+      expect(toTimeoutMs('PT30S')).toBe(30 * 1000)
+    })
+
+    test('5m → 5 minutes', () => {
+      expect(toTimeoutMs('5m')).toBe(5 * 60 * 1000)
+    })
+  })
+
+  describe('numbers', () => {
+    test('30000 → 30000', () => {
+      expect(toTimeoutMs(30000)).toBe(30000)
+    })
+
+    test('zero and negatives are not usable timeouts', () => {
+      expect(toTimeoutMs(0)).toBeUndefined()
+      expect(toTimeoutMs(-1)).toBeUndefined()
+    })
+
+    test('NaN and Infinity are rejected', () => {
+      expect(toTimeoutMs(Number.NaN)).toBeUndefined()
+      expect(toTimeoutMs(Number.POSITIVE_INFINITY)).toBeUndefined()
+    })
+  })
+
+  describe('unusable values return undefined instead of throwing', () => {
+    test.each([
+      ['malformed text', 'not-a-duration'],
+      ['empty string', ''],
+      ['whitespace only', '   '],
+    ])('%s', (_label, value) => {
+      expect(toTimeoutMs(value)).toBeUndefined()
+    })
+
+    test.each([
+      ['undefined', undefined],
+      ['null', null],
+      ['object', {}],
+    ])('%s', (_label, value) => {
+      expect(toTimeoutMs(value)).toBeUndefined()
     })
   })
 })

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -25,7 +25,7 @@ import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { callWebhookConfigSchema } from '../data/validators'
 import { WorkflowActivityJob, WORKFLOW_ACTIVITIES_QUEUE_NAME } from './activity-queue-types'
 import { logWorkflowEvent } from './event-logger'
-import { parseDuration } from './duration'
+import { parseDuration, toTimeoutMs } from './duration'
 import { getWorkflowSafeCommand } from './workflow-safe-commands'
 
 export { isPrivateUrl } from '@open-mercato/shared/lib/network'
@@ -118,11 +118,14 @@ export interface ActivityDefinition {
  * Effective timeout for an activity, in milliseconds.
  *
  * The editor and this executor both speak `timeoutMs`, but the definition
- * schema historically accepted only an ISO 8601 `timeout` string — so stored
- * definitions can carry either. Prefer `timeoutMs`; fall back to parsing
- * `timeout`, ignoring a malformed value rather than throwing mid-execution
- * (an unparseable timeout must not fail an activity that would otherwise
- * succeed). Returns undefined when no usable timeout is configured (#4424).
+ * schema historically accepted only a `timeout` string — so stored definitions
+ * can carry either. Prefer `timeoutMs`; fall back to `toTimeoutMs`, which
+ * reads both a duration string ("PT30S", "5m") and a plain millisecond string
+ * ("30000") — the CrudForm activity editor writes the latter, and its own
+ * placeholder tells the user to. A malformed value is ignored rather than
+ * thrown mid-execution (an unparseable timeout must not fail an activity that
+ * would otherwise succeed). Returns undefined when no usable timeout is
+ * configured (#4424).
  */
 export function resolveActivityTimeoutMs(activity: {
   timeoutMs?: number
@@ -131,15 +134,7 @@ export function resolveActivityTimeoutMs(activity: {
   if (typeof activity.timeoutMs === 'number' && activity.timeoutMs > 0) {
     return activity.timeoutMs
   }
-  if (typeof activity.timeout === 'string' && activity.timeout.trim().length > 0) {
-    try {
-      const parsed = parseDuration(activity.timeout.trim())
-      if (Number.isFinite(parsed) && parsed > 0) return parsed
-    } catch {
-      return undefined
-    }
-  }
-  return undefined
+  return toTimeoutMs(activity.timeout)
 }
 
 export interface RetryPolicy {
@@ -1494,6 +1489,10 @@ function sleep(ms: number): Promise<void> {
 
 /**
  * Execute a promise with timeout
+ *
+ * Only CALL_API and CALL_WEBHOOK honour the abort signal today — they forward
+ * it to `fetch`. SEND_EMAIL, EMIT_EVENT, UPDATE_ENTITY and EXECUTE_FUNCTION
+ * still run to completion after the timeout has been recorded.
  */
 async function executeWithTimeout<T>(
   executor: (signal: AbortSignal) => Promise<T>,

--- a/packages/core/src/modules/workflows/lib/activity-executor.ts
+++ b/packages/core/src/modules/workflows/lib/activity-executor.ts
@@ -25,7 +25,8 @@ import { parseBooleanWithDefault } from '@open-mercato/shared/lib/boolean'
 import { callWebhookConfigSchema } from '../data/validators'
 import { WorkflowActivityJob, WORKFLOW_ACTIVITIES_QUEUE_NAME } from './activity-queue-types'
 import { logWorkflowEvent } from './event-logger'
-import { parseDuration, toTimeoutMs } from './duration'
+import { parseDuration } from './duration'
+import { resolveActivityTimeoutMs } from './activityTimeoutFields'
 import { getWorkflowSafeCommand } from './workflow-safe-commands'
 
 export { isPrivateUrl } from '@open-mercato/shared/lib/network'
@@ -114,28 +115,7 @@ export interface ActivityDefinition {
   compensate?: boolean // Flag to execute compensation on failure
 }
 
-/**
- * Effective timeout for an activity, in milliseconds.
- *
- * The editor and this executor both speak `timeoutMs`, but the definition
- * schema historically accepted only a `timeout` string — so stored definitions
- * can carry either. Prefer `timeoutMs`; fall back to `toTimeoutMs`, which
- * reads both a duration string ("PT30S", "5m") and a plain millisecond string
- * ("30000") — the CrudForm activity editor writes the latter, and its own
- * placeholder tells the user to. A malformed value is ignored rather than
- * thrown mid-execution (an unparseable timeout must not fail an activity that
- * would otherwise succeed). Returns undefined when no usable timeout is
- * configured (#4424).
- */
-export function resolveActivityTimeoutMs(activity: {
-  timeoutMs?: number
-  timeout?: string
-}): number | undefined {
-  if (typeof activity.timeoutMs === 'number' && activity.timeoutMs > 0) {
-    return activity.timeoutMs
-  }
-  return toTimeoutMs(activity.timeout)
-}
+export { resolveActivityTimeoutMs }
 
 export interface RetryPolicy {
   maxAttempts: number
@@ -1492,7 +1472,8 @@ function sleep(ms: number): Promise<void> {
  *
  * Only CALL_API and CALL_WEBHOOK honour the abort signal today — they forward
  * it to `fetch`. SEND_EMAIL, EMIT_EVENT, UPDATE_ENTITY and EXECUTE_FUNCTION
- * still run to completion after the timeout has been recorded.
+ * still run to completion after the timeout has been recorded. Tracked in
+ * #5148.
  */
 async function executeWithTimeout<T>(
   executor: (signal: AbortSignal) => Promise<T>,

--- a/packages/core/src/modules/workflows/lib/activityTimeoutFields.ts
+++ b/packages/core/src/modules/workflows/lib/activityTimeoutFields.ts
@@ -1,0 +1,75 @@
+import { toTimeoutMs } from './duration'
+
+/**
+ * The two timeout fields an activity definition can carry.
+ *
+ * `timeoutMs` is canonical and is what `resolveActivityTimeoutMs` prefers;
+ * `timeout` is the deprecated alias that stored definitions and the CrudForm
+ * activity editor still write. A timeout input must own both fields — read
+ * them merged and write both on every edit — otherwise the box shows the
+ * executor's effective timeout while changing only half of the pair, and the
+ * user's edit is silently discarded.
+ */
+export type ActivityTimeoutFields = {
+  timeout?: string
+  timeoutMs?: number
+}
+
+/**
+ * Effective timeout for an activity, in milliseconds.
+ *
+ * The editors and the executor both speak `timeoutMs`, but the definition
+ * schema historically accepted only a `timeout` string — so stored definitions
+ * can carry either. Prefer `timeoutMs`; fall back to `toTimeoutMs`, which
+ * reads both a duration string ("PT30S", "5m") and a plain millisecond string
+ * ("30000") — the CrudForm activity editor writes the latter, and its own
+ * placeholder tells the user to. A malformed value is ignored rather than
+ * thrown mid-execution (an unparseable timeout must not fail an activity that
+ * would otherwise succeed). Returns undefined when no usable timeout is
+ * configured (#4424).
+ *
+ * `activity-executor` re-exports this so its import path stays stable; it
+ * lives here so the editors can assert the round-trip without pulling in the
+ * server-only executor.
+ */
+export function resolveActivityTimeoutMs(activity: ActivityTimeoutFields): number | undefined {
+  if (typeof activity.timeoutMs === 'number' && activity.timeoutMs > 0) {
+    return activity.timeoutMs
+  }
+  return toTimeoutMs(activity.timeout)
+}
+
+/**
+ * Text shown by a timeout input that accepts duration strings as well as
+ * milliseconds (the CrudForm activity editor, whose placeholder reads
+ * "PT30S or 30000").
+ */
+export function durationTimeoutInputValue(activity: ActivityTimeoutFields): string {
+  if (activity.timeout) return activity.timeout
+  return activity.timeoutMs != null ? String(activity.timeoutMs) : ''
+}
+
+/** Value shown by a millisecond-only timeout input (the two visual editors). */
+export function millisecondTimeoutInputValue(activity: ActivityTimeoutFields): number | '' {
+  return activity.timeoutMs ?? toTimeoutMs(activity.timeout) ?? ''
+}
+
+/**
+ * Fields to merge into an activity after a duration-accepting input changed.
+ *
+ * The raw text stays in the deprecated alias so a partially typed duration
+ * survives the re-render, and `timeoutMs` carries whatever the executor can
+ * actually use — undefined while the text is incomplete or unusable.
+ */
+export function durationTimeoutPatch(raw: string): ActivityTimeoutFields {
+  return { timeout: raw || undefined, timeoutMs: toTimeoutMs(raw) }
+}
+
+/**
+ * Fields to merge into an activity after a millisecond-only input changed.
+ * The deprecated alias is dropped, so clearing the box clears the timeout and
+ * stored definitions migrate off `timeout` as they are edited.
+ */
+export function millisecondTimeoutPatch(raw: string): ActivityTimeoutFields {
+  return { timeout: undefined, timeoutMs: toTimeoutMs(raw) }
+}

--- a/packages/core/src/modules/workflows/lib/duration.ts
+++ b/packages/core/src/modules/workflows/lib/duration.ts
@@ -49,3 +49,40 @@ export function parseDuration(duration: string): number {
 
   throw new Error(`Invalid duration format: ${duration}`)
 }
+
+/**
+ * Normalize a timeout value to milliseconds
+ *
+ * Accepts every shape the activity editors and stored definitions carry:
+ * - a millisecond number (30000)
+ * - a millisecond string ("30000") — what the CrudForm activity editor writes,
+ *   and what its own placeholder ("PT30S or 30000") tells the user to type
+ * - a duration string ("PT30S", "5m")
+ *
+ * Returns undefined for an absent or unusable value rather than throwing, so a
+ * malformed timeout never fails an activity that would otherwise succeed.
+ *
+ * @param value - Raw timeout value
+ * @returns Milliseconds, or undefined when the value is absent or unusable
+ */
+export function toTimeoutMs(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value > 0 ? value : undefined
+  }
+  if (typeof value !== 'string') return undefined
+
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  if (/^\d+$/.test(trimmed)) {
+    const milliseconds = Number(trimmed)
+    return milliseconds > 0 ? milliseconds : undefined
+  }
+
+  try {
+    const milliseconds = parseDuration(trimmed)
+    return Number.isFinite(milliseconds) && milliseconds > 0 ? milliseconds : undefined
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
Supersedes #4502 (originally #4495).

Credit: original implementation by @wojciechszyjka. #4502 has been overtaken by two merges — #4460 landed the timeout-resolution half and #4918 landed the abort wiring — so rebasing it would mostly re-land merged work against a two-month-old base. This PR carries forward the one part of it that is still missing from `develop`, rebuilt on the current base.

## The bug

`ActivityArrayEditor` (the CrudForm activity editor behind `NodeEditDialogCrudForm` and `EdgeEditDialogCrudForm`) writes the deprecated `timeout` string, and its own hint and placeholder tell the user to type **"PT30S or 30000"**.

The millisecond form never worked. `resolveActivityTimeoutMs` passed `timeout` straight to `parseDuration`, which accepts only ISO 8601 (`PT30S`) or the simple unit form (`5m`). `"30000"` threw, the throw was swallowed by design, and the activity ran **with no timeout at all** — the same #4424 class of silent failure, still reachable on `develop` today.

## Changes

- **`lib/duration.ts`** — new `toTimeoutMs()` normalizes every shape the editors and stored definitions carry (millisecond number, millisecond string, duration string) and returns `undefined` for anything unusable, preserving the deliberate "a malformed timeout must not fail an activity that would otherwise succeed" semantics from #4460.
- **`lib/activity-executor.ts`** — `resolveActivityTimeoutMs` resolves the deprecated alias through `toTimeoutMs`. The canonical `timeoutMs` still wins.
- **Three activity editors** — they disagreed on which field they read, so a timeout saved in one was invisible in the others (the two visual editors read only `timeoutMs`, the CrudForm editor only `timeout`). Each now falls back to the other field **for display**. The field each editor writes is unchanged.
- **`executeWithTimeout` doc comment** — names the two activity types that actually honour the abort signal. Raised in review on #4502 and not addressed by #4918.

No contract widening: `timeout` stays `z.string()` in `activityDefinitionSchema` and `string` on `ActivityDefinition`. The review of #4502 flagged its `string | number` widening as needing separate justification — it is not needed to fix this bug, so it is not here.

## Tests

- `toTimeoutMs` — millisecond strings, duration strings, numbers, and the unusable-value cases that must return `undefined` rather than throw.
- `resolveActivityTimeoutMs` — canonical-wins precedence, the `"30000"` regression, duration aliases, malformed-alias tolerance.

## Validation

Runner: local (no compose `app` container running). Validation source: local fallback — this is a new branch with no CI history yet.

- `yarn build:packages` — passed
- `yarn generate` — passed, generated tree clean
- `yarn build:packages` — passed
- `yarn i18n:check-sync` — passed, all 5 locales in sync
- `yarn i18n:check-usage` — passed (advisory)
- `yarn typecheck` — passed, 22/22
- `yarn test` — passed, 9155/9155 across 1183 suites
- `yarn build:app` — passed
- `yarn lint` — 0 errors
- `yarn lint:ds` — 0 errors, no findings in the touched files