### PR TITLE
chore: back-merge main into develop (⚠️ MERGE COMMIT ONLY — DO NOT SQUASH)

### DIFF
--- a/.ai/runs/2026-08-04-pr-4364-review-followups.md
+++ b/.ai/runs/2026-08-04-pr-4364-review-followups.md
@@ -1,0 +1,67 @@
+# PR #4364 — review follow-ups (om-auto-fix-pr)
+
+**Subject PR:** open-mercato/open-mercato#4364 — `fix(scheduler,shared): stop idle-in-transaction reaps crashing the scheduler daemon`
+**Driver:** `om-auto-fix-pr 4364`
+**Follow-up issue:** #4934 (lease-based claim)
+
+## 🎯 Goal
+
+Drive #4364 to merge-ready by resolving the two `changes-requested` reviews on it
+(@wojciechszyjka 2026-07-26, @patzick 2026-08-03) without touching the crash fix
+itself. The PR author's branch lives in the upstream repository and this account
+has read-only access to it, so the work is delivered as a small PR **targeting
+that branch** instead of pushed onto it.
+
+## 📋 Progress
+
+- [x] Claim #4364 (comment only — assignee and `in-progress` label return HTTP 403 for a read-only account)
+- [x] Merge the current `main` into the PR head so review and validation judge the real merge result
+- [x] Major finding — restore an honest guarantee: startup warning + documentation for the lost cross-process exclusion
+- [x] Minor finding — class docstring and the three scheduler docs pages no longer claim advisory-lock single-instance safety
+- [x] Minor finding — `heldKeys` records the one-instance-per-process invariant it relies on
+- [x] Nit — client-level pg error message made state-neutral (an idle reap logs through both handlers)
+- [x] Nit — the never-removed client-level listener documented as a deliberate last-resort sink
+- [x] Test gaps — startup warning, different keys do not block each other, key released when the claim transaction itself rejects
+- [x] Validation gate (local runner): all eight configured commands green
+- [x] Follow-up issue for the deferred lease implementation (#4934)
+- [x] Open the delivery PR against `dokploy-runtime-error-fix`
+- [ ] Author merges the delivery PR; #4364 re-reviewed and labels normalized by a maintainer
+
+## Decisions
+
+**Major finding — option 2, not option 1.** @patzick offered two resolutions: a
+lease-based claim that advances `next_run_at` inside the claim transaction
+(behavior-preserving, restores real cross-process exclusion), or a startup
+warning plus documentation with the lease tracked as a follow-up — explicitly
+stating "I would accept that as a resolution". This run took the second route
+because #4364 is a `priority-high` production hotfix for a crash-loop: changing
+when the scheduler advances `next_run_at` alters the claim/retry path of every
+schedule and deserves its own PR and its own review, not a rider on a hotfix.
+The deferred half is tracked in #4934 with the reviewer's exact proposal quoted.
+
+**Docs beyond the review's ask.** The review named
+`apps/docs/docs/framework/scheduler/overview.mdx`. Two further pages made the
+same now-false promise — `user-guide/scheduler.mdx` ("Uses PostgreSQL advisory
+locks for safety") and `cli/scheduler.mdx` ("Lock Strategy: PostgreSQL advisory
+locks") — so both were corrected in the same pass rather than left to contradict
+the code.
+
+**Delivery shape.** The base-first step was performed as a *validation* step
+only: `main` was merged into a scratch branch and the whole gate ran against that
+merged state, so the fixes are proven against the current base. The delivery PR
+itself is the two fix commits cherry-picked onto the untouched PR head, so its
+diff is nine files instead of the ~1100 a merge commit would have dragged in.
+Updating #4364 against `main` is one "Update branch" click for the author and
+does not need to ride along here. An earlier delivery PR that did carry the merge
+commit was closed for exactly this reason.
+
+## Validation
+
+Local runner (no compose `app` container running). Every command in
+`.ai/agentic.config.json` → `validation.commands`, in order, against the merged
+state: `yarn build:packages`, `yarn generate`, `yarn build:packages`,
+`yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`,
+`yarn build:app` — all green. `yarn test` ran 23/23 turbo tasks; the scheduler
+and shared suites relevant to this change are 37 and 12 tests respectively.
+`i18n:check-usage` reports 2 missing keys and 3819 unused keys as advisory
+pre-existing findings unrelated to this diff (it touches no locale files).

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,161 @@
+name: Release Prepare
+
+# Stage 1 of a release: bump versions on a branch and open a PR.
+# `main` is a protected branch, so the version commit must land through review —
+# the Release workflow then publishes whatever version main already holds.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump type for the release PR'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      resume:
+        description: 'Recover a release that already published to npm (skips the "not on npm yet" and tag guards)'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  prepare:
+    name: Prepare release PR
+    runs-on: ubuntu-latest
+    # Only allow release preparation from main branch
+    if: github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump ${{ inputs.bump }} version
+        id: bump
+        run: |
+          VERSION=$(./scripts/bump-version.sh "${{ inputs.bump }}")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      # Both guards are skipped in resume mode: recovering a release that already
+      # published means npm is deliberately ahead of git, and the bump PR is how
+      # git catches up
+      - name: Verify the target version is not published yet
+        if: ${{ !inputs.resume }}
+        run: ./scripts/check-version-unpublished.sh "${{ steps.bump.outputs.version }}"
+
+      - name: Verify the release tag does not exist
+        if: ${{ !inputs.resume }}
+        run: |
+          TAG="v${{ steps.bump.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "::error::Tag $TAG already exists on origin"
+            exit 1
+          fi
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.bump.outputs.version }}"
+          BRANCH="release/v$VERSION"
+
+          git switch -c "$BRANCH"
+          # Only tracked manifests change here; nothing is built, so -u cannot pick up artifacts
+          git add -u
+          if git diff --cached --quiet; then
+            echo "::error::No version changes to release"
+            exit 1
+          fi
+
+          git commit -m "chore: release v$VERSION"
+          git push origin "$BRANCH"
+
+          if [ "${{ inputs.resume }}" = "true" ]; then
+            BODY="**Recovery** release preparation for **v$VERSION**."
+            BODY="$BODY"$'\n\n'"\`$VERSION\` is already published on npm — this PR brings the repository back in sync."
+            BODY="$BODY"$'\n\n'"- Bumps every public package and the root manifest to \`$VERSION\`"
+            BODY="$BODY"$'\n'"- No build or publish happens here"
+          else
+            BODY="Automated release preparation for **v$VERSION**."
+            BODY="$BODY"$'\n\n'"- Bumps every public package and the root manifest to \`$VERSION\`"
+            BODY="$BODY"$'\n'"- No build or publish happens here"
+          fi
+
+          if ./scripts/changelog-section.sh "$VERSION" > /dev/null 2>&1; then
+            BODY="$BODY"$'\n'"- \`CHANGELOG.md\` already has a \`$VERSION\` entry ✅"
+          else
+            BODY="$BODY"$'\n'"- ⚠️ \`CHANGELOG.md\` has **no \`$VERSION\` entry yet** — add one before releasing, or the Release workflow will stop at its changelog gate"
+            echo "::warning::CHANGELOG.md has no entry for $VERSION; the Release workflow will fail until one is added"
+          fi
+
+          if [ "${{ inputs.resume }}" = "true" ]; then
+            BODY="$BODY"$'\n\n'"After this PR is merged, run the **Release** workflow on \`main\` **with \`resume: true\`**. It will tag \`v$VERSION\`, skip the packages already on npm, and create the GitHub Release from the \`$VERSION\` \`CHANGELOG.md\` section."
+          else
+            BODY="$BODY"$'\n\n'"After this PR is merged, run the **Release** workflow on \`main\` to build, tag \`v$VERSION\`, publish to npm and create the GitHub Release. The release notes are built from the \`$VERSION\` \`CHANGELOG.md\` section."
+          fi
+
+          COMPARE_URL="${{ github.server_url }}/${{ github.repository }}/compare/main...$BRANCH?expand=1"
+
+          # `gh pr create` needs "Allow GitHub Actions to create and approve pull requests"
+          # (Settings → Actions → General). The branch is already pushed either way, so a
+          # blocked token degrades to a one-click compare link instead of failing the run.
+          if PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore: release v$VERSION" \
+            --body "$BODY" 2>"$RUNNER_TEMP/pr-error.txt"); then
+            echo "Opened $PR_URL"
+
+            gh pr edit "$PR_URL" --add-label skip-qa --add-label priority-high --add-label risk-medium || \
+              echo "::warning::Could not apply labels to $PR_URL"
+
+            {
+              echo "### Release v$VERSION prepared"
+              echo ""
+              echo "Pull request: $PR_URL"
+              echo ""
+              echo "Merge it, then run the **Release** workflow on \`main\`."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat "$RUNNER_TEMP/pr-error.txt"
+            echo "::warning::Could not open the pull request automatically; branch $BRANCH is pushed and ready"
+
+            {
+              echo "### Release v$VERSION prepared — PR needs a manual click"
+              echo ""
+              echo "Branch \`$BRANCH\` is pushed. Open the pull request against \`main\`:"
+              echo ""
+              echo "**[Create the release PR]($COMPARE_URL)**"
+              echo ""
+              echo "To let this workflow open it automatically, enable"
+              echo "_Settings → Actions → General → Workflow permissions →"
+              echo "\"Allow GitHub Actions to create and approve pull requests\"_."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,20 @@
 name: Release
 
+# Stage 2 of a release: publish the version already committed on main.
+# The version bump lands through the Release Prepare workflow's PR, so this
+# workflow never pushes to the protected main branch — it only pushes a tag.
+#
+# Ordering matters: every reversible step (checks, build, tag) runs before the
+# irreversible one (npm publish), so a failure never leaves npm ahead of git.
+
 on:
   workflow_dispatch:
     inputs:
-      bump:
-        description: 'Version bump type (`existing` uses root package.json as-is)'
-        required: true
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-          - existing
+      resume:
+        description: 'Resume a partially published release (skips the "not on npm yet" guard)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -57,79 +60,146 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Configure git
+      - name: Resolve release version
+        id: version
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          VERSION=$(jq -r '.version' package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Releasing v$VERSION from $(git rev-parse --short HEAD)"
 
-      - name: Release ${{ inputs.bump }}
-        id: release
+      - name: Verify version alignment
+        run: ./scripts/check-version-alignment.sh --reference package.json
+
+      - name: Verify the version is not published yet
+        if: ${{ !inputs.resume }}
+        run: ./scripts/check-version-unpublished.sh "${{ steps.version.outputs.version }}"
+
+      - name: Extract changelog entry
+        # Gates the release: a version with no CHANGELOG.md section fails here,
+        # before anything is built, tagged or published
         run: |
-          ./scripts/release-${{ inputs.bump }}.sh 2>&1 | tee release-output.txt
+          ./scripts/changelog-section.sh "${{ steps.version.outputs.version }}" \
+            > "$RUNNER_TEMP/changelog-section.md"
+          echo "Changelog entry: $(wc -c < "$RUNNER_TEMP/changelog-section.md") bytes"
 
-          if [ "${{ inputs.bump }}" = "existing" ]; then
-            NEW_VERSION=$(jq -r '.version' package.json)
-          else
-            NEW_VERSION=$(jq -r '.version' packages/shared/package.json)
-          fi
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-
-          # Build packages list from package.json files
-          PACKAGES_JSON=$(find packages -name package.json -not -path "*/node_modules/*" -exec cat {} \; | \
-            jq -s '[.[] | select(.private != true) | {name: .name, version: .version}]')
-
-          echo "packages_json<<EOF" >> $GITHUB_OUTPUT
-          echo "$PACKAGES_JSON" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-      - name: Commit version changes
+      - name: Build packages
+        # `shell: bash` adds `-o pipefail`, so a failure upstream of `tee` still fails the step
+        shell: bash
         run: |
-          if [ "${{ inputs.bump }}" = "existing" ]; then
-            echo "Existing release mode uses committed versions as-is; skipping version commit"
-            exit 0
-          fi
-
-          git add -A
-          if git diff --cached --quiet; then
-            echo "No release changes to commit"
-            exit 0
-          fi
-
-          git commit -m "chore: release v${{ steps.release.outputs.version }}"
-          git push
+          {
+            yarn build:packages
+            yarn generate
+            yarn build:packages
+          } 2>&1 | tee "$RUNNER_TEMP/release-output.txt"
 
       - name: Create git tag
+        # Runs before publishing: a tag is cheap to delete, an npm version is not
         run: |
-          git tag "v${{ steps.release.outputs.version }}"
-          git push origin "v${{ steps.release.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin; leaving it untouched"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Publish packages to npm
+        id: release
+        shell: bash
+        run: |
+          ./scripts/publish-packages.sh 2>&1 | tee -a "$RUNNER_TEMP/release-output.txt"
+
+          PACKAGES_JSON=$(find packages -maxdepth 2 -name package.json -not -path "*/node_modules/*" -exec cat {} \; | \
+            jq -s '[.[] | select(.private != true) | {name: .name, version: .version}]')
+
+          {
+            echo "packages_json<<PACKAGES_EOF"
+            echo "$PACKAGES_JSON"
+            echo "PACKAGES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload release log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-log
+          path: ${{ runner.temp }}/release-output.txt
+          if-no-files-found: ignore
 
       - name: Create GitHub Release
         uses: actions/github-script@v8
         with:
           script: |
-            const packages = ${{ steps.release.outputs.packages_json }};
-            const version = '${{ steps.release.outputs.version }}';
+            const fs = require('fs');
+            const path = require('path');
 
-            let releaseNotes = '## Published Packages\n\n';
-            releaseNotes += '| Package | Version |\n|---------|---------|';
-            for (const pkg of packages) {
-              releaseNotes += `\n| \`${pkg.name}\` | \`${pkg.version}\` |`;
+            const packages = ${{ steps.release.outputs.packages_json }};
+            const version = '${{ steps.version.outputs.version }}';
+            const tag = `v${version}`;
+
+            // Read from disk rather than interpolating: changelog prose contains
+            // backticks, quotes and newlines that would break an inline expression
+            const changelog = fs.readFileSync(
+              path.join(process.env.RUNNER_TEMP, 'changelog-section.md'),
+              'utf8',
+            ).trim();
+
+            let packageNotes = '## Published Packages\n\n';
+            packageNotes += '| Package | Version |\n|---------|---------|';
+            for (const pkg of packages.sort((a, b) => a.name.localeCompare(b.name))) {
+              packageNotes += `\n| \`${pkg.name}\` | \`${pkg.version}\` |`;
             }
 
-            releaseNotes += '\n\n### Install\n\n```bash\n';
-            releaseNotes += 'npm install @open-mercato/shared@' + version + '\n';
-            releaseNotes += '# or\n';
-            releaseNotes += 'yarn add @open-mercato/shared@' + version + '\n';
-            releaseNotes += '```';
+            const CHANGELOG_URL = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/${tag}/CHANGELOG.md`;
+            // GitHub rejects release bodies over 125,000 characters
+            const BODY_LIMIT = 125000;
+            const budget = BODY_LIMIT - packageNotes.length - 500;
+
+            let changelogSection = changelog;
+            if (changelogSection.length > budget) {
+              changelogSection = changelogSection.slice(0, budget) +
+                `\n\n_Changelog truncated — [read the full entry](${CHANGELOG_URL})._`;
+              core.warning(`Changelog entry for ${tag} exceeded the release body limit and was truncated`);
+            }
+
+            const releaseNotes = `${changelogSection}\n\n---\n\n${packageNotes}\n\n[Full changelog](${CHANGELOG_URL})`;
+
+            let existing = null;
+            try {
+              const found = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              existing = found.data;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+
+            // Resuming a partial release refreshes the notes instead of failing
+            if (existing) {
+              await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: existing.id,
+                name: tag,
+                body: releaseNotes,
+              });
+              console.log(`Updated existing release ${tag}`);
+              return;
+            }
 
             await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: `v${version}`,
-              name: `v${version}`,
+              tag_name: tag,
+              name: tag,
               body: releaseNotes,
               draft: false,
               prerelease: false
             });
 
-            console.log(`Created release v${version}`);
+            console.log(`Created release ${tag}`);

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build
 # misc
 .DS_Store
 *.pem
+/release-output.txt
 
 # Exception: Allow public CA certificates for SSL verification
 !certs/*.pem

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Guide shorthand: `<pkg>` = `packages/<pkg>/AGENTS.md` (so `core` = `packages/cor
 | **Spec & PR Automation** | |
 | Spec lifecycle (pre-implement → implement → write/update), code review, DS review | `.agents/skills/{om-spec-writing,om-code-review}/SKILL.md` + `.ai/skills/{om-pre-implement-spec,om-implement-spec,om-ds-guardian}/SKILL.md` + `.ai/specs/AGENTS.md` + `.ai/ds-rules.md` |
 | PR/issue automation (one-shot auto-PR, resumable loop variants, review/merge-buddy, post-merge sync, changelog, UI QA). **Default for one-off bug fixes / small features:** `om-auto-create-pr` | `.agents/skills/{om-auto-create-pr,om-auto-continue-pr,om-auto-create-pr-loop,om-auto-continue-pr-loop,om-auto-review-pr,om-auto-qa-pr,om-merge-buddy,om-review-prs,om-close-fixed-issues,om-auto-update-changelog,om-prepare-issue}/SKILL.md` |
+| Cutting a release (version bump PR, tag, npm publish, release notes) | [`CONTRIBUTING.md`](CONTRIBUTING.md) → Releasing |
 | **Agent harness itself** | |
 | Editing this file or a package `AGENTS.md`; the instruction budget and boundary labels | [`.ai/docs/agent-instructions.md`](.ai/docs/agent-instructions.md) + `scripts/check-agents-md-budget.mjs` (`yarn agents:check-budget`) |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Day to day, the product surface gets noticeably nicer: **DataTable columns resiz
 
 ## ✨ Features
 - ✨ Add community labels. (#4740) *(@MStaniaszek1998)*
-- ✨ Implementation of WMS. (#4566) *(@patzick)*
+- ✨ WMS phase 1 — core inventory module (#388). (#4566, #1701) *(@mkadziolka)*
 - ✨ Add initialValues prop to CreateDealForm (supersedes #3729). (#4485) *(@jakubsobczak-syhi, via @pkarw)*
 - ✨ Cache role lists safely (supersedes #3143). (#4480) *(@adeptofvoltron, via @pkarw)*
 - ✨ Honor custom-field priority and declaration order (supersedes #4417). (#4466) *(@wojciechszyjka, via @pkarw)*
@@ -25,10 +25,9 @@ Day to day, the product surface gets noticeably nicer: **DataTable columns resiz
 - ✨ Allow disabling sales channels via feature toggle. (#3935) *(@jtomaszewski)*
 - ✨ DS system & guardian refresh: docs drift fixes, guardian v2, backend reference, structural lint, Tabs migration, Figma canon. (#3777) *(@zielivia)*
 - ✨ DataTable interactive column resize + width persistence (#1835). (#3774) *(@zielivia)*
-- ✨ WMS phase 1 — core inventory module (#388). (#1701) *(@mkadziolka)*
 
 ## 🔒 Security
-- 🔒 Gate /label on the certified partner registry. (#4761) *(@MStaniaszek1998)*
+- 🔒 Gate /label on the certified partner registry (supersedes #4727). (#4761) *(@matgren, via @MStaniaszek1998)*
 - 🔒 Reject prototype keys in getNestedValue field paths (#3823). (#4517) *(@Marynat)*
 - 🔒 Bump the postcss resolution off the vulnerable 8.5.15 (#4499). (#4500) *(@wojciechszyjka)*
 - 🔒 Run a daily dependency audit and stop caching the audit result (#4479). (#4497) *(@wojciechszyjka)*
@@ -175,7 +174,7 @@ Day to day, the product surface gets noticeably nicer: **DataTable columns resiz
 - 📝 Specify reliable completion events (carry #4314) (supersedes #4314). (#4321) *(@PatrickMade, via @pkarw)*
 - 📝 Specify stable activity output paths (carry #4312) (supersedes #4312). (#4320) *(@PatrickMade, via @pkarw)*
 - 📝 Sync skill roster and docs with skills collection consolidation. (#4296) *(@pkarw)*
-- 📝 Import om-gap-analysis + om-app-spec-writing as repo-local analysis tier. (#4276) *(@pkarw)*
+- 📝 Import om-gap-analysis + om-app-spec-writing as repo-local analysis tier. (#4276) *(@matgren, via @pkarw)*
 - 📝 DS developer-experience roadmap — brand import, UX walkthroughs, mockup composer. (#4270) *(@zielivia)*
 - 📝 Specify scoped member directory. (#4200) *(@pmadajthey)*
 - 📝 Add banner promoting open-mercato/skills. (#4152) *(@pkarw)*
@@ -183,7 +182,7 @@ Day to day, the product surface gets noticeably nicer: **DataTable columns resiz
 ## 👥 Contributors
 
 - @MStaniaszek1998
-- @patzick
+- @mkadziolka
 - @jakubsobczak-syhi
 - @adeptofvoltron
 - @wojciechszyjka
@@ -192,10 +191,11 @@ Day to day, the product surface gets noticeably nicer: **DataTable columns resiz
 - @WebEferen
 - @jtomaszewski
 - @zielivia
-- @mkadziolka
+- @matgren
 - @Marynat
 - @ArtSadWLC
 - @pkarw
+- @patzick
 - @goer
 - @hubert-madej-softiq
 - @dominikpalatynski
@@ -208,7 +208,6 @@ Day to day, the product surface gets noticeably nicer: **DataTable columns resiz
 - @pat-lewczuk
 - @PatrickMade
 - @KamilGrocholski
-- @matgren
 - @pmadajthey
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Day to day, the product surface gets noticeably nicer: **DataTable columns resiz
 - ✨ Add phone custom field type with phone-number editor. (#4147) *(@DarrenStasiakDev4You)*
 - ✨ One-command Windows agentic dev environment (app + MCP + OpenCode). (#3988) *(@WebEferen)*
 - ✨ Allow disabling sales channels via feature toggle. (#3935) *(@jtomaszewski)*
+- ✨ Add demo autologin via env vars. (#3799) *(@jtomaszewski)*
 - ✨ DS system & guardian refresh: docs drift fixes, guardian v2, backend reference, structural lint, Tabs migration, Figma canon. (#3777) *(@zielivia)*
 - ✨ DataTable interactive column resize + width persistence (#1835). (#3774) *(@zielivia)*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,217 @@
+# 0.6.7 (2026-08-05)
+
+## Highlights
+
+Open Mercato `0.6.7` opens a new chapter: **warehouse management arrives**. The first phase of the WMS module lands core inventory in the platform, so stock finally lives next to catalog, orders, and fulfillment instead of in a spreadsheet somewhere. It is phase one — deliberately focused on the inventory core — and the foundation the rest of the warehouse story will be built on.
+
+The other half of this release is **trust under multi-tenant pressure**. A long scoping sweep makes the platform fail *closed* rather than fail quiet: tenant and organization scope is now enforced on command CRUD, custom-entity mutations, entry commands, role assignments, availability lookups, query-index diagnostics, S3 prefixes, and inbound webhooks; the public quote, tenant-lookup, and org-slug endpoints are rate-limited and guarded against null-tenant sessions; raw acceptance-token fallbacks are gone; SSRF is blocked at the OIDC, Ollama, and redirect-hop paths; and custom-entity records gain **opt-in per-entity ACL**. Alongside it, the persistent **"All organizations" 401 refresh loop is fixed** — session refresh no longer mints `null` tenant/org claims, deals and audited org-scoped endpoints handle the all-orgs scope properly, and a stale pre-auth 401 no longer flashes "Session expired" right after a successful login.
+
+Operationally, this release is about **daemons that stay up and builds that stay fast**. Postgres idle-client errors and idle-in-transaction reaps no longer take down the scheduler or webhook workers, Docker deployments forward their production runtime environment and protect Redis queues from eviction, and swallowed Next.js dev startup errors are surfaced with cold-start retries. On the toolchain side the monorepo moves to the **TypeScript 7.0.2 native compiler**, and a batch of generator work (shared registry discovery, skipped unchanged OpenAPI output, no hashing while idle, no app bootstrap after generation) cuts a lot of dead time out of `yarn generate`. Scaffolded apps get real attention too — they now run their own tooling, pass `yarn test` on a fresh scaffold, and there is a **one-command Windows agentic dev environment** for app + MCP + OpenCode.
+
+Day to day, the product surface gets noticeably nicer: **DataTable columns resize and remember their widths**, custom fields pick up a **phone type with a complete country calling-code dictionary**, honor their declared priority and order, and render multiline values as a plain textarea when you ask for it. Workflows stop losing code-defined triggers in the CLI and worker bootstrap, order approval auto-starts on `sales.order.created`, and sales math gets stricter — operator-defined adjustments count toward the grand total, order lines cannot drop below the shipped quantity, saved addresses survive a re-save, and payment sessions are concurrency-safe. Polish translations are complete, the permission catalogs are localized, DS Guardian v2 lands with a structural lint and Figma canon, and the project itself grows up a little: community labels, a certified-partner registry gating `/label`, Enterprise License Agreement Terms v2.2, and the move to Open Mercato sp. z o.o. as the legal entity. Enjoy!
+
+## ✨ Features
+- ✨ Add community labels. (#4740) *(@MStaniaszek1998)*
+- ✨ Implementation of WMS. (#4566) *(@patzick)*
+- ✨ Add initialValues prop to CreateDealForm (supersedes #3729). (#4485) *(@jakubsobczak-syhi, via @pkarw)*
+- ✨ Cache role lists safely (supersedes #3143). (#4480) *(@adeptofvoltron, via @pkarw)*
+- ✨ Honor custom-field priority and declaration order (supersedes #4417). (#4466) *(@wojciechszyjka, via @pkarw)*
+- ✨ Fail loud on colliding backend routes in mercato generate. (#4402) *(@tomaszscigalacshark)*
+- ✨ Configurable excludeInteractionType on profile activity sections. (#4390) *(@wojciechszyjka)*
+- ✨ Editor 'plain' renders multiline custom fields as a plain textarea. (#4389) *(@wojciechszyjka)*
+- ✨ Provide a complete country calling-code dictionary in PhoneNumberField (#4129). (#4195) *(@adeptofvoltron)*
+- ✨ Add phone custom field type with phone-number editor. (#4147) *(@DarrenStasiakDev4You)*
+- ✨ One-command Windows agentic dev environment (app + MCP + OpenCode). (#3988) *(@WebEferen)*
+- ✨ Allow disabling sales channels via feature toggle. (#3935) *(@jtomaszewski)*
+- ✨ DS system & guardian refresh: docs drift fixes, guardian v2, backend reference, structural lint, Tabs migration, Figma canon. (#3777) *(@zielivia)*
+- ✨ DataTable interactive column resize + width persistence (#1835). (#3774) *(@zielivia)*
+- ✨ WMS phase 1 — core inventory module (#388). (#1701) *(@mkadziolka)*
+
+## 🔒 Security
+- 🔒 Gate /label on the certified partner registry. (#4761) *(@MStaniaszek1998)*
+- 🔒 Reject prototype keys in getNestedValue field paths (#3823). (#4517) *(@Marynat)*
+- 🔒 Bump the postcss resolution off the vulnerable 8.5.15 (#4499). (#4500) *(@wojciechszyjka)*
+- 🔒 Run a daily dependency audit and stop caching the audit result (#4479). (#4497) *(@wojciechszyjka)*
+- 🔒 Guard bounded bcrypt candidate loop invariant (#3812). (#4469) *(@DarrenStasiakDev4You)*
+- 🔒 Opt-in per-entity ACL for custom-entity records (supersedes #4208). (#4397) *(@ArtSadWLC, via @pkarw)*
+- 🔒 Consolidate security dependency updates. (#4363) *(@pkarw)*
+- 🔒 Fail closed on empty organization allowlist at key creation (#4168). (#4228) *(@wojciechszyjka)*
+- 🔒 Enforce ctx tenant/org scope on Code Mode api.request (#2658). (#4174) *(@ArtSadWLC)*
+- 🔒 Remove raw acceptance-token fallback in public quote endpoints (#2929). (#2997) *(@adeptofvoltron)*
+
+## 🐛 Fixes
+- 🔐 Stop stale pre-auth 401 flashing "Session expired" after login. (#4917) *(@patzick)*
+- 🐛 Add pr write permissions. (#4754) *(@MStaniaszek1998)*
+- 🐛 Name Open Mercato sp. z o.o. as the marketing-consent controller. (#4751) *(@pkarw)*
+- 🔧 Honor app tsconfig in dynamic loader builds (supersedes #4707). (#4724) *(@goer, via @pkarw)*
+- 🔄 Stop reindex batches from silently dropping records (supersedes #4593). (#4598) *(@jtomaszewski, via @pkarw)*
+- 🐛 Surface swallowed Next.js dev startup errors, retry cold starts. (#4567) *(@patzick)*
+- 🐛 Avoid nested provider controls (supersedes #4524). (#4562) *(@hubert-madej-softiq, via @pkarw)*
+- 🐛 Default the agentic wizard instead of hanging without a TTY. (#4557) *(@wojciechszyjka)*
+- 🔄 Await dynamic import so cache recovery runs (supersedes #4536). (#4540) *(@wojciechszyjka, via @pkarw)*
+- 🔄 Update .gitignore to include npm cache directory. (#4533) *(@dominikpalatynski)*
+- 🔐 Enforce tenant scope in command CRUD. (#4531) *(@andrzejewsky)*
+- 🐛 Give the AGENTS.md budget chain sort an explicit comparator. (#4527) *(@wojciechszyjka)*
+- 🔐 Tenant-scope custom entity mutations (supersedes #4134). (#4511) *(@haxiorz, via @pkarw)*
+- 🔄 Invalidate trigger cache on customize and reset-to-code (#4425). (#4509) *(@wojciechszyjka)*
+- 🐛 Restore ESLint coverage and keep audit green (supersedes #4496). (#4501) *(@wojciechszyjka, via @pkarw)*
+- 🐛 Backfill poisoned customer_entity_id links (#4473). (#4494) *(@wojciechszyjka)*
+- 🔐 Harden rate-limit proxy trust (#4041) (supersedes #4074). (#4490) *(@haxiorz, via @pkarw)*
+- 🐛 Reject over-limit captures (#3880) (supersedes #4083). (#4486) *(@haxiorz, via @pkarw)*
+- 🐛 Explain read-only system entity settings (supersedes #3713). (#4482) *(@adeptofvoltron, via @pkarw)*
+- 🐛 Make yarn test pass on a fresh scaffold (#4328). (#4476) *(@wojciechszyjka)*
+- 🐛 Inline hint when dictionary options need organization context (supersedes #4406). (#4470) *(@wojciechszyjka, via @pkarw)*
+- 🐛 Return 400 for malformed uuid list filters (#3819). (#4468) *(@DarrenStasiakDev4You)*
+- 🔧 Restore request bodies from runtime registry (supersedes #4410). (#4467) *(@wojciechszyjka, via @pkarw)*
+- 🐛 Register code-defined workflow triggers with the trigger engine (supersedes #4443). (#4463) *(@wojciechszyjka, via @pkarw)*
+- 🐛 Scaffolded apps run their own tooling (supersedes #4454). (#4456) *(@wojciechszyjka, via @pkarw)*
+- 🖼️ Library interaction fixes — input focus and download-cell click. (#4450) *(@wojciechszyjka)*
+- 🐛 Malformed ?ids= no longer returns the full list. (#4444) *(@wojciechszyjka)*
+- 🔧 Load command interceptors in the CLI/queue-worker bootstrap. (#4414) *(@wojciechszyjka)*
+- 🐛 Apply overrides.widgets.dashboard to the server-side widget catalog (#4377). (#4408) *(@wojciechszyjka)*
+- 🐛 Restore standalone optimistic locking DI (supersedes #4209). (#4395) *(@migace, via @pkarw)*
+- 🐛 CustomFieldValuesList honors listVisible and formats values by kind. (#4388) *(@wojciechszyjka)*
+- 🐛 Give ActivityTimeline 'Mark done' the compact sizing its sibling uses. (#4387) *(@wojciechszyjka)*
+- 💰 Order-approval trigger listens for sales.order.created so it can auto-start. (#4385) *(@wojciechszyjka)*
+- 🐛 Resolve synthetic code-definition UUID in definitions/[id] GET. (#4383) *(@wojciechszyjka)*
+- 🐛 Simple-approval EMIT_EVENT activities use eventName so instances stop failing. (#4382) *(@wojciechszyjka)*
+- 🐳 Forward runtime environment and protect Redis queues. (#4369) *(@MStaniaszek1998)*
+- 🔐 Handle "All organizations" scope across audited org-scoped endpoints. (#4367) *(@jtomaszewski)*
+- 🐳 Forward production runtime environment. (#4366) *(@MStaniaszek1998)*
+- 🔧 Stop idle-in-transaction reaps crashing the scheduler daemon. (#4364) *(@MStaniaszek1998)*
+- 🔧 Stop pg idle-client error crashing daemons; fix webhook worker payload. (#4360, #4359) *(@MStaniaszek1998)*
+- 💰 Hide compose-message action on order/quote pages when messages module is disabled. (#4352) *(@jtomaszewski)*
+- 🌍 Translate directory edit page chrome and dashboard welcome widget (#4302). (#4343) *(@pkarw)*
+- 🔐 Make the public quote tenant guard fire on null-tenant sessions (#4309). (#4340) *(@pkarw)*
+- 💰 Include currencies and communication_channels in CRM. (#4318) *(@dominikpalatynski)*
+- 🔧 Register catalog/notifications DI factories with .proxy() for CLASSIC mode. (#4299) *(@helloandygithub)*
+- 🔐 Resolve global entity scope from metadata. (#4285) *(@vloneskorpion)*
+- 📦 Retry standalone install through npm quarantine window. (#4281) *(@patzick)*
+- 🐛 Pin scaffolded app to yarn 4.17.1 for TS 7 install. (#4280) *(@patzick)*
+- 🔧 Register code workflows in CLI/worker bootstrap (#4257). (#4263) *(@wojciechszyjka)*
+- 🖼️ Carry reconcile healing fix past audit gate (supersedes #4253). (#4260) *(@wojciechszyjka, via @pkarw)*
+- 🔧 Carry payload parity fix into 0.6.7 (supersedes #4252). (#4259) *(@wojciechszyjka, via @pkarw)*
+- 🔐 Localize pay-page session-start failure and add field a11y semantics (#4212). (#4227) *(@wojciechszyjka)*
+- 🐛 Return 400 for invalid entry input and fix entry dialog a11y (#4218). (#4226) *(@wojciechszyjka)*
+- 🔐 Stop the 401 session-refresh loop on "all organizations". (#4224) *(@piotrchabros)*
+- 🔐 Stop session refresh minting "null" tenant/org scope claims. (#4223) *(@piotrchabros)*
+- 🔐 Stop the deals 401 session-refresh loop on "all organizations". (#4222) *(@piotrchabros)*
+- 🌍 Localize the customer role permission catalog (#4203). (#4205) *(@pkarw)*
+- 🔐 Localize portal permission catalog (#4203). (#4204) *(@pat-lewczuk)*
+- 💰 Include custom/operator-defined order adjustments in the grand total (#4052). (#4198) *(@adeptofvoltron)*
+- 💰 Keep order linked to saved address on re-save (#4169). (#4196) *(@adeptofvoltron)*
+- 🐛 Mobile layout — clamp Export dropdown & demo overlays, scrollable calendar tabs. (#4188) *(@zielivia)*
+- 🔐 Rate-limit the unauthenticated tenant lookup (#3850). (#4182) *(@adeptofvoltron)*
+- 🔐 Fail closed on null-tenant widget-assignment ownership checks (#3843). (#4181) *(@adeptofvoltron)*
+- 🐛 Cap the organizations list pageSize at the platform 100 (#3851). (#4180) *(@adeptofvoltron)*
+- 🔐 Make entry command ensureScope fail closed on null org/tenant (#3846). (#4177) *(@adeptofvoltron)*
+- 🔐 Scope and rate-limit the public org slug lookup (#3849). (#4173) *(@adeptofvoltron)*
+- 🐛 Bound dashboard layout and widget-assignment arrays (#3844). (#4172) *(@adeptofvoltron)*
+- 💰 Block lowering an order line qty below the shipped quantity (#3993). (#4163) *(@adeptofvoltron)*
+- 🐛 Drop unreachable legacy widget injection spots (#3952). (#4162) *(@adeptofvoltron)*
+- 🐛 Hide Company V2 Deals tab without customers.deals.view (#4124). (#4159) *(@adeptofvoltron)*
+- 🐛 Recognize structured-logger noise in dev log policies. (#4158) *(@pkarw)*
+- 🐛 Add Kosovo (XK) to the country dictionary (#4128). (#4157) *(@adeptofvoltron)*
+- 💰 Make primary email fit the order details summary card (#4148). (#4156) *(@adeptofvoltron)*
+- 🐛 Integrations tabs use DS underline variant + violet hover (#2015). (#4138) *(@zielivia)*
+- 🐛 Preserve customer addresses in shipments (#4058). (#4116) *(@pkarw)*
+- 🔐 Require trusted webhook scope (#3865). (#4112) *(@haxiorz)*
+- 🐛 Close disabled self-service flow (#3878). (#4089) *(@haxiorz)*
+- 💰 Make payment sessions concurrency-safe (#4035) (supersedes #4062). (#4087) *(@haxiorz, via @pkarw)*
+- 🔐 Enforce role organization scope (#4032) (supersedes #4050). (#4086) *(@haxiorz, via @pkarw)*
+- 🐛 Prevent anonymous feedback recipient emails (#3879). (#4082) *(@haxiorz)*
+- 🔐 Scope availability command target loads (#3884). (#4078) *(@haxiorz)*
+- 🐛 Clear moderate production advisories (#4046). (#4065) *(@haxiorz)*
+- 🐛 Prevent duplicate provider operations (#4036). (#4064) *(@haxiorz)*
+- 🐛 Protect OIDC requests from SSRF (#4037). (#4063) *(@haxiorz)*
+- 🐛 Enforce Ollama connection-time URL safety (#4038). (#4061) *(@haxiorz)*
+- 🐛 Fail closed on scoped deletion (#4033). (#4051) *(@haxiorz)*
+- 🔐 Scope query index status diagnostics (#3887). (#4015) *(@haxiorz)*
+- 🐛 Resolve /start API base URL server-side to prevent hydration mismatch. (#3995) *(@pkarw)*
+- 🐛 Enforce scoped object access (#3915). (#3961) *(@haxiorz)*
+- 🔐 Scope S3 list prefixes to tenant namespace (#3916). (#3959) *(@haxiorz)*
+- 🔄 Block redirect-hop SSRF (#3919). (#3954) *(@haxiorz)*
+- 🐛 Stream customer CSV imports. (#3950) *(@haxiorz)*
+- 🐛 Gate injection widgets by features (#3930). (#3946) *(@haxiorz)*
+- 🐛 Guard unscoped inbound webhooks. (#3943) *(@haxiorz)*
+- 🐛 Gate UPDATE_ENTITY commands (#3933). (#3941) *(@haxiorz)*
+- 🐛 Fail loud on stale org selection instead of orphaning writes. (#3936) *(@jtomaszewski)*
+- 🖼️ Store uploads under the selected organization, not the uploader home org (#3765). (#3788) *(@adeptofvoltron)*
+- 🔐 Scope recipient picker to the sender's active organization (#3763). (#3787) *(@adeptofvoltron)*
+- 🐛 Clarify and localize field definitions editor (supersedes #3714). (#3759) *(@PatrickMade, via @pmadajthey)*
+- 💰 Pin orders/quotes number column on horizontal scroll (#3039). (#3045) *(@haxiorz)*
+- 🔐 Auto-assign tenant on organization create for non-super-admins (#2988). (#2993) *(@adeptofvoltron)*
+
+## 🛠️ Improvements
+- 🛠️ Cache dictionary-entry value lookups on order create (supersedes #3948). (#4504) *(@KamilGrocholski, via @pkarw)*
+- 🛠️ Translate the remaining Polish CRM strings (#2077, #4380). (#4446) *(@wojciechszyjka)*
+- 🛠️ Bump actions/setup-node from 4 to 7. (#4292)
+- 🛠️ Bump websocket-driver to 0.7.5 on develop. (#4258) *(@pkarw)*
+- 🛠️ Avoid app bootstrap after generation. (#4219) *(@andrzejewsky)*
+- 🛠️ Avoid invalidation after no-op generation. (#4217) *(@andrzejewsky)*
+- 🛠️ Stop hashing generator inputs while idle. (#4216) *(@andrzejewsky)*
+- 🛠️ Skip unchanged OpenAPI generation. (#4215) *(@andrzejewsky)*
+- 🛠️ Share registry discovery across generators. (#4214) *(@andrzejewsky)*
+- 🛠️ Migrate to TypeScript 7.0.2 native compiler. (#4199) *(@patzick)*
+- 🛠️ Adopt the standardized 404 helpers across customers and sales (#2364). (#4183) *(@adeptofvoltron)*
+- 🛠️ Add parseCommaSeparatedList() helper and adopt it across CLI/API handlers (#2363). (#4178) *(@adeptofvoltron)*
+- 🛠️ Prefer the canonical .agents/skills dir in install-skills (#4155). (#4164) *(@adeptofvoltron)*
+- 🛠️ Bump minor-and-patch dependency group (65 updates). (#4161) *(@pkarw)*
+- 🛠️ Rename "Storage" nav group to "Media". (#3731) *(@jtomaszewski)*
+
+## 🧪 Testing
+- 🧪 Stub DNS in the redirect-hop tests so develop is green again (#4515). (#4516) *(@wojciechszyjka)*
+
+## 📝 Specs & Documentation
+- 📝 Migrate legal entity from CT Tornado to Open Mercato sp. z o.o. (#4755) *(@pkarw)*
+- 📝 Publish Enterprise License Agreement Terms v2.2. (#4610) *(@matgren)*
+- 📝 Fit the root AGENTS.md into Codex's 32 KiB instruction budget (#4484). (#4506) *(@wojciechszyjka)*
+- 📝 Note that finishing the self-QA exception needs `triage` permission (#4478). (#4498) *(@wojciechszyjka)*
+- 📝 Clarify three-store architecture, fix stale naming, add evolution spec. (#4492) *(@jtomaszewski)*
+- 📝 Exempt tested no-UI changes from manual QA (supersedes #4448). (#4461) *(@wojciechszyjka, via @pkarw)*
+- 📝 Complete Polish translations and drop duplicated integrations keys (#2077). (#4452) *(@wojciechszyjka)*
+- 📝 Sync agent-pipeline tracker & browser descriptors. (#4393) *(@pkarw)*
+- 📝 Specify secure durable user tasks. (#4336) *(@pmadajthey)*
+- 📝 Specify reliable completion events (carry #4314) (supersedes #4314). (#4321) *(@PatrickMade, via @pkarw)*
+- 📝 Specify stable activity output paths (carry #4312) (supersedes #4312). (#4320) *(@PatrickMade, via @pkarw)*
+- 📝 Sync skill roster and docs with skills collection consolidation. (#4296) *(@pkarw)*
+- 📝 Import om-gap-analysis + om-app-spec-writing as repo-local analysis tier. (#4276) *(@pkarw)*
+- 📝 DS developer-experience roadmap — brand import, UX walkthroughs, mockup composer. (#4270) *(@zielivia)*
+- 📝 Specify scoped member directory. (#4200) *(@pmadajthey)*
+- 📝 Add banner promoting open-mercato/skills. (#4152) *(@pkarw)*
+
+## 👥 Contributors
+
+- @MStaniaszek1998
+- @patzick
+- @jakubsobczak-syhi
+- @adeptofvoltron
+- @wojciechszyjka
+- @tomaszscigalacshark
+- @DarrenStasiakDev4You
+- @WebEferen
+- @jtomaszewski
+- @zielivia
+- @mkadziolka
+- @Marynat
+- @ArtSadWLC
+- @pkarw
+- @goer
+- @hubert-madej-softiq
+- @dominikpalatynski
+- @andrzejewsky
+- @haxiorz
+- @migace
+- @helloandygithub
+- @vloneskorpion
+- @piotrchabros
+- @pat-lewczuk
+- @PatrickMade
+- @KamilGrocholski
+- @matgren
+- @pmadajthey
+
+---
 
 # 0.6.6 (2026-07-17)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,75 @@ PRs do not publish npm canary packages automatically. Maintainers can publish pk
 
 The legacy npm canary snapshot path is still available for comparison by dispatching the `NPM Snapshot Preview` workflow manually with the PR number on a trusted same-repository PR branch. That workflow publishes real npm canary packages and runs standalone app integration against the exact snapshot, so use it only when pkg.pr.new previews are not enough evidence. Both preview workflows are restricted to same-repository PR branches.
 
+## Releasing
+
+Two channels ship packages to npm:
+
+- **Snapshots** — every push to `develop` runs `Develop Snapshot Release`, publishing under the `develop` dist-tag. Fully automatic; nothing to do.
+- **Stable releases** — a maintainer-driven two-stage flow off `main`, described below.
+
+Stable releases are split across two workflows on purpose. `main` is protected, so a workflow cannot push a version bump to it directly; the bump lands through a normal PR, and the publishing workflow only ever pushes a tag.
+
+### Stage 0 — land the changelog
+
+Add the `# <version> (YYYY-MM-DD)` section to [`CHANGELOG.md`](CHANGELOG.md) and merge it to `main`. The release workflow reads its GitHub Release notes from this section and **fails without it**, so this comes first. The `om-auto-update-changelog` skill drafts the entry.
+
+### Stage 1 — `Release Prepare`
+
+Dispatch **Release Prepare** from the Actions tab with a `patch`, `minor` or `major` bump:
+
+```bash
+gh workflow run release-prepare.yml --ref main -f bump=patch
+```
+
+It bumps every public package plus the root manifest, pushes `release/v<version>`, and opens a PR against `main`. It publishes nothing. The PR body confirms whether the changelog entry exists. Review and merge it as usual.
+
+> Opening the PR automatically requires _Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"_. Without it the branch is still pushed and the job summary links straight to the compare page — one click instead of zero.
+
+### Stage 2 — `Release`
+
+With the bump on `main`, dispatch **Release**:
+
+```bash
+gh workflow run release.yml --ref main
+```
+
+The job requires approval from the `production` environment, then runs in a deliberate order — every reversible step before the irreversible one:
+
+1. **Preflight** — version alignment across packages, the version is not already on npm, and the changelog section exists. Nothing has happened yet if any of these fail.
+2. **Build** — `build:packages`, `generate`, `build:packages`.
+3. **Tag** — pushes `v<version>`. A tag is cheap to delete; an npm version is not.
+4. **Publish** — `publish-packages.sh` with npm provenance, skipping anything already published.
+5. **GitHub Release** — notes built from the changelog section plus the published-package table.
+
+### Resuming a failed release
+
+If publishing fails partway, packages are already on npm and cannot be republished — npm is ahead of git, and the repository has to catch up. Both stages take the same `resume` flag for this, which relaxes the guards that would otherwise refuse an already-published version.
+
+If the version bump never landed on `main`, run the whole flow again with `resume: true`:
+
+```bash
+gh workflow run release-prepare.yml --ref main -f bump=patch -f resume=true
+# merge the recovery PR, then
+gh workflow run release.yml --ref main -f resume=true
+```
+
+If the bump is already on `main` and only publishing failed, just the second command is needed.
+
+In resume mode, `Release Prepare` skips the "not on npm yet" and "tag does not exist" checks and marks the PR as a recovery; `Release` skips the same npm preflight, skips packages that already published, reuses the existing tag, and refreshes the release notes instead of failing.
+
+> `resume` disables the guard that prevents double-publishing. Use it only when a run died *after* npm publish — on a normal release it removes a check you want.
+
+### Local equivalents
+
+`yarn release:{patch,minor,major}` bump, build and publish from a working copy; `yarn release:existing` publishes the version already in the root `package.json`. None of them tag or push — prefer the workflows. Useful for inspection:
+
+```bash
+yarn release:bump patch                 # bump manifests only, no build or publish
+yarn release:check-unpublished 0.6.8    # is this version already on npm?
+./scripts/changelog-section.sh 0.6.8    # preview the release notes body
+```
+
 ## Helpful Resources
 
 - 📚 Documentation: [docs.openmercato.com](https://docs.openmercato.com/)

--- a/apps/docs/docs/cli/scheduler.mdx
+++ b/apps/docs/docs/cli/scheduler.mdx
@@ -223,7 +223,7 @@ Starting scheduler in LOCAL mode...
 
 Configuration:
 - Poll Interval: 30000ms
-- Lock Strategy: PostgreSQL advisory locks
+- Lock Strategy: in-process (single instance only)
 - Execution: Direct (queue/command)
 
 Database connected

--- a/apps/docs/docs/framework/scheduler/overview.mdx
+++ b/apps/docs/docs/framework/scheduler/overview.mdx
@@ -64,7 +64,8 @@ import {
 ```typescript
 class LocalSchedulerService {
   // Polls database every 30s (configurable via SCHEDULER_POLL_INTERVAL_MS)
-  // Uses PostgreSQL advisory locks for single-instance safety
+  // Prevents duplicate execution in-process; the PostgreSQL advisory lock
+  // only serialises the claim, not the run
   // Enqueues to target queues or executes commands directly
   async start(): Promise<void>
   async stop(): Promise<void>
@@ -80,6 +81,23 @@ class LocalSchedulerService {
 - ~30 second timing accuracy
 - Single instance only
 - No execution history UI
+
+:::warning Run exactly one process with `QUEUE_STRATEGY=local`
+
+The local strategy provides **no cross-process protection**. Duplicate prevention is
+in-process only: the PostgreSQL advisory lock is released as soon as the short claim
+transaction commits (holding it across the whole run would pin a connection
+idle-in-transaction and get it reaped), and `nextRunAt` is advanced only after the
+target has run. A second process polling the same database therefore sees the schedule
+as still due and executes it too — the same job is enqueued twice, or the same command
+runs twice.
+
+Two entry points start this engine: `mercato scheduler start` and
+`mercato worker --with-scheduler`. Running both, or overlapping containers during a
+rolling redeploy, double-fires every schedule due in that window. Use
+`QUEUE_STRATEGY=async` when more than one instance may run.
+
+:::
 
 #### Async Strategy (`QUEUE_STRATEGY=async`)
 

--- a/apps/docs/docs/user-guide/scheduler.mdx
+++ b/apps/docs/docs/user-guide/scheduler.mdx
@@ -105,7 +105,7 @@ The scheduler supports two execution strategies:
 **Environment:** `QUEUE_STRATEGY=local` (default)
 
 - Polls the database every 30 seconds for due schedules
-- Uses PostgreSQL advisory locks for safety
+- Prevents duplicate execution within the process only — run exactly one scheduler process, or a second one will execute the same due schedule
 - No Redis required
 - Best for development and single-instance deployments
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "release:patch": "./scripts/release-patch.sh",
     "release:minor": "./scripts/release-minor.sh",
     "release:major": "./scripts/release-major.sh",
+    "release:bump": "./scripts/bump-version.sh",
+    "release:check-unpublished": "./scripts/check-version-unpublished.sh",
     "i18n:check-sync": "tsx scripts/i18n-check-sync.ts",
     "i18n:check-usage": "tsx scripts/i18n-check-usage.ts",
     "i18n:check-hardcoded": "tsx scripts/i18n-check-hardcoded.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-mercato",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "private": true,
   "packageManager": "yarn@4.17.1+sha512.ccbfabf7d7b6b32075088be9386fb9a2e00bb6887ef07fa56effabc890a56d53da1ccc4128d62db245fcbd3961b236d75335bdf7d5320ed6eafb7588b7ad4697",
   "engines": {

--- a/packages/ai-assistant/package.json
+++ b/packages/ai-assistant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/ai-assistant",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "engines": {

--- a/packages/cache/package.json
+++ b/packages/cache/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/cache",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "description": "Multi-strategy cache service with tag-based invalidation support",
   "type": "module",

--- a/packages/channel-gmail/package.json
+++ b/packages/channel-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/channel-gmail",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/channel-imap/package.json
+++ b/packages/channel-imap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/channel-imap",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/checkout/package.json
+++ b/packages/checkout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/checkout",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/cli",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/content/package.json
+++ b/packages/content/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/content",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/core",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/src/modules/auth/__tests__/login-feature-check-once.test.tsx
+++ b/packages/core/src/modules/auth/__tests__/login-feature-check-once.test.tsx
@@ -114,3 +114,21 @@ describe('LoginPage — feature-check fires once (#3128)', () => {
     expect(featureCheckCalls()).toBe(1)
   })
 })
+
+describe('LoginPage — session probe opts out of the session-expired redirect', () => {
+  it('sends the unauthorized/forbidden opt-out headers so a late 401 cannot flash "Session expired"', async () => {
+    await act(async () => {
+      render(<LoginPage />)
+    })
+    await waitFor(() => expect(featureCheckCalls()).toBe(1))
+
+    const [, init] = mockApiCall.mock.calls.find(([url]) => url === '/api/auth/feature-check') as [
+      string,
+      { headers?: Record<string, string> },
+    ]
+    expect(init.headers).toMatchObject({
+      'x-om-unauthorized-redirect': '0',
+      'x-om-forbidden-redirect': '0',
+    })
+  })
+})

--- a/packages/core/src/modules/auth/frontend/login.tsx
+++ b/packages/core/src/modules/auth/frontend/login.tsx
@@ -135,7 +135,13 @@ export default function LoginPage() {
       try {
         const res = await apiCall<{ userId?: string }>('/api/auth/feature-check', {
           method: 'POST',
-          headers: { 'content-type': 'application/json' },
+          headers: {
+            'content-type': 'application/json',
+            // Probing for an already-active session: a 401 is the expected answer
+            // for an anonymous visitor, never a session that just expired.
+            'x-om-unauthorized-redirect': '0',
+            'x-om-forbidden-redirect': '0',
+          },
           body: JSON.stringify({ features: [] }),
           cache: 'no-store',
         })

--- a/packages/core/src/modules/customers/__integration__/TC-CRM-086.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-086.spec.ts
@@ -35,6 +35,60 @@ test.describe('TC-CRM-086: DataTable column resize + persistence', () => {
     const targetColumnWidth = () =>
       targetHeader().evaluate((el) => Math.round((el as HTMLElement).getBoundingClientRect().width));
 
+    // The header keeps reflowing after the first row paints (remaining rows land,
+    // the local perspective snapshot hydrates). Grabbing the handle mid-reflow
+    // makes the pointer miss the box captured a moment earlier, and a re-render
+    // during the drag unmounts the handle, which cancels the drag by design — so
+    // wait for the width to hold steady across two samples before measuring.
+    const waitForSettledColumnWidth = async () => {
+      let previous = -1;
+      let settled = -1;
+      await expect
+        .poll(async () => {
+          const current = await targetColumnWidth();
+          const isStable = current === previous;
+          previous = current;
+          if (isStable) settled = current;
+          return isStable;
+        }, { timeout: 15_000, intervals: [200, 200, 300, 500] })
+        .toBe(true);
+      return settled;
+    };
+
+    const dragHandleRight = async (deltaX: number) => {
+      const box = await resizeHandle().boundingBox();
+      expect(box).not.toBeNull();
+      const originX = box!.x + box!.width / 2;
+      const originY = box!.y + box!.height / 2;
+      await page.mouse.move(originX, originY);
+      await page.mouse.down();
+      await page.mouse.move(originX + deltaX, originY, { steps: 10 });
+      await page.mouse.up();
+    };
+
+    const widenedBy = async (baseline: number) => {
+      try {
+        await expect
+          .poll(targetColumnWidth, { timeout: 3_000, intervals: [100, 100, 200, 300] })
+          .toBeGreaterThan(baseline + 80);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    // Returns the baseline the successful gesture started from, so the caller
+    // asserts against the width the drag actually built on.
+    const widenTargetColumn = async (deltaX: number) => {
+      let baseline = await waitForSettledColumnWidth();
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        await dragHandleRight(deltaX);
+        if (await widenedBy(baseline)) return baseline;
+        if (attempt < 3) baseline = await waitForSettledColumnWidth();
+      }
+      return baseline;
+    };
+
     try {
       token = await getAuthToken(request);
       for (let i = 0; i < 2; i++) {
@@ -53,28 +107,21 @@ test.describe('TC-CRM-086: DataTable column resize + persistence', () => {
       await page.goto('/backend/customers/companies', { waitUntil: 'domcontentloaded' });
       await waitForTableReady();
 
-      const handle = resizeHandle();
-      await expect(handle).toBeAttached();
-      const before = await targetColumnWidth();
+      await expect(resizeHandle()).toBeAttached();
 
       // -- Drag the handle right by ~130px → the column widens --------------------
-      const box = await handle.boundingBox();
-      expect(box).not.toBeNull();
-      const cx = box!.x + box!.width / 2;
-      const cy = box!.y + box!.height / 2;
-      await page.mouse.move(cx, cy);
-      await page.mouse.down();
-      await page.mouse.move(cx + 130, cy, { steps: 10 });
-      await page.mouse.up();
-
-      const after = await targetColumnWidth();
-      expect(after, 'dragging the handle should widen the column').toBeGreaterThan(before + 80);
+      const before = await widenTargetColumn(130);
+      await expect
+        .poll(targetColumnWidth, { timeout: 5_000, message: 'dragging the handle should widen the column' })
+        .toBeGreaterThan(before + 80);
 
       // -- The width survives a full reload (persisted, not saved as a view) -----
       await page.reload({ waitUntil: 'domcontentloaded' });
       await waitForTableReady();
-      const afterReload = await targetColumnWidth();
-      expect(afterReload, 'the resized width should survive a page reload').toBeGreaterThan(before + 80);
+      await expect
+        .poll(targetColumnWidth, { timeout: 10_000, message: 'the resized width should survive a page reload' })
+        .toBeGreaterThan(before + 80);
+      const afterReload = await waitForSettledColumnWidth();
 
       // -- Double-click resets the column back to its auto width ------------------
       await resizeHandle().dblclick();

--- a/packages/core/src/modules/entities/api/__tests__/relations.options.test.ts
+++ b/packages/core/src/modules/entities/api/__tests__/relations.options.test.ts
@@ -10,7 +10,26 @@ const mockQE = {
   })),
 }
 
-const mockEm = {}
+// Entity ids the fake ORM metadata knows about, keyed by the class name the
+// resolver derives from the id's entity segment.
+const registeredTables: Record<string, string> = {
+  CustomerEntity: 'customer_entities',
+}
+
+const mockEm = {
+  // Custom (doc-storage) entities: registered rows make an id queryable.
+  findOne: jest.fn(async (_entity: unknown, where: { entityId?: string }) => (
+    typeof where?.entityId === 'string' && where.entityId.startsWith('virtual:')
+      ? { labelField: null }
+      : null
+  )),
+  getMetadata: () => ({
+    find: (className: string) => (
+      registeredTables[className] ? { tableName: registeredTables[className] } : undefined
+    ),
+    getAll: () => Object.values(registeredTables).map((tableName) => ({ tableName })),
+  }),
+}
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: async () => ({ resolve: (key: string) => (key === 'queryEngine' ? mockQE : mockEm) }),
@@ -97,6 +116,39 @@ describe('GET /api/entities/relations/options', () => {
         page: { page: 1, pageSize: 200 },
       }),
     )
+  })
+
+  // #4949: a relation custom field whose `relatedEntityId` was never filled in sent
+  // `entityId=p:0`; the query engine guessed a table name for it and Postgres raised
+  // `relation "0s" does not exist`, surfacing as a 500 on every render of the section.
+  it.each([
+    ['a half-configured placeholder id', 'p:0'],
+    ['a well-formed id no entity backs', 'nosuch:thing'],
+    ['an id without a module segment', 'person'],
+  ])('answers with an empty option list for %s', async (_label, entityId) => {
+    const req = new Request(
+      `http://x/api/entities/relations/options?entityId=${encodeURIComponent(entityId)}`,
+    )
+
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ items: [] })
+    expect(mockQE.query).not.toHaveBeenCalled()
+  })
+
+  it('still queries a registered ORM entity that has no custom entity row', async () => {
+    mockQE.query.mockResolvedValueOnce({ items: [] })
+
+    const req = new Request(
+      'http://x/api/entities/relations/options?entityId=customers:customer_entity&labelField=title',
+    )
+
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    expect(mockEm.findOne).toHaveBeenCalled()
+    expect(mockQE.query).toHaveBeenCalledWith('customers:customer_entity', expect.any(Object))
   })
 
   it('defaults to pageSize 50 when no ids are provided', async () => {

--- a/packages/core/src/modules/entities/api/relations/options.ts
+++ b/packages/core/src/modules/entities/api/relations/options.ts
@@ -8,12 +8,16 @@ import type { EntityManager } from '@mikro-orm/postgresql'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { resolveRegisteredEntityTableName } from '@open-mercato/shared/lib/query/engine'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['entities.definitions.view'] },
 }
 
 const ALLOWED_ROUTE_CONTEXT_FIELDS = new Set(['kind', 'entity_id', 'product_id'])
+
+const logger = createLogger('entities')
 
 export async function GET(req: Request) {
   const url = new URL(req.url)
@@ -44,17 +48,27 @@ export async function GET(req: Request) {
   const qe = container.resolve('queryEngine') as QueryEngine
   const em = container.resolve('em') as EntityManager
 
-  if (!labelField) {
-    const cfg = await em.findOne(CustomEntity, {
-      entityId,
-      $and: [
-        { $or: [ { organizationId: auth.orgId ?? undefined as any }, { organizationId: null } ] },
-        { $or: [ { tenantId: auth.tenantId ?? undefined as any }, { tenantId: null } ] },
-      ],
-      isActive: true,
-    })
-    labelField = (cfg?.labelField as string | undefined) || ''
+  const customEntity = await em.findOne(CustomEntity, {
+    entityId,
+    $and: [
+      { $or: [ { organizationId: auth.orgId ?? undefined as any }, { organizationId: null } ] },
+      { $or: [ { tenantId: auth.tenantId ?? undefined as any }, { tenantId: null } ] },
+    ],
+    isActive: true,
+  })
+
+  // A relation field can point at an entity that does not exist — most often a half-configured
+  // `relatedEntityId` that was never filled in (#4949 reported `entityId=p:0`). The query engine
+  // falls back to a pluralized table-name guess for ids it cannot resolve, so such a lookup used
+  // to reach Postgres as `select ... from "0s"` and escape this handler as an unhandled 500 on
+  // every render of the section holding the field. Resolve the id first and answer with an empty
+  // option list instead, mirroring the empty-`entityId` contract above.
+  if (!customEntity && resolveRegisteredEntityTableName(em, entityId) === null) {
+    logger.warn('Relation options requested for an unresolvable entity id', { entityId })
+    return NextResponse.json({ items: [] })
   }
+
+  if (!labelField) labelField = (customEntity?.labelField as string | undefined) || ''
   if (!labelField) {
     const candidates = ['name', 'title', 'code', 'email']
     const table = tableNameFromEntityId(entityId)
@@ -122,7 +136,7 @@ export const openApi: OpenApiRouteDoc = {
   methods: {
     GET: {
       summary: 'List relation options',
-      description: 'Returns up to 200 option entries for populating relation dropdowns, automatically resolving label fields when omitted.',
+      description: 'Returns up to 200 option entries for populating relation dropdowns, automatically resolving label fields when omitted. An entityId that matches neither an active custom entity nor a registered ORM entity yields an empty option list.',
       query: relationOptionsQuerySchema,
       responses: [
         {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mercato-app",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "type": "module",
   "description": "Create a new Open Mercato application",
   "main": "./dist/index.js",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/enterprise",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/events",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-stripe/package.json
+++ b/packages/gateway-stripe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/gateway-stripe",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/onboarding",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/queue/package.json
+++ b/packages/queue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/queue",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "description": "Multi-strategy job queue with local and BullMQ support",
   "type": "module",

--- a/packages/scheduler/package.json
+++ b/packages/scheduler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/scheduler",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "description": "Database-managed scheduled jobs with admin UI",
   "type": "module",

--- a/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/__tests__/localLockStrategy.test.ts
@@ -87,5 +87,111 @@ describe('LocalLockStrategy', () => {
       await expect(strategy.runWithLock('test-key', fn)).rejects.toThrow(fnError)
       expect(fn).toHaveBeenCalledTimes(1)
     })
+
+    it('should run fn outside the claim transaction', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      let transactionOpen = false
+      transactionalImpl.mockImplementation(async (cb: any) => {
+        transactionOpen = true
+        const result = await cb(mockForkedEm)
+        transactionOpen = false
+        return result
+      })
+
+      let openDuringFn: boolean | null = null
+      const fn = jest.fn(async () => {
+        openDuringFn = transactionOpen
+        return 'ok'
+      })
+
+      const result = await strategy.runWithLock('test-key', fn)
+
+      expect(result).toEqual({ acquired: true, result: 'ok' })
+      expect(openDuringFn).toBe(false)
+    })
+
+    it('should reject a concurrent run for the same key without touching the database', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      let releaseFirst: () => void = () => {}
+      const firstDone = new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      })
+      const firstRun = strategy.runWithLock('test-key', async () => {
+        await firstDone
+        return 'first'
+      })
+      await Promise.resolve()
+
+      const secondFn = jest.fn(async () => 'second')
+      const secondRun = await strategy.runWithLock('test-key', secondFn)
+
+      expect(secondRun).toEqual({ acquired: false })
+      expect(secondFn).not.toHaveBeenCalled()
+      expect(mockConnection.execute).toHaveBeenCalledTimes(1)
+
+      releaseFirst()
+      await expect(firstRun).resolves.toEqual({ acquired: true, result: 'first' })
+    })
+
+    it('should release the key after fn completes or throws', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      await expect(
+        strategy.runWithLock('test-key', async () => {
+          throw new Error('Callback failed')
+        }),
+      ).rejects.toThrow('Callback failed')
+
+      const fn = jest.fn(async () => 'ok')
+      await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should release the key when the claim is not acquired', async () => {
+      ;(mockConnection.execute as any).mockResolvedValueOnce([{ acquired: false }])
+      ;(mockConnection.execute as any).mockResolvedValueOnce([{ acquired: true }])
+
+      await expect(strategy.runWithLock('test-key', async () => 'ok')).resolves.toEqual({ acquired: false })
+
+      const fn = jest.fn(async () => 'ok')
+      await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
+    })
+
+    it('should release the key when the claim transaction itself rejects', async () => {
+      ;(mockConnection.execute as any).mockRejectedValueOnce(new Error('Database connection failed'))
+      ;(mockConnection.execute as any).mockResolvedValueOnce([{ acquired: true }])
+
+      await expect(strategy.runWithLock('test-key', async () => 'ok')).resolves.toEqual({ acquired: false })
+
+      const fn = jest.fn(async () => 'ok')
+      await expect(strategy.runWithLock('test-key', fn)).resolves.toEqual({ acquired: true, result: 'ok' })
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not let a held key block a different key', async () => {
+      ;(mockConnection.execute as any).mockResolvedValue([{ acquired: true }])
+
+      let releaseFirst: () => void = () => {}
+      const firstDone = new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      })
+      const firstRun = strategy.runWithLock('key-a', async () => {
+        await firstDone
+        return 'first'
+      })
+      await Promise.resolve()
+
+      const secondFn = jest.fn(async () => 'second')
+      await expect(strategy.runWithLock('key-b', secondFn)).resolves.toEqual({
+        acquired: true,
+        result: 'second',
+      })
+      expect(secondFn).toHaveBeenCalledTimes(1)
+
+      releaseFirst()
+      await expect(firstRun).resolves.toEqual({ acquired: true, result: 'first' })
+    })
   })
 })

--- a/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
+++ b/packages/scheduler/src/modules/scheduler/lib/localLockStrategy.ts
@@ -4,44 +4,78 @@ import { createLogger } from '@open-mercato/shared/lib/logger'
 const logger = createLogger('scheduler').child({ component: 'local' })
 
 /**
- * PostgreSQL advisory lock strategy for single-instance or local development
+ * Mutual-exclusion strategy for single-instance or local development.
+ *
+ * Exclusion for the duration of the guarded run is IN-PROCESS (`heldKeys`).
+ * The PostgreSQL advisory lock only serialises concurrent *claims* — it is
+ * transaction-scoped and released as soon as the short claim transaction
+ * commits, before the guarded function runs. It therefore does NOT protect
+ * against two processes executing the same key concurrently; that matches the
+ * documented single-instance contract of the local scheduler strategy, and
+ * `LocalSchedulerService.start()` warns about it at startup.
  */
 export class LocalLockStrategy {
+  // Process-local by construction, so it only guards a single strategy
+  // instance. Invariant relied upon: exactly one LocalLockStrategy exists per
+  // process, because the only construction site is LocalSchedulerService
+  // (an Awilix singleton) and only the CLI entry points start the polling
+  // engine. A caller that resolves a second container would silently get an
+  // independent guard — see the single-instance warning in
+  // LocalSchedulerService.start().
+  private heldKeys = new Set<string>()
+
   constructor(private em: () => EntityManager) {}
 
   /**
-   * Execute a function under a PostgreSQL advisory lock.
+   * Execute a function under a mutual-exclusion lock.
    *
-   * IMPORTANT: Uses transaction-scoped advisory locks (`pg_try_advisory_xact_lock`)
-   * to avoid connection pool/session mismatch issues. The lock is automatically
-   * released when the transaction ends.
+   * In-process exclusion for the whole duration of `fn` comes from `heldKeys`
+   * (this strategy is single-instance by contract). The transaction-scoped
+   * advisory lock (`pg_try_advisory_xact_lock`) only guards the claim itself
+   * against a concurrently claiming process and is released when the short
+   * claim transaction commits, BEFORE `fn` runs.
+   *
+   * IMPORTANT: `fn` must NOT run inside that transaction. Holding the
+   * transaction open across `fn` leaves the connection idle-in-transaction
+   * while `fn` awaits non-DB work; the pool's default
+   * `idle_in_transaction_session_timeout` (120s) then makes Postgres kill the
+   * connection (FATAL 25P03), which crashes the scheduler process.
    */
   async runWithLock<T>(key: string, fn: () => Promise<T>): Promise<{ acquired: boolean; result?: T }> {
-    const em = this.em().fork()
-    const hash = this.hashString(key)
-    let lockAcquired = false
+    if (this.heldKeys.has(key)) {
+      return { acquired: false }
+    }
+    // Reserve synchronously before the async claim so a concurrent in-process
+    // caller cannot slip in between our claim transaction committing (which
+    // releases the advisory xact lock) and the start of `fn`.
+    this.heldKeys.add(key)
 
     try {
-      return await em.transactional(async (txEm) => {
-        const result = await txEm.getConnection().execute<{ acquired: boolean }[]>(
-          `SELECT pg_try_advisory_xact_lock(?) as acquired`,
-          [hash],
-        )
+      const em = this.em().fork()
+      const hash = this.hashString(key)
+      let claimed = false
 
-        const acquired = result[0]?.acquired === true
-        if (!acquired) return { acquired: false }
-        lockAcquired = true
-
-        const fnResult = await fn()
-        return { acquired: true, result: fnResult }
-      })
-    } catch (error) {
-      if (lockAcquired) {
-        throw error
+      try {
+        claimed = await em.transactional(async (txEm) => {
+          const result = await txEm.getConnection().execute<{ acquired: boolean }[]>(
+            `SELECT pg_try_advisory_xact_lock(?) as acquired`,
+            [hash],
+          )
+          return result[0]?.acquired === true
+        })
+      } catch (error) {
+        logger.error('Failed to acquire lock', { lockKey: key, err: error })
+        return { acquired: false }
       }
 
-      logger.error('Failed to acquire lock', { lockKey: key, err: error })
-      return { acquired: false }
+      if (!claimed) {
+        return { acquired: false }
+      }
+
+      const fnResult = await fn()
+      return { acquired: true, result: fnResult }
+    } finally {
+      this.heldKeys.delete(key)
     }
   }
 

--- a/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
+++ b/packages/scheduler/src/modules/scheduler/services/__tests__/localSchedulerService.test.ts
@@ -113,6 +113,16 @@ describe('LocalSchedulerService', () => {
       expect(loggerInfo).toHaveBeenCalledWith('Polling engine started')
     })
 
+    it('should warn that the local strategy has no cross-process protection', async () => {
+      mockForkedEm.find.mockResolvedValue([])
+
+      await service.start()
+
+      expect(loggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('no cross-process protection'),
+      )
+    })
+
     it('should run initial poll immediately', async () => {
       mockForkedEm.find.mockResolvedValue([])
 

--- a/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
+++ b/packages/scheduler/src/modules/scheduler/services/localSchedulerService.ts
@@ -29,14 +29,19 @@ export interface LocalSchedulerConfig {
  * 
  * Features:
  * - PostgreSQL polling (configurable interval, default 30s)
- * - PostgreSQL advisory locks for duplicate prevention
+ * - In-process duplicate prevention across overlapping poll ticks
  * - Supports both queue and command targets
  * - Emits the same events as async strategy
  * - Updates nextRunAt after execution
- * 
+ *
  * Limitations:
  * - Polling delay (up to configured interval)
- * - Single instance only (no distributed locking across instances)
+ * - Single instance only (no distributed locking across instances). Duplicate
+ *   prevention is in-process only: the advisory lock serialises the claim, not
+ *   the execution, and nextRunAt is advanced only after the target has run, so
+ *   two processes polling the same database will both execute a due schedule.
+ *   Run exactly one process with QUEUE_STRATEGY=local, or use the async
+ *   strategy, which locks across instances.
  * - Higher database load than async strategy
  * 
  * Set QUEUE_STRATEGY=local to use this service.
@@ -66,6 +71,9 @@ export class LocalSchedulerService {
 
     this.isRunning = true
     logger.info('Starting polling engine', { pollIntervalMs: this.config.pollIntervalMs })
+    logger.warn(
+      'Local scheduler strategy provides no cross-process protection: duplicate prevention is in-process only, so a second process polling the same database will execute the same due schedule. Run exactly one process with QUEUE_STRATEGY=local, or use the async strategy for distributed locking.',
+    )
 
     // Run initial poll immediately
     await this.poll()

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/search",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/shared",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/src/lib/db/__tests__/mikro.test.ts
+++ b/packages/shared/src/lib/db/__tests__/mikro.test.ts
@@ -24,6 +24,31 @@ describe('ORM entity registry', () => {
   })
 })
 
+describe('attachPoolErrorHandlers', () => {
+  it('swallows errors from idle pooled clients (pool-level emit)', async () => {
+    const { EventEmitter } = await import('node:events')
+    const { attachPoolErrorHandlers } = await import('../mikro')
+    const pool = new EventEmitter()
+
+    attachPoolErrorHandlers(pool as any)
+
+    expect(() => pool.emit('error', new Error('terminating connection due to idle-in-transaction timeout'))).not.toThrow()
+  })
+
+  it('swallows errors from checked-out clients (client-level emit)', async () => {
+    const { EventEmitter } = await import('node:events')
+    const { attachPoolErrorHandlers } = await import('../mikro')
+    const pool = new EventEmitter()
+    const client = new EventEmitter()
+
+    attachPoolErrorHandlers(pool as any)
+    pool.emit('connect', client)
+
+    expect(client.listenerCount('error')).toBe(1)
+    expect(() => client.emit('error', new Error('terminating connection due to idle-in-transaction timeout'))).not.toThrow()
+  })
+})
+
 describe('resolvePoolConfig', () => {
   const baseEnv = (extra: Record<string, string | undefined> = {}): NodeJS.ProcessEnv =>
     ({ ...extra }) as NodeJS.ProcessEnv

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -79,6 +79,42 @@ export function resolvePoolConfig(env: NodeJS.ProcessEnv = process.env): Resolve
   }
 }
 
+type PoolLike = {
+  on(event: 'error', listener: (err: unknown) => void): unknown
+  on(event: 'connect', listener: (client: { on(event: 'error', listener: (err: unknown) => void): unknown }) => void): unknown
+  options?: Record<string, unknown>
+}
+
+// Postgres can terminate a connection at any moment (admin termination, network
+// drop, and — most relevantly for long-running daemons — the
+// `idle_in_transaction_session_timeout` configured above, FATAL 25P03). Where
+// node-postgres surfaces that depends on the client's state:
+// - IDLE (checked into the pool): pg-pool re-emits on the pool's 'error' event.
+// - CHECKED OUT (e.g. a connection pinned by an open transaction while the app
+//   awaits non-DB work): pg-pool removes its idle listener, so the FATAL emits
+//   on the Client itself.
+// Either way an unlistened 'error' event crashes the whole process ("Scheduler
+// polling engine exited unexpectedly with exit code 1"). Swallow both: the pool
+// discards the dead client, and any in-flight transaction still fails normally
+// on its next query/commit against the dead connection.
+// The per-client listener is deliberately attached once on 'connect' and never
+// removed: it is a last-resort sink whose only job is to guarantee the 'error'
+// event always has a listener, in every client state. It is not error handling
+// and must not be "cleaned up" — removing it reintroduces the process crash.
+// A reaped IDLE client therefore logs twice (once here, once via the pool-level
+// handler that pg-pool's own idle listener re-emits); the pool-level line is the
+// one that identifies the client as idle.
+export function attachPoolErrorHandlers(pool: PoolLike): void {
+  pool.on('error', (err: unknown) => {
+    logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
+  })
+  pool.on('connect', (client) => {
+    client.on('error', (err: unknown) => {
+      logger.warn('pg client error (connection reaped/terminated)', { err })
+    })
+  })
+}
+
 export async function getOrm() {
   if (ormInstance) {
     return ormInstance
@@ -151,19 +187,8 @@ export async function getOrm() {
       lock_timeout: lockTimeoutMs,
       options: connectionOptions,
       ssl: sslConfig,
-      onPoolCreated: (pool: any) => {
-        // node-postgres re-emits errors from IDLE pooled clients on the pool's
-        // 'error' event. Postgres terminates idle sessions on its own (admin
-        // termination, network drop, and — most relevantly for long-running
-        // daemons like the scheduler — `idle_in_transaction_session_timeout`,
-        // which defaults to 120s above). Without a listener here, such a
-        // termination surfaces as an unhandled 'error' event and crashes the
-        // whole process (e.g. "Scheduler polling engine exited unexpectedly
-        // with exit code 1"). Swallow it: the pool discards the dead client and
-        // opens a fresh connection on the next acquire.
-        pool.on('error', (err: unknown) => {
-          logger.warn('Idle pg pool client error (connection reaped/terminated)', { err })
-        })
+      onPoolCreated: (pool: PoolLike) => {
+        attachPoolErrorHandlers(pool)
         if (process.env.OM_DB_POOL_DEBUG === '1' || process.env.OM_INTEGRATION_TEST === 'true') {
           logger.info('pg pool created with options', {
             max: pool.options?.max,

--- a/packages/storage-s3/package.json
+++ b/packages/storage-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/storage-s3",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sync-akeneo/package.json
+++ b/packages/sync-akeneo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/sync-akeneo",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/ui",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/src/backend/utils/__tests__/api.test.ts
+++ b/packages/ui/src/backend/utils/__tests__/api.test.ts
@@ -149,6 +149,33 @@ describe('apiFetch', () => {
     expect(flash).not.toHaveBeenCalled()
   })
 
+  it('stays silent when a login-page 401 lands after the post-login navigation', async () => {
+    window.history.pushState({}, '', '/login')
+    ;(window as unknown as Record<string, unknown>).__omOriginalFetch = jest.fn(async () => {
+      // The sign-in completes while the pre-auth probe is still in flight, so the
+      // app has already client-navigated to /backend when the 401 arrives.
+      window.history.pushState({}, '', '/backend')
+      return createMockResponse(401, { error: 'Unauthorized' })
+    })
+
+    const result = await apiFetch('/api/auth/feature-check', { method: 'POST' })
+
+    expect(result.status).toBe(401)
+    expect(flash).not.toHaveBeenCalled()
+  })
+
+  it('stays silent when a 401 lands after navigating to the login page', async () => {
+    ;(window as unknown as Record<string, unknown>).__omOriginalFetch = jest.fn(async () => {
+      window.history.pushState({}, '', '/login')
+      return createMockResponse(401, { error: 'Unauthorized' })
+    })
+
+    const result = await apiFetch('/api/private')
+
+    expect(result.status).toBe(401)
+    expect(flash).not.toHaveBeenCalled()
+  })
+
   it('throws UnauthorizedError for 401 responses by default', async () => {
     ;(window as unknown as Record<string, unknown>).__omOriginalFetch = jest.fn(async () =>
       createMockResponse(401, { error: 'Unauthorized' }),

--- a/packages/ui/src/backend/utils/api.ts
+++ b/packages/ui/src/backend/utils/api.ts
@@ -47,6 +47,18 @@ export async function withScopedApiHeaders<T>(headers: Record<string, string>, r
   return scopedHeaders.withScopedHeaders(headers, run)
 }
 
+function readPathname(): string {
+  return typeof window !== 'undefined' ? window.location?.pathname ?? '' : ''
+}
+
+function isLoginPathname(pathname: string): boolean {
+  return pathname.startsWith('/login')
+}
+
+function isPortalPathname(pathname: string): boolean {
+  return /\/[^/]+\/portal(\/|$)/.test(pathname)
+}
+
 export class UnauthorizedError extends Error {
   readonly status = 401
   constructor(message = 'Unauthorized') {
@@ -166,10 +178,15 @@ export async function apiFetch(input: RequestInfo | URL, init?: RequestInit): Pr
   const requestHeaders = new Headers(mergedInit?.headers)
   const disableUnauthorizedRedirect = readRedirectOverride(requestHeaders, 'x-om-unauthorized-redirect')
   const disableForbiddenRedirect = readRedirectOverride(requestHeaders, 'x-om-forbidden-redirect')
+  // Snapshot the pathname BEFORE the request is sent. A 401 for a request that
+  // started on the login page must stay silent even when the response lands after
+  // the post-login client-side navigation to /backend — otherwise the stale
+  // pre-auth 401 raises a bogus "Session expired" banner right after signing in.
+  const requestPathname = readPathname()
   const res = await baseFetch(input, mergedInit)
-  const pathname = typeof window !== 'undefined' ? window.location.pathname : ''
-  const onLoginPage = pathname.startsWith('/login')
-  const onPortalRoute = /\/[^/]+\/portal(\/|$)/.test(pathname)
+  const responsePathname = readPathname()
+  const onLoginPage = isLoginPathname(requestPathname) || isLoginPathname(responsePathname)
+  const onPortalRoute = isPortalPathname(requestPathname) || isPortalPathname(responsePathname)
   if (res.status === 401) {
     // Trigger same redirect flow as protected pages
     // Skip for staff login page and all portal routes (portal has its own auth)

--- a/packages/webhooks/package.json
+++ b/packages/webhooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/webhooks",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "license": "MIT",
   "description": "Webhooks module for Open Mercato — Standard Webhooks compliant outbound/inbound delivery",
   "type": "module",

--- a/scripts/__tests__/release-workflow.test.mjs
+++ b/scripts/__tests__/release-workflow.test.mjs
@@ -3,27 +3,126 @@ import fs from 'node:fs'
 import path from 'node:path'
 import test from 'node:test'
 
-const workflowPath = path.resolve('.github/workflows/release.yml')
+const releasePath = path.resolve('.github/workflows/release.yml')
+const preparePath = path.resolve('.github/workflows/release-prepare.yml')
 
-function extractNamedRunStep(workflow, stepName) {
-  const marker = `- name: ${stepName}`
-  const start = workflow.indexOf(marker)
-  assert.notEqual(start, -1, `Expected workflow to contain step "${stepName}"`)
-
-  const nextStep = workflow.indexOf('\n      - name:', start + marker.length)
-  return workflow.slice(start, nextStep === -1 ? undefined : nextStep)
+function stepIndex(workflow, stepName) {
+  const index = workflow.indexOf(`- name: ${stepName}`)
+  assert.notEqual(index, -1, `Expected workflow to contain step "${stepName}"`)
+  return index
 }
 
-test('release existing mode skips committing version changes', () => {
-  const workflow = fs.readFileSync(workflowPath, 'utf8')
-  const commitStep = extractNamedRunStep(workflow, 'Commit version changes')
+test('release workflow never pushes to the protected main branch', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
 
-  const existingGuardIndex = commitStep.indexOf('if [ "${{ inputs.bump }}" = "existing" ]; then')
-  const gitAddIndex = commitStep.indexOf('git add -A')
+  assert.doesNotMatch(workflow, /git commit/, 'Release must not create commits on main')
+  assert.doesNotMatch(workflow, /^\s+git push\s*$/m, 'Release must not push branches')
+  assert.match(workflow, /git push origin "\$TAG"/, 'Release must push only the release tag')
+})
 
-  assert.notEqual(existingGuardIndex, -1, 'Commit step should guard existing releases')
-  assert.notEqual(gitAddIndex, -1, 'Commit step should keep staging version changes for bump releases')
-  assert.ok(existingGuardIndex < gitAddIndex, 'Existing release guard must run before staging files')
-  assert.match(commitStep, /Existing release mode uses committed versions as-is; skipping version commit/)
-  assert.match(commitStep, /exit 0/)
+test('release workflow tags before publishing to npm', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  assert.ok(
+    stepIndex(workflow, 'Create git tag') < stepIndex(workflow, 'Publish packages to npm'),
+    'Tagging is reversible and must happen before the irreversible npm publish',
+  )
+})
+
+test('release workflow guards against republishing an existing version', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  const guardIndex = stepIndex(workflow, 'Verify the version is not published yet')
+  assert.ok(
+    guardIndex < stepIndex(workflow, 'Build packages'),
+    'The npm version guard must run before any build or publish work',
+  )
+  assert.match(workflow, /check-version-unpublished\.sh/)
+})
+
+test('release workflow keeps its log out of the working tree', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  assert.doesNotMatch(
+    workflow,
+    /tee -?a? ?"?release-output\.txt/,
+    'The release log must be written outside the repository so it can never be committed',
+  )
+  assert.match(workflow, /\$RUNNER_TEMP\/release-output\.txt/)
+})
+
+test('release workflow pipes through a pipefail shell', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  for (const [, block] of workflow.matchAll(/- name: [^\n]+\n((?:\s{8}[^\n]*\n)+)/g)) {
+    if (!block.includes('| tee')) continue
+    assert.match(block, /shell: bash/, 'Steps piping into tee must opt into pipefail via `shell: bash`')
+  }
+})
+
+test('release workflow gates on a changelog entry before publishing', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  const extractIndex = stepIndex(workflow, 'Extract changelog entry')
+  assert.ok(
+    extractIndex < stepIndex(workflow, 'Build packages'),
+    'A missing changelog entry must fail before anything is built or published',
+  )
+  assert.match(workflow, /changelog-section\.sh/)
+})
+
+test('release notes embed the changelog section from disk', () => {
+  const workflow = fs.readFileSync(releasePath, 'utf8')
+
+  assert.match(
+    workflow,
+    /readFileSync\(\s*\n?\s*path\.join\(process\.env\.RUNNER_TEMP, 'changelog-section\.md'\)/,
+    'Changelog prose must be read from disk, never interpolated into the script',
+  )
+  assert.match(workflow, /BODY_LIMIT = 125000/, 'Release bodies must respect the GitHub size limit')
+  assert.match(workflow, /updateRelease/, 'Re-running a release should refresh notes, not fail')
+})
+
+test('release prepare workflow opens a PR instead of pushing to main', () => {
+  const workflow = fs.readFileSync(preparePath, 'utf8')
+
+  assert.match(workflow, /gh pr create/, 'Version bumps must land through a pull request')
+  assert.match(workflow, /git push origin "\$BRANCH"/, 'Prepare must push the release branch only')
+  assert.doesNotMatch(workflow, /git push origin main/)
+  assert.doesNotMatch(workflow, /git add -A/, 'Staging must stay scoped to tracked manifest changes')
+})
+
+test('release prepare targets main explicitly', () => {
+  const workflow = fs.readFileSync(preparePath, 'utf8')
+
+  assert.match(workflow, /--base main \\/, 'The PR base must be pinned to main, not the repo default')
+  assert.match(workflow, /--head "\$BRANCH"/)
+  assert.match(workflow, /compare\/main\.\.\.\$BRANCH/, 'The fallback compare link must also target main')
+})
+
+test('both release stages share the same resume escape hatch', () => {
+  const release = fs.readFileSync(releasePath, 'utf8')
+  const prepare = fs.readFileSync(preparePath, 'utf8')
+
+  for (const [name, workflow] of [['release', release], ['release-prepare', prepare]]) {
+    assert.match(workflow, /resume:\n\s+description:/, `${name} must expose a resume input`)
+    assert.match(workflow, /if: \$\{\{ !inputs\.resume \}\}/, `${name} must gate a guard on resume`)
+  }
+
+  // Recovery means npm is deliberately ahead of git, so neither the npm guard nor the
+  // tag guard should block the catch-up bump PR
+  const gatedGuards = prepare.match(/if: \$\{\{ !inputs\.resume \}\}/g) ?? []
+  assert.equal(gatedGuards.length, 2, 'Prepare must skip both the npm and tag guards when resuming')
+})
+
+test('release prepare survives a token that cannot open PRs', () => {
+  const workflow = fs.readFileSync(preparePath, 'utf8')
+
+  assert.match(workflow, /if PR_URL=\$\(gh pr create/, 'PR creation must be a conditional, not a hard failure')
+  assert.match(workflow, /GITHUB_STEP_SUMMARY/, 'Both branches must report where the release stands')
+  assert.match(
+    workflow,
+    /Allow GitHub Actions to create and approve pull requests/,
+    'The fallback must name the setting that unblocks automatic PR creation',
+  )
 })

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Bump the monorepo version across all public packages and the root manifest.
+# Does not build, publish, commit or tag — see scripts/release-*.sh for those.
+# Usage: ./scripts/bump-version.sh <patch|minor|major>
+set -euo pipefail
+
+BUMP="${1:-}"
+case "$BUMP" in
+  patch|minor|major) ;;
+  *)
+    echo "Usage: ./scripts/bump-version.sh <patch|minor|major>"
+    exit 1
+    ;;
+esac
+
+echo "==> Checking version alignment across packages..." >&2
+./scripts/check-version-alignment.sh >&2
+
+echo "==> Bumping $BUMP version..." >&2
+yarn workspaces foreach -A --no-private version "$BUMP" >&2
+
+NEW_VERSION=$(jq -r '.version' packages/shared/package.json)
+
+echo "==> Syncing root package.json to $NEW_VERSION..." >&2
+jq --arg version "$NEW_VERSION" '.version = $version' package.json > package.json.bump
+mv package.json.bump package.json
+
+echo "==> Verifying alignment against root package.json..." >&2
+./scripts/check-version-alignment.sh --reference package.json >&2
+
+echo "$NEW_VERSION"

--- a/scripts/changelog-section.sh
+++ b/scripts/changelog-section.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Print the CHANGELOG.md section for a release version, without its `# <version> (<date>)`
+# heading — the GitHub Release is already titled with the version.
+# Exits 1 when the version has no changelog entry, so a release can fail before publishing.
+# Usage: ./scripts/changelog-section.sh [version] [--changelog <path>]
+set -euo pipefail
+
+VERSION=""
+CHANGELOG="CHANGELOG.md"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --changelog) CHANGELOG="$2"; shift 2 ;;
+    --help|-h)
+      echo "Usage: ./scripts/changelog-section.sh [version] [--changelog <path>]"
+      exit 0
+      ;;
+    *)
+      if [ -n "$VERSION" ]; then
+        echo "Unexpected argument: $1" >&2
+        exit 1
+      fi
+      VERSION="$1"
+      shift
+      ;;
+  esac
+done
+
+VERSION="${VERSION:-$(jq -r '.version' package.json)}"
+
+if [ ! -f "$CHANGELOG" ]; then
+  echo "ERROR: $CHANGELOG not found" >&2
+  exit 1
+fi
+
+# `index(...) == 1` keeps the match literal, so dots in the version are not treated as regex
+SECTION=$(awk -v heading="# $VERSION (" '
+  index($0, "# ") == 1 {
+    if (found) exit
+    if (index($0, heading) == 1) { found = 1; next }
+  }
+  found { print }
+' "$CHANGELOG")
+
+# Trim leading blank lines, then the section separator and trailing blank lines
+SECTION=$(printf '%s\n' "$SECTION" | sed -e '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba')
+if [ "$(printf '%s\n' "$SECTION" | tail -n 1)" = "---" ]; then
+  SECTION=$(printf '%s\n' "$SECTION" | sed '$d')
+  SECTION=$(printf '%s\n' "$SECTION" | sed -e :a -e '/^\n*$/{$d;N;};/\n$/ba')
+fi
+
+if [ -z "$SECTION" ]; then
+  echo "ERROR: no changelog entry for version $VERSION in $CHANGELOG" >&2
+  echo "Add a '# $VERSION (YYYY-MM-DD)' section before releasing." >&2
+  exit 1
+fi
+
+printf '%s\n' "$SECTION"

--- a/scripts/check-version-unpublished.sh
+++ b/scripts/check-version-unpublished.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Fail when the release version is already on npm for any public package.
+# Publishing is irreversible, so this runs before any release side effect.
+# Usage: ./scripts/check-version-unpublished.sh [version]
+set -euo pipefail
+
+VERSION="${1:-$(jq -r '.version' package.json)}"
+
+PACKAGE_NAMES=$(find packages -maxdepth 2 -name package.json -not -path "*/node_modules/*" -print0 \
+  | xargs -0 jq -r 'select(.private != true) | .name')
+
+if [ -z "$PACKAGE_NAMES" ]; then
+  echo "ERROR: no public packages found to check"
+  exit 1
+fi
+
+ALREADY_PUBLISHED=$(echo "$PACKAGE_NAMES" | xargs -P 8 -I{} \
+  sh -c 'npm view "{}@'"$VERSION"'" version > /dev/null 2>&1 && echo "{}"' || true)
+
+if [ -n "$ALREADY_PUBLISHED" ]; then
+  echo "ERROR: version $VERSION is already published on npm for:"
+  echo "$ALREADY_PUBLISHED" | sed 's/^/  - /'
+  echo "Bump to a new version before releasing; npm versions cannot be republished."
+  echo "To resume a partially published release on purpose, re-run the workflow with resume=true."
+  exit 1
+fi
+
+echo "Version $VERSION is not published yet on any public package."

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -34,6 +34,11 @@ for pkg_dir in $PACKAGES; do
   PKG_VERSION=$(jq -r '.version' "$PKG_PATH/package.json" 2>/dev/null)
   PKG_REPOSITORY_URL=$(jq -r '.repository.url // empty' "$PKG_PATH/package.json" 2>/dev/null)
 
+  if npm view "$PKG_NAME@$PKG_VERSION" version >/dev/null 2>&1; then
+    echo "  Skipping $PKG_NAME@$PKG_VERSION (already published)"
+    continue
+  fi
+
   echo "  Publishing $PKG_NAME@$PKG_VERSION..."
   cd "$PKG_PATH"
 

--- a/scripts/release-existing.sh
+++ b/scripts/release-existing.sh
@@ -15,6 +15,9 @@ echo "==> Checking version alignment across packages against root package.json..
 RELEASE_VERSION=$(jq -r '.version' package.json)
 echo "==> Releasing existing version ${RELEASE_VERSION}..."
 
+echo "==> Verifying the target version is not published yet..."
+./scripts/check-version-unpublished.sh "$RELEASE_VERSION"
+
 echo "==> Building packages..."
 yarn build:packages
 

--- a/scripts/release-major.sh
+++ b/scripts/release-major.sh
@@ -9,11 +9,11 @@ else
   echo "==> Skipping template sync in CI"
 fi
 
-echo "==> Checking version alignment across packages..."
-./scripts/check-version-alignment.sh
+echo "==> Bumping major version (packages + root manifest)..."
+./scripts/bump-version.sh major > /dev/null
 
-echo "==> Bumping major version..."
-yarn workspaces foreach -A --no-private version major
+echo "==> Verifying the target version is not published yet..."
+./scripts/check-version-unpublished.sh
 
 echo "==> Building packages..."
 yarn build:packages

--- a/scripts/release-minor.sh
+++ b/scripts/release-minor.sh
@@ -9,11 +9,11 @@ else
   echo "==> Skipping template sync in CI"
 fi
 
-echo "==> Checking version alignment across packages..."
-./scripts/check-version-alignment.sh
+echo "==> Bumping minor version (packages + root manifest)..."
+./scripts/bump-version.sh minor > /dev/null
 
-echo "==> Bumping minor version..."
-yarn workspaces foreach -A --no-private version minor
+echo "==> Verifying the target version is not published yet..."
+./scripts/check-version-unpublished.sh
 
 echo "==> Building packages..."
 yarn build:packages

--- a/scripts/release-patch.sh
+++ b/scripts/release-patch.sh
@@ -9,11 +9,11 @@ else
   echo "==> Skipping template sync in CI"
 fi
 
-echo "==> Checking version alignment across packages..."
-./scripts/check-version-alignment.sh
+echo "==> Bumping patch version (packages + root manifest)..."
+./scripts/bump-version.sh patch > /dev/null
 
-echo "==> Bumping patch version..."
-yarn workspaces foreach -A --no-private version patch
+echo "==> Verifying the target version is not published yet..."
+./scripts/check-version-unpublished.sh
 
 echo "==> Building packages..."
 yarn build:packages


### PR DESCRIPTION
> ## ⚠️ DO NOT SQUASH THIS PR
>
> Merge it with **"Create a merge commit"**. Squashing defeats its entire purpose — see [Why the merge method matters](#why-the-merge-method-matters) below.

## Why

#4840 (the `develop` → `main` 0.6.7 promotion) is `CONFLICTING`. `main` has advanced past the last back-merge (`8be6177d5`, 2026-08-02) and now carries **11 commits `develop` does not**, including five PRs that never came back:

| PR | What it fixes |
|---|---|
| #5009 / #5007 | release v0.6.7 cut, and the release split that stops pushing to `main` |
| #4968 | 0.6.7 changelog entry |
| #4957 | entities relation-options 500ing on unresolvable entity ids |
| #4364 | idle-in-transaction reaps crashing the scheduler daemon |
| #4917 | stale pre-auth 401 flashing "Session expired" after login |

So this is not just a textual conflict. Promoting `develop` as-is would **regress those fixes on `main`**. This PR is the reconciliation.

## Why the merge method matters

This only clears #4840 if it lands as a real **merge commit recording `main` as a parent** — the way `8be6177d5` did. This repo squash-merges by default, and a squashed back-merge would flatten that parent away: the tree would look right, but git would still not know `main`'s history is contained in `develop`, and the identical conflict would re-form at the very next release cut. The commit here (`93f9836e1`) already has both parents (`d1ce9999e` develop, `f0fb2aa46` main); merging it any other way discards that.

## Conflict resolution — 2 files, both hand-resolved

Everything else auto-merged. 53 files changed, +1333 / −167.

### `packages/core/src/modules/auth/frontend/login.tsx` → kept develop's file, added main's change

Both branches edited the `feature-check` headers block. Resolved at the **hunk** level, not the file level: `develop` has four commits on this file that `main` does not (#4317 DS `Alert` migration, #4185/#4275 perspective-state clearing, #4810 extension-point spot ids, #4554 standalone session fix), so taking `main`'s whole file would have silently reverted all of them.

Kept develop's file, added main's `'x-om-forbidden-redirect': '0'` line and its explanatory comment.

**Verified:** `login-feature-check-once.test.tsx` — the test #4917 shipped, which asserts `toMatchObject({ 'x-om-unauthorized-redirect': '0', 'x-om-forbidden-redirect': '0' })` — passes against the resolved file. Full auth module: **69 suites / 535 tests, all passing**.

### `packages/core/src/modules/customers/__integration__/TC-CRM-086.spec.ts` → kept develop's version

Both branches independently stabilized the *same* flaky column-resize test, from the same base, without knowing about each other:

- **develop** (`8583a9149`, `e6c38e0be`, 2026-07-26) — replaced the real mouse drag with synthetic `PointerEvent` dispatch on `document`, and asserts the **inline style width** (`/^\d+px$/` after resize, `''` after reset).
- **main** (via #4917, 2026-08-04) — kept the real `page.mouse` drag but added settle-polling and a 3-attempt retry, and asserts **computed width** against thresholds.

Kept develop's. Reasons, in order of weight:

1. **It is green in CI right now.** develop's version passed in run `30980642508` in 5.2s with no retry — the two specs that *did* fail in that run are the ones fixed in #5008. There is no evidence develop's version is flaky.
2. Its assertions are strictly more precise — exact inline width preserved across reload and cleared on reset, versus `> baseline + 80` / `< afterReload - 60` thresholds.
3. Dispatching pointer events on `document` is immune to the handle unmounting mid-drag, which is the failure mode main's retry loop only papers over.
4. develop's version is what the promotion carries to `main` anyway; taking main's here would just be re-superseded at the next promotion.

Nothing was hybridized — inventing an unvalidated third version of a flaky test inside a back-merge would be the worst option. If a reviewer prefers main's approach, it should be a deliberate follow-up on `develop`, not a silent side effect of this merge.

## What this does not do

This PR does **not** include the CI test fixes for `TC-CRM-085` and `TC-CAT-035` — those are **#5008**, also targeting `develop`. The two are independent and can land in either order.

## After this merges

1. #4840 becomes mergeable, and the five fixes above stop being at risk.
2. Merge #5008 for the two remaining red checks.
3. Freeze `develop` long enough for one complete CI matrix on the promoted head — `develop` took 7 pushes in 20 minutes today and only 2 of the last 12 runs finished, so #4840 currently has no complete signal to be judged on.

Refs #4840

🤖 Generated with [Claude Code](https://claude.com/claude-code)