### PR TITLE
fix(dashboards): compare null aggregation filters with IS NULL (#5016)

### DIFF
--- a/packages/core/src/modules/dashboards/__integration__/TC-DASH-012-null-comparison-operators.spec.ts
+++ b/packages/core/src/modules/dashboards/__integration__/TC-DASH-012-null-comparison-operators.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import { readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+import {
+  canManageSalesOrders,
+  createSalesOrderFixture,
+  deleteSalesEntityIfExists,
+} from '@open-mercato/core/helpers/integration/salesFixtures'
+
+/**
+ * TC-DASH-012 — production-boundary coverage for #5016.
+ *
+ * The `eq` and `neq` widget-data filter operators used to bind a null value as a parameter, and
+ * MikroORM interpolates parameters into the SQL text rather than binding them, so the aggregation
+ * reached PostgreSQL as `column = NULL` / `column != NULL`. Neither predicate is ever `TRUE` under
+ * three-valued logic, so both filters selected zero rows and answered `200` with an empty
+ * aggregation — a silent zero rather than a loud failure. Null equality is reachable straight from
+ * the public request schema, whose scalar-operator branch types `value` as unknown and optional.
+ *
+ * The assertion is deliberately fixture-independent: `eq null` and `neq null` on the same field
+ * partition the run's own orders, so the two counts must sum to the number created. Before the fix
+ * both sides returned zero and the sum could not hold.
+ *
+ * Self-contained: every order it counts is created here and deleted in `finally`.
+ */
+
+const API = {
+  orders: '/api/sales/orders',
+  widgetData: '/api/dashboards/widgets/data',
+}
+
+const ORDER_COUNT = 3
+
+type WidgetDataResponse = { value?: number | null }
+
+type ScalarFilter = {
+  field: string
+  operator: 'eq' | 'neq' | 'in' | 'is_null' | 'is_not_null'
+  value?: unknown
+}
+
+/**
+ * Counts orders matching `filters`. Every request carries the run's own order ids, so the
+ * two-minute widget-data cache can never serve one run's answer to the next.
+ */
+async function countOrders(
+  request: APIRequestContext,
+  token: string,
+  filters: ScalarFilter[],
+): Promise<number> {
+  const response = await apiRequest(request, 'POST', API.widgetData, {
+    token,
+    data: {
+      entityType: 'sales:orders',
+      metric: { field: 'id', aggregate: 'count' },
+      filters,
+    },
+  })
+  const body = await readJsonSafe<WidgetDataResponse>(response)
+  expect(
+    response.status(),
+    `widget data should execute ${filters.map((filter) => filter.operator).join(' + ')} against PostgreSQL, got ${JSON.stringify(body)}`,
+  ).toBe(200)
+  return Number(body?.value ?? 0)
+}
+
+test.describe('TC-DASH-012: null comparison in widget-data filter operators', () => {
+  test('TC-DASH-012: eq and neq against null select rows instead of answering a silent zero', async ({ request }) => {
+    const adminToken = await getAuthToken(request, 'admin')
+    test.skip(
+      !(await canManageSalesOrders(request, adminToken)),
+      'Sales order writes are not permitted for this actor (role ACLs not synced).',
+    )
+
+    const orderIds: string[] = []
+
+    try {
+      for (let index = 0; index < ORDER_COUNT; index += 1) {
+        orderIds.push(await createSalesOrderFixture(request, adminToken))
+      }
+      const ownRows: ScalarFilter = { field: 'id', operator: 'in', value: orderIds }
+
+      expect(await countOrders(request, adminToken, [ownRows])).toBe(ORDER_COUNT)
+
+      // The shapes that used to render `customer_entity_id = NULL` / `!= NULL` and match no row.
+      const unsetCount = await countOrders(request, adminToken, [
+        ownRows,
+        { field: 'customerEntityId', operator: 'eq', value: null },
+      ])
+      const setCount = await countOrders(request, adminToken, [
+        ownRows,
+        { field: 'customerEntityId', operator: 'neq', value: null },
+      ])
+
+      expect(
+        unsetCount + setCount,
+        'eq null and neq null must partition the run: before #5016 both sides returned zero',
+      ).toBe(ORDER_COUNT)
+
+      // The dedicated null operators were already correct, so they are the reference answer the
+      // equality operators now have to agree with.
+      expect(
+        await countOrders(request, adminToken, [ownRows, { field: 'customerEntityId', operator: 'is_null' }]),
+      ).toBe(unsetCount)
+      expect(
+        await countOrders(request, adminToken, [ownRows, { field: 'customerEntityId', operator: 'is_not_null' }]),
+      ).toBe(setCount)
+
+      // A non-null comparison must still bind its value: an over-correction that sent every `eq`
+      // down the keyword path would count the whole run here instead of the single order asked for.
+      expect(
+        await countOrders(request, adminToken, [
+          ownRows,
+          { field: 'id', operator: 'eq', value: orderIds[0] },
+        ]),
+      ).toBe(1)
+      expect(
+        await countOrders(request, adminToken, [
+          ownRows,
+          { field: 'id', operator: 'neq', value: orderIds[0] },
+        ]),
+      ).toBe(ORDER_COUNT - 1)
+    } finally {
+      for (const orderId of orderIds) {
+        await deleteSalesEntityIfExists(request, adminToken, API.orders, orderId)
+      }
+    }
+  })
+})

--- a/packages/core/src/modules/dashboards/lib/__tests__/aggregations.test.ts
+++ b/packages/core/src/modules/dashboards/lib/__tests__/aggregations.test.ts
@@ -348,6 +348,68 @@ describe('aggregations', () => {
       expect(result?.params).toEqual(['tenant-123', '', 0, false])
     })
 
+    /**
+     * `col = NULL` and `col != NULL` are never TRUE under SQL three-valued logic, so binding a raw
+     * null for the equality operators returned an empty aggregation that is indistinguishable from
+     * a genuinely empty result — a silent zero on a reporting surface (#5016). The scalar branch of
+     * `widgetDataFilterSchema` types `value` as `z.unknown().optional()`, so the shape reaches the
+     * builder straight from the HTTP boundary and not only from in-process callers.
+     */
+    it('compares an eq filter to null with IS NULL and binds no parameter', () => {
+      const result = buildAggregationQuery({
+        ...baseOptions,
+        filters: [{ field: 'customerEntityId', operator: 'eq', value: null }],
+      })
+      expect(result?.sql).toContain('customer_entity_id IS NULL')
+      expect(result?.sql).not.toContain('customer_entity_id = ?')
+      expect(result?.params).toEqual(['tenant-123'])
+    })
+
+    it('compares a neq filter to null with IS NOT NULL and binds no parameter', () => {
+      const result = buildAggregationQuery({
+        ...baseOptions,
+        filters: [{ field: 'customerEntityId', operator: 'neq', value: null }],
+      })
+      expect(result?.sql).toContain('customer_entity_id IS NOT NULL')
+      expect(result?.sql).not.toContain('customer_entity_id != ?')
+      expect(result?.params).toEqual(['tenant-123'])
+    })
+
+    it('keeps binding non-null equality comparisons as parameters', () => {
+      // Over-correction guard: only a null value may take the keyword form.
+      const result = buildAggregationQuery({
+        ...baseOptions,
+        filters: [
+          { field: 'status', operator: 'eq', value: 'completed' },
+          { field: 'paymentStatus', operator: 'neq', value: 'refunded' },
+        ],
+      })
+      expect(result?.sql).toContain('status = ?')
+      expect(result?.sql).toContain('payment_status != ?')
+      expect(result?.sql).not.toContain('IS NULL AND payment_status')
+      expect(result?.params).toEqual(['tenant-123', 'completed', 'refunded'])
+    })
+
+    it('keeps binding falsy non-null equality comparisons as parameters', () => {
+      const result = buildAggregationQuery({
+        ...baseOptions,
+        filters: [{ field: 'status', operator: 'eq', value: '' }],
+      })
+      expect(result?.sql).toContain('status = ?')
+      expect(result?.params).toEqual(['tenant-123', ''])
+    })
+
+    it('applies null equality filters to the encrypted group-source row query as well', () => {
+      const result = buildGroupSourceRowsQuery({
+        ...baseOptions,
+        groupColumn: 'shipping_address_snapshot',
+        rowLimit: 10,
+        filters: [{ field: 'customerEntityId', operator: 'eq', value: null }],
+      })
+      expect(result?.sql).toContain('customer_entity_id IS NULL')
+      expect(result?.params).toEqual(['tenant-123'])
+    })
+
     it('applies set filters to the encrypted group-source row query as well', () => {
       const result = buildGroupSourceRowsQuery({
         ...baseOptions,
@@ -381,6 +443,29 @@ describe('aggregations', () => {
         const rendered = platform.formatQuery(result!.sql, result!.params)
         expect(rendered).toContain("status IN ('completed', 'o''brien')")
         expect(rendered).toContain("payment_status NOT IN ('refunded')")
+      })
+
+      it('renders null equality filters as SQL null predicates', () => {
+        const result = buildAggregationQuery({
+          ...baseOptions,
+          filters: [
+            { field: 'customerEntityId', operator: 'eq', value: null },
+            { field: 'channelId', operator: 'neq', value: null },
+          ],
+        })
+        const rendered = platform.formatQuery(result!.sql, result!.params)
+        expect(rendered).toContain('customer_entity_id IS NULL')
+        expect(rendered).toContain('channel_id IS NOT NULL')
+        expect(rendered).not.toContain('= null')
+        expect(rendered).not.toContain('!= null')
+      })
+
+      it('pins the never-TRUE rendering this fix replaced', () => {
+        // Kept as an executable record of the defect in #5016: MikroORM interpolates the parameter
+        // rather than binding it, so a raw null reached PostgreSQL as the NULL literal and made the
+        // predicate unsatisfiable for every row.
+        expect(platform.formatQuery('customer_entity_id = ?', [null])).toBe('customer_entity_id = null')
+        expect(platform.formatQuery('customer_entity_id != ?', [null])).toBe('customer_entity_id != null')
       })
 
       it('pins the array-as-single-parameter rendering this fix replaced', () => {

--- a/packages/core/src/modules/dashboards/lib/__tests__/aggregations.test.ts
+++ b/packages/core/src/modules/dashboards/lib/__tests__/aggregations.test.ts
@@ -386,7 +386,8 @@ describe('aggregations', () => {
       })
       expect(result?.sql).toContain('status = ?')
       expect(result?.sql).toContain('payment_status != ?')
-      expect(result?.sql).not.toContain('IS NULL AND payment_status')
+      expect(result?.sql).not.toContain('status IS NULL')
+      expect(result?.sql).not.toContain('payment_status IS NOT NULL')
       expect(result?.params).toEqual(['tenant-123', 'completed', 'refunded'])
     })
 

--- a/packages/core/src/modules/dashboards/lib/aggregations.ts
+++ b/packages/core/src/modules/dashboards/lib/aggregations.ts
@@ -173,6 +173,21 @@ function normalizeSetFilterValues(value: unknown): unknown[] {
   return values
 }
 
+/**
+ * Builds the shared WHERE clause every aggregation query reads from, together with its parameters.
+ *
+ * The `eq` / `neq` cases branch on a null value instead of binding it (#5016). Under SQL
+ * three-valued logic neither `column = NULL` nor `column != NULL` is ever `TRUE`, so binding a raw
+ * null selected zero rows and rendered as a legitimate-looking empty aggregation — a silent zero on
+ * a reporting surface. Nullness has to be asked with the `IS NULL` / `IS NOT NULL` keywords, which
+ * take no parameter; that is also what the dedicated `is_null` / `is_not_null` operators emit, and
+ * it mirrors how the query index builds column filters (`query_index/lib/engine.ts`).
+ *
+ * The ordering operators (`gt`/`gte`/`lt`/`lte`) deliberately keep binding the value: comparing an
+ * ordering against NULL is genuinely undefined rather than a mistake, so their never-`TRUE` result
+ * is the correct answer. Set operators refuse null members outright — see
+ * `normalizeSetFilterValues`.
+ */
 function buildWhereClause(
   options: Pick<BuildAggregationQueryOptions, 'entityType' | 'dateRange' | 'filters' | 'scope' | 'registry'>,
 ): { clause: string; params: unknown[] } {
@@ -207,10 +222,18 @@ function buildWhereClause(
 
       switch (filter.operator) {
         case 'eq':
+          if (filter.value === null) {
+            whereClauses.push(`${filterMapping.dbColumn} IS NULL`)
+            break
+          }
           whereClauses.push(`${filterMapping.dbColumn} = ?`)
           params.push(filter.value)
           break
         case 'neq':
+          if (filter.value === null) {
+            whereClauses.push(`${filterMapping.dbColumn} IS NOT NULL`)
+            break
+          }
           whereClauses.push(`${filterMapping.dbColumn} != ?`)
           params.push(filter.value)
           break


### PR DESCRIPTION
Closes #5016

## 🎯 Goal

A dashboard widget filtered on a null value now reports the rows it should. Previously `eq: null` / `neq: null` answered `200` with an empty aggregation — a zero indistinguishable from a genuinely empty result, on a surface whose whole job is reporting numbers.

## 🔍 Problem

Follow-up to #4964, which made the doc-backed and custom-field filter builders null-safe and whose review spotted the same defect surviving in the dashboards aggregation builder — deliberately left out of that PR as out of scope.

`buildWhereClause` in `packages/core/src/modules/dashboards/lib/aggregations.ts` pushed `${dbColumn} = ?` / `${dbColumn} != ?` and bound `filter.value` unconditionally. The shape is reachable straight from the HTTP boundary, not only from in-process callers: the scalar-operator branch of `widgetDataFilterSchema` (`api/widgets/data/schema.ts`) types `value` as `z.unknown().optional()`, which accepts `null`.

## 🔍 Root Cause

MikroORM does not bind parameters at the driver level — `AbstractSqlConnection.execute` calls `platform.formatQuery`, which interpolates each value into the SQL text. Confirmed empirically: `PostgreSqlPlatform.formatQuery('status = ?', [null])` renders the literal text `status = null`. PostgreSQL evaluates `= NULL` and `!= NULL` to NULL, never `TRUE`, under three-valued logic, so the predicate matched zero rows and the widget rendered a legitimate-looking zero.

The adjacent `is_null` / `is_not_null` cases in the same `switch` already emitted correct keyword SQL, and `normalizeSetFilterValues` already refused null set members (#4669), which makes the equality-operator omission an oversight rather than a design choice. It was also a departure from the platform's own convention: `packages/core/src/modules/query_index/lib/engine.ts` branches `value === null ? 'is' / 'is not' : '=' / '!='` in three places.

## What Changed

- **`packages/core/src/modules/dashboards/lib/aggregations.ts`** — `case 'eq'` now emits `${dbColumn} IS NULL` and `case 'neq'` emits `${dbColumn} IS NOT NULL`, both with no bound parameter, when `filter.value === null`; every non-null value keeps `= ?` / `!= ?` and its pushed parameter exactly as before. Because all three public builders (`buildDistinctCurrencyQuery`, `buildAggregationQuery`, `buildGroupSourceRowsQuery`) share `buildWhereClause`, this one edit fixes every dashboards aggregation path at once. A new block docblock on the function records the three-valued-logic reasoning and the operator audit the issue's fourth acceptance criterion asked for: the ordering operators (`gt`/`gte`/`lt`/`lte`) deliberately keep binding their value, because an ordering comparison against NULL is genuinely undefined rather than a mistake, so their never-`TRUE` result is the correct answer; set operators refuse null members outright. After this change no operator in the switch binds an unmatchable raw null.

- **`packages/core/src/modules/dashboards/lib/__tests__/aggregations.test.ts`** — unit coverage for both null branches, two over-correction guards, the group-source row query, and the rendered SQL text.

- **`packages/core/src/modules/dashboards/__integration__/TC-DASH-012-null-comparison-operators.spec.ts`** — new spec driving the real chain widget-data route → aggregation SQL → PostgreSQL, following the module's precedent for this defect class (#4669 → TC-DASH-010, #4852 → TC-DASH-011).

## 🧪 Tests

Both null-branch tests were written before the fix and confirmed red; the pre-fix rendered SQL was literally `customer_entity_id = null AND channel_id != null`, so the coverage is non-vacuous.

- `eq` / `neq` with `value: null` emit the keyword form and leave `params` at `['tenant-123']` — no parameter is bound.
- Two over-correction guards: non-null `eq`/`neq` still emit `= ?` / `!= ?` and bind their values, and a falsy-but-not-null value (`''`) still binds rather than taking the keyword path.
- The null filter reaches the encrypted group-source row query too, since it shares `buildWhereClause`.
- In the existing `rendered SQL (PostgreSqlPlatform.formatQuery)` block: the rendered text now contains `IS NULL` / `IS NOT NULL` and never `= null` / `!= null`, plus a canary pinning the interpolation behavior the fix depends on, in the style of the `#4669` canary already there.
- `TC-DASH-012` asserts a deliberately fixture-independent invariant — `eq null` and `neq null` must partition the run's own orders, which could not hold when both sides returned zero — then cross-checks the equality operators against the already-correct `is_null` / `is_not_null` answers, and pins that a non-null `eq` still selects exactly one row so an over-correction fails loudly. Self-contained: every order is created in the test and deleted in `finally`.

Full validation gate, local mode, run with `TURBO_FORCE=1` (0 cached / 25 tasks, so no turbo cache replay):

| Command | Result |
|---|---|
| `yarn build:packages` | ✅ |
| `yarn generate` | ✅ |
| `yarn build:packages` | ✅ |
| `yarn i18n:check-sync` | ✅ |
| `yarn i18n:check-usage` | ✅ |
| `yarn typecheck` | ✅ (tsconfig includes `__integration__`, so the new spec is typechecked) |
| `yarn test` | ⚠️ see below |
| `yarn build:app` | ✅ |

The changed package is green: **23 suites / 290 tests** in `packages/core/src/modules/dashboards`. `yarn test --continue` reaches 23 of 25 tasks; the two failures are pre-existing and environmental, and were verified to fail **identically with this PR's production change stashed**:

- `@open-mercato/cli` — 1 test, a 5000 ms `fs.watch` timeout in `dev-env-reload.test.ts` (1 failed / 1448 passed, same pristine).
- `create-mercato-app` — 165 agent-harness tests requiring live Claude and credentials (same 165 pristine).

`@open-mercato/core` and `@open-mercato/ui` additionally failed on this machine's Polish locale in `Intl` currency formatting (`1,0 mln` vs `1.0M`); both pass under `LC_ALL=C`, which is what CI uses. Lint reports 0 errors and 12 pre-existing warnings, none in the changed files.

## 💥 Breaking Changes

None to any contract surface — no signature, response shape, route, DI key, ACL feature, event id, DB schema or API schema change, and no migration.

One intended behavior change: an `eq: null` / `neq: null` widget-data filter previously returned an empty aggregation and now returns the rows where the column IS / IS NOT NULL, so any caller that depended on the always-empty answer will start seeing matches. `IS NULL` on a nullable column matches genuinely unset rows, which is the intended "not set" semantics and consistent with the adjacent `is_null` operator.

## Follow-up noted, not fixed here

Because `value` is `.optional()` in the request schema, an `eq` filter with the value **omitted** renders the invalid SQL text `status = undefined`, which PostgreSQL rejects as an unknown column. That is a loud 500 rather than a silent zero — a different defect class and severity, and outside this issue's acceptance criteria, so it is left for a separate follow-up rather than widened into this PR.

## Security impact

None. The change alters only null-comparison SQL for two aggregation filter operators. The null branches emit literal SQL keywords with **no** user-controlled input and strictly *reduce* the number of interpolated values; every non-null value keeps flowing through the existing `?` placeholder path, and column names still come from the analytics registry's `dbColumn` mapping rather than from request input. No tenant/organization scoping, auth, ACL, or encryption logic is touched — the `tenant_id`, `organization_id`, and `deleted_at` predicates are untouched and still precede every filter.
