### PR TITLE
fix(staff): invalidate the CRUD list cache on timesheet direct writes (#4970)

### DIFF
--- a/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-start/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-start/route.ts
@@ -17,6 +17,7 @@ import {
   runStaffMutationGuards,
 } from '../../../../guards'
 import { emitStaffEvent } from '../../../../../events'
+import { invalidateStaffTimeEntryCache } from '../../../../../lib/timesheets/timeEntryCacheInvalidation'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('staff')
@@ -169,6 +170,13 @@ export async function POST(req: Request) {
       await trx.flush()
       return startedAt
     })
+
+    await invalidateStaffTimeEntryCache(
+      container,
+      { id: entry.id, organizationId: entry.organizationId, tenantId: entry.tenantId },
+      tenantId,
+      'timer_started',
+    )
 
     void emitStaffEvent('staff.timesheets.time_entry.timer_started', {
       id: entry.id,

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-stop/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/[id]/timer-stop/route.ts
@@ -17,6 +17,7 @@ import {
   runStaffMutationGuards,
 } from '../../../../guards'
 import { emitStaffEvent } from '../../../../../events'
+import { invalidateStaffTimeEntryCache } from '../../../../../lib/timesheets/timeEntryCacheInvalidation'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('staff')
@@ -151,6 +152,13 @@ export async function POST(req: Request) {
       await trx.flush()
       return { now: stoppedAt, durationMinutes: computedMinutes }
     })
+
+    await invalidateStaffTimeEntryCache(
+      container,
+      { id: entry.id, organizationId: entry.organizationId, tenantId: entry.tenantId },
+      tenantId,
+      'timer_stopped',
+    )
 
     void emitStaffEvent('staff.timesheets.time_entry.timer_stopped', {
       id: entry.id,

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/bulk/__tests__/route.cache.test.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/bulk/__tests__/route.cache.test.ts
@@ -1,0 +1,211 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const timeProjectId = '44444444-4444-4444-8444-444444444444'
+const createdEntryId = '55555555-5555-4555-8555-555555555555'
+
+const deleteByTags = jest.fn()
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScope = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockRunStaffMutationGuards = jest.fn()
+const mockRunStaffMutationGuardAfterSuccess = jest.fn()
+const mockEmitCrudSideEffects = jest.fn()
+const mockFlushCrudSideEffects = jest.fn()
+const mockEntityManagerFind = jest.fn()
+const mockTrxCreate = jest.fn()
+const mockTrxFlush = jest.fn()
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+  deleteByTags,
+}
+
+const forkedEntityManager = {
+  find: (...args: unknown[]) => mockEntityManagerFind(...args),
+  transactional: async (callback: (trx: unknown) => unknown) =>
+    callback({
+      create: (...args: unknown[]) => mockTrxCreate(...args),
+      flush: (...args: unknown[]) => mockTrxFlush(...args),
+    }),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return { fork: () => forkedEntityManager }
+    if (token === 'dataEngine') return { markOrmEntityChange: jest.fn(), flushOrmEntityChanges: jest.fn() }
+    if (token === 'cache') return cache
+    return undefined
+  }),
+}
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: jest.fn((_tenantId: string | null, fn: () => unknown) => fn()),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((req: Request) => mockGetAuthFromRequest(req)),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScope(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  })),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/commands/helpers', () => ({
+  emitCrudSideEffects: jest.fn((...args: unknown[]) => mockEmitCrudSideEffects(...args)),
+  flushCrudSideEffects: jest.fn((...args: unknown[]) => mockFlushCrudSideEffects(...args)),
+}))
+
+jest.mock('../../../../guards', () => ({
+  resolveUserFeatures: jest.fn(() => ['staff.timesheets.manage_own']),
+  runStaffMutationGuards: jest.fn((...args: unknown[]) => mockRunStaffMutationGuards(...args)),
+  runStaffMutationGuardAfterSuccess: jest.fn((...args: unknown[]) =>
+    mockRunStaffMutationGuardAfterSuccess(...args),
+  ),
+}))
+
+const ORIGINAL_ENV = { ...process.env }
+
+const loadRoute = async () => {
+  jest.resetModules()
+  return import('../route')
+}
+
+const buildRequest = () =>
+  new Request('http://localhost/api/staff/timesheets/time-entries/bulk', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      entries: [{ date: '2026-08-03', timeProjectId, durationMinutes: 90 }],
+    }),
+  })
+
+describe('POST /api/staff/timesheets/time-entries/bulk cache invalidation (#4970)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+    mockGetAuthFromRequest.mockResolvedValue({
+      sub: 'user-1',
+      tenantId,
+      orgId: organizationId,
+      features: ['staff.timesheets.manage_own'],
+    })
+    mockResolveOrganizationScope.mockResolvedValue({ tenantId, selectedId: organizationId })
+    mockFindOneWithDecryption.mockResolvedValue({ id: 'staff-member-1' })
+    mockFindWithDecryption.mockResolvedValue([])
+    mockEntityManagerFind.mockResolvedValue([{ id: timeProjectId }])
+    mockRunStaffMutationGuards.mockResolvedValue({ ok: true, afterSuccessCallbacks: [] })
+    mockTrxCreate.mockImplementation((_entity: unknown, data: Record<string, unknown>) => ({
+      id: createdEntryId,
+      ...data,
+    }))
+    mockTrxFlush.mockResolvedValue(undefined)
+    deleteByTags.mockResolvedValue(1)
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('flushes the cached time-entry list after a committed bulk save', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { POST } = await loadRoute()
+
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, created: 1, updated: 0, deleted: 0 })
+
+    expect(mockFlushCrudSideEffects).toHaveBeenCalledTimes(1)
+    expect(deleteByTags).toHaveBeenCalledTimes(1)
+
+    const flushedTags = deleteByTags.mock.calls[0][0] as string[]
+    expect(flushedTags).toContain(
+      `crud:staff.timesheet:tenant:${tenantId}:org:${organizationId}:collection`,
+    )
+    expect(flushedTags).toContain(`crud:staff.timesheet:tenant:${tenantId}:org:null:collection`)
+    expect(flushedTags).toContain(
+      `crud:staff.timesheet:tenant:${tenantId}:record:${createdEntryId}`,
+    )
+  })
+
+  it('invalidates every distinct record a multi-row save touched', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const secondEntryId = '66666666-6666-4666-8666-666666666666'
+    const createdIds = [createdEntryId, secondEntryId]
+    let createCallCount = 0
+    mockTrxCreate.mockImplementation((_entity: unknown, data: Record<string, unknown>) => ({
+      id: createdIds[createCallCount++],
+      ...data,
+    }))
+    const { POST } = await loadRoute()
+
+    const response = await POST(
+      new Request('http://localhost/api/staff/timesheets/time-entries/bulk', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          entries: [
+            { date: '2026-08-03', timeProjectId, durationMinutes: 90 },
+            { date: '2026-08-04', timeProjectId, durationMinutes: 30 },
+          ],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(deleteByTags).toHaveBeenCalledTimes(2)
+    const allFlushedTags = deleteByTags.mock.calls.flatMap(([tags]) => tags as string[])
+    expect(allFlushedTags).toContain(`crud:staff.timesheet:tenant:${tenantId}:record:${createdEntryId}`)
+    expect(allFlushedTags).toContain(`crud:staff.timesheet:tenant:${tenantId}:record:${secondEntryId}`)
+  })
+
+  it('does not re-flush the same record twice when a payload repeats it', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { POST } = await loadRoute()
+
+    const response = await POST(
+      new Request('http://localhost/api/staff/timesheets/time-entries/bulk', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          entries: [
+            { date: '2026-08-03', timeProjectId, durationMinutes: 90 },
+            { date: '2026-08-04', timeProjectId, durationMinutes: 30 },
+          ],
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(deleteByTags).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not touch the cache while the opt-in CRUD list cache is disabled', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { POST } = await loadRoute()
+
+    const response = await POST(buildRequest())
+
+    expect(response.status).toBe(200)
+    expect(deleteByTags).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/bulk/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/bulk/route.ts
@@ -14,6 +14,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { StaffTimeEntry, StaffTeamMember, StaffTimeProject } from '../../../../data/entities'
 import { staffTimeEntryBulkSaveSchema } from '../../../../data/validators'
 import { staffTimeEntryCrudEvents } from '../../../../lib/crud'
+import { invalidateStaffTimeEntryCache } from '../../../../lib/timesheets/timeEntryCacheInvalidation'
 import {
   resolveUserFeatures,
   runStaffMutationGuardAfterSuccess,
@@ -229,6 +230,22 @@ export async function POST(req: Request) {
       })
     }
     await flushCrudSideEffects(dataEngine)
+
+    const invalidatedRecordIds = new Set<string>()
+    for (const change of pendingChanges) {
+      if (invalidatedRecordIds.has(change.entity.id)) continue
+      invalidatedRecordIds.add(change.entity.id)
+      await invalidateStaffTimeEntryCache(
+        container,
+        {
+          id: change.entity.id,
+          organizationId: change.entity.organizationId,
+          tenantId: change.entity.tenantId,
+        },
+        tenantId,
+        `bulk:${change.action}`,
+      )
+    }
 
     if (guardResult.afterSuccessCallbacks.length) {
       await runStaffMutationGuardAfterSuccess(guardResult.afterSuccessCallbacks, {

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/route.ts
@@ -5,6 +5,7 @@ import { resolveCrudRecordId, parseScopedCommandInput } from '@open-mercato/shar
 import { StaffTimeEntry } from '../../../data/entities'
 import { staffTimeEntryCreateSchema, staffTimeEntryUpdateSchema } from '../../../data/validators'
 import { buildTimeEntryListFilters, isParseableDateFilter } from '../../../lib/timesheets/timeEntryListFilters'
+import { staffTimeEntryCommandIds } from '../../../lib/timesheets/timeEntryCacheInvalidation'
 import { createStaffCrudOpenApi, createPagedListResponseSchema, defaultOkResponseSchema } from '../../openapi'
 
 const F = {
@@ -99,7 +100,7 @@ const crud = makeCrudRoute({
   },
   actions: {
     create: {
-      commandId: 'staff.timesheets.time_entries.create',
+      commandId: staffTimeEntryCommandIds.create,
       schema: rawBodySchema,
       mapInput: async ({ raw, ctx }) => {
         const { translate } = await resolveTranslations()
@@ -109,7 +110,7 @@ const crud = makeCrudRoute({
       status: 201,
     },
     update: {
-      commandId: 'staff.timesheets.time_entries.update',
+      commandId: staffTimeEntryCommandIds.update,
       schema: rawBodySchema,
       mapInput: async ({ raw, ctx }) => {
         const { translate } = await resolveTranslations()
@@ -118,7 +119,7 @@ const crud = makeCrudRoute({
       response: () => ({ ok: true }),
     },
     delete: {
-      commandId: 'staff.timesheets.time_entries.delete',
+      commandId: staffTimeEntryCommandIds.delete,
       schema: rawBodySchema,
       mapInput: async ({ parsed, ctx }) => {
         const { translate } = await resolveTranslations()

--- a/packages/core/src/modules/staff/api/timesheets/time-entries/route.ts
+++ b/packages/core/src/modules/staff/api/timesheets/time-entries/route.ts
@@ -5,7 +5,7 @@ import { resolveCrudRecordId, parseScopedCommandInput } from '@open-mercato/shar
 import { StaffTimeEntry } from '../../../data/entities'
 import { staffTimeEntryCreateSchema, staffTimeEntryUpdateSchema } from '../../../data/validators'
 import { buildTimeEntryListFilters, isParseableDateFilter } from '../../../lib/timesheets/timeEntryListFilters'
-import { staffTimeEntryCommandIds } from '../../../lib/timesheets/timeEntryCacheInvalidation'
+import { staffTimeEntryCommandIds } from '../../../lib/crud'
 import { createStaffCrudOpenApi, createPagedListResponseSchema, defaultOkResponseSchema } from '../../openapi'
 
 const F = {

--- a/packages/core/src/modules/staff/lib/crud.ts
+++ b/packages/core/src/modules/staff/lib/crud.ts
@@ -36,6 +36,18 @@ export const staffTeamMemberActivityCrudEvents = buildCrudEvents<StaffTeamMember
 export const staffTeamMemberJobHistoryCrudEvents = buildCrudEvents<StaffTeamMemberJobHistory>('job_history')
 
 // Timesheets
+/**
+ * Command ids the time-entries CRUD route registers. Exported so the route and the
+ * cache-invalidation helper share one string: `makeCrudRoute` derives the CRUD cache
+ * resource tag from the create id, so a second copy of it drifting apart would leave
+ * custom write routes flushing a tag nothing is stored under (#4970).
+ */
+export const staffTimeEntryCommandIds = {
+  create: 'staff.timesheets.time_entries.create',
+  update: 'staff.timesheets.time_entries.update',
+  delete: 'staff.timesheets.time_entries.delete',
+} as const
+
 export const staffTimeEntryCrudEvents = buildCrudEvents<StaffTimeEntry>('timesheets.time_entry')
 export const staffTimeProjectCrudEvents = buildCrudEvents<StaffTimeProject>('timesheets.time_project')
 export const staffTimeProjectMemberCrudEvents = buildCrudEvents<StaffTimeProjectMember>('timesheets.time_project_member')

--- a/packages/core/src/modules/staff/lib/timesheets/__tests__/timeEntryCacheInvalidation.test.ts
+++ b/packages/core/src/modules/staff/lib/timesheets/__tests__/timeEntryCacheInvalidation.test.ts
@@ -1,0 +1,118 @@
+/** @jest-environment node */
+
+const tenantId = '11111111-1111-4111-8111-111111111111'
+const organizationId = '22222222-2222-4222-8222-222222222222'
+const recordId = '33333333-3333-4333-8333-333333333333'
+
+jest.mock('@open-mercato/cache', () => ({
+  runWithCacheTenant: jest.fn((_tenantId: string | null, fn: () => unknown) => fn()),
+}))
+
+const deleteByTags = jest.fn()
+
+const cache = {
+  get: jest.fn(),
+  set: jest.fn(),
+  deleteByTags,
+}
+
+const container = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'cache') return cache
+    throw new Error(`[internal] Unexpected container resolve: ${token}`)
+  }),
+}
+
+const ORIGINAL_ENV = { ...process.env }
+
+const loadHelper = async () => {
+  jest.resetModules()
+  return import('../timeEntryCacheInvalidation')
+}
+
+describe('staff time-entry CRUD cache invalidation (#4970)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...ORIGINAL_ENV }
+    deleteByTags.mockResolvedValue(1)
+  })
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('derives the cache resource from the same create command id the CRUD route registers', async () => {
+    const { staffTimeEntryCacheResource, staffTimeEntryCommandIds } = await loadHelper()
+    const { canonicalizeResourceTag, deriveResourceFromCommandId } = await import(
+      '@open-mercato/shared/lib/crud/cache'
+    )
+
+    expect(staffTimeEntryCacheResource).toBe('staff.timesheet')
+    expect(staffTimeEntryCacheResource).toBe(
+      canonicalizeResourceTag(deriveResourceFromCommandId(staffTimeEntryCommandIds.create)),
+    )
+  })
+
+  it('does not use the entity-derived tag a hand-written literal would guess', async () => {
+    const { staffTimeEntryCacheResource } = await loadHelper()
+    const { canonicalizeResourceTag } = await import('@open-mercato/shared/lib/crud/cache')
+
+    expect(staffTimeEntryCacheResource).not.toBe(canonicalizeResourceTag('staff.time_entry'))
+    expect(staffTimeEntryCacheResource).not.toBe(canonicalizeResourceTag('StaffTimeEntry'))
+  })
+
+  it('flushes the collection and record tags the cached week list is stored under', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { invalidateStaffTimeEntryCache, staffTimeEntryCacheResource } = await loadHelper()
+    const { buildCollectionTags, buildRecordTag } = await import('@open-mercato/shared/lib/crud/cache')
+
+    await invalidateStaffTimeEntryCache(
+      container as never,
+      { id: recordId, organizationId, tenantId },
+      tenantId,
+      'bulk:created',
+    )
+
+    expect(deleteByTags).toHaveBeenCalledTimes(1)
+    const flushedTags = deleteByTags.mock.calls[0][0] as string[]
+
+    expect(flushedTags).toContain(buildRecordTag(staffTimeEntryCacheResource, tenantId, recordId))
+    for (const tag of buildCollectionTags(staffTimeEntryCacheResource, tenantId, [null, organizationId])) {
+      expect(flushedTags).toContain(tag)
+    }
+    expect(flushedTags).toContain(
+      `crud:staff.timesheet:tenant:${tenantId}:org:${organizationId}:collection`,
+    )
+  })
+
+  it('swallows a cache-backend failure so an already-committed write still succeeds', async () => {
+    process.env.ENABLE_CRUD_API_CACHE = 'true'
+    const { invalidateStaffTimeEntryCache } = await loadHelper()
+    deleteByTags.mockRejectedValue(new Error('[internal] cache backend unavailable'))
+
+    await expect(
+      invalidateStaffTimeEntryCache(
+        container as never,
+        { id: recordId, organizationId, tenantId },
+        tenantId,
+        'bulk:created',
+      ),
+    ).resolves.toBeUndefined()
+
+    expect(deleteByTags).toHaveBeenCalledTimes(1)
+  })
+
+  it('stays a no-op while the opt-in CRUD list cache is disabled', async () => {
+    delete process.env.ENABLE_CRUD_API_CACHE
+    const { invalidateStaffTimeEntryCache } = await loadHelper()
+
+    await invalidateStaffTimeEntryCache(
+      container as never,
+      { id: recordId, organizationId, tenantId },
+      tenantId,
+      'bulk:created',
+    )
+
+    expect(deleteByTags).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/staff/lib/timesheets/__tests__/timeEntryCacheInvalidation.test.ts
+++ b/packages/core/src/modules/staff/lib/timesheets/__tests__/timeEntryCacheInvalidation.test.ts
@@ -42,7 +42,8 @@ describe('staff time-entry CRUD cache invalidation (#4970)', () => {
   })
 
   it('derives the cache resource from the same create command id the CRUD route registers', async () => {
-    const { staffTimeEntryCacheResource, staffTimeEntryCommandIds } = await loadHelper()
+    const { staffTimeEntryCacheResource } = await loadHelper()
+    const { staffTimeEntryCommandIds } = await import('../../crud')
     const { canonicalizeResourceTag, deriveResourceFromCommandId } = await import(
       '@open-mercato/shared/lib/crud/cache'
     )

--- a/packages/core/src/modules/staff/lib/timesheets/timeEntryCacheInvalidation.ts
+++ b/packages/core/src/modules/staff/lib/timesheets/timeEntryCacheInvalidation.ts
@@ -6,19 +6,9 @@ import {
   type CrudCacheIdentifiers,
 } from '@open-mercato/shared/lib/crud/cache'
 import { createLogger } from '@open-mercato/shared/lib/logger'
+import { staffTimeEntryCommandIds } from '../crud'
 
 const logger = createLogger('staff').child({ component: 'timesheets-cache' })
-
-/**
- * Command ids the time-entries `makeCrudRoute` registers. They are exported so the
- * route and the cache-invalidation helper below derive their resource tag from one
- * string instead of two that can drift apart.
- */
-export const staffTimeEntryCommandIds = {
-  create: 'staff.timesheets.time_entries.create',
-  update: 'staff.timesheets.time_entries.update',
-  delete: 'staff.timesheets.time_entries.delete',
-} as const
 
 /**
  * The resource tag the CRUD list cache stores time-entry payloads under.

--- a/packages/core/src/modules/staff/lib/timesheets/timeEntryCacheInvalidation.ts
+++ b/packages/core/src/modules/staff/lib/timesheets/timeEntryCacheInvalidation.ts
@@ -1,0 +1,74 @@
+import type { AwilixContainer } from 'awilix'
+import {
+  canonicalizeResourceTag,
+  deriveResourceFromCommandId,
+  invalidateCrudCache,
+  type CrudCacheIdentifiers,
+} from '@open-mercato/shared/lib/crud/cache'
+import { createLogger } from '@open-mercato/shared/lib/logger'
+
+const logger = createLogger('staff').child({ component: 'timesheets-cache' })
+
+/**
+ * Command ids the time-entries `makeCrudRoute` registers. They are exported so the
+ * route and the cache-invalidation helper below derive their resource tag from one
+ * string instead of two that can drift apart.
+ */
+export const staffTimeEntryCommandIds = {
+  create: 'staff.timesheets.time_entries.create',
+  update: 'staff.timesheets.time_entries.update',
+  delete: 'staff.timesheets.time_entries.delete',
+} as const
+
+/**
+ * The resource tag the CRUD list cache stores time-entry payloads under.
+ *
+ * `makeCrudRoute` derives it from the create action's command id (the route declares
+ * no `events` config), which singularizes the command's SECOND segment — so the tag
+ * is `staff.timesheet`, NOT the `staff.time_entry` the entity name suggests. Deriving
+ * it here through the same shared helpers keeps the flush tag equal to the store tag;
+ * a hand-typed literal is how a custom write route silently flushes nothing (#3143,
+ * #3711). The literal fallback only guards against a null derivation at runtime — the
+ * unit test pins the derived value so drift fails in CI instead of in production.
+ */
+export const staffTimeEntryCacheResource =
+  canonicalizeResourceTag(deriveResourceFromCommandId(staffTimeEntryCommandIds.create)) ?? 'staff.timesheet'
+
+/**
+ * Flush the cached time-entry collections and record entries after a committed write.
+ *
+ * Custom write routes that mutate `StaffTimeEntry` through the EntityManager bypass
+ * `makeCrudRoute`'s own POST/PUT/DELETE handlers and the command bus, so neither of
+ * the platform's two `invalidateCrudCache` call sites runs for them. Without this the
+ * opt-in CRUD list cache (`ENABLE_CRUD_API_CACHE`) keeps serving the pre-write payload
+ * and the weekly timesheet grid reloads without the rows it just saved (#4970).
+ *
+ * MUST be called after the transaction commits, never inside it. Because the write is
+ * already committed by then, a failing cache backend is logged rather than thrown — the
+ * command bus guards its own invalidation the same way. Surfacing it would turn a
+ * successful write into an error response and invite a duplicating client retry, while
+ * swallowing it costs at most one TTL of staleness.
+ */
+export async function invalidateStaffTimeEntryCache(
+  container: AwilixContainer,
+  identifiers: CrudCacheIdentifiers,
+  fallbackTenant: string | null,
+  reason: string,
+): Promise<void> {
+  try {
+    await invalidateCrudCache(
+      container,
+      staffTimeEntryCacheResource,
+      identifiers,
+      fallbackTenant,
+      reason,
+    )
+  } catch (err) {
+    logger.warn('Time-entry cache invalidation failed', {
+      resource: staffTimeEntryCacheResource,
+      recordId: identifiers.id ?? null,
+      reason,
+      err,
+    })
+  }
+}


### PR DESCRIPTION
Closes #4970

## 🎯 Goal
A weekly timesheet save is visible to the page that performed it. Typing `1:30` into the grid, saving and reloading no longer shows an empty cell for a row that is sitting in the database.

## 🔍 Problem
With the opt-in CRUD list cache on (`ENABLE_CRUD_API_CACHE=true` — what `yarn test:integration:ephemeral:start` sets), the bulk save endpoint returned `200 {"ok":true,"created":1}` and then the grid's re-fetch of `/api/staff/timesheets/time-entries?...` served a byte-identical **pre-save** payload. The row stayed invisible until something else wrote a time entry through the ordinary single-entry CRUD route or the entry aged out on TTL. In the browser that reads as data loss.

## 🔍 Root Cause
`api/timesheets/time-entries/bulk/route.ts` commits its own `em.transactional` block and then queues side effects with `emitCrudSideEffects` / `flushCrudSideEffects`. Those helpers only reach `dataEngine.markOrmEntityChange` / `flushOrmEntityChanges` (`packages/shared/src/lib/commands/helpers.ts:49-99`) — they raise events and feed the indexer but never call `invalidateCrudCache`. The platform has exactly two invalidation call sites, `makeCrudRoute`'s own POST/PUT/DELETE handlers (`packages/shared/src/lib/crud/factory.ts:2378,2716,3004`) and the command bus (`commands/command-bus.ts:648,680`), and this route goes through neither.

The reason a *single*-entry write made both rows appear at once — the tell in the issue — is the same mechanism from the other side: the command bus adds `deriveResourceFromCommandId(commandId)` to its alias set, so it happens to flush the exact tag the cached list is stored under.

**That tag is the trap.** `resolveResourceAliasesList` (`factory.ts:482-492`) finds no `events` config on the time-entries route, falls back to the create action's command id, and singularizes that id's **second** segment — so the list is cached under `staff.timesheet`, **not** the `staff.time_entry` the entity name suggests. A hand-typed literal here produces a well-formed tag that flushes nothing at all, silently: the same failure mode as #3143 / #3711.

## What Changed
- **New `packages/core/src/modules/staff/lib/timesheets/timeEntryCacheInvalidation.ts`** — owns the tag so no call site has to know the derivation rule. It exports the three time-entry command ids and derives `staffTimeEntryCacheResource` from the create id through the same shared helpers the factory uses (`deriveResourceFromCommandId` → `canonicalizeResourceTag`), rather than hard-coding `'staff.timesheet'`. `invalidateStaffTimeEntryCache(container, identifiers, fallbackTenant, reason)` wraps `invalidateCrudCache`, mirroring `sales/commands/returns.ts` and `notifications/lib/notificationService.ts`. It lives in the staff module's own `lib/` (module-internal per that module's layout) so it mints no new public contract surface for a module slated for extraction into `@open-mercato/staff`.
- **`api/timesheets/time-entries/bulk/route.ts`** — after `flushCrudSideEffects`, invalidates once per distinct changed record. Placed after the transaction commits, per `packages/core/AGENTS.md` ("invalidate **after** the DB write commits, never inside the `withAtomicFlush` block").
- **`api/timesheets/time-entries/[id]/timer-start/route.ts`** and **`[id]/timer-stop/route.ts`** — the same call after their own transactions. Both write `started_at` / `ended_at` / `duration_minutes` / `source` on `StaffTimeEntry` via direct EM writes, all of which are columns in the cached list projection, so both carried the identical gap.
- **`api/timesheets/time-entries/route.ts`** — the three `actions[].commandId` literals now come from the exported constants, so the tag the factory derives on the *store* side and the tag the helper derives on the *flush* side cannot drift apart.
- **Fail-soft by design** — the helper logs invalidation failures instead of throwing, exactly as `command-bus.ts` guards its own. The write is already committed by then; surfacing a cache-backend error would return 400 on a successful save and invite a duplicating client retry, whereas swallowing it costs at most one TTL of staleness.

### Audit of the module's other custom write routes
The issue asked for this, and two of the five named routes turned out **not** to have the gap — they are deliberately untouched rather than defensively patched:
- `start-timer` — routes through the command bus, which already invalidates. No change needed.
- `[id]/segments` and `[id]/segments/[segmentId]` — mutate only `StaffTimeEntrySegment`; the parent `StaffTimeEntry` is loaded solely to take a `PESSIMISTIC_WRITE` lock and is never written. `segments/route.ts` also exports no `GET`, so there is no cached payload to go stale.

## 🧪 Tests
- **New** `lib/timesheets/__tests__/timeEntryCacheInvalidation.test.ts` (5 cases) — pins the resource to `staff.timesheet` **and** asserts it equals `canonicalizeResourceTag(deriveResourceFromCommandId(staffTimeEntryCommandIds.create))`, so a command-id rename or a change in shared canonicalization fails in CI rather than silently flushing nothing in production. Also asserts the tag is *not* what a hand-written `staff.time_entry` / `StaffTimeEntry` literal would produce, plus the fail-soft path and the disabled-cache no-op.
- **New** `api/timesheets/time-entries/bulk/__tests__/route.cache.test.ts` (4 cases) — drives a real bulk `POST` with `ENABLE_CRUD_API_CACHE=true` and asserts `deleteByTags` receives the org-scoped, tenant-level and per-record tags; that a two-row save flushes both records; that a repeated record is not flushed twice; and that nothing touches the cache while the flag is off.
- **Verified these are genuine regression tests**: with the bulk route reverted to its `origin/develop` content, 3 of the 4 route cases fail and only the disabled-cache no-op still passes.
- Full gate (local runner, no compose `app` container), all 8 commands from `.ai/agentic.config.json` in order, every turbo task run with `--force` so nothing was replayed from the shared worktree cache: `build:packages` ✅ · `generate` ✅ · `build:packages` ✅ · `i18n:check-sync` ✅ · `i18n:check-usage` ✅ (advisory) · `typecheck` ✅ · `test` ⚠️ · `build:app` ✅.
- **staff module: 36/36 suites, 158/158 tests.** `@open-mercato/shared`: 1763/1763. `@open-mercato/core`: 9140 passed.
- `test` exits non-zero only on failures confirmed pre-existing and untouched by this diff, which changes nothing outside `packages/core/src/modules/staff/`:
  - `@open-mercato/cli` `dev-env-reload.test.ts` (1) — reproduced identically on a clean `develop` checkout; an `fs.watch` limitation of this machine.
  - `@open-mercato/core` (8 across `dashboards/lib/__tests__/formatters.test.ts`, `CompanyKpiBar.dealStatus.test.tsx`, `DealsKpiStrip.test.tsx`) and `@open-mercato/ui` `format.test.ts` (1) — the runner's Polish system locale (`Expected: "1.0M"` / `Received: "1,0 mln"`).
  - `create-mercato-app` `writable-ast-oracles.test.ts` — `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`; the sandbox cannot set up loopback for its nested typecheck.

## 💥 Breaking Changes
None. No DB schema, API route, response shape, event ID, DI key, ACL feature, or exported platform type changes; the new file is module-internal to `staff`.

With `ENABLE_CRUD_API_CACHE` unset — the default — every added call short-circuits inside `isCrudCacheEnabled()`, so default-configuration behavior is byte-identical. The behavior change is scoped entirely to deployments that opted into the CRUD list cache, where reads now reflect a bulk save instead of a stale week.
