### PR TITLE
test(scripts): guard against duplicate CHANGELOG version headings

### DIFF
--- a/scripts/__tests__/release-workflow.test.mjs
+++ b/scripts/__tests__/release-workflow.test.mjs
@@ -1,10 +1,23 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import test from 'node:test'
 
 const releasePath = path.resolve('.github/workflows/release.yml')
 const preparePath = path.resolve('.github/workflows/release-prepare.yml')
+const changelogPath = path.resolve('CHANGELOG.md')
+const changelogSectionPath = path.resolve('scripts/changelog-section.sh')
+
+const VERSION_HEADING = /^# (\d+\.\d+\.\d+) \(/
+
+function readChangelogLines() {
+  return fs.readFileSync(changelogPath, 'utf8').split('\n')
+}
+
+function listVersionHeadings(lines) {
+  return lines.map((line) => line.match(VERSION_HEADING)?.[1]).filter((version) => version !== undefined)
+}
 
 function stepIndex(workflow, stepName) {
   const index = workflow.indexOf(`- name: ${stepName}`)
@@ -81,6 +94,57 @@ test('release notes embed the changelog section from disk', () => {
   )
   assert.match(workflow, /BODY_LIMIT = 125000/, 'Release bodies must respect the GitHub size limit')
   assert.match(workflow, /updateRelease/, 'Re-running a release should refresh notes, not fail')
+})
+
+test('CHANGELOG.md never repeats a version heading', () => {
+  const versions = listVersionHeadings(readChangelogLines())
+
+  assert.ok(
+    versions.length > 0,
+    'No `# <version> (` headings matched CHANGELOG.md — the heading format drifted and this guard would pass vacuously',
+  )
+
+  const duplicates = [...new Set(versions.filter((version, index) => versions.indexOf(version) !== index))]
+
+  assert.deepEqual(
+    duplicates,
+    [],
+    `Duplicate version heading(s): ${duplicates.join(', ')}. scripts/changelog-section.sh scans for the first "# <version> (" and exits at the next "# " line, so a second heading for the same version silently truncates the release notes — and still exits 0, so nothing downstream can tell half the notes from all of them. This collides when a release is cut from main while develop holds an in-progress draft for the same version (#5014, #5017); reconcile the two sections into one instead of letting the merge keep both.`,
+  )
+})
+
+test('changelog-section.sh round-trips the section it extracts', () => {
+  const lines = readChangelogLines()
+
+  const startIndex = lines.findIndex((line) => VERSION_HEADING.test(line))
+  assert.notEqual(startIndex, -1, 'CHANGELOG.md must open with a `# <version> (<date>)` section')
+
+  const version = lines[startIndex].match(VERSION_HEADING)[1]
+  const nextHeadingIndex = lines.findIndex((line, index) => index > startIndex && line.startsWith('# '))
+  const body = lines.slice(startIndex + 1, nextHeadingIndex === -1 ? undefined : nextHeadingIndex)
+
+  const trimTrailingBlanks = () => {
+    while (body.length > 0 && body[body.length - 1].trim() === '') body.pop()
+  }
+  while (body.length > 0 && body[0].trim() === '') body.shift()
+  trimTrailingBlanks()
+  if (body[body.length - 1] === '---') {
+    body.pop()
+    trimTrailingBlanks()
+  }
+
+  const result = spawnSync('bash', [changelogSectionPath, version, '--changelog', changelogPath], { encoding: 'utf8' })
+
+  assert.equal(
+    result.status,
+    0,
+    `changelog-section.sh ${version} exited ${result.status}; release.yml feeds this straight into the GitHub Release body. stderr: ${result.stderr}`,
+  )
+  assert.equal(
+    result.stdout,
+    `${body.join('\n')}\n`,
+    `changelog-section.sh ${version} did not return the section CHANGELOG.md actually holds for that version. It must emit every line up to the next "# " heading, with the trailing "---" separator and surrounding blank lines stripped — anything shorter is the silent truncation that publishes half a release's notes (#5017).`,
+  )
 })
 
 test('release prepare workflow opens a PR instead of pushing to main', () => {


### PR DESCRIPTION
Fixes #5017

## 🎯 Goal

Stop a duplicate `# <version> (` heading in `CHANGELOG.md` from silently truncating a GitHub Release body, by failing the PR that introduces the duplicate instead of letting it surface at release time.

## 🐛 The failure mode

A release cut from `main` while `develop` still holds an in-progress changelog draft for the same version produces two headings for that version once the sync merge lands. Git has no reason to object — the two sections sit at different offsets with different surrounding context, so the merge is a clean insert with no conflict marker and no failing check. That is exactly what happened in #5014 (`214` additions, `0` deletions).

`scripts/changelog-section.sh` extracts a release's notes with an `awk` scan that sets `found` on the first `# <version> (` heading and exits at the next line starting with `# `:

```awk
index($0, "# ") == 1 {
  if (found) exit
  if (index($0, heading) == 1) { found = 1; next }
}
found { print }
```

With a duplicate heading present it stops at the second one and emits only the first section. `release.yml` feeds that output straight into the GitHub Release body, and the script **exits 0** — so nothing downstream can distinguish "here are the release notes" from "here is half of them".

## 🧪 What this adds

Two tests in `scripts/__tests__/release-workflow.test.mjs`, the natural neighbour: it already asserts that `release.yml` invokes `changelog-section.sh`, so the guards belong together.

1. **`CHANGELOG.md never repeats a version heading`** — parses `^# (\d+\.\d+\.\d+) \(` out of the changelog and asserts the version list has no duplicates. It also asserts at least one heading matched, so a future change to the heading format fails loudly rather than making the guard pass vacuously.
2. **`changelog-section.sh round-trips the section it extracts`** — runs the script for the top version and asserts it exits 0 and returns exactly the section the file holds: every line up to the next `# ` heading, with the trailing `---` separator and surrounding blank lines stripped. This covers the same silent-truncation class (short output, exit 0) in the extractor itself.

### Why this placement

`yarn test:scripts` runs **unconditionally and unfiltered** on every PR (`.github/workflows/ci.yml`, step `Test scripts`), outside the turbo `--filter=[base]...` scoping that would otherwise select no owning package for a `CHANGELOG.md`-only change and skip the guard entirely. So the duplicate fails the PR that introduces it, rather than surfacing at release time detached from its cause — the same reasoning already documented for the create-app parity guards and `test:repo-wide-guards` (#3779, #4527, #4534).

No registration in `scripts/repo-wide-guards.mjs` is needed: `findCrossPackageTestCandidates` scans only `packages/*/src` and `apps/*/src`, and `scripts/__tests__/` is already covered by the unfiltered `Test scripts` step.

## ✅ Verification

Both guards were verified to fail when they should, not just pass on a clean tree:

| Scenario | Result |
|---|---|
| Clean tree | ✅ 13/13 pass in `release-workflow.test.mjs` |
| Replay of #5014 — duplicate `# 0.6.7 (2026-08-01)` heading injected | ❌ duplicate guard fails, naming `0.6.7`; round-trip guard correctly stays green (that placement leaves the top section intact — no false positive) |
| Extractor tampered to stop stripping the `---` separator | ❌ round-trip guard fails |
| Extractor tampered to truncate after 5 lines | ❌ round-trip guard fails |

Full CI step: `yarn test:scripts` → **442/445 pass**, including both new guards. The 3 failures are all in `scripts/__tests__/dev-module-resource-usage-dir.test.mjs`, a file this PR does not touch; they are environmental, caused by the local host's inotify ceiling (`fs.inotify.max_user_watches: 65536 < 4194304`) blocking the dev-wrapper spawn.

Also run: `yarn i18n:check-sync` (in sync). `typecheck`, `lint`, `test`, `build:packages` and `build:app` do not cover this file — the root `tsconfig.json` has `"include": []`, `yarn lint` and `yarn test` run through turbo's package graph, and `scripts/` is not a workspace package.

## 💥 Breaking changes

None. Test-only; no runtime, contract, database, or API surface is touched. `scripts/changelog-section.sh` itself is deliberately left unchanged — per #5017, hardening the extractor is out of scope, and the #5014 instance was already reconciled there.