### PR TITLE
test(scripts): enforce workspace version alignment on the PR path (#5018)

### DIFF
--- a/scripts/__tests__/check-version-alignment.test.mjs
+++ b/scripts/__tests__/check-version-alignment.test.mjs
@@ -73,8 +73,9 @@ test('every public package is aligned with the monorepo version', async () => {
 
   const publicPackages = await readPublicPackages()
   assert.ok(
-    publicPackages.length > 1,
-    'Expected the scan to find the public workspaces — an empty result would pass vacuously',
+    publicPackages.some((pkg) => pkg.name === reference.name),
+    `Expected the scan to reach the reference workspace ${reference.name}. A scan that silently ` +
+      'stopped finding manifests would report alignment over nothing at all',
   )
 
   const mismatched = publicPackages
@@ -92,6 +93,7 @@ test('every public package is aligned with the monorepo version', async () => {
 test('the root manifest carries the monorepo version too', async () => {
   const reference = await readManifest(referenceManifest)
   const root = await readManifest(path.join(rootDir, 'package.json'))
+  assert.ok(root, 'The root package.json is the reference for the release-time bump and must exist')
 
   assert.equal(
     root.version,

--- a/scripts/__tests__/check-version-alignment.test.mjs
+++ b/scripts/__tests__/check-version-alignment.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * PR-path guard for the release-time version-alignment gate.
+ *
+ * `scripts/check-version-alignment.sh` asserts that every public `packages/*` manifest carries
+ * the monorepo version, and it is load-bearing at release time and nowhere else:
+ * `scripts/bump-version.sh:17` and `:29`, `scripts/release-existing.sh:13`, and
+ * `.github/workflows/release.yml:72`. No PR-triggered workflow invoked it, so a misaligned
+ * workspace passed CI and first failed days later at the release's very first gate, detached
+ * from the merge that caused it (#5018).
+ *
+ * The drift is not a slip but a property of the branching model: a workspace added on `develop`
+ * between two releases does not exist on `main` at the release commit, so the release bump never
+ * touches it and the next `main` → `develop` sync has nothing to reconcile. That is how
+ * `@open-mercato/telemetry` stayed at `0.6.6` while everything else moved to `0.6.7` (#5014),
+ * and it will recur the next time a package is introduced mid-cycle. For telemetry the blast
+ * radius reached past the gate: `packages/create-app` pins template dependencies to
+ * `{{PACKAGE_VERSION}}` (`packages/create-app/AGENTS.md`), so a package out of lockstep makes a
+ * fresh scaffold's `yarn install` fail with "No candidates found" — as at `0.6.3` vs `0.6.5`
+ * (`.ai/specs/2026-04-29-telemetry-and-otel.md`).
+ *
+ * This lives in `scripts/__tests__/` rather than in `REPO_WIDE_GUARDS` deliberately. CI runs
+ * `yarn test:scripts` unconditionally and unfiltered (`.github/workflows/ci.yml:628`), outside
+ * the `--filter=[base]...` scoping that selects packages by dependency graph and would skip a
+ * version-only `package.json` edit entirely; `ci.yml:666` already names `yarn test:scripts`
+ * among the guards that "already run unfiltered". `scripts/repo-wide-guards.mjs` is a
+ * jest-per-workspace runner whose enumeration honesty check only scans `/\.test\.tsx?$/`, so an
+ * `.mjs` script test has no place in it.
+ *
+ * The comparison is reimplemented here in plain Node so the guard needs no `jq` or `bash` on the
+ * common PR path. The last test pins the shell script's scope so the two cannot silently desync.
+ */
+
+import assert from 'node:assert/strict'
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const rootDir = path.resolve(__dirname, '../..')
+const packagesDir = path.join(rootDir, 'packages')
+const referenceManifest = path.join(packagesDir, 'shared', 'package.json')
+const alignmentScript = path.join(rootDir, 'scripts', 'check-version-alignment.sh')
+
+async function readManifest(manifestPath) {
+  try {
+    return JSON.parse(await readFile(manifestPath, 'utf8'))
+  } catch (error) {
+    if (error.code === 'ENOENT') return null
+    throw error
+  }
+}
+
+async function readPublicPackages() {
+  const entries = await readdir(packagesDir, { withFileTypes: true })
+  const packages = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+
+    const manifest = await readManifest(path.join(packagesDir, entry.name, 'package.json'))
+    if (!manifest || manifest.private === true) continue
+
+    packages.push({ dir: entry.name, name: manifest.name, version: manifest.version })
+  }
+
+  return packages
+}
+
+test('every public package is aligned with the monorepo version', async () => {
+  const reference = await readManifest(referenceManifest)
+  assert.ok(reference, 'packages/shared/package.json is the reference manifest and must exist')
+
+  const publicPackages = await readPublicPackages()
+  assert.ok(
+    publicPackages.length > 1,
+    'Expected the scan to find the public workspaces — an empty result would pass vacuously',
+  )
+
+  const mismatched = publicPackages
+    .filter((pkg) => pkg.version !== reference.version)
+    .map((pkg) => `${pkg.name}@${pkg.version} (expected ${reference.version})`)
+
+  assert.deepEqual(
+    mismatched,
+    [],
+    `Not aligned with the monorepo version (${reference.version}) from packages/shared/package.json. ` +
+      'Fix their package.json versions — otherwise the next release fails at its first gate.',
+  )
+})
+
+test('the root manifest carries the monorepo version too', async () => {
+  const reference = await readManifest(referenceManifest)
+  const root = await readManifest(path.join(rootDir, 'package.json'))
+
+  assert.equal(
+    root.version,
+    reference.version,
+    'scripts/bump-version.sh and scripts/release-existing.sh also check alignment with ' +
+      '`--reference package.json`, so the root manifest must move with the packages',
+  )
+})
+
+test('the release-time gate still declares the scope this guard mirrors', async () => {
+  const script = await readFile(alignmentScript, 'utf8')
+
+  assert.match(
+    script,
+    /REFERENCE_FILE="packages\/shared\/package\.json"/,
+    'This guard compares against packages/shared/package.json because that is the script default',
+  )
+  assert.match(
+    script,
+    /find packages -maxdepth 2 -name package\.json/,
+    'This guard scans the direct children of packages/ because that is the script scope',
+  )
+  assert.match(
+    script,
+    /\.private != true/,
+    'This guard skips private manifests because the script does — packages/eslint-plugin-ds ' +
+      'is versioned independently',
+  )
+})


### PR DESCRIPTION
Closes #5018

## 🎯 Goal
A workspace whose version has drifted out of lockstep now fails its own PR instead of passing CI and blocking the next release at its first gate, days later and detached from the merge that caused it.

## 🔍 Problem
`scripts/check-version-alignment.sh` is the sole enforcement of "every public `packages/*` manifest carries the monorepo version", and it is load-bearing at release time and nowhere else — `scripts/bump-version.sh:17` and `:29`, `scripts/release-existing.sh:13`, and `.github/workflows/release.yml:72`. It appeared in no PR-triggered workflow and nothing under `scripts/__tests__/` or `packages/` asserted the invariant, so CI went green over a `develop` whose release tooling was already broken. Anyone running `yarn release:bump` by hand hit it immediately.

## 🔍 Root Cause
The drift is structural rather than a slip. A workspace added on `develop` between two releases does not exist on `main` at the release commit, so the release bump never touches it and the next `main` → `develop` sync has nothing to reconcile. That is how `@open-mercato/telemetry` stayed at `0.6.6` while everything else moved to `0.6.7` (#5014, fixed there), and it will recur the next time a package is introduced mid-cycle.

Even a package-hosted test would not have caught it: `.github/workflows/ci.yml` scopes unit tests with `yarn turbo run test --filter=[origin/<base>]...`, which selects packages by dependency graph, so a change that only edits a `package.json` version selects no owning package and runs nothing.

For telemetry the blast radius reached past the gate itself. `packages/create-app/AGENTS.md:70` documents that the template pins every `@open-mercato` dependency to `{{PACKAGE_VERSION}}`, so a package out of lockstep makes a fresh scaffold's `yarn install` fail with "No candidates found" — as at `0.6.3` vs `0.6.5` (`.ai/specs/2026-04-29-telemetry-and-otel.md`), where it was caught late and called a release-blocker.

## What Changed
- **`scripts/__tests__/check-version-alignment.test.mjs`** (new, the only file in this PR) — three assertions on the PR path:
  - Every non-private `packages/*/package.json` matches `packages/shared/package.json`, the shell script's default reference. Failures are reported in the script's own wording (`@open-mercato/telemetry@0.6.6 (expected 0.6.7)`) so the fix is obvious.
  - The root manifest carries the same version, mirroring the `--reference package.json` call sites in `bump-version.sh:29` and `release-existing.sh:13`.
  - `scripts/check-version-alignment.sh` still declares the scope this guard mirrors (default reference, `find packages -maxdepth 2`, the `.private != true` filter), so a scope edit to the script cannot silently desync it from the PR-path guard.
- The comparison is reimplemented in plain Node rather than shelling out, so the common PR path gains no `jq`/`bash` dependency. It honors the script's `.private != true` filter, which matters concretely: `packages/eslint-plugin-ds` is private at `0.7.0` and would otherwise fail the guard on day one.
- A non-vacuous-scan assertion guards the guard: an empty or failed package scan fails loudly instead of passing with nothing to check.

**On the placement question the issue raised** (`REPO_WIDE_GUARDS` vs a standalone test): a standalone `scripts/__tests__/` test is correct. `ci.yml:628` runs `yarn test:scripts` unconditionally and unfiltered ("Turbo never picks up root-level scripts"), and `ci.yml:666` already names it among the guards that "already run unfiltered". `scripts/repo-wide-guards.mjs` is a jest-per-workspace runner — each entry carries a `workspaceDir` and `jestConfig` — and its enumeration honesty check only scans `/\.test\.tsx?$/`, so an `.mjs` script test has no place in it. The issue's option 2 (a dedicated `ci.yml` step) is deliberately not taken: it would be redundant with `yarn test:scripts`.

## 🧪 Tests
- `node --test scripts/__tests__/check-version-alignment.test.mjs` — 3 passed.
- **Regression proof:** pinning `packages/telemetry` back to `0.6.6` — the exact #5014 drift — turns the guard red with `@open-mercato/telemetry@0.6.6 (expected 0.6.7)`; reverting turns it green. The scope-pin test was verified to bite as well: changing the script's `REFERENCE_FILE` fails it.
- `yarn test:scripts` — 446 tests, 443 passed / 3 failed. All 3 failures are pre-existing and environment-specific: they live in `dev-module-resource-usage-dir.test.mjs` and assert this machine's `fs.inotify` limits. With the new file removed the tree is byte-identical to base `982d6097d` and the same 3 still fail, so they are unrelated to this change.
- `yarn test:repo-wide-guards` — all 26 guard files passed (its telemetry entry first needed `yarn workspace @open-mercato/shared build`, a fresh-worktree build-state artifact rather than a code failure).
- Not run, with reason: `yarn lint` is `turbo run lint` and `yarn typecheck` is turbo-scoped per package — neither covers root-level `scripts/`, which is exactly why these repo-wide guards exist. `yarn build:packages`, `yarn generate`, `yarn build:app` and the i18n checks are unaffected: this adds a single test file that nothing imports, with no runtime, build-output, type, or translation surface.

## 💥 Breaking Changes
- None. Test-only addition; no contract surface touched.

## Security impact
None. The change adds no code to any runtime path — it reads workspace manifests and one shell script from disk inside a test. It touches no auth, secrets, encryption, logging, backup, or access-control surface, and introduces no new dependency.
