### PR TITLE
fix(customers): include source-less canonical tasks in the task aggregate (#4868)

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-4868.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-4868.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  createCompanyFixture,
+  createPersonFixture,
+  deleteEntityIfExists,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/crmFixtures'
+
+/**
+ * TC-CRM-4868: the customer task aggregate includes tasks written by the standard
+ * Person/Company task dialog while unified interactions are disabled (issue #4868).
+ *
+ * The dialog POSTs a canonical interaction with `interactionType: 'task'` and no
+ * `source`, which persists as `source = NULL`. Before the fix the compatibility
+ * branch of `/api/customers/interactions/tasks` narrowed its canonical read to
+ * `source = 'adapter:todo'`, so those tasks were visible on the customer record but
+ * absent from `/backend/customer-tasks`, which reads the aggregate.
+ *
+ * `customers.interactions.unified` defaults to `false`, so this test exercises the
+ * defective compatibility branch without touching any feature-toggle override.
+ * `all=true` is used so the assertion never depends on where the fixtures land
+ * inside the aggregate's bounded merged-read window.
+ */
+test.describe('TC-CRM-4868: customer task aggregate includes source-less canonical tasks (#4868)', () => {
+  test('tasks created for a person and a company appear in the aggregate exactly once', async ({ request }) => {
+    test.slow()
+
+    let token: string | null = null
+    let companyId: string | null = null
+    let personId: string | null = null
+    let companyTaskId: string | null = null
+    let personTaskId: string | null = null
+    const stamp = `${Date.now()}`
+    const companyTaskTitle = `QA TC-CRM-4868 company task ${stamp}`
+    const personTaskTitle = `QA TC-CRM-4868 person task ${stamp}`
+
+    const createTask = async (authToken: string, entityId: string, title: string): Promise<string> => {
+      const response = await apiRequest(request, 'POST', '/api/customers/interactions', {
+        token: authToken,
+        data: {
+          entityId,
+          interactionType: 'task',
+          title,
+          body: 'QA TC-CRM-4868 task description',
+          status: 'planned',
+          occurredAt: new Date().toISOString(),
+        },
+      })
+      expect(
+        response.ok(),
+        `POST /api/customers/interactions returned ${response.status()}`,
+      ).toBeTruthy()
+      const payload = (await readJsonSafe(response)) as { id?: string } | null
+      const id = payload?.id ?? null
+      expect(id, 'POST /api/customers/interactions returned no id').toBeTruthy()
+      return id as string
+    }
+
+    const listAggregateTasks = async (
+      authToken: string,
+    ): Promise<Array<{ todoId: string; todoTitle: string | null }>> => {
+      const response = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/interactions/tasks?all=true&search=${encodeURIComponent(stamp)}`,
+        { token: authToken },
+      )
+      expect(
+        response.ok(),
+        `GET /api/customers/interactions/tasks returned ${response.status()}`,
+      ).toBeTruthy()
+      const payload = (await readJsonSafe(response)) as {
+        items?: Array<{ todoId: string; todoTitle: string | null }>
+      } | null
+      return payload?.items ?? []
+    }
+
+    try {
+      token = await getAuthToken(request, 'admin')
+      companyId = await createCompanyFixture(request, token, `QA TC-CRM-4868 Co ${stamp}`)
+      personId = await createPersonFixture(request, token, {
+        firstName: 'Casey',
+        lastName: `TC-CRM-4868-${stamp}`,
+        displayName: `QA TC-CRM-4868 Person ${stamp}`,
+      })
+
+      companyTaskId = await createTask(token, companyId, companyTaskTitle)
+      personTaskId = await createTask(token, personId, personTaskTitle)
+
+      // The canonical endpoint has no source restriction and must see both tasks
+      // with `source: null` — this is the write-path side of the contract.
+      const canonicalRes = await apiRequest(
+        request,
+        'GET',
+        '/api/customers/interactions?interactionType=task&limit=100',
+        { token },
+      )
+      expect(
+        canonicalRes.ok(),
+        `GET /api/customers/interactions returned ${canonicalRes.status()}`,
+      ).toBeTruthy()
+      const canonicalPayload = (await readJsonSafe(canonicalRes)) as {
+        items?: Array<{ id: string; source?: string | null }>
+      } | null
+      const canonicalItems = canonicalPayload?.items ?? []
+      const canonicalById = new Map(canonicalItems.map((item) => [item.id, item]))
+      expect(canonicalById.has(companyTaskId)).toBeTruthy()
+      expect(canonicalById.has(personTaskId)).toBeTruthy()
+      expect(canonicalById.get(companyTaskId)?.source ?? null).toBeNull()
+      expect(canonicalById.get(personTaskId)?.source ?? null).toBeNull()
+
+      // The aggregate the global Customer tasks page reads must agree with it.
+      const aggregateItems = await listAggregateTasks(token)
+      const aggregateIds = aggregateItems.map((item) => item.todoId)
+      expect(aggregateIds).toContain(companyTaskId)
+      expect(aggregateIds).toContain(personTaskId)
+      expect(aggregateIds.filter((id) => id === companyTaskId)).toHaveLength(1)
+      expect(aggregateIds.filter((id) => id === personTaskId)).toHaveLength(1)
+      expect(aggregateItems.map((item) => item.todoTitle)).toEqual(
+        expect.arrayContaining([companyTaskTitle, personTaskTitle]),
+      )
+
+      // Deleting a task removes it from the aggregate; the other one stays.
+      await deleteEntityIfExists(request, token, '/api/customers/interactions', personTaskId)
+      const remainingIds = (await listAggregateTasks(token)).map((item) => item.todoId)
+      expect(remainingIds).not.toContain(personTaskId)
+      expect(remainingIds).toContain(companyTaskId)
+      personTaskId = null
+    } finally {
+      await deleteEntityIfExists(request, token, '/api/customers/interactions', personTaskId)
+      await deleteEntityIfExists(request, token, '/api/customers/interactions', companyTaskId)
+      await deleteEntityIfExists(request, token, '/api/customers/people', personId)
+      await deleteEntityIfExists(request, token, '/api/customers/companies', companyId)
+    }
+  })
+})

--- a/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/__tests__/route.test.ts
@@ -144,4 +144,23 @@ describe('customers customer-todos widget route', () => {
     })
     expect(listLegacyTodoRows).not.toHaveBeenCalled()
   })
+
+  it('does not narrow the canonical read to the todo adapter source in compatibility mode', async () => {
+    const { resolveCustomerInteractionFeatureFlags } =
+      jest.requireMock('../../../../../lib/interactionFeatureFlags')
+    const { listLegacyTodoRows, listCanonicalTodoRows } =
+      jest.requireMock('../../../../../lib/todoCompatibility')
+
+    resolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    listLegacyTodoRows.mockResolvedValue([])
+    listCanonicalTodoRows.mockResolvedValue({ items: [], bridgeIds: new Set<string>() })
+
+    const res = await GET(new Request('http://localhost/api?limit=5'))
+
+    expect(res.status).toBe(200)
+    expect(listCanonicalTodoRows).toHaveBeenCalledTimes(1)
+    const options = listCanonicalTodoRows.mock.calls[0][5]
+    expect(options).toMatchObject({ includeDeleted: true })
+    expect(options).not.toHaveProperty('source')
+  })
 })

--- a/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
@@ -4,7 +4,6 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveWidgetScope, type WidgetScopeContext } from '../utils'
 import { resolveCustomerInteractionFeatureFlags } from '../../../../lib/interactionFeatureFlags'
-import { CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE } from '../../../../lib/interactionCompatibility'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import {
@@ -91,7 +90,6 @@ export async function GET(req: Request) {
             organizationIds ?? null,
             {
               includeDeleted: true,
-              source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
               limit: mergedWindow,
             },
           ),

--- a/packages/core/src/modules/customers/api/interactions/tasks/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/tasks/__tests__/route.test.ts
@@ -211,9 +211,24 @@ function canonicalWhereClauses(em: ReturnType<typeof createFakeEntityManager>) {
     .map(([, where]) => where as Record<string, unknown>)
 }
 
-async function callRoute(query = ''): Promise<{ status: number; body: any }> {
+type AggregateItem = {
+  id: string
+  todoId: string
+  todoSource: string
+  todoTitle: string | null
+}
+
+type AggregateResponse = {
+  items: AggregateItem[]
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+}
+
+async function callRoute(query = ''): Promise<{ status: number; body: AggregateResponse }> {
   const res = await GET(new Request(`http://localhost/api/customers/interactions/tasks${query}`))
-  return { status: res.status, body: await res.json() }
+  return { status: res.status, body: (await res.json()) as AggregateResponse }
 }
 
 describe('GET /api/customers/interactions/tasks', () => {
@@ -241,11 +256,11 @@ describe('GET /api/customers/interactions/tasks', () => {
 
     expect(status).toBe(200)
     expect(body.total).toBe(2)
-    expect(body.items.map((item: { todoTitle: string }) => item.todoTitle)).toEqual([
+    expect(body.items.map((item) => item.todoTitle)).toEqual([
       'Call the company',
       'Call the person',
     ])
-    expect(body.items.every((item: { todoSource: string }) => item.todoSource === CUSTOMER_INTERACTION_TASK_SOURCE)).toBe(true)
+    expect(body.items.every((item) => item.todoSource === CUSTOMER_INTERACTION_TASK_SOURCE)).toBe(true)
     for (const where of canonicalWhereClauses(em)) {
       expect(where).not.toHaveProperty('source')
     }
@@ -275,12 +290,12 @@ describe('GET /api/customers/interactions/tasks', () => {
 
     expect(status).toBe(200)
     expect(body.total).toBe(2)
-    expect(body.items.map((item: { todoTitle: string }) => item.todoTitle)).toEqual([
+    expect(body.items.map((item) => item.todoTitle)).toEqual([
       'Source-less task',
       'Bridged legacy task',
     ])
     expect(
-      body.items.filter((item: { todoId: string }) => item.todoId === bridgedTodoId),
+      body.items.filter((item) => item.todoId === bridgedTodoId),
     ).toHaveLength(1)
   })
 
@@ -303,7 +318,7 @@ describe('GET /api/customers/interactions/tasks', () => {
 
     expect(status).toBe(200)
     expect(body.total).toBe(2)
-    expect(body.items.map((item: { todoSource: string }) => item.todoSource).sort()).toEqual([
+    expect(body.items.map((item) => item.todoSource).sort()).toEqual([
       CUSTOMER_INTERACTION_TASK_SOURCE,
       EXAMPLE_TODO_SOURCE,
     ])
@@ -434,13 +449,13 @@ describe('GET /api/customers/interactions/tasks', () => {
     const first = await callRoute('?page=1&pageSize=2&search=invoice')
     expect(first.status).toBe(200)
     expect(first.body).toMatchObject({ total: 3, page: 1, pageSize: 2, totalPages: 2 })
-    expect(first.body.items.map((item: { todoTitle: string }) => item.todoTitle)).toEqual([
+    expect(first.body.items.map((item) => item.todoTitle)).toEqual([
       'Invoice follow-up one',
       'Invoice follow-up two',
     ])
 
     const second = await callRoute('?page=2&pageSize=2&search=invoice')
-    expect(second.body.items.map((item: { todoTitle: string }) => item.todoTitle)).toEqual([
+    expect(second.body.items.map((item) => item.todoTitle)).toEqual([
       'Invoice follow-up three',
     ])
   })

--- a/packages/core/src/modules/customers/api/interactions/tasks/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/tasks/__tests__/route.test.ts
@@ -1,0 +1,474 @@
+/** @jest-environment node */
+
+import { CustomerInteraction } from '../../../../data/entities'
+import {
+  CUSTOMER_INTERACTION_TASK_SOURCE,
+  CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
+  EXAMPLE_TODO_SOURCE,
+} from '../../../../lib/interactionCompatibility'
+import { GET } from '../route'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}))
+
+jest.mock('../../../../lib/interactionRequestContext', () => ({
+  resolveCustomersRequestContext: jest.fn(),
+}))
+
+jest.mock('../../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn(),
+}))
+
+jest.mock('../../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async ({ interactions }) =>
+    interactions.map((interaction: FakeInteraction) => ({
+      id: interaction.id,
+      interactionType: 'task',
+      title: interaction.title,
+      status: 'planned',
+      createdAt: interaction.createdAt.toISOString(),
+      updatedAt: interaction.createdAt.toISOString(),
+      tenantId: interaction.tenantId,
+      organizationId: interaction.organizationId,
+      entityId: interaction.entity,
+      _integrations: null,
+      customValues: null,
+    })),
+  ),
+  loadCustomerSummaries: jest.fn(async () => new Map()),
+}))
+
+const TENANT = '00000000-0000-0000-0000-000000000001'
+const ORG = '00000000-0000-0000-0000-000000000002'
+const OTHER_ORG = '00000000-0000-0000-0000-000000000003'
+const OTHER_TENANT = '00000000-0000-0000-0000-000000000004'
+const PERSON = '00000000-0000-0000-0000-000000000010'
+const COMPANY = '00000000-0000-0000-0000-000000000011'
+
+type FakeInteraction = {
+  id: string
+  interactionType: string
+  source: string | null
+  title: string
+  entity: string
+  tenantId: string
+  organizationId: string
+  createdAt: Date
+  deletedAt: Date | null
+}
+
+type FakeTodoLink = {
+  id: string
+  todoId: string
+  todoSource: string
+  entity: string
+  tenantId: string
+  organizationId: string
+  createdAt: Date
+  createdByUserId: string | null
+}
+
+type FakeStore = {
+  interactions: FakeInteraction[]
+  links: FakeTodoLink[]
+}
+
+function makeInteraction(overrides: Partial<FakeInteraction> & { id: string }): FakeInteraction {
+  return {
+    interactionType: 'task',
+    source: null,
+    title: 'Canonical task',
+    entity: PERSON,
+    tenantId: TENANT,
+    organizationId: ORG,
+    createdAt: new Date('2026-08-01T10:00:00.000Z'),
+    deletedAt: null,
+    ...overrides,
+  }
+}
+
+function makeTodoLink(overrides: Partial<FakeTodoLink> & { id: string; todoId: string }): FakeTodoLink {
+  return {
+    todoSource: EXAMPLE_TODO_SOURCE,
+    entity: PERSON,
+    tenantId: TENANT,
+    organizationId: ORG,
+    createdAt: new Date('2026-07-01T10:00:00.000Z'),
+    createdByUserId: null,
+    ...overrides,
+  }
+}
+
+function matchesWhere(record: Record<string, unknown>, where: Record<string, unknown>): boolean {
+  return Object.entries(where).every(([key, condition]) => {
+    if (key === '$or') {
+      return (condition as Array<Record<string, unknown>>).some((clause) =>
+        matchesWhere(record, clause),
+      )
+    }
+    const value = record[key]
+    if (condition !== null && typeof condition === 'object' && !(condition instanceof Date)) {
+      const operators = condition as Record<string, unknown>
+      if ('$in' in operators) return (operators.$in as unknown[]).includes(value)
+      if ('$ilike' in operators) {
+        const needle = String(operators.$ilike).replace(/%/g, '').toLowerCase()
+        return typeof value === 'string' && value.toLowerCase().includes(needle)
+      }
+      return false
+    }
+    return value === condition
+  })
+}
+
+function createFakeEntityManager(store: FakeStore) {
+  const select = (entity: unknown, where: Record<string, unknown>) => {
+    const rows: Array<Record<string, unknown>> =
+      entity === CustomerInteraction
+        ? (store.interactions as unknown as Array<Record<string, unknown>>)
+        : (store.links as unknown as Array<Record<string, unknown>>)
+    return rows
+      .filter((row) => matchesWhere(row, where))
+      .sort((left, right) => {
+        const leftTime = (left.createdAt as Date).getTime()
+        const rightTime = (right.createdAt as Date).getTime()
+        return rightTime - leftTime
+      })
+  }
+
+  const find = jest.fn(
+    async (entity: unknown, where: Record<string, unknown>, options?: Record<string, unknown>) => {
+      const matched = select(entity, where)
+      const limit = typeof options?.limit === 'number' ? options.limit : undefined
+      return limit === undefined ? matched : matched.slice(0, limit)
+    },
+  )
+
+  const findAndCount = jest.fn(
+    async (entity: unknown, where: Record<string, unknown>, options?: Record<string, unknown>) => {
+      const matched = select(entity, where)
+      const offset = typeof options?.offset === 'number' ? options.offset : 0
+      const limit = typeof options?.limit === 'number' ? options.limit : undefined
+      const page = limit === undefined ? matched.slice(offset) : matched.slice(offset, offset + limit)
+      return [page, matched.length]
+    },
+  )
+
+  return { find, findAndCount }
+}
+
+function createQueryEngine(store: FakeStore) {
+  return {
+    query: jest.fn(async () => ({
+      items: store.links.map((link) => ({
+        id: link.todoId,
+        title: `Legacy ${link.todoId.slice(-4)}`,
+        is_done: false,
+        organization_id: link.organizationId,
+      })),
+    })),
+  }
+}
+
+function primeRequestContext(store: FakeStore) {
+  const em = createFakeEntityManager(store)
+  const queryEngine = createQueryEngine(store)
+  const container = {
+    resolve: jest.fn((name: string) => {
+      if (name === 'queryEngine') return queryEngine
+      throw new Error(`[internal] Unexpected container resolve: ${name}`)
+    }),
+  }
+  const { resolveCustomersRequestContext } = jest.requireMock(
+    '../../../../lib/interactionRequestContext',
+  )
+  resolveCustomersRequestContext.mockResolvedValue({
+    auth: { tenantId: TENANT, orgId: ORG, sub: 'user-1' },
+    em,
+    organizationIds: [ORG],
+    container,
+    selectedOrganizationId: ORG,
+  })
+  return { em, container, queryEngine }
+}
+
+function setUnified(unified: boolean) {
+  const { resolveCustomerInteractionFeatureFlags } = jest.requireMock(
+    '../../../../lib/interactionFeatureFlags',
+  )
+  resolveCustomerInteractionFeatureFlags.mockResolvedValue({
+    unified,
+    legacyAdapters: true,
+    externalSync: false,
+  })
+}
+
+function canonicalWhereClauses(em: ReturnType<typeof createFakeEntityManager>) {
+  return [...em.find.mock.calls, ...em.findAndCount.mock.calls]
+    .filter(([entity]) => entity === CustomerInteraction)
+    .map(([, where]) => where as Record<string, unknown>)
+}
+
+async function callRoute(query = ''): Promise<{ status: number; body: any }> {
+  const res = await GET(new Request(`http://localhost/api/customers/interactions/tasks${query}`))
+  return { status: res.status, body: await res.json() }
+}
+
+describe('GET /api/customers/interactions/tasks', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns a canonical task written without a source in compatibility mode', async () => {
+    const store: FakeStore = {
+      interactions: [
+        makeInteraction({ id: 'aaaaaaaa-0000-0000-0000-000000000001', title: 'Call the person' }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-000000000002',
+          title: 'Call the company',
+          entity: COMPANY,
+          createdAt: new Date('2026-08-02T10:00:00.000Z'),
+        }),
+      ],
+      links: [],
+    }
+    const { em } = primeRequestContext(store)
+    setUnified(false)
+
+    const { status, body } = await callRoute('?page=1&pageSize=50')
+
+    expect(status).toBe(200)
+    expect(body.total).toBe(2)
+    expect(body.items.map((item: { todoTitle: string }) => item.todoTitle)).toEqual([
+      'Call the company',
+      'Call the person',
+    ])
+    expect(body.items.every((item: { todoSource: string }) => item.todoSource === CUSTOMER_INTERACTION_TASK_SOURCE)).toBe(true)
+    for (const where of canonicalWhereClauses(em)) {
+      expect(where).not.toHaveProperty('source')
+    }
+  })
+
+  it('returns each logical task once when a legacy link and its adapter bridge both exist', async () => {
+    const bridgedTodoId = 'bbbbbbbb-0000-0000-0000-000000000001'
+    const store: FakeStore = {
+      interactions: [
+        makeInteraction({
+          id: bridgedTodoId,
+          title: 'Bridged legacy task',
+          source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
+        }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-000000000003',
+          title: 'Source-less task',
+          createdAt: new Date('2026-08-03T10:00:00.000Z'),
+        }),
+      ],
+      links: [makeTodoLink({ id: 'cccccccc-0000-0000-0000-000000000001', todoId: bridgedTodoId })],
+    }
+    primeRequestContext(store)
+    setUnified(false)
+
+    const { status, body } = await callRoute('?page=1&pageSize=50')
+
+    expect(status).toBe(200)
+    expect(body.total).toBe(2)
+    expect(body.items.map((item: { todoTitle: string }) => item.todoTitle)).toEqual([
+      'Source-less task',
+      'Bridged legacy task',
+    ])
+    expect(
+      body.items.filter((item: { todoId: string }) => item.todoId === bridgedTodoId),
+    ).toHaveLength(1)
+  })
+
+  it('keeps an unbridged legacy todo link visible alongside canonical tasks', async () => {
+    const store: FakeStore = {
+      interactions: [
+        makeInteraction({ id: 'aaaaaaaa-0000-0000-0000-000000000004', title: 'Canonical only' }),
+      ],
+      links: [
+        makeTodoLink({
+          id: 'cccccccc-0000-0000-0000-000000000002',
+          todoId: 'dddddddd-0000-0000-0000-000000000001',
+        }),
+      ],
+    }
+    primeRequestContext(store)
+    setUnified(false)
+
+    const { status, body } = await callRoute('?page=1&pageSize=50')
+
+    expect(status).toBe(200)
+    expect(body.total).toBe(2)
+    expect(body.items.map((item: { todoSource: string }) => item.todoSource).sort()).toEqual([
+      CUSTOMER_INTERACTION_TASK_SOURCE,
+      EXAMPLE_TODO_SOURCE,
+    ])
+  })
+
+  it('excludes soft-deleted canonical tasks and still suppresses their legacy row', async () => {
+    const deletedBridgeId = 'bbbbbbbb-0000-0000-0000-000000000002'
+    const store: FakeStore = {
+      interactions: [
+        makeInteraction({
+          id: deletedBridgeId,
+          title: 'Deleted bridged task',
+          source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
+          deletedAt: new Date('2026-08-04T10:00:00.000Z'),
+        }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-000000000005',
+          title: 'Deleted source-less task',
+          deletedAt: new Date('2026-08-04T11:00:00.000Z'),
+        }),
+        makeInteraction({ id: 'aaaaaaaa-0000-0000-0000-000000000006', title: 'Live task' }),
+      ],
+      links: [makeTodoLink({ id: 'cccccccc-0000-0000-0000-000000000003', todoId: deletedBridgeId })],
+    }
+    primeRequestContext(store)
+    setUnified(false)
+
+    const { status, body } = await callRoute('?page=1&pageSize=50')
+
+    expect(status).toBe(200)
+    expect(body.total).toBe(1)
+    expect(body.items[0]).toMatchObject({ todoTitle: 'Live task' })
+  })
+
+  it('returns the source-less canonical task in unified mode', async () => {
+    const store: FakeStore = {
+      interactions: [
+        makeInteraction({ id: 'aaaaaaaa-0000-0000-0000-000000000007', title: 'Unified task' }),
+      ],
+      links: [
+        makeTodoLink({
+          id: 'cccccccc-0000-0000-0000-000000000004',
+          todoId: 'dddddddd-0000-0000-0000-000000000002',
+        }),
+      ],
+    }
+    const { em } = primeRequestContext(store)
+    setUnified(true)
+
+    const { status, body } = await callRoute('?page=1&pageSize=50')
+
+    expect(status).toBe(200)
+    expect(body.total).toBe(1)
+    expect(body.items[0]).toMatchObject({ todoTitle: 'Unified task' })
+    for (const where of canonicalWhereClauses(em)) {
+      expect(where).not.toHaveProperty('source')
+    }
+  })
+
+  it('scopes the canonical read to the tenant and the allowed organizations', async () => {
+    const store: FakeStore = {
+      interactions: [
+        makeInteraction({ id: 'aaaaaaaa-0000-0000-0000-000000000008', title: 'In scope' }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-000000000009',
+          title: 'Other organization',
+          organizationId: OTHER_ORG,
+        }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-00000000000a',
+          title: 'Other tenant',
+          tenantId: OTHER_TENANT,
+        }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-00000000000b',
+          title: 'Not a task',
+          interactionType: 'note',
+        }),
+      ],
+      links: [],
+    }
+    const { em } = primeRequestContext(store)
+    setUnified(false)
+
+    const { status, body } = await callRoute('?page=1&pageSize=50')
+
+    expect(status).toBe(200)
+    expect(body.items).toHaveLength(1)
+    expect(body.items[0]).toMatchObject({ todoTitle: 'In scope' })
+    for (const where of canonicalWhereClauses(em)) {
+      expect(where).toMatchObject({
+        tenantId: TENANT,
+        interactionType: 'task',
+        organizationId: { $in: [ORG] },
+      })
+    }
+  })
+
+  it('applies search and pagination to the corrected merged set', async () => {
+    const store: FakeStore = {
+      interactions: [
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-00000000000c',
+          title: 'Invoice follow-up one',
+          createdAt: new Date('2026-08-05T10:00:00.000Z'),
+        }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-00000000000d',
+          title: 'Invoice follow-up two',
+          createdAt: new Date('2026-08-05T09:00:00.000Z'),
+        }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-00000000000e',
+          title: 'Invoice follow-up three',
+          createdAt: new Date('2026-08-05T08:00:00.000Z'),
+        }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-00000000000f',
+          title: 'Unrelated task',
+          createdAt: new Date('2026-08-05T07:00:00.000Z'),
+        }),
+      ],
+      links: [],
+    }
+    primeRequestContext(store)
+    setUnified(false)
+
+    const first = await callRoute('?page=1&pageSize=2&search=invoice')
+    expect(first.status).toBe(200)
+    expect(first.body).toMatchObject({ total: 3, page: 1, pageSize: 2, totalPages: 2 })
+    expect(first.body.items.map((item: { todoTitle: string }) => item.todoTitle)).toEqual([
+      'Invoice follow-up one',
+      'Invoice follow-up two',
+    ])
+
+    const second = await callRoute('?page=2&pageSize=2&search=invoice')
+    expect(second.body.items.map((item: { todoTitle: string }) => item.todoTitle)).toEqual([
+      'Invoice follow-up three',
+    ])
+  })
+
+  it('returns the whole corrected set for all=true exports', async () => {
+    const store: FakeStore = {
+      interactions: [
+        makeInteraction({ id: 'aaaaaaaa-0000-0000-0000-000000000010', title: 'Export one' }),
+        makeInteraction({
+          id: 'aaaaaaaa-0000-0000-0000-000000000011',
+          title: 'Export two',
+          createdAt: new Date('2026-08-06T10:00:00.000Z'),
+        }),
+      ],
+      links: [
+        makeTodoLink({
+          id: 'cccccccc-0000-0000-0000-000000000005',
+          todoId: 'dddddddd-0000-0000-0000-000000000003',
+        }),
+      ],
+    }
+    primeRequestContext(store)
+    setUnified(false)
+
+    const { status, body } = await callRoute('?all=true')
+
+    expect(status).toBe(200)
+    expect(body).toMatchObject({ total: 3, page: 1, pageSize: 3, totalPages: 1 })
+    expect(body.items).toHaveLength(3)
+  })
+})

--- a/packages/core/src/modules/customers/api/interactions/tasks/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/tasks/route.ts
@@ -8,7 +8,6 @@ import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import { createCustomersCrudOpenApi, createPagedListResponseSchema } from '../../openapi'
 import { resolveCustomerInteractionFeatureFlags } from '../../../lib/interactionFeatureFlags'
 import { resolveCustomersRequestContext } from '../../../lib/interactionRequestContext'
-import { CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE } from '../../../lib/interactionCompatibility'
 import {
   filterTodoRows,
   listCanonicalTodoRows,
@@ -33,9 +32,9 @@ export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.interactions.view'] },
 }
 
-// Per-source fetch cap used when the legacy adapter must merge legacy and
-// canonical-bridge rows without DB-side union. Bounds memory on tenants with
-// large task history.
+// Per-source fetch cap used when compatibility mode must merge legacy todo
+// links and canonical task rows without DB-side union. Bounds memory on
+// tenants with large task history.
 const MERGED_TASK_FETCH_CAP = 2000
 
 export async function GET(request: Request): Promise<Response> {
@@ -91,7 +90,6 @@ export async function GET(request: Request): Promise<Response> {
         {
           entityId: query.entityId,
           includeDeleted: true,
-          source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
           limit: legacyWindow,
         },
       ),


### PR DESCRIPTION
Closes #4868

## 🎯 Goal
A task created through the standard Person or Company activity/task dialog now appears on the global Customer tasks register at `/backend/customer-tasks`. Previously such a task saved successfully, showed up on the customer record, and was then silently missing from the global page under the default configuration — so the register could not be trusted, and users had no signal that anything was wrong.

## 🔍 Problem
`/backend/customer-tasks` reads `/api/customers/interactions/tasks`. With `customers.interactions.unified = false` — the default in `interactionFeatureFlags.ts` — that aggregate merged legacy `CustomerTodoLink` rows with canonical rows restricted to `source = 'adapter:todo'`. The standard task dialog writes an ordinary canonical interaction with no `source`, which persists as `source = NULL`, so the aggregate excluded exactly the output of the current UI write path. The canonical endpoint `/api/customers/interactions?interactionType=task` returned the task, the aggregate returned an empty list, and the two views disagreed.

## 🔍 Root Cause
The compatibility branch passed `source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE` into `listCanonicalTodoRows`, where it becomes a hard `where.source` predicate (`lib/todoCompatibility.ts`). That filter exists only to fetch legacy **bridge** rows for deduplication — bridges are created reusing the legacy todo id as the interaction id (`commands/todos.ts`), which is why the merge dedupes `legacyRow.todoId` against `canonicalRows.bridgeIds`. But the same predicate also excluded every *ordinary* canonical task, because `createInteractionCommand` writes `source: parsed.source ?? null` and `ScheduleActivityDialog` sends no `source`. The read model's provenance assumption contradicted the write path's.

## What Changed
- `packages/core/src/modules/customers/api/interactions/tasks/route.ts` — the compatibility-mode canonical read no longer narrows to `source = 'adapter:todo'`, so every in-scope canonical task is eligible. `includeDeleted: true` is deliberately kept: it is what lets a soft-deleted bridge still suppress its legacy row, and `listCanonicalTodoRows` already filters deleted rows out of the returned items. The bounded `MERGED_TASK_FETCH_CAP` window, the URL, methods, query parameters and response fields are all unchanged — this is a result-set correctness fix, not a route change.
- `packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts` — the dashboard customer-todos widget carried the identical narrowing and is corrected the same way, covering acceptance criterion 11.
- The `source` parameter stays on `listCanonicalTodoRows`: the deprecated `/api/customers/todos` adapter still uses it legitimately, and that route keeps its adapter-only semantics on purpose — it is the legacy bridge view, is not named in the acceptance criteria, and has tests pinning that behavior.

## 🧪 Tests
- `packages/core/src/modules/customers/api/interactions/tasks/__tests__/route.test.ts` — **new** suite; this route previously had no test coverage at all. It drives the real handler against a fake `EntityManager` that actually evaluates the `where` clause, so the assertions are behavioral rather than mock-shaped. Eight cases lock in: a `source: null` canonical task is returned in compatibility mode; a legacy link plus its `adapter:todo` bridge dedupes to exactly one row; an unbridged legacy link stays visible alongside canonical rows; soft-deleted tasks are excluded while still suppressing their legacy row; unified mode is unchanged; tenant, organization and `interactionType` scoping hold; and search, pagination and `all=true` export operate on the corrected set.
- `packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/__tests__/route.test.ts` — one added case pinning that the widget's compatibility-mode canonical read is not narrowed by source.
- `packages/core/src/modules/customers/__integration__/TC-CRM-4868.spec.ts` — **new** self-contained integration spec covering the reported flow end to end: creates Person and Company fixtures via the API, POSTs a task for each without `source`, asserts the canonical endpoint reports `source: null`, asserts the aggregate returns each task exactly once, asserts a deleted task leaves the aggregate, and cleans up every fixture in `finally`.
- Regression value verified directly: with the two production lines reverted, **8 of the 11 new/updated cases fail**; with the fix in place all 11 pass.
- Validation gate: `yarn build:packages` ✅ (×2) · `yarn generate` ✅ · `yarn i18n:check-sync` ✅ · `yarn i18n:check-usage` ✅ · `yarn typecheck` ✅ 22/22 packages · `yarn test` — `@open-mercato/core` **1184 suites / 9149 tests passed**, all other packages green · `yarn build:app` ✅. Two failures were investigated and confirmed pre-existing and environmental on this machine, reproducing identically on a clean `develop` checkout: `packages/cli` `dev-env-reload.test.ts` (a raw `fs.watch` probe returns `ENOSPC` — the inotify watch limit is exhausted) and the `create-mercato-app` harness cases (`bwrap: setting up uid map: Permission denied`). Neither touches the customers module.

## 💥 Breaking Changes
- None. `/api/customers/interactions/tasks` keeps its URL, methods, query parameters and response fields; no schema migration is required. The change only widens which rows the compatibility branch returns, in the direction the specs already describe.

## Notes for reviewers
Neither SPEC-046b nor SPEC-046c documents the adapter-only read as intended behavior — 046b describes the global tasks page as backed by interactions filtered to actionable types, and 046c makes `customer_interactions` the canonical task source of truth. This fix restores that documented intent, so no spec update ships with it.
