### PR TITLE
test(ui,shared): harden the AST emitter test harness (#4851)

### DIFF
--- a/packages/shared/jest.config.cjs
+++ b/packages/shared/jest.config.cjs
@@ -1,6 +1,23 @@
 /** @type {import('jest').Config} */
 const base = require('../../jest.config.base.cjs')
 
+const transformer = [
+  '<rootDir>/../../scripts/jest-mikroorm-transformer.cjs',
+  {
+    tsconfig: {
+      jsx: 'react-jsx',
+      rootDir: '.',
+      ignoreDeprecations: '6.0',
+    },
+  },
+]
+
+// Jest does not interpolate `<rootDir>` in transform *keys* (only in the transformer
+// path), so the repo's own `scripts/*.cjs` emitters are selected by requiring a
+// `scripts/` segment and excluding `node_modules` outright — third-party `.cjs` inside
+// the allowlisted ESM packages stays untransformed.
+const SCRIPTS_CJS_PATTERN = '^(?!.*[\\\\/]node_modules[\\\\/]).*[\\\\/]scripts[\\\\/].+\\.cjs$'
+
 module.exports = {
   ...base,
   testEnvironment: 'node',
@@ -12,17 +29,9 @@ module.exports = {
     '^@open-mercato/core/(.*)$': '<rootDir>/../core/src/$1',
   },
   transform: {
-    // `.cjs` is included so the build-time source emitters under scripts/ are testable.
-    '^.+\\.(cjs|(t|j)sx?)$': [
-      '<rootDir>/../../scripts/jest-mikroorm-transformer.cjs',
-      {
-        tsconfig: {
-          jsx: 'react-jsx',
-          rootDir: '.',
-          ignoreDeprecations: '6.0',
-        },
-      },
-    ],
+    '^.+\\.(t|j)sx?$': transformer,
+    // Keeps the build-time source emitters under scripts/ testable.
+    [SCRIPTS_CJS_PATTERN]: transformer,
   },
   transformIgnorePatterns: [
     'node_modules/(?!(@mikro-orm|kysely|ai|@ai-sdk|ai-sdk-ollama|@workflow|@standard-schema)/)',

--- a/packages/shared/src/lib/__tests__/versionSource.test.ts
+++ b/packages/shared/src/lib/__tests__/versionSource.test.ts
@@ -1,5 +1,9 @@
+import { join } from 'node:path'
 import { Project, SyntaxKind } from 'ts-morph'
 import { buildVersionSource } from '../../../scripts/versionSource.cjs'
+import jestConfig from '../../../jest.config.cjs'
+
+const packageDir = join(__dirname, '..', '..', '..')
 
 function parse(source: string) {
   const project = new Project({ useInMemoryFileSystem: true })
@@ -42,5 +46,19 @@ describe('buildVersionSource', () => {
 
   it('keeps the build-time banner comment', () => {
     expect(buildVersionSource('1.2.3').startsWith('// Build-time generated version\n')).toBe(true)
+  })
+})
+
+describe('jest transform scope', () => {
+  const transformPatterns = Object.keys(jestConfig.transform).map((key) => new RegExp(key))
+
+  it('transforms the build-time emitter under scripts/', () => {
+    const emitterPath = join(packageDir, 'scripts', 'versionSource.cjs')
+    expect(transformPatterns.some((pattern) => pattern.test(emitterPath))).toBe(true)
+  })
+
+  it('leaves .cjs files inside node_modules untransformed', () => {
+    const vendorPath = join(packageDir, 'node_modules', '@mikro-orm', 'core', 'dist', 'index.cjs')
+    expect(transformPatterns.some((pattern) => pattern.test(vendorPath))).toBe(false)
   })
 })

--- a/packages/ui/jest.config.cjs
+++ b/packages/ui/jest.config.cjs
@@ -1,6 +1,23 @@
 /** @type {import('jest').Config} */
 const base = require('../../jest.config.base.cjs')
 
+const transformer = [
+  '<rootDir>/../../scripts/jest-mikroorm-transformer.cjs',
+  {
+    tsconfig: {
+      jsx: 'react-jsx',
+      rootDir: '.',
+      ignoreDeprecations: '6.0',
+    },
+  },
+]
+
+// Jest does not interpolate `<rootDir>` in transform *keys* (only in the transformer
+// path), so the repo's own `scripts/*.cjs` emitters are selected by requiring a
+// `scripts/` segment and excluding `node_modules` outright — third-party `.cjs` inside
+// the allowlisted ESM packages stays untransformed.
+const SCRIPTS_CJS_PATTERN = '^(?!.*[\\\\/]node_modules[\\\\/]).*[\\\\/]scripts[\\\\/].+\\.cjs$'
+
 module.exports = {
   ...base,
   testEnvironment: 'jsdom',
@@ -16,17 +33,9 @@ module.exports = {
     '^remark-gfm$': '<rootDir>/jest.markdown-mock.tsx',
   },
   transform: {
-    // `.cjs` is included so the build-time source emitters under scripts/ are testable.
-    '^.+\\.(cjs|(t|j)sx?)$': [
-      '<rootDir>/../../scripts/jest-mikroorm-transformer.cjs',
-      {
-        tsconfig: {
-          jsx: 'react-jsx',
-          rootDir: '.',
-          ignoreDeprecations: '6.0',
-        },
-      },
-    ],
+    '^.+\\.(t|j)sx?$': transformer,
+    // Keeps the build-time source emitters under scripts/ testable.
+    [SCRIPTS_CJS_PATTERN]: transformer,
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transformIgnorePatterns: [

--- a/packages/ui/src/backend/icons/__tests__/lucideRegistryGenerator.test.ts
+++ b/packages/ui/src/backend/icons/__tests__/lucideRegistryGenerator.test.ts
@@ -1,8 +1,10 @@
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Project, ScriptKind, SyntaxKind, type ObjectLiteralExpression, type SourceFile } from 'ts-morph'
 import { buildLucideRegistrySource } from '../../../../scripts/lucideRegistrySource.cjs'
+import jestConfig from '../../../../jest.config.cjs'
 
 const packageDir = join(__dirname, '..', '..', '..', '..')
 const iconsDir = join(packageDir, 'src', 'backend', 'icons')
@@ -152,9 +154,43 @@ describe('lucideRegistry barrel', () => {
   })
 })
 
+type GitWorkTreeProbe = { available: true } | { available: false; reason: string }
+
+function gitProbeFailureReason(error: unknown, cwd: string): string {
+  const { code, status } = error as { code?: string; status?: number }
+  if (code === 'ENOENT') return `git could not be executed for ${cwd} (no git executable, or the directory is missing)`
+  if (typeof status === 'number') return `git exited with status ${status} for ${cwd}`
+  return `git could not be executed for ${cwd}`
+}
+
+function detectGitWorkTree(cwd: string): GitWorkTreeProbe {
+  try {
+    const output = execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    if (output.trim() === 'true') return { available: true }
+    return { available: false, reason: `git reported no work tree for ${cwd}` }
+  } catch (error) {
+    return { available: false, reason: gitProbeFailureReason(error, cwd) }
+  }
+}
+
+function importersOutsideIconsFolder(matches: string[]): string[] {
+  return matches.filter((path) => !path.startsWith('packages/ui/src/backend/icons/'))
+}
+
 describe('lucideRegistry.generated importers', () => {
-  it('is imported only from within src/backend/icons', () => {
-    const repoRoot = join(packageDir, '..', '..')
+  const repoRoot = join(packageDir, '..', '..')
+  const workTree = detectGitWorkTree(repoRoot)
+  // `git grep` reads the index, so the guard can only run inside a checkout. Outside
+  // one (a source tarball, or no git binary) it degrades to a skip that states why,
+  // instead of failing an invariant it cannot evaluate.
+  const itInsideWorkTree = workTree.available ? it : it.skip
+  const skipReason = workTree.available ? '' : ` — skipped: ${workTree.reason}`
+
+  itInsideWorkTree(`is imported only from within src/backend/icons${skipReason}`, () => {
     let matches: string[] = []
     try {
       matches = execFileSync(
@@ -169,9 +205,36 @@ describe('lucideRegistry.generated importers', () => {
       if (status !== 1) throw error
     }
 
-    const outsideIconsFolder = matches.filter(
-      (path) => !path.startsWith('packages/ui/src/backend/icons/')
-    )
-    expect(outsideIconsFolder).toEqual([])
+    expect(importersOutsideIconsFolder(matches)).toEqual([])
+  })
+
+  it('flags an importer that lives outside the icons folder', () => {
+    expect(
+      importersOutsideIconsFolder([
+        'packages/ui/src/backend/icons/lucideRegistry.ts',
+        'packages/core/src/modules/catalog/backend/products/page.tsx',
+      ])
+    ).toEqual(['packages/core/src/modules/catalog/backend/products/page.tsx'])
+  })
+
+  it('states a reason instead of throwing when git cannot resolve a work tree', () => {
+    const absentDir = join(tmpdir(), 'lucide-registry-absent-work-tree')
+    const probe = detectGitWorkTree(absentDir)
+    expect(probe.available).toBe(false)
+    expect(probe.available ? '' : probe.reason).toContain(absentDir)
+  })
+})
+
+describe('jest transform scope', () => {
+  const transformPatterns = Object.keys(jestConfig.transform).map((key) => new RegExp(key))
+
+  it('transforms the build-time emitter under scripts/', () => {
+    const emitterPath = join(packageDir, 'scripts', 'lucideRegistrySource.cjs')
+    expect(transformPatterns.some((pattern) => pattern.test(emitterPath))).toBe(true)
+  })
+
+  it('leaves .cjs files inside node_modules untransformed', () => {
+    const vendorPath = join(packageDir, 'node_modules', '@mikro-orm', 'core', 'dist', 'index.cjs')
+    expect(transformPatterns.some((pattern) => pattern.test(vendorPath))).toBe(false)
   })
 })


### PR DESCRIPTION
Closes #4851

## 🎯 Goal
Make the AST-emitter test harness added in #4816 robust outside a git checkout, and stop its Jest `transform` widening from reaching third-party `.cjs`. No production code or emitted output changes — this is test-harness hardening only.

## What Changed
- **`packages/ui/src/backend/icons/__tests__/lucideRegistryGenerator.test.ts`** — the `lucideRegistry.generated` importer guard shelled out to `git grep` unconditionally, so outside a git working tree (a source tarball, or no `git` binary) it failed the suite rather than skipping an invariant it cannot evaluate. It now probes `git rev-parse --is-inside-work-tree` first and, when that fails, degrades to `it.skip` with the reason stated in the test name (`git could not be executed for …` / `git reported no work tree for …` / `git exited with status N …`). Inside a checkout the guard behaves exactly as before and still fails loudly on a real extra importer.
- **`packages/ui/jest.config.cjs`, `packages/shared/jest.config.cjs`** — #4816 widened the transform key to `^.+\.(cjs|(t|j)sx?)$` to pick up the build-time `scripts/*.cjs` emitters, which also transformed third-party `.cjs` inside the allowlisted ESM `node_modules` packages. The `.cjs` arm is now its own key (`^(?!.*[\\/]node_modules[\\/]).*[\\/]scripts[\\/].+\.cjs$`) that requires a `scripts/` segment and excludes `node_modules`, with the shared transformer config hoisted into a `transformer` const so both keys stay identical. A comment records *why* the pattern is written this way: Jest does not interpolate `<rootDir>` in transform **keys** (only in the transformer path), so the repo's own scripts have to be selected by path shape.

## 🧪 Tests
Validation gate run locally in **local mode** (no compose `app` container running), every turbo task with `--force` so nothing was replayed from the shared worktree cache (`Cached: 0 cached` on each):

- `yarn build:packages --force` — 22/22 tasks ✅
- `yarn generate --force` — ✅ (no tracked-file churn)
- `yarn build:packages --force` — 22/22 tasks ✅
- `yarn i18n:check-sync` — ✅ all translation files in sync
- `yarn i18n:check-usage` — ✅ exit 0 (3623 unused keys, advisory, pre-existing baseline)
- `yarn typecheck --force` — 22/22 tasks ✅
- `yarn test --force --continue` — 22/25 tasks ✅; the 3 failures are pre-existing and environmental, not from this change (see below)
- `yarn build:app --force` — ✅
- `yarn template:sync` — ✅ (pre-commit hook parity; no drift)

Directly affected packages:
- `packages/shared` — **169 suites / 1765 tests, all passed**
- `packages/ui` — 220 suites / 1787 tests, 1 pre-existing locale failure (below); `lucideRegistryGenerator` **18/18 passed**, `versionSource` **8/8 passed**

New test cases and what they lock in:
- `flags an importer that lives outside the icons folder` — the guard's filter still rejects an out-of-folder importer, so the skip path cannot silently weaken the invariant.
- `states a reason instead of throwing when git cannot resolve a work tree` — probing a non-existent directory returns `available: false` with a reason naming that directory, instead of throwing.
- `jest transform scope` (both packages) — asserts the transform patterns **do** match the package's own `scripts/*.cjs` emitter and **do not** match `node_modules/@mikro-orm/core/dist/index.cjs`, pinning the narrowing so a future widening fails a test.

<details>
<summary>Pre-existing failures on this machine — unrelated to this PR</summary>

None of these touch files in this diff, and all were verified to be environmental:

1. **`@open-mercato/ui` — `src/utils/__tests__/format.test.ts`** (1 test) and **`@open-mercato/core` — `dashboards/lib/formatters.test.ts`, `customers/…/CompanyKpiBar.dealStatus.test.tsx`, `customers/…/DealsKpiStrip.test.tsx`** (8 tests): this host's default locale is Polish, so `Intl` yields `"1234,50 USD"`, `"1,0 mln"`, `"1,0 tys."` where the tests expect `1,234.5`, `1.0M`, `1.0K`. Re-running all four suites with `LC_ALL=en_US.UTF-8` passes them (`format.test` 15/15; the three core suites 38/38), which is what CI does. `format.test.ts` was last touched by unrelated PR #2365.
2. **`create-mercato-app`**: every failure traces to bubblewrap being unavailable in this sandbox — `bwrap: setting up uid map: Permission denied` (36 occurrences) and `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`, the latter also failing the sandboxed `yarn typecheck` inside `writable-ast-oracles.test.ts`. This package runs under `node --test`, not Jest, so the `jest.config.cjs` changes in this PR cannot reach it.

</details>

## 💥 Breaking Changes
- None. Test-harness and Jest-config only; no production code, no emitted output, no contract surface, no DB or API change. The Jest change strictly *narrows* which files are transformed, and the full suite is green in both affected packages.

## Out of scope
Per the issue, the review's third nit — the ~40 shared lines between `lucideRegistrySource.cjs` and `versionSource.cjs` — is a documented deliberate decision (importing the `packages/cli` AST helpers would create a `ui → cli` / `shared → cli` build edge for build-time-only code) with a stated trigger for revisiting it, and is not deferred work.

Related: #4816, #4671
