### PR TITLE
fix(ai-assistant): stop double-wiring onStepFinish on the tool-loop-agent path

### DIFF
--- a/.ai/runs/2026-08-06-ai-assistant-double-onstepfinish.md
+++ b/.ai/runs/2026-08-06-ai-assistant-double-onstepfinish.md
@@ -34,11 +34,13 @@ tool-call count.
 
 ## Progress
 
+PR: #5053
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Fix and lock the invariant
 
-- [ ] 1.1 Remove the duplicate `onStepFinish` from the `ToolLoopAgent.stream(...)` call
-- [ ] 1.2 Add a regression test asserting a single SDK-side wiring and one caller callback per step
-- [ ] 1.3 Run the targeted ai-assistant test suite
-- [ ] 1.4 Run the full validation gate
+- [x] 1.1 Remove the duplicate `onStepFinish` from the `ToolLoopAgent.stream(...)` call — e506fb866
+- [x] 1.2 Add a regression test asserting a single SDK-side wiring and one caller callback per step — e506fb866
+- [x] 1.3 Run the targeted ai-assistant test suite
+- [x] 1.4 Run the full validation gate

--- a/.ai/runs/2026-08-06-ai-assistant-double-onstepfinish.md
+++ b/.ai/runs/2026-08-06-ai-assistant-double-onstepfinish.md
@@ -1,0 +1,44 @@
+# Fix: `onStepFinish` wired twice on the tool-loop-agent path
+
+Issue: #5042
+Engine: om-auto-create-pr (steps: 4, --loop: no)
+
+## Goal
+
+Stop `runAiAgentText` from wiring the same `onStepFinish` hook twice when
+`executionEngine === 'tool-loop-agent'`, so `BudgetEnforcer` counts each step once
+and a turn is no longer aborted mid-flight with `budget-tool-calls` at 2× the real
+tool-call count.
+
+## Scope
+
+- `packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts` — drop the
+  redundant `onStepFinish` from the `builtToolLoopAgent.stream({ … })` call; the
+  construction-time wiring in `ToolLoopAgentSettings` is the intended one (the
+  surrounding comment already documents it as such).
+- A regression test that locks the invariant: exactly one wiring reaches the SDK,
+  so a per-step event fans out to the caller's hook exactly once.
+
+## Non-goals
+
+- No change to the `stream-text` execution path (its single wiring is correct).
+- No change to `BudgetEnforcer`, `LoopTrace`, or the budget semantics themselves.
+- No dedup logic inside `mergeCallbacks` (that lives in the `ai` SDK).
+
+## Risks
+
+- Low. The removed argument is a duplicate of a hook already wired at construction,
+  so behavior on the tool-loop-agent path is strictly "fires once instead of twice".
+- The path had no unit coverage before this change; the new test is what makes the
+  regression detectable.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fix and lock the invariant
+
+- [ ] 1.1 Remove the duplicate `onStepFinish` from the `ToolLoopAgent.stream(...)` call
+- [ ] 1.2 Add a regression test asserting a single SDK-side wiring and one caller callback per step
+- [ ] 1.3 Run the targeted ai-assistant test suite
+- [ ] 1.4 Run the full validation gate

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime-tool-loop-onstepfinish.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/agent-runtime-tool-loop-onstepfinish.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Regression tests for #5042 — `onStepFinish` on the tool-loop-agent path.
+ *
+ * The hook is wired once, at `ToolLoopAgent` construction. Passing it to
+ * `.stream()` as well made the SDK merge both wirings without dedup, so
+ * `BudgetEnforcer.recordStep` counted every tool call and every token twice and
+ * aborted the turn before the final answer was streamed.
+ */
+
+const streamTextMock = jest.fn()
+const stepCountIsMock = jest.fn((count: number) => ({ __kind: 'stepCount', count }))
+const hasToolCallMock = jest.fn((name: string) => ({ __kind: 'hasToolCall', name }))
+const convertToModelMessagesMock = jest.fn((messages: unknown) => messages)
+
+type StepFinishHook = (event: unknown) => unknown
+
+const toolLoopAgentSettings: Array<{ onStepFinish?: StepFinishHook }> = []
+const toolLoopStreamOptions: Array<Record<string, unknown>> = []
+
+function fakeStreamResult() {
+  return {
+    consumeStream: jest.fn(async () => undefined),
+    toUIMessageStreamResponse: jest.fn(
+      () =>
+        new Response('streamed', {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        }),
+    ),
+  }
+}
+
+jest.mock('ai', () => {
+  const actual = jest.requireActual('ai')
+  class FakeToolLoopAgent {
+    constructor(settings: { onStepFinish?: StepFinishHook }) {
+      toolLoopAgentSettings.push(settings)
+    }
+
+    async stream(options: Record<string, unknown>) {
+      toolLoopStreamOptions.push(options)
+      return fakeStreamResult()
+    }
+  }
+  return {
+    ...actual,
+    streamText: (...args: unknown[]) => streamTextMock(...args),
+    stepCountIs: (count: number) => stepCountIsMock(count),
+    hasToolCall: (name: string) => hasToolCallMock(name),
+    convertToModelMessages: (...args: unknown[]) => convertToModelMessagesMock(...args),
+    Experimental_Agent: FakeToolLoopAgent,
+  }
+})
+
+jest.mock('@open-mercato/shared/lib/ai/llm-provider-registry', () => ({
+  llmProviderRegistry: {
+    resolveFirstConfigured: () => ({
+      id: 'test-provider',
+      defaultModel: 'provider-default-model',
+      resolveApiKey: () => 'test-api-key',
+      createModel: (options: { modelId: string }) => ({ id: options.modelId }),
+      isConfigured: () => true,
+    }),
+    get: () => null,
+  },
+}))
+
+import type { AiAgentDefinition } from '../ai-agent-definition'
+import {
+  resetAgentRegistryForTests,
+  seedAgentRegistryForTests,
+} from '../agent-registry'
+import { toolRegistry } from '../tool-registry'
+import { runAiAgentText } from '../agent-runtime'
+
+const baseAuth = {
+  tenantId: 'tenant-1',
+  organizationId: 'org-1',
+  userId: 'user-1',
+  features: ['*'],
+  isSuperAdmin: true,
+}
+
+const baseMessages = [
+  { role: 'user' as const, id: 'm1', parts: [{ type: 'text' as const, text: 'hi' }] },
+]
+
+function toolLoopAgent(overrides: Partial<AiAgentDefinition> = {}): AiAgentDefinition {
+  return {
+    id: 'mod.tool_loop_agent',
+    moduleId: 'mod',
+    label: 'Tool loop agent',
+    description: 'Tool loop agent description',
+    systemPrompt: 'System prompt.',
+    allowedTools: [],
+    executionEngine: 'tool-loop-agent',
+    ...overrides,
+  }
+}
+
+describe('#5042: onStepFinish is wired once on the tool-loop-agent path', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    toolLoopAgentSettings.length = 0
+    toolLoopStreamOptions.length = 0
+    resetAgentRegistryForTests()
+    toolRegistry.clear()
+    streamTextMock.mockImplementation(() => fakeStreamResult())
+  })
+
+  afterAll(() => {
+    resetAgentRegistryForTests()
+    toolRegistry.clear()
+  })
+
+  it('wires onStepFinish at construction and not again on stream()', async () => {
+    seedAgentRegistryForTests([toolLoopAgent()])
+
+    await runAiAgentText({
+      agentId: 'mod.tool_loop_agent',
+      messages: baseMessages as never,
+      authContext: baseAuth,
+    })
+
+    expect(toolLoopAgentSettings).toHaveLength(1)
+    expect(typeof toolLoopAgentSettings[0].onStepFinish).toBe('function')
+    expect(toolLoopStreamOptions).toHaveLength(1)
+    expect(toolLoopStreamOptions[0]).not.toHaveProperty('onStepFinish')
+    expect(streamTextMock).not.toHaveBeenCalled()
+  })
+
+  it("delivers one caller callback per step when every SDK-side wiring fires", async () => {
+    const callerOnStepFinish = jest.fn()
+    seedAgentRegistryForTests([
+      toolLoopAgent({ loop: { maxSteps: 4, onStepFinish: callerOnStepFinish } }),
+    ])
+
+    await runAiAgentText({
+      agentId: 'mod.tool_loop_agent',
+      messages: baseMessages as never,
+      authContext: baseAuth,
+    })
+
+    const wirings: StepFinishHook[] = [
+      ...toolLoopAgentSettings
+        .map((settings) => settings.onStepFinish)
+        .filter((hook): hook is StepFinishHook => typeof hook === 'function'),
+      ...toolLoopStreamOptions
+        .map((options) => options.onStepFinish)
+        .filter((hook): hook is StepFinishHook => typeof hook === 'function'),
+    ]
+    expect(wirings).toHaveLength(1)
+
+    const stepEvent = {
+      usage: { inputTokens: 10, outputTokens: 5 },
+      toolCalls: [{ toolName: 'mod.tool' }],
+    }
+    for (const wiring of wirings) await wiring(stepEvent)
+
+    expect(callerOnStepFinish).toHaveBeenCalledTimes(1)
+    expect(callerOnStepFinish).toHaveBeenCalledWith(stepEvent)
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/agent-runtime.ts
@@ -1891,11 +1891,13 @@ export async function runAiAgentText(input: RunAiAgentTextInput): Promise<Respon
   // Phase 5 — engine dispatch: tool-loop-agent path vs default stream-text path.
   if (builtToolLoopAgent !== undefined) {
     // `ToolLoopAgent.stream` dispatches via the agent's own prepareCall/prepareStep
-    // pipeline. prepareStep is already wired at construction (security-critical).
+    // pipeline. prepareStep is already wired at construction (security-critical),
+    // and so is `onStepFinish` — passing it here too makes the SDK merge both
+    // wirings without dedup, so the budget enforcer and the loop trace would count
+    // every step twice and abort the turn before the final answer (#5042).
     const agentStreamResult = await builtToolLoopAgent.stream({
       messages: modelMessages,
       abortSignal: abortController.signal,
-      onStepFinish: wiredOnStepFinish,
     })
     if (wallClockTimer !== undefined) {
       const clearTimer = () => clearTimeout(wallClockTimer!)


### PR DESCRIPTION
Closes #5042
Tracking plan: .ai/runs/2026-08-06-ai-assistant-double-onstepfinish.md
Status: complete

## 🎯 Goal
On the `executionEngine: 'tool-loop-agent'` path, `runAiAgentText` wires the same `wiredOnStepFinish` hook twice — once in the `ToolLoopAgentSettings` handed to `new ToolLoopAgent(...)` and again in `builtToolLoopAgent.stream({ ... })`. The AI SDK merges both without dedup, so `BudgetEnforcer.recordStep` counts every tool call and every token twice: `budget.maxToolCalls: N` behaves like `N/2` and the enforcer aborts the turn mid-flight, leaving the user with completed tool cards and no final answer.

## What Changed
- `packages/ai-assistant/.../lib/agent-runtime.ts` — dropped the redundant `onStepFinish` from the `ToolLoopAgent.stream(...)` call. Construction-time wiring stays and remains the single source (the existing comment already documents it as the intended one).

## 🧪 Tests
- `packages/ai-assistant` — 105 suites / 1434 tests passed; full gate green locally (`build:packages`, `generate`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `test`, `build:app`).
- New `agent-runtime-tool-loop-onstepfinish.test.ts` locks the invariant: exactly one SDK-side wiring, one caller callback per step. Both cases were verified failing against the pre-fix code.

## 💥 Breaking Changes
- None.

## 📋 Progress
See the Progress section in the tracking plan.
