### PR TITLE
fix(ui): stop ThemeProvider from remounting the app subtree after hydration

### DIFF
--- a/.ai/runs/2026-08-06-theme-provider-remount.md
+++ b/.ai/runs/2026-08-06-theme-provider-remount.md
@@ -70,7 +70,7 @@ User-visible consequence on `/login`: credentials typed before the remount are d
 
 ### Phase 2: Integration coverage
 
-- [ ] 2.1 Integration spec: login submitted with no settle
+- [x] 2.1 Integration spec: login submitted with no settle — 973e44a17
 
 ### Phase 3: Validation
 

--- a/.ai/runs/2026-08-06-theme-provider-remount.md
+++ b/.ai/runs/2026-08-06-theme-provider-remount.md
@@ -64,9 +64,9 @@ User-visible consequence on `/login`: credentials typed before the remount are d
 
 ### Phase 1: Fix and unit coverage
 
-- [ ] 1.1 Remove the early return in ThemeProvider
-- [ ] 1.2 Unit test: subtree is not remounted
-- [ ] 1.3 Unit test: theme context still resolves after mount
+- [x] 1.1 Remove the early return in ThemeProvider — 70bf15a3f
+- [x] 1.2 Unit test: subtree is not remounted — 70bf15a3f
+- [x] 1.3 Unit test: theme context still resolves after mount — 70bf15a3f
 
 ### Phase 2: Integration coverage
 

--- a/.ai/runs/2026-08-06-theme-provider-remount.md
+++ b/.ai/runs/2026-08-06-theme-provider-remount.md
@@ -1,0 +1,77 @@
+# Fix: ThemeProvider remounts the whole app subtree after hydration
+
+## Goal
+
+Stop `ThemeProvider` from changing the rendered element type after mount, so React re-renders the application subtree instead of unmounting and remounting it — which today discards every component's local state ~200 ms after each page load.
+
+## Context
+
+Diagnosed and measured while QA-ing PR #4170; the defect itself lives on `develop`. Full write-up in issue #5037:
+
+- Diagnosis: https://github.com/open-mercato/open-mercato/issues/5037#issuecomment-5201390829
+- A/B measurement: https://github.com/open-mercato/open-mercato/issues/5037#issuecomment-5201543832
+
+`packages/ui/src/theme/ThemeProvider.tsx` returns `<>{children}</>` until `mounted` flips in its first effect, then returns `<ThemeContext.Provider>{children}</ThemeContext.Provider>`. The element type at that position changes, so React tears the subtree down. In `apps/mercato/src/components/AppProviders.tsx` that subtree is `QueryProvider` → `FrontendLayout` → the page.
+
+Measured on `develop` @ `c95a715a0`, two full rebuilds of the same commit, 3 cold loads each:
+
+| Page | Before | After |
+|---|---|---|
+| `/backend` `/api/` requests | 38 · 38 · 38 | 33 · 33 · 33 |
+| `/backend` duplicate requests | 15 · 15 · 15 | 10 · 10 · 10 |
+| layout remounts | 1 | 0 |
+| time to quiet | 543 · 512 · 494 ms | 490 · 392 · 435 ms (within noise) |
+
+User-visible consequence on `/login`: credentials typed before the remount are discarded and the server answers `400 "Invalid email or password"` for a submit that carried empty fields.
+
+## Scope
+
+- `packages/ui/src/theme/ThemeProvider.tsx` — remove the early return.
+- `packages/ui/src/theme/__tests__/` — unit coverage that the subtree is not remounted and the context still resolves.
+- `packages/core/src/modules/auth/__integration__/` — a login spec that submits with no artificial settle.
+
+## Non-goals
+
+- `useRegisteredComponent` — my first hypothesis, disproven; it is not involved and stays untouched.
+- The remaining 10 duplicate `/api/` requests per dashboard load — a different cause, not addressed here.
+- `ComponentOverridesBootstrap` in PR #4170 — the same anti-pattern one level higher in the provider tree, but that file only exists on that branch. Flagged for its author: https://github.com/open-mercato/open-mercato/pull/4170#issuecomment-5201603934
+- A FOUC regression test — already covered by `packages/create-app/src/lib/root-layout-theme-script.test.ts`, which asserts both root layouts render `THEME_INIT_SCRIPT` as a render-blocking inline script, never through `next/script`, and before `<AppProviders>`. No new test needed.
+
+## Risks
+
+- The removed branch was commented "Prevent flash of wrong theme during hydration". The actual protection is `THEME_INIT_SCRIPT`, applied synchronously before first paint by the root layout (see the Non-goals note). Risk accepted; the existing test guards it.
+- Consumers calling `useTheme()` outside the provider already get safe defaults from the hook, so always rendering the provider cannot break them.
+
+## Implementation Plan
+
+### Phase 1: Fix and unit coverage
+
+1.1 Remove the `if (!mounted)` early return so the element type is stable across the mount flip.
+1.2 Unit test: a child that counts its own mounts stays at 1 across the provider's effect flush (2 before the fix).
+1.3 Unit test: `useTheme()` still reports the resolved theme and `setTheme` still works after mount.
+
+### Phase 2: Integration coverage
+
+2.1 Integration spec: load `/login`, fill both fields with no artificial settle, submit, assert the request carries the typed email and the response redirects to `/backend`.
+
+### Phase 3: Validation
+
+3.1 Run the full configured validation gate and fix anything it surfaces.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Fix and unit coverage
+
+- [ ] 1.1 Remove the early return in ThemeProvider
+- [ ] 1.2 Unit test: subtree is not remounted
+- [ ] 1.3 Unit test: theme context still resolves after mount
+
+### Phase 2: Integration coverage
+
+- [ ] 2.1 Integration spec: login submitted with no settle
+
+### Phase 3: Validation
+
+- [ ] 3.1 Full validation gate green

--- a/.ai/runs/2026-08-06-theme-provider-remount.md
+++ b/.ai/runs/2026-08-06-theme-provider-remount.md
@@ -74,4 +74,4 @@ User-visible consequence on `/login`: credentials typed before the remount are d
 
 ### Phase 3: Validation
 
-- [ ] 3.1 Full validation gate green
+- [x] 3.1 Full validation gate green

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-5037.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-5037.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test'
+
+const ADMIN_EMAIL = process.env.TEST_ADMIN_EMAIL || 'admin@acme.com'
+const ADMIN_PASSWORD = process.env.TEST_ADMIN_PASSWORD || 'secret'
+
+function readMultipartField(body: string, field: string): string | null {
+  const match = body.match(new RegExp(`name="${field}"\\r?\\n\\r?\\n([^\\r\\n]*)`))
+  return match ? match[1] : null
+}
+
+test.describe('TC-AUTH-5037: login submitted immediately after page load', () => {
+  test('keeps the typed credentials when the form is submitted without waiting', async ({ page }) => {
+    // Regression guard for #5037: ThemeProvider used to swap its rendered element
+    // type once its first effect ran, remounting the whole page and discarding
+    // the credentials the user had already typed. The submit then carried empty
+    // fields and the server answered 400 "Invalid email or password".
+    let submittedEmail: string | null = null
+    let loginStatus = 0
+
+    page.on('request', (request) => {
+      if (request.url().includes('/api/auth/login') && request.method() === 'POST') {
+        submittedEmail = readMultipartField(request.postData() ?? '', 'email')
+      }
+    })
+    page.on('response', (response) => {
+      if (response.url().includes('/api/auth/login') && response.request().method() === 'POST') {
+        loginStatus = response.status()
+      }
+    })
+
+    await page.goto('/login', { waitUntil: 'domcontentloaded' })
+
+    // Deliberately no settle: fill and submit as fast as the browser allows,
+    // the way browser autofill and extension password managers do.
+    await page.locator('#email').fill(ADMIN_EMAIL)
+    await page.locator('#password').fill(ADMIN_PASSWORD)
+    await page.getByRole('button', { name: /sign in/i }).click()
+
+    await page.waitForURL(/\/backend/, { timeout: 60_000 })
+
+    expect(submittedEmail).toBe(ADMIN_EMAIL)
+    expect(loginStatus).toBe(200)
+  })
+
+  test('keeps typed input across the initial hydration on the login form', async ({ page }) => {
+    await page.goto('/login', { waitUntil: 'domcontentloaded' })
+    await page.locator('#email').fill(ADMIN_EMAIL)
+
+    // Well past the point where the provider tree finishes initializing.
+    await page.waitForTimeout(3000)
+
+    await expect(page.locator('#email')).toHaveValue(ADMIN_EMAIL)
+  })
+})

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -51,7 +51,6 @@ function applyTheme(resolvedTheme: 'light' | 'dark') {
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setThemeState] = React.useState<Theme>('system')
   const [resolvedTheme, setResolvedTheme] = React.useState<'light' | 'dark'>('light')
-  const [mounted, setMounted] = React.useState(false)
 
   // Initialize theme from localStorage on mount
   React.useEffect(() => {
@@ -60,7 +59,6 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     const resolved = stored === 'system' ? getSystemTheme() : stored
     setResolvedTheme(resolved)
     applyTheme(resolved)
-    setMounted(true)
   }, [])
 
   // Listen for system theme changes
@@ -100,11 +98,11 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
     [theme, resolvedTheme, setTheme]
   )
 
-  // Prevent flash of wrong theme during hydration
-  if (!mounted) {
-    return <>{children}</>
-  }
-
+  // The element type rendered here must not depend on `mounted`. Swapping a
+  // Fragment for the Provider once the first effect runs makes React unmount and
+  // remount everything below this point, discarding the whole page's component
+  // state. Flash of the wrong theme is prevented before first paint by
+  // THEME_INIT_SCRIPT in the root layout, not by this branch.
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
 }
 

--- a/packages/ui/src/theme/__tests__/ThemeProvider.test.tsx
+++ b/packages/ui/src/theme/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react'
+import { act, render, screen } from '@testing-library/react'
+import { ThemeProvider, useTheme } from '../ThemeProvider'
+import { THEME_STORAGE_KEY } from '../theme-init-script'
+
+function mockSystemTheme(prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: query.includes('prefers-color-scheme: dark') ? prefersDark : false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  })
+}
+
+let mountCount = 0
+
+function MountCounter() {
+  React.useEffect(() => {
+    mountCount += 1
+  }, [])
+  return <div data-testid="child" />
+}
+
+function ThemeReadout() {
+  const { theme, resolvedTheme, setTheme } = useTheme()
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
+      <button type="button" onClick={() => setTheme('dark')}>
+        go dark
+      </button>
+    </div>
+  )
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    mountCount = 0
+    document.documentElement.classList.remove('dark')
+    window.localStorage.clear()
+    mockSystemTheme(false)
+  })
+
+  it('does not remount its subtree when the theme initializes', () => {
+    render(
+      <ThemeProvider>
+        <MountCounter />
+      </ThemeProvider>,
+    )
+
+    expect(screen.getByTestId('child')).toBeTruthy()
+    // A `mounted` gate that swapped a Fragment for the context Provider used to
+    // tear this subtree down and rebuild it, losing every child's state.
+    expect(mountCount).toBe(1)
+  })
+
+  it('keeps children mounted across a theme change', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'light')
+    render(
+      <ThemeProvider>
+        <MountCounter />
+        <ThemeReadout />
+      </ThemeProvider>,
+    )
+
+    act(() => {
+      screen.getByRole('button', { name: 'go dark' }).click()
+    })
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark')
+    expect(mountCount).toBe(1)
+  })
+
+  it('exposes the stored theme to consumers after initialization', () => {
+    window.localStorage.setItem(THEME_STORAGE_KEY, 'dark')
+
+    render(
+      <ThemeProvider>
+        <ThemeReadout />
+      </ThemeProvider>,
+    )
+
+    expect(screen.getByTestId('theme').textContent).toBe('dark')
+    expect(screen.getByTestId('resolved').textContent).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('resolves the system preference when nothing is stored', () => {
+    mockSystemTheme(true)
+
+    render(
+      <ThemeProvider>
+        <ThemeReadout />
+      </ThemeProvider>,
+    )
+
+    expect(screen.getByTestId('theme').textContent).toBe('system')
+    expect(screen.getByTestId('resolved').textContent).toBe('dark')
+  })
+})


### PR DESCRIPTION
Fixes #5037
Tracking plan: .ai/runs/2026-08-06-theme-provider-remount.md
Status: complete

## 🎯 Goal
- Stop `ThemeProvider` from remounting the entire application subtree once hydration completes. The provider returned a `Fragment` until its first effect set `mounted`, then switched to the context `Provider`; React treats that as a different element type at the same position, so it unmounts and rebuilds everything below — which in `AppProviders` is `QueryProvider` → `FrontendLayout` → the page. Every component's local state was discarded roughly 200 ms after each page load. On `/login` that wiped the typed credentials, so the submit carried empty fields and the server answered `400 "Invalid email or password"` for a perfectly valid login.

## What Changed
- `packages/ui/src/theme/ThemeProvider.tsx` — always render `<ThemeContext.Provider>`; the `mounted` state that only gated the element type is gone. The comment now records *why* the element type must stay stable, so the gate is not reintroduced.
- `packages/ui/src/theme/__tests__/ThemeProvider.test.tsx` (new) — locks the invariant: a child that counts its own mounts stays at 1 across the provider's effect flush and across a theme change, and consumers still read the stored/system theme afterwards.
- `packages/core/src/modules/auth/__integration__/TC-AUTH-5037.spec.ts` (new) — browser-level regression guard on the user-visible symptom.

### Why removing the gate is safe
The branch was commented "Prevent flash of wrong theme during hydration", but it is not what prevents the flash. `THEME_INIT_SCRIPT` (`packages/ui/src/theme/theme-init-script.ts`) is rendered by the root layout as a plain, non-deferred inline `<script>` and sets the `dark` class on `document.documentElement` synchronously before first paint. That guarantee is already covered by `packages/create-app/src/lib/root-layout-theme-script.test.ts`, which asserts both root layouts render it render-blocking, never via `next/script`, and before `<AppProviders>` — so no new FOUC test was added here on purpose.

`useTheme()` already returns safe defaults when called outside a provider, so always rendering the provider cannot break existing consumers.

## 🧪 Tests
- Full configured gate, all green: `yarn build:packages` (22/22) · `yarn generate` · `yarn build:packages` (22/22) · `yarn i18n:check-sync` · `yarn i18n:check-usage` · `yarn typecheck` (22/22) · `yarn test` (25/25 tasks — core 9150 passed, shared 1763 passed, ui 1787 passed) · `yarn build:app`.
- New unit tests verified to actually catch the regression: reverted to the old implementation and the mount-count assertions fail with `Expected: 1, Received: 2`; they pass with the fix.
- New integration spec passes against a build of this branch (2/2). Its scenario was A/B-measured before the fix and failed there — the login POST carried an empty email and returned 400.

### Measured impact
A/B on `develop` @ `c95a715a0`, two full rebuilds of the same commit, 3 cold loads each, ephemeral env:

| Metric (`/backend`) | Before | After |
|---|---|---|
| `/api/` requests | 38 · 38 · 38 | 33 · 33 · 33 |
| duplicate requests | 15 · 15 · 15 | 10 · 10 · 10 |
| layout remounts | 1 · 1 · 1 | 0 · 0 · 0 |
| time to quiet | 543 · 512 · 494 ms | 490 · 392 · 435 ms |

Five duplicated API calls disappear from every dashboard visit. Two honest caveats: ten duplicate requests survive the fix, so most of the duplication has a different cause this PR does not address; and the timing difference is inside the noise, so this is **not** a latency improvement. Extension-style password managers (which fill via native setters and submit immediately) lose credentials before this fix and work after it. Chrome's built-in autofill is a different code path and was not tested. Full data: https://github.com/open-mercato/open-mercato/issues/5037#issuecomment-5201543832

## 💥 Breaking Changes
- None. No API, database, or contract surface changes; `ThemeProvider`'s props and `useTheme()`'s shape are unchanged.

## ⚠️ Related: PR #4170
PR #4170 introduces the same anti-pattern one level **higher** in the provider tree — `ComponentOverridesBootstrap` does `if (!enabled || !loaded) return <>{children}</>` above `ThemeProvider`. It is invisible today because this bug masks it, but once this merges, that PR will silently reintroduce the remount, and with a longer window because its swap waits on a dynamic import. Flagged for its author: https://github.com/open-mercato/open-mercato/pull/4170#issuecomment-5201603934

## 📋 Progress
See the Progress section in the tracking plan.
