### PR TITLE
test(customers): derive TC-UNDO-003 expectedCloseAt fixtures from the run clock (#5060)

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-UNDO-003-deal-expected-close-date.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-UNDO-003-deal-expected-close-date.spec.ts
@@ -12,6 +12,19 @@ import { expectOperation, undoOk } from '@open-mercato/core/helpers/integration/
  */
 
 const DEALS = '/api/customers/deals'
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Fixture dates are derived from the run clock, never written as literals: a hardcoded
+ * expectedCloseAt would silently drift into the past and make this undo test's outcome
+ * depend on when it runs rather than on the behavior it asserts (#5060). Seconds and
+ * milliseconds are zeroed so the value round-trips through the API byte-for-byte.
+ */
+function futureCloseAtIso(fromEpochMs: number, daysAhead: number): string {
+  const date = new Date(fromEpochMs + daysAhead * DAY_MS)
+  date.setUTCSeconds(0, 0)
+  return date.toISOString()
+}
 
 function findStringByKeys(value: unknown, keys: readonly string[]): string | null {
   if (!value || typeof value !== 'object') return null
@@ -41,8 +54,8 @@ test.describe('TC-UNDO-003 customers.deals.update undo restores expectedCloseAt'
   test('update expectedCloseAt → undo restores the prior date from the audit-log snapshot', async ({ request }) => {
     const token = await getAuthToken(request, 'admin')
     const stamp = Date.now()
-    const beforeCloseAt = '2026-07-20T12:00:00.000Z'
-    const afterCloseAt = '2026-08-15T09:30:00.000Z'
+    const beforeCloseAt = futureCloseAtIso(stamp, 30)
+    const afterCloseAt = futureCloseAtIso(stamp, 60)
     let dealId: string | null = null
 
     try {


### PR DESCRIPTION
## 🎯 Goal

Closes #5060.

`TC-UNDO-003-deal-expected-close-date.spec.ts` pinned both of its `expectedCloseAt` fixture values to absolute ISO literals. `yarn check:time-bombs:fail` flagged the second one as a `[MEDIUM]` finding while CI was being stabilized on #5028, because `2026-08-15T09:30:00.000Z` was about nine days from going stale.

The problem is not that the test fails today — it passes, and it would keep passing for a while. The problem is that a date baked into a fixture makes the test's outcome depend on **when** it runs rather than on the behavior it is supposed to prove. `expectedCloseAt` currently validates as `z.coerce.date().optional()` with no future constraint (`packages/core/src/modules/customers/data/validators.ts`), so nothing compares these values to the clock yet — but the moment anything future-dependent lands (an "expected close date must be in the future" validator, an overdue-deal filter, a stage automation), the failure surfaces in an *undo* test that has nothing to do with the new rule, and whoever hits it starts by suspecting the undo machinery.

## 📋 What changed

Both fixture dates are now derived from the run clock via a small local helper:

```ts
const beforeCloseAt = futureCloseAtIso(stamp, 30)
const afterCloseAt = futureCloseAtIso(stamp, 60)
```

Design notes worth calling out:

- **Both values are in the future** (+30 and +60 days), not just relative. The whole point of the issue is the latent trap of a future-dependent rule landing later; anchoring both dates ahead of `now` means such a rule finds valid fixtures instead of a stale one.
- **Both derive from the single `stamp` = `Date.now()` read** the test already took for its title suffix, so the pair can never straddle a clock boundary between two separate reads.
- **Seconds and milliseconds are zeroed** (`setUTCSeconds(0, 0)`). The assertions compare the API's returned string verbatim (`expect(...).toBe(beforeCloseAt)`), so the value has to round-trip byte-for-byte; keeping the proven `.000Z` shape of the original literals removes any dependence on sub-second precision surviving the Postgres `timestamptz` → JSON path.
- **The two values stay distinct and ordered** (30 < 60 days), so the final assertion still proves the *prior* date was restored and cannot pass by coincidence.

A short docblock on the helper records *why* the dates are clock-relative, so the next person to touch this fixture does not helpfully "simplify" it back into literals.

## 🧪 Verification

| Check | Result |
|---|---|
| `time-bomb-scanner` on the changed file | ✅ 0 findings, including with `--all` (LOW severities shown) |
| Repo-wide scanner count | ✅ 36 → 35 findings; exactly this file's finding removed, nothing else touched |
| `yarn check:time-bombs:fail` | ✅ exit 0 |
| `yarn typecheck` | ✅ 22/22 turbo tasks, `0 cached` (forced, so nothing replayed a stale hash) |
| `yarn build:packages` | ✅ exit 0 |
| `yarn generate` | ✅ exit 0, no generated files left in the diff |
| `yarn i18n:check-sync` | ✅ exit 0 |
| `yarn build:app` | ✅ exit 0 |
| Fixture properties asserted directly | ✅ distinct, ordered, both future, `.000Z` shape, `new Date(v).toISOString() === v` |
| Boundary probes (year-end, leap-adjacent, non-zero ms input) | ✅ well-formed ordered UTC values |

`yarn test` was scoped out on evidence rather than assumption: jest's `testMatch` is `**/__tests__/**/*.test.(ts|tsx)`, so a `__integration__/*.spec.ts` file is never collected by the unit suite and cannot affect it.

The spec itself runs in the **`ephemeral-integration`** job (it needs a live app + database), which is acceptance criterion 4 on the issue — that job is the authoritative check that the round-trip still passes, and it runs on this PR.

### A note on acceptance criterion 3

AC 3 asks that the scan "no longer reports **either** line of this file". Worth recording precisely: only line 45 was ever in the reported set. Line 44's `2026-07-20` had already elapsed, and the scanner rates an already-past fixture `LOW`, which is hidden unless `--all` is passed. Both lines were converted regardless, per AC 1 — and the file is now clean at every severity, which is the stronger guarantee.

### Not in scope

The other 34 `[MEDIUM]` findings from the same scan (catalog 16, business_rules 5, staff 5, wms 3, entities 2, search 2, currencies 1) are deliberately left for a separate sweep, as the issue specifies. Three of them are intentional "never expires" sentinels that belong in `.ai/time-bomb-allowlist.json` rather than being rewritten.

## Security impact

None. The change touches a single Playwright integration fixture: no auth, secrets, encryption, logging, backup, or access-control surface, no database structure change, and no API contract change.
