### PR TITLE
fix(shared): let a command interceptor's rejection carry an HTTP status (#5045)

### DIFF
--- a/.ai/runs/2026-08-06-command-interceptor-http-status.md
+++ b/.ai/runs/2026-08-06-command-interceptor-http-status.md
@@ -1,0 +1,115 @@
+# Execution plan — let a command interceptor's rejection carry an HTTP status
+
+Closes #5045.
+
+## Goal
+
+A command interceptor that deliberately blocks a command can say *how* the rejection should surface
+over HTTP. Today every `{ ok: false, message }` becomes a generic
+`500 { error: 'Internal server error', message: 'Something went wrong. Please try again later.' }`
+and the interceptor's message — in the reporter's case a localized list of missing fields — is lost.
+
+## Context
+
+`CommandInterceptorBeforeResult` (`packages/shared/src/lib/commands/command-interceptor.ts`) exposes
+only `ok` / `message` / `modifiedInput` / `metadata`. Its sibling contract for the same job on the
+sync-event side, `SyncCrudEventResult` (`packages/shared/src/lib/crud/sync-event-types.ts`), has
+carried `status` and `body` from the start, and `runSyncBeforeEvent`'s caller in the CRUD factory
+already maps them (`json(syncResult.errorBody ?? …, { status: syncResult.errorStatus ?? 422 })`). The
+command-interceptor path never grew the equivalent, so:
+
+1. `runCommandInterceptorsBefore` / `runCommandInterceptorsBeforeUndo` narrow the verdict to
+   `error: { message }`;
+2. `CommandBus` rethrows it as `new CommandInterceptorError(beforeResult.error!.message)`
+   (`command-bus.ts`, both the execute and the undo path);
+3. `CommandInterceptorError` (`commands/errors.ts`) is a bare `extends Error` with no transport data;
+4. `handleError` (`crud/factory.ts`) recognizes only `isCrudHttpError`, `ZodError` and transient DB
+   errors, so the rejection reaches the final generic-500 branch.
+
+The reporter's workaround is to throw `CrudHttpError(422, …)` straight from the interceptor, which
+couples command-layer code to the CRUD transport — exactly the coupling the interceptor contract
+exists to avoid.
+
+## Scope
+
+- `packages/shared/src/lib/commands/command-interceptor.ts` — `CommandInterceptorBeforeResult` gains
+  optional `status?: number` and `body?: Record<string, unknown>`, documented like their
+  `SyncCrudEventResult` counterparts.
+- `packages/shared/src/lib/commands/command-interceptor-runner.ts` — a `CommandInterceptorBlockedError`
+  type and a `buildBlockedError` helper normalize the verdict once for both before-hooks; `status`
+  and a derived `body` are attached only when the interceptor supplied a numeric status.
+- `packages/shared/src/lib/commands/errors.ts` — `CommandInterceptorError` gains an optional second
+  constructor argument (`{ status?, body?, cause? }`), readonly `status` / `body`, a
+  `Symbol.for('@open-mercato/CommandInterceptorError')` marker, and an exported
+  `isCommandInterceptorError()` guard.
+- `packages/shared/src/lib/commands/command-bus.ts` — both throw sites forward the verdict's
+  `status` / `body`.
+- `packages/shared/src/lib/commands/index.ts` — additive re-export of the guard and the options type.
+- `packages/shared/src/lib/crud/factory.ts` — `handleError` maps a `CommandInterceptorError` that
+  carries a numeric status onto `json(body ?? { error: message }, { status })`.
+
+## Non-goals
+
+- **No default status.** A rejection without an explicit status keeps today's generic 500. Defaulting
+  to 422 (as sync events do) would change the response of every existing interceptor — a behavior
+  change on a contract surface, and one nobody asked for. Interceptors opt in per rejection.
+- **No reuse of the `CrudHttpError` marker.** It is the other option the issue floats, and it is the
+  wrong one: 98 `isCrudHttpError` call sites across 9 modules would start matching interceptor
+  rejections, including behavioral checks like checkout's `const isConflict = isCrudHttpError(error)`.
+  A distinct marker keeps the blast radius at the one handler that opts in.
+- **The app catch-all route** (`apps/mercato/src/app/api/[...slug]/route.ts`) keeps its narrow
+  tenant-guard mapping. It is not a general error handler.
+
+## Migration & Backward Compatibility
+
+Additive throughout, per `BACKWARD_COMPATIBILITY.md` §2 ("Optional fields may be added freely"):
+
+- `CommandInterceptorBeforeResult` — two new optional fields; existing interceptors compile unchanged.
+- `CommandInterceptorError` — the constructor's second argument is optional, so every existing
+  `new CommandInterceptorError(message)` call site is unaffected, and the class still `extends Error`,
+  so existing `catch` blocks and `instanceof Error` checks behave identically.
+- The runner's returned `error` object gains two optional fields; callers reading `.message` are
+  unaffected.
+- No exports removed or renamed; no runtime behavior changes for any interceptor that does not set a
+  status.
+
+No deprecation bridge is required because nothing is deprecated.
+
+## Progress
+
+- [x] Triage confirmed against `upstream/develop` — real, still-unfixed, no PR or commit in flight
+- [x] `CommandInterceptorBeforeResult` carries optional `status` / `body`
+- [x] Runner normalizes the blocking verdict and propagates it (execute + undo paths)
+- [x] `CommandInterceptorError` carries `status` / `body` behind a `Symbol.for` marker + type guard
+- [x] `CommandBus` forwards the verdict at both throw sites
+- [x] `handleError` maps a status-carrying interceptor error
+- [x] Regression tests — error class, runner (both hooks), CRUD route (500 path and 422 path)
+- [x] Full validation gate green (local mode)
+- [ ] PR opened with labels and summary comment
+
+## Validation
+
+Runner mode: **local** — no compose `app` container was running when the gate started, so the
+`.ai/agentic.config.json` `validation.commands` list runs as plain `yarn <command>`.
+
+| Command | Result |
+|---|---|
+| `yarn build:packages` | ✅ |
+| `yarn generate` | ✅ (no diff — nothing this change touches is auto-discovered) |
+| `yarn build:packages` (2nd) | ✅ |
+| `yarn i18n:check-sync` | ✅ all 5 locales in sync |
+| `yarn i18n:check-usage` | ✅ (3623 unused keys, advisory, pre-existing) |
+| `yarn typecheck` | ✅ 22/22 |
+| `yarn test` | ✅ see below |
+| `yarn build:app` | ✅ |
+
+`yarn test` needed three runs to attribute its failures, and none of them belong to this change:
+
+- Run 1 — `@open-mercato/telemetry` reported one failed suite; it passes in isolation (82/82).
+- Run 2 — `create-mercato-app` failed instead; it passes in isolation (456 pass, 0 fail, exit 0).
+- Run 3 — `@open-mercato/core` exited 1 with `Tests: 9141 passed, 9141 total` and a jest worker
+  killed by `SIGSEGV`. A crashed worker, not a failed assertion.
+
+The failing package moved between runs and never included a package this branch touches. The one
+package that *is* touched, `@open-mercato/shared`, passes in full: **169 suites, 1778 tests, 0
+failures**, including all 12 new regression tests.

--- a/.ai/runs/2026-08-06-command-interceptor-http-status.md
+++ b/.ai/runs/2026-08-06-command-interceptor-http-status.md
@@ -85,7 +85,10 @@ No deprecation bridge is required because nothing is deprecated.
 - [x] `handleError` maps a status-carrying interceptor error
 - [x] Regression tests — error class, runner (both hooks), CRUD route (500 path and 422 path)
 - [x] Full validation gate green (local mode)
-- [ ] PR opened with labels and summary comment
+- [x] PR opened with labels and summary comment — #5067
+- [x] Self-review pass; one minor finding (status/body could drift apart) fixed in `8e74cdd77`
+- [x] Gate re-run on the final head `8e74cdd77` — 8/8 green, `yarn test` 25/25 first try, no generated drift
+- [ ] Maintainer approving review (self-approval not possible) and remote `test` / `ephemeral-integration` green
 
 ## Validation
 

--- a/.ai/runs/2026-08-06-command-interceptor-http-status.md
+++ b/.ai/runs/2026-08-06-command-interceptor-http-status.md
@@ -88,6 +88,15 @@ No deprecation bridge is required because nothing is deprecated.
 - [x] PR opened with labels and summary comment — #5067
 - [x] Self-review pass; one minor finding (status/body could drift apart) fixed in `8e74cdd77`
 - [x] Gate re-run on the final head `8e74cdd77` — 8/8 green, `yarn test` 25/25 first try, no generated drift
+- [x] Latest `develop` merged into the branch (clean, no conflicts) before the review-fix pass
+- [x] Review by @adeptofvoltron (changes requested) addressed — see the four items below
+- [x] Major — spec `.ai/specs/2026-08-06-command-interceptor-http-status.md`, a `BACKWARD_COMPATIBILITY.md`
+      entry, and the three stale blocks in `SPEC-041m4-command-interceptors.md` refreshed
+- [x] Minor 1 — the `beforeUndo` half now has an HTTP consumer: the action-log undo route maps the
+      rejection instead of flattening everything into `400 Undo failed`
+- [x] Minor 2 — `handleError` can no longer throw: `getCommandInterceptorHttpRejection` validates the
+      status is an integer in 400-599 before it reaches `new Response(…)`
+- [x] Minor 3 — `CommandBus` forwarding covered directly in `command-bus.test.ts` (3 cases)
 - [ ] Maintainer approving review (self-approval not possible) and remote `test` / `ephemeral-integration` green
 
 ## Validation

--- a/.ai/specs/2026-08-06-command-interceptor-http-status.md
+++ b/.ai/specs/2026-08-06-command-interceptor-http-status.md
@@ -1,0 +1,146 @@
+# Command interceptor rejections carry an HTTP status
+
+**Status:** implemented
+**Issue:** #5045
+**PR:** #5067
+**Extends:** [`SPEC-041m4-command-interceptors.md`](implemented/SPEC-041m4-command-interceptors.md)
+
+## Problem
+
+A command interceptor that deliberately blocks a command can say *that* it blocked, but not *how*
+the rejection should surface over HTTP. `CommandInterceptorBeforeResult` carried only
+`ok` / `message` / `modifiedInput` / `metadata`, so every `{ ok: false, message }` reached the CRUD
+transport layer as a bare `CommandInterceptorError` and fell through `handleError`'s final branch to
+
+```
+500 { error: 'Internal server error', message: 'Something went wrong. Please try again later.' }
+```
+
+The interceptor's message — in the reporting case a localized list of missing fields — was lost, and
+a deliberate business rejection was reported to the client as a server fault. The only workaround was
+to throw `CrudHttpError(422, …)` straight from the interceptor, which couples command-layer code to
+the CRUD transport — exactly the coupling the interceptor contract exists to avoid.
+
+The sibling contract for the same job on the sync-event side, `SyncCrudEventResult`
+(`packages/shared/src/lib/crud/sync-event-types.ts`), has carried `status` and `body` from the start,
+and the CRUD factory already maps them. The command-interceptor path never grew the equivalent.
+
+## Design
+
+The verdict travels unchanged from the interceptor to the transport layer, normalized once in the
+runner and validated once at the point of use.
+
+| Layer | File | Change |
+|---|---|---|
+| Contract | `packages/shared/src/lib/commands/command-interceptor.ts` | `CommandInterceptorBeforeResult` gains optional `status?: number` and `body?: Record<string, unknown>`, documented like their `SyncCrudEventResult` counterparts. |
+| Runner | `packages/shared/src/lib/commands/command-interceptor-runner.ts` | A `CommandInterceptorBlockedError` type and a `buildBlockedError` helper normalize the blocking verdict once for **both** before-hooks (`beforeExecute`, `beforeUndo`); `status` and a derived `body` are attached only when the interceptor supplied a numeric status. |
+| Error class | `packages/shared/src/lib/commands/errors.ts` | `CommandInterceptorError` gains an optional second constructor argument (`{ status?, body?, cause? }`), readonly `status` / `body`, a `Symbol.for('@open-mercato/CommandInterceptorError')` marker, an exported `isCommandInterceptorError()` guard, and the `getCommandInterceptorHttpRejection()` mapper described below. |
+| Bus | `packages/shared/src/lib/commands/command-bus.ts` | Both throw sites forward the verdict's `status` / `body`. |
+| Exports | `packages/shared/src/lib/commands/index.ts` | Additive re-export of the guard, the mapper, and their types. |
+| CRUD transport | `packages/shared/src/lib/crud/factory.ts` | `handleError` maps a status-carrying rejection onto `json(body, { status })`, ahead of `ZodError` and behind `isCrudHttpError`. |
+| Undo transport | `packages/core/src/modules/audit_logs/api/audit-logs/actions/undo/route.ts` | The undo handler maps the same rejection instead of laundering every failure into `400 Undo failed`. |
+
+### `status` and `body` are strictly paired
+
+`CommandInterceptorError`'s constructor sets `body` only when a numeric `status` was supplied,
+defaulting it to `{ error: message }`. A `body` without a `status` is ignored. The two can therefore
+never drift apart, and the pairing is enforced in the one place that can enforce it.
+
+### One mapper, validated once — `getCommandInterceptorHttpRejection`
+
+Interceptor status codes are third-party data travelling through the runner and the bus, unlike
+`CrudHttpError` statuses which come from literals at framework throw sites. Both transports go
+through one exported mapper:
+
+```typescript
+getCommandInterceptorHttpRejection(err): { status: number; body: Record<string, unknown> } | null
+```
+
+It returns `null` — leaving the caller's generic handling in place — unless the error is an
+interceptor rejection carrying an **integer status in 400–599**. The bound is deliberate:
+
+- `new Response(body, { status })` throws `RangeError` outside 200–599, and that `RangeError` would
+  escape the last-resort error handler itself, replacing a diagnosable 500 with an unhandled route
+  error and skipping the structured log that records the original problem.
+- A `2xx` on a rejection would report a deliberate block to the client as a success.
+- `NaN` passes a bare `typeof x === 'number'` check, so integer-ness is asserted explicitly.
+
+### Transport coverage
+
+| Transport | Honors interceptor status | Notes |
+|---|---|---|
+| `makeCrudRoute` handlers (`POST`/`PUT`/`PATCH`/`DELETE`) | ✅ via `handleError` | The `beforeExecute` path. |
+| `POST /api/audit_logs/audit-logs/actions/undo` | ✅ | The only route in the repository that undoes a command — the `beforeUndo` path. |
+| Routes calling `commandBus.execute` with their own `catch` (~40) | ❌ | They map `isCrudHttpError` and fall back to a generic answer. Out of scope here; see Non-goals. |
+| App catch-all (`apps/mercato/src/app/api/[...slug]/route.ts`) | ❌ | Keeps its narrow tenant-guard mapping; it is not a general error handler. |
+
+## Non-goals
+
+- **No default status.** A rejection without an explicit status keeps today's generic 500. Defaulting
+  to 422 (as sync events do) would change the response of every existing interceptor — a behavior
+  change on a contract surface that nobody asked for. Interceptors opt in per rejection.
+- **No reuse of the `CrudHttpError` marker.** 98 `isCrudHttpError` call sites across 9 modules would
+  start matching interceptor rejections, including behavioral checks such as checkout's
+  `const isConflict = isCrudHttpError(error)`. A distinct marker keeps the blast radius at the
+  handlers that opt in.
+- **Direct-`execute` routes are not migrated.** Roughly forty API routes call `commandBus.execute`
+  inside their own `try/catch` and map only `isCrudHttpError`. Migrating them is mechanical but
+  touches many modules; each can adopt `getCommandInterceptorHttpRejection` when it next changes, and
+  the mapper exists precisely so that adoption is a two-line edit rather than a re-derivation.
+
+## Migration & Backward Compatibility
+
+Additive throughout, per `BACKWARD_COMPATIBILITY.md` § Type interfaces ("Optional fields may be added
+freely"). See the `Command Interceptor HTTP Status (2026-08-06)` entry in `BACKWARD_COMPATIBILITY.md`
+for the surface-by-surface classification.
+
+- `CommandInterceptorBeforeResult` — two new optional fields; every existing interceptor compiles and
+  behaves identically.
+- `CommandInterceptorError` — the constructor's second argument is optional, so every existing
+  `new CommandInterceptorError(message)` call site is unaffected, and the class still `extends Error`,
+  so existing `catch` blocks and `instanceof Error` checks behave identically.
+- The runner's returned `error` object gains two optional fields; callers reading `.message` are
+  unaffected.
+- `isCommandInterceptorError`, `getCommandInterceptorHttpRejection`, `CommandInterceptorErrorOptions`
+  and `CommandInterceptorHttpRejection` are new exports; nothing is removed or renamed.
+- HTTP responses are byte-identical for any interceptor that sets no status — asserted by
+  `crud-factory.test.ts` ("keeps the generic 500 when an interceptor blocks without a status") and by
+  `undo.route.test.ts` ("keeps the generic 400 when the rejection carries no status").
+
+No deprecation bridge is required because nothing is deprecated, and no `UPGRADE_NOTES.md` entry is
+owed because the protocol's items 1–4 govern removals and renames, of which there are none.
+
+## Usage
+
+```typescript
+// commands/interceptors.ts
+export const interceptors: CommandInterceptor[] = [
+  {
+    id: 'compliance.require-vat-id',
+    targetCommand: 'sales.order.*',
+    async beforeExecute(input, ctx) {
+      const missing = collectMissingFields(input)
+      if (!missing.length) return
+      return {
+        ok: false,
+        message: t('compliance.errors.missing_fields', { fields: missing.join(', ') }),
+        status: 422,
+        body: { error: 'Missing required fields', missingFields: missing },
+      }
+    },
+  },
+]
+```
+
+The rejection reaches the caller as `422 { error: 'Missing required fields', missingFields: [...] }`
+instead of a generic 500. Omitting `status` keeps the historical behaviour.
+
+## Test coverage
+
+| Layer | File | Cases |
+|---|---|---|
+| Contract / error class | `packages/shared/src/lib/commands/__tests__/command-interceptor-error.test.ts` | Status/body pairing rules, cross-bundle guard (positive and negative), and the mapper: valid rejection, explicit body, no status, non-interceptor error, out-of-range status, non-integer status. |
+| Runner | `packages/shared/src/lib/commands/__tests__/command-interceptor-runner.test.ts` | Propagation from `beforeExecute` (no status, status only, explicit body, generated fallback message) and from `beforeUndo` (no status, `status: 409`). |
+| Bus forwarding | `packages/shared/src/lib/commands/__tests__/command-bus.test.ts` | A registered interceptor blocking a real `commandBus.execute` — status and derived body forwarded, explicit body forwarded verbatim, no status leaves both undefined, and the command never executes. |
+| CRUD transport | `packages/shared/src/lib/crud/__tests__/crud-factory.test.ts` | A real `makeCrudRoute` POST returning 500 (no status), 422 (status), the explicit body, and 500 again for an out-of-range status. |
+| Undo transport | `packages/core/src/modules/audit_logs/api/__tests__/undo.route.test.ts` | 409 with the message, 422 with an explicit body, generic 400 without a status, generic 400 for an unrelated failure. |

--- a/.ai/specs/implemented/SPEC-041m4-command-interceptors.md
+++ b/.ai/specs/implemented/SPEC-041m4-command-interceptors.md
@@ -107,6 +107,15 @@ interface CommandInterceptorBeforeResult {
   ok?: boolean
   /** Error message when blocking */
   message?: string
+  /**
+   * HTTP status code when blocking. Omit to keep the historical behaviour, where a rejection
+   * without a status surfaces as a generic 500 — set it (e.g. 422) to have the transport layer
+   * answer with a deliberate business-rejection status instead.
+   * Added 2026-08-06, see `.ai/specs/2026-08-06-command-interceptor-http-status.md`.
+   */
+  status?: number
+  /** Error body when blocking (overrides message). Only used together with `status`. */
+  body?: Record<string, unknown>
   /** Modified input — shallow-merged into command input if ok:true */
   modifiedInput?: Record<string, unknown>
   /** Metadata passed to the corresponding after hook */
@@ -159,7 +168,9 @@ async function runCommandInterceptorsBefore(
   userFeatures: string[],
 ): Promise<{
   ok: boolean
-  error?: { message: string }
+  // `status`/`body` are present only when the blocking interceptor supplied a status
+  // (added 2026-08-06, see `.ai/specs/2026-08-06-command-interceptor-http-status.md`).
+  error?: { message: string; status?: number; body?: Record<string, unknown> }
   modifiedInput?: Record<string, unknown>
   metadataByInterceptor: Map<string, Record<string, unknown>>
 }> {
@@ -178,7 +189,9 @@ async function runCommandInterceptorsBefore(
     if (result?.ok === false) {
       return {
         ok: false,
-        error: { message: result.message ?? `Blocked by command interceptor: ${interceptor.id}` },
+        // `buildBlockedError` attaches `status` and a derived `body` only when the interceptor
+        // supplied a numeric status, so a statusless rejection keeps the generic-500 handling.
+        error: buildBlockedError(result, `Blocked by command interceptor: ${interceptor.id}`),
         metadataByInterceptor,
       }
     }
@@ -248,7 +261,9 @@ async function runCommandInterceptorsBeforeUndo(
   userFeatures: string[],
 ): Promise<{
   ok: boolean
-  error?: { message: string }
+  // `status`/`body` are present only when the blocking interceptor supplied a status
+  // (added 2026-08-06, see `.ai/specs/2026-08-06-command-interceptor-http-status.md`).
+  error?: { message: string; status?: number; body?: Record<string, unknown> }
   metadataByInterceptor: Map<string, Record<string, unknown>>
 }> {
   const matching = interceptors
@@ -542,16 +557,40 @@ When a `beforeExecute` interceptor returns `ok: false`, the `CommandBus` throws 
 // packages/shared/src/lib/commands/errors.ts
 
 export class CommandInterceptorError extends Error {
-  constructor(message: string) {
-    super(message)
+  /** HTTP status a deliberate rejection wants to surface; undefined keeps the generic 500. */
+  readonly status?: number
+  /** Response body for the rejection — `options.body`, else `{ error: message }`. Paired with `status`. */
+  readonly body?: Record<string, unknown>
+
+  constructor(message: string, options?: { status?: number; body?: Record<string, unknown>; cause?: unknown }) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined)
     this.name = 'CommandInterceptorError'
+    if (typeof options?.status === 'number') {
+      this.status = options.status
+      this.body = options.body ?? { error: message }
+    }
   }
 }
+
+/** Cross-bundle guard (Symbol.for marker, same pattern as CrudHttpError). */
+export function isCommandInterceptorError(err: unknown): err is CommandInterceptorError
+
+/** Transport mapper — returns `{ status, body }` only for an integer status in 400-599, else null. */
+export function getCommandInterceptorHttpRejection(
+  err: unknown,
+): { status: number; body: Record<string, unknown> } | null
 ```
 
-API routes and UI pages that invoke commands should handle this error and return an appropriate response (e.g., 422 with the interceptor's message). The existing `CrudHttpError` catch-and-map pattern in detail pages already handles thrown errors gracefully.
+> **Update (2026-08-06)** — the `status` / `body` pair, the `Symbol.for` marker with its
+> `isCommandInterceptorError` guard, and the `getCommandInterceptorHttpRejection` mapper were added by
+> `.ai/specs/2026-08-06-command-interceptor-http-status.md` (issue #5045). The second constructor
+> argument is optional, so every prior `new CommandInterceptorError(message)` call site is unchanged.
 
-For `beforeUndo`, the error propagates to the undo caller — typically the action log undo API endpoint, which already returns the error message to the user.
+Transports map the rejection through `getCommandInterceptorHttpRejection(err)`: `handleError` in the
+CRUD factory does it for every `makeCrudRoute` handler, and the action-log undo route does it for the
+`beforeUndo` path. A rejection that sets no status keeps the historical generic response (500 on CRUD
+routes, `400 Undo failed` on undo). Routes that call `commandBus.execute` inside their own `catch`
+opt in with the same two-line mapping.
 
 ---
 

--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -314,3 +314,20 @@ Files in `apps/mercato/.mercato/generated/` are produced by the CLI generators. 
 | Polling cadence | `pollIntervalSeconds` flips 60 → 1800 only when `pushStatus='active'` is persisted. Non-push channels unchanged. | ✓ Behavior-preserving for existing channels |
 
 **Migration path for existing tenants**: no action required. Push is opt-in per channel — until an operator explicitly registers (via connect flow or `POST /push/register`), Gmail channels keep polling on the Spec B baseline. The new ACL feature `communication_channels.channel.push.manage` must be granted via `yarn mercato auth sync-role-acls` post-deploy for the "Re-register push" button to appear.
+
+---
+
+## Command Interceptor HTTP Status (2026-08-06)
+
+`.ai/specs/2026-08-06-command-interceptor-http-status.md` lets a command interceptor's deliberate rejection carry an HTTP status and body, so a business block surfaces as (for example) `422` instead of a generic `500`. **All changes are additive** and pass the contract-surface checks above:
+
+| Surface | Change | Classification |
+|---------|--------|----------------|
+| Type interface (`CommandInterceptorBeforeResult`) | Two new **optional** fields: `status?: number`, `body?: Record<string, unknown>` | ✓ ADDITIVE (Type interface, optional fields) |
+| Function signature (`CommandInterceptorError` constructor) | New **optional** second parameter `options?: { status?, body?, cause? }` | ✓ ADDITIVE (optional parameter appended; every `new CommandInterceptorError(message)` call site compiles and behaves identically) |
+| Function return types (`runCommandInterceptorsBefore`, `runCommandInterceptorsBeforeUndo`) | Returned `error` widens from `{ message: string }` to `{ message: string; status?: number; body?: Record<string, unknown> }` | ✓ ADDITIVE (a widened return type is safe for readers; callers reading `.message` are unaffected) |
+| Import path / exports (`@open-mercato/shared/lib/commands`) | New exports: `isCommandInterceptorError`, `getCommandInterceptorHttpRejection`, `CommandInterceptorErrorOptions`, `CommandInterceptorHttpRejection`. `CommandInterceptorError` keeps its existing export | ✓ ADDITIVE (new exports, nothing removed or renamed) |
+| HTTP response shapes (`makeCrudRoute` handlers, `POST /api/audit_logs/audit-logs/actions/undo`) | A rejection **that sets a status** answers with it; a rejection that sets none keeps the byte-identical generic `500` (CRUD) / `400 Undo failed` (undo) | ✓ Behaviour-preserving for existing interceptors (regression-tested in `crud-factory.test.ts` and `undo.route.test.ts`) |
+| Database schema, event IDs, ACL features, DI names, CLI commands | No change | ✓ n/a |
+
+**Migration path for existing modules**: no action required. The capability is opt-in per rejection — an interceptor that never sets `status` produces exactly the responses it produced before. Interceptors that want a deliberate status add `status` (and optionally `body`) to the `{ ok: false, message }` verdict they already return. Third-party transports that call `commandBus.execute` inside their own `try/catch` can honour the same contract in two lines via `getCommandInterceptorHttpRejection(err)`, which validates the status is an integer in 400-599 before returning it.

--- a/packages/core/src/modules/audit_logs/api/__tests__/undo.route.test.ts
+++ b/packages/core/src/modules/audit_logs/api/__tests__/undo.route.test.ts
@@ -1,5 +1,6 @@
 /** @jest-environment node */
 import { POST } from '@open-mercato/core/modules/audit_logs/api/audit-logs/actions/undo/route'
+import { CommandInterceptorError } from '@open-mercato/shared/lib/commands/errors'
 
 const mockRbac = { userHasAllFeatures: jest.fn() }
 const mockLogs = {
@@ -216,5 +217,69 @@ describe('POST /api/audit_logs/audit-logs/actions/undo', () => {
     const res = await POST(makeRequest({ undoToken: 'token-2' }))
     expect(res.status).toBe(400)
     expect(mockCommandBus.undo).not.toHaveBeenCalled()
+  })
+
+  // Issue #5045 — a beforeUndo interceptor that blocks with an explicit status is a deliberate
+  // business rejection, so the route must answer with that status instead of a flat 400.
+  describe('beforeUndo interceptor rejections', () => {
+    const authorizeUndo = async () => {
+      const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+      ;(getAuthFromRequest as jest.Mock).mockResolvedValue({
+        sub: 'user-1',
+        tenantId: 'tenant-1',
+        orgId: 'org-1',
+      })
+      const target = {
+        id: 'log-1',
+        actorUserId: 'user-1',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        resourceKind: 'auth.user',
+        resourceId: 'user-42',
+        executionState: 'done',
+      }
+      mockLogs.findByUndoToken.mockResolvedValue(target)
+      mockLogs.latestUndoableForResource.mockResolvedValue(target)
+    }
+
+    it('surfaces the interceptor status and message', async () => {
+      await authorizeUndo()
+      mockCommandBus.undo.mockRejectedValue(
+        new CommandInterceptorError('Period already closed', { status: 409 }),
+      )
+
+      const res = await POST(makeRequest({ undoToken: 'token-1' }))
+      expect(res.status).toBe(409)
+      await expect(res.json()).resolves.toEqual({ error: 'Period already closed' })
+    })
+
+    it('surfaces an explicit interceptor body verbatim', async () => {
+      await authorizeUndo()
+      mockCommandBus.undo.mockRejectedValue(
+        new CommandInterceptorError('Blocked', { status: 422, body: { error: 'Blocked', reason: 'locked-period' } }),
+      )
+
+      const res = await POST(makeRequest({ undoToken: 'token-1' }))
+      expect(res.status).toBe(422)
+      await expect(res.json()).resolves.toEqual({ error: 'Blocked', reason: 'locked-period' })
+    })
+
+    it('keeps the generic 400 when the rejection carries no status', async () => {
+      await authorizeUndo()
+      mockCommandBus.undo.mockRejectedValue(new CommandInterceptorError('Blocked'))
+
+      const res = await POST(makeRequest({ undoToken: 'token-1' }))
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toEqual({ error: 'Undo failed' })
+    })
+
+    it('keeps the generic 400 for an unrelated undo failure', async () => {
+      await authorizeUndo()
+      mockCommandBus.undo.mockRejectedValue(new Error('boom'))
+
+      const res = await POST(makeRequest({ undoToken: 'token-1' }))
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toEqual({ error: 'Undo failed' })
+    })
   })
 })

--- a/packages/core/src/modules/audit_logs/api/audit-logs/actions/undo/route.ts
+++ b/packages/core/src/modules/audit_logs/api/audit-logs/actions/undo/route.ts
@@ -6,6 +6,7 @@ import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacS
 import { CommandBus } from '@open-mercato/shared/lib/commands/command-bus'
 import { ActionLogService } from '@open-mercato/core/modules/audit_logs/services/actionLogService'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
+import { getCommandInterceptorHttpRejection } from '@open-mercato/shared/lib/commands/errors'
 import type { AwilixContainer } from 'awilix'
 import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
@@ -120,6 +121,12 @@ export async function POST(req: Request) {
     await commandBus.undo(undoToken, ctx)
     return NextResponse.json({ ok: true, logId: target.id })
   } catch (err) {
+    // A beforeUndo interceptor that blocked with an explicit status is a deliberate business
+    // rejection, not an undo failure — surface its status and message (issue #5045).
+    const interceptorRejection = getCommandInterceptorHttpRejection(err)
+    if (interceptorRejection) {
+      return NextResponse.json(interceptorRejection.body, { status: interceptorRejection.status })
+    }
     logger.error('Undo failed', { err })
     return NextResponse.json({ error: 'Undo failed' }, { status: 400 })
   }
@@ -156,6 +163,12 @@ export const openApi: OpenApiRouteDoc = {
         { status: 400, description: 'Invalid or unavailable undo token', schema: errorSchema },
         { status: 401, description: 'Authentication required', schema: errorSchema },
         { status: 403, description: 'Undo blocked by organization or tenant scope', schema: errorSchema },
+        {
+          status: 422,
+          description:
+            'Undo deliberately blocked by a beforeUndo command interceptor. The interceptor chooses the status (any 4xx/5xx) and may replace the body.',
+          schema: errorSchema,
+        },
       ],
     },
   },

--- a/packages/shared/src/lib/commands/__tests__/command-bus.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/command-bus.test.ts
@@ -4,11 +4,15 @@ import {
   registerCommand,
   registerCommandLoaders,
   CommandBus,
+  isCommandInterceptorError,
 } from '@open-mercato/shared/lib/commands'
+import { registerCommandInterceptors } from '@open-mercato/shared/lib/commands/command-interceptor-store'
+import type { CommandInterceptor } from '@open-mercato/shared/lib/commands/command-interceptor'
 
 describe('CommandBus', () => {
   afterEach(() => {
     commandRegistry.clear()
+    registerCommandInterceptors([])
   })
 
   it('executes registered command and logs action metadata', async () => {
@@ -118,5 +122,64 @@ describe('CommandBus', () => {
 
     expect(result).toEqual({ ok: true })
     expect(execute).toHaveBeenCalledTimes(1)
+  })
+
+  describe('interceptor rejections', () => {
+    const blockingInterceptor = (result: Record<string, unknown>): CommandInterceptor => ({
+      id: 'test.block',
+      targetCommand: 'test.*',
+      beforeExecute: async () => result,
+    })
+
+    const runBlockedCommand = async (interceptor: CommandInterceptor) => {
+      const execute = jest.fn(async () => ({ ok: true }))
+      registerCommand({ id: 'test.command.blocked', execute })
+      registerCommandInterceptors([{ moduleId: 'test', interceptors: [interceptor] }])
+
+      const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+      const bus = new CommandBus()
+      const ctx = {
+        container,
+        auth: { sub: 'user-4', tenantId: 'tenant-4', orgId: null },
+        organizationScope: null,
+        selectedOrganizationId: null,
+        organizationIds: null,
+      }
+
+      const error = await bus.execute('test.command.blocked', { input: {}, ctx }).catch((e: unknown) => e)
+      return { error, execute }
+    }
+
+    it('forwards the interceptor status and derived body onto the thrown error', async () => {
+      const { error, execute } = await runBlockedCommand(
+        blockingInterceptor({ ok: false, message: 'Missing required fields: VAT id', status: 422 }),
+      )
+
+      expect(isCommandInterceptorError(error)).toBe(true)
+      expect((error as { status?: number }).status).toBe(422)
+      expect((error as { body?: Record<string, unknown> }).body).toEqual({
+        error: 'Missing required fields: VAT id',
+      })
+      expect(execute).not.toHaveBeenCalled()
+    })
+
+    it('forwards an explicit interceptor body verbatim', async () => {
+      const body = { error: 'Blocked', missingFields: ['vatId'] }
+      const { error } = await runBlockedCommand(
+        blockingInterceptor({ ok: false, message: 'Blocked', status: 409, body }),
+      )
+
+      expect((error as { status?: number }).status).toBe(409)
+      expect((error as { body?: Record<string, unknown> }).body).toEqual(body)
+    })
+
+    it('leaves status and body undefined when the interceptor supplies no status', async () => {
+      const { error } = await runBlockedCommand(blockingInterceptor({ ok: false, message: 'Blocked' }))
+
+      expect(isCommandInterceptorError(error)).toBe(true)
+      expect((error as Error).message).toBe('Blocked')
+      expect((error as { status?: number }).status).toBeUndefined()
+      expect((error as { body?: unknown }).body).toBeUndefined()
+    })
   })
 })

--- a/packages/shared/src/lib/commands/__tests__/command-interceptor-error.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/command-interceptor-error.test.ts
@@ -1,4 +1,4 @@
-import { CommandInterceptorError } from '../errors'
+import { CommandInterceptorError, isCommandInterceptorError } from '../errors'
 
 describe('CommandInterceptorError', () => {
   it('has the correct name', () => {
@@ -14,5 +14,44 @@ describe('CommandInterceptorError', () => {
   it('is an instance of Error', () => {
     const error = new CommandInterceptorError('test')
     expect(error).toBeInstanceOf(Error)
+  })
+
+  it('carries no transport information when constructed with a message alone', () => {
+    const error = new CommandInterceptorError('test')
+    expect(error.status).toBeUndefined()
+    expect(error.body).toBeUndefined()
+  })
+
+  it('carries the status and derives the body from the message', () => {
+    const error = new CommandInterceptorError('Missing required fields: VAT id', { status: 422 })
+    expect(error.status).toBe(422)
+    expect(error.body).toEqual({ error: 'Missing required fields: VAT id' })
+  })
+
+  it('keeps an explicit body verbatim', () => {
+    const body = { error: 'Blocked', missingFields: ['vatId'] }
+    const error = new CommandInterceptorError('Blocked', { status: 422, body })
+    expect(error.body).toEqual(body)
+  })
+
+  it('preserves the cause when one is supplied', () => {
+    const cause = new Error('underlying')
+    const error = new CommandInterceptorError('Blocked', { cause })
+    expect(error.cause).toBe(cause)
+  })
+
+  it('is detected by isCommandInterceptorError across module boundaries', () => {
+    expect(isCommandInterceptorError(new CommandInterceptorError('test'))).toBe(true)
+    // A structurally identical error from a duplicated bundle carries the same registered symbol.
+    const duplicated = Object.assign(new Error('test'), {
+      [Symbol.for('@open-mercato/CommandInterceptorError')]: true,
+    })
+    expect(isCommandInterceptorError(duplicated)).toBe(true)
+  })
+
+  it('does not treat unrelated values as interceptor errors', () => {
+    expect(isCommandInterceptorError(new Error('plain'))).toBe(false)
+    expect(isCommandInterceptorError(null)).toBe(false)
+    expect(isCommandInterceptorError('CommandInterceptorError')).toBe(false)
   })
 })

--- a/packages/shared/src/lib/commands/__tests__/command-interceptor-error.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/command-interceptor-error.test.ts
@@ -34,6 +34,12 @@ describe('CommandInterceptorError', () => {
     expect(error.body).toEqual(body)
   })
 
+  it('ignores a body supplied without a status, so status and body move together', () => {
+    const error = new CommandInterceptorError('Blocked', { body: { error: 'Blocked' } })
+    expect(error.status).toBeUndefined()
+    expect(error.body).toBeUndefined()
+  })
+
   it('preserves the cause when one is supplied', () => {
     const cause = new Error('underlying')
     const error = new CommandInterceptorError('Blocked', { cause })

--- a/packages/shared/src/lib/commands/__tests__/command-interceptor-error.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/command-interceptor-error.test.ts
@@ -1,4 +1,8 @@
-import { CommandInterceptorError, isCommandInterceptorError } from '../errors'
+import {
+  CommandInterceptorError,
+  getCommandInterceptorHttpRejection,
+  isCommandInterceptorError,
+} from '../errors'
 
 describe('CommandInterceptorError', () => {
   it('has the correct name', () => {
@@ -59,5 +63,46 @@ describe('CommandInterceptorError', () => {
     expect(isCommandInterceptorError(new Error('plain'))).toBe(false)
     expect(isCommandInterceptorError(null)).toBe(false)
     expect(isCommandInterceptorError('CommandInterceptorError')).toBe(false)
+  })
+})
+
+describe('getCommandInterceptorHttpRejection', () => {
+  it('returns the status and body of a status-carrying rejection', () => {
+    const error = new CommandInterceptorError('Missing required fields: VAT id', { status: 422 })
+    expect(getCommandInterceptorHttpRejection(error)).toEqual({
+      status: 422,
+      body: { error: 'Missing required fields: VAT id' },
+    })
+  })
+
+  it('returns the explicit body when the interceptor supplied one', () => {
+    const body = { error: 'Blocked', missingFields: ['vatId'] }
+    const error = new CommandInterceptorError('Blocked', { status: 409, body })
+    expect(getCommandInterceptorHttpRejection(error)).toEqual({ status: 409, body })
+  })
+
+  it('returns null for a rejection that carries no status', () => {
+    expect(getCommandInterceptorHttpRejection(new CommandInterceptorError('Blocked'))).toBeNull()
+  })
+
+  it('returns null for errors that are not interceptor rejections', () => {
+    expect(getCommandInterceptorHttpRejection(new Error('plain'))).toBeNull()
+    expect(getCommandInterceptorHttpRejection(null)).toBeNull()
+  })
+
+  it('rejects a status outside 4xx/5xx so the transport layer keeps its generic handling', () => {
+    // Statuses arrive as third-party interceptor data: outside 200-599 the Response constructor
+    // throws RangeError, and a 2xx would report a deliberate block as a success.
+    for (const status of [200, 302, 399, 600, 999, 0, -1]) {
+      const error = Object.assign(new CommandInterceptorError('Blocked'), { status })
+      expect(getCommandInterceptorHttpRejection(error)).toBeNull()
+    }
+  })
+
+  it('rejects a non-integer status', () => {
+    for (const status of [Number.NaN, 422.5, Number.POSITIVE_INFINITY]) {
+      const error = Object.assign(new CommandInterceptorError('Blocked'), { status })
+      expect(getCommandInterceptorHttpRejection(error)).toBeNull()
+    }
   })
 })

--- a/packages/shared/src/lib/commands/__tests__/command-interceptor-runner.test.ts
+++ b/packages/shared/src/lib/commands/__tests__/command-interceptor-runner.test.ts
@@ -112,6 +112,56 @@ describe('runCommandInterceptorsBefore', () => {
     expect(i2.beforeExecute).not.toHaveBeenCalled()
   })
 
+  // Issue #5045 — a rejection only carries transport information when the interceptor asks for it.
+  it('omits status and body when the rejection carries no status', async () => {
+    const interceptor = makeInterceptor({
+      id: 'i1',
+      beforeExecute: jest.fn().mockResolvedValue({ ok: false, message: 'Blocked' }),
+    })
+    const result = await runCommandInterceptorsBefore([interceptor], 'customers.create-person', {}, baseContext, [])
+    expect(result.error).toEqual({ message: 'Blocked' })
+  })
+
+  it('propagates the status and derives a body from the message', async () => {
+    const interceptor = makeInterceptor({
+      id: 'i1',
+      beforeExecute: jest.fn().mockResolvedValue({ ok: false, message: 'Missing required fields', status: 422 }),
+    })
+    const result = await runCommandInterceptorsBefore([interceptor], 'customers.create-person', {}, baseContext, [])
+    expect(result.error).toEqual({
+      message: 'Missing required fields',
+      status: 422,
+      body: { error: 'Missing required fields' },
+    })
+  })
+
+  it('propagates an explicit body alongside the status', async () => {
+    const interceptor = makeInterceptor({
+      id: 'i1',
+      beforeExecute: jest.fn().mockResolvedValue({
+        ok: false,
+        message: 'Blocked',
+        status: 422,
+        body: { error: 'Blocked', missingFields: ['vatId'] },
+      }),
+    })
+    const result = await runCommandInterceptorsBefore([interceptor], 'customers.create-person', {}, baseContext, [])
+    expect(result.error?.body).toEqual({ error: 'Blocked', missingFields: ['vatId'] })
+  })
+
+  it('falls back to the generated message when a status-carrying rejection has none', async () => {
+    const interceptor = makeInterceptor({
+      id: 'i1',
+      beforeExecute: jest.fn().mockResolvedValue({ ok: false, status: 422 }),
+    })
+    const result = await runCommandInterceptorsBefore([interceptor], 'customers.create-person', {}, baseContext, [])
+    expect(result.error).toEqual({
+      message: 'Blocked by command interceptor: i1',
+      status: 422,
+      body: { error: 'Blocked by command interceptor: i1' },
+    })
+  })
+
   it('accumulates modified input', async () => {
     const i1 = makeInterceptor({
       id: 'i1',
@@ -235,6 +285,29 @@ describe('runCommandInterceptorsBeforeUndo', () => {
     const result = await runCommandInterceptorsBeforeUndo([interceptor], 'customers.create-person', undoContext, baseContext, [])
     expect(result.ok).toBe(false)
     expect(result.error?.message).toBe('Cannot undo')
+  })
+
+  // Issue #5045 — the undo path shares the before-result contract, so it carries a status too.
+  it('omits status and body when the undo rejection carries no status', async () => {
+    const interceptor = makeInterceptor({
+      id: 'i1',
+      beforeUndo: jest.fn().mockResolvedValue({ ok: false, message: 'Cannot undo' }),
+    })
+    const result = await runCommandInterceptorsBeforeUndo([interceptor], 'customers.create-person', undoContext, baseContext, [])
+    expect(result.error).toEqual({ message: 'Cannot undo' })
+  })
+
+  it('propagates the status and body of an undo rejection', async () => {
+    const interceptor = makeInterceptor({
+      id: 'i1',
+      beforeUndo: jest.fn().mockResolvedValue({ ok: false, message: 'Cannot undo a settled invoice', status: 409 }),
+    })
+    const result = await runCommandInterceptorsBeforeUndo([interceptor], 'customers.create-person', undoContext, baseContext, [])
+    expect(result.error).toEqual({
+      message: 'Cannot undo a settled invoice',
+      status: 409,
+      body: { error: 'Cannot undo a settled invoice' },
+    })
   })
 })
 

--- a/packages/shared/src/lib/commands/command-bus.ts
+++ b/packages/shared/src/lib/commands/command-bus.ts
@@ -245,7 +245,8 @@ export class CommandBus {
         allInterceptors, commandId, options.input, interceptorCtx, userFeatures,
       )
       if (!beforeResult.ok) {
-        throw new CommandInterceptorError(beforeResult.error!.message)
+        const blocked = beforeResult.error!
+        throw new CommandInterceptorError(blocked.message, { status: blocked.status, body: blocked.body })
       }
       interceptorMetadata = beforeResult.metadataByInterceptor
       if (beforeResult.modifiedInput) {
@@ -363,7 +364,8 @@ export class CommandBus {
           allInterceptors, log.commandId, undoCtx, interceptorCtx, userFeatures,
         )
         if (!beforeResult.ok) {
-          throw new CommandInterceptorError(beforeResult.error!.message)
+          const blocked = beforeResult.error!
+          throw new CommandInterceptorError(blocked.message, { status: blocked.status, body: blocked.body })
         }
         undoInterceptorMetadata = beforeResult.metadataByInterceptor
       }

--- a/packages/shared/src/lib/commands/command-interceptor-runner.ts
+++ b/packages/shared/src/lib/commands/command-interceptor-runner.ts
@@ -1,5 +1,6 @@
 import type {
   CommandInterceptor,
+  CommandInterceptorBeforeResult,
   CommandInterceptorContext,
   CommandInterceptorUndoContext,
 } from './command-interceptor'
@@ -7,6 +8,26 @@ import { authorizeFeatures } from '../../security/featurePolicy'
 import { createLogger } from '../logger'
 
 const logger = createLogger('shared').child({ component: 'commands' })
+
+/**
+ * A blocking verdict from a before-hook, normalized for the command bus. `status`/`body` are
+ * present only when the interceptor supplied a status, so a rejection without one keeps the
+ * historical generic-500 handling downstream.
+ */
+export type CommandInterceptorBlockedError = {
+  message: string
+  status?: number
+  body?: Record<string, unknown>
+}
+
+function buildBlockedError(
+  result: CommandInterceptorBeforeResult,
+  fallbackMessage: string,
+): CommandInterceptorBlockedError {
+  const message = result.message ?? fallbackMessage
+  if (typeof result.status !== 'number') return { message }
+  return { message, status: result.status, body: result.body ?? { error: message } }
+}
 
 // ---------------------------------------------------------------------------
 // Command pattern matching
@@ -49,7 +70,7 @@ export async function runCommandInterceptorsBefore(
   userFeatures: string[],
 ): Promise<{
   ok: boolean
-  error?: { message: string }
+  error?: CommandInterceptorBlockedError
   modifiedInput?: Record<string, unknown>
   metadataByInterceptor: Map<string, Record<string, unknown>>
 }> {
@@ -65,7 +86,7 @@ export async function runCommandInterceptorsBefore(
     if (result?.ok === false) {
       return {
         ok: false,
-        error: { message: result.message ?? `Blocked by command interceptor: ${interceptor.id}` },
+        error: buildBlockedError(result, `Blocked by command interceptor: ${interceptor.id}`),
         metadataByInterceptor,
       }
     }
@@ -139,7 +160,7 @@ export async function runCommandInterceptorsBeforeUndo(
   userFeatures: string[],
 ): Promise<{
   ok: boolean
-  error?: { message: string }
+  error?: CommandInterceptorBlockedError
   metadataByInterceptor: Map<string, Record<string, unknown>>
 }> {
   const matching = collectMatching(interceptors, commandId, userFeatures)
@@ -153,7 +174,7 @@ export async function runCommandInterceptorsBeforeUndo(
     if (result?.ok === false) {
       return {
         ok: false,
-        error: { message: result.message ?? `Undo blocked by command interceptor: ${interceptor.id}` },
+        error: buildBlockedError(result, `Undo blocked by command interceptor: ${interceptor.id}`),
         metadataByInterceptor,
       }
     }

--- a/packages/shared/src/lib/commands/command-interceptor.ts
+++ b/packages/shared/src/lib/commands/command-interceptor.ts
@@ -67,6 +67,14 @@ export interface CommandInterceptorBeforeResult {
   ok?: boolean
   /** Error message when blocking */
   message?: string
+  /**
+   * HTTP status code when blocking. Omit to keep the historical behaviour, where a rejection
+   * without a status surfaces as a generic 500 — set it (e.g. 422) to have the CRUD transport
+   * layer answer with a deliberate business-rejection status instead.
+   */
+  status?: number
+  /** Error body when blocking (overrides message). Only used together with `status`. */
+  body?: Record<string, unknown>
   /** Modified input — shallow-merged into command input if ok:true */
   modifiedInput?: Record<string, unknown>
   /** Metadata passed to the corresponding after hook */

--- a/packages/shared/src/lib/commands/errors.ts
+++ b/packages/shared/src/lib/commands/errors.ts
@@ -1,6 +1,43 @@
+// Use Symbol.for so the marker survives module duplication across bundle boundaries
+// (same behaviour as CrudHttpError and the globalThis-based DI registries)
+const COMMAND_INTERCEPTOR_ERROR_MARKER = Symbol.for('@open-mercato/CommandInterceptorError')
+
+export type CommandInterceptorErrorOptions = {
+  /** HTTP status the transport layer should answer with. Omit to keep the generic 500. */
+  status?: number
+  /** Response body the transport layer should answer with. Defaults to `{ error: message }`. */
+  body?: Record<string, unknown>
+  cause?: unknown
+}
+
 export class CommandInterceptorError extends Error {
-  constructor(message: string) {
-    super(message)
+  readonly [COMMAND_INTERCEPTOR_ERROR_MARKER] = true
+  /**
+   * HTTP status a deliberate interceptor rejection wants to surface. `undefined` when the
+   * interceptor supplied none, in which case the transport layer keeps its generic 500.
+   */
+  readonly status?: number
+  /** Response body for the rejection. Populated from `options.body`, else `{ error: message }`. */
+  readonly body?: Record<string, unknown>
+
+  constructor(message: string, options?: CommandInterceptorErrorOptions) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined)
     this.name = 'CommandInterceptorError'
+    if (typeof options?.status === 'number') {
+      this.status = options.status
+      this.body = options.body ?? { error: message }
+    } else if (options?.body) {
+      this.body = options.body
+    }
   }
+}
+
+/**
+ * Type-safe check for CommandInterceptorError that works across module/bundle boundaries.
+ * Prefer this over `instanceof CommandInterceptorError` whenever the error may originate
+ * from a different module bundle (e.g. enterprise packages, dynamic imports).
+ */
+export function isCommandInterceptorError(err: unknown): err is CommandInterceptorError {
+  return !!err && typeof err === 'object'
+    && (err as Record<symbol, unknown>)[COMMAND_INTERCEPTOR_ERROR_MARKER] === true
 }

--- a/packages/shared/src/lib/commands/errors.ts
+++ b/packages/shared/src/lib/commands/errors.ts
@@ -5,7 +5,11 @@ const COMMAND_INTERCEPTOR_ERROR_MARKER = Symbol.for('@open-mercato/CommandInterc
 export type CommandInterceptorErrorOptions = {
   /** HTTP status the transport layer should answer with. Omit to keep the generic 500. */
   status?: number
-  /** Response body the transport layer should answer with. Defaults to `{ error: message }`. */
+  /**
+   * Response body the transport layer should answer with, defaulting to `{ error: message }`.
+   * Only meaningful together with `status` — a body on its own is ignored, mirroring the same
+   * rule on `CommandInterceptorBeforeResult`.
+   */
   body?: Record<string, unknown>
   cause?: unknown
 }
@@ -17,7 +21,10 @@ export class CommandInterceptorError extends Error {
    * interceptor supplied none, in which case the transport layer keeps its generic 500.
    */
   readonly status?: number
-  /** Response body for the rejection. Populated from `options.body`, else `{ error: message }`. */
+  /**
+   * Response body for the rejection — `options.body`, else `{ error: message }`. Set only
+   * alongside `status`, so the two are always populated together or not at all.
+   */
   readonly body?: Record<string, unknown>
 
   constructor(message: string, options?: CommandInterceptorErrorOptions) {
@@ -26,8 +33,6 @@ export class CommandInterceptorError extends Error {
     if (typeof options?.status === 'number') {
       this.status = options.status
       this.body = options.body ?? { error: message }
-    } else if (options?.body) {
-      this.body = options.body
     }
   }
 }

--- a/packages/shared/src/lib/commands/errors.ts
+++ b/packages/shared/src/lib/commands/errors.ts
@@ -46,3 +46,26 @@ export function isCommandInterceptorError(err: unknown): err is CommandIntercept
   return !!err && typeof err === 'object'
     && (err as Record<symbol, unknown>)[COMMAND_INTERCEPTOR_ERROR_MARKER] === true
 }
+
+export type CommandInterceptorHttpRejection = {
+  status: number
+  body: Record<string, unknown>
+}
+
+const MIN_REJECTION_STATUS = 400
+const MAX_REJECTION_STATUS = 599
+
+/**
+ * Transport data for a deliberate interceptor rejection, or `null` when the error is not one or
+ * carries no usable status. The status is restricted to 4xx/5xx on purpose: interceptor data is
+ * third-party input travelling through the runner and the bus, `new Response(body, { status })`
+ * throws `RangeError` outside 200-599, and a rejection answered with a 2xx would report a block as
+ * a success. Anything else falls through to the caller's generic handling.
+ */
+export function getCommandInterceptorHttpRejection(err: unknown): CommandInterceptorHttpRejection | null {
+  if (!isCommandInterceptorError(err)) return null
+  const status = err.status
+  if (typeof status !== 'number' || !Number.isInteger(status)) return null
+  if (status < MIN_REJECTION_STATUS || status > MAX_REJECTION_STATUS) return null
+  return { status, body: err.body ?? { error: err.message } }
+}

--- a/packages/shared/src/lib/commands/index.ts
+++ b/packages/shared/src/lib/commands/index.ts
@@ -4,7 +4,11 @@ export { CommandBus } from './command-bus'
 export * from './customFieldSnapshots'
 export * from './undo'
 export * from './redo'
-export { CommandInterceptorError } from './errors'
+export {
+  CommandInterceptorError,
+  isCommandInterceptorError,
+  type CommandInterceptorErrorOptions,
+} from './errors'
 export {
   runCrudCommandWrite,
   type RunCrudCommandWriteOptions,

--- a/packages/shared/src/lib/commands/index.ts
+++ b/packages/shared/src/lib/commands/index.ts
@@ -7,7 +7,9 @@ export * from './redo'
 export {
   CommandInterceptorError,
   isCommandInterceptorError,
+  getCommandInterceptorHttpRejection,
   type CommandInterceptorErrorOptions,
+  type CommandInterceptorHttpRejection,
 } from './errors'
 export {
   runCrudCommandWrite,

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@open-mercato/shared/lib/crud/optimistic-lock-store'
 import { loadCustomFieldDefinitionIndex } from '@open-mercato/shared/lib/crud/custom-fields'
 import { registerMutationGuards } from '@open-mercato/shared/lib/crud/mutation-guard-store'
+import { CommandInterceptorError } from '@open-mercato/shared/lib/commands/errors'
 import { z } from 'zod'
 
 // Keep the real custom-field helpers but spy on the definition loader so we can
@@ -880,6 +881,62 @@ describe('CRUD Factory', () => {
       resourceId: 'cmd-created-1',
       operation: 'create',
     }))
+  })
+
+  // Issue #5045 — a deliberate interceptor rejection must not be laundered into a generic 500.
+  const interceptorErrorRoute = () => makeCrudRoute({
+    metadata: { POST: { requireAuth: true } },
+    orm: { entity: Todo, idField: 'id', orgField: 'organizationId', tenantField: 'tenantId', softDeleteField: 'deletedAt' },
+    indexer: { entityType: 'example.todo' },
+    actions: {
+      create: {
+        commandId: 'example.todo.create',
+        schema: createSchema,
+        response: () => ({ ok: true }),
+      },
+    },
+  })
+
+  const postInterceptorErrorRequest = (route: ReturnType<typeof interceptorErrorRoute>) => route.POST(
+    new Request('http://x/api/example/todos/command', {
+      method: 'POST',
+      body: JSON.stringify({ title: 'A' }),
+      headers: { 'content-type': 'application/json' },
+    }),
+  )
+
+  it('POST command route keeps the generic 500 when an interceptor blocks without a status', async () => {
+    commandBus.execute.mockRejectedValue(new CommandInterceptorError('Missing required fields: VAT id'))
+
+    const res = await postInterceptorErrorRequest(interceptorErrorRoute())
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({
+      error: 'Internal server error',
+      message: 'Something went wrong. Please try again later.',
+    })
+  })
+
+  it('POST command route surfaces the interceptor status and message when the block carries a status', async () => {
+    commandBus.execute.mockRejectedValue(
+      new CommandInterceptorError('Missing required fields: VAT id', { status: 422 }),
+    )
+
+    const res = await postInterceptorErrorRequest(interceptorErrorRoute())
+
+    expect(res.status).toBe(422)
+    await expect(res.json()).resolves.toEqual({ error: 'Missing required fields: VAT id' })
+  })
+
+  it('POST command route surfaces the interceptor body verbatim when one is supplied', async () => {
+    commandBus.execute.mockRejectedValue(
+      new CommandInterceptorError('Blocked', { status: 422, body: { error: 'Blocked', missingFields: ['vatId'] } }),
+    )
+
+    const res = await postInterceptorErrorRequest(interceptorErrorRoute())
+
+    expect(res.status).toBe(422)
+    await expect(res.json()).resolves.toEqual({ error: 'Blocked', missingFields: ['vatId'] })
   })
 
   it('POST command route falls back to the response payload id for guard afterSuccess', async () => {

--- a/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
+++ b/packages/shared/src/lib/crud/__tests__/crud-factory.test.ts
@@ -1040,6 +1040,22 @@ describe('CRUD Factory', () => {
     await expect(res.json()).resolves.toEqual({ error: 'Blocked', missingFields: ['vatId'] })
   })
 
+  it('POST command route keeps the generic 500 when the interceptor status is outside 4xx/5xx', async () => {
+    // A status the Response constructor would reject (or that would report a block as success)
+    // must not escape handleError as a RangeError — it falls back to the generic 500 instead.
+    commandBus.execute.mockRejectedValue(
+      Object.assign(new CommandInterceptorError('Blocked'), { status: 600, body: { error: 'Blocked' } }),
+    )
+
+    const res = await postInterceptorErrorRequest(interceptorErrorRoute())
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({
+      error: 'Internal server error',
+      message: 'Something went wrong. Please try again later.',
+    })
+  })
+
   it('POST command route falls back to the response payload id for guard afterSuccess', async () => {
     commandBus.execute.mockResolvedValue({ result: { lineId: 'line-42' }, logEntry: { id: 'log-1' } })
     const guardAfterSuccess = jest.fn(async () => {})

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -8,6 +8,7 @@ import { SortDir } from '@open-mercato/shared/lib/query/types'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import { resolveOrganizationScopeForRequest, type OrganizationScope } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
+import { isCommandInterceptorError } from '@open-mercato/shared/lib/commands/errors'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import {
   runMutationGuards,
@@ -556,6 +557,12 @@ function attachOperationHeader(res: Response, logEntry: any) {
 function handleError(err: unknown): Response {
   if (err instanceof Response) return err
   if (isCrudHttpError(err)) return json(err.body, { status: err.status })
+  // A command interceptor that blocked with an explicit status is a deliberate business
+  // rejection, not a server fault — surface its status and message instead of a generic 500.
+  // Without a status the error falls through to the historical handling below (issue #5045).
+  if (isCommandInterceptorError(err) && typeof err.status === 'number') {
+    return json(err.body ?? { error: err.message }, { status: err.status })
+  }
   if (err instanceof z.ZodError) return json({ error: 'Invalid input', details: err.issues }, { status: 400 })
   if (isTransientDbError(err)) {
     // Transient DB unavailability (pool exhausted, `max_connections` reached, DB

--- a/packages/shared/src/lib/crud/factory.ts
+++ b/packages/shared/src/lib/crud/factory.ts
@@ -8,7 +8,7 @@ import { SortDir } from '@open-mercato/shared/lib/query/types'
 import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import { resolveOrganizationScopeForRequest, type OrganizationScope } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { serializeOperationMetadata } from '@open-mercato/shared/lib/commands/operationMetadata'
-import { isCommandInterceptorError } from '@open-mercato/shared/lib/commands/errors'
+import { getCommandInterceptorHttpRejection } from '@open-mercato/shared/lib/commands/errors'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
 import {
   runMutationGuards,
@@ -589,9 +589,10 @@ function handleError(err: unknown): Response {
   if (isCrudHttpError(err)) return json(err.body, { status: err.status })
   // A command interceptor that blocked with an explicit status is a deliberate business
   // rejection, not a server fault — surface its status and message instead of a generic 500.
-  // Without a status the error falls through to the historical handling below (issue #5045).
-  if (isCommandInterceptorError(err) && typeof err.status === 'number') {
-    return json(err.body ?? { error: err.message }, { status: err.status })
+  // Without a usable status the error falls through to the historical handling below (issue #5045).
+  const interceptorRejection = getCommandInterceptorHttpRejection(err)
+  if (interceptorRejection) {
+    return json(interceptorRejection.body, { status: interceptorRejection.status })
   }
   if (err instanceof z.ZodError) return json({ error: 'Invalid input', details: err.issues }, { status: 400 })
   if (isTransientDbError(err)) {


### PR DESCRIPTION
Closes #5045
Tracking plan: .ai/runs/2026-08-06-command-interceptor-http-status.md
Status: complete

## 🎯 Goal

A command interceptor that deliberately blocks a command can now say *how* the rejection should surface over HTTP. A business validation that rejects with `{ ok: false, message, status: 422 }` reaches the caller as a real `422` carrying its own message, instead of being laundered into `500 Something went wrong`.

## 🔍 Problem

A `beforeExecute` interceptor returning `{ ok: false, message }` became `throw new CommandInterceptorError(message)`. That class was a bare `Error`, so `handleError` in the CRUD factory did not recognize it and answered with the generic `500 { error: 'Internal server error', message: 'Something went wrong. Please try again later.' }`. The interceptor's message — in the reporter's case a localized list of missing fields — never reached the client. The documented workaround was to throw `CrudHttpError(422, …)` straight from the interceptor, which couples command-layer code to the CRUD transport, exactly the coupling the interceptor contract exists to avoid.

## 🔍 Root Cause

`CommandInterceptorBeforeResult` exposed only `ok` / `message` / `modifiedInput` / `metadata`. Its sibling contract for the same job on the sync-event side, `SyncCrudEventResult`, has carried `status` and `body` from the start, and the CRUD factory already maps those (`json(syncResult.errorBody ?? …, { status: syncResult.errorStatus ?? 422 })`). The command-interceptor path never grew the equivalent, so the transport information was dropped at four consecutive points: the runner narrowed the verdict to `error: { message }`, the bus rethrew only `.message`, `CommandInterceptorError` had nowhere to keep a status, and `handleError` recognized only `isCrudHttpError`, `ZodError` and transient DB errors before its generic-500 branch.

## What Changed

- **`packages/shared/src/lib/commands/command-interceptor.ts`** — `CommandInterceptorBeforeResult` gains optional `status?: number` and `body?: Record<string, unknown>`, documented like their `SyncCrudEventResult` counterparts. Shared by `beforeExecute` and `beforeUndo`, so both hooks get the capability.
- **`packages/shared/src/lib/commands/command-interceptor-runner.ts`** — a `CommandInterceptorBlockedError` type and a `buildBlockedError` helper normalize the blocking verdict once for both before-hooks. `status` and a body (the interceptor's own, else `{ error: message }`) are attached only when the interceptor supplied a numeric status.
- **`packages/shared/src/lib/commands/errors.ts`** — `CommandInterceptorError` gains an optional second constructor argument (`{ status?, body?, cause? }`), readonly `status` / `body`, a `Symbol.for('@open-mercato/CommandInterceptorError')` marker, and an exported `isCommandInterceptorError()` guard that survives module duplication across bundle boundaries (same pattern as `CrudHttpError`, whose `instanceof` check was replaced repo-wide in #1850 for exactly this reason).
- **`packages/shared/src/lib/commands/command-bus.ts`** — both throw sites (execute and undo) forward the verdict's `status` / `body`.
- **`packages/shared/src/lib/commands/index.ts`** — additive re-export of the guard and the options type.
- **`packages/shared/src/lib/crud/factory.ts`** — `handleError` maps a `CommandInterceptorError` carrying a numeric status onto `json(body ?? { error: message }, { status })`, placed after the `isCrudHttpError` branch.

Two deliberate non-choices, both worth a reviewer's attention:

- **No default status.** A rejection without an explicit status keeps today's generic 500 rather than defaulting to 422 the way sync events do. A default would change the response of every interceptor that exists today — a behavior change on a contract surface. Interceptors opt in per rejection instead.
- **No reuse of the `CrudHttpError` marker.** That is the alternative the issue floats, and it would make all 98 `isCrudHttpError` call sites across 9 modules start matching interceptor rejections, including behavioral checks such as checkout's `const isConflict = isCrudHttpError(error)`. A distinct marker keeps the blast radius at the one handler that opts in.

## 🧪 Tests

Full validation gate, local runner mode (no compose `app` container was running): `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck` (22/22), `yarn test`, `yarn build:app` — all green.

`yarn test` needed three runs to attribute its failures, and the failing package moved every time — never one this branch touches:

- Run 1 — `@open-mercato/telemetry` reported a failed suite; passes in isolation (82/82).
- Run 2 — `create-mercato-app` failed instead; passes in isolation (456 pass, 0 fail, exit 0).
- Run 3 — `@open-mercato/core` exited 1 with `Tests: 9141 passed, 9141 total` and a jest worker killed by `SIGSEGV` — a crashed worker, not a failed assertion.

The one package this branch does touch, `@open-mercato/shared`, passes in full: **169 suites, 1778 tests, 0 failures**.

12 new regression tests, covering both paths the issue names:

- `crud/__tests__/crud-factory.test.ts` — end-to-end through a real `makeCrudRoute` POST: an interceptor error **without** a status still returns `500` with the byte-identical generic body; **with** `status: 422` returns `422 { error: 'Missing required fields: VAT id' }`; with an explicit body, that body is returned verbatim.
- `commands/__tests__/command-interceptor-error.test.ts` — constructor with no options, status-only (body derived from the message), explicit body, preserved `cause`, and both directions of the cross-bundle guard.
- `commands/__tests__/command-interceptor-runner.test.ts` — propagation from `beforeExecute` (no status, status-only, explicit body, generated fallback message) and from `beforeUndo` (no status, status 409).

## 💥 Breaking Changes

None. Additive throughout, per `BACKWARD_COMPATIBILITY.md` §2 ("Optional fields may be added freely"):

- `CommandInterceptorBeforeResult` — two new optional fields; existing interceptors compile and behave unchanged.
- `CommandInterceptorError` — the second constructor argument is optional, so every existing `new CommandInterceptorError(message)` call site is unaffected; the class still `extends Error`, so existing `catch` blocks and `instanceof Error` checks are unaffected.
- The runner's returned `error` object gains two optional fields; callers reading `.message` are unaffected.
- No exports removed or renamed, and no runtime behavior change for any interceptor that does not set a status.

No deprecation bridge is required because nothing is deprecated.

## 📋 Progress

See the Progress section in the tracking plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
