### PR TITLE
chore(governance): extend CODEOWNERS to design-system governance files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,19 @@ packages/core/src/modules/customer_accounts/  @open-mercato/maintainers
 SECURITY.md                            @open-mercato/maintainers
 .github/CODEOWNERS                     @open-mercato/maintainers
 
+# Design-system governance — changes require the design owner's review.
+# These files encode how the design system is governed (rules, tokens, lint
+# escalation policy, guardian skill, docs), not the UI code they judge.
+docs/design-system/                    @zielivia
+.ai/ds-rules.md                        @zielivia
+.ai/ui-components.md                   @zielivia
+.ai/skills/om-ds-guardian/             @zielivia
+.ai/scripts/ds-health-check.sh         @zielivia
+packages/eslint-plugin-ds/             @zielivia
+.ai/ds/                                @zielivia
+apps/mercato/src/app/globals.css       @zielivia
+packages/create-app/template/src/app/globals.css  @zielivia
+
 # Certified partner gate. These two files decide who may run `/label` on pull
 # requests, so each one needs sign-off from @matgren specifically — a single
 # owner, because any owner on a line can approve alone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Leverage the module system and follow strict naming and coding conventions to ke
 - Ask before changing branch/PR automation, pipeline labels, QA flow, release behavior, or external official-module submodule pointers.
 - Ask before applying database migrations locally with `yarn db:migrate`; normal PRs should include migration files and snapshots.
 - Ask before introducing provider-specific preconfiguration outside the provider package.
+- Ask before an automated PR touches design-system governance files (the CODEOWNERS design-system section): file an issue for the design owner instead. UI code and modules stay open.
 
 ## Never
 


### PR DESCRIPTION
Closes #5119

## What

Adds a **design-system governance** section to `.github/CODEOWNERS`, mirroring the pattern already applied to CI workflows and publish scripts: paths that encode design judgment require the design owner's review even when everything else is green.

```
docs/design-system/                    @zielivia
.ai/ds-rules.md                        @zielivia
.ai/ui-components.md                   @zielivia
.ai/skills/om-ds-guardian/             @zielivia
.ai/scripts/ds-health-check.sh         @zielivia
packages/eslint-plugin-ds/             @zielivia
.ai/ds/                                @zielivia
apps/mercato/src/app/globals.css       @zielivia
packages/create-app/template/src/app/globals.css  @zielivia
```

Also adds one bullet to the `Ask First` section of `AGENTS.md`, so pipeline agents file an issue and assign the design owner rather than claiming these files.

## What this does not do

Components, screens, modules and migrations stay fully open to the pipeline, including the DS lint gates that judge them. Only the files that define *how the design system is governed* are covered.

## Notes

- **Ordering:** the new section is inserted *above* the certified-partner gate, which documents that it must stay last (CODEOWNERS applies the last matching pattern). None of the new patterns overlap `.github/certified-partners.yml` or `.github/workflows/community-labels.yml`, and no existing maintainer-owned path is affected.
- **`AGENTS.md` instruction budget:** `main` sits at 30,526 of the 30,720-byte `rootMaxBytes` limit, so the bullet had to be written tersely — it lands at 30,709 bytes, 11 bytes under. `node scripts/check-agents-md-budget.mjs` exits 0. The remaining headroom is thin enough that the next root-`AGENTS.md` edit will likely need to trim something; that is pre-existing and not introduced here.
- `@zielivia` has `maintain` permission on the repo, so these entries are effective (verified via the collaborators API).
- Eight of the nine paths exist today. `.ai/ds/` does not; it is included as specified in the issue so ownership applies the moment it is created, and unmatched CODEOWNERS patterns are inert rather than errors.
- Pre-existing and **not** fixed here: the `@open-mercato/maintainers` team does not exist, so all 13 lines referencing it are invalid, and `main` has `require_code_owner_reviews: false`. Tracked in #5123. The entries added here are valid but inherit the branch-protection gap.

## Test plan

Config/docs only — no code paths touched.

- `node scripts/check-agents-md-budget.mjs` → exit 0
- `gh api repos/open-mercato/open-mercato/codeowners/errors?ref=cez/4e5868b1` → the only errors are the 13 pre-existing `@open-mercato/maintainers` lines; the nine lines added here report none