### PR TITLE
fix(customers): sync deal closure with funnel stage (#5106)

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -161,7 +161,7 @@ rg -l '"<area>"|"<module>"|"<topic>"' .ai/lessons/*.md
 - [Restart stale UI previews after package edits](lessons/restart-stale-ui-previews-after-package-edits.md) — area:testing,debugging; module:create_app,ui; topic:package-runtime,testing
 - [Scope Playwright `testIgnore` entries to project root absolute paths](lessons/scope-playwright-testignore-entries-to-project-root.md) — area:testing,integration; module:platform; topic:data-scoping,testing,type-normalization
 - [Use cryptographic randomness in auth-adjacent test helpers](lessons/use-cryptographic-randomness-in-auth-adjacent-test.md) — area:testing,integration,module-data; module:auth,cache,communication_channels; topic:data-scoping,generated-files,filters
-- [Use the bundled Node runtime for sandboxed macOS verification](lessons/use-the-bundled-node-runtime-for-sandboxed-macos.md) — area:testing,debugging; module:platform; topic:testing,node-runtime
+- [Use the bundled Node runtime for sandboxed macOS verification](lessons/use-the-bundled-node-runtime-for-sandboxed-macos.md) — area:testing,debugging; module:platform,create_app; topic:testing,node-runtime
 - [When a task brief requires Playwright coverage, unit tests are not a substitute](lessons/when-a-task-brief-requires-playwright-coverage-unit.md) — area:testing; module:events,search; topic:events,module-boundaries,testing
 
 ### framework-context

--- a/.ai/lessons/use-the-bundled-node-runtime-for-sandboxed-macos.md
+++ b/.ai/lessons/use-the-bundled-node-runtime-for-sandboxed-macos.md
@@ -1,6 +1,6 @@
 ---
 title: "Use the bundled Node runtime for sandboxed macOS verification"
-modules: ["platform"]
+modules: ["platform","create_app"]
 areas: ["testing","debugging"]
 topics: ["testing","node-runtime"]
 ---
@@ -9,6 +9,6 @@ topics: ["testing","node-runtime"]
 
 **Context**: The standalone agent-harness tests launch nested processes inside a macOS sandbox. A Homebrew Node binary can depend on dynamic libraries under `/opt/homebrew`, which the nested sandbox does not allow the process to load. A fresh checkout can also lack the docs search index required by the full gate.
 
-**Rule**: When harness tests fail broadly with `dyld` or blocked Node-library errors, put the workspace's self-contained Node runtime first on `PATH` and rerun the complete gate. Do not diagnose the resulting cascade as product failures until the runtime can start inside the sandbox. Build the docs search index first when a fresh checkout does not contain it.
+**Rule**: When harness tests fail broadly with `dyld` or blocked Node-library errors, put the workspace's self-contained Node runtime first on `PATH` and rerun the same complete gate command. A full `yarn test` run can reach nested create-app suites before exposing the blocked Homebrew dependency, so a targeted package rerun is not equivalent evidence. Do not diagnose the resulting cascade as product failures until the runtime can start inside the sandbox. Build the docs search index first when a fresh checkout does not contain it.
 
 **Applies to**: `create-mercato-app` agent-harness tests and validation gates that execute them on macOS.

--- a/packages/core/src/modules/customers/commands/__tests__/deals.stage-transitions.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/deals.stage-transitions.test.ts
@@ -79,6 +79,8 @@ function createMockContext(deps: {
           return em
         case 'dataEngine':
           return engine
+        case 'eventBus':
+          return undefined
         default:
           throw new Error(`Unexpected dependency: ${token}`)
       }
@@ -271,6 +273,125 @@ describe('customers.deals.update stage transitions', () => {
       }),
     )
   })
+
+  it.each([
+    {
+      closureOutcome: 'won' as const,
+      status: 'win',
+      terminalStageId: '550e8400-e29b-41d4-a716-446655440012',
+      terminalStageLabel: 'Win',
+      lossReasonId: undefined,
+    },
+    {
+      closureOutcome: 'lost' as const,
+      status: 'loose',
+      terminalStageId: '550e8400-e29b-41d4-a716-446655440013',
+      terminalStageLabel: 'Lost',
+      lossReasonId: '550e8400-e29b-41d4-a716-446655440021',
+    },
+  ])(
+    'moves a $closureOutcome deal to the matching terminal stage',
+    async ({ closureOutcome, status, terminalStageId, terminalStageLabel, lossReasonId }) => {
+      const handler = commandRegistry.get('customers.deals.update') as CommandHandler
+      expect(handler).toBeDefined()
+
+      const existingDeal: CustomerDeal = {
+        id: '550e8400-e29b-41d4-a716-446655440000',
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        title: 'Expansion renewal',
+        description: null,
+        status: 'open',
+        pipelineStage: 'Discovery',
+        pipelineId: '550e8400-e29b-41d4-a716-446655440010',
+        pipelineStageId: '550e8400-e29b-41d4-a716-446655440011',
+        valueAmount: '12000',
+        valueCurrency: 'USD',
+        probability: 65,
+        expectedCloseAt: null,
+        ownerUserId: null,
+        source: 'Referral',
+        closureOutcome: null,
+        lossReasonId: null,
+        lossNotes: null,
+        createdAt: new Date('2026-04-10T08:00:00.000Z'),
+        updatedAt: new Date('2026-04-10T08:00:00.000Z'),
+        deletedAt: null,
+        people: [] as any,
+        companies: [] as any,
+        activities: [] as any,
+        comments: [] as any,
+        stageTransitions: [] as any,
+      }
+
+      const terminalStage: CustomerPipelineStage = {
+        id: terminalStageId,
+        pipelineId: '550e8400-e29b-41d4-a716-446655440010',
+        label: terminalStageLabel,
+        order: 7,
+        organizationId: 'org-1',
+        tenantId: 'tenant-1',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as CustomerPipelineStage
+
+      const em = {
+        fork: () => em,
+        findOne: jest.fn(async (ctor: unknown, where: Record<string, unknown>) => {
+          if (ctor === CustomerDeal && where.id === existingDeal.id) return existingDeal
+          if (ctor === CustomerDealStageTransition) return null
+          if (ctor === CustomerDictionaryEntry) return null
+          return null
+        }),
+        find: jest.fn(async (ctor: unknown, where: Record<string, unknown>) => {
+          if (ctor === CustomerPipelineStage && where.pipelineId === existingDeal.pipelineId) {
+            return [terminalStage]
+          }
+          return []
+        }),
+        nativeDelete: jest.fn(async () => {}),
+        create: jest.fn((ctor: unknown, payload: Record<string, unknown>) => ({ __entity: ctor, ...payload })),
+        persist: jest.fn(() => {}),
+        flush: jest.fn(async () => {}),
+        transactional: jest.fn(async (fn: (inner: typeof em) => Promise<unknown>) => fn(em)),
+        begin: jest.fn().mockResolvedValue(undefined),
+        commit: jest.fn().mockResolvedValue(undefined),
+        rollback: jest.fn().mockResolvedValue(undefined),
+        getReference: jest.fn(),
+        remove: jest.fn(),
+      }
+
+      const dataEngine: Pick<DataEngine, 'setCustomFields' | 'emitOrmEntityEvent'> = {
+        setCustomFields: jest.fn(async () => {}),
+        emitOrmEntityEvent: jest.fn(async () => {}),
+      }
+
+      const ctx = createMockContext({ em, dataEngine })
+
+      await handler.execute!(
+        {
+          id: existingDeal.id,
+          closureOutcome,
+          status,
+          ...(lossReasonId ? { lossReasonId } : {}),
+        },
+        ctx,
+      )
+
+      expect(existingDeal.status).toBe(status)
+      expect(existingDeal.closureOutcome).toBe(closureOutcome)
+      expect(existingDeal.pipelineStageId).toBe(terminalStageId)
+      expect(existingDeal.pipelineStage).toBe(terminalStageLabel)
+      expect(existingDeal.lossReasonId).toBe(lossReasonId ?? null)
+      expect(em.persist).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stageId: terminalStageId,
+          stageLabel: terminalStageLabel,
+          stageOrder: 7,
+        }),
+      )
+    },
+  )
 
   it('skips transition persistence when the stage transition table is missing', async () => {
     const handler = commandRegistry.get('customers.deals.update') as CommandHandler

--- a/packages/core/src/modules/customers/commands/deals.ts
+++ b/packages/core/src/modules/customers/commands/deals.ts
@@ -72,6 +72,13 @@ type PipelineStageSnapshot = {
   order: number
 }
 
+type DealClosureOutcome = 'won' | 'lost'
+
+const TERMINAL_PIPELINE_STAGE_LABELS: Record<DealClosureOutcome, ReadonlySet<string>> = {
+  won: new Set(['won', 'win', 'closed won', 'closed win']),
+  lost: new Set(['lost', 'loose', 'closed lost', 'closed loose']),
+}
+
 type DealStageTransitionSnapshot = {
   id: string
   pipelineId: string
@@ -107,6 +114,56 @@ async function loadPipelineStageSnapshot(
   organizationId: string,
 ): Promise<PipelineStageSnapshot | null> {
   const stage = await findOneWithDecryption(em, CustomerPipelineStage, { id: pipelineStageId }, {}, { tenantId, organizationId })
+  if (!stage) return null
+  return {
+    id: stage.id,
+    pipelineId: stage.pipelineId,
+    label: stage.label,
+    order: stage.order,
+  }
+}
+
+function normalizePipelineStageLabel(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+function resolveRequestedClosureOutcome(input: DealUpdateInput): DealClosureOutcome | null {
+  if (input.closureOutcome === 'won' || input.closureOutcome === 'lost') {
+    return input.closureOutcome
+  }
+  if (input.status === 'win') return 'won'
+  if (input.status === 'loose') return 'lost'
+  return null
+}
+
+async function loadClosurePipelineStageSnapshot(
+  em: EntityManager,
+  input: {
+    pipelineId: string | null
+    closureOutcome: DealClosureOutcome
+    tenantId: string
+    organizationId: string
+  },
+): Promise<PipelineStageSnapshot | null> {
+  if (!input.pipelineId) return null
+
+  const stages = await findWithDecryption(
+    em,
+    CustomerPipelineStage,
+    {
+      pipelineId: input.pipelineId,
+      tenantId: input.tenantId,
+      organizationId: input.organizationId,
+    },
+    { orderBy: { order: 'ASC' } },
+    { tenantId: input.tenantId, organizationId: input.organizationId },
+  )
+  const aliases = TERMINAL_PIPELINE_STAGE_LABELS[input.closureOutcome]
+  const stage = stages.find((candidate) => aliases.has(normalizePipelineStageLabel(candidate.label)))
   if (!stage) return null
   return {
     id: stage.id,
@@ -681,6 +738,7 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
     }
     let nextPipelineStageLabel: string | null = null
     let resolvedCurrentPipelineStageLabel: string | null = null
+    let pipelineStageAssignmentChanged = false
 
     await runCrudCommandWrite({
       ctx,
@@ -701,18 +759,32 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
       }),
       phases: [
         async () => {
+          const requestedClosureOutcome = resolveRequestedClosureOutcome(parsed)
+          const requestedPipelineId =
+            parsed.pipelineId !== undefined ? parsed.pipelineId ?? null : record.pipelineId ?? null
+          const closureStageSnapshot =
+            parsed.pipelineStageId === undefined && requestedClosureOutcome
+              ? await loadClosurePipelineStageSnapshot(em, {
+                pipelineId: requestedPipelineId,
+                closureOutcome: requestedClosureOutcome,
+                tenantId: record.tenantId,
+                organizationId: record.organizationId,
+              })
+              : null
+          pipelineStageAssignmentChanged =
+            parsed.pipelineStageId !== undefined || closureStageSnapshot !== null
           const pipelineAssignmentChanged =
-            parsed.pipelineId !== undefined || parsed.pipelineStageId !== undefined
+            parsed.pipelineId !== undefined || pipelineStageAssignmentChanged
           const requestedPipelineStageId =
             parsed.pipelineStageId !== undefined
               ? parsed.pipelineStageId ?? null
-              : record.pipelineStageId ?? null
-          const requestedPipelineId =
-            parsed.pipelineId !== undefined ? parsed.pipelineId ?? null : record.pipelineId ?? null
+              : closureStageSnapshot?.id ?? record.pipelineStageId ?? null
 
-          nextStageSnapshot = requestedPipelineStageId && (pipelineAssignmentChanged || !record.pipelineStage)
-            ? await loadPipelineStageSnapshot(em, requestedPipelineStageId, record.tenantId, record.organizationId)
-            : null
+          nextStageSnapshot = closureStageSnapshot ?? (
+            requestedPipelineStageId && (pipelineAssignmentChanged || !record.pipelineStage)
+              ? await loadPipelineStageSnapshot(em, requestedPipelineStageId, record.tenantId, record.organizationId)
+              : null
+          )
           if (pipelineAssignmentChanged) {
             nextPipelineAssignment = resolvePipelineAssignment({
               pipelineId: requestedPipelineId,
@@ -738,14 +810,14 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
           if (parsed.description !== undefined) record.description = parsed.description ?? null
           if (parsed.status !== undefined) record.status = parsed.status ?? record.status
           if (parsed.pipelineStage !== undefined) record.pipelineStage = parsed.pipelineStage ?? null
-          if (parsed.pipelineId !== undefined || (parsed.pipelineStageId !== undefined && nextStageSnapshot)) {
+          if (parsed.pipelineId !== undefined || (pipelineStageAssignmentChanged && nextStageSnapshot)) {
             record.pipelineId = nextPipelineAssignment.pipelineId
           }
-          if (parsed.pipelineStageId !== undefined) record.pipelineStageId = nextPipelineAssignment.pipelineStageId
+          if (pipelineStageAssignmentChanged) record.pipelineStageId = nextPipelineAssignment.pipelineStageId
 
-          if (nextPipelineStageLabel && (parsed.pipelineStageId !== undefined || !record.pipelineStage)) {
+          if (nextPipelineStageLabel && (pipelineStageAssignmentChanged || !record.pipelineStage)) {
             record.pipelineStage = nextPipelineStageLabel
-          } else if (resolvedCurrentPipelineStageLabel && (parsed.pipelineStageId !== undefined || !record.pipelineStage)) {
+          } else if (resolvedCurrentPipelineStageLabel && (pipelineStageAssignmentChanged || !record.pipelineStage)) {
             record.pipelineStage = resolvedCurrentPipelineStageLabel
           }
 
@@ -774,9 +846,9 @@ const updateDealCommand: CommandHandler<DealUpdateInput, { dealId: string }> = {
           const snapshot = nextStageSnapshot
           if (!snapshot) return
           const shouldRecord =
-            parsed.pipelineStageId !== undefined &&
-            parsed.pipelineStageId !== null &&
-            parsed.pipelineStageId !== previousPipelineStageId
+            pipelineStageAssignmentChanged &&
+            nextPipelineAssignment.pipelineStageId !== null &&
+            nextPipelineAssignment.pipelineStageId !== previousPipelineStageId
           if (!shouldRecord) return
           await upsertDealStageTransition(em, {
             deal: record,


### PR DESCRIPTION
<!--
Please ensure this pull request targets the `develop` branch.
Checking the CLA box below confirms you accept the terms in docs/cla.md.
-->

## Summary

Fixes deal closure synchronization with the CRM funnel. Marking a deal Won now moves it to the matching Win/Won terminal stage, while marking it Lost moves it to Lost/Loose and retains the selected loss reason and notes.

## Changes

- Resolve terminal pipeline stages from normalized Win/Won and Lost/Loose labels.
- Apply the resolved stage and transition inside the canonical atomic deal update flow.
- Preserve explicit stage assignments and legacy behavior when a terminal stage cannot be resolved.
- Add command-level regression coverage for both closure outcomes.
- Record the bundled-Node macOS verification lesson encountered during the validation gate.

## Specification

<!-- We follow spec-driven development. Please check if a spec exists and update it accordingly. -->

**Does a spec exist for this feature/module?**
- [x] Yes
- [ ] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
<!-- Example: .ai/specs/notifications-module.md -->

`.ai/specs/2026-04-06-crm-detail-pages-ux-enhancements.md`

No specification change was required because this restores documented deal-closure behavior without changing public contracts.

## Testing

- Focused deal stage-transition and closure-event suites: 10/10 passed.
- `yarn build:packages` — passed.
- `yarn generate` — passed.
- `yarn build:packages` after generation — passed.
- `yarn i18n:check-sync` — passed.
- `yarn i18n:check-usage` — exited successfully with existing advisory findings.
- `yarn typecheck` — 22/22 passed.
- `yarn build:app` — passed.
- `yarn template:sync` — passed.
- `yarn lessons:check` — passed.
- Full `yarn test` reached 9,235 core assertions before one unrelated Jest worker received a transient `SIGSEGV`; the affected suite immediately passed 3/3 in isolation. The create-app suite passed 458 tests with 5 skipped.
- Seeded browser QA confirmed Won → Win and Lost → Loose, with the selected loss reason and notes retained.
- No new `.ai/qa/tests/` file was required: the command-layer correction has deterministic regression coverage and was exercised through the existing seeded UI flow.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` for low-risk non-customer-facing changes — and for changes with no manually exercisable UI surface that leave the database structure and API surface unchanged, preserve `BACKWARD_COMPATIBILITY.md` contracts, and ship automated tests for the behavior they change — otherwise `needs-qa`. A `needs-qa` PR cannot merge until QA adds `qa-approved` (or an engineer self-QAs: run locally, click through, attach a screenshot/written confirmation, then add `qa-approved` + `qa-self-verified` — without `triage` permission, post the evidence and ask a maintainer to apply those two labels). See `.github/QA-DEPLOYMENT.md` and `AGENTS.md` → PR Workflow for the authoritative rules.

### Design System Compliance
- [x] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [x] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [x] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [x] Loading state handled for async pages
- [x] `aria-label` on all icon-only buttons (`<IconButton>`)
- [x] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

N/A — no UI-rendering files were changed.

## Linked issues

Fixes #5106