### PR TITLE
perf(sales): index tag assignments by document_id and stop rewriting unchanged tag sets

### DIFF
--- a/packages/core/src/modules/sales/commands/__tests__/documents.tag-sync.test.ts
+++ b/packages/core/src/modules/sales/commands/__tests__/documents.tag-sync.test.ts
@@ -1,0 +1,241 @@
+/** @jest-environment node */
+
+/**
+ * syncSalesDocumentTags (packages/core/src/modules/sales/commands/documents.ts)
+ * used to delete every assignment for a document and re-insert the incoming set
+ * on any update that carried `tags`, even when the set was unchanged. These
+ * tests pin the diff behaviour: an equal set writes nothing at all, and a
+ * changed set writes only the delta.
+ */
+
+import { createContainer, asValue, InjectionMode } from 'awilix'
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+import {
+  SalesOrder,
+  SalesDocumentTag,
+  SalesDocumentTagAssignment,
+} from '../../data/entities'
+import type { DocumentUpdateInput } from '../documents'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (key: string) => key,
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/cache', () => {
+  const actual = jest.requireActual('@open-mercato/shared/lib/crud/cache')
+  return {
+    ...actual,
+    invalidateCrudCache: jest.fn(),
+  }
+})
+
+const ORDER_ID = '11111111-1111-4111-8111-111111111111'
+const ORG_ID = '22222222-2222-4222-8222-222222222222'
+const TENANT_ID = '33333333-3333-4333-8333-333333333333'
+const TAG_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TAG_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const TAG_C = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+const KNOWN_TAG_IDS = [TAG_A, TAG_B, TAG_C]
+
+function makeOrder() {
+  return {
+    id: ORDER_ID,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    orderNumber: 'O-1',
+    status: null,
+    statusEntryId: null,
+    customerEntityId: null,
+    customerContactId: null,
+    customerSnapshot: null,
+    billingAddressId: null,
+    shippingAddressId: null,
+    billingAddressSnapshot: null,
+    shippingAddressSnapshot: null,
+    currencyCode: 'USD',
+    shippingMethodId: null,
+    shippingMethodCode: null,
+    shippingMethodSnapshot: null,
+    paymentMethodId: null,
+    paymentMethodCode: null,
+    paymentMethodSnapshot: null,
+    metadata: null,
+    deletedAt: null,
+  }
+}
+
+type AssignmentShape = 'entity' | 'unwrapped' | 'column'
+
+function makeAssignment(tagId: string, shape: AssignmentShape = 'entity') {
+  const base = {
+    id: `assignment-${tagId}`,
+    organizationId: ORG_ID,
+    tenantId: TENANT_ID,
+    documentId: ORDER_ID,
+    documentKind: 'order',
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  }
+  if (shape === 'unwrapped') return { ...base, tag: tagId }
+  if (shape === 'column') return { ...base, tag: null, tag_id: tagId }
+  return { ...base, tag: { id: tagId } }
+}
+
+function makeEm(existingTagIds: string[], shape: AssignmentShape = 'entity') {
+  const assignments = existingTagIds.map((tagId) => makeAssignment(tagId, shape))
+  const em: any = {
+    findOne: jest.fn(async (entityClass: unknown) => {
+      if (entityClass === SalesOrder) return makeOrder()
+      return null
+    }),
+    find: jest.fn(async (entityClass: unknown, where: any) => {
+      if (entityClass === SalesDocumentTag) {
+        const requested: string[] = where?.id?.$in ?? []
+        return requested
+          .filter((id) => KNOWN_TAG_IDS.includes(id))
+          .map((id) => ({ id, organizationId: ORG_ID, tenantId: TENANT_ID }))
+      }
+      if (entityClass === SalesDocumentTagAssignment) return assignments
+      return []
+    }),
+    create: jest.fn((_entityClass: unknown, data: unknown) => data),
+    persist: jest.fn(),
+    remove: jest.fn(),
+    nativeDelete: jest.fn(async () => 0),
+    getReference: jest.fn((_entityClass: unknown, id: string) => ({ id })),
+    flush: jest.fn(async () => {}),
+    begin: jest.fn(async () => {}),
+    commit: jest.fn(async () => {}),
+    rollback: jest.fn(async () => {}),
+    fork: () => em,
+  }
+  return { em, assignments }
+}
+
+function makeCtx(em: unknown) {
+  const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+  container.register({ em: asValue(em) })
+  return {
+    container,
+    auth: { tenantId: TENANT_ID, orgId: ORG_ID, sub: 'user-1' },
+    selectedOrganizationId: ORG_ID,
+    organizationScope: null,
+    organizationIds: null,
+  } as any
+}
+
+async function updateOrderTags(em: unknown, tags: string[]) {
+  const handler = commandRegistry.get<DocumentUpdateInput, { order: SalesOrder }>('sales.orders.update')
+  expect(handler).toBeTruthy()
+  await handler?.execute({ id: ORDER_ID, tags }, makeCtx(em))
+}
+
+function tagIdOf(assignment: any): string {
+  return typeof assignment.tag === 'string'
+    ? assignment.tag
+    : (assignment.tag?.id ?? assignment.tag_id)
+}
+
+function persistedTagIds(em: any): string[] {
+  return em.persist.mock.calls.map(([assignment]: [any]) => tagIdOf(assignment))
+}
+
+function removedTagIds(em: any): string[] {
+  return em.remove.mock.calls.map(([assignment]: [any]) => tagIdOf(assignment))
+}
+
+describe('syncSalesDocumentTags — diff-based tag assignment sync', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../documents')
+  })
+
+  it('writes nothing when the incoming set equals the stored set', async () => {
+    const { em } = makeEm([TAG_A, TAG_B])
+
+    await updateOrderTags(em, [TAG_B, TAG_A])
+
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.remove).not.toHaveBeenCalled()
+    expect(em.nativeDelete).not.toHaveBeenCalled()
+    expect(em.create).not.toHaveBeenCalled()
+  })
+
+  it('persists only the added tag when the incoming set is a superset', async () => {
+    const { em } = makeEm([TAG_A])
+
+    await updateOrderTags(em, [TAG_A, TAG_B])
+
+    expect(persistedTagIds(em)).toEqual([TAG_B])
+    expect(em.remove).not.toHaveBeenCalled()
+  })
+
+  it('removes only the dropped assignment when the incoming set is a subset', async () => {
+    const { em } = makeEm([TAG_A, TAG_B])
+
+    await updateOrderTags(em, [TAG_A])
+
+    expect(removedTagIds(em)).toEqual([TAG_B])
+    expect(em.persist).not.toHaveBeenCalled()
+  })
+
+  it.each<[string, AssignmentShape]>([
+    ['an unwrapped tag id', 'unwrapped'],
+    ['a raw tag_id column', 'column'],
+  ])('recognises a stored assignment exposing %s', async (_label, shape) => {
+    const { em } = makeEm([TAG_A, TAG_B], shape)
+
+    await updateOrderTags(em, [TAG_A, TAG_B])
+
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.remove).not.toHaveBeenCalled()
+  })
+
+  it('keeps the untouched assignment instance when the set changes', async () => {
+    const { em, assignments } = makeEm([TAG_A, TAG_B])
+
+    await updateOrderTags(em, [TAG_A, TAG_C])
+
+    const kept = assignments.find((assignment) => assignment.tag.id === TAG_A)
+    expect(em.remove).not.toHaveBeenCalledWith(kept)
+    expect(removedTagIds(em)).toEqual([TAG_B])
+    expect(persistedTagIds(em)).toEqual([TAG_C])
+  })
+
+  it('removes every assignment when the incoming set is empty', async () => {
+    const { em } = makeEm([TAG_A, TAG_B])
+
+    await updateOrderTags(em, [])
+
+    expect(removedTagIds(em)).toEqual([TAG_A, TAG_B])
+    expect(em.persist).not.toHaveBeenCalled()
+  })
+
+  it('writes nothing when the incoming set is empty and none are stored', async () => {
+    const { em } = makeEm([])
+
+    await updateOrderTags(em, [])
+
+    expect(em.remove).not.toHaveBeenCalled()
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.nativeDelete).not.toHaveBeenCalled()
+  })
+
+  it('rejects a tag outside the document scope before writing anything', async () => {
+    const { em } = makeEm([TAG_A])
+    const unknownTag = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+
+    await expect(updateOrderTags(em, [TAG_A, unknownTag])).rejects.toMatchObject({
+      status: 400,
+    })
+
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.remove).not.toHaveBeenCalled()
+    expect(em.nativeDelete).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -3593,6 +3593,22 @@ function normalizeTagIds(tags?: Array<string | null | undefined>): string[] {
   return Array.from(set);
 }
 
+// A loaded assignment exposes its tag as an entity, an unwrapped id or the raw
+// column depending on how it was fetched; the snapshot loaders read it the same
+// defensive way. Returns null when the id cannot be determined, which callers
+// must treat as "unrecognised" rather than as a match.
+function readAssignmentTagId(assignment: {
+  tag?: unknown;
+}): string | null {
+  const tag = (assignment as { tag?: unknown }).tag;
+  if (typeof tag === "string") return tag;
+  return (
+    (tag as { id?: string } | null | undefined)?.id ??
+    (assignment as { tag_id?: string }).tag_id ??
+    null
+  );
+}
+
 function buildTagChange(
   beforeTags: TagAssignmentSnapshot[] | undefined,
   afterTags: TagAssignmentSnapshot[] | undefined,
@@ -3680,6 +3696,19 @@ function buildDocumentUpdateChangeKeys(kind: SalesDocumentKind, input: DocumentU
   return Array.from(keys);
 }
 
+// Writes only the difference between the stored and the incoming tag set, and
+// no-ops when they are equal. The previous delete-all-then-reinsert rewrote an
+// unchanged set on every save that carried `tags`: on a large
+// sales_document_tag_assignments that delete was the dominant cost of a bulk
+// import, and it also reset each assignment's id/created_at, churned the unique
+// index and left two dead tuples per document per save.
+//
+// Semantics are unchanged — a tag removed out of band still differs from the
+// incoming set and is still restored. Removals go through the UnitOfWork rather
+// than nativeDelete because the assignments are loaded (managed) here; a native
+// delete would leave stale identities behind. The add and remove sets are
+// disjoint by construction, so MikroORM's insert-before-delete commit order can
+// never transiently violate the unique (tag_id, document_id, document_kind).
 async function syncSalesDocumentTags(
   em: EntityManager,
   params: {
@@ -3692,29 +3721,38 @@ async function syncSalesDocumentTags(
 ) {
   if (params.tagIds === undefined) return;
   const tagIds = normalizeTagIds(params.tagIds);
-  if (tagIds.length === 0) {
-    await em.nativeDelete(SalesDocumentTagAssignment, {
-      documentId: params.documentId,
-      documentKind: params.kind,
+  const byId = new Map<string, SalesDocumentTag>();
+  if (tagIds.length > 0) {
+    const tagsInScope = await em.find(SalesDocumentTag, {
+      id: { $in: tagIds },
+      organizationId: params.organizationId,
+      tenantId: params.tenantId,
     });
-    return;
+    if (tagsInScope.length !== tagIds.length) {
+      throw new CrudHttpError(400, {
+        error: "One or more tags not found for this scope",
+      });
+    }
+    tagsInScope.forEach((tag) => byId.set(tag.id, tag));
   }
-  const tagsInScope = await em.find(SalesDocumentTag, {
-    id: { $in: tagIds },
-    organizationId: params.organizationId,
-    tenantId: params.tenantId,
-  });
-  if (tagsInScope.length !== tagIds.length) {
-    throw new CrudHttpError(400, {
-      error: "One or more tags not found for this scope",
-    });
-  }
-  const byId = new Map(tagsInScope.map((tag) => [tag.id, tag]));
-  await em.nativeDelete(SalesDocumentTagAssignment, {
+  const existing = await em.find(SalesDocumentTagAssignment, {
     documentId: params.documentId,
     documentKind: params.kind,
   });
-  for (const tagId of tagIds) {
+  const existingByTagId = new Map<string, (typeof existing)[number]>();
+  existing.forEach((assignment) => {
+    const tagId = readAssignmentTagId(assignment);
+    if (tagId) existingByTagId.set(tagId, assignment);
+  });
+  const wanted = new Set(tagIds);
+  const toRemove = existing.filter((assignment) => {
+    const tagId = readAssignmentTagId(assignment);
+    return tagId === null || !wanted.has(tagId);
+  });
+  const toAdd = tagIds.filter((tagId) => !existingByTagId.has(tagId));
+  if (toRemove.length === 0 && toAdd.length === 0) return;
+  toRemove.forEach((assignment) => em.remove(assignment));
+  for (const tagId of toAdd) {
     const tag = byId.get(tagId);
     if (!tag) continue;
     const assignment = em.create(SalesDocumentTagAssignment, {

--- a/packages/core/src/modules/sales/commands/documents.ts
+++ b/packages/core/src/modules/sales/commands/documents.ts
@@ -3709,6 +3709,15 @@ function buildDocumentUpdateChangeKeys(kind: SalesDocumentKind, input: DocumentU
 // delete would leave stale identities behind. The add and remove sets are
 // disjoint by construction, so MikroORM's insert-before-delete commit order can
 // never transiently violate the unique (tag_id, document_id, document_kind).
+//
+// The assignment read below is deliberately scoped by document only, with no
+// organization/tenant predicate — unlike the display reads in
+// api/documents/factory.ts, and unlike the tag-scope check above. It has to
+// match the scope of the unique constraint it reconciles against, which spans
+// (tag_id, document_id, document_kind) and no scope columns. Narrowing the read
+// would hide a mis-scoped row from the diff, put its tag in the add set, and
+// turn the insert into a unique-constraint violation. The document itself is
+// already scope-checked by the caller before this runs.
 async function syncSalesDocumentTags(
   em: EntityManager,
   params: {

--- a/packages/core/src/modules/sales/data/entities.ts
+++ b/packages/core/src/modules/sales/data/entities.ts
@@ -1947,6 +1947,7 @@ export class SalesDocumentTag {
 
 @Entity({ tableName: 'sales_document_tag_assignments' })
 @Index({ name: 'sales_document_tag_assignments_scope_idx', properties: ['organizationId', 'tenantId'] })
+@Index({ name: 'sales_document_tag_assignments_document_idx', properties: ['documentId'] })
 @Unique({
   name: 'sales_document_tag_assignments_unique',
   properties: ['tag', 'documentId', 'documentKind'],

--- a/packages/core/src/modules/sales/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/sales/migrations/.snapshot-open-mercato.json
@@ -2343,6 +2343,16 @@
         },
         {
           "columnNames": [
+            "document_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sales_document_tag_assignments_document_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
             "tag_id",
             "document_id",
             "document_kind"

--- a/packages/core/src/modules/sales/migrations/Migration20260806120000_sales_tag_assignment_document_idx.ts
+++ b/packages/core/src/modules/sales/migrations/Migration20260806120000_sales_tag_assignment_document_idx.ts
@@ -23,12 +23,17 @@ import { Migration } from '@mikro-orm/migrations';
 // The table is high-churn, so the index is built CONCURRENTLY to avoid blocking
 // writes during the build. CREATE INDEX CONCURRENTLY cannot run inside a
 // transaction, hence isTransactional() => false; the migration runner applies
-// migrations one-by-one, so this opt-out is safe (same pattern as
-// Migration20260611103000_query_index). Drop first so retrying a failed
-// concurrent build removes PostgreSQL's invalid index stub instead of letting
-// IF NOT EXISTS silently accept it: a half-built concurrent index is left
-// INVALID, the planner ignores it, and IF NOT EXISTS would report success while
-// the table stays unindexed.
+// migrations one-by-one, so this opt-out is safe. Drop first so retrying a
+// failed concurrent build removes PostgreSQL's invalid index stub instead of
+// letting IF NOT EXISTS silently accept it: a half-built concurrent index is
+// left INVALID, the planner ignores it, and IF NOT EXISTS would report success
+// while the table stays unindexed.
+//
+// Both halves follow Migration20260731105052_query_index, which builds
+// concurrently and drops first for the same reason. The earlier
+// Migration20260611103000_query_index builds concurrently but uses IF NOT
+// EXISTS without the drop — cited here only so a reader comparing the two knows
+// the divergence is deliberate rather than an oversight.
 //
 // On a database that does not have the index yet — every fresh install — the
 // drop is a no-op and there is no window without it. An operator who already

--- a/packages/core/src/modules/sales/migrations/Migration20260806120000_sales_tag_assignment_document_idx.ts
+++ b/packages/core/src/modules/sales/migrations/Migration20260806120000_sales_tag_assignment_document_idx.ts
@@ -26,7 +26,16 @@ import { Migration } from '@mikro-orm/migrations';
 // migrations one-by-one, so this opt-out is safe (same pattern as
 // Migration20260611103000_query_index). Drop first so retrying a failed
 // concurrent build removes PostgreSQL's invalid index stub instead of letting
-// IF NOT EXISTS silently accept it.
+// IF NOT EXISTS silently accept it: a half-built concurrent index is left
+// INVALID, the planner ignores it, and IF NOT EXISTS would report success while
+// the table stays unindexed.
+//
+// On a database that does not have the index yet — every fresh install — the
+// drop is a no-op and there is no window without it. An operator who already
+// created this index out of band should expect it to be rebuilt here, and the
+// document-scoped scans to fall back to their pre-index cost until the
+// concurrent build finishes; on a large table, run this while the writers that
+// depend on it are paused.
 export class Migration20260806120000_sales_tag_assignment_document_idx extends Migration {
 
   override isTransactional(): boolean {

--- a/packages/core/src/modules/sales/migrations/Migration20260806120000_sales_tag_assignment_document_idx.ts
+++ b/packages/core/src/modules/sales/migrations/Migration20260806120000_sales_tag_assignment_document_idx.ts
@@ -1,0 +1,45 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// sales_document_tag_assignments had no index whose leading column is
+// document_id: the table carries PK(id), (organization_id, tenant_id) and the
+// unique (tag_id, document_id, document_kind) — and the unique index leads with
+// tag_id, which a document-scoped predicate never supplies. Every read and
+// write that resolves a document's tags therefore degraded to a sequential scan
+// as the table grew: syncSalesDocumentTags' per-save delete
+// (commands/documents.ts) and the order/quote grid's
+// `left join ... on id = document_id` (api/documents/factory.ts) alike. On a
+// 2.85M-row / 868MB production table the delete measured 139.9 ms — a full
+// table scan to remove the two rows belonging to one order.
+//
+// document_kind is deliberately omitted. sales_orders.id and sales_quotes.id
+// are both gen_random_uuid() from their own tables, so a document_id already
+// determines its kind; the second column adds no selectivity for ~30% more
+// index and document_kind is simply rechecked over the rows the seek returns.
+// The unique (tag_id, document_id, document_kind) index stays as-is — its
+// leading tag_id is load-bearing for sales.tags.delete (commands/tags.ts), for
+// the grid's tag filter and for the foreign-key check. Both column orders are
+// needed; two indexes is correct.
+//
+// The table is high-churn, so the index is built CONCURRENTLY to avoid blocking
+// writes during the build. CREATE INDEX CONCURRENTLY cannot run inside a
+// transaction, hence isTransactional() => false; the migration runner applies
+// migrations one-by-one, so this opt-out is safe (same pattern as
+// Migration20260611103000_query_index). Drop first so retrying a failed
+// concurrent build removes PostgreSQL's invalid index stub instead of letting
+// IF NOT EXISTS silently accept it.
+export class Migration20260806120000_sales_tag_assignment_document_idx extends Migration {
+
+  override isTransactional(): boolean {
+    return false;
+  }
+
+  override up(): void | Promise<void> {
+    this.addSql(`drop index concurrently if exists "sales_document_tag_assignments_document_idx";`);
+    this.addSql(`create index concurrently "sales_document_tag_assignments_document_idx" on "sales_document_tag_assignments" ("document_id");`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`drop index concurrently if exists "sales_document_tag_assignments_document_idx";`);
+  }
+
+}


### PR DESCRIPTION
## Summary

`syncSalesDocumentTags` deleted every tag assignment for a sales document and re-inserted the incoming set whenever an update payload carried `tags` — even when the incoming set was identical. Two costs, both paid by every consumer of core (admin order saves, quotes, any integrator):

**1. The delete had no usable index.** `sales_document_tag_assignments` carries PK(`id`), `(organization_id, tenant_id)` and the unique `(tag_id, document_id, document_kind)`. The unique index leads with `tag_id`, which a document-scoped predicate never supplies, so nothing could serve a `document_id` filter. `EXPLAIN` on a 2.85M-row / 868MB production table:

> seq scan, 2,849,802 rows removed by filter, 868 MB, **139.9 ms**

Averaged over a traced sample of 10,980 order writes that was **106 ms/order — 35% of the total per-order write cost** (301.6 ms/order; for comparison, the source read feeding that pipeline was 0.6 ms). Every document paid a full table scan to rewrite the two rows it already had. The order/quote grid's `left join … on id = document_id` (`api/documents/factory.ts`) hit the same missing access path on every list page, for every tenant.

**2. The rewrite was pure churn on an unchanged set:** two dead tuples per document per save, the unique index churned, and each assignment's `id`/`created_at` reset — so "when was this tag applied" always read as "just now".

The fix is the pair: the index makes the document-scoped lookup an index seek, and the diff stops issuing the write at all when nothing changed. They are ordered — the diff's read filters on `document_id`, so without the index it would trade one unindexed scan for another.

Measured effect from the same traced sample: **301.6 → ~196 ms/order (1.54×)** from the index alone; the diff then removes the remaining DELETE and two INSERTs on unchanged sets entirely.

## Changes

- **`data/entities.ts`** — `@Index({ name: 'sales_document_tag_assignments_document_idx', properties: ['documentId'] })` on `SalesDocumentTagAssignment`.
- **`migrations/Migration20260806120000_sales_tag_assignment_document_idx.ts`** — creates that index `CONCURRENTLY` with `isTransactional() => false`, following `Migration20260731105052_query_index`. It drops first: a `CREATE INDEX CONCURRENTLY` that fails midway leaves the index **INVALID**, the planner ignores it, and `IF NOT EXISTS` would report success while the table stays unindexed. On a database that does not have the index yet the drop is a no-op and there is no window without it; the header spells out both sides.
- **`migrations/.snapshot-open-mercato.json`** — the new index entry. `yarn db:generate` reports `sales: no changes` against it.
- **`commands/documents.ts`** — `syncSalesDocumentTags` reads the current assignments, computes add/remove, and returns without writing when the sets are equal.
- **`commands/__tests__/documents.tag-sync.test.ts`** — new; the module had no tag-sync coverage.

Two index decisions worth stating explicitly, since both look like omissions:

- **`document_kind` is deliberately not in the index.** `sales_orders.id` and `sales_quotes.id` are both `gen_random_uuid()` from their own tables, so a `document_id` already determines its kind. The second column adds no selectivity for ~30% more index; `document_kind` is simply rechecked over the rows the seek returns.
- **The unique `(tag_id, document_id, document_kind)` index stays as-is.** Reordering it to carry a single index would regress `sales.tags.delete` (`commands/tags.ts`, `nativeDelete({ tag: tag.id })`), the grid's tag filter and the FK check, all of which need `tag_id` leading. Both column orders are genuinely needed.

Notes on the diff implementation:

- **Semantics are unchanged.** A tag removed out of band still differs from the incoming set and is still restored. An out-of-scope tag id still fails with `400` before anything is written. What changes is that assignment `id`/`created_at` now survive an unchanged save — which also makes the forward path agree with the undo restore path, since that recreates assignments by snapshot id.
- **Removals go through the UnitOfWork, not `nativeDelete`.** The assignments are loaded (managed) here, and a native delete would leave stale identities behind — the reason the snapshot-restore paths in this file call `unsetIdentity`.
- **The add and remove sets are disjoint by construction**, so MikroORM's insert-before-delete commit order cannot transiently violate the unique constraint.
- **The read of existing assignments is deliberately scoped by document only**, with no organization/tenant predicate — unlike the display reads in `api/documents/factory.ts`. It has to match the scope of the unique constraint it reconciles against, which spans `(tag_id, document_id, document_kind)` and no scope columns. Narrowing it would hide a mis-scoped row from the diff, put its tag in the add set, and turn the insert into a unique-constraint violation. The document itself is scope-checked by the caller before this runs. Raised in review; the rationale now lives in the code so the predicate does not get "corrected" into a 500.
- The tag id is read off a loaded assignment the same defensive way the snapshot loaders in this file already do (entity / unwrapped id / raw `tag_id` column). This file is under `@ts-nocheck`, so a shape mismatch would not be caught by the compiler, and misreading it would silently degrade the diff back into a full rewrite.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
_None. This is a contained performance fix to one helper plus its index; it changes no contract surface, no API shape and no behaviour a spec would describe._

## Testing

**CI:** all 23 checks pass — `test`, `lint`, `ds-lint`, `audit`, `audit-scope`, `merge-coverage`, `prepare`, `license/cla`, and 15/15 `ephemeral-integration` shards. (`docker-build` skipped.)

Full local gate, also green:

```
yarn build:packages → yarn generate → yarn build:packages
yarn i18n:check-sync → yarn i18n:check-usage
yarn typecheck → yarn lint → yarn test → yarn build:app
```

- `yarn test`: 23/23 workspace packages, including `@open-mercato/core` at **8265 tests** (1085 suites) and **479 sales tests** (71 suites).
- `yarn lint`: 0 errors.
- `yarn db:generate`: reports **`sales: no changes`**, confirming the hand-edited snapshot matches the entity exactly.
- `yarn i18n:check-usage` reports 2 pre-existing missing keys in `packages/ui/src/backend/fields/phone.tsx` — a file this branch does not touch.
- `yarn db:migrate` was **not** run; this PR ships the migration and snapshot, not applied local state.

New unit coverage in `documents.tag-sync.test.ts` (9 cases), mapped to what each pins: an equal set writes nothing at all (the regression this PR exists to prevent, asserted against `persist`, `remove`, `create` **and** `nativeDelete`); a superset/subset writes only the delta; an empty set clears; the untouched assignment instance is never recreated (id/`created_at` stability); the out-of-scope guard still fires before any write; and all three shapes a loaded assignment can expose its tag id in are recognised. Verified to fail (6 of 9) against the pre-change implementation, so they are not passing vacuously.

**Not covered:** the `EntityManager` is mocked, so these tests pin which methods the helper calls, not what MikroORM does with them. The properties the safety argument rests on — that insert-before-delete cannot violate the unique constraint, that `em.remove` on managed entities leaves no stale identity, that a loaded assignment exposes its tag id in one of the handled shapes — are outside what a mocked EM can observe. If the relation ever moves to `ref: true`, a fourth shape would make `readAssignmentTagId` return `null` and silently degrade this back into the full rewrite; that is the moment to add an integration-level assertion.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. <!-- generators run; no locale or doc change required — no user-facing strings added -->
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set.

Notes on the unticked boxes:

- **Integration tests** — no new integration spec is added. The change is exercised through the existing `sales.orders.update` / `sales.quotes.update` command paths, whose integration coverage under `.ai/qa/tests/` is unchanged, and the behaviour being pinned (which SQL statements are issued for a given tag set) is observable at the unit level but not through the HTTP surface.
- **Spec** — see the Specification section above; N/A for a change of this shape.

### Design System Compliance

N/A — no UI files are touched. The diff is four files under `modules/sales` plus the migration snapshot.

## Follow-ups

Deliberately out of scope here, each with its reasoning on the review thread:

- **Tag chip display order.** `attachDocumentTags` reads with no `orderBy`, so chip order was never guaranteed. The old delete-and-reinsert incidentally returned rows in submitted order; keeping untouched rows makes that indeterminacy observable. An explicit `orderBy` would fix it deterministically — a user-visible ordering change that belongs in its own PR with its own QA.
- **`"One or more tags not found for this scope"` is untranslated.** Pre-existing text this diff only moved; routing it through `translate()` means new keys across all four locales, since `i18n:check-sync` requires them in step.
- **Integration-level assertion** on the mocked-EM gap described under Testing.

## Linked issues

None.

---

The unscoped-read rationale and the corrected migration precedent above both came from review feedback on this PR.
