### PR TITLE
fix(create-app): align skill setup message indentation

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1,6 +1,6 @@
 # Lessons
 
-This catalog indexes 116 focused lessons without loading their full text. Route the task first, then read only records whose **modules**, standalone-harness **areas**, or **topics** match the work.
+This catalog indexes 117 focused lessons without loading their full text. Route the task first, then read only records whose **modules**, standalone-harness **areas**, or **topics** match the work.
 
 ## How to use this catalog
 
@@ -149,6 +149,7 @@ rg -l '"<area>"|"<module>"|"<topic>"' .ai/lessons/*.md
 
 - [Anchor repeated route-handler edits to unique context](lessons/anchor-repeated-route-handler-edits-to-unique-context.md) — area:debugging,testing; module:messages; topic:route-coverage,testing
 - [Compose startup commands must not hard-depend on newly added image scripts](lessons/compose-startup-commands-must-not-hard-depend-on-newly.md) — area:debugging,module-data,architecture; module:create_app; topic:command-pattern,runtime-startup,template-sync
+- [Embedded CLI output must inherit its caller's presentation margin](lessons/embedded-cli-output-must-inherit-its-callers-presentation.md) — area:debugging; module:create_app,cli; topic:runtime-startup,testing
 - [Package builds that publish `dist/` must clear stale artifacts first](lessons/package-builds-that-publish-dist-must-clear-stale.md) — area:debugging,module-data,architecture; module:create_app; topic:build-output,generated-files,database-migrations
 - [`/_global-error` prerender failures are Next version issues, not app code](lessons/global-error-prerender-failures-are-next-version-issues.md) — area:debugging,testing,architecture; module:create_app,ui; topic:package-runtime,generated-files,template-sync
 

--- a/.ai/lessons/embedded-cli-output-must-inherit-its-callers-presentation.md
+++ b/.ai/lessons/embedded-cli-output-must-inherit-its-callers-presentation.md
@@ -1,0 +1,16 @@
+---
+title: "Embedded CLI output must inherit its caller's presentation margin"
+modules: ["create_app","cli"]
+areas: ["debugging"]
+topics: ["runtime-startup","testing"]
+---
+
+# Embedded CLI output must inherit its caller's presentation margin
+
+**Context**: The create-app and `mercato agentic:init` wizards printed a three-space-indented skill-installation heading, then inherited the standalone skill installer's independently formatted output.
+
+**Problem**: Inherited child output started at column zero, breaking the wizard's visual hierarchy. Hard-coding the margin in the child would also make direct `yarn install-skills` output unexpectedly indented.
+
+**Rule**: When a CLI embeds another CLI's inherited output, pass presentation context explicitly and apply it uniformly to the child's stdout and stderr. Keep direct invocation formatting unchanged, and test the composed parent-child output with line-anchored assertions.
+
+**Applies to**: `packages/create-app/src/setup/wizard.ts`, `packages/cli/src/lib/agentic-setup.ts`, and `packages/create-app/agentic/shared/scripts/install-skills.mjs`.

--- a/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
+++ b/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
@@ -1,0 +1,48 @@
+# Create-app skill message indentation
+
+## Goal
+
+Make the skill-installation messages emitted during `create-mercato-app` agentic setup use the same three-space indentation as the surrounding wizard output.
+
+## Scope
+
+- Add a regression assertion for the default standalone skill-installer summary.
+- Indent the summary lines that report installed local skills, external skills, layout, and the opt-in tier tip.
+- Preserve all message wording, install behavior, flags, and direct invocation semantics.
+
+## Non-goals
+
+- Rewording or reorganizing the agentic setup summary.
+- Changing skill selection, installation, external downloads, or agent link layout.
+- Changing monorepo shell installer output or unrelated create-app prompts.
+
+## Implementation Plan
+
+### Phase 1: Regression repair
+
+1. Add a regression oracle that requires every default standalone skill-installer summary line to start with the wizard's three-space indentation.
+2. Apply the minimal indentation fix to the default standalone skill-installer summary.
+
+### Phase 2: Verification and delivery
+
+1. Run the focused create-app tests and the configured full validation gate.
+2. Run the authoritative automated PR review/autofix pass and finalize the PR metadata and summary.
+
+## Risks
+
+- Tests or downstream scripts may match the exact console text. The wording remains unchanged, and the regression test limits the intended delta to leading whitespace.
+- The bundled installer is also used by `mercato agentic:init`; consistent indentation is desirable there because its surrounding setup output uses the same three-space convention.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Regression repair
+
+- [ ] 1.1 Add a regression oracle that requires every default standalone skill-installer summary line to start with the wizard's three-space indentation.
+- [ ] 1.2 Apply the minimal indentation fix to the default standalone skill-installer summary.
+
+### Phase 2: Verification and delivery
+
+- [ ] 2.1 Run the focused create-app tests and the configured full validation gate.
+- [ ] 2.2 Run the authoritative automated PR review/autofix pass and finalize the PR metadata and summary.

--- a/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
+++ b/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
@@ -47,4 +47,4 @@ PR: #5158
 ### Phase 2: Verification and delivery
 
 - [x] 2.1 Run the focused create-app tests and the configured full validation gate. — 2535a08d5
-- [ ] 2.2 Run the authoritative automated PR review/autofix pass and finalize the PR metadata and summary.
+- [x] 2.2 Run the authoritative automated PR review/autofix pass and finalize the PR metadata and summary. — 0b0c792db

--- a/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
+++ b/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
@@ -39,8 +39,8 @@ Make the skill-installation messages emitted during `create-mercato-app` agentic
 
 ### Phase 1: Regression repair
 
-- [ ] 1.1 Add a regression oracle that requires every default standalone skill-installer summary line to start with the wizard's three-space indentation.
-- [ ] 1.2 Apply the minimal indentation fix to the default standalone skill-installer summary.
+- [x] 1.1 Add a regression oracle that requires every default standalone skill-installer summary line to start with the wizard's three-space indentation. — 2535a08d5
+- [x] 1.2 Apply the minimal indentation fix to the default standalone skill-installer summary. — 2535a08d5
 
 ### Phase 2: Verification and delivery
 

--- a/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
+++ b/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
@@ -35,6 +35,8 @@ Make the skill-installation messages emitted during `create-mercato-app` agentic
 
 ## Progress
 
+PR: #5158
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Regression repair
@@ -44,5 +46,5 @@ Make the skill-installation messages emitted during `create-mercato-app` agentic
 
 ### Phase 2: Verification and delivery
 
-- [ ] 2.1 Run the focused create-app tests and the configured full validation gate.
+- [x] 2.1 Run the focused create-app tests and the configured full validation gate. — 2535a08d5
 - [ ] 2.2 Run the authoritative automated PR review/autofix pass and finalize the PR metadata and summary.

--- a/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
+++ b/.ai/runs/2026-08-10-create-app-skill-message-indentation.md
@@ -7,7 +7,7 @@ Make the skill-installation messages emitted during `create-mercato-app` agentic
 ## Scope
 
 - Add a regression assertion for the default standalone skill-installer summary.
-- Indent the summary lines that report installed local skills, external skills, layout, and the opt-in tier tip.
+- Indent standalone installer output only when it is embedded by create-app or `mercato agentic:init`, including success and failure messages.
 - Preserve all message wording, install behavior, flags, and direct invocation semantics.
 
 ## Non-goals

--- a/packages/cli/src/lib/agentic-setup.ts
+++ b/packages/cli/src/lib/agentic-setup.ts
@@ -914,7 +914,11 @@ function installSkills(targetDir: string): void {
   if (!existsSync(installScript)) return
   console.log('')
   console.log('   Installing agent skills (local tiers + external open-mercato/skills subset)...')
-  const result = spawnSync(process.execPath, [installScript], { cwd: targetDir, stdio: 'inherit' })
+  const result = spawnSync(process.execPath, [installScript], {
+    cwd: targetDir,
+    stdio: 'inherit',
+    env: { ...process.env, OM_SKILLS_OUTPUT_INDENT: '3' },
+  })
   if (result.error || result.status !== 0) {
     console.log('   ⚠ Skill installation did not complete; run `yarn install-skills` inside the app when online.')
   }

--- a/packages/create-app/agentic/shared/scripts/install-skills.mjs
+++ b/packages/create-app/agentic/shared/scripts/install-skills.mjs
@@ -35,6 +35,27 @@ const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/
 const ARCHIVE_LIMIT_BYTES = 32 * 1024 * 1024
 const EXTRACTED_LIMIT_BYTES = 256 * 1024 * 1024
 const EXTERNAL_OWNERSHIP_FILE = '.om-external-ownership.json'
+const requestedOutputIndent = Number.parseInt(process.env.OM_SKILLS_OUTPUT_INDENT ?? '0', 10)
+const outputIndent = Number.isSafeInteger(requestedOutputIndent) && requestedOutputIndent > 0
+  ? Math.min(requestedOutputIndent, 12)
+  : 0
+const outputPrefix = ' '.repeat(outputIndent)
+
+function formatOutput(message) {
+  return String(message).replace(/^(?=.)/gm, outputPrefix)
+}
+
+function log(message = '') {
+  console.log(formatOutput(message))
+}
+
+function warn(message) {
+  console.warn(formatOutput(message))
+}
+
+function logError(message) {
+  console.error(formatOutput(message))
+}
 
 const USAGE = `Usage: install-skills.mjs [options]
 
@@ -400,14 +421,14 @@ function selectedExternalConfig(manifest, tiers) {
 function printCatalog(manifest) {
   for (const [name, tier] of Object.entries(manifest.tiers).sort(([left], [right]) => left.localeCompare(right))) {
     const label = manifest.default.includes(name) ? 'default' : 'opt-in'
-    console.log(`${name.padEnd(12)} (${tier.skills.length} skills, ${label}):`)
-    console.log(`  ${tier.skills.join(', ')}`)
+    log(`${name.padEnd(12)} (${tier.skills.length} skills, ${label}):`)
+    log(`  ${tier.skills.join(', ')}`)
   }
-  console.log(`\nexternal     (${manifest.external.skills.length} skills available, pinned):`)
-  console.log(`  source: ${manifest.external.source}@${manifest.external.ref}`)
+  log(`\nexternal     (${manifest.external.skills.length} skills available, pinned):`)
+  log(`  source: ${manifest.external.source}@${manifest.external.ref}`)
   for (const [name, tier] of Object.entries(manifest.external.tiers).sort(([left], [right]) => left.localeCompare(right))) {
     const label = manifest.default.includes(name) ? 'default' : 'opt-in'
-    console.log(`  ${name.padEnd(10)} (${tier.skills.length} entry skills, ${label}; dependencies added): ${tier.skills.join(', ')}`)
+    log(`  ${name.padEnd(10)} (${tier.skills.length} entry skills, ${label}; dependencies added): ${tier.skills.join(', ')}`)
   }
 }
 
@@ -834,7 +855,7 @@ async function installExternal(rootDir, external, fetchImpl, downloadSource, act
             removeInstallerTransactionPath(rootDir, transaction.backupDestination)
             transaction.backedUp = false
           } catch (error) {
-            console.warn(`install-skills: warning: committed '${transaction.skill}' but could not remove its hidden backup (${error.message})`)
+            warn(`install-skills: warning: committed '${transaction.skill}' but could not remove its hidden backup (${error.message})`)
           }
         }
       }
@@ -925,7 +946,7 @@ export async function runInstaller({
 } = {}) {
   const options = parseArgs(args, env)
   if (options.help) {
-    console.log(USAGE)
+    log(USAGE)
     return 0
   }
   rootDir = realInstallerRoot(rootDir)
@@ -937,7 +958,7 @@ export async function runInstaller({
   }
   if (options.clean) {
     cleanAllLinks(rootDir)
-    console.log('Removed harness-owned skill links; user-owned paths and installed external directories were preserved.')
+    log('Removed harness-owned skill links; user-owned paths and installed external directories were preserved.')
     return 0
   }
   const ignoredAgents = options.ignoreAgents ?? manifest.agents?.ignore ?? []
@@ -953,7 +974,7 @@ export async function runInstaller({
   prepareLinkDirectory(rootDir, join(rootDir, '.agents', 'skills'), join(rootDir, '.ai', 'skills'), join(rootDir, '.agents', 'skills'))
   const quarantined = reconcileExternalSkillVisibility(rootDir, external)
   for (const item of quarantined) {
-    console.warn(`install-skills: quarantined stale or modified managed skill '${item.skill}' outside agent discovery: ${item.path}`)
+    warn(`install-skills: quarantined stale or modified managed skill '${item.skill}' outside agent discovery: ${item.path}`)
   }
   let externalStatus = 'skipped (--no-external)'
   let refreshDownload
@@ -985,8 +1006,8 @@ export async function runInstaller({
           throw error
         }
         externalStatus = `unavailable (${error.message})`
-        console.warn(`install-skills: warning: ${error.message}`)
-        console.warn('  Local skills will still be installed. Retry with `yarn install-skills` when online.')
+        warn(`install-skills: warning: ${error.message}`)
+        warn('  Local skills will still be installed. Retry with `yarn install-skills` when online.')
       }
     }
   } finally {
@@ -1006,12 +1027,12 @@ export async function runInstaller({
       cleanManagedLinks(rootDir, harnessDir, join(rootDir, '.ai', 'skills'), join(rootDir, '.agents', 'skills'))
     }
   }
-  console.log(`Installed ${localSkills.length} local skills across ${tiers.length} tier(s): ${tiers.join(', ')}.`)
-  console.log(`External skills: ${externalStatus}.`)
-  if (options.update) console.log(`Pinned current shared skills at ${external.ref}.`)
+  log(`Installed ${localSkills.length} local skills across ${tiers.length} tier(s): ${tiers.join(', ')}.`)
+  log(`External skills: ${externalStatus}.`)
+  if (options.update) log(`Pinned current shared skills at ${external.ref}.`)
   const links = linkAgents.filter((agent) => !ignoredAgents.includes(agent))
-  console.log(`Layout: .agents/skills/ (canonical); per-agent links: ${links.join(', ') || 'none'}.`)
-  if (options.mode === 'default') console.log('Tip: inspect opt-in tiers with `yarn install-skills --list`.')
+  log(`Layout: .agents/skills/ (canonical); per-agent links: ${links.join(', ') || 'none'}.`)
+  if (options.mode === 'default') log('Tip: inspect opt-in tiers with `yarn install-skills --list`.')
   return 0
 }
 
@@ -1023,7 +1044,7 @@ const isEntryPoint = process.argv[1] && realpathSync(process.argv[1]) === realpa
 if (isEntryPoint) {
   const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..')
   runInstaller({ rootDir, args: process.argv.slice(2) }).catch((error) => {
-    console.error(error.message)
+    logError(error.message)
     process.exitCode = 1
   })
 }

--- a/packages/create-app/src/lib/install-skills-standalone.test.ts
+++ b/packages/create-app/src/lib/install-skills-standalone.test.ts
@@ -127,7 +127,7 @@ test('standalone installer runs when invoked through a symlinked app path', { sk
     const result = run(aliasRoot, '--no-external')
     assert.equal(result.status, 0, result.stderr)
     assert.equal(fs.readlinkSync(path.join(root, '.agents', 'skills', 'om-alpha')), '../../.ai/skills/om-alpha')
-    assert.match(result.stdout, /Installed 1 local skills/)
+    assert.match(result.stdout, /^Installed 1 local skills/m)
   } finally {
     removeFixture(aliasParent)
     removeFixture(root)

--- a/packages/create-app/src/setup/wizard.test.ts
+++ b/packages/create-app/src/setup/wizard.test.ts
@@ -1,7 +1,14 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { AGENT_TOOL_IDS, parseAgentsValue, promptSelection } from './wizard.js'
 import type { AskFn } from './wizard.js'
+
+const wizardPath = fileURLToPath(new URL('./wizard.ts', import.meta.url))
 
 test('parseAgentsValue: single tool', () => {
   assert.deepEqual(parseAgentsValue('claude-code'), { skip: false, tools: ['claude-code'] })
@@ -76,4 +83,33 @@ test('promptSelection: an interactive shell still honors the answer', async () =
     assert.deepEqual(await promptSelection(() => Promise.resolve('')), ['claude-code'])
     assert.deepEqual(await promptSelection(() => Promise.resolve('5')), ['skip'])
   })
+})
+
+test('runAgenticSetup: embeds skill installer output at the wizard margin', () => {
+  const targetDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'om-wizard-indent-')))
+  const script = `
+    import { runAgenticSetup } from ${JSON.stringify(pathToFileURL(wizardPath).href)}
+    await runAgenticSetup(${JSON.stringify(targetDir)}, async () => '', { tool: 'test-output' })
+  `
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', '--input-type=module', '--eval', script],
+      {
+        cwd: path.dirname(wizardPath),
+        encoding: 'utf8',
+        env: { ...process.env, OM_SKIP_EXTERNAL_SKILLS: '1' },
+      },
+    )
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /^   Installed \d+ local skills/m)
+    assert.match(result.stdout, /^   External skills:/m)
+    assert.match(result.stdout, /^   Layout:/m)
+    assert.match(result.stdout, /^   Tip:/m)
+    assert.doesNotMatch(result.stdout, /^(?:Installed \d+ local skills|External skills:|Layout:|Tip:)/m)
+  } finally {
+    fs.rmSync(targetDir, { recursive: true, force: true })
+  }
 })

--- a/packages/create-app/src/setup/wizard.ts
+++ b/packages/create-app/src/setup/wizard.ts
@@ -197,7 +197,11 @@ function installSkills(targetDir: string): void {
   if (!existsSync(installScript)) return
   console.log('')
   console.log('   Installing agent skills (local tiers + external open-mercato/skills subset)...')
-  const result = spawnSync(process.execPath, [installScript], { cwd: targetDir, stdio: 'inherit' })
+  const result = spawnSync(process.execPath, [installScript], {
+    cwd: targetDir,
+    stdio: 'inherit',
+    env: { ...process.env, OM_SKILLS_OUTPUT_INDENT: '3' },
+  })
   if (result.error || result.status !== 0) {
     console.log('   ⚠ Skill installation did not complete; run `yarn install-skills` inside the app when online.')
   }


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-10-create-app-skill-message-indentation.md
Status: complete

## 🎯 Goal

- Make skill-installation messages line up with the three-space margin used by the surrounding create-app agentic setup, while keeping direct installer output and message wording unchanged.

## What Changed

- Added an internal, bounded output-indent setting to the bundled standalone skill installer and applied it consistently to informational, warning, and error messages.
- Passed a three-space output margin from both create-app's agentic wizard and `mercato agentic:init`, which share the embedded installer.
- Added behavioral regression coverage for the embedded three-space output and the standalone flush-left default.
- Recorded the reusable embedded-CLI presentation lesson and completed the Progress-tracked run plan.

## 🧪 Tests

- `yarn workspace create-mercato-app exec node --import tsx --test --test-timeout=120000 src/setup/wizard.test.ts src/lib/install-skills-standalone.test.ts` — 41 passed.
- `yarn workspace create-mercato-app typecheck` — passed.
- `yarn workspace @open-mercato/cli typecheck` — passed.
- `yarn lessons:check` and `git diff --check` — passed.
- `yarn test:create-app` — passed against the published scaffold and exercised the corrected three-space output.
- Configured validation gate — `yarn build:packages`, `yarn generate`, post-generation `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, and `yarn build:app` all passed. The production build emitted only existing filesystem-tracing warnings.
- Additional exhaustive `yarn test:create-app:integration --cleanup` run — 1,872 passed, 102 skipped, and one harness probe passed on retry. Five unrelated scenarios still failed after retry: invitation email capture, bulk owner processing, two public-token route cases, and a sales-extension update assertion; none exercise the changed installer or embedding paths.

## 💥 Breaking Changes

- None. Commands, flags, message wording, direct output formatting, and install behavior remain compatible.

## 📋 Progress

See the Progress section in the tracking plan.
