### PR TITLE
fix(ai-assistant): stabilize standalone example startup

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -52,7 +52,7 @@ rg -l '"<area>"|"<module>"|"<topic>"' .ai/lessons/*.md
 
 ### module-data
 
-- [`dbMigrate` must not write migration snapshots during initialize flows](lessons/dbmigrate-must-not-write-migration-snapshots-during.md) — area:module-data,architecture; module:cli; topic:generated-files,database-migrations,runtime-startup
+- [`dbMigrate` must not write migration snapshots during initialize flows](lessons/dbmigrate-must-not-write-migration-snapshots-during.md) — area:module-data,architecture; module:cli,create_app; topic:generated-files,database-migrations,runtime-startup
 - [A self-request needs data committed outside the caller's transaction](lessons/a-self-request-needs-data-committed-outside-the-callers.md) — area:module-data; module:auth,checkout,query_index; topic:data-integrity,query-index,workers
 - [Avoid identity-map stale snapshots in command logs](lessons/avoid-identity-map-stale-snapshots-in-command-logs.md) — area:module-data,debugging; module:audit_logs,cache; topic:command-pattern,data-integrity,generated-files
 - [Classify entity metadata by ORM ownership before custom declarations](lessons/classify-entity-metadata-by-orm-ownership-before-custom.md) — area:module-data; module:entities; topic:access-control,filters

--- a/.ai/lessons/dbmigrate-must-not-write-migration-snapshots-during.md
+++ b/.ai/lessons/dbmigrate-must-not-write-migration-snapshots-during.md
@@ -1,6 +1,6 @@
 ---
 title: "`dbMigrate` must not write migration snapshots during initialize flows"
-modules: ["cli"]
+modules: ["cli","create_app"]
 areas: ["module-data","architecture"]
 topics: ["generated-files","database-migrations","runtime-startup"]
 ---
@@ -13,4 +13,6 @@ topics: ["generated-files","database-migrations","runtime-startup"]
 
 **Rule**: Keep stable snapshot naming for `dbGenerate`, but disable migration snapshots for `dbMigrate` (`snapshot: false`) so initialize applies committed migrations without mutating snapshot files.
 
-**Applies to**: `packages/cli/src/lib/db/commands.ts` and any future init/bootstrap flow that calls `dbMigrate`.
+**Activation corollary**: Generating runtime registries does not apply migrations. Any guide that activates a previously inert module with committed migrations must explicitly direct operators to run `yarn db:migrate`; otherwise its routes can become reachable before their tables exist.
+
+**Applies to**: `packages/cli/src/lib/db/commands.ts`, create-app activation guidance, and any future init/bootstrap flow that calls `dbMigrate`.

--- a/.ai/runs/2026-08-10-standalone-example-runtime-bootstrap.md
+++ b/.ai/runs/2026-08-10-standalone-example-runtime-bootstrap.md
@@ -1,0 +1,54 @@
+# Standalone example runtime bootstrap fix
+
+## Goal
+
+Make the canonical example module start cleanly after it is explicitly enabled in a standalone app: AI-tool discovery must be idempotent and the activation guide must include the database migration step required before Todo routes are exercised.
+
+Source doc: `.ai/specs/2026-07-31-standalone-canonical-example-module.md`
+
+## Scope
+
+- Make the AI tool registry loader once-per-process and concurrency-safe so repeated `/api/ai_assistant/tools` requests do not re-register the complete tool set.
+- Keep intentional file-based AI tool replacements on the override path without emitting the generic duplicate-registration warning.
+- Update both byte-identical example-module README copies to prescribe `yarn db:migrate` after generation.
+- Add regression coverage for loader idempotence/concurrency, intentional overrides, and the emitted standalone activation instructions.
+- Record the migration-activation lesson in the existing CLI/runtime-startup lesson.
+
+## Non-goals
+
+- Do not change the example module's entities, migration SQL, table names, or runtime registration default.
+- Do not auto-apply migrations from `yarn generate` or application startup.
+- Do not change AI agent/tool IDs, override precedence, ACL requirements, handlers, or public API response shapes.
+- Do not modify the user's standalone checkout or apply its database migrations.
+
+## Implementation Plan
+
+### Phase 1: Runtime and activation fixes
+
+- Make `loadAllModuleTools` share one in-flight/completed load and apply intentional tool replacements without duplicate warnings.
+- Add focused AI-assistant regression tests for sequential and concurrent loader calls plus the override replacement path.
+- Add the explicit migration command to the mirrored example activation guide and pin it in create-app delivery coverage.
+
+### Phase 2: Knowledge and verification
+
+- Update the matching migration/runtime-startup lesson and run the targeted package tests before the full configured validation gate.
+
+## Risks
+
+- A process-wide loader guard could hide a failed first load or prevent tests from resetting state; the implementation must clear its in-flight memo on rejection and expose only a test reset seam.
+- Tool overrides must still update the registry's module ownership map and preserve the documented precedence order.
+- The example tree is a byte-exact app/template mirror; both README copies must change together.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Runtime and activation fixes
+
+- [ ] 1.1 Make `loadAllModuleTools` share one in-flight/completed load and apply intentional tool replacements without duplicate warnings.
+- [ ] 1.2 Add focused AI-assistant regression tests for sequential and concurrent loader calls plus the override replacement path.
+- [ ] 1.3 Add the explicit migration command to the mirrored example activation guide and pin it in create-app delivery coverage.
+
+### Phase 2: Knowledge and verification
+
+- [ ] 2.1 Update the matching migration/runtime-startup lesson and run the targeted package tests before the full configured validation gate.

--- a/.ai/runs/2026-08-10-standalone-example-runtime-bootstrap.md
+++ b/.ai/runs/2026-08-10-standalone-example-runtime-bootstrap.md
@@ -41,14 +41,16 @@ Source doc: `.ai/specs/2026-07-31-standalone-canonical-example-module.md`
 
 ## Progress
 
+PR: #5159
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Runtime and activation fixes
 
-- [ ] 1.1 Make `loadAllModuleTools` share one in-flight/completed load and apply intentional tool replacements without duplicate warnings.
-- [ ] 1.2 Add focused AI-assistant regression tests for sequential and concurrent loader calls plus the override replacement path.
-- [ ] 1.3 Add the explicit migration command to the mirrored example activation guide and pin it in create-app delivery coverage.
+- [x] 1.1 Make `loadAllModuleTools` share one in-flight/completed load and apply intentional tool replacements without duplicate warnings. — b0a26b75d
+- [x] 1.2 Add focused AI-assistant regression tests for sequential and concurrent loader calls plus the override replacement path. — b0a26b75d
+- [x] 1.3 Add the explicit migration command to the mirrored example activation guide and pin it in create-app delivery coverage. — 670901e72
 
 ### Phase 2: Knowledge and verification
 
-- [ ] 2.1 Update the matching migration/runtime-startup lesson and run the targeted package tests before the full configured validation gate.
+- [x] 2.1 Update the matching migration/runtime-startup lesson and run the targeted package tests before the full configured validation gate. — ff7f925f3

--- a/apps/mercato/src/modules/example/README.md
+++ b/apps/mercato/src/modules/example/README.md
@@ -11,7 +11,14 @@ export default [
 ]
 ```
 
-Then run `yarn generate`. Migrations are not applied automatically.
+Then generate the runtime registries and apply this module's committed migrations before starting the app:
+
+```bash
+yarn generate
+yarn db:migrate
+```
+
+`yarn generate` never applies migrations automatically. If the app was initialized before you enabled `example`, skipping `yarn db:migrate` leaves the Todo routes active without their `todos` table.
 
 ## Do not copy this tree
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/tool-loader.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/tool-loader.test.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod'
 import {
+  applyAiToolOverrideEntries,
+  loadAllModuleTools,
   registerGeneratedAiToolEntries,
+  resetAllModuleToolsLoadForTests,
   type AiToolConfigEntry,
 } from '../tool-loader'
 import { toolRegistry } from '../tool-registry'
 import { convertMcpToolsToAiSdk } from '../mcp-tool-adapter'
 import type { InProcessMcpClient, ToolInfoWithSchema } from '../in-process-client'
+import * as codeModeTools from '../codemode-tools'
+import * as generatedRegistryLoader from '../generated-registry-loader'
 
 function makeTool(name: string) {
   return {
@@ -67,6 +72,30 @@ describe('registerGeneratedAiToolEntries', () => {
     warnSpy.mockRestore()
   })
 
+  it('applies intentional overrides without reporting a duplicate registration', () => {
+    const baseTool = makeTool('example.get_todo_summary')
+    registerGeneratedAiToolEntries([{ moduleId: 'example', tools: [baseTool] }])
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    applyAiToolOverrideEntries([
+      {
+        moduleId: 'example',
+        overrides: {
+          [baseTool.name]: {
+            ...baseTool,
+            description: 'Tool replacement applied through the override layer',
+          },
+        },
+      },
+    ])
+
+    expect(toolRegistry.getTool(baseTool.name)?.description).toBe(
+      'Tool replacement applied through the override layer',
+    )
+    expect(warnSpy.mock.calls.flat().join(' ')).not.toContain('Tool already registered')
+    warnSpy.mockRestore()
+  })
+
   it('skips malformed tool objects instead of throwing', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
     const entries: AiToolConfigEntry[] = [
@@ -121,5 +150,41 @@ describe('registerGeneratedAiToolEntries', () => {
     const out = await adapted.execute({ q: 'hello' })
     expect(callToolMock).toHaveBeenCalledWith('search_query', { q: 'hello' })
     expect(out).toContain('"ok": true')
+  })
+})
+
+describe('loadAllModuleTools', () => {
+  beforeEach(() => {
+    toolRegistry.clear()
+    resetAllModuleToolsLoadForTests()
+    jest.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    toolRegistry.clear()
+    resetAllModuleToolsLoadForTests()
+    jest.restoreAllMocks()
+  })
+
+  it('shares one load across concurrent and sequential callers', async () => {
+    const codeModeSpy = jest.spyOn(codeModeTools, 'loadCodeModeTools').mockResolvedValue(2)
+    const routeManifestSpy = jest
+      .spyOn(generatedRegistryLoader, 'ensureApiRouteManifestsRegistered')
+      .mockResolvedValue(0)
+    jest.spyOn(generatedRegistryLoader, 'findGeneratedFile').mockReturnValue(null)
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const firstLoad = loadAllModuleTools()
+    const concurrentLoad = loadAllModuleTools()
+
+    expect(concurrentLoad).toBe(firstLoad)
+    await Promise.all([firstLoad, concurrentLoad])
+    expect(loadAllModuleTools()).toBe(firstLoad)
+    await loadAllModuleTools()
+
+    expect(codeModeSpy).toHaveBeenCalledTimes(1)
+    expect(routeManifestSpy).toHaveBeenCalledTimes(1)
+    expect(toolRegistry.listToolNames()).toEqual(['context_whoami'])
+    expect(warnSpy.mock.calls.flat().join(' ')).not.toContain('Tool already registered')
   })
 })

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/tool-loader.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/tool-loader.ts
@@ -17,6 +17,8 @@ import {
 
 const logger = createLogger('ai_assistant').child({ component: 'tools' })
 
+let allModuleToolsLoad: Promise<void> | null = null
+
 /**
  * Module tool definition as exported from ai-tools.ts files.
  */
@@ -235,7 +237,7 @@ export async function loadGeneratedModuleAiTools(): Promise<number> {
  * Dynamically load tools from known module paths.
  * This is called during MCP server startup.
  */
-export async function loadAllModuleTools(): Promise<void> {
+async function loadAllModuleToolsUncached(): Promise<void> {
   // 1. Register built-in tools
   registerMcpTool(contextWhoamiTool, { moduleId: 'context' })
   logger.debug('Registered built-in context_whoami tool')
@@ -273,6 +275,21 @@ export async function loadAllModuleTools(): Promise<void> {
   } catch (error) {
     logger.error('Could not register API route manifests', { err: error })
   }
+}
+
+export function loadAllModuleTools(): Promise<void> {
+  if (!allModuleToolsLoad) {
+    allModuleToolsLoad = loadAllModuleToolsUncached().catch((error) => {
+      allModuleToolsLoad = null
+      throw error
+    })
+  }
+  return allModuleToolsLoad
+}
+
+/** @__internal Test-only hook — reset the process-wide loader memo. */
+export function resetAllModuleToolsLoadForTests(): void {
+  allModuleToolsLoad = null
 }
 
 /**

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/tool-registry.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/tool-registry.ts
@@ -19,7 +19,7 @@ class ToolRegistryImpl implements McpToolRegistry {
       throw new Error('MCP tool must define a name')
     }
 
-    if (this.tools.has(tool.name)) {
+    if (this.tools.has(tool.name) && options?.moduleId !== 'ai_overrides') {
       logger.warn('Tool already registered, overwriting', { toolName: tool.name })
     }
 

--- a/packages/create-app/src/lib/starter-preset-example-delivery.test.ts
+++ b/packages/create-app/src/lib/starter-preset-example-delivery.test.ts
@@ -102,6 +102,16 @@ for (const presetId of PRESET_IDS) {
         existsSync(join(exampleDir, 'README.md')),
         `preset ${presetId} routes the spec gate at src/modules/example/README.md, which must exist`,
       )
+      const exampleReadme = readFileSync(join(exampleDir, 'README.md'), 'utf8')
+      assert.match(
+        exampleReadme,
+        /yarn generate[\s\S]*yarn db:migrate/,
+        `preset ${presetId} must tell operators to migrate after enabling the inert example module`,
+      )
+      assert.match(
+        exampleReadme,
+        /skipping `yarn db:migrate` leaves the Todo routes active without their `todos` table/,
+      )
       assert.ok(
         existsSync(join(exampleDir, 'references', 'surface-inventory.json')),
         `preset ${presetId} must emit the capability inventory om-module-scaffold resolves against`,

--- a/packages/create-app/template/src/modules/example/README.md
+++ b/packages/create-app/template/src/modules/example/README.md
@@ -11,7 +11,14 @@ export default [
 ]
 ```
 
-Then run `yarn generate`. Migrations are not applied automatically.
+Then generate the runtime registries and apply this module's committed migrations before starting the app:
+
+```bash
+yarn generate
+yarn db:migrate
+```
+
+`yarn generate` never applies migrations automatically. If the app was initialized before you enabled `example`, skipping `yarn db:migrate` leaves the Todo routes active without their `todos` table.
 
 ## Do not copy this tree
 


### PR DESCRIPTION
Tracking plan: `.ai/runs/2026-08-10-standalone-example-runtime-bootstrap.md`
Source doc: `.ai/specs/2026-07-31-standalone-canonical-example-module.md`
Stacked on: #4897
Status: complete

## 🎯 Goal
- Make an explicitly enabled canonical example module start cleanly in a standalone app by eliminating repeated AI-tool registration and documenting the migration required before Todo routes are used.

## Root Cause
- Every `/api/ai_assistant/tools` request called `loadAllModuleTools()`, which mutated the process-global registry again. Concurrent and sequential requests therefore re-registered every tool and emitted an overwrite warning for each entry.
- The file-based example override intentionally replaces `example.get_todo_summary`, but it used the same registry path as accidental duplicates, adding a misleading generic warning alongside the structured override log.
- The example activation README stopped after `yarn generate`. Generation activates routes and registries but never applies committed migrations, so an app initialized before enabling `example` could serve Todo routes while the `todos` table was still absent.

## What Changed
- Made the complete AI-tool load single-flight and once-per-process, with the memo cleared if the load rejects.
- Kept actual duplicate-registration warnings while suppressing the generic warning for intentional `ai_overrides` replacements.
- Added regression coverage for concurrent/sequential loader calls and the intentional override path.
- Updated both byte-identical example README copies to run `yarn db:migrate` after `yarn generate`, and pinned that activation contract in create-app tests.
- Extended the existing migration/runtime-startup lesson with the module-activation corollary.

## 🧪 Tests
- `yarn jest --config packages/ai-assistant/jest.config.cjs --runInBand --runTestsByPath packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/tool-loader.test.ts`
- `node --import tsx --test --test-timeout=120000 packages/create-app/src/lib/starter-preset-example-delivery.test.ts packages/create-app/src/lib/template-example-module-parity.test.ts`
- Full configured gate: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app`.
- The final gate is green. One intermediate full-test rerun had an OS-level Jest worker `SIGSEGV`; its exact 5-test suite passed in isolation and the complete 25-workspace matrix passed on the required rerun.

## 💥 Breaking Changes
- None. Tool/agent IDs, override precedence, public signatures, API shapes, database schema, migration SQL, and activation defaults are unchanged.

## 📋 Progress
All tracking-plan tasks are complete. The automated code review found no blocker, major, minor, or nit findings; GitHub does not permit the PR author to submit a formal approving review on their own PR, so the complete review report is posted as a PR comment.
