### PR TITLE
feat(docs): add copy-page-as-markdown button

### DIFF
--- a/.ai/specs/2026-08-10-docs-copy-page-as-markdown.md
+++ b/.ai/specs/2026-08-10-docs-copy-page-as-markdown.md
@@ -1,0 +1,133 @@
+# Copy Documentation Page as Markdown
+
+## TLDR
+
+Add a ghost IconButton to every doc page (MDX under `docs/`) that copies the page's raw markdown source to the clipboard. A custom remark plugin injects the raw `.mdx` content at build time; a swizzled `DocItem/Layout` renders the button top-right of the content area. Feedback is a checkmark icon swap for ~2 seconds. Target branch: `develop`.
+
+## Problem Statement
+
+Developers and AI agents frequently need raw markdown from the docs — to paste into prompts, reference in issues, or feed to tools. Today the only path is clicking "Edit this page" → GitHub → copy raw. A one-click copy button eliminates that friction, matching the UX of Claude Code's documentation site.
+
+## Proposed Solution
+
+Three small pieces, all inside `apps/docs/`:
+
+1. **Remark plugin** (`plugins/remark-raw-source.ts`) — reads the raw file content during MDX compilation and injects it as `frontMatter.raw_source`. Zero runtime cost; the string travels through Docusaurus's existing frontmatter pipeline.
+2. **CopyPageButton component** (`src/components/CopyPageButton.tsx`) — reads `raw_source` from `useDoc().frontMatter`, calls `navigator.clipboard.writeText()`, swaps the Copy icon to a Check icon for 2 seconds.
+3. **Swizzled DocItem/Layout** (`src/theme/DocItem/Layout/index.tsx`) — wraps the default layout to position the button top-right of the doc content area.
+
+No external dependencies. No `@open-mercato/ui` usage (docs app is self-contained Docusaurus; adding the design-system package as a dependency would be out of scope).
+
+### Alternatives considered
+
+| Approach | Rejected because |
+|---|---|
+| Runtime fetch from GitHub raw URL | Needs network, rate-limited for unauthenticated users, fails offline |
+| DOM-to-markdown conversion | Lossy — loses frontmatter, custom MDX components, exact formatting |
+| Docusaurus content plugin (`contentLoaded`) | Heavier API surface; remark plugin is simpler and native to the MDX pipeline |
+
+## Architecture
+
+```
+MDX file
+  ↓ (remark plugin reads file.value)
+frontMatter.raw_source = raw string
+  ↓ (Docusaurus build)
+useDoc().frontMatter.raw_source available at runtime
+  ↓
+CopyPageButton reads it, copies to clipboard on click
+  ↓
+Swizzled DocItem/Layout positions the button
+```
+
+No new packages. No cross-package dependencies. Entirely scoped to `apps/docs/`.
+
+## Data Model
+
+None — no database, no API, no persistent state. The raw source string is injected at build time into the page's JavaScript bundle.
+
+### Bundle size impact
+
+Each doc page's bundle grows by the size of its raw MDX source. For a typical 5 KB doc, this is negligible. The `docs/` folder currently has ~50-80 files — total overhead is roughly 250-400 KB across all pages (code-split, so only the visited page's source loads).
+
+## UI/UX
+
+### Button placement
+
+Top-right corner of the doc content area, vertically aligned with the page title (`h1`). Positioned via absolute positioning within the content wrapper.
+
+### Visual spec
+
+- **Idle state**: Ghost-style button, `Copy` icon (from `lucide-react`, already a Docusaurus dependency via Prism), muted foreground color, 28px hit target
+- **Hover**: Subtle background highlight (Docusaurus theme hover token)
+- **Clicked → success**: Icon swaps to `Check`, color shifts to green/success for 2 seconds, then reverts
+- **Tooltip**: `aria-label="Copy page as Markdown"` — optionally a native `title` attribute for hover tooltip
+- **Dark mode**: Inherits Docusaurus theme tokens automatically
+
+### Accessibility
+
+- `aria-label="Copy page as Markdown"`
+- `type="button"` explicit
+- Keyboard-accessible (native button)
+- Success state announced via `aria-live="polite"` visually-hidden text
+
+## Edge Cases & Failure Scenarios
+
+| Scenario | Behavior |
+|---|---|
+| `navigator.clipboard` unavailable (old browser, non-HTTPS) | Button hidden via feature detection (`navigator.clipboard?.writeText`) |
+| `raw_source` missing from frontmatter (custom page, not a doc) | Button not rendered — component guards on `raw_source` existence |
+| Very large MDX file (>50 KB) | Still works; clipboard API handles large strings; bundle impact is acceptable since it's code-split |
+| User clicks rapidly | Debounce not needed — clipboard write is idempotent; icon timer resets on each click |
+
+## Risks & Impact Review
+
+- **Blast radius**: Minimal — entirely within `apps/docs/`, no shared packages touched
+- **Bundle size**: Marginal per-page increase (~size of raw MDX source), code-split
+- **Breaking changes**: None — additive only
+- **Rollback**: Remove the remark plugin from config and delete the swizzled theme component
+
+## Phasing
+
+Single phase — the feature is small enough to ship in one PR.
+
+## Implementation Plan
+
+### Phase 1: Copy Page Button (single PR against `develop`)
+
+**Step 1 — Remark plugin**
+Create `apps/docs/plugins/remark-raw-source.ts`:
+```typescript
+import type { Plugin } from 'unified';
+
+const remarkRawSource: Plugin = () => {
+  return (_tree, file) => {
+    (file.data.frontMatter as Record<string, unknown>) ??= {};
+    (file.data.frontMatter as Record<string, unknown>).raw_source = file.value;
+  };
+};
+
+export default remarkRawSource;
+```
+Register in `docusaurus.config.ts` under the docs preset's `remarkPlugins`.
+
+**Step 2 — CopyPageButton component**
+Create `apps/docs/src/components/CopyPageButton.tsx`:
+- Uses `useDoc()` from `@docusaurus/plugin-content-docs/client` to read `frontMatter.raw_source`
+- `navigator.clipboard.writeText(rawSource)` on click
+- `useState` to toggle icon between `Copy` and `Check`
+- `setTimeout` 2s to revert icon
+- Guard: return `null` if `raw_source` is falsy or clipboard API unavailable
+- Style: ghost button using Docusaurus CSS variables (no external UI lib)
+
+**Step 3 — Swizzle DocItem/Layout**
+Create `apps/docs/src/theme/DocItem/Layout/index.tsx`:
+- Wrap the default `@theme-original/DocItem/Layout`
+- Position `CopyPageButton` absolute top-right of the content container
+- Minimal CSS in a co-located `.module.css` file
+
+**Step 4 — Verify**
+- `yarn build` in `apps/docs` to confirm build succeeds
+- Manual verification: open a doc page, click the copy button, paste into an editor, confirm raw MDX source is copied
+- Check dark mode renders correctly
+- Check pages without `raw_source` (custom pages) don't show the button

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -1,5 +1,6 @@
 import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
+import remarkRawSource from './plugins/remark-raw-source';
 
 const config: Config = {
   title: 'Open Mercato Docs',
@@ -55,6 +56,7 @@ const config: Config = {
           editUrl: 'https://github.com/open-mercato/open-mercato/tree/main/docs',
           showLastUpdateAuthor: true,
           showLastUpdateTime: true,
+          remarkPlugins: [remarkRawSource],
         },
         blog: false,
         theme: {

--- a/apps/docs/plugins/remark-raw-source.ts
+++ b/apps/docs/plugins/remark-raw-source.ts
@@ -1,0 +1,16 @@
+import type { Plugin } from 'unified';
+
+/**
+ * Remark plugin that injects the raw MDX source (Base64-encoded) into
+ * frontMatter so it can be accessed at runtime via useDoc().frontMatter.raw_source.
+ * Base64 encoding avoids JS parse errors from special characters in MDX content.
+ */
+const remarkRawSource: Plugin = () => {
+  return (_tree, file) => {
+    const data = file.data as { frontMatter?: Record<string, unknown> };
+    data.frontMatter ??= {};
+    data.frontMatter.raw_source = Buffer.from(String(file.value)).toString('base64');
+  };
+};
+
+export default remarkRawSource;

--- a/apps/docs/src/components/CopyPageButton.module.css
+++ b/apps/docs/src/components/CopyPageButton.module.css
@@ -1,0 +1,43 @@
+.copyButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ifm-color-emphasis-600);
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.copyButton:hover {
+  background: var(--ifm-color-emphasis-200);
+  color: var(--ifm-color-emphasis-800);
+}
+
+.copyButton:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 2px;
+}
+
+.copied {
+  color: var(--ifm-color-success);
+}
+
+.copied:hover {
+  color: var(--ifm-color-success);
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/apps/docs/src/components/CopyPageButton.tsx
+++ b/apps/docs/src/components/CopyPageButton.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import styles from './CopyPageButton.module.css';
+
+function CopyIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+export default function CopyPageButton(): React.ReactElement | null {
+  const { frontMatter } = useDoc();
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const rawSourceEncoded = (frontMatter as Record<string, unknown>).raw_source;
+
+  const handleCopy = useCallback(async () => {
+    if (typeof rawSourceEncoded !== 'string') return;
+
+    const decoded = atob(rawSourceEncoded);
+    await navigator.clipboard.writeText(decoded);
+    setCopied(true);
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 2000);
+  }, [rawSourceEncoded]);
+
+  if (typeof rawSourceEncoded !== 'string' || typeof navigator?.clipboard?.writeText !== 'function') {
+    return null;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className={`${styles.copyButton} ${copied ? styles.copied : ''}`}
+        onClick={handleCopy}
+        aria-label="Copy page as Markdown"
+        title="Copy page as Markdown"
+      >
+        {copied ? <CheckIcon /> : <CopyIcon />}
+      </button>
+      {copied && (
+        <span className={styles.srOnly} aria-live="polite">
+          Copied to clipboard
+        </span>
+      )}
+    </>
+  );
+}

--- a/apps/docs/src/theme/DocItem/Layout/index.tsx
+++ b/apps/docs/src/theme/DocItem/Layout/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Layout from '@theme-original/DocItem/Layout';
+import type LayoutType from '@theme/DocItem/Layout';
+import type { WrapperProps } from '@docusaurus/types';
+import CopyPageButton from '@site/src/components/CopyPageButton';
+import styles from './styles.module.css';
+
+type Props = WrapperProps<typeof LayoutType>;
+
+export default function LayoutWrapper(props: Props): React.ReactElement {
+  return (
+    <div className={styles.docItemLayoutWrapper}>
+      <div className={styles.copyButtonContainer}>
+        <CopyPageButton />
+      </div>
+      <Layout {...props} />
+    </div>
+  );
+}

--- a/apps/docs/src/theme/DocItem/Layout/styles.module.css
+++ b/apps/docs/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.docItemLayoutWrapper {
+  position: relative;
+}
+
+.copyButtonContainer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 1;
+}


### PR DESCRIPTION
## Summary

- Adds a ghost icon button (top-right of doc content area) that copies the raw MDX source to clipboard
- Custom remark plugin injects Base64-encoded page source at build time — no runtime fetch needed
- Swizzled DocItem/Layout positions the button; icon swaps to checkmark for 2s as feedback
- Scoped entirely to `apps/docs/` — no changes to shared packages

## Spec

`.ai/specs/2026-08-10-docs-copy-page-as-markdown.md`

## Test plan

- [ ] Open any doc page → copy button visible top-right
- [ ] Click copy → icon swaps to checkmark, reverts after 2s
- [ ] Paste into editor → raw MDX source matches the page
- [ ] Dark mode renders correctly
- [ ] Custom pages (homepage) do NOT show the button
- [ ] Build passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)