### PR TITLE
fix(ui): guard apiFetch's session-refresh redirect against endless loops

### DIFF
--- a/packages/core/src/modules/integrations/backend/integrations/__tests__/marketplace-guarded-mutation.test.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/__tests__/marketplace-guarded-mutation.test.tsx
@@ -149,4 +149,14 @@ describe('Integrations marketplace — guarded mutation wiring', () => {
     await waitFor(() => expect(flashMock).toHaveBeenCalledWith('integrations.detail.stateError', 'error'))
     expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false')
   })
+
+  it('flashes the load error and stops the spinner instead of hanging when the initial load rejects (GH #5186)', async () => {
+    apiCallMock.mockReset()
+    apiCallMock.mockRejectedValue(new Error('Unauthorized'))
+
+    renderWithProviders(<IntegrationsMarketplacePage />)
+
+    await waitFor(() => expect(flashMock).toHaveBeenCalledWith('integrations.marketplace.loadError', 'error'))
+    await waitFor(() => expect(screen.getByText('integrations.marketplace.noResults')).toBeInTheDocument())
+  })
 })

--- a/packages/core/src/modules/integrations/backend/integrations/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/page.tsx
@@ -186,14 +186,22 @@ export default function IntegrationsMarketplacePage() {
   const load = React.useCallback(async () => {
     setIsLoading(true)
     const fallback: ListResponse = { items: [], bundles: [], total: 0, page: 1, pageSize: 100, totalPages: 1 }
-    const call = await apiCall<ListResponse>(`/api/integrations${listQuery}`, undefined, { fallback })
-    if (!call.ok) {
+    try {
+      const call = await apiCall<ListResponse>(`/api/integrations${listQuery}`, undefined, { fallback })
+      if (!call.ok) {
+        flash(t('integrations.marketplace.loadError'), 'error')
+        setIsLoading(false)
+        return
+      }
+      setData(call.result ?? fallback)
+      setIsLoading(false)
+    } catch {
+      // apiFetch throws on 401/403 even when its own redirect is suppressed
+      // (e.g. a guarded repeat 401) — without this catch the page would spin
+      // forever instead of surfacing the load error.
       flash(t('integrations.marketplace.loadError'), 'error')
       setIsLoading(false)
-      return
     }
-    setData(call.result ?? fallback)
-    setIsLoading(false)
   }, [listQuery, t])
 
   React.useEffect(() => {

--- a/packages/ui/src/backend/utils/__tests__/api.test.ts
+++ b/packages/ui/src/backend/utils/__tests__/api.test.ts
@@ -45,6 +45,7 @@ describe('apiFetch', () => {
     jest.spyOn(console, 'warn').mockImplementation(() => undefined)
     jest.useFakeTimers()
     window.history.pushState({}, '', '/backend/sales/documents')
+    window.sessionStorage.clear()
     ;(window as unknown as Record<string, unknown>).__omOriginalFetch = undefined
   })
 
@@ -186,5 +187,19 @@ describe('apiFetch', () => {
       'Session expired. Redirecting to sign in…',
       'warning',
     )
+  })
+
+  it('guards the session-refresh redirect from looping when a non-session 401 repeats on the same page (GH #5186)', async () => {
+    ;(window as unknown as Record<string, unknown>).__omOriginalFetch = jest.fn(async () =>
+      createMockResponse(401, { error: 'Unauthorized' }),
+    )
+
+    await expect(apiFetch('/api/private')).rejects.toBeInstanceOf(UnauthorizedError)
+    expect(flash).toHaveBeenCalledTimes(1)
+
+    // The refresh bounce lands back on the same page and the same endpoint
+    // answers 401 again — the second attempt must not re-trigger the redirect.
+    await expect(apiFetch('/api/private')).rejects.toBeInstanceOf(UnauthorizedError)
+    expect(flash).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/ui/src/backend/utils/api.ts
+++ b/packages/ui/src/backend/utils/api.ts
@@ -67,6 +67,32 @@ export class UnauthorizedError extends Error {
   }
 }
 
+const SESSION_REFRESH_ATTEMPT_KEY_PREFIX = 'om:session-refresh-attempt:'
+const SESSION_REFRESH_COOLDOWN_MS = 10_000
+
+// A genuinely expired session redirects once per target, then goes quiet: the
+// refresh always succeeds (the session cookie is fine), bounces back to the
+// same URL, and re-triggers the same 401 for any non-session cause — without
+// this guard that bounce repeats forever (GH #5186).
+function recentlyAttemptedSessionRefresh(target: string): boolean {
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_REFRESH_ATTEMPT_KEY_PREFIX + target)
+    if (!raw) return false
+    const attemptedAt = Number(raw)
+    return Number.isFinite(attemptedAt) && Date.now() - attemptedAt < SESSION_REFRESH_COOLDOWN_MS
+  } catch {
+    return false
+  }
+}
+
+function recordSessionRefreshAttempt(target: string): void {
+  try {
+    window.sessionStorage.setItem(SESSION_REFRESH_ATTEMPT_KEY_PREFIX + target, String(Date.now()))
+  } catch {
+    // no-op
+  }
+}
+
 export function redirectToSessionRefresh() {
   if (typeof window === 'undefined') return
   const current = window.location.pathname + window.location.search
@@ -74,6 +100,8 @@ export function redirectToSessionRefresh() {
   if (window.location.pathname.startsWith('/api/auth')) return
   // Portal routes have their own customer auth — never redirect to staff login
   if (/\/[^/]+\/portal(\/|$)/.test(window.location.pathname)) return
+  if (recentlyAttemptedSessionRefresh(current)) return
+  recordSessionRefreshAttempt(current)
   try {
     flash('Session expired. Redirecting to sign in…', 'warning')
     setTimeout(() => {


### PR DESCRIPTION
## Summary

- `redirectToSessionRefresh()` in `packages/ui/src/backend/utils/api.ts` treated every `401` as an expired session and bounced through `/api/auth/session/refresh`. When a `401` is caused by something other than an actually-expired session (e.g. `/backend/integrations` when a stored integration's upstream OAuth client — Gmail — has been deleted), the refresh always succeeds (the session is valid), lands back on the same page, and the same `401` fires again — an endless reload the user cannot escape from the UI.
- The only existing loop guard skipped the redirect while the current path was already under `/api/auth`, which is never true after the bounce-back, so it could not break this cycle.
- Adds a short `sessionStorage`-backed cooldown keyed on the redirect target: a repeat `401` on the same page within 10s no longer re-triggers the redirect or the "Session expired" toast. `apiFetch` still throws `UnauthorizedError`, so the page's own error handling (e.g. a flash error) takes over instead of looping — matching the issue's third "Expected result" bullet.
- This closes the general loop-guard gap the issue calls out as the higher-priority fix; three prior point-fixes (#4224, #4746, and the guard documented in `dealsOrganizationScope.ts`) each patched a specific `401` source instead. The Gmail-credentials-specific source of the `401` in this scenario (the issue's fix #1 — degrading a dead upstream OAuth client to an `unhealthy` integration status) was not confidently identifiable from the routes on `/backend/integrations` and is left as a follow-up; see the issue's own "Open question for triage" note.

## Test plan

- [x] `yarn workspace @open-mercato/ui test api.test.ts` — new regression test: two consecutive `401`s for the same pathname only trigger the redirect/toast once, and `apiFetch` still rejects with `UnauthorizedError` both times.
- [x] `yarn workspace @open-mercato/ui test` — full package suite (1 pre-existing, unrelated locale failure in `format.test.ts` on this machine's Polish locale; not caused by this change)
- [x] `yarn workspace @open-mercato/ui typecheck`
- [x] `yarn build:packages`
- [x] `npx eslint` on both changed files — no new errors (one pre-existing `no-location-assign-relative-destination` warning on the unchanged `window.location.href` line)

Fixes #5186