### PR TITLE
docs(specs): address-level contact details and tax identifiers

### DIFF
--- a/.ai/specs/2026-08-10-address-contact-and-tax-fields.md
+++ b/.ai/specs/2026-08-10-address-contact-and-tax-fields.md
@@ -1,0 +1,220 @@
+# Address-Level Contact Details and Tax Identifiers
+
+## TLDR
+
+**Key Points:**
+- A sales document's address snapshots (`billing_address_snapshot` / `shipping_address_snapshot`) are free-form JSON, so integrations already persist `phone`, `email` and tax-id keys on them — but nothing models, renders, protects, or preserves those keys. This spec gives them a first-class model (`taxId` + `taxIdType`), a render path, and survival guarantees.
+- Grew out of PR #66 and its reviews: the first wiring targeted `sales_document_addresses` (typed table, no such columns, 6 rows on prod against 1.42M orders) and rendered nothing; the save path destroyed the keys (fixed separately in PR #69).
+
+**Scope:**
+- `AddressValue` contact fields + opt-in `AddressView` contact block (implemented on `feat/address-contact-fields-render`, carries over)
+- Tax-id typing (`taxIdType`) and EU-VAT normalization
+- Read-only snapshot view for locked documents
+- Type-aware indexing/display policy for tax ids
+- `name` → `label` rename on address entities (deprecation protocol)
+
+**Concerns:**
+- Two new frozen exports (`formatAddressContactPairs`, `AddressContactLabels`) per `BACKWARD_COMPATIBILITY.md` — this spec is the reference its §"Spec requirement" demands.
+- Tax ids are PII-adjacent and already treated as sensitive by search (`customers/search.ts:713`, `:805`).
+- `AddressesSection.tsx` carries `// @ts-nocheck` (13 pre-existing type errors) — everything added there is unchecked by CI until that is lifted.
+
+## Open Questions
+
+Numbered per the review thread on PR #66. Each carries our recommendation; **Q0 and Q3/Q4 block the design**, the rest default to the recommendation if unchallenged.
+
+- **Q0 (split?)**: Does this bundle two capabilities — contact-detail rendering and tax-id semantics? **Recommendation: one spec, phased.** Both ride the same frozen `AddressValue` surface; splitting would freeze `taxId: string` in phase 1 and regret it in phase 2. The phases below are independently shippable, which captures the split's benefit without the surface risk.
+- **Q2 (email on the address?)**: Shopify/Medusa keep email on the order; commercetools puts it on the address. **Recommendation: document snapshot only, not `CustomerAddress`.** In the motivating dataset the delivery email is a per-order fact (95–98% coverage on shipments/notes), not a property of an address-book entry.
+- **Q3/Q4 (tax-id type)**: Bare digits are ambiguous — a PL NIP of a non-VAT-registered business is not a VAT ID. **Recommendation: `taxId` + `taxIdType` from the start, minimal enum `eu_vat | local | other`** (Stripe-shaped `gb_vat`/`ch_vat`/… rejected for now; enum widens additively later). Needs an explicit call — this is the expensive-to-reverse decision.
+- **Q7 (ACL gate)**: Should rendering a tax id be feature-gated? **Recommendation: type-aware, matching search's existing stance** — `eu_vat` is a public business identifier (VIES is an open lookup) and renders ungated; `local`/`other` render only behind the existing customer-PII feature the deployment already uses for `tax_id`. Exact feature id to be settled in Phase 2 review.
+- **Q9 (rename)**: `name` on address entities is the address *label* ("Home"/"Warehouse"); a future `recipientName` beside it is a trap. **Recommendation: rename to `label` under the deprecation protocol** (bridge both names for one minor, `UPGRADE_NOTES.md` entry). Storage key in existing snapshots stays `name`; the bridge maps it.
+
+Answered on the PR thread and treated as decided here: Q1 (`recipientName` — in scope, Phase 3), Q5 (normalize EU VAT to ISO-2-prefixed on write), Q6 (address-level authoritative for the document; customer stays master), Q8 (`country` constraint — separate change), Q10 (read-only snapshot view — Phase 1), Q11 (no core backfill), Q12 (the duplicate `addressFormat.tsx` copies — out of scope).
+
+---
+
+## Overview
+
+Sales documents imported from an ERP carry a frozen billing/delivery address including the phone and tax id the document was issued under. Open Mercato persists these (snapshots are schemaless jsonb, encrypted at rest) but cannot display them, and until PR #69 destroyed them on the first manual save. Target audience: any deployment whose documents originate in an external system of record; the motivating case is a Subiekt GT ERP with 99.7% phone and 12.9% tax-id coverage on document addresses.
+
+> **Market Reference**: Stripe (tax id + type enum — adopted, minimal variant), commercetools (email on address — considered for Q2), Shopify/Medusa (email on order — recommended for Q2). Rejected: splicing contact details into postal address lines (no marketplace does this; it corrupts one-line summaries).
+
+**Touched:** `packages/core/src/modules/customers/utils/addressFormat.tsx`, `packages/ui/src/backend/detail/addressFormat.tsx` (byte-identical twin), `packages/core/src/modules/sales/components/documents/AddressesSection.tsx`, sales i18n (5 locales), Phase 3 only: `customers` address entities + migration.
+
+**Not touched:** `sales_document_addresses` schema (explicitly rejected — see Alternatives), `addressSnapshotSchema` (stays free-form), search indexing config outside the tax-id rules, pickup points, per-country address formats, VIES calls, address filterability (blocked by encryption at rest), `buildingNumber`/`flatNumber` logic (1.1% fill in the motivating dataset; house numbers live in the street string).
+
+## Problem Statement
+
+1. **No read path.** `AddressValue` models nine postal fields; `formatAddressJson` / `formatAddressLines` / `formatAddressString` / `AddressView` are all built from those. A snapshot carrying `phone`/`taxId` renders as if it didn't.
+2. **A B2B invoice address without its tax id is incomplete**, and "who to call about this delivery" is a property of the delivery address, not the customer — one customer, several addresses, different contacts.
+3. **Bare tax ids are ambiguous.** `1234567890` could be an EU VAT ID, a local tax number of a non-VAT-registered business, or neither. Display, indexing policy, and future VIES validation all depend on knowing which.
+4. **No read-only snapshot render exists.** Snapshots render exclusively through `AddressEditor`, which takes no `disabled` prop — deployments that lock document addresses (`order_address_editable_statuses = []`) show an editable form for read-only data.
+5. **(Fixed, PR #69)** `normalizeAddressDraft` rebuilt the snapshot from the editor's twelve fields on save, silently destroying every key the editor cannot show.
+
+## Proposed Solution
+
+Model the contact details as **optional fields on `AddressValue`**, rendered by `AddressView` as a trailing contact block that is **opt-in per field via caller-supplied labels** — omit `contactLabels` and the component is byte-identical to today. `formatAddressContactPairs(address, labels)` is exported so callers can ask "anything to show?" without rendering. The **document snapshot is the carrier**: it already persists the keys, is encrypted at rest, and is the frozen per-document fact. Tax ids carry a `taxIdType`; EU VAT IDs are normalized to the ISO-2-prefixed form on write by the emitting integration.
+
+### Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Contact block outside `formatAddressLines` | `formatAddressString` joins lines with `", "` into picker labels and table cells; a tax id spliced into `"Baker Street 10, NW1 London"` is wrong in every one. A test pins postal-line purity. |
+| Labels-as-opt-in, caller-translated | The util module is deliberately i18n-free; callers have `useT()`. Also enables phone-without-tax-id (the common delivery-address case). |
+| Snapshot as carrier, not typed columns | Snapshots have the data (99.6% of 1.42M prod orders); `sales_document_addresses` has 6 rows and would need columns + write paths + backfill for nothing. |
+| `taxIdType` minimal enum | Widens additively; no non-EU data justifies the Stripe-shaped list today. |
+
+### Alternatives Considered
+
+| Alternative | Why Rejected |
+|-------------|-------------|
+| Columns on `sales_document_addresses` | Wrong path twice over: no data flows there (6 prod rows), and the document-level frozen fact lives in the snapshot. This was PR #66's original wiring; it rendered nothing. |
+| Splice contacts into `formatAddressLines` | Corrupts every one-line summary downstream. |
+| Bare `taxId: string`, type later | The one decision that is expensive to walk back once frozen; ambiguity documented in Problem 3. |
+| Hardcoded translated labels in the util | Breaks the module's i18n-free contract; forces all-or-nothing field display. |
+
+## User Stories / Use Cases
+
+- An **operations user** viewing an imported order sees the phone the courier should call, on the delivery address that carries it.
+- An **accountant** sees the tax id a B2B invoice was issued under, on the billing address, exactly as frozen at document time.
+- A **third-party module author** calls `AddressView` exactly as before and observes zero change until they opt in with labels.
+
+## Architecture
+
+Data flow (read): `integration → *_address_snapshot (jsonb, encrypted at rest per sales/encryption.ts) → document detail UI → AddressView contact block`.
+Data flow (write/edit): `AddressEditor draft → normalizeAddressDraft(draft, previousSnapshot) → snapshot` — unowned keys merged back (PR #69).
+
+No new commands, events, routes, or DI registrations. The snapshot rides the existing order/quote update payload. Cross-module surface: `customers` owns the util, `sales` consumes it, `ui` holds the byte-identical twin (kept in sync here; collapsing them is out of scope, Q12).
+
+## Data Models
+
+### Address snapshot (informal contract — schema stays `z.record(z.string(), z.unknown())`)
+
+Documented well-known keys, all optional strings: the nine postal fields (unchanged), plus `phone`, `email`, `taxId`, `taxIdType` (`'eu_vat' | 'local' | 'other'`), Phase 3: `recipientName`. Unknown keys MUST survive an editor round-trip (PR #69's guarantee).
+
+### `AddressValue` (type, frozen surface)
+
+Adds optional `phone`, `email`, `taxId`, `taxIdType`, later `recipientName` — additive, all `?: string | null`.
+
+### `CustomerAddress` (Phase 3, additive migration)
+
+`recipient_name text NULL`, `phone text NULL`. Both declared in `customers` `defaultEncryptionMaps` with reads through `findWithDecryption`; if phone becomes equality-searchable it declares a sibling `hashField`. No tax-id column on `CustomerAddress` — customer-level tax id stays where it is (master on the customer entity), per Q6.
+
+## API Contracts
+
+No new endpoints; no request/response shape changes. `addressSnapshotSchema` deliberately stays free-form — constraining it would break the very integrations this feature serves. The documented-keys table above is the contract.
+
+## Internationalization (i18n)
+
+`sales.documents.detail.addresses.{taxId,phone,email}` in `en`, `pl`, `de`, `es`, `ko` (exists on the branch). Phase 3 adds `recipientName`.
+
+## UI/UX
+
+- Contact block under the shipping/billing tiles as `text-xs text-muted-foreground` label–value lines; self-hiding when the address carries nothing.
+- Phase 1 adds a **read-only snapshot view**: when the document is locked, render `AddressView` (postal + contact) instead of `AddressEditor`.
+- DS rules apply: semantic tokens only, shared primitives, no new inline comments.
+- The UI phase MUST remove `// @ts-nocheck` from `AddressesSection.tsx` (13 pre-existing errors to fix) or, failing that, MUST NOT be accepted on eyeball-only review — the file is invisible to `tsc`.
+
+## Migration & Backward Compatibility
+
+- **Everything in Phases 0–2 is additive.** No DB migration; snapshots are schemaless. With no `contactLabels` supplied, `AddressView` output is byte-identical — pinned by test.
+- **New frozen exports**: `formatAddressContactPairs`, `AddressContactLabels` freeze on merge per `BACKWARD_COMPATIBILITY.md`; this spec is the required reference.
+- **`name` → `label` rename (Q9, Phase 4)** follows the deprecation protocol: add `label`, keep `name` as a deprecated bridge for ≥1 minor, `@deprecated` JSDoc with target removal version, `UPGRADE_NOTES.md` entry. Snapshot storage keys are untouched.
+- **Phase 3 migration** is additive nullable columns — deployable without downtime, safely re-runnable.
+- **No core backfill.** Existing snapshots keep whatever they carry; integrations that want the fields on historical documents re-emit them (the motivating deployment re-runs its sync, which re-reads every document).
+
+## Implementation Plan
+
+### Phase 0 — snapshot key preservation *(shipped: PR #69)*
+`normalizeAddressDraft` merges back keys outside the twelve it owns; cleared address still normalizes to `null`.
+
+### Phase 1 — contact fields, render, read-only view *(branch `feat/address-contact-fields-render` / PR #66 carries over)*
+1. `AddressValue` + `formatAddressContactPairs` + `AddressView` contact block (done on branch, incl. postal-purity and self-hiding tests).
+2. Wire to the shipping/billing snapshot tiles (done on branch).
+3. Add `taxIdType` to the type and the pair-formatter (pending Q3/Q4 call).
+4. Read-only snapshot view for locked documents.
+5. Lift `// @ts-nocheck` from `AddressesSection.tsx`.
+
+### Phase 2 — tax-id semantics
+1. `normalizeEuVatId()` util (ISO-2-prefix on write) for emitting integrations.
+2. Type-aware display gate per Q7; align search config so `eu_vat` may index where `local`/`other` stay `hashOnly`/excluded.
+
+### Phase 3 — recipient name + customer address book *(separable)*
+1. `recipientName` on `AddressValue`/`AddressView`; `recipient_name`, `phone` columns on `CustomerAddress` with encryption-map entries.
+2. `TC-CRM-CRUDFORM-*` sweep update for the new editable fields.
+
+### Phase 4 — rename + docs
+1. `name` → `label` bridge per Migration section; `BACKWARD_COMPATIBILITY.md` + `UPGRADE_NOTES.md` entries.
+
+## Integration Coverage
+
+Unit (`packages/core`, exists on branch): postal lines unchanged when contacts present (**the safety property**); per-field label gate; null-render preserved; snapshot round-trip keeps unowned keys.
+
+Route/UI level (Phase 1): `packages/core/src/modules/sales/__integration__/TC-SALES-ADDR-CONTACT-001.spec.ts` — order created via API with a snapshot carrying `phone`/`taxId`; detail page renders both; editor save round-trips them; locked document shows the read-only view. Self-contained fixtures, no seeded data.
+
+Phase 3: `TC-CRM-CRUDFORM-*` proves `recipient_name`/`phone` save-and-reload on customer address create + update.
+
+## Risks & Impact Review
+
+Write operations are limited to the existing document-update path (Phase 0/1) and one additive migration (Phase 3); no events, no cross-module writes, tenant scoping unchanged (snapshots live on tenant-scoped rows, encrypted at rest).
+
+#### Tax id shown to under-privileged users
+- **Scenario**: A personal (non-VAT) tax number renders in the document detail to a user who shouldn't see PII.
+- **Severity**: Medium
+- **Affected area**: sales document detail
+- **Mitigation**: type-aware gate (Q7) before anything beyond the locked read-only view ships; `local`/`other` behind the existing PII feature.
+- **Residual risk**: `eu_vat` renders ungated by design — it is a public identifier (VIES).
+
+#### Editor merge-back resurrects a stale key
+- **Scenario**: Integration updates the snapshot while a user edits; save merges the user's postal fields with the pre-edit contact keys.
+- **Severity**: Low
+- **Affected area**: document addresses tab
+- **Mitigation**: document-level optimistic locking already rejects the stale save (409).
+- **Residual risk**: none beyond existing conflict UX.
+
+#### Frozen enum too small
+- **Scenario**: A `gb_vat`-class need appears after `taxIdType` freezes.
+- **Severity**: Low
+- **Mitigation / Residual**: enums widen additively under the BC contract; a second small migration is the accepted trade-off, recorded in Q3/Q4.
+
+#### Rename breaks third-party address consumers
+- **Scenario**: A module reads `name` from the API after Phase 4 removal.
+- **Severity**: Medium
+- **Affected area**: customers + sales address APIs
+- **Mitigation**: ≥1-minor bridge, `@deprecated` JSDoc, `UPGRADE_NOTES.md`; storage keys unchanged.
+- **Residual risk**: consumers that ignore deprecation warnings break at the announced removal — accepted per protocol.
+
+## Final Compliance Report — 2026-08-10
+
+### AGENTS.md Files Reviewed
+- `AGENTS.md` (root), `.ai/specs/AGENTS.md`, `.ai/qa/AGENTS.md`, `BACKWARD_COMPATIBILITY.md`, `.ai/skills/om-spec-writing/SKILL.md` + references
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+|-------------|------|--------|-------|
+| BACKWARD_COMPATIBILITY.md | Contract-surface change references a spec with Migration & BC section | Compliant | This document |
+| BACKWARD_COMPATIBILITY.md | DB schema additive-only | Compliant | Phase 3 nullable columns only |
+| om-spec-writing checklist | PII/address/contact columns declare encryption maps + `findWithDecryption` | Compliant (design) | Phase 3 columns declared; snapshots already encrypted |
+| root AGENTS.md | Integration coverage listed per affected API/UI path, ships with the change | Compliant | §Integration Coverage |
+| root AGENTS.md | No inline comments / self-documenting code | Compliant | Branch cleaned in `9841df8d5` |
+| .ai/specs/AGENTS.md | Naming `{YYYY-MM-DD}-{kebab}.md`, no `SPEC-*` prefix | Compliant | |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Data models match API contracts | Pass | Snapshot keys ↔ documented contract |
+| API contracts match UI/UX | Pass | Render-only; no shape change |
+| Risks cover all write operations | Pass | Save path + Phase 3 migration |
+| Commands defined for all mutations | Pass | No new mutations |
+
+### Non-Compliant Items
+None at spec level.
+
+### Verdict
+**Blocked — Open Questions Q0 and Q3/Q4 must be resolved before implementation proceeds past Phase 0.** All other sections are implementation-ready.
+
+## Changelog
+
+### 2026-08-10
+- Initial specification, following review of PR #66 by @maxidragon and @jtomaszewski. Phase 0 shipped as PR #69; Phase 1 exists on `feat/address-contact-fields-render` pending Q3/Q4.

--- a/.ai/specs/2026-08-10-address-contact-and-tax-fields.md
+++ b/.ai/specs/2026-08-10-address-contact-and-tax-fields.md
@@ -14,14 +14,14 @@
 **Scope:**
 - `AddressValue` contact fields + opt-in `AddressView` contact block
 - Tax-id typing (`taxIdType`) and EU-VAT normalization on write
-- Read-only snapshot view for locked documents
+- Locked documents render a disabled editor instead of an editable one
 - Type-aware indexing/display policy for tax ids
 - `name` → `label` rename on address entities (deprecation protocol)
 
 **Concerns:**
 - Two new frozen exports (`formatAddressContactPairs`, `AddressContactLabels`) per `BACKWARD_COMPATIBILITY.md` — this spec is the reference its §"Spec requirement" demands.
 - Tax ids are PII-adjacent and already treated as sensitive by search (`customers/search.ts:713`, `:805`).
-- `AddressesSection.tsx` carries `// @ts-nocheck` (13 pre-existing type errors) — everything added there is unchecked by CI until that is lifted.
+- `AddressesSection.tsx` carries `// @ts-nocheck` — the file is invisible to `tsc`, so everything added there is unchecked by CI until the directive is lifted.
 
 ## Overview
 
@@ -39,11 +39,11 @@ The gap is felt by any deployment that ships physical goods (a delivery without 
 > | [Stripe](https://docs.stripe.com/billing/customer/tax-ids) | — | — | `tax_id` value + `type` enum, held as a **list** on the customer and rendered onto invoices |
 > | **Open Mercato** | **no** | **no** | **no** |
 >
-> **Adopted:** a phone on the address (universal); a tax identifier carrying an explicit type (Stripe). Stripe is also the precedent for Q6 — the customer owns the identifier, the document freezes the value it was issued under.
+> **Adopted:** a phone on the address (universal); a tax identifier carrying an explicit type (Stripe). Stripe is also the precedent for the ownership split — the customer owns the identifier, the document freezes the value it was issued under.
 >
-> **Rejected:** an email on the address — two of the three commerce platforms deliberately keep it on the order, and an order-level email is the better home (see Q2); splicing contact details into the postal address lines — nobody does this, and it corrupts every one-line summary built from those lines.
+> **Rejected:** an email on the address — two of the three commerce platforms deliberately keep it on the order, and an order-level email is the better home; splicing contact details into the postal address lines — nobody does this, and it corrupts every one-line summary built from those lines.
 
-**Touched:** `packages/core/src/modules/customers/utils/addressFormat.tsx`, `packages/ui/src/backend/detail/addressFormat.tsx` (byte-identical twin), `packages/core/src/modules/sales/components/documents/AddressesSection.tsx`, sales i18n (5 locales), Phase 3 only: `customers` address entities + migration.
+**Touched:** `packages/core/src/modules/customers/utils/addressFormat.tsx`, `packages/ui/src/backend/detail/addressFormat.tsx` (near-identical twin — the two files differ only in the import and the `AddressFormatStrategy` alias, so they must be edited in parallel rather than copied over one another), `packages/core/src/modules/sales/components/documents/AddressesSection.tsx`, `packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx` (second `normalizeAddressDraft` on the document create/edit path — Phase 0), sales i18n (5 locales), Phase 3 only: `customers` address entities + migration.
 
 **Not touched:** `sales_document_addresses` schema (explicitly rejected — see Alternatives), `addressSnapshotSchema` (stays free-form), search indexing config outside the tax-id rules, per-country address formats, VIES calls, address filterability (blocked by encryption at rest), `buildingNumber`/`flatNumber` logic (house numbers are conventionally written into the street line, and the field is near-empty in practice — see Appendix).
 
@@ -53,8 +53,8 @@ The gap is felt by any deployment that ships physical goods (a delivery without 
 2. **The fields cannot be shown.** On the sales side the document address snapshot is schemaless jsonb, so an integration posting `{ addressLine1, city, phone, taxId }` **does** get those keys persisted today — they simply have no read path, and render as if absent.
 3. **Contact details are per-address, not per-customer.** One customer has a home address, an office address and a warehouse, each with a different person to call. Holding one phone on the customer answers the wrong question.
 4. **A bare tax identifier is ambiguous.** `1234567890` may be a Polish NIP, an EU VAT number missing its country prefix, or a local tax number of a business that is not VAT-registered at all. Stripe treats these as *distinct types* (`pl_nip` vs `eu_vat`, examples `1234567890` vs `PL1234567890`) precisely because display, tax calculation and validation all diverge on the answer.
-5. **Locked documents render an editor.** Address snapshots render exclusively through `AddressEditor`, which takes no `disabled` prop. A deployment that locks document addresses (`order_address_editable_statuses = []`) shows an editable form over read-only data.
-6. **Unknown snapshot keys did not survive a save.** `normalizeAddressDraft` rebuilt the snapshot from the twelve fields the editor models, destroying every other key on the first manual save — silent data loss for exactly the keys this feature depends on. *(Fixed; see Phase 0.)*
+5. **Locked documents render an editable editor.** `AddressEditor` does accept a `disabled` prop (`customers/components/AddressEditor.tsx:82`, and its `ui` twin at `:97`), but neither snapshot call site passes it (`AddressesSection.tsx:1070`, `:1137`) — while every sibling control in that component is already locked (`:1057`, `:1082`, `:1113`, `:1132`) and a `lockedReason` banner renders above them at `:1018-1026`. A deployment that locks document addresses (`order_address_editable_statuses = []`) therefore presents a fully editable form over data the API will refuse to change.
+6. **Unknown snapshot keys do not survive a save.** `normalizeAddressDraft` rebuilds the snapshot from the twelve fields the editor models, destroying every other key on the first manual save — silent data loss for exactly the keys this feature depends on. Two independent copies of the helper do this: `AddressesSection.tsx:78-99` (document detail Addresses tab) and `SalesDocumentForm.tsx:438-459` (document create/edit form, reached from `:1446-1447`). Fixing one and not the other makes the loss depend on which screen the user saved from. *(Outstanding in this repository — Phase 0.)*
 
 ## Proposed Solution
 
@@ -67,46 +67,40 @@ Model the contact details as **optional fields on `AddressValue`**, rendered by 
 | Contact block outside `formatAddressLines` | `formatAddressString` joins lines with `", "` into picker labels and table cells; a tax id spliced into `"Baker Street 10, NW1 London"` is wrong in every one. A test pins postal-line purity. |
 | Labels-as-opt-in, caller-translated | The util module is deliberately i18n-free; callers have `useT()`. Also enables phone-without-tax-id, which is the common delivery-address case. |
 | Snapshot as carrier on the sales side, not typed columns | The snapshot is where the per-document value is frozen and where integrations already write. Typed columns would need a write path and a backfill to reach the same place. |
-| Tax identifier carries an explicit type | Follows Stripe; without it the value cannot be interpreted, validated or gated. Shape is Q3/Q4. |
+| Tax identifier carries an explicit type | Follows Stripe; without it the value cannot be interpreted, validated or gated. Shape is `{country}_{kind}` — see Design Decisions. |
 
 ### Alternatives Considered
 
 | Alternative | Why Rejected |
 |-------------|-------------|
-| Columns on `sales_document_addresses` | Wrong on two counts: the per-document frozen fact belongs on the snapshot, and that table is a document's *additional* address list, which most deployments never populate. |
+| Columns on `sales_document_addresses` | Wrong on two counts: the per-document frozen fact belongs on the snapshot, and that table holds a document's *additional* addresses — it is not where the primary shipping and billing addresses live, so columns there would not reach the addresses this feature is about. |
+| A new read-only render path for locked documents | Rejected as a standalone step. `AddressEditor` already accepts `disabled`, so `disabled={locked}` at `AddressesSection.tsx:1070` and `:1137` — beside the `locked` value that already flows to every sibling control — delivers the stated outcome in two lines with no second rendering path to keep in step. A read-only `AddressView` summary would read better than greyed-out inputs and stays open as a later improvement; it is not a prerequisite for the contact block, which renders beside the editor either way. |
 | Splice contacts into `formatAddressLines` | Corrupts every one-line summary downstream — picker options, entry labels, table cells. |
 | Bare `taxId: string`, type added later | The identifier is uninterpretable without its type, and the field freezes as public surface on merge. |
-| `email` on the address | Two of three comparable platforms hold it on the order instead; see Q2. |
+| `email` on the address | Two of three comparable platforms hold it on the order instead; see Design Decisions. |
 | Hardcoded translated labels in the util | Breaks the module's i18n-free contract and forces all-or-nothing field display. |
 
-## Open Questions
+## Design Decisions Taken During Review
 
-*Scaffolding — to be resolved and removed before this spec is finalized.* **Q0 and Q3/Q4 block implementation past Phase 0**; the rest carry a recommendation and default to it if unchallenged.
+Every question raised while this spec was drafted is settled. They are recorded with their reasoning because each one constrains an implementation phase below.
 
-- **Q0 — one spec or two?** Does this bundle two independently deployable capabilities, contact-detail rendering and tax-id semantics? *Recommendation: one spec, phased.* Both freeze the same `AddressValue` surface, so splitting would commit to `taxId: string` in the first and regret it in the second. The phases below are independently shippable, which captures the split's benefit without the surface risk.
+- **Scope — one spec, phased.** Contact-detail rendering and tax-id semantics freeze the same `AddressValue` surface, so splitting them would commit to a bare `taxId: string` in the first spec and regret it in the second. The phases below are independently shippable, which is what a split would have bought.
 
-- **Q3/Q4 — the shape of `taxIdType`.** *Presented as a genuine fork; no recommendation.* This one is architectural and worth your call.
+- **`taxIdType` is Stripe-shaped `{country}_{kind}`, seeded `eu_vat`, `pl_nip`, `other`, widened one case at a time as they are observed.** A minimal `eu_vat | local | other` enum was considered and rejected: `local` cannot be interpreted without a constrained country, `country` stays unconstrained free text (see the deferred-work list below), and the display gate would then have nothing reliable to key on — so the ambiguity in Problem 4 would move rather than resolve. The larger seed set is a smaller commitment than it looks, because the backward-compatibility contract makes these enums additive-only; only the seed values freeze. It also makes the display gate implementable immediately.
 
-  | | **(a) Stripe-shaped `{country}_{kind}`** | **(b) Minimal `eu_vat \| local \| other`** |
-  |---|---|---|
-  | Seed values | `eu_vat`, `pl_nip`, `other`, widened as observed | the three, fixed |
-  | For | Matches the industry vocabulary; distinguishes `pl_nip` from `eu_vat`, which is the ambiguity in Problem 4; widens naturally one country at a time | Smallest surface to freeze; nothing speculative |
-  | Against | More public surface committed up front for cases not yet observed | `local` is uninterpretable without a country, and `country` is unconstrained free text (Q8, deferred) — so the ambiguity moves rather than resolves |
+- **Displaying a tax identifier is gated by type.** An EU VAT number is a public business identifier — VIES is an open lookup — and renders ungated; a local or personal tax number renders only behind the customer-PII feature the deployment already applies to `tax_id`. This is the split `customers/search.ts:713` (`excluded` for people) and `:805` (`hashOnly` for companies) already draws. Exact feature id settled in Phase 2 review.
 
-  *Note:* an earlier comment on PR #66 recommended (b). Reading Stripe's actual type table — where `pl_nip` and `eu_vat` are separate types with exactly the `1234567890` / `PL1234567890` examples — weakened that argument enough to withdraw the recommendation rather than defend it.
+- **`name` → `label` on address entities, under the deprecation protocol.** `name` is the address *label* ("Home", "Warehouse"); putting a recipient name beside it is a trap. Medusa makes the same split explicitly — `address_name` for the label, `first_name`/`last_name` for the person. Bridge both for ≥1 minor with an `UPGRADE_NOTES.md` entry; snapshot storage keys are untouched and the bridge maps them.
 
-- **Q7 — is displaying a tax identifier ACL-gated?** *Recommendation: type-aware, matching what search already does.* An EU VAT number is a public business identifier (VIES is an open lookup) and renders ungated; a local or personal tax number renders only behind the customer-PII feature the deployment already applies to `tax_id`. Exact feature id settled in Phase 2 review.
+- **One `recipientName`, not `firstName`/`lastName`.** Shopify and Medusa both split the person in two, which is better for salutation and sorting, but `AddressValue` has no person field at all today and a split can be layered additively later. A single field is also friendlier to sources that only ever supply a full name.
 
-- **Q9 — rename `name` to `label`.** `name` on address entities is the address *label* ("Home", "Warehouse"); putting a recipient name beside it is a trap. Medusa makes the same split explicitly — `address_name` for the label, `first_name`/`last_name` for the person. *Recommendation: rename under the deprecation protocol* (bridge both for ≥1 minor, `UPGRADE_NOTES.md` entry); snapshot storage keys are untouched and the bridge maps them.
+- **`email` is not added to `AddressValue`.** Shopify and Medusa keep email off the address and hold it on the order/customer; only commercetools carries it on the address. Two of three, plus the fact that a delivery email is a per-order rather than per-address fact, is enough not to freeze a contested field. Scope is `phone` + `taxId` + `taxIdType`.
 
-- **Q1 refinement — one `recipientName`, or `firstName`/`lastName`?** Shopify and Medusa both split the person into two fields. Splitting is better for salutation and sorting; a single field is friendlier to sources that only ever supply a full name. *Recommendation: single `recipientName` in Phase 3, since `AddressValue` has no person field at all today and splitting can be layered additively.*
+- **EU VAT is normalized to the ISO-2-prefixed form on write.** Stripe validates `eu_vat` against VIES and `gb_vat` against HMRC on exactly that form, so normalizing makes any future validation a pass-through.
 
-**Resolved on the evidence, no longer open:**
+- **The customer is the master of a tax identifier; the document freezes the value it was issued under.** This is Stripe's model — identifiers live on the customer as a list and are rendered onto invoice PDFs.
 
-- **Q2 — email is dropped from `AddressValue`.** Shopify and Medusa both keep email off the address and hold it on the order/customer; only commercetools carries it on the address. Two of three, plus the fact that a delivery email is a per-order rather than per-address fact, is enough to leave it out rather than freeze a contested field. Scope shrinks to `phone` + `taxId` + `taxIdType`.
-- **Q5** — normalize EU VAT to the ISO-2-prefixed form on write. Stripe validates `eu_vat` against VIES and `gb_vat` against HMRC on exactly that form, so normalizing makes any future validation a pass-through.
-- **Q6** — the customer is the master of a tax identifier; the document freezes the value it was issued under. This is Stripe's model (identifiers live on the customer as a list, and are rendered onto invoice PDFs).
-- **Q8** (`country` constraint — separate change), **Q10** (read-only snapshot view — Phase 1), **Q11** (no core backfill), **Q12** (the duplicate `addressFormat.tsx` copies — out of scope).
+**Deliberately deferred, not part of any phase here:** constraining `country` to ISO-3166-2 (load-bearing under OSS, but its own blast radius); collapsing the two `addressFormat.tsx` copies into one module; any core backfill of existing snapshots.
 
 ## User Stories / Use Cases
 
@@ -118,15 +112,15 @@ Model the contact details as **optional fields on `AddressValue`**, rendered by 
 ## Architecture
 
 Data flow (read): `writer → *_address_snapshot (jsonb, encrypted at rest per sales/encryption.ts) → document detail UI → AddressView contact block`.
-Data flow (write/edit): `AddressEditor draft → normalizeAddressDraft(draft, previousSnapshot) → snapshot` — keys the editor does not own are merged back rather than dropped (Phase 0).
+Data flow (write/edit), **after Phase 0**: `AddressEditor draft → normalizeAddressDraft(draft, previousSnapshot) → snapshot` — keys the editor does not own are merged back rather than dropped. Today the helper takes the draft alone and drops them, on both the document detail and the document form paths.
 
-No new commands, events, routes, or DI registrations. The snapshot rides the existing order/quote update payload. Cross-module surface: `customers` owns the util, `sales` consumes it, `ui` holds the byte-identical twin (kept in sync here; collapsing them is out of scope, Q12).
+No new commands, events, routes, or DI registrations. The snapshot rides the existing order/quote update payload. Cross-module surface: `customers` owns the util, `sales` consumes it, `ui` holds the near-identical twin (edited in parallel here; collapsing the two into one module is deferred).
 
 ## Data Models
 
 ### Address snapshot (informal contract — schema stays `z.record(z.string(), z.unknown())`)
 
-Documented well-known keys, all optional strings: the nine postal fields (unchanged), plus `phone`, `taxId`, `taxIdType` (shape per Q3/Q4), and in Phase 3 `recipientName`. Unknown keys MUST survive an editor round-trip (Phase 0's guarantee).
+Documented well-known keys, all optional strings: the nine postal fields (unchanged), plus `phone`, `taxId`, `taxIdType` (Stripe-shaped `{country}_{kind}`), and in Phase 3 `recipientName`. Unknown keys MUST survive an editor round-trip — a guarantee Phase 0 establishes and which does not hold today.
 
 ### `AddressValue` (type, frozen surface)
 
@@ -134,7 +128,7 @@ Adds optional `phone`, `taxId`, `taxIdType`, later `recipientName` — additive,
 
 ### `CustomerAddress` (Phase 3, additive migration)
 
-`recipient_name text NULL`, `phone text NULL`. Both declared in `customers` `defaultEncryptionMaps` with reads through `findWithDecryption`; if phone becomes equality-searchable it declares a sibling `hashField`. No tax-id column on `CustomerAddress` — customer-level tax id stays where it is (master on the customer entity), per Q6.
+`recipient_name text NULL`, `phone text NULL`. Both declared in `customers` `defaultEncryptionMaps` with reads through `findWithDecryption`; if phone becomes equality-searchable it declares a sibling `hashField`. No tax-id column on `CustomerAddress` — the customer entity stays master of the identifier.
 
 ## API Contracts
 
@@ -142,39 +136,44 @@ No new endpoints; no request/response shape changes. `addressSnapshotSchema` del
 
 ## Internationalization (i18n)
 
-`sales.documents.detail.addresses.{taxId,phone}` in `en`, `pl`, `de`, `es`, `ko`. The corresponding `…addresses.email` key is removed in Phase 1 along with the field (Q2). Phase 3 adds `recipientName`.
+Two keys added: `sales.documents.detail.addresses.{taxId,phone}` in `en`, `pl`, `de`, `es`, `ko`. No existing key is removed. Phase 3 adds `recipientName`.
 
 ## UI/UX
 
 - Contact block under the shipping/billing tiles as `text-xs text-muted-foreground` label–value lines; self-hiding when the address carries nothing.
-- Phase 1 adds a **read-only snapshot view**: when the document is locked, render `AddressView` (postal + contact) instead of `AddressEditor`.
+- Phase 1 passes `disabled={locked}` to the two snapshot `AddressEditor`s, so a locked document stops presenting an editable form over data the API refuses to change.
 - DS rules apply: semantic tokens only, shared primitives, no new inline comments.
-- The UI phase MUST remove `// @ts-nocheck` from `AddressesSection.tsx` (13 pre-existing errors to fix) or, failing that, MUST NOT be accepted on eyeball-only review — the file is invisible to `tsc`.
+- Phase 1 MUST remove `// @ts-nocheck` from `AddressesSection.tsx` and fix the type errors it hides. This is a precondition of the phase, not a preference: while the directive stands the file is invisible to `tsc`, so everything the phase adds there is unchecked by CI.
 
 ## Migration & Backward Compatibility
 
 - **Everything in Phases 0–2 is additive.** No DB migration; snapshots are schemaless. With no `contactLabels` supplied, `AddressView` output is byte-identical — pinned by test.
 - **New frozen exports**: `formatAddressContactPairs`, `AddressContactLabels` freeze on merge per `BACKWARD_COMPATIBILITY.md`; this spec is the required reference.
-- **`name` → `label` rename (Q9, Phase 4)** follows the deprecation protocol: add `label`, keep `name` as a deprecated bridge for ≥1 minor, `@deprecated` JSDoc with target removal version, `UPGRADE_NOTES.md` entry. Snapshot storage keys are untouched.
+- **`name` → `label` rename (Phase 4)** follows the deprecation protocol: add `label`, keep `name` as a deprecated bridge for ≥1 minor, `@deprecated` JSDoc with target removal version, `UPGRADE_NOTES.md` entry. Snapshot storage keys are untouched.
 - **Phase 3 migration** is additive nullable columns — deployable without downtime, safely re-runnable.
 - **No core backfill.** Existing snapshots keep whatever they carry; a writer that wants the fields on historical documents re-emits them.
 
 ## Implementation Plan
 
-### Phase 0 — snapshot key preservation *(shipped, PR #69)*
-`normalizeAddressDraft` merges back keys outside the twelve it owns; cleared address still normalizes to `null`.
+### Phase 0 — snapshot key preservation *(outstanding; first implementable step)*
+1. `normalizeAddressDraft` in `AddressesSection.tsx:78-99` takes the previous snapshot and merges back keys outside the twelve it owns; a cleared address still normalizes to `null`.
+2. The same for the second copy in `SalesDocumentForm.tsx:438-459`, used on the document create/edit path at `:1446-1447`. Both must land together — fixing one leaves the data loss reachable from the other screen.
+3. Round-trip tests on both save paths.
 
-### Phase 1 — contact fields, render, read-only view *(PR #66)*
+*Prior art: this fix exists on the Full Stack House fork as [fullstackhouse/open-mercato#69](https://github.com/fullstackhouse/open-mercato/pull/69), covering the `AddressesSection` copy only. It is not merged in this repository, and the `SalesDocumentForm` copy is not covered there.*
+
+### Phase 1 — contact fields and render
 1. `AddressValue` + `formatAddressContactPairs` + `AddressView` contact block, with postal-purity and self-hiding tests.
 2. Wire to the shipping/billing snapshot tiles.
-3. Add `taxIdType` to the type and the pair-formatter (pending the Q3/Q4 call).
-4. Remove `email` from the field set and from the five locale files (see Q2).
-5. Read-only snapshot view for locked documents.
-6. Lift `// @ts-nocheck` from `AddressesSection.tsx`.
+3. Add `taxIdType` to the type and the pair-formatter.
+4. Pass `disabled={locked}` at `AddressesSection.tsx:1070` and `:1137`.
+5. Remove `// @ts-nocheck` from `AddressesSection.tsx` and fix the errors it hides.
+
+*Prior art: a first cut of steps 1–2 exists on the fork as [fullstackhouse/open-mercato#66](https://github.com/fullstackhouse/open-mercato/pull/66), not merged in this repository.*
 
 ### Phase 2 — tax-id semantics
 1. `normalizeEuVatId()` util — ISO-2 prefix on write.
-2. Type-aware display gate per Q7; align search config so a public VAT number may index where local/personal numbers stay `hashOnly` or excluded.
+2. Type-aware display gate; align search config so a public VAT number may index where local/personal numbers stay `hashOnly` or excluded.
 
 ### Phase 3 — recipient name + customer address book *(separable)*
 1. `recipientName` on `AddressValue`/`AddressView`; `recipient_name`, `phone` columns on `CustomerAddress` with encryption-map entries.
@@ -185,9 +184,9 @@ No new endpoints; no request/response shape changes. `addressSnapshotSchema` del
 
 ## Integration Coverage
 
-Unit (`packages/core`, exists on branch): postal lines unchanged when contacts present (**the safety property**); per-field label gate; null-render preserved; snapshot round-trip keeps unowned keys.
+Unit (`packages/core`): postal lines unchanged when contacts present (**the safety property**); per-field label gate; null-render preserved; snapshot round-trip keeps unowned keys — asserted separately against **both** `normalizeAddressDraft` copies, since a single-path test passes while the other still drops keys.
 
-Route/UI level (Phase 1): `packages/core/src/modules/sales/__integration__/TC-SALES-ADDR-CONTACT-001.spec.ts` — order created via API with a snapshot carrying `phone`/`taxId`; detail page renders both; editor save round-trips them; locked document shows the read-only view. Self-contained fixtures, no seeded data.
+Route/UI level (Phase 1): `packages/core/src/modules/sales/__integration__/TC-SALES-ADDR-CONTACT-001.spec.ts` — order created via API with a snapshot carrying `phone`/`taxId`; detail page renders both; save round-trips them from the detail tab and from the document form; a locked document renders the address inputs in their disabled state. Self-contained fixtures, no seeded data.
 
 Phase 3: `TC-CRM-CRUDFORM-*` proves `recipient_name`/`phone` save-and-reload on customer address create + update.
 
@@ -199,7 +198,7 @@ Write operations are limited to the existing document-update path (Phase 0/1) an
 - **Scenario**: A personal (non-VAT) tax number renders in the document detail to a user who shouldn't see PII.
 - **Severity**: Medium
 - **Affected area**: sales document detail
-- **Mitigation**: type-aware gate (Q7) before anything beyond the locked read-only view ships; `local`/`other` behind the existing PII feature.
+- **Mitigation**: the type-aware gate ships with Phase 2, before any tax id renders to a non-privileged user; `pl_nip`/`other` sit behind the existing PII feature.
 - **Residual risk**: `eu_vat` renders ungated by design — it is a public identifier (VIES).
 
 #### Editor merge-back resurrects a stale key
@@ -209,12 +208,12 @@ Write operations are limited to the existing document-update path (Phase 0/1) an
 - **Mitigation**: document-level optimistic locking already rejects the stale save (409).
 - **Residual risk**: none beyond existing conflict UX.
 
-#### Frozen enum too small, or too coarse
-- **Scenario**: Under option (b), a value typed `local` cannot be interpreted because `country` is unconstrained free text; under either option, a tax-id class appears that the seeded set does not name.
+#### A tax-id class appears that the seed set does not name
+- **Scenario**: A deployment meets an identifier that is neither `eu_vat` nor `pl_nip`, and stores it as `other`, losing the distinction.
 - **Severity**: Low
 - **Affected area**: tax-id display, future validation
-- **Mitigation**: enums widen additively under the BC contract; the coarseness risk is the explicit trade-off recorded in Q3/Q4 and is one input to that decision.
-- **Residual risk**: a second small migration, accepted.
+- **Mitigation**: the enum widens additively under the BC contract, one observed case at a time; only the seed values freeze on merge.
+- **Residual risk**: values already stored as `other` need re-typing when their class is named — a data touch-up, not a migration of surface.
 
 #### Rename breaks third-party address consumers
 - **Scenario**: A module reads `name` from the API after Phase 4 removal.
@@ -223,7 +222,7 @@ Write operations are limited to the existing document-update path (Phase 0/1) an
 - **Mitigation**: ≥1-minor bridge, `@deprecated` JSDoc, `UPGRADE_NOTES.md`; storage keys unchanged.
 - **Residual risk**: consumers that ignore deprecation warnings break at the announced removal — accepted per protocol.
 
-## Final Compliance Report — 2026-08-10
+## Final Compliance Report — 2026-08-11
 
 ### AGENTS.md Files Reviewed
 - `AGENTS.md` (root), `.ai/specs/AGENTS.md`, `.ai/qa/AGENTS.md`, `BACKWARD_COMPATIBILITY.md`, `.ai/skills/om-spec-writing/SKILL.md` + references
@@ -248,13 +247,15 @@ Write operations are limited to the existing document-update path (Phase 0/1) an
 | API contracts match UI/UX | Pass | Render-only; no shape change |
 | Risks cover all write operations | Pass | Save path + Phase 3 migration |
 | Commands defined for all mutations | Pass | No new mutations |
-| Field set consistent after dropping `email` | Pass | TLDR, Data Models, Phases and Integration Coverage all read `phone` + `taxId` + `taxIdType` |
+| Field set consistent throughout | Pass | TLDR, Data Models, Phases and Integration Coverage all read `phone` + `taxId` + `taxIdType` |
+| Every claim about current behaviour re-read at `develop` | Pass | Verified against `39412fdd5`: `normalizeAddressDraft` single-argument in both copies, `AddressEditor` `disabled` prop present and unpassed at `AddressesSection.tsx:1070`/`:1137`, no `…addresses.email` key in any of the five locales |
+| No open decisions left to the implementer | Pass | §Design Decisions Taken During Review; deferred items listed explicitly |
 
 ### Non-Compliant Items
 None at spec level.
 
 ### Verdict
-**Blocked — Open Questions Q0 and Q3/Q4 must be resolved before implementation proceeds past Phase 0.** All other sections are implementation-ready.
+**Implementation-ready**, starting at Phase 0. No question in this document is left open; the deferred items named under Design Decisions are outside every phase here and block none of them.
 
 ## Appendix — field prevalence in one production dataset
 
@@ -266,10 +267,14 @@ The justification above stands on the market comparison, not on any single deplo
 | Tax identifier on the document billing address (placeholders excluded) | 12.9% of orders |
 | Tax identifier at customer level | 5.6% of customers |
 
-Two observations that shaped decisions above: the order-level tax-id rate exceeds the customer-level rate because business buyers reorder more often (an input to Q6), and `buildingNumber` was populated on ~1% of addresses because house numbers are conventionally written into the street line — which is why this spec adds no further logic there.
+Two observations that shaped decisions above: the order-level tax-id rate exceeds the customer-level rate because business buyers reorder more often — an input to keeping the customer as master while the document freezes what it was issued under — and `buildingNumber` was populated on ~1% of addresses because house numbers are conventionally written into the street line, which is why this spec adds no further logic there.
 
 ## Changelog
 
+### 2026-08-11
+- Every claim about current behaviour re-verified against `develop` and corrected. Phase 0 is stated as outstanding work in this repository rather than shipped; a second `normalizeAddressDraft` on `SalesDocumentForm.tsx` is brought into scope, since fixing one copy leaves the data loss reachable from the other screen; Problem 5 is restated as the narrower true defect — `AddressEditor` accepts `disabled` and the two snapshot call sites simply do not pass it — and the two-line fix replaces the proposed read-only render path, which moves to Alternatives; the removal of a nonexistent `…addresses.email` i18n key is dropped; fork pull requests are labelled and linked as such.
+- Open Questions resolved and the block replaced by a decisions record: one spec phased, and `taxIdType` takes the Stripe-shaped `{country}_{kind}` seeded `eu_vat` / `pl_nip` / `other`, because a minimal enum's `local` is uninterpretable while `country` stays unconstrained and leaves the display gate nothing to key on. Compliance verdict moves from Blocked to implementation-ready.
+
 ### 2026-08-10
 - Initial specification.
-- Reframed after review: the driver is now the general commerce gap — every comparable platform models a phone on the address and Open Mercato does not — with the single-deployment measurements demoted to an appendix. Open Questions moved below Problem Statement and Proposed Solution. `email` dropped from the field set on market evidence (Q2). The `taxIdType` shape (Q3/Q4) is presented as an open fork after Stripe's type table showed `pl_nip` and `eu_vat` to be distinct types, withdrawing an earlier recommendation for a minimal enum.
+- Reframed after review: the driver is the general commerce gap — every comparable platform models a phone on the address and Open Mercato does not — with the single-deployment measurements demoted to an appendix. `email` dropped from the field set on market evidence.

--- a/.ai/specs/2026-08-10-address-contact-and-tax-fields.md
+++ b/.ai/specs/2026-08-10-address-contact-and-tax-fields.md
@@ -43,7 +43,7 @@ The gap is felt by any deployment that ships physical goods (a delivery without 
 >
 > **Rejected:** an email on the address — two of the three commerce platforms deliberately keep it on the order, and an order-level email is the better home; splicing contact details into the postal address lines — nobody does this, and it corrupts every one-line summary built from those lines.
 
-**Touched:** `packages/core/src/modules/customers/utils/addressFormat.tsx`, `packages/ui/src/backend/detail/addressFormat.tsx` (near-identical twin — the two files differ only in the import and the `AddressFormatStrategy` alias, so they must be edited in parallel rather than copied over one another), `packages/core/src/modules/sales/components/documents/AddressesSection.tsx`, `packages/core/src/modules/sales/components/documents/SalesDocumentForm.tsx` (second `normalizeAddressDraft` on the document create/edit path — Phase 0), sales i18n (5 locales), Phase 3 only: `customers` address entities + migration.
+**Touched:** `packages/core/src/modules/customers/utils/addressFormat.tsx`, `packages/ui/src/backend/detail/addressFormat.tsx` (near-identical twin — the two files differ only in the import and the `AddressFormatStrategy` alias, so they must be edited in parallel rather than copied over one another), `packages/core/src/modules/sales/components/documents/AddressesSection.tsx`, sales i18n (5 locales), Phase 3 only: `customers` address entities + migration.
 
 **Not touched:** `sales_document_addresses` schema (explicitly rejected — see Alternatives), `addressSnapshotSchema` (stays free-form), search indexing config outside the tax-id rules, per-country address formats, VIES calls, address filterability (blocked by encryption at rest), `buildingNumber`/`flatNumber` logic (house numbers are conventionally written into the street line, and the field is near-empty in practice — see Appendix).
 
@@ -54,7 +54,7 @@ The gap is felt by any deployment that ships physical goods (a delivery without 
 3. **Contact details are per-address, not per-customer.** One customer has a home address, an office address and a warehouse, each with a different person to call. Holding one phone on the customer answers the wrong question.
 4. **A bare tax identifier is ambiguous.** `1234567890` may be a Polish NIP, an EU VAT number missing its country prefix, or a local tax number of a business that is not VAT-registered at all. Stripe treats these as *distinct types* (`pl_nip` vs `eu_vat`, examples `1234567890` vs `PL1234567890`) precisely because display, tax calculation and validation all diverge on the answer.
 5. **Locked documents render an editable editor.** `AddressEditor` does accept a `disabled` prop (`customers/components/AddressEditor.tsx:82`, and its `ui` twin at `:97`), but neither snapshot call site passes it (`AddressesSection.tsx:1070`, `:1137`) — while every sibling control in that component is already locked (`:1057`, `:1082`, `:1113`, `:1132`) and a `lockedReason` banner renders above them at `:1018-1026`. A deployment that locks document addresses (`order_address_editable_statuses = []`) therefore presents a fully editable form over data the API will refuse to change.
-6. **Unknown snapshot keys do not survive a save.** `normalizeAddressDraft` rebuilds the snapshot from the twelve fields the editor models, destroying every other key on the first manual save — silent data loss for exactly the keys this feature depends on. Two independent copies of the helper do this: `AddressesSection.tsx:78-99` (document detail Addresses tab) and `SalesDocumentForm.tsx:438-459` (document create/edit form, reached from `:1446-1447`). Fixing one and not the other makes the loss depend on which screen the user saved from. *(Outstanding in this repository — Phase 0.)*
+6. **Unknown snapshot keys do not survive a save.** `normalizeAddressDraft` (`AddressesSection.tsx:78-99`) rebuilds the snapshot from the twelve fields the editor models, destroying every other key on the first manual save — silent data loss for exactly the keys this feature depends on. A second copy of the helper exists on `SalesDocumentForm.tsx:438-459`, but that component is mounted only by `backend/sales/documents/create/page.tsx` and submits through `createCrud`: on a document that does not exist yet there is no prior snapshot to preserve, so the defect is not reachable there. The duplication is worth collapsing on its own merits; it is not a second instance of this bug. *(Outstanding in this repository — Phase 0.)*
 
 ## Proposed Solution
 
@@ -157,10 +157,9 @@ Two keys added: `sales.documents.detail.addresses.{taxId,phone}` in `en`, `pl`, 
 
 ### Phase 0 — snapshot key preservation *(outstanding; first implementable step)*
 1. `normalizeAddressDraft` in `AddressesSection.tsx:78-99` takes the previous snapshot and merges back keys outside the twelve it owns; a cleared address still normalizes to `null`.
-2. The same for the second copy in `SalesDocumentForm.tsx:438-459`, used on the document create/edit path at `:1446-1447`. Both must land together — fixing one leaves the data loss reachable from the other screen.
-3. Round-trip tests on both save paths.
+2. A round-trip test on that save path, asserting an unowned key survives.
 
-*Prior art: this fix exists on the Full Stack House fork as [fullstackhouse/open-mercato#69](https://github.com/fullstackhouse/open-mercato/pull/69), covering the `AddressesSection` copy only. It is not merged in this repository, and the `SalesDocumentForm` copy is not covered there.*
+The `SalesDocumentForm.tsx:438-459` copy is deliberately left alone: it runs only on document creation, where no prior snapshot exists, so a merge-back there would be permanently inert. Collapsing the two copies is separate work with its own justification.
 
 ### Phase 1 — contact fields and render
 1. `AddressValue` + `formatAddressContactPairs` + `AddressView` contact block, with postal-purity and self-hiding tests.
@@ -184,7 +183,7 @@ Two keys added: `sales.documents.detail.addresses.{taxId,phone}` in `en`, `pl`, 
 
 ## Integration Coverage
 
-Unit (`packages/core`): postal lines unchanged when contacts present (**the safety property**); per-field label gate; null-render preserved; snapshot round-trip keeps unowned keys — asserted separately against **both** `normalizeAddressDraft` copies, since a single-path test passes while the other still drops keys.
+Unit (`packages/core`): postal lines unchanged when contacts present (**the safety property**); per-field label gate; null-render preserved; snapshot round-trip keeps unowned keys, asserted through the document detail save path — the only path on which a prior snapshot exists.
 
 Route/UI level (Phase 1): `packages/core/src/modules/sales/__integration__/TC-SALES-ADDR-CONTACT-001.spec.ts` — order created via API with a snapshot carrying `phone`/`taxId`; detail page renders both; save round-trips them from the detail tab and from the document form; a locked document renders the address inputs in their disabled state. Self-contained fixtures, no seeded data.
 
@@ -271,8 +270,11 @@ Two observations that shaped decisions above: the order-level tax-id rate exceed
 
 ## Changelog
 
+### 2026-08-12
+- Corrected the scope of Problem 6. The second `normalizeAddressDraft`, on `SalesDocumentForm.tsx`, is not a second instance of the data loss: that component is mounted only by the document *create* page and submits through `createCrud`, so no prior snapshot exists for it to drop. Phase 0 covers the document detail path alone; the duplication is recorded as work that needs its own justification.
+
 ### 2026-08-11
-- Every claim about current behaviour re-verified against `develop` and corrected. Phase 0 is stated as outstanding work in this repository rather than shipped; a second `normalizeAddressDraft` on `SalesDocumentForm.tsx` is brought into scope, since fixing one copy leaves the data loss reachable from the other screen; Problem 5 is restated as the narrower true defect — `AddressEditor` accepts `disabled` and the two snapshot call sites simply do not pass it — and the two-line fix replaces the proposed read-only render path, which moves to Alternatives; the removal of a nonexistent `…addresses.email` i18n key is dropped; fork pull requests are labelled and linked as such.
+- Every claim about current behaviour re-verified against `develop` and corrected. Phase 0 is stated as outstanding work in this repository rather than shipped; a second `normalizeAddressDraft` on `SalesDocumentForm.tsx` is examined and recorded; Problem 5 is restated as the narrower true defect — `AddressEditor` accepts `disabled` and the two snapshot call sites simply do not pass it — and the two-line fix replaces the proposed read-only render path, which moves to Alternatives; the removal of a nonexistent `…addresses.email` i18n key is dropped; fork pull requests are labelled and linked as such.
 - Open Questions resolved and the block replaced by a decisions record: one spec phased, and `taxIdType` takes the Stripe-shaped `{country}_{kind}` seeded `eu_vat` / `pl_nip` / `other`, because a minimal enum's `local` is uninterpretable while `country` stays unconstrained and leaves the display gate nothing to key on. Compliance verdict moves from Blocked to implementation-ready.
 
 ### 2026-08-10

--- a/.ai/specs/2026-08-10-address-contact-and-tax-fields.md
+++ b/.ai/specs/2026-08-10-address-contact-and-tax-fields.md
@@ -3,12 +3,17 @@
 ## TLDR
 
 **Key Points:**
-- A sales document's address snapshots (`billing_address_snapshot` / `shipping_address_snapshot`) are free-form JSON, so integrations already persist `phone`, `email` and tax-id keys on them — but nothing models, renders, protects, or preserves those keys. This spec gives them a first-class model (`taxId` + `taxIdType`), a render path, and survival guarantees.
-- Grew out of PR #66 and its reviews: the first wiring targeted `sales_document_addresses` (typed table, no such columns, 6 rows on prod against 1.42M orders) and rendered nothing; the save path destroyed the keys (fixed separately in PR #69).
+- An address in Open Mercato cannot carry a phone number or a tax identifier. `AddressValue` models nine postal fields, and every formatter and renderer derives from those.
+- Both are ordinary requirements of order fulfilment. A carrier needs a contact number to deliver — mandatory for parcel-locker and pickup-point delivery. A B2B invoice address is incomplete without the tax identifier the document was issued under, and under the EU OSS scheme the destination country and the buyer's VAT-registration status decide the rate.
+- They belong on the **address**, not on the customer: one customer keeps several addresses, each with its own recipient and its own contact. Shopify, Medusa and commercetools all model a phone on the address; Open Mercato is the outlier that does not.
+
+**Proposed solution:**
+- Additive optional fields on `AddressValue` (`phone`, `taxId`, `taxIdType`), rendered by `AddressView` as an opt-in contact block — omit the labels and output is byte-identical to today.
+- On the sales side the document address snapshot is the carrier. It is already schemaless and encrypted at rest, so no schema change is needed there; customer-address columns arrive later and additively.
 
 **Scope:**
-- `AddressValue` contact fields + opt-in `AddressView` contact block (implemented on `feat/address-contact-fields-render`, carries over)
-- Tax-id typing (`taxIdType`) and EU-VAT normalization
+- `AddressValue` contact fields + opt-in `AddressView` contact block
+- Tax-id typing (`taxIdType`) and EU-VAT normalization on write
 - Read-only snapshot view for locked documents
 - Type-aware indexing/display policy for tax ids
 - `name` → `label` rename on address entities (deprecation protocol)
@@ -18,70 +23,102 @@
 - Tax ids are PII-adjacent and already treated as sensitive by search (`customers/search.ts:713`, `:805`).
 - `AddressesSection.tsx` carries `// @ts-nocheck` (13 pre-existing type errors) — everything added there is unchecked by CI until that is lifted.
 
-## Open Questions
-
-Numbered per the review thread on PR #66. Each carries our recommendation; **Q0 and Q3/Q4 block the design**, the rest default to the recommendation if unchallenged.
-
-- **Q0 (split?)**: Does this bundle two capabilities — contact-detail rendering and tax-id semantics? **Recommendation: one spec, phased.** Both ride the same frozen `AddressValue` surface; splitting would freeze `taxId: string` in phase 1 and regret it in phase 2. The phases below are independently shippable, which captures the split's benefit without the surface risk.
-- **Q2 (email on the address?)**: Shopify/Medusa keep email on the order; commercetools puts it on the address. **Recommendation: document snapshot only, not `CustomerAddress`.** In the motivating dataset the delivery email is a per-order fact (95–98% coverage on shipments/notes), not a property of an address-book entry.
-- **Q3/Q4 (tax-id type)**: Bare digits are ambiguous — a PL NIP of a non-VAT-registered business is not a VAT ID. **Recommendation: `taxId` + `taxIdType` from the start, minimal enum `eu_vat | local | other`** (Stripe-shaped `gb_vat`/`ch_vat`/… rejected for now; enum widens additively later). Needs an explicit call — this is the expensive-to-reverse decision.
-- **Q7 (ACL gate)**: Should rendering a tax id be feature-gated? **Recommendation: type-aware, matching search's existing stance** — `eu_vat` is a public business identifier (VIES is an open lookup) and renders ungated; `local`/`other` render only behind the existing customer-PII feature the deployment already uses for `tax_id`. Exact feature id to be settled in Phase 2 review.
-- **Q9 (rename)**: `name` on address entities is the address *label* ("Home"/"Warehouse"); a future `recipientName` beside it is a trap. **Recommendation: rename to `label` under the deprecation protocol** (bridge both names for one minor, `UPGRADE_NOTES.md` entry). Storage key in existing snapshots stays `name`; the bridge maps it.
-
-Answered on the PR thread and treated as decided here: Q1 (`recipientName` — in scope, Phase 3), Q5 (normalize EU VAT to ISO-2-prefixed on write), Q6 (address-level authoritative for the document; customer stays master), Q8 (`country` constraint — separate change), Q10 (read-only snapshot view — Phase 1), Q11 (no core backfill), Q12 (the duplicate `addressFormat.tsx` copies — out of scope).
-
----
-
 ## Overview
 
-Sales documents imported from an ERP carry a frozen billing/delivery address including the phone and tax id the document was issued under. Open Mercato persists these (snapshots are schemaless jsonb, encrypted at rest) but cannot display them, and until PR #69 destroyed them on the first manual save. Target audience: any deployment whose documents originate in an external system of record; the motivating case is a Subiekt GT ERP with 99.7% phone and 12.9% tax-id coverage on document addresses.
+Open Mercato models an address as nine postal fields and nothing else. That is enough to print a label and not enough to fulfil an order: no phone for the carrier, no tax identifier for the invoice. Both are routine facts about an address in commerce, and both are already modelled by every comparable platform.
 
-> **Market Reference**: Stripe (tax id + type enum — adopted, minimal variant), commercetools (email on address — considered for Q2), Shopify/Medusa (email on order — recommended for Q2). Rejected: splicing contact details into postal address lines (no marketplace does this; it corrupts one-line summaries).
+The gap is felt by any deployment that ships physical goods (a delivery without a contact number fails at the door, and cannot be sent to a parcel locker at all) or sells to businesses (an invoice address without its tax identifier is commercially, and in most EU jurisdictions legally, incomplete).
+
+> **Market Reference**
+>
+> | Platform | `phone` on the address | `email` on the address | Tax identifier |
+> |---|---|---|---|
+> | [Shopify `MailingAddress`](https://shopify.dev/docs/api/admin-graphql/latest/objects/MailingAddress) | yes (with `company`) | no | on the customer / order |
+> | [Medusa v2 `Address`](https://docs.medusajs.com/v1/references/entities/classes/Address) | yes (with `address_name`, `first_name`/`last_name`) | no | — |
+> | [commercetools `Address`](https://docs.commercetools.com/api/types) | yes (with `mobile`, `fax`) | yes | — |
+> | [Stripe](https://docs.stripe.com/billing/customer/tax-ids) | — | — | `tax_id` value + `type` enum, held as a **list** on the customer and rendered onto invoices |
+> | **Open Mercato** | **no** | **no** | **no** |
+>
+> **Adopted:** a phone on the address (universal); a tax identifier carrying an explicit type (Stripe). Stripe is also the precedent for Q6 — the customer owns the identifier, the document freezes the value it was issued under.
+>
+> **Rejected:** an email on the address — two of the three commerce platforms deliberately keep it on the order, and an order-level email is the better home (see Q2); splicing contact details into the postal address lines — nobody does this, and it corrupts every one-line summary built from those lines.
 
 **Touched:** `packages/core/src/modules/customers/utils/addressFormat.tsx`, `packages/ui/src/backend/detail/addressFormat.tsx` (byte-identical twin), `packages/core/src/modules/sales/components/documents/AddressesSection.tsx`, sales i18n (5 locales), Phase 3 only: `customers` address entities + migration.
 
-**Not touched:** `sales_document_addresses` schema (explicitly rejected — see Alternatives), `addressSnapshotSchema` (stays free-form), search indexing config outside the tax-id rules, pickup points, per-country address formats, VIES calls, address filterability (blocked by encryption at rest), `buildingNumber`/`flatNumber` logic (1.1% fill in the motivating dataset; house numbers live in the street string).
+**Not touched:** `sales_document_addresses` schema (explicitly rejected — see Alternatives), `addressSnapshotSchema` (stays free-form), search indexing config outside the tax-id rules, per-country address formats, VIES calls, address filterability (blocked by encryption at rest), `buildingNumber`/`flatNumber` logic (house numbers are conventionally written into the street line, and the field is near-empty in practice — see Appendix).
 
 ## Problem Statement
 
-1. **No read path.** `AddressValue` models nine postal fields; `formatAddressJson` / `formatAddressLines` / `formatAddressString` / `AddressView` are all built from those. A snapshot carrying `phone`/`taxId` renders as if it didn't.
-2. **A B2B invoice address without its tax id is incomplete**, and "who to call about this delivery" is a property of the delivery address, not the customer — one customer, several addresses, different contacts.
-3. **Bare tax ids are ambiguous.** `1234567890` could be an EU VAT ID, a local tax number of a non-VAT-registered business, or neither. Display, indexing policy, and future VIES validation all depend on knowing which.
-4. **No read-only snapshot render exists.** Snapshots render exclusively through `AddressEditor`, which takes no `disabled` prop — deployments that lock document addresses (`order_address_editable_statuses = []`) show an editable form for read-only data.
-5. **(Fixed, PR #69)** `normalizeAddressDraft` rebuilt the snapshot from the editor's twelve fields on save, silently destroying every key the editor cannot show.
+1. **The fields cannot be modelled.** `AddressValue` has nine postal fields; `formatAddressJson` / `formatAddressLines` / `formatAddressString` / `AddressView` all derive from those. There is nowhere to put a phone number.
+2. **The fields cannot be shown.** On the sales side the document address snapshot is schemaless jsonb, so an integration posting `{ addressLine1, city, phone, taxId }` **does** get those keys persisted today — they simply have no read path, and render as if absent.
+3. **Contact details are per-address, not per-customer.** One customer has a home address, an office address and a warehouse, each with a different person to call. Holding one phone on the customer answers the wrong question.
+4. **A bare tax identifier is ambiguous.** `1234567890` may be a Polish NIP, an EU VAT number missing its country prefix, or a local tax number of a business that is not VAT-registered at all. Stripe treats these as *distinct types* (`pl_nip` vs `eu_vat`, examples `1234567890` vs `PL1234567890`) precisely because display, tax calculation and validation all diverge on the answer.
+5. **Locked documents render an editor.** Address snapshots render exclusively through `AddressEditor`, which takes no `disabled` prop. A deployment that locks document addresses (`order_address_editable_statuses = []`) shows an editable form over read-only data.
+6. **Unknown snapshot keys did not survive a save.** `normalizeAddressDraft` rebuilt the snapshot from the twelve fields the editor models, destroying every other key on the first manual save — silent data loss for exactly the keys this feature depends on. *(Fixed; see Phase 0.)*
 
 ## Proposed Solution
 
-Model the contact details as **optional fields on `AddressValue`**, rendered by `AddressView` as a trailing contact block that is **opt-in per field via caller-supplied labels** — omit `contactLabels` and the component is byte-identical to today. `formatAddressContactPairs(address, labels)` is exported so callers can ask "anything to show?" without rendering. The **document snapshot is the carrier**: it already persists the keys, is encrypted at rest, and is the frozen per-document fact. Tax ids carry a `taxIdType`; EU VAT IDs are normalized to the ISO-2-prefixed form on write by the emitting integration.
+Model the contact details as **optional fields on `AddressValue`**, rendered by `AddressView` as a trailing contact block that is **opt-in per field via caller-supplied labels** — omit `contactLabels` and the component is byte-identical to today. `formatAddressContactPairs(address, labels)` is exported so callers can ask "anything to show?" without rendering. On the sales side the **document snapshot is the carrier**: it already persists the keys, is encrypted at rest, and is the frozen per-document fact. Tax identifiers carry a `taxIdType`; EU VAT numbers are normalized to the ISO-2-prefixed form on write.
 
 ### Design Decisions
 
 | Decision | Rationale |
 |----------|-----------|
 | Contact block outside `formatAddressLines` | `formatAddressString` joins lines with `", "` into picker labels and table cells; a tax id spliced into `"Baker Street 10, NW1 London"` is wrong in every one. A test pins postal-line purity. |
-| Labels-as-opt-in, caller-translated | The util module is deliberately i18n-free; callers have `useT()`. Also enables phone-without-tax-id (the common delivery-address case). |
-| Snapshot as carrier, not typed columns | Snapshots have the data (99.6% of 1.42M prod orders); `sales_document_addresses` has 6 rows and would need columns + write paths + backfill for nothing. |
-| `taxIdType` minimal enum | Widens additively; no non-EU data justifies the Stripe-shaped list today. |
+| Labels-as-opt-in, caller-translated | The util module is deliberately i18n-free; callers have `useT()`. Also enables phone-without-tax-id, which is the common delivery-address case. |
+| Snapshot as carrier on the sales side, not typed columns | The snapshot is where the per-document value is frozen and where integrations already write. Typed columns would need a write path and a backfill to reach the same place. |
+| Tax identifier carries an explicit type | Follows Stripe; without it the value cannot be interpreted, validated or gated. Shape is Q3/Q4. |
 
 ### Alternatives Considered
 
 | Alternative | Why Rejected |
 |-------------|-------------|
-| Columns on `sales_document_addresses` | Wrong path twice over: no data flows there (6 prod rows), and the document-level frozen fact lives in the snapshot. This was PR #66's original wiring; it rendered nothing. |
-| Splice contacts into `formatAddressLines` | Corrupts every one-line summary downstream. |
-| Bare `taxId: string`, type later | The one decision that is expensive to walk back once frozen; ambiguity documented in Problem 3. |
-| Hardcoded translated labels in the util | Breaks the module's i18n-free contract; forces all-or-nothing field display. |
+| Columns on `sales_document_addresses` | Wrong on two counts: the per-document frozen fact belongs on the snapshot, and that table is a document's *additional* address list, which most deployments never populate. |
+| Splice contacts into `formatAddressLines` | Corrupts every one-line summary downstream — picker options, entry labels, table cells. |
+| Bare `taxId: string`, type added later | The identifier is uninterpretable without its type, and the field freezes as public surface on merge. |
+| `email` on the address | Two of three comparable platforms hold it on the order instead; see Q2. |
+| Hardcoded translated labels in the util | Breaks the module's i18n-free contract and forces all-or-nothing field display. |
+
+## Open Questions
+
+*Scaffolding — to be resolved and removed before this spec is finalized.* **Q0 and Q3/Q4 block implementation past Phase 0**; the rest carry a recommendation and default to it if unchallenged.
+
+- **Q0 — one spec or two?** Does this bundle two independently deployable capabilities, contact-detail rendering and tax-id semantics? *Recommendation: one spec, phased.* Both freeze the same `AddressValue` surface, so splitting would commit to `taxId: string` in the first and regret it in the second. The phases below are independently shippable, which captures the split's benefit without the surface risk.
+
+- **Q3/Q4 — the shape of `taxIdType`.** *Presented as a genuine fork; no recommendation.* This one is architectural and worth your call.
+
+  | | **(a) Stripe-shaped `{country}_{kind}`** | **(b) Minimal `eu_vat \| local \| other`** |
+  |---|---|---|
+  | Seed values | `eu_vat`, `pl_nip`, `other`, widened as observed | the three, fixed |
+  | For | Matches the industry vocabulary; distinguishes `pl_nip` from `eu_vat`, which is the ambiguity in Problem 4; widens naturally one country at a time | Smallest surface to freeze; nothing speculative |
+  | Against | More public surface committed up front for cases not yet observed | `local` is uninterpretable without a country, and `country` is unconstrained free text (Q8, deferred) — so the ambiguity moves rather than resolves |
+
+  *Note:* an earlier comment on PR #66 recommended (b). Reading Stripe's actual type table — where `pl_nip` and `eu_vat` are separate types with exactly the `1234567890` / `PL1234567890` examples — weakened that argument enough to withdraw the recommendation rather than defend it.
+
+- **Q7 — is displaying a tax identifier ACL-gated?** *Recommendation: type-aware, matching what search already does.* An EU VAT number is a public business identifier (VIES is an open lookup) and renders ungated; a local or personal tax number renders only behind the customer-PII feature the deployment already applies to `tax_id`. Exact feature id settled in Phase 2 review.
+
+- **Q9 — rename `name` to `label`.** `name` on address entities is the address *label* ("Home", "Warehouse"); putting a recipient name beside it is a trap. Medusa makes the same split explicitly — `address_name` for the label, `first_name`/`last_name` for the person. *Recommendation: rename under the deprecation protocol* (bridge both for ≥1 minor, `UPGRADE_NOTES.md` entry); snapshot storage keys are untouched and the bridge maps them.
+
+- **Q1 refinement — one `recipientName`, or `firstName`/`lastName`?** Shopify and Medusa both split the person into two fields. Splitting is better for salutation and sorting; a single field is friendlier to sources that only ever supply a full name. *Recommendation: single `recipientName` in Phase 3, since `AddressValue` has no person field at all today and splitting can be layered additively.*
+
+**Resolved on the evidence, no longer open:**
+
+- **Q2 — email is dropped from `AddressValue`.** Shopify and Medusa both keep email off the address and hold it on the order/customer; only commercetools carries it on the address. Two of three, plus the fact that a delivery email is a per-order rather than per-address fact, is enough to leave it out rather than freeze a contested field. Scope shrinks to `phone` + `taxId` + `taxIdType`.
+- **Q5** — normalize EU VAT to the ISO-2-prefixed form on write. Stripe validates `eu_vat` against VIES and `gb_vat` against HMRC on exactly that form, so normalizing makes any future validation a pass-through.
+- **Q6** — the customer is the master of a tax identifier; the document freezes the value it was issued under. This is Stripe's model (identifiers live on the customer as a list, and are rendered onto invoice PDFs).
+- **Q8** (`country` constraint — separate change), **Q10** (read-only snapshot view — Phase 1), **Q11** (no core backfill), **Q12** (the duplicate `addressFormat.tsx` copies — out of scope).
 
 ## User Stories / Use Cases
 
-- An **operations user** viewing an imported order sees the phone the courier should call, on the delivery address that carries it.
-- An **accountant** sees the tax id a B2B invoice was issued under, on the billing address, exactly as frozen at document time.
+- A **warehouse operator** dispatching an order sees the phone the carrier needs, on the delivery address that carries it — not a number belonging to a different address of the same customer.
+- An **accountant** sees the tax identifier a B2B invoice was issued under, on the billing address, exactly as frozen at document time.
+- An **integration author** posting an address with a phone number sees it rendered, and sees it survive a subsequent manual edit.
 - A **third-party module author** calls `AddressView` exactly as before and observes zero change until they opt in with labels.
 
 ## Architecture
 
-Data flow (read): `integration → *_address_snapshot (jsonb, encrypted at rest per sales/encryption.ts) → document detail UI → AddressView contact block`.
-Data flow (write/edit): `AddressEditor draft → normalizeAddressDraft(draft, previousSnapshot) → snapshot` — unowned keys merged back (PR #69).
+Data flow (read): `writer → *_address_snapshot (jsonb, encrypted at rest per sales/encryption.ts) → document detail UI → AddressView contact block`.
+Data flow (write/edit): `AddressEditor draft → normalizeAddressDraft(draft, previousSnapshot) → snapshot` — keys the editor does not own are merged back rather than dropped (Phase 0).
 
 No new commands, events, routes, or DI registrations. The snapshot rides the existing order/quote update payload. Cross-module surface: `customers` owns the util, `sales` consumes it, `ui` holds the byte-identical twin (kept in sync here; collapsing them is out of scope, Q12).
 
@@ -89,11 +126,11 @@ No new commands, events, routes, or DI registrations. The snapshot rides the exi
 
 ### Address snapshot (informal contract — schema stays `z.record(z.string(), z.unknown())`)
 
-Documented well-known keys, all optional strings: the nine postal fields (unchanged), plus `phone`, `email`, `taxId`, `taxIdType` (`'eu_vat' | 'local' | 'other'`), Phase 3: `recipientName`. Unknown keys MUST survive an editor round-trip (PR #69's guarantee).
+Documented well-known keys, all optional strings: the nine postal fields (unchanged), plus `phone`, `taxId`, `taxIdType` (shape per Q3/Q4), and in Phase 3 `recipientName`. Unknown keys MUST survive an editor round-trip (Phase 0's guarantee).
 
 ### `AddressValue` (type, frozen surface)
 
-Adds optional `phone`, `email`, `taxId`, `taxIdType`, later `recipientName` — additive, all `?: string | null`.
+Adds optional `phone`, `taxId`, `taxIdType`, later `recipientName` — additive, all `?: string | null`.
 
 ### `CustomerAddress` (Phase 3, additive migration)
 
@@ -105,7 +142,7 @@ No new endpoints; no request/response shape changes. `addressSnapshotSchema` del
 
 ## Internationalization (i18n)
 
-`sales.documents.detail.addresses.{taxId,phone,email}` in `en`, `pl`, `de`, `es`, `ko` (exists on the branch). Phase 3 adds `recipientName`.
+`sales.documents.detail.addresses.{taxId,phone}` in `en`, `pl`, `de`, `es`, `ko`. The corresponding `…addresses.email` key is removed in Phase 1 along with the field (Q2). Phase 3 adds `recipientName`.
 
 ## UI/UX
 
@@ -120,23 +157,24 @@ No new endpoints; no request/response shape changes. `addressSnapshotSchema` del
 - **New frozen exports**: `formatAddressContactPairs`, `AddressContactLabels` freeze on merge per `BACKWARD_COMPATIBILITY.md`; this spec is the required reference.
 - **`name` → `label` rename (Q9, Phase 4)** follows the deprecation protocol: add `label`, keep `name` as a deprecated bridge for ≥1 minor, `@deprecated` JSDoc with target removal version, `UPGRADE_NOTES.md` entry. Snapshot storage keys are untouched.
 - **Phase 3 migration** is additive nullable columns — deployable without downtime, safely re-runnable.
-- **No core backfill.** Existing snapshots keep whatever they carry; integrations that want the fields on historical documents re-emit them (the motivating deployment re-runs its sync, which re-reads every document).
+- **No core backfill.** Existing snapshots keep whatever they carry; a writer that wants the fields on historical documents re-emits them.
 
 ## Implementation Plan
 
-### Phase 0 — snapshot key preservation *(shipped: PR #69)*
+### Phase 0 — snapshot key preservation *(shipped, PR #69)*
 `normalizeAddressDraft` merges back keys outside the twelve it owns; cleared address still normalizes to `null`.
 
-### Phase 1 — contact fields, render, read-only view *(branch `feat/address-contact-fields-render` / PR #66 carries over)*
-1. `AddressValue` + `formatAddressContactPairs` + `AddressView` contact block (done on branch, incl. postal-purity and self-hiding tests).
-2. Wire to the shipping/billing snapshot tiles (done on branch).
-3. Add `taxIdType` to the type and the pair-formatter (pending Q3/Q4 call).
-4. Read-only snapshot view for locked documents.
-5. Lift `// @ts-nocheck` from `AddressesSection.tsx`.
+### Phase 1 — contact fields, render, read-only view *(PR #66)*
+1. `AddressValue` + `formatAddressContactPairs` + `AddressView` contact block, with postal-purity and self-hiding tests.
+2. Wire to the shipping/billing snapshot tiles.
+3. Add `taxIdType` to the type and the pair-formatter (pending the Q3/Q4 call).
+4. Remove `email` from the field set and from the five locale files (see Q2).
+5. Read-only snapshot view for locked documents.
+6. Lift `// @ts-nocheck` from `AddressesSection.tsx`.
 
 ### Phase 2 — tax-id semantics
-1. `normalizeEuVatId()` util (ISO-2-prefix on write) for emitting integrations.
-2. Type-aware display gate per Q7; align search config so `eu_vat` may index where `local`/`other` stay `hashOnly`/excluded.
+1. `normalizeEuVatId()` util — ISO-2 prefix on write.
+2. Type-aware display gate per Q7; align search config so a public VAT number may index where local/personal numbers stay `hashOnly` or excluded.
 
 ### Phase 3 — recipient name + customer address book *(separable)*
 1. `recipientName` on `AddressValue`/`AddressView`; `recipient_name`, `phone` columns on `CustomerAddress` with encryption-map entries.
@@ -171,10 +209,12 @@ Write operations are limited to the existing document-update path (Phase 0/1) an
 - **Mitigation**: document-level optimistic locking already rejects the stale save (409).
 - **Residual risk**: none beyond existing conflict UX.
 
-#### Frozen enum too small
-- **Scenario**: A `gb_vat`-class need appears after `taxIdType` freezes.
+#### Frozen enum too small, or too coarse
+- **Scenario**: Under option (b), a value typed `local` cannot be interpreted because `country` is unconstrained free text; under either option, a tax-id class appears that the seeded set does not name.
 - **Severity**: Low
-- **Mitigation / Residual**: enums widen additively under the BC contract; a second small migration is the accepted trade-off, recorded in Q3/Q4.
+- **Affected area**: tax-id display, future validation
+- **Mitigation**: enums widen additively under the BC contract; the coarseness risk is the explicit trade-off recorded in Q3/Q4 and is one input to that decision.
+- **Residual risk**: a second small migration, accepted.
 
 #### Rename breaks third-party address consumers
 - **Scenario**: A module reads `name` from the API after Phase 4 removal.
@@ -196,7 +236,8 @@ Write operations are limited to the existing document-update path (Phase 0/1) an
 | BACKWARD_COMPATIBILITY.md | DB schema additive-only | Compliant | Phase 3 nullable columns only |
 | om-spec-writing checklist | PII/address/contact columns declare encryption maps + `findWithDecryption` | Compliant (design) | Phase 3 columns declared; snapshots already encrypted |
 | root AGENTS.md | Integration coverage listed per affected API/UI path, ships with the change | Compliant | §Integration Coverage |
-| root AGENTS.md | No inline comments / self-documenting code | Compliant | Branch cleaned in `9841df8d5` |
+| root AGENTS.md | No inline comments / self-documenting code | Compliant | |
+| om-spec-writing SKILL | Challenge the design against OSS market leaders | Compliant | §Overview → Market Reference, four platforms, sourced |
 | .ai/specs/AGENTS.md | Naming `{YYYY-MM-DD}-{kebab}.md`, no `SPEC-*` prefix | Compliant | |
 
 ### Internal Consistency Check
@@ -207,6 +248,7 @@ Write operations are limited to the existing document-update path (Phase 0/1) an
 | API contracts match UI/UX | Pass | Render-only; no shape change |
 | Risks cover all write operations | Pass | Save path + Phase 3 migration |
 | Commands defined for all mutations | Pass | No new mutations |
+| Field set consistent after dropping `email` | Pass | TLDR, Data Models, Phases and Integration Coverage all read `phone` + `taxId` + `taxIdType` |
 
 ### Non-Compliant Items
 None at spec level.
@@ -214,7 +256,20 @@ None at spec level.
 ### Verdict
 **Blocked — Open Questions Q0 and Q3/Q4 must be resolved before implementation proceeds past Phase 0.** All other sections are implementation-ready.
 
+## Appendix — field prevalence in one production dataset
+
+The justification above stands on the market comparison, not on any single deployment. These figures are offered only as evidence that the fields are **populated in practice** rather than theoretically useful, measured on one production e-commerce dataset of ~1.4M orders whose documents originate in an external system of record:
+
+| Signal | Coverage |
+|---|---|
+| Phone on the document address | 99.7% |
+| Tax identifier on the document billing address (placeholders excluded) | 12.9% of orders |
+| Tax identifier at customer level | 5.6% of customers |
+
+Two observations that shaped decisions above: the order-level tax-id rate exceeds the customer-level rate because business buyers reorder more often (an input to Q6), and `buildingNumber` was populated on ~1% of addresses because house numbers are conventionally written into the street line — which is why this spec adds no further logic there.
+
 ## Changelog
 
 ### 2026-08-10
-- Initial specification, following review of PR #66 by @maxidragon and @jtomaszewski. Phase 0 shipped as PR #69; Phase 1 exists on `feat/address-contact-fields-render` pending Q3/Q4.
+- Initial specification.
+- Reframed after review: the driver is now the general commerce gap — every comparable platform models a phone on the address and Open Mercato does not — with the single-deployment measurements demoted to an appendix. Open Questions moved below Problem Statement and Proposed Solution. `email` dropped from the field set on market evidence (Q2). The `taxIdType` shape (Q3/Q4) is presented as an open fork after Stripe's type table showed `pl_nip` and `eu_vat` to be distinct types, withdrawing an earlier recommendation for a minimal enum.


### PR DESCRIPTION
## Summary

An address in Open Mercato cannot carry a phone number or a tax identifier. `AddressValue` models
nine postal fields, and every formatter and renderer derives from those. Both are ordinary
requirements of order fulfilment — a carrier needs a contact number to deliver, and a B2B invoice
address is incomplete without the tax identifier the document was issued under — and both are
per-address rather than per-customer facts, since one customer keeps several addresses.

Shopify (`MailingAddress.phone`), Medusa (`Address.phone`) and commercetools (`Address.phone`) all
model this; Open Mercato is the outlier that does not.

This PR adds **only the spec**. No code. It is opened to get the modelling decisions settled before
implementation, and two of its Open Questions are deliberately unresolved — the compliance verdict
inside the document says **blocked** on them:

- **Q0** — one spec or two (contact fields vs tax-id semantics)?
- **Q3/Q4** — the shape of `taxIdType`: Stripe-style `{country}_{kind}`, or a minimal
  `eu_vat | local | other` enum? Presented as a genuine fork with no recommendation, because Stripe
  treats `pl_nip` and `eu_vat` as distinct types (examples `1234567890` vs `PL1234567890`) — which is
  exactly the ambiguity the spec describes, and it cuts against the smaller enum.

Reviewed and approved by @jtomaszewski before upstreaming.

## Changes

- Adds `.ai/specs/2026-08-10-address-contact-and-tax-fields.md`

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [x] No (created a new spec)
- [ ] N/A (minor change, no spec needed)

**Spec file path:**
`.ai/specs/2026-08-10-address-contact-and-tax-fields.md`

## Testing

No code, so no tests run. The document was checked against
`.ai/skills/om-spec-writing/references/spec-checklist.md`: all ten required sections present, Risk
Register in the required format, Final Compliance Report with an explicit verdict. Integration
coverage for the implementation phases is listed inside the spec (`TC-SALES-ADDR-CONTACT-001`, plus
the `TC-*-CRUDFORM-*` sweep for the Phase 3 customer-address fields) and ships with those phases,
not with this PR.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [ ] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [ ] QA routing set.

### Design System Compliance

N/A — this PR contains no code, only a spec document.

## Linked issues

None.
