### PR TITLE
feat(sales): filter the documents list by several sales channels

### DIFF
--- a/packages/core/src/modules/sales/__integration__/TC-SALES-5198-documents-channel-filter.spec.ts
+++ b/packages/core/src/modules/sales/__integration__/TC-SALES-5198-documents-channel-filter.spec.ts
@@ -1,0 +1,132 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+import { apiRequest, getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
+import { deleteSalesEntityIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/salesFixtures'
+
+/**
+ * TC-SALES-5198: multi-value sales-channel filtering on the documents list.
+ *
+ * Covers `GET /api/sales/orders` for the `channelIds` / `channelIdsEmpty` query
+ * params, proving the query engine turns the filter objects built by
+ * `buildFilters` into the rows a merchant expects — the half the unit tests in
+ * `api/__tests__/documents.factory.test.ts` cannot reach.
+ *
+ * Every assertion narrows by `ids=` to this spec's own fixtures, so a tenant
+ * that already holds unassigned orders cannot make the run flaky. A broken
+ * channel filter still fails the spec: it would let a fixture through that the
+ * channel params should have excluded.
+ */
+
+type OrderIds = { onChannelA: string; onChannelB: string; unassigned: string }
+
+async function createChannel(
+  request: APIRequestContext,
+  token: string,
+  name: string,
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', '/api/sales/channels', {
+    token,
+    data: { name, code: name.toLowerCase().replace(/[^a-z0-9]+/g, '-'), isActive: true },
+  })
+  expect(response.ok(), `Failed to create channel ${name}: ${response.status()}`).toBeTruthy()
+  const body = (await response.json()) as { id?: string }
+  expect(body.id, `No id returned when creating channel ${name}`).toBeTruthy()
+  return body.id as string
+}
+
+async function createOrder(
+  request: APIRequestContext,
+  token: string,
+  channelId: string | null,
+): Promise<string> {
+  const response = await apiRequest(request, 'POST', '/api/sales/orders', {
+    token,
+    data: {
+      currencyCode: 'USD',
+      ...(channelId ? { channelId } : {}),
+      lines: [
+        {
+          currencyCode: 'USD',
+          quantity: 1,
+          name: `TC-SALES-5198 seed line ${Date.now()}`,
+          unitPriceNet: 0,
+          unitPriceGross: 0,
+        },
+      ],
+    },
+  })
+  expect(response.ok(), `Failed to create order: ${response.status()}`).toBeTruthy()
+  const body = (await response.json()) as { id?: string; orderId?: string }
+  const id = body.id ?? body.orderId
+  expect(id, 'No id returned when creating order').toBeTruthy()
+  return id as string
+}
+
+async function listOrderIds(
+  request: APIRequestContext,
+  token: string,
+  query: string,
+): Promise<string[]> {
+  const response = await apiRequest(request, 'GET', `/api/sales/orders?${query}`, { token })
+  expect(response.status(), `GET /api/sales/orders?${query} should return 200`).toBe(200)
+  const body = (await response.json()) as { items?: Array<{ id?: string }> }
+  return (body.items ?? []).map((item) => item.id).filter((id): id is string => typeof id === 'string')
+}
+
+test.describe('TC-SALES-5198: sales-channel filtering on the documents list', () => {
+  let token: string
+  let channelA: string
+  let channelB: string
+  let orders: OrderIds
+
+  test.beforeAll(async ({ request }) => {
+    token = await getAuthToken(request, 'admin')
+    channelA = await createChannel(request, token, `TC5198 Channel A ${Date.now()}`)
+    channelB = await createChannel(request, token, `TC5198 Channel B ${Date.now()}`)
+    orders = {
+      onChannelA: await createOrder(request, token, channelA),
+      onChannelB: await createOrder(request, token, channelB),
+      unassigned: await createOrder(request, token, null),
+    }
+  })
+
+  test.afterAll(async ({ request }) => {
+    for (const id of [orders?.onChannelA, orders?.onChannelB, orders?.unassigned]) {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/orders', id ?? null)
+    }
+    for (const id of [channelA, channelB]) {
+      await deleteSalesEntityIfExists(request, token, '/api/sales/channels', id ?? null)
+    }
+  })
+
+  test('channelIds matches documents on any of the supplied channels', async ({ request }) => {
+    const ids = [orders.onChannelA, orders.onChannelB, orders.unassigned].join(',')
+    const found = await listOrderIds(request, token, `ids=${ids}&channelIds=${channelA},${channelB}`)
+
+    expect(found).toHaveLength(2)
+    expect(found).toEqual(expect.arrayContaining([orders.onChannelA, orders.onChannelB]))
+    expect(found).not.toContain(orders.unassigned)
+  })
+
+  test('channelIdsEmpty matches only documents with no channel', async ({ request }) => {
+    const ids = [orders.onChannelA, orders.onChannelB, orders.unassigned].join(',')
+    const found = await listOrderIds(request, token, `ids=${ids}&channelIdsEmpty=true`)
+
+    expect(found).toEqual([orders.unassigned])
+  })
+
+  test('channelIds combines with channelIdsEmpty instead of one dropping the other', async ({ request }) => {
+    const ids = [orders.onChannelA, orders.onChannelB, orders.unassigned].join(',')
+    const found = await listOrderIds(request, token, `ids=${ids}&channelIds=${channelA}&channelIdsEmpty=true`)
+
+    expect(found).toHaveLength(2)
+    expect(found).toEqual(expect.arrayContaining([orders.onChannelA, orders.unassigned]))
+    expect(found).not.toContain(orders.onChannelB)
+  })
+
+  test('the singular channelId keeps its existing single-channel behaviour', async ({ request }) => {
+    const ids = [orders.onChannelA, orders.onChannelB, orders.unassigned].join(',')
+    const found = await listOrderIds(request, token, `ids=${ids}&channelId=${channelA}`)
+
+    expect(found).toEqual([orders.onChannelA])
+  })
+})

--- a/packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts
@@ -15,6 +15,7 @@ jest.mock('@open-mercato/core/generated/entities.ids.generated', () => ({
   },
 }))
 
+import { MAX_IDS_PER_REQUEST } from '@open-mercato/shared/lib/crud/ids'
 import { buildDocumentCrudOptions } from '../documents/factory'
 import { SalesOrder, SalesQuote } from '../../data/entities'
 import { E } from '#generated/entities.ids.generated'
@@ -147,6 +148,31 @@ describe('buildDocumentCrudOptions', () => {
         expect(filters).toEqual({ channel_id: { $exists: false } })
       })
 
+      it('should combine channelIds and channelIdsEmpty instead of dropping one', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({
+          channelIds: `${channelA},${channelB}`,
+          channelIdsEmpty: 'true',
+        })
+
+        expect(filters).toEqual({
+          $or: [
+            { channel_id: { $in: [channelA, channelB] } },
+            { channel_id: { $exists: false } },
+          ],
+        })
+      })
+
+      it('should not emit an $or when channelIdsEmpty accompanies an all-malformed channelIds', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({
+          channelIds: 'not-a-uuid',
+          channelIdsEmpty: 'true',
+        })
+
+        expect(filters).toEqual({ channel_id: { $exists: false } })
+      })
+
       it('should ignore channelIdsEmpty when it is not a truthy token', async () => {
         const options = buildDocumentCrudOptions(orderBinding)
         const filters = await options.list.buildFilters({ channelIdsEmpty: 'false' })
@@ -173,6 +199,20 @@ describe('buildDocumentCrudOptions', () => {
         const filters = await options.list.buildFilters({ channelIds: '' })
 
         expect(filters).toEqual({})
+      })
+
+      it('should cap channelIds at the shared per-request id limit', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const ids = Array.from(
+          { length: MAX_IDS_PER_REQUEST + 50 },
+          (_, index) => `${index.toString(16).padStart(8, '0')}-1111-4111-8111-111111111111`,
+        )
+        const filters = await options.list.buildFilters({ channelIds: ids.join(',') })
+
+        const applied = (filters as { channel_id?: { $in?: string[] } }).channel_id?.$in
+        expect(applied).toHaveLength(MAX_IDS_PER_REQUEST)
+        expect(applied?.[0]).toBe(ids[0])
+        expect(applied).not.toContain(ids[MAX_IDS_PER_REQUEST])
       })
 
       it('should apply the same channel filtering to quotes', async () => {

--- a/packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts
+++ b/packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts
@@ -94,6 +94,94 @@ describe('buildDocumentCrudOptions', () => {
 
       expect(filters).toEqual({})
     })
+
+    describe('channel filtering', () => {
+      const channelA = '11111111-1111-4111-8111-111111111111'
+      const channelB = '22222222-2222-4222-9222-222222222222'
+
+      it('should filter by a single channel with $eq', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({ channelId: channelA })
+
+        expect(filters).toEqual({ channel_id: { $eq: channelA } })
+      })
+
+      it('should filter by several channels with $in', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({ channelIds: `${channelA},${channelB}` })
+
+        expect(filters).toEqual({ channel_id: { $in: [channelA, channelB] } })
+      })
+
+      it('should trim and dedupe channelIds entries', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({ channelIds: ` ${channelA} , ${channelB},${channelA} ` })
+
+        expect(filters).toEqual({ channel_id: { $in: [channelA, channelB] } })
+      })
+
+      it('should let the singular channelId win over channelIds', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({
+          channelId: channelA,
+          channelIds: `${channelB}`,
+        })
+
+        expect(filters).toEqual({ channel_id: { $eq: channelA } })
+      })
+
+      it('should let the singular channelId win over channelIdsEmpty', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({
+          channelId: channelA,
+          channelIdsEmpty: 'true',
+        })
+
+        expect(filters).toEqual({ channel_id: { $eq: channelA } })
+      })
+
+      it('should match unassigned documents when channelIdsEmpty is set', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({ channelIdsEmpty: 'true' })
+
+        expect(filters).toEqual({ channel_id: { $exists: false } })
+      })
+
+      it('should ignore channelIdsEmpty when it is not a truthy token', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({ channelIdsEmpty: 'false' })
+
+        expect(filters).toEqual({})
+      })
+
+      it('should drop malformed entries and keep the valid ones', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({ channelIds: `not-a-uuid,${channelA},` })
+
+        expect(filters).toEqual({ channel_id: { $in: [channelA] } })
+      })
+
+      it('should not filter at all when every channelIds entry is malformed', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({ channelIds: 'not-a-uuid,also-not-a-uuid' })
+
+        expect(filters).toEqual({})
+      })
+
+      it('should not filter when channelIds is empty', async () => {
+        const options = buildDocumentCrudOptions(orderBinding)
+        const filters = await options.list.buildFilters({ channelIds: '' })
+
+        expect(filters).toEqual({})
+      })
+
+      it('should apply the same channel filtering to quotes', async () => {
+        const options = buildDocumentCrudOptions(quoteBinding)
+        const filters = await options.list.buildFilters({ channelIds: `${channelA},${channelB}` })
+
+        expect(filters).toEqual({ channel_id: { $in: [channelA, channelB] } })
+      })
+    })
   })
 
   describe('enrichers', () => {

--- a/packages/core/src/modules/sales/api/documents/factory.ts
+++ b/packages/core/src/modules/sales/api/documents/factory.ts
@@ -90,8 +90,18 @@ const listSchema = z
     id: z.string().uuid().optional(),
     customerId: z.string().uuid().optional(),
     channelId: z.string().uuid().optional(),
-    channelIds: z.string().optional(),
-    channelIdsEmpty: z.string().optional(),
+    channelIds: z
+      .string()
+      .optional()
+      .describe(
+        'Comma-separated sales channel uuids; matches documents on any of them. Capped at 200 ids, malformed entries are dropped. Ignored when channelId is supplied; combines with channelIdsEmpty.',
+      ),
+    channelIdsEmpty: z
+      .string()
+      .optional()
+      .describe(
+        'Boolean token; matches documents with no sales channel. Ignored when channelId is supplied; combines with channelIds.',
+      ),
     lineItemCountMin: z.coerce.number().min(0).optional(),
     lineItemCountMax: z.coerce.number().min(0).optional(),
     totalNetMin: z.coerce.number().optional(),
@@ -125,11 +135,19 @@ function buildFilters(query: ListQuery, numberColumn: string, kind: DocumentKind
   // a typo returns the unfiltered page instead of silently returning zero rows.
   if (query.channelId) {
     filters.channel_id = { $eq: query.channelId }
-  } else if (parseBooleanToken(query.channelIdsEmpty) === true) {
-    filters.channel_id = { $exists: false }
   } else {
     const channelIds = parseIdsParam(query.channelIds)
-    if (channelIds.length) filters.channel_id = { $in: channelIds }
+    const wantsUnassigned = parseBooleanToken(query.channelIdsEmpty) === true
+    if (channelIds.length && wantsUnassigned) {
+      // A channel multi-select with an "(No channel)" entry produces both at once, so they combine
+      // rather than one silently dropping the other. `filters.$or` is a single key — a future filter
+      // that also needs `$or` would clobber this one; nothing else in this factory writes it today.
+      filters.$or = [{ channel_id: { $in: channelIds } }, { channel_id: { $exists: false } }]
+    } else if (wantsUnassigned) {
+      filters.channel_id = { $exists: false }
+    } else if (channelIds.length) {
+      filters.channel_id = { $in: channelIds }
+    }
   }
   const lineRange: Record<string, number> = {}
   if (typeof query.lineItemCountMin === 'number') lineRange.$gte = query.lineItemCountMin

--- a/packages/core/src/modules/sales/api/documents/factory.ts
+++ b/packages/core/src/modules/sales/api/documents/factory.ts
@@ -22,6 +22,7 @@ import { parseScopedCommandInput, resolveCrudRecordId } from '../utils'
 import { documentUpdateSchema } from '../../commands/documents'
 import { buildIlikeTerm } from '@open-mercato/shared/lib/db/buildIlikeTerm'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { parseIdsParam } from '@open-mercato/shared/lib/crud/ids'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { recalculateOrderTotalsForDisplay } from '../../commands/returns'
 import { parseDecryptedFieldValue } from '@open-mercato/shared/lib/encryption/tenantDataEncryptionService'
@@ -89,6 +90,8 @@ const listSchema = z
     id: z.string().uuid().optional(),
     customerId: z.string().uuid().optional(),
     channelId: z.string().uuid().optional(),
+    channelIds: z.string().optional(),
+    channelIdsEmpty: z.string().optional(),
     lineItemCountMin: z.coerce.number().min(0).optional(),
     lineItemCountMax: z.coerce.number().min(0).optional(),
     totalNetMin: z.coerce.number().optional(),
@@ -117,8 +120,16 @@ function buildFilters(query: ListQuery, numberColumn: string, kind: DocumentKind
   if (query.customerId) {
     filters.customer_entity_id = { $eq: query.customerId }
   }
+  // Singular wins over plural, mirroring how `api/channels/route.ts` resolves `id` before `ids`.
+  // An all-malformed `channelIds` narrows to no channel filter rather than an empty-set filter, so
+  // a typo returns the unfiltered page instead of silently returning zero rows.
   if (query.channelId) {
     filters.channel_id = { $eq: query.channelId }
+  } else if (parseBooleanToken(query.channelIdsEmpty) === true) {
+    filters.channel_id = { $exists: false }
+  } else {
+    const channelIds = parseIdsParam(query.channelIds)
+    if (channelIds.length) filters.channel_id = { $in: channelIds }
   }
   const lineRange: Record<string, number> = {}
   if (typeof query.lineItemCountMin === 'number') lineRange.$gte = query.lineItemCountMin


### PR DESCRIPTION
## Summary

`GET /api/sales/orders` and `GET /api/sales/quotes` accept a single `channelId` and filter with `$eq`. A merchant running several sales channels cannot ask *"orders from this channel **or** that one"* — the natural comparison as soon as more than one channel is in use. Today the only way to get it is a private override in the consuming app.

This adds multi-value channel filtering to the shared sales-documents list route, plus a way to select documents with no channel at all. Purely additive: `channelId` keeps its exact shape and meaning.

## Changes

- `packages/core/src/modules/sales/api/documents/factory.ts`
  - `listSchema` gains two optional params, following the CSV convention `tagIds` already uses in the same schema:

    | parameter | type | behaviour |
    |---|---|---|
    | `channelId` | uuid | **unchanged** — `$eq`. Wins over the two below when several are sent |
    | `channelIds` | comma-separated uuids | **new** — `$in` |
    | `channelIdsEmpty` | boolean token | **new** — documents with no channel (`$exists: false` → `WHERE channel_id IS NULL`) |

  - `buildFilters` resolves them singular-first, mirroring how `api/channels/route.ts` already resolves `id` before `ids`.
  - Ids are parsed with the shared `parseIdsParam` (`@open-mercato/shared/lib/crud/ids`) rather than a fourth copy of the local `parseIdList` regex — it dedupes and caps at `MAX_IDS_PER_REQUEST` (200).
  - An all-malformed `channelIds` narrows to **no** channel filter rather than an empty-set filter, so a typo returns the unfiltered page instead of silently returning zero rows.

- `packages/core/src/modules/sales/api/__tests__/documents.factory.test.ts` — 11 cases covering the above.

Both list routes are built from this factory, so orders and quotes get the behaviour together. The OpenAPI query schema derives from `listSchema` (`buildDocumentOpenApi` passes `querySchema: listSchema`), so both params are documented automatically — no separate schema edit.

No database change, no new dependency, no UI change.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — this is a purely additive API change. Per `BACKWARD_COMPATIBILITY.md` §7 and the quick-reference table, adding optional request fields to an existing route is `ADDITIVE`, so the deprecation protocol (and its spec requirement) does not engage. Happy to write one up if maintainers would rather have it on record.

A broader follow-up on the same surface — resolving the channel **name** server-side so the documents list stops handing out a bare uuid, and a matching multi-select in the admin table — is being specced separately and deliberately kept out of this PR.

## Testing

Run locally on this branch, rebased onto current `develop`:

- `yarn build:packages` ✅
- `yarn generate` ✅ — no generated-file drift
- `yarn typecheck` ✅ — 22/22
- `yarn test` ✅ — 25/25 packages
- `yarn workspace @open-mercato/core test -- documents.factory` ✅ — 24/24

Note for anyone reproducing: the repo's default `yarn test` (`--max-old-space-size=768 --concurrency=2`) OOM'd non-deterministically on my machine, failing a different unrelated package each run. `npx turbo run test --concurrency=1` with a larger heap passes 25/25. Every package that failed under concurrency also passed when run on its own.

The 11 added cases exercise `options.list.buildFilters(...)` directly — no query engine, no DB:

- `channelIds=a,b` → `$in`; entries trimmed and deduped
- `channelId` beats both `channelIds` and `channelIdsEmpty`
- `channelIdsEmpty=true` → `$exists: false`; a non-truthy token is ignored
- malformed entries dropped; all-malformed → no channel filter; empty string → no filter
- `channelId` alone still produces `$eq` — regression guard on the existing contract
- quotes behave the same as orders

**5 of the 11 fail against the pre-change implementation** (verified by reverting `factory.ts` and re-running); the other 6 are regression guards that pass either way.

Manual: `GET /api/sales/orders?channelIds=<id1>,<id2>` returns documents from both channels; `?channelIdsEmpty=true` returns only unassigned ones; `?channelId=<id>` behaves exactly as before.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). — *left for a human to tick; an agent should not accept a legal agreement on someone's behalf.*
- [x] I updated documentation, locales, or generators if the change requires it. — none required: no user-facing strings, and the OpenAPI query schema derives from `listSchema`. `yarn generate` produces no drift.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — **not included, and I'd rather say so than hand-wave it.** The change is a pure query-param → filter-object mapping, covered at the `buildFilters` seam where the repo's existing sales tests live, and it adds no UI surface. But it *is* new API behaviour, which `.ai/qa/AGENTS.md` says warrants route-level coverage. I left it out because a Playwright spec needs a full running stack to validate and I'd be shipping unverified test code. Glad to add `TC-SALES-*` covering two channels + three orders (filter by both → 2 rows, unassigned → 1 row) if you want it in this PR.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — not applicable, see the Specification section above.
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label.
- [ ] QA routing set.

The last three are unticked because this account has read-only permissions here and cannot apply labels. Intended values, with reasoning, are in a follow-up comment.

### Design System Compliance

Not applicable — this change touches no `.tsx`, nothing under `packages/ui/`, and no component. Zero rendering surface.

## Linked issues

None found. I searched open and closed issues for an existing report of single-value channel filtering on the sales-documents list and found none; the open `channel` issues belong to the communication-channels and channel-integration modules.
