### PR TITLE
fix: stabilize develop for release (login state loss, CodeQL, audit gate)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,9 +10,15 @@ name: Scheduled Dependency Audit
 #
 # This workflow re-evaluates the *unchanged* graph on a daily schedule, which
 # is the whole point of the trigger. Consequently it carries no `audit-scope`
-# gate and no result cache: `yarn npm audit` output is a function of the
-# dependency graph AND the advisory database at run time, so a marker keyed on
-# graph content would let the run skip the very scan it exists to perform.
+# gate and no result cache: the audit result is a function of the dependency
+# graph AND the advisory database at run time, so a marker keyed on graph
+# content would let the run skip the very scan it exists to perform.
+#
+# It runs `scripts/audit-ci.mjs`, the same gate as the `audit` job in ci.yml,
+# so the two halves of the pair agree on what counts as a failure. Running raw
+# `yarn npm audit` here instead made this workflow report red for advisories
+# ci.yml had already accepted through `scripts/audit-ci-allowlist.json`, and it
+# refiled the tracking issue every day for a state no one could act on.
 #
 # Deliberately kept out of ci.yml: that workflow uses
 # `concurrency: ci-${{ github.ref }}` with `cancel-in-progress: true`, so a
@@ -82,16 +88,19 @@ jobs:
       - name: Audit dependencies for known CVEs
         id: audit
         continue-on-error: true
+        # Blocking advisories are written to stderr, so both streams have to be
+        # captured — a stdout-only pipe would file a tracking issue with an
+        # empty report.
         run: |
           set -o pipefail
-          yarn npm audit --all --recursive --severity high | tee audit.log
+          node scripts/audit-ci.mjs --severity high 2>&1 | tee audit.log
 
       - name: Publish job summary
         if: always()
         shell: bash
         run: |
           {
-            echo "### \`yarn npm audit --all --recursive --severity high\` — \`${{ matrix.branch }}\`"
+            echo "### \`node scripts/audit-ci.mjs --severity high\` — \`${{ matrix.branch }}\`"
             echo
             if [ "${{ steps.audit.outcome }}" = "success" ]; then
               echo "No advisories at severity \`high\` or above."
@@ -129,10 +138,10 @@ jobs:
             const reportBlock = ['<!-- report:start -->', '```text', report, '```', '<!-- report:end -->'].join('\n')
             const body = [
               marker,
-              `\`yarn npm audit --all --recursive --severity high\` is failing on \`${branch}\`.`,
+              `\`node scripts/audit-ci.mjs --severity high\` is failing on \`${branch}\`.`,
               '',
               `Opened and refreshed automatically by [\`.github/workflows/audit.yml\`](${workflowUrl}).`,
-              'It closes itself on the first scheduled run where the audit passes again — resolve it by bumping the affected dependencies.',
+              'It closes itself on the first scheduled run where the audit passes again — resolve it by bumping the affected dependencies, or, when no patched release exists, by adding a justified entry to `scripts/audit-ci-allowlist.json`.',
               '',
               `- Branch: \`${branch}\``,
               `- Last checked: ${runUrl}`,
@@ -197,7 +206,7 @@ jobs:
             await github.rest.issues.createComment({
               ...context.repo,
               issue_number: existing.number,
-              body: `\`yarn npm audit --all --recursive --severity high\` passes again on \`${branch}\`. Closed from ${runUrl}.`,
+              body: `\`node scripts/audit-ci.mjs --severity high\` passes again on \`${branch}\`. Closed from ${runUrl}.`,
             })
             await github.rest.issues.update({
               ...context.repo,
@@ -209,5 +218,5 @@ jobs:
       - name: Fail the job when advisories were found
         if: steps.audit.outcome == 'failure'
         run: |
-          echo "::error::yarn npm audit reported advisories at severity high or above on ${{ matrix.branch }}."
+          echo "::error::audit-ci reported non-allowlisted advisories at severity high or above on ${{ matrix.branch }}."
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ docker/opencode/opencode.jsonc
 .ai/qa/test-env.lock/
 .ai/qa/test-env-boot.log
 .ai/qa/artifacts_*/
+.ai/qa/email-capture.jsonl
 # entrypoint scripts om-prepare-test-env compiles are bound to the machine that
 # generated them (shell, ports, process tools) — keep them local, never commit
 .ai/scripts/test-env-*

--- a/packages/cli/src/lib/testing/integration.ts
+++ b/packages/cli/src/lib/testing/integration.ts
@@ -1977,6 +1977,12 @@ function buildReusableEnvironment(
     // not have to call flushPendingCrudAccessLogs() explicitly.
     OM_CRUD_ACCESS_LOG_BLOCKING: process.env.OM_CRUD_ACCESS_LOG_BLOCKING ?? '1',
     OM_WEBHOOKS_ALLOW_PRIVATE_URLS: process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS ?? '1',
+    // TC-ONB-001/002 drive the self-service signup flow, whose routes are not
+    // mounted while the feature is off. `apps/mercato/.env` ships it disabled,
+    // so both specs 404'd on every local run while CI stayed green — it exports
+    // the var at the workflow level, the same gap the MOCK_INBOUND_WEBHOOK_SECRET
+    // note below describes. Keep in sync with the app-server env block.
+    SELF_SERVICE_ONBOARDING_ENABLED: process.env.SELF_SERVICE_ONBOARDING_ENABLED ?? 'true',
     // Keep the bus in the Playwright process (used by in-test queue-drain helpers)
     // on the same delivery mode as the app server it drives: inline persistent
     // delivery so event side effects are deterministic for assertions. See the
@@ -3329,6 +3335,10 @@ export async function startEphemeralEnvironment(options: EphemeralRuntimeOptions
       OM_TEST_AUTH_RATE_LIMIT_MODE: 'opt-in',
       OM_DISABLE_EMAIL_DELIVERY: '1',
       OM_WEBHOOKS_ALLOW_PRIVATE_URLS: process.env.OM_WEBHOOKS_ALLOW_PRIVATE_URLS ?? '1',
+      // Read at build time as well as at runtime, so this block has to carry it:
+      // the app build and `yarn start` both run with this environment. See the
+      // matching note on the Playwright-process env block above.
+      SELF_SERVICE_ONBOARDING_ENABLED: process.env.SELF_SERVICE_ONBOARDING_ENABLED ?? 'true',
       ENABLE_CRUD_API_CACHE: 'true',
       MOCK_GATEWAY_WEBHOOK_SECRET: 'open-mercato-mock-dev-webhook-secret',
       MOCK_CARRIER_WEBHOOK_SECRET: 'open-mercato-mock-dev-carrier-webhook-secret',

--- a/packages/core/src/helpers/integration/ui.ts
+++ b/packages/core/src/helpers/integration/ui.ts
@@ -2,6 +2,16 @@ import { expect, type Locator, type Page, type Response } from '@playwright/test
 
 const DEFAULT_UI_TIMEOUT_MS = 10_000
 
+// A React-controlled input renders whatever its state says. A fill that lands
+// before hydration writes only the DOM, and the hydration render then restores
+// the initial state value — the field empties again a few dozen milliseconds
+// later, with the same DOM node. Checking the value once right after the fill
+// reads the window before that happens and reports success on a value the app
+// is about to discard, which is how TC-UMES-E17 came to probe with an empty
+// person id and assert against whichever record the unfiltered query returned
+// first. Re-check after this settle window and let the loop retype.
+const CONTROLLED_INPUT_SETTLE_MS = 400
+
 export async function fillControlledInput(
   input: Locator,
   value: string,
@@ -15,6 +25,8 @@ export async function fillControlledInput(
       await input.scrollIntoViewIfNeeded().catch(() => {})
       await input.click({ timeout: 2_000 })
       await input.fill(value)
+      await expect(input).toHaveValue(value, { timeout: 1_500 })
+      await input.page().waitForTimeout(CONTROLLED_INPUT_SETTLE_MS)
       await expect(input).toHaveValue(value, { timeout: 1_500 })
       return
     } catch (error) {

--- a/packages/ui/src/backend/injection/__tests__/useRegisteredComponent.remount.test.tsx
+++ b/packages/ui/src/backend/injection/__tests__/useRegisteredComponent.remount.test.tsx
@@ -1,0 +1,96 @@
+/** @jest-environment jsdom */
+
+import * as React from 'react'
+import { fireEvent, render } from '@testing-library/react'
+import type { ComponentOverride } from '@open-mercato/shared/modules/widgets/component-registry'
+import { ComponentOverrideProvider } from '../ComponentOverrideProvider'
+import { useRegisteredComponent } from '../useRegisteredComponent'
+
+const COMPONENT_ID = 'section:test.host.form'
+
+function Section({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}
+
+function Host() {
+  const Resolved = useRegisteredComponent<{ children: React.ReactNode }>(COMPONENT_ID, Section)
+  return (
+    <Resolved>
+      <form>
+        <input id="email" name="email" defaultValue="" />
+      </form>
+    </Resolved>
+  )
+}
+
+/**
+ * `overrides` arrives as a brand-new array once the async override bundle
+ * resolves, exactly the way ComponentOverridesBootstrap hands it over after its
+ * dynamic import settles.
+ */
+function App({ overrides }: { overrides: ComponentOverride[] }) {
+  return (
+    <ComponentOverrideProvider overrides={overrides}>
+      <Host />
+    </ComponentOverrideProvider>
+  )
+}
+
+function readEmail(): HTMLInputElement {
+  return document.querySelector('#email') as HTMLInputElement
+}
+
+function typeEmail(value: string): HTMLInputElement {
+  const email = readEmail()
+  fireEvent.change(email, { target: { value } })
+  expect(email.value).toBe(value)
+  return email
+}
+
+describe('useRegisteredComponent — a late override registry must not discard host state', () => {
+  it('keeps typed input when the override bundle resolves with no override for this id', () => {
+    const { rerender } = render(<App overrides={[]} />)
+    const email = typeEmail('admin@acme.com')
+
+    // Same (empty) override set, fresh array identity — the registry revision bumps.
+    rerender(<App overrides={[]} />)
+
+    expect(readEmail()).toBe(email)
+    expect(readEmail().value).toBe('admin@acme.com')
+  })
+
+  it('keeps typed input when unrelated overrides register', () => {
+    const { rerender } = render(<App overrides={[]} />)
+    const email = typeEmail('admin@acme.com')
+
+    const unrelated: ComponentOverride[] = [{
+      target: { componentId: 'section:some.other.component' },
+      priority: 0,
+      metadata: { module: 'other' },
+      wrapper: (Original) => Original,
+    }]
+    rerender(<App overrides={unrelated} />)
+
+    expect(readEmail()).toBe(email)
+    expect(readEmail().value).toBe('admin@acme.com')
+  })
+
+  it('still applies a wrapper registered for this id', () => {
+    const withBanner: ComponentOverride[] = [{
+      target: { componentId: COMPONENT_ID },
+      priority: 0,
+      metadata: { module: 'other' },
+      wrapper: (Original) => {
+        const Wrapped = (props: Record<string, unknown>) => (
+          <div data-testid="wrapper-banner">{React.createElement(Original as React.ComponentType<Record<string, unknown>>, props)}</div>
+        )
+        return Wrapped as typeof Original
+      },
+    }]
+
+    const { getByTestId } = render(<App overrides={withBanner} />)
+
+    expect(getByTestId('wrapper-banner')).toBeTruthy()
+    expect(readEmail()).toBeTruthy()
+  })
+})

--- a/packages/ui/src/backend/injection/useRegisteredComponent.tsx
+++ b/packages/ui/src/backend/injection/useRegisteredComponent.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react'
 import type { ComponentType } from 'react'
+import type { ComponentOverride } from '@open-mercato/shared/modules/widgets/component-registry'
 import { getComponentEntry, getComponentOverrides } from '@open-mercato/shared/modules/widgets/component-registry'
 import { useOverrideRegistryRevision, useOverrideUserFeatures } from './ComponentOverrideProvider'
 import { createLogger } from '@open-mercato/shared/lib/logger'
@@ -31,46 +32,93 @@ class ReplacementErrorBoundary extends React.Component<
   }
 }
 
+type Resolution<TProps> = {
+  original: ComponentType<TProps> | null
+  wrapped: ComponentType<TProps> | null
+  transforms: Array<(props: TProps) => TProps>
+  replacementOverride: ComponentOverride | null
+  replacementModule: string
+}
+
+function resolveComponent<TProps>(
+  componentId: string,
+  fallback: ComponentType<TProps> | undefined,
+  userFeatures: readonly string[],
+): Resolution<TProps> {
+  const entry = getComponentEntry(componentId)
+  const original = (entry?.component as ComponentType<TProps> | undefined) ?? fallback ?? null
+  if (!original) {
+    if (process.env.NODE_ENV !== 'production' && !fallback) {
+      logger.warn('Component is not registered', { componentId })
+    }
+    return { original: null, wrapped: null, transforms: [], replacementOverride: null, replacementModule: 'unknown' }
+  }
+
+  const overrides = getComponentOverrides(componentId, userFeatures)
+  const replacementOverrides = overrides.filter((override) => 'replacement' in override)
+  if (process.env.NODE_ENV !== 'production' && replacementOverrides.length > 1) {
+    logger.warn('Multiple replacements registered; highest-priority replacement is applied', { componentId })
+  }
+
+  let replacement: ComponentType<TProps> | null = null
+  let replacementOverride: ComponentOverride | null = null
+  const wrappers: Array<(Original: ComponentType<TProps>) => ComponentType<TProps>> = []
+  const transforms: Array<(props: TProps) => TProps> = []
+
+  for (const override of overrides) {
+    if ('replacement' in override) {
+      replacement = override.replacement as ComponentType<TProps>
+      replacementOverride = override
+    }
+    if ('wrapper' in override) wrappers.push(override.wrapper as (Original: ComponentType<TProps>) => ComponentType<TProps>)
+    if ('propsTransform' in override) transforms.push(override.propsTransform as (props: TProps) => TProps)
+  }
+
+  const base = replacement ?? original
+  const wrapped = wrappers.reduce<ComponentType<TProps>>((acc, wrapper) => wrapper(acc), base)
+
+  return {
+    original,
+    wrapped,
+    transforms,
+    replacementOverride,
+    replacementModule: replacementOverride?.metadata?.module ?? 'unknown',
+  }
+}
+
+/**
+ * The returned component's identity must depend only on `componentId` and
+ * `fallback` — never on the override registry.
+ *
+ * Overrides arrive asynchronously: `ComponentOverridesBootstrap` dynamically
+ * imports the generated override module and hands the provider a fresh array,
+ * which bumps the registry revision some time after first paint. Resolving the
+ * component in a `useMemo` keyed on that revision handed callers a brand-new
+ * function on every bump, so React saw a different element type at that
+ * position and unmounted the whole subtree — discarding its DOM and state. On
+ * the login form that threw away credentials the user had already typed
+ * (#5037), and the same hazard applied to every host of a registered section.
+ *
+ * Resolution therefore happens *inside* a stable component. When the revision
+ * carries no override for this id, `wrapped` keeps its previous identity and
+ * React reconciles in place; only a genuine replacement or wrapper swaps the
+ * rendered type, where a remount is the correct behaviour.
+ */
 export function useRegisteredComponent<TProps>(
   componentId: string,
   fallback?: ComponentType<TProps>,
 ): ComponentType<TProps> {
-  const userFeatures = useOverrideUserFeatures()
-  const overrideRevision = useOverrideRegistryRevision()
   return React.useMemo(() => {
-    const entry = getComponentEntry(componentId)
-    const original = (entry?.component as ComponentType<TProps> | undefined) ?? fallback ?? null
-    if (!original) {
-      if (process.env.NODE_ENV !== 'production' && !fallback) {
-        logger.warn('Component is not registered', { componentId })
-      }
-      const Missing = () => null
-      return Missing as ComponentType<TProps>
-    }
-    const overrides = getComponentOverrides(componentId, userFeatures)
-    const replacementOverrides = overrides.filter((override) => 'replacement' in override)
-    if (process.env.NODE_ENV !== 'production' && replacementOverrides.length > 1) {
-      logger.warn('Multiple replacements registered; highest-priority replacement is applied', { componentId })
-    }
+    const Registered = (props: TProps) => {
+      const userFeatures = useOverrideUserFeatures()
+      const overrideRevision = useOverrideRegistryRevision()
+      const { original, wrapped, transforms, replacementOverride, replacementModule } = React.useMemo(
+        () => resolveComponent<TProps>(componentId, fallback, userFeatures),
+        [overrideRevision, userFeatures],
+      )
 
-    let replacement: ComponentType<TProps> | null = null
-    let replacementOverride: (typeof overrides)[number] | null = null
-    const wrappers: Array<(Original: ComponentType<TProps>) => ComponentType<TProps>> = []
-    const transforms: Array<(props: TProps) => TProps> = []
+      if (!original || !wrapped) return null
 
-    for (const override of overrides) {
-      if ('replacement' in override) {
-        replacement = override.replacement as ComponentType<TProps>
-        replacementOverride = override
-      }
-      if ('wrapper' in override) wrappers.push(override.wrapper as (Original: ComponentType<TProps>) => ComponentType<TProps>)
-      if ('propsTransform' in override) transforms.push(override.propsTransform as (props: TProps) => TProps)
-    }
-
-    const base = replacement ?? original
-    const wrapped = wrappers.reduce<ComponentType<TProps>>((acc, wrapper) => wrapper(acc), base)
-
-    const Resolved = (props: TProps) => {
       const transformed = transforms.reduce((current, transform) => transform(current), props)
       const Fallback = React.createElement(original as React.ComponentType<Record<string, unknown>>, transformed as Record<string, unknown>)
       if (
@@ -80,7 +128,7 @@ export function useRegisteredComponent<TProps>(
       ) {
         const validation = replacementOverride.propsSchema.safeParse(transformed)
         if (!validation.success) {
-          logger.error('Props schema validation failed for replacement', { componentId, module: replacementOverride.metadata?.module ?? 'unknown', issues: validation.error.format() })
+          logger.error('Props schema validation failed for replacement', { componentId, module: replacementModule, issues: validation.error.format() })
           return Fallback
         }
       }
@@ -88,7 +136,6 @@ export function useRegisteredComponent<TProps>(
         <ReplacementErrorBoundary
           fallback={Fallback}
           onError={(error) => {
-            const replacementModule = overrides.find((override) => 'replacement' in override)?.metadata?.module ?? 'unknown'
             logger.error('Component replacement failed', { componentId, module: replacementModule, err: error })
           }}
         >
@@ -97,9 +144,9 @@ export function useRegisteredComponent<TProps>(
       )
     }
 
-    Resolved.displayName = `RegisteredComponent(${componentId})`
-    return Resolved
-  }, [componentId, fallback, overrideRevision, userFeatures])
+    Registered.displayName = `RegisteredComponent(${componentId})`
+    return Registered
+  }, [componentId, fallback])
 }
 
 export default useRegisteredComponent

--- a/scripts/__tests__/stryker-report.test.mjs
+++ b/scripts/__tests__/stryker-report.test.mjs
@@ -156,6 +156,41 @@ test('escapes pipes so a mutated string can never break the table', () => {
   assert.match(tableRows[0], /a \\\|\\\| b/)
 })
 
+test('escapes backslashes so an escaped pipe in the source cannot break the table', () => {
+  const backslashMutant = {
+    ...SURVIVED_MUTANT,
+    replacement: String.raw`'a\|b'`,
+    location: { start: { line: 3, column: 3 }, end: { line: 3, column: 15 } },
+  }
+
+  const markdown = renderMarkdown(createReport([backslashMutant]))
+  const row = markdown.split('\n').find((line) => line.startsWith('| `src/'))
+
+  // The source backslash becomes `\\`, so the pipe keeps its own `\|` escape and the
+  // cell contributes no extra column. Without the backslash pass the cell renders as a
+  // literal backslash followed by a bare pipe, splitting the row into six columns.
+  assert.match(row, /a\\\\\\\|b/)
+  assert.equal(row.split(/(?<!\\)\|/).length - 1, 5, `table columns not intact: ${row}`)
+})
+
+test('escapes backslashes so a survivor cell cannot smuggle a live code span', () => {
+  const trailingBackslashMutant = {
+    ...SURVIVED_MUTANT,
+    replacement: '\\`@maintainer',
+    location: { start: { line: 3, column: 3 }, end: { line: 3, column: 15 } },
+  }
+
+  const markdown = renderMarkdown(createReport([trailingBackslashMutant]))
+  const row = markdown.split('\n').find((line) => line.startsWith('| `src/'))
+
+  // Strip escaped backslashes before escaped backticks: a survivor ending in `\`
+  // would otherwise consume the backtick's escape and reopen the span, letting the
+  // following `@maintainer` render as a live mention.
+  const unescapedBackticks = row.replace(/\\\\/g, '').replace(/\\`/g, '').match(/`/g) ?? []
+
+  assert.equal(unescapedBackticks.length, 6, `code spans not intact: ${row}`)
+})
+
 test('parses the report path, package name and enforcement flag', () => {
   assert.deepEqual(parseReportArgs(['mutation.json']), {
     reportPath: 'mutation.json',

--- a/scripts/stryker/report.mjs
+++ b/scripts/stryker/report.mjs
@@ -58,9 +58,13 @@ function sliceOriginal(source, location) {
 
 /**
  * Survivor cells carry arbitrary source text into a markdown table that is also
- * posted as a PR comment, so two characters have to be neutralised: `|` would break
- * the table structure, and a backtick would close the inline code span the cell
- * wraps its content in.
+ * posted as a PR comment, so three characters have to be neutralised: `|` would break
+ * the table structure, a backtick would close the inline code span the cell wraps its
+ * content in, and a backslash would consume the escape added for either of them.
+ *
+ * The backslash pass has to run first. Source text such as `\|` would otherwise become
+ * `\\|` — a literal backslash followed by a bare pipe — and the cell would still split
+ * the table. Escaping backslashes up front makes every later escape survive intact.
  *
  * Escaping the backtick is also what keeps `@mention` text inert. GitHub does not
  * linkify a mention inside a code span, so an intact span means a mutated line
@@ -70,6 +74,7 @@ function sliceOriginal(source, location) {
 function toSingleLine(text) {
   return String(text ?? '')
     .replace(/\s+/g, ' ')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .replace(/`/g, '\\`')
     .trim()


### PR DESCRIPTION
## Summary

Stabilizes `develop` for release. Three product/test defects, two CI-gate inconsistencies, and one repo-hygiene fix. Every change was reproduced locally against a real ephemeral app + Postgres before being written, and re-verified after.

The headline finding: **the tests CI recorded as "flaky" were not flaky.** `TC-AUTH-5037` failed **8 out of 8** local runs on `develop`, and `TC-UMES-E17` failed on every run. Both had a deterministic root cause. CI only saw them intermittently because the races they expose resolve differently under different machine timing.

## What was wrong

### 1. `useRegisteredComponent` remounted every registered section (the unfixed half of #5037)

`useRegisteredComponent` resolved its component inside a `useMemo` keyed on the override-registry revision, so every bump handed the caller a **brand-new function identity**. React saw a different element type at that position and unmounted the entire subtree, discarding its DOM and component state.

That bump is not rare. `ComponentOverridesBootstrap` dynamically imports the generated override module and passes `ComponentOverrideProvider` a fresh array once it resolves — shortly after first paint, racing whatever the user is doing. On `/login`, `LoginFormSection` is resolved through this hook and wraps the whole `<form>`, so the import landing mid-typing threw away credentials the user had already entered.

This is exactly the #5037 symptom. The ThemeProvider fix (#5055) corrected the same class of bug one level up in the provider tree and left this one in place.

Resolution now happens *inside* a component whose identity depends only on `componentId` and `fallback`. When a revision carries no override for that id, the rendered element type is unchanged and React reconciles in place; a genuine replacement or wrapper still swaps the type, where remounting is correct.

- `TC-AUTH-5037`: 8/8 failing → 8/8 passing. The first case went from a 20 s timeout to ~380 ms.
- `TC-WF-030` (the one hard failure on the develop snapshot) and `TC-SALES-001` recover in the same change — both drive multi-step forms that the remount was resetting.
- New unit test `useRegisteredComponent.remount.test.tsx`, confirmed to fail against the pre-fix source.

### 2. `fillControlledInput` accepted a value the app was about to discard

The helper filled the field and asserted the value **once, immediately**. A fill that lands before React hydrates writes only the DOM; the hydration render then restores the initial state value and the field empties again ~60 ms later, reusing the same DOM node. The single eager assertion reads the window before that happens.

`TC-UMES-E17` is where it surfaced: the person id never reached `runEnricherProbe`, which then fell back to its unfiltered five-record query, so the test asserted enrichment against whichever person the query happened to return first.

The helper now re-checks after a settle window and lets its existing retry loop retype once the page is interactive. Verified against every caller — `TC-UMES-003`, `TC-UMES-008`, `TC-LOCK-OSS-014`, `TC-LOCK-OSS-015`.

### 3. CodeQL alerts 186 and 187 — `js/incomplete-sanitization`, high

`toSingleLine` in `scripts/stryker/report.mjs` escaped `|` and backtick but not backslash. Source text containing `\|` rendered as a literal backslash plus a bare pipe and split the markdown table; a trailing backslash could consume a backtick's escape and reopen the code span around an `@mention`, turning inert text into a live notification. The backslash pass now runs first. Regression tests confirmed to fail without the source change.

### 4. The scheduled audit ran a different gate than CI

`audit.yml` ran raw `yarn npm audit` while `ci.yml` runs `scripts/audit-ci.mjs`. So the scheduled job went red every day for the two `image-size` advisories `ci.yml` had already accepted through `scripts/audit-ci-allowlist.json`, and refiled the tracking issue for a state nobody could act on. Both now run the same gate; both streams are captured, since blocking advisories go to stderr.

### 5. `yarn test:integration:ephemeral` could not go green as shipped

The ephemeral runner pins every flag the suite depends on — `OM_TEST_MODE`, the
mock webhook secrets, `OM_WEBHOOKS_ALLOW_PRIVATE_URLS`, the enterprise module
flags — but not `SELF_SERVICE_ONBOARDING_ENABLED`. `apps/mercato/.env` ships it
disabled, so the self-service signup routes were never mounted locally and
`TC-ONB-001`/`TC-ONB-002` failed on every run with a `404` from the onboarding
start endpoint.

CI never saw it, because ci.yml exports the var at the workflow level. That is
precisely the gap the `MOCK_INBOUND_WEBHOOK_SECRET` comment already in this file
describes — *"CI exports the var at the workflow level, masking the gap."* This
was the same class of bug, one instance later.

Both env blocks get the entry, since the flag is read at build time as well as at
runtime and the app build and `yarn start` share the app-server environment.
Callers can still override it.

- `TC-ONB-001`'s workspace-creation case: 20 s timeout → **1.7 s**
- `TC-ONB-002`: 43 ms `404` → **9.2 s green**

### 6. `.ai/qa/email-capture.jsonl` is a generated artifact

Written by the integration harness under `EMAIL_CAPTURE`, untracked but not ignored, so it is easy to sweep into a commit. Added to `.gitignore`.

## Two findings that are *not* fixed here, deliberately

**The `ephemeral-integration` failure on #4840 was not a code defect.** The runner failed `git fetch` with `server certificate verification failed. CAfile: none CRLfile: none` and never checked out the tree. That is GitHub infrastructure; nothing in this repo changes it. It needs a re-run, not a patch.

**The 22 open Dependabot alerts are scoped to `main`, not `develop`.** Dependabot scans the default branch. `develop` already pins the fixes — e.g. it resolves `nanoid` to `3.3.17` while `main` still resolves `3.3.16`. Merging `develop` into `main` is what clears that backlog; there is nothing to fix on this branch.

The two `image-size` highs are the exception and cannot be fixed by anyone right now: `2.0.2` is the latest published version and is itself vulnerable, and the project is archived upstream with no maintainer. They are reachable only through `@docusaurus/mdx-loader`, which builds `apps/docs` at CI/dev time from repo-controlled Markdown and never parses attacker-supplied images. They stay allowlisted with that justification.

## Verification

Run locally against an ephemeral app + Postgres, not just in CI.

| Gate | Result |
|---|---|
| `yarn build:packages` → `generate` → `build:packages` | pass, no generated drift |
| `yarn i18n:check-sync`, `yarn i18n:check-usage` | pass |
| `yarn typecheck` | pass |
| `yarn test` | pass — 29/29 workspaces, ~14,600 tests |
| `yarn build:app` | pass |
| `yarn logger:check-console:ci` | pass |
| ds-lint (`ds-lint-report.mjs --check`) | no error-level findings |
| `bash scripts/validate-skills-tiers.sh` | pass — 26 skills across 7 tiers |
| `node scripts/audit-ci.mjs --severity high` | pass — 2 allowlisted, 0 blocking |
| `yarn agents:check-budget` | pass |
| `yarn lint`, `yarn lint:check-graph` | pass |
| Full Playwright integration suite (`yarn test:integration:ephemeral`) | **1854 passed, 84 skipped, 3 flaky, 0 failed** (23.1 min, fresh containerised database) |

## Backward compatibility

No contract surface changes. `useRegisteredComponent` keeps its signature and its resolution semantics — only the identity stability of the component it returns changes, which is the fix. `fillControlledInput` keeps its signature; the added settle window makes it stricter, never more permissive.

## QA

`needs-qa`. The `useRegisteredComponent` change is UI-rendering code under `packages/ui/src/`, so the automated-verification exemption does not apply.

Targeted integration evidence already gathered against a real ephemeral app + Postgres:

- `TC-AUTH-5037` — 8/8 pass (8/8 **fail** on `develop` without the fix); first case 20 s timeout → ~380 ms
- `TC-WF-030`, `TC-SALES-001` — pass (both were red on the develop snapshot)
- `TC-UMES-003` incl. `TC-UMES-E17`, `TC-UMES-008`, `TC-LOCK-OSS-014`, `TC-LOCK-OSS-015` — pass
- `TC-UMES-CR01/CR02/CR03` (component replacement + wrapper) — pass, confirming override resolution still works

Worth a human eye on: log in, confirm typing credentials immediately after page load still submits them, and confirm any module registering a `replace`/`wrapper` component override still takes effect.

### Flakes observed, not fixed here

Three specs failed once and passed on retry, in both full runs:
`TC-EUDR-010` (20.1 s → 2.0 s), `TC-SALES-005` (23.3 s → 5.0 s),
`TC-TRANS-005` (14.9 s → 12.0 s). They look like first-hit route warm-up against
a freshly built app rather than product defects, and the retry policy absorbs
them. `TC-TRANS-005` is the one worth a follow-up: it takes ~12 s even when it
passes, so it sits close to the 20 s budget and is inherently fragile rather than
merely cold-start.
