### PR TITLE
fix(communication_channels): use APP_URL for the oauth callback redirect origin

### DIFF
--- a/packages/core/src/modules/communication_channels/api/get/oauth/[provider]/callback/__tests__/route.test.ts
+++ b/packages/core/src/modules/communication_channels/api/get/oauth/[provider]/callback/__tests__/route.test.ts
@@ -1,0 +1,49 @@
+/** @jest-environment node */
+
+// Regression for https://github.com/open-mercato/open-mercato/issues/5193 —
+// redirectWithFlash() used to build its redirect Location header from
+// `new URL(req.url).origin`, which reflects the internal origin the app sees
+// behind a reverse proxy (e.g. Railway) rather than the public APP_URL.
+
+import { GET } from '../route'
+
+describe('GET /api/communication_channels/oauth/[provider]/callback', () => {
+  const ORIGINAL_ENV = { ...process.env }
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV }
+  })
+
+  function callbackRequest(query: string) {
+    return new Request(`http://localhost:3000/api/communication_channels/oauth/gmail/callback${query}`, {
+      headers: { host: 'localhost:3000' },
+    })
+  }
+
+  test('redirects using APP_URL as origin instead of the raw request origin', async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    process.env.APP_URL = 'https://app.example.com'
+
+    const req = callbackRequest('?error=access_denied')
+    const res = await GET(req, { params: { provider: 'gmail' } })
+
+    expect(res.status).toBe(302)
+    const location = res.headers.get('location')
+    expect(location).toBeTruthy()
+    expect(location!.startsWith('https://app.example.com/')).toBe(true)
+    expect(location).not.toContain('localhost')
+  })
+
+  test('falls back to the request origin when APP_URL is not configured', async () => {
+    delete process.env.NEXT_PUBLIC_APP_URL
+    delete process.env.APP_URL
+
+    const req = callbackRequest('?error=access_denied')
+    const res = await GET(req, { params: { provider: 'gmail' } })
+
+    expect(res.status).toBe(302)
+    const location = res.headers.get('location')
+    expect(location).toBeTruthy()
+    expect(location!.startsWith('http://localhost:3000/')).toBe(true)
+  })
+})

--- a/packages/core/src/modules/communication_channels/api/get/oauth/[provider]/callback/route.ts
+++ b/packages/core/src/modules/communication_channels/api/get/oauth/[provider]/callback/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
-import { toAbsoluteUrl } from '@open-mercato/shared/lib/url'
+import { getAppBaseUrl, toAbsoluteUrl } from '@open-mercato/shared/lib/url'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createConnectedChannelRow, MailboxAlreadyConnectedError } from '../../../../../lib/connect-channel'
@@ -47,7 +47,7 @@ function redirectWithFlash(
 ): Response {
   const base = new URL(
     normalizeOAuthReturnUrl(returnUrl, DEFAULT_OAUTH_RETURN_URL),
-    new URL(req.url).origin,
+    getAppBaseUrl(req),
   )
   base.searchParams.set('flash', flash.type)
   if (flash.code) base.searchParams.set('code', flash.code)


### PR DESCRIPTION
## Summary

`redirectWithFlash()` in the communication-channels OAuth callback route built its redirect `Location` header from `new URL(req.url).origin`, which reflects the internal origin the app sees behind a reverse proxy (e.g. Railway) rather than the app's configured public URL. This sent users back to an unreachable `localhost:3000` URL after successfully connecting an OAuth-based channel (e.g. Gmail).

The fix uses `getAppBaseUrl(req)` (already available from `@open-mercato/shared/lib/url`) instead, matching the pattern already used two lines below in the same file for the OAuth `redirect_uri` via `toAbsoluteUrl(req, ...)`.

## Root cause

`packages/core/src/modules/communication_channels/api/get/oauth/[provider]/callback/route.ts` — `redirectWithFlash()` constructed its redirect `base` URL from the raw request's origin instead of `APP_URL`/`NEXT_PUBLIC_APP_URL`.

## Change

- Replace `new URL(req.url).origin` with `getAppBaseUrl(req)` when building the redirect base in `redirectWithFlash()`.
- Add a regression test covering both the `APP_URL`-configured case (redirect uses the public origin even though the request host says `localhost`) and the fallback case (no `APP_URL` configured → falls back to the request-derived origin, preserving existing dev/test behavior).

## Test plan

- [x] `route.test.ts` — regression test asserting the `Location` header origin
- [x] `yarn build:packages` (before and after `generate`)
- [x] `yarn generate`
- [x] `yarn i18n:check-sync`
- [x] `yarn i18n:check-usage` (advisory only)
- [x] `yarn typecheck`
- [x] `yarn test` (failures confirmed pre-existing/unrelated via `git stash` diff — Polish-locale `Intl` formatting mismatches and inotify/bwrap sandbox limits on this machine)
- [x] `yarn build:app`

Fixes #5193
