### PR TITLE
fix(wms): label additive CSV imports as receipt movements (#4105)

### DIFF
--- a/packages/core/src/modules/wms/__integration__/TC-WMS-025-inventory-import-api.spec.ts
+++ b/packages/core/src/modules/wms/__integration__/TC-WMS-025-inventory-import-api.spec.ts
@@ -15,6 +15,7 @@ import {
   createCrudFixture,
   ensureRoleFeatures,
   fetchBalance,
+  fetchMovements,
   toNumber,
 } from './helpers/wmsFixtures'
 
@@ -193,6 +194,15 @@ test.describe('TC-WMS-025: Inventory CSV import API', () => {
       const balance = await fetchBalance(request, adminToken, warehouseId!, variantId)
       expect(toNumber(balance?.quantity_on_hand)).toBe(25)
 
+      // Regression check for the #4105 QA follow-up: additive imports must post a
+      // 'receipt' ledger entry (shown as "Przyjęcie"), not an 'adjust'/"Korekta" one.
+      const firstReceiptMovements = await fetchMovements(request, adminToken, {
+        warehouseId: warehouseId!,
+        catalogVariantId: variantId,
+        type: 'receipt',
+      })
+      expect(firstReceiptMovements.some((row) => toNumber(row.quantity) === 25)).toBe(true)
+
       // Regression check for #4105: importing a smaller quantity on top of an
       // existing balance must add to it, not reconcile the balance down to it.
       const secondValidateResponse = await apiRequest(request, 'POST', '/api/wms/inventory/import/validate', {
@@ -238,6 +248,13 @@ test.describe('TC-WMS-025: Inventory CSV import API', () => {
 
       const balanceAfterSecondImport = await fetchBalance(request, adminToken, warehouseId!, variantId)
       expect(toNumber(balanceAfterSecondImport?.quantity_on_hand)).toBe(30)
+
+      const secondReceiptMovements = await fetchMovements(request, adminToken, {
+        warehouseId: warehouseId!,
+        catalogVariantId: variantId,
+        type: 'receipt',
+      })
+      expect(secondReceiptMovements.some((row) => toNumber(row.quantity) === 5)).toBe(true)
 
       // Reconcile mode (opt-in checkbox) restores the pre-#4105 opening-balance semantics:
       // quantity is the absolute target balance, so it can reduce existing stock and warns.
@@ -290,6 +307,15 @@ test.describe('TC-WMS-025: Inventory CSV import API', () => {
 
       const balanceAfterReconcile = await fetchBalance(request, adminToken, warehouseId!, variantId)
       expect(toNumber(balanceAfterReconcile?.quantity_on_hand)).toBe(12)
+
+      // Reconcile-mode rows stay labeled as an 'adjust' ledger entry ("Korekta"),
+      // since they can move the balance in either direction, unlike a receipt.
+      const reconcileMovements = await fetchMovements(request, adminToken, {
+        warehouseId: warehouseId!,
+        catalogVariantId: variantId,
+        type: 'adjust',
+      })
+      expect(reconcileMovements.some((row) => toNumber(row.quantity) === -18)).toBe(true)
 
       const tamperedResponse = await apiRequest(request, 'POST', '/api/wms/inventory/import/apply', {
         token: adminToken,

--- a/packages/core/src/modules/wms/commands/inventory-actions.ts
+++ b/packages/core/src/modules/wms/commands/inventory-actions.ts
@@ -46,14 +46,14 @@ import {
   type InventoryStrategy,
 } from '../data/entities'
 import {
-  inventoryAdjustSchema,
+  inventoryAdjustCommandSchema,
   inventoryCycleCountSchema,
   inventoryMoveSchema,
   inventoryReceiveSchema,
   inventoryReservationAllocateSchema,
   inventoryReservationCreateSchema,
   inventoryReservationReleaseSchema,
-  type InventoryAdjustInput,
+  type InventoryAdjustCommandInput,
   type InventoryCycleCountInput,
   type InventoryMoveInput,
   type InventoryReceiveInput,
@@ -1282,12 +1282,12 @@ const allocateInventoryReservationCommand: CommandHandler<InventoryReservationAl
     }),
 }
 
-const adjustInventoryCommand: CommandHandler<InventoryAdjustInput, { movementId: string }> = {
+const adjustInventoryCommand: CommandHandler<InventoryAdjustCommandInput, { movementId: string }> = {
   id: 'wms.inventory.adjust',
   // See "WMS Inventory Mutation Commands — Undo Policy" at top of file.
   isUndoable: false,
   async execute(rawInput, ctx) {
-    const input = inventoryAdjustSchema.parse(rawInput ?? {})
+    const input = inventoryAdjustCommandSchema.parse(rawInput ?? {})
     ensureTenantScope(ctx, input.tenantId)
     ensureOrganizationScope(ctx, input.organizationId)
     const em = resolveEm(ctx)
@@ -1298,6 +1298,13 @@ const adjustInventoryCommand: CommandHandler<InventoryAdjustInput, { movementId:
       const locationWarehouseId = typeof location.warehouse === 'string' ? location.warehouse : location.warehouse.id
       if (locationWarehouseId !== input.warehouseId) {
         throw new CrudHttpError(422, { error: 'invalid_location' })
+      }
+      if (input.movementType === 'receipt') {
+        const profile = await loadProfileForVariant(trx, ctx, input.catalogVariantId, scope)
+        enforceInventoryTrackingRequirements(profile, {
+          lotId: input.lotId ?? null,
+          serialNumber: input.serialNumber ?? null,
+        })
       }
       const { balance, created: balanceWasNew } = await upsertBalanceBucket(trx, scope, {
         warehouseId: input.warehouseId,
@@ -1315,7 +1322,7 @@ const adjustInventoryCommand: CommandHandler<InventoryAdjustInput, { movementId:
         lotId: input.lotId ?? null,
         serialNumber: input.serialNumber ?? null,
         quantity: delta,
-        type: 'adjust',
+        type: input.movementType ?? 'adjust',
         referenceType: input.referenceType,
         referenceId: input.referenceId,
         performedBy: input.performedBy,

--- a/packages/core/src/modules/wms/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/wms/data/__tests__/validators.test.ts
@@ -2,6 +2,7 @@
 
 import { z } from 'zod'
 import {
+  inventoryAdjustCommandSchema,
   inventoryAdjustSchema,
   inventoryCycleCountSchema,
   productInventoryProfileCreateSchema,
@@ -99,6 +100,55 @@ describe('wms validator rules', () => {
         performedBy: '99999999-9999-4999-8999-999999999999',
       }),
     ).toThrow(/non-zero/i)
+  })
+
+  it('strips movementType from the public adjust schema (#4105)', () => {
+    const parsed = inventoryAdjustSchema.parse({
+      ...scoped,
+      warehouseId: '55555555-5555-4555-8555-555555555555',
+      locationId: '66666666-6666-4666-8666-666666666666',
+      catalogVariantId: '77777777-7777-4777-8777-777777777777',
+      delta: 5,
+      reason: 'Manual correction',
+      referenceType: 'manual',
+      referenceId: '88888888-8888-4888-8888-888888888888',
+      performedBy: '99999999-9999-4999-8999-999999999999',
+      movementType: 'receipt',
+    })
+    expect(parsed).not.toHaveProperty('movementType')
+  })
+
+  it('accepts receipt movementType only on the command schema with a positive delta (#4105)', () => {
+    const parsed = inventoryAdjustCommandSchema.parse({
+      ...scoped,
+      warehouseId: '55555555-5555-4555-8555-555555555555',
+      locationId: '66666666-6666-4666-8666-666666666666',
+      catalogVariantId: '77777777-7777-4777-8777-777777777777',
+      delta: 5,
+      reason: 'CSV import inventory receipt',
+      referenceType: 'manual',
+      referenceId: '88888888-8888-4888-8888-888888888888',
+      performedBy: '99999999-9999-4999-8999-999999999999',
+      movementType: 'receipt',
+    })
+    expect(parsed.movementType).toBe('receipt')
+  })
+
+  it('rejects receipt-labeled adjustments with a non-positive delta (#4105)', () => {
+    expect(() =>
+      inventoryAdjustCommandSchema.parse({
+        ...scoped,
+        warehouseId: '55555555-5555-4555-8555-555555555555',
+        locationId: '66666666-6666-4666-8666-666666666666',
+        catalogVariantId: '77777777-7777-4777-8777-777777777777',
+        delta: -5,
+        reason: 'Forged receipt for a stock correction',
+        referenceType: 'manual',
+        referenceId: '88888888-8888-4888-8888-888888888888',
+        performedBy: '99999999-9999-4999-8999-999999999999',
+        movementType: 'receipt',
+      }),
+    ).toThrow(/positive delta/i)
   })
 
   it('defaults autoAdjust to true for cycle count payloads', () => {

--- a/packages/core/src/modules/wms/data/validators.ts
+++ b/packages/core/src/modules/wms/data/validators.ts
@@ -274,6 +274,27 @@ export const inventoryAdjustSchema = scopedSchema.extend({
   metadata: metadataSchema,
 })
 
+/**
+ * Command-only extension of {@link inventoryAdjustSchema}. `movementType` is
+ * intentionally NOT on the public adjust API — additive CSV import (#4105) may
+ * label a positive stock addition as `receipt` without duplicating adjust's
+ * balance/idempotency path. Public `POST /api/wms/inventory/adjust` keeps the
+ * base schema so clients cannot forge receipt ledger rows.
+ */
+export const inventoryAdjustCommandSchema = inventoryAdjustSchema
+  .extend({
+    movementType: z.enum(['adjust', 'receipt']).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.movementType === 'receipt' && value.delta <= 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['delta'],
+        message: 'Receipt-labeled adjustments require a positive delta.',
+      })
+    }
+  })
+
 export const inventoryMoveSchema = scopedSchema.extend({
   warehouseId: uuid(),
   fromLocationId: uuid(),
@@ -340,6 +361,7 @@ export type InventoryReservationCreateInput = z.infer<typeof inventoryReservatio
 export type InventoryReservationReleaseInput = z.infer<typeof inventoryReservationReleaseSchema>
 export type InventoryReservationAllocateInput = z.infer<typeof inventoryReservationAllocateSchema>
 export type InventoryAdjustInput = z.infer<typeof inventoryAdjustSchema>
+export type InventoryAdjustCommandInput = z.infer<typeof inventoryAdjustCommandSchema>
 export type InventoryMoveInput = z.infer<typeof inventoryMoveSchema>
 export type InventoryCycleCountInput = z.infer<typeof inventoryCycleCountSchema>
 

--- a/packages/core/src/modules/wms/lib/__tests__/inventoryImportService.test.ts
+++ b/packages/core/src/modules/wms/lib/__tests__/inventoryImportService.test.ts
@@ -333,7 +333,9 @@ describe('applyInventoryImport', () => {
 
     expect(executeMock).toHaveBeenCalledWith(
       'wms.inventory.adjust',
-      expect.objectContaining({ input: expect.objectContaining({ delta: 5 }) }),
+      expect.objectContaining({
+        input: expect.objectContaining({ delta: 5, movementType: 'receipt' }),
+      }),
     )
     expect(result.summary.applied).toBe(1)
   })
@@ -381,6 +383,7 @@ describe('applyInventoryImport', () => {
       expect.objectContaining({
         input: expect.objectContaining({
           delta: -3,
+          movementType: undefined,
           metadata: expect.objectContaining({ targetQuantity: 5 }),
         }),
       }),

--- a/packages/core/src/modules/wms/lib/inventoryImportService.ts
+++ b/packages/core/src/modules/wms/lib/inventoryImportService.ts
@@ -583,6 +583,11 @@ export async function applyInventoryImport(
           referenceType: 'manual' as const,
           referenceId: randomUUID(),
           performedBy: input.performedBy,
+          // Additive imports genuinely add new stock, so the ledger should read
+          // "Receipt" rather than "Adjustment" (#4105 QA follow-up). Reconcile
+          // mode can move the balance in either direction and stays labeled as
+          // an adjustment/correction.
+          movementType: mode === 'additive' ? ('receipt' as const) : undefined,
           metadata: {
             importBatchId: input.importBatchId,
             importRowNumber: row.rowNumber,


### PR DESCRIPTION
## Summary
- Additive CSV inventory imports now post ledger movements as `receipt` (“Przyjęcie”) instead of `adjust` (“Korekta”), matching the #4105 QA follow-up.
- `movementType` stays on a command-only schema — public `POST /api/wms/inventory/adjust` cannot forge receipt rows; receipt-labeled adjusts require a positive delta and enforce lot/serial tracking like receive.
- Reconcile-mode imports remain `adjust`; covered by unit tests and TC-WMS-025 movement assertions.

## Test plan
- [ ] `yarn workspace @open-mercato/core test --testPathPatterns='modules/wms/(data/__tests__/validators|lib/__tests__/inventoryImportService)'`
- [ ] Run TC-WMS-025 (inventory CSV import API) and confirm additive rows create `receipt` movements and reconcile rows create `adjust`
- [ ] Manually POST `/api/wms/inventory/adjust` with `movementType: "receipt"` and confirm it is ignored/stripped (still creates `adjust`)
- [ ] Additive import of a lot-tracked SKU without a lot fails with `lot_required`


Made with [Cursor](https://cursor.com)