### PR TITLE
test(customers): replace hardcoded expectedCloseAt literal in undo.custom-fields.test.ts (#5062)

### DIFF
--- a/packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts
+++ b/packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts
@@ -476,6 +476,7 @@ describe('customers commands undo custom fields', () => {
     expect(handler).toBeDefined()
     const tenantId = TEST_TENANT_ID
     const organizationId = TEST_ORG_ID
+    const futureExpectedCloseAt = new Date(Date.now() + 30 * 86_400_000)
 
     const personEntity: CustomerEntity = {
       id: 'person-1',
@@ -589,7 +590,7 @@ describe('customers commands undo custom fields', () => {
               valueAmount: '1000',
               valueCurrency: 'USD',
               probability: 20,
-              expectedCloseAt: '2026-07-20T12:00:00.000Z',
+              expectedCloseAt: futureExpectedCloseAt.toISOString(),
               ownerUserId: 'user-8',
               source: 'event',
             },
@@ -635,7 +636,7 @@ describe('customers commands undo custom fields', () => {
       })
     )
     expect(existingDeal.title).toBe('Before Deal')
-    expect(existingDeal.expectedCloseAt).toEqual(new Date('2026-07-20T12:00:00.000Z'))
+    expect(existingDeal.expectedCloseAt).toEqual(futureExpectedCloseAt)
     expect(em.create).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ person: personEntity, isPrimary: true }),


### PR DESCRIPTION
## Summary

Replaces the hardcoded future-dated literal `'2026-07-20T12:00:00.000Z'` used for `expectedCloseAt` in the `deals.update undo restores custom fields` test with a single clock-relative value, `futureExpectedCloseAt = new Date(Date.now() + 30 * 86_400_000)` (matching the house idiom in `TC-CRM-026.spec.ts:107`). The value is computed once at the top of the test and reused for both the `before.deal.expectedCloseAt` snapshot (via `.toISOString()`) and the post-undo `toEqual` assertion, so the round-trip assertion still proves the snapshot restored the prior date and cannot pass by coincidence.

This is the same latent time-bomb pattern already fixed for `TC-UNDO-003` in #5060 / #5061, one severity quieter (`time-bomb-scanner.mjs` rates it LOW because both sides of the assertion were hardcoded and the date had already elapsed).

Closes #5062

## Changes

- `packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts` — derive `expectedCloseAt` from `Date.now()` at run time in the `deals.update` undo test; leaves the other (correctly past-dated, out-of-scope) date literals in the same file untouched.

## Test plan

- [x] `node scripts/time-bomb-scanner.mjs --all packages/core/src/modules/customers/commands/__tests__/undo.custom-fields.test.ts` reports 0 findings for this occurrence (5 unrelated LOW past-date fixtures remain, out of scope for this issue)
- [x] `yarn workspace @open-mercato/core test undo.custom-fields.test.ts` — 1 suite, 17 tests, all passed
- [x] `yarn workspace @open-mercato/core build` passed (typechecks the change)
- [x] `yarn eslint` on the changed file passed

This is a pure test-fixture edit — no production code, schema, or contract change — so the automated-verification exemption applies.
