### PR TITLE
fix(ui): forward the click event through DataTable's onRowClick (#5154)

### DIFF
--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -299,7 +299,7 @@ export type DataTableProps<T extends RowData> = {
   emptyState?: React.ReactNode
   error?: React.ReactNode | string | null
   rowActions?: (row: T) => React.ReactNode
-  onRowClick?: (row: T) => void
+  onRowClick?: (row: T, event: React.MouseEvent<HTMLTableRowElement>) => void
   rowClickActionIds?: string[]
   disableRowClick?: boolean
   bulkActions?: BulkAction<T>[]
@@ -3461,7 +3461,7 @@ export function DataTable<T extends RowData>({
                       }
                       
                       if (onRowClick) {
-                        onRowClick(row.original as T)
+                        onRowClick(row.original as T, e)
                       } else if (defaultRowAction) {
                         if (defaultRowAction.href) {
                           router.push(defaultRowAction.href)

--- a/packages/ui/src/backend/__tests__/DataTable.render.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.render.test.tsx
@@ -128,4 +128,38 @@ describe('DataTable SSR render', () => {
       queryClient.clear()
     }
   })
+
+  it('forwards the click event to onRowClick, and skips it when clicking the actions cell', () => {
+    const columns: ColumnDef<Row>[] = [
+      { accessorKey: 'name', header: 'Name' },
+    ]
+    const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+    const onRowClick = jest.fn()
+    try {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <I18nProvider locale="en" dict={{}}>
+            <DataTable
+              columns={columns}
+              data={[{ id: '1', name: 'Ada' }]}
+              onRowClick={onRowClick}
+              rowActions={() => <button type="button">Edit</button>}
+            />
+          </I18nProvider>
+        </QueryClientProvider>,
+      )
+
+      fireEvent.click(screen.getByText('Ada'))
+      expect(onRowClick).toHaveBeenCalledTimes(1)
+      const [row, event] = onRowClick.mock.calls[0]
+      expect(row).toEqual({ id: '1', name: 'Ada' })
+      expect(event).toEqual(expect.objectContaining({ type: 'click' }))
+      expect(typeof event.currentTarget).not.toBe('undefined')
+
+      fireEvent.click(screen.getByText('Edit'))
+      expect(onRowClick).toHaveBeenCalledTimes(1)
+    } finally {
+      queryClient.clear()
+    }
+  })
 })

--- a/packages/ui/src/backend/__tests__/DataTable.render.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.render.test.tsx
@@ -134,7 +134,10 @@ describe('DataTable SSR render', () => {
       { accessorKey: 'name', header: 'Name' },
     ]
     const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
-    const onRowClick = jest.fn()
+    let capturedRowTagName: string | null = null
+    const onRowClick = jest.fn((_row: Row, event: React.MouseEvent<HTMLTableRowElement>) => {
+      capturedRowTagName = event.currentTarget.tagName
+    })
     try {
       render(
         <QueryClientProvider client={queryClient}>
@@ -153,8 +156,8 @@ describe('DataTable SSR render', () => {
       expect(onRowClick).toHaveBeenCalledTimes(1)
       const [row, event] = onRowClick.mock.calls[0]
       expect(row).toEqual({ id: '1', name: 'Ada' })
-      expect(event).toEqual(expect.objectContaining({ type: 'click' }))
-      expect(typeof event.currentTarget).not.toBe('undefined')
+      expect(event.type).toBe('click')
+      expect(capturedRowTagName).toBe('TR')
 
       fireEvent.click(screen.getByText('Edit'))
       expect(onRowClick).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary

`DataTable`'s `onRowClick` prop only received the clicked row, not the triggering DOM event, so callers had no way to anchor UI (popovers, peek panels, context menus) to the clicked `<tr>`. The row's `onClick` handler already captures the native click event — it uses it to skip clicks on the actions cell — but never forwarded it to `onRowClick`.

This widens `onRowClick` additively to `(row: T, event: React.MouseEvent<HTMLTableRowElement>) => void` and forwards the in-scope event at the call site. Existing single-argument callers remain valid under TypeScript's parameter-count compatibility, so no other call site needed changes.

Fixes #5154

## Changes

- `packages/ui/src/backend/DataTable.tsx` — widen `onRowClick` signature and pass the click event through
- `packages/ui/src/backend/__tests__/DataTable.render.test.tsx` — regression test asserting the event is forwarded and that actions-cell clicks are still excluded

## Test plan

- [x] `yarn workspace @open-mercato/ui test` — new regression test passes
- [x] `yarn build:packages --force` (all 22 packages, cache-bypassed) — no downstream typecheck breaks from the widened signature
- [x] `yarn typecheck --force` (all 22 packages, cache-bypassed) — clean
- [x] `yarn test --force` — pre-existing/environmental failures only (locale-formatting tests on this machine's `pl_PL.UTF-8` locale, a known `@open-mercato/cli` fs.watch flake, sandbox-only `create-mercato-app` failures); none touch `DataTable`/`onRowClick`
- [x] `yarn build:app` — succeeds

## Breaking changes

None — additive optional-parameter widening only.
