### PR TITLE
fix(customers): make the Mark deal as Lost dialog scroll internally

### DIFF
--- a/packages/core/src/modules/customers/components/detail/ConfirmDealLostDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/ConfirmDealLostDialog.tsx
@@ -130,8 +130,11 @@ export function ConfirmDealLostDialog({
 
   return (
     <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose() }}>
-      <DialogContent className="overflow-hidden p-0 sm:max-w-[560px]" onKeyDown={handleKeyDown}>
-        <div className="overflow-hidden rounded-lg bg-card">
+      <DialogContent
+        className="flex max-h-[min(90vh,720px)] flex-col overflow-hidden p-0 sm:max-w-[560px]"
+        onKeyDown={handleKeyDown}
+      >
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg bg-card">
           <DialogHeader className="border-b border-border/70 px-7 py-5">
             <div className="flex items-start gap-4">
               <div className="flex size-10 shrink-0 items-center justify-center rounded-md bg-destructive/10 text-destructive">
@@ -150,7 +153,7 @@ export function ConfirmDealLostDialog({
             </div>
           </DialogHeader>
 
-          <div className="space-y-6 px-7 py-6">
+          <div className="min-h-0 flex-1 space-y-6 overflow-y-auto px-7 py-6">
             <Alert status="warning" className="rounded-md">
               <AlertTitle>
                 {t('customers.deals.detail.lost.warningTitle', 'This action closes the deal')}

--- a/packages/core/src/modules/customers/components/detail/__tests__/ConfirmDealLostDialog.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/ConfirmDealLostDialog.test.tsx
@@ -161,6 +161,20 @@ describe('ConfirmDealLostDialog', () => {
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })
 
+  it('scrolls its body internally instead of clipping content that overflows the viewport', async () => {
+    render(<ConfirmDealLostDialog {...defaultProps} onConfirm={jest.fn()} />)
+
+    await act(async () => {})
+
+    const warningTitle = screen.getByText('This action closes the deal')
+    const scrollRegion = warningTitle.closest('.overflow-y-auto')
+    expect(scrollRegion).not.toBeNull()
+    expect(scrollRegion).toHaveClass('min-h-0', 'flex-1')
+
+    const confirmButton = screen.getByText('Mark as Lost')
+    expect(scrollRegion?.contains(confirmButton)).toBe(false)
+  })
+
   it('accepts another Cmd+Enter after the previous confirmation resolves', async () => {
     let resolveFirst!: () => void
     const onConfirm = jest.fn(


### PR DESCRIPTION
## Summary

- The "Mark deal as Lost?" confirmation dialog (`ConfirmDealLostDialog.tsx`) wrapped its header, body, and footer in a single `overflow-hidden` container with no internal scroll region.
- Once the dialog's content (warning banner + loss reason picker + notes + footer) exceeded the base dialog's `max-h-[90vh]`, the overflow was clipped instead of scrolling, cutting off the bottom of the dialog — including the confirm button — at normal (100%) browser zoom.
- Restructured the dialog into a fixed header, a scrollable body (`min-h-0 flex-1 overflow-y-auto`), and a fixed footer, matching the existing pattern already used by `AssignRoleDialog.tsx` in the same module.

## Test plan

- [x] Added a regression test asserting the dialog body region carries `overflow-y-auto`/`min-h-0`/`flex-1` and that the confirm button sits outside the scroll region (fixed footer).
- [x] `yarn workspace @open-mercato/core test -- ConfirmDealLostDialog.test.tsx` — 6/6 pass.
- [x] `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn typecheck`, `yarn lint` — all pass (pre-existing, unrelated locale-formatting test failures in `CompanyKpiBar.dealStatus.test.tsx` confirmed present on `develop` HEAD before this change).
- [ ] Manual UI verification pending (dialog rendering) — see PR checks.

Fixes #5172