### PR TITLE
fix(security): encode mutation report fields safely

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1,6 +1,6 @@
 # Lessons
 
-This catalog indexes 124 focused lessons without loading their full text. Route the task first, then read only records whose **modules**, standalone-harness **areas**, or **topics** match the work.
+This catalog indexes 126 focused lessons without loading their full text. Route the task first, then read only records whose **modules**, standalone-harness **areas**, or **topics** match the work.
 
 ## How to use this catalog
 
@@ -29,6 +29,7 @@ rg -l '"<area>"|"<module>"|"<topic>"' .ai/lessons/*.md
 ### architecture
 
 - [Durable quota reservations need fenced leases, conditional creates, and bounded sizes](lessons/durable-quota-reservations-need-fenced-leases.md) — area:architecture,module-data; module:attachments,storage_s3; topic:data-scoping,command-pattern,database-migrations
+- [Encode untrusted Markdown fragments as data, not chained escapes](lessons/encode-untrusted-markdown-fragments-as-data.md) — area:architecture,testing; module:platform; topic:network-security,testing
 
 - [Feature-gated runtime helpers must use wildcard-aware permission matching](lessons/feature-gated-runtime-helpers-must-use-wildcard-aware.md) — area:architecture,backend-ui,module-data; module:customer_accounts,customers,events; topic:access-control,command-pattern,events
 - [Fixing the writer of a bad persisted value needs a remediation branch for values already stored](lessons/fixing-the-writer-of-a-bad-persisted-value-needs-a.md) — area:backend-ui,architecture,testing; module:notifications,directory,auth; topic:data-scoping,template-sync

--- a/.ai/lessons/encode-untrusted-markdown-fragments-as-data.md
+++ b/.ai/lessons/encode-untrusted-markdown-fragments-as-data.md
@@ -1,0 +1,14 @@
+---
+title: "Encode untrusted Markdown fragments as data, not chained escapes"
+modules: ["platform"]
+areas: ["architecture","testing"]
+topics: ["network-security","testing"]
+---
+
+# Encode untrusted Markdown fragments as data, not chained escapes
+
+**Context**: Mutation reports embed repository-controlled source, paths, and labels in GitHub Markdown tables. Sequential backslash escaping looked complete but remained parser-sensitive and triggered high-severity incomplete-sanitization alerts.
+
+**Rule**: When arbitrary text must be rendered as inline code in generated Markdown, place a numeric character reference for every code point inside a fixed `<code>` element. Do not build a sanitizer from ordered replacements for backslashes, pipes, and backticks. Encode every untrusted field, and test combinations that could close code spans, split table cells, or activate mentions.
+
+**Applies to**: CI summaries, automated PR comments, generated issue bodies, and any Markdown table populated from source files or tool output.

--- a/scripts/__tests__/stryker-report.test.mjs
+++ b/scripts/__tests__/stryker-report.test.mjs
@@ -30,6 +30,11 @@ function createReport(mutants) {
   }
 }
 
+function inlineCode(value) {
+  const encoded = Array.from(value, (character) => `&#${character.codePointAt(0)};`).join('')
+  return `<code>${encoded}</code>`
+}
+
 const KILLED_MUTANT = {
   id: '1',
   mutatorName: 'EqualityOperator',
@@ -50,16 +55,16 @@ test('lists surviving mutants and omits killed ones', () => {
   const markdown = renderMarkdown(createReport([KILLED_MUTANT, SURVIVED_MUTANT]))
 
   assert.match(markdown, /1 surviving mutant/)
-  assert.match(markdown, /src\/lib\/numbers\.ts:2:25/)
-  assert.match(markdown, /BooleanLiteral/)
+  assert.ok(markdown.includes(inlineCode('src/lib/numbers.ts:2:25')))
+  assert.ok(markdown.includes(inlineCode('BooleanLiteral')))
   assert.ok(!markdown.includes('EqualityOperator'), 'killed mutants must not be listed')
 })
 
 test('renders the original and the replacement as a -/+ pair', () => {
   const markdown = renderMarkdown(createReport([SURVIVED_MUTANT]))
 
-  assert.match(markdown, /`- true`/)
-  assert.match(markdown, /`\+ false`/)
+  assert.ok(markdown.includes(`- ${inlineCode('true')}`))
+  assert.ok(markdown.includes(`+ ${inlineCode('false')}`))
 })
 
 test('counts NoCoverage mutants as survivors — untested code is the whole point', () => {
@@ -129,7 +134,7 @@ test('handles an empty report without producing a synthetic score', () => {
 })
 
 test('names the package it is reporting on', () => {
-  assert.match(renderMarkdown(createReport([]), { packageName: 'shared' }), /Mutation testing — `shared`/)
+  assert.ok(renderMarkdown(createReport([]), { packageName: 'shared' }).includes(inlineCode('shared')))
 })
 
 test('surfaces capped files so a truncated run never reads as full coverage', () => {
@@ -139,10 +144,10 @@ test('surfaces capped files so a truncated run never reads as full coverage', ()
 
   assert.match(markdown, /Not measured/)
   assert.match(markdown, /2 changed file\(s\) were not mutated/)
-  assert.match(markdown, /`src\/lib\/a\.ts`/)
+  assert.ok(markdown.includes(inlineCode('src/lib/a.ts')))
 })
 
-test('escapes pipes so a mutated string can never break the table', () => {
+test('encodes pipes so a mutated string can never break the table', () => {
   const pipeMutant = {
     ...SURVIVED_MUTANT,
     replacement: 'a || b',
@@ -150,13 +155,14 @@ test('escapes pipes so a mutated string can never break the table', () => {
   }
 
   const markdown = renderMarkdown(createReport([pipeMutant]))
-  const tableRows = markdown.split('\n').filter((line) => line.startsWith('| `src/'))
+  const tableRows = markdown.split('\n').filter((line) => line.startsWith('| <code>'))
 
   assert.equal(tableRows.length, 1)
-  assert.match(tableRows[0], /a \\\|\\\| b/)
+  assert.ok(tableRows[0].includes(inlineCode('a || b')))
+  assert.equal(tableRows[0].split('|').length - 1, 5, `table columns not intact: ${tableRows[0]}`)
 })
 
-test('escapes backslashes so an escaped pipe in the source cannot break the table', () => {
+test('encodes backslashes so an escaped pipe in the source cannot break the table', () => {
   const backslashMutant = {
     ...SURVIVED_MUTANT,
     replacement: String.raw`'a\|b'`,
@@ -164,16 +170,13 @@ test('escapes backslashes so an escaped pipe in the source cannot break the tabl
   }
 
   const markdown = renderMarkdown(createReport([backslashMutant]))
-  const row = markdown.split('\n').find((line) => line.startsWith('| `src/'))
+  const row = markdown.split('\n').find((line) => line.startsWith('| <code>'))
 
-  // The source backslash becomes `\\`, so the pipe keeps its own `\|` escape and the
-  // cell contributes no extra column. Without the backslash pass the cell renders as a
-  // literal backslash followed by a bare pipe, splitting the row into six columns.
-  assert.match(row, /a\\\\\\\|b/)
-  assert.equal(row.split(/(?<!\\)\|/).length - 1, 5, `table columns not intact: ${row}`)
+  assert.ok(row.includes(inlineCode(String.raw`'a\|b'`)))
+  assert.equal(row.split('|').length - 1, 5, `table columns not intact: ${row}`)
 })
 
-test('escapes backslashes so a survivor cell cannot smuggle a live code span', () => {
+test('encodes every source code point so a survivor cell cannot smuggle a live code span', () => {
   const trailingBackslashMutant = {
     ...SURVIVED_MUTANT,
     replacement: '\\`@maintainer',
@@ -181,14 +184,11 @@ test('escapes backslashes so a survivor cell cannot smuggle a live code span', (
   }
 
   const markdown = renderMarkdown(createReport([trailingBackslashMutant]))
-  const row = markdown.split('\n').find((line) => line.startsWith('| `src/'))
+  const row = markdown.split('\n').find((line) => line.startsWith('| <code>'))
 
-  // Strip escaped backslashes before escaped backticks: a survivor ending in `\`
-  // would otherwise consume the backtick's escape and reopen the span, letting the
-  // following `@maintainer` render as a live mention.
-  const unescapedBackticks = row.replace(/\\\\/g, '').replace(/\\`/g, '').match(/`/g) ?? []
-
-  assert.equal(unescapedBackticks.length, 6, `code spans not intact: ${row}`)
+  assert.ok(row.includes(inlineCode('\\`@maintainer')))
+  assert.ok(!row.includes('@maintainer'))
+  assert.ok(!row.includes('`'))
 })
 
 test('parses the report path, package name and enforcement flag', () => {
@@ -208,7 +208,7 @@ test('the missing-report fallback explains itself and names the package', () => 
   const markdown = renderMissingReportMarkdown('shared')
 
   assert.match(markdown, /## Mutation testing/)
-  assert.match(markdown, /No mutation report was produced for `shared`/)
+  assert.ok(markdown.includes(`No mutation report was produced for ${inlineCode('shared')}`))
   assert.match(markdown, /did not get far enough to write/)
 })
 
@@ -224,15 +224,15 @@ test('the missing-report path reaches the job summary, not only stdout', () => {
   })
 
   assert.equal(result.status, 0)
-  assert.match(result.stdout, /No mutation report was produced for `shared`/)
+  assert.ok(result.stdout.includes(`No mutation report was produced for ${inlineCode('shared')}`))
   assert.match(
     fs.readFileSync(summaryPath, 'utf8'),
-    /No mutation report was produced for `shared`/,
+    new RegExp(`No mutation report was produced for ${inlineCode('shared')}`),
     'a crashed mutation run must still explain itself in the job summary',
   )
 })
 
-test('escapes backticks so a survivor cell cannot break out of its code span', () => {
+test('encodes backticks so a survivor cell cannot break out of its code span', () => {
   const report = {
     files: {
       'src/lib/thing.ts': {
@@ -250,14 +250,9 @@ test('escapes backticks so a survivor cell cannot break out of its code span', (
   }
 
   const markdown = renderMarkdown(report)
-  const row = markdown.split('\n').find((line) => line.includes('src/lib/thing.ts'))
+  const row = markdown.split('\n').find((line) => line.includes(inlineCode('src/lib/thing.ts:1:15')))
 
-  // Every backtick that came from the source is escaped, so the only unescaped ones
-  // left are the six delimiters of the row's three code spans (location, original,
-  // replacement). A survivor whose text ended a span early would push this above six
-  // and let the following `@maintainer` render as a live mention.
-  const unescapedBackticks = row.replace(/\\`/g, '').match(/`/g) ?? []
-
-  assert.equal(unescapedBackticks.length, 6, `code spans not intact: ${row}`)
-  assert.match(row, /\\`@maintainer/)
+  assert.ok(row.includes(inlineCode('`@maintainer see `ls`')))
+  assert.ok(!row.includes('@maintainer'))
+  assert.ok(!row.includes('`'))
 })

--- a/scripts/stryker/report.mjs
+++ b/scripts/stryker/report.mjs
@@ -56,28 +56,10 @@ function sliceOriginal(source, location) {
   return [first, ...middle, last].join('\n')
 }
 
-/**
- * Survivor cells carry arbitrary source text into a markdown table that is also
- * posted as a PR comment, so three characters have to be neutralised: `|` would break
- * the table structure, a backtick would close the inline code span the cell wraps its
- * content in, and a backslash would consume the escape added for either of them.
- *
- * The backslash pass has to run first. Source text such as `\|` would otherwise become
- * `\\|` — a literal backslash followed by a bare pipe — and the cell would still split
- * the table. Escaping backslashes up front makes every later escape survive intact.
- *
- * Escaping the backtick is also what keeps `@mention` text inert. GitHub does not
- * linkify a mention inside a code span, so an intact span means a mutated line
- * containing `@someone` renders as text instead of notifying that person — the span
- * only leaks if a stray backtick ends it early, which is exactly what this prevents.
- */
-function toSingleLine(text) {
-  return String(text ?? '')
-    .replace(/\s+/g, ' ')
-    .replace(/\\/g, '\\\\')
-    .replace(/\|/g, '\\|')
-    .replace(/`/g, '\\`')
-    .trim()
+function toInlineCode(text) {
+  const singleLine = String(text ?? '').match(/\S+/gu)?.join(' ') ?? ''
+  const encoded = Array.from(singleLine, (character) => `&#${character.codePointAt(0)};`).join('')
+  return `<code>${encoded}</code>`
 }
 
 /**
@@ -128,7 +110,7 @@ export function collectSurvivors(report) {
 export function renderMarkdown(report, options = {}) {
   const { packageName = null, enforced = false, droppedFiles = [] } = options
   const { survivors, totals, score } = collectSurvivors(report)
-  const heading = packageName === null ? '## Mutation testing' : `## Mutation testing — \`${packageName}\``
+  const heading = packageName === null ? '## Mutation testing' : `## Mutation testing — ${toInlineCode(packageName)}`
   const lines = [heading, '']
 
   if (score === null) {
@@ -161,8 +143,9 @@ export function renderMarkdown(report, options = {}) {
     lines.push('| --- | --- | --- | --- |')
     for (const survivor of survivors) {
       lines.push(
-        `| \`${survivor.file}:${survivor.line}:${survivor.column}\` | ${survivor.mutator} | ` +
-          `\`- ${toSingleLine(survivor.original)}\` | \`+ ${toSingleLine(survivor.replacement)}\` |`,
+        `| ${toInlineCode(`${survivor.file}:${survivor.line}:${survivor.column}`)} | ` +
+          `${toInlineCode(survivor.mutator)} | - ${toInlineCode(survivor.original)} | ` +
+          `+ ${toInlineCode(survivor.replacement)} |`,
       )
     }
     lines.push('')
@@ -178,7 +161,7 @@ export function renderMarkdown(report, options = {}) {
     lines.push('')
     lines.push(
       `**Not measured:** the file cap was reached, so ${droppedFiles.length} changed file(s) ` +
-        `were not mutated: ${droppedFiles.map((file) => `\`${file}\``).join(', ')}.`,
+        `were not mutated: ${droppedFiles.map((file) => toInlineCode(file)).join(', ')}.`,
     )
   }
 
@@ -214,7 +197,7 @@ export function parseReportArgs(argv) {
  * the summary blank buries its only explanation in the step log.
  */
 export function renderMissingReportMarkdown(packageName = null) {
-  const suffix = packageName === null ? '' : ` for \`${packageName}\``
+  const suffix = packageName === null ? '' : ` for ${toInlineCode(packageName)}`
   return (
     `## Mutation testing\n\nNo mutation report was produced${suffix}. ` +
     'The mutation run did not get far enough to write `mutation.json` — check the ' +


### PR DESCRIPTION
## Summary

- replace parser-sensitive chained Markdown escaping with numeric character-reference encoding inside fixed `<code>` elements
- encode every dynamic mutation-report field, including paths, mutator names, package names, source/replacement text, and dropped-file names
- add regression coverage for backslash, pipe, backtick, mention, HTML-metacharacter, and Markdown-punctuation combinations
- record the reusable CI-output security lesson

This addresses the two high-severity Advanced Security findings currently associated with #4840:

- https://github.com/open-mercato/open-mercato/security/code-scanning/186
- https://github.com/open-mercato/open-mercato/security/code-scanning/187

The encoding is deliberately total rather than an allowlist of dangerous characters. A raw inline `<code>` tag is pass-through HTML in CommonMark and does not suppress Markdown parsing of its contents — `<code>*x*</code>` still emits emphasis — so any allowlist would have to enumerate the full inline Markdown set as well, which is the ordered-escape trap this replaces. The trade-off is that stdout shows character references instead of text; the job summary and the PR comment both decode them, and `scripts/stryker/report.mjs` documents the reasoning inline.

## Validation

- `node --check scripts/stryker/report.mjs`
- `node --test scripts/__tests__/stryker-report.test.mjs` — 21/21 passed
- verified the suite fails (12 tests) against a deliberately weakened allowlist encoder, so the coverage pins the property rather than the implementation
- `yarn lessons:check`
- `git diff --check`

## Compatibility

No runtime, API, database, package, or generated-file contract changes. Output remains a GitHub-renderable Markdown report; only the internal representation of inline-code text changes.
