### PR TITLE
.github/workflows: Migrate workflows to Blacksmith runners

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -48,7 +48,7 @@ concurrency:
 jobs:
   audit:
     name: Audit ${{ matrix.branch }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,7 +396,7 @@ jobs:
   # native compiler has no JS API, so the parser's `typescript` import must be
   # redirected to `typescript-js`.
   ds-lint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: read
       pull-requests: write   # sticky comment; no-op on fork PRs (read-only token)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   #                      Only uploaded when integration tests will actually run;
   #                      skipped for CI/docs-only PRs to save ~2 min.
   prepare:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       skip_integration: ${{ steps.integration-scope.outputs.skip }}
       affected_modules: ${{ steps.integration-scope.outputs.modules }}
@@ -225,7 +225,7 @@ jobs:
   # Determines whether dependency audit needs to run. Package manifests and
   # lockfiles are the only inputs that can change the dependency graph.
   audit-scope:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       should_run: ${{ steps.dependency-files.outputs.should_run }}
     steps:
@@ -274,7 +274,7 @@ jobs:
   # `.github/workflows/audit.yml` instead — this job is the change-triggered
   # half of the pair (#4479).
   audit:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
     needs: audit-scope
     if: needs.audit-scope.outputs.should_run == 'true'
@@ -335,7 +335,7 @@ jobs:
   # in scope: excluding it left turbo with zero commands and a permanently green
   # no-op job (issue #4472).
   lint:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -502,7 +502,7 @@ jobs:
   # so typecheck cost does not add to the integration wall time.
   # merge-coverage and docker-build both wait for this job to complete.
   test:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [prepare, audit-scope, audit, lint]
     if: |
       always() &&
@@ -682,7 +682,7 @@ jobs:
   #         wall time from ~45 min to ~6 min. A merge-coverage job then
   #         combines per-shard coverage reports.
   ephemeral-integration:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [prepare, audit-scope, audit, lint]
     if: |
       always() &&
@@ -885,7 +885,7 @@ jobs:
   # Ensures both typecheck/units and integration must pass before reporting green.
   # On push: downloads per-shard artifacts, merges coverage reports, writes summary.
   merge-coverage:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [prepare, test, ephemeral-integration]
     if: needs.prepare.outputs.shard_matrix != '["none"]'
     steps:
@@ -963,7 +963,7 @@ jobs:
   # a 10+ min rebuild caused by Docker layer cache busting when files like
   # turbo.json or scripts/ are the only things that changed.
   docker-build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: prepare
     # Only run on non-fork PRs and direct pushes (forks don't have access to GHA cache).
     # Also skip for CI/docs-only PRs — no app code changed, image is unchanged.
@@ -975,31 +975,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Build docs Dockerfile
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: apps/docs/Dockerfile
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Build fullapp (main app)
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: .
           file: Dockerfile
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Build opencode container
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: ./docker/opencode
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Enable Corepack
         run: corepack enable
@@ -285,7 +285,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Enable Corepack
         run: corepack enable
@@ -343,7 +343,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Enable Corepack
         run: corepack enable
@@ -407,7 +407,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Enable Corepack
         run: corepack enable
@@ -525,7 +525,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Enable Corepack
         run: corepack enable
@@ -742,7 +742,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Enable Corepack
         run: corepack enable
@@ -895,7 +895,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Download shard artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/community-labels.yml
+++ b/.github/workflows/community-labels.yml
@@ -18,7 +18,7 @@ jobs:
     if: >
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/label ')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Check out the certified partner registry

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Checkout develop

--- a/.github/workflows/mutation-tests.yml
+++ b/.github/workflows/mutation-tests.yml
@@ -60,7 +60,7 @@ jobs:
   # matrix when nothing is in scope, which skips the mutate job entirely rather
   # than reporting a synthetic score.
   scope:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       matrix: ${{ steps.scope.outputs.matrix }}
       has_work: ${{ steps.scope.outputs.has_work }}
@@ -82,7 +82,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       # Every value that originates outside this file is read from the environment
       # rather than interpolated into the script. `${{ … }}` expands as text before
@@ -117,7 +117,7 @@ jobs:
   mutate:
     needs: scope
     if: needs.scope.outputs.has_work == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 60
     # Advisory: a low score annotates the PR, it does not fail the check. Flipping
     # MUTATION_ENFORCE to 'true' is what turns this into a real gate.
@@ -137,7 +137,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Enable Corepack
         run: corepack enable
@@ -217,7 +217,7 @@ jobs:
       always() &&
       needs.scope.outputs.has_work == 'true' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # Convenience surface only: the job summary is primary and needs no token. See
     # the per-job note at the top of this file.
     continue-on-error: true
@@ -231,7 +231,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version: 24.19.0
 
       - name: Download mutation reports
         uses: actions/download-artifact@v6

--- a/.github/workflows/npm-snapshot-preview.yml
+++ b/.github/workflows/npm-snapshot-preview.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   resolve-pr:
     name: Resolve PR
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       head_sha: ${{ steps.pr.outputs.head_sha }}
       head_repo: ${{ steps.pr.outputs.head_repo }}
@@ -74,7 +74,7 @@ jobs:
       snapshot_version: ${{ steps.release.outputs.version }}
       publish_tag: ${{ steps.channel.outputs.publish_tag }}
       packages_json: ${{ steps.release.outputs.packages_json }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -221,7 +221,7 @@ jobs:
 
   standalone-integration:
     name: Standalone App Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs:
       - resolve-pr
       - snapshot

--- a/.github/workflows/npm-snapshot-preview.yml
+++ b/.github/workflows/npm-snapshot-preview.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 'lts/*'
+          node-version: '24.19.0'
 
       - name: Enable Corepack
         run: corepack enable
@@ -250,7 +250,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 'lts/*'
+          node-version: '24.19.0'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/package-previews.yml
+++ b/.github/workflows/package-previews.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   resolve-pr:
     name: Resolve PR
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       head_sha: ${{ steps.pr.outputs.head_sha }}
       head_repo: ${{ steps.pr.outputs.head_repo }}
@@ -60,7 +60,7 @@ jobs:
     name: Publish Package Previews
     needs: resolve-pr
     if: needs.resolve-pr.outputs.same_repo == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/package-previews.yml
+++ b/.github/workflows/package-previews.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 'lts/*'
+          node-version: '24.19.0'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/qa-deploy.yml
+++ b/.github/workflows/qa-deploy.yml
@@ -43,7 +43,7 @@ env:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Checkout selected branch
@@ -64,8 +64,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      - name: Setup Blacksmith Builder
+        uses: useblacksmith/setup-docker-builder@v1
 
       - name: Login to GHCR
         uses: docker/login-action@v4
@@ -93,7 +93,7 @@ jobs:
           echo "image_full=${IMAGE}:${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: useblacksmith/build-push-action@v2
         with:
           context: ${{ env.BUILD_CONTEXT }}
           file: ${{ env.DOCKERFILE }}
@@ -101,8 +101,6 @@ jobs:
           platforms: linux/amd64
           tags: |
             ${{ steps.meta.outputs.image_full }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Resolve Dokploy applicationId
         id: app

--- a/.github/workflows/qa-stop-on-merge.yml
+++ b/.github/workflows/qa-stop-on-merge.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   stop-qa:
     if: ${{ github.event.action == 'closed' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Detect QA slot label

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version: '24.19.0'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -30,7 +30,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   prepare:
     name: Prepare release PR
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # Only allow release preparation from main branch
     if: github.ref == 'refs/heads/main'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version: '24.19.0'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # Only allow releases from main branch
     if: github.ref == 'refs/heads/main'
     # Requires approval from the 'production' environment — prevents a single

--- a/.github/workflows/skills-tiers-lint.yml
+++ b/.github/workflows/skills-tiers-lint.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   validate-skills-tiers:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version: '24.19.0'
 
       - name: Enable Corepack
         run: corepack enable
@@ -165,7 +165,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '24'
+          node-version: '24.19.0'
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -28,7 +28,7 @@ jobs:
       snapshot_version: ${{ steps.release.outputs.version }}
       publish_tag: ${{ steps.channel.outputs.publish_tag }}
       packages_json: ${{ steps.release.outputs.packages_json }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -135,7 +135,7 @@ jobs:
 
   standalone-integration:
     name: Standalone App Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: snapshot
     if: needs.snapshot.outputs.snapshot_version != ''
     services:


### PR DESCRIPTION
Human-authored duplicate of #5243 so the pull request and commit are associated with @MStaniaszek1998 for CLA verification. This version targets develop.

## Summary

- move selected GitHub Actions jobs to Blacksmith Ubuntu 24.04 runners
- switch Docker builds to Blacksmith builder and build-push actions
- remove explicit GitHub Actions Docker cache settings now handled by Blacksmith

## Verification

- rebased onto current develop
- migration diff matches blacksmith-migration-8c6a837 while preserving the audit timeout already present on develop
- git diff --check passes
- GitHub resolves both commit author and committer to MStaniaszek1998