### PR TITLE
fix(create-app): run snapshot activation helper under CJS

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1,6 +1,6 @@
 # Lessons
 
-This catalog indexes 126 focused lessons without loading their full text. Route the task first, then read only records whose **modules**, standalone-harness **areas**, or **topics** match the work.
+This catalog indexes 127 focused lessons. Route the task first, then read only records whose **modules**, standalone-harness **areas**, or **topics** match the work.
 
 ## How to use this catalog
 
@@ -169,6 +169,7 @@ rg -l '"<area>"|"<module>"|"<topic>"' .ai/lessons/*.md
 - [Keep executable integration tests module-local](lessons/keep-executable-integration-tests-module-local.md) — area:testing,module-data; module:platform; topic:module-boundaries,package-runtime,testing
 - [Meilisearch container healthchecks must probe IPv4 explicitly](lessons/meilisearch-container-healthchecks-must-probe-ipv4.md) — area:testing,architecture; module:search,create_app; topic:network-security,package-runtime,runtime-startup
 - [Restart stale UI previews after package edits](lessons/restart-stale-ui-previews-after-package-edits.md) — area:testing,debugging; module:create_app,ui; topic:package-runtime,testing
+- [Root-level tsx workflow entrypoints must avoid top-level await](lessons/root-level-tsx-workflow-entrypoints-must-avoid-top-level-await.md) — area:testing; module:create_app; topic:package-runtime,testing
 - [Scope Playwright `testIgnore` entries to project root absolute paths](lessons/scope-playwright-testignore-entries-to-project-root.md) — area:testing,integration; module:platform; topic:data-scoping,testing,type-normalization
 - [Use cryptographic randomness in auth-adjacent test helpers](lessons/use-cryptographic-randomness-in-auth-adjacent-test.md) — area:testing,integration,module-data; module:auth,cache,communication_channels; topic:data-scoping,generated-files,filters
 - [Use the bundled Node runtime for sandboxed macOS verification](lessons/use-the-bundled-node-runtime-for-sandboxed-macos.md) — area:testing,debugging; module:platform,create_app; topic:testing,node-runtime

--- a/.ai/lessons/root-level-tsx-workflow-entrypoints-must-avoid-top-level-await.md
+++ b/.ai/lessons/root-level-tsx-workflow-entrypoints-must-avoid-top-level-await.md
@@ -1,0 +1,16 @@
+---
+title: "Root-level tsx workflow entrypoints must avoid top-level await"
+modules: ["create_app"]
+areas: ["testing"]
+topics: ["package-runtime","testing"]
+---
+
+# Root-level tsx workflow entrypoints must avoid top-level await
+
+**Context**: A snapshot workflow invoked `yarn tsx scripts/prepare-standalone-example-integration.ts`, but the root package has no ESM `type` declaration. tsx therefore transformed the entrypoint as CommonJS.
+
+**Problem**: Top-level `await` made the helper fail during transformation before it could verify or activate the standalone fixture. The workflow-source test only checked YAML ordering, so it could not detect that the referenced command was unexecutable.
+
+**Rule**: Root-level TypeScript entrypoints invoked directly by workflows must wrap asynchronous work in an `async main()` and call it without top-level `await`. Add an execution-level regression through the tsx CLI so the test exercises the root package's real module mode, not only the workflow text.
+
+**Applies to**: `scripts/*.ts` entrypoints called by `.github/workflows/**`, especially standalone create-app and snapshot helpers.

--- a/scripts/__tests__/preview-workflows.test.mjs
+++ b/scripts/__tests__/preview-workflows.test.mjs
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 import test from 'node:test'
 
@@ -8,6 +10,8 @@ const npmSnapshotPreviewWorkflowPath = path.resolve('.github/workflows/npm-snaps
 const snapshotWorkflowPath = path.resolve('.github/workflows/snapshot.yml')
 const autoPublishSkillPath = path.resolve('.ai/skills/om-auto-publish-pr/SKILL.md')
 const skillTiersPath = path.resolve('.ai/skills/tiers.json')
+const standaloneExampleActivationScriptPath = path.resolve('scripts/prepare-standalone-example-integration.ts')
+const tsxCliPath = createRequire(import.meta.url).resolve('tsx/cli')
 
 function readText(filePath) {
   return fs.readFileSync(filePath, 'utf8')
@@ -83,6 +87,18 @@ test('published standalone lanes verify the disabled baseline before activating 
   for (const workflowPath of [snapshotWorkflowPath, npmSnapshotPreviewWorkflowPath]) {
     assertStandaloneExampleActivationLane(readText(workflowPath))
   }
+})
+
+test('standalone example activation helper is executable through the workflow CJS entrypoint', () => {
+  const result = spawnSync(process.execPath, [tsxCliPath, standaloneExampleActivationScriptPath], {
+    cwd: path.resolve('.'),
+    encoding: 'utf8',
+  })
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
+
+  assert.equal(result.status, 1)
+  assert.match(output, /Usage: yarn tsx scripts\/prepare-standalone-example-integration\.ts <app-directory>/)
+  assert.doesNotMatch(output, /Top-level await is currently not supported/)
 })
 
 test('auto publish skill only dispatches pkg.pr.new previews and is tiered as automation', () => {

--- a/scripts/prepare-standalone-example-integration.ts
+++ b/scripts/prepare-standalone-example-integration.ts
@@ -8,12 +8,16 @@ import {
   modulesConfigPath,
 } from './lib/module-activation-fixtures'
 
-const appDirArgument = process.argv[2]
-assert.ok(appDirArgument, 'Usage: yarn tsx scripts/prepare-standalone-example-integration.ts <app-directory>')
+async function main(): Promise<void> {
+  const appDirArgument = process.argv[2]
+  assert.ok(appDirArgument, 'Usage: yarn tsx scripts/prepare-standalone-example-integration.ts <app-directory>')
 
-const appDir = path.resolve(appDirArgument)
+  const appDir = path.resolve(appDirArgument)
 
-await assertModulesUnregistered(appDir, ['example', 'example_customers_sync', 'design_system'])
-enableModuleEntry(modulesConfigPath(appDir), EXAMPLE_ACTIVATION_ENTRY)
+  await assertModulesUnregistered(appDir, ['example', 'example_customers_sync', 'design_system'])
+  enableModuleEntry(modulesConfigPath(appDir), EXAMPLE_ACTIVATION_ENTRY)
 
-console.log(`Verified the runtime-disabled module baseline and activated example in ${appDir}`)
+  console.log(`Verified the runtime-disabled module baseline and activated example in ${appDir}`)
+}
+
+void main()


### PR DESCRIPTION
## Summary

- wrap the standalone example activation helper in an async main entrypoint so root-level tsx can compile it as CommonJS
- execute the helper through the real tsx CLI in the preview-workflow regression suite
- record the workflow-entrypoint module-mode rule in the focused lessons catalog

## Root cause

The Develop Snapshot Release job invoked the helper from the root package, which has no ESM type declaration. tsx therefore selected CommonJS output, where the helper top-level await failed during transformation before the disabled-baseline assertion ran.

## Validation

Runner: local macOS worktree

- yarn build:packages
- yarn generate
- yarn build:packages
- yarn i18n:check-sync
- yarn i18n:check-usage
- yarn typecheck
- yarn test — 29/29 package tasks green after one macOS Jest worker SIGSEGV; the affected Gateway Stripe preset suite passed 3/3 in-band before the successful full rerun
- yarn build:app
- node --test scripts/__tests__/preview-workflows.test.mjs — 5/5
- module activation fixtures — 2/2
- yarn lessons:check
- focused ESLint and git diff --check

Stabilizes the failing Standalone App Integration Tests job observed on #4840.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5246"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789200269&installation_model_id=432243&pr_number=5246&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5246&signature=f5b5989828abd35291ba558a991a5499fd9002d7b77a130651dc167fddc393ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->