### PR TITLE
docs: add sponsors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,22 @@ We welcome contributions of all sizes—from fixes and docs updates to new modul
 
 Refer to [AGENTS.md](AGENTS.md) for deeper guidance on architecture and conventions when extending modules.
 
+## Sponsors
+
+### Blacksmith
+
+<a href="https://www.blacksmith.sh/">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/useblacksmith/stickydisk/main/Blacksmith_Logo-White-Large.png" />
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/useblacksmith/stickydisk/main/Blacksmith_Logo-Black-Large.png" />
+    <img src="https://raw.githubusercontent.com/useblacksmith/stickydisk/main/Blacksmith_Logo-Black-Large.png" alt="Blacksmith logo" width="240" />
+  </picture>
+</a>
+
+Open Mercato's continuous integration is powered by [Blacksmith](https://www.blacksmith.sh/), providing fast and reliable GitHub Actions runners for the project.
+
+### Catch The Tornado
+
 Open Mercato is proudly supported by [Catch The Tornado](https://catchthetornado.com/).
 
 <div align="center">


### PR DESCRIPTION
## Summary

Add a dedicated Sponsors section to the README, modeled after Celery's sponsor acknowledgment.

## Changes

- credit Blacksmith for powering Open Mercato's continuous integration
- include Blacksmith's light- and dark-mode logos
- group the existing Catch The Tornado acknowledgment under the new section

## Specification

- [x] N/A — minor documentation-only change

## Testing

- `git diff --check`
- verified all linked sponsor assets return HTTP 200
- confirmed the commit merges cleanly into both `main` and `develop`

## Checklist

- [x] This pull request targets `develop`.
- [x] Documentation is updated.
- [x] Tests are not required for this README-only change.
- [x] Integration tests are not applicable.
- [x] A spec is not required for this minor documentation change.
- [x] Priority is `priority-low`.
- [x] Risk is `risk-low`.
- [x] QA routing is `skip-qa` because this is a README-only change.

## Mirror

A matching pull request targets `main`: #5253.
