### PR TITLE
fix(customer_accounts): write encrypted display_name through the managed entity (#3837)

### DIFF
--- a/packages/core/src/modules/customer_accounts/__tests__/encryptedFieldWrites.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/encryptedFieldWrites.test.ts
@@ -86,7 +86,10 @@ function splitTopLevelArguments(args: string): string[] {
 
 // The update payload is often built in a local variable rather than passed inline, so
 // resolve identifiers back to the object literal they were declared with plus every
-// `payload.field = …` assignment made on them before the write.
+// `payload.field = …` assignment made on them before the write. Resolution is file-scoped
+// and therefore deliberately over-inclusive: when two functions in one file both build a
+// `updates` payload, assignments from both are considered. That direction produces a false
+// alarm at worst, never a missed plaintext write.
 function resolvePayloadText(payload: string, source: string): string {
   if (!/^[A-Za-z_$][\w$]*$/.test(payload)) return payload
   const declaration = new RegExp(`\\b(?:const|let|var)\\s+${payload}\\b[^=]*=\\s*`).exec(source)

--- a/packages/core/src/modules/customer_accounts/__tests__/encryptedFieldWrites.test.ts
+++ b/packages/core/src/modules/customer_accounts/__tests__/encryptedFieldWrites.test.ts
@@ -1,0 +1,161 @@
+/** @jest-environment node */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { defaultEncryptionMaps } from '../encryption'
+
+// `em.nativeUpdate` issues raw SQL and fires none of the MikroORM flush hooks the
+// tenant-data-encryption subscriber depends on, so a field declared in this module's
+// encryption map that is written that way lands in the database as plaintext inside a
+// column contractually holding ciphertext (#3837). The decrypt path passes non-ciphertext
+// values through unchanged, so nothing surfaces the corruption at runtime — this guard is
+// what surfaces it instead. Encrypted fields must be written through a managed entity and
+// `em.flush()` so the subscriber can encrypt them.
+
+const MODULE_DIR = path.resolve(__dirname, '..')
+const SKIPPED_DIRECTORIES = new Set(['__tests__', '__integration__', 'node_modules'])
+
+function toPascalCase(value: string): string {
+  return value
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')
+}
+
+function toCamelCase(value: string): string {
+  return value.replace(/_([a-z])/g, (_match, letter: string) => letter.toUpperCase())
+}
+
+function listSourceFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRECTORIES.has(entry.name)) continue
+      files.push(...listSourceFiles(path.join(dir, entry.name)))
+      continue
+    }
+    if (!/\.tsx?$/.test(entry.name)) continue
+    if (/\.test\.tsx?$/.test(entry.name)) continue
+    files.push(path.join(dir, entry.name))
+  }
+  return files
+}
+
+function readCallArguments(source: string, openParenIndex: number): string | null {
+  let depth = 0
+  for (let index = openParenIndex; index < source.length; index += 1) {
+    const character = source[index]
+    if (character === '(') depth += 1
+    else if (character === ')') {
+      depth -= 1
+      if (depth === 0) return source.slice(openParenIndex + 1, index)
+    }
+  }
+  return null
+}
+
+function splitTopLevelArguments(args: string): string[] {
+  const parts: string[] = []
+  let depth = 0
+  let quote: string | null = null
+  let current = ''
+  for (let index = 0; index < args.length; index += 1) {
+    const character = args[index]
+    if (quote) {
+      if (character === quote && args[index - 1] !== '\\') quote = null
+      current += character
+      continue
+    }
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character
+      current += character
+      continue
+    }
+    if (character === '(' || character === '{' || character === '[') depth += 1
+    if (character === ')' || character === '}' || character === ']') depth -= 1
+    if (character === ',' && depth === 0) {
+      parts.push(current)
+      current = ''
+      continue
+    }
+    current += character
+  }
+  if (current.trim().length > 0) parts.push(current)
+  return parts.map((part) => part.trim())
+}
+
+// The update payload is often built in a local variable rather than passed inline, so
+// resolve identifiers back to the object literal they were declared with plus every
+// `payload.field = …` assignment made on them before the write.
+function resolvePayloadText(payload: string, source: string): string {
+  if (!/^[A-Za-z_$][\w$]*$/.test(payload)) return payload
+  const declaration = new RegExp(`\\b(?:const|let|var)\\s+${payload}\\b[^=]*=\\s*`).exec(source)
+  let text = ''
+  if (declaration) {
+    const literalStart = source.indexOf('{', declaration.index + declaration[0].length - 1)
+    if (literalStart !== -1) {
+      let depth = 0
+      for (let index = literalStart; index < source.length; index += 1) {
+        if (source[index] === '{') depth += 1
+        else if (source[index] === '}') {
+          depth -= 1
+          if (depth === 0) {
+            text += source.slice(literalStart, index + 1)
+            break
+          }
+        }
+      }
+    }
+  }
+  const assignments = new RegExp(`\\b${payload}\\.[\\w$]+\\s*=[^=]`, 'g')
+  text += `\n${(source.match(assignments) ?? []).join('\n')}`
+  const bracketAssignments = new RegExp(`\\b${payload}\\[[^\\]]+\\]\\s*=[^=]`, 'g')
+  text += `\n${(source.match(bracketAssignments) ?? []).join('\n')}`
+  return text
+}
+
+const encryptedPropertiesByEntity = new Map<string, string[]>(
+  defaultEncryptionMaps.map((map) => [
+    toPascalCase(String(map.entityId).split(':').pop() ?? ''),
+    (map.fields ?? []).map((field) => toCamelCase(field.field)),
+  ]),
+)
+
+describe('customer_accounts encrypted fields are never written with nativeUpdate', () => {
+  const sourceFiles = listSourceFiles(MODULE_DIR)
+
+  it('finds the module sources and at least one encrypted entity to guard', () => {
+    expect(sourceFiles.length).toBeGreaterThan(0)
+    expect(encryptedPropertiesByEntity.size).toBeGreaterThan(0)
+    expect(encryptedPropertiesByEntity.get('CustomerUser')).toEqual(
+      expect.arrayContaining(['email', 'displayName']),
+    )
+  })
+
+  it.each(Array.from(encryptedPropertiesByEntity.entries()))(
+    '%s writes none of its encrypted properties through nativeUpdate',
+    (entityName, encryptedProperties) => {
+      const violations: string[] = []
+      for (const file of sourceFiles) {
+        const source = fs.readFileSync(file, 'utf8')
+        if (!source.includes('nativeUpdate')) continue
+        const pattern = /\bnativeUpdate\s*\(/g
+        let match: RegExpExecArray | null = pattern.exec(source)
+        while (match !== null) {
+          const args = readCallArguments(source, match.index + match[0].length - 1)
+          const parts = args === null ? [] : splitTopLevelArguments(args)
+          if (parts[0] === entityName && parts.length >= 3) {
+            const payloadText = resolvePayloadText(parts[2], source)
+            for (const property of encryptedProperties) {
+              if (new RegExp(`\\b${property}\\b`).test(payloadText)) {
+                violations.push(`${path.relative(MODULE_DIR, file)} → ${property}`)
+              }
+            }
+          }
+          match = pattern.exec(source)
+        }
+      }
+      expect(violations).toEqual([])
+    },
+  )
+})

--- a/packages/core/src/modules/customer_accounts/api/admin/users/[id].ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/[id].ts
@@ -183,12 +183,21 @@ export async function PUT(req: Request, { params }: { params: { id: string } }) 
     }
   }
 
+  // `display_name` is encrypted at rest, and `nativeUpdate` skips the flush hooks the
+  // tenant-encryption subscriber relies on, so persisting it below would write plaintext PII
+  // into a ciphertext column (#3837). Route it through the service, which writes it via the
+  // managed entity. Runs before the `nativeUpdate` so the explicit `updated_at` below stays
+  // the value this response reports back as the optimistic-lock version.
+  if (parsed.data.displayName !== undefined) {
+    const customerUserService = container.resolve('customerUserService') as CustomerUserService
+    await customerUserService.updateProfile(user, { displayName: parsed.data.displayName })
+  }
+
   // Always bump updated_at so the optimistic-lock version advances on every save.
   // `nativeUpdate` bypasses MikroORM's `onUpdate` hook, so set it explicitly — without
   // this the version never changes and concurrent edits cannot be detected (#2055).
   const nextUpdatedAt = new Date()
   const updates: Record<string, unknown> = { updatedAt: nextUpdatedAt }
-  if (parsed.data.displayName !== undefined) updates.displayName = parsed.data.displayName
   if (parsed.data.isActive !== undefined) updates.isActive = parsed.data.isActive
   if (parsed.data.lockedUntil !== undefined) updates.lockedUntil = parsed.data.lockedUntil ? new Date(parsed.data.lockedUntil) : null
   if (parsed.data.personEntityId !== undefined) updates.personEntityId = parsed.data.personEntityId

--- a/packages/core/src/modules/customer_accounts/api/admin/users/__tests__/optimistic-lock.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/users/__tests__/optimistic-lock.test.ts
@@ -22,7 +22,10 @@ const mockEm = {
 
 const mockRbacService = { userHasAllFeatures: jest.fn(async () => true) }
 const mockCustomerRbacService = { invalidateUserCache: jest.fn(async () => undefined) }
-const mockCustomerUserService = { softDelete: jest.fn(async () => undefined) }
+const mockCustomerUserService = {
+  softDelete: jest.fn(async () => undefined),
+  updateProfile: jest.fn(async () => undefined),
+}
 const mockCustomerSessionService = { revokeAllUserSessions: jest.fn(async () => undefined) }
 
 const mockContainer = {
@@ -92,6 +95,25 @@ describe('customer_accounts admin user optimistic locking', () => {
     expect(mockEm.nativeUpdate).toHaveBeenCalled()
     const updates = mockEm.nativeUpdate.mock.calls[0][2] as Record<string, unknown>
     expect(updates.updatedAt).toBeInstanceOf(Date)
+  })
+
+  it('PUT never writes the encrypted display_name through nativeUpdate (#3837)', async () => {
+    const res = await PUT(request('PUT', CURRENT_VERSION, { displayName: 'X' }), params)
+    expect(res.status).toBe(200)
+    // `nativeUpdate` skips the flush hooks the tenant-encryption subscriber depends on, so
+    // display_name must travel through the service, which writes it via the managed entity.
+    const updates = mockEm.nativeUpdate.mock.calls[0][2] as Record<string, unknown>
+    expect(updates.displayName).toBeUndefined()
+    expect(mockCustomerUserService.updateProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ id: USER_ID }),
+      { displayName: 'X' },
+    )
+  })
+
+  it('PUT leaves the profile service alone when no display name is submitted', async () => {
+    const res = await PUT(request('PUT', CURRENT_VERSION, { isActive: false }), params)
+    expect(res.status).toBe(200)
+    expect(mockCustomerUserService.updateProfile).not.toHaveBeenCalled()
   })
 
   it('PUT is a no-op (no 409) when the client sends no expected-version header (strictly additive)', async () => {

--- a/packages/core/src/modules/customer_accounts/services/__tests__/customerUserService.updateProfile.test.ts
+++ b/packages/core/src/modules/customer_accounts/services/__tests__/customerUserService.updateProfile.test.ts
@@ -61,7 +61,12 @@ describe('CustomerUserService.updateProfile', () => {
     expect(findOneWithDecryptionMock).toHaveBeenCalledTimes(1)
     const [, entity, where, , scope] = findOneWithDecryptionMock.mock.calls[0]
     expect(entity).toBe(CustomerUser)
-    expect(where).toMatchObject({ id: user.id, tenantId: user.tenantId, deletedAt: null })
+    expect(where).toMatchObject({
+      id: user.id,
+      tenantId: user.tenantId,
+      organizationId: user.organizationId,
+      deletedAt: null,
+    })
     expect(scope).toEqual({ tenantId: user.tenantId, organizationId: user.organizationId })
   })
 

--- a/packages/core/src/modules/customer_accounts/services/__tests__/customerUserService.updateProfile.test.ts
+++ b/packages/core/src/modules/customer_accounts/services/__tests__/customerUserService.updateProfile.test.ts
@@ -1,0 +1,102 @@
+/** @jest-environment node */
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { CustomerUser } from '@open-mercato/core/modules/customer_accounts/data/entities'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { CustomerUserService } from '@open-mercato/core/modules/customer_accounts/services/customerUserService'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+const findOneWithDecryptionMock = findOneWithDecryption as jest.MockedFunction<typeof findOneWithDecryption>
+
+type TestUser = Pick<CustomerUser, 'id' | 'tenantId' | 'organizationId' | 'displayName'>
+
+function buildUser(): TestUser {
+  return {
+    id: 'ccb0d0d6-0f19-4f0e-9ad4-2a4a3c2a6a11',
+    tenantId: 'e4b0a0f2-4f6e-4a51-9d9f-6a2c9d1b3f77',
+    organizationId: '6f2f4b17-7d2f-4b0e-9e08-3b1c1d2f4a55',
+    displayName: 'Old Name',
+  }
+}
+
+function buildEm(overrides: Partial<Record<'flush' | 'nativeUpdate', jest.Mock>> = {}) {
+  return {
+    flush: overrides.flush ?? jest.fn(async () => undefined),
+    nativeUpdate: overrides.nativeUpdate ?? jest.fn(async () => 1),
+  }
+}
+
+describe('CustomerUserService.updateProfile', () => {
+  beforeEach(() => {
+    findOneWithDecryptionMock.mockReset()
+  })
+
+  it('persists display_name through the managed entity so the encryption subscriber encrypts it (#3837)', async () => {
+    const user = buildUser()
+    const managed = { ...user } as CustomerUser
+    findOneWithDecryptionMock.mockResolvedValue(managed as never)
+    const em = buildEm()
+    const service = new CustomerUserService(em as unknown as EntityManager)
+
+    await service.updateProfile(user as CustomerUser, { displayName: 'New Name' })
+
+    expect(managed.displayName).toBe('New Name')
+    expect(em.flush).toHaveBeenCalledTimes(1)
+    // `nativeUpdate` issues raw SQL and skips the flush hooks the tenant-encryption
+    // subscriber depends on, which is exactly how the plaintext write happened.
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+  })
+
+  it('loads the managed entity within the caller tenant and organization scope', async () => {
+    const user = buildUser()
+    findOneWithDecryptionMock.mockResolvedValue({ ...user } as never)
+    const em = buildEm()
+    const service = new CustomerUserService(em as unknown as EntityManager)
+
+    await service.updateProfile(user as CustomerUser, { displayName: 'New Name' })
+
+    expect(findOneWithDecryptionMock).toHaveBeenCalledTimes(1)
+    const [, entity, where, , scope] = findOneWithDecryptionMock.mock.calls[0]
+    expect(entity).toBe(CustomerUser)
+    expect(where).toMatchObject({ id: user.id, tenantId: user.tenantId, deletedAt: null })
+    expect(scope).toEqual({ tenantId: user.tenantId, organizationId: user.organizationId })
+  })
+
+  it('mirrors the saved value onto the entity the caller passed in', async () => {
+    const user = buildUser()
+    findOneWithDecryptionMock.mockResolvedValue({ ...user } as never)
+    const em = buildEm()
+    const service = new CustomerUserService(em as unknown as EntityManager)
+
+    await service.updateProfile(user as CustomerUser, { displayName: 'New Name' })
+
+    expect(user.displayName).toBe('New Name')
+  })
+
+  it('does nothing when no display name is supplied', async () => {
+    const user = buildUser()
+    const em = buildEm()
+    const service = new CustomerUserService(em as unknown as EntityManager)
+
+    await service.updateProfile(user as CustomerUser, {})
+
+    expect(findOneWithDecryptionMock).not.toHaveBeenCalled()
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(em.nativeUpdate).not.toHaveBeenCalled()
+  })
+
+  it('leaves the caller entity untouched when the row is gone', async () => {
+    const user = buildUser()
+    findOneWithDecryptionMock.mockResolvedValue(null as never)
+    const em = buildEm()
+    const service = new CustomerUserService(em as unknown as EntityManager)
+
+    await service.updateProfile(user as CustomerUser, { displayName: 'New Name' })
+
+    expect(em.flush).not.toHaveBeenCalled()
+    expect(user.displayName).toBe('Old Name')
+  })
+})

--- a/packages/core/src/modules/customer_accounts/services/customerUserService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerUserService.ts
@@ -110,12 +110,23 @@ export class CustomerUserService {
     user.passwordHash = passwordHash
   }
 
+  // `display_name` is encrypted at rest. `nativeUpdate` issues raw SQL and fires none of the
+  // flush hooks the tenant-encryption subscriber depends on, so writing it that way persists
+  // plaintext PII into a ciphertext column (#3837). Assign it on the managed entity and flush
+  // so `beforeUpdate` encrypts the value on its way to the database.
   async updateProfile(user: CustomerUser, data: { displayName?: string }): Promise<void> {
-    const updates: Record<string, unknown> = {}
-    if (data.displayName !== undefined) updates.displayName = data.displayName
-    if (Object.keys(updates).length === 0) return
-    await this.em.nativeUpdate(CustomerUser, { id: user.id }, updates)
-    if (data.displayName !== undefined) user.displayName = data.displayName
+    if (data.displayName === undefined) return
+    const managed = await findOneWithDecryption(
+      this.em,
+      CustomerUser,
+      { id: user.id, tenantId: user.tenantId, deletedAt: null } as any,
+      undefined,
+      { tenantId: user.tenantId, organizationId: user.organizationId },
+    )
+    if (!managed) return
+    managed.displayName = data.displayName
+    await this.em.flush()
+    user.displayName = data.displayName
   }
 
   async softDelete(

--- a/packages/core/src/modules/customer_accounts/services/customerUserService.ts
+++ b/packages/core/src/modules/customer_accounts/services/customerUserService.ts
@@ -119,7 +119,7 @@ export class CustomerUserService {
     const managed = await findOneWithDecryption(
       this.em,
       CustomerUser,
-      { id: user.id, tenantId: user.tenantId, deletedAt: null } as any,
+      { id: user.id, tenantId: user.tenantId, organizationId: user.organizationId, deletedAt: null } as any,
       undefined,
       { tenantId: user.tenantId, organizationId: user.organizationId },
     )


### PR DESCRIPTION
Closes #3837

## 🎯 Goal
Stop the customer portal's profile update and the admin customer-user PUT from persisting the encrypted-at-rest `display_name` as plaintext, so the tenant-data-encryption control actually holds for that PII field.

## 🔍 Problem
`display_name` is declared encrypted at rest in `customer_accounts/encryption.ts`, but both write paths persisted it with `em.nativeUpdate`. Any customer editing their own profile display name, or any staff member editing a customer's display name, wrote plaintext PII into a column contractually holding ciphertext. Because `decryptFields` passes non-`v1:iv:tag:ct` values through unchanged, the value still read back correctly — so the corruption was invisible at runtime while the data sat unencrypted in the database (GDPR / at-rest exposure).

## 🔍 Root Cause
`TenantEncryptionSubscriber` encrypts through MikroORM's `beforeCreate` / `beforeUpdate` flush hooks (`packages/shared/src/lib/encryption/subscriber.ts:409-413`). `em.nativeUpdate` issues raw SQL through the query builder and fires none of those hooks, so the value reached the column exactly as supplied. The staff auth module writes its analogous encrypted `name` via managed-entity assignment plus flush, which is why it was never affected.

## What Changed
- `packages/core/src/modules/customer_accounts/services/customerUserService.ts` — `updateProfile` no longer calls `em.nativeUpdate`. It loads the row through `findOneWithDecryption` (tenant + organization scoped, matching the module's data-access convention), assigns `displayName` on the managed entity, and calls `em.flush()` so `beforeUpdate` encrypts the value on its way to the database. The caller's entity is still updated in place, so response shapes are unchanged.
- `packages/core/src/modules/customer_accounts/api/admin/users/[id].ts` — the admin PUT drops `displayName` from its `nativeUpdate` payload and routes it through `customerUserService.updateProfile` instead. It runs **before** the `nativeUpdate`, deliberately: that `nativeUpdate` sets the explicit `updated_at` this route returns as the optimistic-lock version (#2055), so ordering it last keeps the persisted version and the version reported to the client identical. Every other field on that route is unencrypted and keeps its existing `nativeUpdate` write.

## 🧪 Tests
- `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn build:app` — all green (local runner; no compose `app` container running).
- `yarn test` — `@open-mercato/core` 9627 passed / 1238 suites; shared 1876, app 549, search 311, checkout 140, channel-imap 109, telemetry 82, cache 73, sync-akeneo 62 all passed. **Four `create-mercato-app` template dev-wrapper tests fail on this machine only**, from a host limit rather than this branch: the wrapper's preflight reads `/proc/sys/fs/inotify/*` and aborts because `max_user_watches` is 253174 (needs 4194304) and `max_user_instances` is 128 (needs 4096). Nothing in this diff touches `packages/create-app`; CI runners with the documented sysctl values are unaffected.
- `services/__tests__/customerUserService.updateProfile.test.ts` (new) — locks in that `updateProfile` writes via the managed entity and `em.flush()`, never `nativeUpdate`; that the lookup stays tenant/organization scoped; that the caller's entity mirrors the saved value; and the no-op and missing-row paths.
- `api/admin/users/__tests__/optimistic-lock.test.ts` — adds a route-level regression case asserting the admin PUT keeps `displayName` out of its `nativeUpdate` payload and delegates to `updateProfile`, plus a case proving the service is not called when no display name is submitted. The existing `customerUserService` mock gained `updateProfile`.
- `__tests__/encryptedFieldWrites.test.ts` (new) — a module-wide guard that derives the encrypted property names from `defaultEncryptionMaps`, walks every `nativeUpdate` call in the module (resolving payloads passed as variables back to their declaration and `payload.field = …` assignments), and fails if any encrypted field is written that way. It flagged both original sites before the fix, so it would catch a future regression on `email`, session `ip_address` / `user_agent`, or invitation `display_name` too.

All three regression tests were verified failing against the unfixed sources and passing with the fix.

## 💥 Breaking Changes
None. `CustomerUserService.updateProfile` keeps its signature, both HTTP responses keep their shape, and no schema changed.

## ⚠️ Follow-up for operators
New writes store ciphertext, but rows written before this fix stay plaintext (they still read correctly through the pass-through decrypt). They can be re-encrypted in place with the existing `mercato entities rotate-encryption-key` CLI in its non-`--rotate` mode, which encrypts plaintext values under the current DEK and skips rows that are already ciphertext — no new migration is needed. Worth running per tenant after this merges.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789218290&installation_model_id=432243&pr_number=5262&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5262&signature=c7fc4523f8d97cfc3135783dfce367a7ee1d7da4c9bb6188cadb64b0cba285ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->