### PR TITLE
docs(create-app): harden standalone harness routing from session #5251 findings

### DIFF
--- a/.ai/runs/2026-08-13-harness-session-5251-improvements.md
+++ b/.ai/runs/2026-08-13-harness-session-5251-improvements.md
@@ -85,4 +85,4 @@ PR: #5267
 ### Phase 5: Fact-sheet split analysis and spec (resume)
 
 - [x] 5.1 Measure built sheets + inventory the single-file contract surface — 3d66237de
-- [x] 5.2 Land `.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md` (Proposed) with the phased design — 3d66237de
+- [x] 5.2 Land `.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md` (Proposed) with the phased design — 3d66237de (compression figures corrected on review — 706148446)

--- a/.ai/runs/2026-08-13-harness-session-5251-improvements.md
+++ b/.ai/runs/2026-08-13-harness-session-5251-improvements.md
@@ -1,0 +1,75 @@
+# Execution Plan — Standalone harness improvements from session share #5251
+
+Source doc: analysis comment on issue #5251 (https://github.com/open-mercato/open-mercato/issues/5251#issuecomment-5280139353), derived from the shared Kimi Code CLI session `library-books-spec-session`.
+
+## Goal
+
+Land the low-risk, text-level improvements to the create-app standalone agent harness that the #5251 session analysis identified: kill the routed-but-uninstalled-skill search detour, warn agents that generated module fact-sheets can exceed one read-tool cap, bake the Reference Display Rule (names, never raw UUIDs) into the spec template and backend-ui guide, and remove the `surface-inventory.json` location guess in `om-module-scaffold`.
+
+## Scope
+
+- `packages/create-app/template/AGENTS.md` and `packages/create-app/agentic/shared/AGENTS.md.template` (kept byte-for-byte in sync apart from the title line, per create-app AGENTS.md rule 8; the scaffolded root has a 12 KiB budget enforced by `agent-instruction-budget.test.ts` — additions must stay compact).
+- `packages/create-app/agentic/shared/ai/specs/SPEC-000-template.md` (UI and Interaction Contracts section).
+- `packages/create-app/agentic/guides/backend-ui.md`.
+- `packages/create-app/agentic/shared/ai/skills/om-module-scaffold/SKILL.md`.
+
+The CLI `mercato agentic:init` bundles the same `packages/create-app/agentic/` tree (`packages/cli/src/lib/agentic-setup.ts` resolves `AGENTIC_DIR` into it), so no second copy needs syncing beyond the two AGENTS.md variants.
+
+## Non-goals
+
+- No sanitizer tuning or Kimi `wire.jsonl` adapter for `om-share-this-session` — redaction changes weaken a privacy guard and need their own carefully-tested PR (follow-up, tracked on #5251).
+- No stub `SKILL.md` placeholders or doctor check for failed external-skill installs — code change with test surface; follow-up.
+- No changes to the generated module fact-sheet pipeline or fact-sheet splitting.
+- No monorepo-side (`.ai/specs/`, root `AGENTS.md`) changes; this run improves the standalone harness only.
+
+## Implementation Plan
+
+### Phase 1 — Standalone root routing guidance
+
+Add two compact lines to both AGENTS.md variants:
+
+- After the skill-read rule (line 95): a missing routed `om-*` skill means `yarn install-skills` has not completed (external tier, network) — run it; never conclude the skill does not exist. This collapses the observed 10-tool-call search to a single command.
+- In Module-Specific Facts: fact-sheets can exceed a single read-tool output cap — read large ones in sections and never assume one read returned the whole file.
+
+### Phase 2 — Reference Display Rule
+
+- SPEC-000 template: require every cross-record reference surface to be specified as a selection control backed by an option source showing display names; raw IDs appear only in API payloads, never typed or rendered in UI.
+- `backend-ui.md`: add the matching implementation rule alongside the DataTable/CrudForm contracts.
+
+### Phase 3 — om-module-scaffold inventory pointer
+
+- Note in `SKILL.md` that `surface-inventory.json` ships inside the emitted example module (`src/modules/example/references/`), not under the skill's own `references/` folder.
+
+### Phase 4 — Validation
+
+- Run the create-app package test suite (instruction-budget, context-guidance-contracts, agent-surface-coverage, source-link checks).
+- Run the configured full validation gate.
+
+## Risks
+
+- The scaffolded Codex root (enforcement rules + module-guide injection on top of AGENTS.md) must stay ≤ 12288 bytes; additions are sized to fit and `agent-instruction-budget.test.ts` is the gate.
+- Contract tests pin exact routing phrases; all edits are additive sentences, no rewording of pinned lines.
+- Harness evaluation cases (`cases.json`) score routing behavior; additive guidance lines do not remove any routed context.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Standalone root routing guidance
+
+- [ ] 1.1 Missing-skill install-skills line in both AGENTS.md variants
+- [ ] 1.2 Fact-sheet oversize read hint in both AGENTS.md variants
+
+### Phase 2: Reference Display Rule
+
+- [ ] 2.1 SPEC-000 template UI-contract rule
+- [ ] 2.2 backend-ui.md cross-record reference rule
+
+### Phase 3: om-module-scaffold inventory pointer
+
+- [ ] 3.1 SKILL.md location note for surface-inventory.json
+
+### Phase 4: Validation
+
+- [ ] 4.1 create-app package tests green
+- [ ] 4.2 Full validation gate green

--- a/.ai/runs/2026-08-13-harness-session-5251-improvements.md
+++ b/.ai/runs/2026-08-13-harness-session-5251-improvements.md
@@ -57,17 +57,17 @@ Add two compact lines to both AGENTS.md variants:
 
 ### Phase 1: Standalone root routing guidance
 
-- [ ] 1.1 Missing-skill install-skills line in both AGENTS.md variants
-- [ ] 1.2 Fact-sheet oversize read hint in both AGENTS.md variants
+- [x] 1.1 Missing-skill install-skills line in both AGENTS.md variants — 8e8d16ff4
+- [x] 1.2 Fact-sheet oversize read hint in both AGENTS.md variants — 8e8d16ff4
 
 ### Phase 2: Reference Display Rule
 
-- [ ] 2.1 SPEC-000 template UI-contract rule
-- [ ] 2.2 backend-ui.md cross-record reference rule
+- [x] 2.1 SPEC-000 template UI-contract rule — 0c178c7e1
+- [x] 2.2 backend-ui.md cross-record reference rule — 0c178c7e1
 
 ### Phase 3: om-module-scaffold inventory pointer
 
-- [ ] 3.1 SKILL.md location note for surface-inventory.json
+- [x] 3.1 SKILL.md location note for surface-inventory.json — 5f10d6d24
 
 ### Phase 4: Validation
 

--- a/.ai/runs/2026-08-13-harness-session-5251-improvements.md
+++ b/.ai/runs/2026-08-13-harness-session-5251-improvements.md
@@ -84,5 +84,5 @@ PR: #5267
 
 ### Phase 5: Fact-sheet split analysis and spec (resume)
 
-- [ ] 5.1 Measure built sheets + inventory the single-file contract surface
-- [ ] 5.2 Land `.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md` (Proposed) with the phased design
+- [x] 5.1 Measure built sheets + inventory the single-file contract surface — 3d66237de
+- [x] 5.2 Land `.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md` (Proposed) with the phased design — 3d66237de

--- a/.ai/runs/2026-08-13-harness-session-5251-improvements.md
+++ b/.ai/runs/2026-08-13-harness-session-5251-improvements.md
@@ -55,6 +55,8 @@ Add two compact lines to both AGENTS.md variants:
 
 ## Progress
 
+PR: #5267
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Standalone root routing guidance

--- a/.ai/runs/2026-08-13-harness-session-5251-improvements.md
+++ b/.ai/runs/2026-08-13-harness-session-5251-improvements.md
@@ -47,6 +47,8 @@ Add two compact lines to both AGENTS.md variants:
 
 ## Risks
 
+- Host-limit note: this runner's `fs.inotify.*` sysctl values are below the dev-wrapper preflight, so 4 `template-dev-log-files` tests fail locally on any branch; CI validates them on compliant runners.
+
 - The scaffolded Codex root (enforcement rules + module-guide injection on top of AGENTS.md) must stay ≤ 12288 bytes; additions are sized to fit and `agent-instruction-budget.test.ts` is the gate.
 - Contract tests pin exact routing phrases; all edits are additive sentences, no rewording of pinned lines.
 - Harness evaluation cases (`cases.json`) score routing behavior; additive guidance lines do not remove any routed context.
@@ -71,5 +73,5 @@ Add two compact lines to both AGENTS.md variants:
 
 ### Phase 4: Validation
 
-- [ ] 4.1 create-app package tests green
-- [ ] 4.2 Full validation gate green
+- [x] 4.1 create-app package tests green (851 pass; only the 4 known host-limit inotify dev-wrapper tests fail — environmental, sysctl preflight, not branch-caused) — 2330b5443
+- [x] 4.2 Full validation gate green (build:packages, generate no-drift, i18n:check-sync/usage, typecheck, build:app all ✓; yarn test fails only on the same 4 environmental tests) — 2330b5443

--- a/.ai/runs/2026-08-13-harness-session-5251-improvements.md
+++ b/.ai/runs/2026-08-13-harness-session-5251-improvements.md
@@ -19,7 +19,7 @@ The CLI `mercato agentic:init` bundles the same `packages/create-app/agentic/` t
 
 - No sanitizer tuning or Kimi `wire.jsonl` adapter for `om-share-this-session` — redaction changes weaken a privacy guard and need their own carefully-tested PR (follow-up, tracked on #5251).
 - No stub `SKILL.md` placeholders or doctor check for failed external-skill installs — code change with test surface; follow-up.
-- No changes to the generated module fact-sheet pipeline or fact-sheet splitting.
+- No changes to the generated module fact-sheet pipeline or fact-sheet splitting. *(Amended by the Phase 5 resume: the split-vs-hint question is now analyzed and designed in `.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md`; pipeline code changes remain out of scope for this PR.)*
 - No monorepo-side (`.ai/specs/`, root `AGENTS.md`) changes; this run improves the standalone harness only.
 
 ## Implementation Plan
@@ -44,6 +44,10 @@ Add two compact lines to both AGENTS.md variants:
 
 - Run the create-app package test suite (instruction-budget, context-guidance-contracts, agent-surface-coverage, source-link checks).
 - Run the configured full validation gate.
+
+### Phase 5 — Fact-sheet split analysis and spec (resume, 2026-08-13)
+
+Requested by the PR author on resume: analyze whether splitting fact-sheets into separate files + index beats the Phase 1 "read in sections" hint, and make the outcome less error-prone. Measured the built sheets (13 over 50 KB, `customers.md` 218 KB, section skew, 48 % link boilerplate), inventoried the contract surface pinning the single-file layout (363 `cases.json` refs, ~30 test assertions, two build scripts, two setup mirrors), and landed the design as a Proposed spec: in-file Contents index + end-of-facts marker + link-label compression first (Phase 1, additive), directory split as a conditional Phase 2 with full migration inventory.
 
 ## Risks
 
@@ -77,3 +81,8 @@ PR: #5267
 
 - [x] 4.1 create-app package tests green (851 pass; only the 4 known host-limit inotify dev-wrapper tests fail — environmental, sysctl preflight, not branch-caused) — 2330b5443
 - [x] 4.2 Full validation gate green (build:packages, generate no-drift, i18n:check-sync/usage, typecheck, build:app all ✓; yarn test fails only on the same 4 environmental tests) — 2330b5443
+
+### Phase 5: Fact-sheet split analysis and spec (resume)
+
+- [ ] 5.1 Measure built sheets + inventory the single-file contract surface
+- [ ] 5.2 Land `.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md` (Proposed) with the phased design

--- a/.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md
+++ b/.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md
@@ -1,0 +1,93 @@
+# Module Fact-Sheet Sectioned Reading
+
+- **Status:** Proposed
+- **Date:** 2026-08-13
+- **Parent:** [Module Facts Auto-Discovery](2026-07-06-module-facts-auto-discovery.md)
+- **Related:** [Complete Source-Linked Module Extension Contracts](2026-08-02-module-facts-extension-surface-completeness.md), [Module Facts Exact Unified Override Targets](2026-08-02-module-facts-exact-override-targets.md), PR #5267, issue #5251
+- **Scope:** generated module fact-sheet readability under agent read-tool caps — in-file navigation affordances first, an optional directory split second
+
+## TLDR
+
+Generated module fact-sheets routinely exceed a single agent read-tool call (13 sheets over 50 KB in a current build; `customers.md` is 218 KB), and truncation is silent: the #5251 shared session worked from a 50 k-character preview of a fact-sheet without noticing. PR #5267 mitigated this with one routed sentence ("Big fact-sheets: read in sections."), which relies entirely on model discipline. This spec makes truncation detectable and sectioned reading mechanical **without changing the one-file-per-module layout**: a generated `## Contents` index with per-section line anchors and sizes, a terminal end-of-facts marker, and source-link label compression. A full split into a per-module directory of section files plus an index is specified as a conditional Phase 2, because it invalidates a very large pinned contract surface (363 literal `.ai/guides/modules/<id>.md` references in the harness `cases.json` alone) for a benefit Phase 1 already delivers in-place.
+
+## Problem Statement
+
+`renderModuleFactsMarkdown` (`packages/cli/src/lib/generators/module-facts.ts`) emits one flat markdown file per module into `dist/agentic/guides/modules/<id>.md`, copied into scaffolded apps as `.ai/guides/modules/<id>.md`. Measured on the build at PR #5267's head (56 enabled template modules):
+
+- 13 sheets exceed 50 KB; `customers.md` 218 KB, `sales.md` 175 KB, `customer_accounts.md` 125 KB, `catalog.md` 115 KB, `wms.md` 109 KB. Total ~2.1 MB across the emitted set.
+- Sizes are section-skewed: `customers.md` has 27 `##` sections, but `## Exact override targets` alone is 62 KB and `## UMES hosts` 41 KB. `sales.md`'s override-target section is 57 KB.
+- ~48 % of `customers.md` (104 KB) is markdown source-link syntax — the full `node_modules/@open-mercato/...` path written twice per table row (label and href).
+
+Agent CLIs cap single-file reads (≈50 k characters in the Kimi session; 2 000 lines for Claude Code's Read; others vary). Three failure modes follow:
+
+1. **Silent truncation.** A capped read returns the head of the sheet with no reliable signal that sections are missing. The sheet's tail carries the sections most recently added (override targets, domain commands, encryption) — precisely the facts extension work needs.
+2. **No seek target.** Even an agent that knows the sheet is big cannot jump to a section without scanning: sections have no anchors, no offsets, and their order is only documented in generator source.
+3. **Wasted context.** Loading 218 KB to answer a question about one entity burns most of a context window on repeated path boilerplate.
+
+The routed hint from PR #5267 addresses only failure mode 1, and only probabilistically.
+
+## Resolved assumptions (autonomous defaults)
+
+| # | Question | Applied default | Rationale | Confirm? |
+|---|---|---|---|---|
+| Q1 | Split into per-section files now? | No — Phase 1 stays in-file; the split is Phase 2 behind an explicit trigger. | The single-file path is pinned by ~30 test assertions, 363 `cases.json` references, two build scripts, and two injection mirrors (inventory below); Phase 1 achieves detectability and seekability without touching any of it. | ok |
+| Q2 | Compress source links by dropping them? | No — shorten only the **label** to a source-root-relative path; keep the full href. | Source links are the harness's "fact-first" navigation contract (`module-facts.bc-guard.test.ts` link-exactness); labels are pure redundancy since every sheet declares `Source root:` in its header. | ok |
+| Q3 | Line anchors or byte offsets in the Contents index? | Line numbers (plus approximate KB per section). | Every agent read tool addresses lines (`offset`/`limit`, `sed -n`); byte offsets are only addressable via shell. Sheets are generated do-not-edit files, so anchors cannot drift. | ok |
+| Q4 | Where does the "check the end marker" guidance live? | In the sheet itself (header line) and `agentic/guides/architecture.md`; the 12 KiB root keeps the existing compact hint. | The classic Codex root sits at 12 266/12 288 bytes (22 B headroom in the one-extra-module scenario, `agent-instruction-budget.test.ts`); no room for a longer routed sentence. | ok |
+
+## Design
+
+### Phase 1 — in-file sectioned reading affordances (recommended, unconditional)
+
+All changes live in `renderModuleFactsMarkdown` and are additive to the existing layout. No path, filename, or consumer contract changes.
+
+1. **`## Contents` index.** Emitted directly after the `Source root:` line: one bullet per emitted section, in order, with the section's start line in the final rendered file and its approximate size — e.g. `- Exact override targets — L1480, ~62 KB`. Rendering is two-pass (render body, compute line starts, prepend index with a fixed self-size so numbering is stable and deterministic, satisfying the determinism assertion in `module-facts.bc-guard.test.ts`). A one-line instruction follows the index: `Read caps: a read that does not reach the end-of-facts marker was truncated — re-read the missing sections by their line anchors.`
+2. **End-of-facts marker.** Final line of every sheet: `<!-- end module facts: <module> — <n> sections -->`. Together with the Contents index this converts silent truncation into a checkable condition at both ends of the file.
+3. **Source-link label compression.** Table-cell links become `[data/entities.ts](../../../node_modules/@open-mercato/core/src/modules/customers/data/entities.ts)` — label relative to the declared source root, href unchanged and still validated. Measured effect on `customers.md`: ~52 KB saved (~24 %); the 62 KB override-target section drops under ~36 KB, bringing **every individual section on every sheet under a 50 k-character read** — sectioned reads become sufficient, not just helpful.
+4. **Guide reinforcement.** `agentic/guides/architecture.md` (already routed for module work) documents the Contents index, the end marker, and the sectioned-read procedure in two sentences. The root AGENTS.md sentence from PR #5267 stays as-is (byte budget, Q4).
+
+Consequences: `module-facts.bc-guard.test.ts` link-exactness and byte-cap expectations updated (sizes shrink); `module-facts-build.test.ts` heading regexes unaffected (additive `## Contents` heading added to the fixed-order list); harness knowledge-change sha256 stamps refresh on rebuild as designed. Nothing in `cases.json`, `selectModuleFactSheets`, the injection block, ownership manifests, or the evaluator changes.
+
+### Phase 2 — directory split with index (conditional)
+
+Layout: `.ai/guides/modules/<id>/index.md` (header, staleness stamp, per-section file list with sizes and one-line descriptions) plus `<id>/<section-slug>.md` per non-empty section. Trigger: post-Phase-1 evidence (harness evaluations or session analyses like #5251) still showing truncation-driven or context-exhaustion failures.
+
+The split is the more robust end state — plain file reads instead of offset reads, per-section addressability by path, index-first discovery — but it invalidates a pinned surface that must be migrated in one coordinated change:
+
+- **Build:** `packages/create-app/build.mjs` and `packages/cli/build.mjs` (per-module `writeFileSync` → per-section tree; link relativity gains one `../`).
+- **Setup mirrors:** `selectModuleFactSheets` + copy loop + ownership manifest in `packages/create-app/src/setup/tools/shared.ts`; the byte-identical CLI mirror in `packages/cli/src/lib/agentic-setup.ts`; the injected sentence pinned to `` `.ai/guides/modules/<id>.md` `` (root byte budget re-checked).
+- **Tests:** `module-facts-build.test.ts`, `agents-md.module-guides.test.ts`, `agent-instruction-budget.test.ts`, `agent-surface-coverage.test.ts` (~30 literal paths + `reuseInstalledFacts`), `context-guidance-contracts.test.ts`, `agent-harness-evaluator.test.ts`, `agent-harness-knowledge-change.test.ts`, `module-facts.bc-guard.test.ts`, `TC-INT-008.spec.ts`.
+- **Harness data:** 363 literal path references in `agentic/shared/ai/harness/cases.json` (mechanical rewrite, scripted); `evaluate-agent-harness.mjs` path special-cases; `validate-knowledge-change.mjs` (regex already subdirectory-tolerant).
+- **Prose:** five skills/guides referencing the flat path; `architecture.md` directory diagram.
+- **Migration:** `agentic:init --update-harness` must delete superseded flat `<id>.md` files via the ownership manifest (stale flat sheets shadowing fresh split ones would be worse than today's problem); one release of dual-emit (flat + split) is **not** proposed — the sheets are generated copies with a staleness stamp, and the knowledge-change validator already flags stale copies.
+
+## Alternatives considered
+
+- **Hint only (status quo after PR #5267).** Zero cost, but depends on the model noticing an unsignalled condition; the #5251 session demonstrates the failure.
+- **Split without Phase 1's compression.** Two sections (`customers`/`sales` `## Exact override targets`, 62/57 KB) would still exceed a 50 k-character read on their own — a split alone does not reach "every read completes".
+- **JSON sidecar as the primary agent interface.** `module-facts.v2.json` already exists and is machine-consumed (`framework-context.mjs`), but routed guidance, cases, and skills are built around markdown reading; retargeting them is a larger contract change than Phase 2 for less legibility.
+
+## Implementation Breakdown
+
+### Phase 1: sectioned reading affordances
+
+- 1.1 Two-pass Contents index + end marker in `renderModuleFactsMarkdown` (+ reference projection variant), determinism-safe
+- 1.2 Source-link label compression relative to `Source root` across all table renderers
+- 1.3 Update `module-facts.bc-guard.test.ts` (links, byte caps) and `module-facts-build.test.ts` (Contents heading, marker)
+- 1.4 `architecture.md` sectioned-read guidance; rebuild; harness evaluation run green
+
+### Phase 2 (conditional): directory split
+
+- 2.1 Generator + both build scripts emit `<id>/index.md` + section files
+- 2.2 Setup tools + CLI mirror: selection, copy, manifest, injected sentence, root budget
+- 2.3 Scripted `cases.json` path rewrite + evaluator/validator path handling
+- 2.4 Test suite migration (files listed above); skills/guides prose
+- 2.5 `agentic:init --update-harness` stale flat-file cleanup + upgrade note
+
+## Migration & Backward Compatibility
+
+Phase 1 is additive within the existing generated-file contract: paths, filenames, section headings, and href targets are unchanged; only link labels and two new blocks (Contents, end marker) differ, and the affected files are generated do-not-edit artifacts refreshed wholesale by `agentic:init --update-harness`. Phase 2 changes the generated-file layout — a contract surface under `BACKWARD_COMPATIBILITY.md` (generated files) — and therefore ships only with the cleanup step in 2.5, an `UPGRADE_NOTES.md` entry, and a coordinated release of `create-mercato-app` and `@open-mercato/cli`.
+
+## Changelog
+
+- 2026-08-13 — Spec created from the PR #5267 follow-up analysis (split-vs-hint decision), with measured sheet/section sizes and the pinned-contract inventory.

--- a/.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md
+++ b/.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md
@@ -8,7 +8,7 @@
 
 ## TLDR
 
-Generated module fact-sheets routinely exceed a single agent read-tool call (13 sheets over 50 KB in a current build; `customers.md` is 218 KB), and truncation is silent: the #5251 shared session worked from a 50 k-character preview of a fact-sheet without noticing. PR #5267 mitigated this with one routed sentence ("Big fact-sheets: read in sections."), which relies entirely on model discipline. This spec makes truncation detectable and sectioned reading mechanical **without changing the one-file-per-module layout**: a generated `## Contents` index with per-section line anchors and sizes, a terminal end-of-facts marker, and source-link label compression. A full split into a per-module directory of section files plus an index is specified as a conditional Phase 2, because it invalidates a very large pinned contract surface (363 literal `.ai/guides/modules/<id>.md` references in the harness `cases.json` alone) for a benefit Phase 1 already delivers in-place.
+Generated module fact-sheets routinely exceed a single agent read-tool call (13 sheets over 50 KB in a current build; `customers.md` is 218 KB), and truncation is silent: the #5251 shared session worked from a 50 k-character preview of a fact-sheet without noticing. PR #5267 mitigated this with one routed sentence ("Big fact-sheets: read in sections."), which relies entirely on model discipline. This spec makes truncation detectable and sectioned reading mechanical **without changing the one-file-per-module layout**: a generated `## Contents` index with per-section line anchors and sizes, a terminal end-of-facts marker, source-link label compression, and `###` sub-anchors inside oversized sections. A full split into a per-module directory of section files plus an index is specified as a conditional Phase 2, because it invalidates a very large pinned contract surface (363 literal `.ai/guides/modules/<id>.md` references in the harness `cases.json` alone) for a benefit Phase 1 already delivers in-place.
 
 ## Problem Statement
 
@@ -43,8 +43,9 @@ All changes live in `renderModuleFactsMarkdown` and are additive to the existing
 
 1. **`## Contents` index.** Emitted directly after the `Source root:` line: one bullet per emitted section, in order, with the section's start line in the final rendered file and its approximate size — e.g. `- Exact override targets — L1480, ~62 KB`. Rendering is two-pass (render body, compute line starts, prepend index with a fixed self-size so numbering is stable and deterministic, satisfying the determinism assertion in `module-facts.bc-guard.test.ts`). A one-line instruction follows the index: `Read caps: a read that does not reach the end-of-facts marker was truncated — re-read the missing sections by their line anchors.`
 2. **End-of-facts marker.** Final line of every sheet: `<!-- end module facts: <module> — <n> sections -->`. Together with the Contents index this converts silent truncation into a checkable condition at both ends of the file.
-3. **Source-link label compression.** Table-cell links become `[data/entities.ts](../../../node_modules/@open-mercato/core/src/modules/customers/data/entities.ts)` — label relative to the declared source root, href unchanged and still validated. Measured effect on `customers.md`: ~52 KB saved (~24 %); the 62 KB override-target section drops under ~36 KB, bringing **every individual section on every sheet under a 50 k-character read** — sectioned reads become sufficient, not just helpful.
-4. **Guide reinforcement.** `agentic/guides/architecture.md` (already routed for module work) documents the Contents index, the end marker, and the sectioned-read procedure in two sentences. The root AGENTS.md sentence from PR #5267 stays as-is (byte budget, Q4).
+3. **Source-link label compression.** Table-cell links become `[data/entities.ts](../../../node_modules/@open-mercato/core/src/modules/customers/data/entities.ts)` — label relative to the declared source root, href unchanged and still validated. Measured effect on `customers.md`: 218 KB → 180 KB (−17 %); `## Exact override targets` 62 KB → 51 KB, `## UMES hosts` 41 KB → 37.5 KB. Compression alone does **not** bound the largest sections under a 50 k-character read — that is what item 4 is for.
+4. **Sub-anchors for oversized sections.** Any section whose rendered size exceeds ~32 KB is emitted with `###` subheadings along its natural grouping (for `## Exact override targets`, the existing Domain column; for `## UMES hosts`, the family column), and the Contents index lists those subsections with their own line anchors. This bounds every anchored read unit well under any known read cap, making sectioned reads sufficient rather than merely helpful.
+5. **Guide reinforcement.** `agentic/guides/architecture.md` (already routed for module work) documents the Contents index, the end marker, and the sectioned-read procedure in two sentences. The root AGENTS.md sentence from PR #5267 stays as-is (byte budget, Q4).
 
 Consequences: `module-facts.bc-guard.test.ts` link-exactness and byte-cap expectations updated (sizes shrink); `module-facts-build.test.ts` heading regexes unaffected (additive `## Contents` heading added to the fixed-order list); harness knowledge-change sha256 stamps refresh on rebuild as designed. Nothing in `cases.json`, `selectModuleFactSheets`, the injection block, ownership manifests, or the evaluator changes.
 
@@ -73,8 +74,9 @@ The split is the more robust end state — plain file reads instead of offset re
 
 - 1.1 Two-pass Contents index + end marker in `renderModuleFactsMarkdown` (+ reference projection variant), determinism-safe
 - 1.2 Source-link label compression relative to `Source root` across all table renderers
-- 1.3 Update `module-facts.bc-guard.test.ts` (links, byte caps) and `module-facts-build.test.ts` (Contents heading, marker)
-- 1.4 `architecture.md` sectioned-read guidance; rebuild; harness evaluation run green
+- 1.3 `###` sub-anchors (with Contents entries) for sections rendering above ~32 KB
+- 1.4 Update `module-facts.bc-guard.test.ts` (links, byte caps) and `module-facts-build.test.ts` (Contents heading, marker, sub-anchors)
+- 1.5 `architecture.md` sectioned-read guidance; rebuild; harness evaluation run green
 
 ### Phase 2 (conditional): directory split
 

--- a/packages/create-app/agentic/guides/backend-ui.md
+++ b/packages/create-app/agentic/guides/backend-ui.md
@@ -24,6 +24,10 @@ List destinations need stable `pageGroup`, `pageGroupKey`, and order. A `page.me
 
 For a new editable entity or module, unless the brief explicitly excludes an operation, deliver list, create, view/edit, and delete as one connected slice. The `DataTable` list owns server filter/search controls, a localized add action linking to create, and a stable linked row action to view/edit. `CrudForm` owns create/update/delete, custom-field save/reload/clear, `updatedAt` conflicts, and return navigation. Do not leave a new backend entity reachable only by typing a URL.
 
+## Cross-Record References
+
+When a form field or table column references another record — in this module or an installed one — render display names, never raw IDs. Form references are selection controls (searchable select or picker) backed by a scoped option-source route; reuse the owning module's picker or option source when one exists instead of authoring a new route. Table columns render the referenced record's display name or a stored display snapshot. UUIDs appear only in API payloads: a user never types one into a field and never reads one off a page.
+
 ## DataTable
 
 - Use `DataTable` with a stable colon-form `entityId`, explicit typed data/pagination loaded through shared API helpers, and `extensionTableId`. These are host contracts, not cosmetic props; `DataTable` has no `apiPath` prop.

--- a/packages/create-app/agentic/shared/AGENTS.md.template
+++ b/packages/create-app/agentic/shared/AGENTS.md.template
@@ -92,7 +92,7 @@ Match every work-unit row; OPEN its skill before selection.
 
 Spec gate before code: new capability/architecture/schema/API contract/cross-module/multi-phase -> spec first (`spec-first`); covering `.ai/specs` match -> reuse and update it (`reuse-spec`); bug fix/minor fix/docs/dependency/isolated refactor -> proceed (`direct`); only the request's explicit words waive a feature spec; workflow-changing ambiguity -> ask once (`ask`). Then `om-module-scaffold` starts at `src/modules/example/README.md`.
 
-Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override. Commit+ready PR MUST add `spec-pr`, read `.ai/skills/om-auto-create-pr/SKILL.md`, and keep task routes (`delivery-route-preserves-task-routes`).
+Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override. A missing routed skill means `yarn install-skills` has not completed (needs network) — run it; never conclude the skill does not exist. Commit+ready PR MUST add `spec-pr`, read `.ai/skills/om-auto-create-pr/SKILL.md`, and keep task routes (`delivery-route-preserves-task-routes`).
 
 | Route ID | Delivery need | Skill |
 |---|---|---|
@@ -111,7 +111,7 @@ Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override.
 
 ## Module-Specific Facts
 
-Load facts for every named/targeted module, not incidental use. Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal + customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed.
+Load facts for every named/targeted module, not incidental use. Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal + customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Fact-sheets can exceed one read-tool cap: read large ones in sections; never assume a single read returned the whole file.
 
 <!-- om:module-guides:start -->
 <!-- om:module-guides:end -->

--- a/packages/create-app/agentic/shared/AGENTS.md.template
+++ b/packages/create-app/agentic/shared/AGENTS.md.template
@@ -92,7 +92,7 @@ Match every work-unit row; OPEN its skill before selection.
 
 Spec gate before code: new capability/architecture/schema/API contract/cross-module/multi-phase -> spec first (`spec-first`); covering `.ai/specs` match -> reuse and update it (`reuse-spec`); bug fix/minor fix/docs/dependency/isolated refactor -> proceed (`direct`); only the request's explicit words waive a feature spec; workflow-changing ambiguity -> ask once (`ask`). Then `om-module-scaffold` starts at `src/modules/example/README.md`.
 
-Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override. A missing routed skill means `yarn install-skills` has not completed (needs network) — run it; never conclude the skill does not exist. Commit+ready PR MUST add `spec-pr`, read `.ai/skills/om-auto-create-pr/SKILL.md`, and keep task routes (`delivery-route-preserves-task-routes`).
+Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override. Missing skill: `yarn install-skills`. Commit+ready PR MUST add `spec-pr`, read `.ai/skills/om-auto-create-pr/SKILL.md`, and keep task routes (`delivery-route-preserves-task-routes`).
 
 | Route ID | Delivery need | Skill |
 |---|---|---|
@@ -111,7 +111,7 @@ Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override.
 
 ## Module-Specific Facts
 
-Load facts for every named/targeted module, not incidental use. Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal + customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Fact-sheets can exceed one read-tool cap: read large ones in sections; never assume a single read returned the whole file.
+Load facts for every named/targeted module, not incidental use. Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal + customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Big fact-sheets: read in sections.
 
 <!-- om:module-guides:start -->
 <!-- om:module-guides:end -->

--- a/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/SKILL.md
@@ -5,7 +5,7 @@ description: Build a complete standalone business app, module, or CRUD vertical 
 
 # Scaffold a Complete Module
 
-Create the smallest working vertical slice under `src/modules/<id>/`. START at [`src/modules/example/README.md`](../../../src/modules/example/README.md) and adapt only the [`references/surface-inventory.json`](../../../src/modules/example/references/surface-inventory.json) rows it names. Both files ship inside the emitted example module at `src/modules/example/references/` — not under this skill's own `references/` folder, which holds only the procedure guides named below.
+Create the smallest working vertical slice under `src/modules/<id>/`. START at [`src/modules/example/README.md`](../../../src/modules/example/README.md) and adapt only the [`references/surface-inventory.json`](../../../src/modules/example/references/surface-inventory.json) rows it names. The inventory ships inside the emitted example module (`src/modules/example/references/`) — not under this skill's own `references/` folder, which holds only the procedure guides named below.
 
 ## Inputs
 

--- a/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/SKILL.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/SKILL.md
@@ -5,7 +5,7 @@ description: Build a complete standalone business app, module, or CRUD vertical 
 
 # Scaffold a Complete Module
 
-Create the smallest working vertical slice under `src/modules/<id>/`. START at [`src/modules/example/README.md`](../../../src/modules/example/README.md) and adapt only the [`references/surface-inventory.json`](../../../src/modules/example/references/surface-inventory.json) rows it names.
+Create the smallest working vertical slice under `src/modules/<id>/`. START at [`src/modules/example/README.md`](../../../src/modules/example/README.md) and adapt only the [`references/surface-inventory.json`](../../../src/modules/example/references/surface-inventory.json) rows it names. Both files ship inside the emitted example module at `src/modules/example/references/` — not under this skill's own `references/` folder, which holds only the procedure guides named below.
 
 ## Inputs
 

--- a/packages/create-app/agentic/shared/ai/specs/SPEC-000-template.md
+++ b/packages/create-app/agentic/shared/ai/specs/SPEC-000-template.md
@@ -88,6 +88,8 @@ Name the installed records that remain the source of truth. Do not duplicate CRM
 
 List every new or changed page before implementation. Inspect the closest existing Open Mercato page and `.ai/guides/backend-ui.md`; record that reference below. Tabular admin data uses `DataTable`, CRUD create/edit surfaces use `CrudForm`, and backend reads use the shared API helpers. Any custom page or component exception needs an explicit rationale and approval in this section.
 
+Cross-record references follow the reference display rule: every reference to another record is a selection control backed by a scoped option source showing display names (reuse the owning module's picker or option source when one exists), tables render display names or stored display snapshots, and raw IDs live only in API payloads — a user never types or reads one. Specify the option-source route (or the reused picker) for each reference field in the contracts below.
+
 | Surface / route | Purpose and primary actions | Data source / mutations | Closest installed reference | Canonical shell / components | Required states | Requirement IDs |
 |---|---|---|---|---|---|---|
 | `/backend/{route}` | {list/create/edit/etc.} | `{API paths / command IDs}` | `{module/path or component family}` | `Page`, `PageBody`, `DataTable`, `CrudForm`, {others} | loading, empty, error, conflict, success, permission denied | REQ-001 |

--- a/packages/create-app/template/AGENTS.md
+++ b/packages/create-app/template/AGENTS.md
@@ -92,7 +92,7 @@ Match every work-unit row; OPEN its skill before selection.
 
 Spec gate before code: new capability/architecture/schema/API contract/cross-module/multi-phase -> spec first (`spec-first`); covering `.ai/specs` match -> reuse and update it (`reuse-spec`); bug fix/minor fix/docs/dependency/isolated refactor -> proceed (`direct`); only the request's explicit words waive a feature spec; workflow-changing ambiguity -> ask once (`ask`). Then `om-module-scaffold` starts at `src/modules/example/README.md`.
 
-Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override. Commit+ready PR MUST add `spec-pr`, read `.ai/skills/om-auto-create-pr/SKILL.md`, and keep task routes (`delivery-route-preserves-task-routes`).
+Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override. A missing routed skill means `yarn install-skills` has not completed (needs network) — run it; never conclude the skill does not exist. Commit+ready PR MUST add `spec-pr`, read `.ai/skills/om-auto-create-pr/SKILL.md`, and keep task routes (`delivery-route-preserves-task-routes`).
 
 | Route ID | Delivery need | Skill |
 |---|---|---|
@@ -111,7 +111,7 @@ Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override.
 
 ## Module-Specific Facts
 
-Load facts for every named/targeted module, not incidental use. Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal + customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed.
+Load facts for every named/targeted module, not incidental use. Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal + customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Fact-sheets can exceed one read-tool cap: read large ones in sections; never assume a single read returned the whole file.
 
 <!-- om:module-guides:start -->
 <!-- om:module-guides:end -->

--- a/packages/create-app/template/AGENTS.md
+++ b/packages/create-app/template/AGENTS.md
@@ -92,7 +92,7 @@ Match every work-unit row; OPEN its skill before selection.
 
 Spec gate before code: new capability/architecture/schema/API contract/cross-module/multi-phase -> spec first (`spec-first`); covering `.ai/specs` match -> reuse and update it (`reuse-spec`); bug fix/minor fix/docs/dependency/isolated refactor -> proceed (`direct`); only the request's explicit words waive a feature spec; workflow-changing ambiguity -> ask once (`ask`). Then `om-module-scaffold` starts at `src/modules/example/README.md`.
 
-Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override. A missing routed skill means `yarn install-skills` has not completed (needs network) — run it; never conclude the skill does not exist. Commit+ready PR MUST add `spec-pr`, read `.ai/skills/om-auto-create-pr/SKILL.md`, and keep task routes (`delivery-route-preserves-task-routes`).
+Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override. Missing skill: `yarn install-skills`. Commit+ready PR MUST add `spec-pr`, read `.ai/skills/om-auto-create-pr/SKILL.md`, and keep task routes (`delivery-route-preserves-task-routes`).
 
 | Route ID | Delivery need | Skill |
 |---|---|---|
@@ -111,7 +111,7 @@ Read `.agents/skills/<id>/SKILL.md` AND any `.ai/skills/<id>/SKILL.md` override.
 
 ## Module-Specific Facts
 
-Load facts for every named/targeted module, not incidental use. Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal + customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Fact-sheets can exceed one read-tool cap: read large ones in sections; never assume a single read returned the whole file.
+Load facts for every named/targeted module, not incidental use. Mechanisms: events/subscribers→events; long operation/progress→progress; provider settings/health/OAuth→integrations; sync/import→data_sync. Hosts: session/auth→auth; customer/contact/deal/pipeline→customers; product/price/stock/inventory→catalog; currency/money→currencies; cart/checkout/shopper→checkout; portal→portal + customer_accounts; quote/order/invoice/sales assistant→sales; notification→notifications; webhook/callback→webhooks; schedule/reminder→scheduler; workflow/activity/user task→workflows; assistant→ai_assistant; maintained query index/reindex→query_index; search convergence→search. staff/employee≠optional staff; audit/record-who≠audit_logs unless extended. App primitives skip api_docs/search/query_index unless changed. Big fact-sheets: read in sections.
 
 <!-- om:module-guides:start -->
 <!-- om:module-guides:end -->


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-13-harness-session-5251-improvements.md
Status: complete

## Goal
- Land the low-risk, text-level improvements to the create-app standalone agent harness identified by the #5251 shared-session analysis (Kimi Code CLI session `library-books-spec-session`).

## What Changed
- **Standalone root AGENTS.md (template + agentic mirror, kept in sync):** a missing routed skill now routes to `yarn install-skills` instead of a filesystem hunt (the shared session burned ~10 tool calls on this), and module fact-sheets carry a read-in-sections hint (the session silently worked from a 50k-char preview of a 102KB fact-sheet). Phrasing is telegraphic because the generated Codex root has a 12 KiB budget with <80 bytes of headroom.
- **SPEC-000 template + backend-ui guide:** the Reference Display Rule is now default — cross-record references are selection controls backed by scoped option sources showing display names; tables render names or display snapshots; raw UUIDs live only in API payloads. The session needed a user steer ("show names not guids") to get this; new specs get it for free.
- **om-module-scaffold SKILL.md:** states that `surface-inventory.json` ships inside the emitted example module, not the skill's `references/` folder (the session guessed the wrong location first).
- **Fact-sheet sectioning spec (resume 2026-08-13):** the split-vs-hint question raised on this PR is now analyzed and designed in `.ai/specs/2026-08-13-module-fact-sheet-sectioned-reading.md` (Proposed) — measured sheet/section sizes, the full inventory of the contract surface pinning the one-file-per-module layout, and a phased fix (in-file Contents index + end marker + link-label compression + sub-anchors first; directory split as a conditional Phase 2). Implementation ships on its own PR.

## Tests
- Existing enforcement suites cover these files: `agent-instruction-budget.test.ts` (root byte budget incl. one-extra-module scenario), context-guidance/surface-coverage contract tests, template-sync parity, source-link inventory — all green.
- Full validation gate run locally: build:packages ✓, generate ✓ (no drift), build:packages ✓, i18n:check-sync ✓, i18n:check-usage ✓, typecheck ✓, build:app ✓, `yarn template:sync` ✓. `yarn test` fails only on 4 `create-mercato-app` dev-wrapper tests whose preflight asserts host `fs.inotify.*` sysctl minimums this runner cannot meet (needs root) — environmental, expected green in CI.

## Breaking Changes
- None. Docs-only; no contract surface (routes, schemas, exports, events, CLI, DB) touched.

## Byte-budget note
The generated classic Codex root is now 12266 bytes (12284 with one extra module) against the 12288 target — the remaining headroom is small by design; a future module enable may deliberately shed the inline fact index per `enforceRootInstructionBudget`.

## Deferred follow-ups (tracked in the #5251 analysis)
- `om-share-this-session`: sanitizer false-positive tuning + a Kimi `wire.jsonl` adapter (privacy-sensitive; own PR).
- Stub SKILL.md placeholders / doctor check for failed external-skill installs (code + tests; own PR).

Refs #5251

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789220059&installation_model_id=432243&pr_number=5267&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5267&signature=96d97a92079480097b03bd9761f42a8e5c6571716b22fc83665aa0be8f026593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->