### PR TITLE
docs(design-system): replace the stale ds-health-check.sh copy in metrics.md with a pointer

### DIFF
--- a/docs/design-system/metrics.md
+++ b/docs/design-system/metrics.md
@@ -22,92 +22,19 @@
 ## Reporting script
 
 ```bash
-#!/bin/bash
-# ds-health-check.sh — run every sprint
-# Usage: bash .ai/scripts/ds-health-check.sh
-# Portable: works on macOS and Linux
-
-set -euo pipefail
-
-REPORT_DIR=".ai/reports"
-mkdir -p "$REPORT_DIR"
-
-DATE=$(date +%Y-%m-%d)
-REPORT_FILE="$REPORT_DIR/ds-health-$DATE.txt"
-
-# Function to write to stdout and file simultaneously
-report() {
-  echo "$1" | tee -a "$REPORT_FILE"
-}
-
-# Clear the report file (new report)
-> "$REPORT_FILE"
-
-report "=== DESIGN SYSTEM HEALTH CHECK ==="
-report "Date: $DATE"
-report ""
-
-report "--- Hardcoded Status Colors ---"
-HC=$(rg 'text-red-[0-9]|bg-red-[0-9]|border-red-[0-9]|text-green-[0-9]|bg-green-[0-9]|border-green-[0-9]|text-emerald-[0-9]|bg-emerald-[0-9]|border-emerald-[0-9]|text-amber-[0-9]|bg-amber-[0-9]|border-amber-[0-9]|text-blue-[0-9]|bg-blue-[0-9]|border-blue-[0-9]' \
-  --type tsx --glob '!**/__tests__/**' --glob '!**/node_modules/**' -c 2>/dev/null | \
-  awk -F: '{s+=$2} END{print s+0}')
-report "  Count: $HC (target: 0)"
-
-report ""
-report "--- Arbitrary Text Sizes ---"
-AT=$(rg 'text-\[\d+px\]' --type tsx --glob '!**/__tests__/**' -c 2>/dev/null | \
-  awk -F: '{s+=$2} END{print s+0}')
-report "  Count: $AT (target: 1)"
-
-report ""
-report "--- Deprecated Notice Usage ---"
-NC=$(rg "from.*primitives/Notice" --type tsx -l 2>/dev/null | wc -l | tr -d ' ')
-report "  Notice imports: $NC (target: 0)"
-EN=$(rg "ErrorNotice" --type tsx -l 2>/dev/null | wc -l | tr -d ' ')
-report "  ErrorNotice imports: $EN (target: 0)"
-
-report ""
-report "--- Inline SVG ---"
-SVG=$(rg '<svg' --type tsx --glob '!**/__tests__/**' --glob '!**/node_modules/**' -l 2>/dev/null | wc -l | tr -d ' ')
-report "  Files with inline SVG: $SVG (target: 0)"
-
-report ""
-report "--- Raw fetch() in Backend ---"
-RF=$(rg 'fetch\(' --type tsx --glob '**/backend/**' --glob '!**/node_modules/**' -l 2>/dev/null | wc -l | tr -d ' ')
-report "  Raw fetch files: $RF (target: 0)"
-
-report ""
-report "--- Empty State Coverage ---"
-PAGES=$(find packages/core/src/modules/*/backend -name "page.tsx" 2>/dev/null | wc -l | tr -d ' ')
-ES=$(rg 'EmptyState|TabEmptyState' --type tsx --glob '**/backend/**/page.tsx' -l 2>/dev/null | wc -l | tr -d ' ')
-PCT=$(( ES * 100 / PAGES ))
-report "  Pages with empty state: $ES / $PAGES ($PCT%)"
-
-report ""
-report "--- Loading State Coverage ---"
-LS=$(rg 'LoadingMessage|isLoading|Spinner' --type tsx --glob '**/backend/**/page.tsx' -l 2>/dev/null | wc -l | tr -d ' ')
-LPCT=$(( LS * 100 / PAGES ))
-report "  Pages with loading state: $LS / $PAGES ($LPCT%)"
-
-report ""
-report "=== END REPORT ==="
-
-# Compare with previous report
-PREV=$(ls -1 "$REPORT_DIR"/ds-health-*.txt 2>/dev/null | grep -v "$DATE" | sort | tail -1)
-if [ -n "${PREV:-}" ] && [ -f "$PREV" ]; then
-  echo ""
-  echo "=== DELTA vs $(basename "$PREV") ==="
-  diff --unified=0 "$PREV" "$REPORT_FILE" | grep '^[+-]  ' | head -20 || echo "  (no changes)"
-else
-  echo ""
-  echo "=== First report — no previous data to compare ==="
-fi
-
-echo ""
-echo "Report saved to: $REPORT_FILE"
+bash .ai/scripts/ds-health-check.sh          # add --lint for authoritative per-rule counts
 ```
 
-**Tracking cadence:** Run at the beginning of every sprint. The report is saved to `.ai/reports/ds-health-YYYY-MM-DD.txt`. Comparison with the previous report is automatic.
+The script is the single source of truth for these metrics; it is intentionally
+not reproduced here, because an embedded copy drifts from the implementation it
+claims to document (#5095). It reports hardcoded status colors, arbitrary text
+sizes, deprecated `Notice`/`ErrorNotice` usage, the legacy `Alert` variant API,
+arbitrary z-index values, inline SVG, raw `fetch()` in backend code, empty-state
+and loading-state coverage, semantic token adoption (including `destructive-solid`
+loudness and the token parity/contrast gate), Token Snapshot Drift and DS lint
+opt-outs, followed by a per-module breakdown of the top offenders.
+
+**Tracking cadence:** Run at the beginning of every sprint. The report is saved to `.ai/reports/ds-health-latest.txt`, overwriting the previous run — the trend lives in git history (`git log -p .ai/reports/ds-health-latest.txt`). Comparison with the previous run is automatic.
 
 ---
 

--- a/scripts/__tests__/ds-health-check.test.mjs
+++ b/scripts/__tests__/ds-health-check.test.mjs
@@ -119,6 +119,32 @@ test('a run that found nothing reports "(no changes)" and no metric lines', () =
   }
 })
 
+test('the design-system docs describe the rolling report and embed no copy of the script', () => {
+  const docsDir = path.join(repoRoot, 'docs/design-system')
+  const docs = fs
+    .readdirSync(docsDir)
+    .filter((name) => name.endsWith('.md'))
+    .map((name) => ({ name, source: fs.readFileSync(path.join(docsDir, name), 'utf8') }))
+
+  for (const { name, source } of docs) {
+    assert.doesNotMatch(
+      source,
+      /ds-health-(?:YYYY|\d{4})-/,
+      `${name} documents a dated report filename. The health check writes only ${ROLLING_REPORT} (#5033, #5095).`,
+    )
+    assert.doesNotMatch(
+      source,
+      /ds-health-\*\.txt/,
+      `${name} selects the previous report through a ds-health-*.txt glob. That glob also matches the April 2026 baseline anchor, which sorts last (#5072, #5095).`,
+    )
+    assert.doesNotMatch(
+      source,
+      /^REPORT_FILE=/m,
+      `${name} embeds a copy of ds-health-check.sh. Link to .ai/scripts/ds-health-check.sh instead — a second copy drifts (#5095).`,
+    )
+  }
+})
+
 test('both copies of the health check share the same delta block', () => {
   const extractDelta = (file) => {
     const source = fs.readFileSync(file, 'utf8')


### PR DESCRIPTION
Fixes #5095.

## Problem

`docs/design-system/metrics.md` embedded an 85-line copy of `ds-health-check.sh` (lines 24–108) that had drifted into a copy-pasteable version of two defects #5072 already fixed:

- `metrics.md:36` — `REPORT_FILE="$REPORT_DIR/ds-health-$DATE.txt"`. Dated filenames are gitignored under the `.ai/reports/*` rule #5072 added, so a copied run silently produces nothing tracked.
- `metrics.md:96` — `PREV=$(ls -1 "$REPORT_DIR"/ds-health-*.txt … | sort | tail -1)`. Verbatim the defective selector #5072's "Correction 3" removed: the glob also matches `ds-health-baseline-*.txt`, and `b` sorts after the digits of a dated name, so `tail -1` returns the April 2026 pre-drift baseline.

The copy was also missing every section the real script has gained since (`destructive-solid` loudness, token parity/contrast, Token Snapshot Drift, DS lint opt-outs), and the prose at `metrics.md:110` still named the dated filename.

## Change

Took the issue's preferred option — **delete the copy** rather than regenerate it, since a second copy of the script is the condition that produced this issue (and #5094 is separately reducing the script from two copies to one). The section now points at `.ai/scripts/ds-health-check.sh` with the invocation and a prose summary of what it reports, and the tracking-cadence line names `.ai/reports/ds-health-latest.txt`.

Added a guard in `scripts/__tests__/ds-health-check.test.mjs` that scans every `docs/design-system/*.md` and fails on a dated `ds-health-YYYY-MM-DD` filename, a `ds-health-*.txt` previous-report glob, or a re-embedded script body (`^REPORT_FILE=`). Verified it fails against the pre-fix `metrics.md` and passes after.

## Acceptance criteria

- [x] No file under `docs/design-system/**` claims the health report is written to a dated filename.
- [x] No file under `docs/design-system/**` contains a `ds-health-*.txt` glob used to select the previous report.
- [x] `rg 'ds-health-(YYYY|20)' docs/` returns nothing.
- [x] The embedded script block is gone.

## Testing

`node --test scripts/__tests__/*.test.mjs` — 549 pass, 0 fail (CI runs this as `yarn test:scripts`).

## Notes for reviewers

- Base is `develop`, matching current repo practice.
- `docs/design-system/` is in the CODEOWNERS design-system section, so this needs @zielivia's review. The change was explicitly requested against the already-filed issue #5095; flagging it rather than assuming the automation exemption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789221889&installation_model_id=432243&pr_number=5268&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5268&signature=efe5e30dadb86b73128f5fc87b266753907e261ce679e7367799445991f9498e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->