### PR TITLE
test(core): make module-decoupling.test.ts order-independent (#5129)

### DIFF
--- a/packages/core/src/__tests__/module-decoupling.test.ts
+++ b/packages/core/src/__tests__/module-decoupling.test.ts
@@ -87,7 +87,8 @@ jest.mock('@open-mercato/shared/lib/crud/cache', () => ({
 }))
 
 import { registerEntityIds, getEntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
-import { registerModules } from '@open-mercato/shared/lib/modules/registry'
+import type { EntityIds } from '@open-mercato/shared/lib/encryption/entityIds'
+import { registerModules, tryGetModules } from '@open-mercato/shared/lib/modules/registry'
 import type { Module } from '@open-mercato/shared/modules/registry'
 import type { ModuleSetupConfig } from '@open-mercato/shared/modules/setup'
 
@@ -193,9 +194,24 @@ function buildReducedModules(): Module[] {
 
 const reducedModules = buildReducedModules()
 
-beforeAll(() => {
+// The module registry and the entity-id registry are process-global, so this
+// suite must own its own snapshot of both instead of relying on whatever the
+// surrounding run happens to have registered.
+let previousModules: Module[] | null = null
+let previousEntityIds: EntityIds | null = null
+
+beforeEach(() => {
+  previousModules = tryGetModules()
+  previousEntityIds = getEntityIds(false)
   registerEntityIds(reducedE as any)
   registerModules(reducedModules)
+})
+
+afterEach(() => {
+  registerEntityIds(previousEntityIds ?? ({} as EntityIds))
+  registerModules(previousModules ?? [])
+  previousModules = null
+  previousEntityIds = null
 })
 
 describe('Module Decoupling', () => {
@@ -220,9 +236,17 @@ describe('Module Decoupling', () => {
 
   describe('2. attachments/partitions.ts — resolveDefaultPartitionCode', () => {
     it('returns privateAttachments for null, undefined, arbitrary strings, and catalog entity IDs', async () => {
-      const { resolveDefaultPartitionCode } = await import(
-        '@open-mercato/core/modules/attachments/lib/partitions'
-      )
+      // partitions.ts freezes its product-media entity ids at import time, so it
+      // has to be evaluated inside an isolated registry — a cached instance built
+      // from unmocked entity ids would silently answer 'productsMedia' here.
+      let resolveDefaultPartitionCode!: (entityId: string | null | undefined) => string
+      await jest.isolateModulesAsync(async () => {
+        const { E } = await import('#generated/entities.ids.generated')
+        expect((E as Record<string, unknown>).catalog).toBeUndefined()
+        ;({ resolveDefaultPartitionCode } = await import(
+          '@open-mercato/core/modules/attachments/lib/partitions'
+        ))
+      })
 
       expect(resolveDefaultPartitionCode(null)).toBe('privateAttachments')
       expect(resolveDefaultPartitionCode(undefined)).toBe('privateAttachments')


### PR DESCRIPTION
Fixes #5129.

## What was actually wrong

The issue's diagnosis — "the catalog module was registered when the case ran" — points at the module registry, but `resolveDefaultPartitionCode` never reads it:

```ts
// packages/core/src/modules/attachments/lib/partitions.ts
import { E } from '#generated/entities.ids.generated'

const PRODUCT_MEDIA_ENTITY_IDS = new Set<string>(
  [(E as any).catalog?.catalog_product].filter(Boolean) as string[]
)
```

The set is frozen **at import time** from the generated entity ids. `packages/core/jest.mocks/entities.ids.generated.js` is a `Proxy` that answers *every* lookup, so `E.catalog.catalog_product` is `'catalog:catalog_product'` unless a suite mocks the module — which `module-decoupling.test.ts` does.

So the only way line 231 can see `productsMedia` is for the `partitions` module instance it imports to have been evaluated **without** that mock in effect. The suite's `await import(...)` returns whatever is already in the module registry, so it inherits such an instance instead of building its own.

Reproduced directly with a throwaway probe — a `partitions` instance cached from unmocked entity ids, then both import styles against it:

```
OLD => productsMedia        // plain `await import(...)`
NEW => privateAttachments   // `jest.isolateModulesAsync` + `await import(...)`
```

That is exactly the reported diff, and the isolated import is immune to it.

## Changes

**1. Pin the partitions precondition (the actual flake).** Load the module inside `jest.isolateModulesAsync` so its import-time entity-id set is always rebuilt from this file's mock, and assert `E.catalog` is absent first — if the mock ever stops applying, the failure now names the mock instead of looking like a behaviour regression.

**2. Snapshot and restore the global registries (the leak the issue describes).** `registerModules` writes to `globalThis` and `registerEntityIds` to module state; `beforeAll` replaced both and never restored them, so the reduced module set leaked to anything sharing the process. Now captured in `beforeEach` via `tryGetModules()` / `getEntityIds(false)` and restored in `afterEach`. This fixes the outbound direction of the same class of bug.

No behaviour under test changed — the assertions are identical.

## Validation

Runner: local (no compose `app` container running).

| gate | result |
|---|---|
| `module-decoupling.test.ts` | ✅ 12/12 |
| `module-decoupling.test.ts` + `src/modules/attachments` (26 suites) | ✅ 210/210 |
| leak probe (old vs new import, described above) | ✅ old reproduces `productsMedia`, new returns `privateAttachments` |

Two gates could not run in this worktree and are **unrelated to this diff** — its shared `node_modules` is installed from `main` and is stale for `develop`:

- `src/modules/attachments/components/__tests__/assignmentsEditorFocus.test.tsx` — `Cannot find module '@tanstack/react-table/legacy'` (develop declares `^9.0.0`, installed is `8.21.3`)
- `eslint` — `Cannot find module 'eslint-config-next/core-web-vitals'`

`packages/core/tsconfig.json` excludes `**/__tests__/**`, so `yarn typecheck` does not cover this file either way. CI will run all three on a clean install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789222360&installation_model_id=432243&pr_number=5269&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5269&signature=701d8dda8c1e13340fbe4378707075e79c03145cf17c397875fb81c7edd95fc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->