### PR TITLE
fix(ci): restore checkout workflow heading locator

### DIFF
--- a/packages/core/src/modules/workflows/__integration__/TC-WF-030.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-030.spec.ts
@@ -65,7 +65,7 @@ test.describe('TC-WF-030: Checkout demo regression', () => {
       // Advance at most twice: START -> Cart Validation -> Customer Information.
       const advanceButton = page.getByRole('button', { name: 'Advance to Next Step →', exact: true })
       for (let attempt = 0; attempt < 2; attempt += 1) {
-        const customerStep = page.getByRole('heading', { name: 'Customer Information', exact: true })
+        const customerStep = page.getByRole('heading', { name: 'Customer Information Required', exact: true })
         if (await customerStep.isVisible()) break
         await expect(advanceButton).toBeVisible()
         await Promise.all([
@@ -76,7 +76,7 @@ test.describe('TC-WF-030: Checkout demo regression', () => {
         ])
       }
 
-      await expect(page.getByRole('heading', { name: 'Customer Information', exact: true })).toBeVisible()
+      await expect(page.getByRole('heading', { name: 'Customer Information Required', exact: true })).toBeVisible()
       await expect(page.getByRole('heading', { name: 'Order Failed' })).toHaveCount(0)
       await expect(page.getByText(/CALL_WEBHOOK rejected unsafe URL|reason=invalid_url/)).toHaveCount(0)
     } finally {


### PR DESCRIPTION
## Summary

- restores TC-WF-030’s exact locator to the rendered `Customer Information Required` heading
- prevents the test from attempting a second workflow advance after the expected customer-information step is already visible
- stabilizes the `develop` integration shard that failed twice after PR #5249 changed the locator to exact `Customer Information`

## Root cause

The application reached the expected state in every failed attempt. GitHub trace artifacts show the first advance rendered `Customer Information Required`, but the test searched for exact `Customer Information`, treated the step as absent, and waited for an `Advance to Next Step` button that no longer exists. Both the initial workflow and its isolated rerun exhausted the 20-second test deadline at that wait.

## Validation

- GitHub evidence: `develop` workflow 31703427741, attempts 1 and 2; both screenshots/traces show the workflow past Cart Validation
- `git diff --check`
- authoritative CI will run on this PR head

Follow-up to #5236’s post-merge CI monitoring. The auth/i18n and create-app fixes from #5236 already pass their relevant gates; this only corrects the unrelated workflow test regression found on current `develop`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789223211&installation_model_id=432243&pr_number=5271&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5271&signature=083e857ded96184325bdfb5212ab56c893c0359704a954f915e4d172c045a251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->