### PR TITLE
feat(staff): add public identity resolver contracts

### DIFF
--- a/.ai/specs/2026-08-12-staff-identity-resolver-public-contract.md
+++ b/.ai/specs/2026-08-12-staff-identity-resolver-public-contract.md
@@ -1,0 +1,179 @@
+# Staff Auth Identity Link Resolver Public Contract
+
+| Field | Value |
+|---|---|
+| **Status** | Implemented - Full Core Gate Has Baseline Failures |
+| **Created** | 2026-08-12 |
+| **Target** | Current core `staff` module |
+| **Related** | `2026-07-15-staff-member-directory.md`, `implemented/2026-05-08-staff-decouple-from-core.md` |
+
+## TLDR
+
+Add one stable, Staff-owned, read-only `staffIdentityResolver` DI service. It resolves the current active Auth↔Staff link from either a known Auth user UUID or Staff member UUID, enforces exact tenant and organization scope, reports duplicate Auth linkage as `ambiguous`, and exposes no Staff entity.
+
+There is no entity, migration, API, UI, ACL, event, cache, worker, dependency, or downstream-consumer change.
+
+## Overview
+
+Staff entities and helpers are intentionally internal because Staff is optional and planned for package extraction. A server-side optional module nevertheless needs a safe way to validate a current Staff identity or map a known authenticated user to Staff without importing `StaffTeamMember`, trusting client linkage, or reusing a workflow-specific HTTP endpoint.
+
+The existing `availabilityAccessResolver` answers planner authorization. The proposed `staffMemberDirectory` batch-maps authorized user IDs to scheduling references and deliberately preserves duplicates. Neither supplies this contract's bidirectional exact current-link semantics or explicit ambiguity result, so this resolver is a separate narrow public surface.
+
+## Problem Statement
+
+`StaffTeamMember.userId` is nullable and not unique. A direct lookup that silently chooses one active row can make authorization depend on database ordering. A safe integration contract must therefore:
+
+- require explicit tenant and organization scope;
+- consider only active, non-deleted rows;
+- use Staff-owned encryption-aware reads;
+- return ambiguity instead of choosing duplicate Auth linkage;
+- expose only the minimum identity projection;
+- keep database entities and consumer policy private to their owners.
+
+## Proposed Solution
+
+Create the exact public type path `@open-mercato/core/modules/staff/contracts/identityResolver`, implement it in the Staff module, and register a request-scoped resolver under the frozen Awilix key `staffIdentityResolver`.
+
+Trusted server consumers own Auth/RBAC/resource policy and must soft-resolve the service if Staff remains optional. The service validates all UUID inputs before querying and propagates database or decryption failures without plaintext or partial fallback.
+
+## Architecture
+
+### Public Contract
+
+```ts
+export type StaffIdentityScope = {
+  tenantId: string
+  organizationId: string
+}
+
+export type StaffIdentity = {
+  staffMemberId: string
+  userId: string | null
+  displayName: string
+  isActive: boolean
+}
+
+export type StaffIdentityLookupResult =
+  | { kind: 'found'; identity: StaffIdentity }
+  | { kind: 'not_found' }
+  | { kind: 'ambiguous' }
+
+export type StaffIdentityResolver = {
+  resolveByUserId(scope: StaffIdentityScope, userId: string): Promise<StaffIdentityLookupResult>
+  resolveByStaffMemberId(scope: StaffIdentityScope, staffMemberId: string): Promise<StaffIdentityLookupResult>
+}
+```
+
+### Lookup Semantics
+
+- All scope and identity values must be non-empty UUIDs and reject before a query otherwise.
+- `resolveByUserId` queries active, non-deleted Staff in the exact scope with a limit of two: zero results return `not_found`, one returns `found`, and two return `ambiguous` without exposing duplicate IDs.
+- `resolveByStaffMemberId` queries one active, non-deleted row by exact Staff ID and exact scope. It returns only `found` or `not_found`; `ambiguous` is reserved for Auth lookup.
+- Returned identity contains only `staffMemberId`, nullable `userId`, decrypted `displayName`, and `isActive`.
+- Cross-scope, inactive, and deleted records are indistinguishable from absence.
+- No result is cached across requests.
+
+### DI and Module Absence
+
+Staff registers the implementation with `.scoped()` so the current request container supplies its `EntityManager`. Existing `availabilityAccessResolver` registration and behavior remain unchanged. Optional consumers must resolve `staffIdentityResolver` with `allowUnregistered: true` or an equivalent local `tryResolve` helper and own their fallback behavior.
+
+## Data Models
+
+No data-model or migration change is authorized. The implementation reads the existing `StaffTeamMember` fields `id`, `tenantId`, `organizationId`, `userId`, `displayName`, `isActive`, and `deletedAt` through `findWithDecryption` / `findOneWithDecryption`, repeating tenant and organization scope in both the ORM predicate and decryption scope.
+
+## API Contracts
+
+No HTTP, OpenAPI, MCP, or portal API is added. This is a trusted server-side DI contract only. A consumer exposing any result through an API remains responsible for route metadata, authentication, RBAC, validation, and resource authorization.
+
+## UI/UX and Internationalization
+
+N/A. No user-facing surface or copy changes.
+
+## Migration & Backward Compatibility
+
+The change is additive: no existing DI key, exported type, import path, route, event, ACL feature, or schema changes. Once released, `staffIdentityResolver`, the exact contract import path, all required method/property names, and result discriminants are stable under `BACKWARD_COMPATIBILITY.md`. Incompatible evolution requires deprecation, a working bridge for at least one minor release, and upgrade guidance.
+
+If Staff is later extracted, the new package becomes canonical while this core import path remains as a deprecated type-compatible bridge for the required compatibility window. The DI token and semantics remain unchanged.
+
+Before release, rollback removes the additive implementation, registration, export, documentation, and tests together. After release, rollback must retain or deprecate the public surface.
+
+## Implementation Plan
+
+### Phase 1 — Complete Contract
+
+1. Add the public contract file and Staff-owned implementation.
+2. Register `staffIdentityResolver` as request-scoped without changing existing registrations.
+3. Document the token, import path, authorization boundary, and extraction bridge in Staff's `AGENTS.md`.
+4. Add service tests for validation, both lookup directions, active/inactive/deleted behavior, exact scope, ambiguity, minimal projection, nullable linkage, and failure propagation.
+5. Extend DI tests for registration, scoped lifetime, request-scope isolation, CLASSIC-compatible injection, and missing-registration behavior.
+
+### Phase 2 — Validation
+
+1. Run generation and verify no entity or migration diff.
+2. Run focused Staff tests and package build/typecheck.
+3. Run the repository validation gate and review every changed public surface against `BACKWARD_COMPATIBILITY.md`.
+
+## Testing Strategy
+
+Focused tests mock the encryption-aware helpers and assert the complete predicate, query options, decryption scope, output projection, and failure behavior. DI tests use real Awilix scopes with distinct `em` values. No fabricated HTTP or browser integration test is needed because no executable API or UI path changes; the first consumer must add its own staff-disabled integration coverage.
+
+## Risks & Impact Review
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Cross-tenant or cross-organization disclosure | High | Both identifiers are mandatory in the ORM predicate and decryption scope; tests assert the full call. |
+| Duplicate active links lead to nondeterministic authorization | High | Query at most two and return `ambiguous`; never choose or expose duplicate rows. |
+| Consumer treats DI lookup as authorization | Medium | Public documentation states that consumers own Auth/RBAC/resource policy. |
+| Public contract is stranded during Staff extraction | Medium | Preserve the token and provide a type-compatible core import bridge under the deprecation protocol. |
+| DB/KMS failure is mistaken for absence | Medium | Only an actual empty query returns `not_found`; execution failures propagate. |
+
+## Acceptance Criteria
+
+- [x] `staffIdentityResolver` is request-scoped and the exact public contract path resolves without exporting entities.
+- [x] Every query enforces exact tenant/organization scope in both predicate and decryption scope.
+- [x] Auth lookup returns `found | not_found | ambiguous` and never chooses duplicate active linkage.
+- [x] Staff-ID lookup returns `found | not_found` for active, non-deleted exact-scope Staff.
+- [x] Invalid UUIDs reject before query and DB/KMS failures propagate.
+- [x] Results contain only Staff UUID, nullable Auth UUID, display name, and active state.
+- [x] Existing Staff entities, routes, ACLs, events, and `availabilityAccessResolver` remain unchanged.
+- [x] Tests cover the complete semantic and DI contract.
+- [ ] Full validation passes with no entity, migration, API, or UI change. Feature-specific tests and the build, generation, i18n, typecheck, app-build, template-parity, and Docs gates pass with no entity, migration, API, UI, or generated diff. The configured repository test gate remains red from unrelated baseline failures recorded below. Focused tests are supporting evidence, not a substitute for that gate.
+
+## Final Compliance Report
+
+| Rule source | Result |
+|---|---|
+| Root and core `AGENTS.md` | Compliant: Staff owns the narrow DI port; consumers remain soft-optional. |
+| Staff `AGENTS.md` | Compliant: entities remain internal and the new surface is documented as stable. |
+| `BACKWARD_COMPATIBILITY.md` | Compliant: all contract additions are additive and future evolution is governed explicitly. |
+| `.ai/specs/AGENTS.md` | Compliant: filename, required sections, boundaries, risks, and implementation plan are present. |
+
+## Changelog
+
+- 2026-08-12 - Initial reviewed specification imported from the downstream Task & Project Management design and reconciled with current upstream Staff contracts.
+- 2026-08-13 - Implemented the exact contract, encryption-aware Staff resolver, scoped DI registration, stable package export, documentation, and focused tests on `feat/staff-identity-resolver`.
+- 2026-08-13 - Revalidated on the current `origin/develop` baseline, recorded the successful bounded gates, and marked the terminated repository-wide test gate as pending instead of carrying forward historical baseline results.
+- 2026-08-13 - Completed the Core Jest suite as eight deterministic serial shards: 1,224 suites and 9,524 tests passed; eight unrelated tests failed in three baseline suites.
+- 2026-08-13 - Completed the remaining workspace audit serially. Docs passed with process-scoped Git ownership configuration; unrelated Windows/environment/harness baselines remain in CLI, Shared, and create-app.
+
+## Implementation Status
+
+| Phase | Status | Evidence |
+|---|---|---|
+| Public contract and implementation | Done | Exact type-only package path, Staff-owned resolver, and additive request-scoped `staffIdentityResolver` registration added. |
+| Focused resolver and DI tests | Pass | 2 suites, 18 tests. |
+| Planner regressions | Pass | 2 suites, 7 tests. |
+| Staff assignable and Customer compatibility regressions | Pass | 3 suites, 10 tests. |
+| Repository typecheck | Pass | `yarn typecheck`: 22/22 tasks successful when run separately from other resource-heavy gates. |
+| Changed-file lint | Pass | Five changed Staff TypeScript files; only the repository's existing Next.js pages-directory warning was emitted. |
+| Package build | Pass | Both configured `yarn build:packages` passes completed with 22/22 tasks successful, including core and CLI. |
+| Generation | Pass | Configured `yarn generate` completed successfully; no tracked generated diff. |
+| i18n validation | Pass | `yarn i18n:check-sync` and `yarn i18n:check-usage` completed successfully; unused-key output remains advisory. |
+| Application build | Pass | `yarn build:app` completed successfully; existing queue dynamic-filesystem tracing warnings remain non-fatal. |
+| Template parity | Pass | `yarn template:sync` reported source, root-file, and dependency parity. |
+| Exact built import | Pass | Node resolved `@open-mercato/core/modules/staff/contracts/identityResolver`; the type-only module correctly has no runtime exports. |
+| Complete Core Jest suite | Baseline failures | Eight deterministic serial shards completed: 1,224/1,227 suites and 9,524/9,532 tests passed. Four compact-number assertions fail in `customers/components/__tests__/DealsKpiStrip.test.tsx` and `dashboards/lib/__tests__/formatters.test.ts` because this runtime returns lowercase `k`/`m`; four Windows path assertions fail in `attachments/lib/drivers/__tests__/localDriver.test.ts` because the runtime resolves `/storage/...` to `E:\storage\...`. No changed Staff identity test failed. |
+| Remaining workspace Jest suites | Baseline failures | Serialized Turbo runs found two Windows-specific CLI assertions (POSIX `0600` mode comparison in `deploy/railway/__tests__/token.test.ts` and a forward-slash suffix assertion in `deploy/railway/__tests__/state.test.ts`), one Shared environment-state assertion in `lib/encryption/__tests__/likeFilterWarning.test.ts` (172 suites and 1,834 tests passed), and Windows harness failures in `create-mercato-app` including direct `yarn.cmd` spawn `EINVAL`, slash-sensitive output assertions, and Codex app-server fixtures. With Core, CLI, Shared, Docs, and create-app classified separately, the remaining non-Core/CLI/Shared/Docs workspace plan completed 24/25 tasks; only create-app failed. |
+| Docs test | Pass | `open-mercato-docs` production build and search-index test passed after supplying process-scoped Git `safe.directory`; an existing broken-anchor warning for `/installation/wsl2` remains advisory. |
+
+No entity file changed, so no migration was generated or applied.

--- a/.ai/specs/2026-08-13-staff-candidate-resolver-public-contract.md
+++ b/.ai/specs/2026-08-13-staff-candidate-resolver-public-contract.md
@@ -1,0 +1,383 @@
+# Staff Candidate Resolver Public Contract
+
+| Field | Value |
+|---|---|
+| **Status** | Implemented — validated with known unrelated repository baselines |
+| **Created** | 2026-08-13 |
+| **Target** | Current core `staff` module |
+| **Related** | `2026-08-12-staff-identity-resolver-public-contract.md`, `2026-08-13-staff-identity-projection-resolver-public-contract.md`, `2026-07-15-staff-member-directory.md` |
+
+## TLDR
+
+Add one stable, Staff-owned, request-scoped `staffCandidateResolver` DI service for bounded,
+organization-local Staff selection. It returns only active candidate UUIDs and decrypted display
+names, supports linked-only membership selection or linked-and-unlinked assignment selection, and
+keeps consumer authorization outside Staff.
+
+This is the final upstream prerequisite for the Task & Project Management C1 module. It adds no
+entity, migration, HTTP route, UI, ACL, event, cache, worker, or downstream consumer.
+
+## Problem Statement
+
+Optional modules need reusable Staff candidate discovery without importing Staff entities,
+depending on customer-specific endpoints, or copying Staff identity data. Existing identity
+resolvers hydrate known IDs or exact Auth links; they do not provide searchable, paginated
+candidate discovery with consumer-neutral linkage semantics.
+
+## Proposed Solution
+
+Export types from the exact path
+`@open-mercato/core/modules/staff/contracts/candidateResolver`, implement the read inside Staff with
+exact tenant and organization scoping, and register it under the frozen Awilix key
+`staffCandidateResolver`.
+
+The contract accepts `linkage: 'required' | 'any'`, optional bounded search, and validated page
+parameters. It returns a deterministic page containing only `{ staffMemberId, displayName }` plus
+pagination metadata. Consumers remain responsible for authentication, RBAC, resource policy, and
+soft resolution when Staff is optional.
+
+## Overview
+
+Candidate discovery is a read-only server contract for selectors owned by optional modules. Plane's
+official SDK and MCP tooling use lightweight, paginated member endpoints with active-state and
+display-name filters to keep selection flows bounded. This contract adopts the same minimal-result
+and active-only principles, but retains page-number pagination because that response envelope is
+already frozen by the reviewed Projects C1 prerequisite.
+
+The resolver is deliberately distinct from all neighboring Staff surfaces:
+
+- `staffIdentityResolver` verifies one exact active Auth/Staff link.
+- `staffIdentityProjectionResolver` hydrates known Staff IDs, including inactive history.
+- The proposed `staffMemberDirectory` accepts Auth user allowlists and returns scheduling metadata.
+- The existing assignable-Staff HTTP route is customer-authorized and exposes Auth/team fields.
+- `staffCandidateResolver` searches active Staff identities without consumer-specific policy or
+  profile data.
+
+## Architecture
+
+### Public contract
+
+```ts
+export type StaffCandidateScope = {
+  tenantId: string
+  organizationId: string
+}
+
+export type StaffCandidateLinkage = 'required' | 'any'
+
+export type StaffCandidate = {
+  staffMemberId: string
+  displayName: string
+}
+
+export type StaffCandidatePage = {
+  items: StaffCandidate[]
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+}
+
+export type StaffCandidateResolver = {
+  listCandidates(input: StaffCandidateScope & {
+    linkage: StaffCandidateLinkage
+    search?: string
+    page: number
+    pageSize: number
+  }): Promise<StaffCandidatePage>
+}
+```
+
+The exact type-only import path is
+`@open-mercato/core/modules/staff/contracts/candidateResolver`. The exact request-scoped Awilix key
+is `staffCandidateResolver`. Both become stable backward-compatibility surfaces when released.
+
+### Query semantics
+
+The implementation validates all input before either count or data queries:
+
+- `tenantId` and `organizationId` are UUIDs.
+- `linkage` is exactly `required` or `any`.
+- `search`, when supplied, is trimmed and limited to 200 characters. Empty-after-trim behaves as
+  absent.
+- `page` is a positive integer.
+- `pageSize` is an integer from 1 through 100.
+
+Every count and read predicate contains exact `tenantId`, exact `organizationId`,
+`deletedAt: null`, and `isActive: true`. `linkage: 'required'` additionally requires a non-null
+`userId`; `linkage: 'any'` adds no linkage predicate. Search is a case-insensitive escaped substring
+match on the Staff-owned `displayName` field. Wildcards supplied by a caller are treated as literal
+characters, not query operators.
+
+Results sort by `displayName ASC`, then `id ASC`, before offset/limit pagination. The ID tie-breaker
+makes paging deterministic when names match. A page beyond the last returns an empty `items` array
+with the requested `page`; `totalPages` is `ceil(total / pageSize)` and is zero when `total` is zero.
+
+The entity page is read through `findWithDecryption` with the same tenant/organization decryption
+scope and mapped immediately to the two public fields. The count query returns no entity data and
+uses the identical filter. Database and decryption failures propagate; the resolver never returns a
+partial or plaintext fallback.
+
+### Authorization and optional-module boundary
+
+This trusted-server resolver performs no authentication, RBAC, resource-policy, or assignment
+eligibility decision. Consumers must derive scope from authenticated context, authorize the target
+resource before calling, and expose only candidates appropriate to their own workflow. Optional
+consumers use `allowUnregistered: true` only to detect module absence; they must not swallow query or
+decryption failures as absence.
+
+The Staff module owns the query and entity import. Consumers receive plain data and must not import
+`StaffTeamMember`, call customer-specific Staff routes, or persist display names as a projection.
+
+## Data Models
+
+No schema or encryption-map change is required. The resolver reads the existing
+`StaffTeamMember.id`, `displayName`, `userId`, `isActive`, `deletedAt`, `tenantId`, and
+`organizationId` fields. No ORM object crosses the contract boundary.
+
+## API Contracts
+
+No HTTP, OpenAPI, MCP, portal, CLI, or UI surface is added. The public surface is the type-only
+contract and Staff DI service above.
+
+Example linked-only call:
+
+```ts
+const result = await resolver.listCandidates({
+  tenantId,
+  organizationId,
+  linkage: 'required',
+  search: 'Ada',
+  page: 1,
+  pageSize: 25,
+})
+```
+
+Only `{ staffMemberId, displayName }` items are returned. `userId`, email, team, role, description,
+contact, availability, and scheduling metadata are excluded in both linkage modes.
+
+## Edge Cases & Failure Scenarios
+
+| Scenario | Required behavior |
+|---|---|
+| Invalid scope, linkage, search, page, or page size | Reject before any query. |
+| Empty or whitespace-only search | Apply no display-name filter. |
+| Search includes `%`, `_`, or `\\` | Escape it and match the literal text. |
+| No candidates | Return an empty first or requested page with `total: 0` and `totalPages: 0`. |
+| Page exceeds the last page | Return empty items with accurate totals and requested page metadata. |
+| Staff is inactive, deleted, or outside either scope dimension | Omit indistinguishably. |
+| Linked-only mode sees an unlinked Staff row | Omit it; `any` mode may return it. |
+| Equal display names | Order by Staff UUID as the deterministic tie-breaker. |
+| Count, database, or decryption failure | Reject; never return a partial page. |
+
+## Migration & Backward Compatibility
+
+The contract, exact import path, DI key, method name, required input fields, linkage literals,
+pagination envelope, and item fields are additive stable surfaces under `BACKWARD_COMPATIBILITY.md`.
+Once released, incompatible change requires deprecation, a working bridge for at least one minor
+release, and upgrade guidance.
+
+If Staff is extracted, the new package becomes canonical while the core path remains a deprecated,
+type-compatible bridge for the required compatibility window. Before release, rollback removes the
+contract, implementation, registration, export, documentation, and tests together. No database
+rollback is needed.
+
+## Testing Strategy
+
+Focused unit tests cover:
+
+- exact minimal mapping, deterministic sort options, pagination metadata, and exact decryption
+  scope;
+- `required` versus `any` linkage predicates;
+- absent, empty, case-normalized, and escaped-wildcard search behavior;
+- first page, later page, zero results, beyond-last page, page size 1 and 100;
+- invalid scope/linkage/search/page/pageSize rejection before both query helpers;
+- inactive, deleted, and cross-scope omission through exact predicate assertions;
+- count, database, and decryption error propagation;
+- CLASSIC injection, one instance per request scope, distinct EntityManagers across scopes, and
+  soft resolution when Staff is absent;
+- compile/build resolution of the exact published type path.
+
+No integration or browser test is required because this slice adds no executable API or UI path.
+The first consumer must add its own authorized route and Staff-disabled conformance coverage.
+
+## Risks & Impact Review
+
+#### Cross-scope candidate disclosure
+- **Scenario**: A predicate or decryption scope omits tenant or organization and exposes a Staff
+  identity from another scope.
+- **Severity**: High
+- **Affected area**: Every optional consumer using candidate selection.
+- **Mitigation**: Both scope IDs are mandatory in count criteria, read criteria, and decryption
+  scope; tests assert the complete call shapes.
+- **Residual risk**: Low after focused isolation tests.
+
+#### Consumer treats discovery as authorization
+- **Scenario**: A consumer exposes candidates without authorizing the target resource, or assumes a
+  returned candidate may perform an action.
+- **Severity**: High
+- **Affected area**: Consumer APIs and private resources.
+- **Mitigation**: The contract is explicitly consumer-neutral and trusted-server only; consumers
+  own authentication, RBAC, and resource policy before calling.
+- **Residual risk**: Medium outside Staff because consumer conformance requires separate review.
+
+#### Linkage mode is applied incorrectly
+- **Scenario**: Membership selection includes unlinked Staff or assignment unnecessarily excludes
+  them.
+- **Severity**: Medium
+- **Affected area**: Membership and assignment selectors.
+- **Mitigation**: Frozen linkage literals have exact predicates and separate tests. Consumer mapping
+  remains explicit rather than inferred from route identity.
+- **Residual risk**: Low.
+
+#### Non-deterministic or unbounded picker queries
+- **Scenario**: Duplicate names move between pages, or a selector loads an entire organization.
+- **Severity**: Medium
+- **Affected area**: Large-organization request latency and selector stability.
+- **Mitigation**: Page size is capped at 100; offset/limit is mandatory; display name plus UUID is
+  the deterministic sort; wildcard search is escaped.
+- **Residual risk**: Offset pagination may shift under concurrent Staff edits, which is acceptable
+  for a transient picker and creates no stored state.
+
+#### Resolver failure is mistaken for module absence
+- **Scenario**: A consumer catches a DB/KMS error and shows an empty candidate list.
+- **Severity**: Medium
+- **Affected area**: User feedback and operational diagnosis.
+- **Mitigation**: Only missing DI registration is optional; execution errors propagate unchanged.
+- **Residual risk**: Low when consumers follow the documented resolution pattern.
+
+## Phasing
+
+This is one independently deployable read-only capability. Splitting contract, implementation, and
+registration would create unusable intermediate public surfaces, so they ship together in one phase.
+
+## Acceptance Criteria
+
+- [x] Exact type-only package path and request-scoped `staffCandidateResolver` registration exist.
+- [x] Scope, linkage, search, page, and page size validate before count or data reads.
+- [x] Both query paths enforce exact tenant/organization scope, active state, and non-deleted state.
+- [x] `required` excludes unlinked Staff while `any` includes linked and unlinked active Staff.
+- [x] Search is trimmed, bounded, case-insensitive, and treats wildcard characters literally.
+- [x] Pagination is capped, deterministic, and returns accurate zero/beyond-last metadata.
+- [x] Results expose only Staff UUID and display name; no ORM/Auth/profile data crosses the boundary.
+- [x] Count, database, and decryption failures propagate without partial fallback.
+- [x] Existing Staff entities, migrations, APIs, UI, ACLs, events, and public resolvers remain unchanged.
+- [x] Focused, combined, nearby, generation, typecheck, lint, core-build, and package-build gates pass.
+
+## Implementation Plan
+
+### Phase A — Candidate discovery contract
+
+1. Add the type-only public contract and exact package export.
+2. Implement validated, exact-scope, linked-mode-aware paginated Staff reads and minimal mapping.
+3. Register the scoped DI service and document the stable path/key and consumer-owned authorization.
+4. Add focused semantic, failure, scope-isolation, DI-lifetime, and exact-import tests.
+5. Run generation, focused and nearby tests, core typecheck/lint/build, repository package build, and
+   source/migration drift checks.
+
+### File Manifest
+
+| File | Action | Purpose |
+|---|---|---|
+| `.ai/specs/2026-08-13-staff-candidate-resolver-public-contract.md` | Create | Design, compatibility, and validation authority. |
+| `packages/core/src/modules/staff/contracts/candidateResolver.ts` | Create | Stable type-only public contract. |
+| `packages/core/src/modules/staff/lib/candidateResolver.ts` | Create | Staff-owned implementation. |
+| `packages/core/src/modules/staff/lib/__tests__/candidateResolver.test.ts` | Create | Focused behavioral and isolation tests. |
+| `packages/core/src/modules/staff/di.ts` | Modify | Add the scoped resolver token. |
+| `packages/core/src/modules/staff/__tests__/di.test.ts` | Modify | Add lifetime and CLASSIC-injection coverage. |
+| `packages/core/src/modules/staff/AGENTS.md` | Modify | Document the stable contract and boundary. |
+| `packages/core/package.json` | Modify | Freeze the exact public export path. |
+
+## Implementation Status
+
+| Phase | Status | Date | Notes |
+|---|---|---|---|
+| Phase A — Candidate discovery contract | Done | 2026-08-13 | Contract, resolver, scoped DI, export, documentation, and tests complete. |
+
+### Phase A — Detailed Progress
+
+- [x] Add the frozen type-only contract and package export.
+- [x] Implement validated, bounded, exact-scope candidate discovery.
+- [x] Register and document the request-scoped public DI service.
+- [x] Add semantic, isolation, failure, lifetime, and exact-import tests.
+- [x] Run the scoped validation and repository package-build gates.
+
+## Final Compliance Report — 2026-08-13
+
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md`
+- `packages/core/AGENTS.md`
+- `packages/core/src/modules/staff/AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+
+### Compliance Matrix
+
+| Rule Source | Rule | Status | Notes |
+|---|---|---|---|
+| Root `AGENTS.md` | No cross-module entity imports | Compliant | Only Staff imports its entity; consumers receive plain types. |
+| Root/core `AGENTS.md` | Exact tenant and organization scope | Compliant | Both IDs appear in count, read, and decryption scope. |
+| Core `AGENTS.md` | Encrypted reads use framework helpers | Compliant | Candidate entities are read with `findWithDecryption`; no custom crypto. |
+| Staff `AGENTS.md` | New cross-module Staff data uses a narrow DI service | Compliant | One candidate-only resolver is added and documented. |
+| `BACKWARD_COMPATIBILITY.md` | Public paths and DI names remain stable | Compliant | Exact additive path/key and extraction bridge are defined. |
+| Code-review checklist | Validate inputs and bound growing lists | Compliant | Full pre-query validation, 100-item cap, and deterministic paging. |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+|---|---|---|
+| Data fields match public contract | Pass | Existing Staff fields map to two output fields. |
+| API contracts match UI/UX | N/A | No HTTP or UI surface is added. |
+| Risks cover all writes | N/A | Resolver is read-only. |
+| Commands defined for mutations | N/A | No mutation exists. |
+| Cache strategy covers reads | Pass | No cache; bounded current Staff data is read directly. |
+| Module-absence behavior is defined | Pass | Consumers soft-resolve registration only; execution failures propagate. |
+| Backward compatibility is explicit | Pass | Additive stable surfaces and extraction bridge are documented. |
+
+### Non-Compliant Items
+
+None.
+
+### Verdict
+
+Fully compliant and ready for implementation. The independent fresh-context scope-cohesion review
+reported no Critical, High, Medium, or Low findings: linkage modes are cohesive query variants, and
+identity verification, known-ID projection, Auth-user scheduling lookup, customer-authorized HTTP,
+and consumer policy remain separate capabilities.
+
+### Implementation Validation
+
+- Final candidate resolver and Staff DI gate: 2 suites, 23 tests passed.
+- Combined identity, projection, candidate, and Staff DI gate: 4 suites, 50 tests passed.
+- Nearby Planner, Staff, and Customers regressions: 5 suites, 17 tests passed.
+- `yarn generate` passed and reported generated outputs unchanged.
+- Core typecheck and changed-file ESLint passed; ESLint emitted only the existing Next pages
+  directory warning.
+- Core build passed with 3,946 core and 204 generated entry points.
+- `yarn build:packages` passed all 22 package tasks.
+- The exact built contract subpath resolves; runtime exports are intentionally empty because the
+  module is type-only.
+- No entity or migration file changed.
+
+The wider repository baselines already recorded by the related identity-resolver implementation
+remain unrelated Windows/environment failures (path casing/absolute-path expectations, POSIX
+permission assertions, and environment-state assumptions). They are outside this resolver's change
+surface and are not hidden or suppressed here.
+
+## References
+
+- [Plane Python SDK — lightweight paginated workspace/project members](https://github.com/makeplane/plane-python-sdk)
+- [Plane MCP Server — member filters and lightweight pagination](https://github.com/makeplane/plane-mcp-server/releases)
+- [Staff decoupling specification](implemented/2026-05-08-staff-decouple-from-core.md)
+- [`BACKWARD_COMPATIBILITY.md`](../../BACKWARD_COMPATIBILITY.md)
+
+## Changelog
+
+- 2026-08-13 — Created the skeleton from the reviewed Task & Project Management C1 prerequisite.
+- 2026-08-13 — Added market comparison, frozen contract, exact query semantics, failure behavior,
+  compatibility rules, risks, tests, implementation plan, and compliance review.
+- 2026-08-13 — Passed independent fresh-context scope-cohesion review with no findings; marked ready
+  for implementation.
+- 2026-08-13 — Implemented the contract, candidate query, scoped DI registration, package export,
+  documentation, and focused regression coverage; all scoped and package-build gates passed.

--- a/.ai/specs/2026-08-13-staff-identity-projection-resolver-public-contract.md
+++ b/.ai/specs/2026-08-13-staff-identity-projection-resolver-public-contract.md
@@ -1,0 +1,150 @@
+# Staff Identity Projection Resolver Public Contract
+
+| Field | Value |
+|---|---|
+| **Status** | Implemented — validated with known unrelated repository baselines |
+| **Created** | 2026-08-13 |
+| **Target** | Current core `staff` module |
+| **Related** | `2026-08-12-staff-identity-resolver-public-contract.md`, `2026-07-15-staff-member-directory.md` |
+
+## TLDR
+
+Add one stable, Staff-owned, request-scoped `staffIdentityProjectionResolver` DI service. It
+hydrates at most 100 known Staff UUIDs into minimal display projections, including inactive
+non-deleted records, without exposing Staff entities or Auth linkage.
+
+There is no entity, migration, API, UI, ACL, event, cache, worker, dependency, or downstream
+consumer change.
+
+## Problem Statement
+
+Server modules that persist Staff UUID references need historical labels without importing Staff
+entities. The active-only `staffIdentityResolver` cannot represent inactive historical identities,
+and searchable candidate discovery has different filtering and pagination semantics.
+
+The proposed `staffMemberDirectory` is also not a substitute: it accepts Auth user IDs, returns
+active scheduling references with Auth and availability metadata, deliberately preserves duplicate
+Staff links, and uses different batching semantics. This resolver accepts exact Staff IDs, includes
+inactive history, validates a hard bound of 100, and exposes no Auth or scheduling data.
+
+## Proposed Solution
+
+Export types from the exact path
+`@open-mercato/core/modules/staff/contracts/identityProjectionResolver`, implement the read inside
+Staff with encryption-aware helpers, and register it under the frozen Awilix key
+`staffIdentityProjectionResolver`.
+
+The resolver validates exact tenant and organization scope, validates and deduplicates at most 100
+input UUIDs before querying, returns active or inactive non-deleted matches, and omits missing,
+deleted, and cross-scope rows indistinguishably. Empty input returns without querying. Operational
+failures propagate without partial or plaintext fallback.
+
+## Architecture
+
+```ts
+export type StaffIdentityProjectionScope = {
+  tenantId: string
+  organizationId: string
+}
+
+export type StaffIdentityProjection = {
+  staffMemberId: string
+  displayName: string
+  isActive: boolean
+}
+
+export type StaffIdentityProjectionResolver = {
+  resolveByIds(
+    scope: StaffIdentityProjectionScope,
+    staffMemberIds: string[],
+  ): Promise<StaffIdentityProjection[]>
+}
+```
+
+The service promises neither input ordering nor placeholder rows. Consumers map results by
+`staffMemberId`, own authorization, and preserve UUID fallbacks for omitted identities. No Auth
+UUID, team, role, contact, description, or ORM object crosses the public boundary.
+
+## Data Models
+
+No schema change. The implementation reads existing `StaffTeamMember` rows through
+`findWithDecryption`, repeating tenant and organization scope in the ORM predicate and decryption
+scope. It filters `deletedAt: null` but deliberately does not filter `isActive`.
+
+## API Contracts
+
+No HTTP, OpenAPI, MCP, or portal API is added. This is a trusted server-side DI contract only.
+
+## Migration & Backward Compatibility
+
+The contract, exact import path, DI key, method name, required input fields, and projection fields
+are additive stable surfaces under `BACKWARD_COMPATIBILITY.md`. Once released, incompatible change
+requires deprecation, a working bridge for at least one minor release, and upgrade guidance.
+
+If Staff is extracted, the new package becomes canonical while the core path remains a deprecated,
+type-compatible bridge for the required compatibility window. Before release, rollback removes the
+contract, implementation, registration, export, documentation, and tests together. No database
+rollback is needed.
+
+## Testing Strategy
+
+Focused tests assert pre-query validation and bounds, empty-input short-circuiting, deduplication,
+exact scope, inactive inclusion, deleted/missing omission, minimal projection, output deduplication,
+failure propagation, exact published type import, CLASSIC injection, and request-scope isolation.
+
+## Risks & Impact Review
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Cross-scope historical identity disclosure | High | Exact scope in predicate and decryption context; negative tests assert the full call. |
+| Callers treat output position as authoritative | Medium | No order promise; documentation requires mapping by Staff UUID. |
+| Excessive batch size causes broad reads | Medium | Reject more than 100 IDs before querying and deduplicate accepted inputs. |
+| KMS/DB failure yields incomplete labels | Medium | Propagate failures; never return partial or plaintext results. |
+
+## Acceptance Criteria
+
+- [x] Exact type path and request-scoped `staffIdentityProjectionResolver` registration exist.
+- [x] Scope and at most 100 UUIDs validate before query; empty input performs no query.
+- [x] Inputs and outputs are deduplicated and exact-scope non-deleted rows are returned.
+- [x] Active and inactive Staff are included; missing, deleted, and cross-scope rows are omitted.
+- [x] Output contains only Staff UUID, display name, and active state.
+- [x] Database/decryption failures propagate without partial fallback.
+- [x] Existing Staff entities, routes, ACLs, events, and public resolvers remain unchanged.
+- [x] Focused tests and configured validation gates pass without entity or migration drift.
+
+## Implementation Plan
+
+1. Add the type-only contract and internal Staff resolver.
+2. Register the resolver as scoped and document/export the stable surface.
+3. Add semantic, isolation, and published-import tests.
+4. Run generation, focused tests, package build/typecheck, and the configured review gate.
+
+## Final Compliance Report
+
+Implemented as an additive, type-only public contract backed by a Staff-owned scoped resolver. No
+entity, migration, API, UI, ACL, event, or module-structure file changed.
+
+Validation completed on 2026-08-13:
+
+- Projection resolver and Staff DI tests: 2 suites, 19 tests passed.
+- Combined identity resolver, projection resolver, and Staff DI tests: 3 suites, 33 tests passed.
+- Nearby Planner, Staff, and Customers regressions: 5 suites, 17 tests passed.
+- Core typecheck and changed-file ESLint passed; ESLint emitted only the existing Next.js pages
+  directory warning.
+- `yarn generate` completed with generated outputs unchanged.
+- Core build passed, including 3,944 core and 204 generated entry points.
+- `yarn build:packages` passed all 22 package tasks.
+- The exact built contract subpath resolves; its runtime export is intentionally empty because the
+  public module exports types only.
+
+The wider repository baselines already recorded by the related identity-resolver implementation
+remain unrelated Windows/environment failures (path casing/absolute-path expectations, POSIX
+permission assertions, and environment-state assumptions). They do not touch this resolver's
+change surface and are not masked by this implementation.
+
+## Changelog
+
+- 2026-08-13 - Created the upstream implementation specification from the reviewed downstream
+  Task & Project Management prerequisite.
+- 2026-08-13 - Implemented and validated the public projection contract, scoped resolver, DI
+  registration, package export, documentation, and focused regression coverage.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -134,6 +134,18 @@
       "types": "./src/modules/api_keys/index.ts",
       "default": "./dist/modules/api_keys/index.js"
     },
+    "./modules/staff/contracts/identityResolver": {
+      "types": "./src/modules/staff/contracts/identityResolver.ts",
+      "default": "./dist/modules/staff/contracts/identityResolver.js"
+    },
+    "./modules/staff/contracts/identityProjectionResolver": {
+      "types": "./src/modules/staff/contracts/identityProjectionResolver.ts",
+      "default": "./dist/modules/staff/contracts/identityProjectionResolver.js"
+    },
+    "./modules/staff/contracts/candidateResolver": {
+      "types": "./src/modules/staff/contracts/candidateResolver.ts",
+      "default": "./dist/modules/staff/contracts/candidateResolver.js"
+    },
     "./modules/widgets/lib/injection": {
       "types": "./src/modules/widgets/lib/injection.ts",
       "default": "./dist/modules/widgets/lib/injection.js"

--- a/packages/core/src/modules/staff/AGENTS.md
+++ b/packages/core/src/modules/staff/AGENTS.md
@@ -16,7 +16,28 @@ See [`.ai/specs/implemented/2026-05-08-staff-decouple-from-core.md`](../../../..
 
 | Key | Contract |
 |-----|----------|
-| `availabilityAccessResolver` | Resolves an `AvailabilityWriteAccess` shape for the authenticated request, including whether the caller may edit availability for all members vs only themselves. Consumed by `planner/api/access.ts` via `container.resolve(..., { allowUnregistered: true })` — planner gracefully degrades to `403 staff_module_not_loaded` when staff is absent. |
+| `staffIdentityResolver` | Request-scoped, read-only resolver for the current active Auth-to-Staff link in one exact tenant and organization. Consumers own authorization and MUST soft-resolve it when Staff is optional. |
+| `staffIdentityProjectionResolver` | Request-scoped, read-only hydration of at most 100 known Staff UUIDs into minimal active-or-inactive, non-deleted identity projections in one exact tenant and organization. It is presentation-only; consumers own authorization and MUST soft-resolve it when Staff is optional. |
+| `staffCandidateResolver` | Request-scoped, read-only, bounded candidate discovery for active Staff in one exact tenant and organization. `required` linkage includes only Auth-linked Staff; `any` also includes unlinked Staff. Consumers own authorization and MUST soft-resolve it when Staff is optional. |
+| `availabilityAccessResolver` | Resolves an `AvailabilityWriteAccess` shape for the authenticated request, including whether the caller may edit availability for all members vs only themselves. Consumed by `planner/api/access.ts` via `container.resolve(..., { allowUnregistered: true })` - planner gracefully degrades to `403 staff_module_not_loaded` when staff is absent. |
+
+`staffIdentityResolver` exposes only the types from
+`@open-mercato/core/modules/staff/contracts/identityResolver`. The contract returns a minimal
+identity projection and reports duplicate active Auth linkage as `ambiguous`; it never exposes a
+Staff entity. Database/decryption failures propagate and MUST NOT be treated as module absence.
+
+`staffIdentityProjectionResolver` exposes only the types from
+`@open-mercato/core/modules/staff/contracts/identityProjectionResolver`. It accepts known Staff
+UUIDs, includes inactive non-deleted identities for historical display, and returns only Staff UUID,
+decrypted display name, and active state. It performs no Auth lookup, search, paging, or authorization.
+Database/decryption failures propagate and MUST NOT be treated as module absence.
+
+`staffCandidateResolver` exposes only the types from
+`@open-mercato/core/modules/staff/contracts/candidateResolver`. It returns bounded, deterministic
+pages containing only active Staff UUID and decrypted display name. It performs no authentication,
+RBAC, resource policy, assignment eligibility, or HTTP handling. Consumers MUST derive scope from
+authenticated context and authorize the target before calling. Database/decryption failures
+propagate and MUST NOT be treated as module absence.
 
 Resolver shape (from `lib/availabilityAccess.ts`):
 
@@ -75,4 +96,7 @@ This asymmetry will be reconciled in the Phase 2/3 follow-up when staff becomes 
 |-------|-------|
 | DI registrar pattern | [`di.ts`](./di.ts) — call `register(container)` from bootstrap; never call directly from another module |
 | Availability access types | `import type { AvailabilityWriteAccess, AvailabilityAccessContext } from '@open-mercato/core/modules/planner/api/access'` (planner re-exports the same shape it consumes; do not import from staff directly) |
-| Anything else | Go through a public API route — never import entity classes |
+| Staff identity resolver types | `import type { StaffIdentityResolver, StaffIdentityLookupResult } from '@open-mercato/core/modules/staff/contracts/identityResolver'` |
+| Staff identity projection types | `import type { StaffIdentityProjectionResolver } from '@open-mercato/core/modules/staff/contracts/identityProjectionResolver'` |
+| Staff candidate resolver types | `import type { StaffCandidateResolver, StaffCandidatePage } from '@open-mercato/core/modules/staff/contracts/candidateResolver'` |
+| Anything else | Go through a public API route - never import entity classes |

--- a/packages/core/src/modules/staff/__tests__/di.test.ts
+++ b/packages/core/src/modules/staff/__tests__/di.test.ts
@@ -1,9 +1,19 @@
 /** @jest-environment node */
 
-import { createContainer, InjectionMode } from 'awilix'
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { asValue, createContainer, InjectionMode } from 'awilix'
+import type { StaffIdentityResolver } from '@open-mercato/core/modules/staff/contracts/identityResolver'
+import type { StaffIdentityProjectionResolver } from '@open-mercato/core/modules/staff/contracts/identityProjectionResolver'
+import type { StaffCandidateResolver } from '@open-mercato/core/modules/staff/contracts/candidateResolver'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { register } from '../di'
 
-describe('staff/di — availabilityAccessResolver registration', () => {
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn().mockResolvedValue([]),
+}))
+
+describe('staff/di registrations', () => {
   it('registers the availabilityAccessResolver token with a resolveAvailabilityWriteAccess method', () => {
     const container = createContainer({ injectionMode: InjectionMode.PROXY })
     register(container)
@@ -20,5 +30,181 @@ describe('staff/di — availabilityAccessResolver registration', () => {
       allowUnregistered: true,
     })
     expect(resolver).toBeUndefined()
+  })
+
+  it('registers a CLASSIC-compatible resolver isolated to each request scope', async () => {
+    const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+    register(container)
+
+    const firstScope = container.createScope()
+    const secondScope = container.createScope()
+    const firstEm = { scope: 'first' } as unknown as EntityManager
+    const secondEm = { scope: 'second' } as unknown as EntityManager
+    firstScope.register({ em: asValue(firstEm) })
+    secondScope.register({ em: asValue(secondEm) })
+    const first = firstScope.resolve<StaffIdentityResolver>('staffIdentityResolver')
+    const firstAgain = firstScope.resolve<StaffIdentityResolver>('staffIdentityResolver')
+    const second = secondScope.resolve<StaffIdentityResolver>('staffIdentityResolver')
+
+    expect(container.hasRegistration('staffIdentityResolver')).toBe(true)
+    expect(typeof first.resolveByUserId).toBe('function')
+    expect(typeof first.resolveByStaffMemberId).toBe('function')
+    expect(firstAgain).toBe(first)
+    expect(second).not.toBe(first)
+
+    const lookupScope = {
+      tenantId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+    }
+    const userId = '33333333-3333-4333-8333-333333333333'
+    await first.resolveByUserId(lookupScope, userId)
+    await second.resolveByUserId(lookupScope, userId)
+
+    expect(findWithDecryption).toHaveBeenNthCalledWith(
+      1,
+      firstEm,
+      expect.any(Function),
+      expect.any(Object),
+      { limit: 2 },
+      lookupScope,
+    )
+    expect(findWithDecryption).toHaveBeenNthCalledWith(
+      2,
+      secondEm,
+      expect.any(Function),
+      expect.any(Object),
+      { limit: 2 },
+      lookupScope,
+    )
+  })
+
+  it('returns undefined when staffIdentityResolver is not registered', () => {
+    const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+
+    expect(container.resolve('staffIdentityResolver', { allowUnregistered: true })).toBeUndefined()
+  })
+
+  it('registers a CLASSIC-compatible projection resolver isolated to each request scope', async () => {
+    jest.clearAllMocks()
+    const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+    register(container)
+
+    const firstScope = container.createScope()
+    const secondScope = container.createScope()
+    const firstEm = { scope: 'first-projection' } as unknown as EntityManager
+    const secondEm = { scope: 'second-projection' } as unknown as EntityManager
+    firstScope.register({ em: asValue(firstEm) })
+    secondScope.register({ em: asValue(secondEm) })
+    const first = firstScope.resolve<StaffIdentityProjectionResolver>(
+      'staffIdentityProjectionResolver',
+    )
+    const firstAgain = firstScope.resolve<StaffIdentityProjectionResolver>(
+      'staffIdentityProjectionResolver',
+    )
+    const second = secondScope.resolve<StaffIdentityProjectionResolver>(
+      'staffIdentityProjectionResolver',
+    )
+
+    expect(container.hasRegistration('staffIdentityProjectionResolver')).toBe(true)
+    expect(typeof first.resolveByIds).toBe('function')
+    expect(firstAgain).toBe(first)
+    expect(second).not.toBe(first)
+
+    const lookupScope = {
+      tenantId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+    }
+    const staffMemberId = '33333333-3333-4333-8333-333333333333'
+    await first.resolveByIds(lookupScope, [staffMemberId])
+    await second.resolveByIds(lookupScope, [staffMemberId])
+
+    expect(findWithDecryption).toHaveBeenNthCalledWith(
+      1,
+      firstEm,
+      expect.any(Function),
+      expect.objectContaining({ id: { $in: [staffMemberId] } }),
+      undefined,
+      lookupScope,
+    )
+    expect(findWithDecryption).toHaveBeenNthCalledWith(
+      2,
+      secondEm,
+      expect.any(Function),
+      expect.objectContaining({ id: { $in: [staffMemberId] } }),
+      undefined,
+      lookupScope,
+    )
+  })
+
+  it('returns undefined when staffIdentityProjectionResolver is not registered', () => {
+    const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+
+    expect(
+      container.resolve('staffIdentityProjectionResolver', { allowUnregistered: true }),
+    ).toBeUndefined()
+  })
+
+  it('registers a CLASSIC-compatible candidate resolver isolated to each request scope', async () => {
+    jest.clearAllMocks()
+    const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+    register(container)
+
+    const firstScope = container.createScope()
+    const secondScope = container.createScope()
+    const firstCount = jest.fn().mockResolvedValue(1)
+    const secondCount = jest.fn().mockResolvedValue(1)
+    const firstEm = { count: firstCount } as unknown as EntityManager
+    const secondEm = { count: secondCount } as unknown as EntityManager
+    firstScope.register({ em: asValue(firstEm) })
+    secondScope.register({ em: asValue(secondEm) })
+    const first = firstScope.resolve<StaffCandidateResolver>('staffCandidateResolver')
+    const firstAgain = firstScope.resolve<StaffCandidateResolver>('staffCandidateResolver')
+    const second = secondScope.resolve<StaffCandidateResolver>('staffCandidateResolver')
+
+    expect(container.hasRegistration('staffCandidateResolver')).toBe(true)
+    expect(typeof first.listCandidates).toBe('function')
+    expect(firstAgain).toBe(first)
+    expect(second).not.toBe(first)
+
+    const input = {
+      tenantId: '11111111-1111-4111-8111-111111111111',
+      organizationId: '22222222-2222-4222-8222-222222222222',
+      linkage: 'any' as const,
+      page: 1,
+      pageSize: 25,
+    }
+    await first.listCandidates(input)
+    await second.listCandidates(input)
+
+    expect(firstCount).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({
+      tenantId: input.tenantId,
+      organizationId: input.organizationId,
+    }))
+    expect(secondCount).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({
+      tenantId: input.tenantId,
+      organizationId: input.organizationId,
+    }))
+    expect(findWithDecryption).toHaveBeenNthCalledWith(
+      1,
+      firstEm,
+      expect.any(Function),
+      expect.any(Object),
+      expect.objectContaining({ limit: 25, offset: 0 }),
+      { tenantId: input.tenantId, organizationId: input.organizationId },
+    )
+    expect(findWithDecryption).toHaveBeenNthCalledWith(
+      2,
+      secondEm,
+      expect.any(Function),
+      expect.any(Object),
+      expect.objectContaining({ limit: 25, offset: 0 }),
+      { tenantId: input.tenantId, organizationId: input.organizationId },
+    )
+  })
+
+  it('returns undefined when staffCandidateResolver is not registered', () => {
+    const container = createContainer({ injectionMode: InjectionMode.CLASSIC })
+
+    expect(container.resolve('staffCandidateResolver', { allowUnregistered: true })).toBeUndefined()
   })
 })

--- a/packages/core/src/modules/staff/contracts/candidateResolver.ts
+++ b/packages/core/src/modules/staff/contracts/candidateResolver.ts
@@ -1,0 +1,28 @@
+export type StaffCandidateScope = {
+  tenantId: string
+  organizationId: string
+}
+
+export type StaffCandidateLinkage = 'required' | 'any'
+
+export type StaffCandidate = {
+  staffMemberId: string
+  displayName: string
+}
+
+export type StaffCandidatePage = {
+  items: StaffCandidate[]
+  total: number
+  page: number
+  pageSize: number
+  totalPages: number
+}
+
+export type StaffCandidateResolver = {
+  listCandidates(input: StaffCandidateScope & {
+    linkage: StaffCandidateLinkage
+    search?: string
+    page: number
+    pageSize: number
+  }): Promise<StaffCandidatePage>
+}

--- a/packages/core/src/modules/staff/contracts/identityProjectionResolver.ts
+++ b/packages/core/src/modules/staff/contracts/identityProjectionResolver.ts
@@ -1,0 +1,17 @@
+export type StaffIdentityProjectionScope = {
+  tenantId: string
+  organizationId: string
+}
+
+export type StaffIdentityProjection = {
+  staffMemberId: string
+  displayName: string
+  isActive: boolean
+}
+
+export type StaffIdentityProjectionResolver = {
+  resolveByIds(
+    scope: StaffIdentityProjectionScope,
+    staffMemberIds: string[],
+  ): Promise<StaffIdentityProjection[]>
+}

--- a/packages/core/src/modules/staff/contracts/identityResolver.ts
+++ b/packages/core/src/modules/staff/contracts/identityResolver.ts
@@ -1,0 +1,28 @@
+export type StaffIdentityScope = {
+  tenantId: string
+  organizationId: string
+}
+
+export type StaffIdentity = {
+  staffMemberId: string
+  userId: string | null
+  displayName: string
+  isActive: boolean
+}
+
+export type StaffIdentityLookupResult =
+  | { kind: 'found'; identity: StaffIdentity }
+  | { kind: 'not_found' }
+  | { kind: 'ambiguous' }
+
+export type StaffIdentityResolver = {
+  resolveByUserId(
+    scope: StaffIdentityScope,
+    userId: string,
+  ): Promise<StaffIdentityLookupResult>
+
+  resolveByStaffMemberId(
+    scope: StaffIdentityScope,
+    staffMemberId: string,
+  ): Promise<StaffIdentityLookupResult>
+}

--- a/packages/core/src/modules/staff/di.ts
+++ b/packages/core/src/modules/staff/di.ts
@@ -1,10 +1,13 @@
-import { asValue } from 'awilix'
+import { asFunction, asValue } from 'awilix'
 import type { AppContainer } from '@open-mercato/shared/lib/di/container'
 import {
   resolveAvailabilityWriteAccess,
   type AvailabilityAccessContext,
   type AvailabilityWriteAccess,
 } from './lib/availabilityAccess'
+import { createStaffIdentityResolver } from './lib/identityResolver'
+import { createStaffIdentityProjectionResolver } from './lib/identityProjectionResolver'
+import { createStaffCandidateResolver } from './lib/candidateResolver'
 
 export type AvailabilityAccessResolver = {
   resolveAvailabilityWriteAccess(
@@ -16,5 +19,8 @@ export function register(container: AppContainer) {
   const resolver: AvailabilityAccessResolver = { resolveAvailabilityWriteAccess }
   container.register({
     availabilityAccessResolver: asValue(resolver),
+    staffIdentityResolver: asFunction(createStaffIdentityResolver).scoped(),
+    staffIdentityProjectionResolver: asFunction(createStaffIdentityProjectionResolver).scoped(),
+    staffCandidateResolver: asFunction(createStaffCandidateResolver).scoped(),
   })
 }

--- a/packages/core/src/modules/staff/lib/__tests__/candidateResolver.test.ts
+++ b/packages/core/src/modules/staff/lib/__tests__/candidateResolver.test.ts
@@ -1,0 +1,194 @@
+/** @jest-environment node */
+
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import type {
+  StaffCandidateScope,
+} from '@open-mercato/core/modules/staff/contracts/candidateResolver'
+import { StaffTeamMember } from '../../data/entities'
+import { createStaffCandidateResolver } from '../candidateResolver'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(),
+}))
+
+const mockFindWithDecryption = findWithDecryption as jest.MockedFunction<
+  typeof findWithDecryption
+>
+
+const scope: StaffCandidateScope = {
+  tenantId: '11111111-1111-4111-8111-111111111111',
+  organizationId: '22222222-2222-4222-8222-222222222222',
+}
+const firstStaffMemberId = '33333333-3333-4333-8333-333333333333'
+const secondStaffMemberId = '44444444-4444-4444-8444-444444444444'
+
+function member(overrides: Partial<StaffTeamMember> = {}): StaffTeamMember {
+  return {
+    id: firstStaffMemberId,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    displayName: 'Ada Lovelace',
+    userId: '55555555-5555-4555-8555-555555555555',
+    isActive: true,
+    deletedAt: null,
+    ...overrides,
+  } as StaffTeamMember
+}
+
+describe('createStaffCandidateResolver', () => {
+  const mockCount = jest.fn()
+  const em = { count: mockCount } as unknown as EntityManager
+  const resolver = createStaffCandidateResolver(em)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockCount.mockResolvedValue(2)
+    mockFindWithDecryption.mockResolvedValue([])
+  })
+
+  it('returns a linked-only searched page with exact scope and minimal fields', async () => {
+    const search = 'Ada%_\\'
+    mockCount.mockResolvedValue(3)
+    mockFindWithDecryption.mockResolvedValue([
+      member({ id: secondStaffMemberId, displayName: 'Ada Byron' }),
+      member(),
+    ])
+
+    const result = await resolver.listCandidates({
+      ...scope,
+      linkage: 'required',
+      search: `  ${search}  `,
+      page: 2,
+      pageSize: 2,
+    })
+
+    const where = {
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      deletedAt: null,
+      isActive: true,
+      userId: { $ne: null },
+      displayName: { $ilike: `%${escapeLikePattern(search)}%` },
+    }
+    expect(mockCount).toHaveBeenCalledWith(StaffTeamMember, where)
+    expect(mockFindWithDecryption).toHaveBeenCalledWith(
+      em,
+      StaffTeamMember,
+      where,
+      {
+        limit: 2,
+        offset: 2,
+        orderBy: { displayName: 'asc', id: 'asc' },
+      },
+      scope,
+    )
+    expect(result).toEqual({
+      items: [
+        { staffMemberId: secondStaffMemberId, displayName: 'Ada Byron' },
+        { staffMemberId: firstStaffMemberId, displayName: 'Ada Lovelace' },
+      ],
+      total: 3,
+      page: 2,
+      pageSize: 2,
+      totalPages: 2,
+    })
+    expect(result.items.every((item) => !('userId' in item))).toBe(true)
+  })
+
+  it('includes linked and unlinked active Staff for any linkage without an empty search filter', async () => {
+    mockFindWithDecryption.mockResolvedValue([
+      member({ userId: null }),
+    ])
+
+    await expect(resolver.listCandidates({
+      ...scope,
+      linkage: 'any',
+      search: '   ',
+      page: 1,
+      pageSize: 100,
+    })).resolves.toMatchObject({
+      items: [{ staffMemberId: firstStaffMemberId, displayName: 'Ada Lovelace' }],
+      pageSize: 100,
+    })
+
+    const where = mockCount.mock.calls[0]?.[1]
+    expect(where).toEqual({
+      tenantId: scope.tenantId,
+      organizationId: scope.organizationId,
+      deletedAt: null,
+      isActive: true,
+    })
+    expect(where).not.toHaveProperty('userId')
+    expect(where).not.toHaveProperty('displayName')
+    expect(mockFindWithDecryption.mock.calls[0]?.[2]).toEqual(where)
+  })
+
+  it.each([
+    ['no matches', 0, 1, 0],
+    ['a page beyond the end', 2, 3, 2],
+  ] as const)(
+    'returns empty items without a data query for %s',
+    async (_label, total, page, totalPages) => {
+      mockCount.mockResolvedValue(total)
+
+      await expect(resolver.listCandidates({
+        ...scope,
+        linkage: 'any',
+        page,
+        pageSize: 1,
+      })).resolves.toEqual({
+        items: [],
+        total,
+        page,
+        pageSize: 1,
+        totalPages,
+      })
+      expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    ['null input', null],
+    ['tenant UUID', { ...scope, tenantId: 'invalid', linkage: 'any', page: 1, pageSize: 25 }],
+    ['organization UUID', { ...scope, organizationId: '', linkage: 'any', page: 1, pageSize: 25 }],
+    ['linkage', { ...scope, linkage: 'linked', page: 1, pageSize: 25 }],
+    ['search length', { ...scope, linkage: 'any', search: 'x'.repeat(201), page: 1, pageSize: 25 }],
+    ['page zero', { ...scope, linkage: 'any', page: 0, pageSize: 25 }],
+    ['fractional page', { ...scope, linkage: 'any', page: 1.5, pageSize: 25 }],
+    ['page size zero', { ...scope, linkage: 'any', page: 1, pageSize: 0 }],
+    ['page size above 100', { ...scope, linkage: 'any', page: 1, pageSize: 101 }],
+  ])('rejects an invalid %s before either query', async (_label, input) => {
+    await expect(
+      resolver.listCandidates(input as Parameters<typeof resolver.listCandidates>[0]),
+    ).rejects.toBeInstanceOf(TypeError)
+    expect(mockCount).not.toHaveBeenCalled()
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('propagates count failures before loading a page', async () => {
+    const failure = new Error('count failed')
+    mockCount.mockRejectedValueOnce(failure)
+
+    await expect(resolver.listCandidates({
+      ...scope,
+      linkage: 'any',
+      page: 1,
+      pageSize: 25,
+    })).rejects.toBe(failure)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('propagates database or decryption failures without a partial page', async () => {
+    const failure = new Error('read failed')
+    mockFindWithDecryption.mockRejectedValueOnce(failure)
+
+    await expect(resolver.listCandidates({
+      ...scope,
+      linkage: 'any',
+      page: 1,
+      pageSize: 25,
+    })).rejects.toBe(failure)
+  })
+})

--- a/packages/core/src/modules/staff/lib/__tests__/identityProjectionResolver.test.ts
+++ b/packages/core/src/modules/staff/lib/__tests__/identityProjectionResolver.test.ts
@@ -1,0 +1,158 @@
+/** @jest-environment node */
+
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import type {
+  StaffIdentityProjectionScope,
+} from '@open-mercato/core/modules/staff/contracts/identityProjectionResolver'
+import { StaffTeamMember } from '../../data/entities'
+import { createStaffIdentityProjectionResolver } from '../identityProjectionResolver'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(),
+}))
+
+const mockFindWithDecryption = findWithDecryption as jest.MockedFunction<
+  typeof findWithDecryption
+>
+
+const scope: StaffIdentityProjectionScope = {
+  tenantId: '11111111-1111-4111-8111-111111111111',
+  organizationId: '22222222-2222-4222-8222-222222222222',
+}
+const firstStaffMemberId = '33333333-3333-4333-8333-333333333333'
+const secondStaffMemberId = '44444444-4444-4444-8444-444444444444'
+
+function member(overrides: Partial<StaffTeamMember> = {}): StaffTeamMember {
+  return {
+    id: firstStaffMemberId,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    displayName: 'Ada Lovelace',
+    userId: '55555555-5555-4555-8555-555555555555',
+    isActive: true,
+    ...overrides,
+  } as StaffTeamMember
+}
+
+function makeStaffMemberId(index: number): string {
+  return `00000000-0000-4000-8000-${String(index).padStart(12, '0')}`
+}
+
+describe('createStaffIdentityProjectionResolver', () => {
+  const em = {} as EntityManager
+  const resolver = createStaffIdentityProjectionResolver(em)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns an empty projection without querying for a valid empty input', async () => {
+    await expect(resolver.resolveByIds(scope, [])).resolves.toEqual([])
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('returns active and inactive non-deleted matches with exact scope and minimal fields', async () => {
+    mockFindWithDecryption.mockResolvedValue([
+      member({ id: secondStaffMemberId, displayName: 'Grace Hopper', isActive: false }),
+      member(),
+    ])
+
+    const result = await resolver.resolveByIds(scope, [firstStaffMemberId, secondStaffMemberId])
+
+    expect(result).toEqual([
+      {
+        staffMemberId: secondStaffMemberId,
+        displayName: 'Grace Hopper',
+        isActive: false,
+      },
+      {
+        staffMemberId: firstStaffMemberId,
+        displayName: 'Ada Lovelace',
+        isActive: true,
+      },
+    ])
+    expect(result.every((projection) => !('userId' in projection))).toBe(true)
+    expect(mockFindWithDecryption).toHaveBeenCalledWith(
+      em,
+      StaffTeamMember,
+      {
+        id: { $in: [firstStaffMemberId, secondStaffMemberId] },
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        deletedAt: null,
+      },
+      undefined,
+      scope,
+    )
+    const where = mockFindWithDecryption.mock.calls[0]?.[2]
+    expect(where).not.toHaveProperty('isActive')
+  })
+
+  it('deduplicates input IDs before querying and duplicate rows before returning', async () => {
+    mockFindWithDecryption.mockResolvedValue([
+      member(),
+      member({ displayName: 'Latest decrypted value' }),
+    ])
+
+    await expect(
+      resolver.resolveByIds(scope, [firstStaffMemberId, firstStaffMemberId]),
+    ).resolves.toEqual([
+      {
+        staffMemberId: firstStaffMemberId,
+        displayName: 'Latest decrypted value',
+        isActive: true,
+      },
+    ])
+    expect(mockFindWithDecryption.mock.calls[0]?.[2]).toMatchObject({
+      id: { $in: [firstStaffMemberId] },
+    })
+  })
+
+  it('accepts exactly 100 raw IDs', async () => {
+    const ids = Array.from({ length: 100 }, (_, index) => makeStaffMemberId(index + 1))
+    mockFindWithDecryption.mockResolvedValue([])
+
+    await expect(resolver.resolveByIds(scope, ids)).resolves.toEqual([])
+    expect(mockFindWithDecryption).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects more than 100 raw IDs before deduplication or query', async () => {
+    const repeatedIds = Array.from({ length: 101 }, () => firstStaffMemberId)
+
+    await expect(resolver.resolveByIds(scope, repeatedIds)).rejects.toBeInstanceOf(TypeError)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['tenant ID', { ...scope, tenantId: 'invalid' }, [firstStaffMemberId]],
+    ['organization ID', { ...scope, organizationId: '' }, [firstStaffMemberId]],
+    ['Staff member ID', scope, ['not-a-uuid']],
+  ] as const)('rejects an invalid %s before querying', async (_label, invalidScope, ids) => {
+    await expect(resolver.resolveByIds(invalidScope, [...ids])).rejects.toBeInstanceOf(TypeError)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('rejects a non-array runtime input before querying', async () => {
+    await expect(
+      resolver.resolveByIds(scope, null as unknown as string[]),
+    ).rejects.toBeInstanceOf(TypeError)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it.each(['missing', 'deleted', 'cross-scope'])(
+    'omits a %s Staff row filtered out by the exact scoped query',
+    async () => {
+      mockFindWithDecryption.mockResolvedValue([])
+
+      await expect(resolver.resolveByIds(scope, [firstStaffMemberId])).resolves.toEqual([])
+    },
+  )
+
+  it('propagates database or decryption failures without a partial result', async () => {
+    const failure = new Error('read failed')
+    mockFindWithDecryption.mockRejectedValueOnce(failure)
+
+    await expect(resolver.resolveByIds(scope, [firstStaffMemberId])).rejects.toBe(failure)
+  })
+})

--- a/packages/core/src/modules/staff/lib/__tests__/identityResolver.test.ts
+++ b/packages/core/src/modules/staff/lib/__tests__/identityResolver.test.ts
@@ -1,0 +1,171 @@
+/** @jest-environment node */
+
+import type { EntityManager } from '@mikro-orm/postgresql'
+import {
+  findOneWithDecryption,
+  findWithDecryption,
+} from '@open-mercato/shared/lib/encryption/find'
+import type { StaffIdentityScope } from '@open-mercato/core/modules/staff/contracts/identityResolver'
+import { StaffTeamMember } from '../../data/entities'
+import { createStaffIdentityResolver } from '../identityResolver'
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn(),
+}))
+
+const mockFindOneWithDecryption = findOneWithDecryption as jest.MockedFunction<
+  typeof findOneWithDecryption
+>
+const mockFindWithDecryption = findWithDecryption as jest.MockedFunction<
+  typeof findWithDecryption
+>
+
+const scope: StaffIdentityScope = {
+  tenantId: '11111111-1111-4111-8111-111111111111',
+  organizationId: '22222222-2222-4222-8222-222222222222',
+}
+const userId = '33333333-3333-4333-8333-333333333333'
+const staffMemberId = '44444444-4444-4444-8444-444444444444'
+
+function member(overrides: Partial<StaffTeamMember> = {}): StaffTeamMember {
+  return {
+    id: staffMemberId,
+    tenantId: scope.tenantId,
+    organizationId: scope.organizationId,
+    displayName: 'Ada Lovelace',
+    userId,
+    isActive: true,
+    ...overrides,
+  } as StaffTeamMember
+}
+
+describe('createStaffIdentityResolver', () => {
+  const em = {} as EntityManager
+  const resolver = createStaffIdentityResolver(em)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('resolves one active Auth link with the exact scoped query and minimal projection', async () => {
+    mockFindWithDecryption.mockResolvedValue([member()])
+
+    await expect(resolver.resolveByUserId(scope, userId)).resolves.toEqual({
+      kind: 'found',
+      identity: {
+        staffMemberId,
+        userId,
+        displayName: 'Ada Lovelace',
+        isActive: true,
+      },
+    })
+    expect(mockFindWithDecryption).toHaveBeenCalledWith(
+      em,
+      StaffTeamMember,
+      {
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        userId,
+        isActive: true,
+        deletedAt: null,
+      },
+      { limit: 2 },
+      scope,
+    )
+  })
+
+  it('returns not_found when no active Auth link exists', async () => {
+    mockFindWithDecryption.mockResolvedValue([])
+
+    await expect(resolver.resolveByUserId(scope, userId)).resolves.toEqual({
+      kind: 'not_found',
+    })
+  })
+
+  it.each(['inactive', 'deleted', 'cross-scope'])(
+    'does not disclose an %s Auth-linked Staff row filtered out by the scoped query',
+    async () => {
+      mockFindWithDecryption.mockResolvedValue([])
+
+      await expect(resolver.resolveByUserId(scope, userId)).resolves.toEqual({
+        kind: 'not_found',
+      })
+    },
+  )
+
+  it('returns ambiguous without exposing duplicate rows', async () => {
+    mockFindWithDecryption.mockResolvedValue([
+      member(),
+      member({ id: '55555555-5555-4555-8555-555555555555' }),
+    ])
+
+    await expect(resolver.resolveByUserId(scope, userId)).resolves.toEqual({
+      kind: 'ambiguous',
+    })
+  })
+
+  it('resolves an active Staff member by exact scoped ID and normalizes an absent Auth link', async () => {
+    mockFindOneWithDecryption.mockResolvedValue(member({ userId: null }))
+
+    await expect(resolver.resolveByStaffMemberId(scope, staffMemberId)).resolves.toEqual({
+      kind: 'found',
+      identity: {
+        staffMemberId,
+        userId: null,
+        displayName: 'Ada Lovelace',
+        isActive: true,
+      },
+    })
+    expect(mockFindOneWithDecryption).toHaveBeenCalledWith(
+      em,
+      StaffTeamMember,
+      {
+        id: staffMemberId,
+        tenantId: scope.tenantId,
+        organizationId: scope.organizationId,
+        isActive: true,
+        deletedAt: null,
+      },
+      undefined,
+      scope,
+    )
+  })
+
+  it('returns not_found when the exact Staff member lookup has no active row', async () => {
+    mockFindOneWithDecryption.mockResolvedValue(null)
+
+    await expect(resolver.resolveByStaffMemberId(scope, staffMemberId)).resolves.toEqual({
+      kind: 'not_found',
+    })
+  })
+
+  it.each([
+    ['tenant ID', { ...scope, tenantId: 'invalid' }, userId, 'user'],
+    ['organization ID', { ...scope, organizationId: '' }, userId, 'user'],
+    ['Auth user ID', scope, 'not-a-uuid', 'user'],
+    ['Staff member ID', scope, 'not-a-uuid', 'staff'],
+  ] as const)('rejects an invalid %s before querying', async (_label, invalidScope, id, direction) => {
+    const lookup = direction === 'user'
+      ? resolver.resolveByUserId(invalidScope, id)
+      : resolver.resolveByStaffMemberId(invalidScope, id)
+
+    await expect(lookup).rejects.toBeInstanceOf(TypeError)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(mockFindOneWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('propagates Auth lookup database or decryption failures', async () => {
+    const failure = new Error('read failed')
+    mockFindWithDecryption.mockRejectedValueOnce(failure)
+
+    await expect(resolver.resolveByUserId(scope, userId)).rejects.toBe(failure)
+  })
+
+  it('propagates Staff lookup database or decryption failures', async () => {
+    const failure = new Error('read failed')
+    mockFindOneWithDecryption.mockRejectedValueOnce(failure)
+
+    await expect(resolver.resolveByStaffMemberId(scope, staffMemberId)).rejects.toBe(failure)
+  })
+})

--- a/packages/core/src/modules/staff/lib/candidateResolver.ts
+++ b/packages/core/src/modules/staff/lib/candidateResolver.ts
@@ -1,0 +1,88 @@
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
+import { z } from 'zod'
+import { escapeLikePattern } from '@open-mercato/shared/lib/db/escapeLikePattern'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import type {
+  StaffCandidatePage,
+  StaffCandidateResolver,
+} from '../contracts/candidateResolver'
+import { StaffTeamMember } from '../data/entities'
+
+const candidateInputSchema = z.object({
+  tenantId: z.string().uuid(),
+  organizationId: z.string().uuid(),
+  linkage: z.enum(['required', 'any']),
+  search: z.string().trim().max(200).optional(),
+  page: z.number().int().positive(),
+  pageSize: z.number().int().min(1).max(100),
+}).strict()
+
+type CandidateInput = z.infer<typeof candidateInputSchema>
+
+function buildCandidateFilter(input: CandidateInput): FilterQuery<StaffTeamMember> {
+  const where: FilterQuery<StaffTeamMember> = {
+    tenantId: input.tenantId,
+    organizationId: input.organizationId,
+    deletedAt: null,
+    isActive: true,
+  }
+
+  if (input.linkage === 'required') {
+    where.userId = { $ne: null }
+  }
+  if (input.search) {
+    where.displayName = { $ilike: `%${escapeLikePattern(input.search)}%` }
+  }
+
+  return where
+}
+
+export function createStaffCandidateResolver(em: EntityManager): StaffCandidateResolver {
+  return {
+    async listCandidates(rawInput) {
+      const parsedInput = candidateInputSchema.safeParse(rawInput)
+      if (!parsedInput.success) {
+        throw new TypeError('Staff candidate lookup requires valid scoped pagination input')
+      }
+
+      const input = parsedInput.data
+      const where = buildCandidateFilter(input)
+      const total = await em.count(StaffTeamMember, where)
+      const totalPages = Math.ceil(total / input.pageSize)
+      if (total === 0 || input.page > totalPages) {
+        return {
+          items: [],
+          total,
+          page: input.page,
+          pageSize: input.pageSize,
+          totalPages,
+        }
+      }
+
+      const members = await findWithDecryption(
+        em,
+        StaffTeamMember,
+        where,
+        {
+          limit: input.pageSize,
+          offset: (input.page - 1) * input.pageSize,
+          orderBy: { displayName: 'asc', id: 'asc' },
+        },
+        { tenantId: input.tenantId, organizationId: input.organizationId },
+      )
+
+      const items = members.map((member) => ({
+        staffMemberId: member.id,
+        displayName: member.displayName,
+      }))
+
+      return {
+        items,
+        total,
+        page: input.page,
+        pageSize: input.pageSize,
+        totalPages,
+      } satisfies StaffCandidatePage
+    },
+  }
+}

--- a/packages/core/src/modules/staff/lib/identityProjectionResolver.ts
+++ b/packages/core/src/modules/staff/lib/identityProjectionResolver.ts
@@ -1,0 +1,65 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { z } from 'zod'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import type {
+  StaffIdentityProjection,
+  StaffIdentityProjectionResolver,
+  StaffIdentityProjectionScope,
+} from '../contracts/identityProjectionResolver'
+import { StaffTeamMember } from '../data/entities'
+
+const uuidSchema = z.string().uuid()
+const staffMemberIdsSchema = z.array(uuidSchema).max(100)
+
+function assertValidScope(scope: StaffIdentityProjectionScope): void {
+  if (
+    !uuidSchema.safeParse(scope.tenantId).success
+    || !uuidSchema.safeParse(scope.organizationId).success
+  ) {
+    throw new TypeError('Staff identity projection requires valid scope UUIDs')
+  }
+}
+
+function mapProjection(member: StaffTeamMember): StaffIdentityProjection {
+  return {
+    staffMemberId: member.id,
+    displayName: member.displayName,
+    isActive: member.isActive,
+  }
+}
+
+export function createStaffIdentityProjectionResolver(
+  em: EntityManager,
+): StaffIdentityProjectionResolver {
+  return {
+    async resolveByIds(scope, staffMemberIds) {
+      assertValidScope(scope)
+      const parsedIds = staffMemberIdsSchema.safeParse(staffMemberIds)
+      if (!parsedIds.success) {
+        throw new TypeError('Staff identity projection requires at most 100 valid UUIDs')
+      }
+
+      const uniqueIds = [...new Set(parsedIds.data)]
+      if (uniqueIds.length === 0) return []
+
+      const members = await findWithDecryption(
+        em,
+        StaffTeamMember,
+        {
+          id: { $in: uniqueIds },
+          tenantId: scope.tenantId,
+          organizationId: scope.organizationId,
+          deletedAt: null,
+        },
+        undefined,
+        scope,
+      )
+
+      const projections = new Map<string, StaffIdentityProjection>()
+      for (const member of members) {
+        projections.set(member.id, mapProjection(member))
+      }
+      return [...projections.values()]
+    },
+  }
+}

--- a/packages/core/src/modules/staff/lib/identityResolver.ts
+++ b/packages/core/src/modules/staff/lib/identityResolver.ts
@@ -1,0 +1,73 @@
+import type { EntityManager } from '@mikro-orm/postgresql'
+import { z } from 'zod'
+import {
+  findOneWithDecryption,
+  findWithDecryption,
+} from '@open-mercato/shared/lib/encryption/find'
+import type {
+  StaffIdentity,
+  StaffIdentityResolver,
+  StaffIdentityScope,
+} from '../contracts/identityResolver'
+import { StaffTeamMember } from '../data/entities'
+
+const uuidSchema = z.string().uuid()
+
+function assertValidLookup(scope: StaffIdentityScope, id: string): void {
+  const values = [scope.tenantId, scope.organizationId, id]
+  if (values.some((value) => !uuidSchema.safeParse(value).success)) {
+    throw new TypeError('Staff identity lookup requires valid UUIDs')
+  }
+}
+
+function mapIdentity(member: StaffTeamMember): StaffIdentity {
+  return {
+    staffMemberId: member.id,
+    userId: member.userId ?? null,
+    displayName: member.displayName,
+    isActive: member.isActive,
+  }
+}
+
+export function createStaffIdentityResolver(em: EntityManager): StaffIdentityResolver {
+  return {
+    async resolveByUserId(scope, userId) {
+      assertValidLookup(scope, userId)
+      const members = await findWithDecryption(
+        em,
+        StaffTeamMember,
+        {
+          tenantId: scope.tenantId,
+          organizationId: scope.organizationId,
+          userId,
+          isActive: true,
+          deletedAt: null,
+        },
+        { limit: 2 },
+        scope,
+      )
+      if (members.length === 0) return { kind: 'not_found' }
+      if (members.length > 1) return { kind: 'ambiguous' }
+      return { kind: 'found', identity: mapIdentity(members[0]) }
+    },
+
+    async resolveByStaffMemberId(scope, staffMemberId) {
+      assertValidLookup(scope, staffMemberId)
+      const member = await findOneWithDecryption(
+        em,
+        StaffTeamMember,
+        {
+          id: staffMemberId,
+          tenantId: scope.tenantId,
+          organizationId: scope.organizationId,
+          isActive: true,
+          deletedAt: null,
+        },
+        undefined,
+        scope,
+      )
+      if (!member) return { kind: 'not_found' }
+      return { kind: 'found', identity: mapIdentity(member) }
+    },
+  }
+}


### PR DESCRIPTION
Source doc: .ai/specs/2026-08-12-staff-identity-resolver-public-contract.md
Source doc: .ai/specs/2026-08-13-staff-identity-projection-resolver-public-contract.md
Source doc: .ai/specs/2026-08-13-staff-candidate-resolver-public-contract.md

## Goal

Add stable Staff-owned identity contracts that optional modules can consume without importing Staff entities or relying on consumer-specific HTTP endpoints.

## What Changed

- Added `staffIdentityResolver` for exact active Auth-to-Staff and Staff-to-Auth lookup, including fail-closed ambiguity handling.
- Added `staffIdentityProjectionResolver` for bounded hydration of known Staff IDs, including inactive historical display identities.
- Added `staffCandidateResolver` for scoped, paginated active Staff discovery with linked-only or linked-and-unlinked modes.
- Registered all three services as request-scoped Awilix dependencies and documented their consumer-owned authorization boundary.
- Added exact type-only package export paths and comprehensive Staff resolver/DI regression coverage.
- Added reviewed implementation specifications covering isolation, privacy, failure behavior, compatibility, and extraction-time bridges.

## Tests

- Combined Staff resolver and DI gate: 4 suites, 50 tests passed.
- Nearby Planner, Staff, and Customers regressions: 5 suites, 17 tests passed.
- `yarn generate`: passed; generated outputs unchanged.
- Core typecheck and changed-file ESLint: passed; only the existing Next pages-directory warning was emitted.
- Core build: passed with 3,946 core and 204 generated entry points.
- `yarn build:packages`: 22/22 tasks passed.
- Exact built package import smoke tests passed for the type-only contract paths.

## Breaking Changes

None. These are additive public contracts and DI registrations. No entity, migration, API, UI, ACL, event, generated-source, or dependency change is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789225326&installation_model_id=432243&pr_number=5273&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5273&signature=dd8f0d81ebccb266f2f42c97768074c56f8689a07e086fb9f9e456d7fcd376e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->