### PR TITLE
fix(ci): restore npm provenance publishing, close the CodeQL cache-poisoning alert, and de-flake TC-WF-030

### DIFF
--- a/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
+++ b/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
@@ -137,6 +137,8 @@ here. Raising the limits needs `sudo sysctl`, which this run does not do unpromp
 
 ## Progress
 
+PR: #5292
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: npm provenance publishing
@@ -153,6 +155,7 @@ here. Raising the limits needs `sudo sysctl`, which this run does not do unpromp
 
 - [x] 3.1 Drive checkout-demo progression off the instance's server-side step — 09591b1ab
 
-### Phase 4: Validation
+### Phase 4: Validation and review
 
 - [x] 4.1 Run the full validation gate and record results — see the Validation results section
+- [x] 4.2 Authoritative review pass (`om-auto-review-pr --autofix`) — a9967bb41

--- a/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
+++ b/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
@@ -1,0 +1,124 @@
+# Stabilize develop: green CI + CodeQL high-severity alert
+
+**Date:** 2026-08-14
+**Branch:** `fix/stabilize-develop-ci-security`
+**Base:** `develop`
+**Trigger:** PR #4840 (`pre-release: stabilization PR`, develop → main) is red on three checks; the same three are red on `develop` itself.
+
+## Goal
+
+Bring `develop` back to a green CI so the pre-release PR #4840 can go out: fix the three failing checks
+(`Publish Snapshot`, `CodeQL`, `ephemeral-integration (14/15)`) at their root cause, without weakening any
+check, test, or security control.
+
+## Diagnosis
+
+Three independent failures, all reproduced from CI logs and the code-scanning API rather than guessed:
+
+### 1. `Publish Snapshot` — npm rejects provenance from self-hosted runners
+
+```
+npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@open-mercato%2fwebhooks
+- Error verifying sigstore provenance bundle: Unsupported GitHub Actions runner environment:
+  "self-hosted". Only "github-hosted" runners are supported when publishing with provenance.
+```
+
+`scripts/publish-packages.sh` publishes every package with `npm publish --provenance`. Commit `34bd2d42f`
+("Migrate workflows to Blacksmith runners", #5244) moved **every** job in the repo to
+`blacksmith-4vcpu-ubuntu-2404`. Blacksmith runners register as `self-hosted`, and npm's sigstore
+verification only accepts GitHub-hosted runners, so every publish attempt now fails — all 22 packages.
+`Develop Snapshot Release` has been red on every commit since that migration, and the same defect is
+latent in `release.yml`: **the next real release would fail the same way**.
+
+Provenance is a supply-chain integrity control, so the fix moves the runner, not the flag: the three
+jobs that call `npm publish --provenance` go back to GitHub-hosted `ubuntu-latest`. Every other job
+stays on Blacksmith, so the migration's build-speed win is preserved.
+
+### 2. `CodeQL` — 1 high-severity alert: Actions cache poisoning
+
+Alert #188, rule `actions/cache-poisoning/direct-cache`, at `.github/workflows/audit.yml:77`:
+
+> Potential cache poisoning in the context of the default branch due to privilege checkout of untrusted
+> code. (schedule) / (workflow_dispatch).
+
+`audit.yml` runs on `schedule`/`workflow_dispatch`, so it always executes with the *default branch's*
+workflow definition and cache scope, but its matrix checks out `develop` **and** `main` and then
+**writes** a Yarn cache with `actions/cache@v6`. A cache entry produced from the `develop` checkout is
+therefore written into the default branch's cache scope, where any other workflow restoring the same
+`yarn-${{ runner.os }}-…` key would pick it up. That is exactly the poisoning path CodeQL flags.
+
+The audit only needs to *read* package downloads, never to publish them, so the fix is
+`actions/cache/restore@v6` — restore-only. The workflow keeps its warm-cache speed-up (entries written by
+`ci.yml` on the default branch are still restored) while no longer writing a cache from a non-default ref.
+This is the only open code-scanning alert on `develop`.
+
+### 3. `ephemeral-integration (14/15)` — TC-WF-030 races past the step it asserts
+
+`packages/core/src/modules/workflows/__integration__/TC-WF-030.spec.ts` times out at 20 s. The captured
+failure snapshot shows *why*: the run is not stuck, it has gone **too far** — `Start ✓`,
+`Cart Validation ✓`, `Customer Information ✓`, and the page is parked on "Waiting for Payment
+Confirmation" (`PAUSED`), so the `Customer Information Required` heading the test waits for is gone.
+
+Every transition in the `checkout-demo` definition (`packages/core/src/modules/workflows/workflows.ts`)
+has `trigger: 'auto'`, so the background executor walks START → Cart Validation → Customer Information on
+its own and parks on the `USER_TASK`. The spec instead clicks "Advance to Next Step" a **fixed two
+times**. When the executor completes Cart Validation between the spec's visibility probe and its second
+click, that click lands on a stale `RUNNING` render and advances the *server's* current step — which is
+already `customer_info` — one step too far, skipping the user task. Whether the executor wins that race
+is timing-dependent, which is why the identical tree passed shard 14 on the push run and failed it on the
+PR run of the very same SHA (`cdd3f00315`).
+
+The fix drives progression off the instance's server-side `currentStepId` (via the existing
+`pollWorkflowInstance` helper) and only clicks "Advance" when the run is genuinely still parked before
+`customer_info`, so the manual fallback can no longer overshoot. The assertions the test exists for
+(#4179 — reaching Customer Information with no `Order Failed` and no `CALL_WEBHOOK rejected unsafe URL`)
+are unchanged and stay strict.
+
+## Scope
+
+- `.github/workflows/snapshot.yml`, `release.yml`, `npm-snapshot-preview.yml` — runner change for the
+  provenance-publishing jobs only.
+- `.github/workflows/audit.yml` — restore-only Yarn cache.
+- `packages/core/src/modules/workflows/__integration__/TC-WF-030.spec.ts` — race-free progression.
+- `scripts/__tests__/` — two new guard tests so all three regressions are caught by `yarn test:scripts`
+  instead of by a red release.
+
+## Non-goals
+
+- Reverting the Blacksmith migration, or moving any job that does not publish with provenance.
+- Touching the `checkout-demo` workflow definition or its page — the product behavior is correct; only
+  the test's progression logic races.
+- Retuning shard counts, timeouts, or retries to paper over the flake.
+- Dependency bumps, unrelated CodeQL rule tuning, or changes to any other red check outside these three.
+
+## Risks
+
+- **Publish jobs on GitHub-hosted runners are slower** than Blacksmith. Accepted: correctness of a signed
+  release outranks a few minutes of publish time, and provenance cannot be produced any other way.
+- **Restore-only cache in `audit.yml`** means a cold cache when `ci.yml` has not populated the key. The
+  audit job installs dependencies either way; the only cost is a slower daily run.
+- **TC-WF-030 remains timing-sensitive by nature** (it drives a live background executor). The change
+  removes the specific overshoot race; it cannot prove the absence of every future timing issue, so the
+  polling helper is given explicit, bounded timeouts that stay inside the spec's 20 s budget.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: npm provenance publishing
+
+- [ ] 1.1 Move the three provenance-publishing jobs to GitHub-hosted runners
+- [ ] 1.2 Add a guard test asserting provenance publishes never run on self-hosted runners
+
+### Phase 2: CodeQL cache-poisoning alert
+
+- [ ] 2.1 Make the `audit.yml` Yarn cache restore-only
+- [ ] 2.2 Add a guard test asserting no non-default-ref checkout writes an Actions cache
+
+### Phase 3: TC-WF-030 integration flake
+
+- [ ] 3.1 Drive checkout-demo progression off the instance's server-side step
+
+### Phase 4: Validation
+
+- [ ] 4.1 Run the full validation gate and record results

--- a/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
+++ b/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
@@ -112,8 +112,8 @@ are unchanged and stay strict.
 
 ### Phase 2: CodeQL cache-poisoning alert
 
-- [ ] 2.1 Make the `audit.yml` Yarn cache restore-only
-- [ ] 2.2 Add a guard test asserting no non-default-ref checkout writes an Actions cache
+- [x] 2.1 Make the `audit.yml` Yarn cache restore-only — f773f68fe
+- [x] 2.2 Add a guard test asserting no non-default-ref checkout writes an Actions cache — f773f68fe
 
 ### Phase 3: TC-WF-030 integration flake
 

--- a/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
+++ b/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
@@ -117,7 +117,7 @@ are unchanged and stay strict.
 
 ### Phase 3: TC-WF-030 integration flake
 
-- [ ] 3.1 Drive checkout-demo progression off the instance's server-side step
+- [x] 3.1 Drive checkout-demo progression off the instance's server-side step — 09591b1ab
 
 ### Phase 4: Validation
 

--- a/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
+++ b/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
@@ -107,8 +107,8 @@ are unchanged and stay strict.
 
 ### Phase 1: npm provenance publishing
 
-- [ ] 1.1 Move the three provenance-publishing jobs to GitHub-hosted runners
-- [ ] 1.2 Add a guard test asserting provenance publishes never run on self-hosted runners
+- [x] 1.1 Move the three provenance-publishing jobs to GitHub-hosted runners — 685013f51
+- [x] 1.2 Add a guard test asserting provenance publishes never run on self-hosted runners — 685013f51
 
 ### Phase 2: CodeQL cache-poisoning alert
 

--- a/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
+++ b/.ai/runs/2026-08-14-stabilize-develop-ci-security.md
@@ -101,6 +101,40 @@ are unchanged and stay strict.
   removes the specific overshoot race; it cannot prove the absence of every future timing issue, so the
   polling helper is given explicit, bounded timeouts that stay inside the spec's 20 s budget.
 
+## Validation results
+
+Local mode (no compose `app` container was running, so `yarn X` directly rather than
+`node scripts/docker-exec.mjs X`). Full `validation.commands` gate, in order:
+
+| Command | Result |
+|---------|--------|
+| `yarn build:packages` | ✅ pass |
+| `yarn generate` | ✅ pass (no generated-file drift — working tree stayed clean) |
+| `yarn build:packages` | ✅ pass |
+| `yarn i18n:check-sync` | ✅ pass |
+| `yarn i18n:check-usage` | ✅ pass |
+| `yarn typecheck` | ✅ pass |
+| `yarn test` | ⚠️ 22 packages green (`@open-mercato/core` alone: 1236 suites, 0 failures); red **only** on `packages/create-app/src/lib/template-dev-log-files.test.ts` |
+| `yarn test:scripts` | ⚠️ green except 3 monorepo dev-wrapper cases, same cause as above; **all 4 new guard tests pass** |
+| `yarn test:repo-wide-guards` | ✅ pass (also run because CI runs it) |
+| `yarn build:app` | ✅ pass |
+
+The 7 failing cases across `yarn test` and `yarn test:scripts` are all dev-server wrapper
+tests, and every one fails with the same self-describing assertion:
+
+```
+❌ Linux file-watch limits are too low for Turbopack.
+  fs.inotify.max_user_watches: 253174 < 4194304
+  fs.inotify.max_user_instances: 128 < 4096
+  fs.inotify.max_queued_events: 16384 < 65536
+```
+
+This host reports `fs.inotify.max_user_instances = 128` against a required 4096, so the
+assertion is describing the machine, not the branch. The diff touches no file in
+`packages/create-app` and no dev-wrapper script, and CI's `test` job is green on the same
+tree — these fail identically on unmodified `develop` and are not treated as a gate failure
+here. Raising the limits needs `sudo sysctl`, which this run does not do unprompted.
+
 ## Progress
 
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
@@ -121,4 +155,4 @@ are unchanged and stay strict.
 
 ### Phase 4: Validation
 
-- [ ] 4.1 Run the full validation gate and record results
+- [x] 4.1 Run the full validation gate and record results — see the Validation results section

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -74,9 +74,22 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
-      - name: Cache Yarn packages
-        # Package *downloads* are safe to cache — only the audit result is not.
-        uses: actions/cache@v6
+      - name: Restore Yarn package cache
+        # Restore-only, deliberately — `actions/cache` (which also *saves*) is a
+        # cache-poisoning sink here and CodeQL flags it as such
+        # (`actions/cache-poisoning/direct-cache`, high severity).
+        #
+        # This workflow is triggered by `schedule`/`workflow_dispatch`, so it always
+        # runs in the *default branch's* privileged context and writes to the default
+        # branch's cache scope — but the matrix above checks out `develop` and `main`.
+        # A save step would therefore let content from a non-default ref land under a
+        # `yarn-<os>-<lockfile hash>` key that any other workflow, on any branch,
+        # happily restores.
+        #
+        # Restoring is safe and keeps the speed-up: `ci.yml` populates these keys from
+        # the branch being built, and a miss only costs this daily job a cold install.
+        # Guarded by scripts/__tests__/workflow-cache-poisoning.test.mjs.
+        uses: actions/cache/restore@v6
         with:
           path: .yarn/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}

--- a/.github/workflows/npm-snapshot-preview.yml
+++ b/.github/workflows/npm-snapshot-preview.yml
@@ -74,7 +74,11 @@ jobs:
       snapshot_version: ${{ steps.release.outputs.version }}
       publish_tag: ${{ steps.channel.outputs.publish_tag }}
       packages_json: ${{ steps.release.outputs.packages_json }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GitHub-hosted on purpose — do NOT move this job to a Blacksmith runner.
+    # `scripts/publish-packages.sh` publishes with `npm publish --provenance`, which
+    # npm only accepts from a `github-hosted` runner. Guarded by
+    # scripts/__tests__/npm-provenance-runners.test.mjs.
+    runs-on: ubuntu-latest
     env:
       YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,13 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   release:
     name: Release
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GitHub-hosted on purpose — do NOT move this job to a Blacksmith runner.
+    # `scripts/publish-packages.sh` publishes with `npm publish --provenance`, and
+    # npm's sigstore verification only accepts `github-hosted` runners; a
+    # `self-hosted` runner (which is how Blacksmith registers) fails the publish
+    # with a 422 after the release tag has already been pushed.
+    # Guarded by scripts/__tests__/npm-provenance-runners.test.mjs.
+    runs-on: ubuntu-latest
     # Only allow releases from main branch
     if: github.ref == 'refs/heads/main'
     # Requires approval from the 'production' environment — prevents a single

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -28,7 +28,14 @@ jobs:
       snapshot_version: ${{ steps.release.outputs.version }}
       publish_tag: ${{ steps.channel.outputs.publish_tag }}
       packages_json: ${{ steps.release.outputs.packages_json }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GitHub-hosted on purpose — do NOT move this job to a Blacksmith runner.
+    # `scripts/publish-packages.sh` publishes with `npm publish --provenance`, and
+    # npm's sigstore verification rejects every other runner class:
+    #   422 Unprocessable Entity — Error verifying sigstore provenance bundle:
+    #   Unsupported GitHub Actions runner environment: "self-hosted".
+    # Blacksmith runners register as `self-hosted`, so this job published nothing
+    # between #5244 and #5292. Guarded by scripts/__tests__/npm-provenance-runners.test.mjs.
+    runs-on: ubuntu-latest
     env:
       YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/core/src/modules/workflows/__integration__/TC-WF-030.spec.ts
+++ b/packages/core/src/modules/workflows/__integration__/TC-WF-030.spec.ts
@@ -3,7 +3,8 @@ import { login } from '@open-mercato/core/modules/core/__integration__/helpers/a
 import { getAuthToken } from '@open-mercato/core/modules/core/__integration__/helpers/api'
 import { createProductFixture, deleteCatalogProductIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/catalogFixtures'
 import { createCompanyFixture, deleteEntityIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/crmFixtures'
-import { cancelWorkflowInstanceIfExists } from '@open-mercato/core/modules/core/__integration__/helpers/workflowsFixtures'
+import { cancelWorkflowInstanceIfExists, pollWorkflowInstance } from '@open-mercato/core/modules/core/__integration__/helpers/workflowsFixtures'
+import { expectId } from '@open-mercato/core/modules/core/__integration__/helpers/generalFixtures'
 
 /**
  * TC-WF-030: Checkout demo reaches customer information
@@ -59,18 +60,37 @@ test.describe('TC-WF-030: Checkout demo regression', () => {
       expect(startResponse.status()).toBe(201)
       const started = await startResponse.json() as StartResponse
       instanceId = started?.data?.instance?.id ?? null
-      expect(instanceId).toBeTruthy()
+      const startedInstanceId = expectId(instanceId, 'Checkout demo should return a started workflow instance id')
 
-      // The demo exposes manual progression while an automated step is RUNNING.
-      // Advance at most twice: START -> Cart Validation -> Customer Information.
+      // Every checkout-demo transition is `trigger: 'auto'`, so the executor walks
+      // START -> Cart Validation -> Customer Information on its own and parks on the
+      // USER_TASK. The demo's manual progression is only a fallback for a stalled
+      // executor, and it must be driven off the *server's* current step: clicking it
+      // against a page that still renders the previous step advances the instance one
+      // step too far, skipping the user task and leaving the run paused on payment
+      // confirmation — the race that made this spec flaky in CI.
       const advanceButton = page.getByRole('button', { name: 'Advance to Next Step →', exact: true })
-      for (let attempt = 0; attempt < 2; attempt += 1) {
-        const customerStep = page.getByRole('heading', { name: 'Customer Information Required', exact: true })
-        if (await customerStep.isVisible()) break
+      const stepsBeforeCustomerInfo = new Set(['start', 'cart_validation'])
+
+      // Poll budgets stay well inside the spec's 20 s timeout: they only elapse in full
+      // when the executor really has stalled, which is exactly when the manual fallback
+      // is supposed to fire. A healthy run leaves `start`/`cart_validation` in well
+      // under a second and never waits.
+      const stallBudgetsMs = [4_000, 3_000]
+
+      for (let attempt = 0; attempt < stallBudgetsMs.length; attempt += 1) {
+        const snapshot = await pollWorkflowInstance(
+          request,
+          token,
+          startedInstanceId,
+          (instance) => !stepsBeforeCustomerInfo.has(instance.currentStepId ?? ''),
+          { timeoutMs: stallBudgetsMs[attempt] },
+        )
+        if (!stepsBeforeCustomerInfo.has(snapshot?.currentStepId ?? '')) break
         await expect(advanceButton).toBeVisible()
         await Promise.all([
           page.waitForResponse((response) =>
-            response.url().includes(`/api/workflows/instances/${instanceId}/advance`)
+            response.url().includes(`/api/workflows/instances/${startedInstanceId}/advance`)
             && response.request().method() === 'POST'),
           advanceButton.click(),
         ])

--- a/scripts/__tests__/npm-provenance-runners.test.mjs
+++ b/scripts/__tests__/npm-provenance-runners.test.mjs
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { parse } from 'yaml'
+
+// npm verifies a sigstore provenance bundle against the runner that produced it and
+// accepts only GitHub-hosted runners:
+//
+//   422 Unprocessable Entity — Error verifying sigstore provenance bundle:
+//   Unsupported GitHub Actions runner environment: "self-hosted".
+//   Only "github-hosted" runners are supported when publishing with provenance.
+//
+// Third-party runner fleets (Blacksmith, Namespace, Warpbuild, self-hosted metal) all
+// register as `self-hosted`, so moving a publishing job onto one silently breaks every
+// release until someone reads the log — which is what #5244 did to `Publish Snapshot`.
+// This guard makes that a red unit test instead.
+
+const WORKFLOWS_DIR = path.resolve('.github/workflows')
+const SCRIPTS_DIR = path.resolve('scripts')
+const GITHUB_HOSTED_RUNNER = /^(ubuntu|macos|windows)-/
+
+function listFiles(dir, extensions) {
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && extensions.some((extension) => entry.name.endsWith(extension)))
+    .map((entry) => path.join(dir, entry.name))
+}
+
+/**
+ * Scripts that reach `npm publish --provenance`, directly or by calling another script
+ * that does. Resolved transitively so a new release wrapper is covered the day it is
+ * added, without anyone remembering to update this list.
+ */
+function collectProvenancePublishers() {
+  const scripts = listFiles(SCRIPTS_DIR, ['.sh', '.mjs', '.ts'])
+  const sources = new Map(scripts.map((file) => [path.basename(file), fs.readFileSync(file, 'utf8')]))
+  const publishers = new Set(
+    [...sources].filter(([, source]) => /npm publish[^\n]*--provenance/.test(source)).map(([name]) => name),
+  )
+
+  for (;;) {
+    const before = publishers.size
+    for (const [name, source] of sources) {
+      if (publishers.has(name)) continue
+      if ([...publishers].some((publisher) => source.includes(publisher))) publishers.add(name)
+    }
+    if (publishers.size === before) return publishers
+  }
+}
+
+function jobRunnerLabels(job) {
+  const runsOn = job?.['runs-on']
+  if (typeof runsOn === 'string') return [runsOn]
+  if (Array.isArray(runsOn)) return runsOn.filter((label) => typeof label === 'string')
+  return []
+}
+
+function jobRunsAnyOf(job, scriptNames) {
+  return (job?.steps ?? []).some(
+    (step) => typeof step?.run === 'string' && [...scriptNames].some((name) => step.run.includes(name)),
+  )
+}
+
+test('every workflow job that publishes with provenance runs on a GitHub-hosted runner', () => {
+  const publishers = collectProvenancePublishers()
+  assert.ok(
+    publishers.has('publish-packages.sh'),
+    'Expected scripts/publish-packages.sh to be detected as a provenance publisher — the detection heuristic has drifted',
+  )
+
+  const offenders = []
+  let publishingJobs = 0
+
+  for (const workflowPath of listFiles(WORKFLOWS_DIR, ['.yml', '.yaml'])) {
+    const workflow = parse(fs.readFileSync(workflowPath, 'utf8'))
+    for (const [jobId, job] of Object.entries(workflow?.jobs ?? {})) {
+      if (!jobRunsAnyOf(job, publishers)) continue
+      publishingJobs += 1
+      const labels = jobRunnerLabels(job)
+      if (labels.length > 0 && labels.every((label) => GITHUB_HOSTED_RUNNER.test(label))) continue
+      offenders.push(`${path.basename(workflowPath)} › ${jobId} (runs-on: ${labels.join(', ') || '<unset>'})`)
+    }
+  }
+
+  assert.ok(publishingJobs > 0, 'Expected at least one workflow job to publish packages')
+  assert.deepEqual(
+    offenders,
+    [],
+    `npm rejects provenance from non-GitHub-hosted runners, so these publishing jobs would fail with a 422:\n  ${offenders.join('\n  ')}`,
+  )
+})
+
+test('the publish script still requests provenance', () => {
+  const publishScript = fs.readFileSync(path.join(SCRIPTS_DIR, 'publish-packages.sh'), 'utf8')
+
+  assert.match(
+    publishScript,
+    /npm publish[^\n]*--provenance/,
+    'Provenance is a supply-chain integrity control: fix the runner, never drop the flag',
+  )
+})

--- a/scripts/__tests__/workflow-cache-poisoning.test.mjs
+++ b/scripts/__tests__/workflow-cache-poisoning.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { parse } from 'yaml'
+
+// CodeQL rule `actions/cache-poisoning/direct-cache` (high severity), reproduced as a
+// unit test so the alert cannot come back without a red check first.
+//
+// A workflow triggered only by `schedule`/`workflow_dispatch`/`push` always runs in the
+// *default branch's* privileged context and writes to the default branch's cache scope.
+// When such a workflow also checks out some *other* explicit ref, whatever it produces
+// from that ref lands under a cache key any workflow on any branch can restore — the
+// poisoning path. Restoring is fine; only saving is the sink.
+//
+// Workflows that also accept `pull_request` are deliberately out of scope: GitHub
+// isolates a pull request's cache writes to that PR's own scope, so the same shape is
+// not the same risk (see the `mutate` job in mutation-tests.yml).
+
+const WORKFLOWS_DIR = path.resolve('.github/workflows')
+const PRIVILEGED_TRIGGERS = new Set(['schedule', 'workflow_dispatch', 'push'])
+const CACHE_WRITING_ACTIONS = [/^actions\/cache@/, /^actions\/cache\/save@/]
+
+function listWorkflows() {
+  return fs
+    .readdirSync(WORKFLOWS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /\.ya?ml$/.test(entry.name))
+    .map((entry) => path.join(WORKFLOWS_DIR, entry.name))
+}
+
+function triggerNames(workflow) {
+  // `on` is parsed as the boolean `true` by YAML 1.1-style keys; the `yaml` package
+  // keeps it as the string 'on', but accept both so a reformat cannot silently
+  // disable this guard.
+  const triggers = workflow?.on ?? workflow?.true
+  if (typeof triggers === 'string') return [triggers]
+  if (Array.isArray(triggers)) return triggers
+  return Object.keys(triggers ?? {})
+}
+
+function runsOnlyInPrivilegedContext(workflow) {
+  const triggers = triggerNames(workflow)
+  return triggers.length > 0 && triggers.every((trigger) => PRIVILEGED_TRIGGERS.has(trigger))
+}
+
+function explicitCheckoutRefs(job) {
+  return (job?.steps ?? [])
+    .filter((step) => typeof step?.uses === 'string' && step.uses.startsWith('actions/checkout@'))
+    .map((step) => step?.with?.ref)
+    .filter((ref) => typeof ref === 'string' && ref.length > 0)
+}
+
+function cacheWritingSteps(job) {
+  return (job?.steps ?? [])
+    .map((step) => step?.uses)
+    .filter((uses) => typeof uses === 'string' && CACHE_WRITING_ACTIONS.some((pattern) => pattern.test(uses)))
+}
+
+test('privileged-context workflows never write an Actions cache from a non-default checkout', () => {
+  const offenders = []
+  let inspectedJobs = 0
+
+  for (const workflowPath of listWorkflows()) {
+    const workflow = parse(fs.readFileSync(workflowPath, 'utf8'))
+    if (!runsOnlyInPrivilegedContext(workflow)) continue
+
+    for (const [jobId, job] of Object.entries(workflow?.jobs ?? {})) {
+      inspectedJobs += 1
+      const refs = explicitCheckoutRefs(job)
+      const writes = cacheWritingSteps(job)
+      if (refs.length === 0 || writes.length === 0) continue
+      offenders.push(`${path.basename(workflowPath)} › ${jobId}: checks out ${refs.join(', ')} and saves a cache via ${writes.join(', ')}`)
+    }
+  }
+
+  assert.ok(
+    inspectedJobs > 0,
+    'No workflow was classified as privileged-context-only — the trigger parsing has drifted and this guard is inspecting nothing',
+  )
+  assert.deepEqual(
+    offenders,
+    [],
+    `Use actions/cache/restore@… instead — saving here poisons the default branch's cache scope:\n  ${offenders.join('\n  ')}`,
+  )
+})
+
+test('the scheduled dependency audit restores its Yarn cache without saving one', () => {
+  const auditWorkflow = fs.readFileSync(path.join(WORKFLOWS_DIR, 'audit.yml'), 'utf8')
+
+  assert.match(auditWorkflow, /uses: actions\/cache\/restore@/, 'The audit should still restore package downloads')
+  assert.doesNotMatch(
+    auditWorkflow,
+    /uses: actions\/cache@/,
+    'The audit checks out develop and main from the default branch context, so it must never save a cache',
+  )
+})

--- a/scripts/__tests__/workflow-cache-poisoning.test.mjs
+++ b/scripts/__tests__/workflow-cache-poisoning.test.mjs
@@ -19,7 +19,11 @@ import { parse } from 'yaml'
 
 const WORKFLOWS_DIR = path.resolve('.github/workflows')
 const PRIVILEGED_TRIGGERS = new Set(['schedule', 'workflow_dispatch', 'push'])
-const CACHE_WRITING_ACTIONS = [/^actions\/cache@/, /^actions\/cache\/save@/]
+// Any vendor's cache action, not just `actions/cache`: the runner fleets this repo uses
+// ship drop-in replacements (`useblacksmith/cache`, `runs-on/cache`) that write to the
+// same Actions cache scope, so matching only the GitHub-published action would let a
+// one-word swap slip the guard.
+const CACHE_WRITING_ACTIONS = [/^[\w.-]+\/cache@/, /^[\w.-]+\/cache\/save@/]
 
 function listWorkflows() {
   return fs


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-14-stabilize-develop-ci-security.md
Status: complete

## 🎯 Goal
- `develop` is red on three checks, which blocks the pre-release PR #4840 (develop → main). This PR fixes all three at their root cause rather than muting them: npm provenance publishing broken by the Blacksmith runner migration, a high-severity CodeQL Actions cache-poisoning alert in `audit.yml`, and the `TC-WF-030` integration spec racing past the step it asserts.

## What Changed

**1. npm provenance publishing (`snapshot.yml`, `release.yml`, `npm-snapshot-preview.yml`)**
`scripts/publish-packages.sh` publishes with `npm publish --provenance`, and npm's sigstore verification accepts only GitHub-hosted runners — it rejects anything registering as `self-hosted` with `422 … Unsupported GitHub Actions runner environment`. #5244 moved every job in the repo onto `blacksmith-4vcpu-ubuntu-2404`, which registers as self-hosted, so **all 22 packages have failed to publish on every commit since**. The three jobs that publish are moved back to `ubuntu-latest`, each with a comment saying why they must stay there; every other job keeps the Blacksmith speed-up. This also defuses the same latent failure in `release.yml`, where it would have struck *after* the release tag was already pushed.

**2. CodeQL high-severity alert (`audit.yml`)**
Alert #188 (`actions/cache-poisoning/direct-cache`) fired because the scheduled audit runs on `schedule`/`workflow_dispatch` — always in the default branch's privileged context and cache scope — while its matrix checks out `develop` and `main` and then **saves** a Yarn cache. Content from a non-default ref therefore landed under a `yarn-<os>-…` key any workflow on any branch could restore. Switched to `actions/cache/restore@v6`: the audit still restores caches `ci.yml` populates, but no longer writes one. This was the only open code-scanning alert on `develop`.

**3. `TC-WF-030` integration flake (`packages/core/src/modules/workflows/__integration__/`)**
The captured failure snapshot shows the run had gone *too far*, not stalled: Start ✓, Cart Validation ✓, Customer Information ✓, parked on "Waiting for Payment Confirmation". Every `checkout-demo` transition is `trigger: 'auto'`, so the executor reaches the user task on its own, but the spec clicked "Advance to Next Step" a fixed two times. When the executor completed Cart Validation between the visibility probe and the second click, that click hit a stale `RUNNING` render and advanced the *server's* current step past `customer_info`. The spec now polls the instance's `currentStepId` and only uses the manual fallback while the run is genuinely still before `customer_info`. Timing-dependence is why the identical tree passed shard 14 on the push run and failed it on the PR run of the same SHA (`cdd3f00315`).

**4. Two new regression guards (`scripts/__tests__/`)**
`npm-provenance-runners.test.mjs` resolves the scripts that reach `npm publish --provenance` transitively and asserts every workflow job invoking one runs on a GitHub-hosted runner, so a future runner sweep fails a unit test instead of a release. `workflow-cache-poisoning.test.mjs` asserts no privileged-context-only workflow saves an Actions cache from an explicit non-default checkout. Both were verified to fail against the pre-fix state and pass after.

## 🧪 Tests
- Full `validation.commands` gate in local mode: `build:packages`, `generate`, `build:packages`, `i18n:check-sync`, `i18n:check-usage`, `typecheck`, `build:app` — **all pass**. `yarn generate` produced no drift.
- `yarn test`: 22 packages green, `@open-mercato/core` alone 1236 suites with 0 failures. `yarn test:repo-wide-guards`: pass.
- `yarn test:scripts`: the 4 new guard tests pass.
- ⚠️ 7 cases across `yarn test` / `yarn test:scripts` fail on this host, all dev-server wrapper tests in `packages/create-app/src/lib/template-dev-log-files.test.ts` and `scripts/__tests__`, each asserting `fs.inotify.max_user_instances: 128 < 4096`. That is a local machine limit, not a branch failure: the diff touches no create-app or dev-wrapper file, and CI's `test` job is green on the same tree. Details in the tracking plan's Validation results section.
- New coverage: both guard files were confirmed red against the pre-fix workflows and green after, so they genuinely lock in the fixes rather than merely passing.

## 💥 Breaking Changes
- None. No product code, database schema, API surface, or contract from `BACKWARD_COMPATIBILITY.md` is touched. The only behavioral changes are which runner three publishing jobs use, whether the scheduled audit writes a cache, and how one Playwright spec paces itself.

## 📋 Progress
See the Progress section in the tracking plan.
