### PR TITLE
fix(ci): stabilize example generator activation fixture

### DIFF
--- a/apps/mercato/src/modules/example/__integration__/TC-EXAMPLE-016-generator-plugin.spec.ts
+++ b/apps/mercato/src/modules/example/__integration__/TC-EXAMPLE-016-generator-plugin.spec.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
+import * as ts from 'typescript'
 
 const configuredAppRoot = process.env.OM_TEST_APP_ROOT?.trim()
 const appRoot = configuredAppRoot ? path.resolve(configuredAppRoot) : null
@@ -23,6 +24,40 @@ function expectCommandPassed(result: ReturnType<typeof runYarn>, label: string):
   expect(result.status, `${label}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0)
 }
 
+function readStringProperty(objectLiteral: ts.ObjectLiteralExpression, propertyName: string): string | null {
+  for (const property of objectLiteral.properties) {
+    if (!ts.isPropertyAssignment(property)) continue
+    const name = ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)
+      ? property.name.text
+      : null
+    if (name !== propertyName || !ts.isStringLiteral(property.initializer)) continue
+    return property.initializer.text
+  }
+  return null
+}
+
+function removeModuleActivation(source: string, moduleId: string, moduleSource: string): string {
+  const sourceFile = ts.createSourceFile('modules.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || declaration.name.text !== 'enabledModules') continue
+      if (!declaration.initializer || !ts.isArrayLiteralExpression(declaration.initializer)) continue
+      for (const element of declaration.initializer.elements) {
+        if (!ts.isObjectLiteralExpression(element)) continue
+        if (readStringProperty(element, 'id') !== moduleId) continue
+        if (readStringProperty(element, 'from') !== moduleSource) continue
+        const separator = source.slice(element.end).match(/^[ \t]*,/)
+        const end = element.end + (separator?.[0].length ?? 0)
+        return source.slice(0, element.getStart(sourceFile)) + source.slice(end)
+      }
+    }
+  }
+
+  throw new Error(`[internal] Module '${moduleId}' from '${moduleSource}' is not enabled`)
+}
+
 test.describe('TC-EXAMPLE-016: generator plugin', () => {
   test.skip(!appRoot, 'requires the disposable standalone app selected by OM_TEST_APP_ROOT')
   test.setTimeout(240_000)
@@ -39,7 +74,7 @@ test.describe('TC-EXAMPLE-016: generator plugin', () => {
     const originalModules = fs.readFileSync(modulesPath, 'utf8')
     const originalGenerators = fs.readFileSync(generatorsPath, 'utf8')
 
-    expect(originalModules).toMatch(/\{\s*id: 'example',\s*from: '@app'\s*\}/)
+    const disabledModules = removeModuleActivation(originalModules, 'example', '@app')
     expect(originalGenerators).toContain("import type { GeneratorPlugin }")
     expect(originalGenerators).not.toMatch(/^import\s+(?!type\b)/m)
     expect(fs.existsSync(generatedPath)).toBe(true)
@@ -129,10 +164,6 @@ test.describe('TC-EXAMPLE-016: generator plugin', () => {
       expectCommandPassed(runYarn(['generate']), 'generation failed after restoring generators.ts')
     }
 
-    const disabledModules = originalModules.replace(
-      /^\s*\{\s*id: 'example',\s*from: '@app'\s*\},\s*$/m,
-      '',
-    )
     expect(disabledModules).not.toBe(originalModules)
     try {
       fs.writeFileSync(modulesPath, disabledModules)

--- a/packages/create-app/template/src/modules/example/__integration__/TC-EXAMPLE-016-generator-plugin.spec.ts
+++ b/packages/create-app/template/src/modules/example/__integration__/TC-EXAMPLE-016-generator-plugin.spec.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
+import * as ts from 'typescript'
 
 const configuredAppRoot = process.env.OM_TEST_APP_ROOT?.trim()
 const appRoot = configuredAppRoot ? path.resolve(configuredAppRoot) : null
@@ -23,6 +24,40 @@ function expectCommandPassed(result: ReturnType<typeof runYarn>, label: string):
   expect(result.status, `${label}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`).toBe(0)
 }
 
+function readStringProperty(objectLiteral: ts.ObjectLiteralExpression, propertyName: string): string | null {
+  for (const property of objectLiteral.properties) {
+    if (!ts.isPropertyAssignment(property)) continue
+    const name = ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)
+      ? property.name.text
+      : null
+    if (name !== propertyName || !ts.isStringLiteral(property.initializer)) continue
+    return property.initializer.text
+  }
+  return null
+}
+
+function removeModuleActivation(source: string, moduleId: string, moduleSource: string): string {
+  const sourceFile = ts.createSourceFile('modules.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || declaration.name.text !== 'enabledModules') continue
+      if (!declaration.initializer || !ts.isArrayLiteralExpression(declaration.initializer)) continue
+      for (const element of declaration.initializer.elements) {
+        if (!ts.isObjectLiteralExpression(element)) continue
+        if (readStringProperty(element, 'id') !== moduleId) continue
+        if (readStringProperty(element, 'from') !== moduleSource) continue
+        const separator = source.slice(element.end).match(/^[ \t]*,/)
+        const end = element.end + (separator?.[0].length ?? 0)
+        return source.slice(0, element.getStart(sourceFile)) + source.slice(end)
+      }
+    }
+  }
+
+  throw new Error(`[internal] Module '${moduleId}' from '${moduleSource}' is not enabled`)
+}
+
 test.describe('TC-EXAMPLE-016: generator plugin', () => {
   test.skip(!appRoot, 'requires the disposable standalone app selected by OM_TEST_APP_ROOT')
   test.setTimeout(240_000)
@@ -39,7 +74,7 @@ test.describe('TC-EXAMPLE-016: generator plugin', () => {
     const originalModules = fs.readFileSync(modulesPath, 'utf8')
     const originalGenerators = fs.readFileSync(generatorsPath, 'utf8')
 
-    expect(originalModules).toMatch(/\{\s*id: 'example',\s*from: '@app'\s*\}/)
+    const disabledModules = removeModuleActivation(originalModules, 'example', '@app')
     expect(originalGenerators).toContain("import type { GeneratorPlugin }")
     expect(originalGenerators).not.toMatch(/^import\s+(?!type\b)/m)
     expect(fs.existsSync(generatedPath)).toBe(true)
@@ -129,10 +164,6 @@ test.describe('TC-EXAMPLE-016: generator plugin', () => {
       expectCommandPassed(runYarn(['generate']), 'generation failed after restoring generators.ts')
     }
 
-    const disabledModules = originalModules.replace(
-      /^\s*\{\s*id: 'example',\s*from: '@app'\s*\},\s*$/m,
-      '',
-    )
     expect(disabledModules).not.toBe(originalModules)
     try {
       fs.writeFileSync(modulesPath, disabledModules)


### PR DESCRIPTION
Refs #4840

## 🎯 Goal
- Restore the standalone snapshot lane by making the Example generator integration test understand the current module activation shape.

## 🔍 Problem
The test required an exact one-line Example activation entry, while the standalone fixture now emits a multiline entry with integration overrides. The precondition and later disable step therefore failed before testing generator behavior.

## 🔍 Root Cause
The activation fixture gained ACL, navigation, and route overrides, but TC-EXAMPLE-016 retained regexes for the old flat object shape.

## What Changed
- Parse the static enabledModules array with the TypeScript AST.
- Locate the Example entry semantically by id and source, then remove the complete array element for the disable phase.
- Mirror the integration test into the create-app template.

## 🧪 Tests
- yarn build:packages — passed.
- yarn generate — passed.
- yarn template:sync — passed.
- yarn typecheck — 22 tasks passed.
- yarn workspace create-mercato-app test — 773 passed, 5 skipped, 0 failed.
- yarn test:create-app:integration --cleanup -- apps/mercato/src/modules/example/__integration__/TC-EXAMPLE-016-generator-plugin.spec.ts --workers=1 --retries=0 — 1 passed.
- ESLint on TC-EXAMPLE-016 — passed.

## 💥 Breaking Changes
- None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789287114&installation_model_id=432243&pr_number=5297&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5297&signature=4b0cff201c12c88e5a0a1dbe109c2f53b603bb50c99913c03c3c14a5f2bce1cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->