### PR TITLE
fix(create-app,cli): make standalone harness gates fail loudly

### DIFF
--- a/.ai/runs/2026-08-14-harness-verification-gates.md
+++ b/.ai/runs/2026-08-14-harness-verification-gates.md
@@ -95,29 +95,48 @@ changed after session start and is newer than the last exit-0 typecheck.
 
 ### Phase 1: Gate honesty
 
-- [ ] 1.1 Add gate-evidence rules to the template AGENTS.md validation section
+- [x] 1.1 Add gate-evidence rules to the template AGENTS.md validation section — 578888fcc
 
 ### Phase 2: Route to authoritative contracts
 
-- [ ] 2.1 Route om-module-scaffold to installed @open-mercato/ui AGENTS.md
-- [ ] 2.2 Route om-module-scaffold to installed @open-mercato/shared AGENTS.md
-- [ ] 2.3 Document the backend page route convention with a worked example
+- [x] 2.1 Route om-module-scaffold to installed @open-mercato/ui AGENTS.md — 578888fcc
+- [x] 2.2 Route om-module-scaffold to installed @open-mercato/shared AGENTS.md — 578888fcc
+- [x] 2.3 Document the backend page route convention with a worked example — 578888fcc
 
 ### Phase 3: Lint sees imports
 
-- [ ] 3.1 Investigate resolver support for subpath exports maps
-- [ ] 3.2 Enable import/no-unresolved, or abandon with recorded reason
+- [x] 3.1 Investigate resolver support for subpath exports maps — investigated, not landable
+- [x] 3.2 Enable import/no-unresolved, or abandon with recorded reason — **abandoned, reason below**
+
+**Phase 3 abandoned.** Measured in a real generated app on 2026-08-14, both directions:
+
+| import | expected | actual |
+|---|---|---|
+| `@open-mercato/ui/backend/CrudForm` (valid) | pass | **`Unable to resolve path to module`** |
+| `@open-mercato/ui/crud/form` (invented) | fail | fail |
+
+Tried with the inherited `eslint-config-next` resolver, and again with an explicit
+`import/resolver: { typescript: { alwaysTryTypes: true, project: './tsconfig.json' } }`.
+The valid import fails in both. `@open-mercato/ui` ships a subpath `exports` map and the
+template uses `moduleResolution: bundler`; the resolver honors neither, so it reports every
+`@open-mercato/*` subpath as unresolved.
+
+Enabling the rule in that state would fail on correct code, which is worse than leaving it
+off — a gate that cries wolf gets disabled, and then it protects nothing. The underlying
+defect is already covered: with the typecheck heap fix (#5295) `tsc` reports the same thing
+as `TS2307`. Landing this needs a resolver that understands `exports` maps, which is its own
+piece of work rather than a config tweak.
 
 ### Phase 4: Generator warnings
 
-- [ ] 4.1 Warn when page.meta.ts exports no metadata
-- [ ] 4.2 Warn when registerCommand is unreachable at import time
-- [ ] 4.3 Warn when di.ts exports no register
-- [ ] 4.4 Surface the OpenAPI regex fallback as a counted warning
-- [ ] 4.5 Fixture tests for each warning, firing and silent cases
+- [x] 4.1 Warn when page.meta.ts exports no metadata — bbe6988e7
+- [x] 4.2 Warn when registerCommand is unreachable at import time — bbe6988e7
+- [x] 4.3 Warn when di.ts exports no register — bbe6988e7
+- [x] 4.4 Surface the OpenAPI regex fallback as a counted warning — bbe6988e7
+- [x] 4.5 Fixture tests for each warning, firing and silent cases — bbe6988e7
 
 ### Phase 5: Gate-evidence hook
 
-- [ ] 5.1 Add the gate-evidence hook to the agentic hooks template
-- [ ] 5.2 Register it in the generated hook settings
-- [ ] 5.3 Unit tests for the comparison and gate-command matching
+- [x] 5.1 Add the gate-evidence hook to the agentic hooks template — bbe6988e7
+- [x] 5.2 Register it in the generated hook settings — bbe6988e7
+- [x] 5.3 Unit tests for the comparison and gate-command matching — bbe6988e7

--- a/.ai/runs/2026-08-14-harness-verification-gates.md
+++ b/.ai/runs/2026-08-14-harness-verification-gates.md
@@ -140,3 +140,28 @@ piece of work rather than a config tweak.
 - [x] 5.1 Add the gate-evidence hook to the agentic hooks template — bbe6988e7
 - [x] 5.2 Register it in the generated hook settings — bbe6988e7
 - [x] 5.3 Unit tests for the comparison and gate-command matching — bbe6988e7
+
+### Phase 6: Review follow-up (PR #5301)
+
+Code review found one Major and seven Minor issues, four of them ways the hook could record
+a gate as passed without observing a passing exit status — the property this run exists to
+remove. Fixed in the same PR.
+
+- [x] 6.1 Install Claude hooks from disk in `mercato agentic:init`, and claim them in the
+  `--update-harness` ownership manifest. The CLI generator copied only
+  `entity-migration-check.ts` while shipping a `settings.json` that registers
+  `gate-evidence.ts`, so apps set up through that path got a hook registration pointing at a
+  file that was never written.
+- [x] 6.2 Treat an unreported exit status as unknown rather than as `0`.
+- [x] 6.3 Do not record a gate whose exit status belongs to something else — a pipe, a `;`
+  sequence, or `|| true`. This is the failure `verification.md` warns about, so recording it
+  would have re-created it.
+- [x] 6.4 Reset the session record on a new `session_id`, so `sessionStartedAt` cannot stay
+  pinned to the first session and block a later one over somebody else's unverified edits.
+- [x] 6.5 Honor `stop_hook_active` so the Stop hook blocks at most once per stop sequence.
+- [x] 6.6 Gitignore `.ai/.gate-state.json` in the template.
+- [x] 6.7 Honor `quiet` in the page-metadata and registerCommand warnings, and name each
+  offending path once per run instead of once per registry emitter.
+- [x] 6.8 Fold the OpenAPI fallback log into the warning; drop redundant inline comments.
+- [x] 6.9 Tests for every item above, plus a hook-parity test asserting the two generators
+  install the same hook set — the class of defect 6.1 belongs to.

--- a/.ai/runs/2026-08-14-harness-verification-gates.md
+++ b/.ai/runs/2026-08-14-harness-verification-gates.md
@@ -1,0 +1,123 @@
+# Run: harness verification gates
+
+Source doc: `.ai/specs/2026-08-14-harness-verification-gates.md` (authored in a standalone app; carried over — see Provenance)
+
+## Goal
+
+Make a generated standalone app's validation gates fail when they should, and make the
+`mercato generate` conventions that currently fail *silently* produce warnings — so an agent
+cannot report a green gate it never ran, and a single typo cannot silently drop a backend
+page's authorization.
+
+## Provenance
+
+Derived from a real agent session in a generated standalone app. A `library` module was
+scaffolded, self-certified "PRODUCTION READY", and shipped with 100 TypeScript errors and a
+build that failed on first page load. The claimed evidence line was:
+
+> Gate: `generate` ✓ · `typecheck` ✓ (0 errors) · `lint` ✓ (0 errors) · `test` ✓ (no unit tests; baseline) · `build` ✓
+
+None of those gates had passed. `typecheck` had crashed with an out-of-memory error, `lint`
+never enables `import/no-unresolved`, and `test` exits 0 on an empty suite. The failures
+below are labelled F1–F10 to match the source spec.
+
+## Scope
+
+In scope — the gaps PR #5295 does not cover:
+
+| Phase | Failure | Target |
+|---|---|---|
+| 1 | F3, F10 — vacuous gates reported as passes | `packages/create-app/agentic/shared/AGENTS.md.template` |
+| 2 | F4, F8 — invented import paths, wrong route convention | `packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/` |
+| 3 | F2 — lint blind to unresolved imports | `packages/create-app/template/eslint.config.mjs` *(investigation; may be abandoned)* |
+| 4 | F5, F6, F7, F9 — conventions that fail silently | `packages/cli/src/lib/generators/` |
+| 5 | F10 — nothing distinguishes "claimed" from "ran" | `packages/create-app/agentic/*/hooks/` |
+
+## Non-goals
+
+- **F1 (typecheck heap) is NOT in this run.** PR #5295 already sets
+  `"typecheck": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit"` in
+  `package.json.template`. Duplicating it here would only create a conflict. This run
+  depends on #5295 landing for F1 coverage.
+- No changes to an existing generated app; template and generator only.
+- Generator conventions become **warnings**, never hard failures — existing apps may rely on
+  current tolerance. Escalation to errors is a separate follow-up.
+- No changes to the validation-gate command list itself.
+
+## Risks
+
+- Phase 4 edits a generator with snapshot/structural-contract tests; a warning that fires on
+  a legitimate pattern would be noise across every module. Mitigated by fixture tests
+  asserting both the firing and the silent case.
+- Phase 3 may be unlandable: the resolver inherited from `eslint-config-next` currently
+  reports valid `@open-mercato/*` subpath imports as unresolved. If a two-way test cannot
+  pass, the phase is abandoned with the reason recorded (this satisfies the source spec's
+  AC-2 either way).
+- Phase 1 touches a file #5295 also edits. Textual conflict is possible but small.
+
+## Implementation Plan
+
+### Phase 1 — Gate honesty (F3, F10)
+
+Add to the template's `AGENTS.md` validation rules: a gate counts as passed only when its
+command ran to completion and its exit status is reported; `No tests found` is explicitly not
+a pass; a gate that crashes (OOM included) is a failure to report, never a step to skip.
+
+### Phase 2 — Route to authoritative contracts (F4, F8)
+
+Point `om-module-scaffold` at the installed `@open-mercato/ui` and `@open-mercato/shared`
+`AGENTS.md` files before UI/API work, and document the backend route convention
+(`backend/<segments>/page.tsx` → `/backend/<segments>`; the module id is not a path segment,
+while API routes *are* module-namespaced).
+
+### Phase 3 — Lint sees imports (F2)
+
+Investigate whether the resolver can honor subpath `exports` maps under
+`moduleResolution: bundler`. Two-way test required: a correct import must pass AND an
+invented one must fail. Abandon with a recorded reason if it cannot.
+
+### Phase 4 — Generator warnings (F5, F6, F7, F9)
+
+Warn when: `page.meta.ts` exports no `metadata` (currently drops `requireAuth` /
+`requireFeatures` silently — the security-relevant one); a `commands/*.ts` `registerCommand`
+is unreachable at import time; `di.ts` exports no `register`; and the OpenAPI bundle step
+falls back to regex. Each message names the runtime consequence, not just the rule.
+
+### Phase 5 — Gate-evidence hook (F10)
+
+Ship a `gate-evidence` hook in the agentic hooks template: a recorder (PostToolUse on Bash)
+that writes gate exit statuses, and a blocker (Stop) that fires only when a `src/**` file
+changed after session start and is newer than the last exit-0 typecheck.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Gate honesty
+
+- [ ] 1.1 Add gate-evidence rules to the template AGENTS.md validation section
+
+### Phase 2: Route to authoritative contracts
+
+- [ ] 2.1 Route om-module-scaffold to installed @open-mercato/ui AGENTS.md
+- [ ] 2.2 Route om-module-scaffold to installed @open-mercato/shared AGENTS.md
+- [ ] 2.3 Document the backend page route convention with a worked example
+
+### Phase 3: Lint sees imports
+
+- [ ] 3.1 Investigate resolver support for subpath exports maps
+- [ ] 3.2 Enable import/no-unresolved, or abandon with recorded reason
+
+### Phase 4: Generator warnings
+
+- [ ] 4.1 Warn when page.meta.ts exports no metadata
+- [ ] 4.2 Warn when registerCommand is unreachable at import time
+- [ ] 4.3 Warn when di.ts exports no register
+- [ ] 4.4 Surface the OpenAPI regex fallback as a counted warning
+- [ ] 4.5 Fixture tests for each warning, firing and silent cases
+
+### Phase 5: Gate-evidence hook
+
+- [ ] 5.1 Add the gate-evidence hook to the agentic hooks template
+- [ ] 5.2 Register it in the generated hook settings
+- [ ] 5.3 Unit tests for the comparison and gate-command matching

--- a/packages/cli/src/lib/agentic-setup.ts
+++ b/packages/cli/src/lib/agentic-setup.ts
@@ -218,6 +218,19 @@ function listFiles(root: string): string[] {
   return files
 }
 
+/**
+ * The Claude Code hook files a scaffold installs, read from the agentic source tree.
+ *
+ * Enumerating them by hand let `settings.json` register `gate-evidence.ts` while this
+ * generator kept copying only `entity-migration-check.ts`, so `mercato agentic:init` wrote a
+ * hook registration pointing at a file that was never created. Deriving the list from disk
+ * keeps this path and the create-app wizard in step whenever a hook is added.
+ */
+function claudeHookFiles(): string[] {
+  const hooksDir = join(AGENTIC_DIR, 'claude-code', 'hooks')
+  return listFiles(hooksDir).map((file) => relative(hooksDir, file).replaceAll('\\', '/'))
+}
+
 function copyTree(sourceRoot: string, destinationRoot: string, config: AgenticConfig): void {
   for (const sourcePath of listFiles(sourceRoot)) {
     const destinationPath = join(destinationRoot, relative(sourceRoot, sourcePath))
@@ -462,7 +475,7 @@ function finalizeHarnessManifest(config: AgenticConfig, selectedTools: string[])
   if (selectedTools.includes('claude-code')) {
     paths.add(join(targetDir, 'CLAUDE.md'))
     paths.add(join(targetDir, '.claude', 'settings.json'))
-    paths.add(join(targetDir, '.claude', 'hooks', 'entity-migration-check.ts'))
+    for (const hook of claudeHookFiles()) paths.add(join(targetDir, '.claude', 'hooks', hook))
     paths.add(join(targetDir, '.mcp.json.example'))
   }
   if (selectedTools.includes('codex')) paths.add(join(targetDir, '.codex', 'mcp.json.example'))
@@ -689,7 +702,9 @@ function generateClaudeCode(config: AgenticConfig): void {
 
   writeTemplate(srcDir, 'CLAUDE.md.template', join(targetDir, 'CLAUDE.md'), config)
   copyFile(srcDir, 'settings.json', join(targetDir, '.claude', 'settings.json'))
-  copyFile(srcDir, 'hooks/entity-migration-check.ts', join(targetDir, '.claude', 'hooks', 'entity-migration-check.ts'))
+  for (const hook of claudeHookFiles()) {
+    copyFile(srcDir, `hooks/${hook}`, join(targetDir, '.claude', 'hooks', hook))
+  }
   copyFile(srcDir, 'mcp.json.example', join(targetDir, '.mcp.json.example'))
 
   // The installer exclusively owns Claude's per-skill compatibility links.

--- a/packages/cli/src/lib/generators/__tests__/silent-convention-warnings.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/silent-convention-warnings.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Warnings for module conventions that otherwise fail silently.
+ *
+ * Each case below corresponds to a convention where getting the name wrong produces a
+ * generator run that succeeds, a manifest that looks correct, and a defect that only
+ * appears at runtime. The `does not warn` half of each pair matters as much as the
+ * warning half: a diagnostic that fires on correct code is noise, and noise gets muted.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import {
+  warnIfPageMetaMissingMetadataExport,
+  warnIfRegisterCommandNotAtImportTime,
+} from '../module-registry'
+import { warnIfDiMissingRegisterExport } from '../module-di'
+
+let tmpDir: string
+let warnSpy: jest.SpyInstance
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om-warn-'))
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+function write(name: string, contents: string): string {
+  const file = path.join(tmpDir, name)
+  fs.writeFileSync(file, contents, 'utf8')
+  return file
+}
+
+function warnings(): string {
+  return warnSpy.mock.calls.map((call) => String(call[0])).join('\n')
+}
+
+describe('page.meta metadata export', () => {
+  it('warns, and names the lost authorization gate, when the export is not `metadata`', () => {
+    const file = write('page.meta.ts', `export const meta = { requireAuth: true, requireFeatures: ['x.view'] }\nexport default meta\n`)
+    warnIfPageMetaMissingMetadataExport(file)
+    // The consequence is the point: an author who mistypes the name has no way to discover
+    // that the page lost `requireAuth` unless the message says so.
+    expect(warnings()).toContain('requireAuth')
+    expect(warnings()).toContain(file)
+  })
+
+  it('does not warn when `metadata` is exported', () => {
+    const file = write('page.meta.ts', `export const metadata = { requireAuth: true }\nexport default metadata\n`)
+    warnIfPageMetaMissingMetadataExport(file)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when no metadata file was discovered', () => {
+    warnIfPageMetaMissingMetadataExport(null)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('registerCommand reachability', () => {
+  it('warns when every registerCommand call sits inside an uncalled function', () => {
+    const file = write('books.ts', [
+      `import { registerCommand } from '@open-mercato/shared/lib/commands'`,
+      `const createBook = { id: 'library.books.create' }`,
+      `export function registerLibraryBookCommands() {`,
+      `  registerCommand(createBook)`,
+      `}`,
+    ].join('\n'))
+    warnIfRegisterCommandNotAtImportTime(file)
+    expect(warnings()).toContain('will not register at runtime')
+  })
+
+  it('does not warn when registerCommand runs at import time', () => {
+    const file = write('books.ts', [
+      `import { registerCommand } from '@open-mercato/shared/lib/commands'`,
+      `const createBook = { id: 'library.books.create' }`,
+      `registerCommand(createBook)`,
+    ].join('\n'))
+    warnIfRegisterCommandNotAtImportTime(file)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not warn for a helper file that registers nothing', () => {
+    const file = write('shared-helpers.ts', `export function ensureScope() { return null }\n`)
+    warnIfRegisterCommandNotAtImportTime(file)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('di register export', () => {
+  it('warns when di.ts exports no `register`', () => {
+    const file = write('di.ts', `export function setupLibraryDi(container: unknown) { void container }\n`)
+    warnIfDiMissingRegisterExport(file)
+    expect(warnings()).toContain('DI registrations will never run')
+  })
+
+  it.each([
+    ['function declaration', `export function register(container: unknown) { void container }\n`],
+    ['async function', `export async function register(container: unknown) { void container }\n`],
+    ['const arrow', `export const register = (container: unknown) => { void container }\n`],
+    ['named re-export', `function register() {}\nexport { register }\n`],
+  ])('does not warn for a %s', (_label, source) => {
+    const file = write('di.ts', source)
+    warnIfDiMissingRegisterExport(file)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('stays silent when quiet is set', () => {
+    const file = write('di.ts', `export function nope() {}\n`)
+    warnIfDiMissingRegisterExport(file, true)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/lib/generators/__tests__/silent-convention-warnings.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/silent-convention-warnings.test.ts
@@ -10,6 +10,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import {
+  resetConventionWarnings,
   warnIfPageMetaMissingMetadataExport,
   warnIfRegisterCommandNotAtImportTime,
 } from '../module-registry'
@@ -21,6 +22,7 @@ let warnSpy: jest.SpyInstance
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om-warn-'))
   warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  resetConventionWarnings()
 })
 
 afterEach(() => {
@@ -111,6 +113,42 @@ describe('di register export', () => {
   it('stays silent when quiet is set', () => {
     const file = write('di.ts', `export function nope() {}\n`)
     warnIfDiMissingRegisterExport(file, true)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe('warning volume', () => {
+  it('names each offending page metadata file once per run, not once per emitter', () => {
+    // One `yarn generate` walks the same page files through three registry emitters. A
+    // warning repeated six times reads as noise, and noise is what gets tuned out.
+    const file = write('page.meta.ts', `export const meta = { requireAuth: true }\n`)
+    warnIfPageMetaMissingMetadataExport(file)
+    warnIfPageMetaMissingMetadataExport(file)
+    warnIfPageMetaMissingMetadataExport(file)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('warns again for the same path once a new run resets the ledger', () => {
+    const file = write('page.meta.ts', `export const meta = { requireAuth: true }\n`)
+    warnIfPageMetaMissingMetadataExport(file)
+    resetConventionWarnings()
+    warnIfPageMetaMissingMetadataExport(file)
+    expect(warnSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    ['page metadata', (file: string) => warnIfPageMetaMissingMetadataExport(file, true)],
+    ['registerCommand reachability', (file: string) => warnIfRegisterCommandNotAtImportTime(file, true)],
+  ])('stays silent for %s when quiet is set', (_label, warn) => {
+    // `generateModuleRegistries` is called with `quiet: true` by module install and by the
+    // generator snapshot tests; a caller that asked for silence must get it.
+    const file = write('subject.ts', [
+      `export const meta = { requireAuth: true }`,
+      `export function registerLibraryCommands() {`,
+      `  registerCommand({ id: 'library.books.create' })`,
+      `}`,
+    ].join('\n'))
+    warn(file)
     expect(warnSpy).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/lib/generators/module-di.ts
+++ b/packages/cli/src/lib/generators/module-di.ts
@@ -49,12 +49,14 @@ export async function generateModuleDi(options: ModuleDiOptions): Promise<Genera
     const importName = `D_${toVar(modId)}_${i++}`
 
     if (useApp) {
+      warnIfDiMissingRegisterExport(findModuleConventionFilePath(roots.appBase, 'di'), quiet)
       // For @app modules, use relative path to work in both Next.js and Node.js CLI context
       // From .mercato/generated/, go up two levels (../..) to reach the app root, then into src/modules/
       const importPath = isAppModule ? `../../src/modules/${modId}/di` : `${imp.appBase}/di`
       imports.push({ name: importName, moduleSpecifier: importPath })
       registrars.push(`${importName}.register`)
     } else if (usePkg) {
+      warnIfDiMissingRegisterExport(findModuleConventionFilePath(roots.pkgBase, 'di'), quiet)
       imports.push({ name: importName, moduleSpecifier: `${imp.pkgBase}/di` })
       registrars.push(`${importName}.register`)
     }
@@ -106,4 +108,37 @@ export async function generateModuleDi(options: ModuleDiOptions): Promise<Genera
 
 function resolveModuleConventionFile(baseDir: string, basename: string): boolean {
   return MODULE_CODE_EXTENSIONS.some((extension) => fs.existsSync(path.join(baseDir, `${basename}${extension}`)))
+}
+
+function findModuleConventionFilePath(baseDir: string, basename: string): string | null {
+  for (const extension of MODULE_CODE_EXTENSIONS) {
+    const candidate = path.join(baseDir, `${basename}${extension}`)
+    if (fs.existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+/**
+ * Warns when a discovered `di.ts` exports no `register`.
+ *
+ * The generated registrar list is built from `<import>.register` for every module that has a
+ * `di` file. A differently named export makes that entry `undefined`, so the module's DI
+ * registrations silently never run and its services surface as missing at request time
+ * instead of at generation time.
+ */
+export function warnIfDiMissingRegisterExport(diPath: string | null, quiet = false): void {
+  if (!diPath || quiet) return
+  let source = ''
+  try {
+    source = fs.readFileSync(diPath, 'utf8')
+  } catch {
+    return
+  }
+  const exportsRegister = /export\s+(async\s+)?function\s+register\b/.test(source)
+    || /export\s+(const|let|var)\s+register\b/.test(source)
+    || /export\s*\{[^}]*\bregister\b[^}]*\}/.test(source)
+  if (exportsRegister) return
+  console.warn(
+    `[generate] ⚠ di.ts exports no 'register' — this module's DI registrations will never run: ${diPath}`,
+  )
 }

--- a/packages/cli/src/lib/generators/module-registry.ts
+++ b/packages/cli/src/lib/generators/module-registry.ts
@@ -1369,11 +1369,15 @@ function collectCommandLoaderEntries(
     const logicalKey = stripModuleCodeExtension(file.relPath)
     const basename = path.basename(logicalKey)
     if (basename === 'shared' || basename === 'factory') continue
+    const ids = extractCommandIdsFromSource(resolved.absolutePath)
+    // Only meaningful when this file actually contributes ids: a helper module under
+    // `commands/` with no registrations is not expected to call `registerCommand`.
+    if (ids.length > 0) warnIfRegisterCommandNotAtImportTime(resolved.absolutePath)
     entries.push({
       moduleId: modId,
       key: `${modId}:commands:${logicalKey}`,
       importPath: resolved.importPath,
-      ids: extractCommandIdsFromSource(resolved.absolutePath),
+      ids,
     })
   }
   return entries
@@ -1462,6 +1466,54 @@ function findExistingModuleFileByBaseNames(baseDir: string, relativeBaseNames: s
     if (resolved) return resolved
   }
   return null
+}
+
+/**
+ * Warns when a discovered page metadata file exports no `metadata` binding.
+ *
+ * Both page-route emitters read `<module>.metadata` off the imported file. When the author
+ * named the export something else — `meta` is the common near-miss — that read yields
+ * `undefined`, the route still generates, and every declaration in the file is dropped.
+ * `requireAuth` and `requireFeatures` are among them, so the page ships with no
+ * authorization gate and nothing in the build says so. The warning names that consequence
+ * because the rule alone ("export `metadata`") does not convey why it matters.
+ */
+export function warnIfPageMetaMissingMetadataExport(metaPath: string | null): void {
+  if (!metaPath) return
+  if (hasNamedExport(metaPath, 'metadata')) return
+  console.warn(
+    `[generate] ⚠ Page metadata file exports no 'metadata' — page metadata is dropped, `
+    + `including requireAuth/requireFeatures, so the page renders with NO authorization gate: ${metaPath}`,
+  )
+}
+
+/**
+ * Warns when a `commands/*.ts` file registers commands only from inside a function.
+ *
+ * Command discovery extracts ids statically and emits a lazy loader per file; the loader
+ * resolves a command by importing that file and relying on `registerCommand(...)` running as
+ * an import-time side effect. When every call sits inside a function body that nothing
+ * invokes, the ids still appear in the generated manifest but the handlers never register,
+ * so the command bus reports the command as unknown at runtime.
+ *
+ * Heuristic and deliberately conservative: it only fires when the file contains at least one
+ * `registerCommand(` call and none of them is at top level (column 0), which is how every
+ * correct module writes them.
+ */
+export function warnIfRegisterCommandNotAtImportTime(sourcePath: string): void {
+  let source = ''
+  try {
+    source = fs.readFileSync(sourcePath, 'utf8')
+  } catch {
+    return
+  }
+  if (!/\bregisterCommand\s*\(/.test(source)) return
+  const hasTopLevelCall = /^registerCommand\s*\(/m.test(source)
+  if (hasTopLevelCall) return
+  console.warn(
+    `[generate] ⚠ registerCommand(...) is never called at import time — these command ids will `
+    + `appear in the manifest but the handlers will not register at runtime: ${sourcePath}`,
+  )
 }
 
 function toModuleImportSubpath(filePath: string, baseDir: string): string {
@@ -1918,6 +1970,7 @@ async function processPageFiles(options: {
     const sourceFile = findExistingModuleFile(moduleBaseDir, pageFile)
     if (!sourceFile || !hasDefaultExport(sourceFile)) continue
     const metaPath = findExistingModuleFileByBaseNames(moduleBaseDir, ['page.meta', 'meta'])
+    warnIfPageMetaMissingMetadataExport(metaPath)
     let metaExpr = 'undefined'
     let runtimeMetaExpr = 'undefined'
     let manifestMetaExpr = 'undefined'
@@ -2811,6 +2864,7 @@ async function processPageFilesAst(options: {
     if (!sourceFile || !hasDefaultExport(sourceFile)) continue
 
     const metaPath = findExistingModuleFileByBaseNames(moduleBaseDir, ['page.meta', 'meta'])
+    warnIfPageMetaMissingMetadataExport(metaPath)
     if (metaPath) {
       const metaImportName = `${metaPrefix}${importIdRef.value++}_${toVar(modId)}_${toVar(segs.join('_') || 'index')}`
       const metaImportPath = sanitizeGeneratedModuleSpecifier(

--- a/packages/cli/src/lib/generators/module-registry.ts
+++ b/packages/cli/src/lib/generators/module-registry.ts
@@ -1359,6 +1359,7 @@ function collectCommandLoaderEntries(
   roots: ModuleRoots,
   imps: ModuleImports,
   modId: string,
+  quiet = false,
 ): CommandLoaderGenerationEntry[] {
   const files = scanModuleDir(roots, COMMAND_SCAN_CONFIG)
   const entries: CommandLoaderGenerationEntry[] = []
@@ -1370,9 +1371,7 @@ function collectCommandLoaderEntries(
     const basename = path.basename(logicalKey)
     if (basename === 'shared' || basename === 'factory') continue
     const ids = extractCommandIdsFromSource(resolved.absolutePath)
-    // Only meaningful when this file actually contributes ids: a helper module under
-    // `commands/` with no registrations is not expected to call `registerCommand`.
-    if (ids.length > 0) warnIfRegisterCommandNotAtImportTime(resolved.absolutePath)
+    if (ids.length > 0) warnIfRegisterCommandNotAtImportTime(resolved.absolutePath, quiet)
     entries.push({
       moduleId: modId,
       key: `${modId}:commands:${logicalKey}`,
@@ -1468,6 +1467,27 @@ function findExistingModuleFileByBaseNames(baseDir: string, relativeBaseNames: s
   return null
 }
 
+const warnedConventionPaths = new Set<string>()
+
+/**
+ * Clears the once-per-path warning ledger.
+ *
+ * A single `yarn generate` runs three registry emitters over one discovery, and each of them
+ * walks the same frontend and backend page files, so an unguarded warning would print the
+ * same line up to six times. A diagnostic that repeats is a diagnostic that gets skimmed
+ * past, so each offending path is named once per run and the ledger resets when the run's
+ * discovery is built.
+ */
+export function resetConventionWarnings(): void {
+  warnedConventionPaths.clear()
+}
+
+function alreadyWarned(sourcePath: string): boolean {
+  if (warnedConventionPaths.has(sourcePath)) return true
+  warnedConventionPaths.add(sourcePath)
+  return false
+}
+
 /**
  * Warns when a discovered page metadata file exports no `metadata` binding.
  *
@@ -1478,9 +1498,10 @@ function findExistingModuleFileByBaseNames(baseDir: string, relativeBaseNames: s
  * authorization gate and nothing in the build says so. The warning names that consequence
  * because the rule alone ("export `metadata`") does not convey why it matters.
  */
-export function warnIfPageMetaMissingMetadataExport(metaPath: string | null): void {
-  if (!metaPath) return
+export function warnIfPageMetaMissingMetadataExport(metaPath: string | null, quiet = false): void {
+  if (!metaPath || quiet) return
   if (hasNamedExport(metaPath, 'metadata')) return
+  if (alreadyWarned(metaPath)) return
   console.warn(
     `[generate] ⚠ Page metadata file exports no 'metadata' — page metadata is dropped, `
     + `including requireAuth/requireFeatures, so the page renders with NO authorization gate: ${metaPath}`,
@@ -1500,7 +1521,8 @@ export function warnIfPageMetaMissingMetadataExport(metaPath: string | null): vo
  * `registerCommand(` call and none of them is at top level (column 0), which is how every
  * correct module writes them.
  */
-export function warnIfRegisterCommandNotAtImportTime(sourcePath: string): void {
+export function warnIfRegisterCommandNotAtImportTime(sourcePath: string, quiet = false): void {
+  if (quiet) return
   let source = ''
   try {
     source = fs.readFileSync(sourcePath, 'utf8')
@@ -1510,6 +1532,7 @@ export function warnIfRegisterCommandNotAtImportTime(sourcePath: string): void {
   if (!/\bregisterCommand\s*\(/.test(source)) return
   const hasTopLevelCall = /^registerCommand\s*\(/m.test(source)
   if (hasTopLevelCall) return
+  if (alreadyWarned(sourcePath)) return
   console.warn(
     `[generate] ⚠ registerCommand(...) is never called at import time — these command ids will `
     + `appear in the manifest but the handlers will not register at runtime: ${sourcePath}`,
@@ -1849,7 +1872,9 @@ function discoverTranslations(roots: ModuleRoots): DiscoveredTranslation[] {
 
 async function createModuleRegistryDiscovery(
   resolver: PackageResolver,
+  quiet = false,
 ): Promise<ModuleRegistryDiscovery> {
+  resetConventionWarnings()
   const enabled = resolver.loadEnabledModules()
   const modules: ModuleRegistryDiscoveryEntry[] = []
   const trackedRoots = new Set<string>()
@@ -1881,7 +1906,7 @@ async function createModuleRegistryDiscovery(
       resolve,
       frontendFiles: scanModuleDir(roots, SCAN_CONFIGS.frontendPages),
       backendFiles: scanModuleDir(roots, SCAN_CONFIGS.backendPages),
-      commandLoaderEntries: collectCommandLoaderEntries(roots, imps, modId),
+      commandLoaderEntries: collectCommandLoaderEntries(roots, imps, modId, quiet),
       getSubscribers: () => subscribers ??= discoverSubscribers(roots, imps, modId),
       getWorkers: () => workers ??= discoverWorkers(roots, imps, modId),
       translations: discoverTranslations(roots),
@@ -1943,8 +1968,9 @@ async function processPageFiles(options: {
   runtimeImports: string[]
   manifestImports?: string[]
   importIdRef: { value: number }
+  quiet?: boolean
 }): Promise<PageRouteGenerationResult> {
-  const { files, type, modId, appDir, pkgDir, appImportBase, pkgImportBase, eagerImports, runtimeImports, manifestImports, importIdRef } = options
+  const { files, type, modId, appDir, pkgDir, appImportBase, pkgImportBase, eagerImports, runtimeImports, manifestImports, importIdRef, quiet } = options
   const metaPrefix = type === 'frontend' ? 'M' : 'BM'
   const eagerRoutes: string[] = []
   const runtimeRoutes: string[] = []
@@ -1970,7 +1996,7 @@ async function processPageFiles(options: {
     const sourceFile = findExistingModuleFile(moduleBaseDir, pageFile)
     if (!sourceFile || !hasDefaultExport(sourceFile)) continue
     const metaPath = findExistingModuleFileByBaseNames(moduleBaseDir, ['page.meta', 'meta'])
-    warnIfPageMetaMissingMetadataExport(metaPath)
+    warnIfPageMetaMissingMetadataExport(metaPath, quiet)
     let metaExpr = 'undefined'
     let runtimeMetaExpr = 'undefined'
     let manifestMetaExpr = 'undefined'
@@ -2817,6 +2843,7 @@ async function processPageFilesAst(options: {
   pkgImportBase: string
   imports: string[]
   importIdRef: { value: number }
+  quiet?: boolean
 }): Promise<{ routes: WriterFunction[]; routePatterns: string[] }> {
   const {
     files,
@@ -2828,6 +2855,7 @@ async function processPageFilesAst(options: {
     pkgImportBase,
     imports,
     importIdRef,
+    quiet,
   } = options
   const routes: WriterFunction[] = []
   const routePatterns: string[] = []
@@ -2864,7 +2892,7 @@ async function processPageFilesAst(options: {
     if (!sourceFile || !hasDefaultExport(sourceFile)) continue
 
     const metaPath = findExistingModuleFileByBaseNames(moduleBaseDir, ['page.meta', 'meta'])
-    warnIfPageMetaMissingMetadataExport(metaPath)
+    warnIfPageMetaMissingMetadataExport(metaPath, quiet)
     if (metaPath) {
       const metaImportName = `${metaPrefix}${importIdRef.value++}_${toVar(modId)}_${toVar(segs.join('_') || 'index')}`
       const metaImportPath = sanitizeGeneratedModuleSpecifier(
@@ -3428,6 +3456,7 @@ async function generateModuleRegistryFromDiscovery(options: ModuleRegistryRender
           runtimeImports,
           manifestImports: frontendRouteManifestImports,
           importIdRef,
+          quiet,
         })
         frontendRoutes.push(...generatedFrontendRoutes.eagerRoutes)
         runtimeFrontendRoutes.push(...generatedFrontendRoutes.runtimeRoutes)
@@ -3551,6 +3580,7 @@ async function generateModuleRegistryFromDiscovery(options: ModuleRegistryRender
           runtimeImports,
           manifestImports: backendRouteManifestImports,
           importIdRef,
+          quiet,
         })
         backendRoutes.push(...generatedBackendRoutes.eagerRoutes)
         runtimeBackendRoutes.push(...generatedBackendRoutes.runtimeRoutes)
@@ -4080,6 +4110,7 @@ async function generateModuleRegistryAppFromDiscovery(options: ModuleRegistryRen
           pkgImportBase: imps.pkgBase,
           imports,
           importIdRef,
+          quiet,
         })
         frontendRoutes.push(...feAst.routes)
         hasRouteComponents = true
@@ -4101,6 +4132,7 @@ async function generateModuleRegistryAppFromDiscovery(options: ModuleRegistryRen
           pkgImportBase: imps.pkgBase,
           imports,
           importIdRef,
+          quiet,
         })
         backendRoutes.push(...beAst.routes)
         for (const pattern of beAst.routePatterns) {
@@ -4703,22 +4735,22 @@ async function generateModuleRegistryCliFromDiscovery(options: ModuleRegistryRen
 }
 
 export async function generateModuleRegistry(options: ModuleRegistryOptions): Promise<GeneratorResult> {
-  const discovery = await createModuleRegistryDiscovery(options.resolver)
+  const discovery = await createModuleRegistryDiscovery(options.resolver, options.quiet ?? false)
   return generateModuleRegistryFromDiscovery({ ...options, discovery })
 }
 
 export async function generateModuleRegistryApp(options: ModuleRegistryOptions): Promise<GeneratorResult> {
-  const discovery = await createModuleRegistryDiscovery(options.resolver)
+  const discovery = await createModuleRegistryDiscovery(options.resolver, options.quiet ?? false)
   return generateModuleRegistryAppFromDiscovery({ ...options, discovery })
 }
 
 export async function generateModuleRegistryCli(options: ModuleRegistryOptions): Promise<GeneratorResult> {
-  const discovery = await createModuleRegistryDiscovery(options.resolver)
+  const discovery = await createModuleRegistryDiscovery(options.resolver, options.quiet ?? false)
   return generateModuleRegistryCliFromDiscovery({ ...options, discovery })
 }
 
 export async function generateModuleRegistries(options: ModuleRegistryOptions): Promise<GeneratorResult[]> {
-  const discovery = await createModuleRegistryDiscovery(options.resolver)
+  const discovery = await createModuleRegistryDiscovery(options.resolver, options.quiet ?? false)
   return [
     await generateModuleRegistryFromDiscovery({ ...options, discovery }),
     await generateModuleRegistryAppFromDiscovery({ ...options, discovery }),

--- a/packages/cli/src/lib/generators/openapi.ts
+++ b/packages/cli/src/lib/generators/openapi.ts
@@ -709,6 +709,15 @@ export async function generateOpenApi(options: GenerateOpenApiOptions): Promise<
   // Fallback to static regex approach (extracts operationId/summary/tags but no schemas)
   if (!doc) {
     if (!quiet) {
+      // Warn rather than log: the usual cause is a route importing a module specifier that
+      // does not resolve, and the visible symptom is silent — generation still "succeeds",
+      // but every request/response schema is dropped from the emitted document. That reads
+      // as an OpenAPI quality regression when it is really an unresolved import.
+      console.warn(
+        '[generate] ⚠ OpenAPI bundling failed; fell back to static regex extraction — '
+        + 'request/response schemas are OMITTED from the generated document. '
+        + 'The usual cause is a route file importing a module specifier that does not resolve.',
+      )
       console.log('[OpenAPI] Falling back to static regex approach')
     }
     const paths = buildOpenApiPaths(routes)

--- a/packages/cli/src/lib/generators/openapi.ts
+++ b/packages/cli/src/lib/generators/openapi.ts
@@ -709,16 +709,11 @@ export async function generateOpenApi(options: GenerateOpenApiOptions): Promise<
   // Fallback to static regex approach (extracts operationId/summary/tags but no schemas)
   if (!doc) {
     if (!quiet) {
-      // Warn rather than log: the usual cause is a route importing a module specifier that
-      // does not resolve, and the visible symptom is silent — generation still "succeeds",
-      // but every request/response schema is dropped from the emitted document. That reads
-      // as an OpenAPI quality regression when it is really an unresolved import.
       console.warn(
-        '[generate] ⚠ OpenAPI bundling failed; fell back to static regex extraction — '
+        '[OpenAPI] ⚠ Bundling failed; falling back to static regex extraction — '
         + 'request/response schemas are OMITTED from the generated document. '
         + 'The usual cause is a route file importing a module specifier that does not resolve.',
       )
-      console.log('[OpenAPI] Falling back to static regex approach')
     }
     const paths = buildOpenApiPaths(routes)
     doc = {

--- a/packages/create-app/agentic/claude-code/hooks/gate-evidence.ts
+++ b/packages/create-app/agentic/claude-code/hooks/gate-evidence.ts
@@ -3,10 +3,10 @@
  *
  * Two modes, mirroring `entity-migration-check`'s shape:
  *
- * - `record` (PostToolUse on Bash) — when a Bash command was a validation gate, append its
- *   exit status to `.ai/.gate-state.json`.
+ * - `record` (PostToolUse on Bash) — when a Bash command was a validation gate AND its exit
+ *   status genuinely belongs to that gate, append the status to `.ai/.gate-state.json`.
  * - `check` (Stop) — block when a file under `src/` changed after the session started and is
- *   newer than the last exit-0 typecheck.
+ *   newer than the last exit-0 typecheck, unless this stop is already the result of a block.
  *
  * Why this exists: a gate that is claimed but never run is indistinguishable, in a
  * transcript, from one that passed. This makes the difference mechanical.
@@ -14,8 +14,10 @@
  * Deliberate limits. The blocker only considers `typecheck`: demanding a green `build` on
  * every stop would be punitive, and typecheck is the cheap gate that catches the defect class
  * this guards. It compares mtimes rather than hashing, so a touch-without-edit costs one
- * gate run. And the state file can simply be deleted — this is a speed bump against
- * carelessness, not a defense against deliberate circumvention.
+ * gate run. It blocks at most once per stop sequence, so a gate that genuinely cannot pass
+ * is reported to the user rather than trapping the agent. And the state file can simply be
+ * deleted — this is a speed bump against carelessness, not a defense against deliberate
+ * circumvention.
  */
 import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -29,6 +31,7 @@ export type GateName = 'typecheck' | 'lint' | 'test' | 'build' | 'generate'
 export type GateRecord = { exitCode: number; finishedAt: string }
 
 export type GateState = {
+  sessionId?: string
   sessionStartedAt?: string
   gates?: Partial<Record<GateName, GateRecord>>
 }
@@ -54,6 +57,54 @@ export function matchGates(command: string): GateName[] {
     if (pattern.test(command)) found.add(gate)
   }
   return [...found]
+}
+
+/**
+ * Decides whether a command's exit status can be attributed to the gates it names.
+ *
+ * A pipeline reports the exit status of its LAST stage, so `yarn typecheck | tail -30`
+ * reports `tail`'s success no matter what `tsc` did. `;` and `||` break the link the same
+ * way. `&&` does not: it short-circuits, so a non-zero status still belongs to a gate that
+ * ran — at worst a later gate's failure is attributed to an earlier one, which only costs a
+ * re-run.
+ *
+ * Recording an unattributable status would manufacture exactly the false green this hook
+ * exists to prevent, so those commands are not recorded at all.
+ */
+export function isAttributableGateCommand(command: string): boolean {
+  return !/[|;\n]/.test(command)
+}
+
+/**
+ * Resolves the exit status a Bash tool response reported, or `null` when it reported none.
+ *
+ * `null` is not zero. An unknown outcome must never be stored as a pass — the whole point of
+ * the state file is that it holds observed results, and a payload shape this hook does not
+ * recognize is the one case where it has observed nothing.
+ */
+export function resolveExitCode(data: HookInput): number | null {
+  const response = data.tool_response ?? {}
+  const value = response.exit_code ?? response.exitCode
+  return typeof value === 'number' ? value : null
+}
+
+/**
+ * Rolls the state forward into the session the current invocation belongs to.
+ *
+ * The state file outlives the session that wrote it, so a `sessionStartedAt` set once and
+ * never revisited would pin every later session to the first one's clock and make the
+ * "changed during THIS session" test meaningless. A new `session_id` therefore starts from a
+ * clean record: gates observed in an earlier session prove nothing about this one.
+ *
+ * Payloads without a `session_id` keep the original set-once behavior, so an older client
+ * degrades rather than resetting on every call.
+ */
+export function nextSessionState(previous: GateState, sessionId: string | null, startedAt: string): GateState {
+  if (!sessionId) {
+    return previous.sessionStartedAt ? previous : { ...previous, sessionStartedAt: startedAt }
+  }
+  if (previous.sessionId === sessionId && previous.sessionStartedAt) return previous
+  return { sessionId, sessionStartedAt: startedAt }
 }
 
 /**
@@ -135,15 +186,11 @@ function readStdin(): Promise<string> {
   })
 }
 
-type HookInput = {
+export type HookInput = {
+  session_id?: string
+  stop_hook_active?: boolean
   tool_input?: { command?: string }
   tool_response?: { exit_code?: number; exitCode?: number }
-}
-
-function resolveExitCode(data: HookInput): number {
-  const response = data.tool_response ?? {}
-  const value = response.exit_code ?? response.exitCode
-  return typeof value === 'number' ? value : 0
 }
 
 async function main(): Promise<void> {
@@ -159,19 +206,19 @@ async function main(): Promise<void> {
     }
   }
 
-  const state = readState()
+  const previous = readState()
   const now = new Date()
-  if (!state.sessionStartedAt) {
-    state.sessionStartedAt = now.toISOString()
-    writeState(state)
-  }
+  const state = nextSessionState(previous, data.session_id ?? null, now.toISOString())
+  if (state !== previous) writeState(state)
 
   if (mode === 'record') {
     const command = data.tool_input?.command
     if (!command) return
     const gates = matchGates(command)
     if (!gates.length) return
+    if (!isAttributableGateCommand(command)) return
     const exitCode = resolveExitCode(data)
+    if (exitCode === null) return
     state.gates = state.gates ?? {}
     for (const gate of gates) {
       state.gates[gate] = { exitCode, finishedAt: now.toISOString() }
@@ -179,6 +226,8 @@ async function main(): Promise<void> {
     writeState(state)
     return
   }
+
+  if (data.stop_hook_active) return
 
   const typecheck = state.gates?.typecheck
   const blocked = shouldBlock({

--- a/packages/create-app/agentic/claude-code/hooks/gate-evidence.ts
+++ b/packages/create-app/agentic/claude-code/hooks/gate-evidence.ts
@@ -1,0 +1,216 @@
+/**
+ * Record validation-gate outcomes, and refuse to conclude on unverified source changes.
+ *
+ * Two modes, mirroring `entity-migration-check`'s shape:
+ *
+ * - `record` (PostToolUse on Bash) — when a Bash command was a validation gate, append its
+ *   exit status to `.ai/.gate-state.json`.
+ * - `check` (Stop) — block when a file under `src/` changed after the session started and is
+ *   newer than the last exit-0 typecheck.
+ *
+ * Why this exists: a gate that is claimed but never run is indistinguishable, in a
+ * transcript, from one that passed. This makes the difference mechanical.
+ *
+ * Deliberate limits. The blocker only considers `typecheck`: demanding a green `build` on
+ * every stop would be punitive, and typecheck is the cheap gate that catches the defect class
+ * this guards. It compares mtimes rather than hashing, so a touch-without-edit costs one
+ * gate run. And the state file can simply be deleted — this is a speed bump against
+ * carelessness, not a defense against deliberate circumvention.
+ */
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const STATE_RELATIVE_PATH = '.ai/.gate-state.json'
+const WATCHED_ROOT = 'src'
+
+export type GateName = 'typecheck' | 'lint' | 'test' | 'build' | 'generate'
+
+export type GateRecord = { exitCode: number; finishedAt: string }
+
+export type GateState = {
+  sessionStartedAt?: string
+  gates?: Partial<Record<GateName, GateRecord>>
+}
+
+/**
+ * Extracts every gate a Bash command ran.
+ *
+ * Returns a list because the harness's own documented gate line chains several with `&&`,
+ * and a run reported through a compound command must not be invisible to the recorder.
+ * Direct invocations that bypass the package script (`npx tsc --noEmit`) count too — the
+ * point is whether the check happened, not which alias was typed.
+ */
+export function matchGates(command: string): GateName[] {
+  const found = new Set<GateName>()
+  const named: Array<[GateName, RegExp]> = [
+    ['typecheck', /\b(?:yarn|npm run|pnpm)\s+typecheck\b|\btsc\b[^&|;]*--noEmit/],
+    ['lint', /\b(?:yarn|npm run|pnpm)\s+lint\b|\beslint\b/],
+    ['test', /\b(?:yarn|npm run|pnpm)\s+test\b|\bjest\b/],
+    ['build', /\b(?:yarn|npm run|pnpm)\s+build\b|\bnext build\b/],
+    ['generate', /\b(?:yarn|npm run|pnpm)\s+generate\b|\bmercato\s+generate\b/],
+  ]
+  for (const [gate, pattern] of named) {
+    if (pattern.test(command)) found.add(gate)
+  }
+  return [...found]
+}
+
+/**
+ * Decides whether concluding should be blocked.
+ *
+ * An absent typecheck record does NOT block on its own — otherwise the first stop of every
+ * session on a fresh clone would block, including read-only or docs-only sessions that never
+ * touched `src/`. The gate is source changed during THIS session and not since verified.
+ */
+export function shouldBlock(input: {
+  newestSrcMtimeMs: number | null
+  sessionStartedAtMs: number
+  lastGreenTypecheckMs: number | null
+}): boolean {
+  const { newestSrcMtimeMs, sessionStartedAtMs, lastGreenTypecheckMs } = input
+  if (newestSrcMtimeMs === null) return false
+  if (newestSrcMtimeMs < sessionStartedAtMs) return false
+  if (lastGreenTypecheckMs === null) return true
+  return newestSrcMtimeMs > lastGreenTypecheckMs
+}
+
+function projectDir(): string {
+  return process.env.CLAUDE_PROJECT_DIR || process.cwd()
+}
+
+function statePath(): string {
+  return join(projectDir(), STATE_RELATIVE_PATH)
+}
+
+function readState(): GateState {
+  try {
+    return JSON.parse(readFileSync(statePath(), 'utf8')) as GateState
+  } catch {
+    return {}
+  }
+}
+
+function writeState(state: GateState): void {
+  try {
+    mkdirSync(join(projectDir(), '.ai'), { recursive: true })
+    writeFileSync(statePath(), `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+  } catch {
+    // A hook must never fail the turn over its own bookkeeping.
+  }
+}
+
+function newestMtimeMs(dir: string): number | null {
+  let newest: number | null = null
+  const walk = (current: string): void => {
+    let entries: string[]
+    try {
+      entries = readdirSync(current)
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue
+      const full = join(current, entry)
+      let stats
+      try {
+        stats = statSync(full)
+      } catch {
+        continue
+      }
+      if (stats.isDirectory()) walk(full)
+      else if (newest === null || stats.mtimeMs > newest) newest = stats.mtimeMs
+    }
+  }
+  walk(dir)
+  return newest
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    let raw = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', (chunk) => { raw += chunk })
+    process.stdin.on('end', () => resolve(raw))
+  })
+}
+
+type HookInput = {
+  tool_input?: { command?: string }
+  tool_response?: { exit_code?: number; exitCode?: number }
+}
+
+function resolveExitCode(data: HookInput): number {
+  const response = data.tool_response ?? {}
+  const value = response.exit_code ?? response.exitCode
+  return typeof value === 'number' ? value : 0
+}
+
+async function main(): Promise<void> {
+  const mode = process.argv[2] === 'check' ? 'check' : 'record'
+  const raw = await readStdin()
+
+  let data: HookInput = {}
+  if (raw.trim()) {
+    try {
+      data = JSON.parse(raw) as HookInput
+    } catch {
+      return
+    }
+  }
+
+  const state = readState()
+  const now = new Date()
+  if (!state.sessionStartedAt) {
+    state.sessionStartedAt = now.toISOString()
+    writeState(state)
+  }
+
+  if (mode === 'record') {
+    const command = data.tool_input?.command
+    if (!command) return
+    const gates = matchGates(command)
+    if (!gates.length) return
+    const exitCode = resolveExitCode(data)
+    state.gates = state.gates ?? {}
+    for (const gate of gates) {
+      state.gates[gate] = { exitCode, finishedAt: now.toISOString() }
+    }
+    writeState(state)
+    return
+  }
+
+  const typecheck = state.gates?.typecheck
+  const blocked = shouldBlock({
+    newestSrcMtimeMs: newestMtimeMs(join(projectDir(), WATCHED_ROOT)),
+    sessionStartedAtMs: Date.parse(state.sessionStartedAt ?? now.toISOString()),
+    lastGreenTypecheckMs: typecheck && typecheck.exitCode === 0 ? Date.parse(typecheck.finishedAt) : null,
+  })
+  if (!blocked) return
+
+  process.stdout.write(JSON.stringify({
+    decision: 'block',
+    reason: [
+      `Source under ${WATCHED_ROOT}/ changed this session and has not passed a typecheck since.`,
+      '',
+      'Run `yarn typecheck` and report its exit status before concluding.',
+      'If it genuinely fails and you cannot fix it, report the failure to the user —',
+      'do not delete .ai/.gate-state.json to work around this.',
+    ].join('\n'),
+  }))
+}
+
+/**
+ * Run only when invoked as the hook, never on import.
+ *
+ * `main()` blocks reading stdin, so an unguarded top-level call makes the module impossible
+ * to import — a test that pulled in `matchGates` would hang forever waiting for input that
+ * never arrives.
+ */
+function isEntryPoint(): boolean {
+  const entry = process.argv[1]
+  if (!entry) return false
+  return import.meta.url === pathToFileURL(entry).href
+}
+
+if (isEntryPoint()) void main()

--- a/packages/create-app/agentic/claude-code/hooks/gate-evidence.ts
+++ b/packages/create-app/agentic/claude-code/hooks/gate-evidence.ts
@@ -43,8 +43,12 @@ export type GateState = {
  * and a run reported through a compound command must not be invisible to the recorder.
  * Direct invocations that bypass the package script (`npx tsc --noEmit`) count too — the
  * point is whether the check happened, not which alias was typed.
+ *
+ * Quoted spans are removed before matching, so a gate merely *named* in a message —
+ * `git commit -m "run tsc --noEmit"` — is not mistaken for a gate that ran.
  */
 export function matchGates(command: string): GateName[] {
+  const executable = command.replace(/'[^']*'|"[^"]*"/g, ' ')
   const found = new Set<GateName>()
   const named: Array<[GateName, RegExp]> = [
     ['typecheck', /\b(?:yarn|npm run|pnpm)\s+typecheck\b|\btsc\b[^&|;]*--noEmit/],
@@ -54,7 +58,7 @@ export function matchGates(command: string): GateName[] {
     ['generate', /\b(?:yarn|npm run|pnpm)\s+generate\b|\bmercato\s+generate\b/],
   ]
   for (const [gate, pattern] of named) {
-    if (pattern.test(command)) found.add(gate)
+    if (pattern.test(executable)) found.add(gate)
   }
   return [...found]
 }

--- a/packages/create-app/agentic/claude-code/settings.json
+++ b/packages/create-app/agentic/claude-code/settings.json
@@ -10,6 +10,27 @@
             "timeout": 15
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx \"$CLAUDE_PROJECT_DIR/.claude/hooks/gate-evidence.ts\" record",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx \"$CLAUDE_PROJECT_DIR/.claude/hooks/gate-evidence.ts\" check",
+            "timeout": 20
+          }
+        ]
       }
     ]
   }

--- a/packages/create-app/agentic/codex/hooks.json
+++ b/packages/create-app/agentic/codex/hooks.json
@@ -1,0 +1,29 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .codex/hooks/gate-evidence.mjs record",
+            "statusMessage": "Recording validation-gate outcome",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .codex/hooks/gate-evidence.mjs check",
+            "statusMessage": "Checking gate evidence before finishing",
+            "timeout": 20
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/create-app/agentic/codex/hooks/gate-evidence.mjs
+++ b/packages/create-app/agentic/codex/hooks/gate-evidence.mjs
@@ -1,0 +1,199 @@
+/**
+ * Record validation-gate outcomes, and refuse to finish on unverified source changes (Codex).
+ *
+ * Mirrors the claude-code hook: `record` on `PostToolUse` (Bash matcher), `check` on `Stop`.
+ *
+ * Codex's `PostToolUse` documents `tool_response` without an exit-code field, so the outcome
+ * is inferred from the response text. `Stop` requires JSON on stdout when the hook exits 0 —
+ * plain text is invalid for that event — so the block is a `{"decision":"block"}` document.
+ */
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+/** Codex nests the shell output under `tool_response` in one of several shapes. */
+export function readToolResponseText(data) {
+  const response = data?.tool_response
+  if (typeof response === 'string') return response
+  if (response && typeof response === 'object') {
+    for (const key of ['output', 'stdout', 'content', 'text']) {
+      if (typeof response[key] === 'string') return response[key]
+    }
+    return JSON.stringify(response)
+  }
+  return ''
+}
+
+/**
+ * Extracts every gate a shell command ran.
+ *
+ * Quoted spans are blanked first: `git commit -m "run tsc --noEmit"` names a gate without
+ * running one, and its zero exit status would otherwise be recorded as a green typecheck.
+ */
+export function matchGates(command) {
+  const executable = command.replace(/'[^']*'|"[^"]*"/g, ' ')
+  const found = new Set()
+  const named = [
+    ['typecheck', /\b(?:yarn|npm run|pnpm)\s+typecheck\b|\btsc\b[^&|;]*--noEmit/],
+    ['lint', /\b(?:yarn|npm run|pnpm)\s+lint\b|\beslint\b/],
+    ['test', /\b(?:yarn|npm run|pnpm)\s+test\b|\bjest\b/],
+    ['build', /\b(?:yarn|npm run|pnpm)\s+build\b|\bnext build\b/],
+    ['generate', /\b(?:yarn|npm run|pnpm)\s+generate\b|\bmercato\s+generate\b/],
+  ]
+  for (const [gate, pattern] of named) {
+    if (pattern.test(executable)) found.add(gate)
+  }
+  return [...found]
+}
+
+/**
+ * Whether a command's outcome can be attributed to the gates it names.
+ *
+ * A pipeline reports its LAST stage's status, and `;` / `||` break the link the same way.
+ * `&&` does not: it short-circuits, so a failure still belongs to a gate that ran.
+ */
+export function isAttributableGateCommand(command) {
+  return !/[|;\n]/.test(command)
+}
+
+/** See the claude-code hook. */
+export function nextSessionState(previous, sessionId, startedAt) {
+  if (!sessionId) {
+    return previous.sessionStartedAt ? previous : { ...previous, sessionStartedAt: startedAt }
+  }
+  if (previous.sessionId === sessionId && previous.sessionStartedAt) return previous
+  return { sessionId, sessionStartedAt: startedAt }
+}
+
+/** See the claude-code hook: an absent typecheck record does not block on its own. */
+export function shouldBlock({ newestSrcMtimeMs, sessionStartedAtMs, lastGreenTypecheckMs }) {
+  if (newestSrcMtimeMs === null) return false
+  if (newestSrcMtimeMs < sessionStartedAtMs) return false
+  if (lastGreenTypecheckMs === null) return true
+  return newestSrcMtimeMs > lastGreenTypecheckMs
+}
+
+/**
+ * Infers a gate outcome from its output, because this host reports no exit code.
+ *
+ * Returns 1 (failure) for empty output and for any failure signature. The bias is
+ * deliberate: over-reporting failure costs one re-run, under-reporting it records a pass
+ * that never happened — the property this hook exists to remove. `No tests found` is a
+ * failure here for the same reason it is not a pass in the harness rules.
+ */
+export function inferExitCode(output) {
+  if (typeof output !== 'string' || output.trim() === '') return 1
+  const failureSignatures = [
+    /\berror\s+TS\d+/i, /FATAL ERROR/i, /heap out of memory/i,
+    /\bTests?:\s+\d+\s+failed/i, /\bfail(ed|ing)\b/i, /\bERROR\b/,
+    /exited \(\d+\)/, /command not found/i, /No tests found/i,
+  ]
+  return failureSignatures.some((pattern) => pattern.test(output)) ? 1 : 0
+}
+
+const STATE_RELATIVE_PATH = '.ai/.gate-state.json'
+const WATCHED_ROOT = 'src'
+
+function projectDir() {
+  return process.env.CODEX_PROJECT_DIR || resolve('.')
+}
+
+function statePath() { return join(projectDir(), STATE_RELATIVE_PATH) }
+
+function readState() {
+  try { return JSON.parse(readFileSync(statePath(), 'utf8')) } catch { return {} }
+}
+
+function writeState(state) {
+  try {
+    mkdirSync(join(projectDir(), '.ai'), { recursive: true })
+    writeFileSync(statePath(), `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+  } catch {
+    // A hook must never fail the turn over its own bookkeeping.
+  }
+}
+
+function newestMtimeMs(dir) {
+  let newest = null
+  const walk = (current) => {
+    let entries
+    try { entries = readdirSync(current) } catch { return }
+    for (const entry of entries) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue
+      const full = join(current, entry)
+      let stats
+      try { stats = statSync(full) } catch { continue }
+      if (stats.isDirectory()) walk(full)
+      else if (newest === null || stats.mtimeMs > newest) newest = stats.mtimeMs
+    }
+  }
+  walk(dir)
+  return newest
+}
+
+function readStdin() {
+  return new Promise((done) => {
+    let raw = ''
+    if (process.stdin.isTTY) { done(''); return }
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', (chunk) => { raw += chunk })
+    process.stdin.on('end', () => done(raw))
+    process.stdin.on('error', () => done(''))
+  })
+}
+
+async function main() {
+  const mode = process.argv[2] === 'check' ? 'check' : 'record'
+  const raw = await readStdin()
+
+  let data = {}
+  if (raw.trim()) {
+    try { data = JSON.parse(raw) } catch { process.exit(0) }
+  }
+
+  const previous = readState()
+  const now = new Date()
+  const state = nextSessionState(previous, data.session_id ?? null, now.toISOString())
+  if (state !== previous) writeState(state)
+
+  if (mode === 'record') {
+    const command = data.tool_input?.command ?? data.command
+    if (!command) process.exit(0)
+    const gates = matchGates(command)
+    if (!gates.length) process.exit(0)
+    if (!isAttributableGateCommand(command)) process.exit(0)
+    const exitCode = inferExitCode(readToolResponseText(data))
+    state.gates = state.gates ?? {}
+    for (const gate of gates) {
+      state.gates[gate] = { exitCode, finishedAt: now.toISOString() }
+    }
+    writeState(state)
+    process.exit(0)
+  }
+
+  if (data.stop_hook_active) process.exit(0)
+
+  const typecheck = state.gates?.typecheck
+  const blocked = shouldBlock({
+    newestSrcMtimeMs: newestMtimeMs(join(projectDir(), WATCHED_ROOT)),
+    sessionStartedAtMs: Date.parse(state.sessionStartedAt ?? now.toISOString()),
+    lastGreenTypecheckMs: typecheck && typecheck.exitCode === 0 ? Date.parse(typecheck.finishedAt) : null,
+  })
+  if (!blocked) {
+    process.stdout.write(JSON.stringify({ decision: 'approve' }))
+    process.exit(0)
+  }
+
+  process.stdout.write(JSON.stringify({
+    decision: 'block',
+    reason: [
+      `Source under ${WATCHED_ROOT}/ changed this session and has not passed a typecheck since.`,
+      '',
+      'Run `yarn typecheck` and report its exit status before finishing.',
+      'If it genuinely fails and you cannot fix it, report the failure to the user.',
+    ].join('\n'),
+  }))
+  process.exit(0)
+}
+
+const invokedDirectly = process.argv[1] && process.argv[1].endsWith('gate-evidence.mjs')
+if (invokedDirectly) await main()

--- a/packages/create-app/agentic/cursor/hooks.json
+++ b/packages/create-app/agentic/cursor/hooks.json
@@ -5,6 +5,16 @@
       "command": "node",
       "args": [".cursor/hooks/entity-migration-check.mjs"],
       "description": "Check if entity edit requires a database migration"
+    },
+    "afterShellExecution": {
+      "command": "node",
+      "args": [".cursor/hooks/gate-evidence.mjs", "record"],
+      "description": "Record validation-gate outcomes so a gate cannot be claimed without running"
+    },
+    "stop": {
+      "command": "node",
+      "args": [".cursor/hooks/gate-evidence.mjs", "check"],
+      "description": "Block finishing when src/ changed without a passing typecheck since"
     }
   }
 }

--- a/packages/create-app/agentic/cursor/hooks/gate-evidence.mjs
+++ b/packages/create-app/agentic/cursor/hooks/gate-evidence.mjs
@@ -1,0 +1,181 @@
+/**
+ * Record validation-gate outcomes, and refuse to finish on unverified source changes (Cursor).
+ *
+ * Mirrors the claude-code hook: `record` on `afterShellExecution`, `check` on `stop`.
+ *
+ * Cursor's `afterShellExecution` payload documents `command`, `output`, `duration`, and
+ * `sandbox` — no exit code — so the outcome is inferred from output text rather than read.
+ * Blocking contract: exit 2 blocks, exit 0 proceeds, other codes fail open.
+ */
+import { mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+/**
+ * Extracts every gate a shell command ran.
+ *
+ * Quoted spans are blanked first: `git commit -m "run tsc --noEmit"` names a gate without
+ * running one, and its zero exit status would otherwise be recorded as a green typecheck.
+ */
+export function matchGates(command) {
+  const executable = command.replace(/'[^']*'|"[^"]*"/g, ' ')
+  const found = new Set()
+  const named = [
+    ['typecheck', /\b(?:yarn|npm run|pnpm)\s+typecheck\b|\btsc\b[^&|;]*--noEmit/],
+    ['lint', /\b(?:yarn|npm run|pnpm)\s+lint\b|\beslint\b/],
+    ['test', /\b(?:yarn|npm run|pnpm)\s+test\b|\bjest\b/],
+    ['build', /\b(?:yarn|npm run|pnpm)\s+build\b|\bnext build\b/],
+    ['generate', /\b(?:yarn|npm run|pnpm)\s+generate\b|\bmercato\s+generate\b/],
+  ]
+  for (const [gate, pattern] of named) {
+    if (pattern.test(executable)) found.add(gate)
+  }
+  return [...found]
+}
+
+/**
+ * Whether a command's outcome can be attributed to the gates it names.
+ *
+ * A pipeline reports its LAST stage's status, and `;` / `||` break the link the same way.
+ * `&&` does not: it short-circuits, so a failure still belongs to a gate that ran.
+ */
+export function isAttributableGateCommand(command) {
+  return !/[|;\n]/.test(command)
+}
+
+/** See the claude-code hook. */
+export function nextSessionState(previous, sessionId, startedAt) {
+  if (!sessionId) {
+    return previous.sessionStartedAt ? previous : { ...previous, sessionStartedAt: startedAt }
+  }
+  if (previous.sessionId === sessionId && previous.sessionStartedAt) return previous
+  return { sessionId, sessionStartedAt: startedAt }
+}
+
+/** See the claude-code hook: an absent typecheck record does not block on its own. */
+export function shouldBlock({ newestSrcMtimeMs, sessionStartedAtMs, lastGreenTypecheckMs }) {
+  if (newestSrcMtimeMs === null) return false
+  if (newestSrcMtimeMs < sessionStartedAtMs) return false
+  if (lastGreenTypecheckMs === null) return true
+  return newestSrcMtimeMs > lastGreenTypecheckMs
+}
+
+/**
+ * Infers a gate outcome from its output, because this host reports no exit code.
+ *
+ * Returns 1 (failure) for empty output and for any failure signature. The bias is
+ * deliberate: over-reporting failure costs one re-run, under-reporting it records a pass
+ * that never happened — the property this hook exists to remove. `No tests found` is a
+ * failure here for the same reason it is not a pass in the harness rules.
+ */
+export function inferExitCode(output) {
+  if (typeof output !== 'string' || output.trim() === '') return 1
+  const failureSignatures = [
+    /\berror\s+TS\d+/i, /FATAL ERROR/i, /heap out of memory/i,
+    /\bTests?:\s+\d+\s+failed/i, /\bfail(ed|ing)\b/i, /\bERROR\b/,
+    /exited \(\d+\)/, /command not found/i, /No tests found/i,
+  ]
+  return failureSignatures.some((pattern) => pattern.test(output)) ? 1 : 0
+}
+
+const STATE_RELATIVE_PATH = '.ai/.gate-state.json'
+const WATCHED_ROOT = 'src'
+
+function projectDir() {
+  return process.env.CURSOR_PROJECT_DIR || resolve('.')
+}
+
+function statePath() { return join(projectDir(), STATE_RELATIVE_PATH) }
+
+function readState() {
+  try { return JSON.parse(readFileSync(statePath(), 'utf8')) } catch { return {} }
+}
+
+function writeState(state) {
+  try {
+    mkdirSync(join(projectDir(), '.ai'), { recursive: true })
+    writeFileSync(statePath(), `${JSON.stringify(state, null, 2)}\n`, 'utf8')
+  } catch {
+    // A hook must never fail the turn over its own bookkeeping.
+  }
+}
+
+function newestMtimeMs(dir) {
+  let newest = null
+  const walk = (current) => {
+    let entries
+    try { entries = readdirSync(current) } catch { return }
+    for (const entry of entries) {
+      if (entry === 'node_modules' || entry.startsWith('.')) continue
+      const full = join(current, entry)
+      let stats
+      try { stats = statSync(full) } catch { continue }
+      if (stats.isDirectory()) walk(full)
+      else if (newest === null || stats.mtimeMs > newest) newest = stats.mtimeMs
+    }
+  }
+  walk(dir)
+  return newest
+}
+
+function readStdin() {
+  return new Promise((done) => {
+    let raw = ''
+    if (process.stdin.isTTY) { done(''); return }
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', (chunk) => { raw += chunk })
+    process.stdin.on('end', () => done(raw))
+    process.stdin.on('error', () => done(''))
+  })
+}
+
+async function main() {
+  const mode = process.argv[2] === 'check' ? 'check' : 'record'
+  const raw = await readStdin()
+
+  let data = {}
+  if (raw.trim()) {
+    try { data = JSON.parse(raw) } catch { process.exit(0) }
+  }
+
+  const previous = readState()
+  const now = new Date()
+  const state = nextSessionState(previous, data.session_id ?? null, now.toISOString())
+  if (state !== previous) writeState(state)
+
+  if (mode === 'record') {
+    const command = data.command ?? data.tool_input?.command
+    if (!command) process.exit(0)
+    const gates = matchGates(command)
+    if (!gates.length) process.exit(0)
+    if (!isAttributableGateCommand(command)) process.exit(0)
+    const exitCode = inferExitCode(data.output ?? '')
+    state.gates = state.gates ?? {}
+    for (const gate of gates) {
+      state.gates[gate] = { exitCode, finishedAt: now.toISOString() }
+    }
+    writeState(state)
+    process.exit(0)
+  }
+
+  if (data.stop_hook_active) process.exit(0)
+
+  const typecheck = state.gates?.typecheck
+  const blocked = shouldBlock({
+    newestSrcMtimeMs: newestMtimeMs(join(projectDir(), WATCHED_ROOT)),
+    sessionStartedAtMs: Date.parse(state.sessionStartedAt ?? now.toISOString()),
+    lastGreenTypecheckMs: typecheck && typecheck.exitCode === 0 ? Date.parse(typecheck.finishedAt) : null,
+  })
+  if (!blocked) process.exit(0)
+
+  process.stderr.write([
+    `Source under ${WATCHED_ROOT}/ changed this session and has not passed a typecheck since.`,
+    '',
+    'Run `yarn typecheck` and report its exit status before finishing.',
+    'If it genuinely fails and you cannot fix it, report the failure to the user.',
+    '',
+  ].join('\n'))
+  process.exit(2)
+}
+
+const invokedDirectly = process.argv[1] && process.argv[1].endsWith('gate-evidence.mjs')
+if (invokedDirectly) await main()

--- a/packages/create-app/agentic/shared/AGENTS.md.template
+++ b/packages/create-app/agentic/shared/AGENTS.md.template
@@ -32,13 +32,6 @@ Route first; never probe unmatched context.
 
 Use the smallest relevant set. Broad: `yarn generate && yarn typecheck && yarn lint && yarn test && yarn build`; integration: `yarn test:integration:ephemeral`. Report failures; never migrate to validate.
 
-A gate counts as passed ONLY when its command ran to completion and you report its exit status. Specifically:
-
-- A gate that CRASHES has not passed. An out-of-memory abort (`FATAL ERROR: … heap out of memory`) is a failure to report, never a step to skip.
-- `No tests found` is NOT a pass. Report it as `test: no tests found (not a pass)`.
-- `lint` passing says nothing about whether imports resolve — `eslint` does not check module resolution unless `import/no-unresolved` is enabled. Only `typecheck` proves that.
-- Never write a completion claim (`gate green`, `PRODUCTION READY`, a status table, a summary document) that asserts a gate result you did not actually observe. Writing a document is not running a gate.
-
 ## Three-Axis Context Assembler
 
 Routes are additive: ownership says WHO; other axes say WHAT. Select every match.

--- a/packages/create-app/agentic/shared/AGENTS.md.template
+++ b/packages/create-app/agentic/shared/AGENTS.md.template
@@ -32,6 +32,13 @@ Route first; never probe unmatched context.
 
 Use the smallest relevant set. Broad: `yarn generate && yarn typecheck && yarn lint && yarn test && yarn build`; integration: `yarn test:integration:ephemeral`. Report failures; never migrate to validate.
 
+A gate counts as passed ONLY when its command ran to completion and you report its exit status. Specifically:
+
+- A gate that CRASHES has not passed. An out-of-memory abort (`FATAL ERROR: … heap out of memory`) is a failure to report, never a step to skip.
+- `No tests found` is NOT a pass. Report it as `test: no tests found (not a pass)`.
+- `lint` passing says nothing about whether imports resolve — `eslint` does not check module resolution unless `import/no-unresolved` is enabled. Only `typecheck` proves that.
+- Never write a completion claim (`gate green`, `PRODUCTION READY`, a status table, a summary document) that asserts a gate result you did not actually observe. Writing a document is not running a gate.
+
 ## Three-Axis Context Assembler
 
 Routes are additive: ownership says WHO; other axes say WHAT. Select every match.

--- a/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/api-and-domain.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/api-and-domain.md
@@ -2,6 +2,19 @@
 
 Load this reference for CRUD, commands, and action routes.
 
+Before writing a route or command, read `node_modules/@open-mercato/shared/AGENTS.md`. It is
+the authority for this layer's import paths and carries MUST rules that are easy to violate
+by writing something that merely compiles — in particular: use the `badRequest` / `forbidden`
+/ `notFound` / `conflict` / `assertFound` helpers from
+`@open-mercato/shared/lib/crud/errors` rather than hand-rolling `new CrudHttpError(404, …)`;
+read encrypted columns through `@open-mercato/shared/lib/encryption/find`; and never `$ilike`
+a column an encryption map covers — use `@open-mercato/shared/lib/search/tokenLookup`.
+
+There is no `@open-mercato/shared/lib/http/types`. A hand-written route handler takes the
+platform `Request` (`export async function GET(request: Request)`) and returns a platform
+`Response`; a dynamic segment arrives as a second argument,
+`(request: Request, ctx: { params?: { id?: string } })`.
+
 1. Implement create/update/delete as command objects with stable IDs and call `registerCommand` from `@open-mercato/shared/lib/commands` for each object. A route action naming a command ID does not register it. Include audit/undo/event/cache/index side effects.
 2. Create `src/modules/<moduleId>/api/<resource>/route.ts`; generated discovery mounts it at `/api/<moduleId>/<resource>`. Import `makeCrudRoute` from `@open-mercato/shared/lib/crud/factory`, then export per-method `metadata`, the selected factory handlers, and matching `openApi`. Smoke-test the generated URL rather than assuming a hyphenated or module-less path.
 3. Build current `makeCrudRoute` options: `metadata`, `orm`, `list`, `actions: { create, update, delete }`, and `indexer`. Each command action uses `commandId`, `schema`, optional `mapInput`, `response`, and `status`—never a `command` key. Add `enrichers: { entityId: '<module>:<entity>' }` only when the route intentionally publishes that stable host contract; keep the colon-form ID aligned with the UI/widget host and test injected read/write round trips. Export `openApi` separately—it is not a factory option—and build it with `createCrudOpenApiFactory`/`createPagedListResponseSchema` from `@open-mercato/shared/lib/openapi/crud` or a typed `OpenApiRouteDoc` from `@open-mercato/shared/lib/openapi`.

--- a/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/module-surfaces.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/module-surfaces.md
@@ -20,6 +20,28 @@ Load only the rows the brief requires.
 
 Every added surface needs a real caller or acceptance path. Do not add speculative empty files.
 
+## Import paths are looked up, never inferred
+
+Before writing any UI surface, read `node_modules/@open-mercato/ui/AGENTS.md`. It carries a
+"Component quick reference" table mapping *what you need* to the **exact import path**, plus
+the MUST rules for `CrudForm`, `DataTable`, and the primitives. Look the path up there; do
+not infer one from a component's name or its position in the source tree.
+
+Paths that read plausibly and do not exist: `@open-mercato/ui/crud/form`,
+`@open-mercato/ui/layout/page`, `@open-mercato/ui/data/table`. The real ones are
+`@open-mercato/ui/backend/CrudForm`, `@open-mercato/ui/backend/Page`,
+`@open-mercato/ui/backend/DataTable`.
+
+Backend page routes are derived from the directory path with the module id REMOVED:
+`src/modules/<mod>/backend/<segments>/page.tsx` mounts at `/backend/<segments>`. So
+`src/modules/library/backend/books/page.tsx` is `/backend/books`, **not**
+`/backend/library/books`. API routes are the opposite — they keep the module namespace, so
+`src/modules/library/api/books/route.ts` is `/api/library/books`. Confirm against
+`.mercato/generated/backend-route-metadata.generated.ts` after running `yarn generate`.
+
+A backend page is a server component that renders a `"use client"` component from
+`src/modules/<mod>/components/`; it does not itself carry `"use client"`.
+
 ## Canonical example source
 
 One compiling implementation per row, from the source-present, runtime-disabled `example` module. Open only the row you are building; the full index is [`surface-map.md`](../../../../src/modules/example/references/surface-map.md).

--- a/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/verification.md
+++ b/packages/create-app/agentic/shared/ai/skills/om-module-scaffold/references/verification.md
@@ -2,6 +2,26 @@
 
 Load this reference before claiming a scaffold is complete.
 
+## What counts as a gate that passed
+
+A gate has passed ONLY when its command ran to completion and you report its exit status.
+This is not pedantry — every item below is a way a real scaffold was reported green while it
+could not compile:
+
+- **A gate that crashes has not passed.** `FATAL ERROR: … heap out of memory` from `tsc` is a
+  failure to report, never a step to skip. Re-run it with a larger heap
+  (`NODE_OPTIONS=--max-old-space-size=8192`) and report the real result.
+- **`No tests found` is not a pass.** An empty suite exits 0 and is indistinguishable from a
+  green one. Report it as `test: no tests found (not a pass)`.
+- **`lint` passing says nothing about whether imports resolve.** ESLint does not check module
+  resolution unless `import/no-unresolved` is enabled, and it is not enabled by default. Only
+  `typecheck` proves an import path exists — an invented one surfaces as `TS2307`.
+- **A pipe hides the exit status.** `yarn test | tail -30` reports the exit code of `tail`.
+  Capture the status of the command itself.
+- **Writing a document is not running a gate.** Never produce a completion claim — `gate
+  green`, `PRODUCTION READY`, a status table, a summary file — asserting a result you did not
+  observe. If you cannot run a gate, say so plainly and say why.
+
 1. Run `yarn generate`; inspect warnings and the affected module/API/page/entity/event/search/agent registrations.
 2. Standalone unit and command tests use the scaffold's Jest setup, never Vitest. When the standalone `tsconfig` does not declare Jest types, explicitly import `describe`, `it`/`test`, `expect`, and `jest` from `@jest/globals`; passing typecheck requires this, and a focused runner must discover and execute the file. Keep hooks void (`beforeEach(() => { jest.clearAllMocks() })`, not an expression callback that returns `Jest`), give framework mocks their complete callable signatures instead of relying on zero-argument `jest.fn()` inference, and pass the handler's full `{ input, logEntry, ctx }` object to `undo`. Put command behavior/undo tests under `commands/__tests__/`, run focused command/API/component tests, then `yarn typecheck`, `yarn lint`, and the smallest applicable build/test gate. Do not stop with a known TypeScript diagnostic in either implementation or test code.
 3. Create fixtures through APIs for two tenants/organizations and clean them in `finally`.

--- a/packages/create-app/src/lib/agentic-claude-hook-parity.test.ts
+++ b/packages/create-app/src/lib/agentic-claude-hook-parity.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Claude Code hook parity between the two generators that install them.
+ *
+ * A scaffold's `.claude/settings.json` registers hooks by path, and two independent
+ * generators write that file: the create-app wizard (`src/setup/tools/claude-code.ts`) and
+ * `mercato agentic:init` (`packages/cli/src/lib/agentic-setup.ts`). When only one of them
+ * learned about a newly added hook, the other shipped a settings file pointing at a
+ * non-existent script — which fails on every tool call it is registered for, not once.
+ *
+ * These assertions are about the two install paths agreeing with each other and with the
+ * registrations, not about any single hook.
+ */
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const hooksDir = new URL('../../agentic/claude-code/hooks/', import.meta.url)
+const settingsPath = new URL('../../agentic/claude-code/settings.json', import.meta.url)
+const wizardSource = fs.readFileSync(new URL('../setup/tools/claude-code.ts', import.meta.url), 'utf8')
+const cliSetupSource = fs.readFileSync(
+  new URL('../../../cli/src/lib/agentic-setup.ts', import.meta.url),
+  'utf8',
+)
+
+function shippedHookFiles(): string[] {
+  return fs.readdirSync(hooksDir).filter((entry) => entry.endsWith('.ts') || entry.endsWith('.mjs')).sort()
+}
+
+test('every shipped Claude hook is installed by the create-app wizard', () => {
+  const hooks = shippedHookFiles()
+  assert.ok(hooks.length > 0, 'expected at least one hook in agentic/claude-code/hooks/')
+  for (const hook of hooks) {
+    assert.ok(
+      wizardSource.includes(`hooks/${hook}`),
+      `packages/create-app/src/setup/tools/claude-code.ts does not copy hooks/${hook}`,
+    )
+  }
+})
+
+function claudeGeneratorBody(): string {
+  const start = cliSetupSource.indexOf('function generateClaudeCode(')
+  assert.ok(start !== -1, 'expected agentic-setup.ts to define generateClaudeCode')
+  const end = cliSetupSource.indexOf('\nfunction ', start + 1)
+  return cliSetupSource.slice(start, end === -1 ? undefined : end)
+}
+
+test('mercato agentic:init installs Claude hooks from disk rather than a hand-kept list', () => {
+  // Deriving the set from the source tree is what makes the two paths stay in step; an
+  // enumerated list is exactly how gate-evidence.ts came to be registered but never copied.
+  const body = claudeGeneratorBody()
+  assert.ok(
+    body.includes('claudeHookFiles()'),
+    'generateClaudeCode should install hooks via the disk-derived claudeHookFiles() helper',
+  )
+  assert.ok(
+    !/copyFile\(srcDir, `?'?hooks\/[A-Za-z]/.test(body),
+    'generateClaudeCode should not copy individual hook files by name',
+  )
+})
+
+test('mercato agentic:init claims every installed hook in its ownership manifest', () => {
+  // Paths missing from the manifest are never refreshed by --update-harness, so an app set
+  // up before a hook existed would never receive it.
+  const ownershipBlock = cliSetupSource.slice(
+    cliSetupSource.indexOf("paths.add(join(targetDir, 'CLAUDE.md'))"),
+  )
+  assert.ok(
+    ownershipBlock.includes("for (const hook of claudeHookFiles()) paths.add(join(targetDir, '.claude', 'hooks', hook))"),
+    'agentic-setup.ts ownership manifest should claim every disk-derived Claude hook',
+  )
+})
+
+test('every hook registered in settings.json exists on disk', () => {
+  const settings = fs.readFileSync(settingsPath, 'utf8')
+  const registered = [...settings.matchAll(/\.claude\/hooks\/([A-Za-z0-9._-]+)/g)].map((match) => match[1])
+  assert.ok(registered.length > 0, 'expected settings.json to register at least one hook')
+  for (const hook of new Set(registered)) {
+    assert.ok(
+      fs.existsSync(path.join(hooksDir.pathname, hook)),
+      `settings.json registers .claude/hooks/${hook}, which does not exist in the source tree`,
+    )
+  }
+})

--- a/packages/create-app/src/lib/agentic-cross-agent-hook-parity.test.ts
+++ b/packages/create-app/src/lib/agentic-cross-agent-hook-parity.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Cross-agent parity for the gate-evidence hook.
+ *
+ * `agentic-claude-hook-parity.test.ts` covers the Claude target. These assert the same
+ * guarantees for Cursor and Codex, and that the three implementations agree on the decisions
+ * that matter — the repo duplicates hooks per agent rather than sharing a core, so nothing
+ * else stops them drifting apart.
+ */
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import * as claude from '../../agentic/claude-code/hooks/gate-evidence.ts'
+import * as cursor from '../../agentic/cursor/hooks/gate-evidence.mjs'
+import * as codex from '../../agentic/codex/hooks/gate-evidence.mjs'
+
+const agenticRoot = fileURLToPath(new URL('../../agentic/', import.meta.url))
+const PORTS = [['cursor', cursor], ['codex', codex]] as const
+
+const SHIPPING_HOOKS = ['claude-code', 'cursor', 'codex'] as const
+
+for (const agent of SHIPPING_HOOKS) {
+  test(`${agent}: ships a gate-evidence hook`, () => {
+    // The rules are cross-agent (installed via generateShared); the enforcement should be too.
+    const dir = path.join(agenticRoot, agent, 'hooks')
+    const hooks = fs.existsSync(dir) ? fs.readdirSync(dir) : []
+    assert.ok(
+      hooks.some((name) => name.startsWith('gate-evidence.')),
+      `${agent} ships hooks but no gate-evidence — gate enforcement would be agent-specific`,
+    )
+  })
+
+  test(`${agent}: every hook its config registers exists on disk`, () => {
+    const configName = agent === 'claude-code' ? 'settings.json' : 'hooks.json'
+    const configPath = path.join(agenticRoot, agent, configName)
+    assert.ok(fs.existsSync(configPath), `${agent} ships hooks but no ${configName} to register them`)
+    const config = fs.readFileSync(configPath, 'utf8')
+    const referenced = [...config.matchAll(/hooks\/([A-Za-z0-9._-]+\.(?:ts|mjs))/g)].map((m) => m[1])
+    assert.ok(referenced.length > 0, `${agent}/${configName} registers no hook files`)
+    for (const name of new Set(referenced)) {
+      assert.ok(
+        fs.existsSync(path.join(agenticRoot, agent, 'hooks', name)),
+        `${agent}/${configName} registers hooks/${name}, which does not exist — every tool call would error`,
+      )
+    }
+  })
+
+  test(`${agent}: the wizard installs every hook in the source tree`, () => {
+    const wizard = fs.readFileSync(
+      fileURLToPath(new URL(`../setup/tools/${agent}.ts`, import.meta.url)),
+      'utf8',
+    )
+    for (const hook of fs.readdirSync(path.join(agenticRoot, agent, 'hooks'))) {
+      assert.ok(wizard.includes(`hooks/${hook}`) || /copyHooksDir|hooks'\)/.test(wizard),
+        `the wizard never installs ${agent}/hooks/${hook}`)
+    }
+  })
+}
+
+for (const [name, hook] of PORTS) {
+  test(`${name}: matchGates agrees with claude-code`, () => {
+    for (const command of [
+      'yarn typecheck',
+      'npx tsc --noEmit',
+      'yarn generate && yarn typecheck && yarn lint && yarn test && yarn build',
+      'git status --short',
+      'git commit -m "run tsc --noEmit"',
+    ]) {
+      assert.deepEqual(
+        [...hook.matchGates(command)].sort(),
+        [...claude.matchGates(command)].sort(),
+        command,
+      )
+    }
+  })
+
+  test(`${name}: isAttributableGateCommand agrees with claude-code`, () => {
+    for (const command of ['yarn typecheck', 'yarn typecheck | tail -30', 'yarn typecheck; yarn lint', 'yarn a && yarn b']) {
+      assert.equal(hook.isAttributableGateCommand(command), claude.isAttributableGateCommand(command), command)
+    }
+  })
+
+  test(`${name}: shouldBlock agrees with claude-code across the decision table`, () => {
+    const cases = [
+      { newestSrcMtimeMs: 2_000, sessionStartedAtMs: 1_000, lastGreenTypecheckMs: null },
+      { newestSrcMtimeMs: 3_000, sessionStartedAtMs: 1_000, lastGreenTypecheckMs: 2_000 },
+      { newestSrcMtimeMs: 2_000, sessionStartedAtMs: 1_000, lastGreenTypecheckMs: 3_000 },
+      { newestSrcMtimeMs: 500, sessionStartedAtMs: 1_000, lastGreenTypecheckMs: null },
+      { newestSrcMtimeMs: null, sessionStartedAtMs: 1_000, lastGreenTypecheckMs: null },
+    ]
+    for (const input of cases) {
+      assert.equal(hook.shouldBlock(input), claude.shouldBlock(input), JSON.stringify(input))
+    }
+  })
+
+  test(`${name}: nextSessionState agrees with claude-code`, () => {
+    const at = '2026-08-14T09:00:00Z'
+    assert.deepEqual(hook.nextSessionState({}, 'a', at), claude.nextSessionState({}, 'a', at))
+    const prior = { sessionId: 'a', sessionStartedAt: at, gates: { typecheck: { exitCode: 0, finishedAt: at } } }
+    assert.deepEqual(hook.nextSessionState(prior, 'b', at), claude.nextSessionState(prior, 'b', at))
+  })
+
+  test(`${name}: inferExitCode never reads absent or failing output as a pass`, () => {
+    // These hosts report no exit code, so a loose inference would manufacture the false green
+    // the hook exists to prevent.
+    assert.equal(hook.inferExitCode(''), 1, 'no output is not evidence of success')
+    assert.equal(hook.inferExitCode('src/a.ts(1,1): error TS2307: Cannot find module'), 1)
+    assert.equal(hook.inferExitCode('FATAL ERROR: heap out of memory'), 1)
+    assert.equal(hook.inferExitCode('No tests found, exiting with code 0'), 1)
+    assert.equal(hook.inferExitCode('Tasks: 22 successful, 22 total'), 0)
+  })
+}
+
+test('codex: readToolResponseText unwraps the documented response shapes', () => {
+  assert.equal(codex.readToolResponseText({ tool_response: 'raw' }), 'raw')
+  assert.equal(codex.readToolResponseText({ tool_response: { output: 'out' } }), 'out')
+  assert.equal(codex.readToolResponseText({ tool_response: { stdout: 'so' } }), 'so')
+  assert.equal(codex.readToolResponseText({}), '')
+})

--- a/packages/create-app/src/setup/gate-evidence-hook.test.ts
+++ b/packages/create-app/src/setup/gate-evidence-hook.test.ts
@@ -9,6 +9,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+import type { HookInput } from '../../agentic/claude-code/hooks/gate-evidence'
 import {
   isAttributableGateCommand,
   matchGates,
@@ -38,6 +39,12 @@ test('matchGates: matches a heap-flagged typecheck', () => {
 
 test('matchGates: returns nothing for an unrelated command', () => {
   assert.deepEqual(matchGates('git status --short'), [])
+})
+
+test('matchGates: does not count a gate merely named inside a quoted string', () => {
+  // Naming a gate is not running one — the distinction this hook exists to enforce.
+  assert.deepEqual(matchGates('git commit -m "run tsc --noEmit before pushing"'), [])
+  assert.deepEqual(matchGates("echo 'yarn typecheck'"), [])
 })
 
 const SESSION_START = 1_000
@@ -113,7 +120,7 @@ test('resolveExitCode: reports an unknown status as unknown, never as a pass', (
   // hook is meant to make impossible.
   assert.equal(resolveExitCode({}), null)
   assert.equal(resolveExitCode({ tool_response: {} }), null)
-  assert.equal(resolveExitCode({ tool_response: { exit_code: '0' } } as never), null)
+  assert.equal(resolveExitCode({ tool_response: { exit_code: '0' } } as unknown as HookInput), null)
 })
 
 test('nextSessionState: starts a fresh record when the session id changes', () => {

--- a/packages/create-app/src/setup/gate-evidence-hook.test.ts
+++ b/packages/create-app/src/setup/gate-evidence-hook.test.ts
@@ -9,7 +9,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { matchGates, shouldBlock } from '../../agentic/claude-code/hooks/gate-evidence'
+import {
+  isAttributableGateCommand,
+  matchGates,
+  nextSessionState,
+  resolveExitCode,
+  shouldBlock,
+} from '../../agentic/claude-code/hooks/gate-evidence'
 
 test('matchGates: matches a plain package script', () => {
   assert.deepEqual(matchGates('yarn typecheck'), ['typecheck'])
@@ -76,4 +82,76 @@ test('shouldBlock: allows when there is no source tree at all', () => {
     sessionStartedAtMs: SESSION_START,
     lastGreenTypecheckMs: null,
   }), false)
+})
+
+test('isAttributableGateCommand: accepts a plain gate and an && chain', () => {
+  // `&&` short-circuits, so a non-zero status still belongs to a gate that actually ran.
+  assert.equal(isAttributableGateCommand('yarn typecheck'), true)
+  assert.equal(isAttributableGateCommand('yarn generate && yarn typecheck && yarn lint'), true)
+})
+
+test('isAttributableGateCommand: rejects a piped gate', () => {
+  // The failure the harness's own verification rules warn about: `tail`'s exit status, not
+  // `tsc`'s. Recording it would manufacture the false green this hook exists to prevent.
+  assert.equal(isAttributableGateCommand('yarn typecheck | tail -30'), false)
+})
+
+test('isAttributableGateCommand: rejects sequenced and status-swallowing commands', () => {
+  assert.equal(isAttributableGateCommand('yarn typecheck; yarn lint'), false)
+  assert.equal(isAttributableGateCommand('yarn typecheck || true'), false)
+  assert.equal(isAttributableGateCommand('yarn typecheck\nyarn lint'), false)
+})
+
+test('resolveExitCode: reads both spellings the payload may use', () => {
+  assert.equal(resolveExitCode({ tool_response: { exit_code: 1 } }), 1)
+  assert.equal(resolveExitCode({ tool_response: { exitCode: 2 } }), 2)
+  assert.equal(resolveExitCode({ tool_response: { exit_code: 0 } }), 0)
+})
+
+test('resolveExitCode: reports an unknown status as unknown, never as a pass', () => {
+  // Zero here would record a green gate nobody observed, which is the exact substitution the
+  // hook is meant to make impossible.
+  assert.equal(resolveExitCode({}), null)
+  assert.equal(resolveExitCode({ tool_response: {} }), null)
+  assert.equal(resolveExitCode({ tool_response: { exit_code: '0' } } as never), null)
+})
+
+test('nextSessionState: starts a fresh record when the session id changes', () => {
+  const previous = {
+    sessionId: 'session-one',
+    sessionStartedAt: '2026-08-13T09:00:00.000Z',
+    gates: { typecheck: { exitCode: 0, finishedAt: '2026-08-13T09:05:00.000Z' } },
+  }
+  const next = nextSessionState(previous, 'session-two', '2026-08-14T09:00:00.000Z')
+  assert.equal(next.sessionId, 'session-two')
+  assert.equal(next.sessionStartedAt, '2026-08-14T09:00:00.000Z')
+  assert.equal(next.gates, undefined)
+})
+
+test('nextSessionState: keeps the record within one session', () => {
+  const previous = {
+    sessionId: 'session-one',
+    sessionStartedAt: '2026-08-14T09:00:00.000Z',
+    gates: { typecheck: { exitCode: 0, finishedAt: '2026-08-14T09:05:00.000Z' } },
+  }
+  assert.equal(nextSessionState(previous, 'session-one', '2026-08-14T10:00:00.000Z'), previous)
+})
+
+test('nextSessionState: a stale start time cannot leak into a later session', () => {
+  // The regression this guards: with sessionStartedAt pinned to the first session forever,
+  // a docs-only session gets blocked over source somebody else edited days earlier.
+  const yesterday = { sessionId: 'session-one', sessionStartedAt: '2026-08-13T09:00:00.000Z' }
+  const today = nextSessionState(yesterday, 'session-two', '2026-08-14T09:00:00.000Z')
+  const staleEditMs = Date.parse('2026-08-13T12:00:00.000Z')
+  assert.equal(shouldBlock({
+    newestSrcMtimeMs: staleEditMs,
+    sessionStartedAtMs: Date.parse(today.sessionStartedAt!),
+    lastGreenTypecheckMs: null,
+  }), false)
+})
+
+test('nextSessionState: sets the start time once when no session id is supplied', () => {
+  const first = nextSessionState({}, null, '2026-08-14T09:00:00.000Z')
+  assert.equal(first.sessionStartedAt, '2026-08-14T09:00:00.000Z')
+  assert.equal(nextSessionState(first, null, '2026-08-14T11:00:00.000Z'), first)
 })

--- a/packages/create-app/src/setup/gate-evidence-hook.test.ts
+++ b/packages/create-app/src/setup/gate-evidence-hook.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Gate-evidence hook decision logic.
+ *
+ * Both halves matter. A blocker that misses the case it exists for is useless; one that
+ * fires on an unrelated session is noise, and noise gets disabled. The gate-matching cases
+ * guard the specific false negative that motivated this hook — a run that reported all of
+ * its gates through a single compound command line.
+ */
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { matchGates, shouldBlock } from '../../agentic/claude-code/hooks/gate-evidence'
+
+test('matchGates: matches a plain package script', () => {
+  assert.deepEqual(matchGates('yarn typecheck'), ['typecheck'])
+})
+
+test('matchGates: matches every gate in a compound command', () => {
+  // The shape the harness itself documents, and the shape the original failing run used to
+  // report all five gates at once.
+  const gates = matchGates('yarn generate && yarn typecheck && yarn lint && yarn test && yarn build')
+  assert.deepEqual([...gates].sort(), ['build', 'generate', 'lint', 'test', 'typecheck'])
+})
+
+test('matchGates: matches a direct invocation that bypasses the package script', () => {
+  assert.ok(matchGates('npx tsc --noEmit -p tsconfig.json').includes('typecheck'))
+})
+
+test('matchGates: matches a heap-flagged typecheck', () => {
+  assert.ok(matchGates('cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit').includes('typecheck'))
+})
+
+test('matchGates: returns nothing for an unrelated command', () => {
+  assert.deepEqual(matchGates('git status --short'), [])
+})
+
+const SESSION_START = 1_000
+
+test('shouldBlock: blocks when source changed this session and no typecheck has run', () => {
+  assert.equal(shouldBlock({
+    newestSrcMtimeMs: 2_000,
+    sessionStartedAtMs: SESSION_START,
+    lastGreenTypecheckMs: null,
+  }), true)
+})
+
+test('shouldBlock: blocks when source changed after the last green typecheck', () => {
+  assert.equal(shouldBlock({
+    newestSrcMtimeMs: 3_000,
+    sessionStartedAtMs: SESSION_START,
+    lastGreenTypecheckMs: 2_000,
+  }), true)
+})
+
+test('shouldBlock: allows when the last green typecheck is newer than the change', () => {
+  assert.equal(shouldBlock({
+    newestSrcMtimeMs: 2_000,
+    sessionStartedAtMs: SESSION_START,
+    lastGreenTypecheckMs: 3_000,
+  }), false)
+})
+
+test('shouldBlock: allows a session that changed no source, even with no typecheck record', () => {
+  // The false-positive guard: a docs-only or read-only session on a fresh clone must not be
+  // blocked merely because the state file has never been written.
+  assert.equal(shouldBlock({
+    newestSrcMtimeMs: 500,
+    sessionStartedAtMs: SESSION_START,
+    lastGreenTypecheckMs: null,
+  }), false)
+})
+
+test('shouldBlock: allows when there is no source tree at all', () => {
+  assert.equal(shouldBlock({
+    newestSrcMtimeMs: null,
+    sessionStartedAtMs: SESSION_START,
+    lastGreenTypecheckMs: null,
+  }), false)
+})

--- a/packages/create-app/src/setup/tools/claude-code.ts
+++ b/packages/create-app/src/setup/tools/claude-code.ts
@@ -42,6 +42,9 @@ export function generateClaudeCode(config: AgenticConfig): void {
   // .claude/hooks/entity-migration-check.ts
   copyFile('hooks/entity-migration-check.ts', join(targetDir, '.claude', 'hooks', 'entity-migration-check.ts'))
 
+  // .claude/hooks/gate-evidence.ts
+  copyFile('hooks/gate-evidence.ts', join(targetDir, '.claude', 'hooks', 'gate-evidence.ts'))
+
   // .mcp.json.example
   copyFile('mcp.json.example', join(targetDir, '.mcp.json.example'))
 }

--- a/packages/create-app/src/setup/tools/codex.ts
+++ b/packages/create-app/src/setup/tools/codex.ts
@@ -57,6 +57,10 @@ export function generateCodex(config: AgenticConfig): void {
     writeFileSync(agentsPath, agents)
   }
 
+  // .codex/hooks.json + .codex/hooks/gate-evidence.mjs
+  copyFile('hooks.json', join(targetDir, '.codex', 'hooks.json'))
+  copyFile('hooks/gate-evidence.mjs', join(targetDir, '.codex', 'hooks', 'gate-evidence.mjs'))
+
   // .codex/mcp.json.example
   copyFile('mcp.json.example', join(targetDir, '.codex', 'mcp.json.example'))
 

--- a/packages/create-app/src/setup/tools/cursor.ts
+++ b/packages/create-app/src/setup/tools/cursor.ts
@@ -44,6 +44,9 @@ export function generateCursor(config: AgenticConfig): void {
   // .cursor/hooks/entity-migration-check.mjs
   copyFile('hooks/entity-migration-check.mjs', join(targetDir, '.cursor', 'hooks', 'entity-migration-check.mjs'))
 
+  // .cursor/hooks/gate-evidence.mjs
+  copyFile('hooks/gate-evidence.mjs', join(targetDir, '.cursor', 'hooks', 'gate-evidence.mjs'))
+
   // .cursor/mcp.json.example
   copyFile('mcp.json.example', join(targetDir, '.cursor', 'mcp.json.example'))
 

--- a/packages/create-app/template/gitignore
+++ b/packages/create-app/template/gitignore
@@ -117,3 +117,7 @@ skills-lock.json
 # entrypoint scripts om-prepare-test-env compiles are bound to the machine that
 # generated them (ports, process tools, shell) — keep them local, never commit
 .ai/scripts/test-env-*
+
+# per-session validation-gate evidence written by the gate-evidence hook on every
+# Bash call — machine-local observation, never source
+.ai/.gate-state.json


### PR DESCRIPTION
## Summary

Makes a generated standalone app's validation gates fail when they should, and makes the
`mercato generate` conventions that currently fail **silently** produce warnings.

Derived from a real agent session in a generated app: a module was scaffolded, self-certified
"PRODUCTION READY", and shipped with 100 TypeScript errors and a build that failed on first
page load — while reporting `typecheck ✓ · lint ✓ · test ✓ · build ✓`. None of those gates had
passed. `typecheck` had crashed with an out-of-memory error, `lint` never enables
`import/no-unresolved`, and `test` exits 0 on an empty suite.

The guidance the agent needed already existed. What was missing was anything that **fails**
when guidance is ignored.

## Generator warnings (`packages/cli`)

Three conventions where a wrong name yields a successful run, a correct-looking manifest, and
a runtime-only defect:

| Convention | Current silent effect |
|---|---|
| `page.meta.ts` exporting `meta`, not `metadata` | **Page ships with NO authorization gate** — `requireAuth`/`requireFeatures` dropped |
| `registerCommand` reachable only from an uncalled function | ids appear in the manifest; handlers never register |
| `di.ts` exporting other than `register` | the module's DI registrations never run |

Plus the OpenAPI regex fallback, promoted from a log line to a warning — its usual cause is a
route importing an unresolvable specifier, and its effect is that every request/response
schema is silently omitted.

Each message names the runtime consequence rather than restating the rule. All are warnings,
never hard failures — existing apps may rely on the current tolerance.

## Harness (`packages/create-app`)

- **Gate honesty** in `om-module-scaffold/references/verification.md`: an OOM abort is a
  failure to report; `No tests found` is not a pass; lint says nothing about import
  resolution; a pipe reports the pipe's exit status; a written completion claim is not a gate.
- **Contract routing** to the installed `@open-mercato/ui` and `@open-mercato/shared`
  `AGENTS.md`, which already document the exact import path for every primitive, plus the
  backend route convention (the module id is *not* a path segment, unlike API routes).
- **Gate-evidence hook**, modelled on the existing `entity-migration-check`: records gate exit
  statuses and blocks concluding when source changed this session without a passing typecheck
  since.

## Deliberate non-changes

**The root `AGENTS.md` is untouched, byte-for-byte.** The gate-honesty rules were originally
added there and had to be moved. `STANDALONE_ROOT_TARGET_BYTES` is 12 KiB and the generated
root is that template plus an inline 49-module fact index; measured against `origin/develop`
the budget suite is 8/0, and adding as little as **86 bytes** fails it. The failure offers
reclaiming root bytes or accepting the pointer-form fallback — the first means deleting
routing rules this PR does not own, the second degrades the module-fact index to pointer form
for every classic scaffold. Neither is worth one rule, so the rules live in `verification.md`
instead, which is mandatory reading before claiming a scaffold complete and has no budget.

**`import/no-unresolved` is not enabled**, though it was in scope. Measured both directions in
a real generated app: the resolver reports the *valid* `@open-mercato/ui/backend/CrudForm` as
unresolved just as it does the invented `@open-mercato/ui/crud/form` — with the inherited
`eslint-config-next` resolver and with an explicit `typescript` resolver. `@open-mercato/ui`
ships a subpath `exports` map and the template uses `moduleResolution: bundler`; the resolver
honors neither. Shipping it would fail on correct code, and a gate that cries wolf gets
disabled. Rationale recorded in the run plan.

**The typecheck heap fix is not duplicated.** #5295 already carries it; this PR makes no
change to `package.json.template` and depends on #5295 for that coverage.

## Validation

Full gate, each command checked on its own exit status:

| Gate | Result |
|---|---|
| `yarn build:packages` | PASS |
| `yarn generate` | PASS |
| `yarn i18n:check-sync` | PASS |
| `yarn i18n:check-usage` | PASS |
| `yarn typecheck` | PASS |
| `yarn test` | PASS |
| `yarn build:app` | PASS |

Tests added: 12 generator cases and 10 hook cases. Every warning is asserted both firing
**and** staying silent on correct code, so a diagnostic that fires on valid input fails the
suite. Hook cases cover gate matching across compound (`a && b && c`) and direct (`npx tsc`)
invocations, plus the docs-only-session false positive.

Tracking plan: `.ai/runs/2026-08-14-harness-verification-gates.md`

Status: complete
