### PR TITLE
fix(customers/calendar): stabilize week-grid drag test (#5278)

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CAL-008.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CAL-008.spec.ts
@@ -27,11 +27,12 @@ import {
  *   ON). Toggling **Conflict warnings** OFF in the settings modal + Save removes
  *   the badge.
  *
- * Drag-to-create is covered by a second test below: a real-mouse drag over an
- * empty grid cell (resolved via `elementFromPoint` so it never lands on a block)
- * opens the create editor with the dragged time prefilled — exercising the
- * pointer→onCreateRange→editor `defaultRange` wiring. The pure drag time math is
- * additionally unit-tested in `lib/calendar/grid.ts`.
+ * Drag-to-create is covered by a second test below: a unique search filter first
+ * removes every event block from the rendered grid, then a real-mouse drag over
+ * one fixed cell opens the create editor with the dragged time prefilled. This
+ * exercises the pointer→onCreateRange→editor `defaultRange` wiring without
+ * relying on seeded event placement. The pure drag time math is additionally
+ * unit-tested in `lib/calendar/grid.ts`.
  *
  * Determinism notes:
  * - The default Playwright viewport (1280px) boots the calendar in Week view.
@@ -156,40 +157,59 @@ test.describe('TC-CAL-008: Calendar week-view states', () => {
 
   // Real-mouse drag-to-create: covers the end-to-end pointer→onCreateRange→editor
   // `defaultRange` wiring that the grid.ts unit tests (pure time math) cannot reach.
-  // Targets a point where the topmost element is the drag layer (`.cursor-cell`), so
-  // the drag never lands on an event block (which would open the peek instead).
+  // A per-run search token guarantees the rendered grid contains no event blocks.
+  // The drag targets one fixed point in the first weekday layer instead of scanning
+  // the viewport for somewhere that happens to be empty.
   test('dragging empty week-grid space opens the create editor with the dragged time prefilled', async ({ page }) => {
     test.slow();
     await login(page, 'admin');
     await page.goto('/backend/calendar');
     await waitForCalendarLoaded(page);
 
-    const coords = await page.evaluate(() => {
-      const scroller = document.querySelector<HTMLElement>('.overflow-auto');
-      const layers = Array.from(document.querySelectorAll<HTMLElement>('.cursor-cell'));
-      if (!scroller || layers.length === 0) return null;
-      // Scroll into a late-day region where seeded/demo events are unlikely.
-      scroller.scrollTop = Math.floor(scroller.scrollHeight * 0.6);
-      const viewport = scroller.getBoundingClientRect();
-      for (const layer of layers) {
-        const rect = layer.getBoundingClientRect();
-        const x = rect.left + rect.width / 2;
-        for (let fraction = 0.3; fraction < 0.75; fraction += 0.05) {
-          const y = viewport.top + viewport.height * fraction;
-          const hit = document.elementFromPoint(x, y);
-          if (hit && hit.classList.contains('cursor-cell')) {
-            return { x, y0: y, y1: Math.min(y + 130, viewport.bottom - 16) };
-          }
-        }
-      }
-      return null;
-    });
-    expect(coords, 'found empty grid space to drag on').not.toBeNull();
+    const emptyGridSearch = `__qa_empty_drag_${Date.now()}__`;
+    const searchInput = page.locator('[data-calendar-search]');
+    await searchInput.fill(emptyGridSearch);
+    await searchInput.blur();
 
-    await page.mouse.move(coords!.x, coords!.y0);
+    const dragLayer = page.locator('.cursor-cell').first();
+    const scroller = dragLayer.locator(
+      'xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " overflow-auto ")][1]',
+    );
+    await expect(dragLayer, 'week grid should expose a drag layer').toBeVisible();
+
+    await expect.poll(async () => {
+      const [layerBox, scrollerBox] = await Promise.all([
+        dragLayer.boundingBox(),
+        scroller.boundingBox(),
+      ]);
+      if (!layerBox || !scrollerBox) return false;
+      const x = layerBox.x + layerBox.width / 2;
+      const y = scrollerBox.y + scrollerBox.height * 0.45;
+      return page.evaluate(
+        ({ clientX, clientY }) =>
+          document.elementFromPoint(clientX, clientY)?.classList.contains('cursor-cell') === true,
+        { clientX: x, clientY: y },
+      );
+    }, {
+      message: `search filter ${emptyGridSearch} should expose the fixed drag target`,
+    }).toBe(true);
+
+    const [layerBox, scrollerBox] = await Promise.all([
+      dragLayer.boundingBox(),
+      scroller.boundingBox(),
+    ]);
+    expect(layerBox, 'fixed weekday drag layer should have a bounding box').not.toBeNull();
+    expect(scrollerBox, 'week grid scroller should have a bounding box').not.toBeNull();
+    const coords = {
+      x: layerBox!.x + layerBox!.width / 2,
+      y0: scrollerBox!.y + scrollerBox!.height * 0.45,
+      y1: scrollerBox!.y + scrollerBox!.height * 0.65,
+    };
+
+    await page.mouse.move(coords.x, coords.y0);
     await page.mouse.down();
-    await page.mouse.move(coords!.x, (coords!.y0 + coords!.y1) / 2, { steps: 6 });
-    await page.mouse.move(coords!.x, coords!.y1, { steps: 6 });
+    await page.mouse.move(coords.x, (coords.y0 + coords.y1) / 2, { steps: 6 });
+    await page.mouse.move(coords.x, coords.y1, { steps: 6 });
     await page.mouse.up();
 
     const editor = page.getByRole('dialog');


### PR DESCRIPTION
Closes #5278

## 🎯 Goal
- Make TC-CAL-008 reliably exercise week-grid drag-to-create without depending on seeded event placement or searching the viewport for a coincidentally empty point.

## 🔍 Problem
The calendar week-grid drag scenario intermittently failed before the drag interaction because its setup swept a late-day viewport band looking for any point whose topmost element happened to be the drag layer. Seeded or demo events could cover every sampled point even when drag-to-create itself worked correctly.

## 🔍 Root Cause
The test derived its coordinates from mutable page state: it scrolled to 60% of the grid, iterated every drag layer, and sampled a series of viewport fractions with `elementFromPoint`. That heuristic made the prerequisite depend on event density and layout instead of establishing an empty grid deterministically.

## What Changed
- Filter the calendar with a unique per-run token so event blocks are removed from the rendered week grid before dragging.
- Target one fixed point in the first weekday drag layer and poll until the debounced filter exposes that exact point.
- Keep real mouse movement through the pointer-to-create-editor flow and improve prerequisite assertion messages.

## 🧪 Tests
- `yarn mercato test:integration TC-CAL-008` and two customers-scoped repeats — 6/6 scenario executions passed across three managed ephemeral environments.
- `yarn build:packages`; `yarn generate`; `yarn build:packages` — passed.
- `yarn i18n:check-sync`; `yarn i18n:check-usage`; `yarn typecheck` — passed (unused translation keys remain advisory and unrelated).
- `yarn test` — full retry passed all 29 Turbo tasks. The first run had one unrelated Jest worker SIGSEGV; its exact Stripe test passed 2/2 serially before the clean aggregate retry.
- `yarn build:app` — passed.

## 💥 Breaking Changes
- None. This is an integration-test-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789302226&installation_model_id=432243&pr_number=5302&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5302&signature=905e1bd861bec400f560fa58894de98284b05bf5875b40c771aa78b1af5f4805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->