### PR TITLE
security(security): require a genuine WebAuthn assertion for passkey MFA verification

### DIFF
--- a/.ai/qa/scenarios/TC-SEC-004-passkey-enrollment-and-login.md
+++ b/.ai/qa/scenarios/TC-SEC-004-passkey-enrollment-and-login.md
@@ -43,3 +43,8 @@ Verify that a user can register a passkey MFA method from the security profile a
 - Cancel the browser passkey ceremony and expect the enrollment to remain incomplete
 - Attempt login challenge with a missing or rejected WebAuthn assertion and expect the session to remain MFA-pending
 - Verify that the test skips explicitly rather than failing when WebAuthn is unsupported in CI
+
+## Automation Coverage
+Steps 1-7 and the "no assertion" edge case are automated in `TC-SEC-004.spec.ts`, which asserts that a login challenge answered with the disclosed credential id and challenge rather than a signed assertion is refused with `401` (the second-factor bypass fixed in #3852).
+
+Step 8 — the passing browser verification ceremony — stays **manual**. A genuine assertion needs an authenticator, so automating it requires a Playwright virtual authenticator (`WebAuthn.addVirtualAuthenticator`); until that lands, a passing passkey login and a passing passkey sudo step-up must be confirmed by hand against a real authenticator.

--- a/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
+++ b/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
@@ -68,6 +68,8 @@ The Playwright specs used the bypass as their shortcut, so they assert a behavio
 
 ## Progress
 
+PR: #5306
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Close the bypass in PasskeyProvider
@@ -92,4 +94,4 @@ The Playwright specs used the bypass as their shortcut, so they assert a behavio
 
 ### Phase 5: Validation and delivery
 
-- [ ] 5.1 Run the full validation gate and finalize the PR
+- [x] 5.1 Run the full validation gate and finalize the PR — fb98bf0d9 (review pass raised one major finding, fixed in that commit)

--- a/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
+++ b/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
@@ -95,3 +95,11 @@ PR: #5306
 ### Phase 5: Validation and delivery
 
 - [x] 5.1 Run the full validation gate and finalize the PR — fb98bf0d9 (review pass raised one major finding, fixed in that commit)
+
+### Phase 6: Address the strict review round
+
+- [x] 6.1 Resolve the compatibility waiver against the policy gate — added a defined Emergency Security Exception to the Deprecation Protocol and reclassified the passkey entry as an instance of it rather than a one-off
+- [x] 6.2 Write the migration spec the protocol's step 5 requires — `.ai/specs/enterprise/2026-08-14-passkey-mfa-require-webauthn-assertion.md`
+- [x] 6.3 Correct the operator guidance — a shortcut-enrolled credential may hold an attacker-controlled valid keypair, not only an unusable key
+- [x] 6.4 Fix the audit instruction to the real schema (`user_mfa_methods`, column `type`) and replace per-row auditing with reset-and-re-enroll, since provenance is not reconstructible
+- [x] 6.5 Note the mid-body `test.skip` in TC-SEC-006/007 so the unreachable tail is not a surprise

--- a/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
+++ b/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
@@ -1,0 +1,95 @@
+# Execution plan — require a genuine WebAuthn assertion for passkey MFA verification
+
+**Issue:** [#3852](https://github.com/open-mercato/open-mercato/issues/3852) — `security(ent_security): passkey MFA second factor bypassable via non-cryptographic fallback`
+
+**Supersedes:** PR [#5291](https://github.com/open-mercato/open-mercato/pull/5291), a third-party contribution that was closed without merging. `packages/enterprise` is the commercial package and we do not accept outside contributions there, so the fix is re-authored first-party from the issue report and the current `develop` source. No content from the closed PR's diff is carried over.
+
+## Goal
+
+Make a cryptographically verified WebAuthn assertion the only way to pass the passkey second factor, for both login-time MFA (`POST /api/security/mfa/verify`) and passkey-as-sudo step-up (`POST /api/security/sudo/verify`).
+
+## Scope
+
+`packages/enterprise/src/modules/security` only:
+
+- `lib/providers/PasskeyProvider.ts` — the verify payload schema and the two non-cryptographic acceptance branches in `verify()`.
+- `lib/__tests__/PasskeyProvider.test.ts` — replace the test that pins the bypass as intended behavior with regression coverage.
+- a new real-crypto test that signs a genuine assertion with a software authenticator, so the removal is proven not to break real passkeys.
+- `__integration__/` — the Playwright specs and the shared fixture that used the bypass as an API-level shortcut.
+- `BACKWARD_COMPATIBILITY.md` and `UPGRADE_NOTES.md` — record the deliberate, non-deprecated request-shape removal.
+
+### Non-goals
+
+- The **setup-side** shortcut (`setupConfirmationPayloadSchema` accepting a client-supplied `publicKey` with no attestation). It is a separate defect with its own blast radius and gets its own issue.
+- Restoring an integration-level passkey happy path. Producing a genuine assertion over the API is impossible by design; it needs a Playwright virtual authenticator driving the browser flow. Tracked as a follow-up issue.
+- `OtpEmailProvider` / `TotpProvider` verification paths.
+- Any change to challenge TTL handling, attempt limiting, or the signature-counter update.
+
+## Implementation Plan
+
+### Phase 1: Close the bypass in `PasskeyProvider`
+
+`verify()` currently reaches a `true` verdict on three routes: a real `verifyAuthenticationResponse`, a `credentialId` + `challenge` string compare after the assertion branch, and — when no verify context exists at all — a bare `credentialId` compare. Both compared values are public: `prepareChallenge()` returns them to the caller and `GET /api/security/mfa/methods` discloses `providerMetadata.credentialId`.
+
+1.1 Reduce `verifyPayloadSchema` to a single object that requires `response`, and reject a payload that fails the schema by returning `false` rather than throwing. A thrown `ZodError` reaches `mapMfaError` as a logged **500** and bypasses `registerFailedAttempt`, so rejected attempts would stop counting toward the challenge attempt limit; `safeParse` + `false` keeps the documented **401** and the lockout behavior.
+
+1.2 Delete the context-absent `credentialId` fallback and the trailing string-compare block, so a verified `verifyAuthenticationResponse` is the only route to `true`.
+
+### Phase 2: Unit regression coverage
+
+2.1 Replace `supports legacy verification payload for backward compatibility` (which asserted the bypass worked) with regression tests: the legacy shape is refused with a correctly prepared context; a `credentialId`-only payload is refused when the client skipped `/prepare`; a well-formed assertion is refused when no challenge was prepared; and an assertion the authenticator did not sign is refused. The first two also assert `verifyAuthenticationResponse` was never reached.
+
+2.2 Add `PasskeyProvider.webauthn.test.ts`, which does **not** mock `@simplewebauthn/server`: a software authenticator generates a P-256 key pair, stores the COSE public key the way `confirmSetup` does, and signs a real assertion over the prepared challenge. Asserts that a genuine assertion still verifies end to end and that a tampered signature does not. This is the evidence that the removal does not break real passkey login.
+
+### Phase 3: Realign the integration suite
+
+The Playwright specs used the bypass as their shortcut, so they assert a behavior that is now a vulnerability.
+
+3.1 Turn the shared fixture into an explicitly named negative helper and update `TC-SEC-004` to assert that login verification with a non-cryptographic payload is refused.
+
+3.2 Update `TC-SEC-006` and `TC-SEC-007` to assert that passkey sudo verification is refused, then skip their sudo-token-gated remainders with an explicit reason instead of asserting a token they can no longer obtain.
+
+### Phase 4: Contract documentation
+
+4.1 Record the removal in `BACKWARD_COMPATIBILITY.md` as a dated, deliberate exception to the deprecation protocol, and add an `UPGRADE_NOTES.md` entry telling downstream operators what changes and what to do about credentials enrolled through the setup shortcut.
+
+4.2 File the two follow-up issues (setup-side attestation shortcut; virtual-authenticator integration coverage) and link them from the PR.
+
+### Phase 5: Validation and delivery
+
+5.1 Run the full `validation.commands` gate, then finalize the PR: labels, review pass, summary comment.
+
+## Risks
+
+- **Highest risk is a false negative**: over-tightening `verify()` would lock every passkey user out of login and sudo. Mitigated by Phase 2.2, which exercises the untouched `{ response }` path against the real `@simplewebauthn/server` with a genuinely signed assertion.
+- **Deliberate breaking change.** `{ credentialId, challenge }` payloads start returning `401`. This skips the deprecation protocol on purpose: the request shape being removed *is* the vulnerability, so a bridge release would keep the second-factor bypass live. The first-party UI is unaffected — it sends `startAuthentication()` output.
+- **Stranded credentials.** A passkey enrolled through the setup shortcut carries a fabricated public key and can never produce a verifiable assertion. Such a user needs an admin MFA reset. Documented in `UPGRADE_NOTES.md`.
+- **Integration coverage loss.** Passkey verification has no API-level happy path after this change; Phase 3 makes that explicit rather than silent, and Phase 4.2 tracks restoring it.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Close the bypass in PasskeyProvider
+
+- [ ] 1.1 Require a `response` payload and reject unparseable payloads without throwing
+- [ ] 1.2 Delete the context-absent and string-compare acceptance branches
+
+### Phase 2: Unit regression coverage
+
+- [ ] 2.1 Replace the legacy-payload test with bypass regression tests
+- [ ] 2.2 Add a real-crypto test proving a genuine assertion still verifies
+
+### Phase 3: Realign the integration suite
+
+- [ ] 3.1 Rework the shared fixture and TC-SEC-004 into a negative assertion
+- [ ] 3.2 Rework TC-SEC-006 and TC-SEC-007 sudo verification
+
+### Phase 4: Contract documentation
+
+- [ ] 4.1 Document the deliberate break in BACKWARD_COMPATIBILITY.md and UPGRADE_NOTES.md
+- [ ] 4.2 File the setup-shortcut and integration-coverage follow-up issues
+
+### Phase 5: Validation and delivery
+
+- [ ] 5.1 Run the full validation gate and finalize the PR

--- a/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
+++ b/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
@@ -82,13 +82,13 @@ The Playwright specs used the bypass as their shortcut, so they assert a behavio
 
 ### Phase 3: Realign the integration suite
 
-- [ ] 3.1 Rework the shared fixture and TC-SEC-004 into a negative assertion
-- [ ] 3.2 Rework TC-SEC-006 and TC-SEC-007 sudo verification
+- [x] 3.1 Rework the shared fixture and TC-SEC-004 into a negative assertion — 5560dcaec
+- [x] 3.2 Rework TC-SEC-006 and TC-SEC-007 sudo verification — 5560dcaec
 
 ### Phase 4: Contract documentation
 
-- [ ] 4.1 Document the deliberate break in BACKWARD_COMPATIBILITY.md and UPGRADE_NOTES.md
-- [ ] 4.2 File the setup-shortcut and integration-coverage follow-up issues
+- [x] 4.1 Document the deliberate break in BACKWARD_COMPATIBILITY.md and UPGRADE_NOTES.md — b508f95e2
+- [x] 4.2 File the setup-shortcut and integration-coverage follow-up issues — #5296 already existed for the setup shortcut; filed #5307 for integration coverage
 
 ### Phase 5: Validation and delivery
 

--- a/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
+++ b/.ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
@@ -72,13 +72,13 @@ The Playwright specs used the bypass as their shortcut, so they assert a behavio
 
 ### Phase 1: Close the bypass in PasskeyProvider
 
-- [ ] 1.1 Require a `response` payload and reject unparseable payloads without throwing
-- [ ] 1.2 Delete the context-absent and string-compare acceptance branches
+- [x] 1.1 Require a `response` payload and reject unparseable payloads without throwing — b635b1677
+- [x] 1.2 Delete the context-absent and string-compare acceptance branches — b635b1677
 
 ### Phase 2: Unit regression coverage
 
-- [ ] 2.1 Replace the legacy-payload test with bypass regression tests
-- [ ] 2.2 Add a real-crypto test proving a genuine assertion still verifies
+- [x] 2.1 Replace the legacy-payload test with bypass regression tests — 0ed09d4b7
+- [x] 2.2 Add a real-crypto test proving a genuine assertion still verifies — 0ed09d4b7
 
 ### Phase 3: Realign the integration suite
 

--- a/.ai/specs/enterprise/2026-08-14-passkey-mfa-require-webauthn-assertion.md
+++ b/.ai/specs/enterprise/2026-08-14-passkey-mfa-require-webauthn-assertion.md
@@ -1,0 +1,148 @@
+# Enterprise Security — Require a Genuine WebAuthn Assertion for Passkey MFA Verification
+
+> **Status:** Implemented 2026-08-14 (branch `fix/passkey-mfa-require-webauthn-assertion`, PR #5306) — awaiting merge and manual QA
+> **Issue:** [open-mercato#3852](https://github.com/open-mercato/open-mercato/issues/3852)
+> **Scope:** Enterprise — `security` module (`packages/enterprise/src/modules/security`)
+> **Severity:** Critical — second-factor bypass reachable by anyone holding an `mfa_pending` session, in login MFA and in passkey-as-sudo step-up alike.
+
+## TLDR
+
+**Key Points:**
+- `PasskeyProvider.verify()` accepted a `{ credentialId, challenge }` payload beside the genuine `{ response }` assertion and approved it by plain string comparison. Both compared values are **public**: `prepareChallenge()` returns the credential id and the challenge to the caller, and `GET /api/security/mfa/methods` discloses `providerMetadata.credentialId`.
+- A third route needed even less. With no verify context — the client simply never called `/api/security/mfa/prepare` — the provider fell through to comparing only the disclosed credential id and ignored the challenge entirely.
+- `SudoChallengeService.verify` → `MfaVerificationService.verifyChallenge` → `provider.verify` is the same code path, so the bypass defeated login-time MFA **and** passkey-as-sudo step-up.
+
+**Scope:**
+- Collapse `verifyPayloadSchema` from a union to a single object requiring `response`; delete the context-absent `credentialId` fallback and the trailing string-compare block, so a verified `verifyAuthenticationResponse` is the only route to a positive verdict.
+- Replace the test that asserted the bypass worked with regression coverage for every route that previously reached a positive verdict without a signature, plus a real-crypto suite that proves genuine passkeys still authenticate.
+- Record the contract break under the Emergency Security Exception, with client and operator migration instructions.
+
+**Concerns:**
+- This removes a STABLE contract surface with no bridge, which the ordinary deprecation protocol forbids. See § Migration & Backward Compatibility.
+- It closes only the *verification* half. The *enrollment* half (#5296) still accepts a client-supplied `publicKey` with no attestation and is unaffected by this change.
+
+---
+
+## Problem Statement
+
+All references verified against `develop` at issue-filing time.
+
+### The verification schema accepted a non-cryptographic shape
+
+`lib/providers/PasskeyProvider.ts` declared `verifyPayloadSchema` as a union of `{ response }` and `{ credentialId, challenge }`. The second branch was approved by string comparison against values the server itself discloses:
+
+- `prepareChallenge()` returns `options.challenge` to the caller in `clientData`.
+- `GET /api/security/mfa/methods` returns `providerMetadata.credentialId` for every enrolled method.
+
+An attacker therefore did not need to guess either value; the API hands both over.
+
+### An absent verify context weakened the check further
+
+`MfaVerificationService.verifyChallenge` builds the verify context from `challenge.providerChallenge`, which `prepareChallenge` persists. When the client never called `/prepare`, no context existed, and the provider's context-absent fallback compared **only** the disclosed credential id, ignoring the challenge. That is a bypass with a single public value.
+
+### Both entry points route through the same provider
+
+`services/MfaVerificationService.ts` is the only call site of `provider.verify` in the module, and `SudoChallengeService.verify` delegates to it. So the same defect served `POST /api/security/mfa/verify` (login second factor) and `POST /api/security/sudo/verify` (sudo step-up).
+
+### Root cause
+
+The provider treated a *disclosed identifier* as an *authentication secret*. Possession of a credential id and a challenge proves nothing; only a signature over the challenge by the credential's private key does.
+
+## Proposed Solution
+
+Make a verified assertion the sole positive path.
+
+### A. Narrow the payload schema
+
+`verifyPayloadSchema` becomes `z.object({ response: z.record(z.string(), z.unknown()) })`. The union's second branch is removed, so a legacy payload fails the schema before any comparison happens.
+
+### B. Require a prepared verify context
+
+`verifyContextSchema.safeParse(context)` must succeed. An absent or malformed context is a rejection, not a fallback. The existing challenge TTL check runs unchanged against `pending.createdAt`.
+
+### C. Delete the string-compare block
+
+The trailing `credentialId` / `challenge` comparison is removed outright. `verifyAuthenticationResponse` from `@simplewebauthn/server` is the only remaining route to `true`, and the signature-counter update stays gated behind its positive verdict.
+
+### D. Fail closed, and fail as a rejection rather than an error
+
+`safeParse` instead of `parse`, and a `.catch()` around `verifyAuthenticationResponse` that returns `null`. This is deliberate and is the security-relevant choice: a thrown error reaches `mapMfaError` as a logged **500** and skips `registerFailedAttempt`, so rejected attempts would stop counting toward `securityConfig.mfa.maxAttempts` and the challenge lockout would be defeated. Returning `false` preserves the documented **401** and the attempt limit. No verdict flips from negative to positive.
+
+The `.catch()` emits a `warn` through the logging facade (`createLogger('security').child({ component: 'passkey-provider' })`) carrying the method id, the rpId and the verifier's error — but not the assertion — so a misconfigured `rpId`/`expectedOrigins` is diagnosable rather than presenting as a mystery 401.
+
+## Affected Surfaces
+
+| Path | Change |
+|------|--------|
+| `lib/providers/PasskeyProvider.ts` | `verifyPayloadSchema` narrowed; context-absent fallback and string-compare block removed; verifier failure logged and rejected |
+| `lib/__tests__/PasskeyProvider.test.ts` | Bypass-asserting test replaced with regression coverage for each previously-positive route |
+| `lib/__tests__/PasskeyProviderWebAuthn.test.ts` (new) | Real `@simplewebauthn` verifier against a software authenticator |
+| `__integration__/TC-SEC-004.spec.ts` | Asserts login verification answers `401` without an assertion |
+| `__integration__/TC-SEC-006.spec.ts`, `TC-SEC-007.spec.ts` | Sudo step-up asserts `401`; sudo-token-gated remainders skipped with a stated reason (#5307) |
+| `__integration__/helpers/securityFixtures.ts` | `verifyPasskeyChallenge` → the explicitly negative `attemptUnsignedPasskeyVerify` |
+| `BACKWARD_COMPATIBILITY.md`, `UPGRADE_NOTES.md`, `.ai/qa/scenarios/TC-SEC-004-…md` | Contract break, exception record, client and operator migration |
+
+## Test Plan
+
+The load-bearing evidence is `PasskeyProviderWebAuthn.test.ts`, which does **not** mock `@simplewebauthn/server`. It generates a P-256 key pair, encodes the COSE public key the way `confirmSetup` stores it, and signs a genuine assertion over the challenge `prepareChallenge()` produced. Mocking the verifier could not prove what this change most needs proven — that the tightening did not overshoot and lock every passkey user out.
+
+- A real assertion verifies and advances the stored signature counter.
+- A tampered signature is refused and the counter is not advanced.
+- An assertion replayed against a different prepared challenge is refused.
+- The disclosed `{ credentialId, challenge }` pair is refused.
+
+`PasskeyProvider.test.ts` adds five cases against the mocked verifier: the legacy shape is refused even with a correctly prepared context; a `credentialId`-only payload is refused when the client skipped `/prepare`; a well-formed assertion is refused when no challenge was prepared; an assertion the authenticator did not sign is refused without advancing the counter; and an assertion that makes the verifier throw resolves to `false` instead of propagating. The first three also assert `verifyAuthenticationResponse` was never reached. Three of the five fail against the pre-fix provider.
+
+`TC-SEC-004` gives the fix live end-to-end coverage in CI. `TC-SEC-006`/`TC-SEC-007` gate on a pre-existing `test.skip(!passkeyMethod, …)` and the CI environment seeds no admin passkey, so their new `401` assertions are dark in CI today; the fix's CI signal comes from `TC-SEC-004` plus the unit suites, which exercise the identical provider path sudo routes through.
+
+**Coverage gap, tracked as #5307.** Passkey verification has no integration-level *happy* path, because no API-level fixture can produce a signed assertion. Restoring it needs a Playwright virtual authenticator, or decoupling the sudo scenarios from passkeys onto TOTP.
+
+## Migration & Backward Compatibility
+
+This change **breaks a STABLE contract surface without the deprecation protocol, deliberately**, under the [Emergency Security Exception](../../../BACKWARD_COMPATIBILITY.md#emergency-security-exception).
+
+### Classification
+
+The removed shape was publicly supported, not an undocumented accident: it was part of the exported `MfaProviderInterface.verifySchema` union that a third-party client could validate against, and the enterprise suite pinned it in a case named *"supports legacy verification payload for backward compatibility"*. So this is a real category-7 (API request shape) break, and the exception — rather than a claim that no contract existed — is what authorizes it.
+
+### Why no bridge
+
+The protocol's bridge requirement exists to give downstream authors a migration window. Here the request shape being removed *is* the vulnerability: both values it compared are disclosed by the server, so keeping it alongside the assertion path for one minor version would leave the passkey second factor bypassable in login MFA and sudo step-up for that whole window. A security fix that keeps the hole open for a release is not a fix. Correspondingly, **no flag, config toggle or opt-in retains the old branch** — a retained branch would be exactly the bridge the exception refuses.
+
+### Broken surfaces
+
+| Surface | Change |
+|---------|--------|
+| `POST /api/security/mfa/verify`, `POST /api/security/sudo/verify` request shape (`methodType: 'passkey'`) | `{ credentialId, challenge }` now answers `401` |
+| `MfaProviderInterface.verifySchema` for `passkey` | Narrows from a union to a single object requiring `response` |
+| Verification with no prepared challenge | Now a rejection rather than a `credentialId` comparison |
+| Route URLs, HTTP methods, response schemas, DB schema, event IDs, ACL features, DI names, CLI commands | Unchanged |
+
+### Client migration
+
+Send the object returned by `@simplewebauthn/browser`'s `startAuthentication()` as `payload.response`, after calling `/api/security/mfa/prepare` (or `/api/security/sudo/prepare`). The first-party `PasskeyChallengeVerify` component already does this, so shipped UIs need no change. A client that submitted the credential id and challenge was, by construction, not performing cryptographic verification.
+
+### Operator migration
+
+Full instructions are in [`UPGRADE_NOTES.md`](../../../UPGRADE_NOTES.md) under `0.6.7 → 0.7.0`. The essential point, and the one easy to get wrong: a passkey enrolled through the setup path's unattested `publicKey` shortcut is **not** reliably rendered unusable by this change. Such a row holds either a key nobody can sign with (that user is now locked out and needs an admin MFA reset) **or** a keypair the enroller controls, which signs assertions this change accepts. Both enrollment paths write identical `provider_metadata` keys, so the row cannot be attributed to an origin; the conservative remediation is to reset and re-enroll all passkey methods on any deployment that ever provisioned passkeys through the API, and to sequence #5296 ahead of the upgrade where possible.
+
+## Risks & Impact Review
+
+| Risk | Failure scenario | Severity | Mitigation | Residual |
+|------|------------------|----------|------------|----------|
+| Tightening overshoots and refuses genuine assertions | Every passkey user locked out of login and sudo | Critical | `PasskeyProviderWebAuthn.test.ts` proves a real signed assertion still verifies and advances the counter; manual QA against a real authenticator before merge | Low |
+| Third-party client sends the legacy shape | That client's passkey step breaks at upgrade with `401` | Medium | Documented in `UPGRADE_NOTES.md` and `BACKWARD_COMPATIBILITY.md`; accepted under the exception | Accepted |
+| Shortcut-enrolled credential holds an attacker-controlled valid keypair | Account takeover survives this fix | High | Disclosed in `UPGRADE_NOTES.md` with reset-and-re-enroll remediation; closed properly by #5296 | Medium until #5296 lands |
+| Verifier error swallowed as a silent 401 | Misconfigured `rpId`/`expectedOrigins` reads as a user error | Medium | `.catch()` logs a `warn` with method id, rpId and the verifier error | Low |
+| No integration happy path for passkey verification | A future regression in the `{ response }` path is caught only by unit tests | Medium | Tracked as #5307; unit suite runs the real verifier | Medium |
+
+## Open Questions
+
+1. ~~Throw or return `false` on a malformed payload / verifier error.~~ **Resolved (2026-08-14):** return `false`. Throwing produces a 500 that skips `registerFailedAttempt` and defeats the challenge attempt limit. See § D.
+2. ~~Bridge the legacy shape for one minor version.~~ **Resolved (2026-08-14):** no bridge, under the Emergency Security Exception. See § Migration & Backward Compatibility.
+
+_No open questions remain blocking._
+
+## Changelog
+
+- 2026-08-14 — Initial spec, written from issue #3852 and the implementation on `fix/passkey-mfa-require-webauthn-assertion`, to satisfy deprecation-protocol step 5 for the contract break. Records the Emergency Security Exception classification, the client and operator migration paths, and the #5296 / #5307 boundaries.

--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -333,3 +333,21 @@ Files in `apps/mercato/.mercato/generated/` are produced by the CLI generators. 
 | Database schema, event IDs, ACL features, DI names, CLI commands | No change | ✓ n/a |
 
 **Migration path for existing modules**: no action required. The capability is opt-in per rejection — an interceptor that never sets `status` produces exactly the responses it produced before. Interceptors that want a deliberate status add `status` (and optionally `body`) to the `{ ok: false, message }` verdict they already return. Third-party transports that call `commandBus.execute` inside their own `try/catch` can honour the same contract in two lines via `getCommandInterceptorHttpRejection(err)`, which validates the status is an integer in 400-599 before returning it.
+
+---
+
+## Passkey MFA Verification Payload (2026-08-14)
+
+Issue #3852 removed the non-cryptographic passkey verification shape from `PasskeyProvider` in the enterprise `security` module. This is a **deliberate breaking change to a STABLE contract surface (category 7, API request shapes) that does not follow the deprecation protocol**, and it is recorded here as the exception rather than the rule.
+
+| Surface | Change | Classification |
+|---------|--------|----------------|
+| API request shape (`POST /api/security/mfa/verify`, `POST /api/security/sudo/verify`, `methodType: 'passkey'`) | `payload` must be `{ response }` carrying a WebAuthn assertion. The `{ credentialId, challenge }` alternative is removed and now answers `401` | ✗ BREAKING (deliberate — see rationale) |
+| Provider contract (`MfaProviderInterface.verifySchema` for `passkey`) | `verifyPayloadSchema` narrows from a union to a single object requiring `response` | ✗ BREAKING for a caller that validated against the exported schema |
+| Verification behavior | A verified `verifyAuthenticationResponse` is the only route to a positive verdict; an absent verify context is a rejection rather than a `credentialId` comparison | ✗ BREAKING for a client that skipped `/api/security/mfa/prepare` |
+| Failure mode | A payload that fails the schema, and an assertion the verifier throws on, return `false` instead of throwing — so they answer the documented `401` and count toward the challenge attempt limit instead of logging a `500` that skipped lockout | ✓ Strictly safer (no verdict flips from negative to positive) |
+| API route URLs, HTTP methods, response schemas, database schema, event IDs, ACL features, DI names, CLI commands | No change | ✓ n/a |
+
+**Why the deprecation protocol does not apply.** The protocol exists to give downstream authors a bridge release. Here the request shape being removed *is* the vulnerability: both values it compared are disclosed by the server, so a bridge would keep the passkey second factor bypassable for a minor version in both login MFA and sudo step-up. A security fix that leaves the hole open is not a fix.
+
+**Migration path.** Send `startAuthentication()` output as `payload.response`. The first-party `PasskeyChallengeVerify` component already does, so shipped UIs are unaffected. Credentials enrolled through the setup path's client-supplied `publicKey` shortcut carry a fabricated public key and can no longer authenticate — those users need an admin MFA reset and a fresh enrollment. Operator-facing detail is in [`UPGRADE_NOTES.md`](UPGRADE_NOTES.md).

--- a/BACKWARD_COMPATIBILITY.md
+++ b/BACKWARD_COMPATIBILITY.md
@@ -10,6 +10,20 @@ Open Mercato modules are developed by third-party developers who depend on stabl
 4. **Document in UPGRADE_NOTES.md**: every deprecation and every removal must be listed with migration instructions.
 5. **Spec requirement**: any PR that modifies a contract surface MUST reference a spec (in `.ai/specs/`) that includes a "Migration & Backward Compatibility" section.
 
+### Emergency Security Exception
+
+Steps 1-3 — stage the removal, deprecate first, ship a bridge — are waived, and **only** those three, when the contract surface being removed *is itself* the vulnerability: keeping it alongside the replacement would leave the flaw exploitable for the whole deprecation window. A surface that merely makes an insecure usage possible does not qualify; the exception applies only where continued acceptance of the old shape **is** the exploit.
+
+This is not author or reviewer discretion. Every one of the following MUST hold, and a change that cannot satisfy all of them follows the ordinary protocol instead:
+
+1. **The qualifying condition is argued, not asserted.** The PR names the surface, the vulnerability, and why a bridge release would keep it reachable.
+2. **The removal is the narrowest one that closes the hole.** No unrelated tightening rides along, and **no partial bridge retains the vulnerable branch** behind a flag, a config toggle, or an opt-in — a retained branch is the bridge the exception exists to refuse.
+3. **Steps 4 and 5 still apply in full.** An `UPGRADE_NOTES.md` entry with both client *and* operator migration instructions, and a spec under `.ai/specs/` or `.ai/specs/enterprise/` with a "Migration & Backward Compatibility" section.
+4. **A dated entry is added at the end of this document**, recording the surface, its classification, the qualifying argument, and the migration path.
+5. **A maintainer signs off on the exception by name.** The PR carries the `security` label and a human maintainer approval that acknowledges the waiver; an automated review cannot clear it.
+
+Downstream authors get no bridge in this case, so the compensating obligation is disclosure. The `UPGRADE_NOTES.md` entry MUST state plainly what stops working, for whom, and what to do about it — including any stored credential or data state that becomes unusable, or that becomes newly suspect, as a result.
+
 ---
 
 ## Contract Surface Categories
@@ -338,7 +352,19 @@ Files in `apps/mercato/.mercato/generated/` are produced by the CLI generators. 
 
 ## Passkey MFA Verification Payload (2026-08-14)
 
-Issue #3852 removed the non-cryptographic passkey verification shape from `PasskeyProvider` in the enterprise `security` module. This is a **deliberate breaking change to a STABLE contract surface (category 7, API request shapes) that does not follow the deprecation protocol**, and it is recorded here as the exception rather than the rule.
+Issue #3852 removed the non-cryptographic passkey verification shape from `PasskeyProvider` in the enterprise `security` module. This is a **deliberate breaking change to a STABLE contract surface (category 7, API request shapes)** that ships under the [Emergency Security Exception](#emergency-security-exception) rather than the ordinary deprecation protocol.
+
+**Classification.** The removed shape was a *publicly supported* surface, not an undocumented accident: it was part of the exported `MfaProviderInterface.verifySchema` union that a third-party client could validate against, and the enterprise test suite pinned it in a case named *"supports legacy verification payload for backward compatibility"*. It is therefore a genuine STABLE-surface break, and the exception — not a claim that no contract existed — is what authorizes it.
+
+**Exception requirements, as met by this change:**
+
+| Requirement | How it is satisfied |
+|-------------|--------------------|
+| 1. Qualifying condition argued | See *Why the deprecation protocol does not apply* below — both values the removed shape compared are disclosed by the server, so accepting it *is* the bypass |
+| 2. Narrowest removal, no retained vulnerable branch | Only `verifyPayloadSchema` and the two non-cryptographic acceptance paths are deleted. The `{ response }` path, the challenge TTL check and the signature-counter update are untouched, and **no flag, config toggle or opt-in keeps the old shape reachable** |
+| 3. Steps 4 and 5 | [`UPGRADE_NOTES.md`](UPGRADE_NOTES.md) `0.6.7 → 0.7.0` (client *and* operator actions); spec [`.ai/specs/enterprise/2026-08-14-passkey-mfa-require-webauthn-assertion.md`](.ai/specs/enterprise/2026-08-14-passkey-mfa-require-webauthn-assertion.md) § Migration & Backward Compatibility |
+| 4. Dated entry | This section |
+| 5. Maintainer sign-off | PR carries the `security` label; the waiver is called out in the PR body for explicit human approval |
 
 | Surface | Change | Classification |
 |---------|--------|----------------|
@@ -350,4 +376,4 @@ Issue #3852 removed the non-cryptographic passkey verification shape from `Passk
 
 **Why the deprecation protocol does not apply.** The protocol exists to give downstream authors a bridge release. Here the request shape being removed *is* the vulnerability: both values it compared are disclosed by the server, so a bridge would keep the passkey second factor bypassable for a minor version in both login MFA and sudo step-up. A security fix that leaves the hole open is not a fix.
 
-**Migration path.** Send `startAuthentication()` output as `payload.response`. The first-party `PasskeyChallengeVerify` component already does, so shipped UIs are unaffected. Credentials enrolled through the setup path's client-supplied `publicKey` shortcut carry a fabricated public key and can no longer authenticate — those users need an admin MFA reset and a fresh enrollment. Operator-facing detail is in [`UPGRADE_NOTES.md`](UPGRADE_NOTES.md).
+**Migration path.** Send `startAuthentication()` output as `payload.response`. The first-party `PasskeyChallengeVerify` component already does, so shipped UIs are unaffected. Credentials enrolled through the setup path's client-supplied `publicKey` shortcut are **not** reliably rendered unusable by this change — depending on what the client supplied, such a row holds either a key nobody can sign with or a keypair the enroller controls, and the second kind produces assertions this change accepts. That shortcut is a separate open surface (#5296); operator-facing remediation is in [`UPGRADE_NOTES.md`](UPGRADE_NOTES.md).

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -24,6 +24,16 @@ most of the patterns listed below in a user's codebase.
 
 ## 0.6.7 → 0.7.0 (2026-08-12)
 
+### Passkey MFA verification requires a real WebAuthn assertion (#3852)
+
+`PasskeyProvider.verify()` used to accept a second payload shape — `{ credentialId, challenge }` — beside the genuine `{ response }` assertion, and approved it by string comparison. Both compared values are public: `prepareChallenge()` returns the credential id and the challenge to the caller, and `GET /api/security/mfa/methods` discloses `providerMetadata.credentialId`. A third shape needed even less: with no prepared challenge at all, only the disclosed credential id was compared. Anyone who could reach the verify step for a session therefore passed the passkey second factor with no authenticator private key and no signature, in both login-time MFA and passkey-as-sudo step-up.
+
+**`POST /api/security/mfa/verify` and `POST /api/security/sudo/verify` now answer `401` for a passkey payload that is not a WebAuthn assertion.** This is a deliberate break of the request-shape contract with no deprecation window, because the shape being removed *is* the vulnerability — see the matching entry in [`BACKWARD_COMPATIBILITY.md`](BACKWARD_COMPATIBILITY.md).
+
+**Action for client authors:** send the object returned by `@simplewebauthn/browser`'s `startAuthentication()` as `payload.response`. The first-party UI already does this, so no change is needed for apps that use the shipped `PasskeyChallengeVerify` component. A client that submitted the credential id and challenge was, by construction, not performing cryptographic verification.
+
+**Action for operators:** the passkey *enrollment* path still accepts a client-supplied `publicKey` without attestation. A credential enrolled that way carries a public key no authenticator holds the private half of, so it can never produce a verifiable assertion and now fails every login. A user whose only MFA method is such a credential needs an admin MFA reset (`POST /api/security/users/{id}/mfa/reset`) and a fresh enrollment through the browser ceremony. Audit `mfa_methods` rows of type `passkey` before upgrading if you ever provisioned passkeys through the API rather than the UI.
+
 ### Standalone apps gain deterministic design-system and i18n checks
 
 New scaffolds ship `scripts/ds-check.mjs` as the hard-failing `yarn ds:check` gate and

--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -32,7 +32,31 @@ most of the patterns listed below in a user's codebase.
 
 **Action for client authors:** send the object returned by `@simplewebauthn/browser`'s `startAuthentication()` as `payload.response`. The first-party UI already does this, so no change is needed for apps that use the shipped `PasskeyChallengeVerify` component. A client that submitted the credential id and challenge was, by construction, not performing cryptographic verification.
 
-**Action for operators:** the passkey *enrollment* path still accepts a client-supplied `publicKey` without attestation. A credential enrolled that way carries a public key no authenticator holds the private half of, so it can never produce a verifiable assertion and now fails every login. A user whose only MFA method is such a credential needs an admin MFA reset (`POST /api/security/users/{id}/mfa/reset`) and a fresh enrollment through the browser ceremony. Audit `mfa_methods` rows of type `passkey` before upgrading if you ever provisioned passkeys through the API rather than the UI.
+**Action for operators — read this before upgrading.** The passkey *enrollment* path still accepts a client-supplied `publicKey` with no attestation (tracked as #5296; **this release does not close it**). A credential stored through that shortcut can be one of two things, and the row does not say which:
+
+- **An unusable key** — the caller supplied a value no authenticator holds the private half of. It can never produce a verifiable assertion, so it now fails every login. A user whose only MFA method is such a credential is locked out until an admin resets it.
+- **An attacker-controlled but perfectly valid keypair** — the caller generated a real P-256 keypair in software and enrolled its COSE public key. That credential signs assertions this release accepts, exactly as a genuine authenticator would. Requiring a real assertion does not help here; the key is real, it is simply not the user's.
+
+The second case is an account-takeover path, not a lockout inconvenience, so **treat every shortcut-enrolled passkey as potentially hostile rather than merely broken.** It matters most for a user who already holds a password-only (`mfa_pending`) session: `authorizeMfaEnrollmentMutation` in `api/mfa/_shared.ts` authorizes enrollment on `auth.sub` and does not reject a pending token, so an attacker with a stolen password may be able to enroll a key they control and then satisfy the second factor with it.
+
+**Provenance cannot be reconstructed from the stored row.** Both enrollment paths write the same `provider_metadata` keys (`credentialId`, `credentialPublicKey`, `counter`, `transports`, `label`), and the shortcut lets the caller choose all of them, so there is no field that reliably distinguishes a browser-ceremony credential from an API-provisioned one. Do not assume a query can single out the affected rows.
+
+Effective mitigations, strongest first:
+
+1. **Sequence #5296 ahead of this upgrade** if you can, so no new shortcut credential can be enrolled after the audit.
+2. **Reset and re-enroll every passkey method** on any deployment that ever provisioned passkeys through the API, rather than trying to identify individual rows. Enumerate them with:
+
+   ```sql
+   SELECT id, user_id, tenant_id, label, created_at, last_used_at
+     FROM user_mfa_methods
+    WHERE type = 'passkey'
+      AND deleted_at IS NULL
+      AND is_active = true
+    ORDER BY created_at;
+   ```
+
+   Then reset each affected user with `POST /api/security/users/{id}/mfa/reset` and have them re-enroll through the browser ceremony. Communicate the reset in advance: for users whose only method is a passkey it is a lockout until they re-enroll.
+3. If a full re-enrollment is not feasible, at minimum reset the passkey methods of users who hold `security.mfa.manage` or an admin role, since those are the accounts a forged credential is worth targeting.
 
 ### Standalone apps gain deterministic design-system and i18n checks
 

--- a/packages/enterprise/src/modules/security/__integration__/TC-SEC-004.spec.ts
+++ b/packages/enterprise/src/modules/security/__integration__/TC-SEC-004.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import {
+  attemptUnsignedPasskeyVerify,
   createAdminApiToken,
   createUserFixture,
   deleteUserFixture,
@@ -7,7 +8,6 @@ import {
   fetchJson,
   loginViaApi,
   setAuthCookie,
-  verifyPasskeyChallenge,
 } from './helpers/securityFixtures'
 
 test.describe('TC-SEC-004: Passkey enrollment and MFA login', () => {
@@ -27,7 +27,7 @@ test.describe('TC-SEC-004: Passkey enrollment and MFA login', () => {
     await deleteUserFixture(request, adminToken ?? null, userId)
   })
 
-  test('shows the passkey provider UI and completes the simplified passkey contract', async ({ request, page, browserName }) => {
+  test('shows the passkey provider UI, enrolls a passkey, and refuses login verification without an assertion', async ({ request, page, browserName }) => {
     test.skip(browserName !== 'chromium', 'Passkey coverage is only exercised on Chromium in this suite.')
 
     const firstLogin = await loginViaApi(request, userEmail, userPassword)
@@ -58,14 +58,14 @@ test.describe('TC-SEC-004: Passkey enrollment and MFA login', () => {
     const pendingLogin = await loginViaApi(request, userEmail, userPassword)
     expect(pendingLogin.available_methods?.map((method) => method.type)).toContain('passkey')
 
-    const verifyResponse = await verifyPasskeyChallenge(
+    const unsignedVerify = await attemptUnsignedPasskeyVerify(
       request,
       pendingLogin.token,
       pendingLogin.challenge_id as string,
       enrollment.credentialId,
     )
-    expect(verifyResponse.status).toBe(200)
-    expect(verifyResponse.body.ok).toBe(true)
-    expect(verifyResponse.body.redirect).toBe('/backend')
+    expect(unsignedVerify.status).toBe(401)
+    expect(unsignedVerify.body.ok).toBeFalsy()
+    expect(unsignedVerify.body.token).toBeFalsy()
   })
 })

--- a/packages/enterprise/src/modules/security/__integration__/TC-SEC-006.spec.ts
+++ b/packages/enterprise/src/modules/security/__integration__/TC-SEC-006.spec.ts
@@ -32,6 +32,9 @@ test.describe('TC-SEC-006: Sudo challenge and admin override', () => {
     await deleteUserFixture(request, adminToken ?? null, targetUserId)
   })
 
+  // This test stops at the unconditional `test.skip` mid-body: the sudo-config assertions after it
+  // need a genuine WebAuthn assertion and are unreachable until #5307 lands a virtual authenticator.
+  // They stay in place as the blueprint for that work. Everything above the skip runs and can fail.
   test('requires sudo and refuses a passkey step-up without a WebAuthn assertion', async ({ request }) => {
     const adminMethods = await fetchJson<{
       methods: Array<{ type: string; providerMetadata?: Record<string, unknown> | null }>

--- a/packages/enterprise/src/modules/security/__integration__/TC-SEC-006.spec.ts
+++ b/packages/enterprise/src/modules/security/__integration__/TC-SEC-006.spec.ts
@@ -32,7 +32,7 @@ test.describe('TC-SEC-006: Sudo challenge and admin override', () => {
     await deleteUserFixture(request, adminToken ?? null, targetUserId)
   })
 
-  test('requires sudo, issues a token through MFA, and honors disable/re-enable overrides', async ({ request }) => {
+  test('requires sudo and refuses a passkey step-up without a WebAuthn assertion', async ({ request }) => {
     const adminMethods = await fetchJson<{
       methods: Array<{ type: string; providerMetadata?: Record<string, unknown> | null }>
     }>(
@@ -44,7 +44,7 @@ test.describe('TC-SEC-006: Sudo challenge and admin override', () => {
     expect(adminMethods.status).toBe(200)
 
     const passkeyMethod = adminMethods.body.methods.find((method) => method.type === 'passkey')
-    test.skip(!passkeyMethod, 'This environment needs an admin passkey method to verify sudo without knowing a seeded TOTP secret.')
+    test.skip(!passkeyMethod, 'This environment needs an admin passkey method to exercise passkey sudo step-up.')
 
     const credentialId = passkeyMethod?.providerMetadata?.credentialId
     expect(typeof credentialId).toBe('string')
@@ -127,9 +127,13 @@ test.describe('TC-SEC-006: Sudo challenge and admin override', () => {
         },
       },
     )
-    expect(manageVerify.status).toBe(200)
-    expect(manageVerify.body.sudoToken).toBeTruthy()
-    expect(manageVerify.body.expiresAt).toBeTruthy()
+    expect(manageVerify.status).toBe(401)
+    expect(manageVerify.body.sudoToken).toBeFalsy()
+
+    test.skip(
+      true,
+      'Passkey sudo step-up requires a genuine WebAuthn assertion (#3852), which no API-level fixture can produce; the remaining sudo-config coverage needs a Playwright virtual authenticator.',
+    )
 
     const disableReset = await fetchJson<{ ok?: boolean }>(
       request,

--- a/packages/enterprise/src/modules/security/__integration__/TC-SEC-007.spec.ts
+++ b/packages/enterprise/src/modules/security/__integration__/TC-SEC-007.spec.ts
@@ -51,6 +51,10 @@ test.describe('TC-SEC-007: Admin MFA reset and status reporting', () => {
     await deleteUserFixture(request, adminToken ?? null, controlUserId)
   })
 
+  // This test stops at the unconditional `test.skip` mid-body: the sudo-gated admin reset and
+  // post-reset status assertions after it need a genuine WebAuthn assertion and are unreachable
+  // until #5307 lands a virtual authenticator. They stay in place as the blueprint for that work.
+  // Everything above the skip runs and can still fail.
   test('reports user MFA status, enforces sudo for reset, and leaves unrelated users unchanged', async ({ request }) => {
     const targetUser = await createUserFixture(request, adminToken, { password: 'Valid1!Pass' })
     await deleteUserFixture(request, adminToken ?? null, targetUserId)

--- a/packages/enterprise/src/modules/security/__integration__/TC-SEC-007.spec.ts
+++ b/packages/enterprise/src/modules/security/__integration__/TC-SEC-007.spec.ts
@@ -169,8 +169,13 @@ test.describe('TC-SEC-007: Admin MFA reset and status reporting', () => {
         },
       },
     )
-    expect(sudoVerify.status).toBe(200)
-    expect(sudoVerify.body.sudoToken).toBeTruthy()
+    expect(sudoVerify.status).toBe(401)
+    expect(sudoVerify.body.sudoToken).toBeFalsy()
+
+    test.skip(
+      true,
+      'Passkey sudo step-up requires a genuine WebAuthn assertion (#3852), which no API-level fixture can produce; the sudo-gated admin reset coverage below needs a Playwright virtual authenticator.',
+    )
 
     const resetWithSudo = await fetchJson<{ ok?: boolean }>(
       request,

--- a/packages/enterprise/src/modules/security/__integration__/helpers/securityFixtures.ts
+++ b/packages/enterprise/src/modules/security/__integration__/helpers/securityFixtures.ts
@@ -303,7 +303,14 @@ export async function verifyTotpChallenge(
   })
 }
 
-export async function verifyPasskeyChallenge(
+/**
+ * Negative-path helper. It prepares a real passkey challenge and then submits the two values the
+ * server already discloses — the credential id and the challenge — instead of a WebAuthn assertion.
+ * Passkey verification must refuse this; accepting it was the second-factor bypass fixed in #3852.
+ * There is no API-level happy path for passkey verification: producing a genuine assertion requires
+ * an authenticator, so a real one needs a Playwright virtual authenticator driving the browser flow.
+ */
+export async function attemptUnsignedPasskeyVerify(
   request: APIRequestContext,
   pendingToken: string,
   challengeId: string,

--- a/packages/enterprise/src/modules/security/lib/__tests__/PasskeyProvider.test.ts
+++ b/packages/enterprise/src/modules/security/lib/__tests__/PasskeyProvider.test.ts
@@ -209,32 +209,124 @@ describe('PasskeyProvider', () => {
     expect(method.providerMetadata.counter).toBe(1)
   })
 
-  test('supports legacy verification payload for backward compatibility', async () => {
+  test('rejects a credentialId and challenge payload even with a prepared challenge', async () => {
     const provider = new PasskeyProvider(defaultSecurityModuleConfig, TEST_SETUP_TOKEN_SECRET)
     const method = {
-      id: 'method-legacy',
+      id: 'method-1',
       userId: 'user-1',
       type: 'passkey',
       providerMetadata: {
-        credentialId: 'cred-legacy',
+        credentialId: 'cred-123',
         credentialPublicKey: 'AQIDBA',
       },
     }
 
-    generateAuthenticationOptionsMock.mockResolvedValueOnce({
-      challenge: 'legacy-challenge',
-      rpId: 'localhost',
-      allowCredentials: [],
-      timeout: 300000,
-      userVerification: 'preferred',
-    } as never)
-
-    await provider.prepareChallenge('user-1', method)
+    const prepared = await provider.prepareChallenge('user-1', method)
     const valid = await provider.verify('user-1', method, {
-      credentialId: 'cred-legacy',
-      challenge: 'legacy-challenge',
+      credentialId: 'cred-123',
+      challenge: prepared.clientData?.challenge,
+    }, prepared.verifyContext)
+
+    expect(valid).toBe(false)
+    expect(verifyAuthenticationResponseMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects a credentialId payload when the client never prepared a challenge', async () => {
+    const provider = new PasskeyProvider(defaultSecurityModuleConfig, TEST_SETUP_TOKEN_SECRET)
+    const method = {
+      id: 'method-1',
+      userId: 'user-1',
+      type: 'passkey',
+      providerMetadata: {
+        credentialId: 'cred-123',
+        credentialPublicKey: 'AQIDBA',
+      },
+    }
+
+    const valid = await provider.verify('user-1', method, { credentialId: 'cred-123' })
+
+    expect(valid).toBe(false)
+    expect(verifyAuthenticationResponseMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects a WebAuthn assertion when no challenge was prepared', async () => {
+    const provider = new PasskeyProvider(defaultSecurityModuleConfig, TEST_SETUP_TOKEN_SECRET)
+    const method = {
+      id: 'method-1',
+      userId: 'user-1',
+      type: 'passkey',
+      providerMetadata: {
+        credentialId: 'cred-123',
+        credentialPublicKey: 'AQIDBA',
+      },
+    }
+
+    const valid = await provider.verify('user-1', method, {
+      response: {
+        id: 'cred-123',
+        rawId: 'cred-123',
+        type: 'public-key',
+        response: {
+          authenticatorData: 'auth-data',
+          clientDataJSON: 'client-data',
+          signature: 'signature',
+        },
+      },
     })
 
-    expect(valid).toBe(true)
+    expect(valid).toBe(false)
+    expect(verifyAuthenticationResponseMock).not.toHaveBeenCalled()
+  })
+
+  test('rejects an assertion the authenticator did not sign', async () => {
+    verifyAuthenticationResponseMock.mockResolvedValue({ verified: false } as never)
+    const provider = new PasskeyProvider(defaultSecurityModuleConfig, TEST_SETUP_TOKEN_SECRET)
+    const method = {
+      id: 'method-1',
+      userId: 'user-1',
+      type: 'passkey',
+      providerMetadata: {
+        credentialId: 'cred-123',
+        credentialPublicKey: 'AQIDBA',
+        counter: 4,
+      },
+    }
+
+    const prepared = await provider.prepareChallenge('user-1', method)
+    const valid = await provider.verify('user-1', method, {
+      response: {
+        id: 'cred-123',
+        rawId: 'cred-123',
+        type: 'public-key',
+        response: {
+          authenticatorData: 'auth-data',
+          clientDataJSON: 'client-data',
+          signature: 'forged-signature',
+        },
+      },
+    }, prepared.verifyContext)
+
+    expect(valid).toBe(false)
+    expect(method.providerMetadata.counter).toBe(4)
+  })
+
+  test('rejects an assertion that makes the WebAuthn verifier throw', async () => {
+    verifyAuthenticationResponseMock.mockRejectedValue(new Error('Unexpected authentication response'))
+    const provider = new PasskeyProvider(defaultSecurityModuleConfig, TEST_SETUP_TOKEN_SECRET)
+    const method = {
+      id: 'method-1',
+      userId: 'user-1',
+      type: 'passkey',
+      providerMetadata: {
+        credentialId: 'cred-123',
+        credentialPublicKey: 'AQIDBA',
+      },
+    }
+
+    const prepared = await provider.prepareChallenge('user-1', method)
+
+    await expect(provider.verify('user-1', method, {
+      response: {},
+    }, prepared.verifyContext)).resolves.toBe(false)
   })
 })

--- a/packages/enterprise/src/modules/security/lib/__tests__/PasskeyProviderWebAuthn.test.ts
+++ b/packages/enterprise/src/modules/security/lib/__tests__/PasskeyProviderWebAuthn.test.ts
@@ -1,0 +1,161 @@
+import { createHash, createSign, generateKeyPairSync, type KeyObject } from 'node:crypto'
+import { isoCBOR } from '@simplewebauthn/server/helpers'
+import { PasskeyProvider } from '../providers/PasskeyProvider'
+import { defaultSecurityModuleConfig } from '../security-config'
+
+const RP_ID = defaultSecurityModuleConfig.webauthn.rpId
+const ORIGIN = defaultSecurityModuleConfig.webauthn.expectedOrigins[0]
+const CREDENTIAL_ID = 'software-authenticator-credential'
+const TEST_SETUP_TOKEN_SECRET = 'test-mfa-setup-secret'
+
+type SoftwareAuthenticator = {
+  cosePublicKey: string
+  sign: (challenge: string, options?: { signCount?: number }) => {
+    id: string
+    rawId: string
+    type: string
+    clientExtensionResults: Record<string, never>
+    response: {
+      clientDataJSON: string
+      authenticatorData: string
+      signature: string
+    }
+  }
+}
+
+function encodeCosePublicKey(publicKey: KeyObject): Uint8Array {
+  const jwk = publicKey.export({ format: 'jwk' }) as { x: string; y: string }
+  return isoCBOR.encode(new Map<number, number | Uint8Array>([
+    [1, 2],
+    [3, -7],
+    [-1, 1],
+    [-2, new Uint8Array(Buffer.from(jwk.x, 'base64url'))],
+    [-3, new Uint8Array(Buffer.from(jwk.y, 'base64url'))],
+  ]))
+}
+
+function buildAuthenticatorData(signCount: number): Buffer {
+  const rpIdHash = createHash('sha256').update(RP_ID).digest()
+  const flags = Buffer.from([0x05])
+  const counter = Buffer.alloc(4)
+  counter.writeUInt32BE(signCount, 0)
+  return Buffer.concat([rpIdHash, flags, counter])
+}
+
+function createSoftwareAuthenticator(): SoftwareAuthenticator {
+  const { privateKey, publicKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' })
+
+  return {
+    cosePublicKey: Buffer.from(encodeCosePublicKey(publicKey)).toString('base64url'),
+    sign: (challenge, options = {}) => {
+      const clientDataJSON = Buffer.from(JSON.stringify({
+        type: 'webauthn.get',
+        challenge,
+        origin: ORIGIN,
+        crossOrigin: false,
+      }), 'utf8')
+      const authenticatorData = buildAuthenticatorData(options.signCount ?? 1)
+      const signedData = Buffer.concat([
+        authenticatorData,
+        createHash('sha256').update(clientDataJSON).digest(),
+      ])
+      const signature = createSign('sha256').update(signedData).sign(privateKey)
+
+      return {
+        id: CREDENTIAL_ID,
+        rawId: CREDENTIAL_ID,
+        type: 'public-key',
+        clientExtensionResults: {},
+        response: {
+          clientDataJSON: clientDataJSON.toString('base64url'),
+          authenticatorData: authenticatorData.toString('base64url'),
+          signature: signature.toString('base64url'),
+        },
+      }
+    },
+  }
+}
+
+describe('PasskeyProvider against a real WebAuthn authenticator', () => {
+  const authenticator = createSoftwareAuthenticator()
+
+  function createMethod() {
+    return {
+      id: 'method-1',
+      userId: 'user-1',
+      type: 'passkey',
+      providerMetadata: {
+        credentialId: CREDENTIAL_ID,
+        credentialPublicKey: authenticator.cosePublicKey,
+        counter: 0,
+        transports: ['internal'],
+      },
+    }
+  }
+
+  test('accepts an assertion signed by the enrolled credential and advances the counter', async () => {
+    const provider = new PasskeyProvider(defaultSecurityModuleConfig, TEST_SETUP_TOKEN_SECRET)
+    const method = createMethod()
+
+    const prepared = await provider.prepareChallenge('user-1', method)
+    const challenge = prepared.clientData?.challenge as string
+    expect(typeof challenge).toBe('string')
+
+    const verified = await provider.verify(
+      'user-1',
+      method,
+      { response: authenticator.sign(challenge, { signCount: 7 }) },
+      prepared.verifyContext,
+    )
+
+    expect(verified).toBe(true)
+    expect(method.providerMetadata.counter).toBe(7)
+  })
+
+  test('rejects an assertion whose signature was tampered with', async () => {
+    const provider = new PasskeyProvider(defaultSecurityModuleConfig, TEST_SETUP_TOKEN_SECRET)
+    const method = createMethod()
+
+    const prepared = await provider.prepareChallenge('user-1', method)
+    const assertion = authenticator.sign(prepared.clientData?.challenge as string)
+    const forged = {
+      ...assertion,
+      response: {
+        ...assertion.response,
+        signature: Buffer.from('not-a-real-signature').toString('base64url'),
+      },
+    }
+
+    const verified = await provider.verify('user-1', method, { response: forged }, prepared.verifyContext)
+
+    expect(verified).toBe(false)
+    expect(method.providerMetadata.counter).toBe(0)
+  })
+
+  test('rejects an assertion replayed against a different challenge', async () => {
+    const provider = new PasskeyProvider(defaultSecurityModuleConfig, TEST_SETUP_TOKEN_SECRET)
+    const method = createMethod()
+
+    const first = await provider.prepareChallenge('user-1', method)
+    const second = await provider.prepareChallenge('user-1', method)
+    const assertion = authenticator.sign(first.clientData?.challenge as string)
+
+    const verified = await provider.verify('user-1', method, { response: assertion }, second.verifyContext)
+
+    expect(verified).toBe(false)
+  })
+
+  test('rejects the disclosed credentialId and challenge instead of an assertion', async () => {
+    const provider = new PasskeyProvider(defaultSecurityModuleConfig, TEST_SETUP_TOKEN_SECRET)
+    const method = createMethod()
+
+    const prepared = await provider.prepareChallenge('user-1', method)
+
+    const verified = await provider.verify('user-1', method, {
+      credentialId: CREDENTIAL_ID,
+      challenge: prepared.clientData?.challenge,
+    }, prepared.verifyContext)
+
+    expect(verified).toBe(false)
+  })
+})

--- a/packages/enterprise/src/modules/security/lib/providers/PasskeyProvider.ts
+++ b/packages/enterprise/src/modules/security/lib/providers/PasskeyProvider.ts
@@ -44,15 +44,9 @@ const setupConfirmationPayloadSchema = z.union([
   }),
 ])
 
-const verifyPayloadSchema = z.union([
-  z.object({
-    response: z.record(z.string(), z.unknown()),
-  }),
-  z.object({
-    credentialId: z.string().min(1),
-    challenge: z.string().min(1),
-  }),
-])
+const verifyPayloadSchema = z.object({
+  response: z.record(z.string(), z.unknown()),
+})
 
 const setupTokenSchema = z.object({
   version: z.string().min(1),
@@ -275,73 +269,57 @@ export class PasskeyProvider implements MfaProviderInterface {
     context?: MfaVerifyContext,
     runtimeContext?: MfaProviderRuntimeContext,
   ): Promise<boolean> {
-    const parsed = verifyPayloadSchema.parse(payload)
+    const parsed = verifyPayloadSchema.safeParse(payload)
+    if (!parsed.success) return false
     if (method.userId !== userId) return false
 
     const parsedContext = verifyContextSchema.safeParse(context)
+    if (!parsedContext.success) return false
+
     const securityConfig = this.resolveSecurityConfig(runtimeContext)
-    if (!parsedContext.success) {
-      if ('credentialId' in parsed) {
-        const metadataCredentialId = method.providerMetadata?.credentialId
-        return typeof metadataCredentialId === 'string' && metadataCredentialId === parsed.credentialId
-      }
-      return false
-    }
     const pending = parsedContext.data.challenge
     if (Date.now() - pending.createdAt > securityConfig.webauthn.challengeTtlMs) {
       return false
     }
 
-    if ('response' in parsed) {
-      const metadata = method.providerMetadata ?? {}
-      const credentialId = typeof metadata.credentialId === 'string' ? metadata.credentialId : null
-      const credentialPublicKey = typeof metadata.credentialPublicKey === 'string'
-        ? metadata.credentialPublicKey
-        : typeof metadata.publicKey === 'string'
-          ? metadata.publicKey
-          : null
-      const counter = typeof metadata.counter === 'number' && Number.isFinite(metadata.counter)
-        ? metadata.counter
-        : 0
+    const metadata = method.providerMetadata ?? {}
+    const credentialId = typeof metadata.credentialId === 'string' ? metadata.credentialId : null
+    const credentialPublicKey = typeof metadata.credentialPublicKey === 'string'
+      ? metadata.credentialPublicKey
+      : typeof metadata.publicKey === 'string'
+        ? metadata.publicKey
+        : null
+    const counter = typeof metadata.counter === 'number' && Number.isFinite(metadata.counter)
+      ? metadata.counter
+      : 0
 
-      if (!credentialId || !credentialPublicKey) {
-        return false
-      }
-
-      const verification = await verifyAuthenticationResponse({
-        response: parsed.response as never,
-        expectedChallenge: pending.challenge,
-        expectedOrigin: this.getExpectedOrigins(securityConfig),
-        expectedRPID: this.getRpId(securityConfig),
-        requireUserVerification: false,
-        credential: {
-          id: credentialId,
-          publicKey: this.base64UrlToBytes(credentialPublicKey),
-          counter,
-          transports: this.normalizeTransports(metadata.transports),
-        },
-      })
-
-      if (!verification.verified) {
-        return false
-      }
-
-      const nextCounter = verification.authenticationInfo?.newCounter
-      if (typeof nextCounter === 'number' && Number.isFinite(nextCounter)) {
-        const providerMetadata = method.providerMetadata ?? {}
-        providerMetadata.counter = nextCounter
-        method.providerMetadata = providerMetadata
-      }
-
-      return true
-    }
-
-    const metadataCredentialId = method.providerMetadata?.credentialId
-    if (typeof metadataCredentialId !== 'string' || metadataCredentialId !== parsed.credentialId) {
+    if (!credentialId || !credentialPublicKey) {
       return false
     }
-    if (pending.challenge !== parsed.challenge) {
+
+    const verification = await verifyAuthenticationResponse({
+      response: parsed.data.response as never,
+      expectedChallenge: pending.challenge,
+      expectedOrigin: this.getExpectedOrigins(securityConfig),
+      expectedRPID: this.getRpId(securityConfig),
+      requireUserVerification: false,
+      credential: {
+        id: credentialId,
+        publicKey: this.base64UrlToBytes(credentialPublicKey),
+        counter,
+        transports: this.normalizeTransports(metadata.transports),
+      },
+    }).catch(() => null)
+
+    if (!verification?.verified) {
       return false
+    }
+
+    const nextCounter = verification.authenticationInfo?.newCounter
+    if (typeof nextCounter === 'number' && Number.isFinite(nextCounter)) {
+      const providerMetadata = method.providerMetadata ?? {}
+      providerMetadata.counter = nextCounter
+      method.providerMetadata = providerMetadata
     }
 
     return true

--- a/packages/enterprise/src/modules/security/lib/providers/PasskeyProvider.ts
+++ b/packages/enterprise/src/modules/security/lib/providers/PasskeyProvider.ts
@@ -6,6 +6,7 @@ import {
   verifyRegistrationResponse,
 } from '@simplewebauthn/server'
 import type { AuthenticatorTransportFuture } from '@simplewebauthn/types'
+import { createLogger } from '@open-mercato/shared/lib/logger'
 import { z } from 'zod'
 import type {
   MfaMethodRecord,
@@ -23,6 +24,8 @@ import {
 } from '../security-config'
 
 const SETUP_TOKEN_VERSION = 'v1'
+
+const logger = createLogger('security').child({ component: 'passkey-provider' })
 
 const setupPayloadSchema = z.object({
   label: z.string().min(1).max(100).optional(),
@@ -309,7 +312,14 @@ export class PasskeyProvider implements MfaProviderInterface {
         counter,
         transports: this.normalizeTransports(metadata.transports),
       },
-    }).catch(() => null)
+    }).catch((error: unknown) => {
+      logger.warn('Passkey assertion could not be verified', {
+        methodId: method.id,
+        rpId: this.getRpId(securityConfig),
+        err: error,
+      })
+      return null
+    })
 
     if (!verification?.verified) {
       return false


### PR DESCRIPTION
Closes #3852
Tracking plan: .ai/runs/2026-08-14-passkey-mfa-require-webauthn-assertion.md
Status: complete

## 🎯 Goal

Make a cryptographically verified WebAuthn assertion the only way to pass the passkey second factor.

`PasskeyProvider.verify()` accepted a `{ credentialId, challenge }` payload beside the genuine `{ response }` assertion and approved it by plain string comparison. Both compared values are **public**: `prepareChallenge()` hands the credential id and the challenge to the caller, and `GET /api/security/mfa/methods` discloses `providerMetadata.credentialId`. A third route needed even less — when the client never called `/api/security/mfa/prepare`, `MfaVerificationService.verifyChallenge` built no verify context, and the provider fell through to comparing only the disclosed credential id, ignoring the challenge entirely.

So anyone who could reach the verify step for a session — the party already holding `mfa_pending`, or a replay of the prepare response — passed the passkey second factor with no authenticator private key and no signature. `SudoChallengeService.verify` → `MfaVerificationService.verifyChallenge` → `provider.verify` is the same path, so this defeated login-time MFA **and** passkey-as-sudo step-up.

### Why this PR exists rather than #5291

PR #5291 proposed the same remediation as an outside contribution against `packages/enterprise`, our commercial package, which does not accept third-party contributions. It was closed unmerged and the fix is re-authored here first-party from the issue report and the current `develop` source; nothing from that diff is carried over.

## What Changed

- **`packages/enterprise/src/modules/security/lib/providers/PasskeyProvider.ts`** — `verifyPayloadSchema` collapses from a union to a single object requiring `response`. The context-absent `credentialId` fallback and the trailing `credentialId` + `challenge` string-compare block are gone, so a verified `verifyAuthenticationResponse` is the only route to a positive verdict. The challenge TTL check, the signature-counter update, and the `{ response }` path itself are untouched.
- **Failure mode, deliberately chosen** — a payload that fails the schema, and an assertion the WebAuthn verifier throws on, return `false` rather than propagating. A thrown error reaches `mapMfaError` as a logged **500** and skips `registerFailedAttempt`, so rejected attempts would stop counting toward the challenge attempt limit. Returning `false` keeps the **401** the route documents and preserves lockout. No verdict flips from negative to positive.
- **`lib/__tests__/PasskeyProvider.test.ts`** — the test named *"supports legacy verification payload for backward compatibility"* asserted that the bypass worked; it is replaced with regression coverage for every route that used to reach a positive verdict without a signature.
- **`lib/__tests__/PasskeyProviderWebAuthn.test.ts`** (new) — runs the **real** `@simplewebauthn` verifier against a software authenticator, so the removal is proven not to break real passkeys.
- **`__integration__/`** — the Playwright specs used the removed shape as their QA shortcut, so they asserted a behavior that is now a vulnerability. `verifyPasskeyChallenge` becomes the explicitly negative `attemptUnsignedPasskeyVerify`; `TC-SEC-004` asserts login verification answers `401`, and `TC-SEC-006`/`TC-SEC-007` assert passkey sudo step-up answers `401` and then skip their sudo-token-gated remainders with a stated reason.
- **`BACKWARD_COMPATIBILITY.md` / `UPGRADE_NOTES.md` / `.ai/qa/scenarios/TC-SEC-004-…md`** — record the deliberate contract break, what client authors must send, which enrolled credentials stop working, and that the passing passkey ceremony stays manual for now.

## 🧪 Tests

The evidence that matters for a change this risky is the new `PasskeyProviderWebAuthn.test.ts`. It does **not** mock `@simplewebauthn/server`. It generates a P-256 key pair, encodes the COSE public key the way `confirmSetup` stores it, and signs a genuine assertion over the challenge `prepareChallenge()` produced — then asserts that:

- a real assertion still verifies and advances the stored signature counter (the regression that would lock every passkey user out if the tightening went too far);
- a tampered signature is refused and the counter is not advanced;
- an assertion replayed against a different prepared challenge is refused;
- the disclosed `{ credentialId, challenge }` pair is refused.

`PasskeyProvider.test.ts` adds five cases, all against the mocked verifier: the legacy shape is refused even with a correctly prepared context; a `credentialId`-only payload is refused when the client skipped `/prepare`; a well-formed assertion is refused when no challenge was prepared; an assertion the authenticator did not sign is refused without advancing the counter; and an assertion that makes the verifier throw resolves to `false` instead of propagating. The first three also assert `verifyAuthenticationResponse` was never reached.

Three of these five fail against the pre-fix provider (verified by checking the old file back out and re-running); the other two pin behavior that was already correct and must stay correct.

## 💥 Breaking Changes

`POST /api/security/mfa/verify` and `POST /api/security/sudo/verify` no longer accept a `{ credentialId, challenge }` passkey payload — it answers **401** instead of succeeding.

Per `BACKWARD_COMPATIBILITY.md` an API request shape is contract surface (category 7) and the protocol requires a bridge release. **The bridge is deliberately skipped here**, because the shape being removed *is* the vulnerability: a bridge would leave the second-factor bypass live for a full minor version in both login MFA and sudo step-up.

This now ships under a **defined** clause rather than a one-off waiver. `BACKWARD_COMPATIBILITY.md` gains an **Emergency Security Exception** to the Deprecation Protocol: it waives steps 1-3 only when the surface being removed is itself the vulnerability, and only against five stated requirements — a reasoned qualifying argument, the narrowest possible removal with **no partial bridge retaining the vulnerable branch**, steps 4 and 5 still in force, a dated entry, and an explicit human maintainer sign-off that no automated review can supply. The passkey entry invokes that clause and shows how each requirement is met.

The classification is stated rather than dodged: the removed shape was *publicly supported* — exported in `MfaProviderInterface.verifySchema` and pinned by a test literally named *"supports legacy verification payload for backward compatibility"* — so this is a genuine STABLE break authorized by the exception, not a claim that no contract ever existed.

Protocol step 5 requires a spec, so this PR adds [`.ai/specs/enterprise/2026-08-14-passkey-mfa-require-webauthn-assertion.md`](.ai/specs/enterprise/2026-08-14-passkey-mfa-require-webauthn-assertion.md) with the mandated **Migration & Backward Compatibility** section.

The first-party UI is unaffected — `PasskeyChallengeVerify.tsx` sends `startAuthentication()` output as `{ response }`, and `PasskeyProviderDetails.tsx` enrolls through `startRegistration()`. Any third-party client sending the legacy shape was, by construction, not performing cryptographic verification.

**Operator impact — corrected in the review round.** A passkey enrolled through the setup path's unattested `publicKey` shortcut (#5296, still open) is **not** reliably rendered unusable by this change. Such a row is one of two things, and the row does not say which:

- **An unusable key** — nobody holds the private half, so it can never produce a verifiable assertion and now fails every login. A user whose only MFA method is such a credential needs an admin MFA reset.
- **An attacker-controlled but perfectly valid keypair** — a caller who generated a real P-256 keypair in software and enrolled its COSE public key holds a credential that signs assertions this PR *accepts*. Requiring a real assertion does not help; the key is real, it is simply not the user's. That is an account-takeover path, not a lockout inconvenience.

It matters most for a password-only (`mfa_pending`) session: `authorizeMfaEnrollmentMutation` authorizes on `auth.sub` and does not reject a pending token, so an attacker with a stolen password may be able to enroll a key they control and then satisfy the second factor with it.

Provenance is **not** reconstructible from the stored row — both enrollment paths write identical `provider_metadata` keys and the shortcut lets the caller choose all of them — so `UPGRADE_NOTES.md` no longer promises a per-row audit. It now gives a working enumeration query against the real schema (`user_mfa_methods`, discriminated by column `type`; the earlier note named a nonexistent `mfa_methods` table) and conservative remediation: sequence #5296 ahead of the upgrade where possible, otherwise reset and re-enroll every passkey method on any deployment that ever provisioned passkeys through the API.

## Related work — this closes one of two halves

- **#5296** — the *enrollment* side still accepts a client-supplied `publicKey` with no attestation. That issue argues, correctly, that an attacker who supplies the public key of a keypair they generated can then sign a genuine assertion in software. This PR does not close that; it is a separate fix on a separate surface and both need to land.
- **#5307** (filed by this run) — passkey verification now has no integration-level happy path, and `TC-SEC-006`/`TC-SEC-007` lose their sudo-token-gated assertions. Restoring them needs a Playwright virtual authenticator, or decoupling sudo coverage from passkeys onto TOTP.

## ✅ Validation

Full `validation.commands` gate from `.ai/agentic.config.json`, local runner (no compose `app` container running), in order: `build:packages` ✅ · `generate` ✅ (no generated drift) · `build:packages` ✅ · `i18n:check-sync` ✅ · `i18n:check-usage` ✅ · `typecheck` ✅ (22/22) · `test` ⚠️ · `build:app` ✅. `yarn lint`, which is not part of the configured gate, also passes with 0 errors.

`@open-mercato/enterprise` is **60/60 suites, 486/486 tests green**. `yarn test` exits non-zero on exactly one package, `create-mercato-app`, whose assertion is `❌ Linux file-watch limits are too low for Turbopack` — this machine's `fs.inotify.max_user_instances` is 128. That package is not in this branch's diff at all, so the failure cannot originate here; Linux CI is the authority.

The first review pass raised one major finding against this branch — the new `catch` around `verifyAuthenticationResponse` swallowed the verifier's error, so a misconfigured `rpId`/`expectedOrigins` would answer a silent `401` where it previously reached `mapMfaError` and got logged. Fixed in `fb98bf0d9`: the rejection is unchanged, but it now emits a `warn` through the logging facade.

🧪 **Manual QA is still pending.** This sits in the login MFA and sudo step-up flows and the passing passkey ceremony cannot be automated yet (#5307), so a reviewer should confirm that a real passkey login and a real passkey sudo step-up still succeed against a genuine authenticator.

## 🔁 Review round 2 — strict review addressed (`4b9191066`)

All three findings from the strict `CHANGES_REQUESTED` review on `93c93e87f` are addressed; no source behavior changed, the fix itself is untouched.

| # | Finding | Resolution |
|---|---------|-----------|
| Critical | `BACKWARD_COMPATIBILITY.md:341` — waiver granted by fiat against a policy forbidding every unbridged STABLE change | Added a defined **Emergency Security Exception** to the Deprecation Protocol with five hard requirements; classified this break as a real category-7 STABLE break (the shape was publicly supported) and showed the entry meeting each requirement; wrote the migration spec step 5 requires |
| High | `UPGRADE_NOTES.md:35` — describes shortcut-enrolled credentials as necessarily unusable | Rewritten: such a credential is *either* unusable *or* an attacker-controlled valid keypair that this fix accepts; states the `mfa_pending` enrollment reachability; instructs treating all such credentials as potentially hostile; gives release-sequencing and reset-and-re-enroll mitigations |
| Medium | `UPGRADE_NOTES.md:35` — audit instruction does not map to the schema | Query corrected to `user_mfa_methods` / column `type` (verified against the entity and `Migration20260305120000_security_scaffold`); states plainly that provenance is not reconstructible and replaces per-row auditing with conservative reset-and-re-enroll |

The two nits from the first review are also handled: TC-SEC-006/007 now carry a header comment explaining that the body stops at the mid-body `test.skip`, and the `UPGRADE_NOTES.md` audit instruction is now executable.

⚠️ **Requirement 5 of the new exception is a human action and is not satisfied yet:** the waiver needs an explicit maintainer approval that acknowledges it. An automated review cannot clear it, by design.

## 📋 Progress

See the Progress section in the tracking plan.

