### PR TITLE
fix(create-app): make hook validator opt-in

### DIFF
--- a/.ai/runs/2026-08-14-standalone-experimental-hooks-validator.md
+++ b/.ai/runs/2026-08-14-standalone-experimental-hooks-validator.md
@@ -1,0 +1,65 @@
+# Standalone Experimental Hooks Validator
+
+## Goal
+
+Make the standalone harness gate-evidence/typecheck validator hooks opt-in instead of installing them by default. Users can enable the experimental validator explicitly during agentic setup or through `OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR`.
+
+Source doc: `.ai/specs/2026-07-24-standalone-ai-development-harness.md`
+
+## Scope
+
+- Add an additive `--experimental-hooks-validator` option to `create-mercato-app` and `mercato agentic:init`.
+- Resolve the option from `OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR` when the flag is absent.
+- Exclude gate-evidence registrations and scripts by default for Claude Code, Codex, and Cursor while preserving their non-validator agentic assets and hooks.
+- Keep create-app and CLI agentic setup output in parity, including ownership-aware harness updates.
+- Document the opt-in environment variable in the application and create-app template `.env.example` files.
+- Add regression coverage for default-disabled, flag-enabled, and environment-enabled setup.
+
+## Non-goals
+
+- Change gate-evidence matching, recording, or stop-decision semantics.
+- Remove the experimental hook implementations from the source distribution.
+- Change the standalone harness evaluation catalog or release matrix.
+- Apply database migrations or change runtime application behavior.
+
+## Implementation Plan
+
+### Phase 1: Option and generator contract
+
+1. Add and propagate the experimental validator option through both setup entrypoints.
+2. Gate emitted hook registrations, hook scripts, ownership manifests, and setup summaries while preserving tool parity.
+
+### Phase 2: Documentation and regression coverage
+
+1. Document the environment opt-in in both required `.env.example` surfaces and update the standalone harness spec changelog/compatibility notes.
+2. Add focused tests for default-disabled and explicit/env-enabled generation across create-app and CLI setup.
+
+### Phase 3: Verification and delivery
+
+1. Run targeted package tests and the configured validation gate in the repository-selected runner mode.
+2. Complete automated PR review/autofix, publish the final PR summary, and mark the PR ready.
+
+## Risks
+
+- Ownership-aware updates must retire only unmodified previously generated validator assets; locally modified files must remain preserved by the existing manifest conflict behavior.
+- Configuration files that also register non-experimental hooks must be filtered without disabling those stable hooks.
+- The additive CLI flag must behave identically in fresh scaffolds and later `agentic:init` runs.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Option and generator contract
+
+- [ ] 1.1 Add and propagate the experimental validator option through both setup entrypoints
+- [ ] 1.2 Gate emitted hook registrations, hook scripts, ownership manifests, and setup summaries while preserving tool parity
+
+### Phase 2: Documentation and regression coverage
+
+- [ ] 2.1 Document the environment opt-in and update the standalone harness spec
+- [ ] 2.2 Add focused default-disabled and opt-in regression tests across create-app and CLI setup
+
+### Phase 3: Verification and delivery
+
+- [ ] 3.1 Run targeted package tests and the configured validation gate
+- [ ] 3.2 Complete automated PR review/autofix and final PR handoff

--- a/.ai/runs/2026-08-14-standalone-experimental-hooks-validator.md
+++ b/.ai/runs/2026-08-14-standalone-experimental-hooks-validator.md
@@ -56,8 +56,8 @@ Source doc: `.ai/specs/2026-07-24-standalone-ai-development-harness.md`
 
 ### Phase 2: Documentation and regression coverage
 
-- [ ] 2.1 Document the environment opt-in and update the standalone harness spec
-- [ ] 2.2 Add focused default-disabled and opt-in regression tests across create-app and CLI setup
+- [x] 2.1 Document the environment opt-in and update the standalone harness spec — 24cc3e0d9
+- [x] 2.2 Add focused default-disabled and opt-in regression tests across create-app and CLI setup — 24cc3e0d9
 
 ### Phase 3: Verification and delivery
 

--- a/.ai/runs/2026-08-14-standalone-experimental-hooks-validator.md
+++ b/.ai/runs/2026-08-14-standalone-experimental-hooks-validator.md
@@ -61,5 +61,5 @@ Source doc: `.ai/specs/2026-07-24-standalone-ai-development-harness.md`
 
 ### Phase 3: Verification and delivery
 
-- [ ] 3.1 Run targeted package tests and the configured validation gate
+- [x] 3.1 Run targeted package tests and the configured validation gate — 24cc3e0d9
 - [ ] 3.2 Complete automated PR review/autofix and final PR handoff

--- a/.ai/runs/2026-08-14-standalone-experimental-hooks-validator.md
+++ b/.ai/runs/2026-08-14-standalone-experimental-hooks-validator.md
@@ -51,8 +51,8 @@ Source doc: `.ai/specs/2026-07-24-standalone-ai-development-harness.md`
 
 ### Phase 1: Option and generator contract
 
-- [ ] 1.1 Add and propagate the experimental validator option through both setup entrypoints
-- [ ] 1.2 Gate emitted hook registrations, hook scripts, ownership manifests, and setup summaries while preserving tool parity
+- [x] 1.1 Add and propagate the experimental validator option through both setup entrypoints — 0977f8a39
+- [x] 1.2 Gate emitted hook registrations, hook scripts, ownership manifests, and setup summaries while preserving tool parity — 0977f8a39
 
 ### Phase 2: Documentation and regression coverage
 

--- a/.ai/specs/2026-07-24-standalone-ai-development-harness.md
+++ b/.ai/specs/2026-07-24-standalone-ai-development-harness.md
@@ -698,6 +698,7 @@ All runtime framework contract surfaces remain unchanged. The scaffold/harness s
 6. **Agentic rerun:** pre-manifest apps are migrated conservatively; unknown/user files are preserved. Generated marker blocks are replaced idempotently.
 7. **Published assets:** `dist/agentic` cleanup removes stale generated artifacts before package publication, with tests to prevent deleted legacy skills from reappearing.
 8. **Evaluator CLI/results:** `--judge-writable-result` is canonical; `--review-writable-result` and the existing generated-code-review result projection remain compatibility aliases for at least one minor release.
+9. **Experimental validation hooks:** gate-evidence/typecheck validator hooks remain available for Claude Code, Codex, and Cursor but are no longer emitted by default. The additive `--experimental-hooks-validator` option enables them, with `OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR` as its environment default. Ownership-aware updates retire only unchanged generated validator assets and preserve locally modified copies through the existing conflict path.
 
 ## 📋 Phasing
 
@@ -764,6 +765,7 @@ Add all case records, deterministic/live runner, focused/generated-app/Verdaccio
 
 ## Changelog
 
+- **2026-08-14** — Made the gate-evidence/typecheck validator hook layer opt-in across Claude Code, Codex, and Cursor. Fresh scaffolds and `agentic:init` runs omit it by default; the additive `--experimental-hooks-validator` flag or `OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR=1` enables it without changing the underlying validator semantics.
 - **2026-08-12** — Merged the upstream EUDR compliance route as OMH-229 without reusing the PR's existing OMH-214 identity, and synchronized the 229-case/48-writable contract across schema, tests, and release documentation.
 - **2026-08-03** — Added OMH-203 for CRM detail-tab UMES routing, extended bounded installed framework context to read-only routing cases, enforced guidance-before-source ordering, and synchronized the 203-case contract across schema, tests, and release documentation.
 - **2026-08-03** — Replaced the standalone monolithic lesson placeholder with a tagged progressive index plus one-record template, made nested lesson records user-editable in both copy-pipeline manifests, added the shared consistency checker, and taught root/evolution routing to load only area/module/topic matches.

--- a/apps/mercato/.env.example
+++ b/apps/mercato/.env.example
@@ -907,6 +907,13 @@ ACME_EMAIL=
 # channel (the MCP stdio server sets this itself). Default: stdout.
 # OM_LOG_DESTINATION=stderr
 
+# --- Agentic harness (setup-time only) ---
+# Experimental gate-evidence hooks record validation outcomes and can block an
+# agent from finishing after source changes without a newer passing typecheck.
+# Leave unset by default. Set before running `mercato agentic:init`, or pass
+# `--experimental-hooks-validator` directly to agentic setup.
+# OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR=1
+
 # --- Node.js Runtime ---
 # Uncomment to cap the V8 heap and force proactive GC instead of growing until near system RAM.
 # Use ≥4096 if you also run `next build` locally — the TypeScript checker needs >3 GB on this codebase.

--- a/packages/cli/src/lib/__integration__/TC-INT-008.spec.ts
+++ b/packages/cli/src/lib/__integration__/TC-INT-008.spec.ts
@@ -43,8 +43,8 @@ function runCommand(command: string, args: string[], cwd: string, env: NodeJS.Pr
   })
 }
 
-function runMercato(args: string[], cwd: string): string {
-  return runCommand(process.execPath, [cliBin, ...args], cwd)
+function runMercato(args: string[], cwd: string, env: NodeJS.ProcessEnv = {}): string {
+  return runCommand(process.execPath, [cliBin, ...args], cwd, env)
 }
 
 function writeFile(filePath: string, content: string): void {
@@ -144,31 +144,39 @@ function mapSharedSourceToOutput(relativePath: string): string {
   return normalizePath(path.join('.ai', relativePath.slice('ai/'.length)))
 }
 
-function mapClaudeSourceToOutput(relativePath: string): string {
+function mapClaudeSourceToOutput(relativePath: string): string | null {
   if (relativePath === 'CLAUDE.md.template') {
     return 'CLAUDE.md'
   }
   if (relativePath === 'settings.json') {
     return '.claude/settings.json'
   }
+  if (relativePath === 'settings.experimental-hooks-validator.json') {
+    return null
+  }
   if (relativePath === 'mcp.json.example') {
     return '.mcp.json.example'
   }
   if (relativePath.startsWith('hooks/')) {
+    if (relativePath.includes('gate-evidence.')) return null
     return normalizePath(path.join('.claude', relativePath))
   }
 
   throw new Error(`Unexpected Claude source path: ${relativePath}`)
 }
 
-function mapCursorSourceToOutput(relativePath: string): string {
+function mapCursorSourceToOutput(relativePath: string): string | null {
   if (relativePath === 'hooks.json') {
     return '.cursor/hooks.json'
+  }
+  if (relativePath === 'hooks.experimental-hooks-validator.json') {
+    return null
   }
   if (relativePath === 'mcp.json.example') {
     return '.cursor/mcp.json.example'
   }
   if (relativePath.startsWith('hooks/') || relativePath.startsWith('rules/')) {
+    if (relativePath.includes('gate-evidence.')) return null
     return normalizePath(path.join('.cursor', relativePath))
   }
 
@@ -180,6 +188,9 @@ function mapCodexSourceToOutput(relativePath: string): string | null {
     return '.codex/mcp.json.example'
   }
   if (relativePath === 'enforcement-rules.md') {
+    return null
+  }
+  if (relativePath === 'hooks.json' || relativePath === 'hooks/gate-evidence.mjs') {
     return null
   }
 
@@ -298,14 +309,32 @@ test.describe('TC-INT-008: CLI agentic init mirrors standalone scaffolding asset
       expect(fs.existsSync(path.join(appDir, '.mercato', 'generated'))).toBe(false)
 
       const sharedOutputs = listRelativeFiles(path.join(agenticRoot, 'shared')).map(mapSharedSourceToOutput)
-      const claudeOutputs = listRelativeFiles(path.join(agenticRoot, 'claude-code')).map(mapClaudeSourceToOutput)
-      const cursorOutputs = listRelativeFiles(path.join(agenticRoot, 'cursor')).map(mapCursorSourceToOutput)
+      const claudeOutputs = listRelativeFiles(path.join(agenticRoot, 'claude-code'))
+        .map(mapClaudeSourceToOutput)
+        .filter((relativePath): relativePath is string => relativePath !== null)
+      const cursorOutputs = listRelativeFiles(path.join(agenticRoot, 'cursor'))
+        .map(mapCursorSourceToOutput)
+        .filter((relativePath): relativePath is string => relativePath !== null)
       const codexOutputs = listRelativeFiles(path.join(agenticRoot, 'codex'))
         .map(mapCodexSourceToOutput)
         .filter((relativePath): relativePath is string => relativePath !== null)
 
       expect(sharedOutputs).toContain(standalonePlaywrightConfigPath)
       assertPathsExist(appDir, [...sharedOutputs, ...claudeOutputs, ...cursorOutputs, ...codexOutputs])
+      for (const relativePath of [
+        '.claude/hooks/gate-evidence.ts',
+        '.codex/hooks.json',
+        '.codex/hooks/gate-evidence.mjs',
+        '.cursor/hooks/gate-evidence.mjs',
+      ]) {
+        expect(fs.existsSync(path.join(appDir, relativePath))).toBe(false)
+      }
+      expect(fs.readFileSync(path.join(appDir, '.claude', 'settings.json'), 'utf8')).not.toContain('gate-evidence')
+      expect(fs.readFileSync(path.join(appDir, '.cursor', 'hooks.json'), 'utf8')).not.toContain('gate-evidence')
+      const defaultManifest = JSON.parse(
+        fs.readFileSync(path.join(appDir, '.ai', 'harness', 'manifest.json'), 'utf8'),
+      ) as { files: Array<{ path: string }> }
+      expect(defaultManifest.files.some((entry) => entry.path.includes('gate-evidence'))).toBe(false)
       expect(fs.existsSync(path.join(appDir, standalonePlaywrightConfigPath))).toBe(true)
 
       const generatedGuideNames = listRelativeFiles(path.join(appDir, '.ai', 'guides'))
@@ -358,6 +387,59 @@ test.describe('TC-INT-008: CLI agentic init mirrors standalone scaffolding asset
 
       expect(fs.existsSync(path.join(appDir, '.codex', 'skills'))).toBe(false)
       expect(fs.existsSync(path.join(appDir, '.cursor', 'skills'))).toBe(false)
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('installs gate-evidence hooks only through the explicit flag or environment opt-in', () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mercato-cli-agentic-hooks-'))
+
+    try {
+      const flagAppDir = createStandaloneFixture(path.join(tempRoot, 'flag'))
+      runMercato([
+        'agentic:init',
+        '--tool=claude-code,codex,cursor',
+        '--experimental-hooks-validator',
+      ], flagAppDir)
+
+      assertPathsExist(flagAppDir, [
+        '.claude/hooks/gate-evidence.ts',
+        '.codex/hooks.json',
+        '.codex/hooks/gate-evidence.mjs',
+        '.cursor/hooks/gate-evidence.mjs',
+      ])
+      expect(fs.readFileSync(path.join(flagAppDir, '.claude', 'settings.json'), 'utf8')).toContain('gate-evidence')
+      expect(fs.readFileSync(path.join(flagAppDir, '.cursor', 'hooks.json'), 'utf8')).toContain('gate-evidence')
+      const enabledManifest = JSON.parse(
+        fs.readFileSync(path.join(flagAppDir, '.ai', 'harness', 'manifest.json'), 'utf8'),
+      ) as { files: Array<{ path: string }> }
+      expect(enabledManifest.files.filter((entry) => entry.path.includes('gate-evidence'))).toHaveLength(3)
+
+      runMercato([
+        'agentic:init',
+        '--tool=claude-code,codex,cursor',
+        '--update-harness',
+      ], flagAppDir)
+      for (const relativePath of [
+        '.claude/hooks/gate-evidence.ts',
+        '.codex/hooks.json',
+        '.codex/hooks/gate-evidence.mjs',
+        '.cursor/hooks/gate-evidence.mjs',
+      ]) {
+        expect(fs.existsSync(path.join(flagAppDir, relativePath))).toBe(false)
+      }
+      expect(fs.readFileSync(path.join(flagAppDir, '.claude', 'settings.json'), 'utf8')).not.toContain('gate-evidence')
+      expect(fs.readFileSync(path.join(flagAppDir, '.cursor', 'hooks.json'), 'utf8')).not.toContain('gate-evidence')
+
+      const envAppDir = createStandaloneFixture(path.join(tempRoot, 'environment'))
+      runMercato(['agentic:init', '--tool=codex'], envAppDir, {
+        OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR: '1',
+      })
+      assertPathsExist(envAppDir, [
+        '.codex/hooks.json',
+        '.codex/hooks/gate-evidence.mjs',
+      ])
     } finally {
       fs.rmSync(tempRoot, { recursive: true, force: true })
     }

--- a/packages/cli/src/lib/__tests__/agentic-init.test.ts
+++ b/packages/cli/src/lib/__tests__/agentic-init.test.ts
@@ -20,7 +20,12 @@ const loadRunAgenticInit = async ({
   runAgenticSetupImplementation?: (
     targetDir: string,
     ask: (question: string) => Promise<string>,
-    options?: { tool?: string; force?: boolean; updateHarness?: boolean },
+    options?: {
+      tool?: string
+      force?: boolean
+      updateHarness?: boolean
+      experimentalHooksValidator?: boolean
+    },
   ) => Promise<void>
 }): Promise<AgenticInitTestContext> => {
   jest.resetModules()
@@ -180,7 +185,12 @@ describe('runAgenticInit', () => {
       questionAnswer: '  cursor  ',
       runAgenticSetupImplementation: async (currentTargetDir, ask, options) => {
         expect(currentTargetDir).toBe(targetDir)
-        expect(options).toEqual({ tool: undefined, force: undefined, updateHarness: undefined })
+        expect(options).toEqual({
+          tool: undefined,
+          force: undefined,
+          updateHarness: undefined,
+          experimentalHooksValidator: undefined,
+        })
         await expect(ask('Select a tool')).resolves.toBe('cursor')
       },
     })
@@ -208,7 +218,12 @@ describe('runAgenticInit', () => {
     expect(testContext.runAgenticSetup).toHaveBeenCalledWith(
       targetDir,
       expect.any(Function),
-      { tool: 'codex', force: undefined, updateHarness: undefined },
+      {
+        tool: 'codex',
+        force: undefined,
+        updateHarness: undefined,
+        experimentalHooksValidator: undefined,
+      },
     )
     expect(consoleLogSpy.mock.calls.flat()).not.toContain('⚠️  Agentic files already exist:')
     expect(testContext.closeInterface).toHaveBeenCalledTimes(1)
@@ -225,7 +240,12 @@ describe('runAgenticInit', () => {
     expect(testContext.runAgenticSetup).toHaveBeenCalledWith(
       targetDir,
       expect.any(Function),
-      { tool: 'codex', force: true, updateHarness: undefined },
+      {
+        tool: 'codex',
+        force: true,
+        updateHarness: undefined,
+        experimentalHooksValidator: undefined,
+      },
     )
     expect(testContext.closeInterface).toHaveBeenCalledTimes(1)
   })
@@ -241,9 +261,37 @@ describe('runAgenticInit', () => {
     expect(testContext.runAgenticSetup).toHaveBeenCalledWith(
       targetDir,
       expect.any(Function),
-      { tool: 'codex', force: undefined, updateHarness: true },
+      {
+        tool: 'codex',
+        force: undefined,
+        updateHarness: true,
+        experimentalHooksValidator: undefined,
+      },
     )
     expect(testContext.closeInterface).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes the experimental hook validator opt-in to setup', async () => {
+    const testContext = await loadRunAgenticInit({
+      existingPaths: new Set<string>([appModulesPath]),
+    })
+
+    const exitCode = await testContext.runAgenticInit([
+      '--tool=claude-code,codex',
+      '--experimental-hooks-validator',
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(testContext.runAgenticSetup).toHaveBeenCalledWith(
+      targetDir,
+      expect.any(Function),
+      {
+        tool: 'claude-code,codex',
+        force: undefined,
+        updateHarness: undefined,
+        experimentalHooksValidator: true,
+      },
+    )
   })
 
   it('closes the readline interface when setup fails', async () => {

--- a/packages/cli/src/lib/agentic-init.ts
+++ b/packages/cli/src/lib/agentic-init.ts
@@ -6,6 +6,7 @@ interface AgenticInitOptions {
   tool?: string
   force?: boolean
   updateHarness?: boolean
+  experimentalHooksValidator?: boolean
 }
 
 const TOOL_EXISTING_FILES: Record<string, string[]> = {
@@ -30,6 +31,8 @@ function parseArgs(args: string[]): AgenticInitOptions {
       options.force = true
     } else if (arg === '--update-harness') {
       options.updateHarness = true
+    } else if (arg === '--experimental-hooks-validator') {
+      options.experimentalHooksValidator = true
     } else if (arg.startsWith('--tool=')) {
       options.tool = arg.slice('--tool='.length)
     } else if (arg === '--tool') {
@@ -104,6 +107,7 @@ export async function runAgenticInit(args: string[]): Promise<number> {
       tool: options.tool,
       force: options.force,
       updateHarness: options.updateHarness,
+      experimentalHooksValidator: options.experimentalHooksValidator,
     })
   } finally {
     rl.close()

--- a/packages/cli/src/lib/agentic-setup.ts
+++ b/packages/cli/src/lib/agentic-setup.ts
@@ -43,11 +43,13 @@ interface AgenticSetupOptions {
   tool?: string
   force?: boolean
   updateHarness?: boolean
+  experimentalHooksValidator?: boolean
 }
 
 interface AgenticConfig {
   projectName: string
   targetDir: string
+  experimentalHooksValidator: boolean
 }
 
 interface HarnessManifestFile {
@@ -226,9 +228,27 @@ function listFiles(root: string): string[] {
  * hook registration pointing at a file that was never created. Deriving the list from disk
  * keeps this path and the create-app wizard in step whenever a hook is added.
  */
-function claudeHookFiles(): string[] {
+function claudeHookFiles(experimentalHooksValidator: boolean): string[] {
   const hooksDir = join(AGENTIC_DIR, 'claude-code', 'hooks')
-  return listFiles(hooksDir).map((file) => relative(hooksDir, file).replaceAll('\\', '/'))
+  return listFiles(hooksDir)
+    .map((file) => relative(hooksDir, file).replaceAll('\\', '/'))
+    .filter((file) => experimentalHooksValidator || file !== 'gate-evidence.ts')
+}
+
+function resolveExperimentalHooksValidator(
+  explicitValue?: boolean,
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (explicitValue !== undefined) return explicitValue
+
+  const token = environment.OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR?.trim().toLowerCase()
+  if (!token) return false
+  if (['1', 'true', 'yes', 'on'].includes(token)) return true
+  if (['0', 'false', 'no', 'off'].includes(token)) return false
+
+  throw new Error(
+    'OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR must be one of: 1, true, yes, on, 0, false, no, off',
+  )
 }
 
 function copyTree(sourceRoot: string, destinationRoot: string, config: AgenticConfig): void {
@@ -475,14 +495,31 @@ function finalizeHarnessManifest(config: AgenticConfig, selectedTools: string[])
   if (selectedTools.includes('claude-code')) {
     paths.add(join(targetDir, 'CLAUDE.md'))
     paths.add(join(targetDir, '.claude', 'settings.json'))
-    for (const hook of claudeHookFiles()) paths.add(join(targetDir, '.claude', 'hooks', hook))
+    for (const hook of claudeHookFiles(config.experimentalHooksValidator)) {
+      paths.add(join(targetDir, '.claude', 'hooks', hook))
+    }
     paths.add(join(targetDir, '.mcp.json.example'))
   }
-  if (selectedTools.includes('codex')) paths.add(join(targetDir, '.codex', 'mcp.json.example'))
+  if (selectedTools.includes('codex')) {
+    paths.add(join(targetDir, '.codex', 'mcp.json.example'))
+    if (config.experimentalHooksValidator) {
+      paths.add(join(targetDir, '.codex', 'hooks.json'))
+      paths.add(join(targetDir, '.codex', 'hooks', 'gate-evidence.mjs'))
+    }
+  }
   if (selectedTools.includes('cursor')) {
-    for (const file of listFiles(join(AGENTIC_DIR, 'cursor'))) {
-      const rel = relative(join(AGENTIC_DIR, 'cursor'), file)
-      paths.add(join(targetDir, '.cursor', rel))
+    for (const relativePath of [
+      'hooks.json',
+      'hooks/entity-migration-check.mjs',
+      'mcp.json.example',
+      'rules/open-mercato.mdc',
+      'rules/entity-guard.mdc',
+      'rules/generated-guard.mdc',
+    ]) {
+      paths.add(join(targetDir, '.cursor', relativePath))
+    }
+    if (config.experimentalHooksValidator) {
+      paths.add(join(targetDir, '.cursor', 'hooks', 'gate-evidence.mjs'))
     }
   }
   const manifestPath = join(targetDir, '.ai', 'harness', 'manifest.json')
@@ -701,8 +738,12 @@ function generateClaudeCode(config: AgenticConfig): void {
   const srcDir = join(AGENTIC_DIR, 'claude-code')
 
   writeTemplate(srcDir, 'CLAUDE.md.template', join(targetDir, 'CLAUDE.md'), config)
-  copyFile(srcDir, 'settings.json', join(targetDir, '.claude', 'settings.json'))
-  for (const hook of claudeHookFiles()) {
+  copyFile(
+    srcDir,
+    config.experimentalHooksValidator ? 'settings.experimental-hooks-validator.json' : 'settings.json',
+    join(targetDir, '.claude', 'settings.json'),
+  )
+  for (const hook of claudeHookFiles(config.experimentalHooksValidator)) {
     copyFile(srcDir, `hooks/${hook}`, join(targetDir, '.claude', 'hooks', hook))
   }
   copyFile(srcDir, 'mcp.json.example', join(targetDir, '.mcp.json.example'))
@@ -738,6 +779,10 @@ function generateCodex(config: AgenticConfig): void {
     writeFileSync(agentsPath, agents)
   }
 
+  if (config.experimentalHooksValidator) {
+    copyFile(srcDir, 'hooks.json', join(targetDir, '.codex', 'hooks.json'))
+    copyFile(srcDir, 'hooks/gate-evidence.mjs', join(targetDir, '.codex', 'hooks', 'gate-evidence.mjs'))
+  }
   copyFile(srcDir, 'mcp.json.example', join(targetDir, '.codex', 'mcp.json.example'))
 
   // No .codex/skills directory: Codex reads the canonical .agents/skills/,
@@ -751,8 +796,15 @@ function generateCursor(config: AgenticConfig): void {
   writeTemplate(srcDir, 'rules/open-mercato.mdc', join(targetDir, '.cursor', 'rules', 'open-mercato.mdc'), config)
   copyFile(srcDir, 'rules/entity-guard.mdc', join(targetDir, '.cursor', 'rules', 'entity-guard.mdc'))
   copyFile(srcDir, 'rules/generated-guard.mdc', join(targetDir, '.cursor', 'rules', 'generated-guard.mdc'))
-  copyFile(srcDir, 'hooks.json', join(targetDir, '.cursor', 'hooks.json'))
+  copyFile(
+    srcDir,
+    config.experimentalHooksValidator ? 'hooks.experimental-hooks-validator.json' : 'hooks.json',
+    join(targetDir, '.cursor', 'hooks.json'),
+  )
   copyFile(srcDir, 'hooks/entity-migration-check.mjs', join(targetDir, '.cursor', 'hooks', 'entity-migration-check.mjs'))
+  if (config.experimentalHooksValidator) {
+    copyFile(srcDir, 'hooks/gate-evidence.mjs', join(targetDir, '.cursor', 'hooks', 'gate-evidence.mjs'))
+  }
   copyFile(srcDir, 'mcp.json.example', join(targetDir, '.cursor', 'mcp.json.example'))
 
   // No .cursor/skills directory: Cursor reads the canonical .agents/skills/,
@@ -862,6 +914,7 @@ export async function runAgenticSetup(
   const config: AgenticConfig = {
     projectName: basename(targetDir),
     targetDir,
+    experimentalHooksValidator: resolveExperimentalHooksValidator(options?.experimentalHooksValidator),
   }
 
   const stagingDir = mkdtempSync(join(tmpdir(), 'open-mercato-harness-'))
@@ -876,6 +929,7 @@ export async function runAgenticSetup(
     const stagingConfig: AgenticConfig = {
       projectName: config.projectName,
       targetDir: stagingDir,
+      experimentalHooksValidator: config.experimentalHooksValidator,
     }
     generateHarness(stagingConfig, selectedIds)
     const conflicts = applyHarnessUpdate(targetDir, stagingDir, {
@@ -907,6 +961,9 @@ export async function runAgenticSetup(
   }
   if (selectedIds.includes('cursor')) {
     console.log('   ✓ Cursor — .cursor/rules/, .cursor/hooks/, .cursor/mcp.json.example')
+  }
+  if (config.experimentalHooksValidator) {
+    console.log('   ✓ Experimental gate-evidence/typecheck validator hooks')
   }
   console.log('')
   console.log('   .ai/agentic.config.json ships preconfigured (GitHub tracker, labels off);')

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -72,6 +72,9 @@ npx create-mercato-app my-store --preset classic --agents all
 # Set up only Claude Code and Codex
 npx create-mercato-app my-store --agents claude-code,codex
 
+# Opt in to the experimental validation/typecheck hook layer
+npx create-mercato-app my-store --agents claude-code,codex --experimental-hooks-validator
+
 # Create a new app and initialize a local Git repository
 npx create-mercato-app my-store --init-git
 ```
@@ -90,6 +93,8 @@ npx create-mercato-app my-store --init-git
 ## Standalone AI Harness
 
 A bare scaffold can install a standalone-specific AI development harness for Claude Code, Codex, Cursor, or any selected subset. It combines a compact task router, module/task guides, local skills, an integrity-pinned subset of `open-mercato/skills`, exact installed-framework context, and a reproducible evaluation catalog.
+
+The gate-evidence hooks that record validation outcomes and require a newer passing typecheck after source edits are experimental and disabled by default. Opt in with `--experimental-hooks-validator` during creation or `yarn mercato agentic:init`, or set `OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR=1` before setup. The explicit flag takes precedence over the environment default.
 
 ### Install or refresh skills
 

--- a/packages/create-app/agentic/claude-code/settings.experimental-hooks-validator.json
+++ b/packages/create-app/agentic/claude-code/settings.experimental-hooks-validator.json
@@ -1,0 +1,37 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx \"$CLAUDE_PROJECT_DIR/.claude/hooks/entity-migration-check.ts\"",
+            "timeout": 15
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx \"$CLAUDE_PROJECT_DIR/.claude/hooks/gate-evidence.ts\" record",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsx \"$CLAUDE_PROJECT_DIR/.claude/hooks/gate-evidence.ts\" check",
+            "timeout": 20
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/create-app/agentic/claude-code/settings.json
+++ b/packages/create-app/agentic/claude-code/settings.json
@@ -10,27 +10,6 @@
             "timeout": 15
           }
         ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx tsx \"$CLAUDE_PROJECT_DIR/.claude/hooks/gate-evidence.ts\" record",
-            "timeout": 15
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "npx tsx \"$CLAUDE_PROJECT_DIR/.claude/hooks/gate-evidence.ts\" check",
-            "timeout": 20
-          }
-        ]
       }
     ]
   }

--- a/packages/create-app/agentic/cursor/hooks.experimental-hooks-validator.json
+++ b/packages/create-app/agentic/cursor/hooks.experimental-hooks-validator.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": {
+      "command": "node",
+      "args": [".cursor/hooks/entity-migration-check.mjs"],
+      "description": "Check if entity edit requires a database migration"
+    },
+    "afterShellExecution": {
+      "command": "node",
+      "args": [".cursor/hooks/gate-evidence.mjs", "record"],
+      "description": "Record validation-gate outcomes so a gate cannot be claimed without running"
+    },
+    "stop": {
+      "command": "node",
+      "args": [".cursor/hooks/gate-evidence.mjs", "check"],
+      "description": "Block finishing when src/ changed without a passing typecheck since"
+    }
+  }
+}

--- a/packages/create-app/agentic/cursor/hooks.json
+++ b/packages/create-app/agentic/cursor/hooks.json
@@ -5,16 +5,6 @@
       "command": "node",
       "args": [".cursor/hooks/entity-migration-check.mjs"],
       "description": "Check if entity edit requires a database migration"
-    },
-    "afterShellExecution": {
-      "command": "node",
-      "args": [".cursor/hooks/gate-evidence.mjs", "record"],
-      "description": "Record validation-gate outcomes so a gate cannot be claimed without running"
-    },
-    "stop": {
-      "command": "node",
-      "args": [".cursor/hooks/gate-evidence.mjs", "check"],
-      "description": "Block finishing when src/ changed without a passing typecheck since"
     }
   }
 }

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -28,6 +28,7 @@ interface Options {
   registry?: string
   initGit?: boolean
   agents?: string
+  experimentalHooksValidator?: boolean
   skipAgenticSetup: boolean
   verdaccio: boolean
   help: boolean
@@ -58,6 +59,8 @@ ${pc.bold('Options:')}
   --no-init-git      Do not prompt for or initialize a local Git repository
   --agents <list>    Set up agent tooling non-interactively (skips the wizard):
                      comma-separated claude-code,codex,cursor — or 'all' / 'none'
+  --experimental-hooks-validator
+                     Install experimental gate-evidence/typecheck validator hooks
   --skip-agentic-setup  Skip the agentic setup wizard (alias for --agents none)
   --registry <url>   Custom npm registry URL
   --verdaccio        Use local Verdaccio registry (http://localhost:4873)
@@ -71,6 +74,7 @@ ${pc.bold('Examples:')}
   npx create-mercato-app my-store --preset crm
   npx create-mercato-app my-store --init-git
   npx create-mercato-app my-store --agents claude-code,codex
+  npx create-mercato-app my-store --agents codex --experimental-hooks-validator
   npx create-mercato-app my-store --agents all
   npx create-mercato-app my-store --agents none
   npx create-mercato-app my-prm --app prm
@@ -101,6 +105,7 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
     registry: undefined,
     initGit: undefined,
     agents: undefined,
+    experimentalHooksValidator: undefined,
     skipAgenticSetup: false,
     verdaccio: false,
     help: false,
@@ -118,6 +123,8 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
     } else if (arg === '--agents') {
       options.agents = requireOptionValue(args, index, arg)
       index += 1
+    } else if (arg === '--experimental-hooks-validator') {
+      options.experimentalHooksValidator = true
     } else if (arg === '--skip-agentic-setup') {
       options.skipAgenticSetup = true
     } else if (arg === '--init-git') {
@@ -454,13 +461,20 @@ function resolveAgentSelection(options: Options): AgentSelection {
   return { mode: 'tools', tools: parsed.tools }
 }
 
-async function maybeRunAgenticSetup(targetDir: string, selection: AgentSelection): Promise<boolean> {
+async function maybeRunAgenticSetup(
+  targetDir: string,
+  selection: AgentSelection,
+  experimentalHooksValidator?: boolean,
+): Promise<boolean> {
   if (selection.mode === 'skip') {
-    return runAgenticSetup(targetDir, async () => '', { tool: 'skip' })
+    return runAgenticSetup(targetDir, async () => '', { tool: 'skip', experimentalHooksValidator })
   }
 
   if (selection.mode === 'tools') {
-    return runAgenticSetup(targetDir, async () => '', { tool: selection.tools.join(',') })
+    return runAgenticSetup(targetDir, async () => '', {
+      tool: selection.tools.join(','),
+      experimentalHooksValidator,
+    })
   }
 
   const rl = createInterface({ input: process.stdin, output: process.stdout })
@@ -468,7 +482,7 @@ async function maybeRunAgenticSetup(targetDir: string, selection: AgentSelection
     new Promise<string>((resolveAnswer) => rl.question(question, (answer) => resolveAnswer(answer.trim())))
 
   try {
-    return await runAgenticSetup(targetDir, ask)
+    return await runAgenticSetup(targetDir, ask, { experimentalHooksValidator })
   } finally {
     rl.close()
   }
@@ -580,6 +594,11 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
       '--agents is not supported with --app/--app-url. Imported ready apps manage their own agentic tooling; run `yarn mercato agentic:init` inside the app instead.',
     )
   }
+  if (options.experimentalHooksValidator && readyAppSource) {
+    throw new Error(
+      '--experimental-hooks-validator is not supported with --app/--app-url. Run `yarn mercato agentic:init --experimental-hooks-validator` inside the imported app instead.',
+    )
+  }
 
   // Resolve (and validate) the agentic selection up front so a bad --agents
   // value fails before any scaffolding work happens.
@@ -617,7 +636,11 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
 
   let agenticConfigured = false
   if (!readyAppSource) {
-    agenticConfigured = await maybeRunAgenticSetup(targetDir, agentSelection)
+    agenticConfigured = await maybeRunAgenticSetup(
+      targetDir,
+      agentSelection,
+      options.experimentalHooksValidator,
+    )
   }
 
   const gitResult = await maybeInitializeGitRepository(targetDir, options)

--- a/packages/create-app/src/lib/agentic-claude-hook-parity.test.ts
+++ b/packages/create-app/src/lib/agentic-claude-hook-parity.test.ts
@@ -50,8 +50,8 @@ test('mercato agentic:init installs Claude hooks from disk rather than a hand-ke
   // enumerated list is exactly how gate-evidence.ts came to be registered but never copied.
   const body = claudeGeneratorBody()
   assert.ok(
-    body.includes('claudeHookFiles()'),
-    'generateClaudeCode should install hooks via the disk-derived claudeHookFiles() helper',
+    body.includes('claudeHookFiles(config.experimentalHooksValidator)'),
+    'generateClaudeCode should install hooks via the policy-filtered disk-derived helper',
   )
   assert.ok(
     !/copyFile\(srcDir, `?'?hooks\/[A-Za-z]/.test(body),
@@ -66,7 +66,7 @@ test('mercato agentic:init claims every installed hook in its ownership manifest
     cliSetupSource.indexOf("paths.add(join(targetDir, 'CLAUDE.md'))"),
   )
   assert.ok(
-    ownershipBlock.includes("for (const hook of claudeHookFiles()) paths.add(join(targetDir, '.claude', 'hooks', hook))"),
+    ownershipBlock.includes('for (const hook of claudeHookFiles(config.experimentalHooksValidator))'),
     'agentic-setup.ts ownership manifest should claim every disk-derived Claude hook',
   )
 })

--- a/packages/create-app/src/lib/agentic-cross-agent-hook-parity.test.ts
+++ b/packages/create-app/src/lib/agentic-cross-agent-hook-parity.test.ts
@@ -33,7 +33,11 @@ for (const agent of SHIPPING_HOOKS) {
   })
 
   test(`${agent}: every hook its config registers exists on disk`, () => {
-    const configName = agent === 'claude-code' ? 'settings.json' : 'hooks.json'
+    const configName = agent === 'claude-code'
+      ? 'settings.experimental-hooks-validator.json'
+      : agent === 'cursor'
+        ? 'hooks.experimental-hooks-validator.json'
+        : 'hooks.json'
     const configPath = path.join(agenticRoot, agent, configName)
     assert.ok(fs.existsSync(configPath), `${agent} ships hooks but no ${configName} to register them`)
     const config = fs.readFileSync(configPath, 'utf8')
@@ -47,17 +51,27 @@ for (const agent of SHIPPING_HOOKS) {
     }
   })
 
-  test(`${agent}: the wizard installs every hook in the source tree`, () => {
+  test(`${agent}: the wizard keeps every shipped hook available behind setup policy`, () => {
     const wizard = fs.readFileSync(
       fileURLToPath(new URL(`../setup/tools/${agent}.ts`, import.meta.url)),
       'utf8',
     )
     for (const hook of fs.readdirSync(path.join(agenticRoot, agent, 'hooks'))) {
       assert.ok(wizard.includes(`hooks/${hook}`) || /copyHooksDir|hooks'\)/.test(wizard),
-        `the wizard never installs ${agent}/hooks/${hook}`)
+        `the wizard cannot install ${agent}/hooks/${hook}`)
     }
   })
 }
+
+test('default tool configs do not register the experimental gate-evidence validator', () => {
+  for (const [agent, configName] of [
+    ['claude-code', 'settings.json'],
+    ['cursor', 'hooks.json'],
+  ] as const) {
+    const config = fs.readFileSync(path.join(agenticRoot, agent, configName), 'utf8')
+    assert.doesNotMatch(config, /gate-evidence/)
+  }
+})
 
 for (const [name, hook] of PORTS) {
   test(`${name}: matchGates agrees with claude-code`, () => {

--- a/packages/create-app/src/lib/agentic-hook-installation.test.ts
+++ b/packages/create-app/src/lib/agentic-hook-installation.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const packageRoot = fileURLToPath(new URL('../..', import.meta.url))
+const createAppBin = path.join(packageRoot, 'dist', 'index.js')
+
+function scaffold(rootDir: string, appName: string, extraArgs: string[] = []): string {
+  execFileSync(
+    process.execPath,
+    [createAppBin, appName, '--agents', 'all', '--no-init-git', ...extraArgs],
+    {
+      cwd: rootDir,
+      env: {
+        ...process.env,
+        FORCE_COLOR: '0',
+        OM_SKIP_EXTERNAL_SKILLS: '1',
+        OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR: '0',
+      },
+      stdio: 'pipe',
+    },
+  )
+  return path.join(rootDir, appName)
+}
+
+const gateEvidencePaths = [
+  '.claude/hooks/gate-evidence.ts',
+  '.codex/hooks.json',
+  '.codex/hooks/gate-evidence.mjs',
+  '.cursor/hooks/gate-evidence.mjs',
+]
+
+test('create-app omits experimental hook validators by default', () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om-hook-validator-default-'))
+  try {
+    const appDir = scaffold(rootDir, 'default-app')
+    for (const relativePath of gateEvidencePaths) {
+      assert.equal(fs.existsSync(path.join(appDir, relativePath)), false, relativePath)
+    }
+    assert.doesNotMatch(fs.readFileSync(path.join(appDir, '.claude/settings.json'), 'utf8'), /gate-evidence/)
+    assert.doesNotMatch(fs.readFileSync(path.join(appDir, '.cursor/hooks.json'), 'utf8'), /gate-evidence/)
+  } finally {
+    fs.rmSync(rootDir, { recursive: true, force: true })
+  }
+})
+
+test('create-app installs experimental hook validators with the explicit setup option', () => {
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'om-hook-validator-enabled-'))
+  try {
+    const appDir = scaffold(rootDir, 'enabled-app', ['--experimental-hooks-validator'])
+    for (const relativePath of gateEvidencePaths) {
+      assert.equal(fs.existsSync(path.join(appDir, relativePath)), true, relativePath)
+    }
+    assert.match(fs.readFileSync(path.join(appDir, '.claude/settings.json'), 'utf8'), /gate-evidence/)
+    assert.match(fs.readFileSync(path.join(appDir, '.cursor/hooks.json'), 'utf8'), /gate-evidence/)
+  } finally {
+    fs.rmSync(rootDir, { recursive: true, force: true })
+  }
+})

--- a/packages/create-app/src/setup/tools/claude-code.ts
+++ b/packages/create-app/src/setup/tools/claude-code.ts
@@ -37,13 +37,17 @@ export function generateClaudeCode(config: AgenticConfig): void {
   writeTemplate('CLAUDE.md.template', join(targetDir, 'CLAUDE.md'), config)
 
   // .claude/settings.json
-  copyFile('settings.json', join(targetDir, '.claude', 'settings.json'))
+  copyFile(
+    config.experimentalHooksValidator ? 'settings.experimental-hooks-validator.json' : 'settings.json',
+    join(targetDir, '.claude', 'settings.json'),
+  )
 
   // .claude/hooks/entity-migration-check.ts
   copyFile('hooks/entity-migration-check.ts', join(targetDir, '.claude', 'hooks', 'entity-migration-check.ts'))
 
-  // .claude/hooks/gate-evidence.ts
-  copyFile('hooks/gate-evidence.ts', join(targetDir, '.claude', 'hooks', 'gate-evidence.ts'))
+  if (config.experimentalHooksValidator) {
+    copyFile('hooks/gate-evidence.ts', join(targetDir, '.claude', 'hooks', 'gate-evidence.ts'))
+  }
 
   // .mcp.json.example
   copyFile('mcp.json.example', join(targetDir, '.mcp.json.example'))

--- a/packages/create-app/src/setup/tools/codex.ts
+++ b/packages/create-app/src/setup/tools/codex.ts
@@ -57,9 +57,10 @@ export function generateCodex(config: AgenticConfig): void {
     writeFileSync(agentsPath, agents)
   }
 
-  // .codex/hooks.json + .codex/hooks/gate-evidence.mjs
-  copyFile('hooks.json', join(targetDir, '.codex', 'hooks.json'))
-  copyFile('hooks/gate-evidence.mjs', join(targetDir, '.codex', 'hooks', 'gate-evidence.mjs'))
+  if (config.experimentalHooksValidator) {
+    copyFile('hooks.json', join(targetDir, '.codex', 'hooks.json'))
+    copyFile('hooks/gate-evidence.mjs', join(targetDir, '.codex', 'hooks', 'gate-evidence.mjs'))
+  }
 
   // .codex/mcp.json.example
   copyFile('mcp.json.example', join(targetDir, '.codex', 'mcp.json.example'))

--- a/packages/create-app/src/setup/tools/cursor.ts
+++ b/packages/create-app/src/setup/tools/cursor.ts
@@ -38,14 +38,17 @@ export function generateCursor(config: AgenticConfig): void {
   copyFile('rules/entity-guard.mdc', join(targetDir, '.cursor', 'rules', 'entity-guard.mdc'))
   copyFile('rules/generated-guard.mdc', join(targetDir, '.cursor', 'rules', 'generated-guard.mdc'))
 
-  // .cursor/hooks.json
-  copyFile('hooks.json', join(targetDir, '.cursor', 'hooks.json'))
+  copyFile(
+    config.experimentalHooksValidator ? 'hooks.experimental-hooks-validator.json' : 'hooks.json',
+    join(targetDir, '.cursor', 'hooks.json'),
+  )
 
   // .cursor/hooks/entity-migration-check.mjs
   copyFile('hooks/entity-migration-check.mjs', join(targetDir, '.cursor', 'hooks', 'entity-migration-check.mjs'))
 
-  // .cursor/hooks/gate-evidence.mjs
-  copyFile('hooks/gate-evidence.mjs', join(targetDir, '.cursor', 'hooks', 'gate-evidence.mjs'))
+  if (config.experimentalHooksValidator) {
+    copyFile('hooks/gate-evidence.mjs', join(targetDir, '.cursor', 'hooks', 'gate-evidence.mjs'))
+  }
 
   // .cursor/mcp.json.example
   copyFile('mcp.json.example', join(targetDir, '.cursor', 'mcp.json.example'))

--- a/packages/create-app/src/setup/tools/shared.ts
+++ b/packages/create-app/src/setup/tools/shared.ts
@@ -251,14 +251,27 @@ export function finalizeHarnessManifest(config: AgenticConfig, selectedTools: st
     paths.add(join(targetDir, 'CLAUDE.md'))
     paths.add(join(targetDir, '.claude', 'settings.json'))
     paths.add(join(targetDir, '.claude', 'hooks', 'entity-migration-check.ts'))
+    if (config.experimentalHooksValidator) {
+      paths.add(join(targetDir, '.claude', 'hooks', 'gate-evidence.ts'))
+    }
     paths.add(join(targetDir, '.mcp.json.example'))
   }
-  if (selectedTools.includes('codex')) paths.add(join(targetDir, '.codex', 'mcp.json.example'))
+  if (selectedTools.includes('codex')) {
+    paths.add(join(targetDir, '.codex', 'mcp.json.example'))
+    if (config.experimentalHooksValidator) {
+      paths.add(join(targetDir, '.codex', 'hooks.json'))
+      paths.add(join(targetDir, '.codex', 'hooks', 'gate-evidence.mjs'))
+    }
+  }
   if (selectedTools.includes('cursor')) {
-    for (const file of listFiles(join(AGENTIC_ROOT, 'cursor'))) {
-      const rel = relative(join(AGENTIC_ROOT, 'cursor'), file)
-      const mapped = rel === 'mcp.json.example' ? join(targetDir, '.cursor', 'mcp.json.example') : join(targetDir, '.cursor', rel)
-      paths.add(mapped)
+    paths.add(join(targetDir, '.cursor', 'hooks.json'))
+    paths.add(join(targetDir, '.cursor', 'hooks', 'entity-migration-check.mjs'))
+    paths.add(join(targetDir, '.cursor', 'mcp.json.example'))
+    paths.add(join(targetDir, '.cursor', 'rules', 'open-mercato.mdc'))
+    paths.add(join(targetDir, '.cursor', 'rules', 'entity-guard.mdc'))
+    paths.add(join(targetDir, '.cursor', 'rules', 'generated-guard.mdc'))
+    if (config.experimentalHooksValidator) {
+      paths.add(join(targetDir, '.cursor', 'hooks', 'gate-evidence.mjs'))
     }
   }
 

--- a/packages/create-app/src/setup/wizard.test.ts
+++ b/packages/create-app/src/setup/wizard.test.ts
@@ -5,7 +5,12 @@ import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { AGENT_TOOL_IDS, parseAgentsValue, promptSelection } from './wizard.js'
+import {
+  AGENT_TOOL_IDS,
+  parseAgentsValue,
+  promptSelection,
+  resolveExperimentalHooksValidator,
+} from './wizard.js'
 import type { AskFn } from './wizard.js'
 
 const wizardPath = fileURLToPath(new URL('./wizard.ts', import.meta.url))
@@ -44,6 +49,32 @@ test('parseAgentsValue: none cannot combine with a tool', () => {
 
 test('parseAgentsValue: all cannot combine with a tool', () => {
   assert.throws(() => parseAgentsValue('all,codex'), /cannot be combined with individual agents/)
+})
+
+test('resolveExperimentalHooksValidator: stays disabled by default', () => {
+  assert.equal(resolveExperimentalHooksValidator(undefined, {}), false)
+})
+
+test('resolveExperimentalHooksValidator: accepts explicit setup and environment opt-ins', () => {
+  assert.equal(resolveExperimentalHooksValidator(true, {}), true)
+  assert.equal(resolveExperimentalHooksValidator(undefined, {
+    OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR: 'yes',
+  }), true)
+})
+
+test('resolveExperimentalHooksValidator: explicit setup value overrides the environment default', () => {
+  assert.equal(resolveExperimentalHooksValidator(false, {
+    OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR: '1',
+  }), false)
+})
+
+test('resolveExperimentalHooksValidator: rejects ambiguous environment values', () => {
+  assert.throws(
+    () => resolveExperimentalHooksValidator(undefined, {
+      OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR: 'sometimes',
+    }),
+    /must be one of/,
+  )
 })
 
 async function withTty(stdin: boolean, stdout: boolean, run: () => Promise<void>): Promise<void> {

--- a/packages/create-app/src/setup/wizard.ts
+++ b/packages/create-app/src/setup/wizard.ts
@@ -11,11 +11,31 @@ export type AskFn = (question: string) => Promise<string>
 export interface AgenticSetupOptions {
   tool?: string
   force?: boolean
+  experimentalHooksValidator?: boolean
 }
 
 export interface AgenticConfig {
   projectName: string
   targetDir: string
+  experimentalHooksValidator?: boolean
+}
+
+export const EXPERIMENTAL_HOOKS_VALIDATOR_ENV = 'OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR'
+
+export function resolveExperimentalHooksValidator(
+  explicitValue?: boolean,
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (explicitValue !== undefined) return explicitValue
+
+  const token = environment[EXPERIMENTAL_HOOKS_VALIDATOR_ENV]?.trim().toLowerCase()
+  if (!token) return false
+  if (['1', 'true', 'yes', 'on'].includes(token)) return true
+  if (['0', 'false', 'no', 'off'].includes(token)) return false
+
+  throw new Error(
+    `${EXPERIMENTAL_HOOKS_VALIDATOR_ENV} must be one of: 1, true, yes, on, 0, false, no, off`,
+  )
 }
 
 const TOOLS = [
@@ -157,6 +177,7 @@ export async function runAgenticSetup(
   const config: AgenticConfig = {
     projectName: basename(targetDir),
     targetDir,
+    experimentalHooksValidator: resolveExperimentalHooksValidator(options?.experimentalHooksValidator),
   }
 
   // Order matters — codex patches AGENTS.md created by shared
@@ -170,7 +191,7 @@ export async function runAgenticSetup(
   persistAgentSelection(targetDir, selectedIds)
   finalizeHarnessManifest(config, selectedIds)
   installSkills(targetDir)
-  printSummary(selectedIds)
+  printSummary(selectedIds, Boolean(config.experimentalHooksValidator))
   return true
 }
 
@@ -207,7 +228,7 @@ function installSkills(targetDir: string): void {
   }
 }
 
-function printSummary(selectedIds: string[]): void {
+function printSummary(selectedIds: string[], experimentalHooksValidator: boolean): void {
   console.log('')
   console.log('   Agentic setup complete:')
 
@@ -219,6 +240,9 @@ function printSummary(selectedIds: string[]): void {
   }
   if (selectedIds.includes('cursor')) {
     console.log('   ✓ Cursor — .cursor/rules/, .cursor/hooks/, .cursor/mcp.json.example')
+  }
+  if (experimentalHooksValidator) {
+    console.log('   ✓ Experimental gate-evidence/typecheck validator hooks')
   }
 
   if (selectedIds.includes('claude-code')) {

--- a/packages/create-app/template/.env.example
+++ b/packages/create-app/template/.env.example
@@ -760,6 +760,13 @@ ACME_EMAIL=
 # channel (the MCP stdio server sets this itself). Default: stdout.
 # OM_LOG_DESTINATION=stderr
 
+# --- Agentic harness (setup-time only) ---
+# Experimental gate-evidence hooks record validation outcomes and can block an
+# agent from finishing after source changes without a newer passing typecheck.
+# Leave unset by default. Set before running `mercato agentic:init`, or pass
+# `--experimental-hooks-validator` directly to agentic setup.
+# OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR=1
+
 # --- Rate limiting proxy trust ---
 # Number of trusted reverse proxies between clients and the app (default: 0).
 # Keep 0 for direct deployments; set the exact proxy count for trusted X-Forwarded-For extraction.


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-14-standalone-experimental-hooks-validator.md
Source doc: .ai/specs/2026-07-24-standalone-ai-development-harness.md
Status: in-progress

## 🎯 Goal
- Make standalone gate-evidence/typecheck validator hooks disabled by default and opt-in through agentic setup or `OM_HARNESS_EXPERIMENTAL_HOOKS_VALIDATOR`.

## What Changed
- Execution plan committed; implementation is in progress.

## 🧪 Tests
- Pending implementation and validation.

## 💥 Breaking Changes
- None. The new setup flag is additive; default scaffold behavior intentionally stops installing the recently introduced experimental validator.

## 📋 Progress
See the Progress section in the tracking plan.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789311691&installation_model_id=432243&pr_number=5309&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5309&signature=9c9673c67ba0fef2aa15a9276a7a1dad1bbfc55ac3746fcebbc34b43ac725eca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->