### PR TITLE
feat(ui): add a showQueryTime opt-out to DataTable (#5304)

### DIFF
--- a/.ai/runs/2026-08-14-datatable-show-query-time.md
+++ b/.ai/runs/2026-08-14-datatable-show-query-time.md
@@ -1,0 +1,63 @@
+# Execution plan — DataTable `showQueryTime` opt-out (FR #5304)
+
+## Goal
+
+Give `DataTable` an additive, opt-out `showQueryTime` prop so a list page can suppress the
+footer's "… in 142ms" query-duration suffix, without changing behaviour for any existing
+call site.
+
+## Scope
+
+- `packages/ui/src/backend/DataTable.tsx` — add `showQueryTime?: boolean` to `DataTableProps`,
+  default it to `true`, and gate the footer's duration label on it.
+- A unit test pinning **both** branches of the footer string.
+
+### Non-goals
+
+- No environment-dependent default (issue #5304 explicitly leaves "on in dev, off in prod"
+  as a separate, later decision; this PR keeps the default `true` everywhere).
+- No new locale keys — the `false` branch reuses the existing
+  `ui.dataTable.pagination.results` key that the footer already falls back to when no
+  duration is available.
+- No call-site changes anywhere in the product; the prop is purely additive.
+
+## Backward compatibility
+
+`BACKWARD_COMPATIBILITY.md` classifies `DataTable` component props (§3, `@open-mercato/ui/backend`)
+as **MUST NOT remove existing props** — an additive optional prop is permitted with no
+deprecation protocol. No existing prop changes shape, and the default preserves today's
+rendering exactly.
+
+## Implementation Plan
+
+### Phase 1: Prop and footer gate
+
+- 1.1 Add `showQueryTime?: boolean` to `DataTableProps` with a doc comment, and destructure
+  it in the `DataTable` component with a `= true` default.
+- 1.2 Gate the footer's `durationLabel` on the prop so a `false` value renders the
+  count-only `ui.dataTable.pagination.results` string, and add the prop to the footer
+  memo's dependency array.
+
+### Phase 2: Test coverage
+
+- 2.1 Add a test that pins both branches: with a `pagination.durationMs` supplied, the
+  default renders the duration and `showQueryTime={false}` renders the count-only string.
+
+## Risks
+
+- Low. The change is one conditional in a memoized footer renderer. The only real risk is
+  forgetting the memo dependency, which would make a runtime toggle of the prop stale —
+  covered by adding `showQueryTime` to the dependency list in step 1.2.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Prop and footer gate
+
+- [ ] 1.1 Add the prop to DataTableProps and destructure with a true default
+- [ ] 1.2 Gate the footer duration label and update the memo dependencies
+
+### Phase 2: Test coverage
+
+- [ ] 2.1 Add a test pinning both the on and off footer branches

--- a/.ai/runs/2026-08-14-datatable-show-query-time.md
+++ b/.ai/runs/2026-08-14-datatable-show-query-time.md
@@ -55,9 +55,9 @@ rendering exactly.
 
 ### Phase 1: Prop and footer gate
 
-- [ ] 1.1 Add the prop to DataTableProps and destructure with a true default
-- [ ] 1.2 Gate the footer duration label and update the memo dependencies
+- [x] 1.1 Add the prop to DataTableProps and destructure with a true default — 027fbdd0a
+- [x] 1.2 Gate the footer duration label and update the memo dependencies — 027fbdd0a
 
 ### Phase 2: Test coverage
 
-- [ ] 2.1 Add a test pinning both the on and off footer branches
+- [x] 2.1 Add a test pinning both the on and off footer branches — 027fbdd0a

--- a/.ai/runs/2026-08-14-datatable-show-query-time.md
+++ b/.ai/runs/2026-08-14-datatable-show-query-time.md
@@ -51,6 +51,8 @@ rendering exactly.
 
 ## Progress
 
+PR: #5310
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Prop and footer gate

--- a/packages/ui/src/backend/DataTable.tsx
+++ b/packages/ui/src/backend/DataTable.tsx
@@ -295,6 +295,8 @@ export type DataTableProps<T extends RowData> = {
   sorting?: SortingState
   onSortingChange?: (s: SortingState) => void
   pagination?: PaginationProps
+  /** Render the query duration in the pagination footer. Set to false for a count-only footer. */
+  showQueryTime?: boolean
   isLoading?: boolean
   emptyState?: React.ReactNode
   error?: React.ReactNode | string | null
@@ -1206,6 +1208,7 @@ export function DataTable<T extends RowData>({
   sorting: sortingProp,
   onSortingChange,
   pagination,
+  showQueryTime = true,
   isLoading,
   emptyState,
   error,
@@ -2615,7 +2618,7 @@ export function DataTable<T extends RowData>({
     const effectiveDuration = (typeof durationMs === 'number' && Number.isFinite(durationMs) && durationMs >= 0)
       ? durationMs
       : measuredDurationMs ?? undefined
-    const durationLabel = formatDurationLabel(effectiveDuration)
+    const durationLabel = showQueryTime ? formatDurationLabel(effectiveDuration) : ''
     const normalizedCacheStatus = cacheStatus === 'hit' || cacheStatus === 'miss' ? cacheStatus : null
     const cacheBadge = normalizedCacheStatus ? (
       <span
@@ -2669,7 +2672,7 @@ export function DataTable<T extends RowData>({
         />
       </div>
     )
-  }, [pagination, measuredDurationMs, scrollTableIntoView, t])
+  }, [pagination, showQueryTime, measuredDurationMs, scrollTableIntoView, t])
 
   // Auto filters: fetch custom field defs when requested
   const resolvedEntityIds = React.useMemo(() => {

--- a/packages/ui/src/backend/__tests__/DataTable.showQueryTime.test.tsx
+++ b/packages/ui/src/backend/__tests__/DataTable.showQueryTime.test.tsx
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+import * as React from 'react'
+import { renderToString } from 'react-dom/server'
+import { DataTable } from '../DataTable'
+import type { LegacyColumnDef as ColumnDef } from '@tanstack/react-table/legacy'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { I18nProvider } from '@open-mercato/shared/lib/i18n/context'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn(), prefetch: jest.fn() }),
+}))
+
+jest.mock('../injection/useInjectionDataWidgets', () => ({
+  useInjectionDataWidgets: () => ({ widgets: [], isLoading: false }),
+}))
+
+type Row = { id: string; name: string }
+
+function renderFooter(showQueryTime?: boolean): string {
+  const columns: ColumnDef<Row>[] = [
+    { accessorKey: 'name', header: 'Name' },
+  ]
+  const queryClient = new QueryClient({ defaultOptions: { queries: { gcTime: 0 } } })
+  try {
+    return renderToString(
+      React.createElement(
+        QueryClientProvider as any,
+        { client: queryClient },
+        React.createElement(
+          I18nProvider as any,
+          { locale: 'en', dict: {} },
+          React.createElement(DataTable as any, {
+            columns,
+            data: [{ id: '1', name: 'Ada' }],
+            ...(showQueryTime === undefined ? {} : { showQueryTime }),
+            pagination: {
+              page: 1,
+              pageSize: 20,
+              total: 1,
+              totalPages: 1,
+              durationMs: 142,
+              onPageChange: () => {},
+            },
+          }),
+        ),
+      )
+    )
+  } finally {
+    queryClient.clear()
+  }
+}
+
+describe('DataTable showQueryTime', () => {
+  it('renders the query duration in the footer by default', () => {
+    const html = renderFooter(undefined)
+    expect(html).toContain('Showing 1 to 1 of 1 results in 142ms')
+  })
+
+  it('renders the count-only footer when showQueryTime is false', () => {
+    const html = renderFooter(false)
+    expect(html).toContain('Showing 1 to 1 of 1 results')
+    expect(html).not.toContain('142ms')
+    expect(html).not.toContain('results in')
+  })
+
+  it('renders the query duration when showQueryTime is explicitly true', () => {
+    const html = renderFooter(true)
+    expect(html).toContain('Showing 1 to 1 of 1 results in 142ms')
+  })
+})


### PR DESCRIPTION
## Summary

Adds an additive, opt-out `showQueryTime` prop to `DataTable` so a list page can suppress the footer's query-duration suffix ("Showing 1 to 10 of 42 results **in 142ms**"). Requested in #5304: the timing is useful to developers but reads as noise to end users, and until now there was no way to turn it off.

The prop defaults to `true`, so **no existing call site changes behaviour**. When set to `false`, the footer falls back to the existing count-only `ui.dataTable.pagination.results` key that it already uses whenever no duration is available — so no new locale keys are needed in any of the shipped dictionaries.

## Scope

- `packages/ui/src/backend/DataTable.tsx` — the prop, its default, and the footer gate.
- A unit test pinning both branches of the footer string.

Deliberately out of scope, per the issue: making the default environment-dependent ("on in development, off in production"). #5304 names the prop as the smaller, more reversible step that can land first either way, so this PR keeps the default `true` everywhere and leaves that decision open.

## Backward compatibility

`BACKWARD_COMPATIBILITY.md` (§3, Types & Signatures) classifies `DataTable` component props as **MUST NOT remove existing props**. This change removes nothing and narrows nothing — it adds one optional prop whose default reproduces today's rendering exactly, so no deprecation protocol applies.

## Tests

`DataTable.showQueryTime.test.tsx` pins both branches against the same `pagination.durationMs` input: the default render contains the duration suffix, and the `showQueryTime={false}` render contains the count-only string and does not contain the duration.

Tracking plan: `.ai/runs/2026-08-14-datatable-show-query-time.md`
Status: complete

Closes #5304
