### PR TITLE
fix(create-app): separate the Git init prompt from its result (#5316)

### DIFF
--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -153,7 +153,7 @@ function parseArgs(args: string[]): { appName: string | null; options: Options }
   return { appName, options }
 }
 
-type Ask = (question: string) => Promise<string>
+export type Ask = (question: string) => Promise<string>
 
 const PRESET_PROMPT_OPTIONS = [
   { number: '1', id: 'classic', label: 'Classic     (default)', hint: 'full demo-ready starter' },
@@ -241,7 +241,7 @@ function normalizeGitInitAnswer(answer: string): boolean {
   throw new Error(`Unknown answer "${answer}". Choose yes or no.`)
 }
 
-async function promptForGitInitialization(ask: Ask): Promise<boolean> {
+export async function promptForGitInitialization(ask: Ask): Promise<boolean> {
   console.log('')
   console.log('🌱  Git repository setup')
   console.log('')
@@ -253,7 +253,9 @@ async function promptForGitInitialization(ask: Ask): Promise<boolean> {
     const answer = await ask('   Initialize Git repository? [Y/n]: ')
 
     try {
-      return normalizeGitInitAnswer(answer)
+      const shouldInitialize = normalizeGitInitAnswer(answer)
+      console.log('')
+      return shouldInitialize
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       console.log(pc.yellow(`   ${message}`))

--- a/packages/create-app/src/lib/git-init-prompt-spacing.test.ts
+++ b/packages/create-app/src/lib/git-init-prompt-spacing.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { promptForGitInitialization } from '../index.ts'
+
+const PROMPT_MARKER = 'ask> '
+
+async function runGitInitPrompt(answers: string[]): Promise<{ result: boolean, output: string[] }> {
+  const output: string[] = []
+  const originalLog = console.log
+  const queuedAnswers = [...answers]
+
+  console.log = (...args: unknown[]) => {
+    output.push(args.map((arg) => String(arg)).join(' '))
+  }
+
+  try {
+    const result = await promptForGitInitialization(async (question) => {
+      output.push(`${PROMPT_MARKER}${question}`)
+      return queuedAnswers.shift() ?? ''
+    })
+
+    return { result, output }
+  } finally {
+    console.log = originalLog
+  }
+}
+
+test('accepting the Git prompt prints a blank line after the answer', async () => {
+  const { result, output } = await runGitInitPrompt(['y'])
+
+  assert.equal(result, true)
+  assert.equal(output.at(-1), '')
+  assert.ok(output.at(-2)?.startsWith(PROMPT_MARKER))
+})
+
+test('declining the Git prompt prints a blank line after the answer', async () => {
+  const { result, output } = await runGitInitPrompt(['n'])
+
+  assert.equal(result, false)
+  assert.equal(output.at(-1), '')
+  assert.ok(output.at(-2)?.startsWith(PROMPT_MARKER))
+})
+
+test('an unusable answer re-prompts and the blank line follows the accepted answer', async () => {
+  const { result, output } = await runGitInitPrompt(['maybe', 'y'])
+
+  assert.equal(result, true)
+  assert.equal(output.filter((line) => line.startsWith(PROMPT_MARKER)).length, 2)
+  assert.ok(output.some((line) => line.includes('Unknown answer "maybe"')))
+  assert.equal(output.at(-1), '')
+  assert.ok(output.at(-2)?.startsWith(PROMPT_MARKER))
+})


### PR DESCRIPTION
Closes #5316

## 🎯 Goal
- `create-mercato-app` no longer prints its Git-initialization result flush against the echoed prompt answer, so the scaffolder's terminal output stays readable.

## 🔍 Problem
When the interactive Git prompt is answered, the very next line lands directly under the echoed answer:

```
   Initialize Git repository? [Y/n]: y
Initialized local Git repository.
```

The same collision happens when the answer is `n` — the `Next steps:` block starts on the line right after the prompt.

## 🔍 Root Cause
`promptForGitInitialization` in `packages/create-app/src/index.ts` returned the normalized answer straight out of its prompt loop. Every other section of the wizard is separated by a blank line, and `maybeInitializeGitRepository` only prints a trailing blank line after its status message — nothing emitted the leading one, and the skipped path returned before printing anything at all.

## What Changed
- `packages/create-app/src/index.ts`: `promptForGitInitialization` now logs a blank line once `normalizeGitInitAnswer` accepts the answer, before returning. This covers both branches — the `Initialized local Git repository.` / `Git repository already initialized.` / failure status lines and the skipped path that goes straight to `Next steps:`. Re-prompts after an unusable answer are untouched, and the non-interactive `--init-git` / `--no-init-git` paths never reach the prompt, so their spacing is unchanged.
- `packages/create-app/src/index.ts`: `promptForGitInitialization` and the `Ask` type are exported so the prompt's output can be unit-tested (additive only; no existing export changed).
- `packages/create-app/src/lib/git-init-prompt-spacing.test.ts` (new): drives the prompt with a fake `ask`, capturing prompt and `console.log` output in order.

## 🧪 Tests
- `node --import tsx --test src/lib/{git-init-prompt-spacing,registry-config,dev-splash-git-repo-flow,ready-apps}.test.ts` — 28 passed / 0 failed (includes the `--init-git` scaffold integration test).
- `yarn workspace create-mercato-app typecheck` — clean.
- `yarn build:packages` — clean.
- New cases lock in that the blank line is emitted **after** the accepted answer, on the accept path, the decline path, and the re-prompt path. Verified red before the fix (last captured line was the prompt, not a blank line) and green after.
- Gate commands not run in this worktree, none of which touch the changed file: `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, the monorepo-wide `yarn typecheck` / `yarn test`, and `yarn build:app` — left to CI.

## 💥 Breaking Changes
- None. Only terminal whitespace changes; two additive exports in `create-mercato-app`'s entrypoint.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789330543&installation_model_id=432243&pr_number=5319&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5319&signature=ff2a17db9e4fe93f837417e928732261213f0a761960d248ff275bf70bf55287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->