### PR TITLE
fix(customers): stop deal association selectors from searching on mount (#5118)

### DIFF
--- a/packages/core/src/modules/customers/components/detail/DealForm.tsx
+++ b/packages/core/src/modules/customers/components/detail/DealForm.tsx
@@ -102,6 +102,12 @@ type EntityMultiSelectProps = {
   fetchByIds: (ids: string[]) => Promise<EntityOption[]>
   disabled?: boolean
   autoFocus?: boolean
+  /**
+   * Minimum trimmed query length before a lookup request is issued. Defaults to
+   * `1`, so a blank input never queries the address book (issue #5118). Set `0`
+   * to opt back into prefetching an unfiltered first page on mount.
+   */
+  minQueryLength?: number
 }
 
 const DEAL_ENTITY_IDS = [E.customers.customer_deal]
@@ -353,6 +359,7 @@ function EntityMultiSelect({
   fetchByIds,
   disabled = false,
   autoFocus = false,
+  minQueryLength = 1,
 }: EntityMultiSelectProps) {
   const [input, setInput] = React.useState('')
   const [suggestions, setSuggestions] = React.useState<EntityOption[]>([])
@@ -401,11 +408,18 @@ function EntityMultiSelect({
       setLoading(false)
       return
     }
+    const term = input.trim()
+    if (term.length < minQueryLength) {
+      setSuggestions([])
+      setLoading(false)
+      setError(null)
+      return
+    }
     let cancelled = false
     const handler = window.setTimeout(async () => {
       setLoading(true)
       try {
-        const results = await search(input.trim())
+        const results = await search(term)
         if (cancelled) return
         setSuggestions(results)
         setCache((prev) => {
@@ -429,7 +443,7 @@ function EntityMultiSelect({
       cancelled = true
       window.clearTimeout(handler)
     }
-  }, [disabled, errorLabel, input, search])
+  }, [disabled, errorLabel, input, minQueryLength, search])
 
   const filteredSuggestions = React.useMemo(
     () => suggestions.filter((option) => !normalizedValue.includes(option.id)),
@@ -660,12 +674,14 @@ export function DealPeopleSelector({
   options = [],
   disabled = false,
   autoFocus = false,
+  minQueryLength,
 }: {
   value: string[]
   onChange: (next: string[]) => void
   options?: EntityOption[]
   disabled?: boolean
   autoFocus?: boolean
+  minQueryLength?: number
 }) {
   const t = useT()
   const { searchPeople, fetchPeopleByIds } = useDealAssociationLookups()
@@ -685,6 +701,7 @@ export function DealPeopleSelector({
       fetchByIds={fetchPeopleByIds}
       disabled={disabled}
       autoFocus={autoFocus}
+      minQueryLength={minQueryLength}
     />
   )
 }
@@ -694,11 +711,13 @@ export function DealCompaniesSelector({
   onChange,
   options = [],
   disabled = false,
+  minQueryLength,
 }: {
   value: string[]
   onChange: (next: string[]) => void
   options?: EntityOption[]
   disabled?: boolean
+  minQueryLength?: number
 }) {
   const t = useT()
   const { searchCompanies, fetchCompaniesByIds } = useDealAssociationLookups()
@@ -717,6 +736,7 @@ export function DealCompaniesSelector({
       search={searchCompanies}
       fetchByIds={fetchCompaniesByIds}
       disabled={disabled}
+      minQueryLength={minQueryLength}
     />
   )
 }

--- a/packages/core/src/modules/customers/components/detail/__tests__/DealForm.associationLookups.test.tsx
+++ b/packages/core/src/modules/customers/components/detail/__tests__/DealForm.associationLookups.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+
+const apiCallMock = jest.fn()
+const readApiResultOrThrowMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+  readApiResultOrThrow: (...args: unknown[]) => readApiResultOrThrowMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: () => null,
+}))
+
+import { DealCompaniesSelector, DealPeopleSelector } from '../DealForm'
+
+const DEBOUNCE_SETTLE_MS = 400
+
+async function settleDebounce() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, DEBOUNCE_SETTLE_MS))
+  })
+}
+
+describe('deal association selectors', () => {
+  beforeEach(() => {
+    apiCallMock.mockReset()
+    readApiResultOrThrowMock.mockReset()
+    apiCallMock.mockResolvedValue({
+      ok: true,
+      result: {
+        items: [{ id: 'person-1', displayName: 'Ada Lovelace', primaryEmail: 'ada@example.com' }],
+        totalPages: 1,
+      },
+    })
+  })
+
+  it('issues no lookup request while the search input is empty', async () => {
+    renderWithProviders(
+      <>
+        <DealPeopleSelector value={[]} onChange={() => {}} />
+        <DealCompaniesSelector value={[]} onChange={() => {}} />
+      </>,
+    )
+
+    await settleDebounce()
+
+    expect(apiCallMock).not.toHaveBeenCalled()
+  })
+
+  it('searches only after the user types and stops again when the input is cleared', async () => {
+    renderWithProviders(<DealPeopleSelector value={[]} onChange={() => {}} />)
+
+    const input = screen.getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'ada' } })
+
+    await waitFor(() => {
+      expect(apiCallMock).toHaveBeenCalledTimes(1)
+    })
+    expect(apiCallMock).toHaveBeenCalledWith(expect.stringContaining('search=ada'))
+    await screen.findByRole('button', { name: 'Ada Lovelace' })
+
+    fireEvent.change(input, { target: { value: '   ' } })
+    await settleDebounce()
+
+    expect(apiCallMock).toHaveBeenCalledTimes(1)
+    expect(screen.queryByRole('button', { name: 'Ada Lovelace' })).toBeNull()
+  })
+
+  it('still prefetches an unfiltered page when a host opts in with minQueryLength 0', async () => {
+    renderWithProviders(<DealPeopleSelector value={[]} onChange={() => {}} minQueryLength={0} />)
+
+    await waitFor(() => {
+      expect(apiCallMock).toHaveBeenCalledTimes(1)
+    })
+    expect(apiCallMock).toHaveBeenCalledWith(expect.not.stringContaining('search='))
+  })
+})


### PR DESCRIPTION
Closes #5118

## 🎯 Goal
- Opening a deal form (or the "Add deal" dialog) no longer lists an arbitrary first page of every person and every company in the tenant. The People / Companies association selectors stay quiet until the user actually types something, so no contact data is surfaced — and no lookup request is issued — before there is a search term.

## 🔍 Problem
`EntityMultiSelect` ran its debounced search effect on mount with an empty input, so each deal form issued `search('')` once per selector. The customers lookup endpoints treat a blank `search` param as "no filter" and return the first page of the whole address book, which the component then rendered as suggestions before any user input. A single deal form mounts several of these selectors, and every remount repeated the requests — an incidental exposure of unrelated contact records, a noisy first impression for the dropdown, and two unfiltered list queries per form open.

## 🔍 Root Cause
In `packages/core/src/modules/customers/components/detail/DealForm.tsx`, the search effect of `EntityMultiSelect` scheduled its 200 ms debounce unconditionally and then called `search(input.trim())`. On mount `input` is `''`, so the timer elapsed and the lookup went out with an empty term. `searchPeoplePage` / `searchCompaniesPage` only set the `search` query param when the term is non-empty, so a blank term hit `/api/customers/people?page=1&pageSize=20&…` — an unfiltered first page. There was no empty-query guard anywhere on that path.

## What Changed
- `packages/core/src/modules/customers/components/detail/DealForm.tsx`: `EntityMultiSelect` now computes the trimmed term before scheduling anything and returns early when it is shorter than `minQueryLength` (new prop, default `1`), clearing suggestions, the loading flag and the stale error instead of firing a request. No debounce timer is even scheduled for a blank input, and clearing a typed query drops the previous suggestion list rather than replacing it with an unfiltered page.
- Same file: `minQueryLength` is threaded through the exported `DealPeopleSelector` and `DealCompaniesSelector` wrappers, so a host with a large dataset can require two or more characters, and a host that genuinely wants today's prefetch-on-open behavior can opt back in with `minQueryLength={0}`. The debounced request path itself is otherwise untouched.

## 🧪 Tests
- `packages/core/src/modules/customers/components/detail/__tests__/DealForm.associationLookups.test.tsx` (new, 3 cases): no lookup request is issued while the input is empty (both selectors mounted); a request goes out only after the user types, and clearing the input back to whitespace issues no further request and drops the rendered suggestions; `minQueryLength={0}` still prefetches an unfiltered page for hosts that opt in.
- Verified red before the fix — with the guard disabled, the empty-input and clear-input cases both fail with the extra `apiCall` — and green after.
- Validation gate (`.ai/agentic.config.json`, local runner — no compose `app` container was up): `yarn build:packages` ✅ (both passes), `yarn generate` ✅ (no generated-file churn), `yarn i18n:check-sync` ✅, `yarn i18n:check-usage` ✅, `yarn typecheck` ✅ (22 tasks), `yarn test` ✅ for every package except `create-mercato-app`, `yarn build:app` ✅.
- `create-mercato-app`'s `src/lib/agent-harness-evaluator.test.ts` fails locally in this sandbox (65 of 151 cases, all reporting `process-failure: runner timed out or was terminated (SIGABRT)` from the fake Claude/Codex runner processes it spawns). It reproduces the same way when that single suite is run on its own, this PR touches no file in `packages/create-app`, and develop's CI is green at the same base commit — so the failure is environmental, not a regression from this change. CI on this PR is the authoritative check.

## 💥 Breaking Changes
- None. `EntityMultiSelect` is module-internal and the new prop is optional; the exported `DealPeopleSelector` / `DealCompaniesSelector` props are additive. The only behavior change is the intended one: association selectors no longer prefetch an unfiltered page on mount (restorable per host with `minQueryLength={0}`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789331283&installation_model_id=432243&pr_number=5320&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5320&signature=61206d19e5f1e602e2ff44b51ab35fbb0bc3c4d84150c8803358627dad19eb8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->