### PR TITLE
refactor(customers/calendar): delegate Month pill and Agenda row time formatting to the shared helper (#5275)

### DIFF
--- a/packages/core/src/modules/customers/components/calendar/AgendaList.tsx
+++ b/packages/core/src/modules/customers/components/calendar/AgendaList.tsx
@@ -11,6 +11,7 @@ import { cn } from '@open-mercato/shared/lib/utils'
 import { Avatar } from '@open-mercato/ui/primitives/avatar'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { eventDisplayTitle, pluralCategory } from '../../lib/calendar/labels'
+import { formatTimeLabel, formatTimeRangeLabel } from '../../lib/calendar/format'
 import type { AgendaListProps, CalendarCategory, CalendarItem } from './types'
 
 const MAX_AVATARS_PER_ROW = 2
@@ -42,10 +43,6 @@ function formatUrlHost(location: string): string {
   } catch {
     return location
   }
-}
-
-function formatTime(locale: string, date: Date): string {
-  return date.toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' })
 }
 
 function groupLabelOf(locale: string, date: Date): string {
@@ -132,9 +129,9 @@ function AgendaRow({
     : item.locationKind === 'url' && item.location
       ? formatUrlHost(item.location)
       : item.location
-  const startLabel = item.allDay ? t('customers.calendar.grid.allDay', 'All day') : formatTime(locale, item.start)
-  const endLabel = item.allDay ? null : formatTime(locale, item.end)
-  const ariaTime = item.allDay ? startLabel : `${startLabel} – ${endLabel}`
+  const startLabel = item.allDay ? t('customers.calendar.grid.allDay', 'All day') : formatTimeLabel(locale, item.start)
+  const endLabel = item.allDay ? null : formatTimeLabel(locale, item.end)
+  const ariaTime = item.allDay ? startLabel : formatTimeRangeLabel(locale, item.start, item.end)
   return (
     <Button
       type="button"

--- a/packages/core/src/modules/customers/components/calendar/MonthGrid.tsx
+++ b/packages/core/src/modules/customers/components/calendar/MonthGrid.tsx
@@ -10,6 +10,7 @@ import { cn } from '@open-mercato/shared/lib/utils'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { getVisibleRange } from '../../lib/calendar/range'
 import { eventDisplayTitle } from '../../lib/calendar/labels'
+import { formatTimeRangeLabel } from '../../lib/calendar/format'
 import type { CalendarItem, MonthGridProps } from './types'
 
 const MAX_PILLS_PER_DAY = 2
@@ -17,10 +18,6 @@ const SOFT_TINT_ALPHA = '1A'
 
 function dayKeyOf(date: Date): string {
   return format(date, 'yyyy-MM-dd')
-}
-
-function formatTime(locale: string, date: Date): string {
-  return date.toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' })
 }
 
 function fullDateLabel(locale: string, date: Date): string {
@@ -64,7 +61,7 @@ function MonthPill({ item, onItemClick }: { item: CalendarItem; onItemClick: (it
   const locale = useLocale()
   const canceled = item.status === 'canceled'
   const title = eventDisplayTitle(item.title, t('customers.calendar.grid.untitled', 'Untitled'))
-  const timeLabel = item.allDay ? '' : ` · ${formatTime(locale, item.start)} – ${formatTime(locale, item.end)}`
+  const timeLabel = item.allDay ? '' : ` · ${formatTimeRangeLabel(locale, item.start, item.end)}`
   const tintStyle = item.color
     ? { backgroundColor: `${item.color}${SOFT_TINT_ALPHA}`, color: item.color }
     : undefined

--- a/packages/core/src/modules/customers/components/calendar/__tests__/AgendaList.test.tsx
+++ b/packages/core/src/modules/customers/components/calendar/__tests__/AgendaList.test.tsx
@@ -5,6 +5,8 @@ import * as React from 'react'
 import { cleanup } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { AgendaList } from '../AgendaList'
+import { formatTimeRange } from '../EventBlock'
+import { formatTimeLabel } from '../../../lib/calendar/format'
 import { buildCalendarItem } from './fixtures'
 
 const AGENDA_ANCHOR = new Date(2026, 7, 10, 0, 0, 0)
@@ -23,6 +25,11 @@ function dayGroupHeadingText(container: HTMLElement): string {
 
 function eventRowLabel(container: HTMLElement): string {
   return container.querySelector('button[aria-label]')?.getAttribute('aria-label') ?? ''
+}
+
+function eventRowTimes(container: HTMLElement): string[] {
+  const timeColumn = container.querySelector('button[aria-label]')?.firstElementChild
+  return Array.from(timeColumn?.querySelectorAll('span') ?? []).map((span) => span.textContent ?? '')
 }
 
 describe('AgendaList — locale-aware date/time formatting (#5116)', () => {
@@ -59,4 +66,25 @@ describe('AgendaList — locale-aware date/time formatting (#5116)', () => {
     expect(plText).not.toBe('')
     expect(plText).not.toBe(enText)
   })
+})
+
+describe('AgendaList — shared time formatting (#5275)', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it.each(['pl', 'de'])(
+    'renders the event row start, end and range exactly as the week view renders them in %s',
+    (locale) => {
+      const item = buildCalendarItem()
+
+      const view = renderAgenda(locale)
+      const rowLabel = eventRowLabel(view.container)
+      const rowTimes = eventRowTimes(view.container)
+      view.unmount()
+
+      expect(rowTimes).toEqual([formatTimeLabel(locale, item.start), formatTimeLabel(locale, item.end)])
+      expect(rowLabel).toBe(`${item.title} · ${formatTimeRange(locale, item.start, item.end)}`)
+    },
+  )
 })

--- a/packages/core/src/modules/customers/components/calendar/__tests__/MonthGrid.test.tsx
+++ b/packages/core/src/modules/customers/components/calendar/__tests__/MonthGrid.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react'
 import { cleanup } from '@testing-library/react'
 import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
 import { MonthGrid } from '../MonthGrid'
+import { formatTimeRange } from '../EventBlock'
 import type { CalendarItem } from '../types'
 import { buildCalendarItem } from './fixtures'
 
@@ -79,4 +80,23 @@ describe('MonthGrid — locale-aware date formatting (#5116)', () => {
     expect(plLabel).not.toBe('')
     expect(plLabel).not.toBe(enLabel)
   })
+})
+
+describe('MonthGrid — shared time-range formatting (#5275)', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it.each(['pl', 'de'])(
+    'renders the event pill range exactly as the week view renders it in %s',
+    (locale) => {
+      const item = buildCalendarItem()
+
+      const view = renderGrid(locale, [item])
+      const pillLabel = eventPillLabel(view.container)
+      view.unmount()
+
+      expect(pillLabel).toBe(`${item.title} · ${formatTimeRange(locale, item.start, item.end)}`)
+    },
+  )
 })

--- a/packages/core/src/modules/customers/components/calendar/__tests__/MonthGrid.test.tsx
+++ b/packages/core/src/modules/customers/components/calendar/__tests__/MonthGrid.test.tsx
@@ -30,6 +30,10 @@ function eventPillLabel(container: HTMLElement): string {
   return container.querySelector('button[aria-label*="–"]')?.getAttribute('aria-label') ?? ''
 }
 
+function eventPillLabelByTitle(container: HTMLElement, title: string): string {
+  return container.querySelector(`button[aria-label^="${title}"]`)?.getAttribute('aria-label') ?? ''
+}
+
 describe('MonthGrid — locale-aware date formatting (#5116)', () => {
   afterEach(() => {
     cleanup()
@@ -93,7 +97,7 @@ describe('MonthGrid — shared time-range formatting (#5275)', () => {
       const item = buildCalendarItem()
 
       const view = renderGrid(locale, [item])
-      const pillLabel = eventPillLabel(view.container)
+      const pillLabel = eventPillLabelByTitle(view.container, item.title)
       view.unmount()
 
       expect(pillLabel).toBe(`${item.title} · ${formatTimeRange(locale, item.start, item.end)}`)

--- a/packages/core/src/modules/customers/lib/calendar/__tests__/format.test.ts
+++ b/packages/core/src/modules/customers/lib/calendar/__tests__/format.test.ts
@@ -1,4 +1,4 @@
-import { formatDateLabel, formatDateRangeLabel, formatTimeRangeLabel } from '../format'
+import { formatDateLabel, formatDateRangeLabel, formatTimeLabel, formatTimeRangeLabel } from '../format'
 
 const JUN_15 = new Date(2026, 5, 15)
 const JUN_21 = new Date(2026, 5, 21)
@@ -47,6 +47,27 @@ describe('formatDateLabel', () => {
 
   it('keeps English month names for the English locale', () => {
     expect(formatDateLabel('en', JUN_28)).toContain('Jun')
+  })
+})
+
+describe('formatTimeLabel', () => {
+  it('renders a 24h time for Polish without AM/PM markers', () => {
+    expect(formatTimeLabel('pl', AT_14)).toBe('14:00')
+  })
+
+  it('uses the 12h clock for the English locale', () => {
+    expect(formatTimeLabel('en', AT_14)).toBe('2:00 PM')
+  })
+
+  it('uses hydration-stable spacing inside the localized time', () => {
+    expect(formatTimeLabel('en', AT_14)).not.toMatch(HYDRATION_UNSTABLE_SPACING)
+  })
+
+  it('formats each endpoint the same way the range formatter does', () => {
+    for (const locale of ['en', 'pl', 'de']) {
+      const range = formatTimeRangeLabel(locale, AT_14, AT_15)
+      expect(range).toContain(formatTimeLabel(locale, AT_15))
+    }
   })
 })
 

--- a/packages/core/src/modules/customers/lib/calendar/format.ts
+++ b/packages/core/src/modules/customers/lib/calendar/format.ts
@@ -21,6 +21,10 @@ export function formatDateRangeLabel(locale: string, from: Date, to: Date): stri
   }
 }
 
+export function formatTimeLabel(locale: string, date: Date): string {
+  return normalizeIntlSpacing(new Intl.DateTimeFormat(locale, TIME_OPTIONS).format(date))
+}
+
 export function formatTimeRangeLabel(locale: string, start: Date, end: Date): string {
   const formatter = new Intl.DateTimeFormat(locale, TIME_OPTIONS)
   try {


### PR DESCRIPTION
Closes #5275

## 🎯 Goal
- The Month pill and the Agenda row now render event times exactly the way the Week view and the Upcoming cards do, so a Polish or German user no longer sees two different renderings of the same interval on the same calendar screen.

## 🔍 Problem
`packages/core/src/modules/customers/lib/calendar/format.ts` already exported a tested, locale-aware `formatTimeRangeLabel(locale, start, end)`, and `EventBlock` (Week view) plus `UpcomingCards` used it. `MonthGrid.tsx` and `AgendaList.tsx` each kept their own module-private `formatTime` and joined the range by hand with `${start} – ${end}`, leaving the module with three separate time formatters. This is the follow-up #5160 deferred (💅 Nit 1 of @wojciechszyjka's review), not a regression introduced by it.

## 🔍 Root Cause
The private helpers called `date.toLocaleTimeString(locale, …)` per endpoint and concatenated the two results with a hard-coded spaced en dash, while the shared helper uses `Intl.DateTimeFormat.formatRange` plus a spacing normalizer. `formatRange` is not a plain en-dash join in every locale: for the same 12:00–13:00 interval the shared helper produces `12:00–13:00` in `pl` and `12:00–13:00 Uhr` in `de`, whereas the private path produced `12:00 – 13:00` in both. The Month pill and the Agenda row therefore disagreed with the Week view and the Upcoming cards.

## What Changed
- `packages/core/src/modules/customers/lib/calendar/format.ts` — added `formatTimeLabel(locale, date)` next to `formatTimeRangeLabel`, sharing the same `TIME_OPTIONS` and the same `normalizeIntlSpacing` hydration-stable spacing pass, for the callers that need a single endpoint rather than a range.
- `packages/core/src/modules/customers/components/calendar/MonthGrid.tsx` — `MonthPill` builds its time label with `formatTimeRangeLabel(locale, item.start, item.end)`; the module-private `formatTime` is removed.
- `packages/core/src/modules/customers/components/calendar/AgendaList.tsx` — `AgendaRow` renders its two separate start/end spans with `formatTimeLabel` and its `aria-label` range with `formatTimeRangeLabel` instead of a manual en-dash join; the module-private `formatTime` is removed.
- Net effect: the calendar module is down to one locale-aware time formatter family, in one file, with one set of tests.

## 🧪 Tests
- `yarn workspace @open-mercato/core test` — 9735 passed / 1246 suites, including the new cases.
- `format.test.ts` — new `formatTimeLabel` block: 24h rendering for `pl`, 12h `2:00 PM` for `en`, hydration-stable spacing, and an assertion that each endpoint the range formatter emits is byte-identical to `formatTimeLabel` output in `en`, `pl` and `de`.
- `MonthGrid.test.tsx` / `AgendaList.test.tsx` — new `#5275` blocks assert, for `pl` and `de`, that the pill aria label and the agenda row's spans + aria label equal what `formatTimeRange` (the Week view's own exported formatter) produces for the same interval. Both blocks were verified to fail against the pre-fix components (4 failures, e.g. expected `Quarterly review · 12:00–13:00 Uhr`, received `Quarterly review · 12:00 – 13:00`) and to pass after the change.
- Validation gate from `.ai/agentic.config.json`, run locally in order: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test`, `yarn build:app` — all green except `create-mercato-app`'s `writable-ast-oracles` suite, which fails identically on an unmodified checkout of this branch's base (its live Claude/Codex adapter cases and a 120s `yarn typecheck` budget need an environment this worktree does not have). That failure is pre-existing and untouched by this diff.

## 💥 Breaking Changes
- None. `formatTimeLabel` is a new additive export; no existing signature, prop, or rendered string changes for `en`, and the `pl`/`de` strings that do change are the ones the issue asks to bring in line with the Week view.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789331590&installation_model_id=432243&pr_number=5321&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5321&signature=9cffa739753dd87b445ba443d3f23b2fd9115ef94924767a697368a0bd9e3572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->