### PR TITLE
fix(ai-assistant): publish MCP tool annotations in tools/list (#5283)

### DIFF
--- a/.ai/runs/2026-08-20-issue-5283-mcp-readonly-annotations.md
+++ b/.ai/runs/2026-08-20-issue-5283-mcp-readonly-annotations.md
@@ -1,0 +1,51 @@
+# Execution plan — complete MCP tool-annotation review fixes (adopted from PR #5322)
+
+**Origin:** adopted — reconstructed by `om-auto-continue-pr` on 2026-08-20 because PR #5322 carried no execution plan.
+**PR:** #5322 · **Branch:** `fix/issue-5283-mcp-readonly-annotations` · **Base:** `develop`
+**Author:** @Paul-Mlodochowki — this plan interprets their intent; correct it by editing this file or commenting on the PR.
+
+## 🎯 Goal
+
+Publish correct MCP tool annotations and address every actionable finding from the PR's code review.
+
+## Scope
+
+MCP tool metadata, its client/server coverage, and the authoring guidance that governs mutation declarations.
+
+## Non-goals
+
+No change to MCP authorization semantics, API execution behavior, or unrelated documentation.
+
+## Evidence
+
+| Conclusion | Drawn from | Confidence |
+|---|---|---|
+| The annotation implementation is complete. | PR description and commit `f9586eae`. | high |
+| Documentation must make mutation declarations safe to copy. | Review M1 by @pkarw. | high |
+| The remaining Low findings should be resolved with focused code and tests. | Review L1–L4 by @pkarw and user request. | high |
+
+## Assumptions
+
+The user's request to fix the review findings authorizes adoption and execution of this narrow plan without a separate confirmation.
+
+## Risks
+
+MCP annotations guide external approval behavior, so tests must preserve the conservative defaults.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Already landed on this PR (reconstructed)
+
+- [x] 1.1 Publish derived MCP annotations across tools/list surfaces — f9586eae
+
+### Phase 2: Address review findings
+
+- [ ] 2.1 Document `isMutation` as the source of MCP approval metadata
+- [ ] 2.2 Preserve the complete MCP annotation shape and document Code Mode's approval-path exception
+- [ ] 2.3 Add focused coverage for every annotation transport surface
+
+### Phase 3: Verify and hand off
+
+- [ ] 3.1 Run targeted validation, review the diff, and update the PR

--- a/.ai/runs/2026-08-20-issue-5283-mcp-readonly-annotations.md
+++ b/.ai/runs/2026-08-20-issue-5283-mcp-readonly-annotations.md
@@ -42,8 +42,8 @@ MCP annotations guide external approval behavior, so tests must preserve the con
 
 ### Phase 2: Address review findings
 
-- [ ] 2.1 Document `isMutation` as the source of MCP approval metadata
-- [ ] 2.2 Preserve the complete MCP annotation shape and document Code Mode's approval-path exception
+- [x] 2.1 Document `isMutation` as the source of MCP approval metadata — 4e4d4289
+- [x] 2.2 Preserve the complete MCP annotation shape and document Code Mode's approval-path exception — 4e4d4289
 - [ ] 2.3 Add focused coverage for every annotation transport surface
 
 ### Phase 3: Verify and hand off

--- a/apps/docs/docs/framework/ai-assistant/mcp.mdx
+++ b/apps/docs/docs/framework/ai-assistant/mcp.mdx
@@ -239,6 +239,7 @@ registerMcpTool(
     description: 'Do the thing.',
     inputSchema: z.object({ id: z.string().uuid() }),
     requiredFeatures: ['mymodule.manage'],
+    isMutation: true,
     handler: async (input) => ({ ok: true }),
   },
   { moduleId: 'mymodule' },
@@ -250,6 +251,7 @@ registerMcpTool(
 - Set `requiredFeatures` for anything that reads or writes tenant data — never leave it empty for data tools.
 - Use Zod for `inputSchema` — never raw JSON Schema.
 - Return a serializable object from the handler.
+- Set `isMutation: true` on every write tool. `tools/list` derives `readOnlyHint` from this flag, and MCP clients use that hint to decide whether a call needs human approval; an unflagged write is advertised as read-only.
 - Route every mutation through the mutation-approval path (`prepareMutation`).
 - Add the feature ids to the module's `acl.ts` and grant them in `setup.ts` `defaultRoleFeatures`.
 

--- a/packages/ai-assistant/AGENTS.md
+++ b/packages/ai-assistant/AGENTS.md
@@ -166,7 +166,7 @@ const listPeopleTool = defineAiTool({
 MUST rules:
 - MUST set `requiredFeatures` for any tool that reads or writes tenant data. The wildcard-aware ACL matcher is applied before the handler runs.
 - MUST use Zod for `inputSchema` — never raw JSON Schema.
-- MUST set `isMutation: true` on write tools. The policy gate strips these from read-only agents and from read-only tenant overrides.
+- MUST set `isMutation: true` on write tools. The policy gate strips these from read-only agents and from read-only tenant overrides, and `tools/list` derives the MCP `readOnlyHint` from the flag. MCP clients use that hint to decide whether human approval is needed, so an unflagged write is advertised as read-only.
 - MUST route every mutation tool through `prepareMutation(...)` (see the Mutation Approvals guide at `/framework/ai-assistant/mutation-approvals`). Writing directly inside the handler bypasses the approval gate — the runtime fails closed and refuses to return a result to the operator.
 - Mutation preview resolvers SHOULD return a normalized `after` snapshot and display hints when tool inputs contain dictionary IDs or other opaque values. Use `display.fieldLabels`, `display.before`, and `display.after` so `field-diff-card` shows operator-friendly names while `field`, `before`, and `after` keep the raw execution values.
 - MUST expose tools to an agent by listing the tool name in the agent's `allowedTools`. Tools not on the whitelist never reach the model.

--- a/packages/ai-assistant/AGENTS.md
+++ b/packages/ai-assistant/AGENTS.md
@@ -166,7 +166,7 @@ const listPeopleTool = defineAiTool({
 MUST rules:
 - MUST set `requiredFeatures` for any tool that reads or writes tenant data. The wildcard-aware ACL matcher is applied before the handler runs.
 - MUST use Zod for `inputSchema` — never raw JSON Schema.
-- MUST set `isMutation: true` on write tools. The policy gate strips these from read-only agents and from read-only tenant overrides, and `tools/list` derives the MCP `readOnlyHint` from the flag. MCP clients use that hint to decide whether human approval is needed, so an unflagged write is advertised as read-only.
+- MUST set `isMutation: true` on write tools. It gates read-only agents/overrides and drives the MCP `readOnlyHint` in `tools/list`.
 - MUST route every mutation tool through `prepareMutation(...)` (see the Mutation Approvals guide at `/framework/ai-assistant/mutation-approvals`). Writing directly inside the handler bypasses the approval gate — the runtime fails closed and refuses to return a result to the operator.
 - Mutation preview resolvers SHOULD return a normalized `after` snapshot and display hints when tool inputs contain dictionary IDs or other opaque values. Use `display.fieldLabels`, `display.before`, and `display.after` so `field-diff-card` shows operator-friendly names while `field`, `before`, and `after` keep the raw execution values.
 - MUST expose tools to an agent by listing the tool name in the agent's `allowedTools`. Tools not on the whitelist never reach the model.

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tool-annotations.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/codemode-tool-annotations.test.ts
@@ -1,0 +1,58 @@
+import { loadCodeModeTools } from '../codemode-tools'
+import { buildMcpToolAnnotations } from '../mcp-tool-annotations'
+import { registerMcpTool } from '../tool-registry'
+import type { McpToolDefinition } from '../types'
+
+jest.mock('../api-endpoint-index', () => ({
+  getApiEndpoints: jest.fn(async () => []),
+  getRawOpenApiSpec: jest.fn(async () => null),
+}))
+
+jest.mock('../tool-registry', () => ({
+  registerMcpTool: jest.fn(),
+}))
+
+const mockedRegisterMcpTool = jest.mocked(registerMcpTool)
+
+async function loadRegisteredCodeModeTools(): Promise<Map<string, McpToolDefinition>> {
+  await loadCodeModeTools()
+  const tools = new Map<string, McpToolDefinition>()
+  for (const call of mockedRegisterMcpTool.mock.calls) {
+    const tool = call[0] as McpToolDefinition
+    tools.set(tool.name, tool)
+  }
+  return tools
+}
+
+describe('issue #5283 — Code Mode tools declare their mutation surface', () => {
+  beforeEach(() => {
+    mockedRegisterMcpTool.mockClear()
+  })
+
+  it('advertises the spec-querying search tool as read-only', async () => {
+    const tools = await loadRegisteredCodeModeTools()
+    const search = tools.get('search')
+
+    expect(search).toBeDefined()
+    expect(buildMcpToolAnnotations(search!)).toEqual({ readOnlyHint: true })
+  })
+
+  it('never advertises the api.request() execute tool as read-only', async () => {
+    const tools = await loadRegisteredCodeModeTools()
+    const execute = tools.get('execute')
+
+    expect(execute).toBeDefined()
+    expect(buildMcpToolAnnotations(execute!)).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+    })
+  })
+
+  it('registers both Code Mode tools under the codemode module id', async () => {
+    await loadRegisteredCodeModeTools()
+
+    for (const call of mockedRegisterMcpTool.mock.calls) {
+      expect(call[1]).toEqual({ moduleId: 'codemode' })
+    }
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-client.test.ts
@@ -90,4 +90,34 @@ describe('McpClient stdio transport', () => {
     expect(transportArgs.args).not.toContain('omk_secret.value')
     expect(JSON.stringify(transportArgs.args)).not.toContain('omk_secret.value')
   })
+
+  it('preserves all MCP tool annotations returned by a remote server', async () => {
+    mockClientListTools.mockResolvedValueOnce({
+      tools: [{
+        name: 'customers.update_company',
+        description: 'Update a company.',
+        inputSchema: {},
+        annotations: {
+          title: 'Update company',
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      }],
+    })
+    const client = await McpClient.connect({ transport: 'stdio', apiKeySecret: 'test-secret' })
+
+    await expect(client.listTools()).resolves.toEqual([
+      expect.objectContaining({
+        annotations: {
+          title: 'Update company',
+          readOnlyHint: false,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      }),
+    ])
+  })
 })

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-server-tool-annotations.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-server-tool-annotations.test.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod'
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js'
+import { createMcpServer } from '../mcp-server'
+import type { AiToolDefinition, McpServerOptions, McpToolDefinition } from '../types'
+
+const mockCapturedHandlers = new Map<unknown, (request: unknown) => Promise<unknown>>()
+const mockRegisteredTools = new Map<string, McpToolDefinition>()
+
+jest.mock('@modelcontextprotocol/sdk/server/index.js', () => ({
+  Server: class {
+    setRequestHandler(schema: unknown, handler: (request: unknown) => Promise<unknown>) {
+      mockCapturedHandlers.set(schema, handler)
+    }
+  },
+}))
+jest.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+  StdioServerTransport: class {},
+}))
+jest.mock('@modelcontextprotocol/sdk/types.js', () => ({
+  ListToolsRequestSchema: { id: 'tools/list' },
+  CallToolRequestSchema: { id: 'tools/call' },
+}))
+jest.mock('../tool-registry', () => ({
+  getToolRegistry: () => ({
+    getTools: () => mockRegisteredTools,
+    listToolNames: () => Array.from(mockRegisteredTools.keys()),
+  }),
+}))
+jest.mock('../tool-executor', () => ({ executeTool: jest.fn() }))
+jest.mock('../tool-loader', () => ({
+  loadAllModuleTools: jest.fn(),
+  indexToolsForSearch: jest.fn(),
+}))
+jest.mock('../auth', () => ({
+  authenticateMcpRequest: jest.fn(),
+  hasRequiredFeatures: jest.fn(() => true),
+}))
+
+function registerTool(overrides: Partial<AiToolDefinition> & { name: string }): void {
+  mockRegisteredTools.set(overrides.name, {
+    description: `${overrides.name} description`,
+    inputSchema: z.object({ id: z.string() }),
+    handler: async () => ({}),
+    ...overrides,
+  } as McpToolDefinition)
+}
+
+function makeContainer(): McpServerOptions['container'] {
+  return {
+    resolve: () => ({ loadAcl: jest.fn() }),
+  } as unknown as McpServerOptions['container']
+}
+
+type ListedTool = {
+  name: string
+  description: string
+  inputSchema: unknown
+  annotations?: { readOnlyHint?: boolean; destructiveHint?: boolean }
+}
+
+async function listTools(): Promise<ListedTool[]> {
+  await createMcpServer({
+    config: { name: 'test-mcp', version: '0.0.0' },
+    container: makeContainer(),
+    allowUnauthenticatedSuperadmin: true,
+  })
+  const handler = mockCapturedHandlers.get(ListToolsRequestSchema)
+  if (!handler) throw new Error('[internal] tools/list handler was not registered')
+  const response = (await handler({})) as { tools: ListedTool[] }
+  return response.tools
+}
+
+describe('issue #5283 — MCP tools/list publishes readOnlyHint annotations', () => {
+  beforeEach(() => {
+    mockRegisteredTools.clear()
+    mockCapturedHandlers.clear()
+    jest.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('marks read operations as read-only so clients can skip approval', async () => {
+    registerTool({ name: 'customers.get_company' })
+    registerTool({ name: 'customers.list_people' })
+    registerTool({ name: 'search_status', isMutation: false })
+
+    const tools = await listTools()
+
+    expect(tools).toHaveLength(3)
+    for (const tool of tools) {
+      expect(tool.annotations?.readOnlyHint).toBe(true)
+    }
+  })
+
+  it('never marks mutating operations as read-only', async () => {
+    registerTool({ name: 'catalog.update_product', isMutation: true })
+    registerTool({ name: 'customers.manage_deal_comment', isMutation: true, isDestructive: true })
+
+    const tools = await listTools()
+
+    const byName = new Map(tools.map((tool) => [tool.name, tool]))
+    expect(byName.get('catalog.update_product')?.annotations?.readOnlyHint).toBe(false)
+    expect(byName.get('customers.manage_deal_comment')?.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+    })
+  })
+
+  it('keeps the existing name / description / inputSchema fields intact', async () => {
+    registerTool({ name: 'customers.get_company' })
+
+    const [tool] = await listTools()
+
+    expect(tool.name).toBe('customers.get_company')
+    expect(tool.description).toBe('customers.get_company description')
+    expect(tool.inputSchema).toBeDefined()
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-tool-annotations.test.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/__tests__/mcp-tool-annotations.test.ts
@@ -1,0 +1,57 @@
+import { z } from 'zod'
+import { buildMcpToolAnnotations } from '../mcp-tool-annotations'
+import type { AiToolDefinition } from '../types'
+
+function makeTool(overrides: Partial<AiToolDefinition> = {}): AiToolDefinition {
+  return {
+    name: 'customers.get_company',
+    description: 'Fetch a single company record.',
+    inputSchema: z.object({ id: z.string() }),
+    handler: async () => ({}),
+    ...overrides,
+  } as AiToolDefinition
+}
+
+describe('buildMcpToolAnnotations', () => {
+  it('advertises readOnlyHint for tools that do not declare a mutation', () => {
+    expect(buildMcpToolAnnotations(makeTool())).toEqual({ readOnlyHint: true })
+  })
+
+  it('advertises readOnlyHint for tools that explicitly declare isMutation: false', () => {
+    expect(buildMcpToolAnnotations(makeTool({ isMutation: false }))).toEqual({ readOnlyHint: true })
+  })
+
+  it('never advertises readOnlyHint for mutating tools', () => {
+    expect(buildMcpToolAnnotations(makeTool({ isMutation: true }))).toEqual({ readOnlyHint: false })
+  })
+
+  it('advertises destructiveHint when the mutation declares isDestructive', () => {
+    expect(buildMcpToolAnnotations(makeTool({ isMutation: true, isDestructive: true }))).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+    })
+  })
+
+  it('carries an explicit non-destructive declaration through', () => {
+    expect(buildMcpToolAnnotations(makeTool({ isMutation: true, isDestructive: false }))).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+    })
+  })
+
+  it('resolves a per-input isDestructive predicate to true rather than under-warning', () => {
+    const annotations = buildMcpToolAnnotations(
+      makeTool({ isMutation: true, isDestructive: (input: unknown) => (input as { op: string }).op === 'delete' }),
+    )
+    expect(annotations).toEqual({ readOnlyHint: false, destructiveHint: true })
+  })
+
+  it('omits destructiveHint when a mutation does not declare isDestructive', () => {
+    expect(buildMcpToolAnnotations(makeTool({ isMutation: true }))).not.toHaveProperty('destructiveHint')
+  })
+
+  it('never advertises idempotentHint, which no tool definition carries', () => {
+    expect(buildMcpToolAnnotations(makeTool())).not.toHaveProperty('idempotentHint')
+    expect(buildMcpToolAnnotations(makeTool({ isMutation: true }))).not.toHaveProperty('idempotentHint')
+  })
+})

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
@@ -676,7 +676,9 @@ function registerExecuteTool(commonTypes: string): void {
     {
       name: 'execute',
       // api.request() reaches every documented endpoint, including POST/PUT/DELETE,
-      // so the tool is neither read-only nor guaranteed non-destructive.
+      // so the tool is neither read-only nor guaranteed non-destructive. It is
+      // intentionally exempt from prepareMutation: arbitrary sandbox code cannot
+      // provide the structured before/after preview that approval flow requires.
       isMutation: true,
       isDestructive: true,
       description: `Make API calls. Returns JSON.

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/codemode-tools.ts
@@ -13,7 +13,7 @@ import { createLogger } from '@open-mercato/shared/lib/logger'
 import { z } from 'zod'
 import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import { registerMcpTool } from './tool-registry'
-import type { McpToolContext } from './types'
+import type { AiToolDefinition, McpToolContext } from './types'
 import { createSandbox } from './sandbox'
 import { truncateResult } from './truncate'
 import { applyContextScopeToQuery, applyContextScopeToBody } from './scope-injection'
@@ -561,6 +561,15 @@ export const CODE_MODE_MAX_API_CALLS = 50
 export const CODE_MODE_MAX_MUTATION_CALLS = 20
 
 /**
+ * Register a Code Mode tool through the typed definition so the optional
+ * metadata (`isMutation`, `isDestructive`) survives registration — the MCP
+ * `tools/list` annotations are derived from those flags.
+ */
+function registerCodeModeTool(tool: AiToolDefinition<{ code: string }>): void {
+  registerMcpTool(tool, { moduleId: 'codemode' })
+}
+
+/**
  * Load and register the two Code Mode tools.
  * Generates TypeScript type stubs for common endpoints at startup.
  * @returns Number of tools registered (always 2)
@@ -576,9 +585,10 @@ export async function loadCodeModeTools(): Promise<number> {
  * search — Query the OpenAPI spec and entity graph programmatically.
  */
 function registerSearchTool(): void {
-  registerMcpTool(
+  registerCodeModeTool(
     {
       name: 'search',
+      isMutation: false,
       description: `Query the OpenAPI spec and entity schemas. READ-ONLY, no side effects.
 Globals: spec.findEndpoints(keyword), spec.describeEndpoint(path, method), spec.describeEntity(keyword), spec.paths, spec.entitySchemas.
 Use BEFORE execute to learn endpoint schemas for CREATE/UPDATE. Skip for common paths (companies, people, orders, quotes, products).`,
@@ -650,8 +660,7 @@ Use BEFORE execute to learn endpoint schemas for CREATE/UPDATE. Skip for common 
           _memoryContext: memoryContext,
         }
       },
-    },
-    { moduleId: 'codemode' }
+    }
   )
 }
 
@@ -663,9 +672,13 @@ function registerExecuteTool(commonTypes: string): void {
     ? `\n\n${commonTypes}`
     : ''
 
-  registerMcpTool(
+  registerCodeModeTool(
     {
       name: 'execute',
+      // api.request() reaches every documented endpoint, including POST/PUT/DELETE,
+      // so the tool is neither read-only nor guaranteed non-destructive.
+      isMutation: true,
+      isDestructive: true,
       description: `Make API calls. Returns JSON.
 Globals: api.request({ method, path, query?, body? }) → { success, statusCode, data }, context { tenantId, organizationId, userId }.
 RULES: For FIND/LIST → GET only (1 call). For UPDATE → PUT to collection path with id in BODY. NEVER PUT/POST/DELETE unless user explicitly asked to change data. Before ANY write operation (POST/PUT/DELETE), you MUST use the AskUserQuestion tool to get explicit user confirmation. Do NOT just ask in text — use the tool so execution pauses until the user responds.${typesBlock}`,
@@ -749,8 +762,7 @@ RULES: For FIND/LIST → GET only (1 call). For UPDATE → PUT to collection pat
           _memoryContext: memoryContext,
         }
       },
-    },
-    { moduleId: 'codemode' }
+    }
   )
 }
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/http-server.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/http-server.ts
@@ -10,6 +10,7 @@ import { executeTool } from './tool-executor'
 import { loadAllModuleTools, indexToolsForSearch } from './tool-loader'
 import { authenticateMcpRequest, extractApiKeyFromHeaders, hasRequiredFeatures } from './auth'
 import { jsonSchemaToZod, toSafeZodSchema } from './schema-utils'
+import { buildMcpToolAnnotations } from './mcp-tool-annotations'
 import { redactSecretForLog, deriveApiKeySessionId } from './log-redaction'
 import type { McpServerConfig, McpToolContext } from './types'
 import type { SearchService } from '@open-mercato/search/service'
@@ -219,6 +220,7 @@ function createMcpServerForRequest(
         {
           description: tool.description,
           inputSchema: safeSchema,
+          annotations: buildMcpToolAnnotations(tool),
         },
         async (args: unknown) => {
           const toolArgs = (args ?? {}) as Record<string, unknown>

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/in-process-client.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/in-process-client.ts
@@ -1,6 +1,7 @@
 import type { AwilixContainer } from 'awilix'
 import type { z } from 'zod'
 import { toolInputJsonSchema } from './tool-input-schema'
+import { buildMcpToolAnnotations } from './mcp-tool-annotations'
 import { getToolRegistry } from './tool-registry'
 import { executeTool } from './tool-executor'
 import { loadAllModuleTools } from './tool-loader'
@@ -138,6 +139,7 @@ export class InProcessMcpClient implements McpClientInterface {
       name: tool.name,
       description: tool.description,
       inputSchema: toolInputJsonSchema(tool.inputSchema),
+      annotations: buildMcpToolAnnotations(tool),
     }))
   }
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-client.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-client.ts
@@ -147,7 +147,7 @@ export class McpClient implements McpClientInterface {
       name: tool.name,
       description: tool.description ?? '',
       inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown>,
-      annotations: tool.annotations as ToolInfo['annotations'],
+      annotations: tool.annotations,
     }))
   }
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-client.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-client.ts
@@ -147,6 +147,7 @@ export class McpClient implements McpClientInterface {
       name: tool.name,
       description: tool.description ?? '',
       inputSchema: (tool.inputSchema ?? {}) as Record<string, unknown>,
+      annotations: tool.annotations as ToolInfo['annotations'],
     }))
   }
 

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-dev-server.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-dev-server.ts
@@ -8,6 +8,7 @@ import { executeTool } from './tool-executor'
 import { loadAllModuleTools, indexToolsForSearch } from './tool-loader'
 import { authenticateMcpRequest, extractApiKeyFromHeaders, hasRequiredFeatures } from './auth'
 import { jsonSchemaToZod } from './schema-utils'
+import { buildMcpToolAnnotations } from './mcp-tool-annotations'
 import { getApiKeyFromMcpJson } from './mcp-dev-key-resolution'
 import type { McpToolContext } from './types'
 import type { SearchService } from '@open-mercato/search/service'
@@ -111,6 +112,7 @@ function createDevMcpServer(
         {
           description: tool.description,
           inputSchema: safeSchema,
+          annotations: buildMcpToolAnnotations(tool),
         },
         async (args: unknown) => {
           const toolArgs = (args ?? {}) as Record<string, unknown>

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-server.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-server.ts
@@ -5,6 +5,7 @@ import {
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import { toolInputJsonSchema } from './tool-input-schema'
+import { buildMcpToolAnnotations } from './mcp-tool-annotations'
 import { getToolRegistry } from './tool-registry'
 import { executeTool } from './tool-executor'
 import { loadAllModuleTools, indexToolsForSearch } from './tool-loader'
@@ -133,6 +134,7 @@ export async function createMcpServer(options: McpServerOptions): Promise<Server
         name: tool.name,
         description: tool.description,
         inputSchema: toolInputJsonSchema(tool.inputSchema),
+        annotations: buildMcpToolAnnotations(tool),
       })),
     }
   })

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-tool-annotations.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-tool-annotations.ts
@@ -1,11 +1,6 @@
 import type { AiToolDefinition, McpToolAnnotations, McpToolDefinition } from './types'
 
 /**
- * Subset of the MCP `ToolAnnotations` shape that Open Mercato publishes in
- * `tools/list`. Only hints derivable from a registered tool definition are
- * emitted — the remaining ones are left to the client's spec defaults.
- */
-/**
  * Build the MCP annotations advertised for a registered tool.
  *
  * `readOnlyHint` follows the registry's existing mutation contract: a tool is

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-tool-annotations.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-tool-annotations.ts
@@ -1,15 +1,10 @@
-import type { AiToolDefinition, McpToolDefinition } from './types'
+import type { AiToolDefinition, McpToolAnnotations, McpToolDefinition } from './types'
 
 /**
  * Subset of the MCP `ToolAnnotations` shape that Open Mercato publishes in
  * `tools/list`. Only hints derivable from a registered tool definition are
  * emitted — the remaining ones are left to the client's spec defaults.
  */
-export type McpToolAnnotations = {
-  readOnlyHint?: boolean
-  destructiveHint?: boolean
-}
-
 /**
  * Build the MCP annotations advertised for a registered tool.
  *

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-tool-annotations.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/mcp-tool-annotations.ts
@@ -1,0 +1,45 @@
+import type { AiToolDefinition, McpToolDefinition } from './types'
+
+/**
+ * Subset of the MCP `ToolAnnotations` shape that Open Mercato publishes in
+ * `tools/list`. Only hints derivable from a registered tool definition are
+ * emitted — the remaining ones are left to the client's spec defaults.
+ */
+export type McpToolAnnotations = {
+  readOnlyHint?: boolean
+  destructiveHint?: boolean
+}
+
+/**
+ * Build the MCP annotations advertised for a registered tool.
+ *
+ * `readOnlyHint` follows the registry's existing mutation contract: a tool is
+ * read-only unless it declares `isMutation: true`. Every write tool is required
+ * to set that flag (see the module AGENTS.md) and the agent mutation-policy gate
+ * already reads it the same way.
+ *
+ * `destructiveHint` only carries meaning for mutating tools. A predicate
+ * `isDestructive` cannot be evaluated without call input, so it resolves to
+ * `true` rather than under-warning the client. When the flag is absent the hint
+ * is omitted so clients fall back to the conservative MCP default (`true`).
+ *
+ * `idempotentHint` is deliberately not emitted: no tool-definition field
+ * carries that information, so clients keep the MCP default (`false`).
+ */
+export function buildMcpToolAnnotations(tool: McpToolDefinition): McpToolAnnotations {
+  const definition = tool as AiToolDefinition
+
+  if (definition.isMutation !== true) {
+    return { readOnlyHint: true }
+  }
+
+  const { isDestructive } = definition
+  if (isDestructive === undefined) {
+    return { readOnlyHint: false }
+  }
+
+  return {
+    readOnlyHint: false,
+    destructiveHint: typeof isDestructive === 'function' ? true : isDestructive,
+  }
+}

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/types.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/types.ts
@@ -1,6 +1,5 @@
 import type { z } from 'zod'
 import type { AwilixContainer } from 'awilix'
-import type { McpToolAnnotations } from './mcp-tool-annotations'
 
 /**
  * Execution context for MCP tool calls.
@@ -250,6 +249,15 @@ export type ToolInfo = {
   inputSchema: Record<string, unknown>
   /** MCP capability hints advertised for the tool (see `buildMcpToolAnnotations`). */
   annotations?: McpToolAnnotations
+}
+
+/** MCP `ToolAnnotations` values carried through remote and in-process clients. */
+export type McpToolAnnotations = {
+  title?: string
+  readOnlyHint?: boolean
+  destructiveHint?: boolean
+  idempotentHint?: boolean
+  openWorldHint?: boolean
 }
 
 /**

--- a/packages/ai-assistant/src/modules/ai_assistant/lib/types.ts
+++ b/packages/ai-assistant/src/modules/ai_assistant/lib/types.ts
@@ -1,5 +1,6 @@
 import type { z } from 'zod'
 import type { AwilixContainer } from 'awilix'
+import type { McpToolAnnotations } from './mcp-tool-annotations'
 
 /**
  * Execution context for MCP tool calls.
@@ -247,6 +248,8 @@ export type ToolInfo = {
   name: string
   description: string
   inputSchema: Record<string, unknown>
+  /** MCP capability hints advertised for the tool (see `buildMcpToolAnnotations`). */
+  annotations?: McpToolAnnotations
 }
 
 /**


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-20-issue-5283-mcp-readonly-annotations.md
Status: in-progress

Fixes #5283  ## Problem  Every tool descriptor returned by the Open Mercato MCP endpoints carried `annotations: null`, including unambiguous reads (`customers.get_company`, `customers.list_people`, `search_query`, `search_status`, …).  MCP clients that correctly fail closed on missing metadata — e.g. `requireToolApproval: ({ annotations }) => annotations?.readOnlyHint !== true` — therefore suspended **every** call for human approval, so a genuine read could never be auto-executed.  ## Root Cause  None of the `tools/list` surfaces ever populated the MCP `annotations` field. `lib/http-server.ts` and `lib/mcp-dev-server.ts` passed only `{ description, inputSchema }` to `server.registerTool(...)`, and the stdio handler in `lib/mcp-server.ts` mapped only `{ name, description, inputSchema }` — even though the tool definitions already carry `isMutation` / `isDestructive`.  ## What Changed  - **New `lib/mcp-tool-annotations.ts`** exporting `buildMcpToolAnnotations(tool)`, the single place the hints are derived:   - `readOnlyHint: true` when the tool does not declare `isMutation: true`. This is the registry's existing mutation contract — the module AGENTS.md requires every write tool to set the flag, and the agent mutation-policy gate already reads it exactly this way.   - `readOnlyHint: false` for mutations, plus `destructiveHint` when `isDestructive` is declared. A per-input `isDestructive` predicate cannot be evaluated at list time, so it resolves to `true` rather than under-warning the client; when the flag is absent the hint is omitted so clients keep the conservative MCP default (`true`).   - `idempotentHint` is deliberately **not** emitted — no tool-definition field carries that information, and the MCP spec only gives it meaning when `readOnlyHint === false`. Clients keep the conservative default (`false`). - **All three MCP server surfaces publish it**: `lib/http-server.ts` (production `/mcp`), `lib/mcp-dev-server.ts` (`yarn mcp:dev`), `lib/mcp-server.ts` (stdio `tools/list`). - **Both clients carry it through**: `ToolInfo` gained an optional `annotations` field; `lib/in-process-client.ts` derives it and `lib/mcp-client.ts` passes the remote value along. - **Code Mode `execute` now declares `isMutation: true` / `isDestructive: true`.** `api.request()` reaches every documented endpoint including POST/PUT/DELETE, so without the flag it would have advertised itself as read-only — the one genuinely ambiguous tool in the registry. `search` declares `isMutation: false`. Both now register through a small typed `registerCodeModeTool` helper so the metadata survives registration.  ## Tests  New, all failing before the change and passing after:  - `lib/__tests__/mcp-tool-annotations.test.ts` — the derivation table: absent/`false`/`true` `isMutation`, boolean and predicate `isDestructive`, and the two hints that must stay unset. - `lib/__tests__/mcp-server-tool-annotations.test.ts` — drives the real `tools/list` handler and asserts reads come back `readOnlyHint: true`, mutations never do, and `name` / `description` / `inputSchema` are unchanged. - `lib/__tests__/codemode-tool-annotations.test.ts` — `search` lists read-only, `execute` never does.  Validation run locally (Windows): `yarn build:packages`, `yarn generate`, `yarn typecheck`, `yarn lint`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn agents:check-budget`, `yarn build:app` — all green. Unit tests: `@open-mercato/ai-assistant` 1468/1468 pass; `@open-mercato/core` and `@open-mercato/search` tool-related suites pass. Repo-wide `yarn test` is red only in `create-mercato-app`, which is the pre-existing failure set on this machine and untouched by this change.  ## Backward Compatibility  Additive. `annotations` is a new **optional** field on `tools/list` entries and on `ToolInfo`; no field, event id, route, DI name or ACL feature was renamed or removed. Clients that ignore annotations behave exactly as before.  The one behavioral note: Code Mode `execute` gaining `isMutation: true` also makes it visible as a mutation to surfaces that filter on that flag. It is on no agent's `allowedTools`, and `executeTool` does not gate on the flag, so nothing else changes — this only corrects metadata that was previously wrong.  🤖 Generated with [Claude Code](https://claude.com/claude-code)  <!-- codesmith:footer --> --- <a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789398250&installation_model_id=432243&pr_number=5322&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5322&signature=dc3413a0323e990cb57e3975d3b67087fd89f62d9af94dfc75974103bd53c6b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a> <sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>  <!-- codesmith:autofix:disabled --> <!-- /codesmith:footer -->