### PR TITLE
feat(ui): add NotesSection props to force the rich editor and hide appearance controls (#5150)

### DIFF
--- a/.ai/ui-backend-components.md
+++ b/.ai/ui-backend-components.md
@@ -197,7 +197,7 @@ import {
 | `AccessDeniedMessage` | Standard 403 state |
 | `RecordNotFoundState` | `label`, `description?`, `backHref`/`backLabel`, `action?` — neutral missing-record state |
 | `TabEmptyState` | `title`, `description?`, `action?: { label, onClick, icon?, disabled? }` — empty-but-healthy tab |
-| `NotesSection` | `entityId`, `viewerUserId`, `dataAdapter: NotesDataAdapter`, `emptyState`, `addActionLabel`, markdown preference hooks — comments/notes tab |
+| `NotesSection` | `entityId`, `viewerUserId`, `dataAdapter: NotesDataAdapter`, `emptyState`, `addActionLabel`, markdown preference hooks — comments/notes tab. Editor/appearance opt-ins: `disableMarkdown` (plain textarea only), `forceMarkdown` (rich editor only, toggle hidden), `hideMarkdownToggle` (hide the toggle, keep the seeded preference), `disableAppearance` (no palette buttons or appearance dialog) |
 | `ActivitiesSection` | `entityId`, `dataAdapter: ActivitiesDataAdapter`, `activityTypeLabels`, `loadActivityOptions`, `emptyState` — activity timeline tab with dictionary-driven types |
 | `AddressesSection` | `entityId`, `dataAdapter: AddressDataAdapter`, `addressTypesAdapter?`, `loadFormat?`, `emptyState` — address tiles + editor (also exports `AddressTiles`, `AddressEditor`, `AddressView`, `formatAddressLines`) |
 | `TagsSection` | `title`, `tags: TagOption[]`, `loadOptions`, `createTag`, `onSave({ next, added, removed })`, `labels`, `canEdit?`, `autoSave?` |

--- a/packages/ui/src/backend/__tests__/NotesSection.test.tsx
+++ b/packages/ui/src/backend/__tests__/NotesSection.test.tsx
@@ -7,6 +7,33 @@ import { NotesSection, type NotesDataAdapter } from '../detail/NotesSection'
 import { dismissRecordConflict, getRecordConflictForTest } from '../conflicts'
 import { OPTIMISTIC_LOCK_CONFLICT_CODE } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
 
+const createDataAdapter = (): NotesDataAdapter => ({
+  list: jest.fn(async () => [
+    {
+      id: 'note-1',
+      body: 'Existing note',
+      createdAt: '2026-04-10T08:00:00.000Z',
+      authorName: 'Ada Lovelace',
+    },
+  ]),
+  create: jest.fn(async () => ({ id: 'note-2' })),
+  update: jest.fn(async () => undefined),
+  delete: jest.fn(async () => undefined),
+})
+
+const baseProps = (dataAdapter: NotesDataAdapter) => ({
+  entityId: 'person-1',
+  emptyLabel: '—',
+  viewerUserId: 'user-1',
+  viewerName: 'Ada Lovelace',
+  addActionLabel: 'Add note',
+  emptyState: {
+    title: 'No notes yet',
+    actionLabel: 'Add note',
+  },
+  dataAdapter,
+})
+
 describe('NotesSection', () => {
   beforeEach(() => {
     dismissRecordConflict()
@@ -66,6 +93,68 @@ describe('NotesSection', () => {
     await waitFor(() => {
       expect(container.querySelector('textarea')).not.toBeNull()
     })
+  })
+
+  it('renders the markdown toggle and appearance controls by default', async () => {
+    const { container } = renderWithProviders(<NotesSection {...baseProps(createDataAdapter())} />)
+
+    await screen.findByText('Existing note')
+    expect(container.querySelectorAll('svg.lucide-palette').length).toBe(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }))
+
+    await waitFor(() => {
+      expect(container.querySelector('button[aria-pressed]')).not.toBeNull()
+    })
+    expect(screen.getByRole('button', { name: 'Customize appearance' })).toBeTruthy()
+    expect(screen.queryByTestId('markdown-field')).toBeNull()
+  })
+
+  it('keeps the rich editor active and hides the toggle when forceMarkdown is set', async () => {
+    const { container } = renderWithProviders(
+      <NotesSection {...baseProps(createDataAdapter())} forceMarkdown />,
+    )
+
+    await screen.findByText('Existing note')
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('markdown-field')).toBeTruthy()
+    })
+    expect(container.querySelector('button[aria-pressed]')).toBeNull()
+  })
+
+  it('hides the toggle but honors the seeded preference when hideMarkdownToggle is set', async () => {
+    const { container } = renderWithProviders(
+      <NotesSection
+        {...baseProps(createDataAdapter())}
+        hideMarkdownToggle
+        readMarkdownPreference={() => true}
+      />,
+    )
+
+    await screen.findByText('Existing note')
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('markdown-field')).toBeTruthy()
+    })
+    expect(container.querySelector('button[aria-pressed]')).toBeNull()
+  })
+
+  it('removes every appearance affordance when disableAppearance is set', async () => {
+    const { container } = renderWithProviders(
+      <NotesSection {...baseProps(createDataAdapter())} disableAppearance />,
+    )
+
+    await screen.findByText('Existing note')
+    fireEvent.click(screen.getByRole('button', { name: 'Add note' }))
+
+    await waitFor(() => {
+      expect(container.querySelector('button[aria-pressed]')).not.toBeNull()
+    })
+    expect(screen.queryByRole('button', { name: 'Customize appearance' })).toBeNull()
+    expect(container.querySelectorAll('svg.lucide-palette').length).toBe(0)
   })
 
   it('surfaces the unified conflict bar when a write fails with a 409', async () => {

--- a/packages/ui/src/backend/detail/NotesSection.tsx
+++ b/packages/ui/src/backend/detail/NotesSection.tsx
@@ -204,7 +204,20 @@ export type NotesSectionProps<C = unknown> = {
   iconSuggestions?: IconOption[]
   readMarkdownPreference?: () => boolean | null
   writeMarkdownPreference?: (value: boolean) => void
+  /** Force the plain textarea and hide the markdown toggle. Wins over `forceMarkdown`. */
   disableMarkdown?: boolean
+  /**
+   * Keep the rich markdown editor active for every note and hide the markdown toggle,
+   * so the editor shape cannot be switched. Ignored when `disableMarkdown` is set.
+   */
+  forceMarkdown?: boolean
+  /**
+   * Hide the markdown toggle without changing which editor renders — the seeded
+   * `readMarkdownPreference` value stays in effect. Implied by `forceMarkdown`.
+   */
+  hideMarkdownToggle?: boolean
+  /** Hide the appearance (icon/color) affordances: the palette buttons and the appearance dialog. */
+  disableAppearance?: boolean
 }
 
 export function sanitizeHexColor(value: string | null): string | null {
@@ -310,6 +323,9 @@ function NotesSectionImpl<C = unknown>({
   readMarkdownPreference,
   writeMarkdownPreference,
   disableMarkdown,
+  forceMarkdown,
+  hideMarkdownToggle,
+  disableAppearance,
 }: NotesSectionProps<C>) {
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
   const t = React.useMemo<Translator>(() => translator ?? ((key, fallback) => fallback ?? key), [translator])
@@ -445,13 +461,16 @@ function NotesSectionImpl<C = unknown>({
   const [draftIcon, setDraftIcon] = React.useState<string | null>(null)
   const [draftColor, setDraftColor] = React.useState<string | null>(null)
   const [isMarkdownEnabled, setIsMarkdownEnabled] = React.useState(false)
+  const isMarkdownActive = !disableMarkdown && (Boolean(forceMarkdown) || isMarkdownEnabled)
+  const showMarkdownToggle = !disableMarkdown && !forceMarkdown && !hideMarkdownToggle
+  const showAppearanceControls = !disableAppearance
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null)
   const formRef = React.useRef<HTMLFormElement | null>(null)
   const focusComposer = React.useCallback(() => {
     if (!hasEntity) return
     setComposerOpen(true)
     window.requestAnimationFrame(() => {
-      if (isMarkdownEnabled) {
+      if (isMarkdownActive) {
         const markdownTextarea = formRef.current?.querySelector('textarea')
         if (markdownTextarea instanceof HTMLTextAreaElement) {
           markdownTextarea.focus()
@@ -464,7 +483,7 @@ function NotesSectionImpl<C = unknown>({
       element.focus()
       element.scrollIntoView({ behavior: 'smooth', block: 'center' })
     })
-  }, [formRef, hasEntity, isMarkdownEnabled])
+  }, [formRef, hasEntity, isMarkdownActive])
   const [appearanceDialogState, setAppearanceDialogState] = React.useState<
     | { mode: 'create'; icon: string | null; color: string | null }
     | { mode: 'edit'; noteId: string; icon: string | null; color: string | null }
@@ -578,7 +597,7 @@ function NotesSectionImpl<C = unknown>({
 
   React.useEffect(() => {
     adjustTextareaSize(textareaRef.current)
-  }, [adjustTextareaSize, draftBody, isMarkdownEnabled, composerOpen])
+  }, [adjustTextareaSize, draftBody, isMarkdownActive, composerOpen])
 
   React.useEffect(() => {
     const preference = readMarkdownPreference ? readMarkdownPreference() : null
@@ -980,31 +999,33 @@ function NotesSectionImpl<C = unknown>({
             <div className="flex flex-wrap items-center justify-between gap-2">
               <h3 className="text-sm font-medium">{label('addLabel')}</h3>
               <div className="flex flex-wrap items-center gap-1">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => {
-                    setAppearanceDialogError(null)
-                    setAppearanceDialogState({ mode: 'create', icon: draftIcon, color: draftColor })
-                  }}
-                  disabled={isSubmitting || isLoading || !hasEntity}
-                >
-                  <span className="sr-only">{label('appearance.toggleOpen', 'Customize appearance')}</span>
-                  <Palette className="h-4 w-4" />
-                </Button>
-                {disableMarkdown ? null : (
+                {showAppearanceControls ? (
                   <Button
                     type="button"
-                    variant={isMarkdownEnabled ? 'secondary' : 'ghost'}
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => {
+                      setAppearanceDialogError(null)
+                      setAppearanceDialogState({ mode: 'create', icon: draftIcon, color: draftColor })
+                    }}
+                    disabled={isSubmitting || isLoading || !hasEntity}
+                  >
+                    <span className="sr-only">{label('appearance.toggleOpen', 'Customize appearance')}</span>
+                    <Palette className="h-4 w-4" />
+                  </Button>
+                ) : null}
+                {showMarkdownToggle ? (
+                  <Button
+                    type="button"
+                    variant={isMarkdownActive ? 'secondary' : 'ghost'}
                     size="icon"
                     onClick={handleMarkdownToggle}
-                    aria-pressed={isMarkdownEnabled}
+                    aria-pressed={isMarkdownActive}
                     disabled={isSubmitting || isLoading}
                   >
                     <FileCode className="h-4 w-4" />
                   </Button>
-                )}
+                ) : null}
                 <Button
                   type="button"
                   size="sm"
@@ -1080,7 +1101,7 @@ function NotesSectionImpl<C = unknown>({
             <SwitchableMarkdownInput
               value={draftBody}
               onChange={setDraftBody}
-              isMarkdownEnabled={isMarkdownEnabled}
+              isMarkdownEnabled={isMarkdownActive}
               disableMarkdown={disableMarkdown}
               rows={1}
               placeholder={label('placeholder')}
@@ -1204,24 +1225,26 @@ function NotesSectionImpl<C = unknown>({
                     >
                       <Pencil className="h-4 w-4" />
                     </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        setAppearanceDialogError(null)
-                        setAppearanceDialogState({
-                          mode: 'edit',
-                          noteId: note.id,
-                          icon: note.appearanceIcon ?? null,
-                          color: note.appearanceColor ?? null,
-                        })
-                      }}
-                      disabled={appearanceDialogSaving && editingAppearanceNoteId === note.id}
-                    >
-                      {isAppearanceSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Palette className="h-4 w-4" />}
-                    </Button>
+                    {showAppearanceControls ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          setAppearanceDialogError(null)
+                          setAppearanceDialogState({
+                            mode: 'edit',
+                            noteId: note.id,
+                            icon: note.appearanceIcon ?? null,
+                            color: note.appearanceColor ?? null,
+                          })
+                        }}
+                        disabled={appearanceDialogSaving && editingAppearanceNoteId === note.id}
+                      >
+                        {isAppearanceSaving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Palette className="h-4 w-4" />}
+                      </Button>
+                    ) : null}
                     <Button
                       type="button"
                       variant="ghost"
@@ -1247,7 +1270,7 @@ function NotesSectionImpl<C = unknown>({
                     <SwitchableMarkdownInput
                       value={contentEditor.value}
                       onChange={(nextValue) => setContentEditor((prev) => ({ ...prev, value: nextValue }))}
-                      isMarkdownEnabled={isMarkdownEnabled}
+                      isMarkdownEnabled={isMarkdownActive}
                       disableMarkdown={disableMarkdown}
                       rows={3}
                       textareaRef={contentTextareaRef}
@@ -1268,19 +1291,19 @@ function NotesSectionImpl<C = unknown>({
                           inlineLabel('saveShortcut')
                         )}
                       </Button>
-                      {disableMarkdown ? null : (
+                      {showMarkdownToggle ? (
                         <Button
                           type="button"
                           variant="ghost"
                           size="icon"
                           onClick={handleMarkdownToggle}
-                          aria-pressed={isMarkdownEnabled}
-                          className={isMarkdownEnabled ? 'text-primary' : undefined}
+                          aria-pressed={isMarkdownActive}
+                          className={isMarkdownActive ? 'text-primary' : undefined}
                           disabled={contentSavingId === note.id}
                         >
                           <FileCode className="h-4 w-4" />
                         </Button>
-                      )}
+                      ) : null}
                       <Button
                         type="button"
                         size="sm"
@@ -1330,29 +1353,31 @@ function NotesSectionImpl<C = unknown>({
           </div>
         )}
       </div>
-      <AppearanceDialog
-        open={appearanceDialogOpen}
-        title={
-          appearanceDialogState?.mode === 'edit'
-            ? label('appearance.edit')
-            : label('appearance.toggleOpen', 'Customize appearance')
-        }
-        icon={appearanceDialogState?.icon ?? null}
-        color={appearanceDialogState?.color ?? null}
-        labels={noteAppearanceLabels}
-        iconSuggestions={iconSuggestions}
-        onIconChange={(value) => setAppearanceDialogState((prev) => (prev ? { ...prev, icon: value ?? null } : prev))}
-        onColorChange={(value) => setAppearanceDialogState((prev) => (prev ? { ...prev, color: value ?? null } : prev))}
-        onSubmit={() => {
-          void handleAppearanceDialogSubmit()
-        }}
-        onClose={handleAppearanceDialogClose}
-        isSaving={appearanceDialogSaving}
-        errorMessage={appearanceDialogError}
-        primaryLabel={appearanceDialogPrimaryLabel}
-        savingLabel={appearanceDialogSavingLabel}
-        cancelLabel={label('appearance.cancel')}
-      />
+      {showAppearanceControls ? (
+        <AppearanceDialog
+          open={appearanceDialogOpen}
+          title={
+            appearanceDialogState?.mode === 'edit'
+              ? label('appearance.edit')
+              : label('appearance.toggleOpen', 'Customize appearance')
+          }
+          icon={appearanceDialogState?.icon ?? null}
+          color={appearanceDialogState?.color ?? null}
+          labels={noteAppearanceLabels}
+          iconSuggestions={iconSuggestions}
+          onIconChange={(value) => setAppearanceDialogState((prev) => (prev ? { ...prev, icon: value ?? null } : prev))}
+          onColorChange={(value) => setAppearanceDialogState((prev) => (prev ? { ...prev, color: value ?? null } : prev))}
+          onSubmit={() => {
+            void handleAppearanceDialogSubmit()
+          }}
+          onClose={handleAppearanceDialogClose}
+          isSaving={appearanceDialogSaving}
+          errorMessage={appearanceDialogError}
+          primaryLabel={appearanceDialogPrimaryLabel}
+          savingLabel={appearanceDialogSavingLabel}
+          cancelLabel={label('appearance.cancel')}
+        />
+      ) : null}
       {ConfirmDialogElement}
     </div>
   )


### PR DESCRIPTION
Closes #5150

## 🎯 Goal
- Let a deployment pin `NotesSection` to one consistent editing experience — the rich markdown editor with no toggle to flip it back — and drop the per-note appearance (icon/colour) affordance entirely, without forking the component or patching the package.

## 🔍 Problem
`NotesSection` exposed exactly one editor-shape prop, `disableMarkdown`, and it only pointed one way: it forced the plain `<textarea>` and hid the markdown toggle. "Always rich editor, no toggle" was not expressible — `readMarkdownPreference` could seed the state to `true`, but the toggle stayed visible so a user could flip it straight back. The appearance affordance had no prop at all: the palette buttons (composer and per-note) and the appearance dialog rendered unconditionally, and omitting `renderIcon`/`iconSuggestions` only made the dialog less useful rather than removing the control.

## What Changed
- `packages/ui/src/backend/detail/NotesSection.tsx` — three optional props, all defaulting to today's behaviour:
  - `forceMarkdown` — keeps the rich markdown editor active for the composer and every inline editor and hides the toggle, so the editor shape cannot be switched. Ignored when `disableMarkdown` is set, so the existing "force plain text" semantics still win.
  - `hideMarkdownToggle` — hides the toggle without changing which editor renders, so a seeded `readMarkdownPreference` stays in effect. Implied by `forceMarkdown`.
  - `disableAppearance` — removes the composer palette button, the per-note palette button, and the appearance dialog. Existing notes keep rendering their stored icon/colour, so no data is hidden.
  - Internally the render sites now read two derived flags, `isMarkdownActive` (`!disableMarkdown && (forceMarkdown || isMarkdownEnabled)`) and `showMarkdownToggle`, instead of consulting `disableMarkdown`/`isMarkdownEnabled` at each of the four sites. `focusComposer` and the textarea auto-grow effect follow the same derived flag so focus still lands on the right field when the rich editor is forced.
- `.ai/ui-backend-components.md` — the `NotesSection` row now lists the four editor/appearance opt-ins so the component catalogue reflects the new surface.

## 🧪 Tests
- `yarn workspace @open-mercato/ui test` — 1865 passed / 229 suites.
- `yarn generate && yarn build:packages && yarn typecheck` — 22/22 tasks green.
- `yarn i18n:check-sync` — all 5 locales in sync; `yarn i18n:check-usage` — advisory only, no new findings (the change adds no user-facing strings).
- `yarn test` (full monorepo unit gate) — green.
- New cases in `packages/ui/src/backend/__tests__/NotesSection.test.tsx`:
  - the default render still shows both the markdown toggle and the palette controls (regression guard for the untouched path);
  - `forceMarkdown` renders the rich markdown field and no toggle;
  - `hideMarkdownToggle` + `readMarkdownPreference: () => true` renders the rich field with no toggle;
  - `disableAppearance` removes every palette affordance (composer button and per-note button).

## 💥 Breaking Changes
- None. All three props are optional and default to `undefined`, which reproduces the current behaviour exactly; `disableMarkdown` keeps its meaning and takes precedence over `forceMarkdown`. Additive-only per `BACKWARD_COMPATIBILITY.md`.

## Notes for the reviewer
- The issue asked whether the markdown half should instead wait for the `SwitchableMarkdownInput` → DS `RichEditor` migration. This PR deliberately does not pre-empt that migration: it adds no new markdown surface and no new dependency on the deprecated input — it only gates the controls that already exist. If the migration lands, `forceMarkdown`/`hideMarkdownToggle` are the natural props to carry over or retire together with the toggle.
- Naming: the issue flagged that a second `disable*` prop with a different flavour might deserve a better name. That is why hiding the palette is `disableAppearance` (a capability opt-out, matching `disableMarkdown`'s shape) while the markdown controls are split into `forceMarkdown` (which editor renders) and `hideMarkdownToggle` (whether the control renders) rather than overloading one flag.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789404401&installation_model_id=432243&pr_number=5325&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5325&signature=38beb36e81eb105ad7e100181e8d1a47d8705deecf6da6d74de95d904ac517a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->