### PR TITLE
fix(shared): localize relative time strings in the app locale (#5286)

### DIFF
--- a/packages/ai-assistant/src/modules/ai_assistant/widgets/notifications/ConversationSharedRenderer.tsx
+++ b/packages/ai-assistant/src/modules/ai_assistant/widgets/notifications/ConversationSharedRenderer.tsx
@@ -7,7 +7,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 
 export function ConversationSharedRenderer({
@@ -17,6 +17,7 @@ export function ConversationSharedRenderer({
   actions = [],
 }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const router = useRouter()
   const [executing, setExecuting] = React.useState(false)
   const isUnread = notification.status === 'unread'
@@ -34,7 +35,7 @@ export function ConversationSharedRenderer({
     }
   }
 
-  const timeAgo = formatRelativeTime(notification.createdAt, { translate: t }) ?? ''
+  const timeAgo = formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''
 
   return (
     <div

--- a/packages/checkout/src/modules/checkout/widgets/notifications/CheckoutTransactionCompletedRenderer.tsx
+++ b/packages/checkout/src/modules/checkout/widgets/notifications/CheckoutTransactionCompletedRenderer.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 
 export function CheckoutTransactionCompletedRenderer({
@@ -16,6 +16,7 @@ export function CheckoutTransactionCompletedRenderer({
   actions = [],
 }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const router = useRouter()
   const [executing, setExecuting] = React.useState(false)
   const isUnread = notification.status === 'unread'
@@ -69,7 +70,7 @@ export function CheckoutTransactionCompletedRenderer({
             </h4>
             <span className="flex-shrink-0 text-xs text-muted-foreground flex items-center gap-1">
               <Calendar className="h-3 w-3" />
-              {formatRelativeTime(notification.createdAt, { translate: t }) ?? ''}
+              {formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''}
             </span>
           </div>
           {amount ? (

--- a/packages/checkout/src/modules/checkout/widgets/notifications/CheckoutTransactionFailedRenderer.tsx
+++ b/packages/checkout/src/modules/checkout/widgets/notifications/CheckoutTransactionFailedRenderer.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 
 export function CheckoutTransactionFailedRenderer({
@@ -16,6 +16,7 @@ export function CheckoutTransactionFailedRenderer({
   actions = [],
 }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const router = useRouter()
   const [executing, setExecuting] = React.useState(false)
   const isUnread = notification.status === 'unread'
@@ -67,7 +68,7 @@ export function CheckoutTransactionFailedRenderer({
             </h4>
             <span className="flex-shrink-0 text-xs text-muted-foreground flex items-center gap-1">
               <Calendar className="h-3 w-3" />
-              {formatRelativeTime(notification.createdAt, { translate: t }) ?? ''}
+              {formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''}
             </span>
           </div>
           <div className="mt-3 flex gap-2">

--- a/packages/checkout/src/modules/checkout/widgets/notifications/CheckoutUsageLimitReachedRenderer.tsx
+++ b/packages/checkout/src/modules/checkout/widgets/notifications/CheckoutUsageLimitReachedRenderer.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 
 export function CheckoutUsageLimitReachedRenderer({
@@ -16,6 +16,7 @@ export function CheckoutUsageLimitReachedRenderer({
   actions = [],
 }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const router = useRouter()
   const [executing, setExecuting] = React.useState(false)
   const isUnread = notification.status === 'unread'
@@ -73,7 +74,7 @@ export function CheckoutUsageLimitReachedRenderer({
             </div>
             <span className="flex-shrink-0 text-xs text-muted-foreground flex items-center gap-1">
               <Calendar className="h-3 w-3" />
-              {formatRelativeTime(notification.createdAt, { translate: t }) ?? ''}
+              {formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''}
             </span>
           </div>
           <div className="mt-3 flex gap-2">

--- a/packages/core/src/modules/customers/backend/customers/deals/page.tsx
+++ b/packages/core/src/modules/customers/backend/customers/deals/page.tsx
@@ -33,7 +33,7 @@ import { ViewTabsRow } from './pipeline/components/ViewTabsRow'
 import { DealsKpiStrip } from '../../../components/DealsKpiStrip'
 import { E } from '#generated/entities.ids.generated'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import {
   type CustomerDictionaryKind,
@@ -193,6 +193,7 @@ function formatGroupedAmount(amount: number | null | undefined): string | null {
 
 export default function CustomersDealsPage() {
   const t = useT()
+  const locale = useLocale()
   const { confirm, ConfirmDialogElement } = useConfirmDialog()
   const router = useRouter()
   const pathname = usePathname()
@@ -858,7 +859,7 @@ export default function CustomersDealsPage() {
               <span className="text-xs text-muted-foreground">{t('customers.deals.list.close.lost')}</span>
             )
           } else {
-            const relative = formatRelativeTime(expectedCloseAt, { translate: t })
+            const relative = formatRelativeTime(expectedCloseAt, { locale, translate: t })
             if (relative) {
               subtitle = <span className="text-xs text-muted-foreground">{relative}</span>
             }
@@ -984,7 +985,7 @@ export default function CustomersDealsPage() {
       },
       ...customColumns,
     ]
-  }, [customFieldDefs, dictionaryMaps, dictionaryOptions, isDealOverdue, loadOwnerFilterOptions, ownerNames, pipelineNames, resolvedOwnerFilterOptions, t])
+  }, [customFieldDefs, dictionaryMaps, dictionaryOptions, isDealOverdue, loadOwnerFilterOptions, locale, ownerNames, pipelineNames, resolvedOwnerFilterOptions, t])
 
   const { advancedFilterFields } = useAutoDiscoveredFields({ columns, customFieldDefs })
 

--- a/packages/core/src/modules/inbox_ops/widgets/notifications/ProposalCreatedRenderer.tsx
+++ b/packages/core/src/modules/inbox_ops/widgets/notifications/ProposalCreatedRenderer.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 
 export function ProposalCreatedRenderer({
@@ -16,6 +16,7 @@ export function ProposalCreatedRenderer({
   actions = [],
 }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const router = useRouter()
   const [executing, setExecuting] = React.useState(false)
   const isUnread = notification.status === 'unread'
@@ -70,7 +71,7 @@ export function ProposalCreatedRenderer({
             </h4>
             <span className="flex-shrink-0 text-xs text-muted-foreground flex items-center gap-1">
               <Calendar className="h-3 w-3" />
-              {formatRelativeTime(notification.createdAt, { translate: t }) ?? ''}
+              {formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''}
             </span>
           </div>
 

--- a/packages/core/src/modules/sales/widgets/notifications/SalesOrderCreatedRenderer.tsx
+++ b/packages/core/src/modules/sales/widgets/notifications/SalesOrderCreatedRenderer.tsx
@@ -7,7 +7,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 import { formatMoney } from '../../components/documents/lineItemUtils'
 import { useSalesDocumentTotals } from './useSalesDocumentTotals'
@@ -28,6 +28,7 @@ export function SalesOrderCreatedRenderer({
   actions = [],
 }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const router = useRouter()
   const [executing, setExecuting] = React.useState(false)
   const isUnread = notification.status === 'unread'
@@ -57,7 +58,7 @@ export function SalesOrderCreatedRenderer({
     }
   }
 
-  const timeAgo = formatRelativeTime(notification.createdAt, { translate: t }) ?? ''
+  const timeAgo = formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''
 
   return (
     <div

--- a/packages/core/src/modules/sales/widgets/notifications/SalesQuoteCreatedRenderer.tsx
+++ b/packages/core/src/modules/sales/widgets/notifications/SalesQuoteCreatedRenderer.tsx
@@ -5,7 +5,7 @@ import { FileText, ExternalLink, DollarSign, User, Calendar } from 'lucide-react
 import { useRouter } from 'next/navigation'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { cn } from '@open-mercato/shared/lib/utils'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 import { formatMoney } from '../../components/documents/lineItemUtils'
@@ -27,6 +27,7 @@ export function SalesQuoteCreatedRenderer({
   actions = [],
 }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const router = useRouter()
   const [executing, setExecuting] = React.useState(false)
   const isUnread = notification.status === 'unread'
@@ -99,7 +100,7 @@ export function SalesQuoteCreatedRenderer({
             </div>
             <span className="flex-shrink-0 text-xs text-muted-foreground flex items-center gap-1">
               <Calendar className="h-3 w-3" />
-              {formatRelativeTime(notification.createdAt, { translate: t }) ?? ''}
+              {formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''}
             </span>
           </div>
 

--- a/packages/core/src/modules/wms/widgets/notifications/WmsLowStockRenderer.tsx
+++ b/packages/core/src/modules/wms/widgets/notifications/WmsLowStockRenderer.tsx
@@ -7,7 +7,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 
 export function WmsLowStockRenderer({
@@ -17,6 +17,7 @@ export function WmsLowStockRenderer({
   actions = [],
 }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const router = useRouter()
   const [executing, setExecuting] = React.useState(false)
   const isUnread = notification.status === 'unread'
@@ -39,7 +40,7 @@ export function WmsLowStockRenderer({
     }
   }
 
-  const timeAgo = formatRelativeTime(notification.createdAt, { translate: t }) ?? ''
+  const timeAgo = formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''
 
   const stateLabel =
     state === 'below_safety_stock'

--- a/packages/core/src/modules/wms/widgets/notifications/WmsReservationShortfallRenderer.tsx
+++ b/packages/core/src/modules/wms/widgets/notifications/WmsReservationShortfallRenderer.tsx
@@ -7,7 +7,7 @@ import { Button } from '@open-mercato/ui/primitives/button'
 import { IconButton } from '@open-mercato/ui/primitives/icon-button'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 
 export function WmsReservationShortfallRenderer({
@@ -17,6 +17,7 @@ export function WmsReservationShortfallRenderer({
   actions = [],
 }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const router = useRouter()
   const [executing, setExecuting] = React.useState<string | null>(null)
   const isUnread = notification.status === 'unread'
@@ -54,7 +55,7 @@ export function WmsReservationShortfallRenderer({
     }
   }
 
-  const timeAgo = formatRelativeTime(notification.createdAt, { translate: t }) ?? ''
+  const timeAgo = formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''
 
   return (
     <div

--- a/packages/core/src/modules/wms/widgets/notifications/__tests__/WmsLowStockRenderer.test.tsx
+++ b/packages/core/src/modules/wms/widgets/notifications/__tests__/WmsLowStockRenderer.test.tsx
@@ -7,6 +7,7 @@ import { WmsLowStockRenderer } from '../WmsLowStockRenderer'
 
 jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
   useT: () => (_key: string, fallback: string) => fallback ?? _key,
+  useLocale: () => 'en',
 }))
 
 jest.mock('next/navigation', () => ({

--- a/packages/enterprise/src/modules/record_locks/widgets/notifications/IncomingChangesRenderer.tsx
+++ b/packages/enterprise/src/modules/record_locks/widgets/notifications/IncomingChangesRenderer.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 import { GitPullRequestArrow, Calendar } from 'lucide-react'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
-import { useT } from '@open-mercato/shared/lib/i18n/context'
+import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { NotificationRendererProps } from '@open-mercato/shared/modules/notifications/types'
 
 type ChangeRow = {
@@ -35,6 +35,7 @@ function parseRows(notification: NotificationRendererProps['notification']): Cha
 
 export function IncomingChangesRenderer({ notification }: NotificationRendererProps) {
   const t = useT()
+  const locale = useLocale()
   const rows = React.useMemo(() => parseRows(notification), [notification])
   const isUnread = notification.status === 'unread'
 
@@ -63,7 +64,7 @@ export function IncomingChangesRenderer({ notification }: NotificationRendererPr
             </h4>
             <span className="flex items-center gap-1 text-xs text-muted-foreground">
               <Calendar className="h-3 w-3" />
-              {formatRelativeTime(notification.createdAt, { translate: t }) ?? ''}
+              {formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''}
             </span>
           </div>
 

--- a/packages/shared/src/lib/__tests__/time.test.ts
+++ b/packages/shared/src/lib/__tests__/time.test.ts
@@ -82,22 +82,54 @@ describe('formatRelativeTime', () => {
     expect(/year|month/.test(future!)).toBeTruthy()
   })
 
-it('uses fallback if Intl.RelativeTimeFormat is not available', () => {
-  const descriptor = Object.getOwnPropertyDescriptor(Intl, 'RelativeTimeFormat')
-  Object.defineProperty(Intl, 'RelativeTimeFormat', { value: undefined, configurable: true })
-  try {
-    expect(formatRelativeTime(sub(3_600_000))).toMatch(/ago/)
-    expect(formatRelativeTime(add(3_600_000))).toMatch(/from now/)
-  } finally {
-    Object.defineProperty(Intl, 'RelativeTimeFormat', descriptor!)
-  }
-})
+  it('uses fallback if Intl.RelativeTimeFormat is not available', () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Intl, 'RelativeTimeFormat')
+    Object.defineProperty(Intl, 'RelativeTimeFormat', { value: undefined, configurable: true })
+    try {
+      expect(formatRelativeTime(sub(3_600_000))).toMatch(/ago/)
+      expect(formatRelativeTime(add(3_600_000))).toMatch(/from now/)
+    } finally {
+      Object.defineProperty(Intl, 'RelativeTimeFormat', descriptor!)
+    }
+  })
 
-it('uses custom translate if provided', () => {
-  const translate = (key: string, fallback?: string) => `T(${key})`
-  expect(formatRelativeTime(sub(3_600_000), { translate })).toMatch(/T\(time\.relative\.ago\)/)
-  expect(formatRelativeTime(add(3_600_000), { translate })).toMatch(/T\(time\.relative\.fromNow\)/)
-})
+  it('uses custom translate for the fallback suffix when Intl.RelativeTimeFormat is not available', () => {
+    const translate = (key: string) => `T(${key})`
+    const descriptor = Object.getOwnPropertyDescriptor(Intl, 'RelativeTimeFormat')
+    Object.defineProperty(Intl, 'RelativeTimeFormat', { value: undefined, configurable: true })
+    try {
+      expect(formatRelativeTime(sub(3_600_000), { translate })).toMatch(/T\(time\.relative\.ago\)/)
+      expect(formatRelativeTime(add(3_600_000), { translate })).toMatch(/T\(time\.relative\.fromNow\)/)
+    } finally {
+      Object.defineProperty(Intl, 'RelativeTimeFormat', descriptor!)
+    }
+  })
+
+  it('localizes unit, number and suffix in a non-English locale', () => {
+    expect(formatRelativeTime(sub(3_600_000), { locale: 'pl' })).toBe('1 godzinę temu')
+    expect(formatRelativeTime(sub(600_000), { locale: 'pl' })).toBe('10 minut temu')
+    expect(formatRelativeTime(add(18_000_000), { locale: 'pl' })).toBe('za 5 godzin')
+  })
+
+  it('localizes in the requested locale even when a translate function is supplied', () => {
+    const translate = (_key: string, fallback?: string) => fallback ?? _key
+    const polish = formatRelativeTime(sub(600_000), { locale: 'pl', translate })
+    const english = formatRelativeTime(sub(600_000), { locale: 'en', translate })
+    expect(polish).toBe('10 minut temu')
+    expect(polish).not.toMatch(/minutes|ago/)
+    expect(english).not.toEqual(polish)
+  })
+
+  it('applies the locale plural rules instead of English pluralization', () => {
+    expect(formatRelativeTime(sub(120_000), { locale: 'pl' })).toBe('2 minuty temu')
+    expect(formatRelativeTime(sub(300_000), { locale: 'pl' })).toBe('5 minut temu')
+  })
+
+  it('renders differently per locale for the same instant', () => {
+    const value = sub(172_800_000)
+    const rendered = ['en', 'pl', 'de', 'es'].map((locale) => formatRelativeTime(value, { locale }))
+    expect(new Set(rendered).size).toBe(rendered.length)
+  })
 })
 describe('formatDateTime', () => {
   it('returns null for invalid or missing values', () => {

--- a/packages/shared/src/lib/i18n/context.tsx
+++ b/packages/shared/src/lib/i18n/context.tsx
@@ -94,6 +94,16 @@ export function useLocale() {
 }
 
 /**
+ * Like `useLocale`, but returns `undefined` instead of throwing when no
+ * `I18nProvider` is in scope. Use in shared components that receive their
+ * translator as a prop and may render outside a provider (galleries, tests).
+ */
+export function useOptionalLocale(): Locale | undefined {
+  const ctx = useContext(I18nContext)
+  return ctx?.locale
+}
+
+/**
  * True when the active locale is pinned via `OM_FORCE_LOCALE`. Returns `false`
  * when no provider is in scope so callers can render unconditionally.
  */

--- a/packages/shared/src/lib/time.ts
+++ b/packages/shared/src/lib/time.ts
@@ -13,11 +13,12 @@ export type RelativeTimeTranslator = (
 
 export type FormatRelativeTimeOptions = {
   /**
-   * Only used when the runtime has no `Intl.RelativeTimeFormat`. Localization
-   * comes from `Intl` so the number, unit name and plural form follow `locale`.
+   * Supplies the suffix only when the runtime has no `Intl.RelativeTimeFormat`.
+   * Otherwise the number, unit name, plural form and suffix all come from
+   * `Intl` in `locale` — pass `useLocale()` client-side so the text follows the
+   * application language rather than the runtime one.
    */
   translate?: RelativeTimeTranslator
-  /** Application locale; pass `useLocale()` client-side so the text is not rendered in the runtime locale. */
   locale?: string | string[]
 }
 

--- a/packages/shared/src/lib/time.ts
+++ b/packages/shared/src/lib/time.ts
@@ -12,7 +12,12 @@ export type RelativeTimeTranslator = (
 ) => string
 
 export type FormatRelativeTimeOptions = {
+  /**
+   * Only used when the runtime has no `Intl.RelativeTimeFormat`. Localization
+   * comes from `Intl` so the number, unit name and plural form follow `locale`.
+   */
   translate?: RelativeTimeTranslator
+  /** Application locale; pass `useLocale()` client-side so the text is not rendered in the runtime locale. */
   locale?: string | string[]
 }
 
@@ -37,23 +42,16 @@ export function formatRelativeTime(
       ? new Intl.RelativeTimeFormat(options?.locale, { numeric: 'auto' })
       : null
 
-const format = (unit: RelativeTimeUnit, divisor: number) => {
-  const valueToFormat = Math.round(diffSeconds / divisor)
-  const isPast = diffSeconds < 0
+  const format = (unit: RelativeTimeUnit, divisor: number) => {
+    const valueToFormat = Math.round(diffSeconds / divisor)
+    if (rtf) return rtf.format(valueToFormat, unit)
 
-  if (translate) {
-    const suffixKey = isPast ? 'time.relative.ago' : 'time.relative.fromNow'
+    const isPast = diffSeconds < 0
     const fallbackSuffix = isPast ? 'ago' : 'from now'
-    const suffix = translate(suffixKey, fallbackSuffix)
+    const suffixKey = isPast ? 'time.relative.ago' : 'time.relative.fromNow'
+    const suffix = translate ? translate(suffixKey, fallbackSuffix) : fallbackSuffix
     const magnitude = Math.abs(valueToFormat)
     return `${magnitude} ${unit}${magnitude === 1 ? '' : 's'} ${suffix}`
-  }
-
-  if (rtf) return rtf.format(valueToFormat, unit)
-
-  const fallbackSuffix = isPast ? 'ago' : 'from now'
-  const magnitude = Math.abs(valueToFormat)
-  return `${magnitude} ${unit}${magnitude === 1 ? '' : 's'} ${fallbackSuffix}`
   }
 
   if (absSeconds < 45) return format('second', 1)

--- a/packages/ui/src/backend/notifications/NotificationItem.tsx
+++ b/packages/ui/src/backend/notifications/NotificationItem.tsx
@@ -7,6 +7,7 @@ import { IconButton } from '../../primitives/icon-button'
 import { cn } from '@open-mercato/shared/lib/utils'
 import { formatRelativeTime } from '@open-mercato/shared/lib/time'
 import type { NotificationDto, NotificationRendererProps, NotificationTypeAction } from '@open-mercato/shared/modules/notifications/types'
+import { useOptionalLocale } from '@open-mercato/shared/lib/i18n/context'
 import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
 import type { ComponentType } from 'react'
 
@@ -75,6 +76,7 @@ export function NotificationItem({
   customRenderer: CustomRenderer,
 }: NotificationItemProps) {
   const router = useRouter()
+  const locale = useOptionalLocale()
   const [executing, setExecuting] = React.useState<string | null>(null)
 
   const isUnread = notification.status === 'unread'
@@ -96,7 +98,7 @@ export function NotificationItem({
     variables: notification.bodyVariables ?? undefined,
     t,
   })
-  const timeAgo = formatRelativeTime(notification.createdAt, { translate: t }) ?? ''
+  const timeAgo = formatRelativeTime(notification.createdAt, { locale, translate: t }) ?? ''
   const sourceLabel = humanizeModuleId(notification.sourceModule)
 
   const handleClick = async () => {


### PR DESCRIPTION
Closes #5286

## 🎯 Goal
- Relative timestamps ("44 minutes ago", "2 hours ago") now render in the application language everywhere they appear, instead of always falling back to English while the surrounding page is translated.

## 🔍 Problem
On a Polish-configured app, the "Zaktualizowano" column and every other "time ago" surface rendered English text ("8 minutes ago") next to fully translated headings, labels and statuses. The reporter noted the defect is generic to the shared helper rather than specific to one list page, and that is exactly what the code shows.

## 🔍 Root Cause
`formatRelativeTime` in `packages/shared/src/lib/time.ts` built the `Intl.RelativeTimeFormat` instance and then never used it whenever a `translate` function was supplied: that branch short-circuited first and hand-assembled the string as `` `${magnitude} ${unit}${magnitude === 1 ? '' : 's'} ${suffix}` ``. Only the trailing "ago" / "from now" went through the translator (against keys `time.relative.ago` / `time.relative.fromNow` that no dictionary defines, so even that resolved to the English fallback). The unit name came straight from the internal English `RelativeTimeUnit` token and the plural form from an English `+ 's'` rule, which is wrong for Polish (`minut` / `minuty` / `minutę`) and every other locale. Since the notification renderers and the deals list all call the helper with `{ translate: t }`, they all took the broken branch.

## What Changed
- `packages/shared/src/lib/time.ts` — `Intl.RelativeTimeFormat` is now the primary formatter: it renders the number, unit name, plural form and suffix in the requested locale. `translate` is demoted to what it can actually do correctly — supplying the suffix in the degraded fallback path used only when the runtime has no `Intl.RelativeTimeFormat`. The option is documented accordingly; the exported signature is unchanged.
- `packages/shared/src/lib/i18n/context.tsx` — new `useOptionalLocale()`, mirroring the existing `useOptionalT()`: returns `undefined` instead of throwing when no `I18nProvider` is in scope, for shared components that receive their translator as a prop and can render outside a provider (component gallery, unit tests).
- Threaded the application locale into the twelve call sites that were passing a translator but no locale, so the text follows the app language rather than the browser/OS one: the notification renderers in `core` (wms ×2, sales ×2, inbox_ops), `checkout` (×3), `ai-assistant`, `enterprise` (record_locks), the shared `packages/ui/src/backend/notifications/NotificationItem.tsx`, and the deals list column in `packages/core/src/modules/customers/backend/customers/deals/page.tsx` (added to the columns `useMemo` deps so a locale switch re-renders).
- `packages/core/src/modules/wms/widgets/notifications/__tests__/WmsLowStockRenderer.test.tsx` — its `i18n/context` module mock now also stubs `useLocale`.

Out of scope, deliberately: the call sites that pass **neither** a translator nor a locale (`NotesSection`, `ActivitiesSection`, `TimelineItemHeader`, several dashboard widgets) belong to the separate, already-assigned #5276 sweep and are untouched here.

## 🧪 Tests
- `packages/shared/src/lib/__tests__/time.test.ts` — four new cases plus one rewritten: a non-English locale localizes unit, number and suffix (`1 godzinę temu`, `10 minut temu`, `za 5 godzin`); the same instant with a `translate` function supplied still renders Polish and never leaks `minutes` / `ago`; locale plural rules are applied instead of English pluralization (`2 minuty temu` vs `5 minut temu`); the same instant renders distinctly across `en` / `pl` / `de` / `es`; and the translator test now pins its real contract — the suffix fallback when `Intl.RelativeTimeFormat` is absent.
- Verified the regression bites: with the `time.ts` change reverted and the new tests in place, the translator + locale case fails (1 failed / 15 passed); with the fix, `yarn workspace @open-mercato/shared test --testPathPatterns "lib/__tests__/time"` is 16 passed / 16 total.
- Validation gate (local runner, in order): `yarn build:packages` ✅ · `yarn generate` ✅ · `yarn build:packages` ✅ · `yarn i18n:check-sync` ✅ · `yarn i18n:check-usage` ✅ · `yarn typecheck` ✅ · `yarn test` — 28 of 29 workspaces green (core 9727, app 554, checkout 159, ui/shared/enterprise/ai-assistant all passing); `create-mercato-app` fails ❌ · `yarn build:app` ✅.
- The `create-mercato-app` failure is pre-existing and environmental, not caused by this change: it is the standalone AI-harness suite (live Codex/Claude adapter cases needing those CLIs, plus a `target.typecheck: yarn typecheck must complete within 120000ms` budget oracle). Re-running that workspace's tests on the same machine with this branch's changes stashed reproduces the identical failure (exit 1, 161 failing cases), so the baseline is red independently of this PR.

## 💥 Breaking Changes
- None to any exported signature: `formatRelativeTime(value, { translate, locale })` and `FormatRelativeTimeOptions` are unchanged, and `useOptionalLocale` is purely additive.
- One intentional behavior change inside the fix: when a caller supplies `translate` **and** the runtime has `Intl.RelativeTimeFormat`, the output is now the Intl-formatted string rather than the hand-built English one — that is the defect being removed. No dictionary in the repo defines `time.relative.ago` / `time.relative.fromNow`, so no existing translation is dropped; those keys still drive the no-Intl fallback.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789404912&installation_model_id=432243&pr_number=5329&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5329&signature=19fd8955723f98ca0a186983f9ec77d9f5669a97ee2c3de48a8f15f1577882db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->