### PR TITLE
feat(wms): preselect the sole warehouse and support custom fields in the zone dialog (#5239)

### DIFF
--- a/.ai/runs/2026-08-17-issue-5239-wms-zone-dialog.md
+++ b/.ai/runs/2026-08-17-issue-5239-wms-zone-dialog.md
@@ -1,0 +1,81 @@
+# Execution plan — land the #5239 zone dialog work by fixing every code-review finding (adopted from PR #5334)
+
+**Origin:** adopted — reconstructed by `om-auto-continue-pr` on 2026-08-17 because PR #5334 carried no execution plan.
+**PR:** #5334 · **Branch:** `feat/issue-5239-wms-zone-dialog` · **Base:** `develop`
+**Author:** @Paul-Mlodochowki — this plan interprets their intent; correct it by editing this file or commenting on the PR.
+
+## 🎯 Goal
+
+Make PR #5334 mergeable: deliver requirement 2 of #5239 (the zone dialog's custom fields actually persist and read back), remove the `ComboboxInput` label-corruption regression the review reproduced, and close every remaining review finding with the coverage the checklist demands.
+
+## Scope
+
+- `packages/core/src/modules/wms/` — zone commands, zones list route, the configuration page's zone dialog, command unit tests.
+- `packages/ui/src/backend/inputs/ComboboxInput.tsx` and its unit tests.
+- The `TC-WMS-028-zone-dialog` integration spec (comments/links only; its assertions already have the right shape).
+
+## Non-goals
+
+- Rewriting the zone commands onto `runCrudCommandWrite`. The review does not ask for it and it would widen the diff across a shared write path; the existing `emitCrudSideEffects` composition is the pattern the rest of this module already uses.
+- Fixing the `CrudForm` accessibility gap (no `htmlFor`/`id` on dialog fields) that finding **n3** describes. That is a framework-level defect touching every form in the product — it gets its own issue, linked from the spec comment.
+- Backfilling query-index coverage for zones created before this change. The index self-heals through the existing coverage refresh; no migration is in scope.
+
+## Evidence
+
+| Conclusion | Drawn from | Confidence |
+|---|---|---|
+| The goal is "fix everything the review found", not new feature work | The user's invocation, which pasted the full review verbatim and asked for the findings to be fixed | high |
+| Requirement 2 genuinely does not persist | `TC-WMS-028-zone-dialog.spec.ts:248` failing deterministically (`Expected: "Pick face …", Received: null`), reported in the PR body and confirmed by the review | high |
+| The write chain (client → route → command → `dataEngine.setCustomFields`) is correct | The reviewer executed both halves against the real schema/handler and observed the correct call | high |
+| The break is on the **read** projection, not the write | `HybridQueryEngine` (the DI-registered engine) serves `cf:*` from `entity_indexes`, and the zone commands never emit `emitCrudSideEffects`, so no `query_index.upsert_one` ever runs for a zone | high |
+| `ComboboxInput`'s new guard corrupts a picked label into the raw record id | The review reproduced it with a discriminating test: passes on `origin/develop`, fails on `1ac4915`, with only that file swapped | high |
+| The server-side custom-field change has zero unit coverage | `git diff` shows the only new unit tests are the two `ComboboxInput` cases | high |
+
+## Assumptions
+
+- **The indexer is the whole of B1.** The reviewer proved the write reaches `setCustomFields`; the hybrid engine reading `cf:*` out of `entity_indexes` is then the only remaining link that can turn a written value into `null`. If a live run still shows `null` after this change, the next suspect is `upsertIndexRow`'s custom-field projection, not the command wiring.
+- **Adding the indexer to zone commands is safe and additive.** Zones already declare `indexer: { entityType: E.wms.warehouse_zone }` on the CRUD route, so the entity type is already an indexed one; the commands were simply not emitting the side effect.
+- **No new event ids.** `emitCrudSideEffects` is wired with `indexer` only, not `events`, so the existing `wms.zone.created` / `wms.zone.updated` emissions stay the single event source and no undeclared `wms.warehouse_zone.*` event appears.
+- **Adoption mode is `auto`.** A user is in the loop, which normally means `ask`, but they supplied the goal outright (the pasted review plus "fix the findings"), so confirming a reconstructed plan would only cost a turn. Correct this by commenting on the PR.
+
+## Risks
+
+- `ComboboxInput` is a shared primitive; the M1 fix narrows when a focused field syncs, so it needs the M2 coverage cases to prove the other windows still behave.
+- B1 cannot be proven end-to-end without a live environment. Mitigation: the unit tests of Phase 3 pin the command-side contract, and the fix's mechanism is traceable in code from `markOrmEntityChange` to `query_index.upsert_one` to `entity_indexes`.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Already landed on this PR (reconstructed)
+
+- [x] 1.1 Preselect the sole warehouse, wire custom fields through route/commands/form, add the TC-WMS-028 integration spec and two ComboboxInput tests — 1ac4915
+
+### Phase 2: B1 — make the zone custom fields readable
+
+- [ ] 2.1 Emit CRUD side effects with a warehouse-zone indexer from the zone create/update/delete commands and their undo handlers
+
+### Phase 3: B2 — unit coverage for the server-side custom-field change
+
+- [ ] 3.1 Add the zone custom-field command suite (create with/without values, update, both undo resets, snapshot loader)
+
+### Phase 4: M1 and M2 — ComboboxInput
+
+- [ ] 4.1 Never sync a focused field to a self-mapping placeholder label
+- [ ] 4.2 Add the discriminating pick-then-stale-reload test plus the three blast-radius cases
+
+### Phase 5: Minor findings m1–m7
+
+- [ ] 5.1 Give the zone edit dialog optimistic locking (`id` + `updatedAt` in initialValues)
+- [ ] 5.2 Restore custom fields on delete-undo and stop discarding the snapshot
+- [ ] 5.3 Opt the new zones decorator into `stripPrefixedKeys` and type the `customFields` OpenAPI entry
+- [ ] 5.4 Feed the warehouse combobox from the cached query instead of a second round trip
+- [ ] 5.5 Narrow the `ZoneRow` / `ZoneFormValues` index signatures and short-circuit the custom-field snapshot load
+
+### Phase 6: Nits and follow-ups
+
+- [ ] 6.1 Annotate the non-discriminating test, de-couple the ComboboxInput comment from WMS, file the CrudForm accessibility issue
+
+### Phase 7: Validation and delivery
+
+- [ ] 7.1 Run the full validation gate, push, update the PR body and labels, post the summary comment

--- a/.ai/runs/2026-08-17-issue-5239-wms-zone-dialog.md
+++ b/.ai/runs/2026-08-17-issue-5239-wms-zone-dialog.md
@@ -53,29 +53,35 @@ Make PR #5334 mergeable: deliver requirement 2 of #5239 (the zone dialog's custo
 
 ### Phase 2: B1 — make the zone custom fields readable
 
-- [ ] 2.1 Emit CRUD side effects with a warehouse-zone indexer from the zone create/update/delete commands and their undo handlers
+- [x] 2.1 Emit CRUD side effects with a warehouse-zone indexer from the zone create/update/delete commands and their undo handlers — 7fbae24
 
 ### Phase 3: B2 — unit coverage for the server-side custom-field change
 
-- [ ] 3.1 Add the zone custom-field command suite (create with/without values, update, both undo resets, snapshot loader)
+- [x] 3.1 Add the zone custom-field command suite (create with/without values, update, both undo resets, snapshot loader) — 7fbae24
 
 ### Phase 4: M1 and M2 — ComboboxInput
 
-- [ ] 4.1 Never sync a focused field to a self-mapping placeholder label
-- [ ] 4.2 Add the discriminating pick-then-stale-reload test plus the three blast-radius cases
+- [x] 4.1 Never sync a focused field to a self-mapping placeholder label — e35ad73
+- [x] 4.2 Add the discriminating pick-then-stale-reload test plus the three blast-radius cases — e35ad73
 
 ### Phase 5: Minor findings m1–m7
 
-- [ ] 5.1 Give the zone edit dialog optimistic locking (`id` + `updatedAt` in initialValues)
-- [ ] 5.2 Restore custom fields on delete-undo and stop discarding the snapshot
-- [ ] 5.3 Opt the new zones decorator into `stripPrefixedKeys` and type the `customFields` OpenAPI entry
-- [ ] 5.4 Feed the warehouse combobox from the cached query instead of a second round trip
-- [ ] 5.5 Narrow the `ZoneRow` / `ZoneFormValues` index signatures and short-circuit the custom-field snapshot load
+- [x] 5.1 Give the zone edit dialog optimistic locking (`id` + `updatedAt` in initialValues) — 656483e
+- [x] 5.2 Restore custom fields on delete-undo and stop discarding the snapshot — 7fbae24
+- [x] 5.3 Opt the new zones decorator into `stripPrefixedKeys` and type the `customFields` OpenAPI entry — 656483e
+- [x] 5.4 Feed the warehouse combobox from the cached query instead of a second round trip — 656483e
+- [x] 5.5 Narrow the `ZoneRow` / `ZoneFormValues` index signatures and short-circuit the custom-field snapshot load — 656483e
 
 ### Phase 6: Nits and follow-ups
 
-- [ ] 6.1 Annotate the non-discriminating test, de-couple the ComboboxInput comment from WMS, file the CrudForm accessibility issue
+- [x] 6.1 Annotate the non-discriminating test, de-couple the ComboboxInput comment from WMS, file the CrudForm accessibility issue (#5360) — e35ad73, 656483e
 
 ### Phase 7: Validation and delivery
 
-- [ ] 7.1 Run the full validation gate, push, update the PR body and labels, post the summary comment
+- [x] 7.1 Run the full validation gate, push, update the PR body and labels, post the summary comment — 656483e
+
+## Outcome notes
+
+- **m7 was answered with a measurement, not a short-circuit.** The review estimated four extra queries per zone update; `loadCustomFieldValues` returns early on an empty `custom_field_values` result and never issues the `custom_field_defs` query, so a tenant with no zone custom fields pays one lookup per snapshot, not two. Documented at the call site instead of adding a redundant guard.
+- **The row-action zone delete still has no optimistic locking.** m1 scoped the fix to the dialog, and half-wiring a row action — a header without the `surfaceRecordConflict` bar behind it — would be worse than the existing gap. Left for a follow-up that does both.
+- **B1 remains unproven end to end** until `TC-WMS-028-zone-dialog.spec.ts` runs against a live environment. The mechanism is traceable in code and the command-side contract is now pinned by unit tests.

--- a/packages/core/src/modules/wms/__integration__/TC-WMS-028-zone-dialog.spec.ts
+++ b/packages/core/src/modules/wms/__integration__/TC-WMS-028-zone-dialog.spec.ts
@@ -1,0 +1,277 @@
+import { randomUUID } from 'node:crypto'
+import { expect, test, type APIRequestContext, type Locator, type Page } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  apiRequestWithSelectedOrg,
+  createOrganizationFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { getCustomFieldValue } from '@open-mercato/core/helpers/integration/crudFormFields'
+import {
+  expectId,
+  getTokenScope,
+  readJsonSafe,
+} from '@open-mercato/core/helpers/integration/generalFixtures'
+
+export const integrationMeta = {
+  dependsOnModules: ['wms'],
+}
+
+const DEFINITIONS_PATH = '/api/entities/definitions'
+const ZONE_ENTITY_ID = 'wms:warehouse_zone'
+
+type ZoneListResponse = { items?: Array<Record<string, unknown>> }
+
+/**
+ * "The tenant has exactly one warehouse" is the precondition under test, so it must be
+ * established rather than inherited: a throwaway organization holds the single warehouse,
+ * and a dedicated user whose ACL visibility is restricted to that organization drives the
+ * browser. Forcing `om_selected_org` onto an organization the signed-in user cannot see is
+ * silently ignored, which would leave the session in the seeded organization instead.
+ */
+async function createScopedFixture(
+  request: APIRequestContext,
+  token: string,
+  selectedOrgId: string,
+  path: string,
+  data: Record<string, unknown>,
+): Promise<string> {
+  const response = await apiRequestWithSelectedOrg(request, 'POST', path, {
+    token,
+    selectedOrgId,
+    data,
+  })
+  expect(response.ok(), `Failed POST ${path}: ${response.status()}`).toBeTruthy()
+  const body = await readJsonSafe<{ id?: string }>(response)
+  return expectId(body?.id, `Missing id in ${path} create response`)
+}
+
+async function deleteScopedFixture(
+  request: APIRequestContext,
+  token: string | null,
+  selectedOrgId: string | null,
+  path: string,
+  id: string | null,
+): Promise<void> {
+  if (!token || !selectedOrgId || !id) return
+  await apiRequestWithSelectedOrg(request, 'DELETE', `${path}?id=${encodeURIComponent(id)}`, {
+    token,
+    selectedOrgId,
+  }).catch(() => undefined)
+}
+
+async function readZoneById(
+  request: APIRequestContext,
+  token: string,
+  selectedOrgId: string,
+  zoneId: string,
+): Promise<Record<string, unknown> | null> {
+  const response = await apiRequestWithSelectedOrg(
+    request,
+    'GET',
+    `/api/wms/zones?ids=${encodeURIComponent(zoneId)}&page=1&pageSize=10`,
+    { token, selectedOrgId },
+  )
+  expect(response.ok(), `Failed GET /api/wms/zones: ${response.status()}`).toBeTruthy()
+  const body = await readJsonSafe<ZoneListResponse>(response)
+  return (body?.items ?? []).find((item) => item.id === zoneId) ?? null
+}
+
+/**
+ * CrudForm renders its labels as plain text rather than associating them with the input,
+ * so no field in the dialog exposes an accessible name and `getByLabel` matches nothing.
+ * Target the field container instead, the way the rest of the suite does.
+ */
+function crudField(scope: Locator, fieldId: string): Locator {
+  return scope.locator(`[data-crud-field-id="${fieldId}"] input`).first()
+}
+
+async function loginAsScopedUser(
+  page: Page,
+  email: string,
+  password: string,
+  tenantId: string,
+  organizationId: string,
+): Promise<void> {
+  const form = new URLSearchParams()
+  form.set('email', email)
+  form.set('password', password)
+  const response = await page.request.post('/api/auth/login', {
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    data: form.toString(),
+  })
+  expect(response.ok(), `Failed to login zone dialog test user: ${response.status()}`).toBeTruthy()
+
+  const baseUrl = process.env.BASE_URL || 'http://127.0.0.1:5001'
+  await page.context().addCookies([
+    { name: 'om_demo_notice_ack', value: 'ack', url: baseUrl, sameSite: 'Lax' as const },
+    { name: 'om_cookie_notice_ack', value: 'ack', url: baseUrl, sameSite: 'Lax' as const },
+    { name: 'om_feedback_suppress', value: '1', url: baseUrl, sameSite: 'Lax' as const },
+    { name: 'om_selected_tenant', value: tenantId, url: baseUrl, sameSite: 'Lax' as const },
+    { name: 'om_selected_org', value: organizationId, url: baseUrl, sameSite: 'Lax' as const },
+  ])
+}
+
+test.describe('TC-WMS-028: WMS create zone dialog (#5239)', () => {
+  test('pre-selects the only warehouse and round-trips a custom field', async ({ page, request }) => {
+    test.slow()
+
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const scope = getTokenScope(superadminToken)
+    const suffix = randomUUID().slice(0, 8)
+    const customFieldKey = `zone_note_${suffix}`
+    const customFieldLabel = `Zone Note ${suffix}`
+    const customFieldValue = `Pick face ${suffix}`
+    const warehouseName = `TC-WMS-028 Warehouse ${suffix}`
+    const zoneCode = `TCW28Z${suffix}`
+    const zoneName = `TC-WMS-028 Zone ${suffix}`
+    const userEmail = `tc-wms-028-${suffix}@example.com`
+    const userPassword = `Zone!${suffix}`
+
+    let organizationId: string | null = null
+    let userId: string | null = null
+    let warehouseId: string | null = null
+    let zoneId: string | null = null
+    let customFieldCreated = false
+    let userToken: string | null = null
+
+    try {
+      organizationId = await createOrganizationFixture(request, superadminToken, {
+        name: `TC-WMS-028 Org ${suffix}`,
+        tenantId: scope.tenantId,
+      })
+
+      userId = await createUserFixture(request, superadminToken, {
+        email: userEmail,
+        password: userPassword,
+        organizationId,
+        roles: ['employee'],
+        name: `QA Zone Dialog ${suffix}`,
+      })
+      await setUserAclVisibility(request, superadminToken, {
+        userId,
+        features: ['wms.*', 'entities.*'],
+        organizations: [organizationId],
+      })
+      userToken = await getAuthToken(request, userEmail, userPassword)
+
+      warehouseId = await createScopedFixture(request, userToken, organizationId, '/api/wms/warehouses', {
+        name: warehouseName,
+        code: `TCW28W${suffix}`,
+        isActive: true,
+      })
+
+      // Definitions are read back as `organizationId IN (auth.orgId, NULL)`, so the
+      // definition has to be created from the same organization the browser session runs
+      // in. Creating it unscoped stores it against the creator's own organization, and
+      // the dialog then renders no custom field at all.
+      const definitionResponse = await apiRequestWithSelectedOrg(request, 'POST', DEFINITIONS_PATH, {
+        token: userToken,
+        selectedOrgId: organizationId,
+        data: {
+          entityId: ZONE_ENTITY_ID,
+          key: customFieldKey,
+          kind: 'text',
+          configJson: { label: customFieldLabel, formEditable: true, listVisible: true },
+        },
+      })
+      expect(
+        definitionResponse.ok(),
+        `Failed to create ${ZONE_ENTITY_ID} custom field: ${definitionResponse.status()}`,
+      ).toBeTruthy()
+      customFieldCreated = true
+
+      await loginAsScopedUser(page, userEmail, userPassword, scope.tenantId, organizationId)
+
+      // The single warehouse must be the only one this session can see, otherwise the
+      // "sole warehouse" precondition of #5239 is not actually under test.
+      const warehousesResponse = await apiRequestWithSelectedOrg(
+        request,
+        'GET',
+        '/api/wms/warehouses?page=1&pageSize=50',
+        { token: userToken, selectedOrgId: organizationId },
+      )
+      expect(warehousesResponse.ok(), 'Failed GET /api/wms/warehouses').toBeTruthy()
+      const warehousesBody = await readJsonSafe<{ items?: Array<Record<string, unknown>> }>(warehousesResponse)
+      expect(
+        (warehousesBody?.items ?? []).length,
+        'Scoped organization should contain exactly one warehouse',
+      ).toBe(1)
+
+      await page.goto('/backend/wms/zones')
+
+      const addZoneButton = page.getByRole('button', { name: /Add zone/i }).first()
+      await expect(addZoneButton).toBeVisible({ timeout: 15_000 })
+      await addZoneButton.click()
+
+      const dialog = page.getByRole('dialog').filter({ hasText: /Create zone/i }).first()
+      await expect(dialog).toBeVisible()
+
+      // Requirement 1 (#5239): the single warehouse in scope is pre-selected, so the
+      // operator never has to search for the only choice the form can accept.
+      const warehouseInput = crudField(dialog, 'warehouseId')
+      await expect(warehouseInput).toHaveValue(warehouseName, { timeout: 15_000 })
+
+      // Requirement 2 (#5239): the CrudForm renders the entity's custom fields.
+      const customFieldInput = crudField(dialog, `cf_${customFieldKey}`)
+      await expect(customFieldInput).toBeVisible({ timeout: 15_000 })
+
+      await crudField(dialog, 'code').fill(zoneCode)
+      await crudField(dialog, 'name').fill(zoneName)
+      await customFieldInput.fill(customFieldValue)
+      await dialog.getByRole('button', { name: /Save/i }).click()
+      await expect(dialog).toHaveCount(0, { timeout: 15_000 })
+
+      const zoneRow = page.getByRole('row').filter({ hasText: zoneCode }).first()
+      await expect(zoneRow).toBeVisible({ timeout: 15_000 })
+
+      const listResponse = await apiRequestWithSelectedOrg(
+        request,
+        'GET',
+        `/api/wms/zones?search=${encodeURIComponent(zoneCode)}&page=1&pageSize=10`,
+        { token: userToken, selectedOrgId: organizationId },
+      )
+      expect(listResponse.ok(), `Failed GET /api/wms/zones: ${listResponse.status()}`).toBeTruthy()
+      const listBody = await readJsonSafe<ZoneListResponse>(listResponse)
+      const createdZone = (listBody?.items ?? []).find((item) => item.code === zoneCode)
+      expect(createdZone, `Zone ${zoneCode} should exist after saving the dialog`).toBeTruthy()
+      zoneId = typeof createdZone?.id === 'string' ? createdZone.id : null
+      expect(zoneId, 'Created zone should expose an id').toBeTruthy()
+      expect(createdZone?.warehouse_id).toBe(warehouseId)
+
+      // The custom field value entered in the dialog survives the write path.
+      const persisted = await readZoneById(request, userToken, organizationId, zoneId!)
+      expect(persisted, 'Created zone should be readable by id').toBeTruthy()
+      expect(getCustomFieldValue(persisted!, customFieldKey)).toBe(customFieldValue)
+
+      // ...and is hydrated back into the edit dialog rather than coming up blank.
+      await page.reload()
+      const reloadedRow = page.getByRole('row').filter({ hasText: zoneCode }).first()
+      await expect(reloadedRow).toBeVisible({ timeout: 15_000 })
+      await reloadedRow.getByRole('button').last().click()
+      await page.getByRole('menuitem', { name: /Edit/i }).first().click()
+
+      const editDialog = page.getByRole('dialog').filter({ hasText: /Edit zone/i }).first()
+      await expect(editDialog).toBeVisible({ timeout: 15_000 })
+      await expect(crudField(editDialog, `cf_${customFieldKey}`)).toHaveValue(customFieldValue, {
+        timeout: 15_000,
+      })
+      await expect(crudField(editDialog, 'warehouseId')).toHaveValue(warehouseName)
+    } finally {
+      await deleteScopedFixture(request, userToken, organizationId, '/api/wms/zones', zoneId)
+      await deleteScopedFixture(request, userToken, organizationId, '/api/wms/warehouses', warehouseId)
+      if (customFieldCreated && userToken && organizationId) {
+        await apiRequestWithSelectedOrg(request, 'DELETE', DEFINITIONS_PATH, {
+          token: userToken,
+          selectedOrgId: organizationId,
+          data: { entityId: ZONE_ENTITY_ID, key: customFieldKey },
+        }).catch(() => undefined)
+      }
+      await deleteUserIfExists(request, superadminToken, userId)
+      await deleteOrganizationIfExists(request, superadminToken, organizationId)
+    }
+  })
+})

--- a/packages/core/src/modules/wms/__integration__/TC-WMS-028-zone-dialog.spec.ts
+++ b/packages/core/src/modules/wms/__integration__/TC-WMS-028-zone-dialog.spec.ts
@@ -84,6 +84,10 @@ async function readZoneById(
  * CrudForm renders its labels as plain text rather than associating them with the input,
  * so no field in the dialog exposes an accessible name and `getByLabel` matches nothing.
  * Target the field container instead, the way the rest of the suite does.
+ *
+ * Tracked as a framework-level defect in
+ * https://github.com/open-mercato/open-mercato/issues/5360 — switch this helper to
+ * `getByLabel` once the label/control association lands.
  */
 function crudField(scope: Locator, fieldId: string): Locator {
   return scope.locator(`[data-crud-field-id="${fieldId}"] input`).first()

--- a/packages/core/src/modules/wms/api/zones/route.ts
+++ b/packages/core/src/modules/wms/api/zones/route.ts
@@ -79,7 +79,10 @@ const crud = makeCrudRoute({
       }
       return filters
     },
-    decorateCustomFields: { entityIds: [E.wms.warehouse_zone] },
+    // Zones had no decorator before this route gained custom fields, so there is no
+    // legacy consumer reading top-level `cf_*`/`cf:*` — take the canonical single-shape
+    // response (#1769) rather than emitting both forms.
+    decorateCustomFields: { entityIds: [E.wms.warehouse_zone], stripPrefixedKeys: true },
   },
   hooks: {
     afterList: async (payload, ctx) => {
@@ -123,6 +126,16 @@ export const POST = crud.POST
 export const PUT = crud.PUT
 export const DELETE = crud.DELETE
 
+// Mirrors `CustomFieldDisplayEntry` from @open-mercato/shared/lib/crud/custom-fields, so
+// the generated OpenAPI documents how to read an entry instead of an opaque record.
+const customFieldDisplayEntrySchema = z.object({
+  key: z.string(),
+  label: z.string().nullable(),
+  value: z.unknown(),
+  kind: z.string().nullable(),
+  multi: z.boolean(),
+})
+
 const zoneListItemSchema = z.object({
   id: z.string().uuid().nullable().optional(),
   organization_id: z.string().uuid().nullable().optional(),
@@ -136,7 +149,7 @@ const zoneListItemSchema = z.object({
   created_at: z.string().nullable().optional(),
   updated_at: z.string().nullable().optional(),
   customValues: z.record(z.string(), z.unknown()).nullable().optional(),
-  customFields: z.array(z.record(z.string(), z.unknown())).optional(),
+  customFields: z.array(customFieldDisplayEntrySchema).optional(),
 })
 
 export const openApi = createWmsCrudOpenApi({

--- a/packages/core/src/modules/wms/api/zones/route.ts
+++ b/packages/core/src/modules/wms/api/zones/route.ts
@@ -79,6 +79,7 @@ const crud = makeCrudRoute({
       }
       return filters
     },
+    decorateCustomFields: { entityIds: [E.wms.warehouse_zone] },
   },
   hooks: {
     afterList: async (payload, ctx) => {
@@ -134,6 +135,8 @@ const zoneListItemSchema = z.object({
   priority: z.number().nullable().optional(),
   created_at: z.string().nullable().optional(),
   updated_at: z.string().nullable().optional(),
+  customValues: z.record(z.string(), z.unknown()).nullable().optional(),
+  customFields: z.array(z.record(z.string(), z.unknown())).optional(),
 })
 
 export const openApi = createWmsCrudOpenApi({

--- a/packages/core/src/modules/wms/commands/__tests__/configuration.zoneCustomFields.test.ts
+++ b/packages/core/src/modules/wms/commands/__tests__/configuration.zoneCustomFields.test.ts
@@ -1,0 +1,414 @@
+/** @jest-environment node */
+
+import { commandRegistry } from '@open-mercato/shared/lib/commands/registry'
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    locale: 'en',
+    dict: {},
+    t: (key: string) => key,
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+jest.mock('../../events', () => ({
+  emitWmsEvent: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: (emInstance: { findOne: (...args: unknown[]) => unknown }, entity: unknown, filters: unknown) =>
+    emInstance.findOne(entity, filters),
+  findWithDecryption: (emInstance: { find: (...args: unknown[]) => unknown }, entity: unknown, filters: unknown) =>
+    emInstance.find(entity, filters),
+}))
+
+const TENANT = '11111111-1111-4111-8111-111111111111'
+const ORG = '22222222-2222-4222-8222-222222222222'
+const WAREHOUSE_ID = '33333333-3333-4333-8333-333333333333'
+const ZONE_ID = '44444444-4444-4444-8444-444444444444'
+const ZONE_ENTITY_ID = 'wms:warehouse_zone'
+
+type ZoneRecord = {
+  id: string
+  organizationId: string
+  tenantId: string
+  warehouse: { id: string }
+  code: string
+  name: string
+  priority: number
+  metadata: unknown
+  deletedAt: Date | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+type CustomFieldValueRow = {
+  recordId: string
+  fieldKey: string
+  organizationId: string | null
+  tenantId: string | null
+  valueText: string | null
+  valueMultiline: string | null
+  valueInt: number | null
+  valueFloat: number | null
+  valueBool: boolean | null
+}
+
+type SetCustomFieldsCall = {
+  entityId: string
+  recordId: string
+  organizationId: string | null
+  tenantId: string | null
+  values: Record<string, unknown>
+  notify?: boolean
+}
+
+type IndexChange = {
+  action: string
+  identifiers: { id: string; organizationId: string | null; tenantId: string | null }
+  indexerEntityType?: string
+}
+
+function textValueRow(fieldKey: string, value: string): CustomFieldValueRow {
+  return {
+    recordId: ZONE_ID,
+    fieldKey,
+    organizationId: ORG,
+    tenantId: TENANT,
+    valueText: value,
+    valueMultiline: null,
+    valueInt: null,
+    valueFloat: null,
+    valueBool: null,
+  }
+}
+
+function zoneRecord(overrides: Partial<ZoneRecord> = {}): ZoneRecord {
+  return {
+    id: ZONE_ID,
+    organizationId: ORG,
+    tenantId: TENANT,
+    warehouse: { id: WAREHOUSE_ID },
+    code: 'PICK',
+    name: 'Pick face',
+    priority: 5,
+    metadata: null,
+    deletedAt: null,
+    createdAt: new Date('2026-04-15T00:00:00.000Z'),
+    updatedAt: new Date('2026-04-16T00:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+function zoneSnapshot(custom?: Record<string, unknown>) {
+  return {
+    id: ZONE_ID,
+    organizationId: ORG,
+    tenantId: TENANT,
+    warehouseId: WAREHOUSE_ID,
+    code: 'PICK',
+    name: 'Pick face',
+    priority: 5,
+    metadata: null,
+    ...(custom ? { custom } : {}),
+    createdAt: '2026-04-15T00:00:00.000Z',
+    updatedAt: '2026-04-16T00:00:00.000Z',
+  }
+}
+
+/**
+ * Minimal em + container stub covering the lookups the zone commands make. `findOne`
+ * routes on the filter shape because the commands go through `findOneWithDecryption`,
+ * which the mock above collapses onto `em.findOne(entity, filters)` with the entity
+ * class carried opaquely.
+ */
+function createZoneHarness(options: { zone?: ZoneRecord | null; customFieldValues?: CustomFieldValueRow[] } = {}) {
+  const zone = options.zone === undefined ? zoneRecord() : options.zone
+  const customFieldValues = options.customFieldValues ?? []
+  const created: ZoneRecord[] = []
+  const setCustomFieldsCalls: SetCustomFieldsCall[] = []
+  const indexChanges: IndexChange[] = []
+
+  const em: Record<string, jest.Mock> = {
+    findOne: jest.fn(async (_entity: unknown, filters: Record<string, unknown>) => {
+      if (filters.code !== undefined && filters.warehouse !== undefined) return null
+      if (filters.id === WAREHOUSE_ID) {
+        return { id: WAREHOUSE_ID, organizationId: ORG, tenantId: TENANT, deletedAt: null }
+      }
+      if (filters.id === ZONE_ID) return zone
+      return null
+    }),
+    find: jest.fn(async (_entity: unknown, filters: Record<string, unknown>) => {
+      if (filters.recordId !== undefined) return customFieldValues
+      if (filters.key !== undefined) {
+        const keys = (filters.key as { $in?: string[] })?.$in ?? []
+        return keys.map((key) => ({
+          key,
+          kind: 'text',
+          entityId: ZONE_ENTITY_ID,
+          organizationId: ORG,
+          tenantId: TENANT,
+          isActive: true,
+          deletedAt: null,
+          configJson: null,
+        }))
+      }
+      return []
+    }),
+    create: jest.fn((_entity: unknown, data: Partial<ZoneRecord>) => {
+      const record = {
+        ...zoneRecord(),
+        ...data,
+        id: data.id ?? ZONE_ID,
+      } as ZoneRecord
+      created.push(record)
+      return record
+    }),
+    persist: jest.fn(() => em),
+    flush: jest.fn(async () => undefined),
+  }
+
+  const dataEngine = {
+    setCustomFields: jest.fn(async (opts: SetCustomFieldsCall) => {
+      setCustomFieldsCalls.push(opts)
+    }),
+    markOrmEntityChange: jest.fn((opts: { action: string; identifiers: IndexChange['identifiers']; indexer?: { entityType?: string } }) => {
+      indexChanges.push({
+        action: opts.action,
+        identifiers: opts.identifiers,
+        indexerEntityType: opts.indexer?.entityType,
+      })
+    }),
+  }
+
+  const ctx = {
+    auth: { tenantId: TENANT, orgId: ORG },
+    selectedOrganizationId: ORG,
+    container: {
+      resolve: (name: string) => {
+        if (name === 'em') return { fork: () => em }
+        if (name === 'dataEngine') return dataEngine
+        throw new Error(`unexpected resolve: ${name}`)
+      },
+    },
+  }
+
+  return { em, ctx, dataEngine, created, setCustomFieldsCalls, indexChanges }
+}
+
+describe('WMS zone commands — custom fields', () => {
+  beforeAll(async () => {
+    commandRegistry.clear?.()
+    await import('../configuration')
+  })
+
+  it('create writes the submitted custom fields against the canonical zone entity id', async () => {
+    const handler = commandRegistry.get('wms.zones.create')!
+    const harness = createZoneHarness({ zone: null })
+
+    await handler.execute(
+      {
+        organizationId: ORG,
+        tenantId: TENANT,
+        warehouseId: WAREHOUSE_ID,
+        code: 'Z1',
+        name: 'Zone 1',
+        priority: 3,
+        customFields: { zone_note: 'Pick face' },
+      } as never,
+      harness.ctx as never,
+    )
+
+    expect(harness.setCustomFieldsCalls).toHaveLength(1)
+    expect(harness.setCustomFieldsCalls[0]).toMatchObject({
+      entityId: ZONE_ENTITY_ID,
+      recordId: ZONE_ID,
+      organizationId: ORG,
+      tenantId: TENANT,
+      values: { zone_note: 'Pick face' },
+      notify: false,
+    })
+  })
+
+  // Regression guard for #5239: the zones list is served by the hybrid query engine,
+  // which projects `cf:*` out of `entity_indexes`. Without this side effect the value
+  // written above is stored but unreadable, which is exactly how the feature shipped broken.
+  it('create queues a query-index upsert for the zone so the written values become readable', async () => {
+    const handler = commandRegistry.get('wms.zones.create')!
+    const harness = createZoneHarness({ zone: null })
+
+    await handler.execute(
+      {
+        organizationId: ORG,
+        tenantId: TENANT,
+        warehouseId: WAREHOUSE_ID,
+        code: 'Z1',
+        name: 'Zone 1',
+        customFields: { zone_note: 'Pick face' },
+      } as never,
+      harness.ctx as never,
+    )
+
+    expect(harness.indexChanges).toEqual([
+      {
+        action: 'created',
+        identifiers: { id: ZONE_ID, organizationId: ORG, tenantId: TENANT },
+        indexerEntityType: ZONE_ENTITY_ID,
+      },
+    ])
+    expect(harness.dataEngine.setCustomFields.mock.invocationCallOrder[0])
+      .toBeLessThan(harness.dataEngine.markOrmEntityChange.mock.invocationCallOrder[0])
+  })
+
+  it('create without custom fields does not touch the custom field store', async () => {
+    const handler = commandRegistry.get('wms.zones.create')!
+    const harness = createZoneHarness({ zone: null })
+
+    await handler.execute(
+      {
+        organizationId: ORG,
+        tenantId: TENANT,
+        warehouseId: WAREHOUSE_ID,
+        code: 'Z1',
+        name: 'Zone 1',
+      } as never,
+      harness.ctx as never,
+    )
+
+    expect(harness.dataEngine.setCustomFields).not.toHaveBeenCalled()
+    expect(harness.indexChanges).toHaveLength(1)
+  })
+
+  it('update writes the submitted custom fields and reindexes the zone', async () => {
+    const handler = commandRegistry.get('wms.zones.update')!
+    const harness = createZoneHarness()
+
+    await handler.execute(
+      { id: ZONE_ID, name: 'Renamed', customFields: { zone_note: 'Bulk store' } } as never,
+      harness.ctx as never,
+    )
+
+    expect(harness.setCustomFieldsCalls).toHaveLength(1)
+    expect(harness.setCustomFieldsCalls[0]).toMatchObject({
+      entityId: ZONE_ENTITY_ID,
+      recordId: ZONE_ID,
+      values: { zone_note: 'Bulk store' },
+      notify: false,
+    })
+    expect(harness.indexChanges).toEqual([
+      {
+        action: 'updated',
+        identifiers: { id: ZONE_ID, organizationId: ORG, tenantId: TENANT },
+        indexerEntityType: ZONE_ENTITY_ID,
+      },
+    ])
+  })
+
+  it('update without custom fields leaves existing values untouched', async () => {
+    const handler = commandRegistry.get('wms.zones.update')!
+    const harness = createZoneHarness()
+
+    await handler.execute({ id: ZONE_ID, name: 'Renamed' } as never, harness.ctx as never)
+
+    expect(harness.dataEngine.setCustomFields).not.toHaveBeenCalled()
+  })
+
+  it('undo of create nulls exactly the keys the created record held', async () => {
+    const handler = commandRegistry.get('wms.zones.create')!
+    const harness = createZoneHarness()
+
+    await handler.undo!({
+      input: {},
+      logEntry: { commandPayload: { undo: { after: zoneSnapshot({ zone_note: 'Pick face', zone_tags: ['a', 'b'] }) } } } as never,
+      ctx: harness.ctx as never,
+      undoToken: 'token-create-undo',
+    } as never)
+
+    expect(harness.setCustomFieldsCalls).toHaveLength(1)
+    expect(harness.setCustomFieldsCalls[0].values).toEqual({ zone_note: null, zone_tags: [] })
+    expect(harness.indexChanges).toEqual([
+      {
+        action: 'deleted',
+        identifiers: { id: ZONE_ID, organizationId: ORG, tenantId: TENANT },
+        indexerEntityType: ZONE_ENTITY_ID,
+      },
+    ])
+  })
+
+  it('undo of update restores before-values and clears keys the update introduced', async () => {
+    const handler = commandRegistry.get('wms.zones.update')!
+    const harness = createZoneHarness()
+
+    await handler.undo!({
+      input: {},
+      logEntry: {
+        commandPayload: {
+          undo: {
+            before: zoneSnapshot({ zone_note: 'Pick face' }),
+            after: zoneSnapshot({ zone_note: 'Bulk store', zone_owner: 'ops' }),
+          },
+        },
+      } as never,
+      ctx: harness.ctx as never,
+      undoToken: 'token-update-undo',
+    } as never)
+
+    expect(harness.setCustomFieldsCalls).toHaveLength(1)
+    expect(harness.setCustomFieldsCalls[0].values).toEqual({ zone_note: 'Pick face', zone_owner: null })
+    expect(harness.indexChanges).toEqual([
+      {
+        action: 'updated',
+        identifiers: { id: ZONE_ID, organizationId: ORG, tenantId: TENANT },
+        indexerEntityType: ZONE_ENTITY_ID,
+      },
+    ])
+  })
+
+  it('undo of delete restores the custom field values the deleted zone carried', async () => {
+    const handler = commandRegistry.get('wms.zones.delete')!
+    const harness = createZoneHarness({ zone: zoneRecord({ deletedAt: new Date('2026-04-20T00:00:00.000Z') }) })
+
+    await handler.undo!({
+      input: {},
+      logEntry: { commandPayload: { undo: { before: zoneSnapshot({ zone_note: 'Pick face' }) } } } as never,
+      ctx: harness.ctx as never,
+      undoToken: 'token-delete-undo',
+    } as never)
+
+    expect(harness.setCustomFieldsCalls).toHaveLength(1)
+    expect(harness.setCustomFieldsCalls[0].values).toEqual({ zone_note: 'Pick face' })
+    expect(harness.indexChanges).toEqual([
+      {
+        action: 'created',
+        identifiers: { id: ZONE_ID, organizationId: ORG, tenantId: TENANT },
+        indexerEntityType: ZONE_ENTITY_ID,
+      },
+    ])
+  })
+
+  it('delete removes the zone from the query index', async () => {
+    const handler = commandRegistry.get('wms.zones.delete')!
+    const harness = createZoneHarness()
+
+    await handler.execute({ id: ZONE_ID } as never, harness.ctx as never)
+
+    expect(harness.indexChanges).toEqual([
+      {
+        action: 'deleted',
+        identifiers: { id: ZONE_ID, organizationId: ORG, tenantId: TENANT },
+        indexerEntityType: ZONE_ENTITY_ID,
+      },
+    ])
+  })
+
+  it('the snapshot loader captures custom values under bare, un-prefixed keys', async () => {
+    const handler = commandRegistry.get('wms.zones.update')!
+    const harness = createZoneHarness({ customFieldValues: [textValueRow('zone_note', 'Pick face')] })
+
+    const prepared = (await handler.prepare!({ id: ZONE_ID } as never, harness.ctx as never)) as {
+      before?: { custom?: Record<string, unknown> }
+    }
+
+    expect(prepared.before?.custom).toEqual({ zone_note: 'Pick face' })
+  })
+})

--- a/packages/core/src/modules/wms/commands/configuration.ts
+++ b/packages/core/src/modules/wms/commands/configuration.ts
@@ -33,7 +33,13 @@ import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
-import { parseWithCustomFields, setCustomFieldsIfAny } from '@open-mercato/shared/lib/commands/helpers'
+import {
+  emitCrudSideEffects,
+  emitCrudUndoSideEffects,
+  parseWithCustomFields,
+  setCustomFieldsIfAny,
+} from '@open-mercato/shared/lib/commands/helpers'
+import type { DataEngine } from '@open-mercato/shared/lib/data/engine'
 import { buildCustomFieldResetMap, loadCustomFieldSnapshot } from '@open-mercato/shared/lib/commands/customFieldSnapshots'
 import { CrudHttpError, isUniqueViolation } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
@@ -79,6 +85,7 @@ import {
   normalizeOptionalString,
   requireId,
   toNumericString,
+  warehouseZoneCrudIndexer,
 } from './shared'
 import { emitWmsEvent } from '../events'
 
@@ -337,6 +344,11 @@ async function loadWarehouseZoneSnapshot(
   const record = await findOneWithDecryption(em, WarehouseZone, { id }, undefined, resolveScope(ctx))
   if (!record) return null
   const snapshot = snapshotWarehouseZone(record)
+  // The snapshot always carries custom values because undo has to restore them, and
+  // every caller (prepare on update/delete, captureAfter on create/update) feeds undo.
+  // For the common tenant that defined no zone custom fields this costs a single
+  // `custom_field_values` lookup: `loadCustomFieldValues` returns early on an empty
+  // result and never reaches the `custom_field_defs` query.
   snapshot.custom = await loadCustomFieldSnapshot(em, {
     entityId: E.wms.warehouse_zone,
     recordId: record.id,
@@ -344,6 +356,53 @@ async function loadWarehouseZoneSnapshot(
     organizationId: record.organizationId,
   })
   return snapshot
+}
+
+async function writeZoneCustomFields(
+  ctx: CommandRuntimeContext,
+  zone: { id: string; organizationId: string; tenantId: string },
+  values: Record<string, unknown>,
+): Promise<void> {
+  if (!values || !Object.keys(values).length) return
+  await setCustomFieldsIfAny({
+    dataEngine: ctx.container.resolve('dataEngine') as DataEngine,
+    entityId: E.wms.warehouse_zone,
+    recordId: zone.id,
+    organizationId: zone.organizationId,
+    tenantId: zone.tenantId,
+    values,
+  })
+}
+
+// Zone reads go through the hybrid query engine, which projects `cf:*` from
+// `entity_indexes`. Emitting the CRUD side effect is therefore what makes a
+// custom field value written above observable through the zones list API — without
+// it the value sits in `custom_field_values` that no read path consults (#5239).
+// `events` is deliberately omitted: the module already emits `wms.zone.*` itself,
+// and adding an events config here would introduce a second, undeclared
+// `wms.warehouse_zone.*` event id for the same write.
+async function emitZoneCrudSideEffects(
+  ctx: CommandRuntimeContext,
+  action: 'created' | 'updated' | 'deleted',
+  zone: WarehouseZone,
+  origin: 'write' | 'undo' = 'write',
+): Promise<void> {
+  const options = {
+    dataEngine: ctx.container.resolve('dataEngine') as DataEngine,
+    action,
+    entity: zone,
+    identifiers: {
+      id: zone.id,
+      organizationId: zone.organizationId,
+      tenantId: zone.tenantId,
+    },
+    indexer: warehouseZoneCrudIndexer,
+  }
+  if (origin === 'undo') {
+    await emitCrudUndoSideEffects(options)
+    return
+  }
+  await emitCrudSideEffects(options)
 }
 
 function snapshotWarehouseLocation(record: WarehouseLocation): WarehouseLocationSnapshot {
@@ -1001,7 +1060,7 @@ const deleteWarehouseCommand: CommandHandler<{ id?: string }, { warehouseId: str
   },
 }
 
-async function restoreZoneFromSnapshot(em: EntityManager, before: WarehouseZoneSnapshot): Promise<void> {
+async function restoreZoneFromSnapshot(em: EntityManager, before: WarehouseZoneSnapshot): Promise<WarehouseZone> {
   const scope = { tenantId: before.tenantId, organizationId: before.organizationId }
   const warehouseRef = await findOneWithDecryption(em, Warehouse, { id: before.warehouseId }, undefined, scope)
   if (!warehouseRef) {
@@ -1030,6 +1089,7 @@ async function restoreZoneFromSnapshot(em: EntityManager, before: WarehouseZoneS
     record.metadata = before.metadata
     record.deletedAt = null
   }
+  return record
 }
 
 const createWarehouseZoneCommand: CommandHandler<WarehouseZoneCreateInput, { zoneId: string }> = {
@@ -1051,14 +1111,8 @@ const createWarehouseZoneCommand: CommandHandler<WarehouseZoneCreateInput, { zon
       metadata: toJsonValue(parsed.metadata),
     })
     await em.persist(zone).flush()
-    await setCustomFieldsIfAny({
-      dataEngine: ctx.container.resolve('dataEngine'),
-      entityId: E.wms.warehouse_zone,
-      recordId: zone.id,
-      organizationId: zone.organizationId,
-      tenantId: zone.tenantId,
-      values: custom,
-    })
+    await writeZoneCustomFields(ctx, zone, custom)
+    await emitZoneCrudSideEffects(ctx, 'created', zone)
     void emitWmsEvent('wms.zone.created', {
       id: zone.id,
       zoneId: zone.id,
@@ -1094,15 +1148,8 @@ const createWarehouseZoneCommand: CommandHandler<WarehouseZoneCreateInput, { zon
     ensureOrganizationScope(ctx, record.organizationId)
     record.deletedAt = new Date()
     await em.flush()
-    const resetValues = buildCustomFieldResetMap(undefined, after.custom)
-    await setCustomFieldsIfAny({
-      dataEngine: ctx.container.resolve('dataEngine'),
-      entityId: E.wms.warehouse_zone,
-      recordId: after.id,
-      organizationId: after.organizationId,
-      tenantId: after.tenantId,
-      values: resetValues,
-    })
+    await writeZoneCustomFields(ctx, record, buildCustomFieldResetMap(undefined, after.custom))
+    await emitZoneCrudSideEffects(ctx, 'deleted', record, 'undo')
   },
 }
 
@@ -1131,14 +1178,8 @@ const updateWarehouseZoneCommand: CommandHandler<WarehouseZoneUpdateInput, { zon
     if (parsed.priority !== undefined) zone.priority = parsed.priority
     if (parsed.metadata !== undefined) zone.metadata = toJsonValue(parsed.metadata)
     await em.flush()
-    await setCustomFieldsIfAny({
-      dataEngine: ctx.container.resolve('dataEngine'),
-      entityId: E.wms.warehouse_zone,
-      recordId: zone.id,
-      organizationId: zone.organizationId,
-      tenantId: zone.tenantId,
-      values: custom,
-    })
+    await writeZoneCustomFields(ctx, zone, custom)
+    await emitZoneCrudSideEffects(ctx, 'updated', zone)
     void emitWmsEvent('wms.zone.updated', {
       id: zone.id,
       zoneId: zone.id,
@@ -1165,17 +1206,10 @@ const updateWarehouseZoneCommand: CommandHandler<WarehouseZoneUpdateInput, { zon
     const em = resolveEm(ctx)
     ensureTenantScope(ctx, before.tenantId)
     ensureOrganizationScope(ctx, before.organizationId)
-    await restoreZoneFromSnapshot(em, before)
+    const record = await restoreZoneFromSnapshot(em, before)
     await em.flush()
-    const resetValues = buildCustomFieldResetMap(before.custom, payload?.after?.custom)
-    await setCustomFieldsIfAny({
-      dataEngine: ctx.container.resolve('dataEngine'),
-      entityId: E.wms.warehouse_zone,
-      recordId: before.id,
-      organizationId: before.organizationId,
-      tenantId: before.tenantId,
-      values: resetValues,
-    })
+    await writeZoneCustomFields(ctx, record, buildCustomFieldResetMap(before.custom, payload?.after?.custom))
+    await emitZoneCrudSideEffects(ctx, 'updated', record, 'undo')
   },
 }
 
@@ -1193,6 +1227,7 @@ const deleteWarehouseZoneCommand: CommandHandler<{ id?: string }, { zoneId: stri
     const zone = await loadZone(em, ctx, zoneId)
     zone.deletedAt = new Date()
     await em.flush()
+    await emitZoneCrudSideEffects(ctx, 'deleted', zone)
     return { zoneId: zone.id }
   },
   buildLog: async ({ input, result, ctx, snapshots }) => {
@@ -1207,8 +1242,10 @@ const deleteWarehouseZoneCommand: CommandHandler<{ id?: string }, { zoneId: stri
     const em = resolveEm(ctx)
     ensureTenantScope(ctx, before.tenantId)
     ensureOrganizationScope(ctx, before.organizationId)
-    await restoreZoneFromSnapshot(em, before)
+    const record = await restoreZoneFromSnapshot(em, before)
     await em.flush()
+    await writeZoneCustomFields(ctx, record, buildCustomFieldResetMap(before.custom, undefined))
+    await emitZoneCrudSideEffects(ctx, 'created', record, 'undo')
   },
 }
 

--- a/packages/core/src/modules/wms/commands/configuration.ts
+++ b/packages/core/src/modules/wms/commands/configuration.ts
@@ -33,11 +33,14 @@ import { registerCommand } from '@open-mercato/shared/lib/commands'
 import type { CommandRuntimeContext } from '@open-mercato/shared/lib/commands'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { withAtomicFlush } from '@open-mercato/shared/lib/commands/flush'
+import { parseWithCustomFields, setCustomFieldsIfAny } from '@open-mercato/shared/lib/commands/helpers'
+import { buildCustomFieldResetMap, loadCustomFieldSnapshot } from '@open-mercato/shared/lib/commands/customFieldSnapshots'
 import { CrudHttpError, isUniqueViolation } from '@open-mercato/shared/lib/crud/errors'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import { findOneWithDecryption, findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { extractUndoPayload } from '@open-mercato/shared/lib/commands/undo'
 import type { JsonValue } from '@open-mercato/shared/lib/json'
+import { E } from '#generated/entities.ids.generated'
 import {
   InventoryLot,
   type InventoryLotStatus,
@@ -196,6 +199,7 @@ type WarehouseZoneSnapshot = {
   name: string
   priority: number
   metadata: JsonValue | null
+  custom?: Record<string, unknown>
   createdAt: string
   updatedAt: string
 }
@@ -331,7 +335,15 @@ async function loadWarehouseZoneSnapshot(
   id: string,
 ): Promise<WarehouseZoneSnapshot | null> {
   const record = await findOneWithDecryption(em, WarehouseZone, { id }, undefined, resolveScope(ctx))
-  return record ? snapshotWarehouseZone(record) : null
+  if (!record) return null
+  const snapshot = snapshotWarehouseZone(record)
+  snapshot.custom = await loadCustomFieldSnapshot(em, {
+    entityId: E.wms.warehouse_zone,
+    recordId: record.id,
+    tenantId: record.tenantId,
+    organizationId: record.organizationId,
+  })
+  return snapshot
 }
 
 function snapshotWarehouseLocation(record: WarehouseLocation): WarehouseLocationSnapshot {
@@ -1023,7 +1035,7 @@ async function restoreZoneFromSnapshot(em: EntityManager, before: WarehouseZoneS
 const createWarehouseZoneCommand: CommandHandler<WarehouseZoneCreateInput, { zoneId: string }> = {
   id: 'wms.zones.create',
   async execute(rawInput, ctx) {
-    const parsed = warehouseZoneCreateSchema.parse(rawInput ?? {})
+    const { parsed, custom } = parseWithCustomFields(warehouseZoneCreateSchema, rawInput ?? {})
     ensureTenantScope(ctx, parsed.tenantId)
     ensureOrganizationScope(ctx, parsed.organizationId)
     const em = resolveEm(ctx)
@@ -1039,6 +1051,14 @@ const createWarehouseZoneCommand: CommandHandler<WarehouseZoneCreateInput, { zon
       metadata: toJsonValue(parsed.metadata),
     })
     await em.persist(zone).flush()
+    await setCustomFieldsIfAny({
+      dataEngine: ctx.container.resolve('dataEngine'),
+      entityId: E.wms.warehouse_zone,
+      recordId: zone.id,
+      organizationId: zone.organizationId,
+      tenantId: zone.tenantId,
+      values: custom,
+    })
     void emitWmsEvent('wms.zone.created', {
       id: zone.id,
       zoneId: zone.id,
@@ -1074,6 +1094,15 @@ const createWarehouseZoneCommand: CommandHandler<WarehouseZoneCreateInput, { zon
     ensureOrganizationScope(ctx, record.organizationId)
     record.deletedAt = new Date()
     await em.flush()
+    const resetValues = buildCustomFieldResetMap(undefined, after.custom)
+    await setCustomFieldsIfAny({
+      dataEngine: ctx.container.resolve('dataEngine'),
+      entityId: E.wms.warehouse_zone,
+      recordId: after.id,
+      organizationId: after.organizationId,
+      tenantId: after.tenantId,
+      values: resetValues,
+    })
   },
 }
 
@@ -1086,7 +1115,7 @@ const updateWarehouseZoneCommand: CommandHandler<WarehouseZoneUpdateInput, { zon
     return before ? { before } : {}
   },
   async execute(rawInput, ctx) {
-    const parsed = warehouseZoneUpdateSchema.parse(rawInput ?? {})
+    const { parsed, custom } = parseWithCustomFields(warehouseZoneUpdateSchema, rawInput ?? {})
     const em = resolveEm(ctx)
     const zone = await loadZone(em, ctx, parsed.id)
     if (parsed.warehouseId !== undefined) {
@@ -1102,6 +1131,14 @@ const updateWarehouseZoneCommand: CommandHandler<WarehouseZoneUpdateInput, { zon
     if (parsed.priority !== undefined) zone.priority = parsed.priority
     if (parsed.metadata !== undefined) zone.metadata = toJsonValue(parsed.metadata)
     await em.flush()
+    await setCustomFieldsIfAny({
+      dataEngine: ctx.container.resolve('dataEngine'),
+      entityId: E.wms.warehouse_zone,
+      recordId: zone.id,
+      organizationId: zone.organizationId,
+      tenantId: zone.tenantId,
+      values: custom,
+    })
     void emitWmsEvent('wms.zone.updated', {
       id: zone.id,
       zoneId: zone.id,
@@ -1130,6 +1167,15 @@ const updateWarehouseZoneCommand: CommandHandler<WarehouseZoneUpdateInput, { zon
     ensureOrganizationScope(ctx, before.organizationId)
     await restoreZoneFromSnapshot(em, before)
     await em.flush()
+    const resetValues = buildCustomFieldResetMap(before.custom, payload?.after?.custom)
+    await setCustomFieldsIfAny({
+      dataEngine: ctx.container.resolve('dataEngine'),
+      entityId: E.wms.warehouse_zone,
+      recordId: before.id,
+      organizationId: before.organizationId,
+      tenantId: before.tenantId,
+      values: resetValues,
+    })
   },
 }
 

--- a/packages/core/src/modules/wms/commands/shared.ts
+++ b/packages/core/src/modules/wms/commands/shared.ts
@@ -7,6 +7,7 @@ import {
   InventoryBalance,
   InventoryMovement,
   InventoryReservation,
+  WarehouseZone,
 } from '../data/entities'
 
 export function ensureTenantScope(ctx: CommandRuntimeContext, tenantId: string): void {
@@ -46,6 +47,13 @@ export const inventoryReservationCrudIndexer: CrudIndexerConfig<InventoryReserva
 
 export const inventoryMovementCrudIndexer: CrudIndexerConfig<InventoryMovement> = {
   entityType: E.wms.inventory_movement,
+}
+
+// Zones are read through the hybrid query engine, which projects `cf:*` out of
+// `entity_indexes` rather than joining `custom_field_values`. Without this indexer the
+// zone commands write custom field values that no read path can ever see (#5239).
+export const warehouseZoneCrudIndexer: CrudIndexerConfig<WarehouseZone> = {
+  entityType: E.wms.warehouse_zone,
 }
 
 export const inventoryBalanceCrudEvents: CrudEventsConfig<InventoryBalance> = {

--- a/packages/core/src/modules/wms/components/backend/WmsConfigurationPage.tsx
+++ b/packages/core/src/modules/wms/components/backend/WmsConfigurationPage.tsx
@@ -12,10 +12,12 @@ import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { DataTable } from '@open-mercato/ui/backend/DataTable'
 import { EmptyState } from '@open-mercato/ui/backend/EmptyState'
 import { CrudForm, type CrudField, type CrudFieldOption } from '@open-mercato/ui/backend/CrudForm'
+import { extractCustomFieldEntries } from '@open-mercato/shared/lib/crud/custom-fields-client'
 import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useGuardedMutation } from '@open-mercato/ui/backend/injection/useGuardedMutation'
 import { useConfirmDialog } from '@open-mercato/ui/backend/confirm-dialog'
 import { apiCall } from '@open-mercato/ui/backend/utils/apiCall'
+import { collectCustomFieldValues } from '@open-mercato/ui/backend/utils/customFieldValues'
 import { raiseCrudError } from '@open-mercato/ui/backend/utils/serverErrors'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@open-mercato/ui/primitives/dialog'
@@ -79,7 +81,8 @@ type ZoneRow = {
   code?: string | null
   name?: string | null
   priority?: number | null
-}
+  customValues?: Record<string, unknown> | null
+} & Record<string, unknown>
 
 type InventoryProfileRow = {
   id: string
@@ -113,7 +116,7 @@ type ZoneFormValues = {
   code: string
   name: string
   priority?: number
-}
+} & Record<string, unknown>
 
 type InventoryProfileFormValues = {
   catalogProductId: string
@@ -141,12 +144,15 @@ const warehouseFormSchema = z.object({
   isPrimary: z.boolean().default(false),
 })
 
+// passthrough so CrudForm's schema.safeParse keeps the `cf_*` custom field values
+// it collected from the injected custom-field inputs — a plain z.object strips them
+// before onSubmit ever sees them.
 const zoneFormSchema = z.object({
   warehouseId: z.string().uuid(),
   code: z.string().trim().min(1).max(80),
   name: z.string().trim().min(1).max(200),
   priority: z.coerce.number().int().min(0).optional(),
-})
+}).passthrough()
 
 function buildInventoryProfileFormSchema(fefoRequiredMsg: string) {
   return z.object({
@@ -596,6 +602,28 @@ export function ZoneSection({ viewAllHref }: ConfigSectionOptions = {}) {
     },
   })
 
+  // Warehouse options for the dialog's combobox. Loaded whenever the dialog opens so a tenant
+  // with a single warehouse gets it pre-selected instead of an empty "type to search" input,
+  // and so the edit dialog can label the currently linked warehouse without a lookup round-trip.
+  const warehouseOptionsQuery = useQuery({
+    queryKey: ['wms-config', 'zones', 'warehouse-options'],
+    queryFn: () => loadWarehouseOptions(),
+    enabled: dialog !== null,
+    staleTime: 30_000,
+  })
+  const warehouseOptions = warehouseOptionsQuery.data ?? []
+  const soleWarehouseId = warehouseOptions.length === 1 ? warehouseOptions[0].value : null
+
+  const warehouseSeedOptions = React.useMemo<CrudFieldOption[] | undefined>(() => {
+    if (dialog?.mode === 'edit') {
+      const warehouseId = dialog.row.warehouse_id
+      if (!warehouseId) return undefined
+      const label = dialog.row.warehouse_name?.trim() || dialog.row.warehouse_code?.trim() || ''
+      return label ? [{ value: warehouseId, label }] : undefined
+    }
+    return soleWarehouseId ? warehouseOptions : undefined
+  }, [dialog, soleWarehouseId, warehouseOptions])
+
   const fields = React.useMemo<CrudField[]>(() => [
     {
       id: 'warehouseId',
@@ -604,11 +632,12 @@ export function ZoneSection({ viewAllHref }: ConfigSectionOptions = {}) {
       required: true,
       loadOptions: loadWarehouseOptions,
       allowCustomValues: false,
+      seedOptions: warehouseSeedOptions,
     },
     { id: 'code', type: 'text', label: t('wms.backend.config.zones.form.code', 'Code'), required: true },
     { id: 'name', type: 'text', label: t('wms.backend.config.zones.form.name', 'Name'), required: true },
     { id: 'priority', type: 'number', label: t('wms.backend.config.zones.form.priority', 'Priority') },
-  ], [t])
+  ], [t, warehouseSeedOptions])
 
   const columns = React.useMemo<ColumnDef<ZoneRow>[]>(() => [
     {
@@ -643,15 +672,16 @@ export function ZoneSection({ viewAllHref }: ConfigSectionOptions = {}) {
         code: dialog.row.code || '',
         name: dialog.row.name || '',
         priority: dialog.row.priority == null ? undefined : Number(dialog.row.priority),
+        ...extractCustomFieldEntries(dialog.row),
       }
     }
     return {
-      warehouseId: '',
+      warehouseId: soleWarehouseId ?? '',
       code: '',
       name: '',
       priority: undefined,
     }
-  }, [dialog])
+  }, [dialog, soleWarehouseId])
 
   const closeDialog = React.useCallback(() => {
     setDialog(null)
@@ -667,10 +697,14 @@ export function ZoneSection({ viewAllHref }: ConfigSectionOptions = {}) {
     const submitMode = dialog.mode
     setSubmitting(true)
     try {
-      const payload = {
-        ...values,
+      const customFields = collectCustomFieldValues(values)
+      const payload: Record<string, unknown> = {
+        warehouseId: values.warehouseId,
+        code: values.code,
+        name: values.name,
         priority: values.priority === undefined || Number.isNaN(values.priority) ? undefined : Number(values.priority),
       }
+      if (Object.keys(customFields).length) payload.customFields = customFields
       await runMutation({
         operation: async () => {
           const call = await apiCall(

--- a/packages/core/src/modules/wms/components/backend/WmsConfigurationPage.tsx
+++ b/packages/core/src/modules/wms/components/backend/WmsConfigurationPage.tsx
@@ -611,7 +611,10 @@ export function ZoneSection({ viewAllHref }: ConfigSectionOptions = {}) {
     enabled: dialog !== null,
     staleTime: 30_000,
   })
-  const warehouseOptions = warehouseOptionsQuery.data ?? []
+  const warehouseOptions = React.useMemo(
+    () => warehouseOptionsQuery.data ?? [],
+    [warehouseOptionsQuery.data],
+  )
   const soleWarehouseId = warehouseOptions.length === 1 ? warehouseOptions[0].value : null
 
   const warehouseSeedOptions = React.useMemo<CrudFieldOption[] | undefined>(() => {

--- a/packages/core/src/modules/wms/components/backend/WmsConfigurationPage.tsx
+++ b/packages/core/src/modules/wms/components/backend/WmsConfigurationPage.tsx
@@ -81,8 +81,12 @@ type ZoneRow = {
   code?: string | null
   name?: string | null
   priority?: number | null
+  updated_at?: string | null
+  // The zones list route decorates with `stripPrefixedKeys: true`, so custom values
+  // arrive only under this canonical key — never as top-level `cf_*` / `cf:*`.
   customValues?: Record<string, unknown> | null
-} & Record<string, unknown>
+  customFields?: Array<{ key: string; label: string | null; value: unknown; kind: string | null; multi: boolean }>
+}
 
 type InventoryProfileRow = {
   id: string
@@ -111,12 +115,17 @@ type WarehouseFormValues = {
   isPrimary: boolean
 }
 
+// `id` / `updatedAt` are carried in edit mode so CrudForm recognises the form as an edit
+// and derives the optimistic-lock header; the `cf_` index signature holds the values
+// collected from the injected custom-field inputs.
 type ZoneFormValues = {
   warehouseId: string
   code: string
   name: string
   priority?: number
-} & Record<string, unknown>
+  id?: string
+  updatedAt?: string | null
+} & { [key: `cf_${string}`]: unknown }
 
 type InventoryProfileFormValues = {
   catalogProductId: string
@@ -627,20 +636,29 @@ export function ZoneSection({ viewAllHref }: ConfigSectionOptions = {}) {
     return soleWarehouseId ? warehouseOptions : undefined
   }, [dialog, soleWarehouseId, warehouseOptions])
 
+  // The dialog already holds the first page of warehouses; serve the combobox's initial
+  // (unsearched) open from that cache instead of repeating the same request, and only go
+  // back to the network once the user actually types a term the cached page cannot answer.
+  const loadZoneWarehouseOptions = React.useCallback(async (query?: string) => {
+    const term = query?.trim()
+    if (!term) return warehouseOptionsQuery.data ?? loadWarehouseOptions()
+    return loadWarehouseOptions(term)
+  }, [warehouseOptionsQuery.data])
+
   const fields = React.useMemo<CrudField[]>(() => [
     {
       id: 'warehouseId',
       type: 'combobox',
       label: t('wms.backend.config.zones.form.warehouse', 'Warehouse'),
       required: true,
-      loadOptions: loadWarehouseOptions,
+      loadOptions: loadZoneWarehouseOptions,
       allowCustomValues: false,
       seedOptions: warehouseSeedOptions,
     },
     { id: 'code', type: 'text', label: t('wms.backend.config.zones.form.code', 'Code'), required: true },
     { id: 'name', type: 'text', label: t('wms.backend.config.zones.form.name', 'Name'), required: true },
     { id: 'priority', type: 'number', label: t('wms.backend.config.zones.form.priority', 'Priority') },
-  ], [t, warehouseSeedOptions])
+  ], [t, loadZoneWarehouseOptions, warehouseSeedOptions])
 
   const columns = React.useMemo<ColumnDef<ZoneRow>[]>(() => [
     {
@@ -671,6 +689,8 @@ export function ZoneSection({ viewAllHref }: ConfigSectionOptions = {}) {
   const initialValues = React.useMemo<ZoneFormValues>(() => {
     if (dialog?.mode === 'edit') {
       return {
+        id: dialog.row.id,
+        updatedAt: dialog.row.updated_at ?? null,
         warehouseId: dialog.row.warehouse_id || '',
         code: dialog.row.code || '',
         name: dialog.row.name || '',

--- a/packages/ui/src/backend/inputs/ComboboxInput.tsx
+++ b/packages/ui/src/backend/inputs/ComboboxInput.tsx
@@ -250,14 +250,20 @@ export function ComboboxInput({
   // including it would re-run the effect on every render when the prop is an inline function
   }, [value, disabled, knownLabelValues, coveredOptionValues, eagerResolveLabel, loadSuggestions])
 
-  // Sync input with a value that changed outside the component. The guard is "the user
-  // is typing", not "the field has focus": `autoFocus` on the first CrudForm field
-  // focuses the combobox before an async default value arrives (e.g. the sole warehouse
-  // pre-selected in the WMS zone dialog, #5239), so a focus-only guard left the control
-  // rendering an empty label for a value the form had already committed.
+  // Sync input with a value that changed outside the component. A focused field is
+  // synced too, because `autoFocus` can focus the control before an async default value
+  // arrives and a focus-only guard then leaves the control rendering an empty label for
+  // a value the form has already committed. Two conditions still block the sync:
+  //   - the user is typing, so their query is never clobbered mid-keystroke;
+  //   - `optionMap` only holds the self-mapping placeholder it synthesises for an
+  //     uncovered value, which would paint the raw record id over a label the user just
+  //     picked (`asyncOptions` is replaced on every load, so any follow-up load that
+  //     misses the picked entry — a failed request, a debounce race, a composite label
+  //     the route's `?search=` cannot match — drops it back to the placeholder).
   React.useEffect(() => {
-    if (document.activeElement === inputRef.current && userTypedRef.current) return
     const option = optionMap.get(value)
+    const hasRealLabel = Boolean(option && option.label !== option.value)
+    if (document.activeElement === inputRef.current && (userTypedRef.current || !hasRealLabel)) return
     setInput(option?.label ?? value ?? '')
   }, [value, optionMap])
 

--- a/packages/ui/src/backend/inputs/ComboboxInput.tsx
+++ b/packages/ui/src/backend/inputs/ComboboxInput.tsx
@@ -99,6 +99,10 @@ export function ComboboxInput({
   const blurClosePendingRef = React.useRef(false)
   const suppressOpenOnFocusRef = React.useRef(Boolean(autoFocus && !disabled))
   const eagerFallbackLoadedValueRef = React.useRef<string | null>(null)
+  // Tracks whether the user actually typed into the field during the current focus
+  // session. `touched` cannot serve this purpose because it is set by `onFocus`,
+  // which `autoFocus` triggers before the user does anything at all.
+  const userTypedRef = React.useRef(false)
 
   const staticOptions = React.useMemo(
     () => normalizeOptions([...(seedOptions ?? []), ...(suggestions ?? [])]),
@@ -246,12 +250,15 @@ export function ComboboxInput({
   // including it would re-run the effect on every render when the prop is an inline function
   }, [value, disabled, knownLabelValues, coveredOptionValues, eagerResolveLabel, loadSuggestions])
 
-  // Sync input with value when value changes externally and input is not focused.
+  // Sync input with a value that changed outside the component. The guard is "the user
+  // is typing", not "the field has focus": `autoFocus` on the first CrudForm field
+  // focuses the combobox before an async default value arrives (e.g. the sole warehouse
+  // pre-selected in the WMS zone dialog, #5239), so a focus-only guard left the control
+  // rendering an empty label for a value the form had already committed.
   React.useEffect(() => {
-    if (document.activeElement !== inputRef.current) {
-      const option = optionMap.get(value)
-      setInput(option?.label ?? value ?? '')
-    }
+    if (document.activeElement === inputRef.current && userTypedRef.current) return
+    const option = optionMap.get(value)
+    setInput(option?.label ?? value ?? '')
   }, [value, optionMap])
 
   const selectValue = React.useCallback(
@@ -264,6 +271,7 @@ export function ComboboxInput({
       setInput(option?.label ?? trimmed)
       setShowSuggestions(false)
       setSelectedIndex(-1)
+      userTypedRef.current = false
     },
     [disabled, onChange, optionMap, resetBlurCloseState]
   )
@@ -433,6 +441,7 @@ export function ComboboxInput({
         }}
         onChange={(event) => {
           setTouched(true)
+          userTypedRef.current = true
           setInput(event.target.value)
           setShowSuggestions(true)
           setSelectedIndex(-1)
@@ -442,6 +451,7 @@ export function ComboboxInput({
           // Delay closing so clicks on the popup can resolve first. If async
           // suggestions are still loading, keep the dropdown open instead of
           // closing before the first payload arrives.
+          userTypedRef.current = false
           blurClosePendingRef.current = true
           clearBlurCloseTimer()
           if (loadingRef.current) {

--- a/packages/ui/src/backend/inputs/__tests__/ComboboxInput.test.tsx
+++ b/packages/ui/src/backend/inputs/__tests__/ComboboxInput.test.tsx
@@ -396,4 +396,32 @@ describe('ComboboxInput — eager label resolution', () => {
     rerender(<ComboboxInput value="b" onChange={() => {}} resolveLabel={resolveLabel} />)
     await waitFor(() => expect(getInput(container).value).toBe('Label-b'))
   })
+
+  it('shows a default value that arrives after autoFocus already took the field', async () => {
+    const options = [{ value: 'wh-1', label: 'Central warehouse' }]
+    const { container, rerender } = render(
+      <ComboboxInput value="" onChange={() => {}} autoFocus seedOptions={options} />,
+    )
+    expect(document.activeElement).toBe(getInput(container))
+    rerender(<ComboboxInput value="wh-1" onChange={() => {}} autoFocus seedOptions={options} />)
+    await waitFor(() => expect(getInput(container).value).toBe('Central warehouse'))
+  })
+
+  it('does not overwrite the query while the user is typing into a focused field', async () => {
+    const options = [
+      { value: 'red', label: 'Red' },
+      { value: 'green', label: 'Green' },
+    ]
+    const { container, rerender } = render(
+      <ComboboxInput value="red" onChange={() => {}} seedOptions={options} />,
+    )
+    await waitFor(() => expect(getInput(container).value).toBe('Red'))
+    const input = getInput(container)
+    act(() => {
+      input.focus()
+      fireEvent.change(input, { target: { value: 'gre' } })
+    })
+    rerender(<ComboboxInput value="green" onChange={() => {}} seedOptions={options} />)
+    expect(getInput(container).value).toBe('gre')
+  })
 })

--- a/packages/ui/src/backend/inputs/__tests__/ComboboxInput.test.tsx
+++ b/packages/ui/src/backend/inputs/__tests__/ComboboxInput.test.tsx
@@ -407,6 +407,9 @@ describe('ComboboxInput — eager label resolution', () => {
     await waitFor(() => expect(getInput(container).value).toBe('Central warehouse'))
   })
 
+  // Guards the opposite direction of the case above: it passes on both the old
+  // focus-based guard and the current typing-based one, so it is a behavior pin
+  // rather than a regression test for any specific bug.
   it('does not overwrite the query while the user is typing into a focused field', async () => {
     const options = [
       { value: 'red', label: 'Red' },
@@ -423,5 +426,116 @@ describe('ComboboxInput — eager label resolution', () => {
     })
     rerender(<ComboboxInput value="green" onChange={() => {}} seedOptions={options} />)
     expect(getInput(container).value).toBe('gre')
+  })
+
+  // The regression the typing-based guard originally introduced: `selectValue` clears
+  // `userTypedRef` while the field keeps focus, so a follow-up load that no longer
+  // carries the picked option let the self-mapping placeholder overwrite the label with
+  // the raw record id. Fails on the intermediate implementation, passes on this one.
+  it('keeps a picked label when a follow-up load drops the option from the list', async () => {
+    const loadSuggestions = jest.fn(async (query?: string) =>
+      query === 'WH-B' ? [{ value: 'wh-b', label: 'Warehouse B (WH-B)' }] : [],
+    )
+    function Controlled() {
+      const [value, setValue] = React.useState('')
+      return (
+        <ComboboxInput
+          value={value}
+          onChange={setValue}
+          loadSuggestions={loadSuggestions}
+          allowCustomValues={false}
+        />
+      )
+    }
+    const { container } = render(<Controlled />)
+    const input = getInput(container)
+    act(() => {
+      input.focus()
+      fireEvent.change(input, { target: { value: 'WH-B' } })
+    })
+
+    const option = await screen.findByRole('option', { name: /Warehouse B \(WH-B\)/ })
+    act(() => {
+      fireEvent.click(option)
+    })
+    expect(getInput(container).value).toBe('Warehouse B (WH-B)')
+    expect(document.activeElement).toBe(getInput(container))
+
+    // Picking rewrote the query to the label, which re-fires the debounced loader; the
+    // route cannot match a composite label, so the option list comes back empty.
+    await waitFor(() => expect(loadSuggestions).toHaveBeenCalledWith('Warehouse B (WH-B)'))
+    await act(async () => {
+      await new Promise((res) => setTimeout(res, 250))
+    })
+    expect(getInput(container).value).toBe('Warehouse B (WH-B)')
+  })
+
+  it('adopts a real label that arrives while the field is focused', async () => {
+    const { container, rerender } = render(
+      <ComboboxInput value="wh-1" onChange={() => {}} seedOptions={[]} />,
+    )
+    const input = getInput(container)
+    act(() => {
+      input.focus()
+    })
+    expect(getInput(container).value).toBe('wh-1')
+
+    rerender(
+      <ComboboxInput
+        value="wh-1"
+        onChange={() => {}}
+        seedOptions={[{ value: 'wh-1', label: 'Central warehouse' }]}
+      />,
+    )
+    await waitFor(() => expect(getInput(container).value).toBe('Central warehouse'))
+  })
+
+  it('does not resurrect the previous label when the parent keeps the value after a clear', () => {
+    const onChange = jest.fn()
+    const { container } = render(
+      <ComboboxInput
+        value="red"
+        onChange={onChange}
+        clearable
+        seedOptions={[{ value: 'red', label: 'Red' }]}
+      />,
+    )
+    expect(getInput(container).value).toBe('Red')
+
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: /clear value/i }))
+    })
+
+    expect(onChange).toHaveBeenCalledWith('')
+    expect(getInput(container).value).toBe('')
+  })
+
+  it('resumes syncing after a blur, so a later external change is not mistaken for typing', async () => {
+    const options = [
+      { value: 'red', label: 'Red' },
+      { value: 'green', label: 'Green' },
+    ]
+    const { container, rerender } = render(
+      <ComboboxInput value="red" onChange={() => {}} seedOptions={options} allowCustomValues={false} />,
+    )
+    const input = getInput(container)
+    act(() => {
+      input.focus()
+      fireEvent.change(input, { target: { value: 'gre' } })
+    })
+    expect(getInput(container).value).toBe('gre')
+
+    act(() => {
+      fireEvent.blur(input)
+    })
+    await waitFor(() => expect(getInput(container).value).toBe('Red'))
+
+    act(() => {
+      getInput(container).focus()
+    })
+    rerender(
+      <ComboboxInput value="green" onChange={() => {}} seedOptions={options} allowCustomValues={false} />,
+    )
+    await waitFor(() => expect(getInput(container).value).toBe('Green'))
   })
 })


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-17-issue-5239-wms-zone-dialog.md
Status: complete

Fixes #5239

> ✅ **The DO-NOT-MERGE banner is lifted.** Requirement 2 now has a root cause and a fix — see **Why requirement 2 did not persist** below. Every finding from the code review on `1ac4915` is addressed.

## What this does

Addresses both requirements from the issue:

1. **The sole warehouse is preselected.** When the tenant has exactly one warehouse, the dialog opens with it already chosen instead of an empty "type to search" combobox.
2. **The form carries custom fields**, and they now round-trip: the value is written, indexed, and read back by the zones list API.

## Why requirement 2 did not persist

The write chain was correct all along — the review verified both halves independently and reached `dataEngine.setCustomFields` with the right entity id, record, scope and value. The break was on the **read** side:

- The zones list is served by `HybridQueryEngine`, which projects `cf:*` out of **`entity_indexes`**, not by joining `custom_field_values`.
- The zone commands never called `emitCrudSideEffects`, so no `query_index.upsert_one` ever ran for a zone.
- The value therefore sat in `custom_field_values` where no read path consults it, and the API returned `null` — exactly the symptom `TC-WMS-028-zone-dialog.spec.ts:248` reported.

The fix adds `warehouseZoneCrudIndexer` and emits it from create, update, delete and all three undo handlers, always **after** the custom-field write so the index doc carries the new values. `events` is deliberately omitted — the module already emits `wms.zone.*` itself, and an events config here would introduce a second, undeclared `wms.warehouse_zone.*` id for the same write.

## How

- `commands/configuration.ts` round-trips values through the shared `parseWithCustomFields` / `setCustomFieldsIfAny` helpers, captures undo snapshots via `loadCustomFieldSnapshot`, restores them on **delete-undo** via `buildCustomFieldResetMap(before.custom, undefined)`, and emits the CRUD side effects described above.
- `api/zones/route.ts` decorates list responses with `decorateCustomFields` using `stripPrefixedKeys: true` (the canonical single-shape response — the route had no decorator before this PR, so no consumer reads top-level `cf_*`), and documents `customFields` with an explicit `CustomFieldDisplayEntry`-shaped schema.
- `zoneFormSchema` uses `.passthrough()` — a plain `z.object` stripped the collected `cf_*` values before `onSubmit` ever saw them.
- The zone edit dialog now carries `id` and `updatedAt` in `initialValues`, so CrudForm recognises it as an edit and derives the optimistic-lock header.

## ⚠️ Heads-up for reviewers: this touches a shared primitive

`ComboboxInput` synced its displayed label only while the input was **unfocused**. But `autoFocus` on the first `CrudForm` field takes focus before an async default value arrives, so the control rendered an empty label for a value the form had already committed — which is exactly what broke the preselection above. The guard is now *"the user is typing, or the only entry available is a self-mapping placeholder"* rather than *"the field has focus"*.

The placeholder half of that guard closes a regression the review reproduced on the previous head: after picking an option, a follow-up load that no longer carries the picked entry could overwrite the label with the raw record id.

**This affects every combobox in the product, not just WMS.** It is behavioral only — `seedOptions` is an existing prop, so no public contract changed. Five tests pin it, and each was checked against both the previous implementation and `origin/develop`:

| Test | Fails on `develop` | Fails on the intermediate guard |
|---|---|---|
| `shows a default value that arrives after autoFocus already took the field` | ✅ | — |
| `keeps a picked label when a follow-up load drops the option from the list` | — | ✅ (received `"wh-b"`) |
| `adopts a real label that arrives while the field is focused` | ✅ | — |
| `resumes syncing after a blur, so a later external change is not mistaken for typing` | ✅ | — |
| `does not resurrect the previous label when the parent keeps the value after a clear` | — | — |
| `does not overwrite the query while the user is typing into a focused field` | — | — |

The last two are behavior pins rather than regression tests, and say so in a comment.

## Testing

Runner: local (no compose `app` container running).

| Check | Result |
|---|---|
| `yarn build:packages` | ✅ 22/22 |
| `yarn generate` | ✅ no generated-file churn afterwards |
| `yarn i18n:check-sync` | ✅ all locales in sync |
| `yarn i18n:check-usage` | ✅ advisory only |
| `yarn typecheck` | ✅ 22/22 |
| `yarn test` | ⚠️ green except a host-limited baseline — see below |
| `yarn build:app` | ✅ |
| `npx eslint` on the changed files | ✅ 0 errors; the 2 `ComboboxInput` warnings reproduce on `develop` |
| WMS module tests | ✅ 39 suites / 246 tests |
| `packages/ui` ComboboxInput suite | ✅ 26 tests |

**Test-suite baseline.** This Windows host fails 6 `@open-mercato/core` suites (16 tests), 1 `@open-mercato/ui` suite (`utils/__tests__/format.test.ts`), plus suites in `queue`, `shared`, `cli`, `telemetry`, `ai-assistant` and `create-app`. All of them were re-run with this branch's changes stashed and fail identically — currency/ICU formatting, Windows path handling, and an `EPERM` on directory rename. None is in a file this PR touches.

### Integration test

`__integration__/TC-WMS-028-zone-dialog.spec.ts` is unchanged in shape and still the right coverage. It has **not** been re-run since the fix — that needs the ephemeral environment. Requirement 1 passed on the previous run; requirement 2's assertion is what the indexer fix targets.

Note on selectors: the spec deliberately uses `[data-crud-field-id="…"] input` rather than `getByLabel`, because `CrudForm` renders labels with no `htmlFor` and no `id` on the control. Filed as #5360 and linked from the spec.

## Labels

I do not have label permission on this repo. Current set is correct except that `changes-requested` should move to `review` now that the findings are addressed.
