### PR TITLE
fix(ci): register template-i18n-parity in the repo-wide guard registry

### DIFF
--- a/.ai/runs/2026-08-17-repo-wide-guards-template-i18n-parity.md
+++ b/.ai/runs/2026-08-17-repo-wide-guards-template-i18n-parity.md
@@ -1,0 +1,66 @@
+# Register `template-i18n-parity.test.ts` in the repo-wide guard registry
+
+**Date:** 2026-08-17
+**Slug:** `repo-wide-guards-template-i18n-parity`
+**Branch:** `fix/repo-wide-guards-template-i18n-parity`
+**Base:** `develop`
+
+## Goal
+
+Unbreak `develop`: register the cross-package test `packages/create-app/src/lib/template-i18n-parity.test.ts` in `scripts/repo-wide-guards.mjs` so `scripts/__tests__/repo-wide-guards.test.mjs` passes again and the new locale-parity gate is guaranteed to run unfiltered.
+
+## Scope
+
+One entry appended to `CROSS_PACKAGE_EXCEPTIONS` in `scripts/repo-wide-guards.mjs`. Nothing else.
+
+## Background
+
+PR #5272 (merged as `f7a9ed6fa`) added `packages/create-app/src/lib/template-i18n-parity.test.ts`, which reads files outside its own package — `apps/mercato/src/i18n/**` — and imports `scripts/template-sync.ts`.
+
+`scripts/__tests__/repo-wide-guards.test.mjs:87` (`no test that audits other packages is left unclassified`) enforces a repository-wide invariant: every such test must be enumerated in either `REPO_WIDE_GUARDS` (to run unfiltered) or `CROSS_PACKAGE_EXCEPTIONS` (with a stated reason). The new test is in neither list, so the guard fails.
+
+Confirmed against the real `develop` head `f7a9ed6fa`: `node --test scripts/__tests__/repo-wide-guards.test.mjs` → **15 pass, 1 fail**. Until this lands, the `test` job is red on `develop` and on every PR targeting it.
+
+This is not only a red check. The registry exists so the turbo `--filter=[base]...` selection cannot skip a cross-package test on a PR that changes the files it audits. Without the entry, a PR touching only `apps/mercato/src/i18n/**` would not select `create-mercato-app`, so the very drift #5272 was opened to prevent could reappear without its new gate ever running.
+
+`CROSS_PACKAGE_EXCEPTIONS` is the correct list rather than `REPO_WIDE_GUARDS`: the "Check create-app template parity" CI step already runs the whole `create-mercato-app` suite unconditionally, which is exactly what the exception records. The sibling `packages/create-app/src/lib/template-example-module-parity.test.ts` is registered there with that same reason (#3779), so this change follows an established precedent five lines away in the same file.
+
+## Non-goals
+
+- Do not modify `packages/create-app/src/lib/template-i18n-parity.test.ts`, the locale dictionaries, or `scripts/template-sync.ts` — everything else from #5272 is correct and reviewed.
+- Do not add a new test. `scripts/__tests__/repo-wide-guards.test.mjs` is itself the regression test for this change: it fails before the entry and passes after, which is exactly the coverage this fix needs. A second test asserting the presence of a registry entry would duplicate it.
+- Do not move the test into `REPO_WIDE_GUARDS`. That would add it to the seconds-budgeted common PR path for no benefit, since the create-app parity step already runs it unfiltered.
+- Do not revisit the two non-blocking observations from the #5272 review (the `**/*.test.ts` typecheck exclusion; root `AGENTS.md` at 45 bytes of headroom). Both are tracked in that PR's review and neither belongs in a develop-unblocking fix.
+
+## Risks
+
+- **Very low.** One data entry in a repo-local dev script. No runtime, product, or published-package surface is touched; `scripts/repo-wide-guards.mjs` is a developer tooling module.
+- The only way this is wrong is if the stated reason is false — i.e. if the create-app parity CI step did *not* run the suite unconditionally. Verified as part of the #5272 review, and it is the same claim the four sibling create-app entries already rest on.
+
+## Implementation Plan
+
+### Phase 1: Register the test and verify the guard
+
+- 1.1 Add the `template-i18n-parity.test.ts` entry to `CROSS_PACKAGE_EXCEPTIONS` in `scripts/repo-wide-guards.mjs`, directly after the `template-example-module-parity.test.ts` entry.
+- 1.2 Verify `node --test scripts/__tests__/repo-wide-guards.test.mjs` is 16 pass / 0 fail, and confirm it fails without the entry (so the guard is genuinely what this fixes).
+- 1.3 Verify `node --test packages/create-app/src/lib/template-i18n-parity.test.ts` still passes 3/3.
+
+### Phase 2: Validation gate and PR
+
+- 2.1 Run the configured validation gate, scoped to what this diff can affect.
+- 2.2 Open the PR against `develop`, referencing #5272 as the cause and #3779 as the exception precedent.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Register the test and verify the guard
+
+- [ ] 1.1 Add the `CROSS_PACKAGE_EXCEPTIONS` entry
+- [ ] 1.2 Verify the repo-wide guard test goes green, and red without the entry
+- [ ] 1.3 Verify the locale parity test still passes
+
+### Phase 2: Validation gate and PR
+
+- [ ] 2.1 Run the validation gate
+- [ ] 2.2 Open the PR

--- a/.ai/runs/2026-08-17-repo-wide-guards-template-i18n-parity.md
+++ b/.ai/runs/2026-08-17-repo-wide-guards-template-i18n-parity.md
@@ -56,9 +56,9 @@ This is not only a red check. The registry exists so the turbo `--filter=[base].
 
 ### Phase 1: Register the test and verify the guard
 
-- [ ] 1.1 Add the `CROSS_PACKAGE_EXCEPTIONS` entry
-- [ ] 1.2 Verify the repo-wide guard test goes green, and red without the entry
-- [ ] 1.3 Verify the locale parity test still passes
+- [x] 1.1 Add the `CROSS_PACKAGE_EXCEPTIONS` entry — 96ea2ebe5
+- [x] 1.2 Verify the repo-wide guard test goes green, and red without the entry — 96ea2ebe5 (with the entry: 16 pass / 0 fail; stashed control without it: 15 pass / **1 fail**, so the entry is exactly what fixes the guard)
+- [x] 1.3 Verify the locale parity test still passes — 96ea2ebe5 (3 pass / 0 fail)
 
 ### Phase 2: Validation gate and PR
 

--- a/.ai/runs/2026-08-17-repo-wide-guards-template-i18n-parity.md
+++ b/.ai/runs/2026-08-17-repo-wide-guards-template-i18n-parity.md
@@ -52,6 +52,8 @@ This is not only a red check. The registry exists so the turbo `--filter=[base].
 
 ## Progress
 
+PR: #5340
+
 > Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
 
 ### Phase 1: Register the test and verify the guard
@@ -63,4 +65,4 @@ This is not only a red check. The registry exists so the turbo `--filter=[base].
 ### Phase 2: Validation gate and PR
 
 - [x] 2.1 Run the validation gate — scoped to what a dev-script data entry can affect; see the gate table in the PR body. `test:scripts` (the CI job that was red) is 583/587 with the guard case green; the 3 remaining failures are the known host `fs.inotify.max_user_instances=128` dev-wrapper artifacts, **proven pre-existing** by a control run on clean `origin/develop` (0 pass / 3 fail there too, with this change absent).
-- [ ] 2.2 Open the PR
+- [x] 2.2 Open the PR — #5340

--- a/.ai/runs/2026-08-17-repo-wide-guards-template-i18n-parity.md
+++ b/.ai/runs/2026-08-17-repo-wide-guards-template-i18n-parity.md
@@ -62,5 +62,5 @@ This is not only a red check. The registry exists so the turbo `--filter=[base].
 
 ### Phase 2: Validation gate and PR
 
-- [ ] 2.1 Run the validation gate
+- [x] 2.1 Run the validation gate — scoped to what a dev-script data entry can affect; see the gate table in the PR body. `test:scripts` (the CI job that was red) is 583/587 with the guard case green; the 3 remaining failures are the known host `fs.inotify.max_user_instances=128` dev-wrapper artifacts, **proven pre-existing** by a control run on clean `origin/develop` (0 pass / 3 fail there too, with this change absent).
 - [ ] 2.2 Open the PR

--- a/scripts/repo-wide-guards.mjs
+++ b/scripts/repo-wide-guards.mjs
@@ -270,6 +270,10 @@ export const CROSS_PACKAGE_EXCEPTIONS = [
     reason: 'Already unfiltered — the "Check create-app template parity" CI step runs the whole create-mercato-app suite (#3779).',
   },
   {
+    path: 'packages/create-app/src/lib/template-i18n-parity.test.ts',
+    reason: 'Already unfiltered — the "Check create-app template parity" CI step runs the whole create-mercato-app suite (#3779).',
+  },
+  {
     path: 'packages/create-app/src/lib/module-activation-fixtures.test.ts',
     reason: 'Already unfiltered — the "Check create-app template parity" CI step runs the whole create-mercato-app suite (#3779).',
   },


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-17-repo-wide-guards-template-i18n-parity.md
Status: complete

## Goal

- Unbreak `develop`: register `packages/create-app/src/lib/template-i18n-parity.test.ts` in `scripts/repo-wide-guards.mjs` so the repo-wide guard test passes again and the new locale-parity gate is guaranteed to run unfiltered.

## Why develop is red

#5272 (merged as `f7a9ed6fa`) added `packages/create-app/src/lib/template-i18n-parity.test.ts`, which reads `apps/mercato/src/i18n/**` and imports `scripts/template-sync.ts` — so it audits files outside its own package.

`scripts/__tests__/repo-wide-guards.test.mjs:87` enforces that every such test is enumerated in either `REPO_WIDE_GUARDS` (to run unfiltered) or `CROSS_PACKAGE_EXCEPTIONS` (with a reason). The new test is in neither, so the guard fails:

```
✖ no test that audits other packages is left unclassified
  These tests read files outside their own package, so CI's turbo filter can skip them
  on a PR that changes those files. Add each to REPO_WIDE_GUARDS in
  scripts/repo-wide-guards.mjs so it runs unfiltered, or to CROSS_PACKAGE_EXCEPTIONS
  with a reason:
  packages/create-app/src/lib/template-i18n-parity.test.ts
```

Confirmed on the real `develop` head `f7a9ed6fa`: **15 pass, 1 fail**. The `test` job is red on `develop` and on every PR targeting it until this lands.

**It is not only a red check.** The registry exists so the turbo `--filter=[base]...` selection cannot skip a cross-package test on a PR that changes the files it audits. Without the entry, a PR touching only `apps/mercato/src/i18n/**` would not select `create-mercato-app`, so the very drift #5272 was opened to prevent could reappear without its new gate ever running — the same class of silent hole as the original `SYNC_FOLDERS` omission, one level up.

## What Changed

- **`scripts/repo-wide-guards.mjs`** — one entry appended to `CROSS_PACKAGE_EXCEPTIONS`, directly after the sibling `template-example-module-parity.test.ts` entry, carrying the same reason those four create-app entries already use:

  ```js
  {
    path: 'packages/create-app/src/lib/template-i18n-parity.test.ts',
    reason: 'Already unfiltered — the "Check create-app template parity" CI step runs the whole create-mercato-app suite (#3779).',
  },
  ```

`CROSS_PACKAGE_EXCEPTIONS` rather than `REPO_WIDE_GUARDS` is deliberate: the "Check create-app template parity" step already runs the whole `create-mercato-app` suite unconditionally, which is exactly what the exception records. Adding it to `REPO_WIDE_GUARDS` instead would put it on the seconds-budgeted common PR path for no benefit. It is also why the runner never tries to execute this entry — `node scripts/repo-wide-guards.mjs` only spawns `REPO_WIDE_GUARDS`, so `yarn test:repo-wide-guards` behavior is unchanged.

Nothing else from #5272 is touched: not the parity test, not the locale dictionaries, not `scripts/template-sync.ts`.

## Tests

No new test. `scripts/__tests__/repo-wide-guards.test.mjs` **is** the regression test for this change, and I verified it discriminates rather than merely passing:

| | Result |
|---|---|
| With the entry | ✅ **16 pass / 0 fail** |
| Stashed control, without the entry | ❌ **15 pass / 1 fail** (`no test that audits other packages is left unclassified`) |

A second test asserting the presence of a registry entry would only duplicate that.

Also confirmed `node --test packages/create-app/src/lib/template-i18n-parity.test.ts` still passes **3/3**, so the entry changes nothing about the gate itself.

## Validation gate

Scoped to what a data entry in a dev script can affect. This worktree has no dependency install, so `yarn`-fronted commands were run through `npx tsx` where they were relevant at all; CI is authoritative for the rest.

| Command | Status | Notes |
|---|---|---|
| `test:scripts` (the red CI job) | ✅ PASS | 587 tests, **583 pass, 3 fail** — the guard case is green. The 3 failures are the known host `fs.inotify.max_user_instances=128` dev-wrapper artifacts, **proven pre-existing** by a control run on clean `origin/develop`: 0 pass / 3 fail there too, with this change absent. |
| `test:repo-wide-guards` | ✅ unaffected | The entry lives in `CROSS_PACKAGE_EXCEPTIONS`, which the runner does not execute. |
| `i18n:check-sync` | ✅ PASS | `All translation files are already in sync`, 52 modules. |
| `template:sync` | ✅ PASS | Zero drift, synced folders + root files + package deps. |
| `yarn build:packages`, `yarn generate`, `yarn build:app` | ⏭️ not run | No compiled surface, no auto-discovery file, and no app source in the diff. |
| `yarn typecheck` | ⏭️ not run | The changed file is `.mjs` and no TypeScript source imports it. |
| `yarn i18n:check-usage` | ⏭️ not run | Advisory, and no locale key changed. |
| `yarn test` (full) | ⏭️ not run | `grep` confirms `scripts/__tests__` is the only consumer of this registry, so no workspace jest suite can observe the change. |

The pre-commit hook's two auto-fixers (`i18n-check-sync --fix`, `template:sync:fix`) were run manually and produced **zero** file changes, so no hook-applied fix is missing from these commits.

## Breaking Changes

None. `scripts/repo-wide-guards.mjs` is a repo-local developer-tooling module, not a published package surface. The change appends an element to an exported array; no export, signature, or type changed. No runtime, API, DB, event, CLI, DI, or ACL surface is touched, and `BACKWARD_COMPATIBILITY.md` has no applicable category.

## Observation (pre-existing, deliberately not fixed here)

`packages/create-app/src/lib/module-activation-fixtures.test.ts` is listed **twice** in `CROSS_PACKAGE_EXCEPTIONS` (once with the short reason, once with a longer cost note). Harmless — the test only checks membership — and it predates this change, so it is left alone to keep this PR to the single entry that unblocks `develop`. Worth a follow-up cleanup.

## Progress

See the Progress section in the tracking plan.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789553818&installation_model_id=432243&pr_number=5340&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5340&signature=f095ad288a8be07fc4b4b063e772a22279caba271605074b09816638e741c058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->