### PR TITLE
Add WMS starter preset

### DIFF
--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -35,7 +35,7 @@ npx create-mercato-app <app-name> [options]
 |--------|-------------|
 | `--app <name>` | Bootstrap an official Open Mercato ready app from `open-mercato/ready-app-<name>` |
 | `--app-url <url>` | Bootstrap a ready app from a GitHub repository URL |
-| `--preset <id>` | Select the `classic`, `empty`, or `crm` starter without prompting |
+| `--preset <id>` | Select the `classic`, `empty`, `crm`, or `wms` starter without prompting |
 | `--agents <list>` | Set up `claude-code`, `codex`, `cursor`, a comma-separated subset, `all`, or `none` without prompting |
 | `--skip-agentic-setup` | Skip the interactive agentic setup wizard |
 | `--init-git` | Initialize a local Git repository after scaffolding |
@@ -68,6 +68,9 @@ npx create-mercato-app my-store --skip-agentic-setup
 
 # Create a classic app with every supported AI coding-tool configuration
 npx create-mercato-app my-store --preset classic --agents all
+
+# Create a warehouse and inventory app
+npx create-mercato-app my-warehouse --preset wms
 
 # Set up only Claude Code and Codex
 npx create-mercato-app my-store --agents claude-code,codex

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -54,7 +54,7 @@ ${pc.bold('Arguments:')}
 ${pc.bold('Options:')}
   --app <name>       Bootstrap an official ready app from open-mercato/ready-app-<name>
   --app-url <url>    Bootstrap a ready app from a GitHub repository URL
-  --preset <id>      Starter preset: classic, empty, or crm (omit to choose interactively)
+  --preset <id>      Starter preset: classic, empty, crm, or wms (omit to choose interactively)
   --init-git         Initialize a local Git repository after scaffolding
   --no-init-git      Do not prompt for or initialize a local Git repository
   --agents <list>    Set up agent tooling non-interactively (skips the wizard):
@@ -72,6 +72,7 @@ ${pc.bold('Examples:')}
   npx create-mercato-app my-store --preset classic
   npx create-mercato-app my-store --preset empty
   npx create-mercato-app my-store --preset crm
+  npx create-mercato-app my-warehouse --preset wms
   npx create-mercato-app my-store --init-git
   npx create-mercato-app my-store --agents claude-code,codex
   npx create-mercato-app my-store --agents codex --experimental-hooks-validator
@@ -159,6 +160,7 @@ const PRESET_PROMPT_OPTIONS = [
   { number: '1', id: 'classic', label: 'Classic     (default)', hint: 'full demo-ready starter' },
   { number: '2', id: 'empty', label: 'Empty', hint: 'minimal builder-ready baseline' },
   { number: '3', id: 'crm', label: 'CRM', hint: 'minimal CRM starter' },
+  { number: '4', id: 'wms', label: 'WMS', hint: 'warehouse and inventory starter' },
 ] as const
 
 export function normalizePresetAnswer(answer: string): string {
@@ -171,7 +173,7 @@ export function normalizePresetAnswer(answer: string): string {
   ))
 
   if (!selected) {
-    throw new Error(`Unknown preset "${answer}". Choose classic, empty, or crm.`)
+    throw new Error(`Unknown preset "${answer}". Choose classic, empty, crm, or wms.`)
   }
 
   return selected.id

--- a/packages/create-app/src/lib/agent-harness-evaluator.test.ts
+++ b/packages/create-app/src/lib/agent-harness-evaluator.test.ts
@@ -4311,7 +4311,7 @@ function stageSpecTarget(fixtureId: string): string {
       readStatus: 'readable',
       resolvedPath,
       referenceRole,
-      presets: ['classic', 'crm', 'empty'],
+      presets: ['classic', 'crm', 'empty', 'wms'],
       tiers: ['core'],
       galleryItemIds: ['buttons/button'],
       visualReferences: [{
@@ -4320,7 +4320,7 @@ function stageSpecTarget(fixtureId: string): string {
         entryId: 'button',
         importPath: '@open-mercato/ui/primitives/button',
         route: '/backend/design-system/buttons',
-        availabilityByPreset: { classic: 'source-only', crm: 'source-only', empty: 'source-only' },
+        availabilityByPreset: { classic: 'source-only', crm: 'source-only', empty: 'source-only', wms: 'source-only' },
         featureId: 'design_system.view',
         designFoundation: {
           galleryNodeId: 'buttons/button',

--- a/packages/create-app/src/lib/agent-harness-example-read-policy.test.ts
+++ b/packages/create-app/src/lib/agent-harness-example-read-policy.test.ts
@@ -2338,7 +2338,7 @@ test('family 12: source-reference applicability follows real starter presets and
   const records = projectedInventory().records
   const byId = new Map(records.map((record) => [record.referenceId, record]))
   const record = recordIn(records, DESIGN_IMPLEMENTATION_REFERENCE)
-  assert.deepEqual(record.presets, ['classic', 'crm', 'empty'])
+  assert.deepEqual(record.presets, ['classic', 'crm', 'empty', 'wms'])
   assert.deepEqual(record.tiers, ['core'])
 
   const root = stageExampleApp()

--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -92,6 +92,35 @@ test('resolvePreset: crm returns 19-module list extending empty (includes attach
   assert.equal(unique.size, ids.length)
 })
 
+test('resolvePreset: wms returns empty plus the WMS dependency chain', () => {
+  const result = resolvePreset('wms')
+  assert.equal(result.isClassic, false)
+  assert.equal(result.modules.length, 18)
+  const ids = result.modules.map((m) => m.id)
+  assert.deepEqual(ids, [
+    'auth',
+    'directory',
+    'configs',
+    'entities',
+    'query_index',
+    'api_docs',
+    'audit_logs',
+    'notifications',
+    'dashboards',
+    'events',
+    'search',
+    'customers',
+    'dictionaries',
+    'feature_toggles',
+    'catalog',
+    'sales',
+    'wms',
+    'currencies',
+  ])
+  assert.equal(result.modules.find((module) => module.id === 'wms')?.from, '@open-mercato/core')
+  assert.equal(result.modules.find((module) => module.id === 'search')?.from, '@open-mercato/search')
+})
+
 test('resolvePreset: unknown preset throws', () => {
   assert.throws(() => resolvePreset('bogus'), /Unknown preset/)
 })
@@ -131,6 +160,15 @@ test('generateModulesTs: produces valid content for crm modules', () => {
   assert.ok(content.includes("id: 'ai_assistant'"))
   assert.ok(content.includes("from: '@open-mercato/ai-assistant'"))
   assert.ok(!content.includes('example_customers_sync'))
+})
+
+test('generateModulesTs: produces valid content for wms modules', () => {
+  const content = generateModulesTs(resolvePreset('wms').modules)
+  for (const moduleId of ['catalog', 'sales', 'feature_toggles', 'wms', 'currencies']) {
+    assert.ok(content.includes(`id: '${moduleId}'`))
+  }
+  assert.ok(!content.includes("id: 'ai_assistant'"))
+  assert.ok(!content.includes("id: 'example'"))
 })
 
 // applyStarterPreset filesystem tests
@@ -228,6 +266,23 @@ test('applyStarterPreset: crm writes 19-module modules.ts and keeps example sour
   }
 })
 
+test('applyStarterPreset: wms writes the WMS dependency chain and keeps example source present', () => {
+  const dir = makeTempDir()
+  try {
+    applyStarterPreset('wms', dir)
+    const content = readFileSync(join(dir, 'src', 'modules.ts'), 'utf-8')
+    for (const moduleId of ['customers', 'dictionaries', 'feature_toggles', 'catalog', 'sales', 'wms', 'currencies']) {
+      assert.ok(content.includes(`id: '${moduleId}'`))
+    }
+    assert.ok(!content.includes("id: 'ai_assistant'"))
+    assert.ok(existsSync(join(dir, 'src', 'modules', 'example')))
+    const marker = JSON.parse(readFileSync(join(dir, '.mercato', 'starter-preset.json'), 'utf-8'))
+    assert.equal(marker.preset, 'wms')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 // Drift guard: the app shell's topbar renders each affordance on an ACL feature, and
 // `filterGrantsByEnabledModules` strips any feature whose owning module is not in the
 // enabled-modules registry — for every role, superadmin included. A preset that omits
@@ -254,7 +309,7 @@ test('every non-classic preset enables the modules the template topbar gates on'
   assert.ok(requiredModuleIds.includes('search'))
   assert.ok(requiredModuleIds.includes('notifications'))
 
-  for (const presetId of ['empty', 'crm']) {
+  for (const presetId of ['empty', 'crm', 'wms']) {
     const enabledIds = new Set(resolvePreset(presetId).modules.map((m) => m.id))
     for (const moduleId of requiredModuleIds) {
       // ai_assistant is a CRM capability rather than baseline chrome, so the empty
@@ -269,7 +324,7 @@ test('every non-classic preset enables the modules the template topbar gates on'
 })
 
 test('any preset enabling ai_assistant also enables search', () => {
-  for (const presetId of ['classic', 'empty', 'crm']) {
+  for (const presetId of ['classic', 'empty', 'crm', 'wms']) {
     const resolved = resolvePreset(presetId)
     if (resolved.isClassic) continue
     const ids = new Set(resolved.modules.map((m) => m.id))

--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -50,10 +50,10 @@ test('resolvePreset: empty returns 11-module list', () => {
   assert.deepEqual(result.filesToRemove, [])
 })
 
-test('resolvePreset: crm returns 17-module list extending empty (includes currencies + communication_channels + ai_assistant + search)', () => {
+test('resolvePreset: crm returns 19-module list extending empty (includes attachments + messages + currencies + communication_channels + ai_assistant + search)', () => {
   const result = resolvePreset('crm')
   assert.equal(result.isClassic, false)
-  assert.equal(result.modules.length, 17)
+  assert.equal(result.modules.length, 19)
   const ids = result.modules.map((m) => m.id)
   assert.ok(ids.includes('auth'))
   assert.ok(ids.includes('directory'))
@@ -63,6 +63,8 @@ test('resolvePreset: crm returns 17-module list extending empty (includes curren
   assert.ok(ids.includes('api_docs'))
   assert.ok(ids.includes('audit_logs'))
   assert.ok(ids.includes('customers'))
+  assert.ok(ids.includes('attachments'))
+  assert.ok(ids.includes('messages'))
   assert.ok(ids.includes('dictionaries'))
   assert.ok(ids.includes('feature_toggles'))
   assert.ok(ids.includes('notifications'))
@@ -193,13 +195,15 @@ test('applyStarterPreset: empty writes 11-module modules.ts and keeps example so
   }
 })
 
-test('applyStarterPreset: crm writes 17-module modules.ts and keeps example source present', () => {
+test('applyStarterPreset: crm writes 19-module modules.ts and keeps example source present', () => {
   const dir = makeTempDir()
   try {
     applyStarterPreset('crm', dir)
     const content = readFileSync(join(dir, 'src', 'modules.ts'), 'utf-8')
     assert.ok(content.includes("id: 'auth'"))
     assert.ok(content.includes("id: 'customers'"))
+    assert.ok(content.includes("id: 'attachments'"))
+    assert.ok(content.includes("id: 'messages'"))
     assert.ok(content.includes("id: 'dictionaries'"))
     assert.ok(content.includes("id: 'feature_toggles'"))
     assert.ok(content.includes("id: 'currencies'"))

--- a/packages/create-app/src/lib/design-system-inventory.test.ts
+++ b/packages/create-app/src/lib/design-system-inventory.test.ts
@@ -254,11 +254,13 @@ test('preset applicability follows each genuine resolved preset instead of a glo
       classic: 'source-only',
       crm: 'live',
       empty: 'source-only',
+      wms: 'source-only',
     })
     assert.deepEqual(availabilityFromResolvedPresets(resolved, true), {
       classic: 'live',
       crm: 'live',
       empty: 'source-only',
+      wms: 'source-only',
     })
   } finally {
     additions.length = originalLength

--- a/packages/create-app/src/lib/ready-apps.test.ts
+++ b/packages/create-app/src/lib/ready-apps.test.ts
@@ -302,6 +302,41 @@ test('CLI bare scaffold applies explicit crm preset without prompting', () => {
   }
 })
 
+test('CLI bare scaffold applies explicit wms preset without prompting', () => {
+  const targetRoot = makeTempDir('create-mercato-app-cli-wms-preset-')
+  const targetDir = join(targetRoot, 'wms-app')
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', CLI_ENTRY, targetDir, '--skip-agentic-setup', '--preset', 'wms'],
+      {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf8',
+        env: process.env,
+        timeout: CLI_SCAFFOLD_TIMEOUT_MS,
+      },
+    )
+
+    assert.equal(
+      result.status,
+      0,
+      `expected CLI scaffold with --preset wms to succeed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    )
+    assert.doesNotMatch(result.stdout, /No starter preset selected/)
+
+    const modulesTs = readFileSync(join(targetDir, 'src', 'modules.ts'), 'utf8')
+    for (const moduleId of ['catalog', 'sales', 'feature_toggles', 'wms', 'currencies']) {
+      assert.match(modulesTs, new RegExp(`id: '${moduleId}'`))
+    }
+    assert.doesNotMatch(modulesTs, /id: 'ai_assistant'/)
+    assert.equal(existsSync(join(targetDir, 'src', 'modules', 'example')), true)
+    assert.equal(existsSync(join(targetDir, '.mercato', 'starter-preset.json')), true)
+  } finally {
+    rmSync(targetRoot, { recursive: true, force: true })
+  }
+})
+
 test('CLI imported ready apps skip wizard-generated files', async () => {
   const archive = await createGitHubStyleTarball({
     'package.json': '{"name":"ready-app-prm","version":"0.0.1"}\n',

--- a/packages/create-app/src/lib/starter-preset-example-delivery.test.ts
+++ b/packages/create-app/src/lib/starter-preset-example-delivery.test.ts
@@ -13,7 +13,7 @@ const CLI_ENTRY = join(PACKAGE_ROOT, 'src', 'index.ts')
 const TEMPLATE_EXAMPLE_DIR = join(PACKAGE_ROOT, 'template', 'src', 'modules', 'example')
 const CLI_SCAFFOLD_TIMEOUT_MS = 120_000
 const SKIPPED_MODULE_DIRS = new Set(['__tests__', '__integration__'])
-const PRESET_IDS = ['classic', 'empty', 'crm'] as const
+const PRESET_IDS = ['classic', 'empty', 'crm', 'wms'] as const
 
 function collectEmittableRelativeFiles(root: string, prefix = ''): string[] {
   return readdirSync(root).flatMap((entry) => {

--- a/packages/create-app/src/lib/starter-presets.ts
+++ b/packages/create-app/src/lib/starter-presets.ts
@@ -73,6 +73,8 @@ export const STARTER_PRESETS: Record<string, StarterPreset> = {
       mode: 'patch',
       add: [
         { id: 'customers', from: CORE },
+        { id: 'attachments', from: CORE },
+        { id: 'messages', from: CORE },
         { id: 'dictionaries', from: CORE },
         { id: 'feature_toggles', from: CORE },
         { id: 'currencies', from: CORE },

--- a/packages/create-app/src/lib/starter-presets.ts
+++ b/packages/create-app/src/lib/starter-presets.ts
@@ -1,4 +1,4 @@
-export type StarterPresetId = 'classic' | 'empty' | 'crm' | (string & {})
+export type StarterPresetId = 'classic' | 'empty' | 'crm' | 'wms' | (string & {})
 
 export type ModuleEntry = { id: string; from: string }
 
@@ -83,6 +83,27 @@ export const STARTER_PRESETS: Record<string, StarterPreset> = {
       ],
     },
     ui: { startPageVariant: 'crm', hideDemoLinks: true },
+    constraints: { rejectWithReadyApps: true },
+  },
+
+  wms: {
+    id: 'wms',
+    label: 'WMS',
+    description: 'Empty preset plus warehouse and inventory capabilities',
+    extends: 'empty',
+    modules: {
+      mode: 'patch',
+      add: [
+        { id: 'customers', from: CORE },
+        { id: 'dictionaries', from: CORE },
+        { id: 'feature_toggles', from: CORE },
+        { id: 'catalog', from: CORE },
+        { id: 'sales', from: CORE },
+        { id: 'wms', from: CORE },
+        { id: 'currencies', from: CORE },
+      ],
+    },
+    ui: { startPageVariant: 'minimal', hideDemoLinks: true },
     constraints: { rejectWithReadyApps: true },
   },
 }


### PR DESCRIPTION
## Summary

- Add a built-in `wms` starter preset to `create-mercato-app`.
- Include the WMS dependency chain: `catalog`, `sales`, `feature_toggles`, `customers`, and `dictionaries`.
- Include `currencies` for practical order/pricing workflows, while keeping CRM-only messaging, communications, and AI modules out.
- Add CLI help, interactive selection, README usage, scaffold regression coverage, and preset-matrix fixture updates.

## Module research

The WMS module declares `catalog`, `sales`, and `feature_toggles` as required modules. Sales additionally requires `catalog`, `customers`, and `dictionaries`. The preset therefore enables all of those modules on top of the empty platform baseline. `notifications`, `dashboards`, `events`, and `search` are inherited from the baseline because the app shell and operational WMS experience use them.

The resulting preset has 18 modules:
`auth`, `directory`, `configs`, `entities`, `query_index`, `api_docs`, `audit_logs`, `notifications`, `dashboards`, `events`, `search`, `customers`, `dictionaries`, `feature_toggles`, `catalog`, `sales`, `wms`, and `currencies`.

## Validation

- `git diff --check` passed.
- Full Yarn validation was attempted but could not start because this checkout had no install-state; `yarn install --immutable` then failed with `ENOSPC` after the machine reached 100% disk usage (~322 MiB free).
- Local Git commit/push was unavailable because the desktop sandbox exposes `.git` as read-only; the change was published through the connected GitHub API.

<!-- codesmith:footer -->
---