### PR TITLE
Add attachments and messages to CRM preset

### DIFF
--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -50,10 +50,10 @@ test('resolvePreset: empty returns 11-module list', () => {
   assert.deepEqual(result.filesToRemove, [])
 })
 
-test('resolvePreset: crm returns 17-module list extending empty (includes currencies + communication_channels + ai_assistant + search)', () => {
+test('resolvePreset: crm returns 19-module list extending empty (includes attachments + messages + currencies + communication_channels + ai_assistant + search)', () => {
   const result = resolvePreset('crm')
   assert.equal(result.isClassic, false)
-  assert.equal(result.modules.length, 17)
+  assert.equal(result.modules.length, 19)
   const ids = result.modules.map((m) => m.id)
   assert.ok(ids.includes('auth'))
   assert.ok(ids.includes('directory'))
@@ -63,6 +63,8 @@ test('resolvePreset: crm returns 17-module list extending empty (includes curren
   assert.ok(ids.includes('api_docs'))
   assert.ok(ids.includes('audit_logs'))
   assert.ok(ids.includes('customers'))
+  assert.ok(ids.includes('attachments'))
+  assert.ok(ids.includes('messages'))
   assert.ok(ids.includes('dictionaries'))
   assert.ok(ids.includes('feature_toggles'))
   assert.ok(ids.includes('notifications'))
@@ -193,13 +195,15 @@ test('applyStarterPreset: empty writes 11-module modules.ts and keeps example so
   }
 })
 
-test('applyStarterPreset: crm writes 17-module modules.ts and keeps example source present', () => {
+test('applyStarterPreset: crm writes 19-module modules.ts and keeps example source present', () => {
   const dir = makeTempDir()
   try {
     applyStarterPreset('crm', dir)
     const content = readFileSync(join(dir, 'src', 'modules.ts'), 'utf-8')
     assert.ok(content.includes("id: 'auth'"))
     assert.ok(content.includes("id: 'customers'"))
+    assert.ok(content.includes("id: 'attachments'"))
+    assert.ok(content.includes("id: 'messages'"))
     assert.ok(content.includes("id: 'dictionaries'"))
     assert.ok(content.includes("id: 'feature_toggles'"))
     assert.ok(content.includes("id: 'currencies'"))

--- a/packages/create-app/src/lib/starter-presets.ts
+++ b/packages/create-app/src/lib/starter-presets.ts
@@ -73,6 +73,8 @@ export const STARTER_PRESETS: Record<string, StarterPreset> = {
       mode: 'patch',
       add: [
         { id: 'customers', from: CORE },
+        { id: 'attachments', from: CORE },
+        { id: 'messages', from: CORE },
         { id: 'dictionaries', from: CORE },
         { id: 'feature_toggles', from: CORE },
         { id: 'currencies', from: CORE },


### PR DESCRIPTION
## Summary

- Add `attachments` to the CRM starter preset.
- Add `messages` to the CRM starter preset.
- Keep the CRM preset dependency-complete for customer communications and related UI.

## Validation

- Existing CRM preset regression coverage updated for the 19-module list.
- `git diff --check` passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789564983&installation_model_id=432243&pr_number=5355&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5355&signature=6ca686b4f5c5861f3bb6e1e5209063f730af8f30fa3c4dc85cdd896994cb8719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->