### PR TITLE
Add WMS starter preset

### DIFF
--- a/apps/docs/docs/customization/standalone-app.mdx
+++ b/apps/docs/docs/customization/standalone-app.mdx
@@ -46,7 +46,7 @@ This creates a `my-store/` directory with the full application template, includi
 
 | Option | Description |
 | --- | --- |
-| `--preset <id>` | Select `classic`, `empty`, or `crm` without the preset prompt. |
+| `--preset <id>` | Select `classic`, `empty`, `crm`, or `wms` without the preset prompt. |
 | `--agents <list>` | Install the standalone AI harness non-interactively for `claude-code`, `codex`, `cursor`, a comma-separated subset, `all`, or `none`. |
 | `--skip-agentic-setup` | Skip the AI setup wizard; equivalent to `--agents none`. |
 | `--registry <url>` | Use a custom npm registry for `@open-mercato` packages. |

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -35,7 +35,7 @@ npx create-mercato-app <app-name> [options]
 |--------|-------------|
 | `--app <name>` | Bootstrap an official Open Mercato ready app from `open-mercato/ready-app-<name>` |
 | `--app-url <url>` | Bootstrap a ready app from a GitHub repository URL |
-| `--preset <id>` | Select the `classic`, `empty`, or `crm` starter without prompting |
+| `--preset <id>` | Select the `classic`, `empty`, `crm`, or `wms` starter without prompting |
 | `--agents <list>` | Set up `claude-code`, `codex`, `cursor`, a comma-separated subset, `all`, or `none` without prompting |
 | `--skip-agentic-setup` | Skip the interactive agentic setup wizard |
 | `--init-git` | Initialize a local Git repository after scaffolding |
@@ -68,6 +68,9 @@ npx create-mercato-app my-store --skip-agentic-setup
 
 # Create a classic app with every supported AI coding-tool configuration
 npx create-mercato-app my-store --preset classic --agents all
+
+# Create a warehouse and inventory app
+npx create-mercato-app my-warehouse --preset wms
 
 # Set up only Claude Code and Codex
 npx create-mercato-app my-store --agents claude-code,codex

--- a/packages/create-app/agentic/shared/ai/harness/design-system-inventory.json
+++ b/packages/create-app/agentic/shared/ai/harness/design-system-inventory.json
@@ -39,7 +39,9 @@
     "availabilityByPreset": {
       "classic": "source-only",
       "crm": "source-only",
-      "empty": "source-only"
+      "empty": "source-only",
+
+      "wms": "source-only"
     },
     "canonicalUiRowCount": 8,
     "referenceCount": 16,
@@ -78,7 +80,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -108,7 +112,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -226,7 +232,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -260,7 +268,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -288,7 +298,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -406,7 +418,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -440,7 +454,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -468,7 +484,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -497,7 +515,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -579,7 +599,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -608,7 +630,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -637,7 +661,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -719,7 +745,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -748,7 +776,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -780,7 +810,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -810,7 +842,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -878,7 +912,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -930,7 +966,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -983,7 +1021,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1039,7 +1079,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1090,7 +1132,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1140,7 +1184,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1191,7 +1237,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1251,7 +1299,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1303,7 +1353,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1355,7 +1407,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1406,7 +1460,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1457,7 +1513,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1508,7 +1566,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1561,7 +1621,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1613,7 +1675,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1666,7 +1730,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1717,7 +1783,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1768,7 +1836,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1819,7 +1889,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1871,7 +1943,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1923,7 +1997,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1974,7 +2050,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2025,7 +2103,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2076,7 +2156,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2128,7 +2210,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2180,7 +2264,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2233,7 +2319,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2284,7 +2372,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2336,7 +2426,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2388,7 +2480,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2440,7 +2534,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2491,7 +2587,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2543,7 +2641,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2595,7 +2695,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2646,7 +2748,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2697,7 +2801,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2748,7 +2854,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2799,7 +2907,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2850,7 +2960,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2902,7 +3014,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2955,7 +3069,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3007,7 +3123,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3060,7 +3178,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3114,7 +3234,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3166,7 +3288,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3218,7 +3342,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3271,7 +3397,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3322,7 +3450,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3375,7 +3505,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3427,7 +3559,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3479,7 +3613,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3530,7 +3666,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3581,7 +3719,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3632,7 +3772,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3683,7 +3825,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3734,7 +3878,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3786,7 +3932,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3836,7 +3984,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3888,7 +4038,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3940,7 +4092,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3991,7 +4145,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4043,7 +4199,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4095,7 +4253,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4148,7 +4308,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4199,7 +4361,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4252,7 +4416,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4305,7 +4471,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4356,7 +4524,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4408,7 +4578,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4459,7 +4631,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4512,7 +4686,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4563,7 +4739,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4616,7 +4794,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4669,7 +4849,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4721,7 +4903,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4773,7 +4957,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4825,7 +5011,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4876,7 +5064,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4928,7 +5118,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4980,7 +5172,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5031,7 +5225,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5083,7 +5279,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5134,7 +5332,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5185,7 +5385,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5236,7 +5438,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5287,7 +5491,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5338,7 +5544,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5389,7 +5597,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5439,7 +5649,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5490,7 +5702,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5540,7 +5754,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5590,7 +5806,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5640,7 +5858,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5691,7 +5911,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5742,7 +5964,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5793,7 +6017,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5844,7 +6070,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5895,7 +6123,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5946,7 +6176,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5996,7 +6228,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6048,7 +6282,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6100,7 +6336,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6150,7 +6388,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6200,7 +6440,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6252,7 +6494,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6302,7 +6546,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6353,7 +6599,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6404,7 +6652,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6455,7 +6705,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6506,7 +6758,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6559,7 +6813,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6609,7 +6865,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6660,7 +6918,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",

--- a/packages/create-app/agentic/shared/ai/harness/design-system-inventory.json
+++ b/packages/create-app/agentic/shared/ai/harness/design-system-inventory.json
@@ -40,7 +40,6 @@
       "classic": "source-only",
       "crm": "source-only",
       "empty": "source-only",
-
       "wms": "source-only"
     },
     "canonicalUiRowCount": 8,
@@ -81,7 +80,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -113,7 +111,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -233,7 +230,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -269,7 +265,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -299,7 +294,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -419,7 +413,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -455,7 +448,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -485,7 +477,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -516,7 +507,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -600,7 +590,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -631,7 +620,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -662,7 +650,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -746,7 +733,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -777,7 +763,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -811,7 +796,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -843,7 +827,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -913,7 +896,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -967,7 +949,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1022,7 +1003,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1080,7 +1060,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1133,7 +1112,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1185,7 +1163,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1238,7 +1215,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1300,7 +1276,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1354,7 +1329,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1408,7 +1382,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1461,7 +1434,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1514,7 +1486,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1567,7 +1538,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1622,7 +1592,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1676,7 +1645,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1731,7 +1699,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1784,7 +1751,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1837,7 +1803,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1890,7 +1855,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1944,7 +1908,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1998,7 +1961,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2051,7 +2013,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2104,7 +2065,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2157,7 +2117,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2211,7 +2170,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2265,7 +2223,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2320,7 +2277,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2373,7 +2329,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2427,7 +2382,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2481,7 +2435,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2535,7 +2488,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2588,7 +2540,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2642,7 +2593,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2696,7 +2646,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2749,7 +2698,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2802,7 +2750,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2855,7 +2802,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2908,7 +2854,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2961,7 +2906,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3015,7 +2959,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3070,7 +3013,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3124,7 +3066,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3179,7 +3120,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3235,7 +3175,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3289,7 +3228,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3343,7 +3281,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3398,7 +3335,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3451,7 +3387,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3506,7 +3441,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3560,7 +3494,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3614,7 +3547,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3667,7 +3599,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3720,7 +3651,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3773,7 +3703,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3826,7 +3755,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3879,7 +3807,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3933,7 +3860,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3985,7 +3911,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4039,7 +3964,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4093,7 +4017,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4146,7 +4069,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4200,7 +4122,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4254,7 +4175,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4309,7 +4229,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4362,7 +4281,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4417,7 +4335,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4472,7 +4389,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4525,7 +4441,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4579,7 +4494,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4632,7 +4546,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4687,7 +4600,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4740,7 +4652,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4795,7 +4706,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4850,7 +4760,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4904,7 +4813,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4958,7 +4866,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5012,7 +4919,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5065,7 +4971,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5119,7 +5024,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5173,7 +5077,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5226,7 +5129,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5280,7 +5182,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5333,7 +5234,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5386,7 +5286,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5439,7 +5338,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5492,7 +5390,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5545,7 +5442,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5598,7 +5494,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5650,7 +5545,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5703,7 +5597,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5755,7 +5648,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5807,7 +5699,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5859,7 +5750,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5912,7 +5802,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5965,7 +5854,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6018,7 +5906,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6071,7 +5958,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6124,7 +6010,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6177,7 +6062,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6229,7 +6113,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6283,7 +6166,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6337,7 +6219,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6389,7 +6270,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6441,7 +6321,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6495,7 +6374,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6547,7 +6425,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6600,7 +6477,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6653,7 +6529,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6706,7 +6581,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6759,7 +6633,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6814,7 +6687,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6866,7 +6738,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6919,7 +6790,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",

--- a/packages/create-app/agentic/shared/ai/harness/source-link-inventory.json
+++ b/packages/create-app/agentic/shared/ai/harness/source-link-inventory.json
@@ -30,7 +30,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -55,7 +56,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -79,7 +81,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -101,7 +104,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -125,7 +129,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -149,7 +154,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -173,7 +179,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -197,7 +204,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -221,7 +229,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -245,7 +254,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -269,7 +279,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -293,7 +304,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -315,7 +327,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -337,7 +350,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -359,7 +373,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -382,7 +397,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -405,7 +421,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -427,7 +444,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -449,7 +467,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -471,7 +490,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -494,7 +514,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -517,7 +538,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -559,7 +581,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -601,7 +624,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -643,7 +667,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -685,7 +710,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -727,7 +753,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -779,7 +806,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -797,7 +825,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -849,7 +878,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -867,7 +897,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -917,7 +948,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -940,7 +972,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -982,7 +1015,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1024,7 +1058,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1066,7 +1101,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1108,7 +1144,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1150,7 +1187,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1201,7 +1239,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1223,7 +1262,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1245,7 +1285,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1267,7 +1308,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1289,7 +1331,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1309,7 +1352,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1331,7 +1375,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1353,7 +1398,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1378,7 +1424,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1400,7 +1447,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1422,7 +1470,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1444,7 +1493,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1466,7 +1516,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1489,7 +1540,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1511,7 +1563,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1531,7 +1584,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1553,7 +1607,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1576,7 +1631,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1598,7 +1654,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1620,7 +1677,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1643,7 +1701,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1665,7 +1724,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1685,7 +1745,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1708,7 +1769,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1730,7 +1792,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1752,7 +1815,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1774,7 +1838,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1794,7 +1859,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1816,7 +1882,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1838,7 +1905,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1860,7 +1928,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1882,7 +1951,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1904,7 +1974,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1927,7 +1998,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1952,7 +2024,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1974,7 +2047,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1997,7 +2071,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2019,7 +2094,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2041,7 +2117,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2063,7 +2140,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2085,7 +2163,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2107,7 +2186,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2129,7 +2209,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2152,7 +2233,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2175,7 +2257,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2197,7 +2280,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2219,7 +2303,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2241,7 +2326,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2263,7 +2349,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2285,7 +2372,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2307,7 +2395,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2327,7 +2416,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2350,7 +2440,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2372,7 +2463,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2392,7 +2484,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2412,7 +2505,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2434,7 +2528,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2456,7 +2551,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2478,7 +2574,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2500,7 +2597,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2522,7 +2620,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2544,7 +2643,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2566,7 +2666,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2588,7 +2689,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2610,7 +2712,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2632,7 +2735,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2654,7 +2758,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2676,7 +2781,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2698,7 +2804,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2720,7 +2827,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2742,7 +2850,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2764,7 +2873,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2786,7 +2896,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2808,7 +2919,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2830,7 +2942,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2852,7 +2965,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2874,7 +2988,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2896,7 +3011,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2916,7 +3032,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2938,7 +3055,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2960,7 +3078,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2982,7 +3101,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3007,7 +3127,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3030,7 +3151,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3052,7 +3174,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3074,7 +3197,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3096,7 +3220,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3118,7 +3243,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3138,7 +3264,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"

--- a/packages/create-app/scripts/design-system/design-system-inventory.json
+++ b/packages/create-app/scripts/design-system/design-system-inventory.json
@@ -54,7 +54,9 @@
     "availabilityByPreset": {
       "classic": "source-only",
       "crm": "source-only",
-      "empty": "source-only"
+      "empty": "source-only",
+
+      "wms": "source-only"
     },
     "canonicalUiRowCount": 8,
     "referenceCount": 16,
@@ -90,7 +92,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -142,7 +146,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -195,7 +201,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -251,7 +259,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -302,7 +312,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -352,7 +364,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -403,7 +417,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -463,7 +479,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -515,7 +533,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -567,7 +587,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -618,7 +640,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -669,7 +693,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -720,7 +746,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -773,7 +801,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -825,7 +855,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -878,7 +910,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -929,7 +963,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -980,7 +1016,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1031,7 +1069,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1083,7 +1123,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1135,7 +1177,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1186,7 +1230,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1237,7 +1283,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1288,7 +1336,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1340,7 +1390,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1392,7 +1444,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1445,7 +1499,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1496,7 +1552,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1548,7 +1606,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1600,7 +1660,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1652,7 +1714,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1703,7 +1767,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1755,7 +1821,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1807,7 +1875,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1858,7 +1928,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1909,7 +1981,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1960,7 +2034,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2011,7 +2087,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2062,7 +2140,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2114,7 +2194,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2167,7 +2249,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2219,7 +2303,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2272,7 +2358,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2326,7 +2414,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2378,7 +2468,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2430,7 +2522,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2483,7 +2577,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2534,7 +2630,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2587,7 +2685,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2639,7 +2739,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2691,7 +2793,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2742,7 +2846,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2793,7 +2899,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2844,7 +2952,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2895,7 +3005,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2946,7 +3058,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -2998,7 +3112,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3048,7 +3164,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3100,7 +3218,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3152,7 +3272,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3203,7 +3325,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3255,7 +3379,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3307,7 +3433,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3360,7 +3488,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3411,7 +3541,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3464,7 +3596,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3517,7 +3651,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3568,7 +3704,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3620,7 +3758,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3671,7 +3811,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3724,7 +3866,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3775,7 +3919,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3828,7 +3974,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3881,7 +4029,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3933,7 +4083,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -3985,7 +4137,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4037,7 +4191,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4088,7 +4244,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4140,7 +4298,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4192,7 +4352,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4243,7 +4405,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4295,7 +4459,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4346,7 +4512,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4397,7 +4565,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4448,7 +4618,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4499,7 +4671,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4550,7 +4724,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4601,7 +4777,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4651,7 +4829,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4702,7 +4882,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4752,7 +4934,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4802,7 +4986,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4852,7 +5038,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4903,7 +5091,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -4954,7 +5144,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5005,7 +5197,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5056,7 +5250,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5107,7 +5303,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5158,7 +5356,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5208,7 +5408,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5260,7 +5462,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5312,7 +5516,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5362,7 +5568,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5412,7 +5620,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5464,7 +5674,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5514,7 +5726,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5565,7 +5779,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5616,7 +5832,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5667,7 +5885,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5718,7 +5938,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5771,7 +5993,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5821,7 +6045,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5872,7 +6098,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5929,7 +6157,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -5959,7 +6189,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6077,7 +6309,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6111,7 +6345,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6139,7 +6375,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6257,7 +6495,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6291,7 +6531,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6319,7 +6561,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6348,7 +6592,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6430,7 +6676,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6459,7 +6707,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6488,7 +6738,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6570,7 +6822,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6599,7 +6853,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6631,7 +6887,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -6661,7 +6919,9 @@
       "availabilityByPreset": {
         "classic": "source-only",
         "crm": "source-only",
-        "empty": "source-only"
+        "empty": "source-only",
+
+        "wms": "source-only"
       },
       "featureId": "design_system.view",
       "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",

--- a/packages/create-app/scripts/design-system/design-system-inventory.json
+++ b/packages/create-app/scripts/design-system/design-system-inventory.json
@@ -55,7 +55,6 @@
       "classic": "source-only",
       "crm": "source-only",
       "empty": "source-only",
-
       "wms": "source-only"
     },
     "canonicalUiRowCount": 8,
@@ -93,7 +92,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -147,7 +145,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -202,7 +199,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -260,7 +256,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -313,7 +308,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -365,7 +359,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -418,7 +411,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -480,7 +472,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -534,7 +525,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -588,7 +578,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -641,7 +630,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -694,7 +682,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -747,7 +734,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -802,7 +788,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -856,7 +841,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -911,7 +895,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -964,7 +947,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1017,7 +999,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1070,7 +1051,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1124,7 +1104,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1178,7 +1157,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1231,7 +1209,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1284,7 +1261,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1337,7 +1313,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1391,7 +1366,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1445,7 +1419,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1500,7 +1473,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1553,7 +1525,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1607,7 +1578,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1661,7 +1631,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1715,7 +1684,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1768,7 +1736,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1822,7 +1789,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1876,7 +1842,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1929,7 +1894,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -1982,7 +1946,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2035,7 +1998,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2088,7 +2050,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2141,7 +2102,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2195,7 +2155,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2250,7 +2209,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2304,7 +2262,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2359,7 +2316,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2415,7 +2371,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2469,7 +2424,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2523,7 +2477,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2578,7 +2531,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2631,7 +2583,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2686,7 +2637,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2740,7 +2690,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2794,7 +2743,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2847,7 +2795,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2900,7 +2847,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -2953,7 +2899,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3006,7 +2951,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3059,7 +3003,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3113,7 +3056,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3165,7 +3107,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3219,7 +3160,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3273,7 +3213,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3326,7 +3265,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3380,7 +3318,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3434,7 +3371,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3489,7 +3425,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3542,7 +3477,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3597,7 +3531,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3652,7 +3585,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3705,7 +3637,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3759,7 +3690,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3812,7 +3742,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3867,7 +3796,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3920,7 +3848,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -3975,7 +3902,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4030,7 +3956,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4084,7 +4009,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4138,7 +4062,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4192,7 +4115,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4245,7 +4167,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4299,7 +4220,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4353,7 +4273,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4406,7 +4325,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4460,7 +4378,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4513,7 +4430,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4566,7 +4482,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4619,7 +4534,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4672,7 +4586,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4725,7 +4638,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4778,7 +4690,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4830,7 +4741,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4883,7 +4793,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4935,7 +4844,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -4987,7 +4895,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5039,7 +4946,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5092,7 +4998,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5145,7 +5050,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5198,7 +5102,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5251,7 +5154,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5304,7 +5206,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5357,7 +5258,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5409,7 +5309,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5463,7 +5362,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5517,7 +5415,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5569,7 +5466,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5621,7 +5517,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5675,7 +5570,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5727,7 +5621,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5780,7 +5673,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5833,7 +5725,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5886,7 +5777,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5939,7 +5829,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -5994,7 +5883,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6046,7 +5934,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6099,7 +5986,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6158,7 +6044,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6190,7 +6075,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6310,7 +6194,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6346,7 +6229,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6376,7 +6258,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6496,7 +6377,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6532,7 +6412,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6562,7 +6441,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6593,7 +6471,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6677,7 +6554,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6708,7 +6584,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6739,7 +6614,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6823,7 +6697,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6854,7 +6727,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6888,7 +6760,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",
@@ -6920,7 +6791,6 @@
         "classic": "source-only",
         "crm": "source-only",
         "empty": "source-only",
-
         "wms": "source-only"
       },
       "featureId": "design_system.view",

--- a/packages/create-app/scripts/source-links/source-link-inventory.json
+++ b/packages/create-app/scripts/source-links/source-link-inventory.json
@@ -129,7 +129,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -246,7 +247,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -358,7 +360,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -472,7 +475,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -504,7 +508,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -538,7 +543,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -572,7 +578,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -606,7 +613,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -640,7 +648,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -674,7 +683,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -708,7 +718,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -742,7 +753,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "automation",
@@ -780,7 +792,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -823,7 +836,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -866,7 +880,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -920,7 +935,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -975,7 +991,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1016,7 +1033,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1054,7 +1072,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1100,7 +1119,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1142,7 +1162,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1166,7 +1187,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1208,7 +1230,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1250,7 +1273,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1292,7 +1316,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1334,7 +1359,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1376,7 +1402,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1449,7 +1476,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1468,7 +1496,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1541,7 +1570,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1560,7 +1590,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1633,7 +1664,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1657,7 +1689,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1699,7 +1732,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1741,7 +1775,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1783,7 +1818,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1825,7 +1861,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1867,7 +1904,8 @@
           "availabilityByPreset": {
             "classic": "source-only",
             "crm": "source-only",
-            "empty": "source-only"
+            "empty": "source-only",
+            "wms": "source-only"
           },
           "featureId": "design_system.view",
           "baselinePrUrl": "https://github.com/open-mercato/open-mercato/pull/4301",
@@ -1929,7 +1967,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1962,7 +2001,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -1999,7 +2039,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2038,7 +2079,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2071,7 +2113,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2171,7 +2214,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2209,7 +2253,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2246,7 +2291,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2297,7 +2343,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2329,7 +2376,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2361,7 +2409,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2393,7 +2442,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2433,7 +2483,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2499,7 +2550,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2538,7 +2590,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2618,7 +2671,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2654,7 +2708,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2695,7 +2750,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2729,7 +2785,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2763,7 +2820,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2802,7 +2860,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2838,7 +2897,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2866,7 +2926,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2914,7 +2975,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -2958,7 +3020,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3000,7 +3063,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3042,7 +3106,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3078,7 +3143,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3118,7 +3184,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3159,7 +3226,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3203,7 +3271,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3241,7 +3310,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3281,7 +3351,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3332,7 +3403,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3382,7 +3454,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3417,7 +3490,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3458,7 +3532,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3496,7 +3571,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3528,7 +3604,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3560,7 +3637,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3602,7 +3680,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3639,7 +3718,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3679,7 +3759,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3725,7 +3806,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3770,7 +3852,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3807,7 +3890,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3849,7 +3933,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3889,7 +3974,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3926,7 +4012,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3962,7 +4049,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -3999,7 +4087,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4037,7 +4126,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4082,7 +4172,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4125,7 +4216,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4239,7 +4331,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4347,7 +4440,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4393,7 +4487,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4431,7 +4526,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4486,7 +4582,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4528,7 +4625,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4567,7 +4665,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4606,7 +4705,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4644,7 +4744,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4686,7 +4787,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4728,7 +4830,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4764,7 +4867,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4806,7 +4910,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4851,7 +4956,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4898,7 +5004,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4940,7 +5047,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -4982,7 +5090,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5026,7 +5135,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5076,7 +5186,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5120,7 +5231,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5162,7 +5274,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5205,7 +5318,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5244,7 +5358,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5284,7 +5399,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5402,7 +5518,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5441,7 +5558,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5474,7 +5592,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5510,7 +5629,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5552,7 +5672,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5585,7 +5706,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5617,7 +5739,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5651,7 +5774,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5687,7 +5811,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5724,7 +5849,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"
@@ -5776,7 +5902,8 @@
       "presets": [
         "classic",
         "crm",
-        "empty"
+        "empty",
+        "wms"
       ],
       "tiers": [
         "core"

--- a/packages/create-app/src/index.ts
+++ b/packages/create-app/src/index.ts
@@ -54,7 +54,7 @@ ${pc.bold('Arguments:')}
 ${pc.bold('Options:')}
   --app <name>       Bootstrap an official ready app from open-mercato/ready-app-<name>
   --app-url <url>    Bootstrap a ready app from a GitHub repository URL
-  --preset <id>      Starter preset: classic, empty, or crm (omit to choose interactively)
+  --preset <id>      Starter preset: classic, empty, crm, or wms (omit to choose interactively)
   --init-git         Initialize a local Git repository after scaffolding
   --no-init-git      Do not prompt for or initialize a local Git repository
   --agents <list>    Set up agent tooling non-interactively (skips the wizard):
@@ -72,6 +72,7 @@ ${pc.bold('Examples:')}
   npx create-mercato-app my-store --preset classic
   npx create-mercato-app my-store --preset empty
   npx create-mercato-app my-store --preset crm
+  npx create-mercato-app my-warehouse --preset wms
   npx create-mercato-app my-store --init-git
   npx create-mercato-app my-store --agents claude-code,codex
   npx create-mercato-app my-store --agents codex --experimental-hooks-validator
@@ -159,6 +160,7 @@ const PRESET_PROMPT_OPTIONS = [
   { number: '1', id: 'classic', label: 'Classic     (default)', hint: 'full demo-ready starter' },
   { number: '2', id: 'empty', label: 'Empty', hint: 'minimal builder-ready baseline' },
   { number: '3', id: 'crm', label: 'CRM', hint: 'minimal CRM starter' },
+  { number: '4', id: 'wms', label: 'WMS', hint: 'warehouse and inventory starter' },
 ] as const
 
 export function normalizePresetAnswer(answer: string): string {
@@ -171,7 +173,7 @@ export function normalizePresetAnswer(answer: string): string {
   ))
 
   if (!selected) {
-    throw new Error(`Unknown preset "${answer}". Choose classic, empty, or crm.`)
+    throw new Error(`Unknown preset "${answer}". Choose classic, empty, crm, or wms.`)
   }
 
   return selected.id

--- a/packages/create-app/src/lib/agent-harness-evaluator.test.ts
+++ b/packages/create-app/src/lib/agent-harness-evaluator.test.ts
@@ -4311,7 +4311,7 @@ function stageSpecTarget(fixtureId: string): string {
       readStatus: 'readable',
       resolvedPath,
       referenceRole,
-      presets: ['classic', 'crm', 'empty', 'wms'],
+      presets: ['classic', 'crm', 'empty'],
       tiers: ['core'],
       galleryItemIds: ['buttons/button'],
       visualReferences: [{
@@ -4320,7 +4320,7 @@ function stageSpecTarget(fixtureId: string): string {
         entryId: 'button',
         importPath: '@open-mercato/ui/primitives/button',
         route: '/backend/design-system/buttons',
-        availabilityByPreset: { classic: 'source-only', crm: 'source-only', empty: 'source-only', wms: 'source-only' },
+        availabilityByPreset: { classic: 'source-only', crm: 'source-only', empty: 'source-only' },
         featureId: 'design_system.view',
         designFoundation: {
           galleryNodeId: 'buttons/button',

--- a/packages/create-app/src/lib/agent-harness-evaluator.test.ts
+++ b/packages/create-app/src/lib/agent-harness-evaluator.test.ts
@@ -4311,7 +4311,7 @@ function stageSpecTarget(fixtureId: string): string {
       readStatus: 'readable',
       resolvedPath,
       referenceRole,
-      presets: ['classic', 'crm', 'empty'],
+      presets: ['classic', 'crm', 'empty', 'wms'],
       tiers: ['core'],
       galleryItemIds: ['buttons/button'],
       visualReferences: [{
@@ -4320,7 +4320,7 @@ function stageSpecTarget(fixtureId: string): string {
         entryId: 'button',
         importPath: '@open-mercato/ui/primitives/button',
         route: '/backend/design-system/buttons',
-        availabilityByPreset: { classic: 'source-only', crm: 'source-only', empty: 'source-only' },
+        availabilityByPreset: { classic: 'source-only', crm: 'source-only', empty: 'source-only', wms: 'source-only' },
         featureId: 'design_system.view',
         designFoundation: {
           galleryNodeId: 'buttons/button',

--- a/packages/create-app/src/lib/agent-harness-example-read-policy.test.ts
+++ b/packages/create-app/src/lib/agent-harness-example-read-policy.test.ts
@@ -2338,7 +2338,7 @@ test('family 12: source-reference applicability follows real starter presets and
   const records = projectedInventory().records
   const byId = new Map(records.map((record) => [record.referenceId, record]))
   const record = recordIn(records, DESIGN_IMPLEMENTATION_REFERENCE)
-  assert.deepEqual(record.presets, ['classic', 'crm', 'empty'])
+  assert.deepEqual(record.presets, ['classic', 'crm', 'empty', 'wms'])
   assert.deepEqual(record.tiers, ['core'])
 
   const root = stageExampleApp()

--- a/packages/create-app/src/lib/agent-harness-example-read-policy.test.ts
+++ b/packages/create-app/src/lib/agent-harness-example-read-policy.test.ts
@@ -2338,7 +2338,7 @@ test('family 12: source-reference applicability follows real starter presets and
   const records = projectedInventory().records
   const byId = new Map(records.map((record) => [record.referenceId, record]))
   const record = recordIn(records, DESIGN_IMPLEMENTATION_REFERENCE)
-  assert.deepEqual(record.presets, ['classic', 'crm', 'empty', 'wms'])
+  assert.deepEqual(record.presets, ['classic', 'crm', 'empty'])
   assert.deepEqual(record.tiers, ['core'])
 
   const root = stageExampleApp()

--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -50,10 +50,10 @@ test('resolvePreset: empty returns 11-module list', () => {
   assert.deepEqual(result.filesToRemove, [])
 })
 
-test('resolvePreset: crm returns 19-module list extending empty (includes attachments + messages + currencies + communication_channels + ai_assistant + search)', () => {
+test('resolvePreset: crm returns 17-module list extending empty (includes currencies + communication_channels + ai_assistant + search)', () => {
   const result = resolvePreset('crm')
   assert.equal(result.isClassic, false)
-  assert.equal(result.modules.length, 19)
+  assert.equal(result.modules.length, 17)
   const ids = result.modules.map((m) => m.id)
   assert.ok(ids.includes('auth'))
   assert.ok(ids.includes('directory'))
@@ -63,8 +63,6 @@ test('resolvePreset: crm returns 19-module list extending empty (includes attach
   assert.ok(ids.includes('api_docs'))
   assert.ok(ids.includes('audit_logs'))
   assert.ok(ids.includes('customers'))
-  assert.ok(ids.includes('attachments'))
-  assert.ok(ids.includes('messages'))
   assert.ok(ids.includes('dictionaries'))
   assert.ok(ids.includes('feature_toggles'))
   assert.ok(ids.includes('notifications'))
@@ -233,15 +231,13 @@ test('applyStarterPreset: empty writes 11-module modules.ts and keeps example so
   }
 })
 
-test('applyStarterPreset: crm writes 19-module modules.ts and keeps example source present', () => {
+test('applyStarterPreset: crm writes 17-module modules.ts and keeps example source present', () => {
   const dir = makeTempDir()
   try {
     applyStarterPreset('crm', dir)
     const content = readFileSync(join(dir, 'src', 'modules.ts'), 'utf-8')
     assert.ok(content.includes("id: 'auth'"))
     assert.ok(content.includes("id: 'customers'"))
-    assert.ok(content.includes("id: 'attachments'"))
-    assert.ok(content.includes("id: 'messages'"))
     assert.ok(content.includes("id: 'dictionaries'"))
     assert.ok(content.includes("id: 'feature_toggles'"))
     assert.ok(content.includes("id: 'currencies'"))

--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -90,6 +90,35 @@ test('resolvePreset: crm returns 17-module list extending empty (includes curren
   assert.equal(unique.size, ids.length)
 })
 
+test('resolvePreset: wms returns empty plus the WMS dependency chain', () => {
+  const result = resolvePreset('wms')
+  assert.equal(result.isClassic, false)
+  assert.equal(result.modules.length, 18)
+  const ids = result.modules.map((m) => m.id)
+  assert.deepEqual(ids, [
+    'auth',
+    'directory',
+    'configs',
+    'entities',
+    'query_index',
+    'api_docs',
+    'audit_logs',
+    'notifications',
+    'dashboards',
+    'events',
+    'search',
+    'customers',
+    'dictionaries',
+    'feature_toggles',
+    'catalog',
+    'sales',
+    'wms',
+    'currencies',
+  ])
+  assert.equal(result.modules.find((module) => module.id === 'wms')?.from, '@open-mercato/core')
+  assert.equal(result.modules.find((module) => module.id === 'search')?.from, '@open-mercato/search')
+})
+
 test('resolvePreset: unknown preset throws', () => {
   assert.throws(() => resolvePreset('bogus'), /Unknown preset/)
 })
@@ -129,6 +158,15 @@ test('generateModulesTs: produces valid content for crm modules', () => {
   assert.ok(content.includes("id: 'ai_assistant'"))
   assert.ok(content.includes("from: '@open-mercato/ai-assistant'"))
   assert.ok(!content.includes('example_customers_sync'))
+})
+
+test('generateModulesTs: produces valid content for wms modules', () => {
+  const content = generateModulesTs(resolvePreset('wms').modules)
+  for (const moduleId of ['catalog', 'sales', 'feature_toggles', 'wms', 'currencies']) {
+    assert.ok(content.includes(`id: '${moduleId}'`))
+  }
+  assert.ok(!content.includes("id: 'ai_assistant'"))
+  assert.ok(!content.includes("id: 'example'"))
 })
 
 // applyStarterPreset filesystem tests
@@ -193,7 +231,7 @@ test('applyStarterPreset: empty writes 11-module modules.ts and keeps example so
   }
 })
 
-test('applyStarterPreset: crm writes 17-module modules.ts and keeps example source present', () => {
+test('applyStarterPreset: crm writes 19-module modules.ts and keeps example source present', () => {
   const dir = makeTempDir()
   try {
     applyStarterPreset('crm', dir)
@@ -219,6 +257,23 @@ test('applyStarterPreset: crm writes 17-module modules.ts and keeps example sour
     assert.ok(existsSync(join(dir, 'src', 'modules', 'example_customers_sync')))
     const marker = JSON.parse(readFileSync(join(dir, '.mercato', 'starter-preset.json'), 'utf-8'))
     assert.equal(marker.preset, 'crm')
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('applyStarterPreset: wms writes the WMS dependency chain and keeps example source present', () => {
+  const dir = makeTempDir()
+  try {
+    applyStarterPreset('wms', dir)
+    const content = readFileSync(join(dir, 'src', 'modules.ts'), 'utf-8')
+    for (const moduleId of ['customers', 'dictionaries', 'feature_toggles', 'catalog', 'sales', 'wms', 'currencies']) {
+      assert.ok(content.includes(`id: '${moduleId}'`))
+    }
+    assert.ok(!content.includes("id: 'ai_assistant'"))
+    assert.ok(existsSync(join(dir, 'src', 'modules', 'example')))
+    const marker = JSON.parse(readFileSync(join(dir, '.mercato', 'starter-preset.json'), 'utf-8'))
+    assert.equal(marker.preset, 'wms')
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }
@@ -250,7 +305,7 @@ test('every non-classic preset enables the modules the template topbar gates on'
   assert.ok(requiredModuleIds.includes('search'))
   assert.ok(requiredModuleIds.includes('notifications'))
 
-  for (const presetId of ['empty', 'crm']) {
+  for (const presetId of ['empty', 'crm', 'wms']) {
     const enabledIds = new Set(resolvePreset(presetId).modules.map((m) => m.id))
     for (const moduleId of requiredModuleIds) {
       // ai_assistant is a CRM capability rather than baseline chrome, so the empty
@@ -265,7 +320,7 @@ test('every non-classic preset enables the modules the template topbar gates on'
 })
 
 test('any preset enabling ai_assistant also enables search', () => {
-  for (const presetId of ['classic', 'empty', 'crm']) {
+  for (const presetId of ['classic', 'empty', 'crm', 'wms']) {
     const resolved = resolvePreset(presetId)
     if (resolved.isClassic) continue
     const ids = new Set(resolved.modules.map((m) => m.id))

--- a/packages/create-app/src/lib/apply-starter-preset.test.ts
+++ b/packages/create-app/src/lib/apply-starter-preset.test.ts
@@ -50,10 +50,10 @@ test('resolvePreset: empty returns 11-module list', () => {
   assert.deepEqual(result.filesToRemove, [])
 })
 
-test('resolvePreset: crm returns 17-module list extending empty (includes currencies + communication_channels + ai_assistant + search)', () => {
+test('resolvePreset: crm returns 19-module list extending empty (includes attachments + messages + currencies + communication_channels + ai_assistant + search)', () => {
   const result = resolvePreset('crm')
   assert.equal(result.isClassic, false)
-  assert.equal(result.modules.length, 17)
+  assert.equal(result.modules.length, 19)
   const ids = result.modules.map((m) => m.id)
   assert.ok(ids.includes('auth'))
   assert.ok(ids.includes('directory'))
@@ -63,6 +63,8 @@ test('resolvePreset: crm returns 17-module list extending empty (includes curren
   assert.ok(ids.includes('api_docs'))
   assert.ok(ids.includes('audit_logs'))
   assert.ok(ids.includes('customers'))
+  assert.ok(ids.includes('attachments'))
+  assert.ok(ids.includes('messages'))
   assert.ok(ids.includes('dictionaries'))
   assert.ok(ids.includes('feature_toggles'))
   assert.ok(ids.includes('notifications'))
@@ -238,6 +240,8 @@ test('applyStarterPreset: crm writes 19-module modules.ts and keeps example sour
     const content = readFileSync(join(dir, 'src', 'modules.ts'), 'utf-8')
     assert.ok(content.includes("id: 'auth'"))
     assert.ok(content.includes("id: 'customers'"))
+    assert.ok(content.includes("id: 'attachments'"))
+    assert.ok(content.includes("id: 'messages'"))
     assert.ok(content.includes("id: 'dictionaries'"))
     assert.ok(content.includes("id: 'feature_toggles'"))
     assert.ok(content.includes("id: 'currencies'"))
@@ -309,8 +313,8 @@ test('every non-classic preset enables the modules the template topbar gates on'
     const enabledIds = new Set(resolvePreset(presetId).modules.map((m) => m.id))
     for (const moduleId of requiredModuleIds) {
       // ai_assistant is a CRM capability rather than baseline chrome, so the empty
-      // preset is allowed to omit it; every other gated module must be present.
-      if (moduleId === 'ai_assistant' && presetId === 'empty') continue
+      // and WMS presets are allowed to omit it; every other gated module must be present.
+      if (moduleId === 'ai_assistant' && ['empty', 'wms'].includes(presetId)) continue
       assert.ok(
         enabledIds.has(moduleId),
         `preset "${presetId}" must enable module "${moduleId}" — the topbar gates an affordance on one of its features`,

--- a/packages/create-app/src/lib/design-system-inventory.test.ts
+++ b/packages/create-app/src/lib/design-system-inventory.test.ts
@@ -254,11 +254,13 @@ test('preset applicability follows each genuine resolved preset instead of a glo
       classic: 'source-only',
       crm: 'live',
       empty: 'source-only',
+      wms: 'source-only',
     })
     assert.deepEqual(availabilityFromResolvedPresets(resolved, true), {
       classic: 'live',
       crm: 'live',
       empty: 'source-only',
+      wms: 'source-only',
     })
   } finally {
     additions.length = originalLength

--- a/packages/create-app/src/lib/ready-apps.test.ts
+++ b/packages/create-app/src/lib/ready-apps.test.ts
@@ -302,6 +302,41 @@ test('CLI bare scaffold applies explicit crm preset without prompting', () => {
   }
 })
 
+test('CLI bare scaffold applies explicit wms preset without prompting', () => {
+  const targetRoot = makeTempDir('create-mercato-app-cli-wms-preset-')
+  const targetDir = join(targetRoot, 'wms-app')
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', CLI_ENTRY, targetDir, '--skip-agentic-setup', '--preset', 'wms'],
+      {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf8',
+        env: process.env,
+        timeout: CLI_SCAFFOLD_TIMEOUT_MS,
+      },
+    )
+
+    assert.equal(
+      result.status,
+      0,
+      `expected CLI scaffold with --preset wms to succeed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    )
+    assert.doesNotMatch(result.stdout, /No starter preset selected/)
+
+    const modulesTs = readFileSync(join(targetDir, 'src', 'modules.ts'), 'utf8')
+    for (const moduleId of ['catalog', 'sales', 'feature_toggles', 'wms', 'currencies']) {
+      assert.match(modulesTs, new RegExp(`id: '${moduleId}'`))
+    }
+    assert.doesNotMatch(modulesTs, /id: 'ai_assistant'/)
+    assert.equal(existsSync(join(targetDir, 'src', 'modules', 'example')), true)
+    assert.equal(existsSync(join(targetDir, '.mercato', 'starter-preset.json')), true)
+  } finally {
+    rmSync(targetRoot, { recursive: true, force: true })
+  }
+})
+
 test('CLI imported ready apps skip wizard-generated files', async () => {
   const archive = await createGitHubStyleTarball({
     'package.json': '{"name":"ready-app-prm","version":"0.0.1"}\n',

--- a/packages/create-app/src/lib/starter-preset-example-delivery.test.ts
+++ b/packages/create-app/src/lib/starter-preset-example-delivery.test.ts
@@ -13,7 +13,7 @@ const CLI_ENTRY = join(PACKAGE_ROOT, 'src', 'index.ts')
 const TEMPLATE_EXAMPLE_DIR = join(PACKAGE_ROOT, 'template', 'src', 'modules', 'example')
 const CLI_SCAFFOLD_TIMEOUT_MS = 120_000
 const SKIPPED_MODULE_DIRS = new Set(['__tests__', '__integration__'])
-const PRESET_IDS = ['classic', 'empty', 'crm'] as const
+const PRESET_IDS = ['classic', 'empty', 'crm', 'wms'] as const
 
 function collectEmittableRelativeFiles(root: string, prefix = ''): string[] {
   return readdirSync(root).flatMap((entry) => {

--- a/packages/create-app/src/lib/starter-presets.ts
+++ b/packages/create-app/src/lib/starter-presets.ts
@@ -1,4 +1,4 @@
-export type StarterPresetId = 'classic' | 'empty' | 'crm' | (string & {})
+export type StarterPresetId = 'classic' | 'empty' | 'crm' | 'wms' | (string & {})
 
 export type ModuleEntry = { id: string; from: string }
 
@@ -81,6 +81,27 @@ export const STARTER_PRESETS: Record<string, StarterPreset> = {
       ],
     },
     ui: { startPageVariant: 'crm', hideDemoLinks: true },
+    constraints: { rejectWithReadyApps: true },
+  },
+
+  wms: {
+    id: 'wms',
+    label: 'WMS',
+    description: 'Empty preset plus warehouse and inventory capabilities',
+    extends: 'empty',
+    modules: {
+      mode: 'patch',
+      add: [
+        { id: 'customers', from: CORE },
+        { id: 'dictionaries', from: CORE },
+        { id: 'feature_toggles', from: CORE },
+        { id: 'catalog', from: CORE },
+        { id: 'sales', from: CORE },
+        { id: 'wms', from: CORE },
+        { id: 'currencies', from: CORE },
+      ],
+    },
+    ui: { startPageVariant: 'minimal', hideDemoLinks: true },
     constraints: { rejectWithReadyApps: true },
   },
 }


### PR DESCRIPTION
## Summary

- Add a built-in `wms` starter preset to `create-mercato-app`.
- Include the WMS dependency chain: `catalog`, `sales`, `feature_toggles`, `customers`, and `dictionaries`.
- Include `currencies` for practical order/pricing workflows, while keeping CRM-only messaging, communications, and AI modules out.
- Add CLI help, interactive selection, README usage, scaffold regression coverage, and preset-matrix fixture updates.
- Fix WMS-specific regression coverage: WMS may omit the CRM-only AI assistant, and the design-system inventories now include WMS as source-only.

## Module research

The WMS module declares `catalog`, `sales`, and `feature_toggles` as required modules. Sales additionally requires `catalog`, `customers`, and `dictionaries`. The preset therefore enables all of those modules on top of the empty platform baseline. `notifications`, `dashboards`, `events`, and `search` are inherited from the baseline because the app shell and operational WMS experience use them.

The resulting preset has 18 modules:
`auth`, `directory`, `configs`, `entities`, `query_index`, `api_docs`, `audit_logs`, `notifications`, `dashboards`, `events`, `search`, `customers`, `dictionaries`, `feature_toggles`, `catalog`, `sales`, `wms`, and `currencies`.

## Validation

- `git diff --check` passed.
- The reported assertions were corrected.
- Full local Yarn validation was unavailable because the sandbox lacks a usable install-state; the earlier dependency install exhausted disk space.