### PR TITLE
fix(queue): report jobs the queue abandons before the handler runs

### DIFF
--- a/apps/docs/docs/framework/runtime/workers.mdx
+++ b/apps/docs/docs/framework/runtime/workers.mdx
@@ -323,20 +323,40 @@ mid-flight; that attempt has no way to report anything either.) Any state create
 row, a progress record — is stranded in whatever "in progress" state it was left in, and nothing
 reconciles it: the queue says `failed` while the domain row still says `running`.
 
-`onJobAbandoned` is the hook for exactly that case:
+`onJobAbandoned` is the callback for exactly that case, and it is declared **on the worker**, beside
+the queue name it belongs to:
 
 ```typescript
-import { createModuleQueue } from '@open-mercato/queue'
+// workers/my-import.ts
+import type { WorkerMeta } from '@open-mercato/queue'
 
-const queue = createModuleQueue<ImportPayload>('my-import', {
+export const metadata: WorkerMeta = {
+  queue: 'my-import',
   concurrency: 5,
   onJobAbandoned: async (payload, info) => {
     const data = payload as { payload?: { runId?: string } } | undefined
     if (typeof data?.payload?.runId !== 'string') return
     await markRunFailed(data.payload.runId, `the queue abandoned this job: ${info.reason}`)
   },
-})
+}
+
+export default async function handle(job, ctx) { /* ... */ }
 ```
+
+**Declare it here and not on `createModuleQueue`.** That is the single most important thing about this
+callback, and the mistake is silent: the queue you build to *enqueue* jobs is a different instance
+from the one the worker runs on. `runWorker` builds the worker's queue from the worker descriptors,
+so a callback attached to the enqueueing queue is never installed on the consumer — and the process
+that restarts, which is the event being reported, never constructs the enqueueing queue at all. The
+symptom is no error, no log, and a domain row nobody is told about.
+
+Two consequences of travelling through worker metadata:
+
+- **One queue gets one callback.** When several workers share a queue and more than one declares it,
+  the first wins and the CLI warns, naming the queue and the workers involved.
+- **It is detected from the source at build time.** The generator reads `metadata` to emit the
+  registry, so the callback must be declared directly in that object literal — a spread, or a
+  metadata object built by a helper function, will not be seen.
 
 - It fires **only** when the queue abandons a job it never handed to the handler. It is deliberately
   not a general "job failed" hook — a handler that ran and threw already owns its outcome, and firing

--- a/apps/docs/docs/framework/runtime/workers.mdx
+++ b/apps/docs/docs/framework/runtime/workers.mdx
@@ -305,6 +305,63 @@ await queue.enqueue({
 Always use `QUEUE_STRATEGY=async` with Redis in production environments.
 :::
 
+## Jobs the Queue Abandons
+
+A handler can only report what it sees, and there is one failure mode it never sees: the queue giving
+up on a job before the handler is entered.
+
+BullMQ counts how many times a job has stalled, and that counter is cumulative for the job's life —
+it does not reset when a redelivery succeeds. So for a long-lived job (one job that owns an entire
+import for hours or days), `maxStalledCount` is not a tolerance for flakiness; it is a budget for how
+many worker restarts the job may survive. Every deploy spends one. Past the budget BullMQ writes a
+deferred failure onto the job and moves it back to `wait`; the next worker reads that marker and
+fails the job **before** calling the processor.
+
+The handler therefore never runs on that final delivery — it does not throw, and it never learns. (An
+earlier attempt of the same job usually *did* enter the handler, in a process that then died
+mid-flight; that attempt has no way to report anything either.) Any state created on enqueue — a run
+row, a progress record — is stranded in whatever "in progress" state it was left in, and nothing
+reconciles it: the queue says `failed` while the domain row still says `running`.
+
+`onJobAbandoned` is the hook for exactly that case:
+
+```typescript
+import { createModuleQueue } from '@open-mercato/queue'
+
+const queue = createModuleQueue<ImportPayload>('my-import', {
+  concurrency: 5,
+  onJobAbandoned: async (payload, info) => {
+    const data = payload as { payload?: { runId?: string } } | undefined
+    if (typeof data?.payload?.runId !== 'string') return
+    await markRunFailed(data.payload.runId, `the queue abandoned this job: ${info.reason}`)
+  },
+})
+```
+
+- It fires **only** when the queue abandons a job it never handed to the handler. It is deliberately
+  not a general "job failed" hook — a handler that ran and threw already owns its outcome, and firing
+  for that case would double-report and erase the difference between *the work failed* and *the work
+  never started*. The two are told apart by the reason BullMQ records (`job stalled more than
+  allowable limit`, `job started more than allowable limit`), which is exact and identical in every
+  worker process.
+- Keep it small and idempotent, and make it tolerate a payload it does not recognize. It runs on the
+  worker's event emitter; the queue catches and logs anything it throws so a reporting failure cannot
+  take the worker down, and `close()` waits for a report already in flight.
+- **Delivery is at-least-once.** The worker reports as soon as it observes the abandonment, and also
+  sweeps the queue's failed set — on worker start, then every five minutes — for abandoned jobs whose
+  report was never acknowledged. Acknowledgement is a marker written onto the stored job **after**
+  the callback returns, so a callback that threw, or a process that died mid-report, leaves the job
+  unmarked and a later sweep retries it. The failed job itself is kept for diagnosis; acknowledgement
+  marks it, it does not delete it. Two consequences: the callback can be invoked more than once for
+  the same job (hence the idempotency requirement above), and a report is delayed rather than lost.
+  Residual loss remains possible where the failure record itself disappears — `removeOnFail` caps the
+  failed set, and a Redis flush empties it — so state that absolutely must never be stranded should
+  also have a staleness check of its own at the domain level.
+- It is an async-strategy concept. The local strategy runs handlers in-process, so no queue can
+  outlive a handler and abandon its job, and the option is not forwarded.
+- It repairs reporting, not the job. A long-running job still dies when it exhausts its stall budget —
+  it just dies visibly instead of silently.
+
 ## Best Practices
 
 ### 1. Make Handlers Idempotent

--- a/apps/docs/docs/framework/runtime/workers.mdx
+++ b/apps/docs/docs/framework/runtime/workers.mdx
@@ -346,10 +346,13 @@ const queue = createModuleQueue<ImportPayload>('my-import', {
   worker process.
 - Keep it small and idempotent, and make it tolerate a payload it does not recognize. It runs on the
   worker's event emitter; the queue catches and logs anything it throws so a reporting failure cannot
-  take the worker down, and `close()` waits for a report already in flight.
+  take the worker down. `close()` waits for a report already in flight, but only for
+  `ABANDONED_JOB_DRAIN_TIMEOUT_MS` — a hook that hangs must not turn a graceful shutdown into a
+  SIGKILL, and an undelivered report is picked up by the next worker's start-up sweep anyway.
 - **Delivery is at-least-once.** The worker reports as soon as it observes the abandonment, and also
-  sweeps the queue's failed set — on worker start, then every five minutes — for abandoned jobs whose
-  report was never acknowledged. Acknowledgement is a marker written onto the stored job **after**
+  sweeps the queue's failed set — on worker start, then every five minutes
+  (`QUEUE_ABANDONED_SWEEP_INTERVAL_MS` overrides the cadence) — for abandoned jobs whose report was
+  never acknowledged. Acknowledgement is a marker written onto the stored job **after**
   the callback returns, so a callback that threw, or a process that died mid-report, leaves the job
   unmarked and a later sweep retries it. The failed job itself is kept for diagnosis; acknowledgement
   marks it, it does not delete it. Two consequences: the callback can be invoked more than once for

--- a/packages/cli/src/__tests__/resolve-queue-abandon-hook.test.ts
+++ b/packages/cli/src/__tests__/resolve-queue-abandon-hook.test.ts
@@ -1,0 +1,39 @@
+import { resolveQueueAbandonHook } from '../mercato'
+
+/**
+ * Covers the CLI's per-queue pick, which is the last link between worker metadata and the queue the
+ * worker runs on. The warning exists because two handlers on one queue each expecting to report is a
+ * wiring mistake, and a silent first-wins would hide it.
+ */
+describe('resolveQueueAbandonHook', () => {
+  const hookA = jest.fn(async () => {})
+  const hookB = jest.fn(async () => {})
+
+  it('returns undefined when no worker declares one', () => {
+    const warn = jest.fn()
+    expect(resolveQueueAbandonHook('q', [{ id: 'a' }, { id: 'b' }], warn)).toBeUndefined()
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('returns the single declared callback without warning', () => {
+    const warn = jest.fn()
+    expect(resolveQueueAbandonHook('q', [{ id: 'a' }, { id: 'b', onJobAbandoned: hookA }], warn)).toBe(hookA)
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('keeps the first and warns, naming the queue and every declaring worker', () => {
+    const warn = jest.fn()
+    const picked = resolveQueueAbandonHook(
+      'data-sync-import',
+      [{ id: 'first', onJobAbandoned: hookA }, { id: 'second', onJobAbandoned: hookB }],
+      warn,
+    )
+
+    expect(picked).toBe(hookA)
+    expect(warn).toHaveBeenCalledTimes(1)
+    const message = warn.mock.calls[0][0] as string
+    expect(message).toContain('data-sync-import')
+    expect(message).toContain('first')
+    expect(message).toContain('second')
+  })
+})

--- a/packages/cli/src/lib/generators/__tests__/generated-registry-imports.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/generated-registry-imports.test.ts
@@ -1,0 +1,128 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import type { PackageResolver, ModuleEntry } from '../../resolver'
+import { generateModuleRegistry, generateModuleRegistryApp, generateModuleRegistryCli } from '../module-registry'
+
+/**
+ * The generator's output, not its helpers.
+ *
+ * A worker declaring `metadata.onJobAbandoned` makes the registry emit
+ * `createLazyModuleWorkerAbandonHook(...)`, and the import for it used to be opted into per render
+ * site. Forgetting it at one of the six sites produced a file referencing an undeclared name, which
+ * type-checks nowhere and surfaces only at `build:app` — every unit test stayed green because no
+ * fixture declared such a worker.
+ *
+ * These assertions are driven off the files the generators actually wrote, so a renderer added later
+ * is covered without anyone remembering to extend this test.
+ */
+
+let tmpDir: string
+
+function touchFile(filePath: string, content = ''): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content)
+}
+
+function createMockResolver(dir: string, enabled: ModuleEntry[]): PackageResolver {
+  const outputDir = path.join(dir, 'output', 'generated')
+  fs.mkdirSync(outputDir, { recursive: true })
+  return {
+    isMonorepo: () => true,
+    getRootDir: () => dir,
+    getAppDir: () => path.join(dir, 'app'),
+    getOutputDir: () => outputDir,
+    getModulesConfigPath: () => path.join(dir, 'app', 'src', 'modules.ts'),
+    discoverPackages: () => [],
+    loadEnabledModules: () => enabled,
+    getModulePaths: (entry: ModuleEntry) => ({
+      appBase: path.join(dir, 'app', 'src', 'modules', entry.id),
+      pkgBase: path.join(dir, 'packages', 'core', 'src', 'modules', entry.id),
+    }),
+    getModuleImportBase: (entry: ModuleEntry) => ({
+      appBase: `@/modules/${entry.id}`,
+      pkgBase: `@open-mercato/core/modules/${entry.id}`,
+    }),
+    getPackageOutputDir: () => outputDir,
+    getPackageRoot: () => path.join(dir, 'packages', 'core'),
+  }
+}
+
+function scaffoldWorkerModule(dir: string, modId: string, workerSource: string): void {
+  touchFile(path.join(dir, 'packages', 'core', 'src', 'modules', modId, 'workers', 'sync.ts'), workerSource)
+}
+
+function generatedFiles(dir: string): Array<{ name: string; content: string }> {
+  const outputDir = path.join(dir, 'output', 'generated')
+  if (!fs.existsSync(outputDir)) return []
+  return fs.readdirSync(outputDir)
+    .filter((name) => name.endsWith('.ts'))
+    .map((name) => ({ name, content: fs.readFileSync(path.join(outputDir, name), 'utf8') }))
+}
+
+const ABANDON_HOOK_FACTORY = 'createLazyModuleWorkerAbandonHook'
+
+const WORKER_WITH_HOOK = `
+import { failAbandonedRun } from '../lib/abandoned-run'
+export const metadata = {
+  queue: 'demo-queue',
+  id: 'demo:worker',
+  concurrency: 2,
+  onJobAbandoned: failAbandonedRun,
+}
+export default async function handle() {}
+`
+
+const WORKER_WITHOUT_HOOK = `
+export const metadata = {
+  queue: 'demo-queue',
+  id: 'demo:worker',
+  concurrency: 2,
+}
+export default async function handle() {}
+`
+
+async function generateAll(resolver: PackageResolver): Promise<void> {
+  await generateModuleRegistry({ resolver, quiet: true })
+  await generateModuleRegistryApp({ resolver, quiet: true })
+  await generateModuleRegistryCli({ resolver, quiet: true })
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'generated-registry-imports-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('generated registries — emitted identifiers are imported', () => {
+  it('imports the abandon-hook helper in every file that calls it', async () => {
+    scaffoldWorkerModule(tmpDir, 'demo', WORKER_WITH_HOOK)
+    const resolver = createMockResolver(tmpDir, [{ id: 'demo', from: 'pkg' } as ModuleEntry])
+
+    await generateAll(resolver)
+
+    const files = generatedFiles(tmpDir)
+    const callers = files.filter(({ content }) => content.includes(`${ABANDON_HOOK_FACTORY}(`))
+    // The fixture must actually exercise the path, or this test passes vacuously — which is exactly
+    // how the missing import survived every existing suite.
+    expect(callers.length).toBeGreaterThan(0)
+
+    for (const { name, content } of callers) {
+      expect(`${name}: ${content.includes(`import { `) && new RegExp(`import \\{[^}]*\\b${ABANDON_HOOK_FACTORY}\\b[^}]*\\} from`, 's').test(content)}`)
+        .toBe(`${name}: true`)
+    }
+  })
+
+  it('leaves output untouched for a module set whose workers declare no hook', async () => {
+    scaffoldWorkerModule(tmpDir, 'demo', WORKER_WITHOUT_HOOK)
+    const resolver = createMockResolver(tmpDir, [{ id: 'demo', from: 'pkg' } as ModuleEntry])
+
+    await generateAll(resolver)
+
+    for (const { name, content } of generatedFiles(tmpDir)) {
+      expect(`${name}: ${content.includes(ABANDON_HOOK_FACTORY)}`).toBe(`${name}: false`)
+    }
+  })
+})

--- a/packages/cli/src/lib/generators/__tests__/metadata-extraction.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/metadata-extraction.test.ts
@@ -4,6 +4,7 @@ import os from 'node:os'
 import {
   extractNamedObjectLiteralExport,
   hasNamedExport,
+  namedObjectLiteralDeclaresProperty,
   resolveNamedObjectExport,
 } from '../module-registry'
 
@@ -216,5 +217,48 @@ describe('hasNamedExport', () => {
       export async function GET() {}
     `)
     expect(hasNamedExport(file, 'metadata')).toBe(false)
+  })
+})
+
+describe('namedObjectLiteralDeclaresProperty', () => {
+  // A worker declaring `onJobAbandoned: someImportedFn` is the case that broke: the value resolvers
+  // cannot evaluate an imported identifier, so "is it declared" has to be answered from the syntax.
+  // Getting this wrong is silent — the generator simply never emits the hook.
+  it('sees a property whose value is an unresolvable identifier', () => {
+    const file = writeSource('worker.ts', `
+      import { failAbandonedRun } from '../lib/abandoned-run'
+      export const metadata = {
+        queue: 'data-sync-import',
+        concurrency: 5,
+        onJobAbandoned: failAbandonedRun,
+      }
+    `)
+    expect(namedObjectLiteralDeclaresProperty(file, 'metadata', 'onJobAbandoned')).toBe(true)
+    expect(extractNamedObjectLiteralExport(file, 'metadata')?.onJobAbandoned).toBeUndefined()
+  })
+
+  it('sees a property declared as an inline function', () => {
+    const file = writeSource('worker.ts', `
+      export const metadata = {
+        queue: 'q',
+        onJobAbandoned: async () => {},
+      }
+    `)
+    expect(namedObjectLiteralDeclaresProperty(file, 'metadata', 'onJobAbandoned')).toBe(true)
+  })
+
+  it('reports absence for a worker that declares no hook', () => {
+    const file = writeSource('worker.ts', `
+      export const metadata = { queue: 'q', concurrency: 1 }
+    `)
+    expect(namedObjectLiteralDeclaresProperty(file, 'metadata', 'onJobAbandoned')).toBe(false)
+  })
+
+  it('reports absence for a metadata export that is not an object literal', () => {
+    const file = writeSource('worker.ts', `
+      const base = buildMetadata()
+      export const metadata = base
+    `)
+    expect(namedObjectLiteralDeclaresProperty(file, 'metadata', 'onJobAbandoned')).toBe(false)
   })
 })

--- a/packages/cli/src/lib/generators/module-registry.ts
+++ b/packages/cli/src/lib/generators/module-registry.ts
@@ -246,6 +246,15 @@ type SerializableWorkerMetadata = {
   concurrency?: number
   lockDuration?: number
   maxStalledCount?: number
+  /**
+   * Whether the worker's metadata declares an `onJobAbandoned` callback.
+   *
+   * A function cannot be serialized into the registry the way the scalar options are, so the flag is
+   * resolved here at build time and the callback itself is emitted as a lazy import beside the
+   * handler. Recorded only when the source module could actually be loaded — the object-literal
+   * fallback below cannot see whether a referenced identifier is a function.
+   */
+  hasJobAbandonedHook?: boolean
 }
 
 type PageMetadataManifestLoadResult = {
@@ -575,6 +584,55 @@ function extractObjectPropertiesFromAst(sourceFile: string, exportName: string):
   }
 
   return Object.keys(result).length > 0 ? result : null
+}
+
+/**
+ * Whether an exported object literal declares a property, regardless of what it evaluates to.
+ *
+ * Needed for callbacks: the value resolvers above can read literals and local constants, but a
+ * property whose value is an imported function stays unresolvable, so "did the author declare it"
+ * cannot be answered by inspecting the extracted value. Answering it from the syntax instead is what
+ * lets the generator emit a lazy accessor for a hook it can see but cannot serialize.
+ */
+export function namedObjectLiteralDeclaresProperty(sourceFile: string, exportName: string, propertyName: string): boolean {
+  let source = ''
+  try {
+    source = fs.readFileSync(sourceFile, 'utf8')
+  } catch {
+    return false
+  }
+
+  const parsed = ts.createSourceFile(sourceFile, source, ts.ScriptTarget.Latest, true, inferScriptKind(sourceFile))
+  const exportedNames = new Set<string>()
+  for (const statement of parsed.statements) {
+    if (
+      ts.isExportDeclaration(statement)
+      && statement.exportClause
+      && ts.isNamedExports(statement.exportClause)
+      && !statement.moduleSpecifier
+    ) {
+      for (const element of statement.exportClause.elements) exportedNames.add(element.name.text)
+    }
+  }
+
+  for (const statement of parsed.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    const exportsDirectly = (ts.canHaveModifiers(statement) ? ts.getModifiers(statement) : undefined)
+      ?.some((modifier: ts.Modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+    for (const declaration of statement.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || declaration.name.text !== exportName) continue
+      if (!exportsDirectly && !exportedNames.has(exportName)) continue
+      const objectLiteral = unwrapObjectLiteralExpression(declaration.initializer)
+      if (!objectLiteral) return false
+      return objectLiteral.properties.some((property) => {
+        const name = property.name
+        if (!name) return false
+        const key = ts.isIdentifier(name) ? name.text : ts.isStringLiteral(name) ? name.text : null
+        return key === propertyName
+      })
+    }
+  }
+  return false
 }
 
 export function extractNamedObjectLiteralExport(sourceFile: string, exportName: string): Record<string, unknown> | null {
@@ -1777,6 +1835,7 @@ function normalizeWorkerMetadata(raw: unknown): SerializableWorkerMetadata | nul
   if (typeof source.concurrency === 'number') normalized.concurrency = source.concurrency
   if (typeof source.lockDuration === 'number') normalized.lockDuration = source.lockDuration
   if (typeof source.maxStalledCount === 'number') normalized.maxStalledCount = source.maxStalledCount
+  if (typeof source.onJobAbandoned === 'function') normalized.hasJobAbandonedHook = true
   return Object.keys(normalized).length > 0 ? normalized : null
 }
 
@@ -1788,8 +1847,16 @@ async function loadSubscriberMetadata(sourceFile: string): Promise<SerializableS
 
 async function loadWorkerMetadata(sourceFile: string): Promise<SerializableWorkerMetadata | null> {
   const sourceModule = await loadModuleExportsFromSource<Record<string, unknown>>(sourceFile)
-  return normalizeWorkerMetadata(sourceModule?.metadata)
+  const metadata = normalizeWorkerMetadata(sourceModule?.metadata)
     ?? normalizeWorkerMetadata(extractNamedObjectLiteralExport(sourceFile, 'metadata'))
+  if (!metadata) return null
+  // Resolved from the syntax, not the extracted value: a worker module that cannot be imported at
+  // build time falls back to the literal extractor, which cannot tell an imported function from an
+  // unresolvable identifier. Missing this is silent — the hook is simply never installed.
+  if (!metadata.hasJobAbandonedHook && namedObjectLiteralDeclaresProperty(sourceFile, 'metadata', 'onJobAbandoned')) {
+    metadata.hasJobAbandonedHook = true
+  }
+  return metadata
 }
 
 async function discoverSubscribers(
@@ -2326,12 +2393,16 @@ function processSubscribers(discovered: DiscoveredSubscriber[]): string[] {
   return subscribers
 }
 
+function workersDeclareAbandonHook(discovered: DiscoveredWorker[]): boolean {
+  return discovered.some(({ metadata }) => metadata.hasJobAbandonedHook === true)
+}
+
 function processWorkers(discovered: DiscoveredWorker[]): string[] {
   const workers: string[] = []
   for (const { id, importPath, metadata } of discovered) {
     const workerId = metadata.id ?? id
     workers.push(
-      `{ id: ${toLiteral(workerId)}, queue: ${toLiteral(metadata.queue)}, concurrency: ${toLiteral(metadata.concurrency ?? 1)}${metadata.lockDuration === undefined ? '' : `, lockDuration: ${toLiteral(metadata.lockDuration)}`}${metadata.maxStalledCount === undefined ? '' : `, maxStalledCount: ${toLiteral(metadata.maxStalledCount)}`}, handler: createLazyModuleWorker(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)}) }`
+      `{ id: ${toLiteral(workerId)}, queue: ${toLiteral(metadata.queue)}, concurrency: ${toLiteral(metadata.concurrency ?? 1)}${metadata.lockDuration === undefined ? '' : `, lockDuration: ${toLiteral(metadata.lockDuration)}`}${metadata.maxStalledCount === undefined ? '' : `, maxStalledCount: ${toLiteral(metadata.maxStalledCount)}`}${metadata.hasJobAbandonedHook ? `, onJobAbandoned: createLazyModuleWorkerAbandonHook(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)})` : ''}, handler: createLazyModuleWorker(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)}) }`
     )
   }
   return workers
@@ -2567,6 +2638,7 @@ function renderAstModuleRegistryFile(options: {
   imports: string[]
   moduleEntries: WriterFunction[]
   includeCreateElementImport?: boolean
+  includeAbandonHookImport?: boolean
 }): string {
   const sourceFile = createGeneratedSourceFile(options.fileName)
   addAutoGeneratedComment(sourceFile, options.generator)
@@ -2582,6 +2654,7 @@ function renderAstModuleRegistryFile(options: {
     namedImports: [
       { name: 'createLazyModuleSubscriber' },
       { name: 'createLazyModuleWorker' },
+      ...(options.includeAbandonHookImport ? [{ name: 'createLazyModuleWorkerAbandonHook' }] : []),
       { name: 'Module', isTypeOnly: true },
     ],
   })
@@ -2694,10 +2767,13 @@ function renderAstLegacyModuleRegistryOutput(options: {
   imports: GeneratedImportStatement[]
   moduleEntries: string[]
   includeCreateElementImport?: boolean
+  includeAbandonHookImport?: boolean
 }): string {
   const importSection = [
     ...(options.includeCreateElementImport ? ["import { createElement } from 'react'"] : []),
-    "import { createLazyModuleSubscriber, createLazyModuleWorker, type Module } from '@open-mercato/shared/modules/registry'",
+    options.includeAbandonHookImport
+      ? "import { createLazyModuleSubscriber, createLazyModuleWorker, createLazyModuleWorkerAbandonHook, type Module } from '@open-mercato/shared/modules/registry'"
+      : "import { createLazyModuleSubscriber, createLazyModuleWorker, type Module } from '@open-mercato/shared/modules/registry'",
     ...options.imports.map((entry) => serializeGeneratedImport(entry)),
   ].join('\n')
 
@@ -3011,6 +3087,15 @@ function processWorkersAst(discovered: DiscoveredWorker[]): WriterFunction[] {
         { name: 'concurrency', value: metadata.concurrency ?? 1 },
         ...(metadata.lockDuration === undefined ? [] : [{ name: 'lockDuration', value: metadata.lockDuration }]),
         ...(metadata.maxStalledCount === undefined ? [] : [{ name: 'maxStalledCount', value: metadata.maxStalledCount }]),
+        ...(metadata.hasJobAbandonedHook
+          ? [{
+            name: 'onJobAbandoned',
+            value: callExpression(identifier('createLazyModuleWorkerAbandonHook'), [
+              arrowFunction({ body: importExpression(importPath) }),
+              workerId,
+            ]),
+          }]
+          : []),
         {
           name: 'handler',
           value: callExpression(identifier('createLazyModuleWorker'), [
@@ -3384,6 +3469,7 @@ async function generateModuleRegistryFromDiscovery(options: ModuleRegistryRender
   const requiresByModule = new Map<string, string[]>()
   const commandLoaderEntries: CommandLoaderGenerationEntry[] = []
   let hasRouteComponents = false
+  let hasAbandonHookWorkers = false
 
   // UMES conflict detection: collect file paths during module processing
   const umesConflictSources: Array<{
@@ -3635,7 +3721,9 @@ async function generateModuleRegistryFromDiscovery(options: ModuleRegistryRender
     subscribers.push(...processSubscribers(await discovered.getSubscribers()))
 
     // 18. Workers
-    workers.push(...processWorkers(await discovered.getWorkers()))
+    const discoveredWorkersForModule = await discovered.getWorkers()
+    if (workersDeclareAbandonHook(discoveredWorkersForModule)) hasAbandonHookWorkers = true
+    workers.push(...processWorkers(discoveredWorkersForModule))
 
     // Build combined customFieldSets expression
     {
@@ -3801,6 +3889,7 @@ async function generateModuleRegistryFromDiscovery(options: ModuleRegistryRender
     imports,
     moduleEntries: moduleDecls,
     includeCreateElementImport: hasRouteComponents,
+    includeAbandonHookImport: hasAbandonHookWorkers,
   })
   const runtimeOutput = renderAstLegacyModuleRegistryOutput({
     fileName: 'modules.runtime.generated.ts',
@@ -4010,6 +4099,7 @@ async function generateModuleRegistryAppFromDiscovery(options: ModuleRegistryRen
   const requiresByModule = new Map<string, string[]>()
   const commandLoaderEntries: CommandLoaderGenerationEntry[] = []
   let hasRouteComponents = false
+  let hasAbandonHookWorkers = false
   const seenBackendRoutePatterns = new Map<string, string>()
 
   for (const discovered of discovery.modules) {
@@ -4171,7 +4261,9 @@ async function generateModuleRegistryAppFromDiscovery(options: ModuleRegistryRen
 
     subscribers.push(...processSubscribersAst(await discovered.getSubscribers()))
 
-    workers.push(...processWorkersAst(await discovered.getWorkers()))
+    const discoveredWorkersForModule = await discovered.getWorkers()
+    if (workersDeclareAbandonHook(discoveredWorkersForModule)) hasAbandonHookWorkers = true
+    workers.push(...processWorkersAst(discoveredWorkersForModule))
 
     {
       dashboardWidgetsValue = buildModuleDashboardWidgetsValue(discovered.dashboardWidgetEntries)
@@ -4295,6 +4387,7 @@ async function generateModuleRegistryAppFromDiscovery(options: ModuleRegistryRen
     imports,
     moduleEntries: moduleDecls,
     includeCreateElementImport: hasRouteComponents,
+    includeAbandonHookImport: hasAbandonHookWorkers,
   })
   const bootstrapOutput = renderAstModuleRegistryFile({
     fileName: 'modules.bootstrap.generated.ts',
@@ -4397,6 +4490,7 @@ async function generateModuleRegistryAppFromDiscovery(options: ModuleRegistryRen
  * Excludes: frontend routes, backend routes, API handlers, injection widgets
  */
 async function generateModuleRegistryCliFromDiscovery(options: ModuleRegistryRenderOptions): Promise<GeneratorResult> {
+  let hasAbandonHookWorkers = false
   const { resolver, quiet = false } = options
   const { discovery } = options
   const result = createGeneratorResult()
@@ -4548,6 +4642,7 @@ async function generateModuleRegistryCliFromDiscovery(options: ModuleRegistryRen
     // Workers
     const discoveredWorkers = await discovered.getWorkers()
     const workerGenerationEntries = collectWorkerGenerationEntries(discoveredWorkers, modId)
+    if (workersDeclareAbandonHook(discoveredWorkers)) hasAbandonHookWorkers = true
     workers.push(...processWorkersAst(discoveredWorkers))
     devSupervisorWorkers.push(...workerGenerationEntries.map(({ importPath: _importPath, ...worker }) => worker))
 
@@ -4671,6 +4766,7 @@ async function generateModuleRegistryCliFromDiscovery(options: ModuleRegistryRen
     generator: 'registry (CLI version)',
     imports,
     moduleEntries: moduleDecls,
+    includeAbandonHookImport: hasAbandonHookWorkers,
   })
   const legacyOutput = renderAstLegacyAliasFile({
     fileName: 'cli-modules.generated.ts',

--- a/packages/cli/src/lib/generators/module-registry.ts
+++ b/packages/cli/src/lib/generators/module-registry.ts
@@ -2393,6 +2393,15 @@ function processSubscribers(discovered: DiscoveredSubscriber[]): string[] {
   return subscribers
 }
 
+/**
+ * Registry helper emitted for a worker that declares `metadata.onJobAbandoned`.
+ *
+ * Named once because two things must stay in step: the call the worker entry renders, and the import
+ * the file needs for it. A generated file that references this without importing it type-checks
+ * nowhere, and only fails at `build:app` — see `generated-registry-imports.test.ts`.
+ */
+const ABANDON_HOOK_FACTORY = 'createLazyModuleWorkerAbandonHook'
+
 function workersDeclareAbandonHook(discovered: DiscoveredWorker[]): boolean {
   return discovered.some(({ metadata }) => metadata.hasJobAbandonedHook === true)
 }
@@ -2402,7 +2411,7 @@ function processWorkers(discovered: DiscoveredWorker[]): string[] {
   for (const { id, importPath, metadata } of discovered) {
     const workerId = metadata.id ?? id
     workers.push(
-      `{ id: ${toLiteral(workerId)}, queue: ${toLiteral(metadata.queue)}, concurrency: ${toLiteral(metadata.concurrency ?? 1)}${metadata.lockDuration === undefined ? '' : `, lockDuration: ${toLiteral(metadata.lockDuration)}`}${metadata.maxStalledCount === undefined ? '' : `, maxStalledCount: ${toLiteral(metadata.maxStalledCount)}`}${metadata.hasJobAbandonedHook ? `, onJobAbandoned: createLazyModuleWorkerAbandonHook(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)})` : ''}, handler: createLazyModuleWorker(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)}) }`
+      `{ id: ${toLiteral(workerId)}, queue: ${toLiteral(metadata.queue)}, concurrency: ${toLiteral(metadata.concurrency ?? 1)}${metadata.lockDuration === undefined ? '' : `, lockDuration: ${toLiteral(metadata.lockDuration)}`}${metadata.maxStalledCount === undefined ? '' : `, maxStalledCount: ${toLiteral(metadata.maxStalledCount)}`}${metadata.hasJobAbandonedHook ? `, onJobAbandoned: ${ABANDON_HOOK_FACTORY}(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)})` : ''}, handler: createLazyModuleWorker(() => ${buildDynamicImportExpression(importPath)}, ${toLiteral(workerId)}) }`
     )
   }
   return workers
@@ -2654,7 +2663,7 @@ function renderAstModuleRegistryFile(options: {
     namedImports: [
       { name: 'createLazyModuleSubscriber' },
       { name: 'createLazyModuleWorker' },
-      ...(options.includeAbandonHookImport ? [{ name: 'createLazyModuleWorkerAbandonHook' }] : []),
+      ...(options.includeAbandonHookImport ? [{ name: ABANDON_HOOK_FACTORY }] : []),
       { name: 'Module', isTypeOnly: true },
     ],
   })
@@ -2769,9 +2778,14 @@ function renderAstLegacyModuleRegistryOutput(options: {
   includeCreateElementImport?: boolean
   includeAbandonHookImport?: boolean
 }): string {
+  // Derived from what is actually being written, not from a flag the caller has to remember: an
+  // import that must be opted into at every render site produces a file referencing an undeclared
+  // name the first time someone forgets, and the file only fails at `build:app`.
+  const needsAbandonHookImport = options.includeAbandonHookImport
+    || options.moduleEntries.some((entry) => entry.includes(ABANDON_HOOK_FACTORY))
   const importSection = [
     ...(options.includeCreateElementImport ? ["import { createElement } from 'react'"] : []),
-    options.includeAbandonHookImport
+    needsAbandonHookImport
       ? "import { createLazyModuleSubscriber, createLazyModuleWorker, createLazyModuleWorkerAbandonHook, type Module } from '@open-mercato/shared/modules/registry'"
       : "import { createLazyModuleSubscriber, createLazyModuleWorker, type Module } from '@open-mercato/shared/modules/registry'",
     ...options.imports.map((entry) => serializeGeneratedImport(entry)),
@@ -3090,7 +3104,7 @@ function processWorkersAst(discovered: DiscoveredWorker[]): WriterFunction[] {
         ...(metadata.hasJobAbandonedHook
           ? [{
             name: 'onJobAbandoned',
-            value: callExpression(identifier('createLazyModuleWorkerAbandonHook'), [
+            value: callExpression(identifier(ABANDON_HOOK_FACTORY), [
               arrowFunction({ body: importExpression(importPath) }),
               workerId,
             ]),
@@ -3896,6 +3910,7 @@ async function generateModuleRegistryFromDiscovery(options: ModuleRegistryRender
     imports: runtimeImports,
     moduleEntries: runtimeModuleDecls,
     includeCreateElementImport: true,
+    includeAbandonHookImport: hasAbandonHookWorkers,
   })
   const frontendRoutesOutput = renderAstLegacyManifestOutput({
     fileName: 'frontend-routes.generated.ts',
@@ -4394,12 +4409,14 @@ async function generateModuleRegistryAppFromDiscovery(options: ModuleRegistryRen
     generator: 'registry (bootstrap version)',
     imports: bootstrapImports,
     moduleEntries: bootstrapModuleDecls,
+    includeAbandonHookImport: hasAbandonHookWorkers,
   })
   const i18nOutput = renderAstModuleRegistryFile({
     fileName: 'modules.i18n.generated.ts',
     generator: 'registry (i18n version)',
     imports: i18nImports,
     moduleEntries: i18nModuleDecls,
+    includeAbandonHookImport: hasAbandonHookWorkers,
   })
   const legacyOutput = renderAstLegacyAliasFile({
     fileName: 'bootstrap-modules.generated.ts',

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -78,6 +78,29 @@ function getRegisteredCliWorkers(modules: Module[] = getCliModules()): ModuleWor
   return allWorkers
 }
 
+/**
+ * Picks the abandoned-job callback for a queue from its workers.
+ *
+ * The numeric queue options merge across a queue's workers with `Math.max`; two callbacks cannot
+ * merge, so the first declared one wins. Silence there would make a genuine wiring mistake — two
+ * handlers on one queue each expecting to report its abandoned jobs — look like it works while one of
+ * them never runs.
+ */
+export function resolveQueueAbandonHook(
+  queueName: string,
+  queueWorkers: Array<Pick<ModuleWorker, 'id' | 'onJobAbandoned'>>,
+  warn: (message: string) => void = console.warn,
+): ModuleWorker['onJobAbandoned'] {
+  const declaring = queueWorkers.filter((worker) => worker.onJobAbandoned)
+  if (declaring.length > 1) {
+    warn(
+      `[worker] Queue "${queueName}" has ${declaring.length} workers declaring onJobAbandoned `
+      + `(${declaring.map((worker) => worker.id).join(', ')}); using the first and ignoring the rest.`,
+    )
+  }
+  return declaring[0]?.onJobAbandoned
+}
+
 function shouldEmbedLocalSchedulerInSharedWorker(env: NodeJS.ProcessEnv = process.env): boolean {
   return parseBooleanToken(env.OM_DEV_EMBED_SCHEDULER_IN_SHARED_WORKER) === true
 }
@@ -1678,18 +1701,7 @@ export async function run(argv = process.argv) {
                 Math.max(...queueWorkers.map((w) => w.concurrency), 1)
               const maxStalledCount = Math.max(...queueWorkers.map((w) => w.maxStalledCount ?? 1), 1)
               const lockDuration = Math.max(...queueWorkers.map((w) => w.lockDuration ?? 0), 0) || undefined
-              // One queue, one report. Handlers on the same queue share its abandoned-job reporting,
-              // so the first declared hook wins rather than each handler reporting the same job.
-              // Two callbacks cannot be merged the way the numeric options above can, so a second
-              // one is a wiring mistake worth saying out loud rather than dropping silently.
-              const abandonHookWorkers = queueWorkers.filter((w) => w.onJobAbandoned)
-              if (abandonHookWorkers.length > 1) {
-                console.warn(
-                  `[worker] Queue "${queue}" has ${abandonHookWorkers.length} workers declaring onJobAbandoned `
-                  + `(${abandonHookWorkers.map((w) => w.id).join(', ')}); using the first and ignoring the rest.`,
-                )
-              }
-              const onJobAbandoned = abandonHookWorkers[0]?.onJobAbandoned
+              const onJobAbandoned = resolveQueueAbandonHook(queue, queueWorkers)
 
               console.log(`[worker] Starting "${queue}" with ${queueWorkers.length} handler(s), concurrency: ${concurrency}`)
 
@@ -1746,18 +1758,7 @@ export async function run(argv = process.argv) {
               const concurrency = budgetPlan.entries[0]?.effective ?? requested
               const maxStalledCount = Math.max(...queueWorkers.map((w) => w.maxStalledCount ?? 1), 1)
               const lockDuration = Math.max(...queueWorkers.map((w) => w.lockDuration ?? 0), 0) || undefined
-              // One queue, one report. Handlers on the same queue share its abandoned-job reporting,
-              // so the first declared hook wins rather than each handler reporting the same job.
-              // Two callbacks cannot be merged the way the numeric options above can, so a second
-              // one is a wiring mistake worth saying out loud rather than dropping silently.
-              const abandonHookWorkers = queueWorkers.filter((w) => w.onJobAbandoned)
-              if (abandonHookWorkers.length > 1) {
-                console.warn(
-                  `[worker] Queue "${queueName}" has ${abandonHookWorkers.length} workers declaring onJobAbandoned `
-                  + `(${abandonHookWorkers.map((w) => w.id).join(', ')}); using the first and ignoring the rest.`,
-                )
-              }
-              const onJobAbandoned = abandonHookWorkers[0]?.onJobAbandoned
+              const onJobAbandoned = resolveQueueAbandonHook(queueName!, queueWorkers)
 
               console.log(`[worker] Found ${queueWorkers.length} worker(s) for queue "${queueName}"`)
 

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -1678,6 +1678,9 @@ export async function run(argv = process.argv) {
                 Math.max(...queueWorkers.map((w) => w.concurrency), 1)
               const maxStalledCount = Math.max(...queueWorkers.map((w) => w.maxStalledCount ?? 1), 1)
               const lockDuration = Math.max(...queueWorkers.map((w) => w.lockDuration ?? 0), 0) || undefined
+              // One queue, one report. Handlers on the same queue share its abandoned-job reporting,
+              // so the first declared hook wins rather than each handler reporting the same job.
+              const onJobAbandoned = queueWorkers.find((w) => w.onJobAbandoned)?.onJobAbandoned
 
               console.log(`[worker] Starting "${queue}" with ${queueWorkers.length} handler(s), concurrency: ${concurrency}`)
 
@@ -1688,6 +1691,7 @@ export async function run(argv = process.argv) {
                 concurrency,
                 lockDuration,
                 maxStalledCount,
+                onJobAbandoned,
                 background: true,
                 handler: createPerJobWorkerHandler(queueWorkers, createRequestContainer),
               })
@@ -1733,6 +1737,9 @@ export async function run(argv = process.argv) {
               const concurrency = budgetPlan.entries[0]?.effective ?? requested
               const maxStalledCount = Math.max(...queueWorkers.map((w) => w.maxStalledCount ?? 1), 1)
               const lockDuration = Math.max(...queueWorkers.map((w) => w.lockDuration ?? 0), 0) || undefined
+              // One queue, one report. Handlers on the same queue share its abandoned-job reporting,
+              // so the first declared hook wins rather than each handler reporting the same job.
+              const onJobAbandoned = queueWorkers.find((w) => w.onJobAbandoned)?.onJobAbandoned
 
               console.log(`[worker] Found ${queueWorkers.length} worker(s) for queue "${queueName}"`)
 
@@ -1743,6 +1750,7 @@ export async function run(argv = process.argv) {
                 concurrency,
                 lockDuration,
                 maxStalledCount,
+                onJobAbandoned,
                 handler: createPerJobWorkerHandler(queueWorkers, createRequestContainer),
               })
             } else {

--- a/packages/cli/src/mercato.ts
+++ b/packages/cli/src/mercato.ts
@@ -1680,7 +1680,16 @@ export async function run(argv = process.argv) {
               const lockDuration = Math.max(...queueWorkers.map((w) => w.lockDuration ?? 0), 0) || undefined
               // One queue, one report. Handlers on the same queue share its abandoned-job reporting,
               // so the first declared hook wins rather than each handler reporting the same job.
-              const onJobAbandoned = queueWorkers.find((w) => w.onJobAbandoned)?.onJobAbandoned
+              // Two callbacks cannot be merged the way the numeric options above can, so a second
+              // one is a wiring mistake worth saying out loud rather than dropping silently.
+              const abandonHookWorkers = queueWorkers.filter((w) => w.onJobAbandoned)
+              if (abandonHookWorkers.length > 1) {
+                console.warn(
+                  `[worker] Queue "${queue}" has ${abandonHookWorkers.length} workers declaring onJobAbandoned `
+                  + `(${abandonHookWorkers.map((w) => w.id).join(', ')}); using the first and ignoring the rest.`,
+                )
+              }
+              const onJobAbandoned = abandonHookWorkers[0]?.onJobAbandoned
 
               console.log(`[worker] Starting "${queue}" with ${queueWorkers.length} handler(s), concurrency: ${concurrency}`)
 
@@ -1739,7 +1748,16 @@ export async function run(argv = process.argv) {
               const lockDuration = Math.max(...queueWorkers.map((w) => w.lockDuration ?? 0), 0) || undefined
               // One queue, one report. Handlers on the same queue share its abandoned-job reporting,
               // so the first declared hook wins rather than each handler reporting the same job.
-              const onJobAbandoned = queueWorkers.find((w) => w.onJobAbandoned)?.onJobAbandoned
+              // Two callbacks cannot be merged the way the numeric options above can, so a second
+              // one is a wiring mistake worth saying out loud rather than dropping silently.
+              const abandonHookWorkers = queueWorkers.filter((w) => w.onJobAbandoned)
+              if (abandonHookWorkers.length > 1) {
+                console.warn(
+                  `[worker] Queue "${queueName}" has ${abandonHookWorkers.length} workers declaring onJobAbandoned `
+                  + `(${abandonHookWorkers.map((w) => w.id).join(', ')}); using the first and ignoring the rest.`,
+                )
+              }
+              const onJobAbandoned = abandonHookWorkers[0]?.onJobAbandoned
 
               console.log(`[worker] Found ${queueWorkers.length} worker(s) for queue "${queueName}"`)
 

--- a/packages/core/src/modules/data_sync/lib/__tests__/queue-abandoned-run.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/queue-abandoned-run.test.ts
@@ -43,13 +43,15 @@ function abandonedJob(payload: unknown) {
   return { id: 'job-1', payload, createdAt: new Date(0).toISOString() }
 }
 
-function stubRunService(markStatus: jest.Mock) {
+function stubContainer(markStatus: jest.Mock, failJob: jest.Mock = jest.fn(async () => ({}))) {
   createRequestContainerMock.mockResolvedValue({
     resolve: (name: string) => {
-      if (name !== 'dataSyncRunService') throw new Error(`[internal] unexpected resolve: ${name}`)
-      return { markStatus }
+      if (name === 'dataSyncRunService') return { markStatus }
+      if (name === 'progressService') return { failJob }
+      throw new Error(`[internal] unexpected resolve: ${name}`)
     },
   } as unknown as Awaited<ReturnType<typeof createRequestContainer>>)
+  return { markStatus, failJob }
 }
 
 describe('data_sync queue — abandoned job repair', () => {
@@ -61,7 +63,7 @@ describe('data_sync queue — abandoned job repair', () => {
   // resumable-queue policy. These cover what the callback itself does once it fires.
   it('marks the run failed with the reason the queue reported', async () => {
     const markStatus = jest.fn(async () => null)
-    stubRunService(markStatus)
+    stubContainer(markStatus)
 
     const hook = abandonedHookFor('data-sync-import')!
     await hook(abandonedJob({ runId: 'run-1', batchSize: 100, scope: { ...SCOPE, userId: null } }), {
@@ -77,9 +79,36 @@ describe('data_sync queue — abandoned job repair', () => {
     )
   })
 
+  it('fails the run progress job too, with the same reason', async () => {
+    const markStatus = jest.fn(async () => ({ id: 'run-1', progressJobId: 'progress-1' }))
+    const { failJob } = stubContainer(markStatus)
+
+    const hook = abandonedHookFor('data-sync-import')!
+    await hook(abandonedJob({ runId: 'run-1', scope: SCOPE }), {
+      jobId: 'job-1',
+      reason: 'job stalled more than allowable limit',
+    })
+
+    expect(failJob).toHaveBeenCalledWith(
+      'progress-1',
+      { errorMessage: "the queue abandoned this run's job without running it: job stalled more than allowable limit" },
+      SCOPE,
+    )
+  })
+
+  it('leaves the progress service alone for a run that has no progress job', async () => {
+    const markStatus = jest.fn(async () => ({ id: 'run-1', progressJobId: null }))
+    const { failJob } = stubContainer(markStatus)
+
+    const hook = abandonedHookFor('data-sync-import')!
+    await hook(abandonedJob({ runId: 'run-1', scope: SCOPE }), { jobId: 'job-1', reason: 'stalled' })
+
+    expect(failJob).not.toHaveBeenCalled()
+  })
+
   it('does nothing when the payload carries no run id or no tenant scope', async () => {
     const markStatus = jest.fn(async () => null)
-    stubRunService(markStatus)
+    stubContainer(markStatus)
 
     const hook = abandonedHookFor('data-sync-import')!
     await hook(abandonedJob({ progressJobId: 'progress-1', scope: SCOPE }), { jobId: 'job-1', reason: 'stalled' })

--- a/packages/core/src/modules/data_sync/lib/__tests__/queue-abandoned-run.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/queue-abandoned-run.test.ts
@@ -4,19 +4,7 @@ import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { SyncRun } from '../../data/entities'
 import { createSyncRunService } from '../sync-run-service'
-import { getSyncQueue } from '../queue'
-
-// `getSyncQueue` memoizes its queues, so the hook is only handed over on the first call per queue
-// name. Record it here rather than reading it back off the mock's call list, which the per-test
-// reset clears.
-const mockRegisteredHooks = new Map<string, unknown>()
-
-jest.mock('@open-mercato/queue', () => ({
-  createModuleQueue: jest.fn((name: string, options?: { onJobAbandoned?: unknown }) => {
-    mockRegisteredHooks.set(name, options?.onJobAbandoned)
-    return { name, strategy: 'async' }
-  }),
-}))
+import { failAbandonedRun } from '../abandoned-run'
 
 jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: jest.fn(),
@@ -34,9 +22,8 @@ type AbandonedHook = (payload: unknown, info: { jobId: string | null; reason: st
 
 const createRequestContainerMock = createRequestContainer as jest.MockedFunction<typeof createRequestContainer>
 
-function abandonedHookFor(queueName: string): AbandonedHook | undefined {
-  getSyncQueue(queueName)
-  return mockRegisteredHooks.get(queueName) as AbandonedHook | undefined
+function abandonedHookFor(_queueName: string): AbandonedHook {
+  return failAbandonedRun as AbandonedHook
 }
 
 function abandonedJob(payload: unknown) {
@@ -59,8 +46,9 @@ describe('data_sync queue — abandoned job repair', () => {
     jest.clearAllMocks()
   })
 
-  // Which queues receive the callback is asserted in `queue.test.ts`, next to the rest of the
-  // resumable-queue policy. These cover what the callback itself does once it fires.
+  // Where the callback is declared is asserted in `queue.test.ts`; that it reaches the queue the
+  // worker actually runs on is asserted in the queue package's worker-runner test. These cover what
+  // the callback itself does once it fires.
   it('marks the run failed with the reason the queue reported', async () => {
     const markStatus = jest.fn(async () => null)
     stubContainer(markStatus)

--- a/packages/core/src/modules/data_sync/lib/__tests__/queue-abandoned-run.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/queue-abandoned-run.test.ts
@@ -1,0 +1,114 @@
+/** @jest-environment node */
+
+import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
+import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { SyncRun } from '../../data/entities'
+import { createSyncRunService } from '../sync-run-service'
+import { getSyncQueue } from '../queue'
+
+// `getSyncQueue` memoizes its queues, so the hook is only handed over on the first call per queue
+// name. Record it here rather than reading it back off the mock's call list, which the per-test
+// reset clears.
+const mockRegisteredHooks = new Map<string, unknown>()
+
+jest.mock('@open-mercato/queue', () => ({
+  createModuleQueue: jest.fn((name: string, options?: { onJobAbandoned?: unknown }) => {
+    mockRegisteredHooks.set(name, options?.onJobAbandoned)
+    return { name, strategy: 'async' }
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findOneWithDecryption: jest.fn(),
+  findWithDecryption: jest.fn().mockResolvedValue([]),
+  findAndCountWithDecryption: jest.fn().mockResolvedValue([[], 0]),
+}))
+
+const SCOPE = { organizationId: 'org-1', tenantId: 'tenant-1' }
+
+type AbandonedHook = (payload: unknown, info: { jobId: string | null; reason: string }) => Promise<void>
+
+const createRequestContainerMock = createRequestContainer as jest.MockedFunction<typeof createRequestContainer>
+
+function abandonedHookFor(queueName: string): AbandonedHook | undefined {
+  getSyncQueue(queueName)
+  return mockRegisteredHooks.get(queueName) as AbandonedHook | undefined
+}
+
+function abandonedJob(payload: unknown) {
+  return { id: 'job-1', payload, createdAt: new Date(0).toISOString() }
+}
+
+function stubRunService(markStatus: jest.Mock) {
+  createRequestContainerMock.mockResolvedValue({
+    resolve: (name: string) => {
+      if (name !== 'dataSyncRunService') throw new Error(`[internal] unexpected resolve: ${name}`)
+      return { markStatus }
+    },
+  } as unknown as Awaited<ReturnType<typeof createRequestContainer>>)
+}
+
+describe('data_sync queue — abandoned job repair', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  // Which queues receive the callback is asserted in `queue.test.ts`, next to the rest of the
+  // resumable-queue policy. These cover what the callback itself does once it fires.
+  it('marks the run failed with the reason the queue reported', async () => {
+    const markStatus = jest.fn(async () => null)
+    stubRunService(markStatus)
+
+    const hook = abandonedHookFor('data-sync-import')!
+    await hook(abandonedJob({ runId: 'run-1', batchSize: 100, scope: { ...SCOPE, userId: null } }), {
+      jobId: 'job-1',
+      reason: 'job stalled more than allowable limit',
+    })
+
+    expect(markStatus).toHaveBeenCalledWith(
+      'run-1',
+      'failed',
+      SCOPE,
+      "the queue abandoned this run's job without running it: job stalled more than allowable limit",
+    )
+  })
+
+  it('does nothing when the payload carries no run id or no tenant scope', async () => {
+    const markStatus = jest.fn(async () => null)
+    stubRunService(markStatus)
+
+    const hook = abandonedHookFor('data-sync-import')!
+    await hook(abandonedJob({ progressJobId: 'progress-1', scope: SCOPE }), { jobId: 'job-1', reason: 'stalled' })
+    await hook(abandonedJob({ runId: 'run-1' }), { jobId: 'job-1', reason: 'stalled' })
+    await hook(undefined, { jobId: null, reason: 'stalled' })
+
+    expect(markStatus).not.toHaveBeenCalled()
+    expect(createRequestContainerMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves a run that already finished in its terminal state', async () => {
+    const em = { flush: jest.fn().mockResolvedValue(undefined) }
+    const run = { id: 'run-1', status: 'completed' as const, lastError: null }
+    ;(findOneWithDecryption as jest.Mock).mockImplementation((_em: unknown, entity: unknown) =>
+      Promise.resolve(entity === SyncRun ? run : null),
+    )
+    const runService = createSyncRunService(em as never)
+    createRequestContainerMock.mockResolvedValue({
+      resolve: () => runService,
+    } as unknown as Awaited<ReturnType<typeof createRequestContainer>>)
+
+    const hook = abandonedHookFor('data-sync-import')!
+    await hook(abandonedJob({ runId: 'run-1', scope: SCOPE }), {
+      jobId: 'job-1',
+      reason: 'job stalled more than allowable limit',
+    })
+
+    expect(run.status).toBe('completed')
+    expect(run.lastError).toBeNull()
+    expect(em.flush).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/data_sync/lib/__tests__/queue.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/queue.test.ts
@@ -29,12 +29,14 @@ describe('data sync queue configuration', () => {
       attempts: 3,
       lockDuration: DATA_SYNC_LOCK_DURATION_MS,
       maxStalledCount: 10,
+      onJobAbandoned: expect.any(Function),
     })
     expect(mockCreateModuleQueue).toHaveBeenCalledWith('data-sync-export', {
       concurrency: 5,
       attempts: 3,
       lockDuration: DATA_SYNC_LOCK_DURATION_MS,
       maxStalledCount: 10,
+      onJobAbandoned: expect.any(Function),
     })
   })
 

--- a/packages/core/src/modules/data_sync/lib/__tests__/queue.test.ts
+++ b/packages/core/src/modules/data_sync/lib/__tests__/queue.test.ts
@@ -11,6 +11,7 @@ import {
   DATA_SYNC_LOCK_DURATION_MS,
   DATA_SYNC_RESUMABLE_QUEUES,
 } from '../queue-policy'
+import { failAbandonedRun } from '../abandoned-run'
 import { metadata as importWorkerMetadata } from '../../workers/sync-import'
 import { metadata as exportWorkerMetadata } from '../../workers/sync-export'
 
@@ -29,14 +30,12 @@ describe('data sync queue configuration', () => {
       attempts: 3,
       lockDuration: DATA_SYNC_LOCK_DURATION_MS,
       maxStalledCount: 10,
-      onJobAbandoned: expect.any(Function),
     })
     expect(mockCreateModuleQueue).toHaveBeenCalledWith('data-sync-export', {
       concurrency: 5,
       attempts: 3,
       lockDuration: DATA_SYNC_LOCK_DURATION_MS,
       maxStalledCount: 10,
-      onJobAbandoned: expect.any(Function),
     })
   })
 
@@ -44,6 +43,17 @@ describe('data sync queue configuration', () => {
     getSyncQueue('data-sync-something-else')
 
     expect(mockCreateModuleQueue).toHaveBeenCalledWith('data-sync-something-else', { concurrency: 5 })
+  })
+
+  it('declares the abandoned-job hook on the workers, where the queue that runs jobs is built', () => {
+    // Not on `getSyncQueue`: that instance only ever enqueues. `runWorker` builds its own queue from
+    // worker metadata, so a hook attached to the producer is never installed on the consumer.
+    expect(importWorkerMetadata.onJobAbandoned).toBe(failAbandonedRun)
+    expect(exportWorkerMetadata.onJobAbandoned).toBe(failAbandonedRun)
+    expect(mockCreateModuleQueue).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ onJobAbandoned: expect.anything() }),
+    )
   })
 
   it('keeps the worker queue names and the retry policy on the same constants', () => {

--- a/packages/core/src/modules/data_sync/lib/abandoned-run.ts
+++ b/packages/core/src/modules/data_sync/lib/abandoned-run.ts
@@ -1,0 +1,56 @@
+import type { AbandonedJobInfo } from '@open-mercato/queue'
+
+/**
+ * Fail the run behind a job the queue gave up on.
+ *
+ * A resumable data_sync job is ONE long-lived job for a whole run — `runImport` is entered once and
+ * stays there for the duration, which for a full backfill is days. Every worker death (a deploy, an
+ * OOM) therefore stalls that job, and BullMQ's stalled counter is cumulative for the job's life:
+ * past `DATA_SYNC_MAX_STALLED_COUNT` it writes a deferred failure and the next worker fails the job
+ * BEFORE calling the processor.
+ *
+ * So `runImport` never runs, never throws, and never finalizes — and `sync_runs` is left saying
+ * `running` for a run nothing is running, forever. That is the residual state `queue-policy.ts`
+ * describes as what remains after a job exhausts its stall budget; this repairs it.
+ *
+ * It only ever moves a non-terminal run: `markStatus` refuses to overwrite `completed` / `failed` /
+ * `cancelled`, so a job abandoned after its run has ended is a no-op. `onJobAbandoned` may deliver
+ * the same job more than once, which for the same reason is also a no-op.
+ *
+ * The run's progress job is failed alongside it, the way the worker's own catch path does in
+ * `workers/sync-import.ts`. Without that the two halves disagree — the run reads `failed` while the
+ * operation still shows as in flight in the top bar — until the progress staleness sweep eventually
+ * fails it with a generic no-heartbeat message instead of the reason the queue recorded.
+ */
+export async function failAbandonedRun(payload: unknown, info: AbandonedJobInfo): Promise<void> {
+  const data = payload as { payload?: { runId?: unknown; scope?: { organizationId?: unknown; tenantId?: unknown } } } | undefined
+  const runId = data?.payload?.runId
+  const scope = data?.payload?.scope
+  // Nothing to repair without both: the run row is keyed by id AND tenant scope.
+  if (typeof runId !== 'string' || typeof scope?.organizationId !== 'string' || typeof scope?.tenantId !== 'string') return
+
+  const runScope = { organizationId: scope.organizationId, tenantId: scope.tenantId }
+  const errorMessage = `the queue abandoned this run's job without running it: ${info.reason}`
+
+  const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+  const container = await createRequestContainer()
+  const runService = container.resolve('dataSyncRunService') as {
+    markStatus(
+      runId: string,
+      status: string,
+      scope: { organizationId: string; tenantId: string },
+      error?: string,
+    ): Promise<{ progressJobId?: string | null } | null>
+  }
+  const run = await runService.markStatus(runId, 'failed', runScope, errorMessage)
+  if (!run?.progressJobId) return
+
+  const progressService = container.resolve('progressService') as {
+    failJob(
+      jobId: string,
+      input: { errorMessage: string },
+      ctx: { organizationId: string; tenantId: string },
+    ): Promise<unknown>
+  }
+  await progressService.failJob(run.progressJobId, { errorMessage }, runScope)
+}

--- a/packages/core/src/modules/data_sync/lib/queue.ts
+++ b/packages/core/src/modules/data_sync/lib/queue.ts
@@ -1,4 +1,4 @@
-import { createModuleQueue, type AbandonedJobInfo, type Queue } from '@open-mercato/queue'
+import { createModuleQueue, type Queue } from '@open-mercato/queue'
 import {
   DATA_SYNC_LOCK_DURATION_MS,
   DATA_SYNC_MAX_STALLED_COUNT,
@@ -9,61 +9,6 @@ import {
 const queues = new Map<string, Queue<Record<string, unknown>>>()
 
 const resumableQueueNames = new Set<string>(DATA_SYNC_RESUMABLE_QUEUES)
-
-/**
- * Fail the run behind a job the queue gave up on.
- *
- * A resumable data_sync job is ONE long-lived job for a whole run — `runImport` is entered once and
- * stays there for the duration, which for a full backfill is days. Every worker death (a deploy, an
- * OOM) therefore stalls that job, and BullMQ's stalled counter is cumulative for the job's life:
- * past `DATA_SYNC_MAX_STALLED_COUNT` it writes a deferred failure and the next worker fails the job
- * BEFORE calling the processor.
- *
- * So `runImport` never runs, never throws, and never finalizes — and `sync_runs` is left saying
- * `running` for a run nothing is running, forever. That is the residual state `queue-policy.ts`
- * describes as what remains after a job exhausts its stall budget; this repairs it.
- *
- * It only ever moves a non-terminal run: `markStatus` refuses to overwrite `completed` / `failed` /
- * `cancelled`, so a job abandoned after its run has ended is a no-op. `onJobAbandoned` may deliver
- * the same job more than once, which for the same reason is also a no-op.
- *
- * The run's progress job is failed alongside it, the way the worker's own catch path does in
- * `workers/sync-import.ts`. Without that the two halves disagree — the run reads `failed` while the
- * operation still shows as in flight in the top bar — until the progress staleness sweep eventually
- * fails it with a generic no-heartbeat message instead of the reason the queue recorded.
- */
-async function failAbandonedRun(payload: unknown, info: AbandonedJobInfo): Promise<void> {
-  const data = payload as { payload?: { runId?: unknown; scope?: { organizationId?: unknown; tenantId?: unknown } } } | undefined
-  const runId = data?.payload?.runId
-  const scope = data?.payload?.scope
-  // Nothing to repair without both: the run row is keyed by id AND tenant scope.
-  if (typeof runId !== 'string' || typeof scope?.organizationId !== 'string' || typeof scope?.tenantId !== 'string') return
-
-  const runScope = { organizationId: scope.organizationId, tenantId: scope.tenantId }
-  const errorMessage = `the queue abandoned this run's job without running it: ${info.reason}`
-
-  const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
-  const container = await createRequestContainer()
-  const runService = container.resolve('dataSyncRunService') as {
-    markStatus(
-      runId: string,
-      status: string,
-      scope: { organizationId: string; tenantId: string },
-      error?: string,
-    ): Promise<{ progressJobId?: string | null } | null>
-  }
-  const run = await runService.markStatus(runId, 'failed', runScope, errorMessage)
-  if (!run?.progressJobId) return
-
-  const progressService = container.resolve('progressService') as {
-    failJob(
-      jobId: string,
-      input: { errorMessage: string },
-      ctx: { organizationId: string; tenantId: string },
-    ): Promise<unknown>
-  }
-  await progressService.failJob(run.progressJobId, { errorMessage }, runScope)
-}
 
 export function getSyncQueue(queueName: string): Queue<Record<string, unknown>> {
   const existing = queues.get(queueName)
@@ -78,7 +23,6 @@ export function getSyncQueue(queueName: string): Queue<Record<string, unknown>> 
         attempts: DATA_SYNC_QUEUE_ATTEMPTS,
         lockDuration: DATA_SYNC_LOCK_DURATION_MS,
         maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
-        onJobAbandoned: failAbandonedRun,
       }
       : { concurrency },
   )

--- a/packages/core/src/modules/data_sync/lib/queue.ts
+++ b/packages/core/src/modules/data_sync/lib/queue.ts
@@ -26,6 +26,11 @@ const resumableQueueNames = new Set<string>(DATA_SYNC_RESUMABLE_QUEUES)
  * It only ever moves a non-terminal run: `markStatus` refuses to overwrite `completed` / `failed` /
  * `cancelled`, so a job abandoned after its run has ended is a no-op. `onJobAbandoned` may deliver
  * the same job more than once, which for the same reason is also a no-op.
+ *
+ * The run's progress job is failed alongside it, the way the worker's own catch path does in
+ * `workers/sync-import.ts`. Without that the two halves disagree — the run reads `failed` while the
+ * operation still shows as in flight in the top bar — until the progress staleness sweep eventually
+ * fails it with a generic no-heartbeat message instead of the reason the queue recorded.
  */
 async function failAbandonedRun(payload: unknown, info: AbandonedJobInfo): Promise<void> {
   const data = payload as { payload?: { runId?: unknown; scope?: { organizationId?: unknown; tenantId?: unknown } } } | undefined
@@ -33,6 +38,9 @@ async function failAbandonedRun(payload: unknown, info: AbandonedJobInfo): Promi
   const scope = data?.payload?.scope
   // Nothing to repair without both: the run row is keyed by id AND tenant scope.
   if (typeof runId !== 'string' || typeof scope?.organizationId !== 'string' || typeof scope?.tenantId !== 'string') return
+
+  const runScope = { organizationId: scope.organizationId, tenantId: scope.tenantId }
+  const errorMessage = `the queue abandoned this run's job without running it: ${info.reason}`
 
   const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
   const container = await createRequestContainer()
@@ -42,14 +50,19 @@ async function failAbandonedRun(payload: unknown, info: AbandonedJobInfo): Promi
       status: string,
       scope: { organizationId: string; tenantId: string },
       error?: string,
+    ): Promise<{ progressJobId?: string | null } | null>
+  }
+  const run = await runService.markStatus(runId, 'failed', runScope, errorMessage)
+  if (!run?.progressJobId) return
+
+  const progressService = container.resolve('progressService') as {
+    failJob(
+      jobId: string,
+      input: { errorMessage: string },
+      ctx: { organizationId: string; tenantId: string },
     ): Promise<unknown>
   }
-  await runService.markStatus(
-    runId,
-    'failed',
-    { organizationId: scope.organizationId, tenantId: scope.tenantId },
-    `the queue abandoned this run's job without running it: ${info.reason}`,
-  )
+  await progressService.failJob(run.progressJobId, { errorMessage }, runScope)
 }
 
 export function getSyncQueue(queueName: string): Queue<Record<string, unknown>> {

--- a/packages/core/src/modules/data_sync/lib/queue.ts
+++ b/packages/core/src/modules/data_sync/lib/queue.ts
@@ -1,4 +1,4 @@
-import { createModuleQueue, type Queue } from '@open-mercato/queue'
+import { createModuleQueue, type AbandonedJobInfo, type Queue } from '@open-mercato/queue'
 import {
   DATA_SYNC_LOCK_DURATION_MS,
   DATA_SYNC_MAX_STALLED_COUNT,
@@ -9,6 +9,48 @@ import {
 const queues = new Map<string, Queue<Record<string, unknown>>>()
 
 const resumableQueueNames = new Set<string>(DATA_SYNC_RESUMABLE_QUEUES)
+
+/**
+ * Fail the run behind a job the queue gave up on.
+ *
+ * A resumable data_sync job is ONE long-lived job for a whole run — `runImport` is entered once and
+ * stays there for the duration, which for a full backfill is days. Every worker death (a deploy, an
+ * OOM) therefore stalls that job, and BullMQ's stalled counter is cumulative for the job's life:
+ * past `DATA_SYNC_MAX_STALLED_COUNT` it writes a deferred failure and the next worker fails the job
+ * BEFORE calling the processor.
+ *
+ * So `runImport` never runs, never throws, and never finalizes — and `sync_runs` is left saying
+ * `running` for a run nothing is running, forever. That is the residual state `queue-policy.ts`
+ * describes as what remains after a job exhausts its stall budget; this repairs it.
+ *
+ * It only ever moves a non-terminal run: `markStatus` refuses to overwrite `completed` / `failed` /
+ * `cancelled`, so a job abandoned after its run has ended is a no-op. `onJobAbandoned` may deliver
+ * the same job more than once, which for the same reason is also a no-op.
+ */
+async function failAbandonedRun(payload: unknown, info: AbandonedJobInfo): Promise<void> {
+  const data = payload as { payload?: { runId?: unknown; scope?: { organizationId?: unknown; tenantId?: unknown } } } | undefined
+  const runId = data?.payload?.runId
+  const scope = data?.payload?.scope
+  // Nothing to repair without both: the run row is keyed by id AND tenant scope.
+  if (typeof runId !== 'string' || typeof scope?.organizationId !== 'string' || typeof scope?.tenantId !== 'string') return
+
+  const { createRequestContainer } = await import('@open-mercato/shared/lib/di/container')
+  const container = await createRequestContainer()
+  const runService = container.resolve('dataSyncRunService') as {
+    markStatus(
+      runId: string,
+      status: string,
+      scope: { organizationId: string; tenantId: string },
+      error?: string,
+    ): Promise<unknown>
+  }
+  await runService.markStatus(
+    runId,
+    'failed',
+    { organizationId: scope.organizationId, tenantId: scope.tenantId },
+    `the queue abandoned this run's job without running it: ${info.reason}`,
+  )
+}
 
 export function getSyncQueue(queueName: string): Queue<Record<string, unknown>> {
   const existing = queues.get(queueName)
@@ -23,6 +65,7 @@ export function getSyncQueue(queueName: string): Queue<Record<string, unknown>> 
         attempts: DATA_SYNC_QUEUE_ATTEMPTS,
         lockDuration: DATA_SYNC_LOCK_DURATION_MS,
         maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
+        onJobAbandoned: failAbandonedRun,
       }
       : { concurrency },
   )

--- a/packages/core/src/modules/data_sync/workers/sync-export.ts
+++ b/packages/core/src/modules/data_sync/workers/sync-export.ts
@@ -7,6 +7,7 @@ import {
   DATA_SYNC_LOCK_DURATION_MS,
   DATA_SYNC_MAX_STALLED_COUNT,
 } from '../lib/queue-policy'
+import { failAbandonedRun } from '../lib/abandoned-run'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('data_sync').child({ component: 'sync-export' })
@@ -27,6 +28,9 @@ export const metadata: WorkerMeta = {
   concurrency: 5,
   lockDuration: DATA_SYNC_LOCK_DURATION_MS,
   maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
+  // Declared on the worker, not on the enqueueing queue: the abandonment this reports is a worker
+  // restart, and the process that restarts never constructs the producer's queue instance.
+  onJobAbandoned: failAbandonedRun,
 }
 
 type HandlerContext = JobContext & {

--- a/packages/core/src/modules/data_sync/workers/sync-import.ts
+++ b/packages/core/src/modules/data_sync/workers/sync-import.ts
@@ -7,6 +7,7 @@ import {
   DATA_SYNC_LOCK_DURATION_MS,
   DATA_SYNC_MAX_STALLED_COUNT,
 } from '../lib/queue-policy'
+import { failAbandonedRun } from '../lib/abandoned-run'
 import { createLogger } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('data_sync').child({ component: 'sync-import' })
@@ -27,6 +28,9 @@ export const metadata: WorkerMeta = {
   concurrency: 5,
   lockDuration: DATA_SYNC_LOCK_DURATION_MS,
   maxStalledCount: DATA_SYNC_MAX_STALLED_COUNT,
+  // Declared on the worker, not on the enqueueing queue: the abandonment this reports is a worker
+  // restart, and the process that restarts never constructs the producer's queue instance.
+  onJobAbandoned: failAbandonedRun,
 }
 
 type HandlerContext = JobContext & {

--- a/packages/queue/src/__tests__/abandoned-job.test.ts
+++ b/packages/queue/src/__tests__/abandoned-job.test.ts
@@ -1,0 +1,423 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { createModuleQueue } from '../factory'
+import { ABANDONED_JOB_SWEEP_INTERVAL_MS } from '../strategies/async'
+import { getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/connection'
+import type { QueuedJob } from '../types'
+
+type WorkerListener = (...args: unknown[]) => void
+
+let capturedProcessor: ((job: { id?: string; data: unknown; attemptsMade: number }) => Promise<void>) | null = null
+const capturedListeners = new Map<string, WorkerListener[]>()
+
+function emit(event: string, ...args: unknown[]): void {
+  for (const listener of capturedListeners.get(event) ?? []) listener(...args)
+}
+
+jest.mock('@open-mercato/shared/lib/redis/connection', () => ({
+  getRedisUrlOrThrow: jest.fn(),
+  parseRedisUrl: jest.requireActual('@open-mercato/shared/lib/redis/connection').parseRedisUrl,
+  REDIS_WIRE_PROTOCOL: jest.requireActual('@open-mercato/shared/lib/redis/connection').REDIS_WIRE_PROTOCOL,
+}))
+
+const mockQueueGetJobs = jest.fn(async (): Promise<unknown[]> => [])
+
+jest.mock('bullmq', () => {
+  class MockQueue<T> {
+    constructor(_name: string, _opts: unknown) {}
+    add = jest.fn(async () => ({ id: 'bull-job-id' }))
+    close = jest.fn(async () => {})
+    obliterate = jest.fn(async () => {})
+    getJobCounts = jest.fn(async () => ({ waiting: 0, active: 0, completed: 0, failed: 0 }))
+    getJobs = mockQueueGetJobs
+  }
+
+  class MockWorker<T> {
+    constructor(
+      _name: string,
+      processor: (job: { id?: string; data: T; attemptsMade: number }) => Promise<void>,
+      _opts: unknown,
+    ) {
+      capturedProcessor = processor as (job: { id?: string; data: unknown; attemptsMade: number }) => Promise<void>
+    }
+
+    on = (event: string, listener: WorkerListener) => {
+      const existing = capturedListeners.get(event) ?? []
+      existing.push(listener)
+      capturedListeners.set(event, existing)
+    }
+
+    close = jest.fn(async () => {})
+  }
+
+  return { Queue: MockQueue, Worker: MockWorker }
+})
+
+type Payload = { runId: string }
+
+function bullJob(id: string, payload: Payload): { id: string; data: QueuedJob<Payload>; attemptsMade: number } {
+  return {
+    id,
+    data: { id, payload, createdAt: new Date(0).toISOString() },
+    attemptsMade: 0,
+  }
+}
+
+/** A delivery BullMQ did not put its own id on — the payload still carries the id we minted. */
+function bullJobWithoutId(
+  payloadId: string,
+  payload: Payload,
+): { id?: string; data: QueuedJob<Payload>; attemptsMade: number } {
+  return {
+    id: undefined,
+    data: { id: payloadId, payload, createdAt: new Date(0).toISOString() },
+    attemptsMade: 0,
+  }
+}
+
+type FailedSetJob = {
+  id: string
+  data: QueuedJob<Payload>
+  failedReason: string
+  remove: jest.Mock
+  updateData: jest.Mock
+}
+
+/** A job as the sweep sees it in the failed set. `updateData` persists like the real driver's. */
+function failedSetJob(
+  id: string,
+  payload: Payload,
+  failedReason: string,
+  metadata?: Record<string, unknown>,
+): FailedSetJob {
+  const record: FailedSetJob = {
+    id,
+    data: { id, payload, createdAt: new Date(0).toISOString(), ...(metadata ? { metadata } : {}) },
+    failedReason,
+    remove: jest.fn(async () => {}),
+    updateData: jest.fn(async (data: QueuedJob<Payload>) => {
+      record.data = data
+    }),
+  }
+  return record
+}
+
+async function flushAsync(turns = 12): Promise<void> {
+  for (let index = 0; index < turns; index += 1) {
+    await Promise.resolve()
+  }
+}
+
+describe('onJobAbandoned', () => {
+  const getRedisUrlOrThrowMock = getRedisUrlOrThrow as jest.MockedFunction<typeof getRedisUrlOrThrow>
+  const originalStrategy = process.env.QUEUE_STRATEGY
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    capturedProcessor = null
+    capturedListeners.clear()
+    getRedisUrlOrThrowMock.mockReturnValue('redis://localhost:6379')
+    mockQueueGetJobs.mockResolvedValue([])
+    process.env.QUEUE_STRATEGY = 'async'
+  })
+
+  afterEach(() => {
+    if (originalStrategy === undefined) delete process.env.QUEUE_STRATEGY
+    else process.env.QUEUE_STRATEGY = originalStrategy
+  })
+
+  it('fires with the job payload when the queue fails a job it never handed to the handler', async () => {
+    const onJobAbandoned = jest.fn(async () => {})
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {})
+
+    const job = bullJob('job-1', { runId: 'run-1' })
+    emit('failed', job, new Error('job stalled more than allowable limit'))
+    await Promise.resolve()
+
+    expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+    expect(onJobAbandoned).toHaveBeenCalledWith(job.data, {
+      jobId: 'job-1',
+      reason: 'job stalled more than allowable limit',
+    })
+  })
+
+  it('does not fire when the handler ran and threw — that failure is the handler\'s own', async () => {
+    const onJobAbandoned = jest.fn(async () => {})
+    const handlerError = new Error('import batch blew up')
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {
+      throw handlerError
+    })
+
+    const job = bullJob('job-1', { runId: 'run-1' })
+    await expect(capturedProcessor!(job)).rejects.toThrow(handlerError)
+    emit('failed', job, handlerError)
+    await Promise.resolve()
+
+    expect(onJobAbandoned).not.toHaveBeenCalled()
+  })
+
+  it('fires for the abandonment reason BullMQ writes when a job outruns its started limit', async () => {
+    const onJobAbandoned = jest.fn(async () => {})
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {})
+
+    const job = bullJob('job-1', { runId: 'run-1' })
+    emit('failed', job, new Error('job started more than allowable limit'))
+    await Promise.resolve()
+
+    expect(onJobAbandoned).toHaveBeenCalledWith(job.data, {
+      jobId: 'job-1',
+      reason: 'job started more than allowable limit',
+    })
+  })
+
+  it('fires when the same worker earlier ran an attempt of the job that stalled out', async () => {
+    // The zombie case: this process entered the processor for an attempt that hung past the lock
+    // duration, and the final, abandoned delivery lands back in the same process. Classification
+    // must not depend on what this worker remembers doing.
+    const onJobAbandoned = jest.fn(async () => {})
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned, concurrency: 2 })
+    let releaseZombie = () => {}
+    await queue.process(async () => {
+      await new Promise<void>((resolve) => {
+        releaseZombie = resolve
+      })
+    })
+
+    const job = bullJob('job-1', { runId: 'run-1' })
+    void capturedProcessor!(job) // still hanging, exactly like the stalled attempt
+    emit('failed', job, new Error('job stalled more than allowable limit'))
+    await Promise.resolve()
+
+    expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+    releaseZombie()
+  })
+
+  it('reports each abandoned job when several failures arrive together', async () => {
+    const onJobAbandoned = jest.fn(async () => {})
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned, concurrency: 2 })
+    await queue.process(async () => {})
+
+    const handlerFailure = bullJob('job-threw', { runId: 'run-1' })
+    const abandoned = bullJob('job-abandoned', { runId: 'run-2' })
+    emit('failed', handlerFailure, new Error('import batch blew up'))
+    emit('failed', abandoned, new Error('job stalled more than allowable limit'))
+    await Promise.resolve()
+
+    expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+    expect(onJobAbandoned).toHaveBeenCalledWith(abandoned.data, {
+      jobId: 'job-abandoned',
+      reason: 'job stalled more than allowable limit',
+    })
+  })
+
+  it('reports an abandoned job that carries no job id of its own', async () => {
+    const onJobAbandoned = jest.fn(async () => {})
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {})
+
+    const job = bullJobWithoutId('payload-1', { runId: 'run-1' })
+    emit('failed', job, new Error('job stalled more than allowable limit'))
+    await Promise.resolve()
+
+    expect(onJobAbandoned).toHaveBeenCalledWith(job.data, {
+      jobId: null,
+      reason: 'job stalled more than allowable limit',
+    })
+  })
+
+  it('stays quiet when the queue cannot produce the job at all', async () => {
+    const onJobAbandoned = jest.fn(async () => {})
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {})
+
+    emit('failed', undefined, new Error('job stalled more than allowable limit'))
+    emit('failed', { id: 'job-1' }, new Error('job stalled more than allowable limit'))
+    await Promise.resolve()
+
+    expect(onJobAbandoned).not.toHaveBeenCalled()
+  })
+
+  it('drains an in-flight report on close so a shutdown cannot truncate a repair', async () => {
+    let finishReport = () => {}
+    const reportFinished = jest.fn()
+    const onJobAbandoned = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishReport = () => {
+            reportFinished()
+            resolve()
+          }
+        }),
+    )
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {})
+
+    emit('failed', bullJob('job-1', { runId: 'run-1' }), new Error('job stalled more than allowable limit'))
+    await Promise.resolve()
+    expect(reportFinished).not.toHaveBeenCalled()
+
+    const closed = queue.close()
+    let closedEarly = false
+    void closed.then(() => {
+      closedEarly = !reportFinished.mock.calls.length
+    })
+    await Promise.resolve()
+    expect(closedEarly).toBe(false)
+
+    finishReport()
+    await closed
+    expect(reportFinished).toHaveBeenCalledTimes(1)
+  })
+
+  it('swallows a throwing hook so the reporting cannot kill the worker', async () => {
+    const onJobAbandoned = jest.fn(async () => {
+      throw new Error('reporting failed')
+    })
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {})
+
+    const job = bullJob('job-1', { runId: 'run-1' })
+    expect(() => emit('failed', job, new Error('job stalled more than allowable limit'))).not.toThrow()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+  })
+
+  it('sweeps the failed set on worker start and delivers reports nobody was alive to send', async () => {
+    const abandoned = failedSetJob('job-a', { runId: 'run-a' }, 'job stalled more than allowable limit')
+    const handlerFailure = failedSetJob('job-b', { runId: 'run-b' }, 'import batch blew up')
+    const alreadyReported = failedSetJob('job-c', { runId: 'run-c' }, 'job stalled more than allowable limit', {
+      abandonReportedAt: '2026-01-01T00:00:00.000Z',
+    })
+    mockQueueGetJobs.mockResolvedValue([abandoned, handlerFailure, alreadyReported])
+
+    const onJobAbandoned = jest.fn(async () => {})
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {})
+    await flushAsync()
+
+    expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+    expect(onJobAbandoned).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-a' }), {
+      jobId: 'job-a',
+      reason: 'job stalled more than allowable limit',
+    })
+    expect(abandoned.data.metadata?.abandonReportedAt).toEqual(expect.any(String))
+    expect(handlerFailure.updateData).not.toHaveBeenCalled()
+    expect(alreadyReported.updateData).not.toHaveBeenCalled()
+    expect(abandoned.remove).not.toHaveBeenCalled()
+    await queue.close()
+  })
+
+  it('retries an undelivered report on the next sweep instead of losing it', async () => {
+    jest.useFakeTimers()
+    try {
+      const abandoned = failedSetJob('job-a', { runId: 'run-a' }, 'job stalled more than allowable limit')
+      mockQueueGetJobs.mockResolvedValue([abandoned])
+
+      const onJobAbandoned = jest
+        .fn<Promise<void>, [unknown, unknown]>()
+        .mockRejectedValueOnce(new Error('db down'))
+        .mockResolvedValue(undefined)
+      const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+      await queue.process(async () => {})
+      await flushAsync()
+
+      expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+      expect(abandoned.updateData).not.toHaveBeenCalled()
+
+      jest.advanceTimersByTime(ABANDONED_JOB_SWEEP_INTERVAL_MS)
+      await flushAsync()
+
+      expect(onJobAbandoned).toHaveBeenCalledTimes(2)
+      expect(abandoned.updateData).toHaveBeenCalledTimes(1)
+      await queue.close()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('acknowledges a delivered report so later sweeps do not repeat it', async () => {
+    jest.useFakeTimers()
+    try {
+      const job = failedSetJob('job-1', { runId: 'run-1' }, 'job stalled more than allowable limit')
+      const onJobAbandoned = jest.fn(async () => {})
+      const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+      await queue.process(async () => {})
+      await flushAsync()
+
+      emit('failed', job, new Error('job stalled more than allowable limit'))
+      await flushAsync()
+      expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+      expect(job.data.metadata?.abandonReportedAt).toEqual(expect.any(String))
+
+      mockQueueGetJobs.mockResolvedValue([job])
+      jest.advanceTimersByTime(ABANDONED_JOB_SWEEP_INTERVAL_MS)
+      await flushAsync()
+
+      expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+      await queue.close()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('does not report a job twice while its first report is still in flight', async () => {
+    const job = failedSetJob('job-1', { runId: 'run-1' }, 'job stalled more than allowable limit')
+    mockQueueGetJobs.mockResolvedValue([job])
+
+    let finishReport = () => {}
+    const onJobAbandoned = jest.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishReport = resolve
+        }),
+    )
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {})
+    await flushAsync()
+    expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+
+    emit('failed', job, new Error('job stalled more than allowable limit'))
+    await flushAsync()
+    expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+
+    finishReport()
+    await flushAsync()
+    expect(job.updateData).toHaveBeenCalledTimes(1)
+    await queue.close()
+  })
+
+  it('is not forwarded to the local strategy, which cannot abandon a job', async () => {
+    process.env.QUEUE_STRATEGY = 'local'
+    const originalCwd = process.cwd()
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'queue-abandoned-'))
+    process.chdir(tmp)
+
+    try {
+      const onJobAbandoned = jest.fn(async () => {})
+      const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+      expect(queue.strategy).toBe('local')
+
+      await queue.enqueue({ runId: 'run-1' })
+      const result = await queue.process(
+        async () => {
+          throw new Error('handler failed')
+        },
+        { limit: 1 },
+      )
+
+      expect(result.failed).toBe(1)
+      expect(onJobAbandoned).not.toHaveBeenCalled()
+      await queue.close()
+    } finally {
+      process.chdir(originalCwd)
+      fs.rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/queue/src/__tests__/abandoned-job.test.ts
+++ b/packages/queue/src/__tests__/abandoned-job.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os'
 import path from 'node:path'
 
 import { createModuleQueue } from '../factory'
-import { ABANDONED_JOB_SWEEP_INTERVAL_MS } from '../strategies/async'
+import { ABANDONED_JOB_DRAIN_TIMEOUT_MS, ABANDONED_JOB_SWEEP_INTERVAL_MS } from '../strategies/async'
 import { getRedisUrlOrThrow } from '@open-mercato/shared/lib/redis/connection'
 import type { QueuedJob } from '../types'
 
@@ -391,6 +391,77 @@ describe('onJobAbandoned', () => {
     await flushAsync()
     expect(job.updateData).toHaveBeenCalledTimes(1)
     await queue.close()
+  })
+
+  it('gives up on a hanging report at shutdown instead of blocking it forever', async () => {
+    jest.useFakeTimers()
+    try {
+      const onJobAbandoned = jest.fn(() => new Promise<void>(() => {})) // never settles
+      const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+      await queue.process(async () => {})
+
+      emit('failed', bullJob('job-1', { runId: 'run-1' }), new Error('job stalled more than allowable limit'))
+      await flushAsync()
+      expect(onJobAbandoned).toHaveBeenCalledTimes(1)
+
+      let closed = false
+      const closePromise = queue.close().then(() => {
+        closed = true
+      })
+      await flushAsync()
+      expect(closed).toBe(false)
+
+      jest.advanceTimersByTime(ABANDONED_JOB_DRAIN_TIMEOUT_MS)
+      await closePromise
+      expect(closed).toBe(true)
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('does not start a report from a sweep that was already running when close began', async () => {
+    let releaseGetJobs = (_jobs: unknown[]) => {}
+    mockQueueGetJobs.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseGetJobs = resolve as (jobs: unknown[]) => void
+        }),
+    )
+
+    const onJobAbandoned = jest.fn(async () => {})
+    const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+    await queue.process(async () => {})
+    await flushAsync()
+
+    // The start-up sweep is parked inside getJobs; shutdown begins before it returns.
+    const closePromise = queue.close()
+    releaseGetJobs([failedSetJob('job-1', { runId: 'run-1' }, 'job stalled more than allowable limit')])
+    await flushAsync()
+    await closePromise
+
+    expect(onJobAbandoned).not.toHaveBeenCalled()
+  })
+
+  it('honours QUEUE_ABANDONED_SWEEP_INTERVAL_MS for the sweep cadence', async () => {
+    jest.useFakeTimers()
+    process.env.QUEUE_ABANDONED_SWEEP_INTERVAL_MS = '1000'
+    try {
+      mockQueueGetJobs.mockResolvedValue([])
+      const onJobAbandoned = jest.fn(async () => {})
+      const queue = createModuleQueue<Payload>('test-queue', { onJobAbandoned })
+      await queue.process(async () => {})
+      await flushAsync()
+      expect(mockQueueGetJobs).toHaveBeenCalledTimes(1)
+
+      jest.advanceTimersByTime(1000)
+      await flushAsync()
+
+      expect(mockQueueGetJobs).toHaveBeenCalledTimes(2)
+      await queue.close()
+    } finally {
+      delete process.env.QUEUE_ABANDONED_SWEEP_INTERVAL_MS
+      jest.useRealTimers()
+    }
   })
 
   it('is not forwarded to the local strategy, which cannot abandon a job', async () => {

--- a/packages/queue/src/__tests__/bullmq-abandoned-reasons.test.ts
+++ b/packages/queue/src/__tests__/bullmq-abandoned-reasons.test.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { ABANDONED_JOB_REASONS } from '../strategies/async'
+
+/**
+ * `onJobAbandoned` classifies a failure by matching the reason BullMQ records when it destroys a job
+ * without calling the processor. That is a string comparison against another package's internals, so
+ * an upgrade could rename one and silently switch the hook off — the queue would go back to failing
+ * jobs nobody hears about, with every test still green.
+ *
+ * This asserts the strings are still there. If it fails after a BullMQ bump, read the new source and
+ * update `ABANDONED_JOB_REASONS` — do not delete the assertion.
+ */
+function readBullmqSource(): string {
+  const entry = require.resolve('bullmq')
+  const root = path.join(entry.slice(0, entry.lastIndexOf(`${path.sep}dist${path.sep}`)), 'dist')
+  const chunks: string[] = []
+
+  const walk = (dir: string) => {
+    for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, item.name)
+      if (item.isDirectory()) walk(full)
+      else if (item.name.endsWith('.js') || item.name.endsWith('.lua')) chunks.push(fs.readFileSync(full, 'utf8'))
+    }
+  }
+
+  walk(root)
+  return chunks.join('\n')
+}
+
+describe('BullMQ abandonment reasons', () => {
+  const source = readBullmqSource()
+
+  it('reads a non-empty BullMQ source tree', () => {
+    expect(source.length).toBeGreaterThan(0)
+  })
+
+  it.each(ABANDONED_JOB_REASONS)('still emits %p', (reason) => {
+    expect(source).toContain(reason)
+  })
+})

--- a/packages/queue/src/__tests__/worker-abandoned-job.test.ts
+++ b/packages/queue/src/__tests__/worker-abandoned-job.test.ts
@@ -1,0 +1,101 @@
+import { runWorker } from '../worker/runner'
+import type { WorkerDescriptor } from '../types'
+
+type WorkerListener = (...args: unknown[]) => void
+
+const capturedListeners = new Map<string, WorkerListener[]>()
+
+function emit(event: string, ...args: unknown[]): void {
+  for (const listener of capturedListeners.get(event) ?? []) listener(...args)
+}
+
+jest.mock('@open-mercato/shared/lib/redis/connection', () => ({
+  getRedisUrlOrThrow: jest.fn(() => 'redis://localhost:6379'),
+  parseRedisUrl: jest.requireActual('@open-mercato/shared/lib/redis/connection').parseRedisUrl,
+  REDIS_WIRE_PROTOCOL: jest.requireActual('@open-mercato/shared/lib/redis/connection').REDIS_WIRE_PROTOCOL,
+}))
+
+jest.mock('bullmq', () => {
+  class MockQueue<T> {
+    constructor(_name: string, _opts: unknown) {}
+    add = jest.fn(async () => ({ id: 'bull-job-id' }))
+    close = jest.fn(async () => {})
+    obliterate = jest.fn(async () => {})
+    getJobCounts = jest.fn(async () => ({ waiting: 0, active: 0, completed: 0, failed: 0 }))
+    getJobs = jest.fn(async () => [])
+  }
+
+  class MockWorker<T> {
+    constructor(_name: string, _processor: unknown, _opts: unknown) {}
+    on = (event: string, listener: WorkerListener) => {
+      const existing = capturedListeners.get(event) ?? []
+      existing.push(listener)
+      capturedListeners.set(event, existing)
+    }
+
+    close = jest.fn(async () => {})
+  }
+
+  return { Queue: MockQueue, Worker: MockWorker }
+})
+
+/**
+ * Reachability, not wiring.
+ *
+ * The queue that runs jobs is built by `runWorker`, not by whoever enqueues them, so a callback
+ * attached to the enqueueing instance is never installed on the consumer — the failure this guards
+ * against is invisible to any test that asserts the option was *passed* somewhere. This one goes
+ * through the path `worker --all` uses and asserts the callback actually fires.
+ */
+describe('runWorker — abandoned-job reporting', () => {
+  beforeEach(() => {
+    capturedListeners.clear()
+  })
+
+  it('installs a worker descriptor\'s onJobAbandoned on the queue it builds', async () => {
+    const onJobAbandoned = jest.fn(async () => {})
+    const descriptor: WorkerDescriptor = {
+      id: 'test:worker',
+      queue: 'test-queue',
+      concurrency: 1,
+      handler: async () => {},
+      onJobAbandoned,
+    }
+
+    await runWorker({
+      queueName: descriptor.queue,
+      handler: descriptor.handler,
+      concurrency: descriptor.concurrency,
+      onJobAbandoned: descriptor.onJobAbandoned,
+      strategy: 'async',
+      gracefulShutdown: false,
+      background: true,
+    })
+
+    const payload = { id: 'job-1', payload: { runId: 'run-1' }, createdAt: new Date(0).toISOString() }
+    emit('failed', { id: 'job-1', data: payload }, new Error('job stalled more than allowable limit'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(onJobAbandoned).toHaveBeenCalledWith(payload, {
+      jobId: 'job-1',
+      reason: 'job stalled more than allowable limit',
+    })
+  })
+
+  it('leaves the queue without one when no worker declares it', async () => {
+    await runWorker({
+      queueName: 'test-queue',
+      handler: async () => {},
+      strategy: 'async',
+      gracefulShutdown: false,
+      background: true,
+    })
+
+    // Nothing to assert a call against; the guarantee is that the 'failed' path stays inert, which
+    // would otherwise show up as a thrown error inside the listener.
+    expect(() =>
+      emit('failed', { id: 'job-1', data: { id: 'job-1', payload: {}, createdAt: '' } }, new Error('job stalled more than allowable limit')),
+    ).not.toThrow()
+  })
+})

--- a/packages/queue/src/factory.ts
+++ b/packages/queue/src/factory.ts
@@ -82,7 +82,10 @@ export function resolveQueueStrategy(): QueueStrategyType {
  */
 export function createModuleQueue<T = unknown>(
   name: string,
-  options?: Pick<AsyncQueueOptions, 'attempts' | 'concurrency' | 'lockDuration' | 'maxStalledCount'>,
+  options?: Pick<
+    AsyncQueueOptions,
+    'attempts' | 'concurrency' | 'lockDuration' | 'maxStalledCount' | 'onJobAbandoned'
+  >,
 ): Queue<T> {
   const strategy = resolveQueueStrategy()
   if (strategy === 'async') {
@@ -92,7 +95,10 @@ export function createModuleQueue<T = unknown>(
       attempts: options?.attempts,
       lockDuration: options?.lockDuration,
       maxStalledCount: options?.maxStalledCount,
+      onJobAbandoned: options?.onJobAbandoned,
     })
   }
+  // The local strategy runs the handler in-process, so there is no queue that could outlive it and
+  // abandon a job — `onJobAbandoned` has nothing to report and is deliberately not forwarded.
   return createLocalQueue<T>(name, { concurrency: options?.concurrency })
 }

--- a/packages/queue/src/strategies/async.ts
+++ b/packages/queue/src/strategies/async.ts
@@ -36,8 +36,11 @@ interface BullQueueInterface<T> {
   close: () => Promise<void>
   getJobCounts: (...states: string[]) => Promise<Record<string, number>>
   getJobs: (types: string[], start?: number, end?: number) => Promise<Array<{
+    id?: string
     data?: T
+    failedReason?: string
     remove: () => Promise<void>
+    updateData?: (data: T) => Promise<void>
   }>>
 }
 
@@ -65,6 +68,43 @@ interface BullMQModule {
 type BullMQOtelModule = { BullMQOtel: new (tracerName: string) => object }
 
 const REMOVABLE_JOB_STATES = ['waiting', 'delayed', 'prioritized', 'paused', 'waiting-children']
+
+/**
+ * The failures BullMQ records when it gives up on a job *before* handing it to the processor.
+ *
+ * Both are written as a `defa` (deferred failure) marker on the job, after which the next worker
+ * short-circuits in `Worker.processJob` via `getUnrecoverableErrorMessage` and fails the job without
+ * calling the handler. The first comes from the stalled-job script once a job's cumulative stall
+ * count passes `maxStalledCount`; the second from `maxStartedAttempts`.
+ *
+ * Matching the reason is what tells "the queue abandoned this" from "the handler ran and threw", and
+ * it is deliberately stateless: the alternative — tracking which jobs this process has entered — can
+ * only answer "did the handler run *here*", which is the wrong question the moment more than one
+ * worker is running. `bullmq-abandoned-reasons.test.ts` asserts these strings still exist in the
+ * installed BullMQ, so an upgrade that renames them fails loudly instead of silently disabling the
+ * callback.
+ */
+export const ABANDONED_JOB_REASONS = [
+  'job stalled more than allowable limit',
+  'job started more than allowable limit',
+] as const
+
+function isAbandonedJobReason(message: string): boolean {
+  return (ABANDONED_JOB_REASONS as readonly string[]).includes(message)
+}
+
+/**
+ * Metadata key written onto the stored job once `onJobAbandoned` has completed for it.
+ *
+ * BullMQ's failed set is the durable record of abandoned jobs (`removeOnFail` keeps them), so it
+ * doubles as the dead-letter queue for reports: the sweep re-delivers any abandoned job that does not
+ * carry this marker. The marker — not `job.remove()` — is the acknowledgement, so the failed job
+ * itself survives for diagnosis.
+ */
+const ABANDON_REPORT_ACK_KEY = 'abandonReportedAt'
+
+/** How often a worker re-sweeps the failed set for unacknowledged abandoned jobs. */
+export const ABANDONED_JOB_SWEEP_INTERVAL_MS = 5 * 60 * 1000
 
 function payloadMatchesScope(payload: unknown, scope: QueueJobScope): boolean {
   if (!payload || typeof payload !== 'object') return false
@@ -129,11 +169,92 @@ export function createAsyncQueue<T = unknown>(
   const attempts = options?.attempts ?? 3
   const lockDuration = options?.lockDuration
   const maxStalledCount = options?.maxStalledCount
+  const onJobAbandoned = options?.onJobAbandoned
   const logger = packageLogger.child({ queue: name })
 
   let bullQueue: BullQueueInterface<QueuedJob<T>> | null = null
   let bullWorker: BullWorkerInterface | null = null
   let bullmqModule: BullMQModule | null = null
+  let abandonedSweepTimer: ReturnType<typeof setInterval> | null = null
+
+  // In-flight `onJobAbandoned` calls. Detached from the caller that started them (the 'failed'
+  // listener or the sweep), so `close()` drains them rather than letting a deploy truncate a repair
+  // mid-write. The id set stops the two callers from double-reporting a job inside one process.
+  const pendingAbandonedReports = new Set<Promise<void>>()
+  const inFlightAbandonedJobIds = new Set<string>()
+
+  type AbandonedJobRecord = {
+    id?: string
+    data?: QueuedJob<T>
+    updateData?: (data: QueuedJob<T>) => Promise<void>
+  }
+
+  // The acknowledgement that makes delivery at-least-once: written only after the callback returns,
+  // so a callback that threw or a process that died mid-report leaves the job unmarked and a later
+  // sweep retries it. Requires the driver to expose `updateData`; without it the report simply stays
+  // unacknowledged and repeats, which the idempotency contract permits.
+  async function acknowledgeAbandonedReport(job: AbandonedJobRecord): Promise<void> {
+    if (!job.data || typeof job.updateData !== 'function') return
+    await job.updateData({
+      ...job.data,
+      metadata: { ...(job.data.metadata ?? {}), [ABANDON_REPORT_ACK_KEY]: new Date().toISOString() },
+    })
+  }
+
+  function reportAbandonedJob(job: AbandonedJobRecord, reason: string): void {
+    if (!onJobAbandoned) return
+    const payload = job.data
+    if (!payload) return
+    if (payload.metadata && payload.metadata[ABANDON_REPORT_ACK_KEY]) return
+    if (inFlightAbandonedJobIds.has(payload.id)) return
+    inFlightAbandonedJobIds.add(payload.id)
+
+    const jobId = job.id ?? null
+    logger.warn('Job abandoned by the queue without running its handler', { jobId, reason })
+    const report = (async () => {
+      try {
+        await onJobAbandoned(payload, { jobId, reason })
+      } catch (hookError) {
+        logger.error('onJobAbandoned handler threw; the report stays unacknowledged and the sweep will retry it', {
+          jobId,
+          err: hookError as Error,
+        })
+        return
+      }
+      try {
+        await acknowledgeAbandonedReport(job)
+      } catch (ackError) {
+        logger.error('Failed to acknowledge an abandoned-job report; the sweep may repeat it', {
+          jobId,
+          err: ackError as Error,
+        })
+      }
+    })().finally(() => {
+      inFlightAbandonedJobIds.delete(payload.id)
+    })
+    pendingAbandonedReports.add(report)
+    void report.then(() => pendingAbandonedReports.delete(report))
+  }
+
+  // The failed set is this strategy's dead-letter queue for abandoned jobs. Enumerating it on worker
+  // start and on an interval, and re-delivering anything unacknowledged, is what upgrades the
+  // 'failed'-listener fast path from at-most-once to at-least-once: a report lost to a crash is
+  // simply still unmarked when the next sweep looks. Residual loss: `removeOnFail` caps the set, so
+  // a job evicted before any sweep sees it is gone for good.
+  async function sweepAbandonedJobs(): Promise<void> {
+    if (!onJobAbandoned) return
+    try {
+      const queue = await getQueue()
+      const failedJobs = await queue.getJobs(['failed'], 0, -1)
+      for (const failedJob of failedJobs) {
+        const reason = failedJob.failedReason ?? ''
+        if (!isAbandonedJobReason(reason)) continue
+        reportAbandonedJob(failedJob, reason)
+      }
+    } catch (sweepError) {
+      logger.error('Abandoned-job sweep failed', { err: sweepError as Error })
+    }
+  }
   // Resolved once: a BullMQOtel instance (delegate async tracing to BullMQ) or
   // undefined (use our own metadata._trace carrier instead). Memoized as the
   // in-flight promise so concurrent first-time callers share one resolution.
@@ -255,9 +376,24 @@ export function createAsyncQueue<T = unknown>(
     })
 
     bullWorker.on('failed', (job, err) => {
-      const jobWithId = job as { id?: string } | undefined
+      const failedJob = job as AbandonedJobRecord | undefined
       const error = err as Error
-      logger.error('Job failed', { jobId: jobWithId?.id, err: error })
+      logger.error('Job failed', { jobId: failedJob?.id, err: error })
+
+      if (!onJobAbandoned) return
+      // Any other reason means a handler ran and threw. That failure is the handler's own and it has
+      // already had its chance to record it.
+      if (!isAbandonedJobReason(error?.message ?? '')) return
+      // No payload means the queue could not give us the job at all. There is nothing to hand the
+      // callback and nothing it could repair, so reporting could only ever be a false alarm — the
+      // 'Job failed' line above still records it.
+      if (!failedJob?.data) return
+
+      // The fast path: report the moment the abandonment is observed. `reportAbandonedJob` runs the
+      // callback detached with its own try/catch — this is an EventEmitter, where an unhandled
+      // rejection is fatal to the process — and acknowledges the job only afterwards, so a report
+      // lost here is retried by the sweep.
+      reportAbandonedJob(failedJob, error.message)
     })
 
     // A stalled job is redelivered under the same id while the previous worker
@@ -274,6 +410,17 @@ export function createAsyncQueue<T = unknown>(
       const error = err as Error
       logger.error('Worker error', { err: error })
     })
+
+    if (onJobAbandoned) {
+      // Sweep immediately so reports lost to a previous process's crash are re-delivered as soon as
+      // a worker is back, then keep re-sweeping for anything the fast path loses while running.
+      // The timer is unref'd so it never holds the process open.
+      void sweepAbandonedJobs()
+      abandonedSweepTimer = setInterval(() => {
+        void sweepAbandonedJobs()
+      }, ABANDONED_JOB_SWEEP_INTERVAL_MS)
+      ;(abandonedSweepTimer as unknown as { unref?: () => void }).unref?.()
+    }
 
     logger.info('Worker started', { concurrency })
 
@@ -311,9 +458,18 @@ export function createAsyncQueue<T = unknown>(
   }
 
   async function close(): Promise<void> {
+    if (abandonedSweepTimer) {
+      clearInterval(abandonedSweepTimer)
+      abandonedSweepTimer = null
+    }
     if (bullWorker) {
       await bullWorker.close()
       bullWorker = null
+    }
+    // Drain any abandonment report still in flight. Without this a deploy-time shutdown can cut off
+    // the very repair the callback exists to perform — and these never reject, so awaiting is safe.
+    if (pendingAbandonedReports.size) {
+      await Promise.all([...pendingAbandonedReports])
     }
     if (bullQueue) {
       await bullQueue.close()

--- a/packages/queue/src/strategies/async.ts
+++ b/packages/queue/src/strategies/async.ts
@@ -103,8 +103,28 @@ function isAbandonedJobReason(message: string): boolean {
  */
 const ABANDON_REPORT_ACK_KEY = 'abandonReportedAt'
 
-/** How often a worker re-sweeps the failed set for unacknowledged abandoned jobs. */
+/**
+ * How often a worker re-sweeps the failed set for unacknowledged abandoned jobs.
+ *
+ * Override with `QUEUE_ABANDONED_SWEEP_INTERVAL_MS` to trade recovery latency against Redis chatter.
+ */
 export const ABANDONED_JOB_SWEEP_INTERVAL_MS = 5 * 60 * 1000
+
+/**
+ * How long `close()` waits for in-flight reports before giving up on them.
+ *
+ * Bounded on purpose: the hook reaches a database, and a shutdown during an infrastructure incident
+ * is exactly when that write can hang rather than fail. An unbounded wait would turn a graceful
+ * shutdown into a SIGKILL and skip the telemetry flush that follows it. Abandoning the wait is safe
+ * because delivery is at-least-once — an unacknowledged report is re-delivered by the next worker's
+ * start-up sweep, the same path that covers a process which died mid-report.
+ */
+export const ABANDONED_JOB_DRAIN_TIMEOUT_MS = 5000
+
+function resolveSweepIntervalMs(): number {
+  const configured = Number.parseInt(process.env.QUEUE_ABANDONED_SWEEP_INTERVAL_MS ?? '', 10)
+  return Number.isFinite(configured) && configured > 0 ? configured : ABANDONED_JOB_SWEEP_INTERVAL_MS
+}
 
 function payloadMatchesScope(payload: unknown, scope: QueueJobScope): boolean {
   if (!payload || typeof payload !== 'object') return false
@@ -176,6 +196,7 @@ export function createAsyncQueue<T = unknown>(
   let bullWorker: BullWorkerInterface | null = null
   let bullmqModule: BullMQModule | null = null
   let abandonedSweepTimer: ReturnType<typeof setInterval> | null = null
+  let closing = false
 
   // In-flight `onJobAbandoned` calls. Detached from the caller that started them (the 'failed'
   // listener or the sweep), so `close()` drains them rather than letting a deploy truncate a repair
@@ -242,10 +263,14 @@ export function createAsyncQueue<T = unknown>(
   // simply still unmarked when the next sweep looks. Residual loss: `removeOnFail` caps the set, so
   // a job evicted before any sweep sees it is gone for good.
   async function sweepAbandonedJobs(): Promise<void> {
-    if (!onJobAbandoned) return
+    if (!onJobAbandoned || closing) return
     try {
       const queue = await getQueue()
       const failedJobs = await queue.getJobs(['failed'], 0, -1)
+      // Re-checked after the awaits: a sweep already past its guard when `close()` ran would
+      // otherwise start a report the drain has stopped waiting for. The next start-up sweep
+      // re-delivers it, so stopping here loses nothing.
+      if (closing) return
       for (const failedJob of failedJobs) {
         const reason = failedJob.failedReason ?? ''
         if (!isAbandonedJobReason(reason)) continue
@@ -418,7 +443,7 @@ export function createAsyncQueue<T = unknown>(
       void sweepAbandonedJobs()
       abandonedSweepTimer = setInterval(() => {
         void sweepAbandonedJobs()
-      }, ABANDONED_JOB_SWEEP_INTERVAL_MS)
+      }, resolveSweepIntervalMs())
       ;(abandonedSweepTimer as unknown as { unref?: () => void }).unref?.()
     }
 
@@ -458,6 +483,7 @@ export function createAsyncQueue<T = unknown>(
   }
 
   async function close(): Promise<void> {
+    closing = true
     if (abandonedSweepTimer) {
       clearInterval(abandonedSweepTimer)
       abandonedSweepTimer = null
@@ -466,10 +492,21 @@ export function createAsyncQueue<T = unknown>(
       await bullWorker.close()
       bullWorker = null
     }
-    // Drain any abandonment report still in flight. Without this a deploy-time shutdown can cut off
-    // the very repair the callback exists to perform — and these never reject, so awaiting is safe.
+    // Drain any abandonment report still in flight, so a deploy-time shutdown cannot cut off the very
+    // repair the callback exists to perform. Bounded: the hook writes to a database, and a shutdown
+    // during an incident is exactly when that write can hang instead of failing. Giving up costs
+    // nothing permanent — an unacknowledged report is re-delivered by the next start-up sweep.
     if (pendingAbandonedReports.size) {
-      await Promise.all([...pendingAbandonedReports])
+      const drained = Promise.all([...pendingAbandonedReports]).then(() => true)
+      const expired = new Promise<boolean>((resolve) => {
+        const timer = setTimeout(() => resolve(false), ABANDONED_JOB_DRAIN_TIMEOUT_MS)
+        ;(timer as unknown as { unref?: () => void }).unref?.()
+      })
+      if (!(await Promise.race([drained, expired]))) {
+        logger.warn('Abandoned-job reports still in flight at shutdown; the sweep will retry them', {
+          pending: pendingAbandonedReports.size,
+        })
+      }
     }
     if (bullQueue) {
       await bullQueue.close()

--- a/packages/queue/src/strategies/async.ts
+++ b/packages/queue/src/strategies/async.ts
@@ -102,6 +102,9 @@ function isAbandonedJobReason(message: string): boolean {
  * itself survives for diagnosis.
  */
 const ABANDON_REPORT_ACK_KEY = 'abandonReportedAt'
+// NOTE for anyone adding a retry action: the marker lives inside the job's own payload envelope, so a
+// job retried from admin tooling carries it into its next life and a second abandonment of that job
+// would never be reported. A retry path must clear `metadata.abandonReportedAt` when it re-enqueues.
 
 /**
  * How often a worker re-sweeps the failed set for unacknowledged abandoned jobs.
@@ -222,12 +225,12 @@ export function createAsyncQueue<T = unknown>(
     })
   }
 
-  function reportAbandonedJob(job: AbandonedJobRecord, reason: string): void {
-    if (!onJobAbandoned) return
+  function reportAbandonedJob(job: AbandonedJobRecord, reason: string): Promise<void> | null {
+    if (!onJobAbandoned) return null
     const payload = job.data
-    if (!payload) return
-    if (payload.metadata && payload.metadata[ABANDON_REPORT_ACK_KEY]) return
-    if (inFlightAbandonedJobIds.has(payload.id)) return
+    if (!payload) return null
+    if (payload.metadata && payload.metadata[ABANDON_REPORT_ACK_KEY]) return null
+    if (inFlightAbandonedJobIds.has(payload.id)) return null
     inFlightAbandonedJobIds.add(payload.id)
 
     const jobId = job.id ?? null
@@ -255,6 +258,7 @@ export function createAsyncQueue<T = unknown>(
     })
     pendingAbandonedReports.add(report)
     void report.then(() => pendingAbandonedReports.delete(report))
+    return report
   }
 
   // The failed set is this strategy's dead-letter queue for abandoned jobs. Enumerating it on worker
@@ -272,9 +276,16 @@ export function createAsyncQueue<T = unknown>(
       // re-delivers it, so stopping here loses nothing.
       if (closing) return
       for (const failedJob of failedJobs) {
+        // Re-checked every iteration for the same reason: a long fan-out must not outlive the drain.
+        if (closing) return
         const reason = failedJob.failedReason ?? ''
         if (!isAbandonedJobReason(reason)) continue
-        reportAbandonedJob(failedJob, reason)
+        // Awaited one at a time. Each report opens a request container and writes to the database, and
+        // the worst case for this loop is the first worker start after the feature ships, on a
+        // deployment that has been accumulating abandoned jobs — the largest backlog, on the process
+        // least able to absorb it. The sweep is a recovery path with no latency requirement (five
+        // minutes late is its normal mode), so pacing costs nothing worth having.
+        await reportAbandonedJob(failedJob, reason)
       }
     } catch (sweepError) {
       logger.error('Abandoned-job sweep failed', { err: sweepError as Error })

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -299,6 +299,14 @@ export type WorkerMeta = {
   lockDuration?: number
   /** Number of stalled-job recoveries BullMQ permits before failing a job. */
   maxStalledCount?: number
+  /**
+   * Called when the queue abandons one of this worker's jobs without running the handler.
+   *
+   * Declared here rather than on the producing queue because the worker is the side that must hear
+   * it: the event being reported is a worker restart, and the process that restarts never
+   * constructs the enqueueing queue. See `AsyncQueueOptions.onJobAbandoned` for the contract.
+   */
+  onJobAbandoned?: AsyncQueueOptions['onJobAbandoned']
 }
 
 /**
@@ -318,4 +326,6 @@ export type WorkerDescriptor<T = unknown> = {
   lockDuration?: number
   /** Number of stalled-job recoveries BullMQ permits before failing a job. */
   maxStalledCount?: number
+  /** Called when the queue abandons one of this worker's jobs without running the handler. */
+  onJobAbandoned?: AsyncQueueOptions['onJobAbandoned']
 }

--- a/packages/queue/src/types.ts
+++ b/packages/queue/src/types.ts
@@ -99,6 +99,43 @@ export type AsyncQueueOptions = {
   lockDuration?: number
   /** Number of stalled-job recoveries BullMQ permits before failing a job. Defaults to 1. */
   maxStalledCount?: number
+  /**
+   * Called when the queue permanently gives up on a job WITHOUT its handler having run.
+   *
+   * Why this cannot be left to the handler: a queue may destroy a job before ever calling the
+   * processor — the usual cause is a job redelivered once too often, past `maxStalledCount`. The
+   * handler then never runs, never throws and never learns, and any state it created on enqueue (a
+   * run row, a progress record) is orphaned in whatever "in progress" state it was left in, with
+   * nothing to correct it.
+   *
+   * Contract:
+   * - Fires **only** for a job the queue abandoned before its handler ran. It is deliberately not a
+   *   general "job failed" hook: a handler that ran and threw owns its own outcome and has already
+   *   had the chance to record it. Reporting both would double-report and would hide the difference
+   *   between "the work failed" and "the work never started".
+   * - **At-least-once, where the backend allows it.** The strategy reports as soon as it observes
+   *   the abandonment, and also sweeps the backend's dead-job records — on worker start, then
+   *   periodically — for reports that were never acknowledged. A report is acknowledged only after
+   *   this callback returns, so a callback that threw or a process that died mid-report is retried
+   *   by a later sweep. The callback MUST therefore be idempotent, and MUST tolerate a payload it
+   *   does not recognise. Residual loss is still possible when the backend evicts its dead-job
+   *   records before any sweep sees them; state that absolutely must never be stranded should also
+   *   have a staleness check of its own at the domain level.
+   * - Not every strategy can implement it — the local strategy runs handlers in-process, so no queue
+   *   outlives a handler to abandon its job.
+   *
+   * Backend specifics (which failures count as abandonment, and how they are detected) belong to the
+   * strategy; see `strategies/async.ts`.
+   */
+  onJobAbandoned?: (payload: unknown, info: AbandonedJobInfo) => void | Promise<void>
+}
+
+/** What the queue can say about a job it gave up on. */
+export type AbandonedJobInfo = {
+  /** The queue driver's own job id, or null when it did not supply one. */
+  jobId: string | null
+  /** The failure the queue recorded, e.g. 'job stalled more than allowable limit'. */
+  reason: string
 }
 
 /**

--- a/packages/queue/src/worker/runner.ts
+++ b/packages/queue/src/worker/runner.ts
@@ -24,6 +24,8 @@ export type WorkerRunnerOptions<T = unknown> = {
   lockDuration?: number
   /** Number of stalled-job recoveries BullMQ permits before failing a job. */
   maxStalledCount?: number
+  /** Called when the queue abandons a job without running the handler. */
+  onJobAbandoned?: AsyncQueueOptions['onJobAbandoned']
   /** Whether to set up graceful shutdown handlers */
   gracefulShutdown?: boolean
   /** If true, don't block - return immediately after starting processing (for multi-queue mode) */
@@ -151,6 +153,7 @@ export async function runWorker<T = unknown>(
     concurrency = 1,
     lockDuration,
     maxStalledCount,
+    onJobAbandoned,
     gracefulShutdown = true,
     background = false,
     strategy: strategyOption,
@@ -176,6 +179,7 @@ export async function runWorker<T = unknown>(
     concurrency,
     lockDuration,
     maxStalledCount,
+    onJobAbandoned,
   })
 
   // Set up graceful shutdown

--- a/packages/shared/src/modules/registry.ts
+++ b/packages/shared/src/modules/registry.ts
@@ -196,6 +196,14 @@ export type ModuleWorker = {
   concurrency: number
   lockDuration?: number
   maxStalledCount?: number
+  /**
+   * Reports a job the queue abandoned without running the handler.
+   *
+   * Present only for workers whose metadata declares it; the generator emits it as a lazy import
+   * beside the handler, because the registry serializes metadata as literals and a function cannot
+   * survive that.
+   */
+  onJobAbandoned?: (payload: unknown, info: { jobId: string | null; reason: string }) => void | Promise<void>
   handler: ModuleWorkerHandler
 }
 
@@ -552,5 +560,33 @@ export function createLazyModuleWorker(
     )
     const handler = await handlerPromise
     return handler(job, ctx)
+  }
+}
+
+/**
+ * Resolves a worker's `metadata.onJobAbandoned` on first use.
+ *
+ * The generator serializes worker metadata as literals, so a function declared there cannot be
+ * emitted inline the way `concurrency` or `lockDuration` are. It is emitted as this thunk instead —
+ * the same lazy-import treatment the handler already gets — and only for workers whose metadata
+ * declares the callback, so no other queue acquires one (and with it, a sweep) by accident.
+ */
+export function createLazyModuleWorkerAbandonHook(
+  loadModule: () => Promise<unknown>,
+  id: string
+): (payload: unknown, info: { jobId: string | null; reason: string }) => Promise<void> {
+  let hookPromise: Promise<((payload: unknown, info: { jobId: string | null; reason: string }) => unknown) | null> | null = null
+  return async (payload, info) => {
+    hookPromise ??= loadModule().then((loaded) => {
+      const metadata = (loaded as { metadata?: { onJobAbandoned?: unknown } } | null)?.metadata
+      return typeof metadata?.onJobAbandoned === 'function'
+        ? (metadata.onJobAbandoned as (payload: unknown, info: { jobId: string | null; reason: string }) => unknown)
+        : null
+    })
+    const hook = await hookPromise
+    if (!hook) {
+      throw new Error(`[registry] Worker "${id}" was registered with an abandoned-job hook but its metadata no longer declares one`)
+    }
+    await hook(payload, info)
   }
 }


### PR DESCRIPTION
## Fixed after a field report: the hook was attached to a queue instance the worker never uses

Measured on a running deployment, and fixed in `18a9aa188`. The first version of this PR **did not
fire**: an abandoned job sat in the `failed` set for 16 minutes with its `sync_runs` row still
`running` and no log output at all, not even the containment message. The patched build was confirmed
present in the image first.

`onJobAbandoned` was an option on a queue **instance**, and only the producing side supplied one.
`getSyncQueue()` is reached from `lib/start-run.ts` and the two Akeneo routes — enqueue paths. The
worker's queue is built separately by `runWorker` (`packages/queue/src/worker/runner.ts`) via
`createQueue(name, strategy, { connection, concurrency, lockDuration, maxStalledCount })`, taking
those options from the **worker descriptors** — so the `failed` listener and the sweep both lived on
an instance the worker process never constructs. Self-reinforcing: the event being reported is a
worker restart, and a restarted worker has no reason to build the producer's queue.

Put precisely, because it determines the fix: worker metadata was already the transport for every
other queue option, and `onJobAbandoned` was the one option with no way to travel it — no field on
`WorkerMeta`, nothing emitted by the generator, nothing forwarded by `runWorker`. The field evidence
shows the transport working for its neighbours: the job died at a stalled count of 11 against a
threshold of **10** (`DATA_SYNC_MAX_STALLED_COUNT`, not BullMQ's default of 1), so the worker's queue
demonstrably received `maxStalledCount` from `WorkerMeta` — a value `getSyncQueue()` could not have
supplied, since that instance is never built in the worker process.

**The fix** declares it where the other queue options already live — on the worker's `metadata`,
beside the queue name it belongs to. `WorkerMeta`, `ModuleWorker` and `WorkerDescriptor` gain the
option, `runWorker` forwards it to `createQueue`, and the CLI resolves it per queue exactly as it
already resolves `lockDuration` and `maxStalledCount` (first declaring worker wins, so one queue
produces one report). `data_sync`'s callback moved to `lib/abandoned-run.ts` and is declared by both
resumable workers; `getSyncQueue` no longer carries it.

**Why the generator had to change.** Worker metadata is serialized as literals, and only `handler`
survives as code (`createLazyModuleWorker(() => import(…))`), so a function in `metadata` would be
dropped silently. It is emitted as `createLazyModuleWorkerAbandonHook` — the same lazy-import
treatment — and only for workers that declare it, so no other queue acquires a hook, or a sweep, by
accident, and generated output for module sets without one is byte-identical. Detection is a
**syntax-level** check, not a value check: a worker module that cannot be imported at build time falls
back to the literal extractor, which cannot tell an imported function from an unresolvable identifier.
Verified end to end — the generated registry now carries `onJobAbandoned` for both `data_sync`
workers.

**The test lesson, which is the transferable part.** The previous coverage asserted the option was
*passed to `getSyncQueue`* — a wiring assertion that stays green while the feature is inert — and the
queue-package tests built the queue directly, testing the mechanism but never its reachability from
the path that runs jobs. Tests now assert reachability: the queue package builds the queue the way
`runWorker` does and asserts the callback fires; `data_sync` asserts the hook is declared on the
workers and **not** on the producer; the generator asserts that a property whose value is an
unresolvable identifier is still detected.

This touches auto-discovery and generated-registry contract surface, which `AGENTS.md` asks
contributors to raise. It is additive — every existing worker, descriptor and generated file is
unchanged unless a worker declares the option — but it is the maintainers' call, and the alternatives
(having `data_sync` register its worker through `getSyncQueue`, or making `createModuleQueue` cache
per name and merge options) are both narrower in reach and worse in coupling.

## Summary

`queue-policy.ts` already documents where a resumable `data_sync` job ends up once it exhausts its
stall budget:

> A job that poisons its worker still dies — after 10 stalls, with the run left `running` and its
> cursor unmoved, which is the state the admin runs list surfaces.

That state is permanent, and nothing corrects it. The queue records the job as `failed`, the
`sync_runs` row keeps saying `running` with a cursor that stopped advancing hours ago, and no code
path reconciles the two. An operator has to compare the queue against the runs list to notice, then
fix the row by hand.

This PR closes that gap: the queue reports jobs it destroys *before the handler runs*, and `data_sync`
uses the report to mark the run `failed`.

## How it works today, and after this change

**Today**, once the stalled count passes `DATA_SYNC_MAX_STALLED_COUNT`, BullMQ writes a deferred
failure onto the job and returns it to `wait`. The next worker reads that marker first and fails the
job immediately — `Worker.processJob` short-circuits on `getUnrecoverableErrorMessage(job)` and
returns before `callProcessJob`, and `UnrecoverableError` bypasses `attempts`. So `runImport` is never
entered on that delivery, never throws, and never reaches `finalizeRun`. The run row is left exactly
as it was.

**After**, the async strategy's `failed` listener recognises that specific failure and invokes a new
`onJobAbandoned` callback with the job payload and the reason. `data_sync` supplies the callback and
calls `markStatus(runId, 'failed', scope, …)`. The run row and the queue finally agree.

The job still dies at the same point — this reports it honestly, it does not make the run survivable.

## Changes

- **`packages/queue`** — optional `onJobAbandoned` on `AsyncQueueOptions` and an exported
  `AbandonedJobInfo`, forwarded through `createModuleQueue`; invoked from the async strategy's
  `failed` listener and from a sweep over the failed set that makes delivery at-least-once.
- **`packages/core`** — the resumable `data_sync` queues pass a callback that marks the run `failed`
  with the reason the queue recorded.
- **`apps/docs`** — a "Jobs the Queue Abandons" section in `framework/runtime/workers.mdx`.

## Details

### Scope of the callback

It fires **only** for a job the queue destroyed without its handler running. It is deliberately not a
general "job failed" hook: a handler that ran and threw has already had the chance to record its own
outcome, so reporting both would double-report and would erase the difference between *the work
failed* and *the work never started*.

The two are distinguished by the reason BullMQ recorded — `job stalled more than allowable limit`, or
`job started more than allowable limit` for `maxStartedAttempts`. Both are written as the deferred
failure that causes the processor to be skipped, so the reason is an exact signal. This is stateless
on purpose: tracking which jobs a process handed to its handler can only answer "did the handler run
*in this process*", which is the wrong question as soon as more than one worker is running — a worker
whose handler hangs past `lockDuration` would suppress the report for a job it never finished, while
the same job abandoned on another worker would be reported.

Matching another package's string is a real risk, so `bullmq-abandoned-reasons.test.ts` asserts both
strings still exist in the installed BullMQ. A version bump that renames one fails the build instead
of silently disabling the callback.

### Delivery is at-least-once

An in-process notification with no retry would lose the report exactly when processes are dying, which
is the situation that produces abandoned jobs in the first place. So:

- The failed set is already durable (`removeOnFail: 1000`), and serves as the dead-letter queue for
  reports — no new storage.
- The `failed` listener is the fast path, reporting within seconds.
- A report is **acknowledged only after the callback returns**, by writing a
  `metadata.abandonReportedAt` marker onto the stored job. The marker deliberately replaces
  `job.remove()` as the acknowledgement, so the failed job survives for diagnosis.
- Every worker sweeps the failed set on start and every five minutes and re-invokes the callback for
  anything unmarked. A callback that threw, or a process that died mid-report, is retried; reports
  owed by a process that never came back are delivered as soon as any worker starts.
- Duplicates are permitted: within a process an in-flight id set prevents the listener and the sweep
  colliding, and across processes the contract is at-least-once with an idempotent consumer.
  `markStatus` refuses to overwrite a terminal status, so a repeated report is a no-op.

The callback runs detached with its own `try`/`catch` — it is invoked from an EventEmitter, where an
unhandled rejection would terminate the worker — and `close()` awaits reports still in flight so a
deploy cannot truncate one mid-write. The sweep timer is unref'd.

The contract in `types.ts` is behavioural so it survives a change of backend: *at-least-once where the
backend allows it; acknowledged after the callback returns; must be idempotent; not every strategy
implements it*. On a DLQ-style backend the same contract is a dead-letter-queue consumer whose
acknowledgement is consuming the message; everything BullMQ-specific stays in `strategies/async.ts`.
The local strategy does not receive the callback — it runs handlers in-process, so no queue outlives a
handler to abandon its job.

### Residual gap

At-least-once holds while the failure record exists. A job evicted past the `removeOnFail` cap, or
lost to a Redis flush or `obliterate` before any sweep sees it, is not recoverable from the queue —
and neither is a run stranded with no queue failure at all (an enqueue that died after the run row was
created). Those want a periodic staleness check over `sync_runs` itself, which is deliberately not in
this PR. The ownership fence in `commitBatchProgress` already makes such a check safe to add: its
`UPDATE` requires `status = 'running'`, so a run marked `failed` by a sweeper causes the next fenced
commit to raise `SyncRunOwnershipConflictError` and abort the delivery cleanly.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

A bug fix plus one additive option on an existing extension point; no new module, entity or contract.

## Testing

`yarn workspace @open-mercato/queue test` — 11 suites, 99 tests.
`yarn workspace @open-mercato/core test --testPathPatterns data_sync` — 21 suites, 110 tests.
`yarn workspace @open-mercato/queue typecheck` and eslint over both changed trees — clean.

New coverage in `packages/queue/src/__tests__/abandoned-job.test.ts`, each case tied to a way this can
break:

| Test | Bug it catches |
|------|----------------|
| fires with the payload and the queue's reason | the callback not firing at all |
| does not fire when the handler ran and threw | it degrading into a general `onFailed` |
| the `maxStartedAttempts` reason also counts | missing the other pre-processor kill |
| fires when this worker earlier ran an attempt that stalled | a per-process record suppressing a real report |
| only the abandoned job is reported when failures arrive together | reason matching bleeding across concurrent jobs |
| an abandoned job with no queue-supplied id is still reported | dropping a report for want of an id it does not need |
| a `failed` event with no job object reports nothing | a false report when there is no payload to repair |
| a throwing callback does not escape the listener | a reporting failure killing the worker |
| `close()` waits for a callback in flight | a deploy truncating a repair mid-write |
| the start-up sweep delivers unmarked reports, skips marked ones and handler failures, removes nothing | reports owed by a dead process staying undelivered; acknowledgement destroying the diagnostic record |
| a throwing callback is retried by the next sweep and marked on success | a transient consumer failure losing the repair permanently |
| a listener-delivered report is marked, so sweeps skip it | re-reporting every delivered abandonment every five minutes |
| no double report while one is in flight | the listener and the sweep racing in one process |
| the local strategy never invokes it | the option leaking into a strategy that cannot abandon jobs |

`bullmq-abandoned-reasons.test.ts` pins the two reason strings to the installed BullMQ.
`queue-abandoned-run.test.ts` covers the `data_sync` callback: it marks the run failed with the
queue's reason, does nothing without a run id or tenant scope, and — against the real
`SyncRunService` — leaves an already-`completed` run terminal. `queue.test.ts` gains the assertion
that the resumable queues receive the callback (and, unchanged, that other queues do not).

**Not covered:** no integration test. Reproducing the sequence needs a live Redis, a job held open
across enough restarts to exhaust the stall limit, and the deferred-failure redelivery — hours of
wall-clock and repeated process kills. The unit tests assert the exact branch that sequence lands in.

## Backward compatibility

Additive only: a new optional field on `AsyncQueueOptions`, a new exported type, and one more key in
`createModuleQueue`'s `Pick<…>`. A queue created without the callback behaves exactly as before — the
sweep only starts when a callback is supplied. No database schema, API surface, event id, widget spot,
DI key or CLI command touched.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` — not applicable; see "Not covered".
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable) — N/A.
- [ ] Priority label — this account cannot set labels here; see the comment below.
- [ ] Risk label — as above.
- [ ] QA routing — as above.

## Linked issues

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789638455&installation_model_id=432243&pr_number=5368&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5368&signature=361d32f197a73420776f553cd6352778a08ddc61519e4c26de05df4ab0c045aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

