### PR TITLE
perf(query_index): stop rewriting search tokens that have not changed

### DIFF
--- a/.ai/specs/2026-07-30-search-tokens-unbounded-growth.md
+++ b/.ai/specs/2026-07-30-search-tokens-unbounded-growth.md
@@ -118,7 +118,7 @@ source-compatible. Missing fields resolve to the safe defaults above.
 |---|---|---|---|
 | Search terms beyond a configured field or token limit are omitted | Medium | Conservative defaults and explicit tuning variables | Operators must raise a limit when deep-document recall is more important than bounded index size |
 | Two application processes can schedule the same reindex | Low | The cooldown removes the per-request stampede in each process; the existing active-job guard prevents duplicate active work | A small number of redundant persistent events may still be queued during cross-process races |
-| Concurrent token replacements can leave temporary duplicate rows | Low | Queries use existence semantics and the next non-overlapping replacement heals duplicates | Rare duplicates can consume space until the next replacement |
+| Concurrent token replacements can leave temporary duplicate rows | Low | Queries use existence semantics and the next non-overlapping replacement heals duplicates. Since #5402 the batch path skips records whose tokens are unchanged, so "the next replacement" no longer happens unconditionally — the skip compares token *multiplicities* rather than a set, and a stored row count above the built count forces a full rewrite of the scope bucket, so a duplicated record is still routed through the healing rewrite | Rare duplicates can consume space until the next replacement. A duplicated record now also costs its whole scope bucket a rewrite, because the bounded pre-read stops at the built row count rather than reading far enough to identify which record is duplicated |
 | Debounce scope cache grows with tenant churn | Low | The map is capped at 10,000 entries and prunes expired keys | Eviction can allow one additional schedule under extreme scope churn |
 
 ## Migration & Backward Compatibility
@@ -142,6 +142,12 @@ source-compatible. Missing fields resolve to the safe defaults above.
 
 ## Changelog
 
+- 2026-08-20: Noted in the risk table how #5402 (skip rewriting unchanged search
+  tokens) interacts with duplicate healing: the batch path no longer rewrites
+  unconditionally, so healing now depends on the multiplicity comparison and on
+  the bounded pre-read falling back to a full bucket rewrite. The pre-read is
+  bounded by the built row count, which `OM_SEARCH_MAX_TOKENS_PER_RECORD` already
+  caps, so it does not reintroduce an unbounded read of this table.
 - 2026-08-02: Added regression coverage for distinct array-field token budgets
   and duplicated module instances, and completed the canonical environment
   setting references.

--- a/packages/core/src/modules/query_index/__tests__/search-tokens-unchanged-skip.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/search-tokens-unchanged-skip.test.ts
@@ -1,0 +1,306 @@
+import type { Kysely } from 'kysely'
+import { resolveSearchConfig } from '@open-mercato/shared/lib/search/config'
+import { tokenizeText } from '@open-mercato/shared/lib/search/tokenize'
+import { replaceSearchTokensForBatch } from '../lib/search-tokens'
+
+type StoredRow = {
+  id: number
+  entity_type: string
+  entity_id: string
+  organization_id: string | null
+  tenant_id: string | null
+  field: string
+  token_hash: string
+  token: string | null
+}
+
+type RawBuilderLike = { toOperationNode: () => { sqlFragments: string[]; parameters: Array<{ value?: unknown }> } }
+
+const columnOf = (row: StoredRow, column: string): unknown => (row as unknown as Record<string, unknown>)[column]
+
+/**
+ * In-memory stand-in for the `search_tokens` table. Rows carry a synthetic `id` so a test can
+ * distinguish "left alone" from "deleted and re-inserted with identical content" — the only
+ * assertion that actually proves the skip, since a delete-then-reinsert leaves the row count
+ * identical and every id different.
+ */
+function createSearchTokenStore() {
+  const rows: StoredRow[] = []
+  let nextId = 1
+  let transactionCount = 0
+  let selectCount = 0
+
+  const assertTable = (table: unknown) => {
+    if (String(table) !== 'search_tokens') throw new Error(`[internal] unexpected table: ${String(table)}`)
+  }
+
+  const buildPredicate = (args: unknown[]): ((row: StoredRow) => boolean) => {
+    if (args.length === 1) {
+      const node = (args[0] as RawBuilderLike).toOperationNode()
+      const column = String(node.sqlFragments[0]).trim().split(/\s+/)[0]
+      const expected = node.parameters[0]?.value ?? null
+      return (row) => (columnOf(row, column) ?? null) === expected
+    }
+    const [column, operator, value] = args as [string, string, unknown]
+    if (operator === '=') return (row) => String(columnOf(row, column)) === String(value)
+    if (operator === 'in') {
+      const allowed = new Set((value as unknown[]).map(String))
+      return (row) => allowed.has(String(columnOf(row, column)))
+    }
+    throw new Error(`[internal] unsupported where operator: ${operator}`)
+  }
+
+  const selectChain = (table: unknown) => {
+    assertTable(table)
+    const predicates: Array<(row: StoredRow) => boolean> = []
+    let columns: string[] = []
+    const chain: any = {
+      select: (cols: unknown[]) => {
+        columns = cols.map(String)
+        return chain
+      },
+      where: (...args: unknown[]) => {
+        predicates.push(buildPredicate(args))
+        return chain
+      },
+      execute: async () => {
+        selectCount += 1
+        return rows
+          .filter((row) => predicates.every((matches) => matches(row)))
+          .map((row) => Object.fromEntries(columns.map((column) => [column, columnOf(row, column)])))
+      },
+    }
+    return chain
+  }
+
+  const deleteChain = (table: unknown) => {
+    assertTable(table)
+    const predicates: Array<(row: StoredRow) => boolean> = []
+    const chain: any = {
+      where: (...args: unknown[]) => {
+        predicates.push(buildPredicate(args))
+        return chain
+      },
+      execute: async () => {
+        const kept = rows.filter((row) => !predicates.every((matches) => matches(row)))
+        rows.length = 0
+        rows.push(...kept)
+        return []
+      },
+    }
+    return chain
+  }
+
+  const insertChain = (table: unknown) => {
+    assertTable(table)
+    const chain: any = {
+      values: (values: any[]) => {
+        for (const value of values) {
+          rows.push({
+            id: nextId++,
+            entity_type: String(value.entity_type),
+            entity_id: String(value.entity_id),
+            organization_id: value.organization_id ?? null,
+            tenant_id: value.tenant_id ?? null,
+            field: String(value.field),
+            token_hash: String(value.token_hash),
+            token: value.token ?? null,
+          })
+        }
+        return chain
+      },
+      execute: async () => [],
+    }
+    return chain
+  }
+
+  const db = {
+    selectFrom: selectChain,
+    transaction: () => ({
+      execute: async (callback: (trx: unknown) => Promise<void>) => {
+        transactionCount += 1
+        return callback({ deleteFrom: deleteChain, insertInto: insertChain })
+      },
+    }),
+    deleteFrom: deleteChain,
+  } as unknown as Kysely<any>
+
+  return {
+    db,
+    rows,
+    get transactionCount() {
+      return transactionCount
+    },
+    get selectCount() {
+      return selectCount
+    },
+    rowIds: (entityId?: string) =>
+      rows
+        .filter((row) => entityId === undefined || row.entity_id === entityId)
+        .map((row) => row.id)
+        .sort((a, b) => a - b),
+    insertRaw: (row: Omit<StoredRow, 'id'>) => {
+      rows.push({ ...row, id: nextId++ })
+    },
+    duplicateAll: () => {
+      for (const row of [...rows]) rows.push({ ...row, id: nextId++ })
+    },
+  }
+}
+
+const ENTITY_TYPE = 'sales:sales_order'
+
+const payload = (
+  recordId: string,
+  doc: Record<string, unknown>,
+  scope: { organizationId: string | null; tenantId: string | null } = { organizationId: 'org-1', tenantId: 'tenant-1' }
+) => ({ entityType: ENTITY_TYPE, recordId, organizationId: scope.organizationId, tenantId: scope.tenantId, doc })
+
+const hashOf = (word: string): string => tokenizeText(word, resolveSearchConfig()).hashes[0]
+
+describe('replaceSearchTokensForBatch — skips records whose tokens have not changed', () => {
+  const previousEnv = {
+    enabled: process.env.OM_SEARCH_ENABLED,
+    partials: process.env.OM_SEARCH_ENABLE_PARTIAL,
+    rawTokens: process.env.OM_SEARCH_STORE_RAW_TOKENS,
+  }
+
+  beforeAll(() => {
+    process.env.OM_SEARCH_ENABLED = 'true'
+    // Partials off keeps the token set small and the expected hashes predictable; the skip logic is
+    // independent of how many tokens a field yields.
+    process.env.OM_SEARCH_ENABLE_PARTIAL = 'false'
+  })
+
+  afterEach(() => {
+    if (previousEnv.rawTokens === undefined) delete process.env.OM_SEARCH_STORE_RAW_TOKENS
+    else process.env.OM_SEARCH_STORE_RAW_TOKENS = previousEnv.rawTokens
+  })
+
+  afterAll(() => {
+    if (previousEnv.enabled === undefined) delete process.env.OM_SEARCH_ENABLED
+    else process.env.OM_SEARCH_ENABLED = previousEnv.enabled
+    if (previousEnv.partials === undefined) delete process.env.OM_SEARCH_ENABLE_PARTIAL
+    else process.env.OM_SEARCH_ENABLE_PARTIAL = previousEnv.partials
+  })
+
+  it('leaves an unchanged record untouched instead of deleting and re-inserting its rows', async () => {
+    const store = createSearchTokenStore()
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+    // Vacuity guard: with search disabled the function returns early and every assertion below
+    // would hold for the wrong reason.
+    expect(store.rows.length).toBeGreaterThan(0)
+    const idsBefore = store.rowIds()
+
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+
+    expect(store.rowIds()).toEqual(idsBefore)
+    expect(store.transactionCount).toBe(1)
+    expect(store.selectCount).toBe(2)
+  })
+
+  it('still rewrites a changed record, and the new value is searchable afterwards', async () => {
+    const store = createSearchTokenStore()
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+    expect(store.rows.length).toBeGreaterThan(0)
+    const idsBefore = new Set(store.rowIds())
+
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'beta widget' })])
+
+    expect(store.rows.length).toBeGreaterThan(0)
+    expect(store.rowIds().some((id) => idsBefore.has(id))).toBe(false)
+    expect(store.rows.some((row) => row.token_hash === hashOf('beta'))).toBe(true)
+    expect(store.rows.some((row) => row.token_hash === hashOf('alpha'))).toBe(false)
+    expect(store.transactionCount).toBe(2)
+  })
+
+  it('rewrites a record whose stored rows contain a token the document no longer produces', async () => {
+    const store = createSearchTokenStore()
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+    const seededCount = store.rows.length
+    expect(seededCount).toBeGreaterThan(0)
+    store.insertRaw({
+      entity_type: ENTITY_TYPE,
+      entity_id: 'order-1',
+      organization_id: 'org-1',
+      tenant_id: 'tenant-1',
+      field: 'title',
+      token_hash: 'stale-hash',
+      token: null,
+    })
+
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+
+    expect(store.rows.some((row) => row.token_hash === 'stale-hash')).toBe(false)
+    expect(store.rows.length).toBe(seededCount)
+  })
+
+  it('collapses duplicated stored rows instead of reading them as already correct', async () => {
+    const store = createSearchTokenStore()
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+    const seededCount = store.rows.length
+    expect(seededCount).toBeGreaterThan(0)
+    store.duplicateAll()
+    expect(store.rows.length).toBe(seededCount * 2)
+
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+
+    expect(store.rows.length).toBe(seededCount)
+  })
+
+  it('skips an unchanged record when raw tokens are stored, so a stored NULL is not the only case covered', async () => {
+    process.env.OM_SEARCH_STORE_RAW_TOKENS = 'true'
+    const store = createSearchTokenStore()
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+    expect(store.rows.length).toBeGreaterThan(0)
+    expect(store.rows.every((row) => row.token !== null)).toBe(true)
+    const idsBefore = store.rowIds()
+
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+
+    expect(store.rowIds()).toEqual(idsBefore)
+    expect(store.transactionCount).toBe(1)
+  })
+
+  it('narrows the rewrite to the changed scope bucket', async () => {
+    const store = createSearchTokenStore()
+    const orgOne = { organizationId: 'org-1', tenantId: 'tenant-1' }
+    const orgTwo = { organizationId: 'org-2', tenantId: 'tenant-2' }
+    await replaceSearchTokensForBatch(store.db, [
+      payload('order-1', { title: 'alpha widget' }, orgOne),
+      payload('order-2', { title: 'gamma widget' }, orgTwo),
+    ])
+    expect(store.rowIds('order-1').length).toBeGreaterThan(0)
+    expect(store.rowIds('order-2').length).toBeGreaterThan(0)
+    const untouchedIds = store.rowIds('order-1')
+    const rewrittenIds = new Set(store.rowIds('order-2'))
+
+    await replaceSearchTokensForBatch(store.db, [
+      payload('order-1', { title: 'alpha widget' }, orgOne),
+      payload('order-2', { title: 'delta widget' }, orgTwo),
+    ])
+
+    expect(store.rowIds('order-1')).toEqual(untouchedIds)
+    expect(store.rowIds('order-2').some((id) => rewrittenIds.has(id))).toBe(false)
+    expect(store.rows.some((row) => row.token_hash === hashOf('delta'))).toBe(true)
+  })
+
+  it('deletes the stored rows of a record that no longer produces tokens', async () => {
+    const store = createSearchTokenStore()
+    await replaceSearchTokensForBatch(store.db, [
+      payload('order-1', { title: 'alpha widget' }),
+      payload('order-2', { title: 'gamma widget' }),
+    ])
+    expect(store.rowIds('order-1').length).toBeGreaterThan(0)
+    const survivingIds = store.rowIds('order-2')
+    expect(survivingIds.length).toBeGreaterThan(0)
+
+    await replaceSearchTokensForBatch(store.db, [
+      payload('order-1', { title: '' }),
+      payload('order-2', { title: 'gamma widget' }),
+    ])
+
+    expect(store.rowIds('order-1')).toEqual([])
+    expect(store.rowIds('order-2')).toEqual(survivingIds)
+  })
+})

--- a/packages/core/src/modules/query_index/__tests__/search-tokens-unchanged-skip.test.ts
+++ b/packages/core/src/modules/query_index/__tests__/search-tokens-unchanged-skip.test.ts
@@ -26,9 +26,9 @@ const columnOf = (row: StoredRow, column: string): unknown => (row as unknown as
  */
 function createSearchTokenStore() {
   const rows: StoredRow[] = []
+  const reads: Array<{ kind: 'count' | 'rows'; rowCount: number }> = []
   let nextId = 1
   let transactionCount = 0
-  let selectCount = 0
 
   const assertTable = (table: unknown) => {
     if (String(table) !== 'search_tokens') throw new Error(`[internal] unexpected table: ${String(table)}`)
@@ -54,20 +54,46 @@ function createSearchTokenStore() {
     assertTable(table)
     const predicates: Array<(row: StoredRow) => boolean> = []
     let columns: string[] = []
+    let limit: number | null = null
+    let groupedBy: string | null = null
     const chain: any = {
+      // The count probe's select list contains a Kysely aggregate builder rather than a column
+      // name, so the grouped branch below keys off groupBy() instead of parsing it.
       select: (cols: unknown[]) => {
-        columns = cols.map(String)
+        columns = cols.filter((col) => typeof col === 'string').map(String)
         return chain
       },
       where: (...args: unknown[]) => {
         predicates.push(buildPredicate(args))
         return chain
       },
+      groupBy: (column: unknown) => {
+        groupedBy = String(column)
+        return chain
+      },
+      limit: (count: number) => {
+        limit = count
+        return chain
+      },
       execute: async () => {
-        selectCount += 1
-        return rows
-          .filter((row) => predicates.every((matches) => matches(row)))
-          .map((row) => Object.fromEntries(columns.map((column) => [column, columnOf(row, column)])))
+        const matched = rows.filter((row) => predicates.every((matches) => matches(row)))
+        if (groupedBy) {
+          const counts = new Map<string, number>()
+          for (const row of matched) {
+            const groupKey = String(columnOf(row, groupedBy))
+            counts.set(groupKey, (counts.get(groupKey) ?? 0) + 1)
+          }
+          reads.push({ kind: 'count', rowCount: counts.size })
+          return Array.from(counts.entries()).map(([groupKey, count]) => ({
+            [groupedBy as string]: groupKey,
+            token_count: String(count),
+          }))
+        }
+        const limited = limit === null ? matched : matched.slice(0, limit)
+        reads.push({ kind: 'rows', rowCount: limited.length })
+        return limited.map((row) =>
+          Object.fromEntries(columns.map((column) => [column, columnOf(row, column)]))
+        )
       },
     }
     return chain
@@ -131,8 +157,8 @@ function createSearchTokenStore() {
     get transactionCount() {
       return transactionCount
     },
-    get selectCount() {
-      return selectCount
+    get reads() {
+      return reads
     },
     rowIds: (entityId?: string) =>
       rows
@@ -196,7 +222,8 @@ describe('replaceSearchTokensForBatch — skips records whose tokens have not ch
 
     expect(store.rowIds()).toEqual(idsBefore)
     expect(store.transactionCount).toBe(1)
-    expect(store.selectCount).toBe(2)
+    // Whatever the table holds, the rows pulled into memory stay bounded by what was just built.
+    expect(store.reads.filter((read) => read.kind === 'rows').every((read) => read.rowCount <= idsBefore.length)).toBe(true)
   })
 
   it('still rewrites a changed record, and the new value is searchable afterwards', async () => {
@@ -246,6 +273,37 @@ describe('replaceSearchTokensForBatch — skips records whose tokens have not ch
     await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
 
     expect(store.rows.length).toBe(seededCount)
+  })
+
+  it('rewrites a bucket whose stored rows exceed the built count without reading the full stored set', async () => {
+    const store = createSearchTokenStore()
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+    const builtCount = store.rows.length
+    expect(builtCount).toBeGreaterThan(0)
+    // Far more stored rows than the document produces — the shape #4681 reports, and the case an
+    // unbounded read would pull into memory in full.
+    for (let index = 0; index < 200; index += 1) {
+      store.insertRaw({
+        entity_type: ENTITY_TYPE,
+        entity_id: 'order-1',
+        organization_id: 'org-1',
+        tenant_id: 'tenant-1',
+        field: 'title',
+        token_hash: `stale-${index}`,
+        token: null,
+      })
+    }
+    expect(store.rows.length).toBe(builtCount + 200)
+    const readsBefore = store.reads.length
+
+    await replaceSearchTokensForBatch(store.db, [payload('order-1', { title: 'alpha widget' })])
+
+    expect(store.rows.length).toBe(builtCount)
+    expect(store.rows.some((row) => row.token_hash.startsWith('stale-'))).toBe(false)
+    // The count probe alone settles it: the stored count already differs, so none of the 200
+    // surplus rows are ever pulled into memory.
+    const readsDuringCall = store.reads.slice(readsBefore)
+    expect(readsDuringCall.map((read) => read.kind)).toEqual(['count'])
   })
 
   it('skips an unchanged record when raw tokens are stored, so a stored NULL is not the only case covered', async () => {

--- a/packages/core/src/modules/query_index/lib/search-tokens.ts
+++ b/packages/core/src/modules/query_index/lib/search-tokens.ts
@@ -223,6 +223,49 @@ export async function deleteSearchTokensForRecord(
     .execute()
 }
 
+// NUL, not a printable separator: a field name may itself contain a space, so `a b` + hash `c`
+// would otherwise sign identically to field `a` + hash `b c`.
+const SIGNATURE_SEPARATOR = String.fromCharCode(0)
+
+// Identifies one token row for comparison. `token` is NULL unless `storeRawTokens` is on, and a
+// stored NULL has to sign the same as the `null` a freshly built row carries — otherwise every
+// record compares as changed and the skip never fires.
+function tokenSignature(row: { field?: unknown; token_hash?: unknown; token?: unknown }): string {
+  return [
+    String(row.field ?? ''),
+    String(row.token_hash ?? ''),
+    row.token == null ? '' : String(row.token),
+  ].join(SIGNATURE_SEPARATOR)
+}
+
+// Multiplicities, not sets: #4681 reports token rows duplicated by the concurrent-replacement
+// defect, and a set comparison reads such a record as already correct and preserves the duplicates
+// forever. Counting sends it through a full rewrite, which collapses them.
+function tallyEquals(a: Map<string, number> | undefined, b: Map<string, number> | undefined): boolean {
+  const left = a ?? new Map<string, number>()
+  const right = b ?? new Map<string, number>()
+  if (left.size !== right.size) return false
+  for (const [key, count] of left.entries()) {
+    if (right.get(key) !== count) return false
+  }
+  return true
+}
+
+function tallyTokenRows<TRow extends { field?: unknown; token_hash?: unknown; token?: unknown }>(
+  rows: Iterable<TRow>,
+  keyOf: (row: TRow) => string
+): Map<string, Map<string, number>> {
+  const tallies = new Map<string, Map<string, number>>()
+  for (const row of rows) {
+    const key = keyOf(row)
+    const tally = tallies.get(key) ?? new Map<string, number>()
+    const signature = tokenSignature(row)
+    tally.set(signature, (tally.get(signature) ?? 0) + 1)
+    tallies.set(key, tally)
+  }
+  return tallies
+}
+
 export async function replaceSearchTokensForBatch(
   db: Kysely<any>,
   payloads: Array<BuildTokenOptions & { doc: Record<string, unknown> }>
@@ -256,8 +299,47 @@ export async function replaceSearchTokensForBatch(
     scopeBuckets.set(key, bucket)
   }
 
+  const recordKeyOf = (row: SearchTokenRow) =>
+    `${scopeKey(row.organization_id ?? null, row.tenant_id ?? null)}|${String(row.entity_id)}`
+  const builtTally = tallyTokenRows(rows, recordKeyOf)
+
+  // Read outside the transaction, deliberately: this comparison can only ever decide to *skip*
+  // work. The worst a concurrent writer can do is cost us a rewrite we declined — and we declined
+  // it because the table already held exactly the rows this call wanted to write.
+  const changedIdsByBucket = new Map<string, Set<string>>()
+  for (const [key, bucket] of scopeBuckets.entries()) {
+    const ids = Array.from(bucket.ids)
+    const stored = await db
+      .selectFrom('search_tokens' as any)
+      .select(['entity_id' as any, 'field' as any, 'token_hash' as any, 'token' as any])
+      .where('entity_type' as any, '=', payloads[0].entityType)
+      .where(sql<boolean>`organization_id is not distinct from ${bucket.organizationId}`)
+      .where(sql<boolean>`tenant_id is not distinct from ${bucket.tenantId}`)
+      .where('entity_id' as any, 'in', ids)
+      .execute()
+    const storedTally = tallyTokenRows(stored as any[], (row) => String(row.entity_id))
+    const changed = new Set<string>()
+    for (const id of ids) {
+      if (!tallyEquals(builtTally.get(`${key}|${id}`), storedTally.get(id))) changed.add(id)
+    }
+    changedIdsByBucket.set(key, changed)
+  }
+
+  const changedRecordKeys = new Set<string>()
+  for (const [key, changed] of changedIdsByBucket.entries()) {
+    for (const id of changed) changedRecordKeys.add(`${key}|${id}`)
+  }
+  debug('batch.skip', {
+    entityType: payloads[0].entityType,
+    recordCount: payloads.length,
+    changedCount: changedRecordKeys.size,
+  })
+  if (!changedRecordKeys.size) return
+
   await db.transaction().execute(async (trx) => {
-    for (const [, bucket] of scopeBuckets.entries()) {
+    for (const [key, bucket] of scopeBuckets.entries()) {
+      const changed = changedIdsByBucket.get(key)
+      if (!changed?.size) continue
       // Delete by entity_id: a batch replaces all of a record's tokens, and a per-field OR over the
       // whole batch overflows the query compiler's call stack on large batches.
       const deleteQuery = trx
@@ -265,10 +347,12 @@ export async function replaceSearchTokensForBatch(
         .where('entity_type' as any, '=', payloads[0].entityType)
         .where(sql<boolean>`organization_id is not distinct from ${bucket.organizationId}`)
         .where(sql<boolean>`tenant_id is not distinct from ${bucket.tenantId}`)
-        .where('entity_id' as any, 'in', Array.from(bucket.ids))
+        .where('entity_id' as any, 'in', Array.from(changed))
       await deleteQuery.execute()
     }
-    const payloadWithTimestamps = rows.map((row) => ({ ...row, created_at: sql`now()` }))
+    const payloadWithTimestamps = rows
+      .filter((row) => changedRecordKeys.has(recordKeyOf(row)))
+      .map((row) => ({ ...row, created_at: sql`now()` }))
     for (const batch of chunk(payloadWithTimestamps, INSERT_BATCH_SIZE)) {
       await trx.insertInto('search_tokens' as any).values(batch as any).execute()
     }

--- a/packages/core/src/modules/query_index/lib/search-tokens.ts
+++ b/packages/core/src/modules/query_index/lib/search-tokens.ts
@@ -303,24 +303,72 @@ export async function replaceSearchTokensForBatch(
     `${scopeKey(row.organization_id ?? null, row.tenant_id ?? null)}|${String(row.entity_id)}`
   const builtTally = tallyTokenRows(rows, recordKeyOf)
 
-  // Read outside the transaction, deliberately: this comparison can only ever decide to *skip*
-  // work. The worst a concurrent writer can do is cost us a rewrite we declined — and we declined
-  // it because the table already held exactly the rows this call wanted to write.
+  // Read outside the transaction, deliberately. The comparison decides only whether to skip a
+  // rewrite, so a concurrent writer costs us at most a rewrite we declined — declined because the
+  // table already held exactly the rows this call wanted to write. One ordering is worth naming
+  // though: if the read matches and a concurrent writer then commits tokens built from a *staler*
+  // doc, the unconditional rewrite this call used to perform would have overwritten them by
+  // accident. It no longer does, so those stale rows survive until the record's next write. That
+  // is a repair we lose, not a guarantee we break.
   const changedIdsByBucket = new Map<string, Set<string>>()
   for (const [key, bucket] of scopeBuckets.entries()) {
     const ids = Array.from(bucket.ids)
-    const stored = await db
+    const builtCountById = new Map<string, number>()
+    for (const id of ids) {
+      let total = 0
+      const tally = builtTally.get(`${key}|${id}`)
+      if (tally) for (const count of tally.values()) total += count
+      builtCountById.set(id, total)
+    }
+
+    // Count probe first. Its result is one row per record in the batch, so it is bounded by the
+    // batch size — unlike a bare row read, which would be bounded only by how many token rows the
+    // table already holds for these ids, a quantity this function does not control and (per #4681)
+    // has no reason to trust.
+    const storedCounts = await db
       .selectFrom('search_tokens' as any)
-      .select(['entity_id' as any, 'field' as any, 'token_hash' as any, 'token' as any])
+      .select(['entity_id' as any, sql<number>`count(*)`.as('token_count') as any])
       .where('entity_type' as any, '=', payloads[0].entityType)
       .where(sql<boolean>`organization_id is not distinct from ${bucket.organizationId}`)
       .where(sql<boolean>`tenant_id is not distinct from ${bucket.tenantId}`)
       .where('entity_id' as any, 'in', ids)
+      .groupBy('entity_id' as any)
       .execute()
-    const storedTally = tallyTokenRows(stored as any[], (row) => String(row.entity_id))
+    const storedCountById = new Map<string, number>()
+    for (const row of storedCounts as any[]) {
+      storedCountById.set(String(row.entity_id), Number(row.token_count))
+    }
+
     const changed = new Set<string>()
-    for (const id of ids) {
-      if (!tallyEquals(builtTally.get(`${key}|${id}`), storedTally.get(id))) changed.add(id)
+    // A record whose stored row count already differs is changed, whatever the rows say — the
+    // duplicate case from #4681 resolves here without ever materializing the duplicated rows.
+    const contentCandidates = ids.filter((id) => {
+      const builtCount = builtCountById.get(id) ?? 0
+      if ((storedCountById.get(id) ?? 0) !== builtCount) {
+        changed.add(id)
+        return false
+      }
+      return builtCount > 0
+    })
+
+    if (contentCandidates.length) {
+      const rowBudget = contentCandidates.reduce((sum, id) => sum + (builtCountById.get(id) ?? 0), 0)
+      const stored = await db
+        .selectFrom('search_tokens' as any)
+        .select(['entity_id' as any, 'field' as any, 'token_hash' as any, 'token' as any])
+        .where('entity_type' as any, '=', payloads[0].entityType)
+        .where(sql<boolean>`organization_id is not distinct from ${bucket.organizationId}`)
+        .where(sql<boolean>`tenant_id is not distinct from ${bucket.tenantId}`)
+        .where('entity_id' as any, 'in', contentCandidates)
+        // Counts already match, so this cannot truncate — it bounds the damage if a concurrent
+        // writer inserts between the probe and this read. A truncated read compares as changed,
+        // which costs a rewrite rather than a wrong skip.
+        .limit(rowBudget)
+        .execute()
+      const storedTally = tallyTokenRows(stored as any[], (row) => String(row.entity_id))
+      for (const id of contentCandidates) {
+        if (!tallyEquals(builtTally.get(`${key}|${id}`), storedTally.get(id))) changed.add(id)
+      }
     }
     changedIdsByBucket.set(key, changed)
   }


### PR DESCRIPTION
## Summary

Re-indexing a record throws away all of its search tokens and writes them again from scratch — every time, whether or not the record's searchable text actually changed. Nothing in the path asks whether anything moved.

That is invisible when a single record is edited. It dominates a full re-index or a data-sync backfill, which walks every record in the system with nearly all of them unchanged, and every one of them still pays the full cost: two write operations per token, each maintaining a primary key and three secondary indexes, each leaving a dead row behind for vacuum. `search_tokens`' own migration notes that the table is high-churn and that its row count scales with records × tokens, so this is the largest write amplifier in the indexing path.

The fix is to ask first: read the batch's stored tokens once per scope bucket, compare against the ones just built, and skip any record whose stored set already matches. A record that genuinely changed still costs a full rewrite, exactly as before; an unchanged record now costs one indexed read and no writes at all.

This finishes an already-accepted rule rather than proposing a new one — #5145 (*"perf(sales): index tag assignments by document_id and stop rewriting unchanged tag sets"*) applied exactly this rule to tag assignments and is merged. `search_tokens` is the one place it was never applied, and by a wide margin the most expensive one.

## Changes

- `replaceSearchTokensForBatch` gains a comparison pass before the write transaction, in two steps. A `count(*) ... group by entity_id` probe returns one row per record in the batch; any record whose stored count already differs from its built count is marked changed there and then. Only records whose counts match need their content compared, and that read is bounded by the built row count for exactly those records — which `OM_SEARCH_MAX_TOKENS_PER_RECORD` already caps. Both queries are covered by the existing `search_tokens_entity_idx` on `(entity_type, entity_id)`.
- The memory resident set is therefore a function of what was just built and of the batch size, never of how many rows the table happens to hold for those ids.
- Inside the transaction, the delete is narrowed to the changed ids per scope bucket and the insert to the changed records' rows; when nothing in the batch changed, the transaction is never opened.
- New unit test file covering the skip, the rewrite, and the ways each can silently fail.
- `replaceSearchTokensForRecord` (the single-record path) is untouched: it already deletes by `(entity_id, field)` pairs rather than wholesale, and it is not on the backfill's hot path.

Three details the comparison depends on, each with a silent failure mode:

**Compare the tokens, not `entity_indexes.doc`.** The obvious version — diff the built doc against the stored doc, skip if equal — is inert on exactly the records that matter. A doc carrying an encrypted field is re-encrypted under a fresh IV on every build, so stored and rebuilt docs are never byte-equal. That version looks implemented, changes nothing, and gives no signal that it isn't working.

**Compare multiplicities, not the set.** Token rows can already be duplicated in the table by the concurrent-replacement defect in #4681. A `Set` comparison reads such a record as *already correct*, skips it, and the duplicates survive forever. Counting occurrences sends it through a full rewrite instead, which collapses them — so the skip is self-healing rather than duplicate-preserving. Fixing that defect is out of scope here; it is only the reason multiplicities are compared.

**`token` is NULL unless `storeRawTokens` is on.** A stored NULL has to produce the same signature as the `null` a freshly built row carries. Get this wrong and every record compares as changed, the skip never fires, and the change is a no-op that still passes a naive test.

**The read sits outside the transaction, deliberately.** It can only ever decide to *skip* work. The worst a concurrent writer can do is cost us a rewrite we declined — and we declined it because the table already held exactly the rows this call wanted to write.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

N/A — single-function change inside one module, applying a rule already established and merged in #5145 rather than introducing new architecture.

## Testing

Ran on this branch, rebased on `develop`:

- `yarn build:packages` — 25/25 packages
- `yarn generate` — clean, no generated churn
- `yarn typecheck` — 25/25 packages
- `eslint` on both touched files — clean
- `yarn workspace @open-mercato/core test` — **1369 suites / 10854 tests, all passing**

New: `packages/core/src/modules/query_index/__tests__/search-tokens-unchanged-skip.test.ts`, over an in-memory `search_tokens` double whose rows carry synthetic ids. Row **identity** is the assertion throughout, not row count — a delete-then-reinsert of the same tokens leaves the count identical and every id different, so a count assertion would pass whether or not the fix works.

| Test | Catches |
|---|---|
| Unchanged record keeps its row ids, no write transaction opened | The fix not firing at all |
| Changed record gets all-new row ids, and the new value is searchable afterwards | The fix being "satisfied" by never writing tokens |
| A stored row the document no longer produces forces a rewrite | Comparison too permissive on the stored side |
| Duplicated stored rows (×2) collapse back to the seeded count | A `Set` comparison preserving duplicates forever |
| Skip still fires with `OM_SEARCH_STORE_RAW_TOKENS=true` | The stored-NULL signature being the only case that works |
| Multi-scope batch rewrites only the changed bucket | Over-broad delete across tenants/organizations |
| A record that stops producing tokens has its rows deleted while a sibling is skipped | Stale tokens surviving a record going empty |
| A record with far more stored rows than it builds is rewritten, and the count probe alone settles it — no row read | An unbounded read materializing the surplus rows |

Every test asserts the seed actually wrote tokens first — with search disabled the function returns early and "nothing was rewritten" would hold for the wrong reason.

The suite was mutation-checked in both directions: forcing the comparison to always report *changed* fails the four skip assertions while the vacuity guards still pass; forcing it to always report *unchanged* fails all eight. Removing the count-probe short-circuit fails four, including the bounded-read assertion.

**Not covered:** the concurrent-writer argument above is reasoned, not tested — the fake DB has no concurrency, so the `limit` on the content read (which only matters if a writer inserts between the probe and the read) has no test of its own. There is no benchmark in CI, so the win is argued from the write counts in the diff rather than measured by the suite.

## Checklist

- [x] This pull request targets `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`). — **left unticked deliberately: an agent must not accept a legal agreement on a contributor's behalf. @maxidragon to tick.**
- [x] I updated documentation, locales, or generators if the change requires it. — none required: no user-facing strings, no generator inputs changed, and `yarn generate` produces no churn (verified).
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — **documented, not added.** The change has no UI surface and no API route; it is a write-path behavior inside the indexer. The integration harness here is Playwright browser tests, which cannot observe `search_tokens` row identity — the assertion this change actually needs. Unit coverage over the DB write path is the level that can catch it.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — no new spec (see Specification above), but `.ai/specs/2026-07-30-search-tokens-unbounded-growth.md` had its duplicate-healing risk row and changelog updated to describe how this change interacts with it, per review.
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [ ] QA routing set.

The three label boxes are unticked because the account opening this PR has `read` permission on this repo and cannot apply labels. Intended values and rationale are in a follow-up comment for a maintainer to apply.

### Design System Compliance

**N/A — this PR touches no `.tsx`, nothing under `packages/ui/`, and no component. Two files, both in `packages/core/src/modules/query_index/`.**

- [ ] No hardcoded status colors
- [ ] No arbitrary text sizes
- [ ] Empty state handled for list/data pages
- [ ] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons
- [ ] Uses existing DS components

## Linked issues

Relates to #4681 — the non-idempotent DELETE+INSERT behavior this changes. It does not close it: the concurrent-replacement duplicate defect is a separate fix, and this PR only makes the skip self-healing against duplicates rather than duplicate-preserving.

Follows #5145, which established this rule for tag assignments.
