### PR TITLE
fix(events): keep EventBridge alive on SSE heartbeats

### DIFF
--- a/.ai/specs/implemented/SPEC-041c-events-dom-bridge.md
+++ b/.ai/specs/implemented/SPEC-041c-events-dom-bridge.md
@@ -610,7 +610,7 @@ export default {
 ### SSE Endpoint
 - Implemented at `packages/events/src/modules/events/api/stream/route.ts`
 - Uses `ReadableStream` with SSE format (`text/event-stream`)
-- Heartbeat every 30s (`:heartbeat\n\n`)
+- Named heartbeat event every 30s (`event: heartbeat\ndata: {}\n\n`) so browser `EventSource` clients can reset their liveness watchdog
 - Global connection registry pattern: single `*` event bus handler broadcasts to all SSE connections
 - Connection context MUST include `tenantId`, `organizationId`, `userId`, and `roleIds`
 - Server-side audience filtering MUST enforce tenant + organization + recipient user/role checks before enqueueing event to stream
@@ -660,4 +660,5 @@ export default {
 
 ## Changelog
 
+- 2026-08-19: Made staff and portal SSE heartbeats observable as named events so their 45-second client watchdogs no longer reconnect healthy 30-second streams.
 - 2026-02-25: Added mandatory server-side audience filtering contract (tenant/org/user/role), added negative isolation integration coverage requirements (E11-E13), and aligned implementation notes with `/api/events/stream`.

--- a/packages/core/src/modules/customer_accounts/api/portal/events/__tests__/stream.test.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/events/__tests__/stream.test.ts
@@ -213,4 +213,23 @@ describe('Portal SSE event stream — abort listener hygiene', () => {
 
     try { await (res.body as ReadableStream).cancel() } catch {}
   })
+
+  it('emits a named heartbeat event that browser EventSource clients can observe', async () => {
+    jest.useFakeTimers()
+    const res = await GET(makeTrackedRequest().req)
+    const reader = res.body!.getReader()
+
+    try {
+      await drainConnectedComment(reader)
+      const heartbeat = reader.read()
+      jest.advanceTimersByTime(30_000)
+
+      const { value, done } = await heartbeat
+      expect(done).toBe(false)
+      expect(new TextDecoder().decode(value)).toBe('event: heartbeat\ndata: {}\n\n')
+    } finally {
+      await reader.cancel().catch(() => undefined)
+      jest.useRealTimers()
+    }
+  })
 })

--- a/packages/core/src/modules/customer_accounts/api/portal/events/stream.ts
+++ b/packages/core/src/modules/customer_accounts/api/portal/events/stream.ts
@@ -181,7 +181,7 @@ export async function GET(req: Request): Promise<Response> {
 
       heartbeatTimer = setInterval(() => {
         try {
-          controller.enqueue(encoder.encode(':heartbeat\n\n'))
+          controller.enqueue(encoder.encode('event: heartbeat\ndata: {}\n\n'))
         } catch {
           // Stream may have been closed
         }

--- a/packages/events/src/modules/events/api/stream/__tests__/route.test.ts
+++ b/packages/events/src/modules/events/api/stream/__tests__/route.test.ts
@@ -104,6 +104,26 @@ describe('SSE event stream — abort listener hygiene', () => {
     try { await reader.cancel() } catch {}
   })
 
+  it('emits a named heartbeat event that browser EventSource clients can observe', async () => {
+    jest.useFakeTimers()
+    const { req } = makeTrackedRequest()
+    const res = await GET(req)
+    const reader = (res.body as ReadableStream<Uint8Array>).getReader()
+
+    try {
+      await reader.read()
+      const heartbeat = reader.read()
+      jest.advanceTimersByTime(30_000)
+
+      const { value, done } = await heartbeat
+      expect(done).toBe(false)
+      expect(new TextDecoder().decode(value)).toBe('event: heartbeat\ndata: {}\n\n')
+    } finally {
+      try { await reader.cancel() } catch {}
+      jest.useRealTimers()
+    }
+  })
+
   it('uses trusted organization scope when the payload omits it', async () => {
     const { req } = makeTrackedRequest()
     const res = await GET(req)

--- a/packages/events/src/modules/events/api/stream/route.ts
+++ b/packages/events/src/modules/events/api/stream/route.ts
@@ -261,7 +261,7 @@ export async function GET(req: Request): Promise<Response> {
       // Start heartbeat to keep connection alive
       heartbeatTimer = setInterval(() => {
         try {
-          controller.enqueue(encoder.encode(':heartbeat\n\n'))
+          controller.enqueue(encoder.encode('event: heartbeat\ndata: {}\n\n'))
         } catch {
           // Stream may have been closed
         }

--- a/packages/ui/src/backend/injection/__tests__/eventBridgeHeartbeat.test.tsx
+++ b/packages/ui/src/backend/injection/__tests__/eventBridgeHeartbeat.test.tsx
@@ -1,0 +1,81 @@
+/** @jest-environment jsdom */
+import { act, renderHook } from '@testing-library/react'
+import { useEventBridge } from '../eventBridge'
+import { usePortalEventBridge } from '../../../portal/hooks/usePortalEventBridge'
+
+type EventSourceCallback = EventListenerOrEventListenerObject
+
+class MockEventSource {
+  static instances: MockEventSource[] = []
+
+  readonly close = jest.fn()
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  private readonly listeners = new Map<string, Set<EventSourceCallback>>()
+
+  constructor() {
+    MockEventSource.instances.push(this)
+  }
+
+  addEventListener(type: string, callback: EventSourceCallback | null): void {
+    if (!callback) return
+    const callbacks = this.listeners.get(type) ?? new Set<EventSourceCallback>()
+    callbacks.add(callback)
+    this.listeners.set(type, callbacks)
+  }
+
+  emitOpen(): void {
+    this.onopen?.(new Event('open'))
+  }
+
+  emitHeartbeat(): void {
+    const event = new MessageEvent('heartbeat', { data: '{}' })
+    for (const callback of this.listeners.get('heartbeat') ?? []) {
+      if (typeof callback === 'function') callback(event)
+      else callback.handleEvent(event)
+    }
+  }
+}
+
+describe.each([
+  ['staff', useEventBridge],
+  ['portal', usePortalEventBridge],
+] as const)('%s EventBridge heartbeat watchdog', (_surface, useBridge) => {
+  const originalEventSource = globalThis.EventSource
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    MockEventSource.instances = []
+    Object.defineProperty(globalThis, 'EventSource', {
+      configurable: true,
+      writable: true,
+      value: MockEventSource as unknown as typeof EventSource,
+    })
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    Object.defineProperty(globalThis, 'EventSource', {
+      configurable: true,
+      writable: true,
+      value: originalEventSource,
+    })
+  })
+
+  it('keeps the connection alive when a named heartbeat arrives before the timeout', () => {
+    const { unmount } = renderHook(() => useBridge())
+    const source = MockEventSource.instances[0]
+
+    act(() => source.emitOpen())
+    act(() => jest.advanceTimersByTime(30_000))
+    act(() => source.emitHeartbeat())
+    act(() => jest.advanceTimersByTime(16_000))
+
+    expect(source.close).not.toHaveBeenCalled()
+    expect(MockEventSource.instances).toHaveLength(1)
+
+    unmount()
+  })
+})

--- a/packages/ui/src/backend/injection/eventBridge.ts
+++ b/packages/ui/src/backend/injection/eventBridge.ts
@@ -76,6 +76,7 @@ export function useEventBridge(): void {
       try {
         const source = new EventSource(SSE_ENDPOINT, { withCredentials: true })
         sourceRef.current = source
+        source.addEventListener('heartbeat', resetHeartbeatTimer)
 
         source.onopen = () => {
           const shouldEmitReconnect = hasEverConnected.current && reconnectPending.current

--- a/packages/ui/src/portal/hooks/__tests__/usePortalEventBridge.test.tsx
+++ b/packages/ui/src/portal/hooks/__tests__/usePortalEventBridge.test.tsx
@@ -14,6 +14,7 @@ class EventSourceMock {
   onopen: ((event: Event) => void) | null = null
   onmessage: ((event: MessageEvent) => void) | null = null
   onerror: ((event: Event) => void) | null = null
+  addEventListener = jest.fn()
   close = jest.fn()
 
   constructor() {

--- a/packages/ui/src/portal/hooks/usePortalEventBridge.ts
+++ b/packages/ui/src/portal/hooks/usePortalEventBridge.ts
@@ -76,6 +76,7 @@ export function usePortalEventBridge(): void {
       try {
         const source = new EventSource(PORTAL_SSE_ENDPOINT, { withCredentials: true })
         sourceRef.current = source
+        source.addEventListener('heartbeat', resetHeartbeatTimer)
 
         source.onopen = () => {
           const shouldEmitReconnect = hasEverConnected.current && reconnectPending.current


### PR DESCRIPTION
## What

- emit named `heartbeat` SSE events from the staff and portal EventBridge endpoints
- reset both client watchdogs when that named event arrives
- add server-frame and client-liveness regressions
- align SPEC-041c implementation notes with the observable heartbeat contract

## Why

SSE comments are intentionally ignored by browser `EventSource`. The previous
30-second `:heartbeat` comments therefore could not reset the clients'
45-second watchdogs, so healthy idle streams reconnected.

## Risk

High because this changes the liveness contract for both staff and portal
real-time connections. Application event payloads, audience filtering,
authentication, reconnect backoff, and endpoints are unchanged. Named SSE
events are standards-compliant and ignored by clients that do not subscribe to
them.

## Local validation evidence

- staff and portal watchdog regression: 3/3 tests pass across the new liveness coverage and existing portal health lifecycle
- staff SSE route: 10/10 tests pass
- portal SSE route: 5/5 tests pass
- `yarn install --immutable`
- `yarn generate`
- `yarn build:packages` (25/25 tasks, both required passes)
- `yarn i18n:check-sync`
- `yarn i18n:check-usage` (advisory unused-key report only)
- `yarn typecheck` (25/25 tasks)
- `yarn lint` (0 errors; 10 pre-existing warnings outside this patch)
- isolated `@open-mercato/cli` suite: 89/89 suites, 1,729/1,729 tests

The full monorepo test run passed 31/32 package tasks; the CLI task had a
parallel-only failure and passed immediately when isolated. `yarn build:app`
is inconclusive in this runner: both restricted and unrestricted attempts stop
in Turbopack while creating a worker because binding its internal port is not
permitted. The error occurs while processing the unchanged
`@xyflow/react/dist/style.css` dependency.

The full suite and application build are therefore not independently green.

## Pending gates

- normal upstream CI is pending
- browser/manual QA is pending
- the CLA check is pending

## Maintainer action

The contributor account cannot apply repository labels. Please add
`priority-high`, `risk-high`, and `needs-qa` to this draft PR.

Fixes #5406
