### PR TITLE
fix(docker): sync role ACLs on redeploy so newly enabled modules stay reachable

### DIFF
--- a/docker/scripts/init-or-migrate.sh
+++ b/docker/scripts/init-or-migrate.sh
@@ -4,6 +4,7 @@ set -e
 MARKER_FILE="${INIT_MARKER_FILE:-/tmp/init-marker/.seeded}"
 INIT_COMMAND="${INIT_COMMAND:-yarn initialize}"
 MIGRATE_COMMAND="${MIGRATE_COMMAND:-yarn db:migrate}"
+SYNC_ROLE_ACLS_COMMAND="${SYNC_ROLE_ACLS_COMMAND:-yarn mercato auth sync-role-acls}"
 ALREADY_INITIALIZED_PATTERN='Initialization aborted: found [0-9][0-9]* existing user\(s\) in the database\.'
 CLI_NOT_FOUND_PATTERN='command not found: mercato'
 
@@ -11,11 +12,15 @@ run_command_with_cli_recovery() {
   COMMAND="$1"
   LOG_FILE="$2"
 
-  if sh -lc "${COMMAND}" >"${LOG_FILE}" 2>&1; then
+  # `STATUS=$?` after a failed `if ...; then ...; fi` reads the compound statement's own
+  # status, which POSIX defines as 0 — so every failure used to be reported as success and
+  # a broken migration silently fell through to `yarn start`. Capture the status directly.
+  STATUS=0
+  sh -lc "${COMMAND}" >"${LOG_FILE}" 2>&1 || STATUS=$?
+
+  if [ "${STATUS}" -eq 0 ]; then
     return 0
   fi
-
-  STATUS=$?
 
   if ! grep -Fq "${CLI_NOT_FOUND_PATTERN}" "${LOG_FILE}"; then
     return "${STATUS}"
@@ -24,6 +29,23 @@ run_command_with_cli_recovery() {
   echo "Open Mercato CLI missing; running yarn install and retrying..."
   yarn install
   sh -lc "${COMMAND}" >"${LOG_FILE}" 2>&1
+}
+
+# Modules enabled after the database was first seeded declare new `defaultRoleFeatures`
+# that existing tenants never received — `mercato init` applies them only at bootstrap.
+# The sync command is idempotent, so run it after every migration and keep it non-fatal:
+# a stale grant set must not block the container from starting.
+sync_role_acls() {
+  SYNC_LOG_FILE="$(mktemp)"
+
+  if run_command_with_cli_recovery "${SYNC_ROLE_ACLS_COMMAND}" "${SYNC_LOG_FILE}"; then
+    cat "${SYNC_LOG_FILE}"
+  else
+    echo "WARNING: role ACL sync failed; newly enabled modules may be inaccessible until it is run manually."
+    cat "${SYNC_LOG_FILE}"
+  fi
+
+  rm -f "${SYNC_LOG_FILE}"
 }
 
 if [ ! -f "${MARKER_FILE}" ]; then
@@ -48,6 +70,7 @@ if [ ! -f "${MARKER_FILE}" ]; then
       if run_command_with_cli_recovery "${MIGRATE_COMMAND}" "${RECOVERY_LOG_FILE}"; then
         cat "${RECOVERY_LOG_FILE}"
         rm -f "${RECOVERY_LOG_FILE}"
+        sync_role_acls
       else
         RECOVERY_STATUS=$?
         cat "${RECOVERY_LOG_FILE}"
@@ -70,6 +93,7 @@ LOG_FILE="$(mktemp)"
 if run_command_with_cli_recovery "${MIGRATE_COMMAND}" "${LOG_FILE}"; then
   cat "${LOG_FILE}"
   rm -f "${LOG_FILE}"
+  sync_role_acls
   exit 0
 fi
 

--- a/packages/create-app/template/docker/scripts/init-or-migrate.sh
+++ b/packages/create-app/template/docker/scripts/init-or-migrate.sh
@@ -4,6 +4,7 @@ set -e
 MARKER_FILE="${INIT_MARKER_FILE:-/tmp/init-marker/.seeded}"
 INIT_COMMAND="${INIT_COMMAND:-yarn initialize}"
 MIGRATE_COMMAND="${MIGRATE_COMMAND:-yarn db:migrate}"
+SYNC_ROLE_ACLS_COMMAND="${SYNC_ROLE_ACLS_COMMAND:-yarn mercato auth sync-role-acls}"
 ALREADY_INITIALIZED_PATTERN='Initialization aborted: found [0-9][0-9]* existing user\(s\) in the database\.'
 CLI_NOT_FOUND_PATTERN='command not found: mercato'
 
@@ -11,11 +12,15 @@ run_command_with_cli_recovery() {
   COMMAND="$1"
   LOG_FILE="$2"
 
-  if sh -lc "${COMMAND}" >"${LOG_FILE}" 2>&1; then
+  # `STATUS=$?` after a failed `if ...; then ...; fi` reads the compound statement's own
+  # status, which POSIX defines as 0 — so every failure used to be reported as success and
+  # a broken migration silently fell through to `yarn start`. Capture the status directly.
+  STATUS=0
+  sh -lc "${COMMAND}" >"${LOG_FILE}" 2>&1 || STATUS=$?
+
+  if [ "${STATUS}" -eq 0 ]; then
     return 0
   fi
-
-  STATUS=$?
 
   if ! grep -Fq "${CLI_NOT_FOUND_PATTERN}" "${LOG_FILE}"; then
     return "${STATUS}"
@@ -24,6 +29,23 @@ run_command_with_cli_recovery() {
   echo "Open Mercato CLI missing; running yarn install and retrying..."
   yarn install
   sh -lc "${COMMAND}" >"${LOG_FILE}" 2>&1
+}
+
+# Modules enabled after the database was first seeded declare new `defaultRoleFeatures`
+# that existing tenants never received — `mercato init` applies them only at bootstrap.
+# The sync command is idempotent, so run it after every migration and keep it non-fatal:
+# a stale grant set must not block the container from starting.
+sync_role_acls() {
+  SYNC_LOG_FILE="$(mktemp)"
+
+  if run_command_with_cli_recovery "${SYNC_ROLE_ACLS_COMMAND}" "${SYNC_LOG_FILE}"; then
+    cat "${SYNC_LOG_FILE}"
+  else
+    echo "WARNING: role ACL sync failed; newly enabled modules may be inaccessible until it is run manually."
+    cat "${SYNC_LOG_FILE}"
+  fi
+
+  rm -f "${SYNC_LOG_FILE}"
 }
 
 if [ ! -f "${MARKER_FILE}" ]; then
@@ -48,6 +70,7 @@ if [ ! -f "${MARKER_FILE}" ]; then
       if run_command_with_cli_recovery "${MIGRATE_COMMAND}" "${RECOVERY_LOG_FILE}"; then
         cat "${RECOVERY_LOG_FILE}"
         rm -f "${RECOVERY_LOG_FILE}"
+        sync_role_acls
       else
         RECOVERY_STATUS=$?
         cat "${RECOVERY_LOG_FILE}"
@@ -70,6 +93,7 @@ LOG_FILE="$(mktemp)"
 if run_command_with_cli_recovery "${MIGRATE_COMMAND}" "${LOG_FILE}"; then
   cat "${LOG_FILE}"
   rm -f "${LOG_FILE}"
+  sync_role_acls
   exit 0
 fi
 

--- a/scripts/__tests__/init-or-migrate.test.mjs
+++ b/scripts/__tests__/init-or-migrate.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'docker/scripts/init-or-migrate.sh')
+const templateScriptPath = path.join(repoRoot, 'packages/create-app/template/docker/scripts/init-or-migrate.sh')
+
+function runScript({ seeded = false, initFails = false, initReportsExistingUsers = false, syncFails = false } = {}) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'init-or-migrate-'))
+  const markerFile = path.join(tempDir, 'marker', '.seeded')
+  const stepsFile = path.join(tempDir, 'steps.txt')
+
+  if (seeded) {
+    fs.mkdirSync(path.dirname(markerFile), { recursive: true })
+    fs.writeFileSync(markerFile, '')
+  }
+
+  const record = (step) => `printf '%s\\n' ${step} >> ${JSON.stringify(stepsFile)}`
+  const initCommand = initReportsExistingUsers
+    ? `${record('init')}; echo 'Initialization aborted: found 3 existing user(s) in the database.'; exit 1`
+    : initFails
+      ? `${record('init')}; echo 'boom'; exit 1`
+      : record('init')
+
+  const result = spawnSync('sh', [scriptPath], {
+    env: {
+      ...process.env,
+      INIT_MARKER_FILE: markerFile,
+      INIT_COMMAND: initCommand,
+      MIGRATE_COMMAND: record('migrate'),
+      SYNC_ROLE_ACLS_COMMAND: syncFails ? `${record('sync')}; exit 1` : record('sync'),
+    },
+    encoding: 'utf8',
+  })
+
+  const steps = fs.existsSync(stepsFile)
+    ? fs.readFileSync(stepsFile, 'utf8').split('\n').filter(Boolean)
+    : []
+  const markerExists = fs.existsSync(markerFile)
+
+  fs.rmSync(tempDir, { recursive: true, force: true })
+
+  return { markerExists, result, steps }
+}
+
+test('already-seeded run syncs role ACLs after migrating', () => {
+  const { result, steps } = runScript({ seeded: true })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.deepEqual(steps, ['migrate', 'sync'])
+})
+
+test('first run leaves role ACLs to the initializer', () => {
+  const { markerExists, result, steps } = runScript()
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.deepEqual(steps, ['init'])
+  assert.equal(markerExists, true)
+})
+
+test('recovery from an already-initialized database syncs role ACLs after migrating', () => {
+  const { markerExists, result, steps } = runScript({ initReportsExistingUsers: true })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.deepEqual(steps, ['init', 'migrate', 'sync'])
+  assert.equal(markerExists, true)
+})
+
+test('a failing role ACL sync warns without blocking startup', () => {
+  const { result, steps } = runScript({ seeded: true, syncFails: true })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.deepEqual(steps, ['migrate', 'sync'])
+  assert.match(result.stdout, /WARNING: role ACL sync failed/)
+})
+
+test('an initialization failure still aborts startup', () => {
+  const { markerExists, result } = runScript({ initFails: true })
+
+  assert.notEqual(result.status, 0)
+  assert.equal(markerExists, false)
+})
+
+test('the create-app template ships the same boot script', () => {
+  assert.equal(fs.readFileSync(templateScriptPath, 'utf8'), fs.readFileSync(scriptPath, 'utf8'))
+})


### PR DESCRIPTION
## Summary

Module `defaultRoleFeatures` are applied only at tenant bootstrap, but the container boot script runs `mercato init` once and then only `db:migrate` on every later deploy — so modules enabled after the database was first seeded (`design_system`, `eudr`) never reached existing tenants' roles and their pages rendered Access Denied on the demo instance. This runs the idempotent `mercato auth sync-role-acls` after each migration, and fixes a pre-existing bug found while verifying that path: `run_command_with_cli_recovery` reported *every* command failure as success, because `STATUS=$?` after a failed `if ...; then return 0; fi` reads the compound statement's status, which POSIX defines as `0` — meaning a failing migration silently fell through to `yarn start`.

## Changes

- `docker/scripts/init-or-migrate.sh`: new non-fatal `sync_role_acls()` helper (overridable via `SYNC_ROLE_ACLS_COMMAND`), invoked on both the subsequent-run and already-initialized recovery paths; the first-run path is untouched because `mercato init` already applies the grants
- `docker/scripts/init-or-migrate.sh`: capture the command status directly via `|| STATUS=$?` so failures propagate and a broken migration aborts startup instead of silently continuing
- `packages/create-app/template/docker/scripts/init-or-migrate.sh`: mirrored (this file is not covered by `scripts/template-sync.ts`, so parity is now asserted by a test)
- `scripts/__tests__/init-or-migrate.test.mjs`: new coverage for all three boot paths, the non-fatal sync warning, failure propagation, and monorepo/template parity

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — deployment bootstrap fix.

## Testing

- `node --test scripts/__tests__/init-or-migrate.test.mjs` — 6 passed
- `yarn test:scripts` — 592 passed, 0 failed, 1 skipped
- `sh -n` on both scripts; verified the POSIX `$?` semantics behind the status bug with a standalone shell repro
- Not exercised against the demo database; that still needs `yarn mercato auth sync-role-acls` (or a rebuild-redeploy, which now does it automatically)

## Checklist

- [x] Targets `main` — requested by the maintainer for this deployment fix, rather than the template default of `develop`.
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required) — no HTTP/UI surface; the boot script is covered by `scripts/__tests__/init-or-migrate.test.mjs`.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [x] QA routing set: `skip-qa` — no UI-rendering file touched, database structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract affected, and automated tests for the changed behavior ship in this PR.

### Design System Compliance
- [x] No hardcoded status colors — N/A, no UI in this change
- [x] No arbitrary text sizes — N/A
- [x] Empty state handled for list/data pages — N/A
- [x] Loading state handled for async pages — N/A
- [x] `aria-label` on all icon-only buttons — N/A
- [x] Uses existing DS components — N/A

## Linked issues

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789850438&installation_model_id=432243&pr_number=5431&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5431&signature=96ab0a2c3df08659289b4488808df95b607d106813d80b515c30a6fb5c75a703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
