### PR TITLE
fix(ui): align WMS KPI cards, role dialog footer and EUDR area field

### DIFF
--- a/packages/core/src/modules/customers/components/detail/AssignRoleDialog.tsx
+++ b/packages/core/src/modules/customers/components/detail/AssignRoleDialog.tsx
@@ -640,13 +640,18 @@ export function AssignRoleDialog({
           </div>
         </div>
 
-        <DialogFooter className="shrink-0 border-t border-border/70 px-6 py-4 sm:justify-between">
-          <p className="text-xs text-muted-foreground">
-            {t(
-              'customers.roles.dialog.footerNote',
-              'One person per role · can be changed at any time',
-            )}
-          </p>
+        <DialogFooter
+          bordered={false}
+          className="shrink-0 border-t border-border/70 px-6 py-4"
+          leading={
+            <p className="text-xs text-muted-foreground sm:max-w-2xs">
+              {t(
+                'customers.roles.dialog.footerNote',
+                'One person per role · can be changed at any time',
+              )}
+            </p>
+          }
+        >
           <div className="flex items-center gap-2">
             <Button type="button" variant="outline" onClick={onClose}>
               {t('customers.roles.cancelAdd', 'Cancel')}

--- a/packages/core/src/modules/eudr/backend/eudr/plots/[id]/page.tsx
+++ b/packages/core/src/modules/eudr/backend/eudr/plots/[id]/page.tsx
@@ -93,6 +93,8 @@ export default function EditEudrPlotPage({ params }: { params?: { id?: string } 
   const [loading, setLoading] = React.useState(true)
   const [error, setError] = React.useState<string | null>(null)
   const [notFound, setNotFound] = React.useState(false)
+  const [geometryDraft, setGeometryDraft] = React.useState<string | null>(null)
+  const areaRequired = !isPolygonGeometry(geometryDraft ?? formatGeometry(record?.geometry))
 
   React.useEffect(() => {
     let cancelled = false
@@ -197,7 +199,10 @@ export default function EditEudrPlotPage({ params }: { params?: { id?: string } 
         <GeometryInput
           id={id}
           value={typeof value === 'string' ? value : ''}
-          onChange={(nextValue) => setValue(nextValue)}
+          onChange={(nextValue) => {
+            setValue(nextValue)
+            setGeometryDraft(nextValue)
+          }}
           disabled={disabled}
           areaHa={typeof values?.areaHa === 'string' || typeof values?.areaHa === 'number' ? String(values.areaHa) : ''}
         />
@@ -208,6 +213,7 @@ export default function EditEudrPlotPage({ params }: { params?: { id?: string } 
       layout: 'half',
       label: translate('eudr.plots.form.areaHa'),
       type: 'custom',
+      required: areaRequired,
       description: translate('eudr.plots.form.areaHaHelp'),
       component: ({ id, value, setValue, values, disabled }) => {
         const polygonGeometry = isPolygonGeometry(values?.geometry)
@@ -241,7 +247,7 @@ export default function EditEudrPlotPage({ params }: { params?: { id?: string } 
         />
       ),
     },
-  ], [translate])
+  ], [translate, areaRequired])
 
   const groups = React.useMemo<CrudFormGroup[]>(() => [
     {

--- a/packages/core/src/modules/eudr/backend/eudr/plots/create/page.tsx
+++ b/packages/core/src/modules/eudr/backend/eudr/plots/create/page.tsx
@@ -50,6 +50,8 @@ function isCompanySnapshot(value: unknown): value is CompanySnapshot {
 export default function CreateEudrPlotPage() {
   const translate = useT()
   const router = useRouter()
+  const [geometryDraft, setGeometryDraft] = React.useState('')
+  const areaRequired = !isPolygonGeometry(geometryDraft)
 
   const fields = React.useMemo<CrudField[]>(() => [
     {
@@ -113,7 +115,10 @@ export default function CreateEudrPlotPage() {
         <GeometryInput
           id={id}
           value={typeof value === 'string' ? value : ''}
-          onChange={(nextValue) => setValue(nextValue)}
+          onChange={(nextValue) => {
+            setValue(nextValue)
+            setGeometryDraft(nextValue)
+          }}
           disabled={disabled}
           areaHa={typeof values?.areaHa === 'string' || typeof values?.areaHa === 'number' ? String(values.areaHa) : ''}
         />
@@ -124,6 +129,7 @@ export default function CreateEudrPlotPage() {
       layout: 'half',
       label: translate('eudr.plots.form.areaHa'),
       type: 'custom',
+      required: areaRequired,
       description: translate('eudr.plots.form.areaHaHelp'),
       component: ({ id, value, setValue, values, disabled }) => {
         const polygonGeometry = isPolygonGeometry(values?.geometry)
@@ -158,7 +164,7 @@ export default function CreateEudrPlotPage() {
         />
       ),
     },
-  ], [translate])
+  ], [translate, areaRequired])
 
   const groups = React.useMemo<CrudFormGroup[]>(() => [
     {

--- a/packages/core/src/modules/wms/components/backend/WmsLocationDetailPage.tsx
+++ b/packages/core/src/modules/wms/components/backend/WmsLocationDetailPage.tsx
@@ -398,34 +398,38 @@ function LocationKpiCard({
 }: LocationKpiCardProps) {
   return (
     <section className="flex min-h-52 flex-col rounded-lg border bg-card p-5 text-card-foreground shadow-sm">
-      <p className="text-sm font-medium">{title}</p>
-      <p className="mt-3 text-xs text-muted-foreground">{caption}</p>
-      <div className="mt-2 flex items-end gap-3">
-        <p className="text-3xl font-semibold tracking-tight">{value}</p>
-        {badgeLabel ? (
-          <StatusBadge variant={badgeVariant} dot>
-            {badgeLabel}
-          </StatusBadge>
+      <div>
+        <p className="text-sm font-medium">{title}</p>
+        <p className="mt-3 text-xs text-muted-foreground">{caption}</p>
+      </div>
+      <div className="mt-auto pt-2">
+        <div className="flex items-end gap-3">
+          <p className="text-3xl font-semibold tracking-tight">{value}</p>
+          {badgeLabel ? (
+            <StatusBadge variant={badgeVariant} dot>
+              {badgeLabel}
+            </StatusBadge>
+          ) : null}
+        </div>
+        {progress != null ? (
+          <Progress
+            value={progress}
+            max={100}
+            tone={progress >= 80 ? 'warning' : 'accent'}
+            size="sm"
+            className="mt-3"
+          />
+        ) : null}
+        {onCtaClick ? (
+          <LinkButton variant="primary" size="sm" className="mt-4 w-fit" onClick={onCtaClick}>
+            {ctaLabel}
+          </LinkButton>
+        ) : ctaHref ? (
+          <LinkButton asChild variant="primary" size="sm" className="mt-4 w-fit">
+            <Link href={ctaHref}>{ctaLabel}</Link>
+          </LinkButton>
         ) : null}
       </div>
-      {progress != null ? (
-        <Progress
-          value={progress}
-          max={100}
-          tone={progress >= 80 ? 'warning' : 'accent'}
-          size="sm"
-          className="mt-3"
-        />
-      ) : null}
-      {onCtaClick ? (
-        <LinkButton variant="primary" size="sm" className="mt-auto pt-4 w-fit" onClick={onCtaClick}>
-          {ctaLabel}
-        </LinkButton>
-      ) : ctaHref ? (
-        <LinkButton asChild variant="primary" size="sm" className="mt-auto pt-4 w-fit">
-          <Link href={ctaHref}>{ctaLabel}</Link>
-        </LinkButton>
-      ) : null}
     </section>
   )
 }

--- a/packages/core/src/modules/wms/components/backend/WmsLotDetailPage.tsx
+++ b/packages/core/src/modules/wms/components/backend/WmsLotDetailPage.tsx
@@ -480,25 +480,29 @@ function LotKpiCard({
 }: LotKpiCardProps) {
   return (
     <section className="flex min-h-52 flex-col rounded-lg border bg-card p-5 text-card-foreground shadow-sm">
-      <p className="text-sm font-medium">{title}</p>
-      <p className="mt-3 text-xs text-muted-foreground">{caption}</p>
-      <div className="mt-2 flex items-end gap-3">
-        <p className="text-3xl font-semibold tracking-tight">{value}</p>
-        {badgeLabel ? (
-          <StatusBadge variant={badgeVariant} dot>
-            {badgeLabel}
-          </StatusBadge>
+      <div>
+        <p className="text-sm font-medium">{title}</p>
+        <p className="mt-3 text-xs text-muted-foreground">{caption}</p>
+      </div>
+      <div className="mt-auto pt-2">
+        <div className="flex items-end gap-3">
+          <p className="text-3xl font-semibold tracking-tight">{value}</p>
+          {badgeLabel ? (
+            <StatusBadge variant={badgeVariant} dot>
+              {badgeLabel}
+            </StatusBadge>
+          ) : null}
+        </div>
+        {onCtaClick ? (
+          <LinkButton variant="primary" size="sm" className="mt-4 w-fit" onClick={onCtaClick}>
+            {ctaLabel}
+          </LinkButton>
+        ) : ctaHref ? (
+          <LinkButton asChild variant="primary" size="sm" className="mt-4 w-fit">
+            <Link href={ctaHref}>{ctaLabel}</Link>
+          </LinkButton>
         ) : null}
       </div>
-      {onCtaClick ? (
-        <LinkButton variant="primary" size="sm" className="mt-auto pt-4 w-fit" onClick={onCtaClick}>
-          {ctaLabel}
-        </LinkButton>
-      ) : ctaHref ? (
-        <LinkButton asChild variant="primary" size="sm" className="mt-auto pt-4 w-fit">
-          <Link href={ctaHref}>{ctaLabel}</Link>
-        </LinkButton>
-      ) : null}
     </section>
   )
 }

--- a/packages/core/src/modules/wms/components/backend/WmsOperationalDashboardPage.tsx
+++ b/packages/core/src/modules/wms/components/backend/WmsOperationalDashboardPage.tsx
@@ -191,20 +191,24 @@ function DashboardKpiCard({
 }: DashboardKpiCardProps) {
   return (
     <section className="flex min-h-52 flex-col rounded-lg border bg-card p-5 text-card-foreground shadow-sm">
-      <p className="text-sm font-medium">{title}</p>
-      <p className="mt-3 text-xs text-muted-foreground">{caption}</p>
-      <div className="mt-2 flex items-end gap-3">
-        <p className="text-3xl font-semibold tracking-tight">{kpi.count}</p>
-        {badgeLabel ? (
-          <StatusBadge variant={badgeVariant} dot>
-            {badgeLabel}
-          </StatusBadge>
-        ) : null}
+      <div>
+        <p className="text-sm font-medium">{title}</p>
+        <p className="mt-3 text-xs text-muted-foreground">{caption}</p>
       </div>
-      <Sparkline values={kpi.sparkline} className="mt-3 h-9 w-full max-w-40" />
-      <LinkButton asChild variant="primary" size="sm" className="mt-4 w-fit">
-        <Link href={href}>{ctaLabel}</Link>
-      </LinkButton>
+      <div className="mt-auto pt-2">
+        <div className="flex items-end gap-3">
+          <p className="text-3xl font-semibold tracking-tight">{kpi.count}</p>
+          {badgeLabel ? (
+            <StatusBadge variant={badgeVariant} dot>
+              {badgeLabel}
+            </StatusBadge>
+          ) : null}
+        </div>
+        <Sparkline values={kpi.sparkline} className="mt-3 h-9 w-full max-w-40" />
+        <LinkButton asChild variant="primary" size="sm" className="mt-4 w-fit">
+          <Link href={href}>{ctaLabel}</Link>
+        </LinkButton>
+      </div>
     </section>
   )
 }

--- a/packages/core/src/modules/wms/components/backend/WmsSkuDetailPage.tsx
+++ b/packages/core/src/modules/wms/components/backend/WmsSkuDetailPage.tsx
@@ -382,19 +382,23 @@ function SkuKpiCard({
 }: SkuKpiCardProps) {
   return (
     <section className="flex min-h-52 flex-col rounded-lg border bg-card p-5 text-card-foreground shadow-sm">
-      <p className="text-sm font-medium">{title}</p>
-      <p className="mt-3 text-xs text-muted-foreground">{caption}</p>
-      <div className="mt-2 flex items-end gap-3">
-        <p className="text-3xl font-semibold tracking-tight">{value}</p>
-        {badgeLabel ? (
-          <StatusBadge variant={badgeVariant} dot>
-            {badgeLabel}
-          </StatusBadge>
-        ) : null}
+      <div>
+        <p className="text-sm font-medium">{title}</p>
+        <p className="mt-3 text-xs text-muted-foreground">{caption}</p>
       </div>
-      <LinkButton asChild variant="primary" size="sm" className="mt-auto pt-4 w-fit">
-        <Link href={ctaHref}>{ctaLabel}</Link>
-      </LinkButton>
+      <div className="mt-auto pt-2">
+        <div className="flex items-end gap-3">
+          <p className="text-3xl font-semibold tracking-tight">{value}</p>
+          {badgeLabel ? (
+            <StatusBadge variant={badgeVariant} dot>
+              {badgeLabel}
+            </StatusBadge>
+          ) : null}
+        </div>
+        <LinkButton asChild variant="primary" size="sm" className="mt-4 w-fit">
+          <Link href={ctaHref}>{ctaLabel}</Link>
+        </LinkButton>
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## Summary

Three demo-blocking UI inconsistencies reported during pre-release review: WMS KPI cards whose links/badges floated at different heights depending on caption length, a cramped role-assignment modal footer, and the EUDR plot "Area" field missing the required asterisk. Each is fixed at its source without changing any data contract.

## Changes

- **WMS KPI cards** (`WmsOperationalDashboardPage`, `WmsLocationDetailPage`, `WmsLotDetailPage`, `WmsSkuDetailPage`): title + caption sit in a top block and the value/badge/sparkline/progress/CTA move into one bottom block pinned with `mt-auto`, so those rows align across a grid row no matter how many lines the copy takes.
- **`AssignRoleDialog` footer**: now uses `DialogFooter`'s `leading` slot with `sm:max-w-2xs` so the hint wraps to two lines instead of crowding the buttons; `bordered={false}` drops the default `-mx-6` treatment that pushed the button row flush against the edges of this `p-0` dialog, so it lines up with the header again.
- **EUDR plot create/edit forms**: `areaHa` is marked `required` (red asterisk + CrudForm required validation) whenever the geometry is not a polygon, mirroring the existing point-area rule — polygon plots, whose area is computed and the input disabled, stay unaffected.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — presentation-only fixes, no behavior or contract change.

## Testing

- `yarn generate`
- `yarn workspace @open-mercato/core typecheck`, `yarn workspace @open-mercato/ui typecheck`
- `yarn workspace @open-mercato/core test -- modules/wms` (38 suites / 236 tests)
- `yarn workspace @open-mercato/core test -- modules/eudr` (18 suites / 118 tests)
- `yarn workspace @open-mercato/core test -- customers/components/detail/__tests__/AssignRoleDialog.test.tsx`
- `yarn workspace @open-mercato/ui test -- primitives/__tests__/dialog.test.tsx`

## Checklist

- [x] This pull request targets `main` (the repository's default target branch; the template text predates that rename).
- [x] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new strings or generated files.)
- [ ] I added or adjusted tests that cover the change. — layout/label polish; existing suites re-run as regression cover.
- [ ] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — no API/DB surface changed; visual alignment and an asterisk are verified by manual QA.
- [x] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A.
- [x] Priority set: this PR carries exactly one `priority-*` label.
- [x] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [x] QA routing set: `needs-qa` — the change is customer-facing UI without automated coverage for the changed rendering.

### Design System Compliance
- [x] No hardcoded status colors — existing semantic tokens/`StatusBadge` variants untouched
- [x] No arbitrary text sizes — `sm:max-w-2xs` is the Tailwind v4 container scale, no `[Npx]` values
- [x] Empty state handled for list/data pages — unchanged
- [x] Loading state handled for async pages — unchanged
- [x] `aria-label` on all icon-only buttons — no icon-only buttons added
- [x] Uses existing DS components (`DialogFooter` `leading` slot, `StatusBadge`, `LinkButton`, `CrudForm` `required`) — no custom replacements

## Linked issues

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789853822&installation_model_id=432243&pr_number=5432&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5432&signature=73e76cfd4204a38d0df9deae5a78074bac999b34b0e33ff1bee84fa8f6c3c8ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->