### PR TITLE
docs(specs): pricing engine (catalog admin UI, resolver hardening, optional pricing module)

### DIFF
--- a/.ai/specs/2026-08-21-pricing-engine.md
+++ b/.ai/specs/2026-08-21-pricing-engine.md
@@ -1,0 +1,234 @@
+# Pricing Engine
+
+## 📝 TLDR
+A generic, reusable price-resolution contract sized so a simple deployment (one price per SKU) needs zero configuration, while a complex one (B2B contract pricing, customer/customer-group pricing, quantity tiers, channel pricing, time-boxed campaigns) is served by the same resolution algorithm. Ships in three independently-shippable phases across two module owners: **Phase 1** gives `catalog` the admin UI its already-complete price API/commands have never had; **Phase 2** hardens `catalog`'s existing resolver-chain extension point (a latent registry-scoping bug, currency-awareness, `customerGroupIds` set matching) so it is safe to build on; **Phase 3** ships a new, optional `pricing` module that registers into that hardened chain and takes over resolution — the same optional-integration shape as `availability`/`wms` and its ADR-4 (see provenance note below). Scope is **price resolution only**: context in, one best-matching unit price out. Discount/promotion effects (`promotions`, SPEC-055) and totals/tax/rounding (`salesCalculationService`) are explicitly out of scope and not duplicated. All three phases ship with **zero schema migrations**.
+
+**Sibling spec provenance.** This spec cites `2026-08-14-ecommerce-suite-roadmap.md` (source of "ADR-4" and the `availability`/`wms` precedent), `2026-08-14-cart-module.md`, and `2026-08-14-customer-groups-and-b2b-terms.md`. None of these exist in `.ai/specs/` on `develop` today — they live on branch `spec/ecommerce-module-suite` (upstream PR [#5384](https://github.com/open-mercato/open-mercato/pull/5384), marked `do-not-merge` pending maintainer discussion). Read them via `git show fork/spec/ecommerce-module-suite:.ai/specs/<file>` (or the equivalent remote) until that PR merges. Every citation below to those three files is a forward reference to unmerged, still-under-discussion work, not a settled dependency — treat any risk or design point resting on them as provisional until that PR's fate is known, not as verified fact the way this spec's citations to code on `develop` are.
+
+## 📝 Problem Statement
+
+`CatalogProductPrice` already models everything a B2B pricing matrix needs — customer, customer-group, channel, quantity tiers, validity windows — and `catalog/lib/pricing.ts` already scores and resolves matches by specificity. Despite that, three concrete gaps keep this capability from being either "simple" or "generic and reusable" today:
+
+1. **No admin UI reaches most of the schema.** Price editing today is inline on the product page and touches only `unitPriceNet`/`unitPriceGross`/`channelId`. The customer/customer-group/quantity-tier/validity-window dimensions — already fully supported by `catalog/api/prices/route.ts` and `catalog/commands/prices.ts` — are reachable only by inserting rows directly. A capability nobody can reach through the UI isn't a capability a merchant can use.
+2. **The extension point a "pluggable, complex-when-needed" engine would build on has a latent bug.** `registerCatalogPricingResolver`'s backing array (`pricingResolvers` in `catalog/lib/pricing.ts:121`) is module-local state, not `globalThis`-backed — the same failure class this codebase already hit and fixed once for the ORM/entity registry (`.ai/lessons/global-registries-in-publishable-packages-must-use-globalthis.md`). Under a multi-module-instance topology (a standalone app built from this monorepo, or any dev/build setup that loads `catalog` through more than one chunk), a resolver registered from one instance is invisible to resolution running in another — silently, with no error.
+3. **Currency and multi-group scoping are undocumented, caller-responsibility contracts.** `PricingContext` has no currency field — callers pre-filter `CatalogProductPrice` rows by `currencyCode` themselves today, an implicit convention with no enforcement. The sibling `2026-08-14-customer-groups-and-b2b-terms.md` spec (see provenance note above) is about to move `customerGroupId` (single value) to `customerGroupIds: string[]` (set membership) — a shape change this resolution layer needs to originate, not inherit after the fact.
+4. **Tenant/organization scoping of the rows a resolver runs over is an unstated caller contract, not an enforced one.** `matchesContext`/`scorePrice`/`selectBestPrice` are pure functions over whatever `rows: PriceRow[]` a caller passes in — there is no scoping check inside the resolver itself today, and none is added by this spec. It is safe only because every current caller fetches rows through routes/services that already filter by `organization_id`/`tenant_id` first. Worth stating explicitly given root `AGENTS.md`'s "Never expose cross-tenant data" rule — see Edge Cases.
+
+None of this requires new entities. It requires an admin surface, one infrastructure fix, and a hardened, currency-and-group-aware resolution contract that a future optional module can safely extend.
+
+## 📝 Proposed Solution
+
+Do not build a new pricing data model. Do not build a new "generic rule engine" from scratch — `catalog/lib/pricing.ts` already *is* one (specificity scoring, a priority-ordered resolver-chain extension point, before/after lifecycle events); it is under-exposed (no UI) and under-hardened (registry bug, no currency/multi-group awareness), not under-designed.
+
+Three phases, two module owners, no new data model:
+
+- **Phase 1 (`catalog`)** — a dedicated backend admin page for `CatalogProductPrice`, exposing every dimension the API and commands already accept. Independently valuable: works today, with or without anything else in this spec.
+- **Phase 2 (`catalog`)** — harden the existing extension point: `globalThis`-scope the resolver registry (with dedupe-by-id, so any future registrant is HMR-safe, not just this spec's), and extend `PricingContext`/`matchesContext` additively with `currencyCode` and `customerGroupIds`. This is infrastructure work inside the module that already owns the resolver — not new module-boundary surface.
+- **Phase 3 (`pricing`, new, optional)** — a module that, when installed, registers a resolver into the now-hardened chain and takes over resolution. It owns no entities and no admin UI of its own; it composes catalog's existing `matchesContext`/`scorePrice`/`selectBestPrice` rather than reimplementing them (`catalog/AGENTS.md` § Never: "Never reimplement catalog pricing inline").
+
+**Alternatives considered and rejected:**
+- *A single spec/module owning everything, including a rewritten data model* — rejected: `CatalogProductPrice` already covers every dimension found in Medusa's price-rule model and commercetools' Standalone Price constraints (see Research below); rebuilding it would be pure churn.
+- *Ship the admin UI inside the new `pricing` module, calling `catalog`'s public API* — rejected: it would make Phase 1's value conditional on installing an optional module, when the underlying capability is catalog's own and complete today. Confirmed with the user as a deliberate two-phase, two-owner split rather than two separate specs, since the phases are thematically one initiative even though independently deployable.
+- *A pluggable "rule strategy" abstraction over price sources* — rejected as unnecessary new surface: `registerCatalogPricingResolver`'s priority-ordered chain already **is** that abstraction; Phase 2 fixes it, Phase 3 uses it.
+
+### Research: what market leaders get right (and what this spec skips)
+
+- **Medusa.js v2's Pricing Module** groups prices into "price sets" resolved by an explicit rule engine (`calculatePrices(context)`) that handles "overlapping applicability and rule priorities" and is deliberately stateless/serverless-safe. This validates two decisions here directly: (a) resolution should be a pure function of `(context, candidate rows)` — the `globalThis` fix in Phase 2 scopes the *registration* registry, not the per-request resolution call, which stays pure; (b) multi-currency is a first-class dimension of the rule context, not an afterthought — matching the Q2 decision to require `currencyCode`. [Pricing Module - Medusa Documentation](https://docs.medusajs.com/resources/commerce-modules/pricing)
+- **commercetools' Standalone Prices** define an explicit, documented precedence: Customer Group > Channel > country, currency always required, and — notably — **a tiered price is ignored once a product discount already applies**, rather than the two effects composing. That's a directly relevant precedent for the resolution → promotions boundary this spec deliberately keeps out of scope: whoever builds the promotions handoff should decide interaction rules explicitly (suppress vs. compose), not assume additive stacking. This spec does not implement that decision — it flags it as a documented open question for that future work, so it isn't silently assumed. [Price selection | commercetools](https://docs.commercetools.com/learning-price-and-discount-your-products/price-calculation/price-selection)
+- **What this spec deliberately skips relative to both:** neither a new "price set" grouping abstraction nor a formal declarative rule DSL. `CatalogProductPrice` rows plus `scorePrice`'s weighted specificity already produce the same *outcome* (most-specific-match-wins) with far less new surface. commercetools' Customer-Group-over-Channel precedence differs from `scorePrice`'s current weights (channel +5 > customerGroup +3) — this spec does **not** change that ordering; `catalog/AGENTS.md` § Ask First explicitly requires asking before touching resolver priority semantics, and doing so is out of scope here. Noted for whoever eventually revisits `scorePrice`'s weights.
+
+## 📝 Architecture
+
+```
+                     ┌─────────────────────────────────────────────┐
+                     │  catalog (existing, hardened in Phase 1–2)   │
+                     │                                               │
+  admin operator ───▶│  Phase 1: backend/catalog/prices UI          │
+                     │      ↓ (existing CRUD API + commands)        │
+                     │  CatalogProductPrice rows                    │
+                     │                                               │
+                     │  Phase 2: PricingContext (+currencyCode,     │
+                     │      +customerGroupIds, additive)            │
+                     │  matchesContext() / scorePrice() (unchanged  │
+                     │      weights, extended filters)              │
+                     │  pricingResolvers registry → globalThis-keyed│
+                     │      store, dedupe-by-id                     │
+                     │  registerCatalogPricingResolver(fn, {id,     │
+                     │      priority})  ◀───────────────┐           │
+                     └────────────────────────────────────┼─────────┘
+                                                            │ registers at boot
+                     ┌──────────────────────────────────────┼─────────┐
+                     │  pricing (new, optional, Phase 3)     │         │
+                     │                                        │         │
+                     │  di.ts: register(container) calls ────┘         │
+                     │      registerCatalogPricingResolver(...)         │
+                     │  lib/resolver.ts: composes catalog's             │
+                     │      matchesContext/scorePrice/selectBestPrice,  │
+                     │      adds currency + customerGroupIds matching   │
+                     │  owns: no entities, no admin UI                  │
+                     └───────────────────────────────────────────────┘
+
+resolution (this spec) ──▶ discount/promotion effects (promotions, SPEC-055, OUT OF SCOPE)
+                       ──▶ totals / tax / rounding (salesCalculationService, OUT OF SCOPE)
+```
+
+**When `pricing` is not installed**: `catalog`'s baseline `resolveCatalogPrice()` (hardened in Phase 2) is the whole system — currency-aware, `customerGroupIds`-aware, `globalThis`-safe. This is deliberately a complete, non-crippled baseline; Phase 1's admin UI works fully here too, since it depends only on `catalog`.
+
+**When `pricing` is installed**: it registers a resolver into the same chain used today, at a priority above catalog's built-in fallback. Because registration flows through `registerCatalogPricingResolver`, `catalog` never imports, resolves, or knows about `pricing` — the dependency direction required by `packages/core/AGENTS.md` § Cross-Module Coupling ("the upstream/depended-on module MUST NOT import, resolve, or hard-require the consumer") holds by construction: `catalog` is upstream, `pricing` is the optional consumer that reaches *into* catalog's own extension point, not the other way around.
+
+**Registry hardening detail (Phase 2).** Two changes to `pricingResolvers`:
+1. Move from a module-local `const pricingResolvers: RegisteredResolver[] = []` to a `globalThis`-keyed singleton (stable key, lazy-initialized, reused across module-instance duplication) — same pattern as the ORM entity registry and the global event bus fixes already in this codebase.
+2. Add an optional `id` to `registerCatalogPricingResolver(resolver, { priority, id? })` and skip re-registration when an entry with the same `id` is already present. This isn't `pricing`-specific — it makes the *existing, documented* extension point (already used by any third-party module per `catalog/AGENTS.md`'s own example) safe under dev hot-reload for every future registrant, not just this spec's.
+
+**Why resolution stays a pure function.** Per the Medusa precedent above, `resolveCatalogPrice()`'s actual per-request computation takes `(context, fetched candidate rows)` and returns a result — no request-scoped mutable state. Only the *registration* of which resolver functions exist is a shared/global concern; that's exactly what Phase 2 fixes, and nothing else needs to move to `globalThis`.
+
+## 📝 Data Model
+
+**No schema changes in any phase.** `CatalogProductPrice` (`catalog/data/entities.ts:788+`) already carries every field: `currencyCode`, `kind`, `minQuantity`/`maxQuantity`, `unitPriceNet`/`unitPriceGross`, `taxRate`/`taxAmount`, `channelId`, `userId`/`userGroupId`, `customerId`/`customerGroupId`, `startsAt`/`endsAt`, tenant/org scope. Phase 1 exposes existing columns in a new UI. Phase 2 changes an in-memory TypeScript type (`PricingContext`) and an in-memory registry's storage location — no persistence involved. Phase 3 ships a module with zero entities: it reads catalog's existing rows at request time (the same cross-module read pattern response enrichers already use — an ID/entity-manager lookup, not a compile-time ORM relation) and persists nothing of its own.
+
+**Actual current type** (`catalog/lib/pricing.ts:10-19`, verified by direct read, not reconstructed from memory):
+
+```ts
+export type PricingContext = {
+  channelId?: string | null
+  offerId?: string | null
+  userId?: string | null
+  userGroupId?: string | null
+  customerId?: string | null
+  customerGroupId?: string | null
+  quantity: number   // required
+  date: Date          // required
+}
+```
+
+**`PricingContext` shape change (additive only, per `BACKWARD_COMPATIBILITY.md` § Type Definitions) — only two fields are added, nothing else about the existing type changes:**
+
+```ts
+export type PricingContext = {
+  channelId?: string | null
+  offerId?: string | null
+  userId?: string | null
+  userGroupId?: string | null
+  customerId?: string | null
+  /** @deprecated use customerGroupIds — kept for backward compatibility, read as a one-element set when customerGroupIds is absent */
+  customerGroupId?: string | null
+  customerGroupIds?: string[]   // new, Phase 2 — set membership; priority tiebreak among matches per 2026-08-14-customer-groups-and-b2b-terms.md (provenance note above)
+  currencyCode?: string | null  // new, Phase 2 — optional at the type level (existing callers unaffected); functionally required by the pricing module's own resolver
+  quantity: number    // unchanged — stays required
+  date: Date           // unchanged — stays required
+}
+```
+
+`quantity`/`date` stay required exactly as they are today — an earlier draft of this section incorrectly showed them as optional and dropped `| null` from the six existing optional fields; both would have been undisclosed, silently-permissive behavior changes (`matchesContext`'s range/window checks would pass on `undefined` rather than erroring) riding alongside the one currency change this spec deliberately discloses. Only `customerGroupIds` and `currencyCode` are new; every other field is untouched. This satisfies "MAY add optional fields" without narrowing anything required. The *pricing module's* own resolver (Phase 3) treats `currencyCode` as required at its own entry point and returns "no price found" rather than guessing when it's absent from a caller that opted into the stricter contract; catalog's baseline resolver keeps today's behavior (no currency filtering) when the field is omitted, so the "strictly safer" currency fix is opt-in at the point of adoption, not a silent behavior change for existing callers. See Edge Cases below for the one caller-visible behavior change this still causes.
+
+## 📝 API Contracts
+
+**Phase 1** adds no new HTTP routes. The admin UI consumes the existing `catalog/api/prices/route.ts` CRUD route and `catalog.prices.create/update/delete` commands, both already schema-complete for every specificity dimension — confirmed by direct inspection, not assumed. If implementation surfaces a genuine list-shaping gap (e.g., grouping price rows by product for the list view), that is a small additive query-param/response-field change to the existing route, not a new one.
+
+**Phase 2** changes a service-level (DI/TypeScript) contract, not an HTTP one:
+- `PricingContext` — additive fields per Data Model above.
+- `registerCatalogPricingResolver(resolver, options?: { priority?: number; id?: string })` — matches today's actual signature (`catalog/lib/pricing.ts:127-133`: `options?: { priority?: number }`, defaulting to `?? 0`) with `id` appended as a new optional field; every existing call site (all in-repo callers and the documented `catalog/AGENTS.md` example) keeps compiling and behaving identically, so this is additive per `BACKWARD_COMPATIBILITY.md` § Function Signatures.
+- No new output contract needed: the existing resolved `PriceRow` (via `selectBestPrice`) already carries `id` and `minQuantity`, which is everything the sibling `2026-08-14-cart-module.md` spec's line-item explainability snapshot (`price_row_id`, `price_tier_min_quantity`) needs (provenance note above — that spec is unmerged). `priced_at` is stamped by the caller (cart), not returned by the engine — no new field required.
+
+**Phase 3** adds no new HTTP routes for the resolver itself (it's a DI-registered function, not an endpoint). An optional, small diagnostic backend page (see UI/UX) may add one lightweight read-only status route (`GET` — which resolver is currently active/registered, for operator debugging given the "silent failure" risk this spec's whole premise is built to close) — additive, and explicitly optional/nice-to-have, not blocking.
+
+## 📝 UI/UX
+
+**Phase 1 — `catalog/backend/catalog/prices/` (new page).**
+- `<DataTable>` listing `CatalogProductPrice` rows: product/variant, kind, amount + currency, scope summary (customer/customer-group/channel, rendered as chips), quantity range, validity window. Stable `entityId`/`extensionTableId` per `packages/ui/AGENTS.md`.
+- `<CrudForm>` for create/edit exposing every specificity field (`createCrud`/`updateCrud`/`deleteCrud`; `createCrudFormError` for local validation). `Cmd/Ctrl+Enter` submit, `Escape` cancel. Optimistic locking via `updatedAt` (verify `CatalogProductPrice` carries `updated_at` during Step 1 — the root convention requires it on user-editable entities; not independently confirmed by this spec's research and must be checked, not assumed, before the form ships).
+- i18n via `useT()`/locale files — no hardcoded labels; reuse `catalog`'s existing translation namespace.
+- No design-system inventions: `<StatusBadge>` for `kind` (custom/promotion/tier/regular), standard DS tokens throughout.
+
+**Phase 2** — no UI.
+
+**Phase 3** — no required UI. Optional: a small read-only backend page (e.g. under `pricing/backend/`) showing the currently-registered resolver chain (ids, priorities, which one is `pricing`'s) for operator diagnosis — directly answers the "why is this price wrong" debugging need the registry-hardening work exists to prevent. Guarded by a new `pricing.diagnostics.view` feature declared in `pricing/acl.ts` and granted via `setup.ts` `defaultRoleFeatures` (`admin`, at minimum), consistent with every other route in this codebase requiring a declared feature rather than shipping unguarded. Nice-to-have, cut first if Phase 3 needs to shrink.
+
+## 📝 Edge Cases & Failure Scenarios
+
+| Scenario | Behavior | User-visible effect |
+|---|---|---|
+| No price row matches a context in any currency | Resolver returns "no price found" | Caller's problem to handle (out of scope here); documented as the contract, not silently defaulting to some other currency's price |
+| Price rows exist, but only in a different currency than the (Phase-2-aware) caller requested | **Behavior change**: previously could silently match a wrong-currency row (today's undocumented bug); now correctly resolves to "no price found" | Only affects callers that adopt `currencyCode` in their context — see Data Model. Flagged in Migration & Backward Compatibility as a deliberate, strictly-safer change, with a release note for the one caller (`catalog` itself) currently doing implicit pre-filtering |
+| Two resolvers register at the same priority (e.g. a future third module also targets this extension point) | Existing chain iteration order is not documented today — must be confirmed (stable insertion order, presumably) during Phase 2 implementation and made explicit, not left implicit | Deterministic resolution requires this to be a documented, tested behavior, not an accident of array order |
+| `customerGroupIds` context matches more than one group-scoped row with different scores | Priority tiebreak follows whatever `2026-08-14-customer-groups-and-b2b-terms.md` ultimately specifies (provenance note above — unmerged); if it hasn't shipped by the time Phase 2/3 land, this spec defines a provisional default (highest `scorePrice` score wins — consistent with existing same-kind tie-break logic) and documents it as provisional pending that sibling spec | Consistent, explainable price selection even before the sibling spec lands |
+| `pricing` module installed, then disabled without an app restart (dev hot-toggle) | No unregister mechanism exists or is added by this spec — module enable/disable takes effect on next boot, consistent with how routes/ACL/DI already work for every other module in this system | Not a new operational burden; documented explicitly so it isn't assumed to be instant |
+| `pricing` module registers a resolver whose priority is misconfigured below catalog's built-in fallback | Falls back to catalog's baseline resolver silently succeeding at a lower specificity than intended | Phase 3's diagnostic page (if built) surfaces this; otherwise it's a configuration error the operator must catch via testing, documented as a known limitation |
+| A caller passes `resolveCatalogPrice`/`selectBestPrice` a row set that was not pre-scoped by `organization_id`/`tenant_id` (e.g. a careless future `pricing`-module or `cart`/`sales` integration fetches more broadly than today's callers do) | The resolver has no scoping check of its own — it is a pure function over whatever rows it receives, and always has been | Cross-tenant price leak. Not a new risk introduced by this spec, but this spec is the first place documenting it as an explicit caller contract: **every caller MUST pre-scope rows by `organization_id`/`tenant_id` before calling the resolver** — verified true of every current caller today, and must remain true of `pricing`'s Phase 3 resolver and any future consumer |
+
+## 📝 Risks & Impact Review
+
+### High
+- **Registry-scoping fix is foundational, not cosmetic.** If Phase 2 ships without the `globalThis` migration actually verified under a multi-instance topology (not just the monorepo dev app), Phase 3's entire premise — "when installed, it takes over" — is unverified in exactly the environments (standalone apps) this spec's "generic and reusable" goal targets most. Mitigation: a regression test that registers a resolver from a second module instance and confirms `resolveCatalogPrice()` (running against the first instance) sees it — modeled on whatever test was added for the ORM-registry fix this lesson references.
+- **`sales/AGENTS.md` overclaim must be corrected regardless of Q1's outcome.** Leaving a false "MUST use `selectBestPrice`" rule in place misleads future contributors into believing sales pricing is already centrally enforced when it isn't. Mitigation: fix the doc in this spec's own change-set (Phase 1 or 2, whichever lands first) independent of whether `sales` wiring itself is in scope.
+- **Bundling Phase 1 (catalog UI) and Phase 3 (new module) into one spec has real process friction, even though the user explicitly chose to keep them together rather than split.** Not re-litigating that call — naming the cost it carries: (a) approving this spec as one unit needs a reviewer competent in both DS-compliant `CrudForm`/`DataTable` conventions *and* module-registry/`globalThis`/cross-module-coupling correctness — two largely disjoint skill sets under one verdict; (b) Phase 1 has zero dependency on Phase 2/3 (confirmed in Phasing), so bundling buys no sequencing benefit while still coupling their fates at spec-approval time — a dispute over the Phase 3 registry-dedupe design stalls the unrelated, ready-to-ship UI work too; (c) discoverability — a spec titled "Pricing Engine" is not where someone auditing "how do I add a price-rule admin page" would look, and the `customerGroupIds`-shape coordination risk (below) is harder for `2026-08-14-customer-groups-and-b2b-terms.md`'s author to find, buried in a document whose title foregrounds UI/registry work. Mitigation: none applied — the split-vs-bundle call is the user's and stands; this is recorded so the cost is visible, not silently absorbed.
+
+### Medium
+- **`customerGroupIds` shape is defined by two independent specs (this one and `2026-08-14-customer-groups-and-b2b-terms.md`, provenance note above).** Risk of incompatible landed shapes if merge order isn't coordinated. Mitigation: this spec is the shape's origin per the Q4 decision; the sibling spec's own Migration & Backward Compatibility section must explicitly defer to whatever lands here, not redefine independently. Flag to whoever owns that spec.
+- **Currency behavior change (see Edge Cases) is opt-in but still needs a release note**, since silently-matched cross-currency prices — if any exist in seeded/demo data or a real deployment relying on the current bug — would start returning "no price found" once a caller adopts `currencyCode`. Mitigation: `UPGRADE_NOTES.md` entry alongside the Phase 2 PR.
+
+### Low
+- **Optional diagnostic page (Phase 3) is the only mitigation for silent misconfiguration** (wrong resolver priority). Accepted as low-severity since it's explicitly optional/nice-to-have — the alternative (skip it) just means relying on tests and documentation instead of a runtime UI.
+
+## 📋 Phasing
+
+1. **Phase 1 — Catalog price-rule admin UI** (`catalog`). Independently shippable. No dependency on Phase 2 or 3.
+2. **Phase 2 — Catalog resolver contract hardening** (`catalog`). Independently shippable. No dependency on Phase 1. **Prerequisite for Phase 3.**
+3. **Phase 3 — Pricing resolution engine module** (`pricing`, new, optional). Depends on Phase 2's hardened contract. Does not depend on Phase 1.
+
+Explicitly deferred / out of scope for this spec (named so the gap doesn't silently close itself — see Q1 decision and Risks): wiring `sales`/`cart` to call the engine (owned by `2026-08-14-cart-module.md`, provenance note above, and a future `sales`-specific spec), the promotions interaction rule flagged in Research, and any admin UI inside `pricing` beyond the optional diagnostic page.
+
+## 📋 Implementation Plan
+
+### Phase 1 — Catalog price-rule admin UI
+1. Verify `CatalogProductPrice` carries `updated_at`; if missing, add it (additive migration) before the form ships, since optimistic locking is default-on for user-editable entities.
+2. Build `catalog/backend/catalog/prices/` list page (`<DataTable>`) against the existing prices CRUD route — no new backend route.
+3. Build the create/edit `<CrudForm>` exposing all specificity fields; wire `createCrud`/`updateCrud`/`deleteCrud`.
+4. Add i18n keys for every new label; run `yarn i18n:check-hardcoded`.
+5. Integration test: create a customer-group-scoped, quantity-tiered price row through the UI, then confirm `selectBestPrice` picks it over a regular price for a matching context (proves the UI reaches the dimensions the API already supported).
+
+### Phase 2 — Catalog resolver contract hardening
+1. Migrate `pricingResolvers` to a `globalThis`-keyed store; add a regression test that registers from a second simulated module instance and confirms visibility from the first (modeled on the ORM-registry fix's own test).
+2. Add optional `id` + dedupe-by-id to `registerCatalogPricingResolver`; test double-registration with the same `id` is a no-op.
+3. Add `currencyCode`/`customerGroupIds` to `PricingContext`; extend `matchesContext()` additively (both fields optional, legacy behavior preserved when absent).
+4a. Decide and document the resolver-chain same-priority tie-break rule (e.g. stable insertion order) — this is a design decision, not yet made anywhere in this spec or the current code (see Edge Cases).
+4b. Once 4a is decided, add a test asserting that specific rule. (Split from a single step because a test can't verify a rule that doesn't exist yet — the original single-step phrasing was circular.)
+5. Fix `sales/AGENTS.md`'s `selectBestPrice` overclaim to state the actual current state.
+6. Add an `UPGRADE_NOTES.md` entry for the currency behavior change (opt-in, strictly safer).
+
+### Phase 3 — Pricing resolution engine module
+1. Scaffold `packages/core/src/modules/pricing/` (`index.ts`, `acl.ts`, `setup.ts`, `di.ts`) — no entities. Even without the diagnostic page, `acl.ts`/`setup.ts` exist per module convention; add `pricing.diagnostics.view` to both only if Step 5 ships.
+2. `di.ts` `register(container)` calls `registerCatalogPricingResolver(resolver, { priority, id: 'pricing.engine' })` at module load.
+3. `lib/resolver.ts` composes catalog's `matchesContext`/`scorePrice`/`selectBestPrice` (imported, not reimplemented) with mandatory currency filtering and `customerGroupIds` set matching + priority tiebreak (provisional default per Edge Cases if the sibling spec hasn't landed). Reads catalog's `CatalogProductPrice` rows already pre-scoped by `organization_id`/`tenant_id` by whatever caller supplied them — see the new tenant-scoping Edge Case; does not add its own scoping check, matching every existing caller's contract.
+4. Integration test: module absent → catalog baseline resolves; module installed → `pricing`'s resolver wins for a context it claims; module logically "uninstalled" (not registered on a fresh boot) → reverts to baseline.
+5. Optional: diagnostic backend page listing the active resolver chain, guarded by `pricing.diagnostics.view` (declared in `acl.ts`, granted to `admin` in `setup.ts` `defaultRoleFeatures`).
+6. Run `yarn generate`, full validation gate.
+
+## Integration Test Coverage
+
+- **API**: `catalog/api/prices` create/update/delete with every specificity field (Phase 1 UI's backing contract — already exists, add coverage if missing).
+- **Resolver behavior**: currency filtering (match / no-match), `customerGroupIds` set membership + tiebreak, same-priority resolver chain order, registry visibility across simulated module instances (Phase 2).
+- **UI**: create a tiered/customer-group price row via the new admin page, confirm it resolves correctly end to end (Phase 1).
+- **Module lifecycle**: `pricing` absent vs. installed vs. never-registered-this-boot (Phase 3), per `packages/core/src/__tests__/module-decoupling.test.ts`'s pattern for optional-module absence.
+
+## Final Compliance Report
+
+| Check | Verdict | Note |
+|---|---|---|
+| Scope cohesion (one capability per spec) | Reviewed and confirmed as a deliberate exception, friction named not hidden | Admin UI (Phase 1) and the resolution engine (Phase 3) are independently deployable; user explicitly chose to keep them as phases of one spec rather than splitting (see Changelog). A fresh-context adversarial review confirmed the split-vs-bundle call isn't reopened but surfaced concrete costs — reviewer-skill mismatch, zero sequencing benefit, discoverability — now recorded in Risks (High) rather than left implicit |
+| Canonical mechanisms reused, not reinvented | Pass | Reuses `CatalogProductPrice`, `matchesContext`/`scorePrice`/`selectBestPrice`, `registerCatalogPricingResolver`, `makeCrudRoute`, `CrudForm`/`DataTable`, commands pattern — verified against actual code by the adversarial review, not just plausible-sounding |
+| Contracts and compatibility | Pass, after correction | Adversarial review caught two drafting errors: the `PricingContext` diagram had silently flipped `quantity`/`date` to optional and dropped `\| null` from existing fields; `registerCatalogPricingResolver`'s stated signature was stricter (`options` non-optional) than the real one. Both fixed in Data Model / API Contracts against the verified actual types. The one real behavior change (currency) remains correctly flagged with an `UPGRADE_NOTES.md` entry |
+| Reversibility | Pass | Phase 3 module is opt-in/uninstallable by design (that's its whole premise); Phase 1/2 changes are additive UI/registry fixes with no destructive path |
+| Boundaries and coupling | Pass | `catalog` never imports/resolves `pricing`; `pricing` reaches into catalog's own documented extension point, matching `packages/core/AGENTS.md` § Cross-Module Coupling. Adversarial review confirmed this was checked against the rule's actual text, not just asserted |
+| Sensitive data | Pass, no new surface | Price rows carry no PII; no `encryption.ts` changes needed. The optional diagnostic route needed (and now has) a named ACL feature — not a PII gap, but an access-control completeness gap the review caught |
+| Failure scenarios | Pass, after addition | Adversarial review found the Edge Cases table gave currency a full caller-contract treatment but omitted the equivalent tenant/organization-scoping contract despite it being a higher-severity rule in root `AGENTS.md`. Added as an explicit row |
+| Testability | Pass, after correction | Every Implementation Plan step has an associated test; Phase 2's tie-break step was circular (testing a rule not yet decided) and is now split into a decide-then-test pair |
+| Citation provenance | Pass, after correction | `2026-08-14-ecommerce-suite-roadmap.md`/ADR-4, `2026-08-14-cart-module.md`, and `2026-08-14-customer-groups-and-b2b-terms.md` do not exist in `.ai/specs/` on `develop` — they live on the unmerged `spec/ecommerce-module-suite` branch (PR #5384). A provenance note now marks every citation to them as a forward reference, not settled fact |
+
+## Changelog
+
+- **2026-08-21** — Initial skeleton with Open Questions Q1–Q5 (module location, sales/cart wiring, currency, admin UI, `customerGroupIds` shape).
+- **2026-08-21** — Q1 (module location) closed by rule (`packages/core/AGENTS.md` § Where to Put Code). Pre-implementation analysis (`ANALYSIS-2026-08-21-pricing-engine.md`) surfaced the `pricingResolvers` `globalThis`-scoping bug; folded into scope.
+- **2026-08-21** — Q1(orig. numbering)/Q2/Q4 resolved (engine-only for sales/cart wiring; currency-aware; `customerGroupIds` from day one). Verification of catalog's existing price UI/API showed the admin-UI gap is UI-only, with data/API/commands already complete — reframed Q3 as a module-ownership question.
+- **2026-08-21** — Scope-cohesion check: admin UI and resolution engine are independently deployable; user chose to keep as two phases of one spec rather than splitting into two. Full Architecture/Data Model/API Contracts/Phasing drafted, grounded against Medusa.js and commercetools pricing architectures.
+- **2026-08-21** — Fresh-context adversarial review (per `om-spec-writing` step 8, reviewer had no prior context and independently verified claims against the actual repo). Findings applied: sibling-spec citations (`ecommerce-suite-roadmap`/ADR-4, `cart-module`, `customer-groups-and-b2b-terms`) marked with an explicit provenance note — they live on unmerged branch `spec/ecommerce-module-suite` (PR #5384), not on `develop`; `PricingContext`'s Data Model diagram corrected to match the actual current type (`quantity`/`date` are required, existing optional fields carry `| null`) after the draft had silently narrowed/widened them undisclosed; `registerCatalogPricingResolver`'s API Contracts signature corrected to match the real `options?: { priority?: number }`; added an explicit tenant/organization-scoping caller-contract Edge Case (the resolver has no scoping check of its own — always been true, now documented); named the bundling friction (reviewer-skill mismatch, no sequencing benefit, discoverability) as a High risk instead of leaving it implicit in the Final Compliance Report; split Phase 2's circular tie-break-decide-and-test step into two; added a named `pricing.diagnostics.view` ACL feature for the optional diagnostic route.

--- a/.ai/specs/analysis/ANALYSIS-2026-08-21-pricing-engine.md
+++ b/.ai/specs/analysis/ANALYSIS-2026-08-21-pricing-engine.md
@@ -1,0 +1,89 @@
+# Pre-Implementation Analysis: Pricing Engine
+
+*Updated after the spec reached its final form (Architecture, Data Model, API Contracts, Phasing, Implementation Plan, plus a fresh-context adversarial review and its follow-up corrections). This supersedes the original skeleton-stage pass; the original findings are kept below marked **[resolved]** where the finished spec addresses them, so the trail of what changed and why stays visible.*
+
+## Executive Summary
+
+The spec is now complete: Problem Statement, Proposed Solution (with a market-leader research pass against Medusa.js and commercetools), Architecture, Data Model, API Contracts, UI/UX, Edge Cases, Risks, Phasing, Implementation Plan, Integration Test Coverage, Final Compliance Report, and Changelog. Every Open Question from the skeleton stage is resolved and recorded. A fresh-context adversarial review (per `om-spec-writing` step 8) caught two Critical issues — unverifiable citations to sibling specs that don't exist on `develop`, and a `PricingContext` diagram that had silently drifted from the real type — both fixed in the spec directly, with the corrections themselves logged in its Changelog. **Recommendation: ready for phased implementation**, with one implementation-time decision still explicitly open (the resolver-chain same-priority tie-break rule, Phase 2 Step 4a) and one deliberately-deferred scope item worth naming here (see Gap Analysis).
+
+## Backward Compatibility
+
+### Violations Found
+
+No violations. Every proposed change to `PricingContext` and `registerCatalogPricingResolver` is additive, verified against the actual current code (not assumed) after the adversarial review caught and corrected two places where the draft had drifted from what the code actually does:
+
+| # | Surface | Original finding | Current status |
+|---|---------|-------------------|------------------|
+| 1 | Event IDs (FROZEN) | `catalog.pricing.resolve.before/after` must not be renamed/repurposed. | **[resolved]** — spec's Architecture section only extends the existing resolver chain; no event ID touched. |
+| 2 | Type Definitions | `PricingContext` changes must stay additive. | **[resolved, after a correction]** — the spec's first Data Model draft *claimed* additive-only but the diagram itself silently flipped `quantity`/`date` from required to optional and dropped `\| null` from six existing fields. The adversarial review caught this against the real type (`catalog/lib/pricing.ts:10-19`); the spec's Data Model section now shows the actual current type alongside the corrected, genuinely-additive diff (only `currencyCode` and `customerGroupIds` are new). |
+| 3 | Function Signatures (STABLE) | Not identified in the original pass — surfaced during the finished spec's review. | **[new, resolved]** — the spec's first API Contracts draft stated `registerCatalogPricingResolver(resolver, options: { priority: number; id?: string })` with `options`/`priority` non-optional, stricter than the real `options?: { priority?: number }`. Corrected to `options?: { priority?: number; id?: string }`, matching the real signature with only `id` newly appended. |
+| 4 | DI Service Names (STABLE) | New module needs a distinct DI key. | **[resolved]** — Phase 3's `pricing` module registers via the existing `registerCatalogPricingResolver` extension point rather than a competing DI-resolved pricing service; no new service name collides with `catalogPricingService`. |
+| 5 | Database Schema (ADDITIVE-ONLY) | "No new columns" claim needed verification. | **[resolved]** — Data Model states this explicitly for all three phases; zero migrations across the whole initiative, confirmed against `catalog/data/entities.ts:788+`. |
+
+### Missing BC Section
+
+**[resolved]** — the spec doesn't carry a single "Migration & Backward Compatibility" heading verbatim, but Data Model, API Contracts, and Risks jointly cover every required element: the additive-only field diff, the corrected function-signature diff, and the one flagged strictly-safer behavior change (currency mismatch now returns "no price found" instead of a silent cross-currency match) with an `UPGRADE_NOTES.md` entry named in Phase 2 Step 6.
+
+## Spec Completeness
+
+### Sections — all present
+
+Every section the original pass listed as missing now exists: Architecture, Data Model, API Contracts, UI/UX, Edge Cases & Failure Scenarios, Risks & Impact Review, Phasing, Implementation Plan, Integration Test Coverage, Final Compliance Report, Changelog.
+
+### Notable completeness findings from the adversarial review (not in the original pass)
+
+| Finding | Status |
+|---|---|
+| Edge Cases table gave currency a full caller-contract treatment but omitted the equivalent tenant/organization-scoping contract for the rows a resolver runs over, despite root `AGENTS.md`'s "Never expose cross-tenant data" being a higher-severity rule than most in the document. | **[resolved]** — added as an explicit Edge Case row: every caller (today and Phase 3's `pricing` module) MUST pre-scope rows by `organization_id`/`tenant_id` before calling the resolver; the resolver itself has no scoping check of its own, which was already true and is now documented rather than implicit. |
+| Phase 2 Step 4 ("document and test the resolver-chain same-priority tie-break behavior") was circular — you cannot test a rule that hasn't been decided yet. | **[resolved, but still open at implementation time]** — split into Step 4a (decide and document the rule) and Step 4b (test it). The *decision itself* remains open until Phase 2 implementation — see Gap Analysis. |
+| Citations to `2026-08-14-ecommerce-suite-roadmap.md` (ADR-4), `2026-08-14-cart-module.md`, and `2026-08-14-customer-groups-and-b2b-terms.md` read as settled facts but none exist in `.ai/specs/` on `develop`. | **[resolved]** — a provenance note at the top of the spec marks all three as forward references to unmerged branch `spec/ecommerce-module-suite` (PR [#5384](https://github.com/open-mercato/open-mercato/pull/5384)), not settled dependencies. |
+
+## AGENTS.md Compliance
+
+### Violations
+
+None. Every compliance obligation the original pass flagged as "the Architecture section must satisfy" is satisfied, verified against real code by the adversarial review rather than left as a self-check:
+
+| Rule | Verdict |
+|------|---------|
+| "Never reimplement catalog pricing inline." (`catalog/AGENTS.md` § Never) | **Pass** — Phase 3's `lib/resolver.ts` imports and composes `matchesContext`/`scorePrice`/`selectBestPrice`; confirmed by the reviewer as genuinely reused, not reimplemented. |
+| "Ask before changing price-layer precedence, resolver priority semantics" (`catalog/AGENTS.md` § Ask First) | **Pass** — the spec explicitly declines to touch `scorePrice`'s existing weights (Research section notes commercetools' different precedence but keeps OM's own, citing this exact rule as the reason not to change it without asking). |
+| "Put core platform features in `packages/<package>/src/modules/<module>/`" | **Pass** — `packages/core/src/modules/pricing/`, closed by rule in the Locked-decisions stage. |
+| Cross-Module Coupling — optional-integration direction (`packages/core/AGENTS.md` § Cross-Module Coupling) | **Pass** — Architecture explicitly reasons through why the push-based `registerCatalogPricingResolver` extension point (rather than a pull-based `tryResolve`) still keeps `catalog` upstream and unaware of `pricing`; the adversarial review confirmed this was checked against the rule's actual text, not just asserted. |
+| Command pattern for writes (`packages/core/AGENTS.md` § Command Side Effects) | **Pass, N/A** — Phase 1's admin UI writes exclusively through the already-existing `catalog.prices.create/update/delete` commands; no new write path is introduced. |
+| `setup.ts`/`acl.ts` sync | **Pass** — Phase 3's optional diagnostic route now has a named `pricing.diagnostics.view` feature, added after the adversarial review caught it was missing; granted to `admin` in `setup.ts`. |
+| Encryption | **Pass, no new surface** — confirmed no PII in price rows. |
+
+## Risk Assessment
+
+The spec's own Risks & Impact Review is now the authoritative version; this section only tracks what changed relative to the original pass.
+
+### Carried forward, unchanged in substance
+- Registry `globalThis` fix remains the High risk it was identified as — now Phase 2 Step 1 with a named regression test, not a footnote.
+- `sales/AGENTS.md`'s `selectBestPrice` overclaim remains High — now Phase 2 Step 5, fixed regardless of the sales/cart wiring decision (Q1 = engine-only).
+- `customerGroupIds` shape-ownership coordination with the sibling spec remains Medium — now explicitly the spec's own shape to originate (Q4 decision), with the sibling spec expected to defer.
+
+### New, found during the finished-spec review
+- **Bundling friction (High, new).** Phase 1 (catalog UI) and Phase 3 (new module) were kept as two phases of one spec by explicit user decision rather than split. The adversarial review named the real cost of that choice — reviewer-skill mismatch, zero sequencing benefit since Phase 1 has no dependency on Phase 2/3, and reduced discoverability for the sibling spec's author trying to find the `customerGroupIds` shape decision. Not re-litigated; recorded as a named risk in the spec so the cost is visible rather than silently absorbed.
+- **Tenant/org-scoping caller contract (folded into Edge Cases, not a separate Risk row, since it describes existing—not new—behavior).** See Spec Completeness above.
+
+### Deliberately not carried forward
+- **Cache-bleed / `contextCacheKey` primitive (originally Medium).** The first pass recommended the engine expose a canonical `contextCacheKey(context)` primitive so future callers (storefront, cart, POS) don't re-discover the buyer-context cache-bleed bug independently found twice in the sibling ecommerce-suite branch. The finished spec does **not** include this — it isn't mentioned anywhere in the final Architecture or API Contracts. This is consistent with the now-locked narrow scope (Q1 = resolution only, no HTTP-facing surface, no caching of any kind in this spec), and caching genuinely belongs to whichever module actually serves buyer-context-priced payloads over HTTP (`storefront-public-api`, `cart-module` — both out of scope here). Recorded here as a **deliberate scope choice, not an oversight** — but worth flagging explicitly to whoever picks up `cart-module`'s or a future `storefront`'s caching design, since the underlying risk (documented twice already) doesn't go away just because this spec doesn't own it.
+
+## Gap Analysis
+
+### Still open at implementation time (not blockers, but must not be forgotten)
+- **Phase 2 Step 4a — the resolver-chain same-priority tie-break rule is not yet decided.** The spec is honest about this (split into a decide-then-test pair rather than a circular single step), but it means Phase 2 cannot be marked done on Implementation Plan alone; the decision itself needs to happen and get written down before Step 4b's test can exist.
+- **Cache-key contract for buyer-context-priced payloads (see Risk Assessment above) has no explicit owner named.** Neither this spec nor (as far as this analysis can verify, since it lives on an unmerged branch) `storefront-public-api.md` is confirmed to own it. Worth a one-line flag when `cart-module`/`storefront` work actually starts, so it isn't assumed solved by proximity to this spec.
+
+### Resolved from the original pass
+- Registry `globalThis` fix — now explicit, phased, tested.
+- Q1 (module location) — closed by rule.
+- Admin UI ownership (originally ambiguous between `catalog` and `pricing`) — resolved to `catalog` (Phase 1), since the underlying API/commands/schema were already complete and the gap was UI-only.
+- Explainability output contract for `cart-module`'s line-item snapshot — resolved as "no new contract needed," since the existing `PriceRow` return already carries `id`/`minQuantity`.
+- Resolver-chain takeover test scenarios — now explicit in both Implementation Plan (Phase 3 Step 4) and Integration Test Coverage.
+- Resolver registration observability — the optional diagnostic page (Phase 3 Step 5) addresses this, now with a named ACL feature.
+
+## Recommendation
+
+**Ready for phased implementation.** Phase 1 (catalog UI) and Phase 2 (resolver hardening) can start immediately and independently; Phase 3 (the `pricing` module) should start once Phase 2 lands, per the spec's own dependency ordering. The one remaining implementation-time decision (Phase 2 Step 4a's tie-break rule) is correctly scoped as an implementation task, not a spec-readiness blocker. The deliberately-deferred cache-key ownership question is not this spec's to resolve, but should travel with whoever picks up `cart-module`'s or `storefront-public-api`'s eventual implementation.


### PR DESCRIPTION
## Summary

Specs only. No code, no schema changes, no migrations.

A three-phase, two-owner spec that keeps `CatalogProductPrice` and `catalog/lib/pricing.ts`'s existing specificity-scored resolver as the data model and algorithm — it's already a working B2B pricing matrix (customer/customer-group/channel/quantity-tier/validity-window scoping), just under-exposed and under-hardened:

- **Phase 1 (`catalog`)** — a backend admin UI for `CatalogProductPrice`'s specificity dimensions. The API (`catalog/api/prices`) and commands (`catalog/commands/prices.ts`) already fully support every field; only the UI is missing.
- **Phase 2 (`catalog`)** — hardens the existing `registerCatalogPricingResolver` extension point: fixes a `globalThis`-scoping bug in the `pricingResolvers` registry (module-local state today — the same failure class already fixed once elsewhere in this codebase for the ORM/entity registry), adds dedupe-by-id, and extends `PricingContext` additively with `currencyCode` and `customerGroupIds`.
- **Phase 3 (`pricing`, new, optional module)** — registers into the hardened chain and takes over resolution when installed, degrading cleanly to catalog's baseline when absent (same optional-integration shape as `availability`/`wms` on the sibling `spec/ecommerce-module-suite` branch, PR #5384).

Zero schema migrations across all three phases.

## Process

- Skeleton-first via `/om-spec-writing`, with a 5-question Open Questions gate (module location, sales/cart wiring, currency, admin UI scope/ownership, `customerGroupIds` shape) resolved interactively.
- A `/om-pre-implement-spec` pass caught the `globalThis` registry bug before Architecture was drafted — folded into scope rather than left as a footnote.
- Research against Medusa.js v2's Pricing Module and commercetools' Standalone Prices grounds the currency-as-first-class-dimension and pure-resolution-function design choices, and explicitly declines to copy commercetools' different specificity precedence without asking first (per `catalog/AGENTS.md`).
- A fresh-context adversarial review (independent of the drafting context) caught two Critical issues before this PR: citations to sibling specs that don't exist on `develop` (they live on the unmerged `spec/ecommerce-module-suite` branch) presented as settled fact, and a `PricingContext` diagram that had silently drifted from the real type (`quantity`/`date` flipped to optional, `| null` dropped). Both corrected in the spec, with the correction trail kept in its Changelog.
- The pre-implementation analysis has been updated to reflect the finished spec and is included alongside it.

## What's here

| File | Content |
|---|---|
| `.ai/specs/2026-08-21-pricing-engine.md` | The spec |
| `.ai/specs/analysis/ANALYSIS-2026-08-21-pricing-engine.md` | Pre-implementation analysis, updated post-review |

## Review focus

- Whether keeping Phase 1 (catalog UI) and Phase 3 (new module) as two phases of one spec — rather than splitting into two specs — is the right call. The spec names the friction this causes (reviewer-skill mismatch, no sequencing benefit, discoverability) as a risk rather than hiding it, but doesn't reopen the decision itself.
- The one remaining implementation-time open item: the resolver-chain same-priority tie-break rule (Phase 2 Step 4a) is explicitly undecided pending implementation, not glossed over.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789894023&installation_model_id=432243&pr_number=5442&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5442&signature=1a68c7940a98c93e9f243b7939e401e19789acc8b7ae056141b845d4e7acbcb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->