### PR TITLE
fix(shared): warn on duplicate entity class names across modules

### DIFF
--- a/.ai/lessons/standalone-generators-must-reuse-package-generated.md
+++ b/.ai/lessons/standalone-generators-must-reuse-package-generated.md
@@ -11,6 +11,6 @@ topics: ["auto-discovery","build-output","data-scoping"]
 
 **Problem**: The entity-id generator parsed exported classes and property declarations from module entity files. That works against monorepo `src` files, but compiled `dist/modules/**/data/entities.js` files do not preserve that source shape, so standalone generation silently dropped package entities like `organization`.
 
-**Rule**: In standalone mode, when building app-level generated entity IDs/field shims for package-backed modules, prefer the package's shipped `generated/entities.ids.generated.ts` and `generated/entities/*/index.ts` artifacts. Do not rely on parsing compiled `dist` entity files for source-level declarations.
+**Rule**: In standalone mode, when building app-level generated entity IDs/field shims for package-backed modules, prefer the package's shipped `generated/entities.ids.generated.ts` and `generated/entities/*/index.ts` artifacts. Do not rely on parsing compiled `dist` entity files for source-level declarations. Parsing compiled output for *class names alone* is an acceptable last resort when no generated artifact carries them — the entity-registry duplicate-class-name check prefers the package's shipped `src/modules` mirror and only falls back to `dist` for that one fact.
 
 **Applies to**: `packages/cli/src/lib/generators/entity-ids.ts` and standalone `create-app` generation paths.

--- a/packages/cli/src/lib/generators/__tests__/entity-class-declarations.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/entity-class-declarations.test.ts
@@ -1,0 +1,97 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { parseEntityClassNames } from '../entity-class-declarations'
+
+let tmpDir: string
+
+function writeSource(content: string): string {
+  const filePath = path.join(tmpDir, 'entities.ts')
+  fs.writeFileSync(filePath, content)
+  return filePath
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'entity-class-declarations-test-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+describe('parseEntityClassNames', () => {
+  it('collects exported classes decorated with @Entity()', () => {
+    const filePath = writeSource(`
+      import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy'
+
+      @Entity({ tableName: 'invoices' })
+      export class Invoice {
+        @PrimaryKey({ type: 'uuid' })
+        id!: string
+      }
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual(['Invoice'])
+  })
+
+  it('looks past comments and stacked decorators', () => {
+    const filePath = writeSource(`
+      import { Entity, Index, Unique } from '@mikro-orm/decorators/legacy'
+
+      @Entity({ tableName: 'invoices' })
+      // The unique constraint bounds the lookup.
+      @Unique({ properties: ['number'] })
+      @Index({
+        name: 'invoices_number_idx',
+        expression: 'create index "invoices_number_idx" on "invoices" ("number")',
+      })
+      export class Invoice {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual(['Invoice'])
+  })
+
+  it('ignores exported classes that are not entities', () => {
+    const filePath = writeSource(`
+      export class InvoiceBuilder {}
+
+      @Entity({ tableName: 'invoices' })
+      export class Invoice {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual(['Invoice'])
+  })
+
+  it('ignores entity classes that are not exported', () => {
+    const filePath = writeSource(`
+      @Entity({ tableName: 'invoices' })
+      class Invoice {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual([])
+  })
+
+  it('handles a local export list', () => {
+    const filePath = writeSource(`
+      @Entity({ tableName: 'invoices' })
+      class Invoice {}
+
+      export { Invoice }
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual(['Invoice'])
+  })
+
+  it('accepts a bare @Entity decorator', () => {
+    const filePath = writeSource(`
+      @Entity
+      export class Invoice {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual(['Invoice'])
+  })
+
+  it('returns nothing for an unreadable file instead of throwing', () => {
+    expect(parseEntityClassNames(path.join(tmpDir, 'missing.ts'))).toEqual([])
+  })
+})

--- a/packages/cli/src/lib/generators/__tests__/entity-class-declarations.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/entity-class-declarations.test.ts
@@ -53,6 +53,8 @@ describe('parseEntityClassNames', () => {
 
   it('ignores exported classes that are not entities', () => {
     const filePath = writeSource(`
+      import { Entity } from '@mikro-orm/decorators/legacy'
+
       export class InvoiceBuilder {}
 
       @Entity({ tableName: 'invoices' })
@@ -64,6 +66,8 @@ describe('parseEntityClassNames', () => {
 
   it('ignores entity classes that are not exported', () => {
     const filePath = writeSource(`
+      import { Entity } from '@mikro-orm/decorators/legacy'
+
       @Entity({ tableName: 'invoices' })
       class Invoice {}
     `)
@@ -73,6 +77,8 @@ describe('parseEntityClassNames', () => {
 
   it('handles a local export list', () => {
     const filePath = writeSource(`
+      import { Entity } from '@mikro-orm/decorators/legacy'
+
       @Entity({ tableName: 'invoices' })
       class Invoice {}
 
@@ -84,6 +90,8 @@ describe('parseEntityClassNames', () => {
 
   it('accepts a bare @Entity decorator', () => {
     const filePath = writeSource(`
+      import { Entity } from '@mikro-orm/decorators/legacy'
+
       @Entity
       export class Invoice {}
     `)
@@ -126,6 +134,39 @@ describe('parseEntityClassNames', () => {
     expect(parseEntityClassNames(filePath)).toEqual([])
   })
 
+  it('ignores an Entity decorator imported from an unrelated library', () => {
+    // Any library may export an `Entity` decorator; only MikroORM's collides in the ORM
+    // metadata registry, so only a decorator bound to a @mikro-orm/* import counts.
+    const filePath = writeSource(`
+      import { Entity } from 'some-other-orm'
+
+      @Entity({ tableName: 'invoices' })
+      export class Invoice {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual([])
+  })
+
+  it('ignores a namespace-qualified Entity decorator from an unrelated library', () => {
+    const filePath = writeSource(`
+      import * as other from 'some-other-orm'
+
+      @other.Entity({ tableName: 'invoices' })
+      export class Invoice {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual([])
+  })
+
+  it('ignores an Entity decorator with no import to bind it', () => {
+    const filePath = writeSource(`
+      @Entity({ tableName: 'invoices' })
+      export class Invoice {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual([])
+  })
+
   it('parses a .tsx entity file as JSX rather than dropping declarations', () => {
     // MODULE_CODE_EXTENSIONS accepts .tsx, where `<T>` is JSX, not a type assertion.
     const filePath = writeSource(`
@@ -138,5 +179,109 @@ describe('parseEntityClassNames', () => {
     `, 'entities.tsx')
 
     expect(parseEntityClassNames(filePath)).toEqual(['Invoice'])
+  })
+})
+
+describe('parseEntityClassNames on compiled package output', () => {
+  // A package that ships dist only hands the generator its built entity file, where a
+  // decorated class has become a class expression plus a decorator-helper call. Without
+  // this the standalone generator sees no entities at all and misses every collision.
+  it('reads an esbuild ESM emit', () => {
+    const filePath = writeSource(`
+      var __decorateClass = (decorators, target) => target;
+      import { Entity, PrimaryKey } from "@mikro-orm/decorators/legacy";
+      let ApiKey = class {
+      };
+      __decorateClass([
+        PrimaryKey({ type: "uuid" })
+      ], ApiKey.prototype, "id", 2);
+      ApiKey = __decorateClass([
+        Entity({ tableName: "api_keys" })
+      ], ApiKey);
+      export {
+        ApiKey
+      };
+    `, 'entities.js')
+
+    expect(parseEntityClassNames(filePath)).toEqual(['ApiKey'])
+  })
+
+  it('reads a tsc CommonJS emit', () => {
+    const filePath = writeSource(`
+      "use strict";
+      Object.defineProperty(exports, "__esModule", { value: true });
+      exports.ApiKey = void 0;
+      const legacy_1 = require("@mikro-orm/decorators/legacy");
+      let ApiKey = class ApiKey {
+      };
+      ApiKey = __decorate([
+        (0, legacy_1.Entity)({ tableName: "api_keys" })
+      ], ApiKey);
+      exports.ApiKey = ApiKey;
+    `, 'entities.js')
+
+    expect(parseEntityClassNames(filePath)).toEqual(['ApiKey'])
+  })
+
+  it('reads a bundler export table', () => {
+    const filePath = writeSource(`
+      import { Entity } from "@mikro-orm/core";
+      var entities_exports = {};
+      __export(entities_exports, {
+        ApiKey: () => ApiKey
+      });
+      let ApiKey = class {
+      };
+      ApiKey = __decorateClass([
+        Entity({ tableName: "api_keys" })
+      ], ApiKey);
+    `, 'entities.js')
+
+    expect(parseEntityClassNames(filePath)).toEqual(['ApiKey'])
+  })
+
+  it('ignores a compiled class that is never exported', () => {
+    const filePath = writeSource(`
+      import { Entity } from "@mikro-orm/decorators/legacy";
+      let Internal = class {
+      };
+      Internal = __decorateClass([
+        Entity({ tableName: "internal" })
+      ], Internal);
+    `, 'entities.js')
+
+    expect(parseEntityClassNames(filePath)).toEqual([])
+  })
+
+  it('ignores a compiled class decorated by an unrelated library', () => {
+    const filePath = writeSource(`
+      import { Entity } from "some-other-orm";
+      let Invoice = class {
+      };
+      Invoice = __decorateClass([
+        Entity({ tableName: "invoices" })
+      ], Invoice);
+      export {
+        Invoice
+      };
+    `, 'entities.js')
+
+    expect(parseEntityClassNames(filePath)).toEqual([])
+  })
+
+  it('ignores property decorators, which share the helper call', () => {
+    const filePath = writeSource(`
+      import { Entity, Property } from "@mikro-orm/decorators/legacy";
+      let Helper = class {
+      };
+      __decorateClass([
+        Property({ type: "text" })
+      ], Helper.prototype, "name", 2);
+      export {
+        Helper
+      };
+    `, 'entities.js')
+
+    expect(parseEntityClassNames(filePath)).toEqual([])
   })
 })

--- a/packages/cli/src/lib/generators/__tests__/entity-class-declarations.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/entity-class-declarations.test.ts
@@ -5,8 +5,8 @@ import { parseEntityClassNames } from '../entity-class-declarations'
 
 let tmpDir: string
 
-function writeSource(content: string): string {
-  const filePath = path.join(tmpDir, 'entities.ts')
+function writeSource(content: string, fileName = 'entities.ts'): string {
+  const filePath = path.join(tmpDir, fileName)
   fs.writeFileSync(filePath, content)
   return filePath
 }
@@ -93,5 +93,50 @@ describe('parseEntityClassNames', () => {
 
   it('returns nothing for an unreadable file instead of throwing', () => {
     expect(parseEntityClassNames(path.join(tmpDir, 'missing.ts'))).toEqual([])
+  })
+
+  it('recognises an aliased Entity import', () => {
+    const filePath = writeSource(`
+      import { Entity as OrmEntity } from '@mikro-orm/decorators/legacy'
+
+      @OrmEntity({ tableName: 'invoices' })
+      export class Invoice {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual(['Invoice'])
+  })
+
+  it('recognises a namespace-qualified Entity decorator', () => {
+    const filePath = writeSource(`
+      import * as orm from '@mikro-orm/decorators/legacy'
+
+      @orm.Entity({ tableName: 'invoices' })
+      export class Invoice {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual(['Invoice'])
+  })
+
+  it('does not treat an unrelated decorator as an entity', () => {
+    const filePath = writeSource(`
+      @Injectable()
+      export class InvoiceService {}
+    `)
+
+    expect(parseEntityClassNames(filePath)).toEqual([])
+  })
+
+  it('parses a .tsx entity file as JSX rather than dropping declarations', () => {
+    // MODULE_CODE_EXTENSIONS accepts .tsx, where `<T>` is JSX, not a type assertion.
+    const filePath = writeSource(`
+      import { Entity } from '@mikro-orm/decorators/legacy'
+
+      export const icon = () => <span>invoice</span>
+
+      @Entity({ tableName: 'invoices' })
+      export class Invoice {}
+    `, 'entities.tsx')
+
+    expect(parseEntityClassNames(filePath)).toEqual(['Invoice'])
   })
 })

--- a/packages/cli/src/lib/generators/__tests__/module-entities.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/module-entities.test.ts
@@ -185,6 +185,33 @@ describe('generateModuleEntities duplicate entity class names', () => {
     expect(warnSpy).not.toHaveBeenCalled()
   })
 
+  it('reads the app override, not the package file, when an app supplies a package module\'s entities', async () => {
+    // The registry imports the app override for such a module, so the check must read the
+    // same file — parsing the package tree would report names that are never registered.
+    touchFile(
+      path.join(tmpDir, 'packages', 'core', 'src', 'modules', 'billing', 'data', 'entities.ts'),
+      entitySource('PackageInvoice', 'billing_invoices'),
+    )
+    touchFile(
+      path.join(tmpDir, 'app', 'src', 'modules', 'billing', 'data', 'entities.ts'),
+      entitySource('Invoice', 'billing_invoices'),
+    )
+    const modules: ModuleEntry[] = [
+      { id: 'billing', from: '@open-mercato/core' },
+      moduleWithEntities('subscriptions', entitySource('Invoice', 'subscription_invoices')),
+    ]
+
+    const result = await generateModuleEntities({ resolver: createMockResolver(tmpDir, modules), quiet: true })
+
+    expect(result.errors).toEqual([])
+    expect(readGenerated(tmpDir)).toContain('from "@/modules/billing/data/entities"')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const message = warnSpy.mock.calls[0][0] as string
+    expect(message).toContain('Invoice')
+    expect(message).toContain(path.join('app', 'src', 'modules', 'billing', 'data', 'entities.ts'))
+    expect(message).not.toContain('PackageInvoice')
+  })
+
   it('stays silent when only one of the colliding classes is an entity', async () => {
     const modules = [
       moduleWithEntities('billing', entitySource('Invoice', 'billing_invoices')),

--- a/packages/cli/src/lib/generators/__tests__/module-entities.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/module-entities.test.ts
@@ -196,3 +196,134 @@ describe('generateModuleEntities duplicate entity class names', () => {
     expect(warnSpy).not.toHaveBeenCalled()
   })
 })
+
+describe('generateModuleEntities duplicate detection in standalone installs', () => {
+  // A standalone install resolves a package module to its compiled dist tree, where a
+  // decorated class is no longer a class declaration. Published packages ship
+  // src/modules too, so parsing prefers that mirror and falls back to the compiled file.
+  const PACKAGE = '@open-mercato/core'
+
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  function packageRoot(): string {
+    return path.join(tmpDir, 'app', 'node_modules', PACKAGE)
+  }
+
+  function createStandaloneResolver(enabled: ModuleEntry[]): PackageResolver {
+    const outputDir = path.join(tmpDir, 'app', '.mercato', 'generated')
+    fs.mkdirSync(outputDir, { recursive: true })
+
+    return {
+      isMonorepo: () => false,
+      getRootDir: () => path.join(tmpDir, 'app'),
+      getAppDir: () => path.join(tmpDir, 'app'),
+      getOutputDir: () => outputDir,
+      getModulesConfigPath: () => path.join(tmpDir, 'app', 'src', 'modules.ts'),
+      discoverPackages: () => [],
+      loadEnabledModules: () => enabled,
+      getModulePaths: (entry: ModuleEntry) => ({
+        appBase: path.join(tmpDir, 'app', 'src', 'modules', entry.id),
+        pkgBase: path.join(packageRoot(), 'dist', 'modules', entry.id),
+      }),
+      getModuleImportBase: (entry: ModuleEntry) => ({
+        appBase: `@/modules/${entry.id}`,
+        pkgBase: `${PACKAGE}/modules/${entry.id}`,
+      }),
+      getPackageOutputDir: () => outputDir,
+      getPackageRoot: () => packageRoot(),
+    }
+  }
+
+  const compiledEntity = (className: string, tableName: string) => `
+import { Entity } from "@mikro-orm/decorators/legacy";
+let ${className} = class {
+};
+${className} = __decorateClass([
+  Entity({ tableName: "${tableName}" })
+], ${className});
+export {
+  ${className}
+};
+`
+
+  const sourceEntity = (className: string, tableName: string) =>
+    `import { Entity } from '@mikro-orm/decorators/legacy'\n\n@Entity({ tableName: '${tableName}' })\nexport class ${className} {}\n`
+
+  function distModule(id: string, className: string, tableName: string): ModuleEntry {
+    touchFile(path.join(packageRoot(), 'dist', 'modules', id, 'data', 'entities.js'), compiledEntity(className, tableName))
+    return { id, from: PACKAGE }
+  }
+
+  function withSourceMirror(id: string, className: string, tableName: string): void {
+    touchFile(path.join(packageRoot(), 'src', 'modules', id, 'data', 'entities.ts'), sourceEntity(className, tableName))
+  }
+
+  it('detects a package-to-package collision through the shipped source mirror', async () => {
+    const modules = [
+      distModule('billing', 'Invoice', 'billing_invoices'),
+      distModule('subscriptions', 'Invoice', 'subscription_invoices'),
+    ]
+    withSourceMirror('billing', 'Invoice', 'billing_invoices')
+    withSourceMirror('subscriptions', 'Invoice', 'subscription_invoices')
+
+    const result = await generateModuleEntities({ resolver: createStandaloneResolver(modules), quiet: true })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const message = warnSpy.mock.calls[0][0] as string
+    expect(message).toContain('Invoice')
+    expect(message).toContain(path.join('src', 'modules', 'billing', 'data', 'entities.ts'))
+    expect(result.errors).toEqual([])
+    // The runtime import still points at the compiled package entry.
+    expect(readGenerated(tmpDir)).toContain(`from "${PACKAGE}/modules/billing/data/entities"`)
+  })
+
+  it('detects the collision from compiled output when a package ships dist only', async () => {
+    const modules = [
+      distModule('billing', 'Invoice', 'billing_invoices'),
+      distModule('subscriptions', 'Invoice', 'subscription_invoices'),
+    ]
+
+    await generateModuleEntities({ resolver: createStandaloneResolver(modules), quiet: true })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const message = warnSpy.mock.calls[0][0] as string
+    expect(message).toContain('Invoice')
+    expect(message).toContain(path.join('dist', 'modules', 'subscriptions', 'data', 'entities.js'))
+  })
+
+  it('detects a package-to-app collision', async () => {
+    const modules = [
+      distModule('billing', 'Invoice', 'billing_invoices'),
+      { id: 'reporting', from: '@app' } as ModuleEntry,
+    ]
+    withSourceMirror('billing', 'Invoice', 'billing_invoices')
+    touchFile(
+      path.join(tmpDir, 'app', 'src', 'modules', 'reporting', 'data', 'entities.ts'),
+      sourceEntity('Invoice', 'reporting_invoices'),
+    )
+
+    await generateModuleEntities({ resolver: createStandaloneResolver(modules), quiet: true })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0] as string).toContain('reporting')
+  })
+
+  it('stays silent when compiled package entity class names are unique', async () => {
+    const modules = [
+      distModule('billing', 'Invoice', 'billing_invoices'),
+      distModule('subscriptions', 'Subscription', 'subscriptions'),
+    ]
+
+    await generateModuleEntities({ resolver: createStandaloneResolver(modules), quiet: true })
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/lib/generators/__tests__/module-entities.test.ts
+++ b/packages/cli/src/lib/generators/__tests__/module-entities.test.ts
@@ -135,3 +135,64 @@ describe('generateModuleEntities', () => {
     expect(secondStat.mtimeMs).toBe(firstStat.mtimeMs)
   })
 })
+
+describe('generateModuleEntities duplicate entity class names', () => {
+  const entitySource = (className: string, tableName: string) =>
+    `import { Entity } from '@mikro-orm/decorators/legacy'\n\n@Entity({ tableName: '${tableName}' })\nexport class ${className} {}\n`
+
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  function moduleWithEntities(id: string, content: string): ModuleEntry {
+    touchFile(path.join(tmpDir, 'packages', 'core', 'src', 'modules', id, 'data', 'entities.ts'), content)
+    return { id, from: '@open-mercato/core' }
+  }
+
+  it('warns when two modules declare the same entity class name, and still generates', async () => {
+    const modules = [
+      moduleWithEntities('billing', entitySource('Invoice', 'billing_invoices')),
+      moduleWithEntities('subscriptions', entitySource('Invoice', 'subscription_invoices')),
+    ]
+
+    const result = await generateModuleEntities({ resolver: createMockResolver(tmpDir, modules), quiet: true })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const message = warnSpy.mock.calls[0][0] as string
+    expect(message).toContain('[Entities Warning]')
+    expect(message).toContain('Invoice')
+    expect(message).toContain('billing')
+    expect(message).toContain('subscriptions')
+    // Warning-only by design: generation still succeeds.
+    expect(result.errors).toEqual([])
+    expect(readGenerated(tmpDir)).toContain('enhanceEntities')
+  })
+
+  it('stays silent when entity class names are unique', async () => {
+    const modules = [
+      moduleWithEntities('billing', entitySource('Invoice', 'billing_invoices')),
+      moduleWithEntities('subscriptions', entitySource('Subscription', 'subscriptions')),
+    ]
+
+    await generateModuleEntities({ resolver: createMockResolver(tmpDir, modules), quiet: true })
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('stays silent when only one of the colliding classes is an entity', async () => {
+    const modules = [
+      moduleWithEntities('billing', entitySource('Invoice', 'billing_invoices')),
+      moduleWithEntities('subscriptions', 'export class Invoice {}\n'),
+    ]
+
+    await generateModuleEntities({ resolver: createMockResolver(tmpDir, modules), quiet: true })
+
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/lib/generators/entity-class-declarations.ts
+++ b/packages/cli/src/lib/generators/entity-class-declarations.ts
@@ -5,71 +5,213 @@ import ts from 'typescript-js'
  * Names of the `@Entity()`-decorated classes a module's entity file exports.
  *
  * Only decorated classes count: an entity file may also export plain helper classes,
- * and reporting those as entities would raise false collisions. Parsing is used rather
- * than importing because the caller runs during generation, before the module graph
- * exists.
+ * and reporting those as entities would raise false collisions. Only a decorator bound
+ * to a `@mikro-orm/*` import counts, so an unrelated `Entity` decorator from another
+ * library never registers as one.
+ *
+ * Parsing is used rather than importing because the caller runs during generation,
+ * before the module graph exists. A monorepo checkout and a standalone install that
+ * ships `src/modules` both hand this TypeScript source; a package that ships compiled
+ * output only hands it the built file instead, where a decorated class has become a
+ * class expression plus a decorator-helper call, so both shapes are recognised.
  */
+
+const MIKRO_ORM_MODULE_PREFIX = '@mikro-orm/'
+
+type EntityDecoratorBindings = {
+  /** Local names bound to MikroORM's `Entity` export, including aliased imports. */
+  named: Set<string>
+  /** Local names bound to a whole MikroORM module, for `@orm.Entity()`. */
+  namespaces: Set<string>
+}
 
 function inferScriptKind(filePath: string): ts.ScriptKind {
   if (filePath.endsWith('.tsx')) return ts.ScriptKind.TSX
   if (filePath.endsWith('.jsx')) return ts.ScriptKind.JSX
-  if (filePath.endsWith('.js')) return ts.ScriptKind.JS
+  if (filePath.endsWith('.js') || filePath.endsWith('.cjs') || filePath.endsWith('.mjs')) return ts.ScriptKind.JS
   return ts.ScriptKind.TS
 }
 
-/**
- * Local names bound to MikroORM's `Entity` decorator, so an aliased import
- * (`import { Entity as OrmEntity }`) is still recognised.
- */
-function collectEntityDecoratorNames(sourceFile: ts.SourceFile): Set<string> {
-  const names = new Set<string>(['Entity'])
-  sourceFile.forEachChild((node) => {
-    if (!ts.isImportDeclaration(node)) return
-    const bindings = node.importClause?.namedBindings
-    if (!bindings || !ts.isNamedImports(bindings)) return
+function isMikroOrmModule(specifier: string): boolean {
+  return specifier.startsWith(MIKRO_ORM_MODULE_PREFIX)
+}
+
+/** `require('@mikro-orm/core')` as it survives into compiled CommonJS output. */
+function readRequiredModuleSpecifier(expression: ts.Expression | undefined): string | undefined {
+  if (!expression || !ts.isCallExpression(expression)) return undefined
+  if (!ts.isIdentifier(expression.expression) || expression.expression.text !== 'require') return undefined
+  const [argument] = expression.arguments
+  return argument && ts.isStringLiteralLike(argument) ? argument.text : undefined
+}
+
+function collectEntityDecoratorBindings(sourceFile: ts.SourceFile): EntityDecoratorBindings {
+  const named = new Set<string>()
+  const namespaces = new Set<string>()
+
+  const addFromNamedBindings = (bindings: ts.NamedImportBindings | undefined): void => {
+    if (!bindings) return
+    if (ts.isNamespaceImport(bindings)) {
+      namespaces.add(bindings.name.text)
+      return
+    }
     for (const element of bindings.elements) {
-      if ((element.propertyName ?? element.name).text === 'Entity') {
-        names.add(element.name.text)
+      if ((element.propertyName ?? element.name).text === 'Entity') named.add(element.name.text)
+    }
+  }
+
+  sourceFile.forEachChild((node) => {
+    if (ts.isImportDeclaration(node)) {
+      if (!ts.isStringLiteralLike(node.moduleSpecifier) || !isMikroOrmModule(node.moduleSpecifier.text)) return
+      addFromNamedBindings(node.importClause?.namedBindings)
+      return
+    }
+    if (!ts.isVariableStatement(node)) return
+    for (const declaration of node.declarationList.declarations) {
+      const specifier = readRequiredModuleSpecifier(declaration.initializer)
+      if (!specifier || !isMikroOrmModule(specifier)) continue
+      if (ts.isIdentifier(declaration.name)) {
+        namespaces.add(declaration.name.text)
+        continue
+      }
+      if (!ts.isObjectBindingPattern(declaration.name)) continue
+      for (const element of declaration.name.elements) {
+        const sourceName = element.propertyName ?? element.name
+        if (ts.isIdentifier(sourceName) && sourceName.text === 'Entity' && ts.isIdentifier(element.name)) {
+          named.add(element.name.text)
+        }
       }
     }
   })
+
+  return { named, namespaces }
+}
+
+/** Unwraps the `(0, core_1.Entity)` form a CommonJS emit produces. */
+function unwrapReference(expression: ts.Expression): ts.Expression {
+  if (ts.isParenthesizedExpression(expression)) return unwrapReference(expression.expression)
+  if (ts.isBinaryExpression(expression) && expression.operatorToken.kind === ts.SyntaxKind.CommaToken) {
+    return unwrapReference(expression.right)
+  }
+  return expression
+}
+
+/** Accepts `Entity`, an aliased local name, and `<mikroOrmNamespace>.Entity`. */
+function isEntityReference(expression: ts.Expression, bindings: EntityDecoratorBindings): boolean {
+  const reference = unwrapReference(expression)
+  if (ts.isIdentifier(reference)) return bindings.named.has(reference.text)
+  if (!ts.isPropertyAccessExpression(reference)) return false
+  if (reference.name.text !== 'Entity') return false
+  return ts.isIdentifier(reference.expression) && bindings.namespaces.has(reference.expression.text)
+}
+
+/** Accepts `@Entity`, `@Entity(...)` and the aliased or namespace-qualified forms. */
+function isEntityDecorator(decorator: ts.Decorator, bindings: EntityDecoratorBindings): boolean {
+  const expression = ts.isCallExpression(decorator.expression)
+    ? decorator.expression.expression
+    : decorator.expression
+  return isEntityReference(expression, bindings)
+}
+
+function hasEntityDecorator(node: ts.ClassDeclaration, bindings: EntityDecoratorBindings): boolean {
+  if (!ts.canHaveDecorators(node)) return false
+  return (ts.getDecorators(node) ?? []).some((decorator) => isEntityDecorator(decorator, bindings))
+}
+
+function isExportedDeclaration(node: ts.Node): boolean {
+  return ts.canHaveModifiers(node)
+    ? (ts.getModifiers(node) ?? []).some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+    : false
+}
+
+/**
+ * Names the file exports without redeclaring them: `export { X }`, the CommonJS
+ * `exports.X = X`, and the `__export(exports, { X: () => X })` table a bundler emits.
+ */
+function collectIndirectExportNames(sourceFile: ts.SourceFile): Set<string> {
+  const names = new Set<string>()
+
+  const addExportTable = (expression: ts.Expression): void => {
+    if (!ts.isObjectLiteralExpression(expression)) return
+    for (const property of expression.properties) {
+      if (!property.name) continue
+      const name = ts.isIdentifier(property.name) || ts.isStringLiteralLike(property.name)
+        ? property.name.text
+        : undefined
+      if (name) names.add(name)
+    }
+  }
+
+  sourceFile.forEachChild((node) => {
+    if (ts.isExportDeclaration(node) && !node.moduleSpecifier) {
+      const clause = node.exportClause
+      if (clause && ts.isNamedExports(clause)) {
+        for (const element of clause.elements) names.add((element.propertyName ?? element.name).text)
+      }
+      return
+    }
+    if (!ts.isExpressionStatement(node)) return
+    const expression = node.expression
+    if (ts.isCallExpression(expression)) {
+      const callee = expression.expression
+      // esbuild emits `__export(ns, {...})`, SWC `_export(exports, {...})`.
+      if (ts.isIdentifier(callee) && /^_*export$/.test(callee.text) && expression.arguments.length >= 2) {
+        addExportTable(expression.arguments[1])
+      }
+      return
+    }
+    if (!ts.isBinaryExpression(expression) || expression.operatorToken.kind !== ts.SyntaxKind.EqualsToken) return
+    const target = expression.left
+    if (!ts.isPropertyAccessExpression(target)) return
+    if (!ts.isIdentifier(target.expression) || target.expression.text !== 'exports') return
+    names.add(target.name.text)
+  })
+
   return names
 }
 
 /**
- * Accepts `@Entity`, `@Entity(...)`, an aliased local name, and a namespace-qualified
- * form such as `@orm.Entity()`.
+ * The compiled shape of a decorated class: the class becomes an expression assigned to a
+ * variable, and the decorators move into a helper call — `X = __decorateClass([...], X)`
+ * for esbuild, `X = __decorate([...], X)` for tsc, `_ts_decorate` for SWC. The helper's
+ * name is not matched, since it varies by toolchain; the shape is: a call whose first
+ * argument is an array literal and whose result is assigned back to the class binding.
  */
-function isEntityDecorator(decorator: ts.Decorator, entityNames: ReadonlySet<string>): boolean {
-  const expression = ts.isCallExpression(decorator.expression)
-    ? decorator.expression.expression
-    : decorator.expression
-  if (ts.isIdentifier(expression)) return entityNames.has(expression.text)
-  if (ts.isPropertyAccessExpression(expression)) return expression.name.text === 'Entity'
-  return false
-}
-
-function hasEntityDecorator(node: ts.ClassDeclaration, entityNames: ReadonlySet<string>): boolean {
-  if (!ts.canHaveDecorators(node)) return false
-  return (ts.getDecorators(node) ?? []).some((decorator) => isEntityDecorator(decorator, entityNames))
-}
-
-function isExported(node: ts.ClassDeclaration): boolean {
-  return node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ?? false
-}
-
-/** Names re-exported from the same file via `export { X }` (no module specifier). */
-function collectLocalExportNames(sourceFile: ts.SourceFile): Set<string> {
-  const names = new Set<string>()
+function collectCompiledDecoratedClassNames(
+  sourceFile: ts.SourceFile,
+  bindings: EntityDecoratorBindings,
+): string[] {
+  const names: string[] = []
   sourceFile.forEachChild((node) => {
-    if (!ts.isExportDeclaration(node) || node.moduleSpecifier) return
-    const clause = node.exportClause
-    if (!clause || !ts.isNamedExports(clause)) return
-    for (const element of clause.elements) {
-      names.add((element.propertyName ?? element.name).text)
-    }
+    if (!ts.isExpressionStatement(node)) return
+    const assignment = node.expression
+    if (!ts.isBinaryExpression(assignment) || assignment.operatorToken.kind !== ts.SyntaxKind.EqualsToken) return
+    if (!ts.isIdentifier(assignment.left)) return
+    const call = assignment.right
+    if (!ts.isCallExpression(call) || call.arguments.length === 0) return
+    const [decorators] = call.arguments
+    if (!ts.isArrayLiteralExpression(decorators)) return
+    const target = call.arguments[call.arguments.length - 1]
+    if (!target || !ts.isIdentifier(target) || target.text !== assignment.left.text) return
+    const decoratesEntity = decorators.elements.some((element) =>
+      isEntityReference(ts.isCallExpression(element) ? element.expression : element, bindings))
+    if (decoratesEntity) names.push(assignment.left.text)
   })
   return names
+}
+
+/** Class-expression bindings a compiled file declares, so `let X = class {}` is seen. */
+function collectVariableClassNames(sourceFile: ts.SourceFile): Map<string, boolean> {
+  const declared = new Map<string, boolean>()
+  sourceFile.forEachChild((node) => {
+    if (!ts.isVariableStatement(node)) return
+    const exported = isExportedDeclaration(node)
+    for (const declaration of node.declarationList.declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer) continue
+      if (!ts.isClassExpression(declaration.initializer)) continue
+      declared.set(declaration.name.text, exported)
+    }
+  })
+  return declared
 }
 
 export function parseEntityClassNames(filePath: string): string[] {
@@ -87,15 +229,27 @@ export function parseEntityClassNames(filePath: string): string[] {
     true,
     inferScriptKind(filePath),
   )
-  const entityNames = collectEntityDecoratorNames(sourceFile)
-  const localExports = collectLocalExportNames(sourceFile)
+  const bindings = collectEntityDecoratorBindings(sourceFile)
+  const indirectExports = collectIndirectExportNames(sourceFile)
   const classNames: string[] = []
+  const add = (className: string): void => {
+    if (!classNames.includes(className)) classNames.push(className)
+  }
+
   sourceFile.forEachChild((node) => {
     if (!ts.isClassDeclaration(node) || !node.name) return
-    if (!hasEntityDecorator(node, entityNames)) return
+    if (!hasEntityDecorator(node, bindings)) return
     const className = node.name.text
-    if (!isExported(node) && !localExports.has(className)) return
-    if (!classNames.includes(className)) classNames.push(className)
+    if (!isExportedDeclaration(node) && !indirectExports.has(className)) return
+    add(className)
   })
+
+  const variableClasses = collectVariableClassNames(sourceFile)
+  for (const className of collectCompiledDecoratedClassNames(sourceFile, bindings)) {
+    if (!variableClasses.has(className)) continue
+    if (!variableClasses.get(className) && !indirectExports.has(className)) continue
+    add(className)
+  }
+
   return classNames
 }

--- a/packages/cli/src/lib/generators/entity-class-declarations.ts
+++ b/packages/cli/src/lib/generators/entity-class-declarations.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs'
+import ts from 'typescript-js'
+
+/**
+ * Names of the `@Entity()`-decorated classes a module's entity file exports.
+ *
+ * Only decorated classes count: an entity file may also export plain helper classes,
+ * and reporting those as entities would raise false collisions. Parsing is used rather
+ * than importing because the caller runs during generation, before the module graph
+ * exists.
+ */
+
+function isEntityDecorator(decorator: ts.Decorator): boolean {
+  const expression = decorator.expression
+  if (ts.isCallExpression(expression)) {
+    return ts.isIdentifier(expression.expression) && expression.expression.text === 'Entity'
+  }
+  return ts.isIdentifier(expression) && expression.text === 'Entity'
+}
+
+function hasEntityDecorator(node: ts.ClassDeclaration): boolean {
+  if (!ts.canHaveDecorators(node)) return false
+  return (ts.getDecorators(node) ?? []).some(isEntityDecorator)
+}
+
+function isExported(node: ts.ClassDeclaration): boolean {
+  return node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ?? false
+}
+
+/** Names re-exported from the same file via `export { X }` (no module specifier). */
+function collectLocalExportNames(sourceFile: ts.SourceFile): Set<string> {
+  const names = new Set<string>()
+  sourceFile.forEachChild((node) => {
+    if (!ts.isExportDeclaration(node) || node.moduleSpecifier) return
+    const clause = node.exportClause
+    if (!clause || !ts.isNamedExports(clause)) return
+    for (const element of clause.elements) {
+      names.add((element.propertyName ?? element.name).text)
+    }
+  })
+  return names
+}
+
+export function parseEntityClassNames(filePath: string): string[] {
+  let source: string
+  try {
+    source = fs.readFileSync(filePath, 'utf8')
+  } catch {
+    // A warning path must never break generation.
+    return []
+  }
+  const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.ES2020, true, ts.ScriptKind.TS)
+  const localExports = collectLocalExportNames(sourceFile)
+  const classNames: string[] = []
+  sourceFile.forEachChild((node) => {
+    if (!ts.isClassDeclaration(node) || !node.name) return
+    if (!hasEntityDecorator(node)) return
+    const className = node.name.text
+    if (!isExported(node) && !localExports.has(className)) return
+    if (!classNames.includes(className)) classNames.push(className)
+  })
+  return classNames
+}

--- a/packages/cli/src/lib/generators/entity-class-declarations.ts
+++ b/packages/cli/src/lib/generators/entity-class-declarations.ts
@@ -10,17 +10,48 @@ import ts from 'typescript-js'
  * exists.
  */
 
-function isEntityDecorator(decorator: ts.Decorator): boolean {
-  const expression = decorator.expression
-  if (ts.isCallExpression(expression)) {
-    return ts.isIdentifier(expression.expression) && expression.expression.text === 'Entity'
-  }
-  return ts.isIdentifier(expression) && expression.text === 'Entity'
+function inferScriptKind(filePath: string): ts.ScriptKind {
+  if (filePath.endsWith('.tsx')) return ts.ScriptKind.TSX
+  if (filePath.endsWith('.jsx')) return ts.ScriptKind.JSX
+  if (filePath.endsWith('.js')) return ts.ScriptKind.JS
+  return ts.ScriptKind.TS
 }
 
-function hasEntityDecorator(node: ts.ClassDeclaration): boolean {
+/**
+ * Local names bound to MikroORM's `Entity` decorator, so an aliased import
+ * (`import { Entity as OrmEntity }`) is still recognised.
+ */
+function collectEntityDecoratorNames(sourceFile: ts.SourceFile): Set<string> {
+  const names = new Set<string>(['Entity'])
+  sourceFile.forEachChild((node) => {
+    if (!ts.isImportDeclaration(node)) return
+    const bindings = node.importClause?.namedBindings
+    if (!bindings || !ts.isNamedImports(bindings)) return
+    for (const element of bindings.elements) {
+      if ((element.propertyName ?? element.name).text === 'Entity') {
+        names.add(element.name.text)
+      }
+    }
+  })
+  return names
+}
+
+/**
+ * Accepts `@Entity`, `@Entity(...)`, an aliased local name, and a namespace-qualified
+ * form such as `@orm.Entity()`.
+ */
+function isEntityDecorator(decorator: ts.Decorator, entityNames: ReadonlySet<string>): boolean {
+  const expression = ts.isCallExpression(decorator.expression)
+    ? decorator.expression.expression
+    : decorator.expression
+  if (ts.isIdentifier(expression)) return entityNames.has(expression.text)
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text === 'Entity'
+  return false
+}
+
+function hasEntityDecorator(node: ts.ClassDeclaration, entityNames: ReadonlySet<string>): boolean {
   if (!ts.canHaveDecorators(node)) return false
-  return (ts.getDecorators(node) ?? []).some(isEntityDecorator)
+  return (ts.getDecorators(node) ?? []).some((decorator) => isEntityDecorator(decorator, entityNames))
 }
 
 function isExported(node: ts.ClassDeclaration): boolean {
@@ -49,12 +80,19 @@ export function parseEntityClassNames(filePath: string): string[] {
     // A warning path must never break generation.
     return []
   }
-  const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.ES2020, true, ts.ScriptKind.TS)
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.ES2020,
+    true,
+    inferScriptKind(filePath),
+  )
+  const entityNames = collectEntityDecoratorNames(sourceFile)
   const localExports = collectLocalExportNames(sourceFile)
   const classNames: string[] = []
   sourceFile.forEachChild((node) => {
     if (!ts.isClassDeclaration(node) || !node.name) return
-    if (!hasEntityDecorator(node)) return
+    if (!hasEntityDecorator(node, entityNames)) return
     const className = node.name.text
     if (!isExported(node) && !localExports.has(className)) return
     if (!classNames.includes(className)) classNames.push(className)

--- a/packages/cli/src/lib/generators/module-entities.ts
+++ b/packages/cli/src/lib/generators/module-entities.ts
@@ -102,7 +102,7 @@ export async function generateModuleEntities(options: ModuleEntitiesOptions): Pr
     imports.push({ name: importName, moduleSpecifier: relImport })
     entitySources.push({ importName, moduleId: modId })
 
-    const entityFilePath = resolveEntitySourceFile(resolver, entry, found)
+    const entityFilePath = resolveEntitySourceFile(resolver, entry, found, fromApp)
     for (const className of parseEntityClassNames(entityFilePath)) {
       classNameEntries.push({ className, moduleId: modId, sourcePath: entityFilePath })
     }
@@ -249,16 +249,18 @@ function warnOnDuplicateEntityClassNames(entries: readonly EntityClassNameEntry[
  * published packages ship `src/modules` alongside it — so prefer the shipped source, the
  * way `eject` already does, and leave the runtime import pointing at `dist`. A package
  * that ships compiled output only falls back to the resolved base, which the parser also
- * understands.
+ * understands. An app override wins over the package tree entirely: the registry imports
+ * the app file, so that is the file whose class names are registered.
  */
 function resolveEntitySourceFile(
   resolver: PackageResolver,
   entry: ModuleEntry,
   found: { base: string; file: string },
+  fromApp: boolean,
 ): string {
   const resolved = path.join(found.base, found.file)
   const from = entry.from
-  if (!from || from === '@app') return resolved
+  if (fromApp || !from || from === '@app') return resolved
   const sourceBase = path.join(resolver.getPackageRoot(from), 'src', 'modules', entry.id, path.basename(found.base))
   if (path.resolve(sourceBase) === path.resolve(found.base)) return resolved
   const sourceFile = resolveConventionFile(sourceBase, stripModuleCodeExtension(found.file))

--- a/packages/cli/src/lib/generators/module-entities.ts
+++ b/packages/cli/src/lib/generators/module-entities.ts
@@ -1,7 +1,13 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { StructureKind, VariableDeclarationKind } from 'ts-morph'
+import {
+  findDuplicateEntityClassNames,
+  formatDuplicateEntityClassNamesWarning,
+  type EntityClassNameEntry,
+} from '@open-mercato/shared/lib/db/duplicateEntityClassNames'
 import type { PackageResolver } from '../resolver'
+import { parseEntityClassNames } from './entity-class-declarations'
 import { MODULE_CODE_EXTENSIONS, stripModuleCodeExtension } from './scanner'
 import {
   toVar,
@@ -50,6 +56,7 @@ export async function generateModuleEntities(options: ModuleEntitiesOptions): Pr
   const mods = resolver.loadEnabledModules()
   const imports: Array<{ name: string; moduleSpecifier: string }> = []
   const entitySources: Array<{ importName: string; moduleId: string }> = []
+  const classNameEntries: EntityClassNameEntry[] = []
   let n = 0
 
   for (const entry of mods) {
@@ -94,6 +101,11 @@ export async function generateModuleEntities(options: ModuleEntitiesOptions): Pr
     }
     imports.push({ name: importName, moduleSpecifier: relImport })
     entitySources.push({ importName, moduleId: modId })
+
+    const entityFilePath = path.join(found.base, found.file)
+    for (const className of parseEntityClassNames(entityFilePath)) {
+      classNameEntries.push({ className, moduleId: modId, sourcePath: entityFilePath })
+    }
   }
 
   const sourceFile = createGeneratedSourceFile('entities.generated.ts')
@@ -211,7 +223,20 @@ export async function generateModuleEntities(options: ModuleEntitiesOptions): Pr
     quiet,
   })
 
+  warnOnDuplicateEntityClassNames(classNameEntries)
+
   return result
+}
+
+/**
+ * A duplicate entity class name across modules silently corrupts entity resolution at
+ * runtime and no build step otherwise catches it, so surface it here — where the
+ * colliding registry is produced. Reported as a warning; generation still succeeds.
+ */
+function warnOnDuplicateEntityClassNames(entries: readonly EntityClassNameEntry[]): void {
+  const duplicates = findDuplicateEntityClassNames(entries)
+  if (duplicates.length === 0) return
+  console.warn(`\x1b[33m[Entities Warning]\x1b[0m ${formatDuplicateEntityClassNamesWarning(duplicates)}`)
 }
 
 function resolveConventionFile(baseDir: string, basename: string): string | null {

--- a/packages/cli/src/lib/generators/module-entities.ts
+++ b/packages/cli/src/lib/generators/module-entities.ts
@@ -6,7 +6,7 @@ import {
   formatDuplicateEntityClassNamesWarning,
   type EntityClassNameEntry,
 } from '@open-mercato/shared/lib/db/duplicateEntityClassNames'
-import type { PackageResolver } from '../resolver'
+import type { ModuleEntry, PackageResolver } from '../resolver'
 import { parseEntityClassNames } from './entity-class-declarations'
 import { MODULE_CODE_EXTENSIONS, stripModuleCodeExtension } from './scanner'
 import {
@@ -102,7 +102,7 @@ export async function generateModuleEntities(options: ModuleEntitiesOptions): Pr
     imports.push({ name: importName, moduleSpecifier: relImport })
     entitySources.push({ importName, moduleId: modId })
 
-    const entityFilePath = path.join(found.base, found.file)
+    const entityFilePath = resolveEntitySourceFile(resolver, entry, found)
     for (const className of parseEntityClassNames(entityFilePath)) {
       classNameEntries.push({ className, moduleId: modId, sourcePath: entityFilePath })
     }
@@ -241,6 +241,28 @@ function warnOnDuplicateEntityClassNames(entries: readonly EntityClassNameEntry[
   } catch {
     // This check is a diagnostic. It must never be the reason generation fails.
   }
+}
+
+/**
+ * The file to read class names out of, which is not always the file the runtime imports.
+ * A standalone install resolves a package module to its compiled `dist/modules` tree, and
+ * published packages ship `src/modules` alongside it — so prefer the shipped source, the
+ * way `eject` already does, and leave the runtime import pointing at `dist`. A package
+ * that ships compiled output only falls back to the resolved base, which the parser also
+ * understands.
+ */
+function resolveEntitySourceFile(
+  resolver: PackageResolver,
+  entry: ModuleEntry,
+  found: { base: string; file: string },
+): string {
+  const resolved = path.join(found.base, found.file)
+  const from = entry.from
+  if (!from || from === '@app') return resolved
+  const sourceBase = path.join(resolver.getPackageRoot(from), 'src', 'modules', entry.id, path.basename(found.base))
+  if (path.resolve(sourceBase) === path.resolve(found.base)) return resolved
+  const sourceFile = resolveConventionFile(sourceBase, stripModuleCodeExtension(found.file))
+  return sourceFile ?? resolved
 }
 
 function resolveConventionFile(baseDir: string, basename: string): string | null {

--- a/packages/cli/src/lib/generators/module-entities.ts
+++ b/packages/cli/src/lib/generators/module-entities.ts
@@ -234,9 +234,13 @@ export async function generateModuleEntities(options: ModuleEntitiesOptions): Pr
  * colliding registry is produced. Reported as a warning; generation still succeeds.
  */
 function warnOnDuplicateEntityClassNames(entries: readonly EntityClassNameEntry[]): void {
-  const duplicates = findDuplicateEntityClassNames(entries)
-  if (duplicates.length === 0) return
-  console.warn(`\x1b[33m[Entities Warning]\x1b[0m ${formatDuplicateEntityClassNamesWarning(duplicates)}`)
+  try {
+    const duplicates = findDuplicateEntityClassNames(entries)
+    if (duplicates.length === 0) return
+    console.warn(`\x1b[33m[Entities Warning]\x1b[0m ${formatDuplicateEntityClassNamesWarning(duplicates)}`)
+  } catch {
+    // This check is a diagnostic. It must never be the reason generation fails.
+  }
 }
 
 function resolveConventionFile(baseDir: string, basename: string): string | null {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -52,6 +52,10 @@
       "types": "./src/lib/events/patterns.ts",
       "default": "./dist/lib/events/patterns.js"
     },
+    "./lib/db/duplicateEntityClassNames": {
+      "types": "./src/lib/db/duplicateEntityClassNames.ts",
+      "default": "./dist/lib/db/duplicateEntityClassNames.js"
+    },
     "./lib/data/consistency": {
       "types": "./src/lib/data/consistency.ts",
       "default": "./dist/lib/data/consistency.js"

--- a/packages/shared/src/lib/db/__tests__/duplicateEntities.test.ts
+++ b/packages/shared/src/lib/db/__tests__/duplicateEntities.test.ts
@@ -1,0 +1,144 @@
+import 'reflect-metadata'
+import { EntitySchema, MetadataStorage } from '@mikro-orm/core'
+import { findDuplicateRegisteredEntityClassNames } from '../duplicateEntities'
+import { Invoice as InvoiceBilling } from './fixtures/invoiceBilling'
+import { Invoice as InvoiceSubscriptions } from './fixtures/invoiceSubscriptions'
+import { Ledger as LedgerBilling } from './fixtures/ledgerBilling'
+import { Ledger as LedgerSubscriptions } from './fixtures/ledgerSubscriptions'
+import { Ledger as LedgerReporting } from './fixtures/ledgerReporting'
+
+function readSourcePath(entity: unknown): string {
+  return (entity as Record<symbol, string>)[MetadataStorage.PATH_SYMBOL]
+}
+
+/**
+ * Mirrors `enhanceEntities()` in the generated entity registry, which stamps
+ * `<moduleId>.<ExportName>` onto every entity export. The generator marks the property
+ * configurable, so tests can restamp between cases.
+ */
+function stampModuleId(entity: unknown, stamp: string): void {
+  Object.defineProperty(entity, 'entityName', {
+    value: stamp,
+    configurable: true,
+    enumerable: false,
+    writable: false,
+  })
+}
+
+function clearModuleIdStamp(entity: unknown): void {
+  delete (entity as Record<string, unknown>).entityName
+}
+
+describe('MikroORM name-based resolution (upstream behaviour pin)', () => {
+  // Pins the @mikro-orm/core 7.1.9 behaviour this guard exists for. MetadataStorage
+  // keeps a constructor-keyed map and a name-keyed one, and `find()` falls through to
+  // the name-keyed one. If a future MikroORM starts detecting class-name collisions
+  // itself, this test fails and the guard can be reconsidered.
+  it('silently aliases a second entity class onto the first one sharing its name', () => {
+    expect(InvoiceBilling).not.toBe(InvoiceSubscriptions)
+    expect(InvoiceBilling.name).toBe('Invoice')
+    expect(InvoiceSubscriptions.name).toBe('Invoice')
+
+    const storage = new MetadataStorage()
+    storage.get(InvoiceBilling, true)
+    storage.get(InvoiceSubscriptions, true)
+
+    expect(storage.find(InvoiceBilling)?.class).toBe(InvoiceBilling)
+    // The collision: the second class never gets its own metadata, it resolves the
+    // first one's — so it would be mapped to the first class's table.
+    expect(storage.find(InvoiceSubscriptions)?.class).toBe(InvoiceBilling)
+    expect(storage.find('Invoice')?.class).toBe(InvoiceBilling)
+  })
+})
+
+describe('findDuplicateRegisteredEntityClassNames', () => {
+  afterEach(() => {
+    for (const entity of [InvoiceBilling, InvoiceSubscriptions, LedgerBilling, LedgerSubscriptions, LedgerReporting]) {
+      clearModuleIdStamp(entity)
+    }
+  })
+
+  it('reports nothing for an empty registration', () => {
+    expect(findDuplicateRegisteredEntityClassNames([])).toEqual([])
+  })
+
+  it('ignores non-entity exports that share a name', () => {
+    // The generated registry spreads every function export of a module's entity file,
+    // so plain helpers travel alongside entities and must never be reported.
+    const first = function helper(): void {}
+    const second = function helper(): void {}
+    const values = [first, second, { name: 'TestEntity' }, { name: 'TestEntity' }, null, undefined, 'Invoice']
+
+    expect(findDuplicateRegisteredEntityClassNames(values)).toEqual([])
+  })
+
+  it('ignores the same class registered twice (re-export or HMR re-registration)', () => {
+    expect(findDuplicateRegisteredEntityClassNames([InvoiceBilling, InvoiceBilling])).toEqual([])
+  })
+
+  it('reports two distinct classes sharing a name, with module ids and source paths', () => {
+    stampModuleId(InvoiceBilling, 'billing.Invoice')
+    stampModuleId(InvoiceSubscriptions, 'subscriptions.Invoice')
+
+    const groups = findDuplicateRegisteredEntityClassNames([InvoiceBilling, InvoiceSubscriptions])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].className).toBe('Invoice')
+    expect(groups[0].sources).toEqual([
+      { moduleId: 'billing', sourcePath: readSourcePath(InvoiceBilling) },
+      { moduleId: 'subscriptions', sourcePath: readSourcePath(InvoiceSubscriptions) },
+    ])
+  })
+
+  it('recovers module ids that contain dots', () => {
+    stampModuleId(InvoiceBilling, 'acme.billing.Invoice')
+    stampModuleId(InvoiceSubscriptions, 'subscriptions.Invoice')
+
+    const groups = findDuplicateRegisteredEntityClassNames([InvoiceBilling, InvoiceSubscriptions])
+
+    expect(groups[0].sources.map((source) => source.moduleId)).toEqual(['acme.billing', 'subscriptions'])
+  })
+
+  it('still reports a collision when no module id stamp is present', () => {
+    const groups = findDuplicateRegisteredEntityClassNames([InvoiceBilling, InvoiceSubscriptions])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sources.map((source) => source.moduleId)).toEqual([undefined, undefined])
+    expect(groups[0].sources.map((source) => source.sourcePath)).toEqual([
+      readSourcePath(InvoiceBilling),
+      readSourcePath(InvoiceSubscriptions),
+    ])
+  })
+
+  it('detects collisions between EntitySchema instances', () => {
+    const first = new EntitySchema({ name: 'Invoice', properties: {} })
+    const second = new EntitySchema({ name: 'Invoice', properties: {} })
+
+    const groups = findDuplicateRegisteredEntityClassNames([first, second])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].className).toBe('Invoice')
+  })
+
+  it('detects a collision between a decorated class and an EntitySchema', () => {
+    const schema = new EntitySchema({ name: 'Invoice', properties: {} })
+
+    const groups = findDuplicateRegisteredEntityClassNames([InvoiceBilling, schema])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sources).toHaveLength(2)
+  })
+
+  it('reports every colliding name in one pass, including three-way collisions', () => {
+    const groups = findDuplicateRegisteredEntityClassNames([
+      InvoiceBilling,
+      InvoiceSubscriptions,
+      LedgerBilling,
+      LedgerSubscriptions,
+      LedgerReporting,
+    ])
+
+    expect(groups.map((group) => group.className).sort()).toEqual(['Invoice', 'Ledger'])
+    expect(groups.find((group) => group.className === 'Ledger')?.sources).toHaveLength(3)
+  })
+})

--- a/packages/shared/src/lib/db/__tests__/duplicateEntities.test.ts
+++ b/packages/shared/src/lib/db/__tests__/duplicateEntities.test.ts
@@ -142,3 +142,76 @@ describe('findDuplicateRegisteredEntityClassNames', () => {
     expect(groups.find((group) => group.className === 'Ledger')?.sources).toHaveLength(3)
   })
 })
+
+describe('resilience', () => {
+  // The check is a diagnostic; a hostile or exotic export must never be able to turn it
+  // into a bootstrap failure.
+  it('skips an entity whose name getter throws', () => {
+    const hostile = function () {} as unknown as Record<string, unknown>
+    Object.defineProperty(hostile, MetadataStorage.PATH_SYMBOL, { value: '/hostile.ts' })
+    Object.defineProperty(hostile, 'name', {
+      get() {
+        throw new Error('name is not readable')
+      },
+    })
+
+    expect(() => findDuplicateRegisteredEntityClassNames([hostile])).not.toThrow()
+  })
+
+  it('skips an entity whose module id stamp throws', () => {
+    const hostile = function Invoice() {} as unknown as Record<string, unknown>
+    Object.defineProperty(hostile, MetadataStorage.PATH_SYMBOL, { value: '/hostile.ts' })
+    Object.defineProperty(hostile, 'entityName', {
+      get() {
+        throw new Error('entityName is not readable')
+      },
+    })
+
+    expect(() => findDuplicateRegisteredEntityClassNames([hostile])).not.toThrow()
+  })
+
+  it('skips a proxy that throws on every trap', () => {
+    const hostile = new Proxy(function Invoice() {}, {
+      get() {
+        throw new Error('trapped')
+      },
+      has() {
+        throw new Error('trapped')
+      },
+      getOwnPropertyDescriptor() {
+        throw new Error('trapped')
+      },
+    })
+
+    expect(() => findDuplicateRegisteredEntityClassNames([hostile])).not.toThrow()
+  })
+
+  it('still finds a real collision alongside a hostile export', () => {
+    const hostile = function () {} as unknown as Record<string, unknown>
+    Object.defineProperty(hostile, MetadataStorage.PATH_SYMBOL, { value: '/hostile.ts' })
+    Object.defineProperty(hostile, 'name', {
+      get() {
+        throw new Error('name is not readable')
+      },
+    })
+
+    const groups = findDuplicateRegisteredEntityClassNames([hostile, InvoiceBilling, InvoiceSubscriptions])
+
+    expect(groups.map((group) => group.className)).toEqual(['Invoice'])
+  })
+
+  it('tolerates values that are not entities at all', () => {
+    expect(() =>
+      findDuplicateRegisteredEntityClassNames([
+        null,
+        undefined,
+        0,
+        '',
+        Symbol('entity'),
+        Object.create(null),
+        [],
+        new Map(),
+      ]),
+    ).not.toThrow()
+  })
+})

--- a/packages/shared/src/lib/db/__tests__/duplicateEntities.test.ts
+++ b/packages/shared/src/lib/db/__tests__/duplicateEntities.test.ts
@@ -1,5 +1,7 @@
 import 'reflect-metadata'
 import { EntitySchema, MetadataStorage } from '@mikro-orm/core'
+import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy'
+import { MikroORM } from '@mikro-orm/postgresql'
 import { findDuplicateRegisteredEntityClassNames } from '../duplicateEntities'
 import { Invoice as InvoiceBilling } from './fixtures/invoiceBilling'
 import { Invoice as InvoiceSubscriptions } from './fixtures/invoiceSubscriptions'
@@ -30,24 +32,65 @@ function clearModuleIdStamp(entity: unknown): void {
 }
 
 describe('MikroORM name-based resolution (upstream behaviour pin)', () => {
-  // Pins the @mikro-orm/core 7.1.9 behaviour this guard exists for. MetadataStorage
-  // keeps a constructor-keyed map and a name-keyed one, and `find()` falls through to
-  // the name-keyed one. If a future MikroORM starts detecting class-name collisions
-  // itself, this test fails and the guard can be reconsidered.
-  it('silently aliases a second entity class onto the first one sharing its name', () => {
+  // Pins the @mikro-orm/core 7.1.9 behaviour this guard exists for, through real
+  // discovery rather than bare MetadataStorage calls. Discovery keeps one metadata entry
+  // per constructor, so class-based lookups stay correct; the name-keyed map holds only
+  // one of the same-named classes, so everything resolved by name silently picks a
+  // winner. If a future MikroORM starts detecting class-name collisions itself, this
+  // test fails and the guard can be reconsidered.
+  //
+  // `connect: false` keeps it DB-free: discovery and metadata validation run in full,
+  // no connection is opened.
+  let orm: MikroORM
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      entities: [InvoiceBilling, InvoiceSubscriptions],
+      metadataProvider: ReflectMetadataProvider,
+      dbName: 'duplicate-entity-class-names-probe',
+      connect: false,
+      discovery: { warnWhenNoEntities: false },
+      allowGlobalContext: true,
+    })
+  })
+
+  afterAll(async () => {
+    await orm?.close(true)
+  })
+
+  it('accepts both same-named classes without any duplicate error', () => {
     expect(InvoiceBilling).not.toBe(InvoiceSubscriptions)
     expect(InvoiceBilling.name).toBe('Invoice')
     expect(InvoiceSubscriptions.name).toBe('Invoice')
+  })
 
-    const storage = new MetadataStorage()
-    storage.get(InvoiceBilling, true)
-    storage.get(InvoiceSubscriptions, true)
+  it('keeps class-based lookups correct, which is why this never fails loudly', () => {
+    const metadata = orm.getMetadata()
 
-    expect(storage.find(InvoiceBilling)?.class).toBe(InvoiceBilling)
-    // The collision: the second class never gets its own metadata, it resolves the
-    // first one's — so it would be mapped to the first class's table.
-    expect(storage.find(InvoiceSubscriptions)?.class).toBe(InvoiceBilling)
-    expect(storage.find('Invoice')?.class).toBe(InvoiceBilling)
+    expect(metadata.find(InvoiceBilling)?.tableName).toBe('duplicate_entity_fixture_billing')
+    expect(metadata.find(InvoiceSubscriptions)?.tableName).toBe('duplicate_entity_fixture_subscriptions')
+  })
+
+  it('resolves the name to exactly one of them, so the other is unreachable by name', () => {
+    const metadata = orm.getMetadata()
+    const byName = metadata.find('Invoice')
+
+    expect(byName).toBeDefined()
+    // Registration order decides the winner; the point is that one of the two is simply
+    // gone from every name-based path.
+    expect([
+      'duplicate_entity_fixture_billing',
+      'duplicate_entity_fixture_subscriptions',
+    ]).toContain(byName?.tableName)
+    expect(metadata.find(InvoiceBilling)?.tableName === byName?.tableName).not.toBe(
+      metadata.find(InvoiceSubscriptions)?.tableName === byName?.tableName,
+    )
+  })
+
+  it('hands a name-based repository the winner regardless of which module asked', () => {
+    const repositoryTable = orm.em.getRepository('Invoice').getEntityManager().getMetadata().find('Invoice')?.tableName
+
+    expect(repositoryTable).toBe(orm.getMetadata().find('Invoice')?.tableName)
   })
 })
 

--- a/packages/shared/src/lib/db/__tests__/duplicateEntityClassNames.test.ts
+++ b/packages/shared/src/lib/db/__tests__/duplicateEntityClassNames.test.ts
@@ -1,6 +1,9 @@
 import {
+  DUPLICATE_ENTITY_CLASS_NAMES_REASON,
+  DUPLICATE_ENTITY_CLASS_NAMES_REMEDIATION,
   findDuplicateEntityClassNames,
   formatDuplicateEntityClassNamesWarning,
+  toDuplicateEntityClassNameFields,
 } from '../duplicateEntityClassNames'
 
 describe('findDuplicateEntityClassNames', () => {
@@ -97,7 +100,7 @@ describe('formatDuplicateEntityClassNamesWarning', () => {
     expect(message).toContain('  Invoice')
     expect(message).toContain('    - billing (/repo/modules/billing/data/entities.ts)')
     expect(message).toContain('    - subscriptions (/repo/modules/subscriptions/data/entities.ts)')
-    expect(message).toContain('Rename all but one of the classes below')
+    expect(message).toContain('Rename all but one of the colliding classes')
   })
 
   it('lists every colliding name in one message', () => {
@@ -135,5 +138,35 @@ describe('formatDuplicateEntityClassNamesWarning', () => {
 
     const sourceLine = message.split('\n').find((line) => line.startsWith('    - '))
     expect(sourceLine).toBe('    - billing')
+  })
+})
+
+describe('toDuplicateEntityClassNameFields', () => {
+  // The runtime surface logs through the structured facade, where the message must stay
+  // constant and every dynamic value has to be a queryable field.
+  it('carries the collisions as fields beside the constant explanation', () => {
+    const groups = findDuplicateEntityClassNames([
+      { className: 'Invoice', moduleId: 'billing', sourcePath: '/repo/modules/billing/data/entities.ts' },
+      { className: 'Invoice', moduleId: 'subscriptions', sourcePath: '/repo/modules/subscriptions/data/entities.ts' },
+    ])
+
+    expect(toDuplicateEntityClassNameFields(groups)).toEqual({
+      classNames: ['Invoice'],
+      duplicates: [
+        {
+          className: 'Invoice',
+          sources: [
+            { moduleId: 'billing', sourcePath: '/repo/modules/billing/data/entities.ts' },
+            { moduleId: 'subscriptions', sourcePath: '/repo/modules/subscriptions/data/entities.ts' },
+          ],
+        },
+      ],
+      reason: DUPLICATE_ENTITY_CLASS_NAMES_REASON,
+      remediation: DUPLICATE_ENTITY_CLASS_NAMES_REMEDIATION,
+    })
+  })
+
+  it('stays empty for no collisions', () => {
+    expect(toDuplicateEntityClassNameFields([]).classNames).toEqual([])
   })
 })

--- a/packages/shared/src/lib/db/__tests__/duplicateEntityClassNames.test.ts
+++ b/packages/shared/src/lib/db/__tests__/duplicateEntityClassNames.test.ts
@@ -1,0 +1,130 @@
+import {
+  findDuplicateEntityClassNames,
+  formatDuplicateEntityClassNamesWarning,
+} from '../duplicateEntityClassNames'
+
+describe('findDuplicateEntityClassNames', () => {
+  it('reports nothing for an empty or single-entry list', () => {
+    expect(findDuplicateEntityClassNames([])).toEqual([])
+    expect(findDuplicateEntityClassNames([{ className: 'Invoice', moduleId: 'billing' }])).toEqual([])
+  })
+
+  it('reports nothing when class names differ', () => {
+    const groups = findDuplicateEntityClassNames([
+      { className: 'Invoice', moduleId: 'billing' },
+      { className: 'Ledger', moduleId: 'subscriptions' },
+    ])
+
+    expect(groups).toEqual([])
+  })
+
+  it('reports a name declared by two modules', () => {
+    const groups = findDuplicateEntityClassNames([
+      { className: 'Invoice', moduleId: 'billing', sourcePath: 'modules/billing/data/entities.ts' },
+      { className: 'Invoice', moduleId: 'subscriptions', sourcePath: 'modules/subscriptions/data/entities.ts' },
+    ])
+
+    expect(groups).toEqual([
+      {
+        className: 'Invoice',
+        sources: [
+          { moduleId: 'billing', sourcePath: 'modules/billing/data/entities.ts' },
+          { moduleId: 'subscriptions', sourcePath: 'modules/subscriptions/data/entities.ts' },
+        ],
+      },
+    ])
+  })
+
+  it('treats identical module and path as the same class, not a collision', () => {
+    const groups = findDuplicateEntityClassNames([
+      { className: 'Invoice', moduleId: 'billing', sourcePath: 'modules/billing/data/entities.ts' },
+      { className: 'Invoice', moduleId: 'billing', sourcePath: 'modules/billing/data/entities.ts' },
+    ])
+
+    expect(groups).toEqual([])
+  })
+
+  it('treats a shared target as the same class reached twice', () => {
+    const target = class Invoice {}
+    const groups = findDuplicateEntityClassNames([
+      { className: 'Invoice', moduleId: 'billing', target },
+      { className: 'Invoice', moduleId: 'subscriptions', target },
+    ])
+
+    expect(groups).toEqual([])
+  })
+
+  it('collects three-way collisions and multiple names in one pass', () => {
+    const groups = findDuplicateEntityClassNames([
+      { className: 'Invoice', moduleId: 'billing' },
+      { className: 'Ledger', moduleId: 'billing' },
+      { className: 'Invoice', moduleId: 'subscriptions' },
+      { className: 'Ledger', moduleId: 'subscriptions' },
+      { className: 'Ledger', moduleId: 'reporting' },
+    ])
+
+    expect(groups.map((group) => group.className)).toEqual(['Invoice', 'Ledger'])
+    expect(groups[1].sources.map((source) => source.moduleId)).toEqual(['billing', 'subscriptions', 'reporting'])
+  })
+
+  it('skips entries without a class name', () => {
+    expect(findDuplicateEntityClassNames([{ className: '' }, { className: '' }])).toEqual([])
+  })
+})
+
+describe('formatDuplicateEntityClassNamesWarning', () => {
+  it('names the class, the modules and the source files', () => {
+    const message = formatDuplicateEntityClassNamesWarning([
+      {
+        className: 'Invoice',
+        sources: [
+          { moduleId: 'billing', sourcePath: '/repo/modules/billing/data/entities.ts' },
+          { moduleId: 'subscriptions', sourcePath: '/repo/modules/subscriptions/data/entities.ts' },
+        ],
+      },
+    ])
+
+    expect(message).toContain('Duplicate entity class name(s) defined by more than one enabled module: "Invoice".')
+    expect(message).toContain('  Invoice')
+    expect(message).toContain('    - billing (/repo/modules/billing/data/entities.ts)')
+    expect(message).toContain('    - subscriptions (/repo/modules/subscriptions/data/entities.ts)')
+    expect(message).toContain('Rename all but one of the classes below')
+  })
+
+  it('lists every colliding name in one message', () => {
+    const message = formatDuplicateEntityClassNamesWarning([
+      { className: 'Invoice', sources: [{ moduleId: 'a' }, { moduleId: 'b' }] },
+      { className: 'Ledger', sources: [{ moduleId: 'a' }, { moduleId: 'b' }] },
+    ])
+
+    expect(message).toContain('"Invoice", "Ledger"')
+    expect(message).toContain('  Invoice')
+    expect(message).toContain('  Ledger')
+  })
+
+  it('degrades gracefully when the module id or path is unavailable', () => {
+    const message = formatDuplicateEntityClassNamesWarning([
+      {
+        className: 'Invoice',
+        sources: [
+          { moduleId: undefined, sourcePath: '/repo/a/entities.ts' },
+          { moduleId: undefined, sourcePath: undefined },
+        ],
+      },
+    ])
+
+    expect(message).toContain('    - /repo/a/entities.ts')
+    expect(message).toContain('    - unknown module')
+  })
+
+  it('omits a source path that degraded to a bare class name', () => {
+    // MikroORM derives the decorator path by parsing a stack trace and falls back to
+    // the class name when that parse fails.
+    const message = formatDuplicateEntityClassNamesWarning([
+      { className: 'Invoice', sources: [{ moduleId: 'billing', sourcePath: 'Invoice' }] },
+    ])
+
+    const sourceLine = message.split('\n').find((line) => line.startsWith('    - '))
+    expect(sourceLine).toBe('    - billing')
+  })
+})

--- a/packages/shared/src/lib/db/__tests__/duplicateEntityClassNames.test.ts
+++ b/packages/shared/src/lib/db/__tests__/duplicateEntityClassNames.test.ts
@@ -67,6 +67,15 @@ describe('findDuplicateEntityClassNames', () => {
     expect(groups[1].sources.map((source) => source.moduleId)).toEqual(['billing', 'subscriptions', 'reporting'])
   })
 
+  it('keeps unidentifiable entries distinct so a collision fails open', () => {
+    // Neither entry names a module, a file, or a class, so nothing distinguishes them.
+    // Collapsing them into one bucket would hide a genuine collision.
+    const groups = findDuplicateEntityClassNames([{ className: 'Invoice' }, { className: 'Invoice' }])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0].sources).toHaveLength(2)
+  })
+
   it('skips entries without a class name', () => {
     expect(findDuplicateEntityClassNames([{ className: '' }, { className: '' }])).toEqual([])
   })

--- a/packages/shared/src/lib/db/__tests__/duplicateEntityClassNamesExport.test.ts
+++ b/packages/shared/src/lib/db/__tests__/duplicateEntityClassNamesExport.test.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const PACKAGE_ROOT = join(__dirname, '..', '..', '..', '..')
+const SUBPATH = './lib/db/duplicateEntityClassNames'
+
+type ExportTarget = { types?: string | string[]; default?: string }
+
+function readExports(): Record<string, ExportTarget | string> {
+  const packageJson = JSON.parse(readFileSync(join(PACKAGE_ROOT, 'package.json'), 'utf8')) as {
+    exports?: Record<string, ExportTarget | string>
+  }
+  return packageJson.exports ?? {}
+}
+
+/**
+ * Node's subpath resolution: an exact key wins outright, and only when none matches do
+ * the `*` patterns compete on the longest static prefix. `@open-mercato/cli` imports this
+ * subpath across a workspace boundary, and resolvers do not agree on wildcard handling,
+ * so it must not depend on one.
+ */
+function resolveSubpath(exports: Record<string, ExportTarget | string>, subpath: string): string | null {
+  if (Object.prototype.hasOwnProperty.call(exports, subpath)) return subpath
+  let best: string | null = null
+  for (const key of Object.keys(exports)) {
+    const star = key.indexOf('*')
+    if (star < 0) continue
+    const prefix = key.slice(0, star)
+    const suffix = key.slice(star + 1)
+    if (!subpath.startsWith(prefix) || !subpath.endsWith(suffix)) continue
+    if (subpath.length < prefix.length + suffix.length) continue
+    if (!best || prefix.length > best.slice(0, best.indexOf('*')).length) best = key
+  }
+  return best
+}
+
+describe('@open-mercato/shared duplicateEntityClassNames export map', () => {
+  const exports = readExports()
+
+  it('resolves through an explicit entry rather than a wildcard pattern', () => {
+    expect(resolveSubpath(exports, SUBPATH)).toBe(SUBPATH)
+  })
+
+  it('maps types to the source module and default to the built module', () => {
+    expect(exports[SUBPATH]).toEqual({
+      types: './src/lib/db/duplicateEntityClassNames.ts',
+      default: './dist/lib/db/duplicateEntityClassNames.js',
+    })
+  })
+
+  // Both halves of the mapping must exist in a packed package. `default` is produced by
+  // `yarn build:packages`, which the validation gate runs before `yarn test`.
+  it('ships both mapped files', () => {
+    const target = exports[SUBPATH] as ExportTarget
+    expect(existsSync(join(PACKAGE_ROOT, target.types as string))).toBe(true)
+    expect(existsSync(join(PACKAGE_ROOT, target.default as string))).toBe(true)
+  })
+
+  it('keeps the module importable under the mapped default condition', async () => {
+    const target = exports[SUBPATH] as ExportTarget
+    await expect(import(join(PACKAGE_ROOT, target.default as string))).resolves.toBeDefined()
+  })
+})

--- a/packages/shared/src/lib/db/__tests__/fixtures/invoiceBilling.ts
+++ b/packages/shared/src/lib/db/__tests__/fixtures/invoiceBilling.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy'
+
+@Entity({ tableName: 'duplicate_entity_fixture_billing' })
+export class Invoice {
+  @PrimaryKey({ type: 'string' })
+  id!: string
+}

--- a/packages/shared/src/lib/db/__tests__/fixtures/invoiceReporting.ts
+++ b/packages/shared/src/lib/db/__tests__/fixtures/invoiceReporting.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy'
+
+@Entity({ tableName: 'duplicate_entity_fixture_reporting' })
+export class Invoice {
+  @PrimaryKey({ type: 'string' })
+  id!: string
+}

--- a/packages/shared/src/lib/db/__tests__/fixtures/invoiceSubscriptions.ts
+++ b/packages/shared/src/lib/db/__tests__/fixtures/invoiceSubscriptions.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy'
+
+@Entity({ tableName: 'duplicate_entity_fixture_subscriptions' })
+export class Invoice {
+  @PrimaryKey({ type: 'string' })
+  id!: string
+}

--- a/packages/shared/src/lib/db/__tests__/fixtures/ledgerBilling.ts
+++ b/packages/shared/src/lib/db/__tests__/fixtures/ledgerBilling.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy'
+
+@Entity({ tableName: 'duplicate_entity_fixture_ledger_billing' })
+export class Ledger {
+  @PrimaryKey({ type: 'string' })
+  id!: string
+}

--- a/packages/shared/src/lib/db/__tests__/fixtures/ledgerReporting.ts
+++ b/packages/shared/src/lib/db/__tests__/fixtures/ledgerReporting.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy'
+
+@Entity({ tableName: 'duplicate_entity_fixture_ledger_reporting' })
+export class Ledger {
+  @PrimaryKey({ type: 'string' })
+  id!: string
+}

--- a/packages/shared/src/lib/db/__tests__/fixtures/ledgerSubscriptions.ts
+++ b/packages/shared/src/lib/db/__tests__/fixtures/ledgerSubscriptions.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryKey } from '@mikro-orm/decorators/legacy'
+
+@Entity({ tableName: 'duplicate_entity_fixture_ledger_subscriptions' })
+export class Ledger {
+  @PrimaryKey({ type: 'string' })
+  id!: string
+}

--- a/packages/shared/src/lib/db/__tests__/registerOrmEntities.duplicates.test.ts
+++ b/packages/shared/src/lib/db/__tests__/registerOrmEntities.duplicates.test.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata'
 import { MetadataStorage } from '@mikro-orm/core'
 import { Invoice as InvoiceBilling } from './fixtures/invoiceBilling'
 import { Invoice as InvoiceSubscriptions } from './fixtures/invoiceSubscriptions'
+import { Invoice as InvoiceReporting } from './fixtures/invoiceReporting'
 import { Ledger as LedgerBilling } from './fixtures/ledgerBilling'
 import { Ledger as LedgerSubscriptions } from './fixtures/ledgerSubscriptions'
 
@@ -58,13 +59,21 @@ describe('registerOrmEntities duplicate class name reporting', () => {
     registerOrmEntities(entities)
 
     expect(warn).toHaveBeenCalledTimes(1)
-    const message = warn.mock.calls[0][0] as string
-    expect(message).toContain('[Bootstrap] Duplicate entity class name(s)')
-    expect(message).toContain('Invoice')
-    expect(message).toContain('billing')
-    expect(message).toContain('subscriptions')
-    expect(message).toContain(readSourcePath(InvoiceBilling))
-    expect(message).toContain(readSourcePath(InvoiceSubscriptions))
+    // The structured-logging contract keeps the message constant and the dynamic values
+    // in queryable fields.
+    const [message, fields] = warn.mock.calls[0] as [string, Record<string, unknown>]
+    expect(message).toBe('Duplicate entity class names across enabled modules')
+    expect(fields.classNames).toEqual(['Invoice'])
+    expect(fields.duplicates).toEqual([
+      {
+        className: 'Invoice',
+        sources: [
+          { moduleId: 'billing', sourcePath: readSourcePath(InvoiceBilling) },
+          { moduleId: 'subscriptions', sourcePath: readSourcePath(InvoiceSubscriptions) },
+        ],
+      },
+    ])
+    expect(typeof fields.remediation).toBe('string')
     // Warning-only by design: registration must still complete.
     expect(getOrmEntities()).toBe(entities)
   })
@@ -120,9 +129,36 @@ describe('registerOrmEntities duplicate class name reporting', () => {
     registerOrmEntities([InvoiceBilling, InvoiceSubscriptions, LedgerBilling, LedgerSubscriptions])
 
     expect(warn).toHaveBeenCalledTimes(2)
-    const second = warn.mock.calls[1][0] as string
-    expect(second).toContain('Ledger')
     // The already-reported name is not repeated.
-    expect(second).not.toContain('  Invoice')
+    expect(warn.mock.calls[1][1].classNames).toEqual(['Ledger'])
+  })
+
+  it('reports a collision again after it was fixed and reintroduced', async () => {
+    const { registerOrmEntities } = await import('../mikro')
+
+    registerOrmEntities([InvoiceBilling, InvoiceSubscriptions])
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    // The developer renames one of them; the next reload is clean.
+    registerOrmEntities([InvoiceBilling])
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    // Reverting the rename must warn again rather than stay silent forever.
+    registerOrmEntities([InvoiceBilling, InvoiceSubscriptions])
+
+    expect(warn).toHaveBeenCalledTimes(2)
+    expect(warn.mock.calls[1][1].classNames).toEqual(['Invoice'])
+  })
+
+  it('reports again when the same class name starts colliding with a different module', async () => {
+    const { registerOrmEntities } = await import('../mikro')
+
+    registerOrmEntities([InvoiceBilling, InvoiceSubscriptions])
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    registerOrmEntities([InvoiceBilling, InvoiceReporting])
+
+    expect(warn).toHaveBeenCalledTimes(2)
+    expect(warn.mock.calls[1][1].classNames).toEqual(['Invoice'])
   })
 })

--- a/packages/shared/src/lib/db/__tests__/registerOrmEntities.duplicates.test.ts
+++ b/packages/shared/src/lib/db/__tests__/registerOrmEntities.duplicates.test.ts
@@ -2,6 +2,8 @@ import 'reflect-metadata'
 import { MetadataStorage } from '@mikro-orm/core'
 import { Invoice as InvoiceBilling } from './fixtures/invoiceBilling'
 import { Invoice as InvoiceSubscriptions } from './fixtures/invoiceSubscriptions'
+import { Ledger as LedgerBilling } from './fixtures/ledgerBilling'
+import { Ledger as LedgerSubscriptions } from './fixtures/ledgerSubscriptions'
 
 const warn = jest.fn()
 
@@ -12,6 +14,7 @@ jest.mock('../../logger', () => ({
 }))
 
 const GLOBAL_ENTITIES_KEY = '__openMercatoOrmEntities__'
+const GLOBAL_REPORTED_KEY = '__openMercatoReportedDuplicateEntityClassNames__'
 
 function readSourcePath(entity: unknown): string {
   return (entity as Record<symbol, string>)[MetadataStorage.PATH_SYMBOL]
@@ -31,6 +34,8 @@ describe('registerOrmEntities duplicate class name reporting', () => {
 
   beforeEach(() => {
     warn.mockClear()
+    // Collisions are reported once per process; start each case from a clean slate.
+    delete (globalThis as Record<string, unknown>)[GLOBAL_REPORTED_KEY]
   })
 
   afterEach(() => {
@@ -91,5 +96,33 @@ describe('registerOrmEntities duplicate class name reporting', () => {
     ])
 
     expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('reports a standing collision once, not on every HMR re-registration', async () => {
+    stampModuleId(InvoiceBilling, 'billing.Invoice')
+    stampModuleId(InvoiceSubscriptions, 'subscriptions.Invoice')
+    const entities = [InvoiceBilling, InvoiceSubscriptions]
+    const { registerOrmEntities } = await import('../mikro')
+
+    registerOrmEntities(entities)
+    registerOrmEntities(entities)
+    registerOrmEntities(entities)
+
+    expect(warn).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a newly introduced collision even after an earlier one was reported', async () => {
+    const { registerOrmEntities } = await import('../mikro')
+
+    registerOrmEntities([InvoiceBilling, InvoiceSubscriptions])
+    expect(warn).toHaveBeenCalledTimes(1)
+
+    registerOrmEntities([InvoiceBilling, InvoiceSubscriptions, LedgerBilling, LedgerSubscriptions])
+
+    expect(warn).toHaveBeenCalledTimes(2)
+    const second = warn.mock.calls[1][0] as string
+    expect(second).toContain('Ledger')
+    // The already-reported name is not repeated.
+    expect(second).not.toContain('  Invoice')
   })
 })

--- a/packages/shared/src/lib/db/__tests__/registerOrmEntities.duplicates.test.ts
+++ b/packages/shared/src/lib/db/__tests__/registerOrmEntities.duplicates.test.ts
@@ -1,0 +1,95 @@
+import 'reflect-metadata'
+import { MetadataStorage } from '@mikro-orm/core'
+import { Invoice as InvoiceBilling } from './fixtures/invoiceBilling'
+import { Invoice as InvoiceSubscriptions } from './fixtures/invoiceSubscriptions'
+
+const warn = jest.fn()
+
+jest.mock('../../logger', () => ({
+  createLogger: () => ({
+    child: () => ({ debug: jest.fn(), info: jest.fn(), warn, error: jest.fn() }),
+  }),
+}))
+
+const GLOBAL_ENTITIES_KEY = '__openMercatoOrmEntities__'
+
+function readSourcePath(entity: unknown): string {
+  return (entity as Record<symbol, string>)[MetadataStorage.PATH_SYMBOL]
+}
+
+function stampModuleId(entity: unknown, stamp: string): void {
+  Object.defineProperty(entity, 'entityName', {
+    value: stamp,
+    configurable: true,
+    enumerable: false,
+    writable: false,
+  })
+}
+
+describe('registerOrmEntities duplicate class name reporting', () => {
+  const originalEntities = (globalThis as Record<string, unknown>)[GLOBAL_ENTITIES_KEY]
+
+  beforeEach(() => {
+    warn.mockClear()
+  })
+
+  afterEach(() => {
+    for (const entity of [InvoiceBilling, InvoiceSubscriptions]) {
+      delete (entity as Record<string, unknown>).entityName
+    }
+    if (typeof originalEntities === 'undefined') {
+      delete (globalThis as Record<string, unknown>)[GLOBAL_ENTITIES_KEY]
+      return
+    }
+    ;(globalThis as Record<string, unknown>)[GLOBAL_ENTITIES_KEY] = originalEntities
+  })
+
+  it('warns and still registers when two modules contribute the same class name', async () => {
+    stampModuleId(InvoiceBilling, 'billing.Invoice')
+    stampModuleId(InvoiceSubscriptions, 'subscriptions.Invoice')
+    const entities = [InvoiceBilling, InvoiceSubscriptions]
+    const { registerOrmEntities, getOrmEntities } = await import('../mikro')
+
+    registerOrmEntities(entities)
+
+    expect(warn).toHaveBeenCalledTimes(1)
+    const message = warn.mock.calls[0][0] as string
+    expect(message).toContain('[Bootstrap] Duplicate entity class name(s)')
+    expect(message).toContain('Invoice')
+    expect(message).toContain('billing')
+    expect(message).toContain('subscriptions')
+    expect(message).toContain(readSourcePath(InvoiceBilling))
+    expect(message).toContain(readSourcePath(InvoiceSubscriptions))
+    // Warning-only by design: registration must still complete.
+    expect(getOrmEntities()).toBe(entities)
+  })
+
+  it('stays silent for a registration with unique class names', async () => {
+    const { registerOrmEntities } = await import('../mikro')
+
+    registerOrmEntities([InvoiceBilling])
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('stays silent when the same class is registered twice', async () => {
+    const { registerOrmEntities } = await import('../mikro')
+
+    registerOrmEntities([InvoiceBilling, InvoiceBilling])
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('stays silent for non-entity exports that share a name', async () => {
+    const { registerOrmEntities } = await import('../mikro')
+
+    registerOrmEntities([
+      function helper(): void {},
+      function helper(): void {},
+      { name: 'TestEntity' },
+      { name: 'TestEntity' },
+    ])
+
+    expect(warn).not.toHaveBeenCalled()
+  })
+})

--- a/packages/shared/src/lib/db/duplicateEntities.ts
+++ b/packages/shared/src/lib/db/duplicateEntities.ts
@@ -1,0 +1,74 @@
+import { EntitySchema, MetadataStorage } from '@mikro-orm/core'
+import {
+  findDuplicateEntityClassNames,
+  type DuplicateEntityClassNameGroup,
+  type EntityClassNameEntry,
+} from './duplicateEntityClassNames'
+
+/**
+ * Adapts a registered ORM entity array to the dependency-free collision detector in
+ * `./duplicateEntityClassNames`, which explains the underlying MikroORM behaviour.
+ */
+
+type DecoratedEntityClass = {
+  readonly name?: unknown
+  readonly entityName?: unknown
+  readonly [MetadataStorage.PATH_SYMBOL]?: unknown
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+/**
+ * `enhanceEntities()` in the generated entity registry stamps `<moduleId>.<ExportName>`
+ * onto every entity export. MikroORM ignores that stamp, but it is the only place the
+ * contributing module id survives to runtime. Module ids may contain dots; the export
+ * name never does, so split on the last one.
+ */
+function readModuleIdFromStamp(stamp: unknown): string | undefined {
+  const value = readString(stamp)
+  if (!value) return undefined
+  const separator = value.lastIndexOf('.')
+  return separator > 0 ? value.slice(0, separator) : undefined
+}
+
+/**
+ * The registered array holds every function export of each module's entity file, so
+ * plain helper functions travel alongside real entities. Only classes touched by a
+ * MikroORM decorator carry `MetadataStorage.PATH_SYMBOL` as an own property; everything
+ * else is skipped so helpers that happen to share a name are never reported.
+ */
+function toEntityClassNameEntry(value: unknown): EntityClassNameEntry | null {
+  if (EntitySchema.is(value)) {
+    const className = readString(value.meta?.className)
+    if (!className) return null
+    return { className, sourcePath: readString(value.meta?.path), target: value }
+  }
+  if (typeof value !== 'function') return null
+  if (!Object.prototype.hasOwnProperty.call(value, MetadataStorage.PATH_SYMBOL)) return null
+  const entity = value as DecoratedEntityClass
+  const className = readString(entity.name)
+  if (!className) return null
+  return {
+    className,
+    moduleId: readModuleIdFromStamp(entity.entityName),
+    sourcePath: readString(entity[MetadataStorage.PATH_SYMBOL]),
+    target: value,
+  }
+}
+
+export function collectEntityClassNameEntries(entities: readonly unknown[]): EntityClassNameEntry[] {
+  const entries: EntityClassNameEntry[] = []
+  for (const value of entities) {
+    const entry = toEntityClassNameEntry(value)
+    if (entry) entries.push(entry)
+  }
+  return entries
+}
+
+export function findDuplicateRegisteredEntityClassNames(
+  entities: readonly unknown[],
+): DuplicateEntityClassNameGroup[] {
+  return findDuplicateEntityClassNames(collectEntityClassNameEntries(entities))
+}

--- a/packages/shared/src/lib/db/duplicateEntities.ts
+++ b/packages/shared/src/lib/db/duplicateEntities.ts
@@ -40,6 +40,11 @@ function readModuleIdFromStamp(stamp: unknown): string | undefined {
  * else is skipped so helpers that happen to share a name are never reported.
  */
 function toEntityClassNameEntry(value: unknown): EntityClassNameEntry | null {
+  // `enhanceEntities()` in the generated registry keeps only `typeof value === 'function'`
+  // exports, so an EntitySchema a module exports never arrives through it. This branch is
+  // live only for direct callers such as the testing bootstrap — and since the module id
+  // stamp is applied to those same function exports, an EntitySchema carries no module id
+  // and reports by path alone.
   if (EntitySchema.is(value)) {
     const className = readString(value.meta?.className)
     if (!className) return null

--- a/packages/shared/src/lib/db/duplicateEntities.ts
+++ b/packages/shared/src/lib/db/duplicateEntities.ts
@@ -24,7 +24,10 @@ function readString(value: unknown): string | undefined {
  * `enhanceEntities()` in the generated entity registry stamps `<moduleId>.<ExportName>`
  * onto every entity export. MikroORM ignores that stamp, but it is the only place the
  * contributing module id survives to runtime. Module ids may contain dots; the export
- * name never does, so split on the last one.
+ * name never does, so split on the last one. A class that declares its own `entityName`
+ * keeps it — `enhanceEntities()` never overwrites one — so a declared value containing a
+ * dot yields a bogus module id here; cosmetic in the warning text, and a dot-free value
+ * degrades to `undefined`.
  */
 function readModuleIdFromStamp(stamp: unknown): string | undefined {
   const value = readString(stamp)

--- a/packages/shared/src/lib/db/duplicateEntities.ts
+++ b/packages/shared/src/lib/db/duplicateEntities.ts
@@ -61,7 +61,14 @@ function toEntityClassNameEntry(value: unknown): EntityClassNameEntry | null {
 export function collectEntityClassNameEntries(entities: readonly unknown[]): EntityClassNameEntry[] {
   const entries: EntityClassNameEntry[] = []
   for (const value of entities) {
-    const entry = toEntityClassNameEntry(value)
+    let entry: EntityClassNameEntry | null = null
+    try {
+      entry = toEntityClassNameEntry(value)
+    } catch {
+      // Reading a name off an exotic export (a throwing getter, a proxy) must not turn
+      // a diagnostic into a boot failure. Skip the value and keep checking the rest.
+      continue
+    }
     if (entry) entries.push(entry)
   }
   return entries

--- a/packages/shared/src/lib/db/duplicateEntityClassNames.ts
+++ b/packages/shared/src/lib/db/duplicateEntityClassNames.ts
@@ -1,12 +1,12 @@
 /**
  * Detection and reporting for entity class names contributed by more than one module.
  *
- * MikroORM keys entity metadata by the JS class name. `MetadataStorage` holds both a
- * constructor-keyed map and a name-keyed one, and `find()` falls through to the
- * name-keyed one, so when discovery calls `get(cls, true)` for a second class sharing a
- * name it resolves the first class's metadata instead of creating its own. The two
- * classes silently collapse onto one set of metadata — table name included — rather
- * than failing discovery.
+ * MikroORM keys metadata by the JS class name. Discovery does keep a separate metadata
+ * entry per constructor, so class-based lookups such as `em.find(Invoice)` stay correct,
+ * but every name-based resolution — a string relation target, `getRepository('<Name>')`,
+ * relation discovery, serialization — goes through the name-keyed map, where only one of
+ * the same-named classes survives. Which one wins is decided by registration order, and
+ * the loser is reachable by class only. Nothing fails; the wrong table is simply used.
  *
  * Nothing upstream catches it: `discovery.checkDuplicateEntities` is declared as a
  * default in @mikro-orm/core 7.1.9 but is read nowhere, and the one live check compares
@@ -18,6 +18,16 @@
  * is kept separate from reporting so each caller decides whether a collision warns or
  * throws.
  */
+
+/**
+ * Stable, constant sentences shared by both reporting surfaces: the structured runtime
+ * log line puts them in fields, the generator renders them inline.
+ */
+export const DUPLICATE_ENTITY_CLASS_NAMES_REASON =
+  "MikroORM keeps one metadata entry per constructor, so class-based lookups such as em.find(<Name>) stay correct, but every name-based resolution — string relation targets, getRepository('<Name>'), relation discovery and serialization — goes through the name-keyed map, where only one of the same-named classes survives. Which one wins depends on registration order, so the other silently reads and writes the surviving class's table."
+
+export const DUPLICATE_ENTITY_CLASS_NAMES_REMEDIATION =
+  'Rename all but one of the colliding classes so every entity class name is unique across enabled modules, then update their exports, relation targets and imports. Table names may stay as they are.'
 
 export type EntityClassNameEntry = {
   className: string
@@ -105,8 +115,8 @@ export function formatDuplicateEntityClassNamesWarning(
   const names = groups.map((group) => `"${group.className}"`).join(', ')
   const lines = [
     `Duplicate entity class name(s) defined by more than one enabled module: ${names}.`,
-    "MikroORM resolves entities by JS class name for string relation targets, getRepository('<Name>'), relation discovery and serialization, so one silently shadows the other — the shadowed class ends up aliased to the surviving class's metadata, table name included. Class-based lookups such as em.find(<Name>) keep working, which is why this never fails loudly.",
-    'Rename all but one of the classes below so every entity class name is unique across enabled modules, then update their exports, relation targets and imports. Table names may stay as they are.',
+    DUPLICATE_ENTITY_CLASS_NAMES_REASON,
+    DUPLICATE_ENTITY_CLASS_NAMES_REMEDIATION,
   ]
   for (const group of groups) {
     lines.push(`  ${group.className}`)
@@ -115,4 +125,26 @@ export function formatDuplicateEntityClassNamesWarning(
     }
   }
   return lines.join('\n')
+}
+
+export type DuplicateEntityClassNameFields = {
+  classNames: string[]
+  duplicates: Array<{ className: string; sources: DuplicateEntityClassNameSource[] }>
+  reason: string
+  remediation: string
+}
+
+/**
+ * The same collisions as queryable fields, for callers logging through the structured
+ * facade, where the message must stay constant and the dynamic values live beside it.
+ */
+export function toDuplicateEntityClassNameFields(
+  groups: readonly DuplicateEntityClassNameGroup[],
+): DuplicateEntityClassNameFields {
+  return {
+    classNames: groups.map((group) => group.className),
+    duplicates: groups.map((group) => ({ className: group.className, sources: group.sources })),
+    reason: DUPLICATE_ENTITY_CLASS_NAMES_REASON,
+    remediation: DUPLICATE_ENTITY_CLASS_NAMES_REMEDIATION,
+  }
 }

--- a/packages/shared/src/lib/db/duplicateEntityClassNames.ts
+++ b/packages/shared/src/lib/db/duplicateEntityClassNames.ts
@@ -1,0 +1,110 @@
+/**
+ * Detection and reporting for entity class names contributed by more than one module.
+ *
+ * MikroORM keys entity metadata by the JS class name. `MetadataStorage` holds both a
+ * constructor-keyed map and a name-keyed one, and `find()` falls through to the
+ * name-keyed one, so when discovery calls `get(cls, true)` for a second class sharing a
+ * name it resolves the first class's metadata instead of creating its own. The two
+ * classes silently collapse onto one set of metadata — table name included — rather
+ * than failing discovery.
+ *
+ * Nothing upstream catches it: `discovery.checkDuplicateEntities` is declared as a
+ * default in @mikro-orm/core 7.1.9 but is read nowhere, and the one live check compares
+ * table names rather than class names, which never collide here because every entity
+ * declares an explicit `tableName`.
+ *
+ * This module is deliberately dependency-free so both the build-time generator and the
+ * runtime bootstrap can share it without pulling the ORM into the generator. Detection
+ * is kept separate from reporting so each caller decides whether a collision warns or
+ * throws.
+ */
+
+export type EntityClassNameEntry = {
+  className: string
+  moduleId?: string
+  sourcePath?: string
+  /**
+   * Runtime identity of the class. Two entries sharing a target are the same class
+   * reached twice — re-exported through a second import path, or re-registered by an
+   * HMR reload — and never count as a collision. Absent at build time, where the
+   * declaring module and file identify the class instead.
+   */
+  target?: object
+}
+
+export type DuplicateEntityClassNameSource = {
+  moduleId?: string
+  sourcePath?: string
+}
+
+export type DuplicateEntityClassNameGroup = {
+  className: string
+  sources: DuplicateEntityClassNameSource[]
+}
+
+function identify(entry: EntityClassNameEntry): unknown {
+  return entry.target ?? `${entry.moduleId ?? ''}|${entry.sourcePath ?? ''}`
+}
+
+/**
+ * Group entries by class name, keeping only names contributed by two or more distinct
+ * classes. Order follows first appearance, which is the module registration order.
+ */
+export function findDuplicateEntityClassNames(
+  entries: readonly EntityClassNameEntry[],
+): DuplicateEntityClassNameGroup[] {
+  const buckets = new Map<string, Map<unknown, DuplicateEntityClassNameSource>>()
+  for (const entry of entries) {
+    if (!entry.className) continue
+    let bucket = buckets.get(entry.className)
+    if (!bucket) {
+      bucket = new Map<unknown, DuplicateEntityClassNameSource>()
+      buckets.set(entry.className, bucket)
+    }
+    const identity = identify(entry)
+    if (!bucket.has(identity)) {
+      bucket.set(identity, { moduleId: entry.moduleId, sourcePath: entry.sourcePath })
+    }
+  }
+  const groups: DuplicateEntityClassNameGroup[] = []
+  for (const [className, bucket] of buckets) {
+    if (bucket.size < 2) continue
+    groups.push({ className, sources: Array.from(bucket.values()) })
+  }
+  return groups
+}
+
+/**
+ * At runtime the source path comes from MikroORM's decorator, which derives it by
+ * parsing a stack trace and falls back to the bare class name when that parse fails, so
+ * only render a value that still looks like a path.
+ */
+function formatSource(source: DuplicateEntityClassNameSource): string {
+  const path = source.sourcePath && /[\\/]/.test(source.sourcePath) ? source.sourcePath : undefined
+  if (source.moduleId && path) return `    - ${source.moduleId} (${path})`
+  if (source.moduleId) return `    - ${source.moduleId}`
+  if (path) return `    - ${path}`
+  return '    - unknown module'
+}
+
+/**
+ * Render every collision in one message, so a fix does not have to be discovered one
+ * rerun at a time. Callers prepend their own surface prefix.
+ */
+export function formatDuplicateEntityClassNamesWarning(
+  groups: readonly DuplicateEntityClassNameGroup[],
+): string {
+  const names = groups.map((group) => `"${group.className}"`).join(', ')
+  const lines = [
+    `Duplicate entity class name(s) defined by more than one enabled module: ${names}.`,
+    "MikroORM resolves entities by JS class name for string relation targets, getRepository('<Name>'), relation discovery and serialization, so one silently shadows the other — the shadowed class ends up aliased to the surviving class's metadata, table name included. Class-based lookups such as em.find(<Name>) keep working, which is why this never fails loudly.",
+    'Rename all but one of the classes below so every entity class name is unique across enabled modules, then update their exports, relation targets and imports. Table names may stay as they are.',
+  ]
+  for (const group of groups) {
+    lines.push(`  ${group.className}`)
+    for (const source of group.sources) {
+      lines.push(formatSource(source))
+    }
+  }
+  return lines.join('\n')
+}

--- a/packages/shared/src/lib/db/duplicateEntityClassNames.ts
+++ b/packages/shared/src/lib/db/duplicateEntityClassNames.ts
@@ -42,8 +42,16 @@ export type DuplicateEntityClassNameGroup = {
   sources: DuplicateEntityClassNameSource[]
 }
 
+/**
+ * Prefer the runtime class, then the declaring module and file. When an entry carries
+ * none of those, fall back to the entry itself so it stays distinct: an unidentifiable
+ * entry should fail open and surface a possible collision rather than collapse into a
+ * shared bucket key and hide one.
+ */
 function identify(entry: EntityClassNameEntry): unknown {
-  return entry.target ?? `${entry.moduleId ?? ''}|${entry.sourcePath ?? ''}`
+  if (entry.target) return entry.target
+  if (entry.moduleId || entry.sourcePath) return `${entry.moduleId ?? ''}|${entry.sourcePath ?? ''}`
+  return entry
 }
 
 /**

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -31,11 +31,16 @@ function setRegisteredEntities(entities: any[]): void {
  * through — so the logs name the cause instead of only its distant symptoms.
  */
 function warnOnDuplicateEntityClassNames(entities: readonly unknown[]): void {
-  const duplicates = findDuplicateRegisteredEntityClassNames(entities)
-  if (duplicates.length === 0) return
-  logger.warn(`[Bootstrap] ${formatDuplicateEntityClassNamesWarning(duplicates)}`, {
-    classNames: duplicates.map((group) => group.className),
-  })
+  try {
+    const duplicates = findDuplicateRegisteredEntityClassNames(entities)
+    if (duplicates.length === 0) return
+    logger.warn(`[Bootstrap] ${formatDuplicateEntityClassNamesWarning(duplicates)}`, {
+      classNames: duplicates.map((group) => group.className),
+    })
+  } catch (err) {
+    // This check is a diagnostic. It must never be the reason a bootstrap fails.
+    logger.debug('Duplicate entity class name check skipped', { err })
+  }
 }
 
 export function registerOrmEntities(entities: any[]) {

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -6,7 +6,10 @@ import { PostgreSqlDriver, type EntityManager as PostgreSqlEntityManager } from 
 import { getSslConfig } from './ssl'
 import { createLogger } from '../logger'
 import { findDuplicateRegisteredEntityClassNames } from './duplicateEntities'
-import { formatDuplicateEntityClassNamesWarning } from './duplicateEntityClassNames'
+import {
+  toDuplicateEntityClassNameFields,
+  type DuplicateEntityClassNameGroup,
+} from './duplicateEntityClassNames'
 
 const logger = createLogger('shared').child({ component: 'orm' })
 
@@ -16,17 +19,29 @@ let ormInstance: AppMikroORM | null = null
 
 // Use globalThis so standalone apps survive duplicated shared package module instances.
 const GLOBAL_ENTITIES_KEY = '__openMercatoOrmEntities__'
-// Same reason, plus HMR: a module-level set would reset on the very reloads it exists to
+// Same reason, plus HMR: a module-level map would reset on the very reloads it exists to
 // deduplicate across.
 const GLOBAL_REPORTED_DUPLICATE_ENTITY_NAMES_KEY = '__openMercatoReportedDuplicateEntityClassNames__'
 
-function getReportedDuplicateEntityClassNames(): Set<string> {
+function getReportedDuplicateEntityClassNames(): Map<string, string> {
   const globals = globalThis as Record<string, unknown>
   const existing = globals[GLOBAL_REPORTED_DUPLICATE_ENTITY_NAMES_KEY]
-  if (existing instanceof Set) return existing as Set<string>
-  const created = new Set<string>()
+  if (existing instanceof Map) return existing as Map<string, string>
+  const created = new Map<string, string>()
   globals[GLOBAL_REPORTED_DUPLICATE_ENTITY_NAMES_KEY] = created
   return created
+}
+
+/**
+ * Identifies a collision by the modules and files that contribute to it, so a
+ * re-registration reporting the same name from a different pair of modules is a new
+ * collision rather than a repeat.
+ */
+function fingerprintCollision(group: DuplicateEntityClassNameGroup): string {
+  return group.sources
+    .map((source) => `${source.moduleId ?? ''}|${source.sourcePath ?? ''}`)
+    .sort((left, right) => left.localeCompare(right))
+    .join(',')
 }
 
 function getRegisteredEntities(): any[] | null {
@@ -45,17 +60,17 @@ function setRegisteredEntities(entities: any[]): void {
 function warnOnDuplicateEntityClassNames(entities: readonly unknown[]): void {
   try {
     const duplicates = findDuplicateRegisteredEntityClassNames(entities)
-    if (duplicates.length === 0) return
-    // Development re-runs registration on every HMR reload, so report each colliding
-    // name once per process. Reprinting the whole warning on every reload buries it.
-    // A newly introduced collision still reports, because its name is not yet recorded.
+    // Development re-runs registration on every HMR reload, so report a collision only
+    // when it appears or its contributing modules change. Reprinting the same warning on
+    // every reload buries it, while tracking the previous registration rather than every
+    // name ever seen keeps a collision that was fixed and reintroduced reportable.
     const reported = getReportedDuplicateEntityClassNames()
-    const fresh = duplicates.filter((group) => !reported.has(group.className))
+    const current = new Map(duplicates.map((group) => [group.className, fingerprintCollision(group)]))
+    const fresh = duplicates.filter((group) => reported.get(group.className) !== current.get(group.className))
+    reported.clear()
+    for (const [className, fingerprint] of current) reported.set(className, fingerprint)
     if (fresh.length === 0) return
-    for (const group of fresh) reported.add(group.className)
-    logger.warn(`[Bootstrap] ${formatDuplicateEntityClassNamesWarning(fresh)}`, {
-      classNames: fresh.map((group) => group.className),
-    })
+    logger.warn('Duplicate entity class names across enabled modules', toDuplicateEntityClassNameFields(fresh))
   } catch (err) {
     // This check is a diagnostic. It must never be the reason a bootstrap fails.
     logger.debug('Duplicate entity class name check skipped', { err })

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -5,6 +5,8 @@ import { ReflectMetadataProvider } from '@mikro-orm/decorators/legacy'
 import { PostgreSqlDriver, type EntityManager as PostgreSqlEntityManager } from '@mikro-orm/postgresql'
 import { getSslConfig } from './ssl'
 import { createLogger } from '../logger'
+import { findDuplicateRegisteredEntityClassNames } from './duplicateEntities'
+import { formatDuplicateEntityClassNamesWarning } from './duplicateEntityClassNames'
 
 const logger = createLogger('shared').child({ component: 'orm' })
 
@@ -23,7 +25,21 @@ function setRegisteredEntities(entities: any[]): void {
   (globalThis as Record<string, unknown>)[GLOBAL_ENTITIES_KEY] = entities
 }
 
+/**
+ * A duplicate entity class name across modules corrupts entity resolution silently, and
+ * no build step catches it. Report it here — the one point every registration path goes
+ * through — so the logs name the cause instead of only its distant symptoms.
+ */
+function warnOnDuplicateEntityClassNames(entities: readonly unknown[]): void {
+  const duplicates = findDuplicateRegisteredEntityClassNames(entities)
+  if (duplicates.length === 0) return
+  logger.warn(`[Bootstrap] ${formatDuplicateEntityClassNamesWarning(duplicates)}`, {
+    classNames: duplicates.map((group) => group.className),
+  })
+}
+
 export function registerOrmEntities(entities: any[]) {
+  warnOnDuplicateEntityClassNames(entities)
   if (getRegisteredEntities() !== null && process.env.NODE_ENV === 'development') {
     logger.debug('ORM entities re-registered (this may occur during HMR)')
   }

--- a/packages/shared/src/lib/db/mikro.ts
+++ b/packages/shared/src/lib/db/mikro.ts
@@ -16,6 +16,18 @@ let ormInstance: AppMikroORM | null = null
 
 // Use globalThis so standalone apps survive duplicated shared package module instances.
 const GLOBAL_ENTITIES_KEY = '__openMercatoOrmEntities__'
+// Same reason, plus HMR: a module-level set would reset on the very reloads it exists to
+// deduplicate across.
+const GLOBAL_REPORTED_DUPLICATE_ENTITY_NAMES_KEY = '__openMercatoReportedDuplicateEntityClassNames__'
+
+function getReportedDuplicateEntityClassNames(): Set<string> {
+  const globals = globalThis as Record<string, unknown>
+  const existing = globals[GLOBAL_REPORTED_DUPLICATE_ENTITY_NAMES_KEY]
+  if (existing instanceof Set) return existing as Set<string>
+  const created = new Set<string>()
+  globals[GLOBAL_REPORTED_DUPLICATE_ENTITY_NAMES_KEY] = created
+  return created
+}
 
 function getRegisteredEntities(): any[] | null {
   return (globalThis as Record<string, unknown>)[GLOBAL_ENTITIES_KEY] as any[] | null ?? null
@@ -34,8 +46,15 @@ function warnOnDuplicateEntityClassNames(entities: readonly unknown[]): void {
   try {
     const duplicates = findDuplicateRegisteredEntityClassNames(entities)
     if (duplicates.length === 0) return
-    logger.warn(`[Bootstrap] ${formatDuplicateEntityClassNamesWarning(duplicates)}`, {
-      classNames: duplicates.map((group) => group.className),
+    // Development re-runs registration on every HMR reload, so report each colliding
+    // name once per process. Reprinting the whole warning on every reload buries it.
+    // A newly introduced collision still reports, because its name is not yet recorded.
+    const reported = getReportedDuplicateEntityClassNames()
+    const fresh = duplicates.filter((group) => !reported.has(group.className))
+    if (fresh.length === 0) return
+    for (const group of fresh) reported.add(group.className)
+    logger.warn(`[Bootstrap] ${formatDuplicateEntityClassNamesWarning(fresh)}`, {
+      classNames: fresh.map((group) => group.className),
     })
   } catch (err) {
     // This check is a diagnostic. It must never be the reason a bootstrap fails.


### PR DESCRIPTION
## Summary

When two enabled modules each export an entity class with the same JS class name (e.g. both `export class Invoice`), entity resolution is silently corrupted rather than failing. The visible failure lands far from the cause — ORM bootstrap misbehaves, downstream startup steps get skipped, and unrelated subsystems fail (missing role features producing broad 403s, readiness probes returning 500) — so diagnosing it from the symptoms takes a long time.

Nothing catches it today: `yarn generate`, `yarn build`, `tsc`, per-module unit tests and `yarn db:generate` all pass. An ORM init containing only one of the two modules' entities passes too.

Verified first-hand against the installed `@mikro-orm/core@7.1.9`, there are three independent reasons:

1. **`discovery.checkDuplicateEntities` is a dead option.** It is set as a default in `utils/Configuration.js` but is read nowhere in the shipped package, and is not declared in `Configuration.d.ts`'s `MetadataDiscoveryOptions`. `MetadataDiscovery.js` contains no class-name duplicate check at all — so this cannot be fixed by enabling an existing option.
2. **The one live duplicate check compares table names, not class names.** `MetadataValidator.validateDiscovered` throws `MetadataError.duplicateEntityDiscovered` (misleadingly named — its message is `Duplicate table names are not allowed`) and compares `schema + tableName`. It only fires if both classes fall back to the default `classToTableName(class.name)`; every entity in this repo declares an explicit distinct `tableName`, so it never fires.
3. **Name-based metadata lookup silently aliases.** `MetadataStorage` holds both a constructor-keyed map and a name-keyed one, and `find()` falls through to the name-keyed one. When discovery calls `get(cls, true)` for a second class sharing a name, it resolves the *first* class's metadata instead of creating its own — so the two classes collapse onto one set of metadata, table name included. Class-based lookups such as `em.find(Invoice)` keep working, which is exactly why this never fails loudly; everything resolved by name (string relation targets, `getRepository('<Name>')`, relation discovery, serialization) silently gets the wrong entity.

`yarn db:generate` cannot see it either: it initialises MikroORM once per module with `MetadataStorage.clear()` in between, so cross-module collisions are structurally invisible there.

This PR makes the collision self-announcing on both surfaces. Both are **warnings** — generation and bootstrap still complete unchanged.

## Changes

- **New `packages/shared/src/lib/db/duplicateEntityClassNames.ts`** — dependency-free detection and message formatting. No ORM import, deliberately, so the CLI generator can share it without pulling MikroORM into `yarn generate`.
- **New `packages/shared/src/lib/db/duplicateEntities.ts`** — adapts a registered ORM entity array to the detector, filtering to values that actually carry `MetadataStorage.PATH_SYMBOL` (or are `EntitySchema` instances).
- **`packages/shared/src/lib/db/mikro.ts`** — `registerOrmEntities()` now reports collisions as a `[Bootstrap]` warning. This is the single point every runtime registration path funnels through (`lib/bootstrap/factory.ts` and `lib/testing/bootstrap.ts`), so one call site covers both.
- **New `packages/cli/src/lib/generators/entity-class-declarations.ts`** — a TypeScript-AST parse collecting `@Entity()`-decorated exported classes. Handles stacked decorators with interleaved comments, `export { X }`, aliased imports (`import { Entity as OrmEntity }`), namespace-qualified decorators (`@orm.Entity()`), and infers script kind from the file extension since `MODULE_CODE_EXTENSIONS` accepts `.tsx`/`.jsx`.
- **`packages/cli/src/lib/generators/module-entities.ts`** — warns during generation, from the generator that produces the colliding registry.

The message names the class, the contributing modules and their source files, and states the fix:

```
[Entities Warning] Duplicate entity class name(s) defined by more than one enabled module: "ApiKey".
MikroORM resolves entities by JS class name for string relation targets, getRepository('<Name>'), relation discovery
and serialization, so one silently shadows the other — the shadowed class ends up aliased to the surviving class's
metadata, table name included. Class-based lookups such as em.find(<Name>) keep working, which is why this never
fails loudly.
Rename all but one of the classes below so every entity class name is unique across enabled modules, then update
their exports, relation targets and imports. Table names may stay as they are.
  ApiKey
    - api_keys (/…/packages/core/src/modules/api_keys/data/entities.ts)
    - example (/…/apps/mercato/src/modules/example/data/entities.ts)
```

### Design notes

- **False positives are avoided deliberately.** The registered array holds *every* function export of each module's entity file, so plain helper functions travel alongside entities. Only classes carrying `MetadataStorage.PATH_SYMBOL` are compared at runtime; only `@Entity()`-decorated classes at generate time.
- **The same class registered twice never warns.** Comparison is by constructor identity first, so a class re-exported through a second import path, or re-registered by an HMR reload, collapses to one source. The existing HMR debug line in `registerOrmEntities` is untouched.
- **Reported once per process.** Development re-runs registration on every HMR reload; reprinting a multi-line warning each time would bury it. A newly introduced collision still reports. The record lives on `globalThis` because a module-level set would reset on the very reloads it exists to deduplicate across — the same reason the entity registry above it already does.
- **It can never break its host.** Detection is a pure function, separate from the logging, and both reporting boundaries are guarded, so an exotic export (a throwing getter, a trapping proxy) degrades to a skipped check rather than a failed bootstrap.
- **Warning-only is deliberate**, and the split between detection and reporting means escalating to a throw later is a one-line change per call site.

### Deliberately out of scope

The generator stamps `entityName = "<moduleId>.<ExportName>"` on every entity export. MikroORM v7 reads that property nowhere (`Utils.className` returns plain `class.name`, and `EntitySchema`'s constructor even overwrites an explicitly passed `name`), so the stamp is **vestigial**. It is left alone and only read as a source of the module id for the runtime message. Making it authoritative would need a custom metadata provider / naming strategy touching every name-based lookup, entity id and serialization path — a much larger change.

### Known limitations, both backstopped by the runtime check

- The generate-time pass is static, so entities re-exported via `export * from` are not seen.
- For app modules bundled through esbuild, the runtime source path resolves to the generated bundle rather than the original file; the module id is still correct.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**

`.ai/specs/` was checked and holds no spec covering ORM entity registration or discovery. This is a self-contained diagnostic for an existing platform footgun — no new feature, module, API surface, or database change — so it was treated as not requiring one. Happy to write a spec if maintainers would prefer it recorded.

## Testing

Full gate, per `.ai/agentic.config.json`, run locally: `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn lint` (0 errors), `yarn test`, `yarn build:app`.

Unit coverage added:

- `duplicateEntityClassNames.test.ts` — the pure detector and message formatter, including three-way collisions, degraded module id / path rendering, and the fail-open contract for unidentifiable entries.
- `duplicateEntities.test.ts` — a **characterization test pinning the upstream MikroORM behaviour** this guard exists for (`MetadataStorage` aliasing a second same-named class onto the first; DB-free, public API only). It documents *why* the guard exists and will fail if a future MikroORM starts detecting class-name collisions itself. Plus adapter coverage and resilience against hostile exports.
- `registerOrmEntities.duplicates.test.ts` — warns *and still registers*; silent for unique names, the same class twice, and non-entity exports sharing a name; reports once across re-registration; still reports a newly introduced collision.
- `entity-class-declarations.test.ts` — parser coverage: stacked decorators with interleaved comments, `export { X }`, bare `@Entity`, aliased and namespace-qualified decorators, non-exported and non-entity classes, `.tsx` files, unreadable files.
- `module-entities.test.ts` — generator warns on a real collision and still generates; silent when names are unique or only one colliding class is an entity.

Verified end to end by temporarily introducing a real collision: `yarn generate` printed the warning naming both modules and files, and a real app bootstrap logged the `[Bootstrap]` warning and then **completed** — confirming it is warning-only — and stayed silent on a second registration. `yarn generate` emits nothing for the current module set (272 entity classes across 51 files), so there are no pre-existing collisions and no false positives.

**Performance:** runtime detection over the full 254-entity registry costs **0.071 ms** per `registerOrmEntities()` call; generate-time parsing of all 51 entity files costs **125 ms**, well under 1% of a `yarn generate` run.

**On integration tests (`.ai/qa/tests/`):** none added, and documented here as not applicable. The change adds no HTTP route, no UI surface, and no user-visible behaviour — its entire output is a log line at ORM registration and a console warning during generation, neither of which is reachable from an integration test driving the app. Both are covered by unit tests plus the end-to-end manual verification above.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required).
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable).
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius (`risk-low`/`risk-medium`/`risk-high`).
- [ ] QA routing set: `skip-qa` for low-risk non-customer-facing changes — and for changes with no manually exercisable UI surface that leave the database structure and API surface unchanged, preserve `BACKWARD_COMPATIBILITY.md` contracts, and ship automated tests for the behavior they change — otherwise `needs-qa`.

> **On the four unticked boxes above.** The CLA box is deliberately left for a human to tick — an agent must not accept a legal agreement on a contributor's behalf. The spec box is unticked because no spec was created (see the Specification section for why). The three label boxes cannot be ticked from this account: it has read-only permission on this repository, so it cannot apply labels here. Intended labels and rationale are in a follow-up comment for a maintainer to apply.

### Design System Compliance

Not applicable — this change touches no UI. It adds no `.tsx`, nothing under `packages/ui/src/`, and nothing under any `components/` tree; the only user-visible output is a log line and a console warning.

- [ ] No hardcoded status colors (`text-red-*`, `bg-green-*`, `text-emerald-*`, `bg-amber-*`, `bg-blue-*`) — use semantic tokens
- [ ] No arbitrary text sizes (`text-[Npx]`) — use typography scale or `text-overline`
- [ ] Empty state handled for list/data pages (`<EmptyState>` or DataTable `emptyState` prop)
- [ ] Loading state handled for async pages
- [ ] `aria-label` on all icon-only buttons (`<IconButton>`)
- [ ] Uses existing DS components (Alert, StatusBadge, FormField) — no custom replacements

## Linked issues

No tracker issue is linked — this was reported directly. Happy to open one if maintainers prefer it tracked.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789911956&installation_model_id=432243&pr_number=5448&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5448&signature=461b92b3bb6ab689e55eba76aadab0233f27a2ea65070e3250d74cb1086289c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->