### PR TITLE
fix(audit_logs): stack the changed-fields diff instead of scrolling it off-screen on narrow viewports

### DIFF
--- a/packages/core/src/modules/audit_logs/lib/__tests__/display-helpers.test.tsx
+++ b/packages/core/src/modules/audit_logs/lib/__tests__/display-helpers.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { render, screen, within } from '@testing-library/react'
+import type { TranslateFn } from '@open-mercato/shared/lib/i18n/context'
+import { ChangedFieldsTable } from '../display-helpers'
+
+const dict: Record<string, string> = {
+  'audit_logs.actions.details.changed_fields': 'Changed fields',
+  'audit_logs.actions.details.field': 'Field',
+  'audit_logs.actions.details.before': 'Before',
+  'audit_logs.actions.details.after': 'After',
+  'audit_logs.actions.details.no_changes': 'No tracked field changes',
+}
+
+const t = ((key: string) => dict[key] ?? key) as TranslateFn
+
+const changeRows = [
+  { field: 'lifecycleStage', from: 'lead', to: 'customer' },
+  { field: 'cf_billing_address', from: null, to: { city: 'Bristol' } },
+]
+
+describe('ChangedFieldsTable', () => {
+  it('renders the table header from the shared i18n keys', () => {
+    render(<ChangedFieldsTable changeRows={changeRows} noneLabel="None" t={t} />)
+    const headers = screen.getAllByRole('columnheader').map((cell) => cell.textContent)
+    expect(headers).toEqual(['Field', 'Before', 'After'])
+  })
+
+  it('renders each field and its values exactly once', () => {
+    render(<ChangedFieldsTable changeRows={changeRows} noneLabel="None" t={t} />)
+    expect(screen.getAllByText('Lifecycle Stage')).toHaveLength(1)
+    expect(screen.getAllByText('lead')).toHaveLength(1)
+    expect(screen.getAllByText('customer')).toHaveLength(1)
+    expect(screen.getAllByText('Billing Address')).toHaveLength(1)
+  })
+
+  it('repeats the before/after labels inside every row so the stacked layout stays readable', () => {
+    render(<ChangedFieldsTable changeRows={changeRows} noneLabel="None" t={t} />)
+    const rows = screen.getAllByRole('row').slice(1)
+    expect(rows).toHaveLength(changeRows.length)
+    for (const row of rows) {
+      expect(within(row).getByText('Before')).toBeInTheDocument()
+      expect(within(row).getByText('After')).toBeInTheDocument()
+    }
+  })
+
+  it('uses the beforeLabel/afterLabel overrides for both the header and the per-row labels', () => {
+    render(
+      <ChangedFieldsTable
+        changeRows={changeRows}
+        noneLabel="None"
+        t={t}
+        beforeLabel="Incoming"
+        afterLabel="Current"
+      />,
+    )
+    const headers = screen.getAllByRole('columnheader').map((cell) => cell.textContent)
+    expect(headers).toEqual(['Field', 'Incoming', 'Current'])
+    expect(screen.getAllByText('Incoming')).toHaveLength(1 + changeRows.length)
+    expect(screen.getAllByText('Current')).toHaveLength(1 + changeRows.length)
+    expect(screen.queryByText('Before')).not.toBeInTheDocument()
+  })
+
+  it('falls back to noneLabel for empty values', () => {
+    render(<ChangedFieldsTable changeRows={changeRows} noneLabel="None" t={t} />)
+    expect(screen.getByText('None')).toBeInTheDocument()
+  })
+
+  it('renders the empty state instead of a table when there are no changes', () => {
+    render(<ChangedFieldsTable changeRows={[]} noneLabel="None" t={t} />)
+    expect(screen.getByText('No tracked field changes')).toBeInTheDocument()
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+  })
+})

--- a/packages/core/src/modules/audit_logs/lib/__tests__/display-helpers.test.tsx
+++ b/packages/core/src/modules/audit_logs/lib/__tests__/display-helpers.test.tsx
@@ -16,8 +16,14 @@ const dict: Record<string, string> = {
 
 const t = ((key: string) => dict[key] ?? key) as TranslateFn
 
+// A value with no break opportunities is the case that regressed the layout:
+// overflow-wrap: break-word does not reduce a cell's min-content contribution,
+// so the table kept a floor far wider than its container. See PR #105.
+const unbreakableToken = 'a'.repeat(60) + '9f3c1e2b9a7d4c118b521f9e0a6d3c47' + 'q'.repeat(88)
+
 const changeRows = [
   { field: 'lifecycleStage', from: 'lead', to: 'customer' },
+  { field: 'apiKeyHash', from: null, to: unbreakableToken },
   { field: 'cf_billing_address', from: null, to: { city: 'Bristol' } },
 ]
 
@@ -34,6 +40,21 @@ describe('ChangedFieldsTable', () => {
     expect(screen.getAllByText('lead')).toHaveLength(1)
     expect(screen.getAllByText('customer')).toHaveLength(1)
     expect(screen.getAllByText('Billing Address')).toHaveLength(1)
+    expect(screen.getAllByText(unbreakableToken)).toHaveLength(1)
+  })
+
+  it('keeps every value able to break mid-token so no cell can set a min-content floor', () => {
+    render(<ChangedFieldsTable changeRows={changeRows} noneLabel="None" t={t} />)
+    expect(screen.getByText(unbreakableToken)).toHaveClass('wrap-anywhere')
+  })
+
+  it('drops out of table layout below the breakpoint and back into it above', () => {
+    render(<ChangedFieldsTable changeRows={changeRows} noneLabel="None" t={t} />)
+    // A block tbody inside a display:table parent gets wrapped in an anonymous
+    // table cell, which reintroduces the min-content floor the stacking removes.
+    const table = screen.getByRole('table')
+    expect(table).toHaveClass('block')
+    expect(table).toHaveClass('@lg/changes:table')
   })
 
   it('repeats the before/after labels inside every row so the stacked layout stays readable', () => {
@@ -65,7 +86,8 @@ describe('ChangedFieldsTable', () => {
 
   it('falls back to noneLabel for empty values', () => {
     render(<ChangedFieldsTable changeRows={changeRows} noneLabel="None" t={t} />)
-    expect(screen.getByText('None')).toBeInTheDocument()
+    // apiKeyHash and cf_billing_address both have an empty `from`.
+    expect(screen.getAllByText('None')).toHaveLength(2)
   })
 
   it('renders the empty state instead of a table when there are no changes', () => {

--- a/packages/core/src/modules/audit_logs/lib/display-helpers.tsx
+++ b/packages/core/src/modules/audit_logs/lib/display-helpers.tsx
@@ -33,9 +33,9 @@ export function renderValue(value: unknown, fallback: string) {
   if (typeof value === 'boolean') return <span>{value ? 'true' : 'false'}</span>
   if (typeof value === 'number' || typeof value === 'bigint') return <span>{String(value)}</span>
   if (value instanceof Date) return <span>{value.toISOString()}</span>
-  if (typeof value === 'string') return <span className="break-words">{value}</span>
+  if (typeof value === 'string') return <span className="wrap-anywhere">{value}</span>
   return (
-    <pre className="max-h-40 overflow-y-auto whitespace-pre-wrap break-words rounded-md bg-muted/50 px-2 py-1 text-xs leading-5 text-muted-foreground">
+    <pre className="max-h-40 overflow-y-auto whitespace-pre-wrap wrap-anywhere rounded-md bg-muted/50 px-2 py-1 text-xs leading-5 text-muted-foreground">
       {safeStringify(value)}
     </pre>
   )
@@ -86,7 +86,7 @@ export function ChangedFieldsTable({ changeRows, noneLabel, t, beforeLabel, afte
       {changeRows.length ? (
         <div className="@container/changes mt-2">
           <div className="overflow-x-auto rounded-lg border">
-            <table className="w-full divide-y text-sm @lg/changes:min-w-full">
+            <table className="block w-full divide-y text-sm @lg/changes:table @lg/changes:min-w-full">
               <thead className="hidden bg-muted/50 @lg/changes:table-header-group">
                 <tr>
                   <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">

--- a/packages/core/src/modules/audit_logs/lib/display-helpers.tsx
+++ b/packages/core/src/modules/audit_logs/lib/display-helpers.tsx
@@ -76,43 +76,53 @@ export type ChangedFieldsTableProps = {
 }
 
 export function ChangedFieldsTable({ changeRows, noneLabel, t, beforeLabel, afterLabel }: ChangedFieldsTableProps) {
+  const beforeHeading = beforeLabel ?? t('audit_logs.actions.details.before')
+  const afterHeading = afterLabel ?? t('audit_logs.actions.details.after')
   return (
     <section>
       <h3 className="text-sm font-semibold">
         {t('audit_logs.actions.details.changed_fields')}
       </h3>
       {changeRows.length ? (
-        <div className="mt-2 overflow-x-auto rounded-lg border">
-          <table className="min-w-full divide-y text-sm">
-            <thead className="bg-muted/50">
-              <tr>
-                <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
-                  {t('audit_logs.actions.details.field')}
-                </th>
-                <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
-                  {beforeLabel ?? t('audit_logs.actions.details.before')}
-                </th>
-                <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
-                  {afterLabel ?? t('audit_logs.actions.details.after')}
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y">
-              {changeRows.map((row) => (
-                <tr key={row.field} className="align-top">
-                  <td className="px-4 py-2 align-top font-medium">
-                    {humanizeField(normalizeChangeField(row.field))}
-                  </td>
-                  <td className="px-4 py-2">
-                    {renderValue(row.from, noneLabel)}
-                  </td>
-                  <td className="px-4 py-2">
-                    {renderValue(row.to, noneLabel)}
-                  </td>
+        <div className="@container/changes mt-2">
+          <div className="overflow-x-auto rounded-lg border">
+            <table className="w-full divide-y text-sm @lg/changes:min-w-full">
+              <thead className="hidden bg-muted/50 @lg/changes:table-header-group">
+                <tr>
+                  <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+                    {t('audit_logs.actions.details.field')}
+                  </th>
+                  <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+                    {beforeHeading}
+                  </th>
+                  <th scope="col" className="px-4 py-2 text-left font-medium text-muted-foreground">
+                    {afterHeading}
+                  </th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody className="block divide-y @lg/changes:table-row-group">
+                {changeRows.map((row) => (
+                  <tr key={row.field} className="block px-4 py-3 align-top @lg/changes:table-row @lg/changes:p-0">
+                    <td className="block font-medium @lg/changes:table-cell @lg/changes:px-4 @lg/changes:py-2 @lg/changes:align-top">
+                      {humanizeField(normalizeChangeField(row.field))}
+                    </td>
+                    <td className="mt-2 block @lg/changes:mt-0 @lg/changes:table-cell @lg/changes:px-4 @lg/changes:py-2">
+                      <span className="mb-0.5 block text-xs font-medium uppercase tracking-wide text-muted-foreground @lg/changes:hidden">
+                        {beforeHeading}
+                      </span>
+                      {renderValue(row.from, noneLabel)}
+                    </td>
+                    <td className="mt-2 block @lg/changes:mt-0 @lg/changes:table-cell @lg/changes:px-4 @lg/changes:py-2">
+                      <span className="mb-0.5 block text-xs font-medium uppercase tracking-wide text-muted-foreground @lg/changes:hidden">
+                        {afterHeading}
+                      </span>
+                      {renderValue(row.to, noneLabel)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </div>
       ) : (
         <p className="mt-2 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

`ChangedFieldsTable` renders a three-column before/after diff inside an `overflow-x-auto` wrapper. Values carried `break-words`, but `overflow-wrap: break-word` does not reduce a cell's **min-content contribution** — so one realistic value (a CDN URL, a JSON snapshot) pins the table's intrinsic width well past its container. The wrapper then scrolls sideways and the "After" column — the one comparison the component exists to make — sits off-screen.

The row layout now stacks into labelled blocks below `32rem` and keeps the original table above it, and values can break mid-token so no cell can set a min-content floor.

A **container query on the component's own wrapper**, not a viewport breakpoint: the narrowest consumer — the version-history drawer — is `max-w-md` at *every* viewport, so `sm:`/`md:` variants would leave it broken on a desktop monitor.

Measured horizontal overflow with a URL-valued row, per consumer width:

| consumer | width | before | after |
|---|---|---|---|
| audit dialog (375px phone) | 343px | 299px | 0 |
| version-history drawer | 416px | 226px | 0 |
| record-locks conflict dialog | 464px | 178px | 0 |
| audit dialog (desktop) | 720px | 0 | 0, table preserved |

Two follow-up commits fix a mechanism the first pass missed: the `<table>` stayed `display:table` while `thead/tbody/tr/td` became block, so the browser wrapped the block-level tbody in an *anonymous table row and cell* and the table still sized to at least that cell's min-content width. At a 416px container with a 180-char unbroken token that was 1083px of overflow → 0. `wrap-anywhere` (rather than `break-words`) is not redundant with it: with the table fix alone the **wide** table variant still overflowed 920px on an unbroken token at a 720px container — the same pre-existing bug, just on a wide surface.

## Changes

- `display-helpers.tsx` — `ChangedFieldsTable` stacks into labelled blocks below `@lg/changes` via a container query on its own wrapper, and returns to `display:table` above it. Single DOM tree, not duplicated markup, so screen readers do not announce every value twice and large JSON blobs are not rendered twice.
- `display-helpers.tsx` — `block @lg/changes:table` on the `<table>` itself, so the stacked variant is block all the way down and no anonymous table box is generated.
- `display-helpers.tsx` — `renderValue` uses `wrap-anywhere` instead of `break-words`. `anywhere` reduces min-content contribution where `break-word` does not, and unlike `break-all` it only breaks when there is no other opportunity, so ordinary text is unchanged.
- Per-row before/after labels keep the stacked view self-describing once the `thead` is hidden. They reuse the existing i18n keys and the `beforeLabel`/`afterLabel` prop overrides — **no new strings**.
- `display-helpers.test.tsx` — fixture now includes an unbroken token (the original fixture only used values with break opportunities, which is exactly why the bug hid from it), plus guards for both mechanisms.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
n/a — presentation-only fix to one existing component, no contract or behavior surface added.

## Testing

- `yarn test` — `packages/core/src/modules/audit_logs/lib/__tests__/display-helpers.test.tsx`, 8 cases including two new layout guards:
  - `keeps every value able to break mid-token so no cell can set a min-content floor`
  - `drops out of table layout below the breakpoint and back into it above`
- Overflow figures in the table above were measured in a real browser at each consumer's container width; jsdom cannot measure layout, which is why those two guards assert class names where the rest of the file deliberately avoids doing so — the class *is* the fix, and both were silently wrong on the first pass.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. (No new strings — reuses existing i18n keys.)
- [x] I added or adjusted tests that cover the change.
- [ ] I added or updated integration tests in `.ai/qa/tests/` — not required: this is a presentation-only change to one component with no API, route, or data surface; the layout mechanism is covered by unit guards and the overflow figures were verified in-browser.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — N/A, see above.
- [ ] Priority set: this PR carries exactly one `priority-*` label. — this account cannot set labels upstream; requested in a comment below.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius. — same.
- [ ] QA routing set. — `needs-qa` requested in a comment below; this account cannot apply labels.

### Design System Compliance
- [x] No hardcoded status colors — none added; existing `text-muted-foreground` / `bg-muted/50` tokens only.
- [x] No arbitrary text sizes — `text-xs` from the typography scale.
- [x] Empty state handled — pre-existing `noneLabel` / no-changes paragraph preserved.
- [x] Loading state handled for async pages — N/A, this component is synchronous.
- [x] `aria-label` on all icon-only buttons — N/A, no buttons.
- [x] Uses existing DS components — no custom replacements; the `<table>` and its tokens are unchanged, only layout utilities were added.

## Linked issues

n/a

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789916376&installation_model_id=432243&pr_number=5451&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5451&signature=1d1125baa67698b77c325cbf458e2a5b8334fc52b45b96c6b3253976548f3ff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->