### PR TITLE
fix(integrations): prevent masked secret corruption

### DIFF
--- a/.ai/lessons.md
+++ b/.ai/lessons.md
@@ -1,6 +1,6 @@
 # Lessons
 
-This catalog indexes 136 focused lessons. Route the task first, then read only records whose modules, areas, or topics match the work.
+This catalog indexes 137 focused lessons. Route the task first, then read only records whose modules, areas, or topics match the work.
 
 ## How to use this catalog
 
@@ -95,6 +95,7 @@ This catalog indexes 136 focused lessons. Route the task first, then read only r
 
 ### backend-ui
 
+- [Write-only secret editors need explicit unchanged intent and separate form state](lessons/write-only-secret-editors-need-explicit-unchanged-intent.md) — area:backend-ui,integration,testing; module:integrations,ui; topic:data-integrity,ui-components,testing
 - [Always propagate structured conflict payload from `onBeforeSave` blockers](lessons/always-propagate-structured-conflict-payload-from.md) — area:backend-ui,umes,debugging; module:ui; topic:concurrency,optimistic-locking,ui-components
 - [Async edit selects must be hydrated as value-plus-options](lessons/async-edit-selects-must-be-hydrated-as-value-plus.md) — area:backend-ui,integration,testing; module:checkout,entities,ui; topic:custom-fields,filters,testing
 - [Async select controls must not treat synthetic empty changes as user clears](lessons/async-select-controls-must-not-treat-synthetic-empty.md) — area:backend-ui,testing,module-data; module:ui,catalog,events; topic:command-pattern,events,testing

--- a/.ai/lessons/write-only-secret-editors-need-explicit-unchanged-intent.md
+++ b/.ai/lessons/write-only-secret-editors-need-explicit-unchanged-intent.md
@@ -1,0 +1,16 @@
+---
+title: "Write-only secret editors need explicit unchanged intent and separate form state"
+modules: ["integrations","ui"]
+areas: ["backend-ui","integration","testing"]
+topics: ["data-integrity","ui-components","testing"]
+---
+
+# Write-only secret editors need explicit unchanged intent and separate form state
+
+**Context**: Integration credential GET masked configured secrets with an opaque sentinel and returned a separate configured-state map. Generic credential editors copied the masked object into password inputs, so the sentinel became real editable text.
+
+**Problem**: Partial edits persisted hybrid sentinel/user strings as encrypted credentials. Reinterpreting every omitted secret as unchanged would have fixed the first-party form while breaking the stable full-blob replacement contract, clear-all clients, deliberate provider clears, and a widget context that already consumed the raw masked map. A duplicate bundle editor had the same prefill path.
+
+**Rule**: Keep the raw masked response for existing transport and extension contracts, derive separate empty form values from configured-state metadata, and submit an explicit bounded list of unchanged secret field names. The server intersects that intent with trusted schema secret types; plain omission keeps its prior replacement semantics and explicit values always win. Audit every generic editor, extension context, clear path, and integration test before changing shared secret behavior.
+
+**Applies to**: Integration credentials, write-only settings forms, password/token replacement inputs, full-blob APIs, bundle editors, and any masked-secret contract with generic UI rendering.

--- a/.ai/specs/2026-08-21-integration-secret-credential-editing.md
+++ b/.ai/specs/2026-08-21-integration-secret-credential-editing.md
@@ -1,0 +1,397 @@
+# Integration Secret Credential Editing
+
+## TLDR
+
+The integration and bundle credential forms will treat stored secret credentials as write-only values: configured secret fields render empty, explain that a value already exists, and only submit a replacement when the operator types one. The UI sends an additive list of intentionally unchanged secret field names so the server can preserve them without changing the existing full-blob replacement contract or exposing the sentinel as editable form state.
+
+Scope is limited to the two core-owned generic `integrations` credential editors and credentials merge behavior described in [issue #5421](https://github.com/open-mercato/open-mercato/issues/5421). It does not change credential storage, encryption, registry types, route URLs, ACLs, database schema, or provider-specific logic.
+
+## Problem Statement
+
+`GET /api/integrations/:id/credentials` replaces configured secrets with the internal `__om_secret_unchanged__` sentinel and separately returns `secretFieldsConfigured`. The integration detail page currently passes the response object directly to `CrudForm`, so `PasswordInput` receives the sentinel as editable text. Partial edits can therefore persist a hybrid sentinel/user value, while a reload hides the corruption behind a fresh sentinel.
+
+## Proposed Solution
+
+- Consume `secretFieldsConfigured` when loading the integration detail form.
+- Remove configured secret values from `CrudForm.initialValues` so `PasswordInput` is genuinely empty and never exposes the sentinel as a field value.
+- Apply the same write-only state to the bundle credentials editor, which currently copies the masked response into a password input through a duplicate path.
+- Show an i18n-backed configured-state hint telling the operator that typing replaces the saved secret.
+- Let a required secret validate as satisfied when the server says it is already configured and the replacement input is empty.
+- Omit empty, already-configured secret values from the credentials object and list their field names under a new optional `unchangedSecretFields` request property; continue sending non-secret values and newly typed replacements.
+- Extend the server merge helper so only explicitly listed omitted secret keys are preserved. A plain omitted key keeps the existing full-blob replacement/clear semantics, explicit empty strings still clear, and sentinel submissions remain backward compatible.
+- Add regression coverage for initial rendering, untouched saves, replacements, explicit clears, and API compatibility.
+
+## Overview
+
+This is a core correction to the generic integrations credential editors. Every provider that declares a credential field with `type: 'secret'` uses the integration detail page or bundle page, so provider-specific extensions cannot repair the common initial-value and submission behavior. The existing `CrudForm`, `PasswordInput`, `apiCall`, `useGuardedMutation`, optimistic-lock header, credentials encryption service, and tenant/organization scope remain authoritative. The bundle page keeps its existing custom host in this narrowly scoped fix but uses the DS `PasswordInput` for its touched secret control.
+
+The implementation intentionally separates two concepts that the current form conflates:
+
+1. **Configured state** — server-owned metadata in `secretFieldsConfigured` indicating that encrypted storage contains a value.
+2. **Replacement input** — a new, initially empty browser value that exists only when the operator types it.
+
+This matches the established write-only-secret UX while avoiding the placeholder failure mode reported in another major open-source automation platform: n8n users have repeatedly seen its internal blank-value sentinel in editable credential fields and interpreted resulting saves as data loss or failed persistence ([n8n issue #30846](https://github.com/n8n-io/n8n/issues/30846)). Open Mercato adopts the useful write-only boundary but rejects an editable sentinel as UI state.
+
+## Acceptance Criteria
+
+1. Loading an integration whose secret is configured renders the corresponding `PasswordInput` empty.
+2. The literal `__om_secret_unchanged__` does not appear in the rendered form or become the input's controlled value, including after using the reveal toggle.
+3. A configured secret field shows localized guidance equivalent to “Configured. Enter a new value to replace it.”
+4. On the direct detail page, a required configured secret passes form validation when its replacement input is empty.
+5. Saving without editing a configured secret omits that key from the PUT credentials object, includes its name in `unchangedSecretFields`, and preserves the encrypted stored value.
+6. Typing a replacement submits that exact value and persists it through the existing encrypted credential service.
+7. A legacy request with `{ credentials: {} }` still clears all credentials, an explicit `""` still clears its secret, and an existing client that submits the sentinel still preserves it.
+8. First-time configuration remains unchanged: on the direct detail page an unconfigured required secret starts empty, remains required, and is submitted when entered.
+9. Non-secret fields, guarded mutation hooks, optimistic locking, events, authorization, and tenant/organization scoping remain unchanged. Switching `storage_s3` to ambient authentication still explicitly clears access-key secrets instead of having omission preserve them.
+10. Direct detail and bundle credential editors both satisfy criteria 1–3 and 5–6; the direct page also satisfies criterion 4 through its existing Zod/CrudForm validation.
+11. Unit, route, jsdom UI, and module-local Playwright coverage exercise the changed API and UI paths.
+
+## Architecture
+
+### Extension Mode
+
+**Core modification.** The defect is in the core-owned generic integration detail/bundle pages and credentials PUT merge contract. A UMES widget cannot safely replace the common initial values, required-field validation, or server merge behavior for every provider. The change stays inside `packages/core/src/modules/integrations/` and introduces no provider-specific branch.
+
+### Data Flow
+
+1. The existing GET route decrypts credentials through `integrationCredentialsService`, masks secret values, and returns `secretFieldsConfigured` plus `updatedAt`.
+2. The direct detail page keeps the raw masked credentials map unchanged for the FROZEN `integrations.detail.v1` widget context and derives separate form initial values with configured secret keys removed. The bundle page, which has no equivalent credential widget context, stores the sanitized edit values directly.
+3. Both editors store the configured-state map and use it to add localized guidance; touched secret controls use the existing DS `PasswordInput` primitive.
+4. Direct-detail Zod validation treats an empty configured `secret` replacement as satisfied, but still rejects an empty required secret when the map reports `false`.
+5. A shared submission helper removes empty configured secret values and returns their names in `unchangedSecretFields` before the existing guarded PUT. A deliberate clear path such as `storage_s3` ambient authentication removes those names from the unchanged list, retaining the current full-replacement clear behavior.
+6. `saveCredentialsSchema` accepts the new optional, bounded field-name list. `mergeMaskedSecretCredentials` preserves a missing value only when its name is listed and the schema declares it secret; explicit submitted values win over the list. Exact sentinel preservation remains for legacy clients.
+7. The existing save service encrypts and persists the merged full object, emits the same event, and returns the same response.
+
+### Relevant Architecture Rules
+
+- §4: keep the change within the owning `integrations` module; no cross-module imports or provider special cases.
+- §§7–8: preserve the custom route's Zod boundary, metadata/OpenAPI, mutation guards, and trusted scope.
+- §10: retain `CrudForm`, `PasswordInput`, `apiCall`, `useGuardedMutation`, and optimistic-lock handling.
+- §§14–16: preserve feature guards, tenant/organization scope, encrypted reads, and the write-only secret boundary.
+- §22: use existing DS primitives, semantic classes, and localized copy.
+- §27: add behavior without renaming/removing stable routes, response keys, function parameters, or other contract surfaces.
+- §31: apply the full code-review checklist, especially C, E, H, I, L, N, and O.
+
+### Frontend Architecture Contract
+
+#### Server/Client Boundary Map
+
+| Route / surface | Server root | Client island | Data owner | Notes |
+| --- | --- | --- | --- | --- |
+| `/backend/integrations/:id` | Existing module catch-all | Existing `backend/integrations/[id]/page.tsx` | `/api/integrations/:id` and `/api/integrations/:id/credentials` | No new provider or global bootstrap; the existing page is already a client component. |
+| `/backend/integrations/bundle/:id` | Existing module catch-all | Existing `backend/integrations/bundle/[id]/page.tsx` | Same detail/credentials APIs for the bundle id | Duplicate credential editor is fixed under the same contract. |
+
+#### `"use client"` Ledger
+
+| File | Reason | Imported by | Heavy deps | Risk / alternative |
+| --- | --- | --- | --- | --- |
+| `packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx` | Existing stateful `CrudForm`, API loading, revealable password input, tabs, and guarded mutations | Module route registry | No new dependency | The file already exceeds 300 lines. This fix adds only localized state/plumbing; decomposing the legacy page is a separate refactor with much larger regression risk. Pure transformations should be extracted only when doing so materially improves testability. |
+| `packages/core/src/modules/integrations/backend/integrations/bundle/[id]/page.tsx` | Existing stateful bundle credentials/toggles editor | Module route registry | No new dependency | Keep the existing host, replace only the touched secret control with `PasswordInput`, and preserve guarded writes. |
+
+#### Budgets and Evidence
+
+| Budget | Target |
+| --- | --- |
+| New page-root client components | 0 |
+| New heavy browser dependencies | 0 |
+| New global providers/bootstrap imports | 0 |
+| New arbitrary DS values/raw controls | 0 |
+| Hydration/interactivity | Module-local Playwright route load plus password edit/save assertions |
+| Static/build evidence | `yarn check:client-boundaries` when returned by `required-checks`; configured build/type/test gates |
+
+## Data Models
+
+No entity, migration, index, encryption-map, or database-column change. `IntegrationCredentials.credentials` remains encrypted at rest through the current module encryption map and credential service.
+
+Existing values corrupted before this fix cannot be identified reliably: a legitimate secret and a partially edited sentinel are both arbitrary encrypted strings. The safe remediation is explicit replacement by an operator; automatic pattern deletion could destroy valid credentials. The configured-state hint makes that replacement path clear, while health checks continue to expose authentication failures.
+
+## API Contracts
+
+### `GET /api/integrations/:id/credentials`
+
+No URL, method, guard, response-key, or widget-context value change.
+
+Relevant response shape remains:
+
+```json
+{
+  "credentials": {
+    "nonSecretField": "value",
+    "configuredSecret": "__om_secret_unchanged__"
+  },
+  "secretFieldsConfigured": {
+    "configuredSecret": true
+  },
+  "updatedAt": "2026-08-21T12:00:00.000Z"
+}
+```
+
+The first-party form treats the sentinel as transport compatibility data and strips it before form initialization. This preserves existing API clients that round-trip the sentinel while eliminating the editable-placeholder defect.
+
+### `PUT /api/integrations/:id/credentials`
+
+Request URL, method, authorization, mutation guards, optimistic-lock header, response, and default full-blob replacement behavior remain stable. The request adds one optional property:
+
+```json
+{
+  "credentials": {
+    "nonSecretField": "value"
+  },
+  "unchangedSecretFields": ["configuredSecret"]
+}
+```
+
+`unchangedSecretFields` is bounded to at most 200 non-empty field names of at most 128 characters, matching the credentials record limits. Only names declared by the provider schema as secret-bearing are eligible for preservation; unknown or non-secret names do not retain data. An explicitly submitted credential value takes precedence over the list.
+
+Update `apps/docs/docs/api/integrations-data-sync.mdx` to document masked/write-only GET values, `secretFieldsConfigured`, the optional unchanged-field intent, full-replacement/default clear behavior, and the route's actual `integrations.credentials.manage` feature requirement.
+
+Secret merge semantics become:
+
+| Incoming secret key | Existing value | Result |
+| --- | --- | --- |
+| Omitted, name explicitly listed unchanged | Present | Preserve existing |
+| Exact sentinel | Present | Preserve existing (legacy compatibility) |
+| Omitted, not listed | Any | Remove through the existing full-blob replacement behavior |
+| Listed or sentinel | Absent | Keep absent |
+| Non-empty string | Any | Replace with submitted value |
+| Empty string | Any | Explicitly clear, preserving current API semantics |
+
+Failure behavior remains fail-closed: invalid payloads return `422`, stale optimistic locks return `409`, unavailable encryption returns `503`, missing scope/auth returns the existing `401`/organization-scope response, and unexpected failures do not persist a partial credential object.
+
+## Permissions and Data Boundaries
+
+- GET and PUT remain guarded by `integrations.credentials.manage` and authenticated tenant context.
+- Organization scope continues to come from `resolveActiveOrganizationId(auth)`, never the request body.
+- Existing credentials are resolved and saved with `{ tenantId, organizationId }` through the DI credential service.
+- Plaintext stored secrets never enter the response, form initial state, logs, errors, review artifacts, or test snapshots.
+- The UI's configured-state map contains booleans only and is not a secret oracle beyond the already-authorized credential-management page.
+- The unchanged list carries provider-declared field names only, never values, and the server intersects it with the trusted schema before preservation.
+
+## UI/UX and Internationalization
+
+- Reuse the existing direct-detail `CrudForm` and custom `PasswordInput` field renderer; migrate the touched bundle secret control from generic `Input type="password"` to `PasswordInput`.
+- Set credential replacement inputs to `autoComplete="new-password"` so password managers do not refill stored-account passwords into provider secret fields.
+- Configured secret inputs remain empty even after reveal; the reveal control only reveals newly entered replacement text.
+- Add one `integrations.detail.credentials.secretConfigured` key to every shipped locale (`de`, `en`, `es`, `ko`, `pl`).
+- Render the hint as standard secondary form description text through the existing `CrudField.description` surface; do not introduce a custom alert, color, icon, or raw control.
+- Preserve provider help text/setup guidance and append the configured-state hint without replacing it.
+- Preserve `storage_s3` ambient-mode cleanup by translating its deliberate secret removal into the API's existing explicit-empty clear representation before generic untouched-secret omission runs.
+- Preserve `Cmd/Ctrl+Enter`, `Escape`, dirty-state tracking, `FormHeader`, and the page-level guarded mutation path provided by the existing host.
+
+## Migration, Rollout, and Backward Compatibility
+
+No migration or feature flag is required. The fix is deployable independently and takes effect on the next form load.
+
+| Contract surface | Effect |
+| --- | --- |
+| Auto-discovery files/exports | None |
+| Public types/interfaces | `SaveCredentialsInput` gains one optional field only |
+| Function signatures | `mergeMaskedSecretCredentials` gains a trailing optional unchanged-field list; existing calls compile and behave unchanged |
+| Import paths | None |
+| Event IDs/payloads | None |
+| Widget spots/replacement handles | None |
+| API routes/methods/response keys | None |
+| Database schema | None |
+| DI service names | None |
+| ACL feature IDs | None |
+| Notification IDs | None |
+| CLI commands | None |
+| Generated file contracts | None |
+
+The default GET sentinel stays available for existing clients and the existing detail widget context keeps receiving the same raw masked map. PUT continues accepting exact sentinel submissions, explicit empty-string clears, and `{ credentials: {} }` clear-all requests. A missing secret is preserved only when the caller opts into the additive `unchangedSecretFields` intent, so existing clients require no migration and keep byte-for-byte default behavior.
+
+## Testing Strategy
+
+### Unit and Route Tests
+
+- `credentials-masking.test.ts`
+  - listed omitted `secret`, `oauth`, and `ssh_keypair` values preserve stored values;
+  - unlisted omission keeps full-blob removal behavior;
+  - unknown/non-secret unchanged names do not preserve values;
+  - sentinel compatibility, replacement, explicit clear, and non-secret behavior remain covered.
+- `validators.test.ts`
+  - accepts a bounded optional unchanged list and rejects excessive/invalid names.
+- `credentials-route.test.ts`
+  - PUT with a listed omitted configured secret saves the stored value;
+  - PUT with plain omission/empty credentials keeps clear behavior;
+  - existing GET masking and PUT sentinel/replacement/explicit-clear cases remain green.
+
+### UI Regression Test
+
+Add a jsdom page test that mocks the authorized detail/credentials APIs and proves:
+
+- configured secret response mounts an empty `PasswordInput`;
+- the sentinel is absent from the DOM and reveal does not expose it;
+- the configured hint is visible;
+- untouched submit omits the secret key;
+- typed replacement is present in the subsequent PUT body;
+- an unconfigured required secret still validates as required.
+
+Add equivalent focused coverage for the bundle page's empty secret input, configured hint, unchanged list, and replacement payload. Shared pure helper tests cover both hosts' value/payload transformations without duplicating assertions.
+
+### Module-Local Playwright Test
+
+Add a self-contained test under `packages/core/src/modules/integrations/__integration__/` after live selector discovery. It asserts route hydration, empty configured secret input, configured hint, untouched save with the unchanged-field list, and replacement save. Prefer deterministic API interception or a disposable isolated fixture over mutating/restoring an existing masked credential row, because a GET response cannot recover prior plaintext. Use `domcontentloaded` plus explicit input/button readiness rather than `networkidle` because backend pages may keep long-lived streams.
+
+Update existing integration-test assertions/comments whose current full-replacement or “decrypted verbatim” descriptions would become inaccurate. The clear-all test must continue proving `{ credentials: {} }` clears schema-declared secrets unless an unchanged list is explicitly sent.
+
+### Validation
+
+Run the focused core Jest suites, the new Playwright spec, all commands returned by harness `required-checks`, and the configured ordered gate. UI review also runs the DS guardian and local QA workflow without staging their artifacts.
+
+## Implementation Plan
+
+### Phase 1 — Additive Server Intent
+
+1. Add the optional bounded `unchangedSecretFields` request field and pass it through mutation-guard reparsing.
+2. Extend `mergeMaskedSecretCredentials` with a trailing optional list while preserving default full-blob behavior.
+3. Extend validator/helper/route/integration tests for listed omission, plain omission, sentinel, replacement, explicit clear, and clear-all behavior.
+4. Correct the public credentials API documentation and stale test contract prose.
+
+### Phase 2 — Write-Only Form State
+
+1. Add shared pure helpers for sanitized edit values and `{ credentials, unchangedSecretFields }` submission intent.
+2. Consume and store `secretFieldsConfigured` in both credential editors.
+3. Preserve the direct page's raw masked `credentialValues` widget context while giving `CrudForm` separate sanitized initial values.
+4. Append the localized configured hint and make direct-page required validation aware of configured secrets.
+5. Preserve provider-specific normalization; exclude deliberate `storage_s3` ambient clears from the unchanged list.
+6. Migrate the touched bundle secret control to `PasswordInput` and use the shared submission contract.
+7. Add locale keys and focused helper/jsdom coverage for both hosts.
+
+### Phase 3 — Integration Evidence and Review
+
+1. Add the module-local Playwright regression using deterministic API interception.
+2. Run focused tests, DS checks, full required validation, and exact-diff independent review.
+3. Update implementation status and changelog before the final packet.
+
+## Risks & Impact Review
+
+### Existing Corrupted Credentials Remain Stored
+
+- **Scenario**: A credential was already saved as a hybrid sentinel/user string before deployment.
+- **Severity**: High
+- **Affected area**: Any integration using a generic `secret` field.
+- **Mitigation**: The fixed UI provides an explicit empty replacement input and configured-state guidance; provider health checks reveal authentication failures and operators can replace the value normally.
+- **Residual risk**: The server cannot distinguish a corrupted hybrid from a legitimate arbitrary secret without false positives, so no automatic destructive cleanup is safe.
+
+### Unchanged Intent Is Forged for a Non-Secret Field
+
+- **Scenario**: A caller lists an unknown or non-secret field in `unchangedSecretFields` to retain data it omitted from the full replacement.
+- **Severity**: Medium
+- **Affected area**: Credentials PUT merge behavior.
+- **Mitigation**: Bound the list in Zod and intersect it with trusted provider schema secret types; explicit submitted values always win.
+- **Residual risk**: Invalid names may be ignored rather than rejected semantically, but they cannot retain non-secret or undeclared data.
+
+### Required Validation Accepts an Actually Missing Secret
+
+- **Scenario**: Client form state incorrectly marks an absent secret as configured.
+- **Severity**: Medium
+- **Affected area**: Credential form validation.
+- **Mitigation**: The boolean map comes from the authorized server response after inspecting stored encrypted data; first-time `false` stays required. UI and route tests cover both states.
+- **Residual risk**: A stale response can race another writer, but existing optimistic locking rejects stale saves.
+
+### Secret Sentinel Re-enters the Form During Reload
+
+- **Scenario**: A refresh path bypasses the sanitizer and remounts the raw GET object.
+- **Severity**: High
+- **Affected area**: Integration detail credential editing.
+- **Mitigation**: Centralize all credential reloads through `loadCredentials`, and cover initial load plus post-save reload in UI/browser tests.
+- **Residual risk**: A future separate form implementation could repeat the mistake; the spec and tests document the canonical configured-state contract.
+
+### Frontend Page Regression
+
+- **Scenario**: Extra state/description composition disrupts a provider's existing help text, conditional visibility, or `storage_s3` normalization.
+- **Severity**: Medium
+- **Affected area**: Generic integration detail page.
+- **Mitigation**: Preserve the existing field builder and submit sequence, append rather than replace descriptions, and regression-test non-secret payloads alongside secret behavior.
+- **Residual risk**: Provider-specific combinations remain broader than one synthetic browser fixture; full core tests and configured build gate cover type/runtime integration.
+
+### Deliberate Secret Clearing Is Misclassified as Untouched
+
+- **Scenario**: A provider flow intentionally removes a secret by omitting its key, but the new server merge preserves it.
+- **Severity**: High
+- **Affected area**: `storage_s3` switching from access keys to ambient credentials and any future deliberate clear flow.
+- **Mitigation**: Preserve only fields explicitly listed unchanged. Deliberate clear paths omit the value without listing it (or send an explicit empty string); cover the `storage_s3` branch in the UI regression suite.
+- **Residual risk**: Future provider-specific clear flows must not accidentally add their field to the unchanged list, which is documented in the merge table and helper tests.
+
+## Final Compliance Report — 2026-08-21
+
+### AGENTS.md Files Reviewed
+
+- `AGENTS.md`
+- `packages/core/AGENTS.md`
+- `packages/core/src/modules/integrations/AGENTS.md`
+- `packages/ui/AGENTS.md`
+- `packages/ui/src/backend/AGENTS.md`
+- `.ai/specs/AGENTS.md`
+- `.ai/qa/AGENTS.md`
+- `BACKWARD_COMPATIBILITY.md`
+- `omdyo-general/architecture/ARCHITECTURE.md` relevant sections and complete §31
+
+### Compliance Matrix
+
+| Rule source | Rule | Status | Notes |
+| --- | --- | --- | --- |
+| Root/core integrations | Secrets remain encrypted, scoped, and never logged | Compliant | Existing credential service and scope are unchanged; form receives no plaintext. |
+| Root/core API | Auth, organization scope, mutation guards, OpenAPI, optimistic locking | Compliant | Existing custom route path remains intact. |
+| UI/backend | Use `CrudForm`, `PasswordInput`, `apiCall`, and guarded mutation | Compliant | No new form host, raw fetch, or raw input. |
+| DS/i18n | Existing primitive, semantic classes, all locales | Compliant | One secondary description; no new color or arbitrary value. |
+| Backward compatibility | No removal/rename/narrowing | Compliant | Sentinel, plain omission/full replacement, clear-all, and explicit clear remain supported; new intent is optional/additive. |
+| Testing | API and key UI paths have integration coverage | Compliant | Route/Jest/jsdom/Playwright plan is explicit and self-contained. |
+
+### Internal Consistency Check
+
+| Check | Status | Notes |
+| --- | --- | --- |
+| Data model matches API | Pass | No model change; merge semantics operate on the existing encrypted record. |
+| API matches UI | Pass | Configured map drives empty input, validation, hint, and explicit unchanged intent. |
+| Risks cover writes | Pass | Omission, stale state, existing corruption, and reload paths covered. |
+| Commands/events | N/A | Existing custom credentials service/event flow is preserved. |
+| Cache/search | N/A | Credential data is not introduced into cache or search. |
+
+### Verdict
+
+**Fully compliant — pre-implementation audit passed; ready for implementation.**
+
+## Implementation Status
+
+| Phase | Status | Date | Notes |
+| --- | --- | --- | --- |
+| Phase 1 — Additive Server Intent | Done | 2026-08-21 | Optional intent, merge semantics, and 27 focused validator/helper/route tests pass. |
+| Phase 2 — Write-Only Form State | Done | 2026-08-21 | Both editors, locale/docs, helper/jsdom coverage, and live browser regression pass. |
+| Phase 3 — Integration Evidence and Review | In Progress | 2026-08-21 | Automated implementation, browser evidence, and full local gates complete; human review and publication pending. |
+
+### Phase 1 — Detailed Progress
+
+- [x] Add bounded `unchangedSecretFields` request validation.
+- [x] Preserve only explicitly listed omitted schema-secret fields.
+- [x] Retain sentinel, replacement, explicit-empty, plain-omission, and full-replacement behavior.
+- [x] Pass focused validator/helper/route regression tests.
+
+### Phase 2 — Detailed Progress
+
+- [x] Keep raw masked direct-page widget context while deriving empty form values.
+- [x] Add shared edit/save transformations and explicit unchanged-field intent.
+- [x] Fix direct and bundle editors, configured hints, required validation, autocomplete, and S3 ambient clears.
+- [x] Update five locales and public API documentation.
+- [x] Pass 35 focused Jest tests across both hosts and the server path.
+- [x] Observe the live Stripe page and pass `TC-INT-011` in Chromium.
+
+### Phase 3 — Detailed Progress
+
+- [x] Rebase the implementation onto current `develop` in an isolated staged-only worktree.
+- [x] Capture a regression test failing because the secret input contained `__om_secret_unchanged__`.
+- [x] Pass the configured build, generation, translation, typecheck, unit-test, and app-build gates.
+- [x] Pass lesson-catalog and design-system checks without new violations.
+- [x] Pass the current-diff `TC-INT-011` Playwright regression in an isolated ephemeral environment.
+- [ ] Complete human review and publication.
+
+## Changelog
+
+### 2026-08-21
+
+- Added the initial specification for issue #5421.
+- Completed architecture, compatibility, security, frontend-boundary, risk, and test planning.
+- Revised the design after the readiness audit to preserve full-blob replacement, the clear-all contract, and the raw masked widget context; added bundle-editor coverage.
+- Passed the pre-implementation analysis in `analysis/ANALYSIS-2026-08-21-integration-secret-credential-editing.md` with no remaining blockers.
+- Completed the current-`develop` implementation with 35 focused Jest tests, the full configured local gate, and the `TC-INT-011` Chromium regression passing.

--- a/.ai/specs/analysis/ANALYSIS-2026-08-21-integration-secret-credential-editing.md
+++ b/.ai/specs/analysis/ANALYSIS-2026-08-21-integration-secret-credential-editing.md
@@ -1,0 +1,123 @@
+# Pre-Implementation Analysis: Integration Secret Credential Editing
+
+## Executive Summary
+
+The revised specification is ready to implement. The first draft would have changed the stable full-blob PUT contract by treating every omitted secret as unchanged; the audited design removes that blocker by adding a bounded, optional `unchangedSecretFields` intent list, retaining default clear/full-replacement semantics, preserving the raw masked widget context, and covering both direct and bundle credential editors.
+
+## Backward Compatibility
+
+### Violations Found
+
+| # | Surface | Issue | Severity | Proposed Fix |
+| --- | --- | --- | --- | --- |
+| — | None in the revised design | No public surface is removed, renamed, narrowed, or given a new required input. | — | Implement the additive request field and trailing optional helper argument exactly as specified. |
+
+### Missing BC Section
+
+None. The spec audits every protected surface and explicitly preserves route/method/response keys, the GET sentinel, exact-sentinel PUT compatibility, plain omission/full replacement, `{ credentials: {} }` clear-all, explicit empty-string clear, DI/ACL/event/widget IDs, schema, imports, and generated contracts.
+
+### Compatibility Evidence
+
+- `TC-INT-004.spec.ts` documents and tests `{ credentials: {} }` as a valid clear-all request.
+- `TC-INTEG-CRUDFORM-001.spec.ts` documents credentials PUT as a full-blob upsert, although its claim that every credential is returned decrypted verbatim is stale after issue #2253 and must be corrected.
+- The direct detail page publishes raw masked `credentialValues` in the `integrations.detail.v1` injection context. The revised spec keeps that value unchanged and derives separate form initial values.
+- `storage_s3` deliberately deletes access-key credentials when switching to ambient mode. The revised explicit list lets that omission continue clearing instead of being restored.
+
+## Spec Completeness
+
+### Missing Sections
+
+| Section | Impact | Recommendation |
+| --- | --- | --- |
+| None | All required sections are present or marked N/A with rationale. | No change. |
+
+### Incomplete Sections
+
+| Section | Gap | Recommendation |
+| --- | --- | --- |
+| None | Acceptance, architecture/extension mode, data, API, permissions, UI/i18n, failure behavior, rollout/BC, frontend contract, test coverage, risks, phasing, compliance, status, and changelog are implementation-ready. | No change. |
+
+## AGENTS.md Compliance
+
+### Violations
+
+| Rule | Location | Fix |
+| --- | --- | --- |
+| None in the revised design | — | Apply the implementation plan without broad page refactors or provider-specific core branches. |
+
+### Key Compliance Decisions
+
+- Core placement is justified because generic host/form/server behavior cannot be repaired by a provider extension.
+- Existing auth, feature guards, organization resolution, tenant scope, encryption service, mutation guards, optimistic locking, event emission, `CrudForm`, `PasswordInput`, `apiCall`, and `useGuardedMutation` remain in place.
+- No entity, migration, encryption map, cache, search, event, ACL, DI, notification, CLI, or generated-file change is proposed.
+- All new request data is Zod-validated and bounded.
+- All new copy is planned for `de`, `en`, `es`, `ko`, and `pl`.
+- The bundle page's touched secret control moves to `PasswordInput`; touched DS violations must be corrected under the Boy Scout rule without expanding into a full page rewrite.
+
+## Risk Assessment
+
+### High Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Plain omission semantics accidentally change | Existing clients could fail to clear credentials. | Preserve full replacement by default; preserve only schema-declared secrets named in the optional unchanged list. |
+| Raw widget context changes | Third-party integration-detail widgets could receive empty values instead of the existing sentinel map. | Keep raw masked `credValues` for `integrations.detail.v1`; derive separate `CrudForm` values. |
+| `storage_s3` ambient switch retains access-key secrets | Health checks can reject the configuration and stored secrets remain unexpectedly. | Exclude deliberate clear fields from `unchangedSecretFields`; verify the branch in regression tests. |
+| Existing hybrid-corrupted values remain | Affected integrations continue failing auth until rotation. | Provide an obvious replacement path and configured hint; do not pattern-delete arbitrary encrypted secrets that cannot be distinguished safely. |
+| Bundle editor remains vulnerable | Shared bundle secrets can still expose/edit the sentinel. | Include the duplicate bundle form in the same capability and shared helper contract. |
+
+### Medium Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Forged unchanged names retain unrelated data | A caller might try to preserve undeclared/non-secret fields. | Bound the list and intersect it with trusted provider schema secret types; explicit values win. |
+| Stale configured-state response | UI validation could treat a concurrently cleared secret as configured. | Existing optimistic lock rejects the stale save; test the conflict path remains intact. |
+| Provider help text is replaced | Operators lose setup guidance. | Append the configured hint to existing descriptions instead of replacing them. |
+| Existing integration tests restore masked data unsafely | Tests can overwrite meaningful credentials. | Prefer deterministic API interception/disposable fixtures and correct stale test descriptions/assertions. |
+
+### Low Risks
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Page size/client blob grows slightly | Existing client roots remain large. | Add no dependency/provider and keep pure transformations in one small shared helper. |
+| Password managers autofill replacement fields | Unintended secret changes. | Use `autoComplete="new-password"` on touched secret inputs. |
+
+## Gap Analysis
+
+### Critical Gaps (Block Implementation)
+
+None after the spec revision.
+
+### Important Gaps (Should Address)
+
+- Correct stale integration-test descriptions that claim provider-declared secrets are returned verbatim or that omission always means unchanged.
+- Explore the live page before finalizing Playwright selectors, then keep the executable browser test module-local and deterministic.
+- Cover direct detail, bundle detail, helper, validator, route, clear-all, sentinel compatibility, explicit clear, replacement, widget-context stability, and `storage_s3` deliberate clear behavior.
+
+### Nice-to-Have Gaps
+
+- A future separate UX could add an explicit “Clear stored secret” control. It is not required for #5421 because the existing API clear contract remains available and this change is scoped to safe replacement.
+- A future migration may retire the GET sentinel after a deprecation window; this fix intentionally preserves it.
+
+## Remediation Plan
+
+### Before Implementation (Must Do)
+
+1. Use the revised additive unchanged-field intent rather than global omission preservation.
+2. Keep raw masked direct-page credentials separate from sanitized form values.
+3. Include the bundle credential editor in the change.
+
+### During Implementation (Add to Spec)
+
+1. Record exact changed files and focused validation evidence in implementation status.
+2. Update test comments/assertions where the preserved full-replacement contract makes current prose inaccurate.
+3. Apply the DS Boy Scout rule to every touched bundle-page line.
+
+### Post-Implementation (Follow Up)
+
+1. Run required checks, configured gate, live browser regression, DS review, and fresh exact-diff review.
+2. Do not attempt automatic cleanup of pre-existing hybrid secrets; report manual rotation as residual operational risk.
+
+## Recommendation
+
+**Ready to implement.** The revised spec closes the sentinel-editing defect without a breaking API/default behavior change and includes the necessary compatibility, security, UI, and regression-test gates.

--- a/apps/docs/docs/api/integrations-data-sync.mdx
+++ b/apps/docs/docs/api/integrations-data-sync.mdx
@@ -82,13 +82,15 @@ If integration has no declared `apiVersions`, the endpoint returns `422`.
 
 ### Get credentials - `GET /integrations/{id}/credentials`
 
-**Feature:** `integrations.view`
+**Feature:** `integrations.credentials.manage`
 
 Returns:
 
 - `integrationId`
 - resolved `schema`
-- `credentials` object (empty object if none)
+- `credentials` object; configured secret-bearing fields contain an opaque mask rather than plaintext
+- `secretFieldsConfigured`, a field-name-to-boolean map for write-only secret state
+- `updatedAt`, used for optimistic locking
 
 ```bash
 curl -X GET "$BASE_URL/integrations/$INTEGRATION_ID/credentials" \
@@ -99,15 +101,17 @@ curl -X GET "$BASE_URL/integrations/$INTEGRATION_ID/credentials" \
 
 **Feature:** `integrations.credentials.manage`
 
+The request remains a full-blob replacement by default. To retain an already configured write-only secret while updating other fields, omit its value from `credentials` and list its schema field name in `unchangedSecretFields`. Plain omission without that list removes the field; an explicit empty string clears it.
+
 ```bash
 curl -X PUT "$BASE_URL/integrations/$INTEGRATION_ID/credentials" \
   -H "X-Api-Key: $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "credentials": {
-      "apiUrl": "https://api.example.com",
-      "apiKey": "secret"
-    }
+      "apiUrl": "https://api.example.com"
+    },
+    "unchangedSecretFields": ["apiKey"]
   }'
 ```
 

--- a/packages/core/src/modules/integrations/__integration__/TC-INT-004.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INT-004.spec.ts
@@ -94,6 +94,15 @@ test.describe('TC-INT-004: Integration credentials payload validation', () => {
     }
     expect(initialResponse.status()).toBe(200)
     const initialBody = await readJson(initialResponse)
+    const secretFieldsConfigured = (
+      initialBody.secretFieldsConfigured && typeof initialBody.secretFieldsConfigured === 'object'
+        ? initialBody.secretFieldsConfigured
+        : {}
+    ) as Record<string, boolean>
+    if (Object.values(secretFieldsConfigured).some(Boolean)) {
+      test.skip(true, 'Configured write-only secrets cannot be restored safely in this shared integration')
+      return
+    }
     const originalCredentials =
       initialBody.credentials && typeof initialBody.credentials === 'object'
         ? (initialBody.credentials as JsonRecord)
@@ -121,7 +130,7 @@ test.describe('TC-INT-004: Integration credentials payload validation', () => {
       expect(credentials.booleanField).toBe(true)
       expect(credentials.nullField).toBeNull()
 
-      // An empty object clears all credentials and is a valid payload.
+      // A plain empty object keeps the full-replacement clear-all contract.
       const clearResponse = await apiRequest(request, 'PUT', path, { token, data: { credentials: {} } })
       expect(clearResponse.status(), 'empty credentials object should be accepted').toBe(200)
       const clearedBody = await readJson(await apiRequest(request, 'GET', path, { token }))

--- a/packages/core/src/modules/integrations/__integration__/TC-INT-011-secret-credential-editing.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INT-011-secret-credential-editing.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from '@playwright/test'
+import { login } from '@open-mercato/core/helpers/integration/auth'
+
+const MASKED_SECRET_VALUE = '__om_secret_unchanged__'
+
+const integrationDetail = {
+  integration: {
+    id: 'gateway_stripe',
+    title: 'Stripe',
+    description: 'Stripe integration',
+    category: 'payment',
+    credentials: {
+      fields: [
+        { key: 'publishableKey', label: 'Publishable Key', type: 'text', required: true },
+        { key: 'secretKey', label: 'Secret Key', type: 'secret', required: true },
+        { key: 'webhookSecret', label: 'Webhook Signing Secret', type: 'secret', required: true },
+      ],
+    },
+  },
+  state: {
+    isEnabled: false,
+    apiVersion: null,
+    reauthRequired: false,
+    lastHealthStatus: null,
+    lastHealthCheckedAt: null,
+    lastHealthLatencyMs: null,
+    enabledAt: null,
+    updatedAt: '2026-08-21T12:00:00.000Z',
+  },
+  hasCredentials: true,
+  credentialsUpdatedAt: '2026-08-21T12:00:00.000Z',
+  healthStatus: 'unconfigured',
+  analytics: {
+    lastActivityAt: null,
+    totalCount: 0,
+    errorCount: 0,
+    errorRate: 0,
+    dailyCounts: [0, 0, 0, 0, 0, 0, 0],
+  },
+}
+
+test.describe('TC-INT-011: write-only integration secret editing', () => {
+  test('keeps configured secrets out of editable values and submits explicit unchanged intent', async ({ page }) => {
+    await login(page, 'admin')
+
+    const submittedBodies: Array<Record<string, unknown>> = []
+
+    await page.route('**/api/integrations/gateway_stripe', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(integrationDetail),
+      })
+    })
+    await page.route('**/api/integrations/gateway_stripe/credentials', async (route) => {
+      if (route.request().method() === 'PUT') {
+        submittedBodies.push(route.request().postDataJSON() as Record<string, unknown>)
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ ok: true }),
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          credentials: {
+            publishableKey: 'pk_test_ui',
+            secretKey: MASKED_SECRET_VALUE,
+            webhookSecret: MASKED_SECRET_VALUE,
+          },
+          secretFieldsConfigured: { secretKey: true, webhookSecret: true },
+          updatedAt: '2026-08-21T12:00:00.000Z',
+        }),
+      })
+    })
+    await page.route('**/api/integrations/logs?*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ items: [] }),
+      })
+    })
+
+    await page.goto('/backend/integrations/gateway_stripe', { waitUntil: 'domcontentloaded' })
+
+    const secretField = page.locator('[data-crud-field-id="secretKey"]')
+    const secretInput = secretField.locator('input')
+    await expect(secretInput).toBeVisible()
+    await expect(secretInput).toHaveValue('')
+    await expect(secretField).toContainText('Configured. Enter a new value to replace it.')
+    await expect(page.getByText(MASKED_SECRET_VALUE, { exact: false })).toHaveCount(0)
+
+    await secretField.getByRole('button', { name: 'Show password' }).click()
+    await expect(secretInput).toHaveAttribute('type', 'text')
+    await expect(secretInput).toHaveValue('')
+
+    await page.getByRole('button', { name: 'Save Credentials' }).click()
+    await expect.poll(() => submittedBodies.length).toBe(1)
+    expect(submittedBodies[0]).toEqual({
+      credentials: { publishableKey: 'pk_test_ui' },
+      unchangedSecretFields: ['secretKey', 'webhookSecret'],
+    })
+
+    const reloadedSecretInput = page.locator('[data-crud-field-id="secretKey"] input')
+    await expect(reloadedSecretInput).toBeVisible()
+    await reloadedSecretInput.fill('rotated-secret')
+    await page.getByRole('button', { name: 'Save Credentials' }).click()
+    await expect.poll(() => submittedBodies.length).toBe(2)
+    expect(submittedBodies[1]).toEqual({
+      credentials: {
+        publishableKey: 'pk_test_ui',
+        secretKey: 'rotated-secret',
+      },
+      unchangedSecretFields: ['webhookSecret'],
+    })
+  })
+})

--- a/packages/core/src/modules/integrations/__integration__/TC-INTEG-CRUDFORM-001.spec.ts
+++ b/packages/core/src/modules/integrations/__integration__/TC-INTEG-CRUDFORM-001.spec.ts
@@ -23,8 +23,9 @@ import {
  * - The save body is `{ credentials: Record<string, string | number | boolean | null> }`
  *   (`saveCredentialsSchema`, ≤200 keys); the route does NOT enforce the provider's declared
  *   schema, so any secret/text/select-shaped keys round-trip.
- * - The GET returns `{ integrationId, schema, credentials }` with `credentials` DECRYPTED
- *   verbatim (no field masking — encryption is at-rest only), so exact-value assertions are valid.
+ * - The GET returns non-secret and undeclared primitive fields verbatim. Provider-declared secret
+ *   fields are masked and reported through `secretFieldsConfigured`, so this generic value-shape
+ *   sweep skips an integration that already has a configured secret it cannot restore.
  * - Both verbs require `integrations.credentials.manage` (the seeded admin has it).
  *
  * Self-contained: the integration provider is discovered at runtime from `GET /api/integrations`
@@ -48,12 +49,23 @@ async function readCredentials(
   request: APIRequestContext,
   token: string,
   integrationId: string,
-): Promise<{ status: number; credentials: CrudRecord }> {
+): Promise<{
+  status: number;
+  credentials: CrudRecord;
+  secretFieldsConfigured: Record<string, boolean>;
+}> {
   const response = await apiRequest(request, 'GET', `/api/integrations/${integrationId}/credentials`, { token });
-  const body = (await readJsonSafe<{ credentials?: CrudRecord }>(response)) ?? {};
+  const body = (await readJsonSafe<{
+    credentials?: CrudRecord;
+    secretFieldsConfigured?: Record<string, boolean>;
+  }>(response)) ?? {};
   const credentials =
     body.credentials && typeof body.credentials === 'object' ? (body.credentials as CrudRecord) : {};
-  return { status: response.status(), credentials };
+  return {
+    status: response.status(),
+    credentials,
+    secretFieldsConfigured: body.secretFieldsConfigured ?? {},
+  };
 }
 
 test.describe('TC-INTEG-CRUDFORM-001: Integration credentials CrudForm persists every field on save + update', () => {
@@ -61,7 +73,7 @@ test.describe('TC-INTEG-CRUDFORM-001: Integration credentials CrudForm persists 
     skipIfCrudFormExtensionTestsDisabled();
   });
 
-  test('round-trips secret/text/select credential fields on save and update', async ({ request }) => {
+  test('round-trips primitive credential values on save and update', async ({ request }) => {
     const token = await getAuthToken(request, 'admin');
 
     const integrationId = await pickIntegrationId(request, token);
@@ -79,18 +91,21 @@ test.describe('TC-INTEG-CRUDFORM-001: Integration credentials CrudForm persists 
       return;
     }
     expect(initial.status, 'credentials GET should be 200 when encryption is available').toBe(200);
+    if (Object.values(initial.secretFieldsConfigured).some(Boolean)) {
+      test.skip(true, 'Configured write-only secrets cannot be restored safely in this shared integration');
+      return;
+    }
     const originalCredentials = initial.credentials;
 
     const stamp = Date.now();
-    // secret / text / select are the headline kinds for this surface; number/boolean/null exercise
-    // the rest of the saveCredentialsSchema value union so "every field value persists" holds here.
+    // Strings plus number/boolean/null exercise the saveCredentialsSchema value union.
     const savedCredentials: CrudRecord = {
-      apiSecret: `sk_crudform_${stamp}`,
+      stringToken: `token_crudform_${stamp}`,
       displayLabel: `QA CRUDFORM Integration ${stamp}`,
       environment: 'sandbox',
       maxConnections: 3,
       verboseLogging: true,
-      legacyToken: `legacy_${stamp}`,
+      nullableToken: `legacy_${stamp}`,
     };
 
     try {
@@ -104,15 +119,13 @@ test.describe('TC-INTEG-CRUDFORM-001: Integration credentials CrudForm persists 
       expect(afterSave.status, 'read-back after save should be 200').toBe(200);
       assertScalarFieldsPersisted(afterSave.credentials, savedCredentials, 'after-save');
 
-      // Update: rotate the secret, edit the text, switch the select, change number/boolean, and
-      // clear a secret with null — proving an edit round-trips and a null clears the stored value.
       const updatedCredentials: CrudRecord = {
-        apiSecret: `sk_crudform_${stamp}_ROTATED`,
+        stringToken: `token_crudform_${stamp}_ROTATED`,
         displayLabel: `QA CRUDFORM Integration ${stamp} EDITED`,
         environment: 'production',
         maxConnections: 5,
         verboseLogging: false,
-        legacyToken: null,
+        nullableToken: null,
       };
       const updateResponse = await apiRequest(request, 'PUT', credentialsPath, {
         token,
@@ -123,7 +136,7 @@ test.describe('TC-INTEG-CRUDFORM-001: Integration credentials CrudForm persists 
       const afterUpdate = await readCredentials(request, token, integrationId);
       expect(afterUpdate.status, 'read-back after update should be 200').toBe(200);
       assertScalarFieldsPersisted(afterUpdate.credentials, updatedCredentials, 'after-update');
-      expect(afterUpdate.credentials.legacyToken, 'a secret cleared to null persists as null').toBeNull();
+      expect(afterUpdate.credentials.nullableToken, 'a nullable value persists as null').toBeNull();
     } finally {
       await apiRequest(request, 'PUT', credentialsPath, {
         token,

--- a/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
+++ b/packages/core/src/modules/integrations/api/[id]/credentials/route.ts
@@ -183,11 +183,13 @@ export async function PUT(req: Request, ctx: { params?: Promise<{ id?: string }>
   }
 
   try {
-    // Secret fields are returned masked on GET; when the client round-trips the
-    // mask sentinel it means "unchanged", so restore the existing stored secret
-    // instead of overwriting it with the placeholder.
     const existing = await credentialsService.resolve(integration.id, scope)
-    const credentialsToSave = mergeMaskedSecretCredentials(schema, payloadData.credentials, existing ?? {})
+    const credentialsToSave = mergeMaskedSecretCredentials(
+      schema,
+      payloadData.credentials,
+      existing ?? {},
+      payloadData.unchangedSecretFields,
+    )
     await credentialsService.save(integration.id, credentialsToSave, scope)
   } catch (error) {
     if (isCredentialsEncryptionUnavailableError(error)) {

--- a/packages/core/src/modules/integrations/api/__tests__/credentials-route.test.ts
+++ b/packages/core/src/modules/integrations/api/__tests__/credentials-route.test.ts
@@ -44,11 +44,14 @@ const akeneoSchema: IntegrationCredentialsSchema = {
   ],
 }
 
-function buildRequest(credentials: Record<string, unknown>): Request {
+function buildRequest(
+  credentials: Record<string, unknown>,
+  unchangedSecretFields?: string[],
+): Request {
   return new Request('http://localhost/api/integrations/sync_akeneo/credentials', {
     method: 'PUT',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ credentials }),
+    body: JSON.stringify({ credentials, unchangedSecretFields }),
   })
 }
 
@@ -190,6 +193,46 @@ describe('integrations credentials route — secret masking (issue #2253)', () =
     expect(saveMock).toHaveBeenCalledWith(
       'sync_akeneo',
       { apiUrl: 'https://akeneo.example', clientSecret: 'rotated-secret' },
+      { organizationId: 'o1', tenantId: 't1' },
+    )
+  })
+
+  it('PUT preserves a listed omitted secret without changing plain omission semantics', async () => {
+    resolveMock.mockResolvedValue({ apiUrl: 'https://akeneo.example', clientSecret: 'stored-secret' })
+    const preserveResponse = await PUT(
+      buildRequest({ apiUrl: 'https://akeneo.example' }, ['clientSecret']),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(preserveResponse.status).toBe(200)
+    expect(saveMock).toHaveBeenLastCalledWith(
+      'sync_akeneo',
+      { apiUrl: 'https://akeneo.example', clientSecret: 'stored-secret' },
+      { organizationId: 'o1', tenantId: 't1' },
+    )
+
+    saveMock.mockClear()
+    const clearResponse = await PUT(
+      buildRequest({ apiUrl: 'https://akeneo.example' }),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(clearResponse.status).toBe(200)
+    expect(saveMock).toHaveBeenCalledWith(
+      'sync_akeneo',
+      { apiUrl: 'https://akeneo.example' },
+      { organizationId: 'o1', tenantId: 't1' },
+    )
+  })
+
+  it('PUT keeps explicit empty-string clearing when a secret is configured', async () => {
+    resolveMock.mockResolvedValue({ clientSecret: 'stored-secret' })
+    const response = await PUT(
+      buildRequest({ clientSecret: '' }),
+      { params: { id: 'sync_akeneo' } },
+    )
+    expect(response.status).toBe(200)
+    expect(saveMock).toHaveBeenCalledWith(
+      'sync_akeneo',
+      { clientSecret: '' },
       { organizationId: 'o1', tenantId: 't1' },
     )
   })

--- a/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-conflict.test.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/__tests__/credentials-conflict.test.tsx
@@ -93,6 +93,8 @@ const RECORD_MODIFIED_MESSAGE = 'This record was modified by someone else. Refre
 
 const dict = {
   'ui.forms.flash.recordModified': RECORD_MODIFIED_MESSAGE,
+  'ui.forms.errors.required': 'This field is required',
+  'integrations.detail.credentials.secretConfigured': 'Configured. Enter a new value to replace it.',
 }
 
 const integrationDetail = {
@@ -101,7 +103,10 @@ const integrationDetail = {
     title: 'Stripe',
     category: 'payment',
     credentials: {
-      fields: [{ key: 'publishableKey', label: 'Publishable Key', type: 'text', required: false }],
+      fields: [
+        { key: 'publishableKey', label: 'Publishable Key', type: 'text', required: false },
+        { key: 'secretKey', label: 'Secret Key', type: 'secret', required: true },
+      ],
     },
   },
   state: {
@@ -140,7 +145,7 @@ function makeResponse(status: number, body: unknown): Response {
   } as unknown as Response
 }
 
-function mockApiResponses() {
+function mockApiResponses(secretConfigured = true) {
   apiCallMock.mockImplementation((url: unknown, init?: RequestInit) => {
     const href = typeof url === 'string' ? url : ''
     const method = (init?.method ?? 'GET').toUpperCase()
@@ -153,7 +158,14 @@ function mockApiResponses() {
           response: makeResponse(409, conflictBody),
         })
       }
-      const body = { credentials: { publishableKey: 'pk_test_123' }, updatedAt: '2026-06-29T09:00:00.000Z' }
+      const body = {
+        credentials: {
+          publishableKey: 'pk_test_123',
+          ...(secretConfigured ? { secretKey: '__om_secret_unchanged__' } : {}),
+        },
+        secretFieldsConfigured: { secretKey: secretConfigured },
+        updatedAt: '2026-06-29T09:00:00.000Z',
+      }
       return Promise.resolve({ ok: true, status: 200, result: body, response: makeResponse(200, body) })
     }
     if (href.includes('/logs')) {
@@ -188,6 +200,19 @@ describe('Integration credentials — optimistic-lock conflict surfacing (#3676)
       expect(form).not.toBeNull()
     })
 
+    const secretField = container.querySelector('[data-crud-field-id="secretKey"]')
+    const secretInput = secretField?.querySelector('input')
+    expect(secretInput).not.toBeNull()
+    expect(secretInput).toHaveValue('')
+    expect(secretField).toHaveTextContent('Configured. Enter a new value to replace it.')
+    expect(container).not.toHaveTextContent('__om_secret_unchanged__')
+
+    const revealButton = secretField?.querySelector('button[aria-pressed]')
+    expect(revealButton).not.toBeNull()
+    fireEvent.click(revealButton as HTMLButtonElement)
+    expect(secretInput).toHaveAttribute('type', 'text')
+    expect(secretInput).toHaveValue('')
+
     await act(async () => {
       fireEvent.submit(form as unknown as HTMLFormElement)
     })
@@ -207,5 +232,37 @@ describe('Integration credentials — optimistic-lock conflict surfacing (#3676)
       ([, init]) => (init as RequestInit | undefined)?.method === 'PUT',
     )
     expect(putCall).toBeTruthy()
+    expect(JSON.parse(String((putCall?.[1] as RequestInit).body))).toEqual({
+      credentials: { publishableKey: 'pk_test_123' },
+      unchangedSecretFields: ['secretKey'],
+    })
+  })
+
+  it('keeps an unconfigured required secret mandatory and does not submit an empty value', async () => {
+    apiCallMock.mockReset()
+    mockApiResponses(false)
+
+    const { container } = renderWithProviders(
+      <IntegrationDetailPage params={{ id: 'gateway_stripe' }} />,
+      { dict },
+    )
+
+    let form: HTMLFormElement | null = null
+    await waitFor(() => {
+      form = container.querySelector('form')
+      expect(form).not.toBeNull()
+    })
+
+    await act(async () => {
+      fireEvent.submit(form as HTMLFormElement)
+    })
+
+    const secretField = container.querySelector('[data-crud-field-id="secretKey"]')
+    await waitFor(() => expect(secretField).toHaveTextContent('This field is required'))
+
+    const putCall = apiCallMock.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'PUT',
+    )
+    expect(putCall).toBeUndefined()
   })
 })

--- a/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/[id]/page.tsx
@@ -52,6 +52,11 @@ import {
   refreshIntegrationDetailPanels,
   refreshIntegrationRunActivityPanels,
 } from '../detail-page-refresh'
+import {
+  buildCredentialEditValues,
+  buildIntegrationCredentialSavePayload,
+  type SecretFieldsConfigured,
+} from '../credential-secret-fields'
 import { isValidCredentialUrl } from '../../../lib/credentials-field-validation'
 
 type CredentialField = IntegrationCredentialField
@@ -290,19 +295,32 @@ function resolvePathnameId(pathname: string): string | undefined {
   return decodeURIComponent(integrationId)
 }
 
-function buildCredentialFields(credFields: CredentialField[]): CrudField[] {
+function buildCredentialFields(
+  credFields: CredentialField[],
+  secretFieldsConfigured: SecretFieldsConfigured,
+  t: ReturnType<typeof useT>,
+): CrudField[] {
   return credFields.map((field) => {
+    const baseDescription = field.helpDetails ? (
+      <div className="space-y-1">
+        {field.helpText ? <div>{field.helpText}</div> : null}
+        <WebhookSetupGuide guide={field.helpDetails} />
+      </div>
+    ) : field.helpText
+    const description = field.type === 'secret' && secretFieldsConfigured[field.key] ? (
+      <div className="space-y-1">
+        {baseDescription ? <div>{baseDescription}</div> : null}
+        <p className="text-xs text-muted-foreground">
+          {t('integrations.detail.credentials.secretConfigured')}
+        </p>
+      </div>
+    ) : baseDescription
     const shared = {
       id: field.key,
       label: field.label,
-      description: field.helpDetails ? (
-        <div className="space-y-1">
-          {field.helpText ? <div>{field.helpText}</div> : null}
-          <WebhookSetupGuide guide={field.helpDetails} buttonLabel="Show details" />
-        </div>
-      ) : field.helpText,
+      description,
       placeholder: field.placeholder,
-      required: field.required,
+      required: field.required && !(field.type === 'secret' && secretFieldsConfigured[field.key]),
       visibleWhen: field.visibleWhen,
     }
 
@@ -317,6 +335,7 @@ function buildCredentialFields(credFields: CredentialField[]): CrudField[] {
             value={typeof value === 'string' ? value : ''}
             onChange={(event) => setValue(event.target.value)}
             disabled={disabled}
+            autoComplete="new-password"
           />
         ),
       }
@@ -426,6 +445,7 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
   const [isNotFound, setIsNotFound] = React.useState(false)
 
   const [credValues, setCredValues] = React.useState<Record<string, unknown>>({})
+  const [secretFieldsConfigured, setSecretFieldsConfigured] = React.useState<SecretFieldsConfigured>({})
   const [credentialsUpdatedAt, setCredentialsUpdatedAt] = React.useState<string | null>(null)
   const [credentialsFormKey, setCredentialsFormKey] = React.useState(0)
   const [isSavingCredentials, setIsSavingCredentials] = React.useState(false)
@@ -490,13 +510,18 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
   const loadCredentials = React.useCallback(async () => {
     const currentIntegrationId = resolveCurrentIntegrationId()
     if (!currentIntegrationId) return
-    const call = await apiCall<{ credentials: Record<string, unknown>; updatedAt?: string | null }>(
+    const call = await apiCall<{
+      credentials: Record<string, unknown>
+      secretFieldsConfigured?: SecretFieldsConfigured
+      updatedAt?: string | null
+    }>(
       `/api/integrations/${encodeURIComponent(currentIntegrationId)}/credentials`,
       undefined,
       { fallback: null },
     )
     if (call.ok && call.result) {
       setCredentialsUpdatedAt(call.result.updatedAt ?? null)
+      setSecretFieldsConfigured(call.result.secretFieldsConfigured ?? {})
     }
     if (call.ok && call.result?.credentials) {
       const next = { ...call.result.credentials }
@@ -713,35 +738,32 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
     if (!currentIntegrationId) return
     setIsSavingCredentials(true)
     try {
-      const sanitizedValues = { ...values }
-      if (currentIntegrationId === 'storage_s3') {
-        const authMode = sanitizedValues.authMode
-        if (authMode !== 'access_keys' && authMode !== 'ambient') {
-          const hasKeys = Boolean(sanitizedValues.accessKeyId || sanitizedValues.secretAccessKey)
-          sanitizedValues.authMode = hasKeys ? 'access_keys' : 'ambient'
-        }
-        if (sanitizedValues.authMode === 'ambient') {
-          delete sanitizedValues.accessKeyId
-          delete sanitizedValues.secretAccessKey
-          delete sanitizedValues.sessionToken
-        }
-      }
+      const credentialFields = (
+        detail?.integration.credentials?.fields
+        ?? detail?.bundle?.credentials?.fields
+        ?? []
+      )
+      const savePayload = buildIntegrationCredentialSavePayload(
+        currentIntegrationId,
+        values,
+        credentialFields,
+        secretFieldsConfigured,
+      )
       const call = await runMutationWithContext({
         actionId: 'save-credentials',
         tabId: 'credentials',
-        mutationPayload: { integrationId: currentIntegrationId, credentials: sanitizedValues },
+        mutationPayload: { integrationId: currentIntegrationId, ...savePayload },
         operation: () => withScopedApiRequestHeaders(
           buildOptimisticLockHeader(credentialsUpdatedAt),
           () => apiCall(`/api/integrations/${encodeURIComponent(currentIntegrationId)}/credentials`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ credentials: sanitizedValues }),
+            body: JSON.stringify(savePayload),
           }, { fallback: null }),
         ),
       })
 
       if (call.ok) {
-        setCredValues(sanitizedValues)
         setCredentialsFormKey((current) => current + 1)
         flash(t('integrations.detail.credentials.saved'), 'success')
         void loadCredentials()
@@ -759,7 +781,7 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
     } finally {
       setIsSavingCredentials(false)
     }
-  }, [credentialsUpdatedAt, loadCredentials, resolveCurrentIntegrationId, runMutationWithContext, t])
+  }, [credentialsUpdatedAt, detail, loadCredentials, resolveCurrentIntegrationId, runMutationWithContext, secretFieldsConfigured, t])
 
   const handleVersionChange = React.useCallback(async (version: string) => {
     const currentIntegrationId = resolveCurrentIntegrationId()
@@ -837,8 +859,12 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
     [detail?.bundle?.credentials?.fields, detail?.integration.credentials?.fields],
   )
   const credentialFormFields = React.useMemo(
-    () => buildCredentialFields(editableCredentialFields),
-    [editableCredentialFields],
+    () => buildCredentialFields(editableCredentialFields, secretFieldsConfigured, t),
+    [editableCredentialFields, secretFieldsConfigured, t],
+  )
+  const credentialFormValues = React.useMemo(
+    () => buildCredentialEditValues(credValues, secretFieldsConfigured),
+    [credValues, secretFieldsConfigured],
   )
   const credentialSchema = React.useMemo(() => (
     z.object({}).passthrough().superRefine((rawValues, ctx) => {
@@ -880,7 +906,11 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
 
         const normalizedValue = typeof value === 'string' ? value : ''
 
-        if (field.required && normalizedValue.trim().length === 0) {
+        if (
+          field.required
+          && normalizedValue.trim().length === 0
+          && !(field.type === 'secret' && secretFieldsConfigured[field.key])
+        ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: [field.key],
@@ -922,7 +952,7 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
         }
       })
     })
-  ) as z.ZodType<Record<string, unknown>>, [editableCredentialFields, t])
+  ) as z.ZodType<Record<string, unknown>>, [editableCredentialFields, secretFieldsConfigured, t])
   const latestHealthLog = React.useMemo(() => logs.find(isHealthLog) ?? null, [logs])
   const latestOperationalLog = React.useMemo(
     () => logs.find((log) => (
@@ -1257,7 +1287,7 @@ export default function IntegrationDetailPage({ params }: IntegrationDetailPageP
                     entityId="integrations.integration"
                     schema={credentialSchema}
                     fields={credentialFormFields}
-                    initialValues={credValues}
+                    initialValues={credentialFormValues}
                     onSubmit={handleSaveCredentials}
                     embedded
                     hideFooterActions

--- a/packages/core/src/modules/integrations/backend/integrations/__tests__/credential-secret-fields.test.ts
+++ b/packages/core/src/modules/integrations/backend/integrations/__tests__/credential-secret-fields.test.ts
@@ -1,0 +1,80 @@
+import type { IntegrationCredentialField } from '@open-mercato/shared/modules/integrations/types'
+
+import {
+  buildCredentialEditValues,
+  buildCredentialSavePayload,
+  buildIntegrationCredentialSavePayload,
+} from '../credential-secret-fields'
+
+const fields: IntegrationCredentialField[] = [
+  { key: 'clientId', label: 'Client ID', type: 'text' },
+  { key: 'apiSecret', label: 'API Secret', type: 'secret' },
+  { key: 'oauthTokens', label: 'OAuth Tokens', type: 'oauth' },
+  { key: 'sshKey', label: 'SSH Key', type: 'ssh_keypair' },
+]
+
+describe('credential secret field form state', () => {
+  it('removes configured secret transport values from editable values', () => {
+    expect(buildCredentialEditValues(
+      {
+        clientId: 'client-123',
+        apiSecret: '__masked__',
+        oauthTokens: '__masked__',
+        sshKey: '__masked__',
+      },
+      { apiSecret: true, oauthTokens: true, sshKey: true },
+    )).toEqual({ clientId: 'client-123' })
+  })
+
+  it('lists untouched configured secrets while keeping replacements and non-secret values', () => {
+    expect(buildCredentialSavePayload(
+      { clientId: 'client-456', apiSecret: 'rotated-secret', oauthTokens: '' },
+      fields,
+      { apiSecret: true, oauthTokens: true, sshKey: true },
+    )).toEqual({
+      credentials: { clientId: 'client-456', apiSecret: 'rotated-secret' },
+      unchangedSecretFields: ['oauthTokens', 'sshKey'],
+    })
+  })
+
+  it('keeps unconfigured empty values as explicit submissions', () => {
+    expect(buildCredentialSavePayload(
+      { apiSecret: '' },
+      fields,
+      { apiSecret: false },
+    )).toEqual({ credentials: { apiSecret: '' } })
+  })
+
+  it('omits deliberately cleared secrets without marking them unchanged', () => {
+    expect(buildCredentialSavePayload(
+      { clientId: 'client-123', apiSecret: '', oauthTokens: '' },
+      fields,
+      { apiSecret: true, oauthTokens: true },
+      new Set(['apiSecret']),
+    )).toEqual({
+      credentials: { clientId: 'client-123' },
+      unchangedSecretFields: ['oauthTokens'],
+    })
+  })
+
+  it('keeps storage_s3 ambient mode as an explicit access-key clear', () => {
+    const storageFields: IntegrationCredentialField[] = [
+      { key: 'authMode', label: 'Authentication mode', type: 'select' },
+      { key: 'accessKeyId', label: 'Access key ID', type: 'text' },
+      { key: 'secretAccessKey', label: 'Secret access key', type: 'secret' },
+      { key: 'sessionToken', label: 'Session token', type: 'secret' },
+    ]
+
+    expect(buildIntegrationCredentialSavePayload(
+      'storage_s3',
+      {
+        authMode: 'ambient',
+        accessKeyId: 'stored-access-key-id',
+        secretAccessKey: '',
+        sessionToken: '',
+      },
+      storageFields,
+      { secretAccessKey: true, sessionToken: true },
+    )).toEqual({ credentials: { authMode: 'ambient' } })
+  })
+})

--- a/packages/core/src/modules/integrations/backend/integrations/bundle/[id]/__tests__/bundle-guarded-mutation.test.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/bundle/[id]/__tests__/bundle-guarded-mutation.test.tsx
@@ -71,7 +71,7 @@ const bundleDetail = {
     id: 'payments_bundle',
     title: 'Payments bundle',
     description: 'Shared payment credentials',
-    credentials: { fields: [{ key: 'apiKey', label: 'API Key', type: 'text', required: true }] },
+    credentials: { fields: [{ key: 'apiKey', label: 'API Key', type: 'secret', required: true }] },
   },
   bundleIntegrations: [
     { id: 'gateway_stripe', title: 'Stripe', category: 'payment', isEnabled: false },
@@ -83,7 +83,13 @@ const bundleDetail = {
 function mockLoadResponses() {
   apiCallMock.mockImplementation((url: string) => {
     if (typeof url === 'string' && url.endsWith('/credentials')) {
-      return Promise.resolve({ ok: true, result: { credentials: { apiKey: 'existing' } } })
+      return Promise.resolve({
+        ok: true,
+        result: {
+          credentials: { apiKey: '__om_secret_unchanged__' },
+          secretFieldsConfigured: { apiKey: true },
+        },
+      })
     }
     return Promise.resolve({ ok: true, result: bundleDetail })
   })
@@ -100,7 +106,18 @@ describe('Integrations bundle — guarded mutation wiring', () => {
   it('routes the child integration toggle through runMutation and updates local state on success', async () => {
     runMutationMock.mockResolvedValue({ ok: true, result: null })
 
-    renderWithProviders(<BundleConfigPage params={{ id: 'payments_bundle' }} />)
+    const { container } = renderWithProviders(<BundleConfigPage params={{ id: 'payments_bundle' }} />)
+
+    const secretInput = await screen.findByLabelText(/API Key/)
+    expect(secretInput).toHaveValue('')
+    expect(container).not.toHaveTextContent('__om_secret_unchanged__')
+    expect(screen.getByText('integrations.detail.credentials.secretConfigured')).toBeVisible()
+
+    const revealButton = container.querySelector('button[aria-pressed]')
+    expect(revealButton).not.toBeNull()
+    fireEvent.click(revealButton as HTMLButtonElement)
+    expect(secretInput).toHaveAttribute('type', 'text')
+    expect(secretInput).toHaveValue('')
 
     const toggle = await screen.findByRole('switch')
     expect(toggle).toHaveAttribute('aria-checked', 'false')
@@ -127,9 +144,25 @@ describe('Integrations bundle — guarded mutation wiring', () => {
     await waitFor(() => expect(runMutationMock).toHaveBeenCalled())
     const saveCall = runMutationMock.mock.calls.find((call) => call[0]?.context?.actionId === 'save-credentials')
     expect(saveCall).toBeTruthy()
-    expect(saveCall[0].mutationPayload).toMatchObject({ bundleId: 'payments_bundle' })
+    expect(saveCall[0].mutationPayload).toEqual({
+      bundleId: 'payments_bundle',
+      credentials: {},
+      unchangedSecretFields: ['apiKey'],
+    })
     expect(typeof saveCall[0].operation).toBe('function')
 
     await waitFor(() => expect(flashMock).toHaveBeenCalledWith('integrations.detail.credentials.saved', 'success'))
+
+    fireEvent.change(await screen.findByLabelText(/API Key/), { target: { value: 'rotated-secret' } })
+    fireEvent.click(await screen.findByText('integrations.detail.credentials.save'))
+
+    await waitFor(() => {
+      const saveCalls = runMutationMock.mock.calls.filter((call) => call[0]?.context?.actionId === 'save-credentials')
+      expect(saveCalls).toHaveLength(2)
+      expect(saveCalls[1][0].mutationPayload).toEqual({
+        bundleId: 'payments_bundle',
+        credentials: { apiKey: 'rotated-secret' },
+      })
+    })
   })
 })

--- a/packages/core/src/modules/integrations/backend/integrations/bundle/[id]/page.tsx
+++ b/packages/core/src/modules/integrations/backend/integrations/bundle/[id]/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@open-mercato/ui/primitives/badge'
 import { Button } from '@open-mercato/ui/primitives/button'
 import { Switch } from '@open-mercato/ui/primitives/switch'
 import { Input } from '@open-mercato/ui/primitives/input'
+import { PasswordInput } from '@open-mercato/ui/primitives/password-input'
 import {
   Select,
   SelectContent,
@@ -23,6 +24,11 @@ import { flash } from '@open-mercato/ui/backend/FlashMessages'
 import { useT } from '@open-mercato/shared/lib/i18n/context'
 import type { CredentialFieldType, IntegrationCredentialField } from '@open-mercato/shared/modules/integrations/types'
 import { LoadingMessage, ErrorMessage, RecordNotFoundState } from '@open-mercato/ui/backend/detail'
+import {
+  buildCredentialEditValues,
+  buildCredentialSavePayload,
+  type SecretFieldsConfigured,
+} from '../../credential-secret-fields'
 
 type CredentialField = IntegrationCredentialField
 
@@ -88,6 +94,7 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
   const [error, setError] = React.useState<string | null>(null)
   const [isNotFound, setIsNotFound] = React.useState(false)
   const [credValues, setCredValues] = React.useState<Record<string, unknown>>({})
+  const [secretFieldsConfigured, setSecretFieldsConfigured] = React.useState<SecretFieldsConfigured>({})
   const [credentialsUpdatedAt, setCredentialsUpdatedAt] = React.useState<string | null>(null)
   const [isSavingCreds, setIsSavingCreds] = React.useState(false)
   const [togglingIds, setTogglingIds] = React.useState<Set<string>>(new Set())
@@ -134,13 +141,18 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
     }
     setDetail(call.result)
 
-    const credCall = await apiCall<{ credentials: Record<string, unknown>; updatedAt?: string | null }>(
+    const credCall = await apiCall<{
+      credentials: Record<string, unknown>
+      secretFieldsConfigured?: SecretFieldsConfigured
+      updatedAt?: string | null
+    }>(
       `/api/integrations/${encodeURIComponent(currentBundleId)}/credentials`,
       undefined,
       { fallback: null },
     )
     if (credCall.ok && credCall.result) {
       setCredentialsUpdatedAt(credCall.result.updatedAt ?? null)
+      setSecretFieldsConfigured(credCall.result.secretFieldsConfigured ?? {})
     }
     if (credCall.ok && credCall.result?.credentials) {
       const next = { ...credCall.result.credentials }
@@ -151,7 +163,10 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
           next.authMode = hasKeys ? 'access_keys' : 'ambient'
         }
       }
-      setCredValues(next)
+      setCredValues(buildCredentialEditValues(
+        next,
+        credCall.result.secretFieldsConfigured ?? {},
+      ))
     }
     setIsLoading(false)
   }, [resolveCurrentBundleId, t])
@@ -163,8 +178,13 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
     if (!currentBundleId) return
     setIsSavingCreds(true)
     try {
+      const savePayload = buildCredentialSavePayload(
+        credValues,
+        detail?.bundle?.credentials?.fields ?? [],
+        secretFieldsConfigured,
+      )
       const call = await runMutation({
-        mutationPayload: { bundleId: currentBundleId, credentials: credValues },
+        mutationPayload: { bundleId: currentBundleId, ...savePayload },
         context: {
           formId: mutationContextId,
           operation: 'update',
@@ -179,7 +199,7 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
           () => apiCall(`/api/integrations/${encodeURIComponent(currentBundleId)}/credentials`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ credentials: credValues }),
+            body: JSON.stringify(savePayload),
           }, { fallback: null }),
         ),
       })
@@ -194,7 +214,7 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
     } finally {
       setIsSavingCreds(false)
     }
-  }, [resolveCurrentBundleId, runMutation, mutationContextId, retryLastMutation, credValues, credentialsUpdatedAt, load, t])
+  }, [resolveCurrentBundleId, runMutation, mutationContextId, retryLastMutation, credValues, credentialsUpdatedAt, detail?.bundle?.credentials?.fields, load, secretFieldsConfigured, t])
 
   const handleToggle = React.useCallback(async (integrationId: string, enabled: boolean, updatedAt?: string | null) => {
     setTogglingIds((prev) => new Set(prev).add(integrationId))
@@ -295,15 +315,15 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
             <CardContent className="space-y-4">
               {credFields.filter(isFieldVisible).map((field) => (
                 <div key={field.key} className="space-y-1.5">
-                  <label className="text-sm font-medium">
-                    {field.label}{field.required && <span className="text-red-500 ml-0.5">*</span>}
+                  <label htmlFor={`bundle-credential-${field.key}`} className="text-sm font-medium">
+                    {field.label}{field.required && <span className="ml-0.5 text-destructive">*</span>}
                   </label>
                   {field.type === 'select' && field.options ? (
                     <Select
                       value={(credValues[field.key] as string) || undefined}
                       onValueChange={(value) => setCredValues((prev) => ({ ...prev, [field.key]: value ?? '' }))}
                     >
-                      <SelectTrigger>
+                      <SelectTrigger id={`bundle-credential-${field.key}`}>
                         <SelectValue placeholder="—" />
                       </SelectTrigger>
                       <SelectContent>
@@ -314,17 +334,32 @@ export default function BundleConfigPage({ params }: BundleConfigPageProps) {
                     </Select>
                   ) : field.type === 'boolean' ? (
                     <Switch
+                      id={`bundle-credential-${field.key}`}
                       checked={Boolean(credValues[field.key])}
                       onCheckedChange={(checked) => setCredValues((prev) => ({ ...prev, [field.key]: checked }))}
                     />
+                  ) : field.type === 'secret' ? (
+                    <PasswordInput
+                      id={`bundle-credential-${field.key}`}
+                      placeholder={field.placeholder}
+                      value={(credValues[field.key] as string) ?? ''}
+                      onChange={(event) => setCredValues((prev) => ({ ...prev, [field.key]: event.target.value }))}
+                      autoComplete="new-password"
+                    />
                   ) : (
                     <Input
-                      type={field.type === 'secret' ? 'password' : 'text'}
+                      id={`bundle-credential-${field.key}`}
+                      type="text"
                       placeholder={field.placeholder}
                       value={(credValues[field.key] as string) ?? ''}
                       onChange={(e) => setCredValues((prev) => ({ ...prev, [field.key]: e.target.value }))}
                     />
                   )}
+                  {field.type === 'secret' && secretFieldsConfigured[field.key] ? (
+                    <p className="text-xs text-muted-foreground">
+                      {t('integrations.detail.credentials.secretConfigured')}
+                    </p>
+                  ) : null}
                 </div>
               ))}
               <Button type="button" onClick={() => void handleSaveCredentials()} disabled={isSavingCreds}>

--- a/packages/core/src/modules/integrations/backend/integrations/credential-secret-fields.ts
+++ b/packages/core/src/modules/integrations/backend/integrations/credential-secret-fields.ts
@@ -1,0 +1,84 @@
+import type { IntegrationCredentialField } from '@open-mercato/shared/modules/integrations/types'
+import { SECRET_CREDENTIAL_FIELD_TYPES } from '../../lib/credentials-masking'
+
+export type SecretFieldsConfigured = Record<string, boolean>
+
+export type CredentialSavePayload = {
+  credentials: Record<string, unknown>
+  unchangedSecretFields?: string[]
+}
+
+export function buildCredentialEditValues(
+  credentials: Record<string, unknown>,
+  secretFieldsConfigured: SecretFieldsConfigured,
+): Record<string, unknown> {
+  const editValues = { ...credentials }
+
+  for (const [fieldKey, configured] of Object.entries(secretFieldsConfigured)) {
+    if (configured) delete editValues[fieldKey]
+  }
+
+  return editValues
+}
+
+export function buildCredentialSavePayload(
+  values: Record<string, unknown>,
+  fields: readonly IntegrationCredentialField[],
+  secretFieldsConfigured: SecretFieldsConfigured,
+  deliberatelyClearedSecretFields: ReadonlySet<string> = new Set(),
+): CredentialSavePayload {
+  const credentials = { ...values }
+  const unchangedSecretFields = new Set<string>()
+
+  for (const field of fields) {
+    if (!SECRET_CREDENTIAL_FIELD_TYPES.has(field.type)) continue
+
+    if (deliberatelyClearedSecretFields.has(field.key)) {
+      delete credentials[field.key]
+      continue
+    }
+
+    if (!secretFieldsConfigured[field.key]) continue
+    const value = credentials[field.key]
+    if (value !== undefined && value !== '') continue
+
+    delete credentials[field.key]
+    unchangedSecretFields.add(field.key)
+  }
+
+  return unchangedSecretFields.size > 0
+    ? { credentials, unchangedSecretFields: [...unchangedSecretFields] }
+    : { credentials }
+}
+
+export function buildIntegrationCredentialSavePayload(
+  integrationId: string,
+  values: Record<string, unknown>,
+  fields: readonly IntegrationCredentialField[],
+  secretFieldsConfigured: SecretFieldsConfigured,
+): CredentialSavePayload {
+  const normalizedValues = { ...values }
+  const deliberatelyClearedSecretFields = new Set<string>()
+
+  if (integrationId === 'storage_s3') {
+    const authMode = normalizedValues.authMode
+    if (authMode !== 'access_keys' && authMode !== 'ambient') {
+      const hasKeys = Boolean(normalizedValues.accessKeyId || normalizedValues.secretAccessKey)
+      normalizedValues.authMode = hasKeys ? 'access_keys' : 'ambient'
+    }
+    if (normalizedValues.authMode === 'ambient') {
+      delete normalizedValues.accessKeyId
+      delete normalizedValues.secretAccessKey
+      delete normalizedValues.sessionToken
+      deliberatelyClearedSecretFields.add('secretAccessKey')
+      deliberatelyClearedSecretFields.add('sessionToken')
+    }
+  }
+
+  return buildCredentialSavePayload(
+    normalizedValues,
+    fields,
+    secretFieldsConfigured,
+    deliberatelyClearedSecretFields,
+  )
+}

--- a/packages/core/src/modules/integrations/data/__tests__/validators.test.ts
+++ b/packages/core/src/modules/integrations/data/__tests__/validators.test.ts
@@ -1,4 +1,4 @@
-import { listIntegrationsQuerySchema } from '../validators'
+import { listIntegrationsQuerySchema, saveCredentialsSchema } from '../validators'
 
 describe('integrations validators', () => {
   test('listIntegrationsQuerySchema accepts empty queries and applies defaults', () => {
@@ -16,5 +16,26 @@ describe('integrations validators', () => {
 
   test('listIntegrationsQuerySchema treats blank optional boolean query tokens as omitted', () => {
     expect(listIntegrationsQuerySchema.parse({ isEnabled: '' }).isEnabled).toBeUndefined()
+  })
+
+  test('saveCredentialsSchema accepts a bounded list of unchanged secret fields', () => {
+    expect(saveCredentialsSchema.parse({
+      credentials: { apiUrl: 'https://example.com' },
+      unchangedSecretFields: ['apiSecret'],
+    })).toEqual({
+      credentials: { apiUrl: 'https://example.com' },
+      unchangedSecretFields: ['apiSecret'],
+    })
+  })
+
+  test('saveCredentialsSchema rejects duplicate or excessive unchanged secret fields', () => {
+    expect(saveCredentialsSchema.safeParse({
+      credentials: {},
+      unchangedSecretFields: ['apiSecret', 'apiSecret'],
+    }).success).toBe(false)
+    expect(saveCredentialsSchema.safeParse({
+      credentials: {},
+      unchangedSecretFields: Array.from({ length: 201 }, (_, index) => `secret_${index}`),
+    }).success).toBe(false)
   })
 })

--- a/packages/core/src/modules/integrations/data/validators.ts
+++ b/packages/core/src/modules/integrations/data/validators.ts
@@ -1,13 +1,23 @@
 import { z } from 'zod'
 
+const credentialFieldKeySchema = z.string().min(1).max(128)
+
 export const saveCredentialsSchema = z.object({
   credentials: z.record(
-    z.string().min(1).max(128),
+    credentialFieldKeySchema,
     z.union([z.string().max(20_000), z.number(), z.boolean(), z.null()]),
   ),
+  unchangedSecretFields: z.array(credentialFieldKeySchema).max(200).optional(),
 }).refine((value) => Object.keys(value.credentials).length <= 200, {
   message: 'At most 200 credential fields are allowed',
-})
+}).refine(
+  (value) => !value.unchangedSecretFields
+    || new Set(value.unchangedSecretFields).size === value.unchangedSecretFields.length,
+  {
+    message: 'Unchanged secret field names must be unique',
+    path: ['unchangedSecretFields'],
+  },
+)
 
 export type SaveCredentialsInput = z.infer<typeof saveCredentialsSchema>
 

--- a/packages/core/src/modules/integrations/i18n/de.json
+++ b/packages/core/src/modules/integrations/i18n/de.json
@@ -15,6 +15,7 @@
   "integrations.detail.credentials.save": "Zugangsdaten speichern",
   "integrations.detail.credentials.saveError": "Zugangsdaten konnten nicht gespeichert werden",
   "integrations.detail.credentials.saved": "Zugangsdaten gespeichert",
+  "integrations.detail.credentials.secretConfigured": "Konfiguriert. Geben Sie einen neuen Wert ein, um ihn zu ersetzen.",
   "integrations.detail.credentials.validation.boolean": "Select a valid value.",
   "integrations.detail.credentials.validation.option": "Select one of the available options.",
   "integrations.detail.credentials.validation.required": "{field} is required.",

--- a/packages/core/src/modules/integrations/i18n/en.json
+++ b/packages/core/src/modules/integrations/i18n/en.json
@@ -15,6 +15,7 @@
   "integrations.detail.credentials.save": "Save Credentials",
   "integrations.detail.credentials.saveError": "Failed to save credentials",
   "integrations.detail.credentials.saved": "Credentials saved",
+  "integrations.detail.credentials.secretConfigured": "Configured. Enter a new value to replace it.",
   "integrations.detail.credentials.validation.boolean": "Select a valid value.",
   "integrations.detail.credentials.validation.option": "Select one of the available options.",
   "integrations.detail.credentials.validation.required": "{field} is required.",

--- a/packages/core/src/modules/integrations/i18n/es.json
+++ b/packages/core/src/modules/integrations/i18n/es.json
@@ -15,6 +15,7 @@
   "integrations.detail.credentials.save": "Guardar credenciales",
   "integrations.detail.credentials.saveError": "No se pudieron guardar las credenciales",
   "integrations.detail.credentials.saved": "Credenciales guardadas",
+  "integrations.detail.credentials.secretConfigured": "Configurado. Introduce un valor nuevo para reemplazarlo.",
   "integrations.detail.credentials.validation.boolean": "Select a valid value.",
   "integrations.detail.credentials.validation.option": "Select one of the available options.",
   "integrations.detail.credentials.validation.required": "{field} is required.",

--- a/packages/core/src/modules/integrations/i18n/ko.json
+++ b/packages/core/src/modules/integrations/i18n/ko.json
@@ -15,6 +15,7 @@
   "integrations.detail.credentials.save": "자격 증명 저장",
   "integrations.detail.credentials.saveError": "자격 증명 저장에 실패했습니다",
   "integrations.detail.credentials.saved": "자격 증명이 저장되었습니다",
+  "integrations.detail.credentials.secretConfigured": "구성됨. 바꾸려면 새 값을 입력하세요.",
   "integrations.detail.credentials.validation.boolean": "유효한 값을 선택하세요.",
   "integrations.detail.credentials.validation.option": "사용 가능한 옵션 중 하나를 선택하세요.",
   "integrations.detail.credentials.validation.required": "{field}은(는) 필수입니다.",

--- a/packages/core/src/modules/integrations/i18n/pl.json
+++ b/packages/core/src/modules/integrations/i18n/pl.json
@@ -15,6 +15,7 @@
   "integrations.detail.credentials.save": "Zapisz dane",
   "integrations.detail.credentials.saveError": "Nie udało się zapisać danych",
   "integrations.detail.credentials.saved": "Dane zapisane",
+  "integrations.detail.credentials.secretConfigured": "Skonfigurowano. Wpisz nową wartość, aby ją zastąpić.",
   "integrations.detail.credentials.validation.boolean": "Select a valid value.",
   "integrations.detail.credentials.validation.option": "Select one of the available options.",
   "integrations.detail.credentials.validation.required": "{field} is required.",

--- a/packages/core/src/modules/integrations/lib/__tests__/credentials-masking.test.ts
+++ b/packages/core/src/modules/integrations/lib/__tests__/credentials-masking.test.ts
@@ -84,6 +84,46 @@ describe('mergeMaskedSecretCredentials', () => {
     expect(merged.apiSecret).toBe('rotated-secret')
   })
 
+  it('preserves only listed omitted secret fields', () => {
+    const merged = mergeMaskedSecretCredentials(
+      schema,
+      { apiUrl: 'https://example.com' },
+      {
+        clientId: 'stored-client',
+        apiSecret: 'stored-secret',
+        sshKey: { privateKey: 'PRIVATE', publicKey: 'PUBLIC' },
+      },
+      ['clientId', 'apiSecret', 'sshKey', 'unknownSecret'],
+    )
+
+    expect(merged).toEqual({
+      apiUrl: 'https://example.com',
+      apiSecret: 'stored-secret',
+      sshKey: { privateKey: 'PRIVATE', publicKey: 'PUBLIC' },
+    })
+  })
+
+  it('keeps plain omission as full replacement behavior', () => {
+    const merged = mergeMaskedSecretCredentials(
+      schema,
+      { apiUrl: 'https://example.com' },
+      { apiSecret: 'stored-secret' },
+    )
+
+    expect(merged).toEqual({ apiUrl: 'https://example.com' })
+  })
+
+  it('lets an explicit replacement win over the unchanged list', () => {
+    const merged = mergeMaskedSecretCredentials(
+      schema,
+      { apiSecret: 'rotated-secret' },
+      { apiSecret: 'stored-secret' },
+      ['apiSecret'],
+    )
+
+    expect(merged.apiSecret).toBe('rotated-secret')
+  })
+
   it('clears the secret when the client submits an empty string', () => {
     const merged = mergeMaskedSecretCredentials(
       schema,
@@ -99,6 +139,11 @@ describe('mergeMaskedSecretCredentials', () => {
       { apiSecret: MASKED_SECRET_VALUE },
       {},
     )
+    expect(merged).not.toHaveProperty('apiSecret')
+  })
+
+  it('does not create a listed secret when nothing was stored before', () => {
+    const merged = mergeMaskedSecretCredentials(schema, {}, {}, ['apiSecret'])
     expect(merged).not.toHaveProperty('apiSecret')
   })
 

--- a/packages/core/src/modules/integrations/lib/credentials-masking.ts
+++ b/packages/core/src/modules/integrations/lib/credentials-masking.ts
@@ -84,22 +84,26 @@ export function maskSecretCredentials(
 }
 
 /**
- * Reverse of {@link maskSecretCredentials} for the save path. When the client
- * submits the mask sentinel for a secret field it means "leave it unchanged":
- * restore the existing stored secret, or drop the field entirely when nothing
- * was previously stored (so the literal sentinel is never persisted). Any other
- * value (including an empty string, which clears the secret) is written as-is.
+ * Reverse of {@link maskSecretCredentials} for the save path. The exact mask
+ * sentinel and explicitly listed omitted secret fields mean "leave unchanged".
+ * Explicit values win over the list, including an empty string used to clear a
+ * secret, while plain omission retains the full-replacement contract.
  */
 export function mergeMaskedSecretCredentials(
   schema: IntegrationCredentialsSchema | undefined,
   incoming: Record<string, unknown>,
   existing: Record<string, unknown>,
+  unchangedSecretFields: readonly string[] = [],
 ): Record<string, unknown> {
   const merged: Record<string, unknown> = { ...incoming }
+  const unchangedSecretFieldSet = new Set(unchangedSecretFields)
 
   for (const field of schema?.fields ?? []) {
     if (!isSecretField(field.type)) continue
-    if (merged[field.key] !== MASKED_SECRET_VALUE) continue
+    const hasIncomingValue = Object.prototype.hasOwnProperty.call(merged, field.key)
+    const submittedMask = merged[field.key] === MASKED_SECRET_VALUE
+    const explicitlyUnchanged = !hasIncomingValue && unchangedSecretFieldSet.has(field.key)
+    if (!submittedMask && !explicitlyUnchanged) continue
 
     if (hasPresentValue(existing[field.key])) {
       merged[field.key] = existing[field.key]


### PR DESCRIPTION
Closes #5421

## Goal

Keep configured integration secrets write-only and safely replaceable without exposing the masking sentinel in credential editors.

## Problem and root cause

The credentials API masks configured secrets with an opaque sentinel and returns a separate configured-state map. Both first-party credential editors copied the masked object directly into controlled password inputs, so a partial edit could persist a hybrid sentinel/user value as the real encrypted credential.

## What changed

- Separate the raw masked transport state from empty write-only form values in both the direct and bundle editors.
- Add a bounded optional `unchangedSecretFields` PUT property; the server intersects the submitted names with secret fields from the trusted provider schema.
- Preserve legacy sentinel handling, full-blob omission semantics, explicit clearing, widget context behavior, and S3 ambient-credential clearing.
- Update the API documentation, localized UI guidance, specification, engineering lesson, unit coverage, and browser regression coverage.
- Prevent shared integration tests from mutating integrations whose configured write-only secrets cannot be restored safely.

## Validation

- `yarn build:packages` — passed before and after `yarn generate`.
- `yarn generate` — passed; generated outputs remained unchanged.
- `yarn i18n:check-sync` and `yarn i18n:check-usage` — passed; repository-wide unused keys remain advisory.
- `yarn typecheck` — all 26 configured tasks passed.
- `yarn test` — all 33 Turbo tasks passed, including 1,388 core suites and 11,121 core assertions. Later repeat runs encountered transient unrelated Jest worker crashes; both affected suites passed immediately in isolation.
- Focused Jest regression gate — 6 suites and 36 tests passed after review remediation.
- Chromium `TC-INT-011-secret-credential-editing` — passed against the isolated ephemeral application environment.
- Playwright discovery — all 3 corrected shared-integration scenarios were discovered successfully.
- `yarn build:app` — passed with 9 existing non-blocking Turbopack tracing warnings.
- `yarn lessons:check`, `yarn lint:ds`, `yarn template:sync`, and `git diff --check` — passed; DS lint reported 0 errors and 226 existing repository warnings.

## Review evidence

- Initial code review approved the implementation direction.
- Fresh independent review found one blocker and two major issues in test safety, endpoint documentation, and required-field coverage.
- All findings were remediated; the final fresh re-review approved with no remaining findings.

## Breaking changes

None. The PUT contract adds an optional property and the credential merge helper adds a trailing optional parameter. Existing clients retain sentinel, omission, replacement, and explicit-clear behavior.

## Labels and delivery

- `review` — ready for code review.
- `bug` — fixes stored credential corruption.
- `needs-qa` — changes backoffice credential UI; QA approval is required before merge.
- `priority-high` — silent credential corruption can break active integrations.
- `risk-medium` — shared credential editor/API behavior changes across providers, with additive compatibility and regression coverage.

## Manual QA

1. Configure a provider secret and reload the direct integration editor; the input should be empty and show the configured-secret hint.
2. Reveal the input; it should remain empty.
3. Save without touching the secret; the configured secret should remain usable.
4. Enter a replacement secret and save; the integration should use the replacement.
5. Repeat the untouched and replacement checks in the bundle editor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789923573&installation_model_id=432243&pr_number=5454&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5454&signature=8113cbd67aa0f72c0b0e8d9ca52e1859c87c50a5cf7ef4baf8a03273997c395b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->