### PR TITLE
fix(customers): scope deal-analyzer person links to tenant/org via deal map

### DIFF
--- a/packages/core/src/modules/customers/__tests__/ai-tools/deal-analyzer-pack.test.ts
+++ b/packages/core/src/modules/customers/__tests__/ai-tools/deal-analyzer-pack.test.ts
@@ -321,12 +321,56 @@ describe('customers.analyze_deals handler', () => {
     // activity where
     const activityWhere = findWithDecryptionMock.mock.calls[1][2]
     expect(activityWhere).toMatchObject({ tenantId: 'tenant-1', organizationId: 'org-1' })
-    // person link where (raw em.find)
+    // person link where (raw em.find) — junction has no tenant/org columns, so
+    // DB scoping is via the tenant-filtered dealIds. Post-fetch filtering
+    // against the scoped deals map provides defense-in-depth (see next test).
     expect(findMock).toHaveBeenCalledTimes(1)
     const personLinkWhere = findMock.mock.calls[0][1]
     expect(personLinkWhere).toEqual({ deal: { $in: ['deal-1'] } })
     expect(personLinkWhere).not.toHaveProperty('tenantId')
     expect(personLinkWhere).not.toHaveProperty('organizationId')
+  })
+
+  it('discards person links whose deal is not in the tenant-scoped deal set (defense-in-depth)', async () => {
+    const deal = makeDeal({ id: 'deal-1', title: 'Scoped Deal' })
+    findWithDecryptionMock
+      .mockResolvedValueOnce([deal]) // deals — only deal-1 is tenant-scoped
+      .mockResolvedValueOnce([]) // activities
+      .mockResolvedValueOnce([
+        {
+          id: 'person-1',
+          displayName: 'Alice InScope',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+        },
+      ]) // CustomerEntity — only the in-scope person is resolved
+
+    const findMock = jest.fn().mockResolvedValue([
+      { id: 'link-1', deal: { id: 'deal-1' }, person: { id: 'person-1' } },
+      { id: 'link-foreign', deal: { id: 'deal-other' }, person: { id: 'person-foreign' } },
+    ])
+    const ctx = makeCtx()
+    ;(ctx.container.resolve as jest.Mock).mockImplementation((name: string) => {
+      if (name === 'em') return { find: findMock, count: jest.fn().mockResolvedValue(0) }
+      throw new Error(`unexpected resolve: ${name}`)
+    })
+
+    const result = (await tool.handler({}, ctx as any)) as {
+      deals: Array<{ id: string; primaryContact: string | null }>
+    }
+
+    // The raw junction query still uses the scoped dealIds.
+    expect(findMock.mock.calls[0][1]).toEqual({ deal: { $in: ['deal-1'] } })
+    // But even if the DB returned an extra cross-tenant link (deal-other),
+    // the handler filtered it to the scoped set before resolving persons.
+    expect(findWithDecryptionMock.mock.calls[2][2]).toEqual({
+      id: { $in: ['person-1'] },
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+    })
+    expect(result.deals).toHaveLength(1)
+    expect(result.deals[0].id).toBe('deal-1')
+    expect(result.deals[0].primaryContact).toBe('Alice InScope')
   })
 
   it('rejects calls with no tenant scope', async () => {

--- a/packages/core/src/modules/customers/ai-tools/deal-analyzer-pack.ts
+++ b/packages/core/src/modules/customers/ai-tools/deal-analyzer-pack.ts
@@ -192,14 +192,29 @@ const analyzeDealsToolDefinition: CustomersAiToolDefinition<AnalyzeDealsInput, A
     // has no encrypted columns, but the linked CustomerEntity.display_name is
     // encrypted, so resolve names via findWithDecryption rather than
     // populating the relation through raw em.find.
+    // Defense-in-depth: `customer_deal_people` carries no tenant/org columns,
+    // so DB-level scoping is via the tenant-filtered `dealIds` set. Filter the
+    // returned rows against the caller-scoped deals map so a future refactor
+    // that widens `dealIds` cannot surface cross-tenant links.
+    const dealById = new Map<string, CustomerDeal>(deals.map((deal) => [deal.id, deal]))
+    const scopedDealIds = Array.from(dealById.keys())
     const personLinkWhere: Record<string, unknown> = {
-      deal: { $in: dealIds },
+      deal: { $in: scopedDealIds },
     }
-    const personLinks = await em.find(
+    const personLinksRaw = await em.find(
       CustomerDealPersonLink,
       personLinkWhere as any,
       { limit: 500 },
     )
+    const personLinks = personLinksRaw.filter((link) => {
+      const dealRefId = refIdOf((link as { deal?: unknown }).deal)
+      if (!dealRefId) return false
+      const scopedDeal = dealById.get(dealRefId)
+      if (!scopedDeal) return false
+      if (scopedDeal.tenantId !== tenantId) return false
+      if (ctx.organizationId && scopedDeal.organizationId !== ctx.organizationId) return false
+      return true
+    })
 
     const linksByDeal = new Map<string, string>() // dealId → personId (first link wins)
     for (const link of personLinks) {


### PR DESCRIPTION
Closes #3842

## Goal
Harden `customers.analyze_deals` so the `CustomerDealPersonLink` junction read cannot surface cross-tenant links even if the `dealIds` derivation is later widened. No change in behavior for correct callers.

## Problem
`deal-analyzer-pack.ts:195-202` loaded `CustomerDealPersonLink` with raw `em.find` and no explicit tenant/org scoping. Safety was transitive via the tenant+org-filtered `CustomerDeal` query, but the read itself carried no explicit scope.

## Root Cause
The junction table `customer_deal_people` has no `tenant_id`/`organization_id` columns, so a DB-level `where: { tenantId }` is not applicable without a migration. The handler relied solely on the prior `deals` query for scoping, leaving the link read fragile against future refactors.

## What Changed
- `packages/core/src/modules/customers/ai-tools/deal-analyzer-pack.ts` � Build `dealById` map from the tenant-scoped `deals`, query `personLinksRaw` with scoped dealIds, then filter against `dealById` checking `tenantId` and `organizationId` before building `linksByDeal`.
- `packages/core/src/modules/customers/__tests__/ai-tools/deal-analyzer-pack.test.ts` � Added regression test `discards person links whose deal is not in the tenant-scoped deal set` which verifies an extra foreign link is filtered before resolving `CustomerEntity`.

## Tests
- `yarn build:packages` � passed
- `yarn generate` � passed
- `yarn i18n:check-sync` � passed
- `yarn typecheck` � passed
- `yarn workspace @open-mercato/core test --testPathPatterns=deal-analyzer-pack` � 18 passed (including new test)

## Breaking Changes
None. No API, event, config, or DB schema change. The added filter matches the pre-scoped `dealIds`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789939783&installation_model_id=432243&pr_number=5459&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5459&signature=6cb7bb9df13f1813d963b7654bd65b3c698900fbc4d67fe794db6b3e3e5c7970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->