### PR TITLE
fix(customers): enforce organization scoping on legacy activities list (#3841)

### DIFF
--- a/packages/core/src/modules/customers/api/activities/__tests__/org-scoping.test.ts
+++ b/packages/core/src/modules/customers/api/activities/__tests__/org-scoping.test.ts
@@ -1,0 +1,395 @@
+/** @jest-environment node */
+
+import { CustomerActivity } from '../../../data/entities'
+import { GET } from '../route'
+
+const TENANT_ID = '123e4567-e89b-41d3-a456-426614174010'
+const ORG_1 = '123e4567-e89b-41d3-a456-426614174001'
+
+const mockCommandBus = { execute: jest.fn() }
+const mockEm = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  findAndCount: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'commandBus') return mockCommandBus
+    if (name === 'em') return mockEm
+    if (name === 'queryEngine') return { query: jest.fn() }
+    throw new Error(`Unknown dependency: ${name}`)
+  }),
+}
+
+let mockContext: Record<string, unknown> = {}
+
+jest.mock('../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn(),
+}))
+
+jest.mock('../../../lib/interactionRequestContext', () => ({
+  resolveCustomersRequestContext: jest.fn(async () => mockContext),
+}))
+
+jest.mock('../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+  loadCustomerSummaries: jest.fn(async () => new Map()),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+jest.mock('../../../lib/interactionCompatibility', () => ({
+  mapInteractionRecordToActivitySummary: jest.fn(),
+  CUSTOMER_INTERACTION_ACTIVITY_ADAPTER_SOURCE: 'adapter:activity',
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn(async () => []),
+}))
+
+describe('activities GET organization scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    const { resolveCustomerInteractionFeatureFlags } = jest.requireMock(
+      '../../../lib/interactionFeatureFlags',
+    )
+    resolveCustomerInteractionFeatureFlags.mockResolvedValue({
+      unified: false,
+      legacyAdapters: true,
+      externalSync: false,
+    })
+
+    mockEm.findAndCount.mockImplementation(async () => [[], 0])
+    mockEm.find.mockImplementation(async () => [])
+    mockEm.count.mockImplementation(async () => 0)
+
+    jest.requireMock('../../../lib/interactionReadModel').hydrateCanonicalInteractions
+      .mockImplementation(async () => [])
+  })
+
+  it('returns empty results and does NOT query all orgs when non-superadmin has organizationIds = null', async () => {
+    mockContext = {
+      auth: {
+        sub: 'user-1',
+        tenantId: TENANT_ID,
+        orgId: null,
+        isSuperAdmin: false,
+      },
+      em: mockEm,
+      organizationIds: null,
+      selectedOrganizationId: null,
+      scope: {
+        selectedId: null,
+        filterIds: null,
+        allowedIds: [ORG_1],
+        tenantId: TENANT_ID,
+      },
+      container: mockContainer,
+      commandContext: {
+        container: mockContainer,
+        auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: null },
+        organizationScope: { selectedId: null, filterIds: null, allowedIds: [ORG_1], tenantId: TENANT_ID },
+        selectedOrganizationId: null,
+        organizationIds: null,
+        request: undefined,
+      },
+    }
+
+    const res = await GET(new Request('http://localhost/api/customers/activities?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([])
+    expect(body.total).toBe(0)
+
+    expect(mockEm.findAndCount).not.toHaveBeenCalled()
+    expect(mockEm.find).not.toHaveBeenCalled()
+    expect(mockEm.count).not.toHaveBeenCalled()
+  })
+
+  it('returns empty results and does NOT query all orgs when non-superadmin has organizationIds = []', async () => {
+    mockContext = {
+      auth: {
+        sub: 'user-1',
+        tenantId: TENANT_ID,
+        orgId: null,
+        isSuperAdmin: false,
+      },
+      em: mockEm,
+      organizationIds: [],
+      selectedOrganizationId: null,
+      scope: {
+        selectedId: null,
+        filterIds: [],
+        allowedIds: [ORG_1],
+        tenantId: TENANT_ID,
+      },
+      container: mockContainer,
+      commandContext: {
+        container: mockContainer,
+        auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: null },
+        organizationScope: { selectedId: null, filterIds: [], allowedIds: [ORG_1], tenantId: TENANT_ID },
+        selectedOrganizationId: null,
+        organizationIds: [],
+        request: undefined,
+      },
+    }
+
+    const res = await GET(new Request('http://localhost/api/customers/activities?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([])
+    expect(body.total).toBe(0)
+
+    expect(mockEm.findAndCount).not.toHaveBeenCalled()
+    expect(mockEm.find).not.toHaveBeenCalled()
+    expect(mockEm.count).not.toHaveBeenCalled()
+  })
+
+  it('allows tenant-wide query when user is superadmin and organizationIds is null', async () => {
+    mockContext = {
+      auth: {
+        sub: 'superadmin-1',
+        tenantId: TENANT_ID,
+        orgId: null,
+        isSuperAdmin: true,
+      },
+      em: mockEm,
+      organizationIds: null,
+      selectedOrganizationId: null,
+      scope: {
+        selectedId: null,
+        filterIds: null,
+        allowedIds: null,
+        tenantId: TENANT_ID,
+      },
+      container: mockContainer,
+      commandContext: {
+        container: mockContainer,
+        auth: { sub: 'superadmin-1', tenantId: TENANT_ID, orgId: null, isSuperAdmin: true },
+        organizationScope: { selectedId: null, filterIds: null, allowedIds: null, tenantId: TENANT_ID },
+        selectedOrganizationId: null,
+        organizationIds: null,
+        request: undefined,
+      },
+    }
+
+    const res = await GET(new Request('http://localhost/api/customers/activities?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+
+    const legacyCall = mockEm.findAndCount.mock.calls.find(
+      (args) => args[0] === CustomerActivity,
+    )
+    expect(legacyCall).toBeDefined()
+    const where = legacyCall![1] as Record<string, unknown>
+    expect(where.tenantId).toBe(TENANT_ID)
+    expect(where.organizationId).toBeUndefined()
+  })
+
+  it('allows tenant-wide query when user has unrestricted scope (allowedIds === null) and organizationIds is null', async () => {
+    mockContext = {
+      auth: {
+        sub: 'user-unrestricted',
+        tenantId: TENANT_ID,
+        orgId: null,
+        isSuperAdmin: false,
+      },
+      em: mockEm,
+      organizationIds: null,
+      selectedOrganizationId: null,
+      scope: {
+        selectedId: null,
+        filterIds: null,
+        allowedIds: null,
+        tenantId: TENANT_ID,
+      },
+      container: mockContainer,
+      commandContext: {
+        container: mockContainer,
+        auth: { sub: 'user-unrestricted', tenantId: TENANT_ID, orgId: null },
+        organizationScope: { selectedId: null, filterIds: null, allowedIds: null, tenantId: TENANT_ID },
+        selectedOrganizationId: null,
+        organizationIds: null,
+        request: undefined,
+      },
+    }
+
+    const res = await GET(new Request('http://localhost/api/customers/activities?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+
+    const legacyCall = mockEm.findAndCount.mock.calls.find(
+      (args) => args[0] === CustomerActivity,
+    )
+    expect(legacyCall).toBeDefined()
+    const where = legacyCall![1] as Record<string, unknown>
+    expect(where.tenantId).toBe(TENANT_ID)
+    expect(where.organizationId).toBeUndefined()
+  })
+
+  it('applies organizationId filter when organizationIds is provided', async () => {
+    mockContext = {
+      auth: {
+        sub: 'user-1',
+        tenantId: TENANT_ID,
+        orgId: ORG_1,
+        isSuperAdmin: false,
+      },
+      em: mockEm,
+      organizationIds: [ORG_1],
+      selectedOrganizationId: ORG_1,
+      scope: {
+        selectedId: ORG_1,
+        filterIds: [ORG_1],
+        allowedIds: [ORG_1],
+        tenantId: TENANT_ID,
+      },
+      container: mockContainer,
+      commandContext: {
+        container: mockContainer,
+        auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: ORG_1 },
+        organizationScope: { selectedId: ORG_1, filterIds: [ORG_1], allowedIds: [ORG_1], tenantId: TENANT_ID },
+        selectedOrganizationId: ORG_1,
+        organizationIds: [ORG_1],
+        request: undefined,
+      },
+    }
+
+    const res = await GET(new Request('http://localhost/api/customers/activities?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+
+    const legacyCall = mockEm.findAndCount.mock.calls.find(
+      (args) => args[0] === CustomerActivity,
+    )
+    expect(legacyCall).toBeDefined()
+    const where = legacyCall![1] as Record<string, unknown>
+    expect(where.organizationId).toEqual({ $in: [ORG_1] })
+  })
+
+  it('returns empty results in unified mode when non-superadmin has organizationIds = null', async () => {
+    const { resolveCustomerInteractionFeatureFlags } = jest.requireMock(
+      '../../../lib/interactionFeatureFlags',
+    )
+    resolveCustomerInteractionFeatureFlags.mockResolvedValue({
+      unified: true,
+      legacyAdapters: true,
+      externalSync: false,
+    })
+
+    mockContext = {
+      auth: {
+        sub: 'user-1',
+        tenantId: TENANT_ID,
+        orgId: null,
+        isSuperAdmin: false,
+      },
+      em: mockEm,
+      organizationIds: null,
+      selectedOrganizationId: null,
+      scope: {
+        selectedId: null,
+        filterIds: null,
+        allowedIds: [ORG_1],
+        tenantId: TENANT_ID,
+      },
+      container: mockContainer,
+      commandContext: {
+        container: mockContainer,
+        auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: null },
+        organizationScope: { selectedId: null, filterIds: null, allowedIds: [ORG_1], tenantId: TENANT_ID },
+        selectedOrganizationId: null,
+        organizationIds: null,
+        request: undefined,
+      },
+    }
+
+    const res = await GET(new Request('http://localhost/api/customers/activities?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([])
+    expect(body.total).toBe(0)
+
+    expect(mockEm.findAndCount).not.toHaveBeenCalled()
+    expect(mockEm.find).not.toHaveBeenCalled()
+    expect(mockEm.count).not.toHaveBeenCalled()
+  })
+
+  it('allows tenant-wide query when superadmin has organizationIds = [] (empty filterIds from stale scope)', async () => {
+    mockContext = {
+      auth: {
+        sub: 'superadmin-1',
+        tenantId: TENANT_ID,
+        orgId: null,
+        isSuperAdmin: true,
+      },
+      em: mockEm,
+      organizationIds: [],
+      selectedOrganizationId: null,
+      scope: {
+        selectedId: null,
+        filterIds: [],
+        allowedIds: null,
+        tenantId: TENANT_ID,
+      },
+      container: mockContainer,
+      commandContext: {
+        container: mockContainer,
+        auth: { sub: 'superadmin-1', tenantId: TENANT_ID, orgId: null, isSuperAdmin: true },
+        organizationScope: { selectedId: null, filterIds: [], allowedIds: null, tenantId: TENANT_ID },
+        selectedOrganizationId: null,
+        organizationIds: [],
+        request: undefined,
+      },
+    }
+
+    const res = await GET(new Request('http://localhost/api/customers/activities?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+
+    const legacyCall = mockEm.findAndCount.mock.calls.find(
+      (args) => args[0] === CustomerActivity,
+    )
+    expect(legacyCall).toBeDefined()
+    const where = legacyCall![1] as Record<string, unknown>
+    expect(where.tenantId).toBe(TENANT_ID)
+    expect(where.organizationId).toBeUndefined()
+  })
+
+  it('returns empty results when scope is absent and organizationIds is null (scope shape omitted)', async () => {
+    mockContext = {
+      auth: {
+        sub: 'user-1',
+        tenantId: TENANT_ID,
+        orgId: null,
+        isSuperAdmin: false,
+      },
+      em: mockEm,
+      organizationIds: null,
+      selectedOrganizationId: null,
+      scope: undefined as unknown as null,
+      container: mockContainer,
+      commandContext: {
+        container: mockContainer,
+        auth: { sub: 'user-1', tenantId: TENANT_ID, orgId: null },
+        organizationScope: undefined as unknown as null,
+        selectedOrganizationId: null,
+        organizationIds: null,
+        request: undefined,
+      },
+    }
+
+    const res = await GET(new Request('http://localhost/api/customers/activities?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([])
+    expect(body.total).toBe(0)
+
+    expect(mockEm.findAndCount).not.toHaveBeenCalled()
+    expect(mockEm.find).not.toHaveBeenCalled()
+    expect(mockEm.count).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/activities/route.ts
+++ b/packages/core/src/modules/customers/api/activities/route.ts
@@ -284,7 +284,22 @@ async function listCanonicalActivities(
   organizationIds: string[] | null,
   query: z.infer<typeof listSchema>,
   options?: { includeDeleted?: boolean; source?: string | string[] | null; paginate?: boolean },
+  isUnrestricted?: boolean,
 ): Promise<CanonicalActivityListResult> {
+  if (organizationIds && organizationIds.length === 0 && !isUnrestricted) {
+    return {
+      items: [],
+      total: 0,
+      bridgeIds: new Set(),
+    }
+  }
+  if (organizationIds === null && !isUnrestricted) {
+    return {
+      items: [],
+      total: 0,
+      bridgeIds: new Set(),
+    }
+  }
   const where: Record<string, unknown> = {
     tenantId,
     interactionType: { $ne: 'task' },
@@ -361,7 +376,14 @@ async function listLegacyActivities(
   query: z.infer<typeof listSchema>,
   options?: { paginate?: boolean },
   selectedOrganizationId?: string | null,
+  isUnrestricted?: boolean,
 ): Promise<{ items: ActivityItem[]; total: number }> {
+  if (organizationIds && organizationIds.length === 0 && !isUnrestricted) {
+    return { items: [], total: 0 }
+  }
+  if (organizationIds === null && !isUnrestricted) {
+    return { items: [], total: 0 }
+  }
   const where: Record<string, unknown> = { tenantId }
   if (organizationIds && organizationIds.length > 0) {
     where.organizationId = { $in: organizationIds }
@@ -410,10 +432,29 @@ export async function GET(request: Request): Promise<Response> {
       organizationIds,
       container,
       selectedOrganizationId,
+      scope,
     } = await resolveCustomersRequestContext(request)
     const flags = await resolveCustomerInteractionFeatureFlags(container, auth.tenantId)
     if (!flags.legacyAdapters) {
       return await legacyAdaptersDisabledResponse()
+    }
+
+    const isUnrestricted = auth.isSuperAdmin === true || scope?.allowedIds === null
+    if (!isUnrestricted && (!organizationIds || organizationIds.length === 0)) {
+      logger.warn('activities.list collapsed organization scope — returning empty page', {
+        tenantId: auth.tenantId,
+        organizationIds,
+        scope,
+      })
+      return withAdapterHeaders(
+        NextResponse.json({
+          items: [],
+          total: 0,
+          page: query.page,
+          pageSize: query.pageSize,
+          totalPages: 1,
+        }),
+      )
     }
 
     const sortDir = query.sortDir ?? 'desc'
@@ -427,6 +468,8 @@ export async function GET(request: Request): Promise<Response> {
           auth.tenantId,
           organizationIds,
           query,
+          undefined,
+          isUnrestricted,
         )
       : await (async () => {
         const windowSize = Math.min(
@@ -442,6 +485,7 @@ export async function GET(request: Request): Promise<Response> {
             windowedQuery,
             { paginate: true },
             selectedOrganizationId,
+            isUnrestricted,
           ),
           listCanonicalActivities(
             em,
@@ -456,6 +500,7 @@ export async function GET(request: Request): Promise<Response> {
               paginate: true,
               source: CUSTOMER_INTERACTION_ACTIVITY_ADAPTER_SOURCE,
             },
+            isUnrestricted,
           ),
         ])
         const merged = sortActivityItems(


### PR DESCRIPTION
Closes #3841

## 🎯 Goal
Enforce proper organization scoping on the deprecated `GET /api/customers/activities` endpoint to prevent cross-organization reads for non-superadmin callers with null or empty organization scope.

## 🔍 Problem
`GET /api/customers/activities` only attached `where.organizationId = { $in: organizationIds }` when `organizationIds && organizationIds.length > 0`. When a non-superadmin principal had `scope.filterIds: null` and `auth.orgId: null` (or `organizationIds: []`), the query dropped the organization filter entirely, resulting in a tenant-wide query that returned customer activities across all organizations in the tenant.

## 🔍 Root Cause
The legacy and canonical activity fetch helpers checked only `if (organizationIds && organizationIds.length > 0)` before applying the organization filter clause. For superadmins / unrestricted users (`auth.isSuperAdmin === true` or `scope.allowedIds === null`), omitting the filter is expected behavior, but for restricted callers with null or empty scope, this resulted in an unintended cross-organization read.

## What Changed
- `packages/core/src/modules/customers/api/activities/route.ts`:
  - Resolved `isUnrestricted = auth.isSuperAdmin === true || scope?.allowedIds === null`.
  - Gated the `GET` handler to return an empty paged result set immediately when `!isUnrestricted && (!organizationIds || organizationIds.length === 0)`.
  - Added fail-closed guards in `listLegacyActivities` and `listCanonicalActivities` returning empty result sets on null or empty scope for non-unrestricted callers.
  - Forwarded `isUnrestricted` to activity listing functions so superadmin / unrestricted all-org querying continues to work as intended.
- `packages/core/src/modules/customers/api/activities/__tests__/org-scoping.test.ts`:
  - Added comprehensive test suite verifying:
    - Non-superadmin with null `organizationIds` returns empty items.
    - Non-superadmin with empty array `organizationIds` returns empty items.
    - Superadmin with null `organizationIds` performs unrestricted tenant-wide query.
    - User with `scope.allowedIds === null` performs unrestricted tenant-wide query.
    - Principal with explicit `organizationIds` applies `{ $in: organizationIds }` filter.
    - Unified mode (`flags.unified = true`) correctly enforces org scoping.

## 🧪 Tests
- `yarn workspace @open-mercato/core test packages/core/src/modules/customers/api/activities/` (4 suites, 18 tests passed)
- `yarn build:packages && yarn generate && yarn typecheck && yarn build:app` (all passed)

## 💥 Breaking Changes
None. Superadmin and unrestricted principals continue to have tenant-wide read access; non-superadmin callers without an active organization scope receive empty results rather than cross-organization data.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789944251&installation_model_id=432243&pr_number=5462&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5462&signature=02b508d9377b8007faa2d6587b796eaed200614f48585d7ca7032280ca204f10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->