### PR TITLE
fix(business_rules): redact rule condition and entity values from debug logs (#3822)

### DIFF
--- a/packages/core/src/modules/business_rules/lib/__tests__/rule-evaluation-logging.test.ts
+++ b/packages/core/src/modules/business_rules/lib/__tests__/rule-evaluation-logging.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, jest, beforeEach } from '@jest/globals'
+
+type CapturedLogCall = { msg: string; fields?: Record<string, unknown> }
+
+const mockDebugCalls: CapturedLogCall[] = []
+
+jest.mock('@open-mercato/shared/lib/logger', () => {
+  const makeLogger = () => ({
+    debug: (msg: string, fields?: Record<string, unknown>) => {
+      mockDebugCalls.push({ msg, fields })
+    },
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    child: () => makeLogger(),
+  })
+  return { createLogger: () => makeLogger(), isLevelEnabled: () => true }
+})
+
+import { evaluateExpression, type SimpleCondition } from '../expression-evaluator'
+import { evaluateSingleRule } from '../rule-evaluator'
+import type { BusinessRule } from '../../data/entities'
+
+const createTestRule = (overrides: Partial<BusinessRule> = {}): BusinessRule =>
+  ({
+    id: 'test-id',
+    ruleId: 'TEST-001',
+    ruleName: 'Test Rule',
+    ruleType: 'GUARD',
+    entityType: 'customers_person',
+    conditionExpression: { field: 'primary_email', operator: '=', value: 'john.doe@example.com' },
+    enabled: true,
+    priority: 100,
+    version: 1,
+    tenantId: 'tenant-123',
+    organizationId: 'org-456',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }) as BusinessRule
+
+const piiData = {
+  primary_email: 'john.doe@example.com',
+  phone_number: '+48600100200',
+  street_address: '1 Secret Street',
+}
+
+const piiCondition: SimpleCondition = {
+  field: 'primary_email',
+  operator: '=',
+  value: 'john.doe@example.com',
+}
+
+const serializedCalls = (): string[] => mockDebugCalls.map((call) => JSON.stringify(call))
+
+describe('rule evaluation logging hygiene', () => {
+  beforeEach(() => {
+    mockDebugCalls.length = 0
+  })
+
+  test('simple condition debug logs carry no raw entity values', () => {
+    const passed = evaluateExpression(piiCondition, piiData, {})
+    expect(passed).toBe(true)
+    expect(mockDebugCalls.length).toBeGreaterThan(0)
+
+    for (const payload of serializedCalls()) {
+      expect(payload).not.toContain('john.doe@example.com')
+      expect(payload).not.toContain('+48600100200')
+      expect(payload).not.toContain('1 Secret Street')
+    }
+
+    const loggedKeys = mockDebugCalls.flatMap((call) => Object.keys(call.fields ?? {}))
+    expect(loggedKeys).not.toContain('actualValue')
+    expect(loggedKeys).not.toContain('expectedValue')
+
+    const conditionLog = mockDebugCalls.find((call) => call.msg === 'Simple condition evaluated')
+    expect(conditionLog).toBeDefined()
+    expect(conditionLog?.fields).toMatchObject({
+      field: 'primary_email',
+      operator: '=',
+      passed: true,
+    })
+  })
+
+  test('single rule evaluation logs do not expose condition expressions or entity values', async () => {
+    const rule = createTestRule({ conditionExpression: piiCondition })
+
+    const result = await evaluateSingleRule(rule, piiData, {})
+    expect(result.conditionsPassed).toBe(true)
+    expect(mockDebugCalls.length).toBeGreaterThan(0)
+
+    for (const payload of serializedCalls()) {
+      expect(payload).not.toContain('john.doe@example.com')
+      expect(payload).not.toContain('+48600100200')
+      expect(payload).not.toContain('1 Secret Street')
+    }
+
+    const loggedKeys = mockDebugCalls.flatMap((call) => Object.keys(call.fields ?? {}))
+    expect(loggedKeys).not.toContain('conditions')
+
+    const evaluatingLog = mockDebugCalls.find((call) => call.msg === 'Evaluating rule')
+    expect(evaluatingLog).toBeDefined()
+    expect(evaluatingLog?.fields).toMatchObject({ ruleId: 'TEST-001', ruleType: 'GUARD' })
+  })
+})

--- a/packages/core/src/modules/business_rules/lib/expression-evaluator.ts
+++ b/packages/core/src/modules/business_rules/lib/expression-evaluator.ts
@@ -1,7 +1,7 @@
 import type { ComparisonOperator, LogicalOperator } from '../data/validators'
 import { testLinearRegex } from '@open-mercato/shared/lib/regex/linear'
 import { getNestedValue, resolveSpecialValue } from './value-resolver'
-import { createLogger } from '@open-mercato/shared/lib/logger'
+import { createLogger, isLevelEnabled } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('business_rules').child({ component: 'expression-evaluator' })
 
@@ -86,14 +86,14 @@ function evaluateSimpleCondition(
 
   const result = applyOperator(leftValue, condition.operator, rightValue)
 
-  logger.debug('Simple condition evaluated', {
-    field: condition.field,
-    operator: condition.operator,
-    expectedValue: rightValue,
-    actualValue: leftValue,
-    actualValueType: typeof leftValue,
-    passed: result,
-  })
+  if (isLevelEnabled('debug')) {
+    logger.debug('Simple condition evaluated', {
+      field: condition.field,
+      operator: condition.operator,
+      actualValueType: typeof leftValue,
+      passed: result,
+    })
+  }
 
   return result
 }

--- a/packages/core/src/modules/business_rules/lib/rule-evaluator.ts
+++ b/packages/core/src/modules/business_rules/lib/rule-evaluator.ts
@@ -1,6 +1,6 @@
 import type { BusinessRule } from '../data/entities'
 import { evaluateExpression, type EvaluationContext, type ConditionExpression } from './expression-evaluator'
-import { createLogger } from '@open-mercato/shared/lib/logger'
+import { createLogger, isLevelEnabled } from '@open-mercato/shared/lib/logger'
 
 const logger = createLogger('business_rules').child({ component: 'rule-evaluator' })
 
@@ -105,14 +105,15 @@ export async function evaluateSingleRule(
 ): Promise<SingleRuleResult> {
   const startTime = Date.now()
 
-  logger.debug('Evaluating rule', {
-    ruleId: rule.ruleId,
-    ruleName: rule.ruleName,
-    ruleType: rule.ruleType,
-    entityType: rule.entityType,
-    eventType: rule.eventType,
-    conditions: rule.conditionExpression,
-  })
+  if (isLevelEnabled('debug')) {
+    logger.debug('Evaluating rule', {
+      ruleId: rule.ruleId,
+      ruleName: rule.ruleName,
+      ruleType: rule.ruleType,
+      entityType: rule.entityType,
+      eventType: rule.eventType,
+    })
+  }
 
   try {
     // Check if rule is enabled


### PR DESCRIPTION
Closes #3822

## Goal

Rule evaluations no longer write raw entity field values or condition expressions to stdout logs.

## Problem and root cause

Every rule evaluation - including the wildcard CRUD subscriber that fires for all domain events -
emitted `actualValue`/`expectedValue` resolved straight from entity data plus the full
`conditionExpression` through `logger.debug`. The structured-logging migration (#4003) gated these
lines by level but kept the payloads; the default level is debug outside production
(`packages/shared/src/lib/logger/__tests__/logger.test.ts:111`), so raw PII (email, phone,
address, amounts) reached stdout/aggregators by default in dev/staging and whenever operators raise
the level. The DB execution-log path redacts via `sanitizeForLogging`; the stdout path did not -
and that sanitizer is key-pattern-based and could not protect primitive values anyway.

## What changed

- business_rules/expression-evaluator: 'Simple condition evaluated' debug log no longer carries
  `actualValue`/`expectedValue`; keeps field/operator/type/passed; construction gated behind
  `isLevelEnabled('debug')`.
- business_rules/rule-evaluator: 'Evaluating rule' no longer carries the condition expression;
  keeps ids/names/types/event.
- New regression suite mocks the shared logger, asserts captured payloads contain none of the
  PII fixture values nor value-bearing keys while structural fields remain (observed failing
  before the fix).

## Validation

- `yarn workspace @open-mercato/core test --testPathPatterns rule-evaluation-logging|expression-evaluator|rule-evaluator|rule-engine|crud-rule-trigger` - 5 suites / 108 tests green (regression suite red-first)
- `yarn typecheck` - 26/26 workspaces green
- `yarn generate` / `yarn build:packages` / `yarn i18n:check-sync` / `yarn i18n:check-usage` / `yarn build:app` - all green
- Full-suite note: two pre-existing Windows-environment failures (queue EPERM rename flake; docs
  template-link assertion) reproduce identically on untouched develop without this diff

## Automated review

- `om-code-review` - approve (direct pass, 1 round)
- Unresolved findings - None blocking (1 nit: optional negative-branch test for the level gate)

## Breaking changes

None. Debug-log payload keys are not a contract surface per BACKWARD_COMPATIBILITY.md; log output
only. No API/wire/schema/event/DI change.

## Labels and delivery

- `review` - verified fix, ready for maintainer review
- `security`, `bug` - closes a PII-to-stdout leak found in a security audit
- `skip-qa` - log-only change: no UI-rendering file touched, DB structure and API surface
  unchanged, automated tests ship in the same change
- `priority-medium` - matches issue triage
- `risk-low` - log-only blast radius; evaluation behavior covered by existing suites

## Manual QA

Automation sufficient: behavior covered by unit suites; nothing user-visible to click.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789950386&installation_model_id=432243&pr_number=5463&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5463&signature=2170d48c49d9017ae8f4a23ee354c0ec3b049eac85a21a552c327d1ccf6eb3ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->