### PR TITLE
security(customer_accounts): reject domain registration for organizations outside the caller's tenant (#3839)

### DIFF
--- a/packages/core/src/modules/customer_accounts/api/admin/domain-mappings.ts
+++ b/packages/core/src/modules/customer_accounts/api/admin/domain-mappings.ts
@@ -14,6 +14,7 @@ import {
 import { registerDomainSchema } from '@open-mercato/core/modules/customer_accounts/data/validators'
 import {
   DomainMappingService,
+  DomainMappingOrgScopeError,
   type ResolveResult,
 } from '@open-mercato/core/modules/customer_accounts/services/domainMappingService'
 import { DomainMapping } from '@open-mercato/core/modules/customer_accounts/data/entities'
@@ -140,6 +141,12 @@ export async function POST(req: Request) {
       return NextResponse.json(
         { ok: false, error: 'This domain is not available. Please choose a different hostname.' },
         { status: 409 },
+      )
+    }
+    if (err instanceof DomainMappingOrgScopeError) {
+      return NextResponse.json(
+        { ok: false, error: 'Organization was not found in the current tenant.' },
+        { status: 400 },
       )
     }
     const message = err instanceof Error ? err.message : 'Failed to register domain'

--- a/packages/core/src/modules/customer_accounts/services/__tests__/domainMappingService.test.ts
+++ b/packages/core/src/modules/customer_accounts/services/__tests__/domainMappingService.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment node */
 import type { EntityManager } from '@mikro-orm/postgresql'
-import { DomainMappingService } from '@open-mercato/core/modules/customer_accounts/services/domainMappingService'
+import { DomainMappingService, DomainMappingOrgScopeError } from '@open-mercato/core/modules/customer_accounts/services/domainMappingService'
 import {
   DomainMapping,
   type DomainStatus,
@@ -43,7 +43,7 @@ type Row = {
   updatedAt: Date | null
 }
 
-type OrgRow = { id: string; slug: string | null }
+type OrgRow = { id: string; slug: string | null; tenantId: string }
 
 let nextId = 1
 function makeId(): string {
@@ -91,7 +91,7 @@ function rowMatches(row: Row, where: WhereClause): boolean {
 }
 
 type FakeEm = jest.Mocked<
-  Pick<EntityManager, 'find' | 'findOne' | 'create' | 'persist' | 'remove' | 'flush'>
+  Pick<EntityManager, 'find' | 'findOne' | 'create' | 'persist' | 'remove' | 'flush' | 'getConnection'>
 > & {
   __store: Map<string, Row>
   __orgs: Map<string, OrgRow>
@@ -104,6 +104,15 @@ function createFakeEm(seed: { domains?: Row[]; orgs?: OrgRow[] } = {}): FakeEm {
   const removed = new Set<string>()
   for (const row of seed.domains ?? []) store.set(row.id, row)
   for (const org of seed.orgs ?? []) orgs.set(org.id, org)
+
+  const getConnection = jest.fn(() => ({
+    execute: async <T>(_: string, params: unknown[]): Promise<T> => {
+      const [organizationId, tenantId] = params as [string, string]
+      const org = orgs.get(organizationId)
+      if (org && org.tenantId === tenantId) return [{ slug: org.slug ?? null }] as T
+      return [] as T
+    },
+  }))
 
   const findOne = jest.fn(async (entity: unknown, where: WhereClause) => {
     if (entity === DomainMapping) {
@@ -187,6 +196,7 @@ function createFakeEm(seed: { domains?: Row[]; orgs?: OrgRow[] } = {}): FakeEm {
     persist,
     remove,
     flush,
+    getConnection,
     __store: store,
     __orgs: orgs,
     __removed: removed,
@@ -225,7 +235,7 @@ beforeEach(() => {
 
 describe('DomainMappingService.register', () => {
   it('creates a pending mapping for a valid hostname (happy path)', async () => {
-    const em = createFakeEm()
+    const em = createFakeEm({ orgs: [{ id: ORG_A, slug: null, tenantId: TENANT_A }] })
     const service = new DomainMappingService(em as unknown as EntityManager)
 
     const result = await service.register({
@@ -244,7 +254,7 @@ describe('DomainMappingService.register', () => {
   })
 
   it('normalizes mixed-case + trailing dot hostnames before persisting', async () => {
-    const em = createFakeEm()
+    const em = createFakeEm({ orgs: [{ id: ORG_A, slug: null, tenantId: TENANT_A }] })
     const service = new DomainMappingService(em as unknown as EntityManager)
 
     const result = await service.register({
@@ -275,7 +285,7 @@ describe('DomainMappingService.register', () => {
       organizationId: ORG_A,
       status: 'active',
     })
-    const em = createFakeEm({ domains: [replacedRow] })
+    const em = createFakeEm({ domains: [replacedRow], orgs: [{ id: ORG_A, slug: null, tenantId: TENANT_A }] })
     const service = new DomainMappingService(em as unknown as EntityManager)
 
     const created = await service.register({
@@ -298,7 +308,7 @@ describe('DomainMappingService.register', () => {
       organizationId: ORG_B,
       status: 'active',
     })
-    const em = createFakeEm({ domains: [replacedRow] })
+    const em = createFakeEm({ domains: [replacedRow], orgs: [{ id: ORG_A, slug: null, tenantId: TENANT_A }] })
     const service = new DomainMappingService(em as unknown as EntityManager)
 
     const created = await service.register({
@@ -311,6 +321,39 @@ describe('DomainMappingService.register', () => {
     // service.findOne is filtered by tenantId in register(), so the foreign
     // record is invisible — replacement pointer must remain null.
     expect((created as unknown as Row).replacesDomain).toBeNull()
+  })
+
+  it('rejects registration when organizationId belongs to another tenant (org-scope regression #3839)', async () => {
+    const foreignOrg = { id: ORG_B, slug: 'foreign' as const, tenantId: TENANT_B }
+    const em = createFakeEm({ orgs: [foreignOrg] })
+    const service = new DomainMappingService(em as unknown as EntityManager)
+
+    await expect(
+      service.register({ hostname: 'shop.example.com', tenantId: TENANT_A, organizationId: ORG_B }),
+    ).rejects.toBeInstanceOf(DomainMappingOrgScopeError)
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.__store.size).toBe(0)
+  })
+
+  it('rejects registration when organizationId does not exist', async () => {
+    const em = createFakeEm({ orgs: [{ id: ORG_A, slug: null, tenantId: TENANT_A }] })
+    const service = new DomainMappingService(em as unknown as EntityManager)
+
+    await expect(
+      service.register({
+        hostname: 'shop.example.com',
+        tenantId: TENANT_A,
+        organizationId: ORG_A2,
+      }),
+    ).rejects.toBeInstanceOf(DomainMappingOrgScopeError)
+    expect(em.persist).not.toHaveBeenCalled()
+    expect(em.__store.size).toBe(0)
+  })
+
+  it('resolves the supplied organization through findOrganizationInTenant (org-scope wiring guard)', async () => {
+    const src = DomainMappingService.prototype.register.toString()
+    expect(src).toContain('findOrganizationInTenant')
+    expect(src).toContain('DomainMappingOrgScopeError')
   })
 })
 

--- a/packages/core/src/modules/customer_accounts/services/domainMappingService.ts
+++ b/packages/core/src/modules/customer_accounts/services/domainMappingService.ts
@@ -9,8 +9,16 @@ import {
 import { Organization } from '@open-mercato/core/modules/directory/data/entities'
 import { emitCustomerAccountsEvent } from '@open-mercato/core/modules/customer_accounts/events'
 import { normalizeHostname, tryNormalizeHostname } from '@open-mercato/core/modules/customer_accounts/lib/hostname'
+import { findOrganizationInTenant } from '@open-mercato/core/modules/customer_accounts/lib/organizationLookup'
 import { platformDomains } from '@open-mercato/core/modules/customer_accounts/lib/platformDomains'
 import { detectProxy, isInKnownProxyRange } from '@open-mercato/core/modules/customer_accounts/lib/proxyRanges'
+
+export class DomainMappingOrgScopeError extends Error {
+  constructor(organizationId: string) {
+    super(`[internal] organizationId ${organizationId} does not belong to the caller's tenant`)
+    this.name = 'DomainMappingOrgScopeError'
+  }
+}
 
 const DOMAIN_ROUTING_TAG = 'domain_routing'
 const RESOLVE_KEY_PREFIX = 'domain_routing:resolve'
@@ -269,6 +277,8 @@ export class DomainMappingService {
 
   async register(input: RegisterInput): Promise<DomainMapping> {
     const hostname = normalizeHostname(input.hostname)
+    const organization = await findOrganizationInTenant(this.em, input.organizationId, input.tenantId)
+    if (!organization) throw new DomainMappingOrgScopeError(input.organizationId)
 
     let replacesDomain: DomainMapping | null = null
     if (input.replacesDomainId) {


### PR DESCRIPTION
Closes #3839

## Goal

Admins can only bind custom domains to organizations they actually own.

## Problem and root cause

`DomainMappingService.register()` stamped the caller's `tenantId` next to a client-supplied `organizationId` without verifying membership, so an admin holding `customer_accounts.domain.manage` could register a hostname bound to another tenant's org id, corrupting the org→domain routing map within their tenant (unvalidated-FK write). The signup path already validated membership via `findOrganizationInTenant`, so this route was inconsistent with the established pattern.

## What changed

- `register()` in `packages/core/src/modules/customer_accounts/services/domainMappingService.ts` now resolves the organization through `findOrganizationInTenant(em, organizationId, tenantId)` before creating anything and throws the new exported `DomainMappingOrgScopeError` on miss.
- The admin POST route (`packages/core/src/modules/customer_accounts/api/admin/domain-mappings.ts`) maps that error to `400`, mirroring signup's rejection shape; 409/500 paths unchanged.
- Regression tests (`services/__tests__/domainMappingService.test.ts`): foreign-tenant and unknown org ids are rejected before any persist/event/cache side effect, in-tenant happy paths unchanged, plus a source guard pinning the lookup wiring inside `register()`.

## Validation

- `yarn generate` — pass, no generated drift
- `yarn build:packages` — pass (26/26 tasks)
- `yarn i18n:check-sync` / `yarn i18n:check-usage` — pass
- `yarn typecheck` — pass (26/26 tasks)
- `yarn build:app` — pass
- Targeted suite `npx jest --config jest.config.cjs domainMappingService` — 48/48 pass; both new regression tests were observed failing before the fix (red run) because `register()` persisted the cross-tenant pair
- Honest limitation: full `yarn test` fails on Windows in the unrelated `@open-mercato/queue` `local.strategy.test.ts` with an EPERM rename/watch flake that reproduces identically on pristine `origin/develop` at the same commit; every other package is green on this branch

## Automated review

- `om-code-review` — approve; one round, zero blocker/major/minor findings
- Review policy — direct author review pass, satisfied
- Unresolved findings — None (two informational nits recorded)

## Breaking changes

None. No route URL, method, response field, schema, or event surface changes; registrations with a non-owned `organizationId` are now rejected by design (the intended behavior change from the issue); legitimate callers supplying an owned org id are unaffected.

## Labels and delivery

- `review` — fix complete and verified, awaiting human review
- `bug` + `security` — unvalidated-FK write closing a tenant-scoping gap found during a security audit
- `skip-qa` — no UI-rendering file touched, database structure unchanged, and the changed behavior is covered by automated regression tests
- `priority-low` — matches the issue's triage; admin-gated with caller-tenant-scoped impact
- `risk-medium` — single-module scoping change with a deliberate behavior change on one endpoint, fully unit-covered

## Manual QA

Automation sufficient: service-level rejection and route error mapping are covered by focused unit tests; no UI surface changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789953002&installation_model_id=432243&pr_number=5464&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5464&signature=2a8140b83fe01c55582952429424725bc14cda314adb3bd4ab734cee3f0d57be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->