### PR TITLE
fix(customers): fail closed on collapsed org scope for todos and tasks (#5466)

### DIFF
--- a/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/__tests__/route.test.ts
@@ -1,5 +1,8 @@
 import { GET } from '../route'
 
+const TENANT_ID = '33333333-3333-3333-3333-333333333333'
+const ORG_ID = '22222222-2222-2222-2222-222222222222'
+
 jest.mock('../../utils', () => ({
   resolveWidgetScope: jest.fn(async () => ({
     container: {
@@ -11,6 +14,7 @@ jest.mock('../../utils', () => ({
     em: {},
     tenantId: '33333333-3333-3333-3333-333333333333',
     organizationIds: ['22222222-2222-2222-2222-222222222222'],
+    isUnrestrictedOrganizationScope: false,
   })),
 }))
 
@@ -162,5 +166,66 @@ describe('customers customer-todos widget route', () => {
     const options = listCanonicalTodoRows.mock.calls[0][5]
     expect(options).toMatchObject({ includeDeleted: true })
     expect(options).not.toHaveProperty('source')
+  })
+
+  it('passes unrestricted widget scope through to tenant-wide helper reads', async () => {
+    const { resolveWidgetScope } = jest.requireMock('../../utils')
+    const { resolveCustomerInteractionFeatureFlags } =
+      jest.requireMock('../../../../../lib/interactionFeatureFlags')
+    const { listLegacyTodoRows, listCanonicalTodoRows } =
+      jest.requireMock('../../../../../lib/todoCompatibility')
+
+    resolveWidgetScope.mockResolvedValueOnce({
+      container: {
+        resolve: jest.fn((name: string) => {
+          if (name === 'queryEngine') return { kind: 'query-engine' }
+          throw new Error(`Unexpected container resolve: ${name}`)
+        }),
+      },
+      em: {},
+      tenantId: TENANT_ID,
+      organizationIds: null,
+      isUnrestrictedOrganizationScope: true,
+    })
+    resolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    listLegacyTodoRows.mockResolvedValue([])
+    listCanonicalTodoRows.mockResolvedValue({ items: [], bridgeIds: new Set<string>() })
+
+    const res = await GET(new Request('http://localhost/api?limit=5'))
+
+    expect(res.status).toBe(200)
+    expect(listLegacyTodoRows).toHaveBeenCalledTimes(1)
+    expect(listLegacyTodoRows.mock.calls[0][3]).toBeNull()
+    expect(listLegacyTodoRows.mock.calls[0][5]).toEqual(
+      expect.objectContaining({ isUnrestricted: true }),
+    )
+    expect(listCanonicalTodoRows).toHaveBeenCalledTimes(1)
+    expect(listCanonicalTodoRows.mock.calls[0][4]).toBeNull()
+    expect(listCanonicalTodoRows.mock.calls[0][5]).toEqual(
+      expect.objectContaining({ isUnrestricted: true }),
+    )
+  })
+
+  it('passes explicit organization scope through as restricted helper reads', async () => {
+    const { resolveCustomerInteractionFeatureFlags } =
+      jest.requireMock('../../../../../lib/interactionFeatureFlags')
+    const { listLegacyTodoRows, listCanonicalTodoRows } =
+      jest.requireMock('../../../../../lib/todoCompatibility')
+
+    resolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    listLegacyTodoRows.mockResolvedValue([])
+    listCanonicalTodoRows.mockResolvedValue({ items: [], bridgeIds: new Set<string>() })
+
+    const res = await GET(new Request('http://localhost/api?limit=5'))
+
+    expect(res.status).toBe(200)
+    expect(listLegacyTodoRows.mock.calls[0][3]).toEqual([ORG_ID])
+    expect(listLegacyTodoRows.mock.calls[0][5]).toEqual(
+      expect.objectContaining({ isUnrestricted: false }),
+    )
+    expect(listCanonicalTodoRows.mock.calls[0][4]).toEqual([ORG_ID])
+    expect(listCanonicalTodoRows.mock.calls[0][5]).toEqual(
+      expect.objectContaining({ isUnrestricted: false }),
+    )
   })
 })

--- a/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
@@ -28,7 +28,10 @@ export const metadata = {
 
 type WidgetContext = WidgetScopeContext & { limit: number }
 
-async function resolveContext(req: Request, translate: (key: string, fallback?: string) => string): Promise<WidgetContext> {
+async function resolveContext(
+  req: Request,
+  translate: (key: string, fallback?: string) => string,
+): Promise<WidgetContext> {
   const url = new URL(req.url)
   const rawQuery: Record<string, string> = {}
   for (const [key, value] of url.searchParams.entries()) {
@@ -39,16 +42,18 @@ async function resolveContext(req: Request, translate: (key: string, fallback?: 
     throw new CrudHttpError(400, { error: translate('customers.errors.invalid_query', 'Invalid query parameters') })
   }
 
-  const { container, em, tenantId, organizationIds } = await resolveWidgetScope(req, translate, {
-    tenantId: parsed.data.tenantId ?? null,
-    organizationId: parsed.data.organizationId ?? null,
-  })
+  const { container, em, tenantId, organizationIds, isUnrestrictedOrganizationScope } =
+    await resolveWidgetScope(req, translate, {
+      tenantId: parsed.data.tenantId ?? null,
+      organizationId: parsed.data.organizationId ?? null,
+    })
 
   return {
     container,
     em,
     tenantId,
     organizationIds,
+    isUnrestrictedOrganizationScope,
     limit: parsed.data.limit,
   }
 }
@@ -56,7 +61,8 @@ async function resolveContext(req: Request, translate: (key: string, fallback?: 
 export async function GET(req: Request) {
   const { translate } = await resolveTranslations()
   try {
-    const { container, em, tenantId, organizationIds, limit } = await resolveContext(req, translate)
+    const { container, em, tenantId, organizationIds, isUnrestrictedOrganizationScope, limit } =
+      await resolveContext(req, translate)
     const auth = {
       tenantId,
       orgId: organizationIds?.[0] ?? null,
@@ -64,7 +70,7 @@ export async function GET(req: Request) {
     }
     const flags = await resolveCustomerInteractionFeatureFlags(container, tenantId)
     const mergedWindow = Math.min(limit * 4, 50)
-    const isUnrestricted = organizationIds === null
+    const isUnrestricted = isUnrestrictedOrganizationScope === true
     const rows = flags.unified
       ? (await listCanonicalTodoRows(
           em,

--- a/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
+++ b/packages/core/src/modules/customers/api/dashboard/widgets/customer-todos/route.ts
@@ -64,6 +64,7 @@ export async function GET(req: Request) {
     }
     const flags = await resolveCustomerInteractionFeatureFlags(container, tenantId)
     const mergedWindow = Math.min(limit * 4, 50)
+    const isUnrestricted = organizationIds === null
     const rows = flags.unified
       ? (await listCanonicalTodoRows(
           em,
@@ -71,7 +72,7 @@ export async function GET(req: Request) {
           auth,
           organizationIds?.[0] ?? null,
           organizationIds ?? null,
-          { pagination: { page: 1, pageSize: limit } },
+          { pagination: { page: 1, pageSize: limit }, isUnrestricted },
         )).items
       : await Promise.all([
           listLegacyTodoRows(
@@ -80,7 +81,7 @@ export async function GET(req: Request) {
             tenantId,
             organizationIds ?? null,
             undefined,
-            { limit: mergedWindow },
+            { limit: mergedWindow, isUnrestricted },
           ),
           listCanonicalTodoRows(
             em,
@@ -91,6 +92,7 @@ export async function GET(req: Request) {
             {
               includeDeleted: true,
               limit: mergedWindow,
+              isUnrestricted,
             },
           ),
         ]).then(([legacyRows, canonicalRows]) =>

--- a/packages/core/src/modules/customers/api/interactions/tasks/__tests__/org-scoping.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/tasks/__tests__/org-scoping.test.ts
@@ -167,6 +167,18 @@ describe('interactions/tasks GET organization scoping', () => {
     expectNoQueries()
   })
 
+  it('returns export-shaped empty page for all=true when restricted has organizationIds = null', async () => {
+    mockContext = buildContext({ organizationIds: null })
+
+    const res = await GET(
+      new Request('http://localhost/api/customers/interactions/tasks?page=3&pageSize=50&all=true'),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ items: [], total: 0, page: 1, pageSize: 0, totalPages: 1 })
+    expectNoQueries()
+  })
+
   it('allows tenant-wide query when superadmin has organizationIds = null', async () => {
     mockContext = buildContext({ organizationIds: null, isSuperAdmin: true, allowedIds: null })
 
@@ -190,6 +202,24 @@ describe('interactions/tasks GET organization scoping', () => {
     expect(res.status).toBe(200)
     expectTenantWideQueries()
   })
+
+  it(
+    'allows tenant-wide query in unified mode when unrestricted non-superadmin has organizationIds = null',
+    async () => {
+      setFlags({ unified: true })
+      mockContext = buildContext({
+        organizationIds: null,
+        isSuperAdmin: false,
+        allowedIds: null,
+      })
+
+      const res = await GET(
+        new Request('http://localhost/api/customers/interactions/tasks?page=1&pageSize=50'),
+      )
+      expect(res.status).toBe(200)
+      expectTenantWideQueries()
+    },
+  )
 
   it('allows tenant-wide query when superadmin has organizationIds = []', async () => {
     mockContext = buildContext({ organizationIds: [], isSuperAdmin: true, allowedIds: null })

--- a/packages/core/src/modules/customers/api/interactions/tasks/__tests__/org-scoping.test.ts
+++ b/packages/core/src/modules/customers/api/interactions/tasks/__tests__/org-scoping.test.ts
@@ -1,0 +1,218 @@
+/** @jest-environment node */
+
+import { GET } from '../route'
+
+const TENANT_ID = '123e4567-e89b-41d3-a456-426614174010'
+const ORG_1 = '123e4567-e89b-41d3-a456-426614174001'
+
+const mockEm = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  findAndCount: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'commandBus') return { execute: jest.fn() }
+    if (name === 'em') return mockEm
+    if (name === 'queryEngine') return { query: jest.fn() }
+    throw new Error(`Unknown dependency: ${name}`)
+  }),
+}
+
+let mockContext: Record<string, unknown> = {}
+
+jest.mock('../../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn(),
+}))
+
+jest.mock('../../../../lib/interactionRequestContext', () => ({
+  resolveCustomersRequestContext: jest.fn(async () => mockContext),
+}))
+
+jest.mock('../../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+  loadCustomerSummaries: jest.fn(async () => new Map()),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+function setFlags(overrides?: { unified?: boolean }) {
+  const { resolveCustomerInteractionFeatureFlags } = jest.requireMock(
+    '../../../../lib/interactionFeatureFlags',
+  )
+  resolveCustomerInteractionFeatureFlags.mockResolvedValue({
+    unified: overrides?.unified ?? false,
+    legacyAdapters: true,
+    externalSync: false,
+  })
+}
+
+function buildContext(input: {
+  organizationIds: string[] | null
+  isSuperAdmin?: boolean
+  allowedIds?: string[] | null
+  omitScope?: boolean
+}) {
+  const isSuperAdmin = input.isSuperAdmin === true
+  const allowedIds = input.omitScope
+    ? undefined
+    : (Object.prototype.hasOwnProperty.call(input, 'allowedIds')
+        ? input.allowedIds
+        : (isSuperAdmin ? null : [ORG_1]))
+  const scope = input.omitScope
+    ? undefined
+    : {
+        selectedId: input.organizationIds?.[0] ?? null,
+        filterIds: input.organizationIds,
+        allowedIds,
+        tenantId: TENANT_ID,
+      }
+  return {
+    auth: {
+      sub: isSuperAdmin ? 'superadmin-1' : 'user-1',
+      tenantId: TENANT_ID,
+      orgId: input.organizationIds?.[0] ?? null,
+      isSuperAdmin,
+    },
+    em: mockEm,
+    organizationIds: input.organizationIds,
+    selectedOrganizationId: input.organizationIds?.[0] ?? null,
+    scope,
+    container: mockContainer,
+    commandContext: {
+      container: mockContainer,
+      auth: {
+        sub: isSuperAdmin ? 'superadmin-1' : 'user-1',
+        tenantId: TENANT_ID,
+        orgId: input.organizationIds?.[0] ?? null,
+        isSuperAdmin,
+      },
+      organizationScope: scope,
+      selectedOrganizationId: input.organizationIds?.[0] ?? null,
+      organizationIds: input.organizationIds,
+      request: undefined,
+    },
+  }
+}
+
+function expectNoQueries() {
+  expect(mockEm.find).not.toHaveBeenCalled()
+  expect(mockEm.findAndCount).not.toHaveBeenCalled()
+  expect(mockEm.count).not.toHaveBeenCalled()
+}
+
+function expectTenantWideQueries() {
+  const calls = [...mockEm.find.mock.calls, ...mockEm.findAndCount.mock.calls]
+  expect(calls.length).toBeGreaterThan(0)
+  for (const call of calls) {
+    const where = call[1] as Record<string, unknown>
+    expect(where.tenantId).toBe(TENANT_ID)
+    expect(where.organizationId).toBeUndefined()
+  }
+}
+
+describe('interactions/tasks GET organization scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setFlags()
+    mockEm.find.mockImplementation(async () => [])
+    mockEm.findAndCount.mockImplementation(async () => [[], 0])
+    mockEm.count.mockImplementation(async () => 0)
+  })
+
+  it.each([
+    { label: 'organizationIds = null', organizationIds: null as string[] | null },
+    { label: 'organizationIds = []', organizationIds: [] as string[] },
+  ])('returns empty and does not query when restricted has $label', async ({ organizationIds }) => {
+    mockContext = buildContext({ organizationIds })
+
+    const res = await GET(
+      new Request('http://localhost/api/customers/interactions/tasks?page=1&pageSize=50'),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ items: [], total: 0, page: 1, pageSize: 50, totalPages: 1 })
+    expectNoQueries()
+  })
+
+  it('returns empty in unified mode when restricted has organizationIds = null', async () => {
+    setFlags({ unified: true })
+    mockContext = buildContext({ organizationIds: null })
+
+    const res = await GET(
+      new Request('http://localhost/api/customers/interactions/tasks?page=1&pageSize=50'),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([])
+    expect(body.total).toBe(0)
+    expectNoQueries()
+  })
+
+  it('returns empty when scope is omitted and organizationIds is null', async () => {
+    mockContext = buildContext({ organizationIds: null, omitScope: true })
+
+    const res = await GET(
+      new Request('http://localhost/api/customers/interactions/tasks?page=1&pageSize=50'),
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([])
+    expectNoQueries()
+  })
+
+  it('allows tenant-wide query when superadmin has organizationIds = null', async () => {
+    mockContext = buildContext({ organizationIds: null, isSuperAdmin: true, allowedIds: null })
+
+    const res = await GET(
+      new Request('http://localhost/api/customers/interactions/tasks?page=1&pageSize=50'),
+    )
+    expect(res.status).toBe(200)
+    expectTenantWideQueries()
+  })
+
+  it('allows tenant-wide query when unrestricted non-superadmin has organizationIds = null', async () => {
+    mockContext = buildContext({
+      organizationIds: null,
+      isSuperAdmin: false,
+      allowedIds: null,
+    })
+
+    const res = await GET(
+      new Request('http://localhost/api/customers/interactions/tasks?page=1&pageSize=50'),
+    )
+    expect(res.status).toBe(200)
+    expectTenantWideQueries()
+  })
+
+  it('allows tenant-wide query when superadmin has organizationIds = []', async () => {
+    mockContext = buildContext({ organizationIds: [], isSuperAdmin: true, allowedIds: null })
+
+    const res = await GET(
+      new Request('http://localhost/api/customers/interactions/tasks?page=1&pageSize=50'),
+    )
+    expect(res.status).toBe(200)
+    expectTenantWideQueries()
+  })
+
+  it('applies organizationId filter when organizationIds is provided', async () => {
+    mockContext = buildContext({ organizationIds: [ORG_1] })
+
+    const res = await GET(
+      new Request('http://localhost/api/customers/interactions/tasks?page=1&pageSize=50'),
+    )
+    expect(res.status).toBe(200)
+
+    const calls = [...mockEm.find.mock.calls, ...mockEm.findAndCount.mock.calls]
+    expect(calls.length).toBeGreaterThan(0)
+    for (const call of calls) {
+      expect((call[1] as Record<string, unknown>).organizationId).toEqual({ $in: [ORG_1] })
+    }
+  })
+})

--- a/packages/core/src/modules/customers/api/interactions/tasks/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/tasks/route.ts
@@ -40,10 +40,26 @@ const MERGED_TASK_FETCH_CAP = 2000
 export async function GET(request: Request): Promise<Response> {
   const { translate } = await resolveTranslations()
   try {
-    const { auth, em, organizationIds, container, selectedOrganizationId } =
+    const { auth, em, organizationIds, container, selectedOrganizationId, scope } =
       await resolveCustomersRequestContext(request)
     const query = querySchema.parse(Object.fromEntries(new URL(request.url).searchParams))
     const flags = await resolveCustomerInteractionFeatureFlags(container, auth.tenantId)
+    const isUnrestricted = auth.isSuperAdmin === true || scope?.allowedIds === null
+    if (!isUnrestricted && (!organizationIds || organizationIds.length === 0)) {
+      logger.warn('customers.interactions.tasks.list collapsed organization scope', {
+        tenantId: auth.tenantId,
+        organizationIds,
+        selectedId: scope?.selectedId ?? null,
+        allowedIdsCount: scope?.allowedIds?.length ?? null,
+      })
+      return NextResponse.json({
+        items: [],
+        total: 0,
+        page: query.page,
+        pageSize: query.pageSize,
+        totalPages: 1,
+      })
+    }
     const exportAll = parseBooleanToken(query.all) === true
     const search = normalizeTodoSearch(query.search)
     const queryEngine = container.resolve('queryEngine') as QueryEngine
@@ -59,6 +75,7 @@ export async function GET(request: Request): Promise<Response> {
           entityId: query.entityId,
           pagination: exportAll ? null : { page: query.page, pageSize: query.pageSize },
           searchText: search,
+          isUnrestricted,
         },
       )
       const total = canonical.total
@@ -80,6 +97,7 @@ export async function GET(request: Request): Promise<Response> {
     const [legacyRows, canonicalRows] = await Promise.all([
       listLegacyTodoRows(em, queryEngine, auth.tenantId, organizationIds, query.entityId, {
         limit: legacyWindow,
+        isUnrestricted,
       }),
       listCanonicalTodoRows(
         em,
@@ -91,6 +109,7 @@ export async function GET(request: Request): Promise<Response> {
           entityId: query.entityId,
           includeDeleted: true,
           limit: legacyWindow,
+          isUnrestricted,
         },
       ),
     ])

--- a/packages/core/src/modules/customers/api/interactions/tasks/route.ts
+++ b/packages/core/src/modules/customers/api/interactions/tasks/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { CrudHttpError, isCrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { isUnrestrictedOrganizationScope } from '@open-mercato/shared/lib/auth/organizationAccess'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { QueryEngine } from '@open-mercato/shared/lib/query/types'
 import { createCustomersCrudOpenApi, createPagedListResponseSchema } from '../../openapi'
@@ -44,7 +45,11 @@ export async function GET(request: Request): Promise<Response> {
       await resolveCustomersRequestContext(request)
     const query = querySchema.parse(Object.fromEntries(new URL(request.url).searchParams))
     const flags = await resolveCustomerInteractionFeatureFlags(container, auth.tenantId)
-    const isUnrestricted = auth.isSuperAdmin === true || scope?.allowedIds === null
+    const exportAll = parseBooleanToken(query.all) === true
+    const isUnrestricted = isUnrestrictedOrganizationScope({
+      isSuperAdmin: auth.isSuperAdmin === true,
+      allowedOrganizationIds: scope?.allowedIds,
+    })
     if (!isUnrestricted && (!organizationIds || organizationIds.length === 0)) {
       logger.warn('customers.interactions.tasks.list collapsed organization scope', {
         tenantId: auth.tenantId,
@@ -55,12 +60,11 @@ export async function GET(request: Request): Promise<Response> {
       return NextResponse.json({
         items: [],
         total: 0,
-        page: query.page,
-        pageSize: query.pageSize,
+        page: exportAll ? 1 : query.page,
+        pageSize: exportAll ? 0 : query.pageSize,
         totalPages: 1,
       })
     }
-    const exportAll = parseBooleanToken(query.all) === true
     const search = normalizeTodoSearch(query.search)
     const queryEngine = container.resolve('queryEngine') as QueryEngine
 

--- a/packages/core/src/modules/customers/api/todos/__tests__/org-scoping.test.ts
+++ b/packages/core/src/modules/customers/api/todos/__tests__/org-scoping.test.ts
@@ -162,6 +162,16 @@ describe('todos GET organization scoping', () => {
     expectNoQueries()
   })
 
+  it('returns export-shaped empty page for all=true when restricted has organizationIds = null', async () => {
+    mockContext = buildContext({ organizationIds: null })
+
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=3&pageSize=50&all=true'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toEqual({ items: [], total: 0, page: 1, pageSize: 0, totalPages: 1 })
+    expectNoQueries()
+  })
+
   it('allows tenant-wide query when superadmin has organizationIds = null', async () => {
     mockContext = buildContext({ organizationIds: null, isSuperAdmin: true, allowedIds: null })
 
@@ -181,6 +191,22 @@ describe('todos GET organization scoping', () => {
     expect(res.status).toBe(200)
     expectTenantWideQueries()
   })
+
+  it(
+    'allows tenant-wide query in unified mode when unrestricted non-superadmin has organizationIds = null',
+    async () => {
+      setFlags({ unified: true })
+      mockContext = buildContext({
+        organizationIds: null,
+        isSuperAdmin: false,
+        allowedIds: null,
+      })
+
+      const res = await GET(new Request('http://localhost/api/customers/todos?page=1&pageSize=50'))
+      expect(res.status).toBe(200)
+      expectTenantWideQueries()
+    },
+  )
 
   it('allows tenant-wide query when superadmin has organizationIds = []', async () => {
     mockContext = buildContext({ organizationIds: [], isSuperAdmin: true, allowedIds: null })

--- a/packages/core/src/modules/customers/api/todos/__tests__/org-scoping.test.ts
+++ b/packages/core/src/modules/customers/api/todos/__tests__/org-scoping.test.ts
@@ -1,0 +1,205 @@
+/** @jest-environment node */
+
+import { GET } from '../route'
+
+const TENANT_ID = '123e4567-e89b-41d3-a456-426614174010'
+const ORG_1 = '123e4567-e89b-41d3-a456-426614174001'
+
+const mockEm = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+  findAndCount: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((name: string) => {
+    if (name === 'commandBus') return { execute: jest.fn() }
+    if (name === 'em') return mockEm
+    if (name === 'queryEngine') return { query: jest.fn() }
+    throw new Error(`Unknown dependency: ${name}`)
+  }),
+}
+
+let mockContext: Record<string, unknown> = {}
+
+jest.mock('../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn(),
+}))
+
+jest.mock('../../../lib/interactionRequestContext', () => ({
+  resolveCustomersRequestContext: jest.fn(async () => mockContext),
+}))
+
+jest.mock('../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+  loadCustomerSummaries: jest.fn(async () => new Map()),
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: jest.fn(async () => ({
+    translate: (_key: string, fallback: string) => fallback,
+  })),
+}))
+
+function setFlags(overrides?: { unified?: boolean; legacyAdapters?: boolean }) {
+  const { resolveCustomerInteractionFeatureFlags } = jest.requireMock(
+    '../../../lib/interactionFeatureFlags',
+  )
+  resolveCustomerInteractionFeatureFlags.mockResolvedValue({
+    unified: overrides?.unified ?? false,
+    legacyAdapters: overrides?.legacyAdapters ?? true,
+    externalSync: false,
+  })
+}
+
+function buildContext(input: {
+  organizationIds: string[] | null
+  isSuperAdmin?: boolean
+  allowedIds?: string[] | null
+  omitScope?: boolean
+}) {
+  const isSuperAdmin = input.isSuperAdmin === true
+  const allowedIds = input.omitScope
+    ? undefined
+    : (Object.prototype.hasOwnProperty.call(input, 'allowedIds')
+        ? input.allowedIds
+        : (isSuperAdmin ? null : [ORG_1]))
+  const scope = input.omitScope
+    ? undefined
+    : {
+        selectedId: input.organizationIds?.[0] ?? null,
+        filterIds: input.organizationIds,
+        allowedIds,
+        tenantId: TENANT_ID,
+      }
+  return {
+    auth: {
+      sub: isSuperAdmin ? 'superadmin-1' : 'user-1',
+      tenantId: TENANT_ID,
+      orgId: input.organizationIds?.[0] ?? null,
+      isSuperAdmin,
+    },
+    em: mockEm,
+    organizationIds: input.organizationIds,
+    selectedOrganizationId: input.organizationIds?.[0] ?? null,
+    scope,
+    container: mockContainer,
+    commandContext: {
+      container: mockContainer,
+      auth: {
+        sub: isSuperAdmin ? 'superadmin-1' : 'user-1',
+        tenantId: TENANT_ID,
+        orgId: input.organizationIds?.[0] ?? null,
+        isSuperAdmin,
+      },
+      organizationScope: scope,
+      selectedOrganizationId: input.organizationIds?.[0] ?? null,
+      organizationIds: input.organizationIds,
+      request: undefined,
+    },
+  }
+}
+
+function expectNoQueries() {
+  expect(mockEm.find).not.toHaveBeenCalled()
+  expect(mockEm.findAndCount).not.toHaveBeenCalled()
+  expect(mockEm.count).not.toHaveBeenCalled()
+}
+
+function expectTenantWideQueries() {
+  const calls = [...mockEm.find.mock.calls, ...mockEm.findAndCount.mock.calls]
+  expect(calls.length).toBeGreaterThan(0)
+  for (const call of calls) {
+    const where = call[1] as Record<string, unknown>
+    expect(where.tenantId).toBe(TENANT_ID)
+    expect(where.organizationId).toBeUndefined()
+  }
+}
+
+describe('todos GET organization scoping', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    setFlags()
+    mockEm.find.mockImplementation(async () => [])
+    mockEm.findAndCount.mockImplementation(async () => [[], 0])
+    mockEm.count.mockImplementation(async () => 0)
+  })
+
+  it.each([
+    { label: 'organizationIds = null', organizationIds: null as string[] | null },
+    { label: 'organizationIds = []', organizationIds: [] as string[] },
+  ])('returns empty and does not query when restricted has $label', async ({ organizationIds }) => {
+    mockContext = buildContext({ organizationIds })
+
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    expect(res.headers.get('Deprecation')).toBe('true')
+    const body = await res.json()
+    expect(body).toEqual({ items: [], total: 0, page: 1, pageSize: 50, totalPages: 1 })
+    expectNoQueries()
+  })
+
+  it('returns empty in unified mode when restricted has organizationIds = null', async () => {
+    setFlags({ unified: true })
+    mockContext = buildContext({ organizationIds: null })
+
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([])
+    expect(body.total).toBe(0)
+    expectNoQueries()
+  })
+
+  it('returns empty when scope is omitted and organizationIds is null', async () => {
+    mockContext = buildContext({ organizationIds: null, omitScope: true })
+
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.items).toEqual([])
+    expectNoQueries()
+  })
+
+  it('allows tenant-wide query when superadmin has organizationIds = null', async () => {
+    mockContext = buildContext({ organizationIds: null, isSuperAdmin: true, allowedIds: null })
+
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    expectTenantWideQueries()
+  })
+
+  it('allows tenant-wide query when unrestricted non-superadmin has organizationIds = null', async () => {
+    mockContext = buildContext({
+      organizationIds: null,
+      isSuperAdmin: false,
+      allowedIds: null,
+    })
+
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    expectTenantWideQueries()
+  })
+
+  it('allows tenant-wide query when superadmin has organizationIds = []', async () => {
+    mockContext = buildContext({ organizationIds: [], isSuperAdmin: true, allowedIds: null })
+
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+    expectTenantWideQueries()
+  })
+
+  it('applies organizationId filter when organizationIds is provided', async () => {
+    mockContext = buildContext({ organizationIds: [ORG_1] })
+
+    const res = await GET(new Request('http://localhost/api/customers/todos?page=1&pageSize=50'))
+    expect(res.status).toBe(200)
+
+    const calls = [...mockEm.find.mock.calls, ...mockEm.findAndCount.mock.calls]
+    expect(calls.length).toBeGreaterThan(0)
+    for (const call of calls) {
+      expect((call[1] as Record<string, unknown>).organizationId).toEqual({ $in: [ORG_1] })
+    }
+  })
+})

--- a/packages/core/src/modules/customers/api/todos/route.ts
+++ b/packages/core/src/modules/customers/api/todos/route.ts
@@ -9,6 +9,7 @@ import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import type { CommandBus } from '@open-mercato/shared/lib/commands'
 import { isCrudHttpError, notFound } from '@open-mercato/shared/lib/crud/errors'
 import { parseBooleanToken } from '@open-mercato/shared/lib/boolean'
+import { isUnrestrictedOrganizationScope } from '@open-mercato/shared/lib/auth/organizationAccess'
 import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import {
   runCrudMutationGuardAfterSuccess,
@@ -240,7 +241,11 @@ export async function GET(request: Request): Promise<Response> {
     if (!flags.legacyAdapters) {
       return await legacyAdaptersDisabledResponse()
     }
-    const isUnrestricted = auth.isSuperAdmin === true || scope?.allowedIds === null
+    const exportAll = parseBooleanToken(query.all) === true
+    const isUnrestricted = isUnrestrictedOrganizationScope({
+      isSuperAdmin: auth.isSuperAdmin === true,
+      allowedOrganizationIds: scope?.allowedIds,
+    })
     if (!isUnrestricted && (!organizationIds || organizationIds.length === 0)) {
       logger.warn('customers.todos.list collapsed organization scope', {
         tenantId: auth.tenantId,
@@ -252,14 +257,13 @@ export async function GET(request: Request): Promise<Response> {
         NextResponse.json({
           items: [],
           total: 0,
-          page: query.page,
-          pageSize: query.pageSize,
+          page: exportAll ? 1 : query.page,
+          pageSize: exportAll ? 0 : query.pageSize,
           totalPages: 1,
         }),
       )
     }
     const queryEngine = container.resolve('queryEngine') as QueryEngine
-    const exportAll = parseBooleanToken(query.all) === true
     const search = normalizeTodoSearch(query.search)
 
     if (flags.unified) {

--- a/packages/core/src/modules/customers/api/todos/route.ts
+++ b/packages/core/src/modules/customers/api/todos/route.ts
@@ -233,12 +233,30 @@ async function resolveCanonicalTodoTargetId(
 
 export async function GET(request: Request): Promise<Response> {
   try {
-    const { auth, em, organizationIds, container, selectedOrganizationId } =
+    const { auth, em, organizationIds, container, selectedOrganizationId, scope } =
       await resolveCustomersRequestContext(request)
     const query = querySchema.parse(Object.fromEntries(new URL(request.url).searchParams))
     const flags = await resolveCustomerInteractionFeatureFlags(container, auth.tenantId)
     if (!flags.legacyAdapters) {
       return await legacyAdaptersDisabledResponse()
+    }
+    const isUnrestricted = auth.isSuperAdmin === true || scope?.allowedIds === null
+    if (!isUnrestricted && (!organizationIds || organizationIds.length === 0)) {
+      logger.warn('customers.todos.list collapsed organization scope', {
+        tenantId: auth.tenantId,
+        organizationIds,
+        selectedId: scope?.selectedId ?? null,
+        allowedIdsCount: scope?.allowedIds?.length ?? null,
+      })
+      return withAdapterHeaders(
+        NextResponse.json({
+          items: [],
+          total: 0,
+          page: query.page,
+          pageSize: query.pageSize,
+          totalPages: 1,
+        }),
+      )
     }
     const queryEngine = container.resolve('queryEngine') as QueryEngine
     const exportAll = parseBooleanToken(query.all) === true
@@ -255,6 +273,7 @@ export async function GET(request: Request): Promise<Response> {
           entityId: query.entityId,
           pagination: exportAll ? null : { page: query.page, pageSize: query.pageSize },
           searchText: search,
+          isUnrestricted,
         },
       )
       const total = canonical.total
@@ -275,6 +294,7 @@ export async function GET(request: Request): Promise<Response> {
     const [legacyRows, canonicalRows] = await Promise.all([
       listLegacyTodoRows(em, queryEngine, auth.tenantId, organizationIds, query.entityId, {
         limit: legacyWindow,
+        isUnrestricted,
       }),
       listCanonicalTodoRows(
         em,
@@ -287,6 +307,7 @@ export async function GET(request: Request): Promise<Response> {
           includeDeleted: true,
           source: CUSTOMER_INTERACTION_TODO_ADAPTER_SOURCE,
           limit: legacyWindow,
+          isUnrestricted,
         },
       ),
     ])

--- a/packages/core/src/modules/customers/lib/__tests__/todoCompatibility.org-scoping.test.ts
+++ b/packages/core/src/modules/customers/lib/__tests__/todoCompatibility.org-scoping.test.ts
@@ -1,0 +1,145 @@
+/** @jest-environment node */
+
+import { CustomerInteraction, CustomerTodoLink } from '../../data/entities'
+import { listCanonicalTodoRows, listLegacyTodoRows } from '../todoCompatibility'
+
+jest.mock('../interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+  loadCustomerSummaries: jest.fn(async () => new Map()),
+}))
+
+const TENANT = '00000000-0000-0000-0000-000000000001'
+const ORG = '00000000-0000-0000-0000-000000000002'
+
+function createEm() {
+  return {
+    find: jest.fn(async () => []),
+    findAndCount: jest.fn(async () => [[], 0]),
+    count: jest.fn(async () => 0),
+  }
+}
+
+describe('todoCompatibility organization scoping', () => {
+  it.each([null, [] as string[]])(
+    'listLegacyTodoRows returns empty and does not query when restricted has organizationIds=%p',
+    async (organizationIds) => {
+      const em = createEm()
+      const queryEngine = { query: jest.fn() } as any
+
+      const rows = await listLegacyTodoRows(em as any, queryEngine, TENANT, organizationIds, undefined, {
+        isUnrestricted: false,
+      })
+
+      expect(rows).toEqual([])
+      expect(em.find).not.toHaveBeenCalled()
+      expect(queryEngine.query).not.toHaveBeenCalled()
+    },
+  )
+
+  it('listLegacyTodoRows fails closed when isUnrestricted is omitted and organizationIds is null', async () => {
+    const em = createEm()
+    const queryEngine = { query: jest.fn() } as any
+
+    const rows = await listLegacyTodoRows(em as any, queryEngine, TENANT, null, undefined)
+
+    expect(rows).toEqual([])
+    expect(em.find).not.toHaveBeenCalled()
+  })
+
+  it.each([null, [] as string[]])(
+    'listLegacyTodoRows queries tenant-wide when unrestricted has organizationIds=%p',
+    async (organizationIds) => {
+      const em = createEm()
+      const queryEngine = { query: jest.fn() } as any
+
+      await listLegacyTodoRows(em as any, queryEngine, TENANT, organizationIds, undefined, {
+        isUnrestricted: true,
+      })
+
+      expect(em.find).toHaveBeenCalledTimes(1)
+      expect(em.find.mock.calls[0][0]).toBe(CustomerTodoLink)
+      expect(em.find.mock.calls[0][1]).toEqual({ tenantId: TENANT })
+    },
+  )
+
+  it('listLegacyTodoRows applies $in when organizationIds is provided', async () => {
+    const em = createEm()
+    const queryEngine = { query: jest.fn() } as any
+
+    await listLegacyTodoRows(em as any, queryEngine, TENANT, [ORG], undefined, {
+      isUnrestricted: false,
+    })
+
+    expect(em.find.mock.calls[0][1]).toEqual({
+      tenantId: TENANT,
+      organizationId: { $in: [ORG] },
+    })
+  })
+
+  it.each([null, [] as string[]])(
+    'listCanonicalTodoRows returns empty and does not query when restricted has organizationIds=%p',
+    async (organizationIds) => {
+      const em = createEm()
+      const container = { resolve: jest.fn() }
+
+      const result = await listCanonicalTodoRows(
+        em as any,
+        container,
+        { tenantId: TENANT, orgId: null },
+        null,
+        organizationIds,
+        { isUnrestricted: false },
+      )
+
+      expect(result).toEqual({ items: [], bridgeIds: new Set(), total: 0 })
+      expect(em.find).not.toHaveBeenCalled()
+      expect(em.findAndCount).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([null, [] as string[]])(
+    'listCanonicalTodoRows queries tenant-wide when unrestricted has organizationIds=%p',
+    async (organizationIds) => {
+      const em = createEm()
+      const container = { resolve: jest.fn() }
+
+      await listCanonicalTodoRows(
+        em as any,
+        container,
+        { tenantId: TENANT, orgId: null },
+        null,
+        organizationIds,
+        { isUnrestricted: true },
+      )
+
+      expect(em.find).toHaveBeenCalledTimes(1)
+      expect(em.find.mock.calls[0][0]).toBe(CustomerInteraction)
+      expect(em.find.mock.calls[0][1]).toEqual({
+        tenantId: TENANT,
+        interactionType: 'task',
+        deletedAt: null,
+      })
+    },
+  )
+
+  it('listCanonicalTodoRows applies $in when organizationIds is provided', async () => {
+    const em = createEm()
+    const container = { resolve: jest.fn() }
+
+    await listCanonicalTodoRows(
+      em as any,
+      container,
+      { tenantId: TENANT, orgId: ORG },
+      ORG,
+      [ORG],
+      { isUnrestricted: false },
+    )
+
+    expect(em.find.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        tenantId: TENANT,
+        organizationId: { $in: [ORG] },
+      }),
+    )
+  })
+})

--- a/packages/core/src/modules/customers/lib/todoCompatibility.ts
+++ b/packages/core/src/modules/customers/lib/todoCompatibility.ts
@@ -78,6 +78,17 @@ export type CanonicalTodoListResult = {
   total: number
 }
 
+function emptyCanonicalTodoList(): CanonicalTodoListResult {
+  return { items: [], bridgeIds: new Set(), total: 0 }
+}
+
+function isCollapsedRestrictedOrganizationScope(
+  organizationIds: string[] | null | undefined,
+  isUnrestricted: boolean | undefined,
+): boolean {
+  return isUnrestricted !== true && (!organizationIds || organizationIds.length === 0)
+}
+
 export type ListTodosPagination = { page: number; pageSize: number }
 
 function resolveLegacyTodoSource(source: string | null | undefined): string {
@@ -377,8 +388,11 @@ export async function listLegacyTodoRows(
   tenantId: string,
   organizationIds: string[] | null,
   entityId: string | undefined,
-  options?: { limit?: number | null },
+  options?: { limit?: number | null; isUnrestricted?: boolean },
 ): Promise<CustomerTodoRow[]> {
+  if (isCollapsedRestrictedOrganizationScope(organizationIds, options?.isUnrestricted)) {
+    return []
+  }
   const where: Record<string, unknown> = { tenantId }
   if (organizationIds && organizationIds.length > 0) {
     where.organizationId = { $in: organizationIds }
@@ -425,8 +439,12 @@ export async function listCanonicalTodoRows(
     pagination?: ListTodosPagination | null
     searchText?: string | null
     limit?: number | null
+    isUnrestricted?: boolean
   },
 ): Promise<CanonicalTodoListResult> {
+  if (isCollapsedRestrictedOrganizationScope(organizationIds, options?.isUnrestricted)) {
+    return emptyCanonicalTodoList()
+  }
   const where: Record<string, unknown> = {
     tenantId: auth.tenantId,
     interactionType: 'task',

--- a/packages/core/src/modules/dashboards/lib/widgetScope.ts
+++ b/packages/core/src/modules/dashboards/lib/widgetScope.ts
@@ -1,6 +1,7 @@
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { createRequestContainer, type AppContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import { isUnrestrictedOrganizationScope } from '@open-mercato/shared/lib/auth/organizationAccess'
 import { CrudHttpError } from '@open-mercato/shared/lib/crud/errors'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
 
@@ -9,6 +10,7 @@ export type WidgetScopeContext = {
   em: EntityManager
   tenantId: string
   organizationIds: string[] | null
+  isUnrestrictedOrganizationScope?: boolean
 }
 
 function normalizeScopeId(value: string | null | undefined): string | null {
@@ -91,5 +93,9 @@ export async function resolveWidgetScope(
     em,
     tenantId,
     organizationIds,
+    isUnrestrictedOrganizationScope: isUnrestrictedOrganizationScope({
+      isSuperAdmin,
+      allowedOrganizationIds: scope?.allowedIds,
+    }),
   }
 }

--- a/packages/shared/src/lib/auth/__tests__/organizationAccess.test.ts
+++ b/packages/shared/src/lib/auth/__tests__/organizationAccess.test.ts
@@ -1,4 +1,39 @@
-import { isOrganizationAccessAllowed } from '@open-mercato/shared/lib/auth/organizationAccess'
+import {
+  isOrganizationAccessAllowed,
+  isUnrestrictedOrganizationScope,
+} from '@open-mercato/shared/lib/auth/organizationAccess'
+
+describe('isUnrestrictedOrganizationScope', () => {
+  it('allows super admins regardless of allowed organizations', () => {
+    expect(
+      isUnrestrictedOrganizationScope({
+        isSuperAdmin: true,
+        allowedOrganizationIds: [],
+      }),
+    ).toBe(true)
+  })
+
+  it('allows truly unrestricted non-superadmin scopes', () => {
+    expect(
+      isUnrestrictedOrganizationScope({
+        isSuperAdmin: false,
+        allowedOrganizationIds: null,
+      }),
+    ).toBe(true)
+  })
+
+  it.each([undefined, [] as string[], ['org-a']])(
+    'denies restricted non-superadmin scopes with allowedOrganizationIds=%p',
+    (allowedOrganizationIds) => {
+      expect(
+        isUnrestrictedOrganizationScope({
+          isSuperAdmin: false,
+          allowedOrganizationIds,
+        }),
+      ).toBe(false)
+    },
+  )
+})
 
 describe('isOrganizationAccessAllowed', () => {
   it('allows super admins regardless of scope', () => {

--- a/packages/shared/src/lib/auth/organizationAccess.ts
+++ b/packages/shared/src/lib/auth/organizationAccess.ts
@@ -4,6 +4,15 @@ export type OrganizationAccessDecisionInput = {
   targetOrganizationId: string | null
 }
 
+export type UnrestrictedOrganizationScopeInput = {
+  isSuperAdmin: boolean
+  allowedOrganizationIds: readonly string[] | null | undefined
+}
+
+export function isUnrestrictedOrganizationScope(input: UnrestrictedOrganizationScopeInput): boolean {
+  return input.isSuperAdmin || input.allowedOrganizationIds === null
+}
+
 /**
  * Fail-closed organization-access predicate. The single source of truth for
  * "may this principal act on `targetOrganizationId`".
@@ -15,8 +24,7 @@ export type OrganizationAccessDecisionInput = {
  * - restricted + target org            -> allow iff the target is a member of the allowed set
  */
 export function isOrganizationAccessAllowed(input: OrganizationAccessDecisionInput): boolean {
-  if (input.isSuperAdmin) return true
-  if (input.allowedOrganizationIds === null) return true
+  if (isUnrestrictedOrganizationScope(input)) return true
   if (!input.targetOrganizationId) return false
-  return input.allowedOrganizationIds.includes(input.targetOrganizationId)
+  return (input.allowedOrganizationIds ?? []).includes(input.targetOrganizationId)
 }


### PR DESCRIPTION
## Summary

- Closes #5466. Follow-up to #5462 / #3841: the same `organizationIds && organizationIds.length > 0` fail-open guard was still live on customer todos/tasks.
- Restricted principals whose resolved scope collapses to `organizationIds: null` or `[]` no longer receive a tenant-wide read of `CustomerTodoLink` / task-type `CustomerInteraction` rows. Superadmin and unrestricted (`scope.allowedIds === null`) callers keep tenant-wide access, including the stale-scope `[]` case from #5462's M1.
- Gate sits on both request-scoped list routes before any query:
  - `GET /api/customers/interactions/tasks` (canonical, non-deprecated)
  - `GET /api/customers/todos` (legacy adapter; deprecation headers preserved on the empty page)
- The exported list helpers take the same `isUnrestricted` policy as defense in depth. The dashboard widget is unchanged in behavior (`resolveWidgetScope` already handles this) but now passes the flag so the helper guard cannot empty an unrestricted widget read.

## Test plan

- [x] Helper tests: restricted `null`/`[]` and omitted `isUnrestricted` do not query; unrestricted `null`/`[]` stay tenant-wide; explicit ids apply `{ $in: [...] }`
- [x] Route tests on both GET handlers: restricted `null`/`[]`/omitted `scope`/unified mode return an empty page with `em.find`/`findAndCount`/`count` never called; superadmin `null` and `[]`, unrestricted non-superadmin, and explicit ids pin the `where` clause
- [x] Existing todos route, tasks route, pagination, widget, and scope-forgery suites still pass
- [ ] Maintainer: intended labels `review`, `bug`, `security`, `skip-qa`, `priority-medium`, `risk-medium` (fork account cannot write labels on upstream)

`skip-qa` matches the automated-verification exemption: no `.tsx` / `packages/ui/` changes, database and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract broken, and the changed behavior is covered by tests in this PR.

## Breaking Changes

| Surface | Status |
|---------|--------|
| API route paths and methods | Unchanged |
| Query schema and response envelope | Unchanged (empty page is the existing zero-result shape) |
| OpenAPI | Unchanged |
| Database schema | Untouched |
| Exported helpers | Additive optional `options.isUnrestricted`. Restricted callers that previously passed `null`/`[]` without the flag now get an empty list instead of a tenant-wide read — the intended security fix |

No other protected surface from `BACKWARD_COMPATIBILITY.md` is affected.


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789978670&installation_model_id=432243&pr_number=5469&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5469&signature=6fa2804bfc613880d4904f46cb90bfc267e245774ad9cca4976d74bc5caa4146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->