### PR TITLE
fix(ci): fix the documents failures the standalone lane can now reach

### DIFF
--- a/.github/workflows/npm-snapshot-preview.yml
+++ b/.github/workflows/npm-snapshot-preview.yml
@@ -314,10 +314,16 @@ jobs:
           DATABASE_URL=postgres://mercato:secret@localhost:5432/mercato_test
           APP_URL=http://localhost:3001
           NEXT_PUBLIC_APP_URL=http://localhost:3001
-          # `yarn start` serves a production build, so NODE_ENV is production in
-          # the server process regardless of the NODE_ENV=test line below, and
-          # customer-portal email links refuse to fall back to localhost there.
-          # Without this every portal invite 502s (TC-AUTH-032/033, TC-CACC-INVITE-PERSON-001).
+          # Customer-portal email links refuse to fall back to a localhost origin,
+          # so every portal invite 502s without this (TC-AUTH-032/033,
+          # TC-CACC-INVITE-PERSON-001).
+          # NOTE: this lane's server process really does run with NODE_ENV=test —
+          # the .env value below wins, unlike the ephemeral harness which pins
+          # NODE_ENV=production for both the app and the Playwright process. That
+          # divergence is observable: the login route marks its auth_token cookie
+          # `secure` only under NODE_ENV=production, so here the cookie is stored by
+          # the Playwright request jar and replayed on later calls. Specs must not
+          # depend on that jar being empty — see withCredentialIsolatedRequest.
           PLATFORM_PORTAL_BASE_URL=http://localhost:3001
           AUTH_SECRET=ci-standalone-test-auth-secret
           JWT_SECRET=ci-standalone-test-jwt-secret-32-chars-min
@@ -333,6 +339,15 @@ jobs:
           # app from its own .env instead, so without the mirror TC-PUSH-003 can
           # never resolve an adapter and every delivery lands in `failed`.
           OM_ENABLE_PUSH_STUB_ADAPTER=1
+          # Documents collaboration. The ephemeral lane configures it at the ci.yml
+          # workflow level; this lane configured none of it, so the collab-token route
+          # took its graceful "not ready" branch and returned an EMPTY token
+          # (TC-DOCUMENTS-009), and the editor never left single-user mode so the
+          # read-only banner never rendered (TC-DOCUMENTS-013).
+          # NEXT_PUBLIC_* is inlined at build time, so it MUST be written here, before
+          # the `Build standalone app` step, not only on the test-run env.
+          NEXT_PUBLIC_DOCUMENTS_COLLAB_URL=ws://127.0.0.1:4101
+          DOCUMENTS_COLLAB_JWT_SECRET_V2=ci-standalone-documents-collab-v2-secret-32b
           OM_DISABLE_EMAIL_DELIVERY=1
           OM_WEBHOOKS_ALLOW_PRIVATE_URLS=1
           ENABLE_CRUD_API_CACHE=true
@@ -444,6 +459,12 @@ jobs:
           # the ephemeral harness sets it on both the Playwright process and the
           # app server (TC-PUSH-003).
           OM_ENABLE_PUSH_STUB_ADAPTER: '1'
+          # The Playwright process starts the collaboration sidecar itself
+          # (ensureManagedCollabSidecar reads NEXT_PUBLIC_DOCUMENTS_COLLAB_URL) and the
+          # sidecar verifies the tokens the app mints, so both halves need the same
+          # secret. Mirrors the app .env written above.
+          NEXT_PUBLIC_DOCUMENTS_COLLAB_URL: 'ws://127.0.0.1:4101'
+          DOCUMENTS_COLLAB_JWT_SECRET_V2: 'ci-standalone-documents-collab-v2-secret-32b'
         run: yarn test:integration
 
       - name: Print standalone app log on test failure

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -234,10 +234,16 @@ jobs:
           DATABASE_URL=postgres://mercato:secret@localhost:5432/mercato_test
           APP_URL=http://localhost:3001
           NEXT_PUBLIC_APP_URL=http://localhost:3001
-          # `yarn start` serves a production build, so NODE_ENV is production in
-          # the server process regardless of the NODE_ENV=test line below, and
-          # customer-portal email links refuse to fall back to localhost there.
-          # Without this every portal invite 502s (TC-AUTH-032/033, TC-CACC-INVITE-PERSON-001).
+          # Customer-portal email links refuse to fall back to a localhost origin,
+          # so every portal invite 502s without this (TC-AUTH-032/033,
+          # TC-CACC-INVITE-PERSON-001).
+          # NOTE: this lane's server process really does run with NODE_ENV=test —
+          # the .env value below wins, unlike the ephemeral harness which pins
+          # NODE_ENV=production for both the app and the Playwright process. That
+          # divergence is observable: the login route marks its auth_token cookie
+          # `secure` only under NODE_ENV=production, so here the cookie is stored by
+          # the Playwright request jar and replayed on later calls. Specs must not
+          # depend on that jar being empty — see withCredentialIsolatedRequest.
           PLATFORM_PORTAL_BASE_URL=http://localhost:3001
           AUTH_SECRET=ci-standalone-test-auth-secret
           JWT_SECRET=ci-standalone-test-jwt-secret-32-chars-min
@@ -253,6 +259,15 @@ jobs:
           # app from its own .env instead, so without the mirror TC-PUSH-003 can
           # never resolve an adapter and every delivery lands in `failed`.
           OM_ENABLE_PUSH_STUB_ADAPTER=1
+          # Documents collaboration. The ephemeral lane configures it at the ci.yml
+          # workflow level; this lane configured none of it, so the collab-token route
+          # took its graceful "not ready" branch and returned an EMPTY token
+          # (TC-DOCUMENTS-009), and the editor never left single-user mode so the
+          # read-only banner never rendered (TC-DOCUMENTS-013).
+          # NEXT_PUBLIC_* is inlined at build time, so it MUST be written here, before
+          # the `Build standalone app` step, not only on the test-run env.
+          NEXT_PUBLIC_DOCUMENTS_COLLAB_URL=ws://127.0.0.1:4101
+          DOCUMENTS_COLLAB_JWT_SECRET_V2=ci-standalone-documents-collab-v2-secret-32b
           OM_DISABLE_EMAIL_DELIVERY=1
           OM_WEBHOOKS_ALLOW_PRIVATE_URLS=1
           ENABLE_CRUD_API_CACHE=true
@@ -385,6 +400,12 @@ jobs:
           # enabled here too, exactly as the ephemeral harness sets it on both the
           # Playwright process and the app server (TC-PUSH-003).
           OM_ENABLE_PUSH_STUB_ADAPTER: '1'
+          # The Playwright process starts the collaboration sidecar itself
+          # (ensureManagedCollabSidecar reads NEXT_PUBLIC_DOCUMENTS_COLLAB_URL) and the
+          # sidecar verifies the tokens the app mints, so both halves need the same
+          # secret. Mirrors the app .env written above.
+          NEXT_PUBLIC_DOCUMENTS_COLLAB_URL: 'ws://127.0.0.1:4101'
+          DOCUMENTS_COLLAB_JWT_SECRET_V2: 'ci-standalone-documents-collab-v2-secret-32b'
         run: yarn test:integration
 
       - name: Print standalone app log on test failure

--- a/packages/core/src/helpers/integration/api.ts
+++ b/packages/core/src/helpers/integration/api.ts
@@ -1,4 +1,4 @@
-import { type APIRequestContext } from '@playwright/test';
+import { request as playwrightRequest, type APIRequestContext } from '@playwright/test';
 import { DEFAULT_CREDENTIALS, type Role } from './auth';
 
 const BASE_URL = process.env.BASE_URL?.trim() || null;
@@ -140,4 +140,32 @@ export async function postForm(
     },
     data: form.toString(),
   });
+}
+
+/**
+ * Runs `use` against a request context that shares no cookies with the caller's.
+ *
+ * The `request` fixture keeps a cookie jar, and `/api/auth/login` sets `auth_token`
+ * on it. Every later call through that fixture therefore carries the LAST logged-in
+ * user's session, even one that deliberately sends no Authorization header or an
+ * `ApiKey` one. Whether that cookie is stored at all depends on the deployment:
+ * the login route marks it `secure` only when `NODE_ENV === 'production'`, so a lane
+ * that serves the app with any other NODE_ENV over http keeps it while a production
+ * lane silently drops it.
+ *
+ * A spec asserting "no credentials are rejected" or "this API key alone decides
+ * access" must not depend on which lane it happens to run in — it must issue the
+ * request from a jar that never saw a login. TC-DOCUMENTS-009 and TC-DOCUMENTS-018
+ * both failed in the standalone lane for exactly that reason while passing in the
+ * ephemeral one.
+ */
+export async function withCredentialIsolatedRequest<T>(
+  use: (request: APIRequestContext) => Promise<T>,
+): Promise<T> {
+  const context = await playwrightRequest.newContext(BASE_URL ? { baseURL: BASE_URL } : {});
+  try {
+    return await use(context);
+  } finally {
+    await context.dispose();
+  }
 }

--- a/packages/core/src/modules/eudr/__integration__/TC-EUDR-010.spec.ts
+++ b/packages/core/src/modules/eudr/__integration__/TC-EUDR-010.spec.ts
@@ -100,26 +100,39 @@ test.describe('TC-EUDR-010: Searchable product picker', () => {
       const productField = page.locator('[data-crud-field-id="productId"]').first()
       await expect(productField).toBeVisible()
 
-      const searchRequestPromise = page.waitForRequest((candidate) => {
-        const url = new URL(candidate.url())
-        return url.pathname.endsWith(CATALOG_PRODUCTS_PATH)
-          && (url.searchParams.get('search') ?? '').includes(stamp)
-      }, { timeout: 30_000 })
-      // The picker only queries once the search term reaches its minimum length,
-      // so there is no initial empty-query fetch to synchronise hydration on.
-      // Retry the fill until the value sticks — hydration can swap the input
-      // out from under a first-paint fill.
+      // The picker only queries once the search term reaches its minimum length, so
+      // there is no initial empty-query fetch to synchronise hydration on. A fill that
+      // lands on the pre-hydration input satisfies `toHaveValue` and is then wiped by
+      // the re-mount, so the debounce has nothing to send: the box ends up visibly
+      // empty ("Start typing to search.") while `waitForRequest` waits out its whole
+      // timeout. Asserting the value stuck is therefore not enough — retry the entire
+      // interaction until a search actually reaches the server, which a listener
+      // records regardless of which attempt produced it.
+      const observedSearchTerms: string[] = []
+      page.on('request', (candidate) => {
+        let url: URL
+        try {
+          url = new URL(candidate.url())
+        } catch {
+          return
+        }
+        if (!url.pathname.endsWith(CATALOG_PRODUCTS_PATH)) return
+        const search = url.searchParams.get('search') ?? ''
+        if (search.includes(stamp)) observedSearchTerms.push(search)
+      })
       const productInput = productField.locator('input').first()
       await expect(productInput).toBeEditable()
       await expect(async () => {
-        await productInput.fill(stamp)
-        await expect(productInput).toHaveValue(stamp)
-      }).toPass({ timeout: 15_000 })
-      const searchRequest = await searchRequestPromise
-      expect(
-        new URL(searchRequest.url()).searchParams.get('search'),
-        'typing in the product picker should trigger a server-side search request',
-      ).toContain(stamp)
+        if (observedSearchTerms.length === 0) {
+          await productInput.fill('')
+          await productInput.fill(stamp)
+          await expect(productInput).toHaveValue(stamp)
+        }
+        expect(
+          observedSearchTerms.length,
+          'typing in the product picker should trigger a server-side search request',
+        ).toBeGreaterThan(0)
+      }).toPass({ timeout: 30_000, intervals: [1_000, 2_000, 3_000] })
 
       const option = productField.getByRole('option').filter({ hasText: productTitle }).first()
       await expect(option, 'picker option should show the product name').toBeVisible({ timeout: 15_000 })

--- a/packages/create-app/src/lib/standalone-portal-email-env-guard.test.ts
+++ b/packages/create-app/src/lib/standalone-portal-email-env-guard.test.ts
@@ -33,6 +33,15 @@ const REQUIRED_VARIABLES = [
   'PLATFORM_PORTAL_BASE_URL',
   'OM_TEST_EMAIL_CAPTURE_PATH',
   'OM_ENABLE_PUSH_STUB_ADAPTER',
+  // NEXT_PUBLIC_DOCUMENTS_COLLAB_URL is inlined into the bundle at build time, so the
+  // app .env copy is what the browser sees; the test-process copy is what
+  // `ensureManagedCollabSidecar` reads to decide whether to start a sidecar at all.
+  // DOCUMENTS_COLLAB_JWT_SECRET_V2 has to match on both sides too: the app mints the
+  // collaboration token and the sidecar verifies it. With neither configured the
+  // collab-token route returns an empty token (TC-DOCUMENTS-009) and the editor stays
+  // in single-user mode (TC-DOCUMENTS-013).
+  'NEXT_PUBLIC_DOCUMENTS_COLLAB_URL',
+  'DOCUMENTS_COLLAB_JWT_SECRET_V2',
 ]
 
 const STANDALONE_LANES = [

--- a/packages/documents/src/modules/documents/__integration__/TC-DOCUMENTS-009.spec.ts
+++ b/packages/documents/src/modules/documents/__integration__/TC-DOCUMENTS-009.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test, type APIRequestContext } from '@playwright/test'
-import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  apiRequest,
+  getAuthToken,
+  withCredentialIsolatedRequest,
+} from '@open-mercato/core/helpers/integration/api'
 import {
   createRoleFixture,
   createUserFixture,
@@ -573,8 +577,12 @@ test.describe('TC-DOCUMENTS-009: capability, folder, token, and readiness harden
       )
       expect(denied.status(), 'caller without documents.view is forbidden').toBe(403)
 
-      const unauthenticated = await request.get(
-        `/api/documents/${encodeURIComponent(document.id)}/principals`,
+      // `request` carries the auth_token cookie the last login left in its jar, so a
+      // bare request.get() here is not unauthenticated at all — it authenticates as
+      // `noView` and answers 403. Issue this one call from a jar that never saw a login.
+      const principalsPath = `/api/documents/${encodeURIComponent(document.id)}/principals`
+      const unauthenticated = await withCredentialIsolatedRequest(
+        (anonymous) => anonymous.get(principalsPath),
       )
       expect(unauthenticated.status(), 'unauthenticated caller is rejected').toBe(401)
     } finally {

--- a/packages/documents/src/modules/documents/__integration__/TC-DOCUMENTS-018.spec.ts
+++ b/packages/documents/src/modules/documents/__integration__/TC-DOCUMENTS-018.spec.ts
@@ -1,5 +1,9 @@
 import { expect, type APIRequestContext, test } from '@playwright/test'
-import { apiRequest, getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  apiRequest,
+  getAuthToken,
+  withCredentialIsolatedRequest,
+} from '@open-mercato/core/helpers/integration/api'
 import {
   createOrganizationFixture,
   createRoleFixture,
@@ -152,18 +156,28 @@ async function deleteApiKeyIfExists(
   }).catch(() => undefined)
 }
 
+/**
+ * This spec exists to prove that the API KEY alone decides access, so the request must
+ * carry no other credential. The `request` fixture's cookie jar holds the auth_token
+ * the last fixture login left behind, and that session would answer the call instead —
+ * which is how the cross-organization assertion below read 200 (the other-org owner's
+ * own session) rather than the expected 403/404. Issue every key call from a jar that
+ * never saw a login.
+ */
 async function getDocumentWithApiKey(
-  request: APIRequestContext,
   secret: string,
   documentId: string,
   selectedOrganizationId?: string,
 ) {
-  return request.fetch(resolveUrl(`/api/documents/${encodeURIComponent(documentId)}`), {
-    headers: {
-      Authorization: `ApiKey ${secret}`,
-      ...(selectedOrganizationId ? { Cookie: `om_selected_org=${selectedOrganizationId}` } : {}),
+  return withCredentialIsolatedRequest((keyOnly) => keyOnly.fetch(
+    resolveUrl(`/api/documents/${encodeURIComponent(documentId)}`),
+    {
+      headers: {
+        Authorization: `ApiKey ${secret}`,
+        ...(selectedOrganizationId ? { Cookie: `om_selected_org=${selectedOrganizationId}` } : {}),
+      },
     },
-  })
+  ))
 }
 
 test.describe('TC-DOCUMENTS-018: real API-key role-share authorization', () => {
@@ -225,7 +239,7 @@ test.describe('TC-DOCUMENTS-018: real API-key role-share authorization', () => {
         organizationId: homeScope.organizationId,
         roleIds: [keyRoleId],
       })
-      expect((await getDocumentWithApiKey(request, activeKey.secret, homeDocument.id)).status()).toBe(200)
+      expect((await getDocumentWithApiKey(activeKey.secret, homeDocument.id)).status()).toBe(200)
 
       otherOrganizationId = await createOrganizationFixture(request, superadminToken, {
         name: `TC-DOCUMENTS-018 other org ${stamp}`,
@@ -238,7 +252,7 @@ test.describe('TC-DOCUMENTS-018: real API-key role-share authorization', () => {
       })
       otherOrgDocument = await createDocument(request, otherOrgOwner.token, `TC-DOCUMENTS-018 other org ${stamp}`)
       expect([403, 404]).toContain(
-        (await getDocumentWithApiKey(request, activeKey.secret, otherOrgDocument.id)).status(),
+        (await getDocumentWithApiKey(activeKey.secret, otherOrgDocument.id)).status(),
       )
 
       // Materialize a historical role share while the role is tenant-wide,
@@ -313,7 +327,6 @@ test.describe('TC-DOCUMENTS-018: real API-key role-share authorization', () => {
       expect(tenantScopedKey.organizationId, 'tenant-scoped key must not inherit the creator organization').toBeNull()
       expect([403, 404]).toContain(
         (await getDocumentWithApiKey(
-          request,
           tenantScopedKey.secret,
           otherOrgDocument.id,
           otherOrganizationId,
@@ -336,7 +349,7 @@ test.describe('TC-DOCUMENTS-018: real API-key role-share authorization', () => {
         `TC-DOCUMENTS-018 other tenant ${stamp}`,
       )
       expect([403, 404]).toContain(
-        (await getDocumentWithApiKey(request, activeKey.secret, otherTenantDocument.id)).status(),
+        (await getDocumentWithApiKey(activeKey.secret, otherTenantDocument.id)).status(),
       )
 
       await setRoleAclFeatures(request, adminToken, {
@@ -345,7 +358,7 @@ test.describe('TC-DOCUMENTS-018: real API-key role-share authorization', () => {
         organizations: [homeScope.organizationId],
       })
       expect([401, 403]).toContain(
-        (await getDocumentWithApiKey(request, activeKey.secret, homeDocument.id)).status(),
+        (await getDocumentWithApiKey(activeKey.secret, homeDocument.id)).status(),
       )
       await setRoleAclFeatures(request, adminToken, {
         roleId: keyRoleId,
@@ -360,17 +373,17 @@ test.describe('TC-DOCUMENTS-018: real API-key role-share authorization', () => {
         roleIds: [keyRoleId],
         expiresAt: new Date(Date.now() + 1_500).toISOString(),
       })
-      expect((await getDocumentWithApiKey(request, expiringKey.secret, homeDocument.id)).status()).toBe(200)
+      expect((await getDocumentWithApiKey(expiringKey.secret, homeDocument.id)).status()).toBe(200)
       await new Promise((resolve) => setTimeout(resolve, 1_700))
       expect([401, 403]).toContain(
-        (await getDocumentWithApiKey(request, expiringKey.secret, homeDocument.id)).status(),
+        (await getDocumentWithApiKey(expiringKey.secret, homeDocument.id)).status(),
       )
 
       await deleteApiKeyIfExists(request, adminToken, activeKey.id)
       const deletedSecret = activeKey.secret
       activeKey = null
       expect([401, 403]).toContain(
-        (await getDocumentWithApiKey(request, deletedSecret, homeDocument.id)).status(),
+        (await getDocumentWithApiKey(deletedSecret, homeDocument.id)).status(),
       )
     } finally {
       await deleteApiKeyIfExists(request, adminToken, activeKey?.id ?? null)

--- a/packages/documents/src/modules/documents/__integration__/helpers/collabSidecar.ts
+++ b/packages/documents/src/modules/documents/__integration__/helpers/collabSidecar.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process'
+import { createRequire } from 'node:module'
 import path from 'node:path'
 
 /**
@@ -26,6 +27,28 @@ function formatSidecarOutput(chunks: string[]): string {
   return chunks.join('').trim().slice(-4_000)
 }
 
+/**
+ * Resolve the sidecar entry from the APP under test rather than from a fixed monorepo
+ * path. The standalone lane drives a scaffolded app that installs `@open-mercato/*` from
+ * npm, so the monorepo `packages/documents/dist` build is both a different copy and a
+ * different resolution root: running it against that app root would load two copies of
+ * `@open-mercato/shared` (DI container, entity metadata) into one process. Resolving
+ * through the app's own `package.json` keeps the sidecar on exactly the code the app
+ * runs — and in the monorepo it resolves through the workspace link back to the same
+ * `packages/documents/dist` file this helper used before, so that lane is unchanged.
+ */
+function resolveSidecarEntry(appRoot: string): { entry: string; cwd: string } {
+  try {
+    const requireFromApp = createRequire(path.join(appRoot, 'package.json'))
+    return { entry: requireFromApp.resolve('@open-mercato/documents/collab-server'), cwd: appRoot }
+  } catch {
+    return {
+      entry: path.resolve(process.cwd(), 'packages/documents/dist/server/documents-collab-server.js'),
+      cwd: process.cwd(),
+    }
+  }
+}
+
 async function stopSidecarProcess(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) return
   child.kill('SIGTERM')
@@ -50,10 +73,10 @@ export async function startManagedCollabSidecar(baseUrl: string): Promise<Manage
 
   const port = collabUrl.port || '80'
   const appRoot = process.env.OM_TEST_APP_ROOT?.trim() || path.resolve(process.cwd(), 'apps/mercato')
-  const serverEntry = path.resolve(process.cwd(), 'packages/documents/dist/server/documents-collab-server.js')
+  const { entry: serverEntry, cwd: serverCwd } = resolveSidecarEntry(appRoot)
   const output: string[] = []
   const child = spawn(process.execPath, [serverEntry], {
-    cwd: process.cwd(),
+    cwd: serverCwd,
     env: {
       ...process.env,
       NODE_ENV: 'production',

--- a/scripts/test-create-app-integration.ts
+++ b/scripts/test-create-app-integration.ts
@@ -101,6 +101,11 @@ function writeStandaloneEnv(appDir: string): void {
     // which sets it on both the app server and the Playwright process; without it
     // TC-PUSH-003 resolves no adapter and every delivery lands in `failed`.
     'OM_ENABLE_PUSH_STUB_ADAPTER=1',
+    // Documents collaboration. NEXT_PUBLIC_* is inlined at build time, so it must be
+    // in the app .env before the build; the sidecar the Playwright process starts
+    // verifies the tokens this app mints, so both halves share one secret.
+    'NEXT_PUBLIC_DOCUMENTS_COLLAB_URL=ws://127.0.0.1:4101',
+    'DOCUMENTS_COLLAB_JWT_SECRET_V2=local-standalone-documents-collab-v2-secret-32b',
     'OM_DISABLE_EMAIL_DELIVERY=1',
     'OM_WEBHOOKS_ALLOW_PRIVATE_URLS=1',
     'ENABLE_CRUD_API_CACHE=true',
@@ -244,6 +249,8 @@ async function main(): Promise<void> {
     // `push-deliveries` job runs in a drain child of THIS process, which never
     // reads the scaffolded app's .env.
     OM_ENABLE_PUSH_STUB_ADAPTER: '1',
+    NEXT_PUBLIC_DOCUMENTS_COLLAB_URL: 'ws://127.0.0.1:4101',
+    DOCUMENTS_COLLAB_JWT_SECRET_V2: 'local-standalone-documents-collab-v2-secret-32b',
     OM_DISABLE_EMAIL_DELIVERY: '1',
     OM_WEBHOOKS_ALLOW_PRIVATE_URLS: '1',
     ENABLE_CRUD_API_CACHE: 'true',


### PR DESCRIPTION
Follow-up to #5467. That PR unblocked the standalone build, so `Develop Snapshot Release / Standalone App Integration Tests` ran the suite for the first time since the documents module landed — and reached four `packages/documents` specs it had never been able to execute.

Confirmed fixed by #5467 in [run 32556696939](https://github.com/open-mercato/open-mercato/actions/runs/32556696939): the build passes, `TC-PUSH-003` and `TC-WC-028` are gone from the failure list, and `2058 passed`. Remaining: `4 failed`, `1 flaky`.

Every diagnosis below comes from that run's `trace.zip` / `error-context.md` artifacts, not from inference.

## 1. Credential leakage through the Playwright request jar (2 failures, 1 cause)

| Spec | Expected | Got |
|---|---|---|
| `TC-DOCUMENTS-009` — "unauthenticated caller is rejected" | 401 | 403 |
| `TC-DOCUMENTS-018` — cross-organization API-key read | 403/404 | 200 |

Both calls deliberately avoid a `Bearer` token — one sends no credential, the other only `Authorization: ApiKey …`. The traces show that **both carry an `auth_token` cookie**:

```
GET /api/documents/<id>/principals -> 403
  req headers: {'cookie': 'auth_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'}

GET /api/documents/<other-org-doc> -> 200
  Authorization ApiKey omk_6d46db7c...
  cookie        auth_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
```

The `request` fixture keeps a cookie jar and `/api/auth/login` sets `auth_token` on it, so every later call carries the **last fixture login's** session. The 403 is the `noView` user being correctly refused; the 200 is the other-org owner reading their own document through their own session.

**This is not a cross-organization data exposure.** The product behaved correctly in both cases; the requests simply were not the requests the specs believed they were sending.

They pass in the ephemeral lane because that lane pins `NODE_ENV=production` for the app (`buildReusableEnvironment`, and again on the app-server env), and the login route sets `secure: process.env.NODE_ENV === 'production'` on the cookie — so the jar never stores it over `http`. The standalone lane's app really runs with `NODE_ENV=test` (its `.env` value wins), the cookie is not `Secure`, and the jar keeps it. An accidental pass in one lane, not a deliberate one.

**Fix:** `withCredentialIsolatedRequest()` in the shared integration helpers runs a call through a context that never saw a login, and both call sites use it. The assertions now mean what they claim in either lane.

## 2. Documents collaboration was configured in no standalone lane (2 failures)

`ci.yml` sets `NEXT_PUBLIC_DOCUMENTS_COLLAB_URL`, `DOCUMENTS_COLLAB_JWT_SECRET_V2` and `OM_DOCUMENTS_COLLAB_INTEGRATION` for the ephemeral lane. The standalone lanes set none of them:

- **`TC-DOCUMENTS-009`** — `expectId(collabBody?.token)` fails because with no `DOCUMENTS_COLLAB_JWT_SECRET_V2`, `isCollabTokenV2Ready()` is `false` and the route takes its deliberate graceful branch: HTTP 200 with `token: ''`. The status assertion passes; the token is empty.
- **`TC-DOCUMENTS-013`** — the read-only banner never renders because `ensureManagedCollabSidecar()` returns `null` when `NEXT_PUBLIC_DOCUMENTS_COLLAB_URL` is unset, so no sidecar exists and the editor stays in single-user mode. The spec's own comment already says it needs a reachable sidecar.

**Fix:** pin both variables on all three standalone lanes (`snapshot.yml`, `npm-snapshot-preview.yml`, `scripts/test-create-app-integration.ts`), on the app `.env` **and** the test process — `NEXT_PUBLIC_*` is inlined at build time, so the `.env` copy must exist before the build step, while the test-process copy is what the sidecar helper reads. The existing standalone env-parity guard now covers them, so a lane cannot drift again.

`OM_DOCUMENTS_COLLAB_INTEGRATION` is deliberately **not** set: it only gates `TC-DOCUMENTS-017`, which opts in explicitly elsewhere, and un-gating it is not needed for either failure.

**Sidecar resolution.** `startManagedCollabSidecar` hardcoded `packages/documents/dist/server/documents-collab-server.js` relative to `cwd`. In the standalone lane `cwd` is the monorepo, so that would run monorepo code against a scaffolded app root — loading two copies of `@open-mercato/shared` (DI container, entity metadata) into one process. It now resolves `@open-mercato/documents/collab-server` through the app's own `package.json`. Verified locally that in the monorepo this resolves through the workspace link back to the exact same file, so the ephemeral lane is byte-identical — and PR CI exercises that path via `TC-DOCUMENTS-017`.

## 3. TC-EUDR-010 was still flaky after `test.slow()`

`test.slow()` (from #5467) removed the 20 s test-budget timeout, and the failure moved to its real location: `page.waitForRequest` timing out after 30 s. The captured page snapshot shows why — the picker input is **empty**:

```yaml
- combobox "Select product" [active]
- paragraph: Start typing to search.
```

The fill lands on the pre-hydration input, satisfies `toHaveValue`, and is then wiped by the hydration re-mount, leaving the debounce nothing to send. Asserting that the value stuck is therefore not sufficient. The interaction is now retried until a search **actually reaches the server**, observed through a request listener so a search from any attempt counts.

## Also

Corrects the standalone lanes' comment claiming `NODE_ENV` is production in their server process. It is not — the `.env` value wins — and the cookie behaviour in §1 is the observable proof. The variable that comment guards (`PLATFORM_PORTAL_BASE_URL`) is still required; only the stated premise was wrong.

## Validation

Run locally on this branch (no compose `app` container — local runner):

- `yarn install --immutable` ✅
- `yarn build:packages` → `yarn generate` (no diff) → `yarn build:packages` ✅
- `yarn typecheck` ✅
- `yarn lint` ✅
- `yarn i18n:check-sync`, `yarn i18n:check-usage` ✅
- `yarn packages:check-peer-deps` ✅
- `yarn test:repo-wide-guards` ✅
- `yarn test` ✅
- `yarn build:app` ✅
- standalone env-parity guard: 16/16 ✅

Two pre-existing local-only failures, each reproduced identically on a stashed clean tree and therefore not from this branch: 4 `create-mercato-app` and 6 `scripts/__tests__` cases that assert a Turbopack file-watch preflight (`fs.inotify.max_user_instances: 128 < 4096`). This machine has no passwordless sudo to raise the limits; CI runners are unaffected.

**What cannot be verified before merge:** the standalone lane cannot be reproduced locally — it installs published snapshot packages that only exist after this lands. §1 and §3 are lane-independent and provable from the artifacts; §2's env additions and the sidecar start in that lane are only observable in the post-merge snapshot run. If the sidecar fails to start there, the error carries its captured stdout/stderr, and the fallback is to gate `TC-DOCUMENTS-009/013/015` on collaboration being configured.

## QA

`skip-qa`: no UI-rendering file is touched (no `.tsx` outside integration specs, nothing under `packages/ui/src/` or `**/components/**`), database structure and API surface are unchanged, no `BACKWARD_COMPATIBILITY.md` contract is affected, and the changed behaviour is covered by automated tests in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789982852&installation_model_id=432243&pr_number=5471&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5471&signature=317796e697ec11d51076aad2eabfbaf6901fc30a5029b5cdf786c1311e5454ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->