### PR TITLE
fix(ci): let the standalone lane accept its loopback collaboration URL

### DIFF
--- a/.github/workflows/npm-snapshot-preview.yml
+++ b/.github/workflows/npm-snapshot-preview.yml
@@ -314,16 +314,10 @@ jobs:
           DATABASE_URL=postgres://mercato:secret@localhost:5432/mercato_test
           APP_URL=http://localhost:3001
           NEXT_PUBLIC_APP_URL=http://localhost:3001
-          # Customer-portal email links refuse to fall back to a localhost origin,
-          # so every portal invite 502s without this (TC-AUTH-032/033,
-          # TC-CACC-INVITE-PERSON-001).
-          # NOTE: this lane's server process really does run with NODE_ENV=test —
-          # the .env value below wins, unlike the ephemeral harness which pins
-          # NODE_ENV=production for both the app and the Playwright process. That
-          # divergence is observable: the login route marks its auth_token cookie
-          # `secure` only under NODE_ENV=production, so here the cookie is stored by
-          # the Playwright request jar and replayed on later calls. Specs must not
-          # depend on that jar being empty — see withCredentialIsolatedRequest.
+          # `yarn start` serves a production build, so NODE_ENV is production in
+          # the server process regardless of the NODE_ENV=test line below, and
+          # customer-portal email links refuse to fall back to localhost there.
+          # Without this every portal invite 502s (TC-AUTH-032/033, TC-CACC-INVITE-PERSON-001).
           PLATFORM_PORTAL_BASE_URL=http://localhost:3001
           AUTH_SECRET=ci-standalone-test-auth-secret
           JWT_SECRET=ci-standalone-test-jwt-secret-32-chars-min
@@ -348,6 +342,18 @@ jobs:
           # the `Build standalone app` step, not only on the test-run env.
           NEXT_PUBLIC_DOCUMENTS_COLLAB_URL=ws://127.0.0.1:4101
           DOCUMENTS_COLLAB_JWT_SECRET_V2=ci-standalone-documents-collab-v2-secret-32b
+          # Required for the loopback collab URL above to be ACCEPTED. This lane's
+          # server runs with NODE_ENV=production, and
+          # resolveDocumentsCollaborationEndpoint() rejects a loopback ws:// host
+          # under production unless this flag opts in — it logged "Ignoring
+          # NEXT_PUBLIC_DOCUMENTS_COLLAB_URL ... not a valid browser-reachable ws(s)
+          # endpoint" and TC-DOCUMENTS-013 saw "Realtime unavailable" instead of the
+          # access-tier banner.
+          # Deliberately app-side ONLY: the same variable has a second, unrelated
+          # meaning in the Playwright process, where it opts TC-DOCUMENTS-017's
+          # realtime UI spec in. This lane wants the server-side permission, not that
+          # spec, so do NOT mirror this onto the integration-test env.
+          OM_DOCUMENTS_COLLAB_INTEGRATION=1
           OM_DISABLE_EMAIL_DELIVERY=1
           OM_WEBHOOKS_ALLOW_PRIVATE_URLS=1
           ENABLE_CRUD_API_CACHE=true

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -234,16 +234,10 @@ jobs:
           DATABASE_URL=postgres://mercato:secret@localhost:5432/mercato_test
           APP_URL=http://localhost:3001
           NEXT_PUBLIC_APP_URL=http://localhost:3001
-          # Customer-portal email links refuse to fall back to a localhost origin,
-          # so every portal invite 502s without this (TC-AUTH-032/033,
-          # TC-CACC-INVITE-PERSON-001).
-          # NOTE: this lane's server process really does run with NODE_ENV=test —
-          # the .env value below wins, unlike the ephemeral harness which pins
-          # NODE_ENV=production for both the app and the Playwright process. That
-          # divergence is observable: the login route marks its auth_token cookie
-          # `secure` only under NODE_ENV=production, so here the cookie is stored by
-          # the Playwright request jar and replayed on later calls. Specs must not
-          # depend on that jar being empty — see withCredentialIsolatedRequest.
+          # `yarn start` serves a production build, so NODE_ENV is production in
+          # the server process regardless of the NODE_ENV=test line below, and
+          # customer-portal email links refuse to fall back to localhost there.
+          # Without this every portal invite 502s (TC-AUTH-032/033, TC-CACC-INVITE-PERSON-001).
           PLATFORM_PORTAL_BASE_URL=http://localhost:3001
           AUTH_SECRET=ci-standalone-test-auth-secret
           JWT_SECRET=ci-standalone-test-jwt-secret-32-chars-min
@@ -268,6 +262,18 @@ jobs:
           # the `Build standalone app` step, not only on the test-run env.
           NEXT_PUBLIC_DOCUMENTS_COLLAB_URL=ws://127.0.0.1:4101
           DOCUMENTS_COLLAB_JWT_SECRET_V2=ci-standalone-documents-collab-v2-secret-32b
+          # Required for the loopback collab URL above to be ACCEPTED. This lane's
+          # server runs with NODE_ENV=production, and
+          # resolveDocumentsCollaborationEndpoint() rejects a loopback ws:// host
+          # under production unless this flag opts in — it logged "Ignoring
+          # NEXT_PUBLIC_DOCUMENTS_COLLAB_URL ... not a valid browser-reachable ws(s)
+          # endpoint" and TC-DOCUMENTS-013 saw "Realtime unavailable" instead of the
+          # access-tier banner.
+          # Deliberately app-side ONLY: the same variable has a second, unrelated
+          # meaning in the Playwright process, where it opts TC-DOCUMENTS-017's
+          # realtime UI spec in. This lane wants the server-side permission, not that
+          # spec, so do NOT mirror this onto the integration-test env.
+          OM_DOCUMENTS_COLLAB_INTEGRATION=1
           OM_DISABLE_EMAIL_DELIVERY=1
           OM_WEBHOOKS_ALLOW_PRIVATE_URLS=1
           ENABLE_CRUD_API_CACHE=true

--- a/packages/core/src/helpers/integration/api.ts
+++ b/packages/core/src/helpers/integration/api.ts
@@ -162,7 +162,13 @@ export async function postForm(
 export async function withCredentialIsolatedRequest<T>(
   use: (request: APIRequestContext) => Promise<T>,
 ): Promise<T> {
-  const context = await playwrightRequest.newContext(BASE_URL ? { baseURL: BASE_URL } : {});
+  // A hand-built context does not inherit the project's `use.baseURL` the way the
+  // `request` fixture does, so it has to repeat the config's own resolution — otherwise
+  // a relative path throws here on any run that leaves BASE_URL unset, while the same
+  // path works through the fixture.
+  const context = await playwrightRequest.newContext({
+    baseURL: BASE_URL ?? 'http://localhost:3000',
+  });
   try {
     return await use(context);
   } finally {

--- a/packages/core/src/helpers/integration/api.ts
+++ b/packages/core/src/helpers/integration/api.ts
@@ -148,16 +148,14 @@ export async function postForm(
  * The `request` fixture keeps a cookie jar, and `/api/auth/login` sets `auth_token`
  * on it. Every later call through that fixture therefore carries the LAST logged-in
  * user's session, even one that deliberately sends no Authorization header or an
- * `ApiKey` one. Whether that cookie is stored at all depends on the deployment:
- * the login route marks it `secure` only when `NODE_ENV === 'production'`, so a lane
- * that serves the app with any other NODE_ENV over http keeps it while a production
- * lane silently drops it.
+ * `ApiKey` one.
  *
  * A spec asserting "no credentials are rejected" or "this API key alone decides
- * access" must not depend on which lane it happens to run in — it must issue the
- * request from a jar that never saw a login. TC-DOCUMENTS-009 and TC-DOCUMENTS-018
- * both failed in the standalone lane for exactly that reason while passing in the
- * ephemeral one.
+ * access" must therefore issue the request from a jar that never saw a login,
+ * rather than assuming the fixture's jar is empty. TC-DOCUMENTS-009 and
+ * TC-DOCUMENTS-018 both observably failed in the standalone lane — with the
+ * replayed cookie visible in the trace — while passing in the ephemeral one, and
+ * routing them through this helper fixed both.
  */
 export async function withCredentialIsolatedRequest<T>(
   use: (request: APIRequestContext) => Promise<T>,

--- a/packages/create-app/src/lib/standalone-portal-email-env-guard.test.ts
+++ b/packages/create-app/src/lib/standalone-portal-email-env-guard.test.ts
@@ -44,6 +44,16 @@ const REQUIRED_VARIABLES = [
   'DOCUMENTS_COLLAB_JWT_SECRET_V2',
 ]
 
+// The inverse of REQUIRED_VARIABLES: variables that must be set exactly ONCE per lane,
+// on the standalone app's .env side only. OM_DOCUMENTS_COLLAB_INTEGRATION means two
+// unrelated things depending on which process reads it. In the app server it is the
+// permission that lets resolveDocumentsCollaborationEndpoint() accept the loopback
+// ws:// URL above under NODE_ENV=production; in the Playwright process it is the gate
+// that opts TC-DOCUMENTS-017's realtime UI spec in. Mirroring it onto the
+// integration-test env the way the variables above are mirrored would silently enable
+// a heavy realtime spec in a lane that has never run it.
+const APP_ONLY_VARIABLES = ['OM_DOCUMENTS_COLLAB_INTEGRATION']
+
 const STANDALONE_LANES = [
   '.github/workflows/snapshot.yml',
   '.github/workflows/npm-snapshot-preview.yml',
@@ -66,6 +76,19 @@ for (const lane of STANDALONE_LANES) {
       assert.ok(
         countAssignments(source, variable) >= 2,
         `${lane} must set ${variable} for the standalone app .env AND the integration-test env; the two run in different processes with different working directories`,
+      )
+    })
+  }
+}
+
+for (const lane of STANDALONE_LANES) {
+  for (const variable of APP_ONLY_VARIABLES) {
+    test(`${lane} pins ${variable} for the app process only`, () => {
+      const source = readRepoFile(lane)
+      assert.equal(
+        countAssignments(source, variable),
+        1,
+        `${lane} must set ${variable} exactly once, on the standalone app .env side. In the Playwright process the same variable is a spec gate, not the server-side loopback permission, so a second assignment opts TC-DOCUMENTS-017's realtime UI spec into a lane that has never run it`,
       )
     })
   }

--- a/packages/documents/src/modules/documents/__integration__/TC-DOCUMENTS-017.spec.ts
+++ b/packages/documents/src/modules/documents/__integration__/TC-DOCUMENTS-017.spec.ts
@@ -1,5 +1,3 @@
-import { spawn, type ChildProcess } from 'node:child_process'
-import path from 'node:path'
 import {
   expect,
   type APIRequestContext,
@@ -22,6 +20,10 @@ import {
 } from '@open-mercato/core/helpers/integration/crmFixtures'
 import { expectId, getTokenContext, getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
 import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
+import {
+  startManagedCollabSidecar,
+  type ManagedCollabSidecar,
+} from './helpers/collabSidecar'
 
 export const integrationMeta = {
   dependsOnModules: ['documents', 'customers'],
@@ -33,81 +35,11 @@ const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
 const PASSWORD = 'DocsRecovery1!Pass'
 const COLLAB_INTEGRATION_ENABLED = process.env.OM_DOCUMENTS_COLLAB_INTEGRATION === '1'
 
-type ManagedCollabSidecar = {
-  stop: () => Promise<void>
-}
-
-function formatSidecarOutput(chunks: string[]): string {
-  return chunks.join('').trim().slice(-4_000)
-}
-
-async function stopSidecarProcess(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) return
-  child.kill('SIGTERM')
-  await Promise.race([
-    new Promise<void>((resolve) => child.once('exit', () => resolve())),
-    new Promise<void>((resolve) => setTimeout(resolve, 10_000)),
-  ])
-  if (child.exitCode === null && child.signalCode === null) {
-    child.kill('SIGKILL')
-  }
-}
-
-async function startManagedCollabSidecar(): Promise<ManagedCollabSidecar> {
-  const configuredUrl = process.env.NEXT_PUBLIC_DOCUMENTS_COLLAB_URL?.trim()
-  if (!configuredUrl) {
-    throw new Error('NEXT_PUBLIC_DOCUMENTS_COLLAB_URL is required when OM_DOCUMENTS_COLLAB_INTEGRATION=1')
-  }
-  const collabUrl = new URL(configuredUrl)
-  if (collabUrl.protocol !== 'ws:' || !['127.0.0.1', 'localhost'].includes(collabUrl.hostname)) {
-    throw new Error('Documents collaboration integration requires a loopback ws:// URL')
-  }
-
-  const port = collabUrl.port || '80'
-  const appRoot = process.env.OM_TEST_APP_ROOT?.trim() || path.resolve(process.cwd(), 'apps/mercato')
-  const serverEntry = path.resolve(process.cwd(), 'packages/documents/dist/server/documents-collab-server.js')
-  const output: string[] = []
-  const child = spawn(process.execPath, [serverEntry], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      NODE_ENV: 'production',
-      APP_URL: BASE_URL,
-      NEXT_PUBLIC_APP_URL: BASE_URL,
-      DOCUMENTS_COLLAB_ALLOWED_ORIGINS: new URL(BASE_URL).origin,
-      DOCUMENTS_COLLAB_APP_ROOT: appRoot,
-      DOCUMENTS_COLLAB_PORT: port,
-      // This UI scenario needs one real sidecar. The dedicated
-      // test:multi-instance gate separately proves Redis replication.
-      DOCUMENTS_COLLAB_REDIS_URL: '',
-      REDIS_URL: '',
-    },
-    stdio: ['ignore', 'pipe', 'pipe'],
-  })
-  child.stdout?.on('data', (chunk: Buffer) => output.push(chunk.toString()))
-  child.stderr?.on('data', (chunk: Buffer) => output.push(chunk.toString()))
-
-  const healthUrl = `http://${collabUrl.hostname}:${port}/healthz`
-  const deadline = Date.now() + 30_000
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null || child.signalCode !== null) {
-      throw new Error(`Documents collaboration sidecar exited during startup.\n${formatSidecarOutput(output)}`)
-    }
-    try {
-      const response = await fetch(healthUrl)
-      if (response.ok) {
-        return { stop: () => stopSidecarProcess(child) }
-      }
-    } catch {
-      // The process may still be binding the port.
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250))
-  }
-
-  await stopSidecarProcess(child)
-  throw new Error(`Timed out waiting for documents collaboration sidecar.\n${formatSidecarOutput(output)}`)
-}
-
+// The sidecar starter used to be duplicated here, byte-for-byte apart from taking
+// its base URL from the module constant. The copy kept the monorepo-only entry path
+// that the shared helper has since dropped, so it would have loaded a second copy of
+// @open-mercato/shared if this spec ever ran against a scaffolded app. Use the shared
+// helper instead of maintaining two.
 async function createCollaborator(
   request: APIRequestContext,
   adminToken: string,
@@ -347,7 +279,7 @@ test.describe('TC-DOCUMENTS-017: realtime rollover, pages, PDF, and record snaps
     let collabSidecar: ManagedCollabSidecar | null = null
 
     try {
-      collabSidecar = await startManagedCollabSidecar()
+      collabSidecar = await startManagedCollabSidecar(BASE_URL)
       token = await getAuthToken(request, 'admin')
       document = await createDocument(request, token, `TC-DOCUMENTS-017 ${stamp}`)
       companyId = await createCompanyFixture(request, token, companyName)

--- a/packages/documents/src/modules/documents/__integration__/TC-DOCUMENTS-017.spec.ts
+++ b/packages/documents/src/modules/documents/__integration__/TC-DOCUMENTS-017.spec.ts
@@ -21,6 +21,8 @@ import {
 import { expectId, getTokenContext, getTokenScope, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
 import { OPTIMISTIC_LOCK_HEADER_NAME } from '@open-mercato/shared/lib/crud/optimistic-lock-headers'
 import {
+  COLLAB_INTEGRATION_ENABLED,
+  COLLAB_INTEGRATION_SKIP_REASON,
   startManagedCollabSidecar,
   type ManagedCollabSidecar,
 } from './helpers/collabSidecar'
@@ -33,7 +35,6 @@ type CreatedDocument = { id: string; updatedAt: string }
 type TestUser = { id: string; roleId: string; email: string; name: string; token: string }
 const BASE_URL = process.env.BASE_URL?.trim() || 'http://localhost:3000'
 const PASSWORD = 'DocsRecovery1!Pass'
-const COLLAB_INTEGRATION_ENABLED = process.env.OM_DOCUMENTS_COLLAB_INTEGRATION === '1'
 
 // The sidecar starter used to be duplicated here, byte-for-byte apart from taking
 // its base URL from the module constant. The copy kept the monorepo-only entry path
@@ -262,10 +263,7 @@ test.describe('TC-DOCUMENTS-017: realtime rollover, pages, PDF, and record snaps
   })
 
   test('keeps realtime live and inserts authorized record fields into a paginated export', async ({ browser, page, request }) => {
-    test.skip(
-      !COLLAB_INTEGRATION_ENABLED,
-      'Realtime Documents coverage runs in CI with OM_DOCUMENTS_COLLAB_INTEGRATION=1 and a managed sidecar.',
-    )
+    test.skip(!COLLAB_INTEGRATION_ENABLED, COLLAB_INTEGRATION_SKIP_REASON)
     test.slow()
     test.setTimeout(120_000)
     const stamp = Date.now()

--- a/scripts/test-create-app-integration.ts
+++ b/scripts/test-create-app-integration.ts
@@ -106,6 +106,11 @@ function writeStandaloneEnv(appDir: string): void {
     // verifies the tokens this app mints, so both halves share one secret.
     'NEXT_PUBLIC_DOCUMENTS_COLLAB_URL=ws://127.0.0.1:4101',
     'DOCUMENTS_COLLAB_JWT_SECRET_V2=local-standalone-documents-collab-v2-secret-32b',
+    // Required for the loopback collab URL above to be accepted: the server runs
+    // with NODE_ENV=production and resolveDocumentsCollaborationEndpoint() rejects a
+    // loopback ws:// host there unless this opts in. App-side only — in the Playwright
+    // process the same variable opts TC-DOCUMENTS-017's realtime spec in instead.
+    'OM_DOCUMENTS_COLLAB_INTEGRATION=1',
     'OM_DISABLE_EMAIL_DELIVERY=1',
     'OM_WEBHOOKS_ALLOW_PRIVATE_URLS=1',
     'ENABLE_CRUD_API_CACHE=true',


### PR DESCRIPTION
Third round of develop CI stabilization. #5471 took the standalone lane from **4 failures to 1** — [run 32565791370](https://github.com/open-mercato/open-mercato/actions/runs/32565791370): `2061 passed`, with `TC-DOCUMENTS-009` (both tests), `TC-DOCUMENTS-018` and `TC-EUDR-010` all fixed and `CI for Develop&Main` + CodeQL green on the same commit.

This finishes the last one, and corrects a claim I got wrong in #5471.

## The remaining failure: `TC-DOCUMENTS-013`

The standalone app log names the cause outright:

```
{"level":40,"name":"documents","component":"api",
 "msg":"Ignoring NEXT_PUBLIC_DOCUMENTS_COLLAB_URL because it is not a valid
        browser-reachable ws(s) endpoint; collaboration is disabled and clients
        fall back to non-collaborative editing."}
```

`resolveDocumentsCollaborationEndpoint()` rejects a loopback `ws://` host when `NODE_ENV` is production, unless `OM_DOCUMENTS_COLLAB_INTEGRATION=1` opts in:

```ts
const allowLoopback = options.allowLoopback ?? (
  nodeEnv !== 'production' || process.env.OM_DOCUMENTS_COLLAB_INTEGRATION === '1'
)
if (!allowLoopback && isLoopbackHostname(hostname)) return null
```

`ws://127.0.0.1:4101` is a well-formed ws URL, so that branch is the only way the warning can fire. The collab-token route therefore answered `url: null`, the browser never reached the sidecar, and the page rendered the *realtime-unavailable* banner instead of the *access-tier* one the spec waits for:

```yaml
- status: Realtime unavailable
- alert:
  - paragraph: Realtime is unavailable — showing the last saved version (read-only).
```

The same skip shows up in `TC-DOCUMENTS-009`'s readiness test, which is gated on `!tokenBody?.url`. `ci.yml` sets this flag for the ephemeral lane for exactly this reason.

**Fix:** set `OM_DOCUMENTS_COLLAB_INTEGRATION=1` in the standalone lanes — **app-side only**, and deliberately so. In the Playwright process the identical variable means something unrelated: it opts `TC-DOCUMENTS-017`'s realtime UI spec in. This lane needs the server-side permission, not that spec, so mirroring it onto the test env would silently enable a heavy spec that has never run here. The workflow comment says this so nobody "fixes" the asymmetry later.

## Correcting #5471

That PR rewrote these lanes' comment to claim the standalone server runs with `NODE_ENV=test`. **That was wrong** — the warning above can only fire under `NODE_ENV=production`, so the original comment was right and is restored.

The reasoning that led there: the traces showed `auth_token` cookies riding along on calls that were supposed to carry no session, and I explained it with the login route's `secure: NODE_ENV === 'production'` attribute. The leak was real and the fix is proven — `TC-DOCUMENTS-009` and `TC-DOCUMENTS-018` both pass now — but `secure` handling was not why the ephemeral lane tolerated it. Rather than swap in another guess, the explanation is dropped and only the observed fact is stated.

## Two supporting changes

**`TC-DOCUMENTS-017` carried a duplicate sidecar starter.** Byte-for-byte identical to the shared helper apart from taking its base URL from a module constant — including the monorepo-only entry path that #5471 removed from the shared copy. Left alone, opting any lane into that spec would spawn the monorepo sidecar against a scaffolded app root and load a second copy of `@open-mercato/shared` (DI container, entity metadata) into one process. It now uses the shared helper. The ephemeral lane runs this spec, so PR CI covers the change.

**`withCredentialIsolatedRequest` had no baseURL fallback.** It set `baseURL` only when `BASE_URL` was present, but a hand-built context does not inherit the project's `use.baseURL` the way the `request` fixture does, and the config falls back to `http://localhost:3000`. A relative path would have thrown on any local run leaving `BASE_URL` unset. Both CI lanes set it, so this never surfaced there.

## Known remaining

`TC-DOCUMENTS-001` was flaky-on-retry in that run: `POST /api/documents/folders` returned 401 on a Bearer call, which is the documented stale-cached-token class `clearAuthTokenCache()` exists for. One occurrence, retry-covered, untouched by this PR — left alone rather than chased on a single data point.

## Validation

Run locally (no compose `app` container — local runner):

- `yarn build:packages` → `yarn generate` (no diff) → `yarn build:packages` ✅
- `yarn typecheck` ✅ · `yarn lint` ✅
- `yarn i18n:check-sync`, `yarn i18n:check-usage` ✅
- `yarn packages:check-peer-deps` ✅ · `yarn test:repo-wide-guards` ✅
- standalone env-parity guard 16/16 ✅
- `yarn test` ✅ · `yarn build:app` ✅

Pre-existing local-only failures, reproduced identically on a stashed clean tree: 4 `create-mercato-app` cases asserting a Turbopack file-watch preflight (`fs.inotify.max_user_instances: 128 < 4096`). No passwordless sudo on this machine; CI runners are unaffected.

The standalone lane still cannot be reproduced locally — it installs published snapshot packages that only exist after this lands — so the flag's effect is observable only in the post-merge snapshot run. Unlike the previous rounds this one is a single-line env change whose failure mode is already documented in the app log, so the next run will say plainly whether it worked.

## QA

`skip-qa`: no UI-rendering file touched (no `.tsx` outside integration specs, nothing under `packages/ui/src/` or `**/components/**`), database structure and API surface unchanged, no `BACKWARD_COMPATIBILITY.md` contract affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789988775&installation_model_id=432243&pr_number=5472&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5472&signature=8710d982d14ffeaa0ac0d48f34db3faeb6c2bcaacd7af82a90eb132868d5f057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->