### PR TITLE
fix(eudr): stop offering Delete on archived statements and surface the reason (#5461)

### DIFF
--- a/packages/core/src/modules/eudr/__integration__/TC-EUDR-007.spec.ts
+++ b/packages/core/src/modules/eudr/__integration__/TC-EUDR-007.spec.ts
@@ -534,6 +534,13 @@ test.describe('TC-EUDR-007: Statement lifecycle', () => {
       await expectErrorKey(archivedEditResponse, 'archivedReadOnly')
       const archivedReopenResponse = await updateStatement(request, token, { id: archivedStatementId, status: 'draft' })
       await expectErrorKey(archivedReopenResponse, 'invalidTransition')
+      const archivedDeleteResponse = await apiRequest(
+        request,
+        'DELETE',
+        `${STATEMENTS_PATH}?id=${encodeURIComponent(archivedStatementId)}`,
+        { token },
+      )
+      await expectErrorKey(archivedDeleteResponse, 'archivedReadOnly')
 
       const assessedStatementId = await createStatement(request, token, `TC-EUDR-007 Latest risk ${stamp}`)
       statementIds.push(assessedStatementId)

--- a/packages/core/src/modules/eudr/backend/eudr/statements/[id]/__tests__/page.test.tsx
+++ b/packages/core/src/modules/eudr/backend/eudr/statements/[id]/__tests__/page.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * @jest-environment jsdom
+ */
+import * as React from 'react'
+import { waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@open-mercato/shared/lib/testing/renderWithProviders'
+import EditEudrStatementPage from '../page'
+
+const apiCallMock = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PageBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: () => <div>table</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/detail', () => ({
+  ErrorMessage: ({ label }: { label: string }) => <div>{label}</div>,
+  LoadingMessage: ({ label }: { label: string }) => <div>{label}</div>,
+  RecordNotFoundState: ({ label }: { label: string }) => <div>{label}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/crud', () => ({
+  updateCrud: jest.fn(),
+  deleteCrud: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/serverErrors', () => ({
+  createCrudFormError: (message: string) => new Error(message),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: jest.fn(),
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/empty-state', () => ({
+  EmptyState: () => null,
+}))
+
+jest.mock('@open-mercato/ui/primitives/status-badge', () => ({
+  StatusBadge: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => {
+  const stableTranslate = (key: string) => key
+  return {
+    useT: () => stableTranslate,
+    I18nProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  }
+})
+
+const crudFormPropsCapture: { current: Record<string, unknown> | null } = { current: null }
+jest.mock('@open-mercato/ui/backend/CrudForm', () => ({
+  CrudForm: (props: Record<string, unknown>) => {
+    crudFormPropsCapture.current = props
+    return <div>form</div>
+  },
+}))
+
+jest.mock('../../../../../components/StatementLifecycleBar', () => ({
+  StatementLifecycleBar: () => null,
+}))
+
+jest.mock('../../../../../components/StatementReadinessChecklist', () => ({
+  StatementReadinessChecklist: () => null,
+}))
+
+jest.mock('../../../../../components/StatementRiskSection', () => ({
+  StatementRiskSection: () => null,
+  riskConclusionBadgeVariant: () => 'neutral',
+  riskTierBadgeVariant: () => 'neutral',
+}))
+
+jest.mock('../../../../../components/PlotMapPreview', () => ({
+  PlotMapPreview: () => null,
+}))
+
+jest.mock('../../../../../components/formConfig', () => ({
+  OrderSelectField: () => null,
+  ReferencedStatementsField: () => null,
+  actorRoleOptions: () => [],
+  activityTypeOptions: () => [],
+  commodityOptions: () => [],
+  statusBadgeVariant: () => 'neutral',
+  translateEudrCrudError: (err: unknown) => err,
+}))
+
+function statementRecord(status: string) {
+  return {
+    id: 'statement-1',
+    title: 'Statement 1',
+    commodity: 'coffee',
+    referenceNumber: null,
+    verificationNumber: null,
+    status,
+    activityType: null,
+    actorRole: null,
+    referencedStatements: [],
+    quantityKg: null,
+    supplementaryUnit: null,
+    supplementaryQuantity: null,
+    orderId: null,
+    submittedAt: null,
+    referenceIssuedAt: null,
+    orderSnapshot: null,
+    notes: null,
+    latestRisk: null,
+    createdAt: '2026-08-01T09:00:00.000Z',
+    updatedAt: '2026-08-01T10:00:00.000Z',
+  }
+}
+
+async function renderDetailFor(status: string): Promise<void> {
+  apiCallMock.mockImplementation(async (url: string) => {
+    if (typeof url === 'string' && url.startsWith('/api/eudr/statements?')) {
+      return { ok: true, result: { items: [statementRecord(status)] } }
+    }
+    return { ok: true, result: { items: [] } }
+  })
+  renderWithProviders(<EditEudrStatementPage params={{ id: 'statement-1' }} />)
+  await waitFor(() => expect(crudFormPropsCapture.current).not.toBeNull())
+}
+
+describe('EditEudrStatementPage delete affordance', () => {
+  beforeEach(() => {
+    apiCallMock.mockReset()
+    crudFormPropsCapture.current = null
+  })
+
+  it('keeps Delete available for a statement that can still be deleted', async () => {
+    await renderDetailFor('draft')
+
+    expect(crudFormPropsCapture.current?.deleteVisible).toBe(true)
+  })
+
+  it('hides Delete for an archived statement, which the server always refuses', async () => {
+    await renderDetailFor('archived')
+
+    expect(crudFormPropsCapture.current?.deleteVisible).toBe(false)
+  })
+})

--- a/packages/core/src/modules/eudr/backend/eudr/statements/[id]/page.tsx
+++ b/packages/core/src/modules/eudr/backend/eudr/statements/[id]/page.tsx
@@ -29,6 +29,7 @@ import {
   type ReferencedStatementValue,
   translateEudrCrudError,
 } from '../../../../components/formConfig'
+import { canDeleteStatement } from '../../../../lib/statement-lifecycle'
 import { StatementLifecycleBar } from '../../../../components/StatementLifecycleBar'
 import { StatementReadinessChecklist } from '../../../../components/StatementReadinessChecklist'
 import { StatementRiskSection, type StatementLatestRisk } from '../../../../components/StatementRiskSection'
@@ -644,6 +645,7 @@ export default function EditEudrStatementPage({ params }: { params?: { id?: stri
           backHref="/backend/eudr/statements"
           cancelHref="/backend/eudr/statements"
           deleteRedirect="/backend/eudr/statements"
+          deleteVisible={canDeleteStatement(record.status)}
           submitLabel={translate('eudr.statements.form.submitUpdate')}
           fields={fields}
           groups={groups}

--- a/packages/core/src/modules/eudr/backend/eudr/statements/__tests__/page.test.tsx
+++ b/packages/core/src/modules/eudr/backend/eudr/statements/__tests__/page.test.tsx
@@ -1,0 +1,191 @@
+/** @jest-environment jsdom */
+
+import * as React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import EudrStatementsPage from '../page'
+
+type StatementRowStub = {
+  id: string
+  title: string
+  commodity: string
+  status: string
+  updatedAt: string
+  latestRisk: null
+}
+
+const mockApiCall = jest.fn()
+const mockRunMutation = jest.fn()
+const mockConfirm = jest.fn(async () => true)
+const mockFlash = jest.fn()
+
+const messages: Record<string, string> = {
+  'eudr.errors.archivedReadOnly': 'Archived statements are read-only.',
+  'eudr.statements.list.deleteError': 'Could not delete the statement.',
+  'eudr.statements.list.actions.delete': 'Delete',
+  'eudr.statements.list.actions.edit': 'Edit',
+  'eudr.statements.duplicateAction': 'Duplicate',
+}
+
+function statementRow(id: string, status: string): StatementRowStub {
+  return {
+    id,
+    title: `Statement ${id}`,
+    commodity: 'coffee',
+    status,
+    updatedAt: '2026-08-01T10:00:00.000Z',
+    latestRisk: null,
+  }
+}
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/Page', () => ({
+  Page: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PageBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+jest.mock('@open-mercato/ui/backend/DataTable', () => ({
+  DataTable: ({
+    data,
+    rowActions,
+  }: {
+    data?: StatementRowStub[]
+    rowActions?: (row: StatementRowStub) => React.ReactNode
+  }) => (
+    <div>
+      {(data ?? []).map((row) => (
+        <div key={row.id} data-testid={`row-${row.id}`}>
+          {rowActions?.(row)}
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/RowActions', () => ({
+  RowActions: ({ items }: { items: Array<{ id?: string; label: string; onSelect?: () => void }> }) => (
+    <>
+      {items.map((item) => (
+        <button key={item.id} type="button" data-testid={`action-${item.id}`} onClick={item.onSelect}>
+          {item.label}
+        </button>
+      ))}
+    </>
+  ),
+}))
+
+jest.mock('@open-mercato/ui/backend/filters/ListEmptyState', () => ({
+  ListEmptyState: () => null,
+}))
+
+jest.mock('@open-mercato/ui/backend/injection/useGuardedMutation', () => ({
+  useGuardedMutation: () => ({
+    runMutation: (...args: unknown[]) => mockRunMutation(...args),
+    retryLastMutation: jest.fn(),
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/confirm-dialog', () => ({
+  useConfirmDialog: () => ({
+    confirm: (...args: unknown[]) => mockConfirm(...args),
+    ConfirmDialogElement: null,
+  }),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => mockApiCall(...args),
+  withScopedApiRequestHeaders: (_headers: unknown, operation: () => unknown) => operation(),
+}))
+
+jest.mock('@open-mercato/ui/backend/utils/optimisticLock', () => ({
+  buildOptimisticLockHeader: jest.fn(() => ({})),
+}))
+
+jest.mock('@open-mercato/ui/backend/FlashMessages', () => ({
+  flash: (...args: unknown[]) => mockFlash(...args),
+}))
+
+jest.mock('@open-mercato/ui/backend/conflicts', () => ({
+  surfaceRecordConflict: jest.fn(() => false),
+}))
+
+jest.mock('@open-mercato/ui/primitives/button', () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@open-mercato/ui/primitives/status-badge', () => ({
+  StatusBadge: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+jest.mock('@open-mercato/shared/lib/frontend/useOrganizationScope', () => ({
+  useOrganizationScopeVersion: () => 1,
+}))
+
+jest.mock('@open-mercato/shared/lib/i18n/context', () => ({
+  useLocale: () => 'en',
+  useT: () => (key: string) => messages[key] ?? key,
+}))
+
+async function renderListWith(rows: StatementRowStub[]): Promise<void> {
+  mockApiCall.mockResolvedValue({
+    ok: true,
+    result: { items: rows, total: rows.length, totalPages: 1 },
+  })
+  render(<EudrStatementsPage />)
+  await waitFor(() => expect(screen.getByTestId(`row-${rows[0].id}`)).toBeTruthy())
+}
+
+describe('EUDR statements list delete affordance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockConfirm.mockResolvedValue(true)
+  })
+
+  it('offers Delete for a statement that can still be deleted', async () => {
+    await renderListWith([statementRow('draft-1', 'draft')])
+
+    expect(screen.queryByTestId('action-delete')).not.toBeNull()
+  })
+
+  it('hides Delete for an archived statement, which the server always refuses', async () => {
+    await renderListWith([statementRow('archived-1', 'archived')])
+
+    expect(screen.queryByTestId('action-edit')).not.toBeNull()
+    expect(screen.queryByTestId('action-duplicate')).not.toBeNull()
+    expect(screen.queryByTestId('action-delete')).toBeNull()
+  })
+
+  it('names the reason when a delete is refused instead of showing generic copy', async () => {
+    mockRunMutation.mockRejectedValue(
+      Object.assign(new Error('[internal] eudr statement delete failed'), {
+        status: 400,
+        error: 'eudr.errors.archivedReadOnly',
+      }),
+    )
+
+    await renderListWith([statementRow('draft-1', 'draft')])
+    fireEvent.click(screen.getByTestId('action-delete'))
+
+    await waitFor(() => expect(mockFlash).toHaveBeenCalled())
+    expect(mockFlash).toHaveBeenCalledWith('Archived statements are read-only.', 'error')
+  })
+
+  it('falls back to the generic copy when the failure carries no reason', async () => {
+    mockRunMutation.mockRejectedValue(new Error('Failed to fetch'))
+
+    await renderListWith([statementRow('draft-1', 'draft')])
+    fireEvent.click(screen.getByTestId('action-delete'))
+
+    await waitFor(() => expect(mockFlash).toHaveBeenCalled())
+    expect(mockFlash).toHaveBeenCalledWith('Could not delete the statement.', 'error')
+  })
+})

--- a/packages/core/src/modules/eudr/backend/eudr/statements/page.tsx
+++ b/packages/core/src/modules/eudr/backend/eudr/statements/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation'
 import { Page, PageBody } from '@open-mercato/ui/backend/Page'
 import { DataTable } from '@open-mercato/ui/backend/DataTable'
 import { ListEmptyState } from '@open-mercato/ui/backend/filters/ListEmptyState'
-import { RowActions } from '@open-mercato/ui/backend/RowActions'
+import { RowActions, type RowActionItem } from '@open-mercato/ui/backend/RowActions'
 import type { FilterDef, FilterValues } from '@open-mercato/ui/backend/FilterBar'
 import { apiCall, withScopedApiRequestHeaders } from '@open-mercato/ui/backend/utils/apiCall'
 import { buildOptimisticLockHeader } from '@open-mercato/ui/backend/utils/optimisticLock'
@@ -22,7 +22,8 @@ import type { LegacyColumnDef as ColumnDef } from '@tanstack/react-table/legacy'
 import { useOrganizationScopeVersion } from '@open-mercato/shared/lib/frontend/useOrganizationScope'
 import { useLocale, useT } from '@open-mercato/shared/lib/i18n/context'
 import type { EudrActivityType, EudrCommodity, EudrRiskConclusion, EudrRiskTier, EudrStatementStatus } from '../../../data/validators'
-import { commodityOptions, statementStatusOptions, statusBadgeVariant } from '../../../components/formConfig'
+import { commodityOptions, statementStatusOptions, statusBadgeVariant, translateEudrErrorMessage } from '../../../components/formConfig'
+import { canDeleteStatement } from '../../../lib/statement-lifecycle'
 import {
   riskConclusionBadgeVariant,
   riskTierBadgeVariant,
@@ -186,7 +187,11 @@ export default function EudrStatementsPage() {
       refreshRows()
     } catch (error) {
       if (surfaceRecordConflict(error, translate, { onRefresh: refreshRows })) return
-      flash(translate('eudr.statements.list.deleteError'), 'error')
+      flash(
+        translateEudrErrorMessage(error, translate, translate('eudr.statements.list.deleteError')),
+        'error',
+      )
+      refreshRows()
     }
   }, [confirm, mutationContextId, refreshRows, retryLastMutation, runMutation, translate])
 
@@ -309,30 +314,31 @@ export default function EudrStatementsPage() {
               </Link>
             </Button>
           )}
-          rowActions={(row) => (
-            <RowActions
-              items={[
-                {
-                  id: 'edit',
-                  label: translate('eudr.statements.list.actions.edit'),
-                  href: `/backend/eudr/statements/${row.id}`,
+          rowActions={(row) => {
+            const items: RowActionItem[] = [
+              {
+                id: 'edit',
+                label: translate('eudr.statements.list.actions.edit'),
+                href: `/backend/eudr/statements/${row.id}`,
+              },
+              {
+                id: 'duplicate',
+                label: translate('eudr.statements.duplicateAction'),
+                href: `/backend/eudr/statements/create?duplicateFrom=${encodeURIComponent(row.id)}`,
+              },
+            ]
+            if (canDeleteStatement(row.status)) {
+              items.push({
+                id: 'delete',
+                label: translate('eudr.statements.list.actions.delete'),
+                destructive: true,
+                onSelect: () => {
+                  void handleDelete(row)
                 },
-                {
-                  id: 'duplicate',
-                  label: translate('eudr.statements.duplicateAction'),
-                  href: `/backend/eudr/statements/create?duplicateFrom=${encodeURIComponent(row.id)}`,
-                },
-                {
-                  id: 'delete',
-                  label: translate('eudr.statements.list.actions.delete'),
-                  destructive: true,
-                  onSelect: () => {
-                    void handleDelete(row)
-                  },
-                },
-              ]}
-            />
-          )}
+              })
+            }
+            return <RowActions items={items} />
+          }}
           onRowClick={(row) => router.push(`/backend/eudr/statements/${row.id}`)}
           rowClickActionIds={['edit']}
           emptyState={(

--- a/packages/core/src/modules/eudr/commands/statements.ts
+++ b/packages/core/src/modules/eudr/commands/statements.ts
@@ -43,9 +43,11 @@ import {
 } from '../data/validators'
 import {
   EUDR_AMEND_GUARDED_FIELDS,
+  canDeleteStatement,
   canTransition,
   evaluateSubmissionGate,
   isAmendWindowOpen,
+  isStatementReadOnly,
   type GateAssessmentView,
   type GateSubmissionView,
 } from '../lib/statement-lifecycle'
@@ -495,7 +497,7 @@ async function validateStatementUpdate(
   }
 
   const hasBaseChanges = hasStatementFieldChanges(record, parsed)
-  if (record.status === 'archived' && (hasBaseChanges || Object.keys(custom).length > 0)) {
+  if (isStatementReadOnly(record.status) && (hasBaseChanges || Object.keys(custom).length > 0)) {
     throw new CrudHttpError(400, { error: 'eudr.errors.archivedReadOnly' })
   }
 
@@ -844,7 +846,7 @@ const deleteStatementCommand: CommandHandler<{ body?: Record<string, unknown>; q
     if (!record) throw new CrudHttpError(404, { error: 'EUDR due diligence statement not found' })
     ensureTenantScope(ctx, record.tenantId)
     ensureOrganizationScope(ctx, record.organizationId)
-    if (record.status === 'archived') {
+    if (isStatementStatus(record.status) && !canDeleteStatement(record.status)) {
       throw new CrudHttpError(400, { error: 'eudr.errors.archivedReadOnly' })
     }
     if (record.status === 'available') {

--- a/packages/core/src/modules/eudr/components/__tests__/crudErrorI18n.test.ts
+++ b/packages/core/src/modules/eudr/components/__tests__/crudErrorI18n.test.ts
@@ -1,0 +1,38 @@
+import { translateEudrErrorMessage } from '../crudErrorI18n'
+
+const messages: Record<string, string> = {
+  'eudr.errors.archivedReadOnly': 'Archived statements are read-only.',
+}
+
+const translate = (key: string) => messages[key] ?? key
+
+const fallback = 'Could not delete the statement.'
+
+describe('translateEudrErrorMessage', () => {
+  it('surfaces the reason carried on the rejection error property', () => {
+    const err = Object.assign(new Error('[internal] eudr statement delete failed'), {
+      status: 400,
+      error: 'eudr.errors.archivedReadOnly',
+    })
+
+    expect(translateEudrErrorMessage(err, translate, fallback)).toBe('Archived statements are read-only.')
+  })
+
+  it('surfaces the reason carried on the rejection message', () => {
+    const err = new Error('eudr.errors.archivedReadOnly')
+
+    expect(translateEudrErrorMessage(err, translate, fallback)).toBe('Archived statements are read-only.')
+  })
+
+  it('falls back for rejections that carry no eudr error token', () => {
+    expect(translateEudrErrorMessage(new Error('Failed to fetch'), translate, fallback)).toBe(fallback)
+    expect(translateEudrErrorMessage({ status: 500 }, translate, fallback)).toBe(fallback)
+    expect(translateEudrErrorMessage(null, translate, fallback)).toBe(fallback)
+  })
+
+  it('falls back when the token has no translation rather than showing the raw key', () => {
+    const err = Object.assign(new Error('boom'), { error: 'eudr.errors.notMappedAnywhere' })
+
+    expect(translateEudrErrorMessage(err, translate, fallback)).toBe(fallback)
+  })
+})

--- a/packages/core/src/modules/eudr/components/crudErrorI18n.ts
+++ b/packages/core/src/modules/eudr/components/crudErrorI18n.ts
@@ -15,6 +15,37 @@ function translateEudrErrorToken(token: string, translate: Translator): string {
   return translated === trimmed ? token : translated
 }
 
+function readEudrErrorToken(err: unknown): string | null {
+  if (err == null || typeof err !== 'object') return null
+  const candidates = [
+    (err as { error?: unknown }).error,
+    (err as { message?: unknown }).message,
+  ]
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string') continue
+    const trimmed = candidate.trim()
+    if (EUDR_ERROR_KEY_PATTERN.test(trimmed)) return trimmed
+  }
+  return null
+}
+
+/**
+ * Resolves the user-facing message for a rejected EUDR mutation, preferring the
+ * server's `eudr.errors.*` token over the caller's generic copy so the reason
+ * survives to the user. Falls back to `fallbackMessage` when the rejection
+ * carries no known token (network errors, 5xx, unmapped tokens).
+ */
+export function translateEudrErrorMessage(
+  err: unknown,
+  translate: Translator,
+  fallbackMessage: string,
+): string {
+  const token = readEudrErrorToken(err)
+  if (!token) return fallbackMessage
+  const translated = translate(token)
+  return translated === token ? fallbackMessage : translated
+}
+
 export function translateEudrCrudError(err: unknown, translate: Translator): unknown {
   if (!(err instanceof Error)) return err
   const rawMessage = typeof err.message === 'string' ? err.message : ''

--- a/packages/core/src/modules/eudr/components/formConfig.tsx
+++ b/packages/core/src/modules/eudr/components/formConfig.tsx
@@ -592,7 +592,7 @@ export function parseGeolocationInput(raw: string, translate: Translator): Recor
   return parsed
 }
 
-export { translateEudrCrudError } from './crudErrorI18n'
+export { translateEudrCrudError, translateEudrErrorMessage } from './crudErrorI18n'
 
 let referencedStatementRowKeySeq = 0
 

--- a/packages/core/src/modules/eudr/i18n/de.json
+++ b/packages/core/src/modules/eudr/i18n/de.json
@@ -239,7 +239,7 @@
   "eudr.lifecycle.amendWindowClosed": "Änderungsfenster geschlossen",
   "eudr.lifecycle.amendWindowRemaining": "Verbleibendes Änderungsfenster: {hours} Std. {minutes} Min.",
   "eudr.lifecycle.confirmArchive": "Erklärung archivieren?",
-  "eudr.lifecycle.confirmArchiveBody": "Die Erklärung wird archiviert.",
+  "eudr.lifecycle.confirmArchiveBody": "Die Erklärung wird archiviert. Archivierte Erklärungen sind schreibgeschützt und können nicht bearbeitet, wiederhergestellt oder gelöscht werden.",
   "eudr.lifecycle.confirmMarkAvailable": "Erklärung als verfügbar markieren?",
   "eudr.lifecycle.confirmMarkAvailableBody": "Referenzdetails sind erforderlich, bevor die Erklärung verfügbar wird.",
   "eudr.lifecycle.confirmReturnToDraft": "Erklärung in Entwurf zurücksetzen?",

--- a/packages/core/src/modules/eudr/i18n/en.json
+++ b/packages/core/src/modules/eudr/i18n/en.json
@@ -239,7 +239,7 @@
   "eudr.lifecycle.amendWindowClosed": "Amend window closed",
   "eudr.lifecycle.amendWindowRemaining": "Amend window remaining: {hours} h {minutes} min",
   "eudr.lifecycle.confirmArchive": "Archive statement?",
-  "eudr.lifecycle.confirmArchiveBody": "The statement will be archived.",
+  "eudr.lifecycle.confirmArchiveBody": "The statement will be archived. Archived statements are read-only and cannot be edited, restored, or deleted.",
   "eudr.lifecycle.confirmMarkAvailable": "Mark statement available?",
   "eudr.lifecycle.confirmMarkAvailableBody": "Reference details are required before the statement becomes available.",
   "eudr.lifecycle.confirmReturnToDraft": "Return statement to draft?",

--- a/packages/core/src/modules/eudr/i18n/es.json
+++ b/packages/core/src/modules/eudr/i18n/es.json
@@ -239,7 +239,7 @@
   "eudr.lifecycle.amendWindowClosed": "Ventana de modificación cerrada",
   "eudr.lifecycle.amendWindowRemaining": "Ventana de modificación restante: {hours} h {minutes} min",
   "eudr.lifecycle.confirmArchive": "¿Archivar declaración?",
-  "eudr.lifecycle.confirmArchiveBody": "La declaración se archivará.",
+  "eudr.lifecycle.confirmArchiveBody": "La declaración se archivará. Las declaraciones archivadas son de solo lectura y no se pueden editar, restaurar ni eliminar.",
   "eudr.lifecycle.confirmMarkAvailable": "¿Marcar declaración como disponible?",
   "eudr.lifecycle.confirmMarkAvailableBody": "Los detalles de referencia son obligatorios antes de que la declaración esté disponible.",
   "eudr.lifecycle.confirmReturnToDraft": "¿Volver la declaración a borrador?",

--- a/packages/core/src/modules/eudr/i18n/ko.json
+++ b/packages/core/src/modules/eudr/i18n/ko.json
@@ -239,7 +239,7 @@
   "eudr.lifecycle.amendWindowClosed": "수정 기간 종료",
   "eudr.lifecycle.amendWindowRemaining": "남은 수정 기간: {hours}시간 {minutes}분",
   "eudr.lifecycle.confirmArchive": "진술서를 보관하시겠습니까?",
-  "eudr.lifecycle.confirmArchiveBody": "진술서가 보관됩니다.",
+  "eudr.lifecycle.confirmArchiveBody": "진술서가 보관됩니다. 보관된 진술서는 읽기 전용이며 수정, 복원 또는 삭제할 수 없습니다.",
   "eudr.lifecycle.confirmMarkAvailable": "진술서를 사용 가능으로 표시하시겠습니까?",
   "eudr.lifecycle.confirmMarkAvailableBody": "진술서가 사용 가능해지기 전에 참조 세부 정보가 필요합니다.",
   "eudr.lifecycle.confirmReturnToDraft": "진술서를 초안으로 되돌리시겠습니까?",

--- a/packages/core/src/modules/eudr/i18n/pl.json
+++ b/packages/core/src/modules/eudr/i18n/pl.json
@@ -239,7 +239,7 @@
   "eudr.lifecycle.amendWindowClosed": "Okno zmiany zamknięte",
   "eudr.lifecycle.amendWindowRemaining": "Pozostały czas okna zmiany: {hours} godz. {minutes} min",
   "eudr.lifecycle.confirmArchive": "Zarchiwizować oświadczenie?",
-  "eudr.lifecycle.confirmArchiveBody": "Oświadczenie zostanie zarchiwizowane.",
+  "eudr.lifecycle.confirmArchiveBody": "Oświadczenie zostanie zarchiwizowane. Zarchiwizowane oświadczenia są tylko do odczytu i nie można ich edytować, przywrócić ani usunąć.",
   "eudr.lifecycle.confirmMarkAvailable": "Oznaczyć oświadczenie jako dostępne?",
   "eudr.lifecycle.confirmMarkAvailableBody": "Szczegóły referencji są wymagane, zanim oświadczenie stanie się dostępne.",
   "eudr.lifecycle.confirmReturnToDraft": "Przywrócić oświadczenie do wersji roboczej?",

--- a/packages/core/src/modules/eudr/lib/__tests__/statement-lifecycle.test.ts
+++ b/packages/core/src/modules/eudr/lib/__tests__/statement-lifecycle.test.ts
@@ -1,8 +1,11 @@
 import {
+  canDeleteStatement,
   canTransition,
   evaluateSubmissionGate,
   isAmendWindowOpen,
+  isStatementReadOnly,
 } from '../statement-lifecycle'
+import { EUDR_STATEMENT_STATUSES } from '../../data/validators'
 
 describe('canTransition', () => {
   it('allows only declared statement status transitions', () => {
@@ -10,6 +13,29 @@ describe('canTransition', () => {
     expect(canTransition('available', 'withdrawn')).toBe(true)
     expect(canTransition('archived', 'draft')).toBe(false)
     expect(canTransition('draft', 'available')).toBe(false)
+  })
+})
+
+describe('canDeleteStatement', () => {
+  it('refuses deletion for archived statements only', () => {
+    expect(canDeleteStatement('archived')).toBe(false)
+
+    for (const status of EUDR_STATEMENT_STATUSES) {
+      if (status === 'archived') continue
+      expect(canDeleteStatement(status)).toBe(true)
+    }
+  })
+
+  it('agrees with the read-only predicate the update guard uses', () => {
+    for (const status of EUDR_STATEMENT_STATUSES) {
+      expect(canDeleteStatement(status)).toBe(!isStatementReadOnly(status))
+    }
+  })
+
+  it('keeps archived terminal, so a blocked delete has no un-archive escape hatch', () => {
+    for (const status of EUDR_STATEMENT_STATUSES) {
+      expect(canTransition('archived', status)).toBe(false)
+    }
   })
 })
 

--- a/packages/core/src/modules/eudr/lib/statement-lifecycle.ts
+++ b/packages/core/src/modules/eudr/lib/statement-lifecycle.ts
@@ -13,6 +13,14 @@ export function canTransition(from: EudrStatementStatus, to: EudrStatementStatus
   return EUDR_STATEMENT_TRANSITIONS[from].includes(to)
 }
 
+export function isStatementReadOnly(status: EudrStatementStatus): boolean {
+  return status === 'archived'
+}
+
+export function canDeleteStatement(status: EudrStatementStatus): boolean {
+  return !isStatementReadOnly(status)
+}
+
 export const EUDR_AMEND_GUARDED_FIELDS = [
   'commodity',
   'quantityKg',


### PR DESCRIPTION
Closes #5461

## 🎯 Goal
An archived EUDR due-diligence statement no longer offers a Delete action that can never succeed, and when a delete is refused anyway the user is told why instead of getting generic copy.

## 🔍 Problem
Archiving a statement is a two-click, irreversible step. Afterwards the record can be neither edited, un-archived, nor removed — yet Delete stayed available on both the statement detail page and the list row menu (⋯ → Delete). Attempting it returned the accurate server reason `eudr.errors.archivedReadOnly`, but the list path replaced it with a constant "Could not delete the statement.", so nothing indicated the action could never succeed and the natural response was to retry. The same page already proved the correct behaviour exists: after archiving, Submit and Archive disappear and Save reports "Archived statements are read-only."

## 🔍 Root Cause
The terminal-`archived` rule lived only in `commands/statements.ts` and was duplicated nowhere the UI could see it. `deleteStatementCommand.execute` threw `CrudHttpError(400, { error: 'eudr.errors.archivedReadOnly' })` for `record.status === 'archived'`, mirroring the update guard, and `canTransition('archived', …)` allowed nothing outgoing. Neither delete surface consulted that rule: the detail page rendered `CrudForm` without `deleteVisible`, so `showDelete` fell back to `!isNewRecord` and Delete was always shown; the list rendered an unconditional `delete` row action. On the list, `handleDelete`'s catch discarded the thrown error — whose `error` property carried the token — and flashed the constant copy. This is the departure from the module's own pattern: `StatementLifecycleBar` already derives Submit/Archive visibility from `status`.

## What Changed
- `lib/statement-lifecycle.ts` — new `isStatementReadOnly(status)` / `canDeleteStatement(status)` exported next to `canTransition`, giving the terminal-`archived` rule a single owner.
- `commands/statements.ts` — the update guard and the delete guard now call the shared predicates instead of inline `status === 'archived'` comparisons. Behavior, status codes and the `eudr.errors.archivedReadOnly` token are unchanged.
- `backend/eudr/statements/[id]/page.tsx` — passes `deleteVisible={canDeleteStatement(record.status)}` to `CrudForm`, so Delete disappears for archived statements exactly as Submit and Archive already do. Its `onDelete` already routed through `translateEudrCrudError` and was correct, so it is untouched.
- `backend/eudr/statements/page.tsx` — the `RowActions` array is built conditionally and omits `delete` for archived rows; `handleDelete`'s catch now resolves the server reason and refreshes the list, so a row archived in another tab reveals its real status rather than silently failing again.
- `components/crudErrorI18n.ts` (re-exported from `formConfig.tsx`) — new `translateEudrErrorMessage(err, translate, fallback)` reads an `eudr.errors.*` token from either the rejection's `error` property (how `apiCall` rejections carry it) or its `message`, falling back to the caller's generic copy only when no known token is present.
- `i18n/{en,de,es,ko,pl}.json` — `eudr.lifecycle.confirmArchiveBody` now warns that archived statements are read-only and cannot be edited, restored, or deleted, closing the trap the issue's Impact section describes. Copy-only change to an existing key; no new keys.

Deliberately out of scope, as the issue requests: whether archived statements should be un-archivable or hard-deletable at all is a product decision, and the three orphaned rows the reporter created remain unremovable.

## 🧪 Tests
- `yarn workspace @open-mercato/core test --testPathPattern "modules/eudr"` — 19 suites / 125 tests passed.
- `yarn workspace @open-mercato/core typecheck` — clean. `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync` (in sync), `yarn i18n:check-usage` (advisory only) — all green. eslint over the changed files reports one pre-existing `react-hooks/exhaustive-deps` warning at `statements/page.tsx:284`, in a memo this change does not touch.
- The repo-wide `yarn test` and `yarn build:app` were left to CI rather than run locally.
- New in `lib/__tests__/statement-lifecycle.test.ts`: `archived` is the only non-deletable status; `canDeleteStatement` agrees with the read-only predicate the update guard uses; `archived` stays terminal for every status, so a blocked delete has no un-archive escape hatch.
- New `components/__tests__/crudErrorI18n.test.ts`: the reason is surfaced from a token on `error` and from a token on `message`, and untokened rejections (network error, bare object, `null`) plus tokens with no translation fall back to the generic copy rather than showing a raw key.
- `__integration__/TC-EUDR-007.spec.ts` already asserted the archived `PUT` and invalid-transition rejections; it now also asserts `DELETE /api/eudr/statements` → 400 `archivedReadOnly`, covering the wire-level contract the issue documents.

## 💥 Breaking Changes
- None. `isStatementReadOnly` / `canDeleteStatement` are additive exports; the API contract, response shapes, status machine and error token are unchanged. The only wire-visible difference is that two UI surfaces stop offering an action the server always rejected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789997924&installation_model_id=432243&pr_number=5480&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5480&signature=0fa4cb7e02efabe803c399741810aaebe10f04128863df18d0824977a4bde4b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->