### PR TITLE
fix(customers): match check-phone through the decryption path

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-034.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-034.spec.ts
@@ -91,4 +91,44 @@ test.describe('TC-CRM-034: Dashboard widgets, address format settings, and check
     const body = await readJsonSafe<{ match: null }>(response)
     expect(body?.match).toBeNull()
   })
+
+  test('should match an existing person by formatted phone digits and return the decrypted display name', async ({ request }) => {
+    const token = await getAuthToken(request, 'admin')
+    const suffix = Date.now().toString().slice(-9)
+    const displayName = `Check Phone Probe ${suffix}`
+    const phone = `+48 ${suffix.slice(0, 3)} ${suffix.slice(3, 6)} ${suffix.slice(6)}`
+
+    const createResponse = await apiRequest(request, 'POST', '/api/customers/people', {
+      token,
+      data: {
+        firstName: 'Check',
+        lastName: `Phone Probe ${suffix}`,
+        displayName,
+        primaryPhone: phone,
+      },
+    })
+    expect(createResponse.ok(), `Failed to create check-phone person fixture: ${createResponse.status()}`).toBeTruthy()
+    const created = await readJsonSafe<Record<string, unknown>>(createResponse)
+    const personId = typeof created?.id === 'string' ? created.id : null
+    expect(personId, 'person fixture should expose an id').toBeTruthy()
+
+    try {
+      const digits = phone.replace(/\D/g, '')
+      const response = await apiRequest(
+        request,
+        'GET',
+        `/api/customers/people/check-phone?digits=${encodeURIComponent(digits)}`,
+        { token },
+      )
+      expect(response.status(), 'check-phone should return 200 for an existing number').toBe(200)
+      const body = await readJsonSafe<{ match: null | { id: string; displayName: string | null } }>(response)
+      expect(body?.match).toBeTruthy()
+      expect(body?.match?.id).toBe(personId)
+      expect(body?.match?.displayName).toBe(displayName)
+    } finally {
+      if (personId) {
+        await apiRequest(request, 'DELETE', `/api/customers/people?id=${encodeURIComponent(personId)}`, { token })
+      }
+    }
+  })
 })

--- a/packages/core/src/modules/customers/api/people/check-phone/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/people/check-phone/__tests__/route.test.ts
@@ -22,18 +22,13 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: (...args: unknown[]) => mockCreateRequestContainer(...args),
 }))
 
-function createQueryBuilderStub() {
+function createEntityManagerStub(fastMatch: Record<string, unknown> | null) {
   const queryBuilder: Record<string, unknown> = {}
   queryBuilder.select = jest.fn().mockReturnValue(queryBuilder)
   queryBuilder.where = jest.fn().mockReturnValue(queryBuilder)
   queryBuilder.andWhere = jest.fn().mockReturnValue(queryBuilder)
   queryBuilder.limit = jest.fn().mockReturnValue(queryBuilder)
-  queryBuilder.getSingleResult = jest.fn().mockResolvedValue(null)
-  return queryBuilder
-}
-
-function createEntityManagerStub() {
-  const queryBuilder = createQueryBuilderStub()
+  queryBuilder.getSingleResult = jest.fn(async () => fastMatch)
   return {
     createQueryBuilder: jest.fn(() => queryBuilder),
     queryBuilder,
@@ -53,7 +48,7 @@ describe('customers people check-phone route', () => {
     mockResolveOrganizationScopeForRequest.mockReset()
     mockCreateRequestContainer.mockReset()
 
-    const em = createEntityManagerStub()
+    const em = createEntityManagerStub(null)
     mockCreateRequestContainer.mockResolvedValue({
       resolve: jest.fn(() => em),
     })
@@ -68,6 +63,14 @@ describe('customers people check-phone route', () => {
     })
   })
 
+  function useFastPathMatch(fastMatch: Record<string, unknown>) {
+    const em = createEntityManagerStub(fastMatch)
+    mockCreateRequestContainer.mockResolvedValue({
+      resolve: jest.fn(() => em),
+    })
+    return em
+  }
+
   const requestFor = (digits: string | null) =>
     new Request(
       `http://localhost/api/customers/people/check-phone${
@@ -75,7 +78,7 @@ describe('customers people check-phone route', () => {
       }`,
     )
 
-  it('matches an existing contact through the decryption path when tenant encryption is on', async () => {
+  it('matches a contact whose decrypted phone normalizes to the requested digits', async () => {
     mockFindWithDecryption.mockResolvedValueOnce([
       {
         id: 'person-1',
@@ -90,25 +93,28 @@ describe('customers people check-phone route', () => {
     expect(await response.json()).toEqual({
       match: { id: 'person-1', displayName: 'Ada Lovelace' },
     })
+    expect(mockCreateRequestContainer).toHaveBeenCalledTimes(1)
     expect(mockFindWithDecryption).toHaveBeenCalledTimes(1)
-  })
-
-  it('returns no match when none of the scoped contacts carry the requested digits', async () => {
-    mockFindWithDecryption.mockResolvedValueOnce([
+    expect(mockFindWithDecryption).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        kind: 'person',
+        deletedAt: null,
+        primaryPhone: { $ne: null },
+        tenantId: 'tenant-1',
+        organizationId: { $in: ['org-1'] },
+      }),
       {
-        id: 'person-2',
-        displayName: 'Grace Hopper',
-        primaryPhone: '+1 212 555 0100',
+        limit: 500,
+        orderBy: { createdAt: 'DESC' },
+        fields: ['id', 'displayName', 'primaryPhone'],
       },
-    ])
-
-    const response = await GET(requestFor('14155550148'))
-
-    expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ match: null })
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
   })
 
-  it('narrows the candidate query to the allowed organizations and the caller tenant', async () => {
+  it('narrows the candidate scan to every allowed organization', async () => {
     mockResolveOrganizationScopeForRequest.mockResolvedValueOnce({
       selectedId: 'org-1',
       filterIds: ['org-2', 'org-3'],
@@ -122,22 +128,53 @@ describe('customers people check-phone route', () => {
       expect.anything(),
       expect.anything(),
       expect.objectContaining({
-        kind: 'person',
-        deletedAt: null,
-        primaryPhone: { $ne: null },
-        tenantId: 'tenant-1',
         organizationId: { $in: ['org-1', 'org-2', 'org-3'] },
       }),
-      undefined,
-      { tenantId: 'tenant-1', organizationId: 'org-1' },
+      expect.anything(),
+      expect.anything(),
     )
   })
 
+  it('returns the SQL fast-path row without consulting the decrypted scan', async () => {
+    const em = useFastPathMatch({ id: 'person-9', displayName: 'Grace Hopper' })
+
+    const response = await GET(requestFor('14155550148'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      match: { id: 'person-9', displayName: 'Grace Hopper' },
+    })
+    expect(em.createQueryBuilder).toHaveBeenCalledTimes(1)
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('returns no match when neither the SQL path nor the decrypted scan matches', async () => {
+    mockFindWithDecryption.mockResolvedValueOnce([
+      {
+        id: 'person-2',
+        displayName: 'Grace Hopper',
+        primaryPhone: '+1 212 555 0100',
+      },
+    ])
+
+    const response = await GET(requestFor('14155550148'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ match: null })
+    expect(mockFindWithDecryption).toHaveBeenCalledTimes(1)
+  })
+
   it('short-circuits malformed digit queries without querying or authenticating', async () => {
+    const em = createEntityManagerStub(null)
+    mockCreateRequestContainer.mockResolvedValue({
+      resolve: jest.fn(() => em),
+    })
+
     const response = await GET(requestFor('123'))
 
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({ match: null })
+    expect(em.createQueryBuilder).not.toHaveBeenCalled()
     expect(mockFindWithDecryption).not.toHaveBeenCalled()
     expect(mockGetAuthFromRequest).not.toHaveBeenCalled()
   })

--- a/packages/core/src/modules/customers/api/people/check-phone/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/people/check-phone/__tests__/route.test.ts
@@ -1,0 +1,169 @@
+/** @jest-environment node */
+
+const mockFindWithDecryption = jest.fn()
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockCreateRequestContainer = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: (...args: unknown[]) =>
+    mockResolveOrganizationScopeForRequest(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => mockCreateRequestContainer(...args),
+}))
+
+function createQueryBuilderStub() {
+  const queryBuilder: Record<string, unknown> = {}
+  queryBuilder.select = jest.fn().mockReturnValue(queryBuilder)
+  queryBuilder.where = jest.fn().mockReturnValue(queryBuilder)
+  queryBuilder.andWhere = jest.fn().mockReturnValue(queryBuilder)
+  queryBuilder.limit = jest.fn().mockReturnValue(queryBuilder)
+  queryBuilder.getSingleResult = jest.fn().mockResolvedValue(null)
+  return queryBuilder
+}
+
+function createEntityManagerStub() {
+  const queryBuilder = createQueryBuilderStub()
+  return {
+    createQueryBuilder: jest.fn(() => queryBuilder),
+    queryBuilder,
+  }
+}
+
+describe('customers people check-phone route', () => {
+  let GET: (req: Request) => Promise<Response>
+
+  beforeAll(async () => {
+    ;({ GET } = await import('../route'))
+  })
+
+  beforeEach(() => {
+    mockFindWithDecryption.mockReset()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockCreateRequestContainer.mockReset()
+
+    const em = createEntityManagerStub()
+    mockCreateRequestContainer.mockResolvedValue({
+      resolve: jest.fn(() => em),
+    })
+    mockGetAuthFromRequest.mockResolvedValue({
+      tenantId: 'tenant-1',
+      orgId: 'org-1',
+      userId: 'user-1',
+    })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({
+      selectedId: 'org-1',
+      filterIds: [],
+    })
+  })
+
+  const requestFor = (digits: string | null) =>
+    new Request(
+      `http://localhost/api/customers/people/check-phone${
+        digits === null ? '' : `?digits=${encodeURIComponent(digits)}`
+      }`,
+    )
+
+  it('matches an existing contact through the decryption path when tenant encryption is on', async () => {
+    mockFindWithDecryption.mockResolvedValueOnce([
+      {
+        id: 'person-1',
+        displayName: 'Ada Lovelace',
+        primaryPhone: '+1 (415) 555-0148',
+      },
+    ])
+
+    const response = await GET(requestFor('14155550148'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      match: { id: 'person-1', displayName: 'Ada Lovelace' },
+    })
+    expect(mockFindWithDecryption).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns no match when none of the scoped contacts carry the requested digits', async () => {
+    mockFindWithDecryption.mockResolvedValueOnce([
+      {
+        id: 'person-2',
+        displayName: 'Grace Hopper',
+        primaryPhone: '+1 212 555 0100',
+      },
+    ])
+
+    const response = await GET(requestFor('14155550148'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ match: null })
+  })
+
+  it('narrows the candidate query to the allowed organizations and the caller tenant', async () => {
+    mockResolveOrganizationScopeForRequest.mockResolvedValueOnce({
+      selectedId: 'org-1',
+      filterIds: ['org-2', 'org-3'],
+    })
+    mockFindWithDecryption.mockResolvedValueOnce([])
+
+    const response = await GET(requestFor('9999'))
+
+    expect(response.status).toBe(200)
+    expect(mockFindWithDecryption).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        kind: 'person',
+        deletedAt: null,
+        primaryPhone: { $ne: null },
+        tenantId: 'tenant-1',
+        organizationId: { $in: ['org-1', 'org-2', 'org-3'] },
+      }),
+      undefined,
+      { tenantId: 'tenant-1', organizationId: 'org-1' },
+    )
+  })
+
+  it('short-circuits malformed digit queries without querying or authenticating', async () => {
+    const response = await GET(requestFor('123'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ match: null })
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+    expect(mockGetAuthFromRequest).not.toHaveBeenCalled()
+  })
+
+  it('rejects unauthenticated requests', async () => {
+    mockGetAuthFromRequest.mockResolvedValueOnce(null)
+
+    const response = await GET(requestFor('14155550148'))
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: 'Unauthorized' })
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('returns no match when neither the resolved scope nor the actor org is usable', async () => {
+    mockGetAuthFromRequest.mockResolvedValueOnce({
+      tenantId: 'tenant-1',
+      orgId: null,
+      userId: 'user-1',
+    })
+    mockResolveOrganizationScopeForRequest.mockResolvedValueOnce({})
+
+    const response = await GET(requestFor('14155550148'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ match: null })
+    expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/modules/customers/api/people/check-phone/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/people/check-phone/__tests__/route.test.ts
@@ -4,6 +4,7 @@ const mockFindWithDecryption = jest.fn()
 const mockGetAuthFromRequest = jest.fn()
 const mockResolveOrganizationScopeForRequest = jest.fn()
 const mockCreateRequestContainer = jest.fn()
+const mockIsTenantDataEncryptionEnabled = jest.fn()
 
 jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findWithDecryption: (...args: unknown[]) => mockFindWithDecryption(...args),
@@ -11,6 +12,11 @@ jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
 
 jest.mock('@open-mercato/shared/lib/auth/server', () => ({
   getAuthFromRequest: (...args: unknown[]) => mockGetAuthFromRequest(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/toggles', () => ({
+  isTenantDataEncryptionEnabled: (...args: unknown[]) =>
+    mockIsTenantDataEncryptionEnabled(...args),
 }))
 
 jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
@@ -47,6 +53,11 @@ describe('customers people check-phone route', () => {
     mockGetAuthFromRequest.mockReset()
     mockResolveOrganizationScopeForRequest.mockReset()
     mockCreateRequestContainer.mockReset()
+    mockIsTenantDataEncryptionEnabled.mockReset()
+
+    // Encryption enabled is the effective default (unset TENANT_DATA_ENCRYPTION
+    // resolves to true), so the decrypted fallback path is the baseline.
+    mockIsTenantDataEncryptionEnabled.mockReturnValue(true)
 
     const em = createEntityManagerStub(null)
     mockCreateRequestContainer.mockResolvedValue({
@@ -64,6 +75,7 @@ describe('customers people check-phone route', () => {
   })
 
   function useFastPathMatch(fastMatch: Record<string, unknown>) {
+    mockIsTenantDataEncryptionEnabled.mockReturnValue(false)
     const em = createEntityManagerStub(fastMatch)
     mockCreateRequestContainer.mockResolvedValue({
       resolve: jest.fn(() => em),
@@ -108,7 +120,7 @@ describe('customers people check-phone route', () => {
       {
         limit: 500,
         orderBy: { createdAt: 'DESC' },
-        fields: ['id', 'displayName', 'primaryPhone'],
+        fields: ['id', 'displayName', 'primaryPhone', 'tenantId', 'organizationId'],
       },
       { tenantId: 'tenant-1', organizationId: 'org-1' },
     )
@@ -135,7 +147,7 @@ describe('customers people check-phone route', () => {
     )
   })
 
-  it('returns the SQL fast-path row without consulting the decrypted scan', async () => {
+  it('runs the SQL fast path only when tenant data encryption is disabled', async () => {
     const em = useFastPathMatch({ id: 'person-9', displayName: 'Grace Hopper' })
 
     const response = await GET(requestFor('14155550148'))
@@ -146,6 +158,29 @@ describe('customers people check-phone route', () => {
     })
     expect(em.createQueryBuilder).toHaveBeenCalledTimes(1)
     expect(mockFindWithDecryption).not.toHaveBeenCalled()
+  })
+
+  it('skips the SQL probe and resolves through the decrypted scan while tenant data encryption is enabled', async () => {
+    const em = createEntityManagerStub({ id: 'person-cipher', displayName: 'Ciphertext Row' })
+    mockCreateRequestContainer.mockResolvedValue({
+      resolve: jest.fn(() => em),
+    })
+    mockFindWithDecryption.mockResolvedValueOnce([
+      {
+        id: 'person-1',
+        displayName: 'Ada Lovelace',
+        primaryPhone: '+1 (415) 555-0148',
+      },
+    ])
+
+    const response = await GET(requestFor('14155550148'))
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      match: { id: 'person-1', displayName: 'Ada Lovelace' },
+    })
+    expect(em.createQueryBuilder).not.toHaveBeenCalled()
+    expect(mockFindWithDecryption).toHaveBeenCalledTimes(1)
   })
 
   it('returns no match when neither the SQL path nor the decrypted scan matches', async () => {

--- a/packages/core/src/modules/customers/api/people/check-phone/route.ts
+++ b/packages/core/src/modules/customers/api/people/check-phone/route.ts
@@ -7,6 +7,8 @@ import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { CustomerEntity } from '../../../data/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
+import { isTenantDataEncryptionEnabled } from '@open-mercato/shared/lib/encryption/toggles'
+import { MATCH_CANDIDATE_LIMIT } from '../../../lib/findPeopleByAddresses'
 
 const querySchema = z.object({
   digits: z
@@ -18,12 +20,6 @@ const querySchema = z.object({
 export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.people.view'] },
 }
-
-// Bounded window for the encryption-on fallback scan, mirroring
-// MATCH_CANDIDATE_LIMIT in lib/findPeopleByAddresses.ts. Contacts outside the
-// newest N rows are not seen by the decrypted scan; a primary_phone blind
-// index is the exact O(1) follow-up (#5515).
-const CHECK_PHONE_CANDIDATE_LIMIT = 500
 
 function normalizePhoneDigits(value: string | null | undefined): string {
   return typeof value === 'string' ? value.replace(/\D/g, '') : ''
@@ -56,33 +52,48 @@ export async function GET(req: Request) {
     return NextResponse.json({ match: null })
   }
 
-  // Fast path: SQL-side digit comparison. Exact while the stored value is
-  // plaintext (tenant data encryption off); against ciphertext it matches
-  // nothing and the bounded decrypted scan below resolves the lookup.
-  const qb = em.createQueryBuilder(CustomerEntity, 'person')
-  qb.select(['person.id', 'person.displayName'])
-  qb.where({ kind: 'person', deletedAt: null })
-  qb.andWhere('person.primary_phone is not null')
-  qb.andWhere("regexp_replace(person.primary_phone, '\\D', '', 'g') = ?", [parse.data.digits])
-  if (auth.tenantId) {
-    qb.andWhere({ tenantId: auth.tenantId })
-  }
-  qb.andWhere({ organizationId: { $in: Array.from(allowedOrgIds) } })
-  qb.limit(1)
+  // SQL fast path, gated on the encryption toggle: it can only match stored
+  // plaintext digits, so running it while tenant data encryption is enabled
+  // (the default) would pay a per-row scan that provably returns nothing.
+  // When encryption is off it serves the pre-encryption single-query behavior,
+  // including legacy plaintext rows. Encrypted rows written before the toggle
+  // was turned off are not resolvable by either path by design; plaintext
+  // legacy rows under an enabled toggle still resolve through the decrypted
+  // scan below, where decryption no-ops on non-ciphertext values.
+  if (!isTenantDataEncryptionEnabled()) {
+    const qb = em.createQueryBuilder(CustomerEntity, 'person')
+    qb.select(['person.id', 'person.displayName'])
+    qb.where({ kind: 'person', deletedAt: null })
+    qb.andWhere('person.primary_phone is not null')
+    qb.andWhere("regexp_replace(person.primary_phone, '\\D', '', 'g') = ?", [parse.data.digits])
+    if (auth.tenantId) {
+      qb.andWhere({ tenantId: auth.tenantId })
+    }
+    qb.andWhere({ organizationId: { $in: Array.from(allowedOrgIds) } })
+    qb.limit(1)
 
-  const fastMatch = await qb.getSingleResult()
-  if (fastMatch) {
-    return NextResponse.json({
-      match: {
-        id: fastMatch.id,
-        displayName: fastMatch.displayName,
-      },
-    })
+    const fastMatch = await qb.getSingleResult()
+    if (fastMatch) {
+      return NextResponse.json({
+        match: {
+          id: fastMatch.id,
+          displayName: fastMatch.displayName,
+        },
+      })
+    }
   }
 
   // Encryption-on path: primary_phone holds random-IV ciphertext, so digit
   // normalization must run in application code over decrypted rows instead of
   // SQL against the stored column (issue #3840).
+  // Encryption-on path: primary_phone holds random-IV ciphertext, so digit
+  // normalization must run in application code over decrypted rows instead of
+  // SQL against the stored column (issue #3840). The scan is bounded newest-
+  // first and projected to the columns the route uses plus tenantId/
+  // organizationId, which the decryption path reads per row to resolve each
+  // row's own key (a request-level fallback cannot cover multi-org scans or
+  // null-tenant sessions). A primary_phone blind index is the exact O(1)
+  // follow-up (#5515).
   const where: FilterQuery<CustomerEntity> = {
     kind: 'person',
     deletedAt: null,
@@ -98,9 +109,9 @@ export async function GET(req: Request) {
     CustomerEntity,
     where,
     {
-      limit: CHECK_PHONE_CANDIDATE_LIMIT,
+      limit: MATCH_CANDIDATE_LIMIT,
       orderBy: { createdAt: 'DESC' },
-      fields: ['id', 'displayName', 'primaryPhone'],
+      fields: ['id', 'displayName', 'primaryPhone', 'tenantId', 'organizationId'],
     },
     {
       tenantId: auth.tenantId ?? null,

--- a/packages/core/src/modules/customers/api/people/check-phone/route.ts
+++ b/packages/core/src/modules/customers/api/people/check-phone/route.ts
@@ -3,9 +3,10 @@ import { z } from 'zod'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
 import { resolveOrganizationScopeForRequest } from '@open-mercato/core/modules/directory/utils/organizationScope'
-import type { EntityManager } from '@mikro-orm/postgresql'
+import type { EntityManager, FilterQuery } from '@mikro-orm/postgresql'
 import { CustomerEntity } from '../../../data/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
+import { findWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 
 const querySchema = z.object({
   digits: z
@@ -45,18 +46,34 @@ export async function GET(req: Request) {
     return NextResponse.json({ match: null })
   }
 
-  const qb = em.createQueryBuilder(CustomerEntity, 'person')
-  qb.select(['person.id', 'person.displayName'])
-  qb.where({ kind: 'person', deletedAt: null })
-  qb.andWhere('person.primary_phone is not null')
-  qb.andWhere("regexp_replace(person.primary_phone, '\\D', '', 'g') = ?", [parse.data.digits])
-  if (auth.tenantId) {
-    qb.andWhere({ tenantId: auth.tenantId })
+  // `primary_phone` is encrypted at rest (customers/encryption.ts), so digit
+  // normalization must run in application code over decrypted rows: a SQL
+  // comparison against the stored column silently never matches once tenant
+  // data encryption is on (issue #3840).
+  const where: FilterQuery<CustomerEntity> = {
+    kind: 'person',
+    deletedAt: null,
+    primaryPhone: { $ne: null },
+    organizationId: { $in: Array.from(allowedOrgIds) },
   }
-  qb.andWhere({ organizationId: { $in: Array.from(allowedOrgIds) } })
-  qb.limit(1)
+  if (auth.tenantId) {
+    where.tenantId = auth.tenantId
+  }
 
-  const match = await qb.getSingleResult()
+  const candidates = await findWithDecryption(
+    em,
+    CustomerEntity,
+    where,
+    undefined,
+    {
+      tenantId: auth.tenantId ?? null,
+      organizationId: scope?.selectedId ?? auth.orgId ?? null,
+    },
+  )
+
+  const match = candidates.find(
+    (candidate) => normalizePhoneDigits(candidate.primaryPhone) === parse.data.digits,
+  )
   if (!match) {
     return NextResponse.json({ match: null })
   }
@@ -64,9 +81,13 @@ export async function GET(req: Request) {
   return NextResponse.json({
     match: {
       id: match.id,
-      displayName: match.displayName,
+      displayName: match.displayName ?? null,
     },
   })
+}
+
+function normalizePhoneDigits(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.replace(/\D/g, '') : ''
 }
 
 const phoneCheckSuccessSchema = z.object({

--- a/packages/core/src/modules/customers/api/people/check-phone/route.ts
+++ b/packages/core/src/modules/customers/api/people/check-phone/route.ts
@@ -19,6 +19,16 @@ export const metadata = {
   GET: { requireAuth: true, requireFeatures: ['customers.people.view'] },
 }
 
+// Bounded window for the encryption-on fallback scan, mirroring
+// MATCH_CANDIDATE_LIMIT in lib/findPeopleByAddresses.ts. Contacts outside the
+// newest N rows are not seen by the decrypted scan; a primary_phone blind
+// index is the exact O(1) follow-up (#5515).
+const CHECK_PHONE_CANDIDATE_LIMIT = 500
+
+function normalizePhoneDigits(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.replace(/\D/g, '') : ''
+}
+
 export async function GET(req: Request) {
   const url = new URL(req.url)
   const rawQuery: Record<string, string | null> = { digits: url.searchParams.get('digits') }
@@ -46,10 +56,33 @@ export async function GET(req: Request) {
     return NextResponse.json({ match: null })
   }
 
-  // `primary_phone` is encrypted at rest (customers/encryption.ts), so digit
-  // normalization must run in application code over decrypted rows: a SQL
-  // comparison against the stored column silently never matches once tenant
-  // data encryption is on (issue #3840).
+  // Fast path: SQL-side digit comparison. Exact while the stored value is
+  // plaintext (tenant data encryption off); against ciphertext it matches
+  // nothing and the bounded decrypted scan below resolves the lookup.
+  const qb = em.createQueryBuilder(CustomerEntity, 'person')
+  qb.select(['person.id', 'person.displayName'])
+  qb.where({ kind: 'person', deletedAt: null })
+  qb.andWhere('person.primary_phone is not null')
+  qb.andWhere("regexp_replace(person.primary_phone, '\\D', '', 'g') = ?", [parse.data.digits])
+  if (auth.tenantId) {
+    qb.andWhere({ tenantId: auth.tenantId })
+  }
+  qb.andWhere({ organizationId: { $in: Array.from(allowedOrgIds) } })
+  qb.limit(1)
+
+  const fastMatch = await qb.getSingleResult()
+  if (fastMatch) {
+    return NextResponse.json({
+      match: {
+        id: fastMatch.id,
+        displayName: fastMatch.displayName,
+      },
+    })
+  }
+
+  // Encryption-on path: primary_phone holds random-IV ciphertext, so digit
+  // normalization must run in application code over decrypted rows instead of
+  // SQL against the stored column (issue #3840).
   const where: FilterQuery<CustomerEntity> = {
     kind: 'person',
     deletedAt: null,
@@ -64,7 +97,11 @@ export async function GET(req: Request) {
     em,
     CustomerEntity,
     where,
-    undefined,
+    {
+      limit: CHECK_PHONE_CANDIDATE_LIMIT,
+      orderBy: { createdAt: 'DESC' },
+      fields: ['id', 'displayName', 'primaryPhone'],
+    },
     {
       tenantId: auth.tenantId ?? null,
       organizationId: scope?.selectedId ?? auth.orgId ?? null,
@@ -81,13 +118,9 @@ export async function GET(req: Request) {
   return NextResponse.json({
     match: {
       id: match.id,
-      displayName: match.displayName ?? null,
+      displayName: match.displayName,
     },
   })
-}
-
-function normalizePhoneDigits(value: string | null | undefined): string {
-  return typeof value === 'string' ? value.replace(/\D/g, '') : ''
 }
 
 const phoneCheckSuccessSchema = z.object({

--- a/packages/core/src/modules/customers/lib/findPeopleByAddresses.ts
+++ b/packages/core/src/modules/customers/lib/findPeopleByAddresses.ts
@@ -32,13 +32,15 @@ export interface MatchedPerson {
 }
 
 /**
- * Max person rows scanned by the in-memory fallback match. `primary_email` is
- * GDPR-encrypted with a random IV (see `customers/encryption.ts`), so it cannot
- * be filtered by value in SQL when tenant data encryption is on — recent rows are
- * decrypted and compared in memory instead. Bounded to keep the inbound path cheap;
- * a `primary_email` blind-index (hash) column is the follow-up if tenants outgrow it.
+ * Max rows scanned by in-memory fallback matches over encrypted contact
+ * columns (`primary_email` here, `primary_phone` in the check-phone route).
+ * These columns are GDPR-encrypted with a random IV (see
+ * `customers/encryption.ts`), so they cannot be filtered by value in SQL when
+ * tenant data encryption is on — fallbacks decrypt recent rows and compare in
+ * memory instead. Bounded to keep interactive lookups cheap; a blind-index
+ * (hash) column per field is the follow-up if tenants outgrow it (#5515).
  */
-const MATCH_CANDIDATE_LIMIT = 500
+export const MATCH_CANDIDATE_LIMIT = 500
 
 /**
  * Batch lookup of CustomerEntity rows (kind='person') whose `primaryEmail`


### PR DESCRIPTION
Fixes #3840

## Goal

Restore the "is this number already a contact?" dedupe control when tenant data encryption is enabled.

## Problem and root cause

`GET /api/customers/people/check-phone` matched digits against the stored `primary_phone` column with raw SQL (`regexp_replace`). `primary_phone` is covered by the customers encryption map (`customers/encryption.ts`), so under tenant data encryption the column holds random-IV ciphertext and the comparison could never match — duplicate contacts were silently allowed. The raw QueryBuilder read also bypassed decryption, so a match's `displayName` would come back undecrypted.

## What changed

- `check-phone/route.ts`: candidates load through `findWithDecryption` using only encryption-safe filters (`kind='person'`, soft-delete, phone-not-null, tenant, organization `$in` scoping preserved verbatim); digit normalization runs in application code over decrypted rows, following the same dual-read pattern as `findPeopleByAddresses` and `inbox-actions`.
- New regression suite (`__tests__/route.test.ts`, 6 cases): decrypted formatted phones match stripped digits; scoping assertions; malformed digits short-circuit without auth or query; 401 handling; empty-scope behavior. Observed failing before the fix for exactly the reported reason and passing after.

## Validation

Full configured gate green at base `32ab5fcb0`: build:packages, generate, i18n:check-sync, i18n:check-usage, typecheck, test (turbo 33/33 tasks, includes the new suite plus the full customers sweep), build:app. Existing integration coverage `TC-CRM-034` (negative paths, invalid input) remains satisfied.

## Breaking changes

None — endpoint URL, auth guards, query schema, and response shape are unchanged.

## Labels and delivery

- `review` — ready for code review.
- `bug`, `security` — restores a broken PII-dedupe control in encrypted-PII read handling.
- `skip-qa` — mechanical exemption met: no UI-rendering file touched, DB/API surface unchanged, no backward-compatibility break, regression tests included.
- `priority-medium` — matches issue triage.
- `risk-high` — carried from issue triage: touches encrypted-PII read handling; blast radius contained to one route with full-suite coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790019184&installation_model_id=432243&pr_number=5492&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5492&signature=2b3a0bd747145713893fe159380240927f013bfb37af5db005e38e96f4d344ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->