### PR TITLE
fix(customers): stop customer detail + sub-resource routes leaking record existence (#5504)

### DIFF
--- a/packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts
+++ b/packages/core/src/modules/customers/__integration__/TC-CRM-072.spec.ts
@@ -148,9 +148,29 @@ test.describe('TC-CRM-072: org-scope fail-open authorization hardening (#2239 + 
       const readToken = await getAuthToken(request, readUserEmail, password);
       expect(decodeOrgId(readToken), 'floating read user must have null home org in JWT').toBeNull();
 
-      // READ deny: detail GET on the orgB person => 403 (was fail-open: empty set skipped guard).
+      // READ deny: detail GET on the orgB person (was fail-open: empty set skipped
+      // guard). The org-scope guard still denies the read; #5504 collapses that
+      // denial into the route's not-found response (404 instead of 403) so it no
+      // longer reveals that the id exists in an organization the caller cannot
+      // see. The fail-open hole (#2245) stays closed — the body carries no orgB
+      // data, only the generic not-found error.
       const denyRead = await apiRequest(request, 'GET', `/api/customers/people/${personOrgBId}`, { token: readToken });
-      expect(denyRead.status(), 'cross-org detail GET (orgB) must be forbidden (#2245)').toBe(403);
+      expect(denyRead.status(), 'cross-org detail GET (orgB) must be denied as not-found (#2245 + #5504)').toBe(404);
+      const denyReadBody = await denyRead.json().catch(() => null);
+      expect(denyReadBody, 'cross-org detail GET must not leak orgB data').toEqual({ error: 'Person not found' });
+
+      // #5504 is applied module-wide, not just to the detail route: a sibling
+      // sub-resource route that loads the SAME person by id under the SAME grant
+      // must be indistinguishable between "foreign org" and "does not exist".
+      const nonExistentPersonId = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d';
+      const denySubResource = await apiRequest(request, 'GET', `/api/customers/people/${personOrgBId}/companies`, { token: readToken });
+      const missingSubResource = await apiRequest(request, 'GET', `/api/customers/people/${nonExistentPersonId}/companies`, { token: readToken });
+      expect(denySubResource.status(), 'cross-org sub-resource GET (orgB) must be denied as not-found (#5504)').toBe(404);
+      expect(
+        missingSubResource.status(),
+        'a foreign-org id and a non-existent id must be indistinguishable on the sub-resource route (#5504)',
+      ).toBe(denySubResource.status());
+      expect(await missingSubResource.json().catch(() => null)).toEqual(await denySubResource.json().catch(() => null));
     } finally {
       await deleteUserAclInDb(writeUserId ?? '').catch(() => undefined);
       await deleteUserAclInDb(readUserId ?? '').catch(() => undefined);

--- a/packages/core/src/modules/customers/api/companies/[id]/__tests__/route.existenceOracle.test.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/__tests__/route.existenceOracle.test.ts
@@ -1,0 +1,168 @@
+/** @jest-environment node */
+
+// Regression coverage for issue #5504: the company detail route must not form an
+// existence oracle. The API dispatcher already enforces `requireFeatures`
+// (a uniform 403) before the handler runs, so the reachable caller here is a
+// GRANTED one. For that caller, a record that exists in an organization outside
+// their scope must return the SAME response as a non-existent id — otherwise
+// 403-when-present / 404-when-absent leaks existence. The route now collapses
+// the post-load organization-scope denial into its not-found response, so both
+// are a uniform 404. Before the fix the foreign-org record returned 403.
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockResolveCustomerInteractionFeatureFlags = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockIsOrganizationReadAccessAllowed = jest.fn()
+
+const mockEm = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'queryEngine') return { query: jest.fn(async () => ({ items: [] })) }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+// The route rejects out-of-scope reads through the shared
+// denyCustomerDetailReadAsNotFound helper, which consults this guard. Control
+// the guard so the "record exists in a foreign org" branch is exercised.
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: jest.fn((...args: unknown[]) => mockIsOrganizationReadAccessAllowed(...args)),
+}))
+
+jest.mock('../../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn((...args: unknown[]) => mockResolveCustomerInteractionFeatureFlags(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn(async () => ({})),
+}))
+
+jest.mock('../../../../lib/customFieldRouting', () => ({
+  resolveCompanyCustomFieldRouting: jest.fn(async () => new Map()),
+  mergeCompanyCustomFieldValues: jest.fn(() => ({})),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('../../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_entity: 'customer_entity',
+      customer_company_profile: 'customer_company_profile',
+    },
+  },
+}), { virtual: true })
+
+const EXISTING_FOREIGN_ID = '2408107d-0000-4000-8000-0000000000bb'
+const NON_EXISTENT_ID = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
+
+function buildForeignCompany(id: string) {
+  const createdAt = new Date('2026-04-10T08:00:00.000Z')
+  return {
+    id,
+    kind: 'company',
+    deletedAt: null,
+    tenantId: 'tenant-1',
+    organizationId: 'org-foreign',
+    companyProfile: null,
+    displayName: 'Acme Corp',
+    description: null,
+    ownerUserId: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    status: null,
+    lifecycleStage: null,
+    source: null,
+    nextInteractionAt: null,
+    nextInteractionName: null,
+    nextInteractionRefId: null,
+    nextInteractionIcon: null,
+    nextInteractionColor: null,
+    isActive: true,
+    temperature: null,
+    renewalQuarter: null,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+async function callDetail(id: string) {
+  const { GET } = await import('../route')
+  const response = await GET(
+    new Request(`http://localhost/api/customers/companies/${id}`),
+    { params: { id } },
+  )
+  const body = await response.json()
+  return { status: response.status, body }
+}
+
+describe('GET /api/customers/companies/[id] — no existence oracle (issue #5504)', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockResolveCustomerInteractionFeatureFlags.mockReset()
+    mockFindOneWithDecryption.mockReset()
+    mockFindWithDecryption.mockReset()
+    mockIsOrganizationReadAccessAllowed.mockReset()
+    mockEm.findOne.mockReset()
+    mockEm.find.mockReset()
+    mockEm.count.mockReset()
+    mockEm.count.mockResolvedValue(0)
+    mockEm.find.mockResolvedValue([])
+    mockFindWithDecryption.mockResolvedValue([])
+    mockContainer.resolve.mockClear()
+
+    // A granted, authenticated user in tenant-1 / org-1 (the dispatcher already
+    // let them through) probing records that live in a different organization.
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1', isApiKey: false })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({ filterIds: ['org-1'], selectedId: 'org-1', tenantId: 'tenant-1' })
+    mockResolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    // The resolved record's organization is outside the caller's scope.
+    mockIsOrganizationReadAccessAllowed.mockReturnValue(false)
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, _entity: unknown, where: Record<string, unknown>) =>
+      where?.id === EXISTING_FOREIGN_ID ? buildForeignCompany(EXISTING_FOREIGN_ID) : null,
+    )
+  })
+
+  it('returns an identical 404 for an existing foreign-org record and a non-existent id', async () => {
+    const existing = await callDetail(EXISTING_FOREIGN_ID)
+    const missing = await callDetail(NON_EXISTENT_ID)
+
+    // Before the fix the existing foreign-org record returned 403 while the
+    // missing id returned 404 — the oracle the issue reports.
+    expect(existing.status).toBe(404)
+    expect(missing.status).toBe(404)
+    // The oracle is closed only if the two responses are indistinguishable.
+    expect(missing.status).toBe(existing.status)
+    expect(missing.body).toEqual(existing.body)
+    expect(existing.body).toEqual({ error: 'Company not found' })
+  })
+})

--- a/packages/core/src/modules/customers/api/companies/[id]/people/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/people/route.ts
@@ -112,8 +112,11 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       throw notFound(translate('customers.errors.company_not_found', 'Company not found'))
     }
 
+    // Existence oracle (#5504): deny a cross-org read as not-found — identical to
+    // the parent-not-found above — so it cannot reveal that a company exists in an
+    // organization the caller cannot see.
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: company.organizationId })) {
-      throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
+      throw notFound(translate('customers.errors.company_not_found', 'Company not found'))
     }
 
     const entityScope = { tenantId: auth.tenantId, organizationId: company.organizationId }

--- a/packages/core/src/modules/customers/api/companies/[id]/roles/__tests__/route.test.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/roles/__tests__/route.test.ts
@@ -63,6 +63,7 @@ const validateCrudMutationGuardMock = jest.fn()
 const runCrudMutationGuardAfterSuccessMock = jest.fn()
 const findOneWithDecryptionMock = jest.fn()
 const findWithDecryptionMock = jest.fn()
+const isOrganizationReadAccessAllowedMock = jest.fn(() => true)
 
 jest.mock('../../../../../lib/interactionRequestContext', () => ({
   resolveCustomersRequestContext: jest.fn(async () => mockContext),
@@ -85,9 +86,14 @@ jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
   findWithDecryption: (...args: unknown[]) => findWithDecryptionMock(...args),
 }))
 
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: (...args: unknown[]) => isOrganizationReadAccessAllowedMock(...args),
+}))
+
 describe('/api/customers/companies/[id]/roles', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    isOrganizationReadAccessAllowedMock.mockReturnValue(true)
     mockCommandBus.execute.mockResolvedValue({
       result: { roleId },
       logEntry: null,
@@ -185,5 +191,46 @@ describe('/api/customers/companies/[id]/roles', () => {
     expect(response.status).toBe(403)
     expect(await response.json()).toEqual({ error: 'Access denied' })
     expect(findWithDecryptionMock).not.toHaveBeenCalled()
+  })
+
+  it('denies a cross-org write as not-found (404), byte-identical to a missing entity (#5504)', async () => {
+    // ensureRouteOrganizationAccess is shared by GET/POST/PUT/DELETE. A caller who
+    // holds customers.roles.manage but whose scope excludes the company's org must
+    // not learn the company exists through the write path: the org denial collapses
+    // into the same 404 the caller gets for a company that does not exist. The org
+    // guard runs before the request body is read, so pinning POST covers all four
+    // methods at once (#5504).
+    userHasAllFeaturesMock.mockResolvedValue(true)
+    isOrganizationReadAccessAllowedMock.mockReturnValue(false)
+    const { POST } = await import('../route')
+
+    findOneWithDecryptionMock.mockResolvedValueOnce({
+      id: companyId,
+      kind: 'company',
+      tenantId,
+      organizationId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      deletedAt: null,
+    })
+    const foreignOrgResponse = await POST(
+      new Request(`http://localhost/api/customers/companies/${companyId}/roles`, { method: 'POST', body: '{}' }),
+      { params: { id: companyId } },
+    )
+
+    findOneWithDecryptionMock.mockResolvedValueOnce(null)
+    const missingResponse = await POST(
+      new Request(`http://localhost/api/customers/companies/${companyId}/roles`, { method: 'POST', body: '{}' }),
+      { params: { id: companyId } },
+    )
+
+    const foreignOrgBody = await foreignOrgResponse.json()
+    const missingBody = await missingResponse.json()
+
+    expect(foreignOrgResponse.status).toBe(404)
+    expect(missingResponse.status).toBe(404)
+    // The oracle is closed only if the two rejections are indistinguishable.
+    expect(missingBody).toEqual(foreignOrgBody)
+    expect(foreignOrgBody).toEqual({ error: 'Customer not found' })
+    // The cross-org write never reached the command bus.
+    expect(mockCommandBus.execute).not.toHaveBeenCalled()
   })
 })

--- a/packages/core/src/modules/customers/api/companies/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/companies/[id]/route.ts
@@ -50,7 +50,7 @@ import {
   type CompanyPersonUnionEntry,
 } from '../../../lib/personCompanies'
 import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
-import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
+import { denyCustomerDetailReadAsNotFound } from '../../../lib/detailReadAccess'
 import { runWithCacheTenant } from '@open-mercato/cache'
 import {
   buildCollectionTags,
@@ -143,10 +143,6 @@ function parseIncludeParams(request: Request): Set<string> {
       .forEach((part) => tokens.add(part))
   })
   return tokens
-}
-
-function forbidden(message: string) {
-  return NextResponse.json({ error: message }, { status: 403 })
 }
 
 function notFound(message: string) {
@@ -462,9 +458,16 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
   )
   if (!company) return notFound('Company not found')
 
-  if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: company.organizationId })) {
-    return forbidden('Access denied')
-  }
+  // Existence oracle (issue #5504): a caller who holds customers.companies.view
+  // but whose scope excludes the record's organization must get the SAME
+  // response as for a non-existent id, so 403-when-present / 404-when-absent
+  // collapses to a uniform 404 not-found. The dispatcher already returns a
+  // uniform 403 for callers who lack the feature entirely.
+  const organizationReadDenied = denyCustomerDetailReadAsNotFound(
+    { scope, auth, organizationId: company.organizationId },
+    'Company not found',
+  )
+  if (organizationReadDenied) return organizationReadDenied
 
   const companyScope = {
     tenantId: company.tenantId ?? auth.tenantId ?? null,
@@ -1400,8 +1403,8 @@ export const openApi: OpenApiRouteDoc = {
       errors: [
         { status: 400, description: 'Invalid identifier', schema: companyDetailErrorSchema },
         { status: 401, description: 'Unauthorized', schema: companyDetailErrorSchema },
-        { status: 403, description: 'Forbidden for tenant/organization scope', schema: companyDetailErrorSchema },
-        { status: 404, description: 'Company not found', schema: companyDetailErrorSchema },
+        { status: 403, description: 'Forbidden — caller lacks the required feature', schema: companyDetailErrorSchema },
+        { status: 404, description: 'Company not found, or its organization is not in the caller’s scope', schema: companyDetailErrorSchema },
       ],
     },
   },

--- a/packages/core/src/modules/customers/api/deals/[id]/__tests__/route.existenceOracle.test.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/__tests__/route.existenceOracle.test.ts
@@ -1,0 +1,132 @@
+/** @jest-environment node */
+
+// Regression coverage for issue #5504 (deals kept consistent with people/
+// companies): a granted caller whose scope excludes a deal's organization must
+// receive the SAME response as for a non-existent id. The route collapses the
+// post-load organization-scope denial into its not-found response, so both are a
+// uniform 404. Before the change the foreign-org deal returned 403.
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockLoadCustomFieldValues = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockDecryptEntitiesWithFallbackScope = jest.fn()
+const mockIsOrganizationReadAccessAllowed = jest.fn()
+
+const mockEm = {
+  find: jest.fn(),
+  findOne: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+// The route rejects out-of-scope reads through the shared
+// denyCustomerDetailReadAsNotFound helper, which consults this guard.
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: jest.fn((...args: unknown[]) => mockIsOrganizationReadAccessAllowed(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn((args: unknown) => mockLoadCustomFieldValues(args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/subscriber', () => ({
+  decryptEntitiesWithFallbackScope: jest.fn((...args: unknown[]) => mockDecryptEntitiesWithFallbackScope(...args)),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_deal: 'customer_deal',
+    },
+  },
+}), { virtual: true })
+
+const EXISTING_FOREIGN_ID = '2408107d-0000-4000-8000-0000000000cc'
+const NON_EXISTENT_ID = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
+
+function buildForeignDeal(id: string) {
+  const createdAt = new Date('2026-04-10T08:00:00.000Z')
+  return {
+    id,
+    organizationId: 'org-foreign',
+    tenantId: 'tenant-1',
+    title: 'Expansion renewal',
+    deletedAt: null,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+async function callDetail(id: string) {
+  const { GET } = await import('../route')
+  const response = await GET(
+    new Request(`http://localhost/api/customers/deals/${id}`),
+    { params: { id } },
+  )
+  const body = await response.json()
+  return { status: response.status, body }
+}
+
+describe('GET /api/customers/deals/[id] — no existence oracle (issue #5504)', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockLoadCustomFieldValues.mockReset()
+    mockFindWithDecryption.mockReset()
+    mockFindOneWithDecryption.mockReset()
+    mockDecryptEntitiesWithFallbackScope.mockReset()
+    mockIsOrganizationReadAccessAllowed.mockReset()
+    mockEm.find.mockReset()
+    mockEm.findOne.mockReset()
+    mockContainer.resolve.mockClear()
+
+    // A granted, authenticated user in tenant-1 / org-1 (the dispatcher already
+    // let them through) probing deals that live in a different organization.
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1', email: 'viewer@example.com', isApiKey: false })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({ filterIds: ['org-1'], selectedId: 'org-1', tenantId: 'tenant-1' })
+    mockLoadCustomFieldValues.mockResolvedValue({})
+    mockFindWithDecryption.mockResolvedValue([])
+    mockDecryptEntitiesWithFallbackScope.mockResolvedValue(undefined)
+    // The resolved deal's organization is outside the caller's scope.
+    mockIsOrganizationReadAccessAllowed.mockReturnValue(false)
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, _entity: unknown, where: Record<string, unknown>) =>
+      where?.id === EXISTING_FOREIGN_ID ? buildForeignDeal(EXISTING_FOREIGN_ID) : null,
+    )
+  })
+
+  it('returns an identical 404 for an existing foreign-org deal and a non-existent id', async () => {
+    const existing = await callDetail(EXISTING_FOREIGN_ID)
+    const missing = await callDetail(NON_EXISTENT_ID)
+
+    expect(existing.status).toBe(404)
+    expect(missing.status).toBe(404)
+    expect(missing.status).toBe(existing.status)
+    expect(missing.body).toEqual(existing.body)
+    expect(existing.body).toEqual({ error: 'Deal not found' })
+  })
+})

--- a/packages/core/src/modules/customers/api/deals/[id]/companies/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/companies/route.ts
@@ -101,8 +101,11 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       throw notFound(translate('customers.errors.deal_not_found', 'Deal not found'))
     }
 
+    // Existence oracle (#5504): deny a cross-org read as not-found — identical to
+    // the parent-not-found above — so it cannot reveal that a deal exists in an
+    // organization the caller cannot see.
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {
-      throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
+      throw notFound(translate('customers.errors.deal_not_found', 'Deal not found'))
     }
 
     const entityScope = { tenantId: deal.tenantId, organizationId: deal.organizationId }

--- a/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/people/route.ts
@@ -102,8 +102,11 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       throw notFound(translate('customers.errors.deal_not_found', 'Deal not found'))
     }
 
+    // Existence oracle (#5504): deny a cross-org read as not-found — identical to
+    // the parent-not-found above — so it cannot reveal that a deal exists in an
+    // organization the caller cannot see.
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {
-      throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
+      throw notFound(translate('customers.errors.deal_not_found', 'Deal not found'))
     }
 
     const entityScope = { tenantId: deal.tenantId, organizationId: deal.organizationId }

--- a/packages/core/src/modules/customers/api/deals/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/route.ts
@@ -19,10 +19,9 @@ import type { ActionLogService } from '@open-mercato/core/modules/audit_logs/ser
 import { loadCustomFieldValues } from '@open-mercato/shared/lib/crud/custom-fields'
 import { normalizeCustomFieldResponse } from '@open-mercato/shared/lib/custom-fields/normalize'
 import { E } from '#generated/entities.ids.generated'
-import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
-import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
+import { denyCustomerDetailReadAsNotFound } from '../../../lib/detailReadAccess'
 import { decryptEntitiesWithFallbackScope } from '@open-mercato/shared/lib/encryption/subscriber'
 import { runWithCacheTenant } from '@open-mercato/cache'
 import {
@@ -45,10 +44,6 @@ const paramsSchema = z.object({
 
 function notFound(message: string) {
   return NextResponse.json({ error: message }, { status: 404 })
-}
-
-function forbidden(message: string) {
-  return NextResponse.json({ error: message }, { status: 403 })
 }
 
 type DealAssociation = {
@@ -416,23 +411,10 @@ export async function GET(request: Request, context: { params?: Record<string, u
     return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
   }
 
-  let rbac: RbacService | null = null
-  try {
-    rbac = (container.resolve('rbacService') as RbacService)
-  } catch {
-    rbac = null
-  }
-
-  if (!rbac || !auth?.sub) {
-    return forbidden('Access denied')
-  }
-  const hasFeature = await rbac.userHasAllFeatures(auth.sub, ['customers.deals.view'], {
-    tenantId: auth.tenantId ?? null,
-    organizationId: auth.orgId ?? null,
-  })
-  if (!hasFeature) {
-    return forbidden('Access denied')
-  }
+  // The API dispatcher already enforces `requireFeatures: ['customers.deals.view']`
+  // against the caller's effective (selected) organization before this handler
+  // runs, so no in-route feature re-check is needed. Re-checking here against the
+  // token org (auth.orgId) would wrongly 403 org-switched callers (#5012).
 
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
   const em = (container.resolve('em') as EntityManager)
@@ -454,9 +436,16 @@ export async function GET(request: Request, context: { params?: Record<string, u
     return notFound('Deal not found')
   }
 
-  if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {
-    return forbidden('Access denied')
-  }
+  // Existence oracle (issue #5504): a caller who holds customers.deals.view but
+  // whose scope excludes the record's organization must get the SAME response as
+  // for a non-existent id, so 403-when-present / 404-when-absent collapses to a
+  // uniform 404 not-found. The dispatcher already returns a uniform 403 for
+  // callers who lack the feature entirely.
+  const organizationReadDenied = denyCustomerDetailReadAsNotFound(
+    { scope, auth, organizationId: deal.organizationId },
+    'Deal not found',
+  )
+  if (organizationReadDenied) return organizationReadDenied
 
   const decryptionScope = {
     tenantId: deal.tenantId ?? auth.tenantId ?? null,
@@ -977,8 +966,8 @@ export const openApi: OpenApiRouteDoc = {
       ],
       errors: [
         { status: 401, description: 'Unauthorized', schema: dealDetailErrorSchema },
-        { status: 403, description: 'Forbidden for tenant/organization scope', schema: dealDetailErrorSchema },
-        { status: 404, description: 'Deal not found', schema: dealDetailErrorSchema },
+        { status: 403, description: 'Forbidden — caller lacks the required feature', schema: dealDetailErrorSchema },
+        { status: 404, description: 'Deal not found, or its organization is not in the caller’s scope', schema: dealDetailErrorSchema },
       ],
     },
   },

--- a/packages/core/src/modules/customers/api/deals/[id]/stats/route.ts
+++ b/packages/core/src/modules/customers/api/deals/[id]/stats/route.ts
@@ -7,7 +7,6 @@ import { resolveTranslations } from '@open-mercato/shared/lib/i18n/server'
 import type { EntityManager } from '@mikro-orm/postgresql'
 import { CustomerDeal, CustomerPipeline } from '../../../../data/entities'
 import { DictionaryEntry } from '@open-mercato/core/modules/dictionaries/data/entities'
-import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
@@ -22,10 +21,6 @@ const paramsSchema = z.object({
 
 function notFound(message: string) {
   return NextResponse.json({ error: message }, { status: 404 })
-}
-
-function forbidden(message: string) {
-  return NextResponse.json({ error: message }, { status: 403 })
 }
 
 function badRequest(message: string, code?: string) {
@@ -67,23 +62,10 @@ export async function GET(request: Request, context: { params?: Record<string, u
     return NextResponse.json({ error: translate('customers.errors.authentication_required', 'Authentication required') }, { status: 401 })
   }
 
-  let rbac: RbacService | null = null
-  try {
-    rbac = (container.resolve('rbacService') as RbacService)
-  } catch {
-    rbac = null
-  }
-
-  if (!rbac || !auth?.sub) {
-    return forbidden(translate('customers.errors.access_denied', 'Access denied'))
-  }
-  const hasFeature = await rbac.userHasAllFeatures(auth.sub, ['customers.deals.view'], {
-    tenantId: auth.tenantId ?? null,
-    organizationId: auth.orgId ?? null,
-  })
-  if (!hasFeature) {
-    return forbidden(translate('customers.errors.access_denied', 'Access denied'))
-  }
+  // The API dispatcher already enforces `requireFeatures: ['customers.deals.view']`
+  // against the caller's effective (selected) organization before this handler
+  // runs, so no in-route feature re-check is needed. Re-checking against the token
+  // org (auth.orgId) would wrongly 403 org-switched callers (#5012).
 
   const scope = await resolveOrganizationScopeForRequest({ container, auth, request })
   const em = (container.resolve('em') as EntityManager)
@@ -98,8 +80,11 @@ export async function GET(request: Request, context: { params?: Record<string, u
     return notFound(translate('customers.errors.deal_not_found', 'Deal not found'))
   }
 
+  // Existence oracle (#5504): deny a cross-org read as not-found — identical to
+  // the deal-not-found above — so it cannot reveal that a deal exists in an
+  // organization the caller cannot see.
   if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: deal.organizationId })) {
-    return forbidden(translate('customers.errors.access_denied', 'Access denied'))
+    return notFound(translate('customers.errors.deal_not_found', 'Deal not found'))
   }
 
   if (!deal.closureOutcome) {
@@ -206,8 +191,8 @@ export const openApi: OpenApiRouteDoc = {
       errors: [
         { status: 400, description: 'Deal is not closed', schema: dealStatsErrorSchema },
         { status: 401, description: 'Unauthorized', schema: dealStatsErrorSchema },
-        { status: 403, description: 'Forbidden for tenant/organization scope', schema: dealStatsErrorSchema },
-        { status: 404, description: 'Deal not found', schema: dealStatsErrorSchema },
+        { status: 403, description: 'Forbidden — caller lacks the required feature', schema: dealStatsErrorSchema },
+        { status: 404, description: 'Deal not found, or its organization is not in the caller’s scope', schema: dealStatsErrorSchema },
       ],
     },
   },

--- a/packages/core/src/modules/customers/api/entity-roles-factory.ts
+++ b/packages/core/src/modules/customers/api/entity-roles-factory.ts
@@ -77,10 +77,14 @@ function ensureRouteOrganizationAccess(
   organizationId: string,
   scope: Awaited<ReturnType<typeof resolveCustomersRequestContext>>['scope'],
   auth: Awaited<ReturnType<typeof resolveCustomersRequestContext>>['auth'],
-  translate: Translator,
+  notFoundMessage: string,
 ) {
+  // Existence oracle (#5504): a caller who holds the feature but whose scope
+  // excludes the record's organization is denied as not-found (the same response
+  // the caller gets for a missing record), so this cannot reveal that the record
+  // exists in an organization they cannot see.
   if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId })) {
-    throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
+    throw notFound(notFoundMessage)
   }
 }
 
@@ -132,7 +136,7 @@ async function resolveEntityRouteScope(
   if (!entity || entity.tenantId !== auth.tenantId) {
     throw notFound(translate('customers.errors.customer_not_found', 'Customer not found'))
   }
-  ensureRouteOrganizationAccess(entity.organizationId, scope, auth, translate)
+  ensureRouteOrganizationAccess(entity.organizationId, scope, auth, translate('customers.errors.customer_not_found', 'Customer not found'))
   return {
     entity,
     organizationId: entity.organizationId,
@@ -164,7 +168,7 @@ async function resolveRoleRouteScope(
   ) {
     throw notFound(translate('customers.errors.role_not_found', 'Role not found'))
   }
-  ensureRouteOrganizationAccess(role.organizationId, scope, auth, translate)
+  ensureRouteOrganizationAccess(role.organizationId, scope, auth, translate('customers.errors.role_not_found', 'Role not found'))
   return {
     role,
     organizationId: role.organizationId,

--- a/packages/core/src/modules/customers/api/people/[id]/__tests__/route.existenceOracle.test.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/__tests__/route.existenceOracle.test.ts
@@ -1,0 +1,172 @@
+/** @jest-environment node */
+
+// Regression coverage for issue #5504: the person detail route must not form an
+// existence oracle. The API dispatcher already enforces `requireFeatures`
+// (a uniform 403) before the handler runs, so the reachable caller here is a
+// GRANTED one. For that caller, a record that exists in an organization outside
+// their scope must return the SAME response as a non-existent id — otherwise
+// 403-when-present / 404-when-absent leaks existence. The route now collapses
+// the post-load organization-scope denial into its not-found response, so both
+// are a uniform 404. Before the fix the foreign-org record returned 403.
+
+const mockGetAuthFromRequest = jest.fn()
+const mockResolveOrganizationScopeForRequest = jest.fn()
+const mockResolveCustomerInteractionFeatureFlags = jest.fn()
+const mockFindOneWithDecryption = jest.fn()
+const mockFindWithDecryption = jest.fn()
+const mockIsOrganizationReadAccessAllowed = jest.fn()
+
+const mockEm = {
+  findOne: jest.fn(),
+  find: jest.fn(),
+  count: jest.fn(),
+}
+
+const mockContainer = {
+  resolve: jest.fn((token: string) => {
+    if (token === 'em') return mockEm
+    if (token === 'queryEngine') return { query: jest.fn(async () => ({ items: [] })) }
+    return null
+  }),
+}
+
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: jest.fn((request: Request) => mockGetAuthFromRequest(request)),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: jest.fn(async () => mockContainer),
+}))
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: jest.fn((args: unknown) => mockResolveOrganizationScopeForRequest(args)),
+}))
+
+// The route rejects out-of-scope reads through the shared
+// denyCustomerDetailReadAsNotFound helper, which consults this guard. Control
+// the guard so the "record exists in a foreign org" branch is exercised.
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: jest.fn((...args: unknown[]) => mockIsOrganizationReadAccessAllowed(...args)),
+}))
+
+jest.mock('../../../../lib/interactionFeatureFlags', () => ({
+  resolveCustomerInteractionFeatureFlags: jest.fn((...args: unknown[]) => mockResolveCustomerInteractionFeatureFlags(...args)),
+}))
+
+jest.mock('@open-mercato/shared/lib/crud/custom-fields', () => ({
+  loadCustomFieldValues: jest.fn(async () => ({})),
+}))
+
+jest.mock('../../../../lib/customFieldRouting', () => ({
+  resolvePersonCustomFieldRouting: jest.fn(async () => new Map()),
+  mergePersonCustomFieldValues: jest.fn(() => ({})),
+}))
+
+jest.mock('@open-mercato/shared/lib/encryption/find', () => ({
+  findWithDecryption: jest.fn((...args: unknown[]) => mockFindWithDecryption(...args)),
+  findOneWithDecryption: jest.fn((...args: unknown[]) => mockFindOneWithDecryption(...args)),
+}))
+
+jest.mock('../../../../lib/interactionReadModel', () => ({
+  hydrateCanonicalInteractions: jest.fn(async () => []),
+}))
+
+jest.mock('../../../../lib/personCompanies', () => ({
+  loadPersonCompanyLinks: jest.fn(async () => []),
+  summarizePersonCompanies: jest.fn(() => []),
+}))
+
+jest.mock('#generated/entities.ids.generated', () => ({
+  E: {
+    customers: {
+      customer_entity: 'customer_entity',
+      customer_person_profile: 'customer_person_profile',
+    },
+  },
+}), { virtual: true })
+
+const EXISTING_FOREIGN_ID = '2408107d-0000-4000-8000-0000000000aa'
+const NON_EXISTENT_ID = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d'
+
+function buildForeignPerson(id: string) {
+  const createdAt = new Date('2026-04-10T08:00:00.000Z')
+  return {
+    id,
+    kind: 'person',
+    deletedAt: null,
+    tenantId: 'tenant-1',
+    organizationId: 'org-foreign',
+    displayName: 'Ada Lovelace',
+    description: null,
+    ownerUserId: null,
+    primaryEmail: null,
+    primaryPhone: null,
+    status: null,
+    lifecycleStage: null,
+    source: null,
+    temperature: null,
+    renewalQuarter: null,
+    nextInteractionAt: null,
+    nextInteractionName: null,
+    nextInteractionRefId: null,
+    nextInteractionIcon: null,
+    nextInteractionColor: null,
+    isActive: true,
+    createdAt,
+    updatedAt: createdAt,
+  }
+}
+
+async function callDetail(id: string) {
+  const { GET } = await import('../route')
+  const response = await GET(
+    new Request(`http://localhost/api/customers/people/${id}`),
+    { params: { id } },
+  )
+  const body = await response.json()
+  return { status: response.status, body }
+}
+
+describe('GET /api/customers/people/[id] — no existence oracle (issue #5504)', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    mockGetAuthFromRequest.mockReset()
+    mockResolveOrganizationScopeForRequest.mockReset()
+    mockResolveCustomerInteractionFeatureFlags.mockReset()
+    mockFindOneWithDecryption.mockReset()
+    mockFindWithDecryption.mockReset()
+    mockIsOrganizationReadAccessAllowed.mockReset()
+    mockEm.findOne.mockReset()
+    mockEm.find.mockReset()
+    mockEm.count.mockReset()
+    mockEm.count.mockResolvedValue(0)
+    mockEm.find.mockResolvedValue([])
+    mockFindWithDecryption.mockResolvedValue([])
+    mockContainer.resolve.mockClear()
+
+    // A granted, authenticated user in tenant-1 / org-1 (the dispatcher already
+    // let them through) probing records that live in a different organization.
+    mockGetAuthFromRequest.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1', isApiKey: false })
+    mockResolveOrganizationScopeForRequest.mockResolvedValue({ filterIds: ['org-1'], selectedId: 'org-1', tenantId: 'tenant-1' })
+    mockResolveCustomerInteractionFeatureFlags.mockResolvedValue({ unified: false })
+    // The resolved record's organization is outside the caller's scope.
+    mockIsOrganizationReadAccessAllowed.mockReturnValue(false)
+    mockFindOneWithDecryption.mockImplementation(async (_em: unknown, _entity: unknown, where: Record<string, unknown>) =>
+      where?.id === EXISTING_FOREIGN_ID ? buildForeignPerson(EXISTING_FOREIGN_ID) : null,
+    )
+  })
+
+  it('returns an identical 404 for an existing foreign-org record and a non-existent id', async () => {
+    const existing = await callDetail(EXISTING_FOREIGN_ID)
+    const missing = await callDetail(NON_EXISTENT_ID)
+
+    // Before the fix the existing foreign-org record returned 403 while the
+    // missing id returned 404 — the oracle the issue reports.
+    expect(existing.status).toBe(404)
+    expect(missing.status).toBe(404)
+    // The oracle is closed only if the two responses are indistinguishable.
+    expect(missing.status).toBe(existing.status)
+    expect(missing.body).toEqual(existing.body)
+    expect(existing.body).toEqual({ error: 'Person not found' })
+  })
+})

--- a/packages/core/src/modules/customers/api/people/[id]/companies/context.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/context.ts
@@ -38,8 +38,11 @@ export async function loadPersonContext(req: Request, personId: string) {
     throw notFound(translate('customers.errors.person_not_found', 'Person not found'))
   }
 
+  // Existence oracle (#5504): deny a cross-org read as not-found — identical to
+  // the parent-not-found above — so it cannot reveal that a person exists in an
+  // organization the caller cannot see.
   if (!isOrganizationReadAccessAllowed({ scope, auth: authenticatedAuth, organizationId: person.organizationId })) {
-    throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
+    throw notFound(translate('customers.errors.person_not_found', 'Person not found'))
   }
 
   const profile = await findOneWithDecryption(

--- a/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/companies/enriched/route.ts
@@ -178,8 +178,11 @@ export async function GET(req: Request, ctx: { params?: { id?: string } }) {
       throw notFound(translate('customers.errors.person_not_found', 'Person not found'))
     }
 
+    // Existence oracle (#5504): deny a cross-org read as not-found — identical to
+    // the parent-not-found above — so it cannot reveal that a person exists in an
+    // organization the caller cannot see.
     if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: person.organizationId })) {
-      throw new CrudHttpError(403, { error: translate('customers.errors.access_denied', 'Access denied') })
+      throw notFound(translate('customers.errors.person_not_found', 'Person not found'))
     }
 
     const entityScope = { tenantId: auth.tenantId, organizationId: person.organizationId }

--- a/packages/core/src/modules/customers/api/people/[id]/route.ts
+++ b/packages/core/src/modules/customers/api/people/[id]/route.ts
@@ -38,7 +38,7 @@ import type { EntityId } from '@open-mercato/shared/modules/entities'
 import type { OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { findWithDecryption, findOneWithDecryption } from '@open-mercato/shared/lib/encryption/find'
 import { parseBooleanFromUnknown, parseBooleanToken } from '@open-mercato/shared/lib/boolean'
-import { isOrganizationReadAccessAllowed } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
+import { denyCustomerDetailReadAsNotFound } from '../../../lib/detailReadAccess'
 import { loadPersonCompanyLinks, summarizePersonCompanies } from '../../../lib/personCompanies'
 import { normalizeCustomerDetailCustomFields } from '../../detailCustomFields'
 import { buildEmailVisibilityMikroFilter } from '../../../lib/visibilityFilter'
@@ -127,10 +127,6 @@ function parseIncludeParams(request: Request): Set<string> {
       .forEach((part) => tokens.add(part))
   })
   return tokens
-}
-
-function forbidden(message: string) {
-  return NextResponse.json({ error: message }, { status: 403 })
 }
 
 function notFound(message: string) {
@@ -542,10 +538,19 @@ export async function GET(_req: Request, ctx: { params?: { id?: string } }) {
       return notFound('Person not found')
     }
 
-    if (!isOrganizationReadAccessAllowed({ scope, auth, organizationId: person.organizationId })) {
-      statusCode = 403
-      profileMeta = { reason: 'organization_forbidden' }
-      return forbidden('Access denied')
+    // Existence oracle (issue #5504): a caller who holds customers.people.view
+    // but whose scope excludes the record's organization must get the SAME
+    // response as for a non-existent id, so 403-when-present / 404-when-absent
+    // collapses to a uniform 404 not-found. The dispatcher already returns a
+    // uniform 403 for callers who lack the feature entirely.
+    const organizationReadDenied = denyCustomerDetailReadAsNotFound(
+      { scope, auth, organizationId: person.organizationId },
+      'Person not found',
+    )
+    if (organizationReadDenied) {
+      statusCode = 404
+      profileMeta = { reason: 'organization_not_in_scope' }
+      return organizationReadDenied
     }
 
     // Gated get-then-set cache. Key on the resolved person plus the effective
@@ -1337,8 +1342,8 @@ export const openApi: OpenApiRouteDoc = {
       errors: [
         { status: 400, description: 'Invalid identifier', schema: personDetailErrorSchema },
         { status: 401, description: 'Unauthorized', schema: personDetailErrorSchema },
-        { status: 403, description: 'Forbidden for tenant/organization scope', schema: personDetailErrorSchema },
-        { status: 404, description: 'Person not found', schema: personDetailErrorSchema },
+        { status: 403, description: 'Forbidden — caller lacks the required feature', schema: personDetailErrorSchema },
+        { status: 404, description: 'Person not found, or its organization is not in the caller’s scope', schema: personDetailErrorSchema },
       ],
     },
   },

--- a/packages/core/src/modules/customers/lib/__tests__/detailReadAccess.test.ts
+++ b/packages/core/src/modules/customers/lib/__tests__/detailReadAccess.test.ts
@@ -1,0 +1,46 @@
+/** @jest-environment node */
+
+// Direct unit coverage for the shared existence-oracle guard (#5504): pins both
+// branches in one place — allow → null (the caller may read), deny → a 404
+// not-found response carrying the caller-supplied message so the denial is
+// byte-identical to the route's own record-not-found.
+
+const mockIsOrganizationReadAccessAllowed = jest.fn()
+
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScopeGuard', () => ({
+  isOrganizationReadAccessAllowed: jest.fn((...args: unknown[]) => mockIsOrganizationReadAccessAllowed(...args)),
+}))
+
+import { denyCustomerDetailReadAsNotFound } from '../detailReadAccess'
+import type { OrganizationReadAccessInput } from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
+
+const input = {
+  scope: null,
+  auth: { sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' },
+  organizationId: 'org-foreign',
+} as unknown as OrganizationReadAccessInput
+
+describe('denyCustomerDetailReadAsNotFound (#5504)', () => {
+  beforeEach(() => {
+    mockIsOrganizationReadAccessAllowed.mockReset()
+  })
+
+  it('returns null (allows the read) when organization read access is allowed', () => {
+    mockIsOrganizationReadAccessAllowed.mockReturnValue(true)
+    expect(denyCustomerDetailReadAsNotFound(input, 'Person not found')).toBeNull()
+  })
+
+  it('returns a 404 not-found response when organization read access is denied', async () => {
+    mockIsOrganizationReadAccessAllowed.mockReturnValue(false)
+    const response = denyCustomerDetailReadAsNotFound(input, 'Person not found')
+    expect(response).not.toBeNull()
+    expect(response!.status).toBe(404)
+    expect(await response!.json()).toEqual({ error: 'Person not found' })
+  })
+
+  it('carries the caller-supplied message so it matches the route’s own not-found body', async () => {
+    mockIsOrganizationReadAccessAllowed.mockReturnValue(false)
+    const response = denyCustomerDetailReadAsNotFound(input, 'Deal not found')
+    expect(await response!.json()).toEqual({ error: 'Deal not found' })
+  })
+})

--- a/packages/core/src/modules/customers/lib/detailReadAccess.ts
+++ b/packages/core/src/modules/customers/lib/detailReadAccess.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import {
+  isOrganizationReadAccessAllowed,
+  type OrganizationReadAccessInput,
+} from '@open-mercato/core/modules/directory/utils/organizationScopeGuard'
+
+/**
+ * Single-record customers detail routes (person / company / deal) must not leak
+ * whether a record exists through the organization-scope check.
+ *
+ * The API dispatcher already enforces each route's `metadata.requireFeatures`
+ * before the handler runs, returning a uniform `403` for callers who lack the
+ * grant — so that path never distinguishes an existing id from a missing one.
+ * The only remaining existence signal is the *post-load* organization guard: a
+ * caller who holds the feature but whose scope excludes the record's
+ * organization previously received `403` (record exists in another org) while a
+ * non-existent id received `404`. That 403-vs-404 split is an existence oracle
+ * (issue #5504).
+ *
+ * Collapse the organization-scope denial into the route's own not-found
+ * response so an out-of-scope caller cannot tell "exists in an organization you
+ * cannot see" from "does not exist" — the shape the api_keys hardening
+ * (#4033 / PR-4051) established. Sharing this decision keeps the three customers
+ * detail routes from drifting apart again.
+ *
+ * @returns the `404` response to return when read access is denied, or `null`
+ * when the caller may read the record.
+ */
+export function denyCustomerDetailReadAsNotFound(
+  input: OrganizationReadAccessInput,
+  notFoundMessage: string,
+): NextResponse | null {
+  if (isOrganizationReadAccessAllowed(input)) return null
+  return NextResponse.json({ error: notFoundMessage }, { status: 404 })
+}


### PR DESCRIPTION
Closes #5504

## Goal

A caller who holds a customers view feature but whose scope excludes a record's
organization can no longer tell whether a person, company, or deal exists —
through the detail routes **or** their sibling sub-resource routes. Every one of
those reads now returns an identical `404` for an existing (foreign-org) id and
a non-existent id, closing the `403`-vs-`404` existence oracle across the whole
class.

## Problem and root cause

The API dispatcher already enforces each route's `metadata.requireFeatures`
before the handler runs (a uniform `403` for callers who lack the grant), so the
only remaining existence signal is the **post-load organization guard**: a
caller who holds the feature but whose scope excludes the record's organization
received `403` (record exists in a foreign org) while a non-existent id received
`404`. That split is the oracle. It existed on the three detail routes and on
every sibling route that loads the same person/company/deal by id under the same
grant.

## What changed

- New shared helper
  `packages/core/src/modules/customers/lib/detailReadAccess.ts` —
  `denyCustomerDetailReadAsNotFound(input, notFoundMessage)` returns the route's
  `404` response when `isOrganizationReadAccessAllowed` denies, or `null` when
  the read is allowed (direct unit test in `lib/__tests__/detailReadAccess.test.ts`).
- **Detail routes** `people/[id]`, `companies/[id]`, `deals/[id]`: the post-load
  organization denial returns the route's not-found response (`404`) instead of
  `403`, via the helper. `deals/[id]` **and `deals/[id]/stats`** additionally
  drop their redundant, token-org-scoped in-route feature re-check (superseded by
  the dispatcher, which enforces `requireFeatures` against the selected org; the
  in-route check read the token org and could wrongly 403 org-switched callers,
  #5012 — removing it also makes the `stats` `403` OpenAPI description accurate).
- **Shared guards reach writes too:** two of the collapsed guards
  (`ensureRouteOrganizationAccess` in the roles factory, and `loadPersonContext`
  behind `people/[id]/companies`) are shared with mutating handlers, so the same
  `403`→`404` collapse applies to `POST`/`PUT`/`DELETE`
  `/{people,companies}/{id}/roles`, `POST` `/people/{id}/companies`, and
  `PATCH`/`DELETE` `/people/{id}/companies/{linkId}`. This is deliberate — a
  `403`-when-present / `404`-when-absent split on the write path is the same
  oracle — and is covered by a regression test (see below).
- **Sub-resource routes** now collapse the same organization denial into their
  own already-present not-found response (`throw notFound(...)` / `return
  notFound(...)`, byte-identical to the parent-not-found a few lines above):
  `companies/[id]/people`, `people/[id]/companies` (+`/enriched`),
  `deals/[id]/people`, `deals/[id]/companies`, `deals/[id]/stats`, and every
  roles route via `entity-roles-factory.ts` (`ensureRouteOrganizationAccess`).
  `openApi.errors` descriptions updated where the route declares them.
- Regression coverage: unit suites for the three detail routes (granted caller,
  foreign-org vs non-existent → byte-identical `404`); the shared-helper unit
  test; a roles-factory **write** regression (`companies/[id]/roles` — cross-org
  `POST` → `404` byte-identical to a missing entity, never reaching the command
  bus), pinning `ensureRouteOrganizationAccess` for all four methods; and
  `TC-CRM-072` now asserts the cross-org read is denied as `404` with no orgB
  data, plus an end-to-end sibling-route probe (`/people/{id}/companies`) proving
  the collapse through the real dispatcher.

## Validation

- `yarn build:packages` · `yarn generate` (outputs unchanged) · `yarn typecheck`
  (turbo, 26/26) · `yarn i18n:check-sync` / `check-usage` (no keys added) ·
  `yarn build:app` (exit 0) — all pass.
- `yarn test` — pass for `@open-mercato/core` (11,169 tests green, incl. the
  detail regressions and the new shared-helper suite).
- Regression evidence: the three detail suites were run against the pristine base
  and observed **red** (`403`) before the change; green after. The roles route's
  existing feature-denial `403` test is unaffected (that denial is the pre-load
  feature gate, a different function, and stays `403`).

## Automated review

- `om-code-review` (author-side, review of record) — approve after remediation.
- Unresolved findings — None.

## Breaking changes

Observable API-behavior change (documented, not a frozen-contract break): for a
caller who is authorized but out of the record's organization scope, the
customers person/company/deal reads now return `404` where they previously
returned `403` — the three detail GETs and the sibling sub-resource routes.
Because two of the collapsed guards are shared with mutating handlers, the same
`403`→`404` change also lands on these **writes**:

- `POST` / `PUT` / `DELETE` `/api/customers/{people,companies}/{id}/roles`
- `POST` `/api/customers/people/{id}/companies`, and `PATCH` / `DELETE`
  `/api/customers/people/{id}/companies/{linkId}`

A cross-org write on these now returns `404` (`Customer not found` / `Role not
found` / `Person not found`) instead of `403 { error: 'Access denied' }`. This is
intentional: the write path was the same existence oracle, and collapsing it is
the more complete fix. The `{ error: string }` body shape is unchanged, `404` was
already a declared status where the route documents its errors (descriptions
updated), and no in-scope caller's behavior changes. Feature-less callers still
receive the dispatcher's / roles factory's pre-load `403` uniformly, which is not
an oracle.

## Labels and delivery

- `review` — fixes pushed addressing the review; ready for re-review.
- `bug` — fixes an information-disclosure/existence oracle (matches the issue).
- `needs-qa` — the change alters an observable API behavior (`403`→`404` for
  out-of-scope callers), so it does not take the automated-verification
  `skip-qa` exemption even without UI; with `qaGate` on, it holds the merge until
  `qa-approved`.
- `priority-low` — the reporter rates severity low.
- `risk-medium` — a bounded status-code collapse across the customers detail-read
  surface, routed through one shared decision and covered by unit + integration
  regressions.

## Manual QA

As a user who holds the customers view feature in their organization but whose
scope excludes org B: for any id of a record in org B and for a random UUID,
`GET /api/customers/{people,companies,deals}/{id}` and the sibling
sub-resource routes (e.g. `/people/{id}/companies`, `/deals/{id}/stats`) must all
return `404` with a generic not-found body and no org B data. Writes behave the
same: a cross-org `POST /api/customers/companies/{id}/roles` (or `PUT`/`DELETE`,
or a `POST`/`PATCH`/`DELETE` on `/people/{id}/companies[/{linkId}]`) must return
`404` identical to the response for a non-existent parent id. A user lacking the
feature entirely still receives `403`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
