### PR TITLE
fix(warranty_claims): localize error responses instead of leaking i18n keys (#5512)

### DIFF
--- a/packages/core/src/modules/warranty_claims/__tests__/error-response-localized.test.ts
+++ b/packages/core/src/modules/warranty_claims/__tests__/error-response-localized.test.ts
@@ -1,0 +1,127 @@
+/** @jest-environment node */
+import { randomUUID } from 'node:crypto'
+
+// The translator resolves each key to its fallback sentence, so a raw i18n key
+// that leaks straight into the response body (the #5512 defect) is trivially
+// distinguishable from a genuinely localized message.
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}))
+
+const getAuthMock = jest.fn()
+jest.mock('@open-mercato/shared/lib/auth/server', () => ({
+  getAuthFromRequest: (...args: unknown[]) => getAuthMock(...args),
+}))
+
+const containerStub = { resolve: jest.fn() }
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: async () => containerStub,
+}))
+
+const resolveOrganizationScopeForRequestMock = jest.fn()
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveOrganizationScopeForRequest: (...args: unknown[]) => resolveOrganizationScopeForRequestMock(...args),
+}))
+
+const resolveAssigneeDisplayNamesMock = jest.fn()
+jest.mock('../lib/assigneeNames', () => ({
+  resolveAssigneeDisplayNames: (...args: unknown[]) => resolveAssigneeDisplayNamesMock(...args),
+}))
+
+const getCustomerAuthMock = jest.fn()
+jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () => ({
+  getCustomerAuthFromRequest: (...args: unknown[]) => getCustomerAuthMock(...args),
+}))
+
+import { GET as assigneesGET } from '../api/assignees/route'
+import { GET as portalClaimsGET } from '../api/portal/claims/route'
+
+const RAW_I18N_KEY = /^warranty_claims\./
+
+async function readError(res: Response): Promise<{ status: number; body: Record<string, unknown>; error: string }> {
+  const body = (await res.json()) as Record<string, unknown>
+  return { status: res.status, body, error: String(body.error) }
+}
+
+describe('warranty_claims error responses are localized, never raw i18n keys (#5512)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    getAuthMock.mockResolvedValue({ sub: 'user-1', tenantId: 'tenant-1', orgId: 'org-1' })
+    resolveOrganizationScopeForRequestMock.mockResolvedValue({
+      tenantId: 'tenant-1',
+      selectedId: 'org-1',
+      filterIds: ['org-1'],
+      allowedIds: ['org-1'],
+    })
+    resolveAssigneeDisplayNamesMock.mockResolvedValue(new Map())
+    getCustomerAuthMock.mockResolvedValue(null)
+  })
+
+  describe('GET /api/warranty_claims/assignees', () => {
+    it('returns a localized 400 when the required ids param is missing', async () => {
+      const { status, error } = await readError(
+        await assigneesGET(new Request('http://localhost/api/warranty_claims/assignees')),
+      )
+      expect(status).toBe(400)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+      expect(error).toBe('Invalid input')
+    })
+
+    it('returns a localized 400 when ids is present but empty', async () => {
+      const { status, error } = await readError(
+        await assigneesGET(new Request('http://localhost/api/warranty_claims/assignees?ids=')),
+      )
+      expect(status).toBe(400)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 401 when the caller is unauthenticated', async () => {
+      getAuthMock.mockResolvedValue(null)
+      const { status, error } = await readError(
+        await assigneesGET(new Request(`http://localhost/api/warranty_claims/assignees?ids=${randomUUID()}`)),
+      )
+      expect(status).toBe(401)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 500 when the assignee lookup helper fails', async () => {
+      resolveAssigneeDisplayNamesMock.mockRejectedValue(new Error('boom'))
+      const { status, error } = await readError(
+        await assigneesGET(new Request(`http://localhost/api/warranty_claims/assignees?ids=${randomUUID()}`)),
+      )
+      expect(status).toBe(500)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+  })
+
+  describe('GET /api/warranty_claims/portal/claims', () => {
+    it('returns a localized 401 when there is no portal session', async () => {
+      const { status, body, error } = await readError(
+        await portalClaimsGET(new Request('http://localhost/api/warranty_claims/portal/claims')),
+      )
+      expect(status).toBe(401)
+      expect(body.ok).toBe(false)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 403 when the account is not linked to a customer record', async () => {
+      getCustomerAuthMock.mockResolvedValue({
+        sub: 'customer-1',
+        sid: 'session-1',
+        tenantId: 'tenant-1',
+        orgId: 'org-1',
+        email: 'buyer@example.com',
+        customerEntityId: null,
+        personEntityId: null,
+      })
+      const { status, body, error } = await readError(
+        await portalClaimsGET(new Request('http://localhost/api/warranty_claims/portal/claims')),
+      )
+      expect(status).toBe(403)
+      expect(body.ok).toBe(false)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+  })
+})

--- a/packages/core/src/modules/warranty_claims/__tests__/error-response-localized.test.ts
+++ b/packages/core/src/modules/warranty_claims/__tests__/error-response-localized.test.ts
@@ -36,9 +36,20 @@ jest.mock('@open-mercato/core/modules/customer_accounts/lib/customerAuth', () =>
 }))
 
 import { GET as assigneesGET } from '../api/assignees/route'
-import { GET as portalClaimsGET } from '../api/portal/claims/route'
+import { GET as portalClaimsGET, POST as portalClaimsPOST } from '../api/portal/claims/route'
 
 const RAW_I18N_KEY = /^warranty_claims\./
+
+const LINKED_PORTAL_AUTH = {
+  sub: 'customer-1',
+  sid: 'session-1',
+  tenantId: 'tenant-1',
+  orgId: 'org-1',
+  email: 'buyer@example.com',
+  customerEntityId: 'customer-entity-1',
+  personEntityId: null,
+  displayName: 'Buyer One',
+}
 
 async function readError(res: Response): Promise<{ status: number; body: Record<string, unknown>; error: string }> {
   const body = (await res.json()) as Record<string, unknown>
@@ -120,6 +131,43 @@ describe('warranty_claims error responses are localized, never raw i18n keys (#5
         await portalClaimsGET(new Request('http://localhost/api/warranty_claims/portal/claims')),
       )
       expect(status).toBe(403)
+      expect(body.ok).toBe(false)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 400 when the list query is invalid', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, body, error } = await readError(
+        await portalClaimsGET(new Request('http://localhost/api/warranty_claims/portal/claims?page=0')),
+      )
+      expect(status).toBe(400)
+      expect(body.ok).toBe(false)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 400 when the POST body is not valid JSON', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, body, error } = await readError(
+        await portalClaimsPOST(new Request('http://localhost/api/warranty_claims/portal/claims', {
+          method: 'POST',
+          body: '{not-json',
+        })),
+      )
+      expect(status).toBe(400)
+      expect(body.ok).toBe(false)
+      expect(error).not.toMatch(RAW_I18N_KEY)
+    })
+
+    it('returns a localized 400 when the POST body fails intake validation', async () => {
+      getCustomerAuthMock.mockResolvedValue(LINKED_PORTAL_AUTH)
+      const { status, body, error } = await readError(
+        await portalClaimsPOST(new Request('http://localhost/api/warranty_claims/portal/claims', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{}',
+        })),
+      )
+      expect(status).toBe(400)
       expect(body.ok).toBe(false)
       expect(error).not.toMatch(RAW_I18N_KEY)
     })

--- a/packages/core/src/modules/warranty_claims/api/assignees/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/assignees/route.ts
@@ -40,12 +40,12 @@ export function parseRequestedIds(raw: string): string[] {
 }
 
 export async function GET(req: Request) {
+  const { translate } = await resolveTranslations()
   try {
     const url = new URL(req.url)
     const parsedQuery = querySchema.parse(Object.fromEntries(url.searchParams))
     const container = await createRequestContainer()
     const auth = await getAuthFromRequest(req)
-    const { translate } = await resolveTranslations()
     if (!auth || !auth.tenantId) {
       throw new CrudHttpError(401, { error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') })
     }
@@ -75,10 +75,10 @@ export async function GET(req: Request) {
       return NextResponse.json(error.body, { status: error.status })
     }
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+      return NextResponse.json({ error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
     }
     logger.error('[warranty_claims] Failed to resolve assignee display names', { error })
-    return NextResponse.json({ error: 'warranty_claims.errors.load_failed' }, { status: 500 })
+    return NextResponse.json({ error: translate('warranty_claims.errors.load_failed', 'Failed to load warranty claim data.') }, { status: 500 })
   }
 }
 

--- a/packages/core/src/modules/warranty_claims/api/portal/claims/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/claims/route.ts
@@ -155,10 +155,12 @@ function serializePortalClaim(claim: WarrantyClaim, lines: WarrantyClaimLine[]) 
 async function resolvePortalContext(req: Request): Promise<PortalContext | Response> {
   const auth = await getCustomerAuthFromRequest(req)
   if (!auth) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.unauthorized' }, { status: 401 })
+    const { translate } = await resolveTranslations()
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') }, { status: 401 })
   }
   if (!auth.customerEntityId) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.customerAccountNotLinked' }, { status: 403 })
+    const { translate } = await resolveTranslations()
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.customerAccountNotLinked', 'Customer account is not linked to a customer record') }, { status: 403 })
   }
   const container = await createRequestContainer()
   const em = container.resolve('em') as EntityManager
@@ -264,6 +266,7 @@ async function validatePortalOrderOwnership(
   context: PortalContext,
   input: PortalIntakeInput,
 ): Promise<OrderValidationResult | Response> {
+  const { translate } = await resolveTranslations()
   const orderLineIds = Array.from(new Set(input.lines.flatMap((line) => line.orderLineId ? [line.orderLineId] : [])))
   const orderLinesById = await loadOwnedOrderLines(context, orderLineIds)
   const orderIds = new Set<string>()
@@ -273,7 +276,7 @@ async function validatePortalOrderOwnership(
   let resolvedOrder = input.orderId ? (ordersById.get(input.orderId) ?? null) : null
   if (input.orderId) {
     if (!resolvedOrder) {
-      return NextResponse.json({ ok: false, error: 'warranty_claims.errors.orderNotOwned' }, { status: 404 })
+      return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.orderNotOwned', 'Order not found.') }, { status: 404 })
     }
   }
 
@@ -282,10 +285,9 @@ async function validatePortalOrderOwnership(
     const resolvedLine = orderLinesById.get(line.orderLineId)
     const lineOrder = resolvedLine ? ordersById.get(resolvedLine.orderId) : null
     if (!resolvedLine || !lineOrder) {
-      return NextResponse.json({ ok: false, error: 'warranty_claims.errors.orderLineMismatch' }, { status: 404 })
+      return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.orderLineMismatch', 'Order line does not belong to the selected order') }, { status: 404 })
     }
     if (resolvedOrder && lineOrder.id !== resolvedOrder.id) {
-      const { translate } = await resolveTranslations()
       return NextResponse.json(
         { ok: false, error: translate('warranty_claims.errors.orderLineMismatch', 'Order line does not belong to the selected order') },
         { status: 400 },
@@ -337,7 +339,8 @@ export async function GET(req: Request) {
     serialNumber: url.searchParams.get('serialNumber') ?? undefined,
   })
   if (!query.success) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    const { translate } = await resolveTranslations()
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   const { page, pageSize, search, status, stateGroup, serialNumber } = query.data
   const where = buildPortalOwnedClaimWhere(context)
@@ -415,15 +418,16 @@ export async function POST(req: Request) {
   const contextOrResponse = await resolvePortalContext(req)
   if (contextOrResponse instanceof Response) return contextOrResponse
   const context = contextOrResponse
+  const { translate } = await resolveTranslations()
   let body: unknown
   try {
     body = await req.json()
   } catch {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   const parsed = portalIntakeInputSchema.safeParse(body)
   if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: 'warranty_claims.errors.invalidInput' }, { status: 400 })
+    return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.invalidInput', 'Invalid input') }, { status: 400 })
   }
   const ownership = await validatePortalOrderOwnership(context, parsed.data)
   if (ownership instanceof Response) return ownership
@@ -487,7 +491,7 @@ export async function POST(req: Request) {
     )
     const claimId = createResult.result?.claimId
     if (typeof claimId !== 'string') {
-      return NextResponse.json({ ok: false, error: 'warranty_claims.errors.save_failed' }, { status: 500 })
+      return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.save_failed', 'Failed to save warranty claim.') }, { status: 500 })
     }
     try {
       await commandBus.execute<{ id: string; actorCustomerId: string }, { claimId: string }>(

--- a/packages/core/src/modules/warranty_claims/api/portal/claims/route.ts
+++ b/packages/core/src/modules/warranty_claims/api/portal/claims/route.ts
@@ -153,13 +153,12 @@ function serializePortalClaim(claim: WarrantyClaim, lines: WarrantyClaimLine[]) 
 }
 
 async function resolvePortalContext(req: Request): Promise<PortalContext | Response> {
+  const { translate } = await resolveTranslations()
   const auth = await getCustomerAuthFromRequest(req)
   if (!auth) {
-    const { translate } = await resolveTranslations()
     return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.unauthorized', 'Unauthorized') }, { status: 401 })
   }
   if (!auth.customerEntityId) {
-    const { translate } = await resolveTranslations()
     return NextResponse.json({ ok: false, error: translate('warranty_claims.errors.customerAccountNotLinked', 'Customer account is not linked to a customer record') }, { status: 403 })
   }
   const container = await createRequestContainer()


### PR DESCRIPTION
Refs #5512

## Goal

Warranty-claims API error responses show a localized sentence instead of a raw i18n key — on the two routes named in #5512.

## Problem and root cause

The `assignees` and `portal/claims` routes returned the raw translation key (e.g. `warranty_claims.errors.invalidInput`) in the `error` field on several paths. Reported evidence:

| Request | Response (before) |
|---|---|
| `GET /api/warranty_claims/assignees` (missing `ids`) | `400 {"error":"warranty_claims.errors.invalidInput"}` |
| `GET /api/warranty_claims/assignees?ids=` (empty) | `400 {"error":"warranty_claims.errors.invalidInput"}` |
| `GET /api/warranty_claims/portal/claims` (no portal session) | `401 {"ok":false,"error":"warranty_claims.errors.unauthorized"}` |

The `error` field is an API contract surface consumed by direct API callers and third-party modules, so returning a raw key there is the defect regardless of whether a first-party page renders it — the impact is API response quality. (The two changed routes' own in-repo consumers happen to use their own fallback keys rather than rendering the server string: `backend/components/useUserDisplayNames.ts` swallows the rejection with an `[internal]` message, `backend/warranty_claims/settings/page.tsx` substitutes `t('warranty_claims.detail.unknownUser')`, and the portal pages branch on status and call `t(...)` with their own keys.) The module already localized some paths via `translate(key, fallback)` (assignees 401, the portal order-line-mismatch 400); the paths in this diff were simply missed.

## What changed

- `assignees/route.ts`: hoisted `resolveTranslations()` so the catch block can localize the ZodError 400 and the 500 fallback.
- `portal/claims/route.ts`: localized every remaining raw-key error response in this route (401/403 in `resolvePortalContext`; 404 orderNotOwned/orderLineMismatch in `validatePortalOrderOwnership`; GET 400; POST two 400s and the 500), reusing the module's `translate(key, fallback)` idiom; deduped one redundant `resolveTranslations()` and hoisted the `resolvePortalContext` translator above its guards for consistency.
- Added `error-response-localized.test.ts` (9 cases) asserting the error body never matches `/^warranty_claims\./` for the unit-reachable error paths.
- No new i18n keys (all already present in de/en/es/ko/pl); response shape and status codes unchanged.

## Scope

This PR is deliberately scoped to the two routes named in #5512 and therefore uses `Refs`, not `Closes`. The same raw-key defect remains on **~78 sites across 14 other `warranty_claims` API route files** (32 of them customer-facing portal endpoints, including byte-identical `resolvePortalContext` copies in `api/portal/attachments/route.ts` and `api/portal/claims/[id]/shared.ts`). Those are the same mechanical `translate(key, fallback)` substitution with no new i18n keys and are tracked in **#5522**. #5512 stays open until that surface is covered.

## Validation

- `yarn build:packages` / `yarn generate` (no discovery drift) / `yarn i18n:check-sync` / `yarn i18n:check-usage` / `yarn typecheck` (26/26) / `yarn build:app` — all pass.
- `yarn workspace @open-mercato/core test` — 11169 passed, 2 skipped.
- The new regression suite was observed failing before the fix (raw keys `invalidInput`/`load_failed`/`unauthorized`/`customerAccountNotLinked`) and passing after. It covers 7 of the 10 newly-localized sites (assignees 400/500, portal 401/403, portal GET 400, both POST 400s); the POST-500 and the two order-ownership 404s are integration-level (command bus / Kysely) and are the identical mechanical substitution.
- Note: full-monorepo `yarn test` has one unrelated pre-existing failure (`open-mercato-docs` reference-example-module test) that only reproduces on a local checkout path containing a space; it passes on CI.

## Automated review

- `om-code-review` — approve, 0 remediation rounds (author-side, pre-review).
- Addressed the changes-requested review on this PR: re-scoped to `Refs #5512` + this Scope section + follow-up #5522 (the Minor), hoisted `resolvePortalContext`'s translator, added portal GET/POST 400 test coverage, and corrected the client-evidence framing (the Nits).
- Unresolved findings — None.

## Breaking changes

None. Only the human-readable value of the existing `error` field changes (raw key → localized sentence); field names, response shape, and status codes are unchanged. No frozen/stable contract surface affected.

## Labels and delivery

- `review` — the PR is ready and non-draft, so it enters the review pipeline state.
- `bug` — it fixes a user-facing defect (raw i18n keys shown to users), matching the issue's category.
- `skip-qa` — the change touches no UI-rendering file (no `.tsx` outside tests, nothing under `packages/ui/src` or `**/components/**`), leaves DB structure and API shape unchanged, breaks no `BACKWARD_COMPATIBILITY.md` contract, and ships automated tests for the changed behavior, so it meets the automated-verification exemption; not combined with `needs-qa`.
- `priority-low` — a message-quality defect with no functional or data impact.
- `risk-low` — a mechanical, additive localization of error strings in two routes, fully covered by tests, with no schema/contract/behavior-graph change.

## Manual QA

Not required (see `skip-qa` rationale). If desired: `GET /api/warranty_claims/assignees` (no `ids`) now returns a localized `error`; `GET /api/warranty_claims/portal/claims` without a portal session returns a localized `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
