### PR TITLE
fix(auth): surface login failures instead of an empty 500

### DIFF
--- a/packages/core/src/modules/auth/api/__tests__/login.unhandled-error.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/login.unhandled-error.test.ts
@@ -1,0 +1,121 @@
+/** @jest-environment node */
+/**
+ * Regression guard: an infrastructure failure inside the login route must
+ * surface as a JSON 500 and a server-side log line, not as a bare 500 with an
+ * empty body. The empty-body case gives the client nothing to render and the
+ * operator nothing to grep, which is what made a demo outage (database
+ * unreachable) indistinguishable from a bug in this route.
+ */
+import { registerApiInterceptors } from '@open-mercato/shared/lib/crud/interceptor-registry'
+
+const createRequestContainerMock = jest.fn()
+const loggerErrorMock = jest.fn()
+
+jest.mock('@open-mercato/shared/lib/i18n/server', () => ({
+  resolveTranslations: async () => ({
+    translate: (_key: string, fallback?: string) => fallback ?? '',
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/di/container', () => ({
+  createRequestContainer: (...args: unknown[]) => createRequestContainerMock(...args),
+}))
+
+jest.mock('@open-mercato/shared/lib/logger', () => ({
+  createLogger: () => ({
+    error: (...args: unknown[]) => loggerErrorMock(...args),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  }),
+}))
+
+jest.mock('@open-mercato/shared/lib/auth/jwt', () => ({ signJwt: () => 'jwt-token' }))
+
+jest.mock('@open-mercato/core/modules/auth/lib/rateLimitCheck', () => ({
+  checkAuthRateLimit: jest.fn(async () => ({ error: null, compoundKey: null })),
+  resetAuthRateLimit: jest.fn(async () => undefined),
+}))
+
+jest.mock('@open-mercato/core/modules/auth/events', () => ({
+  emitAuthEvent: jest.fn(async () => undefined),
+}))
+
+const { POST } = require('@open-mercato/core/modules/auth/api/login')
+
+function loginRequest() {
+  return new Request('http://localhost/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ email: 'someone@example.com', password: 'whatever' }).toString(),
+  })
+}
+
+describe('POST /api/auth/login — unhandled infrastructure failure', () => {
+  beforeEach(() => {
+    registerApiInterceptors([])
+    jest.clearAllMocks()
+  })
+
+  test('returns a JSON 500 body instead of an empty response when the container cannot be built', async () => {
+    createRequestContainerMock.mockRejectedValue(new Error('connect ECONNREFUSED 10.0.0.5:5432'))
+
+    const response = await POST(loginRequest())
+
+    expect(response.status).toBe(500)
+    const body = await response.json()
+    expect(body).toEqual({ ok: false, error: 'An error occurred. Please try again.' })
+  })
+
+  test('logs the underlying cause under a stable scope so it is greppable in deploy logs', async () => {
+    const cause = new Error('connect ECONNREFUSED 10.0.0.5:5432')
+    createRequestContainerMock.mockRejectedValue(cause)
+
+    await POST(loginRequest())
+
+    expect(loggerErrorMock).toHaveBeenCalledTimes(1)
+    const [message, fields] = loggerErrorMock.mock.calls[0] as [string, Record<string, unknown>]
+    expect(message).toBe('Unhandled auth route error')
+    expect(fields).toMatchObject({ scope: 'auth.login', err: cause })
+  })
+
+  test('never leaks the underlying failure to an unauthenticated caller', async () => {
+    createRequestContainerMock.mockRejectedValue(new Error('connect ECONNREFUSED 10.0.0.5:5432'))
+
+    const response = await POST(loginRequest())
+    const serialized = JSON.stringify(await response.json())
+
+    expect(serialized).not.toMatch(/ECONNREFUSED/)
+    expect(serialized).not.toMatch(/10\.0\.0\.5/)
+    expect(serialized).not.toMatch(/5432/)
+  })
+
+  test('a throw after authentication is still contained rather than escaping as an empty 500', async () => {
+    // Reaching the session/JWT tail means credentials were already accepted, so
+    // a failure here (missing signing secret, unwritable session store) must not
+    // hand the browser a bodiless response either.
+    createRequestContainerMock.mockResolvedValue({
+      resolve: (name: string) => {
+        if (name === 'authService') {
+          return {
+            findUsersByEmail: async (email: string) => ([{ id: 1, email, passwordHash: 'hash', tenantId: 't1', organizationId: 'o1' }]),
+            verifyPassword: async () => true,
+            getUserRoles: async () => ['admin'],
+            updateLastLoginAt: async () => undefined,
+            createSession: async () => { throw new Error('JWT_SECRET is not set') },
+          }
+        }
+        if (name === 'eventBus') return { emitEvent: async () => undefined }
+        if (name === 'em') return {}
+        return null
+      },
+    })
+
+    const response = await POST(loginRequest())
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({ ok: false, error: 'An error occurred. Please try again.' })
+    expect(loggerErrorMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/core/src/modules/auth/api/login.ts
+++ b/packages/core/src/modules/auth/api/login.ts
@@ -15,6 +15,7 @@ import { checkAuthRateLimit, resetAuthRateLimit } from '@open-mercato/core/modul
 import { runCustomRouteAfterInterceptors } from '@open-mercato/shared/lib/crud/custom-route-interceptor'
 import { sanitizeRedirectPath } from '@open-mercato/core/modules/auth/lib/safeRedirect'
 import { getAppBaseUrl } from '@open-mercato/shared/lib/url'
+import { handleAuthRouteError } from '@open-mercato/core/modules/auth/api/routeError'
 
 const loginRateLimitConfig = readEndpointRateLimitConfig('LOGIN', {
   points: 5, duration: 60, blockDuration: 60, keyPrefix: 'login',
@@ -84,7 +85,29 @@ async function parseLoginForm(req: Request): Promise<ParsedLoginForm> {
   }
 }
 
+// Resolving translations can itself be what failed, so the generic message is
+// recovered defensively — the error path must never throw a second time.
+async function resolveGenericLoginError(): Promise<string> {
+  try {
+    const { translate } = await resolveTranslations()
+    return translate('auth.login.errors.generic', 'An error occurred. Please try again.')
+  } catch {
+    return 'An error occurred. Please try again.'
+  }
+}
+
 export async function POST(req: Request) {
+  try {
+    return await handleLoginRequest(req)
+  } catch (error) {
+    return handleAuthRouteError(error, {
+      scope: 'auth.login',
+      message: await resolveGenericLoginError(),
+    })
+  }
+}
+
+async function handleLoginRequest(req: Request) {
   const { translate } = await resolveTranslations()
   const { email, password, remember, tenantIdRaw, requiredRoles, redirectTo } = await parseLoginForm(req)
   // Rate limit — two layers, both checked before validation and DB work

--- a/packages/core/src/modules/auth/api/routeError.ts
+++ b/packages/core/src/modules/auth/api/routeError.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+import { createLogger } from '@open-mercato/shared/lib/logger'
+
+const logger = createLogger('auth.api')
+
+export type AuthRouteErrorOptions = {
+  /** Stable identifier for the failing route, e.g. `auth.login`. Logged, never returned. */
+  scope: string
+  /** Already-translated, user-safe message. Must not describe the underlying failure. */
+  message: string
+}
+
+/**
+ * Last-resort handler for an unexpected throw inside a public auth route.
+ *
+ * Without this, an infrastructure failure (database unreachable, DI container
+ * unable to build, a missing signing secret) escapes the handler and Next.js
+ * answers with a bare 500 carrying no body at all — nothing for the client to
+ * render and nothing in the response to tell an operator what broke. The
+ * failure then looks identical to a bug in the route itself.
+ *
+ * The cause is logged server-side under a stable scope so it is greppable in
+ * deployment logs; the response stays deliberately generic, because auth
+ * responses must never let an unauthenticated caller distinguish one failure
+ * from another.
+ */
+export function handleAuthRouteError(error: unknown, options: AuthRouteErrorOptions): NextResponse {
+  logger.error('Unhandled auth route error', { err: error, scope: options.scope })
+  return NextResponse.json({ ok: false, error: options.message }, { status: 500 })
+}


### PR DESCRIPTION
## 🎯 Why

`demo.openmercato.com` started answering `POST /api/auth/login` with a **500 and no response body at all**. That gave the browser nothing to render and the response nothing an operator could act on, so the outage was indistinguishable from a bug in the login route.

It was not a login bug. Probing the deployment showed the split cleanly:

| Endpoint | Needs DI/DB? | Result |
|---|---|---|
| `GET /api/version` | no | 200 |
| `GET /api/auth/locale` | no (i18n only) | 400 with a proper JSON body |
| `GET /login` | no | 200 HTML |
| `POST /api/auth/login` | **yes** | **500, empty** |
| `GET /api/checkout/pay/<bogus>` | **yes** | **500** `{"error":"Internal server error"}` |

Two unrelated modules failing at the same `createRequestContainer()` / `resolve('em')` boundary — an infrastructure problem. The reason `checkout` returned a readable body and `auth` returned nothing is simply that the checkout route has a top-level `try/catch` and the login route did not.

This PR closes that diagnostic gap. **It does not fix the outage** — it makes the next one legible.

## 🔧 What changed

`POST` had no top-level `try/catch`, so anything thrown between `resolveTranslations()` and the final response escaped the handler. It is now wrapped:

- The cause is logged through the structured logger under the stable scope `auth.login`, so it is greppable in deployment logs.
- The response is a generic **translated** message (`auth.login.errors.generic`, which already existed) with a proper JSON body — deliberately generic, because auth responses must never let an unauthenticated caller distinguish one failure from another.
- Recovering that message is itself defensive: `resolveTranslations()` can be the thing that failed, so it falls back to the literal rather than throwing a second time inside the error path.

The handler body moved into `handleLoginRequest` instead of being re-indented inside a `try` block, so the diff is a small wrapper rather than a 120-line whitespace change.

Also adds `handleAuthRouteError`, mirroring the existing `handleCheckoutRouteError`, so the pattern is reusable rather than copy-pasted.

## 📌 Scope — the same gap exists in five sibling routes

Verified by inspection: `logout.ts`, `autologin.ts`, `reset.ts`, `reset/confirm.ts` and `session/refresh.ts` all begin their handler with real work rather than a `try`, so they fail the same opaque way. **This PR deliberately fixes only `login.ts`**, which is the reported symptom; the shared helper is in place so extending it is a small follow-up. Say the word and I will widen it here or in a separate PR.

## 🧪 Tests

`login.unhandled-error.test.ts` — four cases, each of which **fails against `main` and passes here** (verified by stashing the `login.ts` change and re-running):

- a container that cannot be built returns a JSON 500 body rather than an empty response;
- the cause is logged once, under scope `auth.login`, with the original error attached;
- the underlying failure never reaches the caller — the serialized body is asserted not to contain the host, port, or `ECONNREFUSED` from the simulated database error;
- a throw *after* successful authentication (the session/JWT tail, e.g. a missing signing secret) is contained too, not just early failures.

Local runs, related scope only:

- `jest src/modules/auth` → **629 passed, 78 suites, 0 failed**
- `tsc --noEmit` on `packages/core` → 0 errors (excluding the pre-existing `#generated/…` not-found noise present on `main`)
- ESLint on the three touched files → clean

## 🔍 Review notes

- No behavior change on any path that already returned a response — 400/401/403/429 and the success path are untouched.
- Nothing new is logged on ordinary failed logins; the logger only fires on an unhandled throw.
- Per the auth module rules, no credential reaches the log: the password never enters a query, and only the error object plus a scope string are logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790076157&installation_model_id=432243&pr_number=5529&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5529&signature=8da8902a20aae3f14d34bd772751689412d93697b731598c5c8bce750d4c1891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->