### PR TITLE
fix(release): bump apps/* with the monorepo version

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -100,11 +100,11 @@ jobs:
           if [ "${{ inputs.resume }}" = "true" ]; then
             BODY="**Recovery** release preparation for **v$VERSION**."
             BODY="$BODY"$'\n\n'"\`$VERSION\` is already published on npm — this PR brings the repository back in sync."
-            BODY="$BODY"$'\n\n'"- Bumps every public package and the root manifest to \`$VERSION\`"
+            BODY="$BODY"$'\n\n'"- Bumps every public package, the app workspaces (\`apps/*\`) and the root manifest to \`$VERSION\`"
             BODY="$BODY"$'\n'"- No build or publish happens here"
           else
             BODY="Automated release preparation for **v$VERSION**."
-            BODY="$BODY"$'\n\n'"- Bumps every public package and the root manifest to \`$VERSION\`"
+            BODY="$BODY"$'\n\n'"- Bumps every public package, the app workspaces (\`apps/*\`) and the root manifest to \`$VERSION\`"
             BODY="$BODY"$'\n'"- No build or publish happens here"
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Dispatch **Release Prepare** from the Actions tab with a `patch`, `minor` or `ma
 gh workflow run release-prepare.yml --ref main -f bump=patch
 ```
 
-It bumps every public package plus the root manifest, pushes `release/v<version>`, and opens a PR against `main`. It publishes nothing. The PR body confirms whether the changelog entry exists. Review and merge it as usual.
+It bumps every public package, the app workspaces (`apps/*`) and the root manifest, pushes `release/v<version>`, and opens a PR against `main`. It publishes nothing. The PR body confirms whether the changelog entry exists. Review and merge it as usual.
 
 > Opening the PR automatically requires _Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"_. Without it the branch is still pushed and the job summary links straight to the compare page — one click instead of zero.
 
@@ -104,7 +104,7 @@ gh workflow run release.yml --ref main
 
 The job requires approval from the `production` environment, then runs in a deliberate order — every reversible step before the irreversible one:
 
-1. **Preflight** — version alignment across packages, the version is not already on npm, and the changelog section exists. Nothing has happened yet if any of these fail.
+1. **Preflight** — version alignment across packages and app workspaces, the version is not already on npm, and the changelog section exists. Nothing has happened yet if any of these fail.
 2. **Build** — `build:packages`, `generate`, `build:packages`.
 3. **Tag** — pushes `v<version>`. A tag is cheap to delete; an npm version is not.
 4. **Publish** — `publish-packages.sh` with npm provenance, skipping anything already published.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-mercato-docs",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "dev": "docusaurus start",

--- a/apps/mercato/package.json
+++ b/apps/mercato/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-mercato/app",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/__tests__/check-version-alignment.test.mjs
+++ b/scripts/__tests__/check-version-alignment.test.mjs
@@ -1,10 +1,11 @@
 /**
  * PR-path guard for the release-time version-alignment gate.
  *
- * `scripts/check-version-alignment.sh` asserts that every public `packages/*` manifest carries
- * the monorepo version, and it is load-bearing at release time and nowhere else:
- * `scripts/bump-version.sh:17` and `:29`, `scripts/release-existing.sh:13`, and
- * `.github/workflows/release.yml:72`. No PR-triggered workflow invoked it, so a misaligned
+ * `scripts/check-version-alignment.sh` asserts that every public `packages/*` manifest and every
+ * `apps/*` manifest carries the monorepo version, and it is load-bearing at release time and
+ * nowhere else:
+ * `scripts/bump-version.sh:17` and `:37`, `scripts/release-existing.sh:13`, and
+ * `.github/workflows/release.yml:78`. No PR-triggered workflow invoked it, so a misaligned
  * workspace passed CI and first failed days later at the release's very first gate, detached
  * from the merge that caused it (#5018).
  *
@@ -39,6 +40,7 @@ import { fileURLToPath } from 'node:url'
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const rootDir = path.resolve(__dirname, '../..')
 const packagesDir = path.join(rootDir, 'packages')
+const appsDir = path.join(rootDir, 'apps')
 const referenceManifest = path.join(packagesDir, 'shared', 'package.json')
 const alignmentScript = path.join(rootDir, 'scripts', 'check-version-alignment.sh')
 
@@ -67,6 +69,22 @@ async function readPublicPackages() {
   return packages
 }
 
+async function readAppWorkspaces() {
+  const entries = await readdir(appsDir, { withFileTypes: true })
+  const apps = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+
+    const manifest = await readManifest(path.join(appsDir, entry.name, 'package.json'))
+    if (!manifest) continue
+
+    apps.push({ dir: entry.name, name: manifest.name, version: manifest.version })
+  }
+
+  return apps
+}
+
 test('every public package is aligned with the monorepo version', async () => {
   const reference = await readManifest(referenceManifest)
   assert.ok(reference, 'packages/shared/package.json is the reference manifest and must exist')
@@ -87,6 +105,29 @@ test('every public package is aligned with the monorepo version', async () => {
     [],
     `Not aligned with the monorepo version (${reference.version}) from packages/shared/package.json. ` +
       'Fix their package.json versions — otherwise the next release fails at its first gate.',
+  )
+})
+
+test('every app workspace is aligned with the monorepo version', async () => {
+  const reference = await readManifest(referenceManifest)
+  const apps = await readAppWorkspaces()
+
+  assert.ok(
+    apps.some((app) => app.dir === 'mercato'),
+    'Expected the scan to reach apps/mercato. A scan that silently stopped finding manifests ' +
+      'would report alignment over nothing at all',
+  )
+
+  const mismatched = apps
+    .filter((app) => app.version !== reference.version)
+    .map((app) => `${app.name}@${app.version} (expected ${reference.version})`)
+
+  assert.deepEqual(
+    mismatched,
+    [],
+    `Not aligned with the monorepo version (${reference.version}) from packages/shared/package.json. ` +
+      'apps/* are private so `yarn workspaces foreach --no-private version` never touches them; ' +
+      'scripts/bump-version.sh syncs them explicitly instead.',
   )
 })
 
@@ -121,5 +162,23 @@ test('the release-time gate still declares the scope this guard mirrors', async 
     /\.private != true/,
     'This guard skips private manifests because the script does — packages/eslint-plugin-ds ' +
       'is versioned independently',
+  )
+  assert.match(
+    script,
+    /find apps -maxdepth 2 -name package\.json/,
+    'This guard scans the direct children of apps/ because that is the script scope. apps/* are ' +
+      'private but ship as the release app shell, so they are checked without the private filter',
+  )
+})
+
+test('the bump script moves the app workspaces too', async () => {
+  const script = await readFile(path.join(rootDir, 'scripts', 'bump-version.sh'), 'utf8')
+
+  assert.match(
+    script,
+    /find apps -maxdepth 2 -name package\.json/,
+    '`yarn workspaces foreach --no-private version` skips apps/* because they are private, so ' +
+      'scripts/bump-version.sh must sync them explicitly — otherwise the alignment gate above ' +
+      'fails on the very release PR that is supposed to fix it',
   )
 })

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Bump the monorepo version across all public packages and the root manifest.
+# Bump the monorepo version across all public packages, the app workspaces and the root manifest.
 # Does not build, publish, commit or tag — see scripts/release-*.sh for those.
 # Usage: ./scripts/bump-version.sh <patch|minor|major>
 set -euo pipefail
@@ -24,6 +24,14 @@ NEW_VERSION=$(jq -r '.version' packages/shared/package.json)
 echo "==> Syncing root package.json to $NEW_VERSION..." >&2
 jq --arg version "$NEW_VERSION" '.version = $version' package.json > package.json.bump
 mv package.json.bump package.json
+
+# `yarn workspaces foreach --no-private` skips apps/* because they are private, but they ship
+# as the app shell of a release and must carry the monorepo version like everything else.
+while IFS= read -r app_json; do
+  echo "==> Syncing $app_json to $NEW_VERSION..." >&2
+  jq --arg version "$NEW_VERSION" '.version = $version' "$app_json" > "$app_json.bump"
+  mv "$app_json.bump" "$app_json"
+done < <(find apps -maxdepth 2 -name package.json -not -path "*/node_modules/*")
 
 echo "==> Verifying alignment against root package.json..." >&2
 ./scripts/check-version-alignment.sh --reference package.json >&2

--- a/scripts/check-version-alignment.sh
+++ b/scripts/check-version-alignment.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# Check that all public packages have the same version as the selected reference manifest.
+# Check that all public packages and the app workspaces have the same version as the
+# selected reference manifest.
+# `apps/*` are private and never published, but they ship as the app shell of a release,
+# so they move in lockstep too. Private `packages/*` (packages/eslint-plugin-ds) stay out.
 # Exits with code 1 and prints mismatches if any are found.
 set -euo pipefail
 
@@ -25,20 +28,26 @@ done
 REFERENCE_VERSION=$(jq -r '.version' "$REFERENCE_FILE")
 MISMATCHED=()
 
+MANIFESTS=$(
+  find packages -maxdepth 2 -name package.json -not -path "*/node_modules/*" \
+    | xargs -I{} sh -c 'jq -e ".private != true" {} > /dev/null 2>&1 && echo {}'
+  find apps -maxdepth 2 -name package.json -not -path "*/node_modules/*"
+)
+
 while IFS= read -r pkg_json; do
+  [ -n "$pkg_json" ] || continue
   pkg_version=$(jq -r '.version' "$pkg_json")
   pkg_name=$(jq -r '.name' "$pkg_json")
   if [ "$pkg_version" != "$REFERENCE_VERSION" ]; then
     MISMATCHED+=("$pkg_name@$pkg_version (expected $REFERENCE_VERSION)")
   fi
-done < <(find packages -maxdepth 2 -name package.json -not -path "*/node_modules/*" \
-  | xargs -I{} sh -c 'jq -e ".private != true" {} > /dev/null 2>&1 && echo {}')
+done <<< "$MANIFESTS"
 
 if [ ${#MISMATCHED[@]} -gt 0 ]; then
-  echo "ERROR: The following packages are not aligned with the monorepo version ($REFERENCE_VERSION) from $REFERENCE_FILE:"
+  echo "ERROR: The following workspaces are not aligned with the monorepo version ($REFERENCE_VERSION) from $REFERENCE_FILE:"
   for m in "${MISMATCHED[@]}"; do echo "  - $m"; done
   echo "Fix their package.json versions before releasing."
   exit 1
 fi
 
-echo "All public packages are aligned at version $REFERENCE_VERSION from $REFERENCE_FILE."
+echo "All public packages and app workspaces are aligned at version $REFERENCE_VERSION from $REFERENCE_FILE."


### PR DESCRIPTION
## Problem

`scripts/bump-version.sh` bumps public packages with `yarn workspaces foreach -A --no-private version`. `apps/mercato` and `apps/docs` are `private: true`, so that command skips them — they were left behind at **0.6.5** while every public package and the root manifest moved to **0.7.0**.

Nothing caught it: `scripts/check-version-alignment.sh` (the release preflight gate) only scanned `packages/*`, and its PR-path guard mirrored the same scope.

## Fix

- **`apps/mercato` and `apps/docs` → `0.7.0`**, matching the monorepo version.
- **`scripts/bump-version.sh`** now syncs every `apps/*` manifest to the new version right after the root manifest, so future releases keep them in lockstep.
- **`scripts/check-version-alignment.sh`** now checks `apps/*` too, so the drift fails the release preflight instead of shipping silently. Private `packages/*` (`packages/eslint-plugin-ds`) stay excluded — they are versioned independently.
- **`scripts/__tests__/check-version-alignment.test.mjs`** gains two guards mirroring the shell script: one asserting app-workspace alignment on the PR path, one pinning that `bump-version.sh` still moves `apps/*`. CI runs `yarn test:scripts` unfiltered, so a version-only `package.json` edit cannot slip past it.
- **`.github/workflows/release-prepare.yml`** + **`CONTRIBUTING.md`**: the PR body and the release docs now say the app workspaces are bumped too.

## Standalone app copy — checked, no change needed

The `create-mercato-app` scaffold is unaffected by this class of drift:

- `packages/create-app/template/package.json.template` keeps its own `"version": "0.1.0"` — a scaffolded user app starts its own versioning and must not inherit the monorepo version.
- Every `@open-mercato/*` dependency in the template is pinned to `{{PACKAGE_VERSION}}`, substituted from `create-mercato-app`'s own version (`packages/create-app/src/index.ts:21`). That package is public, so the existing bump already covers it.
- `scripts/template-sync.ts` only reconciles `dependencies`, never `version`, so the app bump causes no template drift.

## Verification

Runner: local (no compose `app` container running).

- `yarn test:scripts` — **594 passed**, 1 skipped, 0 failed.
- `./scripts/check-version-alignment.sh` and `--reference package.json` — both pass at `0.7.0`.
- Negative tests, run manually against a dirty tree and reverted:
  - `apps/docs` at `0.0.1` → gate exits 1 and names `open-mercato-docs@0.0.1` ✅
  - `packages/telemetry` at `0.0.1` → gate exits 1 ✅ (public scope still enforced)
  - `packages/eslint-plugin-ds` at `0.0.1` → gate passes ✅ (private `packages/*` still excluded)
- `scripts/bump-version.sh`'s new loop exercised in a sandbox with fake `apps/*` manifests: both rewritten to the target version.
- `yarn template:sync` — dependency sync passes. It reports 2 pre-existing missing files (`components/__tests__/DemoFeedbackWidget.test.tsx`, `components/__tests__/demoFeedbackFlag.test.ts`) unrelated to this change.
- `yarn.lock` records workspaces as `0.0.0-use.local`, so there is no lockfile churn and `yarn install --immutable` is unaffected.

## Labels

`skip-qa` per the automated-verification exemption: no `.tsx` outside tests, nothing under `packages/ui/src/` or `**/components/**`, no database or API surface change, no `BACKWARD_COMPATIBILITY.md` contract touched, and the changed behavior ships with automated tests in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790076270&installation_model_id=432243&pr_number=5530&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5530&signature=057189e53b52d4f1d1879e19029d7e2160507db92976202ed97ce91d93904164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->