### PR TITLE
fix(webhooks): use static notification preference label

### DIFF
--- a/packages/webhooks/src/modules/webhooks/__tests__/notifications.test.ts
+++ b/packages/webhooks/src/modules/webhooks/__tests__/notifications.test.ts
@@ -1,0 +1,27 @@
+import de from '../i18n/de.json'
+import en from '../i18n/en.json'
+import es from '../i18n/es.json'
+import ko from '../i18n/ko.json'
+import pl from '../i18n/pl.json'
+import { notificationTypes } from '../notifications'
+
+const dictionaries: Record<string, Record<string, string>> = { de, en, es, ko, pl }
+
+describe('webhook notification catalogue', () => {
+  it('uses a static delivery-failure label in every locale', () => {
+    const deliveryFailed = notificationTypes.find((definition) => definition.type === 'webhooks.delivery.failed')
+
+    expect(deliveryFailed).toMatchObject({
+      labelKey: 'webhooks.notifications.delivery.failed.label',
+      titleKey: 'webhooks.notifications.delivery.failed.title',
+    })
+    expect(deliveryFailed?.labelKey).not.toBe(deliveryFailed?.titleKey)
+
+    for (const dictionary of Object.values(dictionaries)) {
+      const label = dictionary[deliveryFailed?.labelKey ?? '']
+      expect(label).toBeDefined()
+      expect(label).not.toMatch(/\{[^}]+\}/)
+      expect(label).not.toBe(deliveryFailed?.labelKey)
+    }
+  })
+})

--- a/packages/webhooks/src/modules/webhooks/i18n/de.json
+++ b/packages/webhooks/src/modules/webhooks/i18n/de.json
@@ -158,5 +158,6 @@
   "webhooks.nav.group": "Integrations",
   "webhooks.nav.title": "Webhooks",
   "webhooks.notifications.delivery.failed.body": "Webhook {webhookName} konnte das Ereignis {eventType} nicht zustellen. {errorMessage}",
+  "webhooks.notifications.delivery.failed.label": "Webhook-Zustellung fehlgeschlagen",
   "webhooks.notifications.delivery.failed.title": "Webhook-Zustellung für {webhookName} fehlgeschlagen"
 }

--- a/packages/webhooks/src/modules/webhooks/i18n/en.json
+++ b/packages/webhooks/src/modules/webhooks/i18n/en.json
@@ -158,5 +158,6 @@
   "webhooks.nav.group": "Integrations",
   "webhooks.nav.title": "Webhooks",
   "webhooks.notifications.delivery.failed.body": "Webhook {webhookName} could not deliver event {eventType}. {errorMessage}",
+  "webhooks.notifications.delivery.failed.label": "Webhook delivery failed",
   "webhooks.notifications.delivery.failed.title": "Webhook delivery failed for {webhookName}"
 }

--- a/packages/webhooks/src/modules/webhooks/i18n/es.json
+++ b/packages/webhooks/src/modules/webhooks/i18n/es.json
@@ -158,5 +158,6 @@
   "webhooks.nav.group": "Integrations",
   "webhooks.nav.title": "Webhooks",
   "webhooks.notifications.delivery.failed.body": "El webhook {webhookName} no pudo entregar el evento {eventType}. {errorMessage}",
+  "webhooks.notifications.delivery.failed.label": "La entrega del webhook falló",
   "webhooks.notifications.delivery.failed.title": "La entrega del webhook falló para {webhookName}"
 }

--- a/packages/webhooks/src/modules/webhooks/i18n/ko.json
+++ b/packages/webhooks/src/modules/webhooks/i18n/ko.json
@@ -158,5 +158,6 @@
   "webhooks.nav.group": "통합",
   "webhooks.nav.title": "웹훅",
   "webhooks.notifications.delivery.failed.body": "웹훅 {webhookName}이(가) 이벤트 {eventType}을(를) 전달하지 못했습니다. {errorMessage}",
+  "webhooks.notifications.delivery.failed.label": "웹훅 전달 실패",
   "webhooks.notifications.delivery.failed.title": "{webhookName}의 웹훅 전달 실패"
 }

--- a/packages/webhooks/src/modules/webhooks/i18n/pl.json
+++ b/packages/webhooks/src/modules/webhooks/i18n/pl.json
@@ -158,5 +158,6 @@
   "webhooks.nav.group": "Integracje",
   "webhooks.nav.title": "Webhooki",
   "webhooks.notifications.delivery.failed.body": "Webhook {webhookName} nie mógł dostarczyć zdarzenia {eventType}. {errorMessage}",
+  "webhooks.notifications.delivery.failed.label": "Dostawa webhooka nie powiodła się",
   "webhooks.notifications.delivery.failed.title": "Dostawa webhooka nie powiodła się dla {webhookName}"
 }

--- a/packages/webhooks/src/modules/webhooks/notifications.ts
+++ b/packages/webhooks/src/modules/webhooks/notifications.ts
@@ -4,6 +4,7 @@ export const notificationTypes: NotificationTypeDefinition[] = [
   {
     type: 'webhooks.delivery.failed',
     module: 'webhooks',
+    labelKey: 'webhooks.notifications.delivery.failed.label',
     titleKey: 'webhooks.notifications.delivery.failed.title',
     bodyKey: 'webhooks.notifications.delivery.failed.body',
     icon: 'webhook',


### PR DESCRIPTION
Closes #5496

## Goal

Show a static, translated label for webhook delivery-failure notification preferences while preserving the interpolated runtime notification title.

## Problem and root cause

The webhook delivery-failed notification omitted `labelKey`. Notification type synchronization therefore fell back to `titleKey`, which contains the runtime `{webhookName}` placeholder. The unresolved placeholder appeared in the preference row and switch accessibility labels.

## What changed

- Added a dedicated static preference `labelKey`.
- Added translations for all five supported locales.
- Added regression coverage verifying the label is present, translated, static, and distinct from the runtime title.

## Validation

- `yarn build:packages` — 26 package build tasks passed.
- `yarn generate` — all generators completed and generated outputs were unchanged.
- `yarn i18n:check-sync` — all five locale files are synchronized.
- `yarn i18n:check-usage` — completed successfully with the existing unused-key advisory.
- `yarn typecheck` — all 26 typecheck tasks passed.
- `TURBO_CONCURRENCY=2 yarn test` — all 33 workspace tasks passed; webhooks passed 19 suites and 146 tests, and create-app passed 878 tests with five intentional skips.
- `yarn build:app` — the production application build completed successfully.
- `git diff --cached --check` — passed.
- The regression test was observed failing before the implementation and passing afterward.

## Automated review

- `om-code-review` — approved with zero remediation rounds.
- Fresh independent review — not configured for the standard review profile; the direct review of record approved the complete patch.
- Unresolved findings — None.

## Breaking changes

None. The notification type ID, runtime title key, API surface, database schema, and delivery behavior are unchanged.

## Labels and delivery

- `review` — The verified, non-draft change is ready for maintainer review.
- `bug` — The change fixes a raw interpolation placeholder rendered in notification preferences.
- `skip-qa` — No UI-rendering, API, database, or compatibility-contract surface changed, and automated regression and localization checks cover the behavior, so the automated-verification exemption applies.
- `priority-medium` — This is an ordinary user-visible bug without outage, security, or release-blocking impact.
- `risk-medium` — The patch is isolated to one module and carries focused regression coverage, matching the ordinary single-module bug-fix classification.

## Manual QA

Manual QA is not required because the patch changes notification metadata and locale values without modifying a UI-rendering file. The regression test verifies the static preference label in every locale, while the localization checks verify catalog consistency.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790108619&installation_model_id=432243&pr_number=5540&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5540&signature=9f4c88ed5470653891ac351e18ab1a2fac30afec0df25dac964f3d829159c14a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->