### PR TITLE
fix(auth): align feature checks with selected organization

### DIFF
--- a/.ai/runs/2026-08-25-issue-5498-feature-check-org-scope.md
+++ b/.ai/runs/2026-08-25-issue-5498-feature-check-org-scope.md
@@ -1,0 +1,62 @@
+# Execution plan — finish selected-organization feature-check fix (adopted from PR #5544)
+
+**Origin:** adopted — reconstructed by `om-auto-continue-pr` on 2026-08-25 because PR #5544 carried no execution plan.
+**PR:** #5544 · **Branch:** `fix/issue-5498-feature-check-org-scope` · **Base:** `develop`
+**Author:** @haxiorz — this plan records the requested review follow-up on the existing branch.
+
+## 🎯 Goal
+
+Finish PR #5544 by correcting the two documentation issues requested in review while preserving the already-approved auth implementation and regression coverage for issue #5498.
+
+## Scope
+
+- Correct the remaining stale selected-organization rationale in `.ai/specs/2026-03-25-coherent-access-denied-ux.md`.
+- Record the specification revision in that document's changelog.
+- Re-run the repository validation gate and the authoritative PR review pass before handing the PR back for review.
+
+## Non-goals
+
+- Do not change the approved feature-check route implementation, unit test, or integration scenario.
+- Do not address the reviewer-noted platform-level empty-organization-list divergence; it is explicitly non-blocking and outside this PR.
+- Do not change API, database, UI, RBAC, or backward-compatibility contracts.
+
+## Evidence
+
+| Conclusion | Drawn from | Confidence |
+|---|---|---|
+| Feature checks must use the request-selected organization scope | Issue #5498, the PR description, and commit `f0f1e718a` | high |
+| The code and tests require no changes | Requested-changes review by @pkarw on PR #5544 | high |
+| One stale decision sentence and one missing changelog row block approval | Requested-changes review and handback comments on PR #5544 | high |
+| Existing priority, risk, and QA labels remain appropriate | Review label rationale and green CI on `f0f1e718a` | high |
+
+## External References
+
+- https://github.com/open-mercato/open-mercato/issues/5498 — adopted as the defect and acceptance evidence.
+- https://github.com/open-mercato/open-mercato/pull/5544 — adopted as the implementation, review, and CI evidence.
+- https://github.com/open-mercato/open-mercato/pull/5544#issuecomment-5389762371 — adopted as the review handback scope.
+
+## Assumptions
+
+- The narrowest complete response is to make the two requested spec edits and leave the approved code unchanged.
+- The existing `skip-qa`, `priority-medium`, and `risk-medium` labels remain valid because this resume only corrects documentation.
+
+## Risks
+
+- A documentation edit could accidentally broaden or reverse the original navigation decision; the diff and review pass must confirm that built-in navigation remains server-sourced.
+- No runtime behavior is changed in this resume, so the residual product risk remains the already-tested auth behavior on the existing PR.
+
+## Progress
+
+> Convention: `- [ ]` pending, `- [x]` done. Append ` — <commit sha>` when a step lands. Do not rename step titles.
+
+### Phase 1: Already landed on this PR (reconstructed)
+
+- [x] 1.1 Align feature-check RBAC scope with the request-selected organization and add regression coverage — f0f1e718a
+
+### Phase 2: Address requested documentation changes
+
+- [ ] 2.1 Correct the remaining stale navigation rationale and add the specification changelog entry
+
+### Phase 3: Validate and return for review
+
+- [ ] 3.1 Run the configured validation gate and authoritative PR review pass, then update the PR handoff

--- a/.ai/runs/2026-08-25-issue-5498-feature-check-org-scope.md
+++ b/.ai/runs/2026-08-25-issue-5498-feature-check-org-scope.md
@@ -59,4 +59,4 @@ Finish PR #5544 by correcting the two documentation issues requested in review w
 
 ### Phase 3: Validate and return for review
 
-- [ ] 3.1 Run the configured validation gate and authoritative PR review pass, then update the PR handoff
+- [x] 3.1 Run the configured validation gate and authoritative PR review pass, then update the PR handoff — cac373572

--- a/.ai/runs/2026-08-25-issue-5498-feature-check-org-scope.md
+++ b/.ai/runs/2026-08-25-issue-5498-feature-check-org-scope.md
@@ -55,7 +55,7 @@ Finish PR #5544 by correcting the two documentation issues requested in review w
 
 ### Phase 2: Address requested documentation changes
 
-- [ ] 2.1 Correct the remaining stale navigation rationale and add the specification changelog entry
+- [x] 2.1 Correct the remaining stale navigation rationale and add the specification changelog entry — f803f94f5
 
 ### Phase 3: Validate and return for review
 

--- a/.ai/specs/2026-03-25-coherent-access-denied-ux.md
+++ b/.ai/specs/2026-03-25-coherent-access-denied-ux.md
@@ -296,7 +296,7 @@ The user explicitly requested: "we should not automatically log out the user." T
 
 ### Decision: Keep built-in settings navigation server-scoped
 
-Built-in settings navigation continues to be derived from the server-side nav build in backend layout. This avoids introducing a second ACL source that is not selected-organization aware.
+Built-in settings navigation continues to be derived from the server-side nav build in backend layout. Although issue #5498 made `/api/auth/feature-check` selected-organization aware, this avoids introducing a second scoped ACL snapshot that can drift from the authoritative server-built one.
 
 ### Decision: "Sign in as different user" is opt-in navigation, not auto-redirect
 
@@ -493,5 +493,6 @@ Phases A and B should ship together as they fix the most visible user-facing bug
 
 | Date | Change |
 |------|--------|
+| 2026-08-25 | Corrected feature-check scope statements after #5498 aligned the endpoint with the request-selected organization; built-in navigation stays server-sourced |
 | 2026-03-25 | Initial draft — root cause analysis and five-phase solution |
 | 2026-03-25 | Revised draft after pre-implementation analysis — added BC bridges, full settings guard inventory, server-scoped nav model, explicit in-page forbidden-state contract, and template parity requirements |

--- a/.ai/specs/2026-03-25-coherent-access-denied-ux.md
+++ b/.ai/specs/2026-03-25-coherent-access-denied-ux.md
@@ -69,7 +69,7 @@ Built-in settings items are already filtered once during server-side nav constru
 This creates two problems:
 
 1. The settings nav pipeline cannot reason about access rules consistently because built-in item metadata is lost during conversion
-2. Introducing a second, client-side `/api/auth/feature-check` pass would be unsafe because that endpoint is not selected-organization aware, while page guards are
+2. Introducing a second, client-side `/api/auth/feature-check` pass would create a second filtering source that can drift from the server-built navigation snapshot. Issue #5498 later aligned the endpoint with the same request-selected organization scope used by page and API guards, but built-in navigation still has one authoritative server-side source.
 
 ### Root Cause 4: No in-page "access denied" state for data components
 
@@ -136,7 +136,7 @@ This preserves legitimate role-only settings pages.
 
 **Goal:** Built-in settings navigation never exposes broader access than page guards, without introducing a second ACL source.
 
-**Key decision:** This spec does **not** add a new client-side built-in settings filter based on `/api/auth/feature-check`. That endpoint is not selected-organization aware, while backend page guards are. The built-in settings navigation should continue to rely on the server-side nav build performed in backend layout.
+**Key decision:** This spec does **not** add a new client-side built-in settings filter based on `/api/auth/feature-check`. Although issue #5498 later made that endpoint selected-organization aware, built-in settings navigation should continue to rely on the server-side nav build performed in backend layout so one scoped snapshot remains authoritative.
 
 **Implementation approach:**
 
@@ -384,7 +384,7 @@ No database schema changes required. This spec only affects client-side UI behav
 |------|----------|------|------------|----------|
 | Phase A updates `apiFetch` but misses QueryProvider | High | Auth / UI | Change both `apiFetch` and `QueryProvider` in the same phase; add unit tests for both layers | Low |
 | Removing `redirectToForbiddenLogin()` would break public imports | High | Backward compatibility | Keep the helper as a deprecated exported bridge for at least one minor version | Low |
-| Built-in settings nav is re-filtered client-side using `/api/auth/feature-check` | High | RBAC scope | Do not add that second ACL source in this spec; keep built-ins server-scoped | None |
+| Built-in settings nav is re-filtered client-side using `/api/auth/feature-check` | High | RBAC consistency | Do not add a second scoped ACL snapshot in this spec; keep built-ins server-sourced | None |
 | Role-only settings pages get forced into `requireFeatures` | Medium | Auth | Validation rule allows either `requireFeatures` or `requireRoles` | Low |
 | Existing employees lose access to Translations page after Phase B | Low | UX | This is the intended fix. Admins can grant `translations.manage_locales` to employees who need it. | None |
 | DataTable / CrudForm forbidden props are ignored by existing consumers | None | UI | Props are additive and default to false | None |
@@ -423,7 +423,7 @@ Phases A and B should ship together as they fix the most visible user-facing bug
 1. Extend nav item types to preserve `requireFeatures` / `requireRoles`
 2. Copy those fields through settings nav conversion helpers
 3. Add nav helper tests that guard metadata survives conversion
-4. Keep built-in settings filtering sourced from backend layout rather than adding a new client feature-check pass
+4. Keep built-in settings filtering sourced from backend layout rather than adding a second client feature-check snapshot
 
 ### Phase D
 

--- a/packages/core/src/modules/auth/__integration__/TC-AUTH-063-feature-check-org-scope.spec.ts
+++ b/packages/core/src/modules/auth/__integration__/TC-AUTH-063-feature-check-org-scope.spec.ts
@@ -1,0 +1,75 @@
+import { randomInt } from 'node:crypto'
+import { expect, test } from '@playwright/test'
+import { getAuthToken } from '@open-mercato/core/helpers/integration/api'
+import {
+  apiRequestWithSelectedOrg,
+  createOrganizationFixture,
+  createRoleFixture,
+  createUserFixture,
+  deleteOrganizationIfExists,
+  deleteRoleIfExists,
+  deleteUserIfExists,
+  setUserAclVisibility,
+} from '@open-mercato/core/helpers/integration/authFixtures'
+import { getTokenContext, readJsonSafe } from '@open-mercato/core/helpers/integration/generalFixtures'
+
+const GRANTED_FEATURE = 'auth.users.list'
+
+type FeatureCheckResponse = {
+  ok?: boolean
+  granted?: string[]
+}
+
+test.describe('TC-AUTH-063: feature-check uses the request-selected organization', () => {
+  test('agrees with route guards for a non-home organization ACL', async ({ request }) => {
+    const superadminToken = await getAuthToken(request, 'superadmin')
+    const { organizationId: homeOrganizationId, tenantId } = getTokenContext(superadminToken)
+    const stamp = `${Date.now()}-${randomInt(1_000_000)}`
+    const email = `qa-tc-auth-063-${stamp}@example.com`
+    const password = 'StrongSecret123!'
+    let selectedOrganizationId: string | null = null
+    let roleId: string | null = null
+    let userId: string | null = null
+
+    try {
+      selectedOrganizationId = await createOrganizationFixture(request, superadminToken, {
+        name: `QA TC-AUTH-063 ${stamp}`,
+        tenantId,
+      })
+      roleId = await createRoleFixture(request, superadminToken, { name: `qa-tc-auth-063-${stamp}` })
+      userId = await createUserFixture(request, superadminToken, {
+        email,
+        password,
+        organizationId: homeOrganizationId,
+        roles: [roleId],
+        name: 'QA TC-AUTH-063',
+      })
+      await setUserAclVisibility(request, superadminToken, {
+        userId,
+        organizations: [selectedOrganizationId],
+        features: [GRANTED_FEATURE],
+      })
+      const userToken = await getAuthToken(request, email, password)
+
+      const selectedResponse = await apiRequestWithSelectedOrg(request, 'POST', '/api/auth/feature-check', {
+        token: userToken,
+        selectedOrgId: selectedOrganizationId,
+        data: { features: [GRANTED_FEATURE] },
+      })
+      const selectedCheck = await readJsonSafe<FeatureCheckResponse>(selectedResponse)
+      expect(selectedResponse.status(), 'feature-check should return 200 in the selected scope').toBe(200)
+      expect(selectedCheck?.ok, 'feature-check should grant the selected-organization feature').toBe(true)
+      expect(selectedCheck?.granted ?? []).toContain(GRANTED_FEATURE)
+
+      const guardedRoute = await apiRequestWithSelectedOrg(request, 'GET', '/api/auth/users?pageSize=1', {
+        token: userToken,
+        selectedOrgId: selectedOrganizationId,
+      })
+      expect(guardedRoute.status(), 'the route guard should grant the same selected-organization feature').toBe(200)
+    } finally {
+      await deleteUserIfExists(request, superadminToken, userId)
+      await deleteRoleIfExists(request, superadminToken, roleId)
+      await deleteOrganizationIfExists(request, superadminToken, selectedOrganizationId)
+    }
+  })
+})

--- a/packages/core/src/modules/auth/api/__tests__/feature-check.test.ts
+++ b/packages/core/src/modules/auth/api/__tests__/feature-check.test.ts
@@ -12,6 +12,11 @@ jest.mock('@open-mercato/shared/lib/di/container', () => ({
   createRequestContainer: async () => ({ resolve: (k: string) => (k === 'rbacService' ? mockRbac : null) }),
 }))
 
+const mockResolveFeatureCheckContext = jest.fn()
+jest.mock('@open-mercato/core/modules/directory/utils/organizationScope', () => ({
+  resolveFeatureCheckContext: (...args: unknown[]) => mockResolveFeatureCheckContext(...args),
+}))
+
 function makeReq(body: unknown) {
   return new Request('http://localhost/api/auth/feature-check', {
     method: 'POST',
@@ -24,6 +29,11 @@ describe('POST /api/auth/feature-check', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockRbac.userHasAllFeatures.mockResolvedValue(true)
+    mockResolveFeatureCheckContext.mockResolvedValue({
+      organizationId: 'o1',
+      scope: { selectedId: 'o1', filterIds: ['o1'], allowedIds: ['o1'], tenantId: 't1' },
+      allowedOrganizationIds: ['o1'],
+    })
   })
 
   it('returns 401 when not authenticated', async () => {
@@ -59,6 +69,38 @@ describe('POST /api/auth/feature-check', () => {
     const data = await res.json()
     expect(data.ok).toBe(false)
     expect(Array.isArray(data.granted)).toBe(true)
+  })
+
+  it('uses the request-selected scope for aggregate and individual checks', async () => {
+    const { getAuthFromRequest } = await import('@open-mercato/shared/lib/auth/server')
+    const auth = { sub: 'u1', tenantId: 'home-tenant', orgId: 'home-org' }
+    ;(getAuthFromRequest as jest.Mock).mockReturnValue(auth)
+    mockResolveFeatureCheckContext.mockResolvedValueOnce({
+      organizationId: 'selected-org',
+      scope: {
+        selectedId: 'selected-org',
+        filterIds: ['selected-org'],
+        allowedIds: ['selected-org'],
+        tenantId: 'selected-tenant',
+      },
+      allowedOrganizationIds: ['selected-org'],
+    })
+    mockRbac.userHasAllFeatures
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    const req = makeReq({ features: ['a.b', 'c.d'] })
+
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ ok: false, granted: ['a.b'], userId: 'u1' })
+    expect(mockResolveFeatureCheckContext).toHaveBeenCalledWith(expect.objectContaining({ auth, request: req }))
+    expect(mockRbac.userHasAllFeatures.mock.calls).toEqual([
+      ['u1', ['a.b', 'c.d'], { tenantId: 'selected-tenant', organizationId: 'selected-org' }],
+      ['u1', ['a.b'], { tenantId: 'selected-tenant', organizationId: 'selected-org' }],
+      ['u1', ['c.d'], { tenantId: 'selected-tenant', organizationId: 'selected-org' }],
+    ])
   })
 
   describe('input validation — returns 400', () => {

--- a/packages/core/src/modules/auth/api/feature-check.ts
+++ b/packages/core/src/modules/auth/api/feature-check.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 import type { OpenApiMethodDoc, OpenApiRouteDoc } from '@open-mercato/shared/lib/openapi'
 import { createRequestContainer } from '@open-mercato/shared/lib/di/container'
 import { getAuthFromRequest } from '@open-mercato/shared/lib/auth/server'
+import type { RbacService } from '@open-mercato/core/modules/auth/services/rbacService'
+import { resolveFeatureCheckContext } from '@open-mercato/core/modules/directory/utils/organizationScope'
 import { featureCheckRequestSchema } from '../data/validators'
 
 export const metadata = {
@@ -37,8 +39,13 @@ export async function POST(req: Request) {
   }
 
   const container = await createRequestContainer()
-  const rbac = (container.resolve('rbacService') as any)
-  const ok = await rbac.userHasAllFeatures(auth.sub, features, { tenantId: auth.tenantId, organizationId: auth.orgId })
+  const rbac = container.resolve<RbacService>('rbacService')
+  const featureContext = await resolveFeatureCheckContext({ container, auth, request: req })
+  const featureScope = {
+    tenantId: featureContext.scope.tenantId ?? auth.tenantId ?? null,
+    organizationId: featureContext.organizationId,
+  }
+  const ok = await rbac.userHasAllFeatures(auth.sub, features, featureScope)
   if (ok) {
     return NextResponse.json({ ok: true, granted: features, userId: auth.sub })
   }
@@ -46,7 +53,7 @@ export async function POST(req: Request) {
   // Check individually to see which features are granted
   const granted: string[] = []
   for (const f of features) {
-    const hasFeature = await rbac.userHasAllFeatures(auth.sub, [f], { tenantId: auth.tenantId, organizationId: auth.orgId })
+    const hasFeature = await rbac.userHasAllFeatures(auth.sub, [f], featureScope)
     if (hasFeature) granted.push(f)
   }
 


### PR DESCRIPTION
Tracking plan: .ai/runs/2026-08-25-issue-5498-feature-check-org-scope.md
Status: complete

Closes #5498

## Goal

Make client-side feature visibility agree with API and page guards when a user selects a non-home organization.

## Problem and root cause

`POST /api/auth/feature-check` evaluated permissions with the organization and tenant embedded in the JWT. Route guards already resolve the request-selected organization, so users with a scoped grant in another allowed organization could pass the guarded route while the feature-check endpoint reported that the same feature was denied.

## What changed

- Resolve feature-check authorization through the established request organization-scope helper.
- Reuse the same resolved tenant and organization for aggregate and per-feature checks.
- Add unit coverage for the selected scope and a self-contained integration regression that compares the endpoint with a guarded route.
- Correct stale specification statements while retaining server-built navigation as the single authoritative navigation snapshot.

## Validation

- `yarn build:packages` — passed before and after generation (26 package tasks)
- `yarn generate` — passed; no unintended tracked output
- `yarn i18n:check-sync` — passed
- `yarn i18n:check-usage` — passed with the existing advisory unused-key inventory
- `yarn typecheck` — passed (26 package tasks)
- `yarn test` — passed (33/33 package tasks)
- `yarn build:app` — passed
- `yarn workspace @open-mercato/core test --runTestsByPath src/modules/auth/api/__tests__/feature-check.test.ts --runInBand` — passed (11/11)
- `yarn test:integration:ephemeral --no-reuse-env --no-screenshots TC-AUTH-063-feature-check-org-scope` — passed (1/1)
- `yarn template:sync` — passed

## Automated review

- `om-code-review` — approved with no findings and no remediation required
- Standard-profile direct review — approved with zero findings
- Unresolved findings — none

## Breaking changes

None. Authentication, request and response schemas, endpoint URL, status codes, wildcard behavior, and the empty-feature fast path are unchanged. There are no database, event, import-path, or other contract-surface changes.

## Labels and delivery

- `review`
- `bug`
- `skip-qa`
- `priority-medium`
- `risk-medium`

## Manual QA

Manual UI QA is not required: this changes no UI-rendering file, database structure, or API shape, and the changed behavior is covered by focused unit tests plus a fresh isolated integration scenario.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790123565&installation_model_id=432243&pr_number=5544&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5544&signature=4ab9797b2de2ac9f8b7863e50236ceefa6a1b35346bd3dd5f256000ef89c2873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->