### PR TITLE
fix(sales): treat line discountAmount as a line total, not a per-unit rate (#3757)

### DIFF
--- a/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
+++ b/packages/core/src/modules/sales/lib/__tests__/calculations.test.ts
@@ -575,4 +575,172 @@ describe('calculateDocumentTotals', () => {
       unregister()
     }
   })
+
+  it('applies a stored discountAmount as the line total, not per unit, on quantity > 1 lines (issue #3757)', async () => {
+    const result = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines: [
+        {
+          kind: 'product',
+          quantity: 3,
+          currencyCode: 'USD',
+          unitPriceNet: 85,
+          discountPercent: 5,
+          discountAmount: 12.75,
+          taxRate: 0,
+        },
+      ],
+      adjustments: [],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    expect(result.lines[0].discountAmount).toBeCloseTo(12.75, 4)
+    expect(result.lines[0].netAmount).toBeCloseTo(242.25, 4)
+    expect(result.totals.subtotalNetAmount).toBeCloseTo(242.25, 4)
+    expect(result.totals.discountTotalAmount).toBeCloseTo(12.75, 4)
+  })
+
+  it('applies a stored discountAmount unchanged on quantity 1 lines', async () => {
+    const result = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines: [
+        {
+          kind: 'product',
+          quantity: 1,
+          currencyCode: 'USD',
+          unitPriceNet: 85,
+          discountAmount: 12.75,
+          taxRate: 0,
+        },
+      ],
+      adjustments: [],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    expect(result.lines[0].discountAmount).toBeCloseTo(12.75, 4)
+    expect(result.lines[0].netAmount).toBeCloseTo(72.25, 4)
+    expect(result.totals.subtotalNetAmount).toBeCloseTo(72.25, 4)
+  })
+
+  it('keeps discountPercent-only lines scaling with quantity', async () => {
+    const result = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines: [
+        {
+          kind: 'product',
+          quantity: 1,
+          currencyCode: 'USD',
+          unitPriceNet: 100,
+          discountPercent: 10,
+          taxRate: 0,
+        },
+        {
+          kind: 'product',
+          quantity: 4,
+          currencyCode: 'USD',
+          unitPriceNet: 100,
+          discountPercent: 10,
+          taxRate: 0,
+        },
+      ],
+      adjustments: [],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    expect(result.lines[0].discountAmount).toBeCloseTo(10, 4)
+    expect(result.lines[0].netAmount).toBeCloseTo(90, 4)
+    expect(result.lines[1].discountAmount).toBeCloseTo(40, 4)
+    expect(result.lines[1].netAmount).toBeCloseTo(360, 4)
+    expect(result.totals.subtotalNetAmount).toBeCloseTo(450, 4)
+    expect(result.totals.discountTotalAmount).toBeCloseTo(50, 4)
+  })
+
+  it('clamps a stored discountAmount that exceeds the line subtotal', async () => {
+    const result = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines: [
+        {
+          kind: 'product',
+          quantity: 2,
+          currencyCode: 'USD',
+          unitPriceNet: 50,
+          discountAmount: 500,
+          taxRate: 0,
+        },
+      ],
+      adjustments: [],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    expect(result.lines[0].discountAmount).toBeCloseTo(100, 4)
+    expect(result.lines[0].netAmount).toBeCloseTo(0, 4)
+  })
+
+  it('stays stable when the persisted discountAmount is fed back into repeated recalculations (issue #3757)', async () => {
+    let storedDiscountAmount: number | null = null
+
+    for (let pass = 0; pass < 5; pass += 1) {
+      const result = await calculateDocumentTotals({
+        documentKind: 'order',
+        lines: [
+          {
+            kind: 'product',
+            quantity: 3,
+            currencyCode: 'USD',
+            unitPriceNet: 85,
+            discountPercent: 5,
+            discountAmount: storedDiscountAmount,
+            taxRate: 0,
+          },
+        ],
+        adjustments: [],
+        context: { ...baseContext, metadata: {} },
+      })
+
+      expect(result.lines[0].discountAmount).toBeCloseTo(12.75, 4)
+      expect(result.lines[0].netAmount).toBeCloseTo(242.25, 4)
+      storedDiscountAmount = result.lines[0].discountAmount
+    }
+  })
+
+  it('keeps the order subtotal net consistent with gross after return credits on a discounted multi-unit line (issue #3757)', async () => {
+    const result = await calculateDocumentTotals({
+      documentKind: 'order',
+      lines: [
+        {
+          kind: 'product',
+          quantity: 3,
+          currencyCode: 'USD',
+          unitPriceNet: 85,
+          discountPercent: 5,
+          discountAmount: 12.75,
+          taxRate: 0,
+          totalNetAmount: 242.25,
+          totalGrossAmount: 242.25,
+        },
+      ],
+      adjustments: [
+        {
+          scope: 'line',
+          kind: 'return',
+          amountNet: 20.1,
+          amountGross: 20.1,
+          currencyCode: 'USD',
+        },
+        {
+          scope: 'line',
+          kind: 'return',
+          amountNet: 15,
+          amountGross: 15,
+          currencyCode: 'USD',
+        },
+      ],
+      context: { ...baseContext, metadata: {} },
+    })
+
+    expect(result.totals.subtotalNetAmount).toBeCloseTo(207.15, 4)
+    expect(result.totals.subtotalGrossAmount).toBeCloseTo(207.15, 4)
+    expect(result.totals.grandTotalNetAmount).toBeCloseTo(207.15, 4)
+    expect(result.totals.grandTotalGrossAmount).toBeCloseTo(207.15, 4)
+  })
 })

--- a/packages/core/src/modules/sales/lib/calculations.ts
+++ b/packages/core/src/modules/sales/lib/calculations.ts
@@ -85,14 +85,25 @@ function buildBaseLineResult(line: SalesLineSnapshot): SalesLineCalculationResul
     (line.unitPriceGross !== null && line.unitPriceGross !== undefined
       ? toNumber(line.unitPriceGross) / (1 + taxRate)
       : 0)
-  const discountPerUnit =
+  const netSubtotalBeforeDiscount = toNumber(unitNet, 0) * quantity
+  // `discountAmount` is a per-LINE total everywhere it is produced or consumed:
+  // the write path persists this function's own `discountTotal` back into it and
+  // the UI validates it against `percent * unitPriceNet * quantity`. Reading it
+  // as a per-unit rate and multiplying by `quantity` inflated the discount
+  // `quantity`-fold on multi-unit lines, clamping their net contribution to 0
+  // while gross stayed correct (#3757). The percent branch is unchanged:
+  // `percent / 100 * unitNet * quantity` is the same value as
+  // `percent / 100 * netSubtotalBeforeDiscount`.
+  const discountRequested =
     line.discountAmount ??
     (line.discountPercent !== null && line.discountPercent !== undefined
-      ? toNumber(line.discountPercent, 0) / 100 * toNumber(unitNet, 0)
+      ? toNumber(line.discountPercent, 0) / 100 * netSubtotalBeforeDiscount
       : 0)
 
-  const netSubtotalBeforeDiscount = toNumber(unitNet, 0) * quantity
-  const discountTotal = Math.min(Math.max(discountPerUnit * quantity, 0), netSubtotalBeforeDiscount)
+  const discountTotal = Math.min(
+    Math.max(toNumber(discountRequested, 0), 0),
+    netSubtotalBeforeDiscount
+  )
   const netSubtotal = Math.max(netSubtotalBeforeDiscount - discountTotal, 0)
   const explicitTaxAmount = line.taxAmount !== null && line.taxAmount !== undefined
   let taxAmount = explicitTaxAmount


### PR DESCRIPTION
Refs #3757
Spec: `.ai/specs/2026-08-07-sales-line-discount-amount-contract.md` (merged in #5200, tracking #5019 — the twin of #3757)

> **⚠️ Status: blocked on two maintainer decisions. Do not merge as-is.**
>
> This PR was opened without the spec above in view, and @pkarw's review (2026-08-24) correctly identified that. The spec covers exactly this function and this defect, is still marked `draft — design decision requested`, and states twice that no implementation lands until its § Proposed Solution 1 and 2 are approved. This PR implements a partial § 1 and stops.
>
> The body below has been corrected: the original "Breaking Changes: None" claim was **wrong**, and the linkage has been changed from `Closes #3757` to `Refs #3757` because the reported symptom does not clear on an already-corrupted row. Both corrections are explained in place. The diagnosis, the fix location and the six tests stand; what needs deciding is the shape of the contract around them.

## 🎯 Goal

Make `sales_order_lines.discount_amount` mean one thing on the read path and the write path, so an order containing a discounted multi-unit line stops reporting a Subtotal (net) that is inconsistent with its gross.

## 🔍 Problem

`SalesOrderLine.discount_amount` is written as a per-**line** total by every writer, but the totals-recalculation engine read it back as a per-**unit** rate. On a line with `quantity > 1` and a non-zero stored discount the recomputed discount was inflated `quantity`-fold, clamped to the line's full pre-discount subtotal, and the line's net contribution collapsed toward `0`, while its gross stayed correct because `buildBaseLineResult` takes gross from the already-correct persisted `total_gross_amount`. With `quantity === 1` the extra multiplication is a no-op, which is why it went unnoticed.

## 🔍 Root Cause

In `packages/core/src/modules/sales/lib/calculations.ts`, `buildBaseLineResult` named its local `discountPerUnit`, seeded it from `line.discountAmount`, and computed `discountTotal = Math.min(Math.max(discountPerUnit * quantity, 0), netSubtotalBeforeDiscount)`.

The `discountPercent` branch was correct — `(percent / 100) * unitNet * quantity` is by definition the line total. The `discountAmount` branch was not, for every value that arrives from a **persisted row**:

- `commands/documents.ts:3124` persists `toNumericString(lineResult.discountAmount)` — this function's own `round(discountTotal)`.
- `seed/examples.ts:1414,1646` write the same value.
- `commands/documents.ts:2906,2937` and `commands/returns.ts:155` rebuild `SalesLineSnapshot` straight from that persisted column.
- `percentAccountsForAmount` in `components/documents/lineItemUtils.ts:35-46` validates a stored amount against `(percent / 100) * unitPriceNet * quantity`, so the display layer also reads the column as a line total.

Because the engine writes its own inflated result back into the same column, the error **compounds across recalculations**: for the reproduction line in #3757 (`quantity 3`, `unit_price_net 85`, `discount_percent 5`) the stored discount grows `12.75 → 38.25 → 114.75 → clamped to 255`, at which point it equals the whole line subtotal and net is exactly `0` — matching the `discount_amount = 255.0000` alongside a correct `total_net_amount = 242.25` observed on the seeded order.

### Correction to the original root-cause claim

The first version of this description asserted that "the calculation engine was the only place in the system interpreting the column as per-unit". That is **not accurate**, and the review was right to flag it. `components/documents/SalesOrderDraftLines.tsx:68` also multiplies by quantity:

```ts
discountAmount: normalizeNumber(payload.discountAmount, 0) * quantity,
```

It is unreachable today — neither caller populates `payload.discountAmount`, so it always evaluates `0 * quantity` — but it is a second site holding the per-unit reading. Whether it is a defect depends on Decision 1/3 below: if caller-supplied amounts keep their per-unit meaning (the spec's § 3), this line is **correct** as written and must stay; only if caller input flips to line-total does it become wrong. It is therefore listed here as decision-dependent rather than fixed in this PR.

## What Changed

- `packages/core/src/modules/sales/lib/calculations.ts` — in `buildBaseLineResult`, `netSubtotalBeforeDiscount` is computed before the discount is resolved; the `discountPercent` branch derives from it directly; and the clamp no longer multiplies by `quantity`.

The `discountPercent` path is algebraically identical to before, so every pre-existing expectation holds bit for bit.

## 💥 Breaking Changes — corrected

**The original "None" claim was wrong.** It reasoned only about the persistence direction and missed the create path.

`commands/documents.ts:3036` (`createLineSnapshotFromInput`) passes caller-supplied `discountAmount` from `DocumentLineCreateInput` — the validated request body of `POST /api/sales/orders`, `POST /api/sales/quotes`, and `POST`/`PUT` on `/api/sales/order-lines` and `/api/sales/quote-lines` — straight into `buildBaseLineResult` unmodified. Under the old engine that value was multiplied by quantity, so the API input was *de facto* per-unit. As this PR stands, it silently becomes a line total:

| caller posts `quantity: 60, unitPriceNet: 50.00, discountAmount: 5.00` | discount applied | stored `total_net_amount` |
|---|---:|---:|
| before this PR | 300.00 | 2700.00 |
| as this PR stands | 5.00 | 2995.00 |

A silent 60× change in the direction of undercharging the discount, with no 4xx, no warning and no version gate. `BACKWARD_COMPATIBILITY.md` classifies API request semantics as a contract surface and its deprecation protocol was not followed; `UPGRADE_NOTES.md` has no entry.

This is exactly what the spec's § 3 exists to prevent, via a `discountAmountBasis` flag (caller-supplied, defaulting to `'unit'`) paired with `discountAmountFromStoredRow` (mapper-only), so that only mapper-rebuilt snapshots are read as line totals and no existing caller has to change. That is not implemented here.

## ⚠️ Why the linkage is now `Refs`, not `Closes`

The original body claimed recalculated totals move "always toward the correct value". For an **already-corrupted** row that is false. Feeding the reproduction row (`discount_amount = 255`, `quantity 3 × unitPriceNet 85`) through the patched function:

```
netSubtotalBeforeDiscount = 255
discountRequested         = 255      // stored line total, no longer multiplied
discountTotal             = min(max(255, 0), 255) = 255
netSubtotal               = max(255 - 255, 0)     = 0
```

Still `0`. This PR stops new corruption but does not undo existing corruption, and the row cannot self-heal because `discountAmount` still wins over `discountPercent` via `??` even though the correct `discount_percent = 5` sits in the same row. The issue's Expected result therefore does not clear on `SO-DEMO-2001` or on any database where the buggy engine already ran, so `Closes #3757` would have been untrue. Self-healing is the spec's § 2 (percentage-first precedence), which is Decision 2 below.

## 🧪 Tests

Full validation gate run locally on this tree, in order, none skipped: `yarn build:packages`, `yarn generate`, `yarn build:packages`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn test` (184 suites, 1998 passed / 5 skipped), `yarn build:app`. All 14 reported GitHub checks on `0a271d08` are green.

Six unit tests added to `packages/core/src/modules/sales/lib/__tests__/calculations.test.ts`: a stored line-total discount on a qty-3 line; the same at qty 1; `discountPercent`-only at qty 1 and qty 4; a stored discount exceeding the line subtotal (clamping); a five-pass round trip feeding the persisted discount back in, which is the regression for the compounding runaway; and a document-level test driving `buildBaseDocumentResult`'s `Math.max(subtotal + delta, 0)` return clamp. Three of the six fail against the unfixed engine (verified by stashing only the source change: `3 failed, 16 passed`).

These tests are written against the current partial shape. If Decision 1/3 lands the spec's basis flag, the caller-input cases will need to move to the mapper-sourced form.

## 📋 Outstanding — the two gated decisions

Per the spec, both need maintainer sign-off before an implementation lands:

1. **Decision 1 — the column's meaning.** `discount_amount` is a line total (spec § 1). This PR assumes it; the spec still lists it as unsigned-off.
2. **Decision 2 — percentage-first precedence** (spec § 2), which is what makes corrupted rows self-heal. Its documented cost is that a caller sending only `discountAmount` on `PUT /api/sales/order-lines`, against a row that carries a non-zero stored `discount_percent`, silently loses the amount it just sent.

Given a decision, the remaining work is the spec's § 2 (precedence), § 3 (`discountAmountBasis` / `discountAmountFromStoredRow`, plus de-duplicating the mapper shared with `commands/returns.ts:137`), and § 4 (decomposing the `parsed.discountAmount ?? existingSnapshot?.discountAmount ?? 0` coalescing at `documents.ts:7177` and `:7671`), together with an `UPGRADE_NOTES.md` entry and a decision on repairing already-corrupted rows.
