### PR TITLE
perf(sales): index sales_notes and sales_document_addresses by document context

### DIFF
--- a/packages/core/src/__tests__/hot-path-indexes.test.ts
+++ b/packages/core/src/__tests__/hot-path-indexes.test.ts
@@ -82,4 +82,64 @@ describe('hot-path indexes (#2966)', () => {
       expect(indexNames).toContain('user_roles_role_id_idx')
     })
   })
+
+  /**
+   * sales_notes (context_id) and sales_document_addresses (document_id), plus
+   * the order_id / quote_id FK columns on both.
+   *
+   * Every read of these tables filters by document context, never by scope
+   * alone: loadOrderSnapshot / loadQuoteSnapshot (sales/commands/documents.ts)
+   * fetch both in the same Promise.all, and the command bus runs them around
+   * every command via prepare() / captureAfter(). The lone
+   * (organization_id, tenant_id) index matches every row on a
+   * single-organization deployment, so the planner discarded it and scanned.
+   * The order_id / quote_id indexes cover the `on delete set null` child side,
+   * which Postgres does not index automatically.
+   */
+  describe('sales_notes and sales_document_addresses document indexes', () => {
+    it('declares the context and FK indexes on the SalesNote entity', () => {
+      const source = readEntities('sales')
+      expect(source).toContain("@Index({ name: 'sales_notes_context_idx', properties: ['contextId'] })")
+      expect(source).toContain("@Index({ name: 'sales_notes_order_idx', properties: ['order'] })")
+      expect(source).toContain("@Index({ name: 'sales_notes_quote_idx', properties: ['quote'] })")
+    })
+
+    it('declares the document and FK indexes on the SalesDocumentAddress entity', () => {
+      const source = readEntities('sales')
+      expect(source).toContain(
+        "@Index({ name: 'sales_document_addresses_document_idx', properties: ['documentId'] })",
+      )
+      expect(source).toContain("@Index({ name: 'sales_document_addresses_order_idx', properties: ['order'] })")
+      expect(source).toContain("@Index({ name: 'sales_document_addresses_quote_idx', properties: ['quote'] })")
+    })
+
+    it('creates all six indexes concurrently in a sales migration', () => {
+      const sql = readAllMigrationSql('sales')
+      expect(sql).toContain('create index concurrently "sales_notes_context_idx" on "sales_notes" ("context_id")')
+      expect(sql).toContain('create index concurrently "sales_notes_order_idx" on "sales_notes" ("order_id")')
+      expect(sql).toContain('create index concurrently "sales_notes_quote_idx" on "sales_notes" ("quote_id")')
+      expect(sql).toContain(
+        'create index concurrently "sales_document_addresses_document_idx" on "sales_document_addresses" ("document_id")',
+      )
+      expect(sql).toContain(
+        'create index concurrently "sales_document_addresses_order_idx" on "sales_document_addresses" ("order_id")',
+      )
+      expect(sql).toContain(
+        'create index concurrently "sales_document_addresses_quote_idx" on "sales_document_addresses" ("quote_id")',
+      )
+    })
+
+    it('records all six indexes in the sales schema snapshot', () => {
+      expect(readSnapshotIndexNames('sales', 'sales_notes')).toEqual(
+        expect.arrayContaining(['sales_notes_context_idx', 'sales_notes_order_idx', 'sales_notes_quote_idx']),
+      )
+      expect(readSnapshotIndexNames('sales', 'sales_document_addresses')).toEqual(
+        expect.arrayContaining([
+          'sales_document_addresses_document_idx',
+          'sales_document_addresses_order_idx',
+          'sales_document_addresses_quote_idx',
+        ]),
+      )
+    })
+  })
 })

--- a/packages/core/src/modules/sales/data/entities.ts
+++ b/packages/core/src/modules/sales/data/entities.ts
@@ -1790,6 +1790,9 @@ export class SalesPaymentAllocation {
 
 @Entity({ tableName: 'sales_notes' })
 @Index({ name: 'sales_notes_scope_idx', properties: ['organizationId', 'tenantId'] })
+@Index({ name: 'sales_notes_context_idx', properties: ['contextId'] })
+@Index({ name: 'sales_notes_order_idx', properties: ['order'] })
+@Index({ name: 'sales_notes_quote_idx', properties: ['quote'] })
 export class SalesNote {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string
@@ -1836,6 +1839,9 @@ export class SalesNote {
 
 @Entity({ tableName: 'sales_document_addresses' })
 @Index({ name: 'sales_document_addresses_scope_idx', properties: ['organizationId', 'tenantId'] })
+@Index({ name: 'sales_document_addresses_document_idx', properties: ['documentId'] })
+@Index({ name: 'sales_document_addresses_order_idx', properties: ['order'] })
+@Index({ name: 'sales_document_addresses_quote_idx', properties: ['quote'] })
 export class SalesDocumentAddress {
   @PrimaryKey({ type: 'uuid', defaultRaw: 'gen_random_uuid()' })
   id!: string

--- a/packages/core/src/modules/sales/migrations/.snapshot-open-mercato.json
+++ b/packages/core/src/modules/sales/migrations/.snapshot-open-mercato.json
@@ -1962,6 +1962,36 @@
           "keyName": "sales_document_addresses_scope_idx",
           "primary": false,
           "unique": false
+        },
+        {
+          "columnNames": [
+            "document_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sales_document_addresses_document_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "order_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sales_document_addresses_order_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "quote_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sales_document_addresses_quote_idx",
+          "primary": false,
+          "unique": false
         }
       ],
       "checks": [],
@@ -3748,6 +3778,36 @@
           "composite": true,
           "constraint": false,
           "keyName": "sales_notes_scope_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "context_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sales_notes_context_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "order_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sales_notes_order_idx",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "quote_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "sales_notes_quote_idx",
           "primary": false,
           "unique": false
         }

--- a/packages/core/src/modules/sales/migrations/Migration20260821120000_sales_notes_addresses_context_idx.ts
+++ b/packages/core/src/modules/sales/migrations/Migration20260821120000_sales_notes_addresses_context_idx.ts
@@ -1,0 +1,87 @@
+import { Migration } from '@mikro-orm/migrations';
+
+// sales_notes and sales_document_addresses each carried a single index —
+// (organization_id, tenant_id) — and are never read by that predicate alone.
+// loadOrderSnapshot / loadQuoteSnapshot (commands/documents.ts) read them by
+// context in the same Promise.all:
+//
+//   findWithDecryption(em, SalesNote, { contextType, contextId, ...scope })
+//   findWithDecryption(em, SalesDocumentAddress, { documentId, documentKind, ...scope })
+//
+// On a single-organization deployment the scope index matches every row, so the
+// planner discards it and scans. The cost is CPU filtering, so a warm cache does
+// not reduce it. Measured on a table of ~331k rows / 110 MB: a parallel
+// sequential scan removing 110,457 rows per worker, 82 ms per read to return 0
+// rows. The command bus runs prepare() and captureAfter() around every command
+// and both load a document snapshot, so one written document — itself several
+// commands (the document, one per changed line, the payment reconcile) —
+// performs roughly 20 of these reads. Counters over one bulk-import batch of 100
+// records showed 1,971 sequential scans reading 217,670,528 rows, 2.18M rows per
+// imported record; repeatable across consecutive batches (1,971 / 1,974 / 1,911).
+//
+// context_type and document_kind are deliberately omitted, as they were for
+// sales_document_tag_assignments_document_idx (Migration20260806120000), and the
+// scope columns with them. sales_orders.id and sales_quotes.id are both
+// gen_random_uuid() from their own tables, so a context_id already determines its
+// context_type and its tenant; the seek returns the handful of rows belonging to
+// one document and the remaining terms are rechecked over those. Folding three
+// more columns in — one text and two uuids — roughly triples the index entry for
+// no selectivity, on tables that take a write per document save and a note per
+// order status change. The sibling scope indexes that do fold scope in
+// (sales_order_lines_scope_idx, sales_payments_scope_idx) predate that reasoning.
+//
+// order_id and quote_id are separate indexes rather than a widening of the above:
+// both tables are the child side of `on delete set null` constraints, which
+// PostgreSQL does not index automatically, and the constraint check probes
+// order_id / quote_id — columns the context index cannot serve even though they
+// hold the same uuid. Without them every delete of a parent order or quote scans
+// the child table in full.
+//
+// Both tables are high-churn, so the indexes are built CONCURRENTLY to avoid
+// blocking writes during the build. CREATE INDEX CONCURRENTLY cannot run inside a
+// transaction, hence isTransactional() => false; the migration runner applies
+// migrations one-by-one, so this opt-out is safe. Drop first so retrying a failed
+// concurrent build removes PostgreSQL's invalid index stub instead of letting IF
+// NOT EXISTS silently accept it: a half-built concurrent index is left INVALID,
+// the planner ignores it, and IF NOT EXISTS would report success while the table
+// stays unindexed. Same shape as Migration20260806120000 and
+// Migration20260731105052_query_index.
+//
+// On a database that does not have these indexes yet — every fresh install — the
+// drops are no-ops and there is no window without them. An operator who already
+// created one out of band should expect it to be rebuilt here, and the reads that
+// depend on it to fall back to their pre-index cost until the concurrent build
+// finishes; on a large table, run this while the writers that depend on it are
+// paused.
+export class Migration20260821120000_sales_notes_addresses_context_idx extends Migration {
+
+  override isTransactional(): boolean {
+    return false;
+  }
+
+  override up(): void | Promise<void> {
+    this.addSql(`drop index concurrently if exists "sales_notes_context_idx";`);
+    this.addSql(`create index concurrently "sales_notes_context_idx" on "sales_notes" ("context_id");`);
+    this.addSql(`drop index concurrently if exists "sales_notes_order_idx";`);
+    this.addSql(`create index concurrently "sales_notes_order_idx" on "sales_notes" ("order_id");`);
+    this.addSql(`drop index concurrently if exists "sales_notes_quote_idx";`);
+    this.addSql(`create index concurrently "sales_notes_quote_idx" on "sales_notes" ("quote_id");`);
+
+    this.addSql(`drop index concurrently if exists "sales_document_addresses_document_idx";`);
+    this.addSql(`create index concurrently "sales_document_addresses_document_idx" on "sales_document_addresses" ("document_id");`);
+    this.addSql(`drop index concurrently if exists "sales_document_addresses_order_idx";`);
+    this.addSql(`create index concurrently "sales_document_addresses_order_idx" on "sales_document_addresses" ("order_id");`);
+    this.addSql(`drop index concurrently if exists "sales_document_addresses_quote_idx";`);
+    this.addSql(`create index concurrently "sales_document_addresses_quote_idx" on "sales_document_addresses" ("quote_id");`);
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`drop index concurrently if exists "sales_document_addresses_quote_idx";`);
+    this.addSql(`drop index concurrently if exists "sales_document_addresses_order_idx";`);
+    this.addSql(`drop index concurrently if exists "sales_document_addresses_document_idx";`);
+    this.addSql(`drop index concurrently if exists "sales_notes_quote_idx";`);
+    this.addSql(`drop index concurrently if exists "sales_notes_order_idx";`);
+    this.addSql(`drop index concurrently if exists "sales_notes_context_idx";`);
+  }
+
+}


### PR DESCRIPTION
## Summary

`sales_notes` and `sales_document_addresses` each declare exactly one index — `(organization_id, tenant_id)` — and neither table is ever read by that predicate. Both are read by **document context**, in the same `Promise.all` inside `loadOrderSnapshot` / `loadQuoteSnapshot` (`packages/core/src/modules/sales/commands/documents.ts`):

```ts
findWithDecryption(em, SalesNote,            { contextType: 'order', contextId: id }, undefined, scope)
findWithDecryption(em, SalesDocumentAddress, { documentId: id, documentKind: 'order' }, undefined, scope)
```

A scope index cannot serve that. On a single-organization deployment it matches *every row in the table*, so the planner discards it and sequentially scans. There was no index on `context_id` or `document_id` at all.

The cost multiplies through the command bus. `CommandBus` runs `handler.prepare()` before `execute` and `handler.captureAfter()` after it on **every** command, and for sales documents both load a full document snapshot — which reads both of these tables. A single document write is several commands (the document itself, one per changed line, the payment reconcile), so one written record performs roughly **20 of these reads**, each a full scan.

Separately, `order_id` and `quote_id` on both tables are the child side of `on delete set null` foreign keys. PostgreSQL does not index the child side of a constraint automatically, so every delete of a parent order or quote scanned the child table in full.

### Measured

Observed during a bulk import on a deployment where `sales_notes` holds ~331,000 rows (110 MB):

```
Parallel Seq Scan on sales_notes  (actual time=64.691..64.691 rows=0 loops=3)
  Filter: ((context_type = 'order') AND (context_id = $1) AND (organization_id = $2) AND (tenant_id = $3))
  Rows Removed by Filter: 110457
Execution Time: 82.450 ms
```

The cost is CPU filtering, so a warm cache does not reduce it. Counters over one import batch of 100 records showed **1,971 sequential scans reading 217,670,528 rows — 2.18 million rows per imported record**, against a table of 331k. Repeatable across consecutive batches: 1,971 / 1,974 / 1,911.

Every consumer of the sales module benefits from the fix; the deployment above is simply the one where the cost became visible.

## Changes

Six indexes, declared on the entities in `packages/core/src/modules/sales/data/entities.ts` and created in one migration:

| Table | Index | Columns | Serves |
|---|---|---|---|
| `sales_notes` | `sales_notes_context_idx` | `(context_id)` | the snapshot read |
| `sales_notes` | `sales_notes_order_idx` | `(order_id)` | FK check on order delete |
| `sales_notes` | `sales_notes_quote_idx` | `(quote_id)` | FK check on quote delete |
| `sales_document_addresses` | `sales_document_addresses_document_idx` | `(document_id)` | the snapshot read |
| `sales_document_addresses` | `sales_document_addresses_order_idx` | `(order_id)` | FK check on order delete |
| `sales_document_addresses` | `sales_document_addresses_quote_idx` | `(quote_id)` | FK check on quote delete |

- `packages/core/src/modules/sales/data/entities.ts` — the six `@Index` declarations
- `packages/core/src/modules/sales/migrations/Migration20260821120000_sales_notes_addresses_context_idx.ts` — the matching migration
- `packages/core/src/modules/sales/migrations/.snapshot-open-mercato.json` — updated so `db:generate` sees no drift
- `packages/core/src/__tests__/hot-path-indexes.test.ts` — extends the existing guard

### Why the context indexes are single-column

`context_type` / `document_kind` and the scope columns are omitted deliberately. `sales_orders.id` and `sales_quotes.id` are both `gen_random_uuid()` from their own tables, so a `context_id` already determines its `context_type` **and** its tenant; the seek returns the handful of rows belonging to one document and the remaining terms are rechecked over those. Folding three more columns in — one `text` and two `uuid` — roughly triples the index entry for no selectivity, on tables that take a write per document save and a note per order status change.

This follows `sales_document_tag_assignments_document_idx` (`Migration20260806120000`), the module's most recent decision on exactly this predicate shape, which omitted `document_kind` for the same reason. The older sibling indexes that *do* fold scope in (`sales_order_lines_scope_idx`, `sales_payments_scope_idx`) predate that reasoning. Happy to widen these to match the older convention if maintainers prefer the consistency — the narrow form is both smaller and no less selective, so I went with the newer precedent.

`order_id` / `quote_id` are separate indexes rather than a widening of the context index: the FK constraint check probes those columns, which the context index cannot serve even though it holds the same uuid.

### Migration shape

Built `CONCURRENTLY` — both tables are high-churn, so the build must not block writes. `CREATE INDEX CONCURRENTLY` cannot run inside a transaction, hence `isTransactional() => false`; the runner applies migrations one at a time, so the opt-out is safe. Each index is dropped first so that retrying a failed concurrent build removes PostgreSQL's INVALID stub rather than letting `IF NOT EXISTS` report success over an unusable index. Same shape as `Migration20260806120000` and `Migration20260731105052_query_index`.

On a fresh install the drops are no-ops and there is no window without the index. An operator who created one of these out of band should expect it to be rebuilt here.

### Declared on the entities, not only in SQL

The module diffs entity metadata against `.snapshot-open-mercato.json`, so an index that exists only in a migration is invisible to that diff and a later `db:generate` would propose dropping it. All six are on the entity decorators, and the snapshot is updated to match — `yarn db:generate` reports `sales: no changes` on this branch.

### Deliberately out of scope

The snapshot-per-command amplification described above is a separate and much larger design question, and is untouched here.

Not included, but the same defect class if maintainers want it in a follow-up: `sales_document_tag_assignments.order_id` / `.quote_id` are also unindexed `on delete set null` child columns.

## Specification

**Does a spec exist for this feature/module?**
- [ ] Yes
- [ ] No (created a new spec)
- [x] N/A (minor change, no spec needed)

**Spec file path:**
N/A — this is a missing index, not a design change. No behavior, schema semantics, API surface or contract changes.

## Testing

Extended `packages/core/src/__tests__/hot-path-indexes.test.ts`, the repo's existing guard for this class of fix (#2966). It pins each index at all three declaration sites — entity decorator, migration SQL, schema snapshot — so a later refactor cannot silently drop one.

Run against this branch, rebased on `develop`:

| Command | Result |
|---|---|
| `yarn db:generate` | `sales: no changes` — the snapshot matches entity metadata exactly |
| `yarn generate` | pass |
| `yarn build:packages` | pass |
| `yarn i18n:check-sync` | pass |
| `yarn i18n:check-usage` | pass |
| `yarn typecheck` | pass |
| `yarn test` (`@open-mercato/core`) | 1426 suites, 11457 tests, 0 failures |
| `yarn build:app` | pass |

Migrations are **not** applied here — the PR ships the migration file and snapshot only.

One note on the full-monorepo `yarn test`: the `@open-mercato/cli` `module-facts` generator suites flake under parallel load, failing a *different* suite on each run. I reproduced this on a clean `develop` checkout without this branch's commit (3/3 runs, different suite each time), so it is pre-existing and unrelated to this change.

## Checklist

- [x] This pull request targets `develop`.
- [ ] I have read and accept the Open Mercato Contributor License Agreement (see `docs/cla.md`).
- [x] I updated documentation, locales, or generators if the change requires it. — no user-facing strings and no locale changes; `yarn generate` produces no diff.
- [x] I added or adjusted tests that cover the change.
- [x] I added or updated integration tests in `.ai/qa/tests/` (or documented why integration coverage is not required). — not required: this change adds indexes only. There is no API path or UI path to exercise, no request/response shape changes, and index selection is not observable from an integration test. The three-site guard above is the coverage that can actually fail if the change regresses.
- [ ] I created or updated the spec in `.ai/specs/` with a changelog entry (if applicable). — not applicable, see Specification above.
- [ ] Priority set: this PR carries exactly one `priority-*` label.
- [ ] Risk set: this PR carries exactly one `risk-*` label describing its blast radius.
- [ ] QA routing set.

The last three are unticked because this account has read-only permissions here and cannot apply labels. Intended values are in a separate comment below for a maintainer to apply.

### Design System Compliance

Not applicable — this change touches no `.tsx` file, nothing under `packages/ui/src/`, and no component. The four changed files are two entity/migration files, a JSON schema snapshot, and a test.

## Linked issues

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790150237&installation_model_id=432243&pr_number=5555&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5555&signature=7ecad8f9c45408db8210c8ff88d06e86405ed69803981326467b30b72b46117e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->