### PR TITLE
fix(security): align Dependabot cooldown with npmMinimalAgeGate (#5549)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,15 +13,16 @@ updates:
     # Dependabot keeps proposing versions whose PR cannot install: `yarn install`
     # fails with `YN0016 ... quarantined` and scripts/ci/npm-retry-on-quarantine.sh
     # fast-fails, because waiting inside a CI job never clears a client-side gate.
-    # The extra day absorbs the mismatch between Dependabot's whole-day cooldown
-    # arithmetic and yarn's exact-duration gate, so a PR opened the moment the
-    # cooldown lapses is already past 5d of real elapsed time.
+    # Five needs no safety margin: dependabot-core compares exact seconds
+    # (`Time.now - release_date < days * 86400`), not calendar days, and resolution
+    # in CI happens strictly after the PR is opened, so the version is only ever
+    # older by then.
     # Cooldown covers version updates only — a Dependabot *security* update may
     # still propose a version the yarn gate rejects, which is the intended
     # trade-off: the advisory is the signal to reach for `--no-time-gate`.
     # Guarded by scripts/__tests__/npm-minimal-age-gate.test.mjs.
     cooldown:
-      default-days: 6
+      default-days: 5
     groups:
       # Batch minor/patch updates for non-security deps to reduce noise
       minor-and-patch:
@@ -41,9 +42,9 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     # Actions live outside yarn's dependency graph, so `npmMinimalAgeGate` never
-    # sees them and a too-young action breaks no install — this cooldown is the
-    # only release-age defence on that supply chain and needs no install-margin.
-    # Five days matches the window agreed for npm in
+    # sees them — this cooldown is the only release-age defence on that supply
+    # chain, and it is set independently of the yarn gate rather than derived
+    # from it. Five days matches the window agreed for npm in
     # .ai/specs/briefs/2026-08-09-dependabot-cooldown-ci-gate.md, which is long
     # enough to cover the detection time of the action-hijack incidents on record.
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,20 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 10
+    # Must stay at or above `npmMinimalAgeGate` in .yarnrc.yml (5d). Yarn refuses
+    # to resolve a version younger than that gate, so without a matching cooldown
+    # Dependabot keeps proposing versions whose PR cannot install: `yarn install`
+    # fails with `YN0016 ... quarantined` and scripts/ci/npm-retry-on-quarantine.sh
+    # fast-fails, because waiting inside a CI job never clears a client-side gate.
+    # The extra day absorbs the mismatch between Dependabot's whole-day cooldown
+    # arithmetic and yarn's exact-duration gate, so a PR opened the moment the
+    # cooldown lapses is already past 5d of real elapsed time.
+    # Cooldown covers version updates only — a Dependabot *security* update may
+    # still propose a version the yarn gate rejects, which is the intended
+    # trade-off: the advisory is the signal to reach for `--no-time-gate`.
+    # Guarded by scripts/__tests__/npm-minimal-age-gate.test.mjs.
+    cooldown:
+      default-days: 6
     groups:
       # Batch minor/patch updates for non-security deps to reduce noise
       minor-and-patch:
@@ -26,3 +40,11 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # Actions live outside yarn's dependency graph, so `npmMinimalAgeGate` never
+    # sees them and a too-young action breaks no install — this cooldown is the
+    # only release-age defence on that supply chain and needs no install-margin.
+    # Five days matches the window agreed for npm in
+    # .ai/specs/briefs/2026-08-09-dependabot-cooldown-ci-gate.md, which is long
+    # enough to cover the detection time of the action-hijack incidents on record.
+    cooldown:
+      default-days: 5

--- a/scripts/__tests__/npm-minimal-age-gate.test.mjs
+++ b/scripts/__tests__/npm-minimal-age-gate.test.mjs
@@ -2,12 +2,18 @@ import assert from 'node:assert/strict'
 import fs from 'node:fs'
 import path from 'node:path'
 import test from 'node:test'
+import { parse } from 'yaml'
 
 const rootYarnrcPath = path.resolve('.yarnrc.yml')
 const templateYarnrcPath = path.resolve('packages/create-app/template/.yarnrc.yml.template')
 const retryScriptPath = path.resolve('scripts/ci/npm-retry-on-quarantine.sh')
+const dependabotConfigPath = path.resolve('.github/dependabot.yml')
 
 const AGREED_MINIMAL_AGE_GATE = '5d'
+
+const DURATION_UNIT_IN_DAYS = { m: 1 / 1440, h: 1 / 24, d: 1, w: 7 }
+
+const COOLDOWN_DAY_KEYS = ['default-days', 'semver-major-days', 'semver-minor-days', 'semver-patch-days']
 
 function readText(filePath) {
   return fs.readFileSync(filePath, 'utf8')
@@ -15,6 +21,26 @@ function readText(filePath) {
 
 function readMinimalAgeGate(filePath) {
   return readText(filePath).match(/^npmMinimalAgeGate:\s*(\S+)$/m)?.[1]
+}
+
+function durationToDays(duration) {
+  const parsed = String(duration).match(/^(\d+)([mhdw])$/)
+
+  assert.ok(
+    parsed,
+    `cannot read "${duration}" as a yarn duration — teach durationToDays the new unit before changing npmMinimalAgeGate, otherwise this guard silently stops comparing`
+  )
+
+  return Number(parsed[1]) * DURATION_UNIT_IN_DAYS[parsed[2]]
+}
+
+function readDependabotEcosystem(ecosystem) {
+  const config = parse(readText(dependabotConfigPath))
+  const entry = config.updates?.find((update) => update['package-ecosystem'] === ecosystem)
+
+  assert.ok(entry, `.github/dependabot.yml must keep an updates entry for the "${ecosystem}" ecosystem`)
+
+  return entry
 }
 
 test('the monorepo and scaffolded apps quarantine third-party releases for the agreed duration', () => {
@@ -30,6 +56,39 @@ test('the monorepo and scaffolded apps quarantine third-party releases for the a
     template,
     root,
     'packages/create-app/template/.yarnrc.yml.template must declare the same npmMinimalAgeGate as the monorepo, otherwise scaffolded apps silently fall back to yarn\'s 1d default'
+  )
+})
+
+test('dependabot holds npm updates back at least as long as the yarn release-age gate', () => {
+  const gateDays = durationToDays(AGREED_MINIMAL_AGE_GATE)
+  const cooldown = readDependabotEcosystem('npm').cooldown
+
+  assert.ok(
+    cooldown,
+    'the npm entry in .github/dependabot.yml must declare a cooldown — without one Dependabot proposes versions younger than npmMinimalAgeGate, and those PRs cannot install (`yarn install` fails with YN0016 ... quarantined until the version ages out)'
+  )
+
+  const declaredKeys = COOLDOWN_DAY_KEYS.filter((key) => cooldown[key] !== undefined)
+
+  assert.ok(
+    declaredKeys.includes('default-days'),
+    'the npm cooldown must set default-days — dependabot falls back to its own 3-day default for every bump type left unspecified, which is shorter than npmMinimalAgeGate'
+  )
+
+  for (const key of declaredKeys) {
+    assert.ok(
+      cooldown[key] >= gateDays,
+      `the npm cooldown ${key} (${cooldown[key]}) must be at least npmMinimalAgeGate from .yarnrc.yml (${AGREED_MINIMAL_AGE_GATE}); a shorter window lets dependabot open update PRs that yarn refuses to resolve`
+    )
+  }
+})
+
+test('dependabot applies a release-age cooldown to github actions as well', () => {
+  const cooldown = readDependabotEcosystem('github-actions').cooldown
+
+  assert.ok(
+    cooldown?.['default-days'] >= 1,
+    'the github-actions entry in .github/dependabot.yml must declare a cooldown default-days — actions sit outside yarn\'s dependency graph, so this cooldown is the only release-age defence on that supply chain'
   )
 })
 


### PR DESCRIPTION
Closes #5549

## 🎯 Goal
Stop Dependabot from opening npm update PRs that cannot install. #5138 raised yarn's `npmMinimalAgeGate` to `5d`, but Dependabot was unaware of that window, so its weekly Monday run kept proposing versions published within the previous five days — PRs that sit red until the version simply ages out.

## 🔍 Problem
`.github/dependabot.yml` declared no `cooldown`. Yarn's `npmMinimalAgeGate` is a client-side gate applied during resolution, so any Dependabot PR bumping a version younger than five days fails `yarn install` with `YN0016: … All versions satisfying "<range>" are quarantined`. `scripts/ci/npm-retry-on-quarantine.sh` correctly fast-fails rather than retrying — no amount of waiting inside a CI job clears a client-side age gate — and its message points at `npmPreapprovedPackages`, a standing exception somebody then has to remember to remove. Two mechanisms that should agree were contradicting each other.

## 🔍 Root Cause
The two age windows live in different files and had no link between them: yarn's gate in `.yarnrc.yml`, Dependabot's schedule in `.github/dependabot.yml`. #5138 deliberately kept its diff to `.yarnrc.yml` and the create-app template and recorded the gap as a known follow-up in `.ai/specs/briefs/2026-08-09-dependabot-cooldown-ci-gate.md`, because the repository's agent instructions require asking before changing dependency-update automation. This PR closes that gap.

## What Changed
- `.github/dependabot.yml`, npm ecosystem — added `cooldown.default-days: 5`, exactly matching `npmMinimalAgeGate: 5d`. No safety margin is needed: `dependabot-core`'s `CooldownCalculation.within_cooldown_window?` compares exact seconds (`Time.now.to_i - release_date.to_i < cooldown_days * 86400`), not calendar days, so five cooldown days is five real days; and resolution in CI happens strictly after the PR is opened, so the version is only ever older by the time yarn checks it. A comment at the config site explains the coupling, names the failure mode, and points at the guard test. (The first push of this branch used `6` on the mistaken assumption of whole-day arithmetic; the review pass verified the upstream implementation and corrected it in `ccb7ceb`.)
- `.github/dependabot.yml`, github-actions ecosystem — added `cooldown.default-days: 5`. This is the acceptance criterion's "reviewed for the same treatment" resolved as *apply it*: actions sit outside yarn's dependency graph, so `npmMinimalAgeGate` never sees them and this cooldown is the only release-age defence on that supply chain. The value is set independently of the yarn gate rather than derived from it — five days matches the window agreed for npm and covers the detection time of the action-hijack incidents on record.
- `scripts/__tests__/npm-minimal-age-gate.test.mjs` — extended with two guards that parse `.github/dependabot.yml` with `yaml` and compare it against `npmMinimalAgeGate`. The npm guard checks `default-days` *and* every `semver-*-days` key that is present, because a per-bump-type key takes precedence over `default-days` and would otherwise let patch updates slip back under the gate unnoticed. Both configured values are valid against the published `dependabot-2.0` schema (`default-days` accepts 1–90 and is supported for every ecosystem here).

Two behaviours are worth naming for reviewers, both documented in the config comments:

- Dependabot's `cooldown` applies to **version updates only**, never security updates. A Dependabot *security* update can still propose a version yarn quarantines. That is the intended trade-off: an advisory is exactly the situation where `yarn add pkg@version --no-time-gate` is the right escape hatch, and suppressing security updates for five days would be strictly worse.
- Dependabot applies a 3-day cooldown by default even when unconfigured, which is shorter than the yarn gate — hence the explicit `default-days`, and the guard assertion that it must be present.

## 🧪 Tests
- `node --test scripts/__tests__/npm-minimal-age-gate.test.mjs` — 5 passed / 0 failed (2 of them new).
- Regression proof: re-running the same file against the pre-fix `.github/dependabot.yml` from `develop` fails both new tests with the intended messages, and passes again once the fix is restored.
- `node --test scripts/__tests__/*.test.mjs` — 637 passed / 1 failed, 638 total. The single failure is `check-package-peer-deps.test.mjs` ("Cannot verify peer dependencies: none of the 196 declared dependencies could be resolved, so nothing was actually checked. Run `yarn install` first"), a pre-existing environment failure in an agent worktree with no `node_modules`; it is unrelated to this diff and passes in CI, which installs first.
- Gate commands skipped, with reason: `yarn build:packages`, `yarn generate`, `yarn i18n:check-sync`, `yarn i18n:check-usage`, `yarn typecheck`, `yarn build:app`. This diff touches one YAML config and one `node:test` guard script — no TypeScript, no package source, no i18n strings, no app code — and the worktree has no installed dependencies to run them against. `yarn test:scripts` is the gate command that actually covers the changed surface, and it is the one that ran.

## ⏭️ One acceptance criterion is deliberately deferred
> *"The relationship between the two values is documented where the gate is configured, so raising one prompts raising the other."*

The relationship is documented on the Dependabot side and enforced by the guard test, but the reciprocal comment in `.yarnrc.yml` is **not** in this PR: the agent session's permission mode denied edits to `.yarnrc.yml`, and routing around that block would defeat the point of the restriction. The intended addition, directly above `npmMinimalAgeGate: 5d`:

```yaml
# Raising this value means raising the npm `cooldown` in .github/dependabot.yml
# to match — Dependabot cannot see this gate, so a shorter cooldown makes it
# propose versions whose PR fails to install.
# scripts/__tests__/npm-minimal-age-gate.test.mjs fails when the two drift apart.
```

It is a comment-only change with no effect on yarn behaviour, and the maintainer decided during the run to ship without it rather than hold the fix. That is a defensible trade because the comment was never the enforcement — the guard test is, and it ships here: raising `npmMinimalAgeGate` without raising the cooldown turns the `test` job red. What is lost is only the courtesy pointer that would have warned the editor before they hit the failure. The gap is recorded on #5549 so it stays visible after this PR closes the issue.

## 💥 Breaking Changes
None. No runtime code, no public contract, no database schema, and no API surface is touched. The only behavioural change is that Dependabot waits longer before opening a version-update PR; nothing that already exists in `yarn.lock` is re-resolved or re-checked.
