### PR TITLE
fix(staff): expose timesheet duration errors to assistive tech (#5507)

### DIFF
--- a/packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx
+++ b/packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx
@@ -283,9 +283,20 @@ describe('MyTimesheetsPage — duration entry (#4846)', () => {
   })
 })
 
-function describedTextFor(input: HTMLInputElement): string[] {
+function describingNodesFor(input: HTMLInputElement): HTMLElement[] {
   const ids = (input.getAttribute('aria-describedby') ?? '').split(' ').filter(Boolean)
-  return ids.map((id) => document.getElementById(id)?.textContent ?? '')
+  return ids.flatMap((id) => {
+    const node = document.getElementById(id)
+    return node ? [node] : []
+  })
+}
+
+function describedTextFor(input: HTMLInputElement): string[] {
+  return describingNodesFor(input).map((node) => node.textContent ?? '')
+}
+
+function alertNodeFor(input: HTMLInputElement): HTMLElement | undefined {
+  return describingNodesFor(input).find((node) => node.getAttribute('role') === 'alert')
 }
 
 describe('MyTimesheetsPage — duration error accessibility (#5507)', () => {
@@ -309,12 +320,7 @@ describe('MyTimesheetsPage — duration error accessibility (#5507)', () => {
     await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-invalid', 'true'))
     const message = 'Maximum 24h per day. Use 1:30 or 90m for shorter entries.'
     expect(describedTextFor(inputs[0])).toContain(message)
-
-    const errorId = inputs[0].getAttribute('aria-errormessage') as string
-    expect(errorId).toBeTruthy()
-    const errorNode = document.getElementById(errorId) as HTMLElement
-    expect(errorNode).toHaveTextContent(message)
-    expect(errorNode).toHaveAttribute('role', 'alert')
+    expect(alertNodeFor(inputs[0])).toHaveTextContent(message)
   })
 
   it('exposes the unparseable-input reason the same way', async () => {
@@ -332,7 +338,7 @@ describe('MyTimesheetsPage — duration error accessibility (#5507)', () => {
     typeAndBlur(inputs[0], 'abc')
 
     await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-invalid', 'true'))
-    expect(inputs[1]).not.toHaveAttribute('aria-errormessage')
+    expect(alertNodeFor(inputs[1])).toBeUndefined()
     expect(describedTextFor(inputs[1])).not.toContain(
       'Unrecognised duration. Use 8, 1.5, 1:30, 90m or 1h 30m.',
     )
@@ -341,12 +347,12 @@ describe('MyTimesheetsPage — duration error accessibility (#5507)', () => {
   it('withdraws the announced error once the cell is corrected', async () => {
     const inputs = await renderGrid()
     typeAndBlur(inputs[0], 'abc')
-    await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-errormessage'))
-    const errorId = inputs[0].getAttribute('aria-errormessage') as string
+    await waitFor(() => expect(alertNodeFor(inputs[0])).toBeDefined())
+    const errorId = (alertNodeFor(inputs[0]) as HTMLElement).id
 
     typeAndBlur(inputs[0], '1:30')
     await waitFor(() => expect(inputs[0]).not.toHaveAttribute('aria-invalid', 'true'))
-    expect(inputs[0]).not.toHaveAttribute('aria-errormessage')
+    expect(alertNodeFor(inputs[0])).toBeUndefined()
     expect(document.getElementById(errorId)).toBeNull()
   })
 })

--- a/packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx
+++ b/packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx
@@ -282,3 +282,71 @@ describe('MyTimesheetsPage — duration entry (#4846)', () => {
     ).toBeGreaterThan(0)
   })
 })
+
+function describedTextFor(input: HTMLInputElement): string[] {
+  const ids = (input.getAttribute('aria-describedby') ?? '').split(' ').filter(Boolean)
+  return ids.map((id) => document.getElementById(id)?.textContent ?? '')
+}
+
+describe('MyTimesheetsPage — duration error accessibility (#5507)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    stubApiRoutes()
+  })
+
+  it('describes every cell with the accepted duration formats, not only a native tooltip', async () => {
+    const inputs = await renderGrid()
+
+    expect(describedTextFor(inputs[0])).toContain(
+      'Enter hours (8 or 1.5), h:mm (1:30) or minutes (90m). Max 24h per day.',
+    )
+  })
+
+  it('exposes the out-of-range reason to assistive tech instead of hiding it in the title attribute', async () => {
+    const inputs = await renderGrid()
+    typeAndBlur(inputs[0], '30')
+
+    await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-invalid', 'true'))
+    const message = 'Maximum 24h per day. Use 1:30 or 90m for shorter entries.'
+    expect(describedTextFor(inputs[0])).toContain(message)
+
+    const errorId = inputs[0].getAttribute('aria-errormessage') as string
+    expect(errorId).toBeTruthy()
+    const errorNode = document.getElementById(errorId) as HTMLElement
+    expect(errorNode).toHaveTextContent(message)
+    expect(errorNode).toHaveAttribute('role', 'alert')
+  })
+
+  it('exposes the unparseable-input reason the same way', async () => {
+    const inputs = await renderGrid()
+    typeAndBlur(inputs[0], 'abc')
+
+    await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-invalid', 'true'))
+    expect(describedTextFor(inputs[0])).toContain(
+      'Unrecognised duration. Use 8, 1.5, 1:30, 90m or 1h 30m.',
+    )
+  })
+
+  it('describes only the offending cell, leaving its neighbours announced as valid', async () => {
+    const inputs = await renderGrid()
+    typeAndBlur(inputs[0], 'abc')
+
+    await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-invalid', 'true'))
+    expect(inputs[1]).not.toHaveAttribute('aria-errormessage')
+    expect(describedTextFor(inputs[1])).not.toContain(
+      'Unrecognised duration. Use 8, 1.5, 1:30, 90m or 1h 30m.',
+    )
+  })
+
+  it('withdraws the announced error once the cell is corrected', async () => {
+    const inputs = await renderGrid()
+    typeAndBlur(inputs[0], 'abc')
+    await waitFor(() => expect(inputs[0]).toHaveAttribute('aria-errormessage'))
+    const errorId = inputs[0].getAttribute('aria-errormessage') as string
+
+    typeAndBlur(inputs[0], '1:30')
+    await waitFor(() => expect(inputs[0]).not.toHaveAttribute('aria-invalid', 'true'))
+    expect(inputs[0]).not.toHaveAttribute('aria-errormessage')
+    expect(document.getElementById(errorId)).toBeNull()
+  })
+})

--- a/packages/core/src/modules/staff/backend/staff/timesheets/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/timesheets/page.tsx
@@ -178,6 +178,12 @@ export default function MyTimesheetsPage() {
     blockedMessage: t('ui.forms.flash.saveBlocked', 'Save blocked by validation'),
   })
 
+  const gridInstanceId = React.useId()
+  const durationHintId = `${gridInstanceId}-duration-hint`
+  const describeDurationErrorId = React.useCallback(
+    (projectId: string, dateKey: string): string => `${gridInstanceId}-duration-error-${projectId}-${dateKey}`,
+    [gridInstanceId],
+  )
   const durationFormatHint = t(
     'staff.timesheets.my.duration.hint',
     'Enter hours (8 or 1.5), h:mm (1:30) or minutes (90m). Max 24h per day.',
@@ -919,6 +925,7 @@ export default function MyTimesheetsPage() {
                       const isDirty = dirty[project.id]?.[dateKey] !== undefined
                       const cellError = cellErrors[project.id]?.[dateKey]
                       const cellErrorMessage = cellError ? describeDurationError(cellError) : undefined
+                      const cellErrorId = cellErrorMessage ? describeDurationErrorId(project.id, dateKey) : undefined
                       return (
                         <td key={dateKey} className={`px-0.5 py-0.5 ${weekend ? 'bg-muted/40' : ''}`}>
                           {weekend ? (
@@ -943,9 +950,14 @@ export default function MyTimesheetsPage() {
                               placeholder={t('staff.timesheets.my.durationPlaceholder', '0')}
                               aria-invalid={cellError !== undefined}
                               aria-label={describeDurationCell(project.name, date)}
+                              aria-describedby={[durationHintId, cellErrorId].filter(Boolean).join(' ')}
+                              aria-errormessage={cellErrorId}
                               title={cellErrorMessage ?? durationFormatHint}
                             />
                           )}
+                          {cellErrorMessage ? (
+                            <span id={cellErrorId} role="alert" className="sr-only">{cellErrorMessage}</span>
+                          ) : null}
                         </td>
                       )
                     })}
@@ -984,7 +996,7 @@ export default function MyTimesheetsPage() {
                 </tr>
               </tfoot>
             </table>
-            <p className="px-3 py-2 text-xs text-muted-foreground">{durationFormatHint}</p>
+            <p id={durationHintId} className="px-3 py-2 text-xs text-muted-foreground">{durationFormatHint}</p>
           </div>
         )}
         </div>

--- a/packages/core/src/modules/staff/backend/staff/timesheets/page.tsx
+++ b/packages/core/src/modules/staff/backend/staff/timesheets/page.tsx
@@ -180,7 +180,7 @@ export default function MyTimesheetsPage() {
 
   const gridInstanceId = React.useId()
   const durationHintId = `${gridInstanceId}-duration-hint`
-  const describeDurationErrorId = React.useCallback(
+  const buildDurationErrorId = React.useCallback(
     (projectId: string, dateKey: string): string => `${gridInstanceId}-duration-error-${projectId}-${dateKey}`,
     [gridInstanceId],
   )
@@ -925,7 +925,7 @@ export default function MyTimesheetsPage() {
                       const isDirty = dirty[project.id]?.[dateKey] !== undefined
                       const cellError = cellErrors[project.id]?.[dateKey]
                       const cellErrorMessage = cellError ? describeDurationError(cellError) : undefined
-                      const cellErrorId = cellErrorMessage ? describeDurationErrorId(project.id, dateKey) : undefined
+                      const cellErrorId = cellErrorMessage ? buildDurationErrorId(project.id, dateKey) : undefined
                       return (
                         <td key={dateKey} className={`px-0.5 py-0.5 ${weekend ? 'bg-muted/40' : ''}`}>
                           {weekend ? (
@@ -951,7 +951,6 @@ export default function MyTimesheetsPage() {
                               aria-invalid={cellError !== undefined}
                               aria-label={describeDurationCell(project.name, date)}
                               aria-describedby={[durationHintId, cellErrorId].filter(Boolean).join(' ')}
-                              aria-errormessage={cellErrorId}
                               title={cellErrorMessage ?? durationFormatHint}
                             />
                           )}


### PR DESCRIPTION
Closes #5507

## 🎯 Goal
- A screen-reader user entering time in the timesheet grid now hears *why* a duration was rejected and which formats are accepted, instead of only being told the field is invalid.

## 🔍 Problem
When a duration cell is rejected, the timesheet grid sets `aria-invalid="true"` and turns the text red, and it does carry a genuinely helpful, localized message — but only in a native `title` tooltip. There was no `aria-describedby`, no `aria-errormessage` and no `role="alert"` anywhere in the grid, so assistive technology announced "invalid" and never announced the reason or the accepted duration formats. The onboarding form on the same product already associates its error text correctly, so this was an internal inconsistency rather than a missing capability.

## 🔍 Root Cause
`packages/core/src/modules/staff/backend/staff/timesheets/page.tsx` rendered the cell as an `InlineInput` carrying `aria-invalid`, `aria-label` and `title={cellErrorMessage ?? durationFormatHint}`. The message existed only as the value of that `title` attribute — it was never rendered into the accessibility tree as an element with an id, so there was nothing for `aria-describedby` or `aria-errormessage` to point at, and nothing for a live region to announce. The visible "Enter hours (8 or 1.5), h:mm (1:30) or minutes (90m). Max 24h per day." hint below the table was likewise unassociated with the inputs it describes. The underlying `Input` primitive already spreads every prop onto the native `<input>`, so no primitive change was required — only the missing wiring in the page.

## What Changed
- `packages/core/src/modules/staff/backend/staff/timesheets/page.tsx` — the duration format hint below the grid now has a stable id (derived from `React.useId`) and every duration cell references it through `aria-describedby`, so the accepted formats are announced on focus rather than only being readable on screen. Each rejected cell additionally renders a screen-reader-only element holding the already-localized error message, with `role="alert"` so the rejection is announced at the moment it happens; the input points at it through `aria-describedby`, alongside the existing `aria-invalid`. `aria-errormessage` is deliberately not used: screen readers that support it would announce a node that is also in `aria-describedby` twice, and `FormField` does not use it either. This follows the pattern the repository's own `FormField` primitive (`packages/ui/src/primitives/form-field.tsx`) already uses — an `id`-bearing `role="alert"` node referenced from the field. The `title` tooltip, the red styling, the save-blocking behavior and the visible "Fix the highlighted durations to save" banner are all unchanged, and no new user-facing strings were introduced.

## 🧪 Tests
- The full configured validation gate was run locally, in order: `build:packages` (26/26), `generate`, `build:packages` again, `i18n:check-sync` (all five locales in sync), `i18n:check-usage` (advisory only), `typecheck` (26/26), `test`, and `build:app` (compiled and generated static pages successfully).
- `yarn test` — 32 of 33 packages green, including `@open-mercato/core` (1426 suites / 11458 tests) and `@open-mercato/ui` (233 suites / 1924 tests). The one failing package, `create-mercato-app`, fails in its agent-harness suite for environmental reasons (tests that launch live external CLI adapters and sandboxed child processes); it is untouched by this change and every required CI check on this PR is green.
- Five new cases in `packages/core/src/modules/staff/backend/staff/timesheets/__tests__/page.durationEntry.test.tsx` lock in the behavior: every cell is described by the accepted-formats hint; the out-of-range reason and the unparseable-input reason are each reachable through `aria-describedby` from an element carrying `role="alert"`; only the offending cell is described as invalid while its neighbours stay clean; and correcting a cell withdraws both the association and the message node. Four of the five fail against the unpatched page, so they genuinely guard the regression.
- 📸 Browser QA ran against this branch on a disposable, freshly seeded database and passed all nine steps — see the evidence comment for the screenshots and the observed accessibility-tree values.

## 💥 Breaking Changes
- None. This is additive ARIA wiring on one admin page — no API, database, event, widget-spot or component-contract surface is touched.
