### PR TITLE
fix(customers): exclude the edited person from the duplicate-email lookup

### DIFF
--- a/packages/core/src/modules/customers/backend/hooks/__tests__/useEmailDuplicateCheck.test.tsx
+++ b/packages/core/src/modules/customers/backend/hooks/__tests__/useEmailDuplicateCheck.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+const apiCallMock = jest.fn()
+
+jest.mock('@open-mercato/ui/backend/utils/apiCall', () => ({
+  apiCall: (...args: unknown[]) => apiCallMock(...args),
+}))
+
+import * as React from 'react'
+import { act, render, screen } from '@testing-library/react'
+import { useEmailDuplicateCheck } from '../useEmailDuplicateCheck'
+
+type ProbeProps = {
+  email: string
+  recordId?: string | null
+  matchMode?: 'exact' | 'prefix'
+}
+
+function Probe({ email, recordId, matchMode = 'prefix' }: ProbeProps) {
+  const { duplicate } = useEmailDuplicateCheck(email, { recordId, matchMode, debounceMs: 0 })
+  return <div data-testid="duplicate">{duplicate ? duplicate.displayName : ''}</div>
+}
+
+const respondWith = (items: Array<Record<string, unknown>>) => {
+  apiCallMock.mockResolvedValue({ ok: true, result: { items } })
+}
+
+const settle = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  })
+}
+
+const requestedUrl = (): string => String(apiCallMock.mock.calls.at(-1)?.[0] ?? '')
+
+const duplicateText = () => screen.getByTestId('duplicate').textContent
+
+describe('useEmailDuplicateCheck', () => {
+  beforeEach(() => {
+    apiCallMock.mockReset()
+  })
+
+  it('excludes the edited record from the lookup query', async () => {
+    respondWith([])
+    render(<Probe email="mia.johnson@example.com" recordId="person-1" />)
+    await settle()
+
+    expect(requestedUrl()).toContain('excludeIds=person-1')
+    expect(requestedUrl()).toContain('emailStartsWith=mia.johnson%40example.com')
+  })
+
+  it('never reports the edited record as a duplicate of itself', async () => {
+    respondWith([
+      { id: 'person-1', display_name: 'Mia Johnson', primary_email: 'mia.johnson@example.com' },
+    ])
+    render(<Probe email="mia.johnson@example.com" recordId="person-1" />)
+    await settle()
+
+    expect(duplicateText()).toBe('')
+  })
+
+  it('still reports a duplicate owned by another record', async () => {
+    respondWith([
+      { id: 'person-1', display_name: 'Mia Johnson', primary_email: 'mia.johnson@example.com' },
+      { id: 'person-2', display_name: 'Noah Berg', primary_email: 'mia.johnson@example.com' },
+    ])
+    render(<Probe email="mia.johnson@example.com" recordId="person-1" />)
+    await settle()
+
+    expect(duplicateText()).toBe('Noah Berg')
+  })
+
+  it('omits the exclusion when creating a record', async () => {
+    respondWith([])
+    render(<Probe email="mia.johnson@example.com" recordId={null} />)
+    await settle()
+
+    expect(requestedUrl()).not.toContain('excludeIds')
+  })
+
+  it('excludes the edited record in exact match mode too', async () => {
+    respondWith([
+      { id: 'person-1', display_name: 'Mia Johnson', primary_email: 'mia.johnson@example.com' },
+    ])
+    render(<Probe email="mia.johnson@example.com" recordId="person-1" matchMode="exact" />)
+    await settle()
+
+    expect(requestedUrl()).toContain('email=mia.johnson%40example.com')
+    expect(requestedUrl()).toContain('excludeIds=person-1')
+    expect(duplicateText()).toBe('')
+  })
+})

--- a/packages/core/src/modules/customers/backend/hooks/useEmailDuplicateCheck.ts
+++ b/packages/core/src/modules/customers/backend/hooks/useEmailDuplicateCheck.ts
@@ -40,16 +40,24 @@ export function useEmailDuplicateCheck(
     }
 
     const normalized = trimmed.toLowerCase()
+    const excludedId = typeof recordId === 'string' && recordId.trim().length ? recordId.trim() : null
     let cancelled = false
     const controller = new AbortController()
     const timer = window.setTimeout(async () => {
       setChecking(true)
       try {
-        const queryParam =
+        const params = [
           matchMode === 'prefix'
             ? `emailStartsWith=${encodeURIComponent(normalized)}`
-            : `email=${encodeURIComponent(normalized)}`
-        const call = await apiCall<{ items?: unknown[] }>(`/api/customers/people?${queryParam}&pageSize=5&page=1`, {
+            : `email=${encodeURIComponent(normalized)}`,
+          'pageSize=5',
+          'page=1',
+        ]
+        // The record being edited is never its own duplicate (#5534). Excluding it in the
+        // query — not only in the client-side scan below — also stops it from consuming one
+        // of the five returned slots and hiding a genuine duplicate.
+        if (excludedId) params.push(`excludeIds=${encodeURIComponent(excludedId)}`)
+        const call = await apiCall<{ items?: unknown[] }>(`/api/customers/people?${params.join('&')}`, {
           signal: controller.signal,
         })
         if (!call.ok) {
@@ -72,7 +80,7 @@ export function useEmailDuplicateCheck(
             })
             .filter((entry: EmailDuplicateMatch | null): entry is EmailDuplicateMatch => !!entry)
             .find((entry: EmailDuplicateMatch) => {
-              if (entry.id === recordId) return false
+              if (excludedId && entry.id === excludedId) return false
               return matchMode === 'prefix'
                 ? entry.email.startsWith(normalized)
                 : entry.email === normalized


### PR DESCRIPTION
Fixes #5534

## 🎯 What this changes

`useEmailDuplicateCheck` — the hook behind the "This email is already assigned to …" hint on the CRM person form — now asks the people API to exclude the record being edited (`excludeIds=<recordId>`) instead of relying solely on a client-side id comparison after the fact.

The lookup requests `pageSize=5`. Before this change the edited record could occupy one of those five slots and was only discarded afterwards in the browser, which has two consequences:

- a genuine duplicate could be pushed out of the returned page and silently missed (false negative), and
- the *only* thing standing between the user and a self-referential "already assigned to <yourself>" warning was that client-side id compare — if the id the form holds and the id the list returns ever diverge, the record is reported as its own duplicate, which is exactly the symptom reported in #5534.

The client-side guard is kept as defense in depth; the query-level exclusion makes the self-match impossible at the source.

## 🔍 Investigation note for the reviewer and for QA

I want to be straightforward about what I could and could not verify, because it affects how this PR should be signed off.

I traced the full path behind the reported warning — `createPrimaryEmailField` → `useEmailDuplicateCheck` → `GET /api/customers/people` → `CrudForm`'s `recordId` (derived from `values.id`) — and wrote throwaway probes against the real `CrudForm` and the real form config. In the current code on `develop`, `recordId` does reach the field on `/backend/customers/people-v2/<id>`, and with it the hook already refuses to report the edited record. I could not reproduce the exact reported repro from the code alone.

So this PR implements the fix the issue asks for and closes the entire class of self-match false positives at the query layer, but I cannot claim to have watched the reported symptom disappear. If QA still sees the warning after this lands, the remaining explanations are worth checking directly in the tenant:

- a second person record sharing the same display name (the warning would then be correct, just confusing), or
- the prefix match mode — the hint fires when another record's address merely *starts with* what was typed, while the copy claims the address is "already assigned", which is only true for an exact match.

Both are separate from this change and would each deserve their own issue.

## 🧪 Tests

New: `packages/core/src/modules/customers/backend/hooks/__tests__/useEmailDuplicateCheck.test.tsx` — the hook had no coverage at all before this.

- sends `excludeIds` for the edited record, in both `prefix` and `exact` match modes
- never reports the edited record as its own duplicate, even when the API returns it anyway
- still reports a duplicate that belongs to a different record
- omits the exclusion on create, where there is no record yet

Verification run in this worktree: the new suite passes, and the full customers module suite passes (247 suites / 1587 tests). `tsc --noEmit` reports no errors in the touched files. The worktree has no `node_modules`, so the full ordered gate (`yarn build:packages` → `yarn generate` → … → `yarn build:app`) could not run locally and is left to CI — Jest and `tsc` were invoked directly from the repository toolchain instead.

## 💥 Breaking changes

None. `excludeIds` is an existing, already-supported query parameter on `GET /api/customers/people`; no schema, API surface, or contract change.

## 📸 Manual QA

Still pending — this PR carries `needs-qa` deliberately rather than taking the automated-verification exemption, because the reported symptom was observed by a human and I could not reproduce it in code. Please re-run the original repro from #5534 on a person record and confirm the warning no longer appears after saving a fresh address.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/open-mercato/codesmith/open-mercato/pr/5566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790167764&installation_model_id=432243&pr_number=5566&repository=open-mercato%2Fopen-mercato&return_to=https%3A%2F%2Fgithub.com%2Fopen-mercato%2Fopen-mercato%2Fpull%2F5566&signature=89ab46922bae132b24e94cd6b00fafade40a8414e26be3e68896655b65988215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->